### PR TITLE
feat: Tasks v1 (2/7) — task-create, task-list, task-update, task-complete skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **`task-create` skill** — creates a new task in the backlog with owner, priority, due date, tags, parent/blocked-by links, and optional `wake_at` (creates a linked one-shot `scheduled_jobs` row atomically). (Tasks v1, issue 2 of 7, closes #835)
+- **`task-list` skill** — lists tasks with filters (status, owner, tag, parent, due-before); returns priority-sorted results with last progress note and next wake-up time. (Tasks v1, #835)
+- **`task-update` skill** — updates task fields; enforces terminal-state guard (done/cancelled → no exit); replacing `wake_at` cancels the old scheduled wake-up and creates a new one atomically. (Tasks v1, #835)
+- **`task-complete` skill** — sets a task to done and auto-cancels pending wake-up jobs in one CTE. Kept separate from `task-update` for coordinator prompt clarity and audit-log differentiation. (Tasks v1, #835)
+- **`TaskRepo` service** — new capability-gated service (`capabilities: ["taskRepo"]`) providing all task CRUD and wake-up job management; publishes `task.created`, `task.updated`, `task.completed` bus events.
+- **`task.created`, `task.updated`, `task.completed` bus events** — three new event types added to the `BusEvent` discriminated union (breaking: exhaustive switch statements must add cases). (Tasks v1, #835)
+
 ### Changed
 - **`agent_tasks` → `tasks` migration** — promotes the scheduler's persistent-task table to a first-class tasks table with CEO-visible columns (`title`, `owner`, `priority`, `due_at`, `tags`, etc.); flips the `scheduled_job_id` back-FK to a forward `scheduled_jobs.task_id`; adds a status CHECK accepting both legacy and new task-lifecycle values. No behavior change for existing scheduler and persistent-task callers. (Tasks v1, issue 1 of 7, closes #834)
 - **Console tasks view** — updated to match the migrated `tasks` schema: drops `scheduled_job_id`, adds all new columns (`title`, `owner`, `priority`, `due_at`, `source`, `tags`, `description`, FK references), extends status filters with new task-lifecycle values, and updates the scheduled-jobs view to display the linked `task_id`. (#869)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
-- **`task-create` skill** — creates a new task in the backlog with owner, priority, due date, tags, parent/blocked-by links, and optional `wake_at` (creates a linked one-shot `scheduled_jobs` row atomically). (Tasks v1, issue 2 of 7, closes #835)
-- **`task-list` skill** — lists tasks with filters (status, owner, tag, parent, due-before); returns priority-sorted results with last progress note and next wake-up time. (Tasks v1, #835)
-- **`task-update` skill** — updates task fields; enforces terminal-state guard (done/cancelled → no exit); replacing `wake_at` cancels the old scheduled wake-up and creates a new one atomically. (Tasks v1, #835)
-- **`task-complete` skill** — sets a task to done and auto-cancels pending wake-up jobs in one CTE. Kept separate from `task-update` for coordinator prompt clarity and audit-log differentiation. (Tasks v1, #835)
-- **`TaskRepo` service** — new capability-gated service (`capabilities: ["taskRepo"]`) providing all task CRUD and wake-up job management; publishes `task.created`, `task.updated`, `task.completed` bus events.
-- **`task.created`, `task.updated`, `task.completed` bus events** — three new event types added to the `BusEvent` discriminated union (breaking: exhaustive switch statements must add cases). (Tasks v1, #835)
+- **Tasks v1 CRUD skills** — `task-create`, `task-list`, `task-update`, `task-complete` skills backed by a new capability-gated `TaskRepo`; promotes `agent_tasks` to a first-class `tasks` table with CEO-visible columns; adds `task.created`, `task.updated`, `task.completed` bus events. (#834, #835)
 
 ### Changed
-- **`agent_tasks` → `tasks` migration** — promotes the scheduler's persistent-task table to a first-class tasks table with CEO-visible columns (`title`, `owner`, `priority`, `due_at`, `tags`, etc.); flips the `scheduled_job_id` back-FK to a forward `scheduled_jobs.task_id`; adds a status CHECK accepting both legacy and new task-lifecycle values. No behavior change for existing scheduler and persistent-task callers. (Tasks v1, issue 1 of 7, closes #834)
 - **Console tasks view** — updated to match the migrated `tasks` schema: drops `scheduled_job_id`, adds all new columns (`title`, `owner`, `priority`, `due_at`, `source`, `tags`, `description`, FK references), extends status filters with new task-lifecycle values, and updates the scheduled-jobs view to display the linked `task_id`. (#869)
 
 ### Added

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -643,6 +643,10 @@ pinned_skills:
   - approval-expiry-sweep
   - pending-actions-digest
   - scheduler-report
+  - task-create
+  - task-list
+  - task-update
+  - task-complete
 allow_discovery: true
 schedule:
   - cron: "0 * * * *"

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.4.0"
+version: "0.5.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:

--- a/skills/task-complete/handler.test.ts
+++ b/skills/task-complete/handler.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { TaskCompleteHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { TaskRepo } from '../../src/db/task-repo.js';
+import type { TaskRow } from '../../src/db/queries/tasks.js';
+
+const silentLog = pino({ level: 'silent' });
+const VALID_UUID = '00000000-0000-0000-0000-000000000002';
+
+function makeCtx(overrides: Partial<SkillContext> = {}): SkillContext {
+  return {
+    input: {},
+    secret: () => 'unused',
+    log: silentLog,
+    agentId: 'coordinator',
+    timezone: 'America/Toronto',
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+function makeTaskRow(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    id: VALID_UUID,
+    agentId: 'coordinator',
+    intentAnchor: 'Call accountant',
+    title: 'Call accountant',
+    description: null,
+    status: 'done',
+    progress: { notes: [{ at: '2026-06-03T15:00:00.000Z', note: 'Called — filed extension' }] },
+    errorBudget: {},
+    conversationId: null,
+    createdAt: '2026-06-01T10:00:00.000Z',
+    updatedAt: '2026-06-03T15:00:00.000Z',
+    owner: 'curia',
+    waitingOnContactId: null,
+    waitingOnText: null,
+    parentTaskId: null,
+    blockedByTaskId: null,
+    priority: 50,
+    dueAt: null,
+    source: 'coordinator',
+    sourceAgentId: 'coordinator',
+    createdBy: 'coordinator',
+    tags: [],
+    ...overrides,
+  };
+}
+
+function makeTaskRepo(overrides: Partial<TaskRepo> = {}): TaskRepo {
+  return {
+    createTask: vi.fn(),
+    getTask: vi.fn(),
+    listTasks: vi.fn(),
+    updateTask: vi.fn(),
+    completeTask: vi.fn().mockResolvedValue(makeTaskRow()),
+    cancelWakeUpJobs: vi.fn(),
+    ...overrides,
+  } as unknown as TaskRepo;
+}
+
+describe('TaskCompleteHandler', () => {
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns error when task_id is missing', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: {}, taskRepo });
+
+    const result = await new TaskCompleteHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/task_id/);
+  });
+
+  it('returns error when task_id is not a valid UUID', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { task_id: 'not-a-uuid' }, taskRepo });
+
+    const result = await new TaskCompleteHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/UUID/);
+  });
+
+  it('returns error when taskRepo is not injected', async () => {
+    const ctx = makeCtx({ input: { task_id: VALID_UUID } });
+
+    const result = await new TaskCompleteHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/taskRepo/);
+  });
+
+  // ── Status transition guards ──────────────────────────────────────────────
+
+  it('propagates already-terminal error when trying to complete a done task', async () => {
+    const taskRepo = makeTaskRepo({
+      completeTask: vi.fn().mockRejectedValue(
+        new Error("Cannot complete task — it is already in terminal state 'done'."),
+      ),
+    });
+    const ctx = makeCtx({ input: { task_id: VALID_UUID }, taskRepo });
+
+    const result = await new TaskCompleteHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/terminal state/);
+  });
+
+  it('propagates error when trying to complete a cancelled task', async () => {
+    const taskRepo = makeTaskRepo({
+      completeTask: vi.fn().mockRejectedValue(
+        new Error("Cannot complete task — it is already in terminal state 'cancelled'."),
+      ),
+    });
+    const ctx = makeCtx({ input: { task_id: VALID_UUID }, taskRepo });
+
+    const result = await new TaskCompleteHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/terminal state/);
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it('completes a task and returns status=done', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { task_id: VALID_UUID }, taskRepo });
+
+    const result = await new TaskCompleteHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { status: string; task_id: string } }).data;
+    expect(data.status).toBe('done');
+    expect(data.task_id).toBe(VALID_UUID);
+  });
+
+  it('passes completion_note to TaskRepo.completeTask', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { task_id: VALID_UUID, completion_note: 'Filed extension with accountant' },
+      taskRepo,
+    });
+
+    await new TaskCompleteHandler().execute(ctx);
+
+    const calls = (taskRepo.completeTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![1]).toBe('Filed extension with accountant');
+  });
+
+  it('returns task-not-found error when TaskRepo returns null', async () => {
+    const taskRepo = makeTaskRepo({ completeTask: vi.fn().mockResolvedValue(null) });
+    const ctx = makeCtx({ input: { task_id: VALID_UUID }, taskRepo });
+
+    const result = await new TaskCompleteHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/not found/);
+  });
+
+  it('returns displayTimezone in the result', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { task_id: VALID_UUID }, taskRepo });
+
+    const result = await new TaskCompleteHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { displayTimezone: string } }).data;
+    expect(typeof data.displayTimezone).toBe('string');
+  });
+});

--- a/skills/task-complete/handler.ts
+++ b/skills/task-complete/handler.ts
@@ -22,8 +22,13 @@ export class TaskCompleteHandler implements SkillHandler {
     if (!UUID_RE.test(input.task_id)) {
       return { success: false, error: 'task_id must be a valid UUID' };
     }
-    if (input.completion_note && input.completion_note.length > 2000) {
-      return { success: false, error: 'completion_note must be 2000 characters or fewer' };
+    if (input.completion_note !== undefined) {
+      if (typeof input.completion_note !== 'string') {
+        return { success: false, error: 'completion_note must be a string' };
+      }
+      if (input.completion_note.length > 2000) {
+        return { success: false, error: 'completion_note must be 2000 characters or fewer' };
+      }
     }
 
     if (!ctx.taskRepo) {
@@ -53,7 +58,7 @@ export class TaskCompleteHandler implements SkillHandler {
           task_id: completed.id,
           title: completed.title,
           status: completed.status,
-          completed_at: toLocalIso(new Date(completed.updatedAt).getTime() / 1000, tz) ?? completed.updatedAt,
+          completed_at: toLocalIso(Math.floor(new Date(completed.updatedAt).getTime() / 1000), tz) ?? completed.updatedAt,
           displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : 'UTC',
         },
       };

--- a/skills/task-complete/handler.ts
+++ b/skills/task-complete/handler.ts
@@ -1,0 +1,66 @@
+// handler.ts — task-complete skill.
+//
+// Sets a task to 'done' and cancels pending wake-up jobs atomically.
+// Kept as a separate skill from task-update so the coordinator prompt can reason about
+// completion cleanly and the audit log distinguishes completion from generic updates.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class TaskCompleteHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input = ctx.input as {
+      task_id?: string;
+      completion_note?: string;
+    };
+
+    if (!input.task_id || typeof input.task_id !== 'string') {
+      return { success: false, error: 'Missing required input: task_id (string)' };
+    }
+    if (!UUID_RE.test(input.task_id)) {
+      return { success: false, error: 'task_id must be a valid UUID' };
+    }
+    if (input.completion_note && input.completion_note.length > 2000) {
+      return { success: false, error: 'completion_note must be 2000 characters or fewer' };
+    }
+
+    if (!ctx.taskRepo) {
+      return {
+        success: false,
+        error: 'task-complete: taskRepo not available — check ExecutionLayer configuration.',
+      };
+    }
+
+    ctx.log.info({ taskId: input.task_id }, 'Completing task');
+
+    try {
+      const completed = await ctx.taskRepo.completeTask(
+        input.task_id,
+        input.completion_note,
+        ctx.agentId,
+      );
+
+      if (!completed) {
+        return { success: false, error: `Task not found: ${input.task_id}` };
+      }
+
+      const tz = ctx.timezone;
+      return {
+        success: true,
+        data: {
+          task_id: completed.id,
+          title: completed.title,
+          status: completed.status,
+          completed_at: toLocalIso(new Date(completed.updatedAt).getTime() / 1000, tz) ?? completed.updatedAt,
+          displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : 'UTC',
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, taskId: input.task_id }, 'Failed to complete task');
+      return { success: false, error: `Failed to complete task: ${message}` };
+    }
+  }
+}

