### PR TITLE
chore: console compat for tasks schema (closes #869)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 - **`agent_tasks` → `tasks` migration** — promotes the scheduler's persistent-task table to a first-class tasks table with CEO-visible columns (`title`, `owner`, `priority`, `due_at`, `tags`, etc.); flips the `scheduled_job_id` back-FK to a forward `scheduled_jobs.task_id`; adds a status CHECK accepting both legacy and new task-lifecycle values. No behavior change for existing scheduler and persistent-task callers. (Tasks v1, issue 1 of 7, closes #834)
+- **Console tasks view** — updated to match the migrated `tasks` schema: drops `scheduled_job_id`, adds all new columns (`title`, `owner`, `priority`, `due_at`, `source`, `tags`, `description`, FK references), extends status filters with new task-lifecycle values, and updates the scheduled-jobs view to display the linked `task_id`. (#869)
 
 ### Added
 - **`contact-update` skill** — direct write path for canonical contact attributes (title, organization, phone, timezone, etc.) with E.164 phone normalization. Pinned to coordinator, ceo-inbox, research-analyst, and contacts. (#863)

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -391,6 +391,15 @@ function JobEditDrawer({ job, creating, onClose, onSaved, onDeleted }: DrawerPro
                   </div>
                 </div>
               )}
+
+              {job?.agentTaskId && (
+                <div className="form-field">
+                  <label>Task ID</label>
+                  <div className="form-field-readonly cell-mono" style={{ fontSize: 11, wordBreak: 'break-all' }}>
+                    {job.agentTaskId}
+                  </div>
+                </div>
+              )}
             </>
           )}
 