--- a/skills/task-complete/skill.json
+++ b/skills/task-complete/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "task-complete",
+  "description": "Mark a task as done. Optionally provide a completion_note to record what was accomplished. Auto-cancels any pending wake-up jobs for this task. Tasks already in 'done' or 'cancelled' state will return an error.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "task_id": "string",
+    "completion_note": "string?"
+  },
+  "outputs": {
+    "task_id": "string",
+    "title": "string",
+    "status": "string",
+    "completed_at": "string",
+    "displayTimezone": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["taskRepo"]
+}

--- a/skills/task-create/handler.test.ts
+++ b/skills/task-create/handler.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { TaskCreateHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { TaskRepo } from '../../src/db/task-repo.js';
+import type { TaskRow } from '../../src/db/queries/tasks.js';
+
+const silentLog = pino({ level: 'silent' });
+
+function makeCtx(overrides: Partial<SkillContext> = {}): SkillContext {
+  return {
+    input: {},
+    secret: () => 'unused',
+    log: silentLog,
+    agentId: 'coordinator',
+    timezone: 'America/Toronto',
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+function makeTaskRow(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    agentId: 'coordinator',
+    intentAnchor: 'Book dentist appointment',
+    title: 'Book dentist appointment',
+    description: null,
+    status: 'open',
+    progress: { notes: [] },
+    errorBudget: {},
+    conversationId: null,
+    createdAt: '2026-06-03T10:00:00.000Z',
+    updatedAt: '2026-06-03T10:00:00.000Z',
+    owner: 'curia',
+    waitingOnContactId: null,
+    waitingOnText: null,
+    parentTaskId: null,
+    blockedByTaskId: null,
+    priority: 50,
+    dueAt: null,
+    source: 'coordinator',
+    sourceAgentId: 'coordinator',
+    createdBy: 'coordinator',
+    tags: [],
+    ...overrides,
+  };
+}
+
+function makeTaskRepo(overrides: Partial<TaskRepo> = {}): TaskRepo {
+  return {
+    createTask: vi.fn().mockResolvedValue(makeTaskRow()),
+    getTask: vi.fn(),
+    listTasks: vi.fn(),
+    updateTask: vi.fn(),
+    completeTask: vi.fn(),
+    cancelWakeUpJobs: vi.fn(),
+    ...overrides,
+  } as unknown as TaskRepo;
+}
+
+describe('TaskCreateHandler', () => {
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns error when title is missing', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: {}, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/title/);
+  });
+
+  it('returns error when title is blank', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { title: '   ' }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/title/);
+  });
+
+  it('returns error when title exceeds 500 characters', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { title: 'x'.repeat(501) }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/500/);
+  });
+
+  it('returns error for invalid owner', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { title: 'Do a thing', owner: 'robot' }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/owner/);
+  });
+
+  it('returns error for priority out of range', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { title: 'Do a thing', priority: 150 }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/priority/);
+  });
+
+  it('returns error when taskRepo is not injected', async () => {
+    const ctx = makeCtx({ input: { title: 'Do a thing' } });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/taskRepo/);
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it('creates a task and returns the task_id', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Book dentist appointment', owner: 'ceo', priority: 70 },
+      taskRepo,
+    });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { task_id: string; status: string } }).data;
+    expect(data.task_id).toBe('00000000-0000-0000-0000-000000000001');
+    expect(data.status).toBe('open');
+  });
+
+  it('passes title, owner, and priority to TaskRepo.createTask', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Prepare board deck', owner: 'ceo', priority: 80, tags: ['board-prep'] },
+      taskRepo,
+      agentId: 'ceo-inbox',
+    });
+
+    await new TaskCreateHandler().execute(ctx);
+
+    const calls = (taskRepo.createTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toMatchObject({
+      title: 'Prepare board deck',
+      owner: 'ceo',
+      priority: 80,
+      tags: ['board-prep'],
+      agentId: 'ceo-inbox',
+      source: 'agent',
+    });
+  });
+
+  it('derives source=coordinator when agentId is coordinator', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Follow up with Alex' },
+      taskRepo,
+      agentId: 'coordinator',
+    });
+
+    await new TaskCreateHandler().execute(ctx);
+
+    const calls = (taskRepo.createTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0].source).toBe('coordinator');
+  });
+
+  it('passes wake_at as a Date to TaskRepo.createTask', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Call Steve', wake_at: '2026-06-10T09:00:00.000Z' },
+      taskRepo,
+    });
+
+    await new TaskCreateHandler().execute(ctx);
+
+    const calls = (taskRepo.createTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0].wakeAt).toBeInstanceOf(Date);
+    expect((calls[0]![0].wakeAt as Date).toISOString()).toBe('2026-06-10T09:00:00.000Z');
+  });
+
+  it('returns displayTimezone in the result', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { title: 'Task with timezone' }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { displayTimezone: string } }).data;
+    expect(typeof data.displayTimezone).toBe('string');
+    expect(data.displayTimezone).not.toBe('');
+  });
+
+  // ── Error propagation ─────────────────────────────────────────────────────
+
+  it('returns error when TaskRepo.createTask throws', async () => {
+    const taskRepo = makeTaskRepo({
+      createTask: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+    });
+    const ctx = makeCtx({ input: { title: 'Failing task' }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/DB connection lost/);
+  });
+});

--- a/skills/task-create/handler.test.ts
+++ b/skills/task-create/handler.test.ts
@@ -101,6 +101,34 @@ describe('TaskCreateHandler', () => {
     expect((result as { success: false; error: string }).error).toMatch(/owner/);
   });
 
+  it('returns error for non-ISO due_at (permissive date strings)', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { title: 'Task', due_at: '2026/06/10 09:00:00' }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/due_at/);
+  });
+
+  it('accepts and formats due_at with millisecond precision from DB', async () => {
+    const taskRepo = makeTaskRepo({
+      createTask: vi.fn().mockResolvedValue(
+        makeTaskRow({ dueAt: '2026-06-10T09:00:00.123Z' }),
+      ),
+    });
+    const ctx = makeCtx({
+      input: { title: 'Task', due_at: '2026-06-10T09:00:00.000Z' },
+      taskRepo,
+    });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { due_at: string | null } }).data;
+    expect(data.due_at).not.toBeNull();
+  });
+
   it('returns error for priority out of range', async () => {
     const taskRepo = makeTaskRepo();
     const ctx = makeCtx({ input: { title: 'Do a thing', priority: 150 }, taskRepo });

--- a/skills/task-create/handler.ts
+++ b/skills/task-create/handler.ts
@@ -62,6 +62,21 @@ export class TaskCreateHandler implements SkillHandler {
     const derivedSource = (input.source as 'ceo' | 'agent' | 'scheduler' | 'coordinator' | undefined)
       ?? (ctx.agentId === 'coordinator' ? 'coordinator' : 'agent');
 
+    let dueAt: Date | undefined;
+    if (input.due_at) {
+      dueAt = new Date(input.due_at);
+      if (isNaN(dueAt.getTime())) {
+        return { success: false, error: 'due_at must be a valid ISO 8601 date string' };
+      }
+    }
+    let wakeAt: Date | undefined;
+    if (input.wake_at) {
+      wakeAt = new Date(input.wake_at);
+      if (isNaN(wakeAt.getTime())) {
+        return { success: false, error: 'wake_at must be a valid ISO 8601 date string' };
+      }
+    }
+
     ctx.log.info({ title: input.title, owner: input.owner ?? 'curia' }, 'Creating task');
 
     try {
@@ -73,8 +88,8 @@ export class TaskCreateHandler implements SkillHandler {
         parentTaskId: input.parent_task_id,
         blockedByTaskId: input.blocked_by_task_id,
         priority: input.priority,
-        dueAt: input.due_at ? new Date(input.due_at) : undefined,
-        wakeAt: input.wake_at ? new Date(input.wake_at) : undefined,
+        dueAt,
+        wakeAt,
         tags: input.tags,
         waitingOnContactId: input.waiting_on_contact_id,
         waitingOnText: input.waiting_on_text,

--- a/skills/task-create/handler.ts
+++ b/skills/task-create/handler.ts
@@ -1,0 +1,113 @@
+// handler.ts — task-create skill.
+//
+// Creates a new task row. Auto-fills agent_id and source_agent_id from the caller context.
+// When wake_at is provided, creates a linked one-shot scheduled_jobs row atomically.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+
+const VALID_OWNERS = new Set(['curia', 'ceo', 'external']);
+const VALID_SOURCES = new Set(['ceo', 'agent', 'scheduler', 'coordinator']);
+
+export class TaskCreateHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input = ctx.input as {
+      title?: string;
+      description?: string;
+      owner?: string;
+      parent_task_id?: string;
+      blocked_by_task_id?: string;
+      priority?: number;
+      due_at?: string;
+      wake_at?: string;
+      tags?: string[];
+      waiting_on_contact_id?: string;
+      waiting_on_text?: string;
+      intent_anchor?: string;
+      source?: string;
+    };
+
+    if (!input.title || typeof input.title !== 'string' || !input.title.trim()) {
+      return { success: false, error: 'Missing required input: title (string)' };
+    }
+    if (input.title.length > 500) {
+      return { success: false, error: 'title must be 500 characters or fewer' };
+    }
+    if (input.description && input.description.length > 5000) {
+      return { success: false, error: 'description must be 5000 characters or fewer' };
+    }
+    if (input.owner && !VALID_OWNERS.has(input.owner)) {
+      return { success: false, error: `owner must be one of: curia, ceo, external` };
+    }
+    if (input.source && !VALID_SOURCES.has(input.source)) {
+      return { success: false, error: `source must be one of: ceo, agent, scheduler, coordinator` };
+    }
+    if (input.priority !== undefined) {
+      if (typeof input.priority !== 'number' || input.priority < 0 || input.priority > 100) {
+        return { success: false, error: 'priority must be a number between 0 and 100' };
+      }
+    }
+    if (input.tags && !Array.isArray(input.tags)) {
+      return { success: false, error: 'tags must be an array of strings' };
+    }
+
+    if (!ctx.taskRepo) {
+      return {
+        success: false,
+        error: 'task-create: taskRepo not available — check ExecutionLayer configuration.',
+      };
+    }
+
+    // Derive source from the calling agent name when not supplied.
+    const derivedSource = (input.source as 'ceo' | 'agent' | 'scheduler' | 'coordinator' | undefined)
+      ?? (ctx.agentId === 'coordinator' ? 'coordinator' : 'agent');
+
+    ctx.log.info({ title: input.title, owner: input.owner ?? 'curia' }, 'Creating task');
+
+    try {
+      const task = await ctx.taskRepo.createTask({
+        agentId: ctx.agentId ?? 'system',
+        title: input.title.trim(),
+        description: input.description,
+        owner: (input.owner as 'curia' | 'ceo' | 'external') ?? 'curia',
+        parentTaskId: input.parent_task_id,
+        blockedByTaskId: input.blocked_by_task_id,
+        priority: input.priority,
+        dueAt: input.due_at ? new Date(input.due_at) : undefined,
+        wakeAt: input.wake_at ? new Date(input.wake_at) : undefined,
+        tags: input.tags,
+        waitingOnContactId: input.waiting_on_contact_id,
+        waitingOnText: input.waiting_on_text,
+        intentAnchor: input.intent_anchor,
+        source: derivedSource,
+        sourceAgentId: ctx.agentId ?? undefined,
+        createdBy: ctx.agentId ?? 'system',
+      });
+
+      const tz = ctx.timezone;
+      const dueAtDisplay = task.dueAt
+        ? toLocalIso(new Date(task.dueAt).getTime() / 1000, tz)
+        : null;
+      const createdAtDisplay = toLocalIso(new Date(task.createdAt).getTime() / 1000, tz);
+
+      return {
+        success: true,
+        data: {
+          task_id: task.id,
+          title: task.title,
+          status: task.status,
+          owner: task.owner,
+          priority: task.priority,
+          due_at: dueAtDisplay,
+          tags: task.tags,
+          created_at: createdAtDisplay,
+          displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : 'UTC',
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, title: input.title }, 'Failed to create task');
+      return { success: false, error: `Failed to create task: ${message}` };
+    }
+  }
+}

--- a/skills/task-create/handler.ts
+++ b/skills/task-create/handler.ts
@@ -9,6 +9,10 @@ import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 const VALID_OWNERS = new Set(['curia', 'ceo', 'external']);
 const VALID_SOURCES = new Set(['ceo', 'agent', 'scheduler', 'coordinator']);
 
+// Strict ISO-8601 datetime with timezone offset. Rejects loose strings like
+// "June 10 2026" or "2026/06/10" that new Date() would silently accept.
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
 export class TaskCreateHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const input = ctx.input as {
@@ -64,6 +68,9 @@ export class TaskCreateHandler implements SkillHandler {
 
     let dueAt: Date | undefined;
     if (input.due_at) {
+      if (!ISO_DATETIME_RE.test(input.due_at)) {
+        return { success: false, error: 'due_at must be a valid ISO 8601 date string' };
+      }
       dueAt = new Date(input.due_at);
       if (isNaN(dueAt.getTime())) {
         return { success: false, error: 'due_at must be a valid ISO 8601 date string' };
@@ -71,6 +78,9 @@ export class TaskCreateHandler implements SkillHandler {
     }
     let wakeAt: Date | undefined;
     if (input.wake_at) {
+      if (!ISO_DATETIME_RE.test(input.wake_at)) {
+        return { success: false, error: 'wake_at must be a valid ISO 8601 date string' };
+      }
       wakeAt = new Date(input.wake_at);
       if (isNaN(wakeAt.getTime())) {
         return { success: false, error: 'wake_at must be a valid ISO 8601 date string' };
@@ -101,9 +111,12 @@ export class TaskCreateHandler implements SkillHandler {
 
       const tz = ctx.timezone;
       const dueAtDisplay = task.dueAt
-        ? toLocalIso(new Date(task.dueAt).getTime() / 1000, tz)
+        ? toLocalIso(Math.floor(new Date(task.dueAt).getTime() / 1000), tz)
         : null;
-      const createdAtDisplay = toLocalIso(new Date(task.createdAt).getTime() / 1000, tz);
+      const createdAtDisplay = toLocalIso(
+        Math.floor(new Date(task.createdAt).getTime() / 1000),
+        tz,
+      );
 
       return {
         success: true,

--- a/skills/task-create/skill.json
+++ b/skills/task-create/skill.json
@@ -1,0 +1,37 @@
+{
+  "name": "task-create",
+  "description": "Create a new task in the backlog. Provide a title and optionally description, owner (curia/ceo/external), priority (0-100), due date, tags, parent task, blocked-by task, waiting-on contact, and an intent anchor. When wake_at is set, schedules a one-shot wake-up for this task at that time.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "title": "string",
+    "description": "string?",
+    "owner": "string?",
+    "parent_task_id": "string?",
+    "blocked_by_task_id": "string?",
+    "priority": "number?",
+    "due_at": "timestamp?",
+    "wake_at": "timestamp?",
+    "tags": "string[]?",
+    "waiting_on_contact_id": "string?",
+    "waiting_on_text": "string?",
+    "intent_anchor": "string?",
+    "source": "string?"
+  },
+  "outputs": {
+    "task_id": "string",
+    "title": "string",
+    "status": "string",
+    "owner": "string",
+    "priority": "number",
+    "due_at": "string?",
+    "tags": "string[]",
+    "created_at": "string",
+    "displayTimezone": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["taskRepo"]
+}

--- a/skills/task-list/handler.test.ts
+++ b/skills/task-list/handler.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { TaskListHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { TaskRepo, TaskListRow } from '../../src/db/task-repo.js';
+
+const silentLog = pino({ level: 'silent' });
+
+function makeCtx(overrides: Partial<SkillContext> = {}): SkillContext {
+  return {
+    input: {},
+    secret: () => 'unused',
+    log: silentLog,
+    agentId: 'coordinator',
+    timezone: 'America/Toronto',
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+function makeListRow(overrides: Partial<TaskListRow> = {}): TaskListRow {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    agentId: 'coordinator',
+    intentAnchor: 'Write Q3 report',
+    title: 'Write Q3 report',
+    description: null,
+    status: 'open',
+    progress: { notes: [{ at: '2026-06-01T10:00:00.000Z', note: 'Started outline' }] },
+    errorBudget: {},
+    conversationId: null,
+    createdAt: '2026-06-01T10:00:00.000Z',
+    updatedAt: '2026-06-01T10:00:00.000Z',
+    owner: 'curia',
+    waitingOnContactId: null,
+    waitingOnText: null,
+    parentTaskId: null,
+    blockedByTaskId: null,
+    priority: 60,
+    dueAt: null,
+    source: 'coordinator',
+    sourceAgentId: 'coordinator',
+    createdBy: 'coordinator',
+    tags: ['board-prep'],
+    nextWakeAt: null,
+    ...overrides,
+  };
+}
+
+function makeTaskRepo(overrides: Partial<TaskRepo> = {}): TaskRepo {
+  return {
+    createTask: vi.fn(),
+    getTask: vi.fn(),
+    listTasks: vi.fn().mockResolvedValue([]),
+    updateTask: vi.fn(),
+    completeTask: vi.fn(),
+    cancelWakeUpJobs: vi.fn(),
+    ...overrides,
+  } as unknown as TaskRepo;
+}
+
+describe('TaskListHandler', () => {
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns error for invalid status value', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { status: 'pending' }, taskRepo });
+
+    const result = await new TaskListHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/status/);
+  });
+
+  it('returns error for invalid owner', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { owner: 'robot' }, taskRepo });
+
+    const result = await new TaskListHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/owner/);
+  });
+
+  it('returns error when taskRepo is not injected', async () => {
+    const ctx = makeCtx({ input: {} });
+
+    const result = await new TaskListHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/taskRepo/);
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it('returns empty tasks list when no tasks match', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: {}, taskRepo });
+
+    const result = await new TaskListHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { tasks: unknown[]; count: number } }).data;
+    expect(data.tasks).toHaveLength(0);
+    expect(data.count).toBe(0);
+  });
+
+  it('returns tasks with required fields', async () => {
+    const taskRepo = makeTaskRepo({
+      listTasks: vi.fn().mockResolvedValue([makeListRow()]),
+    });
+    const ctx = makeCtx({ input: {}, taskRepo });
+
+    const result = await new TaskListHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { tasks: Array<{ task_id: string; title: string; last_progress_note: string | null }> } }).data;
+    expect(data.tasks).toHaveLength(1);
+    expect(data.tasks[0]!.task_id).toBe('00000000-0000-0000-0000-000000000001');
+    expect(data.tasks[0]!.title).toBe('Write Q3 report');
+    // Last progress note from progress.notes
+    expect(data.tasks[0]!.last_progress_note).toBe('Started outline');
+  });
+
+  it('passes comma-separated statuses as array to TaskRepo.listTasks', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { status: 'open,in_progress' }, taskRepo });
+
+    await new TaskListHandler().execute(ctx);
+
+    const calls = (taskRepo.listTasks as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0].statuses).toEqual(['open', 'in_progress']);
+  });
+
+  it('caps limit at 100', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { limit: 500 }, taskRepo });
+
+    await new TaskListHandler().execute(ctx);
+
+    const calls = (taskRepo.listTasks as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0].limit).toBe(100);
+  });
+
+  it('defaults limit to 25', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: {}, taskRepo });
+
+    await new TaskListHandler().execute(ctx);
+
+    const calls = (taskRepo.listTasks as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0].limit).toBe(25);
+  });
+
+  it('includes next_wake_at when scheduled', async () => {
+    const taskRepo = makeTaskRepo({
+      listTasks: vi.fn().mockResolvedValue([
+        makeListRow({ nextWakeAt: '2026-06-10T09:00:00.000Z' }),
+      ]),
+    });
+    const ctx = makeCtx({ input: {}, taskRepo });
+
+    const result = await new TaskListHandler().execute(ctx);
+
+    const data = (result as { success: true; data: { tasks: Array<{ next_wake_at: string | null }> } }).data;
+    expect(data.tasks[0]!.next_wake_at).not.toBeNull();
+  });
+
+  it('returns displayTimezone in the result', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: {}, taskRepo });
+
+    const result = await new TaskListHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { displayTimezone: string } }).data;
+    expect(typeof data.displayTimezone).toBe('string');
+  });
+});

--- a/skills/task-list/handler.ts
+++ b/skills/task-list/handler.ts
@@ -40,6 +40,14 @@ export class TaskListHandler implements SkillHandler {
       return { success: false, error: `owner must be one of: curia, ceo, external` };
     }
 
+    let dueBefore: Date | undefined;
+    if (input.due_before) {
+      dueBefore = new Date(input.due_before);
+      if (isNaN(dueBefore.getTime())) {
+        return { success: false, error: 'due_before must be a valid ISO 8601 date string' };
+      }
+    }
+
     const limit = input.limit !== undefined
       ? Math.min(Math.max(1, Math.floor(input.limit)), MAX_LIMIT)
       : 25;
@@ -59,7 +67,7 @@ export class TaskListHandler implements SkillHandler {
         owner: input.owner,
         tag: input.tag,
         parentTaskId: input.parent_task_id,
-        dueBefore: input.due_before ? new Date(input.due_before) : undefined,
+        dueBefore,
         limit,
       });
 
@@ -106,7 +114,7 @@ export class TaskListHandler implements SkillHandler {
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to list tasks');
+      ctx.log.error({ err, statuses, owner: input.owner, limit }, 'Failed to list tasks');
       return { success: false, error: `Failed to list tasks: ${message}` };
     }
   }

--- a/skills/task-list/handler.ts
+++ b/skills/task-list/handler.ts
@@ -8,6 +8,9 @@ import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 import type { TaskListRow } from '../../src/db/task-repo.js';
 
 const VALID_STATUSES = new Set(['open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled']);
+
+// Strict ISO-8601 datetime with timezone offset. Rejects loose strings that new Date() would accept.
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
 const VALID_OWNERS = new Set(['curia', 'ceo', 'external']);
 const MAX_LIMIT = 100;
 