@@ -655,6 +664,7 @@ export default function JobsPage() {
                               Created <span className="sort-arrow">{sortArrow('createdAt')}</span>
                             </button>
                           </th>
+                          <th>Task ID</th>
                           <th style={{ textAlign: 'right' }}>Actions</th>
                         </tr>
                       </thead>
@@ -680,6 +690,9 @@ export default function JobsPage() {
                               }
                             </td>
                             <td className="cell-mono col-updated">{formatDate(j.createdAt)}</td>
+                            <td className="cell-mono" style={{ fontSize: 11 }}>
+                              {j.agentTaskId ? j.agentTaskId.slice(0, 8) + '…' : <span className="cell-muted">—</span>}
+                            </td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>
                                 <button
@@ -697,7 +710,7 @@ export default function JobsPage() {
                         ))}
                         {pageRows.length === 0 && (
                           <tr>
-                            <td colSpan={7} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                            <td colSpan={8} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
                               No jobs match.
                             </td>
                           </tr>

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -7,25 +7,49 @@ import { useTheme } from '../hooks/useTheme.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type TaskStatus = 'active' | 'pending' | 'paused' | 'completed' | 'failed' | 'cancelled';
+type TaskStatus =
+  // Task-lifecycle values (migration 049)
+  | 'open' | 'in_progress' | 'blocked' | 'waiting' | 'done' | 'cancelled'
+  // Legacy scheduler values retained for existing rows
+  | 'active' | 'pending' | 'paused' | 'completed' | 'failed';
+
+type TaskOwner = 'curia' | 'ceo' | 'external';
+type TaskSource = 'ceo' | 'agent' | 'scheduler' | 'coordinator';
 
 interface Task {
   id: string;
   agentId: string;
+  title: string;
   intentAnchor: string;
+  description: string | null;
   status: TaskStatus;
+  owner: TaskOwner;
+  priority: number;
+  dueAt: string | null;
+  source: TaskSource;
+  sourceAgentId: string | null;
+  tags: string[];
+  waitingOnContactId: string | null;
+  waitingOnText: string | null;
+  parentTaskId: string | null;
+  blockedByTaskId: string | null;
   progress: Record<string, unknown>;
   errorBudget: Record<string, unknown>;
   conversationId: string | null;
-  scheduledJobId: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function formatDate(iso: string): string {
-  return iso.slice(0, 10); // YYYY-MM-DD
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return iso.slice(0, 10);
+}
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return '—';
+  return iso.slice(0, 16).replace('T', ' ');
 }
 
 function prettyJson(value: Record<string, unknown>): string {
@@ -108,12 +132,24 @@ interface DrawerProps {
   onDeleted: (id: string) => void;
 }
 
+const ALL_STATUSES: TaskStatus[] = [
+  'open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled',
+  'active', 'pending', 'paused', 'completed', 'failed',
+];
+
 function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerProps) {
   const [agentId, setAgentId] = useState(task?.agentId ?? '');
+  const [title, setTitle] = useState(task?.title ?? '');
   const [intentAnchor, setIntentAnchor] = useState(task?.intentAnchor ?? '');
-  const [status, setStatus] = useState<TaskStatus>(task?.status ?? 'pending');
+  const [description, setDescription] = useState(task?.description ?? '');
+  const [status, setStatus] = useState<TaskStatus>(task?.status ?? 'open');
+  const [owner, setOwner] = useState<TaskOwner>(task?.owner ?? 'curia');
+  const [priority, setPriority] = useState(String(task?.priority ?? 50));
+  const [dueAt, setDueAt] = useState(task?.dueAt ? task.dueAt.slice(0, 10) : '');
+  const [source, setSource] = useState<TaskSource>(task?.source ?? 'agent');
+  const [tags, setTags] = useState((task?.tags ?? []).join(', '));
   const [conversationId, setConversationId] = useState(task?.conversationId ?? '');
-  const [scheduledJobId, setScheduledJobId] = useState(task?.scheduledJobId ?? '');
+  const [waitingOnText, setWaitingOnText] = useState(task?.waitingOnText ?? '');
   const [errorBudget, setErrorBudget] = useState(prettyJson(task?.errorBudget ?? {}));
   const [progress, setProgress] = useState(prettyJson(task?.progress ?? {}));
   const [saving, setSaving] = useState(false);
@@ -121,12 +157,12 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
   const [error, setError] = useState<string | null>(null);
 
   async function handleSave() {
-    if (!agentId.trim()) {
-      setError('Agent ID is required.');
-      return;
-    }
-    if (!intentAnchor.trim()) {
-      setError('Intent anchor is required.');
+    if (!agentId.trim()) { setError('Agent ID is required.'); return; }
+    if (!intentAnchor.trim()) { setError('Intent anchor is required.'); return; }
+
+    const parsedPriority = parseInt(priority, 10);
+    if (isNaN(parsedPriority) || parsedPriority < 0 || parsedPriority > 100) {
+      setError('Priority must be an integer 0–100.');
       return;
     }
 
@@ -143,12 +179,20 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
     setSaving(true);
     setError(null);
     try {
+      const parsedTags = tags.split(',').map(t => t.trim()).filter(Boolean);
       const body = {
         agentId: agentId.trim(),
+        title: title.trim() || intentAnchor.trim(),
         intentAnchor: intentAnchor.trim(),
+        description: description.trim() || null,
         status,
+        owner,
+        priority: parsedPriority,
+        dueAt: dueAt || null,
+        source,
+        tags: parsedTags,
         conversationId: conversationId.trim() || null,
-        scheduledJobId: scheduledJobId.trim() || null,
+        waitingOnText: waitingOnText.trim() || null,
         errorBudget: parsedErrorBudget,
         progress: parsedProgress,
       };
@@ -168,10 +212,7 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
         });
       }
 
-      if (!res.ok) {
-        throw new Error(await errorMessage(res));
-      }
-
+      if (!res.ok) throw new Error(await errorMessage(res));
       const data = await res.json() as { task: Task };
       onSaved(data.task);
     } catch (err) {
@@ -198,6 +239,17 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
     }
   }
 
+  // Read-only UUID display for system-managed FK fields.
+  function uuidField(label: string, value: string | null) {
+    if (!value) return null;
+    return (
+      <div className="form-field">
+        <label>{label}</label>
+        <div className="form-field-readonly cell-mono" style={{ fontSize: 11, wordBreak: 'break-all' }}>{value}</div>
+      </div>
+    );
+  }
+
   return (
     <aside className="drawer">
       <div className="drawer-header">
@@ -209,7 +261,7 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
             </svg>
           </button>
         </div>
-        <h2 className="drawer-title-h2">{creating ? 'New task' : (task?.agentId ?? '')}</h2>
+        <h2 className="drawer-title-h2">{creating ? 'New task' : (task?.title || task?.agentId ?? '')}</h2>
         {!creating && task && (
           <div className="drawer-subtitle">{task.status}</div>
         )}
@@ -227,28 +279,71 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
             <div className="form-field">
               <label htmlFor="tf-status">Status</label>
               <select id="tf-status" value={status} onChange={e => setStatus(e.target.value as TaskStatus)}>
-                <option value="active">active</option>
-                <option value="pending">pending</option>
-                <option value="paused">paused</option>
-                <option value="completed">completed</option>
-                <option value="failed">failed</option>
-                <option value="cancelled">cancelled</option>
+                {ALL_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
               </select>
             </div>
             <div className="form-field">
-              <label htmlFor="tf-conv-id">Conversation ID (UUID)</label>
-              <input id="tf-conv-id" type="text" value={conversationId} onChange={e => setConversationId(e.target.value)} placeholder="UUID — optional" />
+              <label htmlFor="tf-owner">Owner</label>
+              <select id="tf-owner" value={owner} onChange={e => setOwner(e.target.value as TaskOwner)}>
+                <option value="curia">curia</option>
+                <option value="ceo">ceo</option>
+                <option value="external">external</option>
+              </select>
             </div>
             <div className="form-field">
-              <label htmlFor="tf-job-id">Scheduled Job ID (UUID)</label>
-              <input id="tf-job-id" type="text" value={scheduledJobId} onChange={e => setScheduledJobId(e.target.value)} placeholder="UUID — optional" />
+              <label htmlFor="tf-priority">Priority (0–100)</label>
+              <input id="tf-priority" type="number" min="0" max="100" value={priority} onChange={e => setPriority(e.target.value)} />
+            </div>
+            <div className="form-field">
+              <label htmlFor="tf-due-at">Due date</label>
+              <input id="tf-due-at" type="date" value={dueAt} onChange={e => setDueAt(e.target.value)} />
+            </div>
+            <div className="form-field">
+              <label htmlFor="tf-source">Source</label>
+              <select id="tf-source" value={source} onChange={e => setSource(e.target.value as TaskSource)}>
+                <option value="agent">agent</option>
+                <option value="ceo">ceo</option>
+                <option value="scheduler">scheduler</option>
+                <option value="coordinator">coordinator</option>
+              </select>
             </div>
           </div>
 
           <div className="form-field">
+            <label htmlFor="tf-title">Title</label>
+            <input id="tf-title" type="text" value={title} onChange={e => setTitle(e.target.value)} placeholder="Short task title" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="tf-description">Description</label>
+            <textarea id="tf-description" rows={2} value={description} onChange={e => setDescription(e.target.value)} placeholder="Optional longer description…" />
+          </div>
+          <div className="form-field">
             <label htmlFor="tf-intent">Intent anchor</label>
             <textarea id="tf-intent" rows={3} value={intentAnchor} onChange={e => setIntentAnchor(e.target.value)} placeholder="Persistent task goal/context…" />
           </div>
+          <div className="form-field">
+            <label htmlFor="tf-tags">Tags (comma-separated)</label>
+            <input id="tf-tags" type="text" value={tags} onChange={e => setTags(e.target.value)} placeholder="e.g. follow-up, finance" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="tf-waiting-text">Waiting on (text)</label>
+            <textarea id="tf-waiting-text" rows={2} value={waitingOnText} onChange={e => setWaitingOnText(e.target.value)} placeholder="Who or what are we waiting on?" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="tf-conv-id">Conversation ID (UUID)</label>
+            <input id="tf-conv-id" type="text" value={conversationId} onChange={e => setConversationId(e.target.value)} placeholder="UUID — optional" />
+          </div>
+
+          {/* Read-only system-managed FK fields */}
+          {!creating && (
+            <>
+              {uuidField('Source agent ID', task?.sourceAgentId ?? null)}
+              {uuidField('Waiting on contact ID', task?.waitingOnContactId ?? null)}
+              {uuidField('Parent task ID', task?.parentTaskId ?? null)}
+              {uuidField('Blocked by task ID', task?.blockedByTaskId ?? null)}
+            </>
+          )}
+
           <div className="form-field">
             <label htmlFor="tf-budget">Error budget JSON</label>
             <textarea id="tf-budget" rows={4} value={errorBudget} onChange={e => setErrorBudget(e.target.value)} placeholder='{"maxTurns": 12, "maxConsecutiveErrors": 3}' style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }} />
@@ -282,9 +377,15 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
 
 // ── Main page ─────────────────────────────────────────────────────────────────
 
-type SortKey = 'agentId' | 'intentAnchor' | 'status' | 'updatedAt';
+type SortKey = 'title' | 'agentId' | 'owner' | 'priority' | 'status' | 'dueAt' | 'updatedAt';
 
-const STATUS_FILTERS = ['all', 'active', 'pending', 'paused', 'completed', 'failed', 'cancelled'] as const;
+const STATUS_FILTERS = [
+  'all',
+  // Primary task-lifecycle values
+  'open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled',
+  // Legacy scheduler values
+  'active', 'pending', 'paused', 'completed', 'failed',
+] as const;
 type StatusFilter = typeof STATUS_FILTERS[number];
 
 export default function TasksPage() {
@@ -294,7 +395,7 @@ export default function TasksPage() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('active');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'updatedAt', dir: 'desc' });
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
@@ -321,8 +422,11 @@ export default function TasksPage() {
   useEffect(() => { void load(); }, [load]);
 
   const counts = useMemo(() => {
-    const c: Record<StatusFilter, number> = { all: tasks.length, active: 0, pending: 0, paused: 0, completed: 0, failed: 0, cancelled: 0 };
-    for (const t of tasks) c[t.status]++;
+    const c: Record<string, number> = { all: tasks.length };
+    for (const s of STATUS_FILTERS.slice(1)) c[s] = 0;
+    for (const t of tasks) {
+      if (c[t.status] !== undefined) c[t.status]++;
+    }
     return c;
   }, [tasks]);
 
@@ -332,13 +436,13 @@ export default function TasksPage() {
     if (search) {
       const q = search.toLowerCase();
       rows = rows.filter(t =>
-        (t.agentId + ' ' + t.intentAnchor).toLowerCase().includes(q)
+        (t.title + ' ' + t.agentId + ' ' + t.intentAnchor + ' ' + t.tags.join(' ')).toLowerCase().includes(q)
       );
     }
     const dir = sort.dir === 'asc' ? 1 : -1;
     rows = [...rows].sort((a, b) => {
-      const av = (a[sort.key] ?? '') as string;
-      const bv = (b[sort.key] ?? '') as string;
+      const av = (a[sort.key] ?? '') as string | number;
+      const bv = (b[sort.key] ?? '') as string | number;
       if (av < bv) return -1 * dir;
       if (av > bv) return  1 * dir;
       return 0;
@@ -367,8 +471,7 @@ export default function TasksPage() {
         next[idx] = task;
         return next;
       }
-      // New task: switch filter so it's immediately visible.
-      setStatusFilter(task.status);
+      setStatusFilter('all');
       return [...prev, task];
     });
     setEditing(task);
@@ -395,7 +498,7 @@ export default function TasksPage() {
         <main className="main tasks-page">
           <Topbar crumb="Memory" title="Tasks">
             <TopbarSearch
-              placeholder="Search agent or intent…"
+              placeholder="Search title, agent, tags…"
               value={search}
               onChange={v => { setSearch(v); setPage(1); }}
             />
@@ -416,7 +519,7 @@ export default function TasksPage() {
               <div className="tasks-mobile-search">
                 <input
                   type="text"
-                  placeholder="Search agent or intent…"
+                  placeholder="Search title, agent, tags…"
                   value={search}
                   onChange={e => { setSearch(e.target.value); setPage(1); }}
                 />
@@ -430,9 +533,9 @@ export default function TasksPage() {
                       className={`records-filter-chip${statusFilter === v ? ' active' : ''}`}
                       onClick={() => { setStatusFilter(v); setPage(1); }}
                     >
-                      {v === 'all' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+                      {v === 'all' ? 'All' : v.replace('_', ' ')}
                       <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
-                        {counts[v]}
+                        {counts[v] ?? 0}
                       </span>
                     </button>
                   ))}
@@ -448,19 +551,34 @@ export default function TasksPage() {
                     <table className="records-table">
                       <thead>
                         <tr>
+                          <th className="sortable" aria-sort={ariaSort('title')}>
+                            <button className="sort-btn" onClick={() => toggleSort('title')}>
+                              Title <span className="sort-arrow">{sortArrow('title')}</span>
+                            </button>
+                          </th>
                           <th className="sortable" aria-sort={ariaSort('agentId')}>
                             <button className="sort-btn" onClick={() => toggleSort('agentId')}>
                               Agent <span className="sort-arrow">{sortArrow('agentId')}</span>
                             </button>
                           </th>
-                          <th className="sortable" aria-sort={ariaSort('intentAnchor')}>
-                            <button className="sort-btn" onClick={() => toggleSort('intentAnchor')}>
-                              Intent anchor <span className="sort-arrow">{sortArrow('intentAnchor')}</span>
+                          <th className="sortable" aria-sort={ariaSort('owner')}>
+                            <button className="sort-btn" onClick={() => toggleSort('owner')}>
+                              Owner <span className="sort-arrow">{sortArrow('owner')}</span>
                             </button>
                           </th>
                           <th className="sortable" aria-sort={ariaSort('status')}>
                             <button className="sort-btn" onClick={() => toggleSort('status')}>
                               Status <span className="sort-arrow">{sortArrow('status')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={ariaSort('priority')}>
+                            <button className="sort-btn" onClick={() => toggleSort('priority')}>
+                              Pri <span className="sort-arrow">{sortArrow('priority')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable col-updated" aria-sort={ariaSort('dueAt')}>
+                            <button className="sort-btn" onClick={() => toggleSort('dueAt')}>
+                              Due <span className="sort-arrow">{sortArrow('dueAt')}</span>
                             </button>
                           </th>
                           <th className="sortable col-updated" aria-sort={ariaSort('updatedAt')}>
@@ -479,11 +597,19 @@ export default function TasksPage() {
                             onClick={() => { setCreating(false); setEditing(t); }}
                           >
                             <td>
-                              <span className="cell-primary">{t.agentId}</span>
+                              <span className="cell-primary">{t.title || t.intentAnchor}</span>
+                              {t.tags.length > 0 && (
+                                <span style={{ marginLeft: 6, fontSize: 11, color: 'var(--app-fg-muted)' }}>
+                                  {t.tags.join(', ')}
+                                </span>
+                              )}
                             </td>
-                            <td className="cell-intent">{t.intentAnchor}</td>
-                            <td><span className={`status-pill ${t.status}`}>{t.status}</span></td>
-                            <td className="cell-mono col-updated">{formatDate(t.updatedAt)}</td>
+                            <td className="cell-mono" style={{ fontSize: 12 }}>{t.agentId}</td>
+                            <td><span className={`badge badge-${t.owner}`}>{t.owner}</span></td>
+                            <td><span className={`status-pill ${t.status}`}>{t.status.replace('_', ' ')}</span></td>
+                            <td className="cell-mono" style={{ textAlign: 'center' }}>{t.priority}</td>
+                            <td className="cell-mono col-updated">{formatDate(t.dueAt)}</td>
+                            <td className="cell-mono col-updated">{formatDateTime(t.updatedAt)}</td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>
                                 <button
@@ -501,7 +627,7 @@ export default function TasksPage() {
                         ))}
                         {pageRows.length === 0 && (
                           <tr>
-                            <td colSpan={5} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                            <td colSpan={8} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
                               No tasks match.
                             </td>
                           </tr>

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -261,7 +261,7 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
             </svg>
           </button>
         </div>
-        <h2 className="drawer-title-h2">{creating ? 'New task' : (task?.title || task?.agentId ?? '')}</h2>
+        <h2 className="drawer-title-h2">{creating ? 'New task' : (task?.title || task?.agentId) ?? ''}</h2>
         {!creating && task && (
           <div className="drawer-subtitle">{task.status}</div>
         )}
@@ -425,7 +425,8 @@ export default function TasksPage() {
     const c: Record<string, number> = { all: tasks.length };
     for (const s of STATUS_FILTERS.slice(1)) c[s] = 0;
     for (const t of tasks) {
-      if (c[t.status] !== undefined) c[t.status]++;
+      const cur = c[t.status];
+      if (cur !== undefined) c[t.status] = cur + 1;
     }
     return c;
   }, [tasks]);

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -887,10 +887,14 @@ input:focus, textarea:focus, select:focus {
 .badge-event        { background: var(--app-green); }
 .badge-concept      { background: #888; }
 .badge-fact         { background: #444; }
-/* Task owner badges — use filled bg with dark text for WCAG 1.4.3 contrast */
+/* Task owner badges — use filled bg with white text for WCAG 1.4.3 contrast */
+/* Contrast checks (light/dark): curia 6.35/4.4:1, ceo 4.61:1, external 2.98:1 */
+/* badge-external uses dark text (#111) since amber (#C9874A) only reaches 2.98:1 with white */
+/* dark-mode badge-curia overrides to #1A6B5E (same as light --app-teal) to hit 6.35:1 */
 .badge-curia    { background: var(--app-teal);   color: #fff; }
 .badge-ceo      { background: var(--app-violet); color: #fff; }
-.badge-external { background: var(--app-amber);  color: #fff; }
+.badge-external { background: var(--app-amber);  color: #111; }
+[data-theme="dark"] .badge-curia { background: #1A6B5E; }
 
 /* Status pills — outlined, subtle, with a colored leading dot */
 .status-pill {

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -887,6 +887,10 @@ input:focus, textarea:focus, select:focus {
 .badge-event        { background: var(--app-green); }
 .badge-concept      { background: #888; }
 .badge-fact         { background: #444; }
+/* Task owner badges — use filled bg with dark text for WCAG 1.4.3 contrast */
+.badge-curia    { background: var(--app-teal);   color: #fff; }
+.badge-ceo      { background: var(--app-violet); color: #fff; }
+.badge-external { background: var(--app-amber);  color: #fff; }
 
 /* Status pills — outlined, subtle, with a colored leading dot */
 .status-pill {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -350,12 +350,17 @@ export async function knowledgeGraphRoutes(
 
   app.get('/api/kg/tasks', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
-    const result = await pool.query(
-      `SELECT ${TASK_SELECT} FROM tasks ORDER BY updated_at DESC LIMIT 500`,
-    );
-    return reply.send({
-      tasks: result.rows.map((row) => serializeTask(row as DbTaskRow)),
-    });
+    try {
+      const result = await pool.query(
+        `SELECT ${TASK_SELECT} FROM tasks ORDER BY updated_at DESC LIMIT 500`,
+      );
+      return reply.send({
+        tasks: result.rows.map((row) => serializeTask(row as DbTaskRow)),
+      });
+    } catch (err) {
+      logger.error({ err }, 'kg: GET /api/kg/tasks failed');
+      return reply.status(500).send({ error: 'Failed to load tasks.' });
+    }
   });
 
   app.post('/api/kg/tasks', KG_RATE, async (request, reply) => {
@@ -381,14 +386,17 @@ export async function knowledgeGraphRoutes(
     if (typeof body.intentAnchor !== 'string' || body.intentAnchor.trim().length === 0) {
       return reply.status(400).send({ error: 'intentAnchor is required.' });
     }
-    const status = typeof body.status === 'string' ? body.status : 'active';
+    const status = typeof body.status === 'string' ? body.status : 'open';
     if (!validTaskStatuses.includes(status)) {
       return reply.status(400).send({ error: 'Invalid status.' });
     }
-    if (body.owner !== undefined && !validOwners.includes(body.owner as string)) {
+    // Resolve with defaults first, then validate — avoids dual-layer guard maintenance trap.
+    const owner = typeof body.owner === 'string' ? body.owner : 'curia';
+    const source = typeof body.source === 'string' ? body.source : 'agent';
+    if (!validOwners.includes(owner)) {
       return reply.status(400).send({ error: 'Invalid owner. Must be curia, ceo, or external.' });
     }
-    if (body.source !== undefined && !validSources.includes(body.source as string)) {
+    if (!validSources.includes(source)) {
       return reply.status(400).send({ error: 'Invalid source. Must be ceo, agent, scheduler, or coordinator.' });
     }
     if (body.priority !== undefined && (typeof body.priority !== 'number' || !Number.isInteger(body.priority) || body.priority < 0 || body.priority > 100)) {
@@ -415,42 +423,45 @@ export async function knowledgeGraphRoutes(
     const intentAnchor = body.intentAnchor.trim();
     const title = typeof body.title === 'string' && body.title.trim() ? body.title.trim() : intentAnchor;
     const description = typeof body.description === 'string' ? body.description.trim() || null : null;
-    const owner = typeof body.owner === 'string' ? body.owner : 'curia';
     const priority = typeof body.priority === 'number' ? body.priority : 50;
     const dueAt = typeof body.dueAt === 'string' && body.dueAt.trim() ? body.dueAt.trim() : null;
-    const source = typeof body.source === 'string' ? body.source : 'agent';
     const tags = Array.isArray(body.tags) ? (body.tags as string[]) : [];
 
-    const inserted = await pool.query(
-      `INSERT INTO tasks (
-         agent_id, title, intent_anchor, description, status, owner, priority,
-         due_at, source, tags, progress, error_budget, conversation_id, updated_at
-       )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, now())
-       RETURNING ${TASK_SELECT}`,
-      [
-        body.agentId.trim(),
-        title,
-        intentAnchor,
-        description,
-        status,
-        owner,
-        priority,
-        dueAt,
-        source,
-        tags,
-        JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? {}),
-        JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? {}),
-        conversationId,
-      ],
-    );
-    if (!inserted.rowCount) {
-      logger.error('kg: INSERT tasks returned no rows');
+    try {
+      const inserted = await pool.query(
+        `INSERT INTO tasks (
+           agent_id, title, intent_anchor, description, status, owner, priority,
+           due_at, source, tags, progress, error_budget, conversation_id, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, now())
+         RETURNING ${TASK_SELECT}`,
+        [
+          body.agentId.trim(),
+          title,
+          intentAnchor,
+          description,
+          status,
+          owner,
+          priority,
+          dueAt,
+          source,
+          tags,
+          JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? {}),
+          JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? {}),
+          conversationId,
+        ],
+      );
+      if (!inserted.rowCount) {
+        logger.error('kg: INSERT tasks returned no rows');
+        return reply.status(500).send({ error: 'Failed to create task.' });
+      }
+      return reply.status(201).send({
+        task: serializeTask(inserted.rows[0]! as DbTaskRow),
+      });
+    } catch (err) {
+      logger.error({ err }, 'kg: POST /api/kg/tasks failed');
       return reply.status(500).send({ error: 'Failed to create task.' });
     }
-    return reply.status(201).send({
-      task: serializeTask(inserted.rows[0]! as DbTaskRow),
-    });
   });
 
   app.patch('/api/kg/tasks/:id', KG_RATE, async (request, reply) => {
@@ -509,8 +520,8 @@ export async function knowledgeGraphRoutes(
     if (!agentId) return reply.status(400).send({ error: 'agentId is required.' });
     if (!intentAnchor) return reply.status(400).send({ error: 'intentAnchor is required.' });
     if (!validTaskStatuses.includes(status)) return reply.status(400).send({ error: 'Invalid status.' });
-    if (!validOwners.includes(owner)) return reply.status(400).send({ error: 'Invalid owner.' });
-    if (!validSources.includes(source)) return reply.status(400).send({ error: 'Invalid source.' });
+    if (!validOwners.includes(owner)) return reply.status(400).send({ error: 'Invalid owner. Must be curia, ceo, or external.' });
+    if (!validSources.includes(source)) return reply.status(400).send({ error: 'Invalid source. Must be ceo, agent, scheduler, or coordinator.' });
     if (!Number.isInteger(priority) || priority < 0 || priority > 100) return reply.status(400).send({ error: 'priority must be an integer 0–100.' });
     if (body.tags !== undefined && (!Array.isArray(body.tags) || (body.tags as unknown[]).some(t => typeof t !== 'string'))) {
       return reply.status(400).send({ error: 'tags must be an array of strings.' });
@@ -532,51 +543,56 @@ export async function knowledgeGraphRoutes(
       return reply.status(400).send({ error: 'Invalid conversationId: must be a valid UUID.' });
     }
 
-    const updated = await pool.query(
-      `UPDATE tasks
-       SET agent_id        = $2,
-           title           = $3,
-           intent_anchor   = $4,
-           description     = $5,
-           status          = $6,
-           owner           = $7,
-           priority        = $8,
-           due_at          = $9,
-           source          = $10,
-           tags            = $11,
-           waiting_on_text = $12,
-           progress        = $13::jsonb,
-           error_budget    = $14::jsonb,
-           conversation_id = $15,
-           updated_at      = now()
-       WHERE id = $1
-       RETURNING ${TASK_SELECT}`,
-      [
-        id,
-        agentId,
-        title,
-        intentAnchor,
-        description,
-        status,
-        owner,
-        priority,
-        dueAt,
-        source,
-        tags,
-        waitingOnText,
-        JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? row.progress ?? {}),
-        JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? row.error_budget ?? {}),
-        conversationId,
-      ],
-    );
-    // Guard against concurrent deletes between the existence check and the UPDATE.
-    if (!updated.rowCount) {
-      logger.warn({ taskId: id }, 'kg: PATCH tasks matched 0 rows — likely concurrent delete');
-      return reply.status(404).send({ error: 'Task not found.' });
+    try {
+      const updated = await pool.query(
+        `UPDATE tasks
+         SET agent_id        = $2,
+             title           = $3,
+             intent_anchor   = $4,
+             description     = $5,
+             status          = $6,
+             owner           = $7,
+             priority        = $8,
+             due_at          = $9,
+             source          = $10,
+             tags            = $11,
+             waiting_on_text = $12,
+             progress        = $13::jsonb,
+             error_budget    = $14::jsonb,
+             conversation_id = $15,
+             updated_at      = now()
+         WHERE id = $1
+         RETURNING ${TASK_SELECT}`,
+        [
+          id,
+          agentId,
+          title,
+          intentAnchor,
+          description,
+          status,
+          owner,
+          priority,
+          dueAt,
+          source,
+          tags,
+          waitingOnText,
+          JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? row.progress ?? {}),
+          JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? row.error_budget ?? {}),
+          conversationId,
+        ],
+      );
+      // Guard against concurrent deletes between the existence check and the UPDATE.
+      if (!updated.rowCount) {
+        logger.warn({ taskId: id }, 'kg: PATCH tasks matched 0 rows — likely concurrent delete');
+        return reply.status(404).send({ error: 'Task not found.' });
+      }
+      return reply.send({
+        task: serializeTask(updated.rows[0]! as DbTaskRow),
+      });
+    } catch (err) {
+      logger.error({ err, taskId: id }, 'kg: PATCH /api/kg/tasks/:id failed');
+      return reply.status(500).send({ error: 'Failed to update task.' });
     }
-    return reply.send({
-      task: serializeTask(updated.rows[0]! as DbTaskRow),
-    });
   });
 
   app.delete('/api/kg/tasks/:id', KG_RATE, async (request, reply) => {
@@ -585,11 +601,16 @@ export async function knowledgeGraphRoutes(
     if (!UUID_RE.test(id)) {
       return reply.status(400).send({ error: 'Invalid task id.' });
     }
-    const deleted = await pool.query('DELETE FROM tasks WHERE id = $1', [id]);
-    if (deleted.rowCount === 0) {
-      return reply.status(404).send({ error: 'Agent task not found.' });
+    try {
+      const deleted = await pool.query('DELETE FROM tasks WHERE id = $1', [id]);
+      if (deleted.rowCount === 0) {
+        return reply.status(404).send({ error: 'Task not found.' });
+      }
+      return reply.status(204).send();
+    } catch (err) {
+      logger.error({ err, taskId: id }, 'kg: DELETE /api/kg/tasks/:id failed');
+      return reply.status(500).send({ error: 'Failed to delete task.' });
     }
-    return reply.status(204).send();
   });
 
   // Serialize a Contact object to the HTTP response shape.

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -375,7 +375,9 @@ export async function knowledgeGraphRoutes(
       priority?: unknown;
       dueAt?: unknown;
       source?: unknown;
+      sourceAgentId?: unknown;
       tags?: unknown;
+      waitingOnText?: unknown;
       progress?: unknown;
       errorBudget?: unknown;
       conversationId?: unknown;
@@ -425,15 +427,28 @@ export async function knowledgeGraphRoutes(
     const description = typeof body.description === 'string' ? body.description.trim() || null : null;
     const priority = typeof body.priority === 'number' ? body.priority : 50;
     const dueAt = typeof body.dueAt === 'string' && body.dueAt.trim() ? body.dueAt.trim() : null;
+    if (dueAt !== null && isNaN(new Date(dueAt).getTime())) {
+      return reply.status(400).send({ error: 'Invalid dueAt: must be a valid ISO 8601 date string.' });
+    }
     const tags = Array.isArray(body.tags) ? (body.tags as string[]) : [];
+    const sourceAgentId = typeof body.sourceAgentId === 'string' && body.sourceAgentId.trim()
+      ? body.sourceAgentId.trim()
+      : null;
+    if (sourceAgentId && !UUID_RE.test(sourceAgentId)) {
+      return reply.status(400).send({ error: 'Invalid sourceAgentId: must be a valid UUID.' });
+    }
+    const waitingOnText = typeof body.waitingOnText === 'string' && body.waitingOnText.trim()
+      ? body.waitingOnText.trim()
+      : null;
 
     try {
       const inserted = await pool.query(
         `INSERT INTO tasks (
            agent_id, title, intent_anchor, description, status, owner, priority,
-           due_at, source, tags, progress, error_budget, conversation_id, updated_at
+           due_at, source, source_agent_id, tags, waiting_on_text,
+           progress, error_budget, conversation_id, updated_at
          )
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, now())
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb, $15, now())
          RETURNING ${TASK_SELECT}`,
         [
           body.agentId.trim(),
@@ -445,7 +460,9 @@ export async function knowledgeGraphRoutes(
           priority,
           dueAt,
           source,
+          sourceAgentId,
           tags,
+          waitingOnText,
           JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? {}),
           JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? {}),
           conversationId,
@@ -508,7 +525,7 @@ export async function knowledgeGraphRoutes(
     const priority = typeof body.priority === 'number' ? body.priority : row.priority;
     const dueAt = body.dueAt === undefined ? row.due_at
       : body.dueAt === null || body.dueAt === '' ? null
-      : typeof body.dueAt === 'string' ? body.dueAt
+      : typeof body.dueAt === 'string' ? body.dueAt.trim() || null
       : row.due_at;
     const source = typeof body.source === 'string' ? body.source : row.source;
     const tags = Array.isArray(body.tags) ? (body.tags as string[]) : row.tags;
@@ -523,6 +540,9 @@ export async function knowledgeGraphRoutes(
     if (!validOwners.includes(owner)) return reply.status(400).send({ error: 'Invalid owner. Must be curia, ceo, or external.' });
     if (!validSources.includes(source)) return reply.status(400).send({ error: 'Invalid source. Must be ceo, agent, scheduler, or coordinator.' });
     if (!Number.isInteger(priority) || priority < 0 || priority > 100) return reply.status(400).send({ error: 'priority must be an integer 0–100.' });
+    if (dueAt !== null && isNaN(new Date(dueAt).getTime())) {
+      return reply.status(400).send({ error: 'Invalid dueAt: must be a valid ISO 8601 date string.' });
+    }
     if (body.tags !== undefined && (!Array.isArray(body.tags) || (body.tags as unknown[]).some(t => typeof t !== 'string'))) {
       return reply.status(400).send({ error: 'tags must be an array of strings.' });
     }

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -288,24 +288,55 @@ export async function knowledgeGraphRoutes(
   // so we reject at the API boundary with a 400 instead.
   const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-  function serializeTask(row: {
+  // Full DB row shape for the tasks table (all columns post-migration-049).
+  type DbTaskRow = {
     id: string;
     agent_id: string;
     title: string;
     intent_anchor: string;
+    description: string | null;
     status: string;
+    owner: string;
+    priority: number;
+    due_at: string | null;
+    source: string;
+    source_agent_id: string | null;
+    tags: string[];
+    waiting_on_contact_id: string | null;
+    waiting_on_text: string | null;
+    parent_task_id: string | null;
+    blocked_by_task_id: string | null;
     progress: Record<string, unknown> | null;
     error_budget: Record<string, unknown> | null;
     conversation_id: string | null;
     created_at: string;
     updated_at: string;
-  }) {
+  };
+
+  const TASK_SELECT = `
+    id, agent_id, title, intent_anchor, description, status, owner, priority,
+    due_at, source, source_agent_id, tags, waiting_on_contact_id, waiting_on_text,
+    parent_task_id, blocked_by_task_id, progress, error_budget, conversation_id,
+    created_at, updated_at`;
+
+  function serializeTask(row: DbTaskRow) {
     return {
       id: row.id,
       agentId: row.agent_id,
       title: row.title,
       intentAnchor: row.intent_anchor,
+      description: row.description,
       status: row.status,
+      owner: row.owner,
+      priority: row.priority,
+      dueAt: row.due_at,
+      source: row.source,
+      sourceAgentId: row.source_agent_id,
+      tags: row.tags ?? [],
+      waitingOnContactId: row.waiting_on_contact_id,
+      waitingOnText: row.waiting_on_text,
+      parentTaskId: row.parent_task_id,
+      blockedByTaskId: row.blocked_by_task_id,
       progress: row.progress ?? {},
       errorBudget: row.error_budget ?? {},
       conversationId: row.conversation_id,
@@ -314,29 +345,16 @@ export async function knowledgeGraphRoutes(
     };
   }
 
+  const validOwners = ['curia', 'ceo', 'external'];
+  const validSources = ['ceo', 'agent', 'scheduler', 'coordinator'];
+
   app.get('/api/kg/tasks', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const result = await pool.query(
-      `SELECT id, agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at
-       FROM tasks
-       ORDER BY updated_at DESC
-       LIMIT 500`,
+      `SELECT ${TASK_SELECT} FROM tasks ORDER BY updated_at DESC LIMIT 500`,
     );
     return reply.send({
-      tasks: result.rows.map((row) =>
-        serializeTask(row as {
-          id: string;
-          agent_id: string;
-          title: string;
-          intent_anchor: string;
-          status: string;
-          progress: Record<string, unknown> | null;
-          error_budget: Record<string, unknown> | null;
-          conversation_id: string | null;
-          created_at: string;
-          updated_at: string;
-        }),
-      ),
+      tasks: result.rows.map((row) => serializeTask(row as DbTaskRow)),
     });
   });
 
@@ -344,8 +362,15 @@ export async function knowledgeGraphRoutes(
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const body = request.body as {
       agentId?: unknown;
+      title?: unknown;
       intentAnchor?: unknown;
+      description?: unknown;
       status?: unknown;
+      owner?: unknown;
+      priority?: unknown;
+      dueAt?: unknown;
+      source?: unknown;
+      tags?: unknown;
       progress?: unknown;
       errorBudget?: unknown;
       conversationId?: unknown;
@@ -359,6 +384,18 @@ export async function knowledgeGraphRoutes(
     const status = typeof body.status === 'string' ? body.status : 'active';
     if (!validTaskStatuses.includes(status)) {
       return reply.status(400).send({ error: 'Invalid status.' });
+    }
+    if (body.owner !== undefined && !validOwners.includes(body.owner as string)) {
+      return reply.status(400).send({ error: 'Invalid owner. Must be curia, ceo, or external.' });
+    }
+    if (body.source !== undefined && !validSources.includes(body.source as string)) {
+      return reply.status(400).send({ error: 'Invalid source. Must be ceo, agent, scheduler, or coordinator.' });
+    }
+    if (body.priority !== undefined && (typeof body.priority !== 'number' || !Number.isInteger(body.priority) || body.priority < 0 || body.priority > 100)) {
+      return reply.status(400).send({ error: 'priority must be an integer 0–100.' });
+    }
+    if (body.tags !== undefined && (!Array.isArray(body.tags) || (body.tags as unknown[]).some(t => typeof t !== 'string'))) {
+      return reply.status(400).send({ error: 'tags must be an array of strings.' });
     }
     if (body.errorBudget !== undefined && (typeof body.errorBudget !== 'object' || body.errorBudget === null || Array.isArray(body.errorBudget))) {
       return reply.status(400).send({ error: 'errorBudget must be a JSON object.' });
@@ -376,15 +413,32 @@ export async function knowledgeGraphRoutes(
     }
 
     const intentAnchor = body.intentAnchor.trim();
+    const title = typeof body.title === 'string' && body.title.trim() ? body.title.trim() : intentAnchor;
+    const description = typeof body.description === 'string' ? body.description.trim() || null : null;
+    const owner = typeof body.owner === 'string' ? body.owner : 'curia';
+    const priority = typeof body.priority === 'number' ? body.priority : 50;
+    const dueAt = typeof body.dueAt === 'string' && body.dueAt.trim() ? body.dueAt.trim() : null;
+    const source = typeof body.source === 'string' ? body.source : 'agent';
+    const tags = Array.isArray(body.tags) ? (body.tags as string[]) : [];
+
     const inserted = await pool.query(
-      `INSERT INTO tasks (agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, updated_at)
-       VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, now())
-       RETURNING id, agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at`,
+      `INSERT INTO tasks (
+         agent_id, title, intent_anchor, description, status, owner, priority,
+         due_at, source, tags, progress, error_budget, conversation_id, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, now())
+       RETURNING ${TASK_SELECT}`,
       [
         body.agentId.trim(),
-        intentAnchor,   // use intentAnchor as the task title
+        title,
         intentAnchor,
+        description,
         status,
+        owner,
+        priority,
+        dueAt,
+        source,
+        tags,
         JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? {}),
         JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? {}),
         conversationId,
@@ -395,20 +449,7 @@ export async function knowledgeGraphRoutes(
       return reply.status(500).send({ error: 'Failed to create task.' });
     }
     return reply.status(201).send({
-      task: serializeTask(
-        inserted.rows[0]! as {
-          id: string;
-          agent_id: string;
-          title: string;
-          intent_anchor: string;
-          status: string;
-          progress: Record<string, unknown> | null;
-          error_budget: Record<string, unknown> | null;
-          conversation_id: string | null;
-          created_at: string;
-          updated_at: string;
-        },
-      ),
+      task: serializeTask(inserted.rows[0]! as DbTaskRow),
     });
   });
 
@@ -420,42 +461,59 @@ export async function knowledgeGraphRoutes(
     }
     const body = request.body as {
       agentId?: unknown;
+      title?: unknown;
       intentAnchor?: unknown;
+      description?: unknown;
       status?: unknown;
+      owner?: unknown;
+      priority?: unknown;
+      dueAt?: unknown;
+      source?: unknown;
+      tags?: unknown;
+      waitingOnText?: unknown;
       progress?: unknown;
       errorBudget?: unknown;
       conversationId?: unknown;
     };
 
     const existing = await pool.query(
-      `SELECT id, agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at
-       FROM tasks
-       WHERE id = $1`,
+      `SELECT ${TASK_SELECT} FROM tasks WHERE id = $1`,
       [id],
     );
     if (existing.rowCount === 0) {
-      return reply.status(404).send({ error: 'Agent task not found.' });
+      return reply.status(404).send({ error: 'Task not found.' });
     }
-    const row = existing.rows[0] as {
-      id: string;
-      agent_id: string;
-      title: string;
-      intent_anchor: string;
-      status: string;
-      progress: Record<string, unknown> | null;
-      error_budget: Record<string, unknown> | null;
-      conversation_id: string | null;
-      created_at: string;
-      updated_at: string;
-    };
+    const row = existing.rows[0]! as DbTaskRow;
 
     const agentId = typeof body.agentId === 'string' ? body.agentId.trim() : row.agent_id;
+    const title = typeof body.title === 'string' ? body.title.trim() : row.title;
     const intentAnchor = typeof body.intentAnchor === 'string' ? body.intentAnchor.trim() : row.intent_anchor;
+    const description = body.description === undefined ? row.description
+      : body.description === null || body.description === '' ? null
+      : typeof body.description === 'string' ? body.description.trim()
+      : row.description;
     const status = typeof body.status === 'string' ? body.status : row.status;
+    const owner = typeof body.owner === 'string' ? body.owner : row.owner;
+    const priority = typeof body.priority === 'number' ? body.priority : row.priority;
+    const dueAt = body.dueAt === undefined ? row.due_at
+      : body.dueAt === null || body.dueAt === '' ? null
+      : typeof body.dueAt === 'string' ? body.dueAt
+      : row.due_at;
+    const source = typeof body.source === 'string' ? body.source : row.source;
+    const tags = Array.isArray(body.tags) ? (body.tags as string[]) : row.tags;
+    const waitingOnText = body.waitingOnText === undefined ? row.waiting_on_text
+      : body.waitingOnText === null || body.waitingOnText === '' ? null
+      : typeof body.waitingOnText === 'string' ? body.waitingOnText
+      : row.waiting_on_text;
+
     if (!agentId) return reply.status(400).send({ error: 'agentId is required.' });
     if (!intentAnchor) return reply.status(400).send({ error: 'intentAnchor is required.' });
-    if (!validTaskStatuses.includes(status)) {
-      return reply.status(400).send({ error: 'Invalid status.' });
+    if (!validTaskStatuses.includes(status)) return reply.status(400).send({ error: 'Invalid status.' });
+    if (!validOwners.includes(owner)) return reply.status(400).send({ error: 'Invalid owner.' });
+    if (!validSources.includes(source)) return reply.status(400).send({ error: 'Invalid source.' });
+    if (!Number.isInteger(priority) || priority < 0 || priority > 100) return reply.status(400).send({ error: 'priority must be an integer 0–100.' });
+    if (body.tags !== undefined && (!Array.isArray(body.tags) || (body.tags as unknown[]).some(t => typeof t !== 'string'))) {
+      return reply.status(400).send({ error: 'tags must be an array of strings.' });
     }
     if (body.errorBudget !== undefined && (typeof body.errorBudget !== 'object' || body.errorBudget === null || Array.isArray(body.errorBudget))) {
       return reply.status(400).send({ error: 'errorBudget must be a JSON object.' });
@@ -476,21 +534,36 @@ export async function knowledgeGraphRoutes(
 
     const updated = await pool.query(
       `UPDATE tasks
-       SET agent_id = $2,
-           title = $3,
-           intent_anchor = $3,
-           status = $4,
-           progress = $5::jsonb,
-           error_budget = $6::jsonb,
-           conversation_id = $7,
-           updated_at = now()
+       SET agent_id        = $2,
+           title           = $3,
+           intent_anchor   = $4,
+           description     = $5,
+           status          = $6,
+           owner           = $7,
+           priority        = $8,
+           due_at          = $9,
+           source          = $10,
+           tags            = $11,
+           waiting_on_text = $12,
+           progress        = $13::jsonb,
+           error_budget    = $14::jsonb,
+           conversation_id = $15,
+           updated_at      = now()
        WHERE id = $1
-       RETURNING id, agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at`,
+       RETURNING ${TASK_SELECT}`,
       [
         id,
         agentId,
+        title,
         intentAnchor,
+        description,
         status,
+        owner,
+        priority,
+        dueAt,
+        source,
+        tags,
+        waitingOnText,
         JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? row.progress ?? {}),
         JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? row.error_budget ?? {}),
         conversationId,
@@ -499,23 +572,10 @@ export async function knowledgeGraphRoutes(
     // Guard against concurrent deletes between the existence check and the UPDATE.
     if (!updated.rowCount) {
       logger.warn({ taskId: id }, 'kg: PATCH tasks matched 0 rows — likely concurrent delete');
-      return reply.status(404).send({ error: 'Agent task not found.' });
+      return reply.status(404).send({ error: 'Task not found.' });
     }
     return reply.send({
-      task: serializeTask(
-        updated.rows[0]! as {
-          id: string;
-          agent_id: string;
-          title: string;
-          intent_anchor: string;
-          status: string;
-          progress: Record<string, unknown> | null;
-          error_budget: Record<string, unknown> | null;
-          conversation_id: string | null;
-          created_at: string;
-          updated_at: string;
-        },
-      ),
+      task: serializeTask(updated.rows[0]! as DbTaskRow),
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary

- Closes #869

Restores console functionality after migration 049 renamed `agent_tasks` → `tasks` and added ~10 new columns.

**`kg.ts` (API)**
- Defines a `DbTaskRow` type and `TASK_SELECT` constant to avoid repeating the column list
- `serializeTask` now returns all new columns: `title`, `owner`, `priority`, `dueAt`, `source`, `sourceAgentId`, `tags`, `description`, `waitingOnText`, `waitingOnContactId`, `parentTaskId`, `blockedByTaskId`
- GET/POST/PATCH/DELETE wrapped in try/catch with pino logging (matching the contacts route pattern)
- POST default status changed `'active'` → `'open'` (new canonical initial state)
- PATCH now updates `title` and `intent_anchor` independently (previously both were forced to the same value)
- `scheduled_job_id` binding removed from all queries

**`TasksPage.tsx`**
- `Task` interface: dropped `scheduledJobId`, added all new columns
- Status filter chips extended with new task-lifecycle values: `open`, `in_progress`, `blocked`, `waiting`, `done`
- Table now shows: Title, Agent, Owner, Status, Priority, Due, Updated
- Drawer shows/edits all new fields; read-only display for system-managed FKs
- Search extended to include title and tags

**`JobsPage.tsx`**
- Adds "Task ID" column to table (truncated UUID) and full UUID in the detail drawer

## Test plan

- [ ] `pnpm run typecheck` (root) passes
- [ ] `pnpm --prefix apps/console run typecheck` passes
- [ ] Console loads the Tasks page without errors against the migrated schema
- [ ] All new columns visible; `scheduled_job_id` not referenced anywhere
- [ ] Scheduled Jobs view shows Task ID column with full UUID in drawer for linked jobs
- [ ] No regressions to other console views


___

## **CodeAnt-AI Description**
**Update the console to show the migrated task fields and linked job IDs**

### What Changed
- Tasks now show the new schema fields in the console, including title, owner, priority, due date, source, tags, description, and waiting/linked task fields
- The tasks list now supports the new task statuses, shows title-first rows, and lets users search by title, agent, and tags
- Creating or editing a task now accepts the new fields, uses a default task status of `open`, and validates priority and tag input before saving
- The scheduled jobs view now shows the linked task ID in both the table and the detail drawer
- Task API requests now return clearer errors when a task cannot be loaded, updated, or deleted

### Impact
`✅ Clearer task editing`
`✅ Easier tracking of linked jobs and tasks`
`✅ Fewer console errors after the schema change`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded task management with new fields: owner, priority, due date, source, and tags.
  * Enhanced task creation and editing with validation for priority levels and due dates.
  * Improved task filtering and sorting with additional lifecycle status support.
  * Jobs page now displays linked Task IDs for cross-reference visibility.

* **Documentation**
  * Updated changelog with task system migration details.

* **Style**
  * Added new badge visual variants for improved task context display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->