@@ -25,6 +28,9 @@ export class TaskListHandler implements SkillHandler {
     // Parse comma-separated status filter.
     let statuses: string[] | undefined;
     if (input.status) {
+      if (typeof input.status !== 'string') {
+        return { success: false, error: 'status must be a comma-separated string' };
+      }
       statuses = input.status.split(',').map(s => s.trim()).filter(Boolean);
       for (const s of statuses) {
         if (!VALID_STATUSES.has(s)) {
@@ -42,6 +48,9 @@ export class TaskListHandler implements SkillHandler {
 
     let dueBefore: Date | undefined;
     if (input.due_before) {
+      if (!ISO_DATETIME_RE.test(input.due_before)) {
+        return { success: false, error: 'due_before must be a valid ISO 8601 date string' };
+      }
       dueBefore = new Date(input.due_before);
       if (isNaN(dueBefore.getTime())) {
         return { success: false, error: 'due_before must be a valid ISO 8601 date string' };
@@ -91,12 +100,12 @@ export class TaskListHandler implements SkillHandler {
           status: row.status,
           owner: row.owner,
           priority: row.priority,
-          due_at: row.dueAt ? toLocalIso(new Date(row.dueAt).getTime() / 1000, tz) : null,
+          due_at: row.dueAt ? toLocalIso(Math.floor(new Date(row.dueAt).getTime() / 1000), tz) : null,
           tags: row.tags,
           age,
           last_progress_note: lastNote,
           next_wake_at: row.nextWakeAt
-            ? toLocalIso(new Date(row.nextWakeAt).getTime() / 1000, tz)
+            ? toLocalIso(Math.floor(new Date(row.nextWakeAt).getTime() / 1000), tz)
             : null,
           source_agent_id: row.sourceAgentId,
           blocked_by_task_id: row.blockedByTaskId,

--- a/skills/task-list/handler.ts
+++ b/skills/task-list/handler.ts
@@ -1,0 +1,113 @@
+// handler.ts — task-list skill.
+//
+// Lists tasks with optional filters. Returns up to `limit` (default 25) tasks sorted
+// by priority DESC, due_at ASC NULLS LAST. Joins to include the next pending wake-up.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+import type { TaskListRow } from '../../src/db/task-repo.js';
+
+const VALID_STATUSES = new Set(['open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled']);
+const VALID_OWNERS = new Set(['curia', 'ceo', 'external']);
+const MAX_LIMIT = 100;
+
+export class TaskListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input = ctx.input as {
+      status?: string;
+      owner?: string;
+      tag?: string;
+      parent_task_id?: string;
+      due_before?: string;
+      limit?: number;
+    };
+
+    // Parse comma-separated status filter.
+    let statuses: string[] | undefined;
+    if (input.status) {
+      statuses = input.status.split(',').map(s => s.trim()).filter(Boolean);
+      for (const s of statuses) {
+        if (!VALID_STATUSES.has(s)) {
+          return {
+            success: false,
+            error: `Invalid status '${s}'. Valid values: ${[...VALID_STATUSES].join(', ')}`,
+          };
+        }
+      }
+    }
+
+    if (input.owner && !VALID_OWNERS.has(input.owner)) {
+      return { success: false, error: `owner must be one of: curia, ceo, external` };
+    }
+
+    const limit = input.limit !== undefined
+      ? Math.min(Math.max(1, Math.floor(input.limit)), MAX_LIMIT)
+      : 25;
+
+    if (!ctx.taskRepo) {
+      return {
+        success: false,
+        error: 'task-list: taskRepo not available — check ExecutionLayer configuration.',
+      };
+    }
+
+    ctx.log.info({ statuses, owner: input.owner, limit }, 'Listing tasks');
+
+    try {
+      const rows = await ctx.taskRepo.listTasks({
+        statuses,
+        owner: input.owner,
+        tag: input.tag,
+        parentTaskId: input.parent_task_id,
+        dueBefore: input.due_before ? new Date(input.due_before) : undefined,
+        limit,
+      });
+
+      const tz = ctx.timezone;
+      const displayTimezone = tz ? formatDisplayTimezone(tz, new Date()) : 'UTC';
+
+      const tasks = rows.map((row: TaskListRow) => {
+        const lastNote = Array.isArray(row.progress.notes) && row.progress.notes.length > 0
+          ? (row.progress.notes[row.progress.notes.length - 1] as { note?: string } | null)?.note ?? null
+          : null;
+
+        const ageMs = Date.now() - new Date(row.createdAt).getTime();
+        const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24));
+        const age = ageDays === 0 ? 'today'
+          : ageDays === 1 ? '1 day'
+          : `${ageDays} days`;
+
+        return {
+          task_id: row.id,
+          title: row.title,
+          status: row.status,
+          owner: row.owner,
+          priority: row.priority,
+          due_at: row.dueAt ? toLocalIso(new Date(row.dueAt).getTime() / 1000, tz) : null,
+          tags: row.tags,
+          age,
+          last_progress_note: lastNote,
+          next_wake_at: row.nextWakeAt
+            ? toLocalIso(new Date(row.nextWakeAt).getTime() / 1000, tz)
+            : null,
+          source_agent_id: row.sourceAgentId,
+          blocked_by_task_id: row.blockedByTaskId,
+          parent_task_id: row.parentTaskId,
+        };
+      });
+
+      return {
+        success: true,
+        data: {
+          tasks,
+          count: tasks.length,
+          displayTimezone,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to list tasks');
+      return { success: false, error: `Failed to list tasks: ${message}` };
+    }
+  }
+}

--- a/skills/task-list/skill.json
+++ b/skills/task-list/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "task-list",
+  "description": "List tasks from the backlog. Filter by status (comma-separated: open,in_progress,blocked,waiting,done,cancelled), owner (curia/ceo/external), tag, parent task, or due-before date. Returns up to 25 tasks by default, sorted by priority then due date. Each result includes the next scheduled wake-up time if any.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "status": "string?",
+    "owner": "string?",
+    "tag": "string?",
+    "parent_task_id": "string?",
+    "due_before": "timestamp?",
+    "limit": "number?"
+  },
+  "outputs": {
+    "tasks": "object[]",
+    "count": "number",
+    "displayTimezone": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["taskRepo"]
+}

--- a/skills/task-update/handler.test.ts
+++ b/skills/task-update/handler.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { TaskUpdateHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { TaskRepo } from '../../src/db/task-repo.js';
+import type { TaskRow } from '../../src/db/queries/tasks.js';
+
+const silentLog = pino({ level: 'silent' });
+const VALID_UUID = '00000000-0000-0000-0000-000000000001';
+
+function makeCtx(overrides: Partial<SkillContext> = {}): SkillContext {
+  return {
+    input: {},
+    secret: () => 'unused',
+    log: silentLog,
+    agentId: 'coordinator',
+    timezone: 'America/Toronto',
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+function makeTaskRow(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    id: VALID_UUID,
+    agentId: 'coordinator',
+    intentAnchor: 'Prepare report',
+    title: 'Prepare report',
+    description: null,
+    status: 'open',
+    progress: { notes: [] },
+    errorBudget: {},
+    conversationId: null,
+    createdAt: '2026-06-01T10:00:00.000Z',
+    updatedAt: '2026-06-03T12:00:00.000Z',
+    owner: 'curia',
+    waitingOnContactId: null,
+    waitingOnText: null,
+    parentTaskId: null,
+    blockedByTaskId: null,
+    priority: 50,
+    dueAt: null,
+    source: 'coordinator',
+    sourceAgentId: 'coordinator',
+    createdBy: 'coordinator',
+    tags: [],
+    ...overrides,
+  };
+}
+
+function makeTaskRepo(overrides: Partial<TaskRepo> = {}): TaskRepo {
+  return {
+    createTask: vi.fn(),
+    getTask: vi.fn(),
+    listTasks: vi.fn(),
+    updateTask: vi.fn().mockResolvedValue(makeTaskRow()),
+    completeTask: vi.fn(),
+    cancelWakeUpJobs: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as TaskRepo;
+}
+
+describe('TaskUpdateHandler', () => {
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns error when task_id is missing', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { status: 'in_progress' }, taskRepo });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/task_id/);
+  });
+
+  it('returns error when task_id is not a valid UUID', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { task_id: 'not-a-uuid', status: 'in_progress' }, taskRepo });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/UUID/);
+  });
+
+  it('returns error for invalid status', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { task_id: VALID_UUID, status: 'active' }, taskRepo });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/status/);
+  });
+
+  it('returns error when no fields are provided', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { task_id: VALID_UUID }, taskRepo });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/at least one/i);
+  });
+
+  it('returns error when taskRepo is not injected', async () => {
+    const ctx = makeCtx({ input: { task_id: VALID_UUID, status: 'in_progress' } });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/taskRepo/);
+  });
+
+  // ── Status transition guards ──────────────────────────────────────────────
+
+  it('propagates terminal-state error from TaskRepo.updateTask', async () => {
+    // TaskRepo.updateTask throws when trying to transition from a terminal state.
+    const taskRepo = makeTaskRepo({
+      updateTask: vi.fn().mockRejectedValue(
+        new Error("Cannot transition task from 'done' — it is a terminal state."),
+      ),
+    });
+    const ctx = makeCtx({
+      input: { task_id: VALID_UUID, status: 'open' },
+      taskRepo,
+    });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/terminal state/);
+  });
+
+  it('propagates terminal-state error for cancelled → in_progress', async () => {
+    const taskRepo = makeTaskRepo({
+      updateTask: vi.fn().mockRejectedValue(
+        new Error("Cannot transition task from 'cancelled' — it is a terminal state."),
+      ),
+    });
+    const ctx = makeCtx({
+      input: { task_id: VALID_UUID, status: 'in_progress' },
+      taskRepo,
+    });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/terminal state/);
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it('updates status and returns updated task fields', async () => {
+    const taskRepo = makeTaskRepo({
+      updateTask: vi.fn().mockResolvedValue(makeTaskRow({ status: 'in_progress' })),
+    });
+    const ctx = makeCtx({ input: { task_id: VALID_UUID, status: 'in_progress' }, taskRepo });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { status: string; task_id: string } }).data;
+    expect(data.status).toBe('in_progress');
+    expect(data.task_id).toBe(VALID_UUID);
+  });
+
+  it('cancels wake-up jobs when status is set to cancelled', async () => {
+    const taskRepo = makeTaskRepo({
+      updateTask: vi.fn().mockResolvedValue(makeTaskRow({ status: 'cancelled' })),
+    });
+    const ctx = makeCtx({ input: { task_id: VALID_UUID, status: 'cancelled' }, taskRepo });
+
+    await new TaskUpdateHandler().execute(ctx);
+
+    expect((taskRepo.cancelWakeUpJobs as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    expect((taskRepo.cancelWakeUpJobs as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe(VALID_UUID);
+  });
+
+  it('does not call cancelWakeUpJobs for non-cancelled status updates', async () => {
+    const taskRepo = makeTaskRepo({
+      updateTask: vi.fn().mockResolvedValue(makeTaskRow({ status: 'in_progress' })),
+    });
+    const ctx = makeCtx({ input: { task_id: VALID_UUID, status: 'in_progress' }, taskRepo });
+
+    await new TaskUpdateHandler().execute(ctx);
+
+    expect((taskRepo.cancelWakeUpJobs as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it('passes wake_at as a Date to TaskRepo.updateTask', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { task_id: VALID_UUID, wake_at: '2026-06-15T14:00:00.000Z' },
+      taskRepo,
+    });
+
+    await new TaskUpdateHandler().execute(ctx);
+
+    const calls = (taskRepo.updateTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![1].wakeAt).toBeInstanceOf(Date);
+  });
+
+  it('returns task-not-found error when TaskRepo returns null', async () => {
+    const taskRepo = makeTaskRepo({ updateTask: vi.fn().mockResolvedValue(null) });
+    const ctx = makeCtx({ input: { task_id: VALID_UUID, status: 'in_progress' }, taskRepo });
+
+    const result = await new TaskUpdateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/not found/);
+  });
+});

--- a/skills/task-update/handler.test.ts
+++ b/skills/task-update/handler.test.ts
@@ -164,26 +164,20 @@ describe('TaskUpdateHandler', () => {
     expect(data.task_id).toBe(VALID_UUID);
   });
 
-  it('cancels wake-up jobs when status is set to cancelled', async () => {
+  it('passes status=cancelled to TaskRepo.updateTask (atomically cancels wake-ups in repo)', async () => {
+    // Wake-up job cancellation is now handled atomically inside TaskRepo.updateTask.
+    // The handler simply passes the status; no separate cancelWakeUpJobs call.
     const taskRepo = makeTaskRepo({
       updateTask: vi.fn().mockResolvedValue(makeTaskRow({ status: 'cancelled' })),
     });
     const ctx = makeCtx({ input: { task_id: VALID_UUID, status: 'cancelled' }, taskRepo });
 
-    await new TaskUpdateHandler().execute(ctx);
+    const result = await new TaskUpdateHandler().execute(ctx);
 
-    expect((taskRepo.cancelWakeUpJobs as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
-    expect((taskRepo.cancelWakeUpJobs as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe(VALID_UUID);
-  });
-
-  it('does not call cancelWakeUpJobs for non-cancelled status updates', async () => {
-    const taskRepo = makeTaskRepo({
-      updateTask: vi.fn().mockResolvedValue(makeTaskRow({ status: 'in_progress' })),
-    });
-    const ctx = makeCtx({ input: { task_id: VALID_UUID, status: 'in_progress' }, taskRepo });
-
-    await new TaskUpdateHandler().execute(ctx);
-
+    expect(result.success).toBe(true);
+    const calls = (taskRepo.updateTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![1].status).toBe('cancelled');
+    // cancelWakeUpJobs is NOT called from the handler — repo handles it
     expect((taskRepo.cancelWakeUpJobs as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
   });
 

--- a/skills/task-update/handler.ts
+++ b/skills/task-update/handler.ts
@@ -13,6 +13,9 @@ const VALID_OWNERS = new Set(['curia', 'ceo', 'external']);
 // Patterns that look like UUIDs — lightweight check before sending to DB.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Strict ISO-8601 datetime with timezone offset. Rejects loose strings that new Date() would accept.
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
 export class TaskUpdateHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const input = ctx.input as {
@@ -54,6 +57,11 @@ export class TaskUpdateHandler implements SkillHandler {
     if (input.progress_note && input.progress_note.length > 2000) {
       return { success: false, error: 'progress_note must be 2000 characters or fewer' };
     }
+    if (input.blocked_by_task_id !== undefined && input.blocked_by_task_id !== null) {
+      if (typeof input.blocked_by_task_id !== 'string' || !UUID_RE.test(input.blocked_by_task_id)) {
+        return { success: false, error: 'blocked_by_task_id must be a valid UUID' };
+      }
+    }
 
     // Require at least one field to update.
     const hasUpdate = input.status !== undefined || input.priority !== undefined
@@ -67,6 +75,9 @@ export class TaskUpdateHandler implements SkillHandler {
 
     let dueAt: Date | undefined;
     if (input.due_at) {
+      if (!ISO_DATETIME_RE.test(input.due_at)) {
+        return { success: false, error: 'due_at must be a valid ISO 8601 date string' };
+      }
       dueAt = new Date(input.due_at);
       if (isNaN(dueAt.getTime())) {
         return { success: false, error: 'due_at must be a valid ISO 8601 date string' };
@@ -74,6 +85,9 @@ export class TaskUpdateHandler implements SkillHandler {
     }
     let wakeAt: Date | undefined;
     if (input.wake_at) {
+      if (!ISO_DATETIME_RE.test(input.wake_at)) {
+        return { success: false, error: 'wake_at must be a valid ISO 8601 date string' };
+      }
       wakeAt = new Date(input.wake_at);
       if (isNaN(wakeAt.getTime())) {
         return { success: false, error: 'wake_at must be a valid ISO 8601 date string' };
@@ -119,10 +133,10 @@ export class TaskUpdateHandler implements SkillHandler {
           owner: updated.owner,
           priority: updated.priority,
           due_at: updated.dueAt
-            ? toLocalIso(new Date(updated.dueAt).getTime() / 1000, tz)
+            ? toLocalIso(Math.floor(new Date(updated.dueAt).getTime() / 1000), tz)
             : null,
           tags: updated.tags,
-          updated_at: toLocalIso(new Date(updated.updatedAt).getTime() / 1000, tz) ?? updated.updatedAt,
+          updated_at: toLocalIso(Math.floor(new Date(updated.updatedAt).getTime() / 1000), tz) ?? updated.updatedAt,
           displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : 'UTC',
         },
       };

--- a/skills/task-update/handler.ts
+++ b/skills/task-update/handler.ts
@@ -65,6 +65,21 @@ export class TaskUpdateHandler implements SkillHandler {
       return { success: false, error: 'At least one field to update must be provided' };
     }
 
+    let dueAt: Date | undefined;
+    if (input.due_at) {
+      dueAt = new Date(input.due_at);
+      if (isNaN(dueAt.getTime())) {
+        return { success: false, error: 'due_at must be a valid ISO 8601 date string' };
+      }
+    }
+    let wakeAt: Date | undefined;
+    if (input.wake_at) {
+      wakeAt = new Date(input.wake_at);
+      if (isNaN(wakeAt.getTime())) {
+        return { success: false, error: 'wake_at must be a valid ISO 8601 date string' };
+      }
+    }
+
     if (!ctx.taskRepo) {
       return {
         success: false,
@@ -81,8 +96,8 @@ export class TaskUpdateHandler implements SkillHandler {
           status: input.status,
           priority: input.priority,
           owner: input.owner,
-          dueAt: input.due_at ? new Date(input.due_at) : undefined,
-          wakeAt: input.wake_at ? new Date(input.wake_at) : undefined,
+          dueAt,
+          wakeAt,
           tags: input.tags,
           progressNote: input.progress_note,
           blockedByTaskId: input.blocked_by_task_id,

--- a/skills/task-update/handler.ts
+++ b/skills/task-update/handler.ts
@@ -1,0 +1,127 @@
+// handler.ts — task-update skill.
+//
+// Updates mutable fields on an existing task. Status transitions from terminal states
+// (done, cancelled) are rejected. Setting wake_at replaces any existing pending wake-up.
+// Setting status='cancelled' also cancels pending wake-up jobs.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+
+const VALID_STATUSES = new Set(['open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled']);
+const VALID_OWNERS = new Set(['curia', 'ceo', 'external']);
+
+// Patterns that look like UUIDs — lightweight check before sending to DB.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class TaskUpdateHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input = ctx.input as {
+      task_id?: string;
+      status?: string;
+      priority?: number;
+      owner?: string;
+      due_at?: string;
+      wake_at?: string;
+      tags?: string[];
+      progress_note?: string;
+      blocked_by_task_id?: string;
+    };
+
+    if (!input.task_id || typeof input.task_id !== 'string') {
+      return { success: false, error: 'Missing required input: task_id (string)' };
+    }
+    if (!UUID_RE.test(input.task_id)) {
+      return { success: false, error: 'task_id must be a valid UUID' };
+    }
+
+    if (input.status && !VALID_STATUSES.has(input.status)) {
+      return {
+        success: false,
+        error: `Invalid status '${input.status}'. Valid values: ${[...VALID_STATUSES].join(', ')}`,
+      };
+    }
+    if (input.owner && !VALID_OWNERS.has(input.owner)) {
+      return { success: false, error: `owner must be one of: curia, ceo, external` };
+    }
+    if (input.priority !== undefined) {
+      if (typeof input.priority !== 'number' || input.priority < 0 || input.priority > 100) {
+        return { success: false, error: 'priority must be a number between 0 and 100' };
+      }
+    }
+    if (input.tags && !Array.isArray(input.tags)) {
+      return { success: false, error: 'tags must be an array of strings' };
+    }
+    if (input.progress_note && input.progress_note.length > 2000) {
+      return { success: false, error: 'progress_note must be 2000 characters or fewer' };
+    }
+
+    // Require at least one field to update.
+    const hasUpdate = input.status !== undefined || input.priority !== undefined
+      || input.owner !== undefined || input.due_at !== undefined
+      || input.wake_at !== undefined || input.tags !== undefined
+      || input.progress_note !== undefined || input.blocked_by_task_id !== undefined;
+
+    if (!hasUpdate) {
+      return { success: false, error: 'At least one field to update must be provided' };
+    }
+
+    if (!ctx.taskRepo) {
+      return {
+        success: false,
+        error: 'task-update: taskRepo not available — check ExecutionLayer configuration.',
+      };
+    }
+
+    ctx.log.info({ taskId: input.task_id, status: input.status }, 'Updating task');
+
+    try {
+      const updated = await ctx.taskRepo.updateTask(
+        input.task_id,
+        {
+          status: input.status,
+          priority: input.priority,
+          owner: input.owner,
+          dueAt: input.due_at ? new Date(input.due_at) : undefined,
+          wakeAt: input.wake_at ? new Date(input.wake_at) : undefined,
+          tags: input.tags,
+          progressNote: input.progress_note,
+          blockedByTaskId: input.blocked_by_task_id,
+        },
+        ctx.agentId,
+      );
+
+      if (!updated) {
+        return { success: false, error: `Task not found: ${input.task_id}` };
+      }
+
+      // If status was set to 'cancelled', also cancel any pending wake-ups
+      // (updateTask handles this when wakeAt is provided, but a bare status='cancelled'
+      // without wakeAt still needs to cancel them).
+      if (input.status === 'cancelled' && !input.wake_at) {
+        await ctx.taskRepo.cancelWakeUpJobs(input.task_id);
+      }
+
+      const tz = ctx.timezone;
+      return {
+        success: true,
+        data: {
+          task_id: updated.id,
+          title: updated.title,
+          status: updated.status,
+          owner: updated.owner,
+          priority: updated.priority,
+          due_at: updated.dueAt
+            ? toLocalIso(new Date(updated.dueAt).getTime() / 1000, tz)
+            : null,
+          tags: updated.tags,
+          updated_at: toLocalIso(new Date(updated.updatedAt).getTime() / 1000, tz) ?? updated.updatedAt,
+          displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : 'UTC',
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, taskId: input.task_id }, 'Failed to update task');
+      return { success: false, error: `Failed to update task: ${message}` };
+    }
+  }
+}

--- a/skills/task-update/handler.ts
+++ b/skills/task-update/handler.ts
@@ -94,13 +94,6 @@ export class TaskUpdateHandler implements SkillHandler {
         return { success: false, error: `Task not found: ${input.task_id}` };
       }
 
-      // If status was set to 'cancelled', also cancel any pending wake-ups
-      // (updateTask handles this when wakeAt is provided, but a bare status='cancelled'
-      // without wakeAt still needs to cancel them).
-      if (input.status === 'cancelled' && !input.wake_at) {
-        await ctx.taskRepo.cancelWakeUpJobs(input.task_id);
-      }
-
       const tz = ctx.timezone;
       return {
         success: true,

--- a/skills/task-update/skill.json
+++ b/skills/task-update/skill.json
@@ -1,0 +1,33 @@
+{
+  "name": "task-update",
+  "description": "Update an existing task's fields. Can change status, priority, owner, due date, tags, progress note, or blocked-by dependency. Status transitions from 'done' or 'cancelled' are rejected. When wake_at is set, any existing pending wake-up for this task is cancelled and a new one is scheduled. Setting status='cancelled' auto-cancels pending wake-ups.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "task_id": "string",
+    "status": "string?",
+    "priority": "number?",
+    "owner": "string?",
+    "due_at": "timestamp?",
+    "wake_at": "timestamp?",
+    "tags": "string[]?",
+    "progress_note": "string?",
+    "blocked_by_task_id": "string?"
+  },
+  "outputs": {
+    "task_id": "string",
+    "title": "string",
+    "status": "string",
+    "owner": "string",
+    "priority": "number",
+    "due_at": "string?",
+    "tags": "string[]",
+    "updated_at": "string",
+    "displayTimezone": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["taskRepo"]
+}

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -503,6 +503,36 @@ interface HumanDecisionPayload {
 }
 
 
+// Task event payloads — emitted by TaskRepo (execution layer) when task lifecycle
+// operations complete. Breaking change: these types expand the BusEvent union.
+
+// task.created — published when a new task is inserted via task-create skill.
+interface TaskCreatedPayload {
+  taskId: string;
+  title: string;
+  owner: string;
+  source: string;
+  sourceAgentId: string | null;
+  agentId: string;
+}
+
+// task.updated — published when a task's fields are changed via task-update skill.
+// previousStatus and newStatus are both included when a status transition occurred.
+interface TaskUpdatedPayload {
+  taskId: string;
+  previousStatus: string;
+  newStatus?: string;          // present when the status field changed
+  progressNote?: string;       // present when a progress_note was appended
+  agentId: string | null;
+}
+
+// task.completed — published when a task is set to done via task-complete skill.
+interface TaskCompletedPayload {
+  taskId: string;
+  completionNote?: string;
+  agentId: string | null;
+}
+
 // -- Discriminated union --
 // The `type` field is the discriminant; `sourceLayer` records which layer emitted the event.
 
@@ -802,6 +832,25 @@ export interface ConversationCheckpointEvent extends BaseEvent {
   payload: ConversationCheckpointPayload;
 }
 
+// Task lifecycle events — emitted by TaskRepo (execution layer).
+export interface TaskCreatedEvent extends BaseEvent {
+  type: 'task.created';
+  sourceLayer: 'execution';
+  payload: TaskCreatedPayload;
+}
+
+export interface TaskUpdatedEvent extends BaseEvent {
+  type: 'task.updated';
+  sourceLayer: 'execution';
+  payload: TaskUpdatedPayload;
+}
+
+export interface TaskCompletedEvent extends BaseEvent {
+  type: 'task.completed';
+  sourceLayer: 'execution';
+  payload: TaskCompletedPayload;
+}
+
 export type BusEvent =
   | InboundMessageEvent
   | AgentTaskEvent
@@ -837,7 +886,10 @@ export type BusEvent =
   | SecretAccessedEvent      // Spec 06: secrets isolation audit trail (name only, never value)
   | AutonomySkillBlockedEvent  // Autonomy Phase 2: skill blocked by action_risk gate
   | AutonomySendBlockedEvent   // Autonomy Phase 2: outbound send blocked by score < 70 gate
-  | EmbeddingCallEvent;        // #654: embedding API call cost telemetry
+  | EmbeddingCallEvent         // #654: embedding API call cost telemetry
+  | TaskCreatedEvent           // Tasks v1: task created via task-create skill (#835)
+  | TaskUpdatedEvent           // Tasks v1: task fields updated via task-update skill (#835)
+  | TaskCompletedEvent;        // Tasks v1: task set to done via task-complete skill (#835)
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -1355,6 +1407,48 @@ export function createEmbeddingCall(
     timestamp: new Date(),
     type: 'embedding.call',
     sourceLayer: 'system',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createTaskCreated(
+  payload: TaskCreatedPayload & { parentEventId?: string },
+): TaskCreatedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'task.created',
+    sourceLayer: 'execution',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createTaskUpdated(
+  payload: TaskUpdatedPayload & { parentEventId?: string },
+): TaskUpdatedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'task.updated',
+    sourceLayer: 'execution',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createTaskCompleted(
+  payload: TaskCompletedPayload & { parentEventId?: string },
+): TaskCompletedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'task.completed',
+    sourceLayer: 'execution',
     payload: rest,
     parentEventId,
   };

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -15,6 +15,15 @@ import {
 import type { DbTaskRow, TaskRow } from './queries/tasks.js';
 import { mapTaskRow } from './queries/tasks.js';
 
+// All SELECT / RETURNING clauses use this column list. Centralised so a schema
+// change only needs updating in one place.
+const TASK_COLUMNS = `
+  id, agent_id, intent_anchor, title, description, status, progress, error_budget,
+  conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
+  waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
+  source, source_agent_id, created_by, tags
+`;
+
 // -- Public types --
 
 export interface CreateTaskParams {
@@ -110,10 +119,7 @@ export class TaskRepo {
       )
       VALUES ($1, $2, $3, $4, 'open', '{"notes":[]}'::jsonb, '{}'::jsonb,
               $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-      RETURNING id, agent_id, intent_anchor, title, description, status, progress, error_budget,
-                conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
-                waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
-                source, source_agent_id, created_by, tags
+      RETURNING ${TASK_COLUMNS}
     `;
     const taskParams: unknown[] = [
       agentId,
@@ -148,10 +154,7 @@ export class TaskRepo {
           )
           VALUES ($1, $2, $3, $4, 'open', '{"notes":[]}'::jsonb, '{}'::jsonb,
                   $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-          RETURNING id, agent_id, intent_anchor, title, description, status, progress, error_budget,
-                    conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
-                    waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
-                    source, source_agent_id, created_by, tags
+          RETURNING ${TASK_COLUMNS}
         ),
         _wake_job AS (
           INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id)
@@ -195,11 +198,7 @@ export class TaskRepo {
    */
   async getTask(taskId: string): Promise<TaskRow | null> {
     const { rows } = await this.pool.query(
-      `SELECT id, agent_id, intent_anchor, title, description, status, progress, error_budget,
-              conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
-              waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
-              source, source_agent_id, created_by, tags
-         FROM tasks WHERE id = $1`,
+      `SELECT ${TASK_COLUMNS} FROM tasks WHERE id = $1`,
       [taskId],
     );
     const row = rows[0] as DbTaskRow | undefined;
@@ -338,21 +337,23 @@ export class TaskRepo {
     const updateSql = `
       UPDATE tasks SET ${setClauses.join(', ')}
       WHERE id = $${whereIdx}
-      RETURNING id, agent_id, intent_anchor, title, description, status, progress, error_budget,
-                conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
-                waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
-                source, source_agent_id, created_by, tags
+      RETURNING ${TASK_COLUMNS}
     `;
+
+    // Terminal-status transitions (cancelled / done) always cancel pending wake-up jobs.
+    // When wakeAt is also provided the cancel+create is already atomic; the extra
+    // _cancel_wake arm here handles the bare status-only path.
+    const cancelOnTerminal = (updates.status === 'cancelled' || updates.status === 'done')
+      && !updates.wakeAt;
 
     let updatedRow: DbTaskRow;
 
-    if (updates.wakeAt) {
-      // Atomic CTE: update task + cancel old wake-up jobs + insert new one.
-      // updateParams already ends with taskId at position $whereIdx.
+    if (updates.wakeAt || cancelOnTerminal) {
+      // Atomic CTE: update task + cancel old wake-up jobs + optionally insert new one.
       const wakeAgentIdx = whereIdx + 1;
-      const wakeRunAtIdx = whereIdx + 2;
-      const wakeCreatedByIdx = whereIdx + 3;
-      const wakeTzIdx = whereIdx + 4;
+      const wakeRunAtIdx = updates.wakeAt ? whereIdx + 2 : null;
+      const wakeCreatedByIdx = updates.wakeAt ? whereIdx + 3 : null;
+      const wakeTzIdx = updates.wakeAt ? whereIdx + 4 : null;
 
       const cteSql = `
         WITH updated_task AS (
@@ -361,21 +362,23 @@ export class TaskRepo {
         _cancel_wake AS (
           UPDATE scheduled_jobs SET status = 'cancelled'
           WHERE task_id = $${whereIdx} AND status = 'pending'
-        ),
+        )${updates.wakeAt ? `,
         _new_wake AS (
           INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id)
           VALUES ($${wakeAgentIdx}, $${wakeRunAtIdx}, '{"type":"task-wake"}'::jsonb, 'pending',
                   $${wakeRunAtIdx}, $${wakeCreatedByIdx}, $${wakeTzIdx}, $${whereIdx})
-        )
+        )` : ''}
         SELECT * FROM updated_task
       `;
-      const allParams = [
-        ...updateParams,
-        callerAgentId ?? current.agentId, // $wakeAgentIdx
-        updates.wakeAt,                   // $wakeRunAtIdx
-        callerAgentId ?? current.agentId, // $wakeCreatedByIdx
-        this.timezone,                    // $wakeTzIdx
-      ];
+      const allParams: unknown[] = [...updateParams];
+      if (updates.wakeAt) {
+        allParams.push(
+          callerAgentId ?? current.agentId, // $wakeAgentIdx
+          updates.wakeAt,                   // $wakeRunAtIdx
+          callerAgentId ?? current.agentId, // $wakeCreatedByIdx
+          this.timezone,                    // $wakeTzIdx
+        );
+      }
       const { rows } = await this.pool.query(cteSql, allParams);
       updatedRow = rows[0] as DbTaskRow | undefined
         ?? (() => { throw new Error(`task-repo: updateTask CTE returned no row for ${taskId}`); })();
@@ -434,10 +437,7 @@ export class TaskRepo {
         UPDATE tasks
         SET status = 'done', progress = $1::jsonb, updated_at = now()
         WHERE id = $2
-        RETURNING id, agent_id, intent_anchor, title, description, status, progress, error_budget,
-                  conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
-                  waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
-                  source, source_agent_id, created_by, tags
+        RETURNING ${TASK_COLUMNS}
       ),
       _cancel_wake AS (
         UPDATE scheduled_jobs SET status = 'cancelled'

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -1,0 +1,475 @@
+// task-repo.ts — database operations for the tasks table and associated wake-up jobs.
+//
+// Skills cannot access the pool directly, so all task CRUD goes through this repo.
+// The TaskRepo also publishes task.created / task.updated / task.completed bus events
+// (same pattern as SchedulerService publishing schedule.created).
+
+import type { Pool } from 'pg';
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+import {
+  createTaskCreated,
+  createTaskUpdated,
+  createTaskCompleted,
+} from '../bus/events.js';
+import type { DbTaskRow, TaskRow } from './queries/tasks.js';
+import { mapTaskRow } from './queries/tasks.js';
+
+// -- Public types --
+
+export interface CreateTaskParams {
+  agentId: string;
+  title: string;
+  description?: string;
+  owner?: 'curia' | 'ceo' | 'external';
+  parentTaskId?: string;
+  blockedByTaskId?: string;
+  priority?: number;
+  dueAt?: Date;
+  tags?: string[];
+  waitingOnContactId?: string;
+  waitingOnText?: string;
+  intentAnchor?: string;
+  source?: 'ceo' | 'agent' | 'scheduler' | 'coordinator';
+  sourceAgentId?: string;
+  createdBy?: string;
+  /** When set, creates a linked one-shot scheduled_jobs row in the same transaction. */
+  wakeAt?: Date;
+}
+
+export interface UpdateTaskParams {
+  status?: string;
+  priority?: number;
+  owner?: string;
+  dueAt?: Date | null;
+  tags?: string[];
+  progressNote?: string;
+  blockedByTaskId?: string | null;
+  /** When provided, cancels existing pending wake-up jobs and creates a new one-shot. */
+  wakeAt?: Date;
+}
+
+export interface ListTasksFilters {
+  statuses?: string[];
+  owner?: string;
+  tag?: string;
+  parentTaskId?: string;
+  dueBefore?: Date;
+  limit?: number;
+}
+
+// Extended row returned by list — includes the next pending wake-up time if any.
+export interface TaskListRow extends TaskRow {
+  nextWakeAt: string | null;
+}
+
+// Terminal statuses: no transitions out of these.
+const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
+
+export class TaskRepo {
+  constructor(
+    private readonly pool: Pool,
+    private readonly bus: EventBus,
+    private readonly logger: Logger,
+    private readonly timezone: string = 'UTC',
+  ) {}
+
+  /**
+   * Insert a new task row. When `wakeAt` is provided, the insert and the
+   * scheduled_jobs insert are wrapped in a single CTE for atomicity.
+   */
+  async createTask(params: CreateTaskParams): Promise<TaskRow> {
+    const {
+      agentId,
+      title,
+      description,
+      owner = 'curia',
+      parentTaskId,
+      blockedByTaskId,
+      priority = 50,
+      dueAt,
+      tags = [],
+      waitingOnContactId,
+      waitingOnText,
+      intentAnchor,
+      source = 'agent',
+      sourceAgentId,
+      createdBy,
+      wakeAt,
+    } = params;
+
+    const resolvedCreatedBy = createdBy ?? agentId;
+    const resolvedIntentAnchor = intentAnchor ?? title;
+
+    // Always insert with 'open' status for skill-created tasks.
+    const taskInsertSql = `
+      INSERT INTO tasks (
+        agent_id, title, intent_anchor, description, status, progress, error_budget,
+        owner, parent_task_id, blocked_by_task_id, priority, due_at, tags,
+        waiting_on_contact_id, waiting_on_text, source, source_agent_id, created_by
+      )
+      VALUES ($1, $2, $3, $4, 'open', '{"notes":[]}'::jsonb, '{}'::jsonb,
+              $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+      RETURNING id, agent_id, intent_anchor, title, description, status, progress, error_budget,
+                conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
+                waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
+                source, source_agent_id, created_by, tags
+    `;
+    const taskParams: unknown[] = [
+      agentId,
+      title,
+      resolvedIntentAnchor,
+      description ?? null,
+      owner,
+      parentTaskId ?? null,
+      blockedByTaskId ?? null,
+      priority,
+      dueAt ?? null,
+      tags,
+      waitingOnContactId ?? null,
+      waitingOnText ?? null,
+      source,
+      sourceAgentId ?? null,
+      resolvedCreatedBy,
+    ];
+
+    let row: DbTaskRow;
+
+    if (wakeAt) {
+      // Atomic CTE: insert task + insert linked one-shot wake-up job in one round-trip.
+      // The task_payload carries minimal context; the dispatcher (issue 4) loads the full
+      // task from tasks.id via the scheduled_jobs.task_id FK.
+      const cteSql = `
+        WITH new_task AS (
+          INSERT INTO tasks (
+            agent_id, title, intent_anchor, description, status, progress, error_budget,
+            owner, parent_task_id, blocked_by_task_id, priority, due_at, tags,
+            waiting_on_contact_id, waiting_on_text, source, source_agent_id, created_by
+          )
+          VALUES ($1, $2, $3, $4, 'open', '{"notes":[]}'::jsonb, '{}'::jsonb,
+                  $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+          RETURNING id, agent_id, intent_anchor, title, description, status, progress, error_budget,
+                    conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
+                    waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
+                    source, source_agent_id, created_by, tags
+        ),
+        _wake_job AS (
+          INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id)
+          SELECT $16, $17, '{"type":"task-wake"}'::jsonb, 'pending', $17, $18, $19, new_task.id
+          FROM new_task
+        )
+        SELECT * FROM new_task
+      `;
+      const { rows } = await this.pool.query(cteSql, [
+        ...taskParams,
+        agentId,           // $16 — scheduled_jobs.agent_id
+        wakeAt,            // $17 — run_at / next_run_at
+        resolvedCreatedBy, // $18 — created_by
+        this.timezone,     // $19 — timezone
+      ]);
+      row = rows[0] as DbTaskRow | undefined
+        ?? (() => { throw new Error('task-repo: createTask CTE returned no row'); })();
+    } else {
+      const { rows } = await this.pool.query(taskInsertSql, taskParams);
+      row = rows[0] as DbTaskRow | undefined
+        ?? (() => { throw new Error('task-repo: createTask INSERT returned no row'); })();
+    }
+
+    const task = mapTaskRow(row);
+
+    await this.bus.publish('execution', createTaskCreated({
+      taskId: task.id,
+      title: task.title,
+      owner: task.owner,
+      source: task.source,
+      sourceAgentId: task.sourceAgentId,
+      agentId: task.agentId,
+    }));
+
+    this.logger.info({ taskId: task.id, title: task.title }, 'task-repo: created task');
+    return task;
+  }
+
+  /**
+   * Fetch a single task by ID. Returns null if not found.
+   */
+  async getTask(taskId: string): Promise<TaskRow | null> {
+    const { rows } = await this.pool.query(
+      `SELECT id, agent_id, intent_anchor, title, description, status, progress, error_budget,
+              conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
+              waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
+              source, source_agent_id, created_by, tags
+         FROM tasks WHERE id = $1`,
+      [taskId],
+    );
+    const row = rows[0] as DbTaskRow | undefined;
+    return row ? mapTaskRow(row) : null;
+  }
+
+  /**
+   * List tasks with optional filters. Returns rows ordered by priority DESC, due_at ASC NULLS LAST.
+   * Joins with scheduled_jobs to include the next pending wake-up time.
+   */
+  async listTasks(filters: ListTasksFilters = {}): Promise<TaskListRow[]> {
+    const { statuses, owner, tag, parentTaskId, dueBefore, limit = 25 } = filters;
+
+    const conditions: string[] = [];
+    const queryParams: unknown[] = [];
+    let idx = 1;
+
+    if (statuses && statuses.length > 0) {
+      conditions.push(`t.status = ANY($${idx++})`);
+      queryParams.push(statuses);
+    }
+    if (owner) {
+      conditions.push(`t.owner = $${idx++}`);
+      queryParams.push(owner);
+    }
+    if (tag) {
+      conditions.push(`$${idx++} = ANY(t.tags)`);
+      queryParams.push(tag);
+    }
+    if (parentTaskId) {
+      conditions.push(`t.parent_task_id = $${idx++}`);
+      queryParams.push(parentTaskId);
+    }
+    if (dueBefore) {
+      conditions.push(`t.due_at < $${idx++}`);
+      queryParams.push(dueBefore);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    queryParams.push(limit);
+
+    const sql = `
+      SELECT
+        t.id, t.agent_id, t.intent_anchor, t.title, t.description, t.status, t.progress,
+        t.error_budget, t.conversation_id, t.created_at, t.updated_at, t.owner,
+        t.waiting_on_contact_id, t.waiting_on_text, t.parent_task_id, t.blocked_by_task_id,
+        t.priority, t.due_at, t.source, t.source_agent_id, t.created_by, t.tags,
+        (
+          SELECT sj.run_at FROM scheduled_jobs sj
+          WHERE sj.task_id = t.id AND sj.status = 'pending'
+          ORDER BY sj.run_at ASC LIMIT 1
+        ) AS next_wake_at
+      FROM tasks t
+      ${whereClause}
+      ORDER BY t.priority DESC, t.due_at ASC NULLS LAST
+      LIMIT $${idx}
+    `;
+
+    const { rows } = await this.pool.query(sql, queryParams);
+    return (rows as Array<DbTaskRow & { next_wake_at: string | null }>).map(r => ({
+      ...mapTaskRow(r),
+      nextWakeAt: r.next_wake_at,
+    }));
+  }
+
+  /**
+   * Update a task's fields. Validates status transitions: done and cancelled are terminal.
+   * When `wakeAt` is provided, existing pending wake-up jobs are cancelled and a new one
+   * is created — all in a single CTE for atomicity.
+   *
+   * Returns the updated task row, or null if the task was not found.
+   */
+  async updateTask(
+    taskId: string,
+    updates: UpdateTaskParams,
+    callerAgentId?: string,
+  ): Promise<TaskRow | null> {
+    const current = await this.getTask(taskId);
+    if (!current) return null;
+
+    // Enforce terminal-state guard.
+    if (updates.status && updates.status !== current.status) {
+      if (TERMINAL_STATUSES.has(current.status)) {
+        throw new Error(
+          `Cannot transition task from '${current.status}' — it is a terminal state.`,
+        );
+      }
+    }
+
+    // Append progress note to progress.notes if provided.
+    let newProgress = current.progress;
+    if (updates.progressNote) {
+      const notes = (Array.isArray(newProgress.notes) ? newProgress.notes : []) as Array<unknown>;
+      notes.push({ at: new Date().toISOString(), note: updates.progressNote });
+      newProgress = { ...newProgress, notes };
+    }
+
+    // Build the SET clause dynamically — only update columns that were supplied.
+    const setClauses: string[] = ['updated_at = now()'];
+    const updateParams: unknown[] = [];
+    let idx = 1;
+
+    if (updates.status !== undefined) {
+      setClauses.push(`status = $${idx++}`);
+      updateParams.push(updates.status);
+    }
+    if (updates.priority !== undefined) {
+      setClauses.push(`priority = $${idx++}`);
+      updateParams.push(updates.priority);
+    }
+    if (updates.owner !== undefined) {
+      setClauses.push(`owner = $${idx++}`);
+      updateParams.push(updates.owner);
+    }
+    if ('dueAt' in updates) {
+      setClauses.push(`due_at = $${idx++}`);
+      updateParams.push(updates.dueAt ?? null);
+    }
+    if (updates.tags !== undefined) {
+      setClauses.push(`tags = $${idx++}`);
+      updateParams.push(updates.tags);
+    }
+    if (updates.progressNote !== undefined) {
+      setClauses.push(`progress = $${idx++}::jsonb`);
+      updateParams.push(JSON.stringify(newProgress));
+    }
+    if ('blockedByTaskId' in updates) {
+      setClauses.push(`blocked_by_task_id = $${idx++}`);
+      updateParams.push(updates.blockedByTaskId ?? null);
+    }
+
+    updateParams.push(taskId); // $N — WHERE id = $N
+    const whereIdx = idx;
+
+    const updateSql = `
+      UPDATE tasks SET ${setClauses.join(', ')}
+      WHERE id = $${whereIdx}
+      RETURNING id, agent_id, intent_anchor, title, description, status, progress, error_budget,
+                conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
+                waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
+                source, source_agent_id, created_by, tags
+    `;
+
+    let updatedRow: DbTaskRow;
+
+    if (updates.wakeAt) {
+      // Atomic CTE: update task + cancel old wake-up jobs + insert new one.
+      // updateParams already ends with taskId at position $whereIdx.
+      const wakeAgentIdx = whereIdx + 1;
+      const wakeRunAtIdx = whereIdx + 2;
+      const wakeCreatedByIdx = whereIdx + 3;
+      const wakeTzIdx = whereIdx + 4;
+
+      const cteSql = `
+        WITH updated_task AS (
+          ${updateSql}
+        ),
+        _cancel_wake AS (
+          UPDATE scheduled_jobs SET status = 'cancelled'
+          WHERE task_id = $${whereIdx} AND status = 'pending'
+        ),
+        _new_wake AS (
+          INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id)
+          VALUES ($${wakeAgentIdx}, $${wakeRunAtIdx}, '{"type":"task-wake"}'::jsonb, 'pending',
+                  $${wakeRunAtIdx}, $${wakeCreatedByIdx}, $${wakeTzIdx}, $${whereIdx})
+        )
+        SELECT * FROM updated_task
+      `;
+      const allParams = [
+        ...updateParams,
+        callerAgentId ?? current.agentId, // $wakeAgentIdx
+        updates.wakeAt,                   // $wakeRunAtIdx
+        callerAgentId ?? current.agentId, // $wakeCreatedByIdx
+        this.timezone,                    // $wakeTzIdx
+      ];
+      const { rows } = await this.pool.query(cteSql, allParams);
+      updatedRow = rows[0] as DbTaskRow | undefined
+        ?? (() => { throw new Error(`task-repo: updateTask CTE returned no row for ${taskId}`); })();
+    } else {
+      const { rows } = await this.pool.query(updateSql, updateParams);
+      updatedRow = rows[0] as DbTaskRow | undefined
+        ?? (() => { throw new Error(`task-repo: updateTask returned no row for ${taskId}`); })();
+    }
+
+    const updated = mapTaskRow(updatedRow);
+
+    await this.bus.publish('execution', createTaskUpdated({
+      taskId: updated.id,
+      previousStatus: current.status,
+      newStatus: updates.status !== undefined && updates.status !== current.status
+        ? updates.status
+        : undefined,
+      progressNote: updates.progressNote,
+      agentId: callerAgentId ?? null,
+    }));
+
+    this.logger.info(
+      { taskId: updated.id, previousStatus: current.status, newStatus: updated.status },
+      'task-repo: updated task',
+    );
+    return updated;
+  }
+
+  /**
+   * Set a task to 'done' and cancel any pending wake-up jobs.
+   * The update + cancellation happen atomically via a CTE.
+   */
+  async completeTask(
+    taskId: string,
+    completionNote?: string,
+    callerAgentId?: string,
+  ): Promise<TaskRow | null> {
+    const current = await this.getTask(taskId);
+    if (!current) return null;
+
+    if (TERMINAL_STATUSES.has(current.status)) {
+      throw new Error(
+        `Cannot complete task — it is already in terminal state '${current.status}'.`,
+      );
+    }
+
+    // Append completion note to progress.notes if provided.
+    const notes = (Array.isArray(current.progress.notes) ? current.progress.notes : []) as Array<unknown>;
+    if (completionNote) {
+      notes.push({ at: new Date().toISOString(), note: completionNote });
+    }
+    const newProgress = { ...current.progress, notes };
+
+    const cteSql = `
+      WITH done_task AS (
+        UPDATE tasks
+        SET status = 'done', progress = $1::jsonb, updated_at = now()
+        WHERE id = $2
+        RETURNING id, agent_id, intent_anchor, title, description, status, progress, error_budget,
+                  conversation_id, created_at, updated_at, owner, waiting_on_contact_id,
+                  waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
+                  source, source_agent_id, created_by, tags
+      ),
+      _cancel_wake AS (
+        UPDATE scheduled_jobs SET status = 'cancelled'
+        WHERE task_id = $2 AND status = 'pending'
+      )
+      SELECT * FROM done_task
+    `;
+
+    const { rows } = await this.pool.query(cteSql, [JSON.stringify(newProgress), taskId]);
+    const row = rows[0] as DbTaskRow | undefined;
+    if (!row) return null;
+
+    const updated = mapTaskRow(row);
+
+    await this.bus.publish('execution', createTaskCompleted({
+      taskId: updated.id,
+      completionNote,
+      agentId: callerAgentId ?? null,
+    }));
+
+    this.logger.info({ taskId: updated.id }, 'task-repo: completed task');
+    return updated;
+  }
+
+  /**
+   * Cancel all pending wake-up jobs for a task without changing the task itself.
+   * Used when status transitions to 'cancelled' via updateTask with status='cancelled'.
+   */
+  async cancelWakeUpJobs(taskId: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE scheduled_jobs SET status = 'cancelled' WHERE task_id = $1 AND status = 'pending'`,
+      [taskId],
+    );
+  }
+}

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -341,9 +341,13 @@ export class TaskRepo {
     updateParams.push(taskId); // $N — WHERE id = $N
     const whereIdx = idx;
 
+    // WHERE clause includes the terminal-state guard. If a concurrent write moved
+    // the task to 'done' or 'cancelled' between our pre-check and this UPDATE,
+    // the guard here ensures we don't overwrite the terminal state. An empty
+    // RETURNING is then handled below with a follow-up SELECT.
     const updateSql = `
       UPDATE tasks SET ${setClauses.join(', ')}
-      WHERE id = $${whereIdx}
+      WHERE id = $${whereIdx} AND status NOT IN ('done', 'cancelled')
       RETURNING ${TASK_COLUMNS}
     `;
 
@@ -387,12 +391,16 @@ export class TaskRepo {
         );
       }
       const { rows } = await this.pool.query(cteSql, allParams);
-      updatedRow = rows[0] as DbTaskRow | undefined
-        ?? (() => { throw new Error(`task-repo: updateTask CTE returned no row for ${taskId}`); })();
+      if (!rows[0]) {
+        return await this.resolveEmptyUpdateReturning(taskId);
+      }
+      updatedRow = rows[0] as DbTaskRow;
     } else {
       const { rows } = await this.pool.query(updateSql, updateParams);
-      updatedRow = rows[0] as DbTaskRow | undefined
-        ?? (() => { throw new Error(`task-repo: updateTask returned no row for ${taskId}`); })();
+      if (!rows[0]) {
+        return await this.resolveEmptyUpdateReturning(taskId);
+      }
+      updatedRow = rows[0] as DbTaskRow;
     }
 
     const updated = mapTaskRow(updatedRow);
@@ -416,6 +424,23 @@ export class TaskRepo {
       'task-repo: updated task',
     );
     return updated;
+  }
+
+  /**
+   * Called when an UPDATE...RETURNING returns no rows after a confirmed pre-check.
+   * Distinguishes "task was deleted concurrently" (return null) from "task reached a
+   * terminal state concurrently and the WHERE guard blocked the write" (throw).
+   */
+  private async resolveEmptyUpdateReturning(taskId: string): Promise<null> {
+    const { rows } = await this.pool.query(
+      `SELECT id, status FROM tasks WHERE id = $1`,
+      [taskId],
+    );
+    if (!rows[0]) return null;
+    const { status } = rows[0] as { status: string };
+    throw new Error(
+      `task-repo: update rejected — task ${taskId} reached terminal state '${status}' concurrently`,
+    );
   }
 
   /**
@@ -443,11 +468,13 @@ export class TaskRepo {
     }
     const newProgress = { ...current.progress, notes };
 
+    // The WHERE guard prevents a concurrent write from moving the task to a terminal
+    // state between our pre-check read and this UPDATE.
     const cteSql = `
       WITH done_task AS (
         UPDATE tasks
         SET status = 'done', progress = $1::jsonb, updated_at = now()
-        WHERE id = $2
+        WHERE id = $2 AND status NOT IN ('done', 'cancelled')
         RETURNING ${TASK_COLUMNS}
       ),
       _cancel_wake AS (
@@ -460,10 +487,9 @@ export class TaskRepo {
     const { rows } = await this.pool.query(cteSql, [JSON.stringify(newProgress), taskId]);
     const row = rows[0] as DbTaskRow | undefined;
     if (!row) {
-      // Task existed at getTask time and was not terminal — if RETURNING is empty,
-      // the row was deleted or mutated by a concurrent write. Throw so callers
-      // get a distinct signal rather than a misleading "not found" error.
-      throw new Error(`task-repo: completeTask CTE returned no row for ${taskId} — possible concurrent modification`);
+      // Task existed at pre-check time and was not terminal — if RETURNING is empty,
+      // the row was either deleted or moved to a terminal state concurrently.
+      return await this.resolveEmptyUpdateReturning(taskId);
     }
 
     const updated = mapTaskRow(row);

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -180,14 +180,21 @@ export class TaskRepo {
 
     const task = mapTaskRow(row);
 
-    await this.bus.publish('execution', createTaskCreated({
-      taskId: task.id,
-      title: task.title,
-      owner: task.owner,
-      source: task.source,
-      sourceAgentId: task.sourceAgentId,
-      agentId: task.agentId,
-    }));
+    // The DB write has committed. A bus-publish failure is an observability gap,
+    // not a data-integrity failure — log it but do not surface it as a task-creation
+    // failure (which would cause the caller to retry and create a duplicate row).
+    try {
+      await this.bus.publish('execution', createTaskCreated({
+        taskId: task.id,
+        title: task.title,
+        owner: task.owner,
+        source: task.source,
+        sourceAgentId: task.sourceAgentId,
+        agentId: task.agentId,
+      }));
+    } catch (busErr) {
+      this.logger.error({ busErr, taskId: task.id }, 'task-repo: bus publish failed after createTask');
+    }
 
     this.logger.info({ taskId: task.id, title: task.title }, 'task-repo: created task');
     return task;
@@ -390,15 +397,19 @@ export class TaskRepo {
 
     const updated = mapTaskRow(updatedRow);
 
-    await this.bus.publish('execution', createTaskUpdated({
-      taskId: updated.id,
-      previousStatus: current.status,
-      newStatus: updates.status !== undefined && updates.status !== current.status
-        ? updates.status
-        : undefined,
-      progressNote: updates.progressNote,
-      agentId: callerAgentId ?? null,
-    }));
+    try {
+      await this.bus.publish('execution', createTaskUpdated({
+        taskId: updated.id,
+        previousStatus: current.status,
+        newStatus: updates.status !== undefined && updates.status !== current.status
+          ? updates.status
+          : undefined,
+        progressNote: updates.progressNote,
+        agentId: callerAgentId ?? null,
+      }));
+    } catch (busErr) {
+      this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after updateTask');
+    }
 
     this.logger.info(
       { taskId: updated.id, previousStatus: current.status, newStatus: updated.status },
@@ -448,15 +459,24 @@ export class TaskRepo {
 
     const { rows } = await this.pool.query(cteSql, [JSON.stringify(newProgress), taskId]);
     const row = rows[0] as DbTaskRow | undefined;
-    if (!row) return null;
+    if (!row) {
+      // Task existed at getTask time and was not terminal — if RETURNING is empty,
+      // the row was deleted or mutated by a concurrent write. Throw so callers
+      // get a distinct signal rather than a misleading "not found" error.
+      throw new Error(`task-repo: completeTask CTE returned no row for ${taskId} — possible concurrent modification`);
+    }
 
     const updated = mapTaskRow(row);
 
-    await this.bus.publish('execution', createTaskCompleted({
-      taskId: updated.id,
-      completionNote,
-      agentId: callerAgentId ?? null,
-    }));
+    try {
+      await this.bus.publish('execution', createTaskCompleted({
+        taskId: updated.id,
+        completionNote,
+        agentId: callerAgentId ?? null,
+      }));
+    } catch (busErr) {
+      this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after completeTask');
+    }
 
     this.logger.info({ taskId: updated.id }, 'task-repo: completed task');
     return updated;
@@ -464,12 +484,15 @@ export class TaskRepo {
 
   /**
    * Cancel all pending wake-up jobs for a task without changing the task itself.
-   * Used when status transitions to 'cancelled' via updateTask with status='cancelled'.
+   * Available as an explicit hook for callers that need to cancel wake-ups independently
+   * of a status transition (e.g. external cleanup). For status='cancelled' and status='done'
+   * transitions via updateTask, the cancellation is handled atomically in the CTE.
    */
   async cancelWakeUpJobs(taskId: string): Promise<void> {
-    await this.pool.query(
+    const result = await this.pool.query(
       `UPDATE scheduled_jobs SET status = 'cancelled' WHERE task_id = $1 AND status = 'pending'`,
       [taskId],
     );
+    this.logger.info({ taskId, rowsAffected: result.rowCount }, 'task-repo: cancelled wake-up jobs');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ import { bootstrapAgentIdentity } from './entity-context/bootstrap.js';
 import { bootstrapCeoContact } from './contacts/ceo-bootstrap.js';
 import { AutonomyService } from './autonomy/autonomy-service.js';
 import { ActionLogRepo } from './autonomy/action-log-repo.js';
+import { TaskRepo } from './db/task-repo.js';
 import { ApprovalTriggerService } from './autonomy/approval-trigger.js';
 import { AutonomyScoringPass } from './autonomy/scoring-pass.js';
 import type { ScoringPassConfig } from './autonomy/scoring-pass.js';
@@ -907,6 +908,9 @@ async function main(): Promise<void> {
   // can be passed to the gateway at construction time.
   const actionLogRepo = new ActionLogRepo(pool, logger);
 
+  // TaskRepo — used by task-create, task-list, task-update, task-complete skills.
+  const taskRepo = new TaskRepo(pool, bus, logger, config.timezone);
+
   // Load principal's channel identities for the outbound gateway recipient check.
   // Cached for the lifetime of the process — restart picks up changes.
   // Load principal contact reference and cache it for the readiness check below (avoid a redundant DB query).
@@ -1259,7 +1263,7 @@ async function main(): Promise<void> {
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
   // infraLlmService provides constrained LLM access (classify/extract) with telemetry.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, officeIdentityService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, officeIdentityService, browserService, bullpenService, approvalTrigger, actionLogRepo, taskRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -85,6 +85,7 @@ export class ExecutionLayer {
   private bullpenService?: import('../memory/bullpen.js').BullpenService;
   private approvalTrigger?: ApprovalTriggerService;
   private actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
+  private taskRepo?: import('../db/task-repo.js').TaskRepo;
   private confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
   private tempFileStore?: TempFileStore;
   private readonly infraLlmService?: InfraLlmService;
@@ -118,6 +119,7 @@ export class ExecutionLayer {
     bullpenService?: import('../memory/bullpen.js').BullpenService;
     approvalTrigger?: ApprovalTriggerService;
     actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
+    taskRepo?: import('../db/task-repo.js').TaskRepo;
     confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
     tempFileStore?: TempFileStore;
     infraLlmService?: InfraLlmService;
@@ -147,6 +149,7 @@ export class ExecutionLayer {
     this.bullpenService = options?.bullpenService;
     this.approvalTrigger = options?.approvalTrigger;
     this.actionLogRepo = options?.actionLogRepo;
+    this.taskRepo = options?.taskRepo;
     this.confidencePipeline = options?.confidencePipeline;
     this.tempFileStore = options?.tempFileStore;
     this.infraLlmService = options?.infraLlmService;
@@ -579,6 +582,7 @@ export class ExecutionLayer {
       executiveProfileService: this.executiveProfileService,
       officeIdentityService: this.officeIdentityService,
       actionLogRepo: this.actionLogRepo,
+      taskRepo: this.taskRepo,
       confidencePipeline: this.confidencePipeline,
       // tempFileStore is handled as a special case in the injection loop (writeTempFile closure).
       // Listed here so the missing-cap guard knows it's configured when this.tempFileStore is set.

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -29,7 +29,7 @@ export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'schedulerService', 'entityMemory', 'nylasCalendarClient',
   'autonomyService', 'executiveProfileService', 'officeIdentityService', 'browserService', 'bullpenService', 'skillSearch',
   'actionLogRepo', 'executionLayer', 'confidencePipeline', 'tempFileStore',
-  'infraLlm', 'outboundContext',
+  'infraLlm', 'outboundContext', 'taskRepo',
 ]);
 
 /**

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -217,6 +217,10 @@ export interface SkillContext {
    *  Provides read/write access to the autonomy_action_log table for approval lifecycle
    *  management. Used by approve-action, deny-action, dismiss-action, list-pending-actions. */
   actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
+  /** Task repo — available to skills declaring 'taskRepo' in capabilities.
+   *  Provides CRUD access to the tasks table and manages linked wake-up scheduled_jobs rows.
+   *  Used by task-create, task-list, task-update, task-complete. */
+  taskRepo?: import('../db/task-repo.js').TaskRepo;
   /** Execution layer — available to skills declaring 'executionLayer' in capabilities.
    *  Allows re-invocation of skills with humanApproved bypass. Only approve-action (#428)
    *  should declare this capability; it is sensitivity: "elevated" (CEO-only). */


### PR DESCRIPTION
## Summary

- Introduces four new skills (`task-create`, `task-list`, `task-update`, `task-complete`) backed by a new `TaskRepo` service following the `ActionLogRepo` pattern
- `TaskRepo` handles all task CRUD, wake-up job management (atomic CTE for create/replace), status transition guards, and publishes `task.created` / `task.updated` / `task.completed` bus events
- `wake_at` scheduling uses a single CTE to atomically insert the `scheduled_jobs` row linked via `task_id` FK; replacing it (on update) cancels the old row and creates the new one in the same transaction
- Terminal-status transitions (`done → *`, `cancelled → *`) rejected by `TaskRepo.updateTask`; setting `status='done'` or `status='cancelled'` also cancels pending wake-up jobs atomically
- All four skills pinned to `coordinator.yaml`
- Bus event union extended with `task.created`, `task.updated`, `task.completed` (breaking: exhaustive switch statements must add cases)

Closes #835

## Test plan

- [ ] `pnpm run typecheck` passes clean
- [ ] 42 new skill unit tests pass (`skills/task-{create,list,update,complete}/handler.test.ts`)
- [ ] Happy path round-trip: call `task-create` → `task-list` → `task-update status=done` via dev CLI; verify tasks table row and no orphaned scheduled_jobs rows
- [ ] `wake_at` round-trip: `task-create wake_at=<future>` → verify scheduled_jobs row with correct `task_id`; `task-complete` → verify scheduled_jobs row status='cancelled'
- [ ] Status guard: `task-update status=open` on a done task → returns error containing "terminal state"
- [ ] Bus events: `task.created`, `task.updated`, `task.completed` appear in audit log
- [ ] Startup validation: `action_risk` set on all four manifests; `taskRepo` in VALID_CAPABILITIES allowlist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added task management capabilities: create, list, update, and complete tasks.
  * Support for task metadata including status, priority, due dates, completion notes, and tags.
  * Enabled scheduled task reminders through wake-up job management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->