### PR TITLE
feat: Tasks v1 (4/7) — scheduler dispatch for task-wake fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
-- **Tasks v1 scheduler dispatch** — task-wake fires now route to `scheduled_jobs.agent_id` (which `task-create` and `task-update` set to `tasks.source_agent_id`) and include `task_id`, `title`, `progress` in the content bundle; fixes `task-update` to preserve the source agent's routing target when coordinator reschedules a wake-up. (#837)
+- **Tasks v1 scheduler dispatch** — task-wake fires route to `scheduled_jobs.agent_id` and include `task_id`, `title`, `progress` in the content bundle; `updateTask()` now writes the wake-up job's `agent_id` using `source_agent_id ?? tasks.agent_id ?? callerAgentId` so coordinator-triggered reschedules preserve the specialist's routing target. (#837)
 - **Tasks v1 CRUD skills** — `task-create`, `task-list`, `task-update`, `task-complete` skills backed by a new capability-gated `TaskRepo`; promotes `agent_tasks` to a first-class `tasks` table with CEO-visible columns; adds `task.created`, `task.updated`, `task.completed` bus events. (#834, #835)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
+- **Tasks v1 scheduler dispatch** — task-wake fires now route to `scheduled_jobs.agent_id` (which `task-create` and `task-update` set to `tasks.source_agent_id`) and include `task_id`, `title`, `progress` in the content bundle; fixes `task-update` to preserve the source agent's routing target when coordinator reschedules a wake-up. (#837)
 - **Tasks v1 CRUD skills** — `task-create`, `task-list`, `task-update`, `task-complete` skills backed by a new capability-gated `TaskRepo`; promotes `agent_tasks` to a first-class `tasks` table with CEO-visible columns; adds `task.created`, `task.updated`, `task.completed` bus events. (#834, #835)
 
 ### Changed

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -384,11 +384,13 @@ export class TaskRepo {
       const allParams: unknown[] = [...updateParams];
       if (updates.wakeAt) {
         allParams.push(
-          // Route the new wake-up job to the task's source agent (the specialist best
-          // positioned to resume it). Fall back to the caller, then the task's original
-          // creator. This ensures coordinator-reschedules (e.g. backlog sweep) still
-          // fire at the right specialist rather than coordinator.
-          current.sourceAgentId ?? callerAgentId ?? current.agentId, // $wakeAgentIdx
+          // Route the new wake-up job to the correct specialist, in priority order:
+          // 1. source_agent_id — explicit specialist set at task-create time
+          // 2. tasks.agent_id  — stable task ownership (covers legacy/manual tasks where
+          //                      source_agent_id is NULL but agent_id names a specialist)
+          // 3. callerAgentId   — last resort; avoids routing to coordinator when the
+          //                      task has no agent assignment at all
+          current.sourceAgentId ?? current.agentId ?? callerAgentId, // $wakeAgentIdx
           updates.wakeAt,                                             // $wakeRunAtIdx
           callerAgentId ?? current.agentId,                          // $wakeCreatedByIdx
           this.timezone,                                             // $wakeTzIdx

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -384,10 +384,14 @@ export class TaskRepo {
       const allParams: unknown[] = [...updateParams];
       if (updates.wakeAt) {
         allParams.push(
-          callerAgentId ?? current.agentId, // $wakeAgentIdx
-          updates.wakeAt,                   // $wakeRunAtIdx
-          callerAgentId ?? current.agentId, // $wakeCreatedByIdx
-          this.timezone,                    // $wakeTzIdx
+          // Route the new wake-up job to the task's source agent (the specialist best
+          // positioned to resume it). Fall back to the caller, then the task's original
+          // creator. This ensures coordinator-reschedules (e.g. backlog sweep) still
+          // fire at the right specialist rather than coordinator.
+          current.sourceAgentId ?? callerAgentId ?? current.agentId, // $wakeAgentIdx
+          updates.wakeAt,                                             // $wakeRunAtIdx
+          callerAgentId ?? current.agentId,                          // $wakeCreatedByIdx
+          this.timezone,                                             // $wakeTzIdx
         );
       }
       const { rows } = await this.pool.query(cteSql, allParams);

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -56,6 +56,8 @@ export interface JobRow {
   agentTaskId: string | null;
   intentAnchor: string | null;
   progress: Record<string, unknown> | null;
+  /** Human-readable task title — included in the content bundle so receiving agents have context. */
+  taskTitle: string | null;
   runStartedAt: string | null;
   expectedDurationSeconds: number | null;
   lastRunOutcome: 'completed' | 'failed' | 'timed_out' | null;
@@ -91,6 +93,7 @@ interface DbJobRow {
   agent_task_id: string | null;
   intent_anchor: string | null;
   progress: Record<string, unknown> | null;
+  task_title: string | null;
   run_started_at: string | null;          // set when job enters 'running'; cleared on completion
   expected_duration_seconds: number | null; // per-job timeout hint; NULL → system default (600s)
   last_run_outcome: 'completed' | 'failed' | 'timed_out' | null;
@@ -293,7 +296,8 @@ export class SchedulerService {
       SELECT sj.*,
              t.id AS agent_task_id,
              t.intent_anchor,
-             t.progress
+             t.progress,
+             t.title AS task_title
         FROM scheduled_jobs sj
         LEFT JOIN tasks t ON sj.task_id = t.id
        WHERE sj.id = $1
@@ -330,7 +334,8 @@ export class SchedulerService {
       SELECT sj.*,
              t.id AS agent_task_id,
              t.intent_anchor,
-             t.progress
+             t.progress,
+             t.title AS task_title
         FROM scheduled_jobs sj
         LEFT JOIN tasks t ON sj.task_id = t.id
        ${whereClause}
@@ -934,6 +939,7 @@ function mapJobRow(row: DbJobRow): JobRow {
     agentTaskId: row.agent_task_id,
     intentAnchor: row.intent_anchor ?? null,
     progress: row.progress,
+    taskTitle: row.task_title ?? null,
     runStartedAt: row.run_started_at,
     expectedDurationSeconds: row.expected_duration_seconds,
     lastRunOutcome: row.last_run_outcome,

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -248,7 +248,8 @@ export class Scheduler {
         SELECT sj.*,
                t.id AS agent_task_id,
                t.intent_anchor,
-               t.progress
+               t.progress,
+               t.title AS task_title
           FROM scheduled_jobs sj
           LEFT JOIN tasks t ON sj.task_id = t.id
          WHERE sj.status IN ('pending', 'failed')
@@ -277,6 +278,7 @@ export class Scheduler {
           agentTaskId: row.agent_task_id ?? null,
           intentAnchor: row.intent_anchor ?? null,
           progress: row.progress ?? null,
+          taskTitle: row.task_title ?? null,
           runStartedAt: row.run_started_at ?? null,
           expectedDurationSeconds: row.expected_duration_seconds ?? null,
           lastRunOutcome: row.last_run_outcome ?? null,
@@ -339,13 +341,16 @@ export class Scheduler {
       return;
     }
 
-    // Build the agent.task content. For persistent tasks, include progress and
-    // the original task payload so the agent has execution context. Intent anchor
-    // is passed in the event payload (not content) so the runtime can inject it
-    // into the system prompt as a non-negotiable behavioral instruction.
+    // Build the agent.task content. For task-bound jobs, include task_id, title,
+    // progress, and the original task payload so the receiving specialist has full
+    // context. Intent anchor is passed in the event payload (not content) so the
+    // runtime injects it into the system prompt as a non-negotiable behavioral
+    // instruction. For non-task-bound jobs the payload is used as-is.
     let content = JSON.stringify(job.taskPayload);
     if (job.agentTaskId) {
       content = JSON.stringify({
+        task_id: job.agentTaskId,
+        ...(job.taskTitle !== null && { title: job.taskTitle }),
         progress: job.progress ?? {},
         task_payload: job.taskPayload,
       });

--- a/tests/integration/scheduler-task-dispatch.test.ts
+++ b/tests/integration/scheduler-task-dispatch.test.ts
@@ -10,7 +10,7 @@ import { EventBus } from '../../src/bus/bus.js';
 import { AgentRuntime } from '../../src/agents/runtime.js';
 import { Scheduler } from '../../src/scheduler/scheduler.js';
 import type { LLMProvider } from '../../src/agents/llm/provider.js';
-import pino from 'pino';
+import { createLogger } from '../../src/logger.js';
 
 const MOCK_PROVENANCE = {
   requestedModel: 'mock-model',
@@ -62,7 +62,7 @@ function fakeTaskWakeRow(overrides: Record<string, unknown> = {}) {
 
 describe('Scheduler task-bound dispatch integration', () => {
   it('delivers task-wake fire to the specialist agent with task context in content', async () => {
-    const logger = pino({ level: 'silent' });
+    const logger = createLogger('silent');
     const bus = new EventBus(logger);
     const schedulerService = mockSchedulerService();
 
@@ -156,7 +156,7 @@ describe('Scheduler task-bound dispatch integration', () => {
   });
 
   it('falls back to coordinator when agent_id is coordinator (CEO-created task with no specialist)', async () => {
-    const logger = pino({ level: 'silent' });
+    const logger = createLogger('silent');
     const bus = new EventBus(logger);
     const schedulerService = mockSchedulerService();
 
@@ -223,7 +223,7 @@ describe('Scheduler task-bound dispatch integration', () => {
   });
 
   it('non-task-bound jobs fire without task context in content', async () => {
-    const logger = pino({ level: 'silent' });
+    const logger = createLogger('silent');
     const bus = new EventBus(logger);
     const schedulerService = mockSchedulerService();
 

--- a/tests/integration/scheduler-task-dispatch.test.ts
+++ b/tests/integration/scheduler-task-dispatch.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Integration test: scheduler task-bound dispatch routing (Tasks v1, issue 4).
+ *
+ * Uses a real EventBus and real AgentRuntime instances (mock LLM, mock pool) to verify
+ * that task-wake fires reach the correct specialist agent and carry the expected context.
+ * No Postgres required — the pool is mocked to return pre-built job rows.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from '../../src/bus/bus.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { Scheduler } from '../../src/scheduler/scheduler.js';
+import type { LLMProvider } from '../../src/agents/llm/provider.js';
+import pino from 'pino';
+
+const MOCK_PROVENANCE = {
+  requestedModel: 'mock-model',
+  actualModel: 'mock-model',
+  providerRequestId: 'msg_mock_000',
+} as const;
+
+function mockSchedulerService() {
+  return {
+    completeJobRun: vi.fn().mockResolvedValue({ suspended: false }),
+    upsertDeclarativeJob: vi.fn(),
+    cancelStaleDeclarativeJobs: vi.fn(),
+    getJob: vi.fn(),
+    nextRunFromCron: vi.fn(),
+    recoverStuckJob: vi.fn(),
+    pauseJobForDrift: vi.fn(),
+  };
+}
+
+/** Build a fake task-wake scheduled_jobs row joined with the linked tasks columns. */
+function fakeTaskWakeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'job-task-wake-1',
+    agent_id: 'meeting-debrief',
+    cron_expr: null,
+    run_at: new Date().toISOString(),
+    task_payload: { type: 'task-wake' },
+    status: 'pending',
+    last_run_at: null,
+    next_run_at: new Date().toISOString(),
+    last_error: null,
+    consecutive_failures: 0,
+    created_by: 'task-create',
+    created_at: new Date().toISOString(),
+    timezone: 'UTC',
+    agent_task_id: 'task-abc-123',
+    intent_anchor: 'Follow up with board on Q3 results',
+    progress: { notes: [{ at: '2026-06-01T10:00:00Z', note: 'Initial debrief complete' }] },
+    task_title: 'Board Q3 follow-up',
+    run_started_at: null,
+    expected_duration_seconds: null,
+    last_run_outcome: null,
+    last_run_summary: null,
+    last_run_context: null,
+    originator: null,
+    ...overrides,
+  };
+}
+
+describe('Scheduler task-bound dispatch integration', () => {
+  it('delivers task-wake fire to the specialist agent with task context in content', async () => {
+    const logger = pino({ level: 'silent' });
+    const bus = new EventBus(logger);
+    const schedulerService = mockSchedulerService();
+
+    // Capture every agent.task event published to the bus.
+    const agentTaskEvents: Array<{ agentId: string; content: string; intentAnchor?: string }> = [];
+    bus.subscribe('agent.task', 'system', (event) => {
+      const e = event as { payload: { agentId: string; content: string; intentAnchor?: string } };
+      agentTaskEvents.push({
+        agentId: e.payload.agentId,
+        content: e.payload.content,
+        intentAnchor: e.payload.intentAnchor,
+      });
+    });
+
+    // Register the specialist agent ('meeting-debrief') with a mock LLM.
+    const specialistLlm: LLMProvider = {
+      id: 'mock-specialist',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Debrief task advanced.',
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+    const specialist = new AgentRuntime({
+      agentId: 'meeting-debrief',
+      systemPrompt: 'You process meeting debriefs.',
+      provider: specialistLlm,
+      bus,
+      logger,
+    });
+    specialist.register();
+
+    // Register coordinator as a canary — it must NOT receive this fire.
+    const coordinatorLlm: LLMProvider = {
+      id: 'mock-coordinator',
+      chat: vi.fn(),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are the coordinator.',
+      provider: coordinatorLlm,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    // Mock pool: returns one task-wake job (agent_id = 'meeting-debrief').
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [fakeTaskWakeRow()] })  // SELECT due jobs
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] }),     // UPDATE claim
+    };
+
+    const scheduler = new Scheduler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pool: pool as any,
+      bus,
+      logger,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      schedulerService: schedulerService as any,
+    });
+
+    scheduler.start();
+    await scheduler.pollDueJobs();
+
+    // Wait for the agent.response to propagate back through handleCompletion.
+    await vi.waitFor(() => {
+      expect(schedulerService.completeJobRun).toHaveBeenCalled();
+    });
+
+    scheduler.stop();
+
+    // The agent.task must target 'meeting-debrief', not 'coordinator'.
+    expect(agentTaskEvents).toHaveLength(1);
+    expect(agentTaskEvents[0]!.agentId).toBe('meeting-debrief');
+
+    // Content bundle must carry task_id, title, and progress.
+    const content = JSON.parse(agentTaskEvents[0]!.content) as Record<string, unknown>;
+    expect(content.task_id).toBe('task-abc-123');
+    expect(content.title).toBe('Board Q3 follow-up');
+    expect(content.progress).toEqual({ notes: [{ at: '2026-06-01T10:00:00Z', note: 'Initial debrief complete' }] });
+
+    // intent_anchor travels in the event payload, not in content.
+    expect(agentTaskEvents[0]!.intentAnchor).toBe('Follow up with board on Q3 results');
+    expect(content.intent_anchor).toBeUndefined();
+
+    // Specialist LLM was called; coordinator LLM was not.
+    expect(specialistLlm.chat).toHaveBeenCalledOnce();
+    expect(coordinatorLlm.chat).not.toHaveBeenCalled();
+  });
+
+  it('falls back to coordinator when agent_id is coordinator (CEO-created task with no specialist)', async () => {
+    const logger = pino({ level: 'silent' });
+    const bus = new EventBus(logger);
+    const schedulerService = mockSchedulerService();
+
+    const agentTaskEvents: Array<{ agentId: string }> = [];
+    bus.subscribe('agent.task', 'system', (event) => {
+      const e = event as { payload: { agentId: string } };
+      agentTaskEvents.push({ agentId: e.payload.agentId });
+    });
+
+    const coordinatorLlm: LLMProvider = {
+      id: 'mock-coordinator',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Handled by coordinator.',
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are the coordinator.',
+      provider: coordinatorLlm,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    // CEO-created task: task-create called by coordinator → agent_id = 'coordinator',
+    // source_agent_id = null, so scheduled_jobs.agent_id = 'coordinator'.
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [fakeTaskWakeRow({
+            id: 'job-ceo-task',
+            agent_id: 'coordinator',
+            agent_task_id: 'task-ceo-456',
+            task_title: 'Call Steve re: partnership',
+          })],
+        })
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] }),
+    };
+
+    const scheduler = new Scheduler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pool: pool as any,
+      bus,
+      logger,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      schedulerService: schedulerService as any,
+    });
+
+    scheduler.start();
+    await scheduler.pollDueJobs();
+
+    await vi.waitFor(() => {
+      expect(schedulerService.completeJobRun).toHaveBeenCalled();
+    });
+
+    scheduler.stop();
+
+    expect(agentTaskEvents).toHaveLength(1);
+    expect(agentTaskEvents[0]!.agentId).toBe('coordinator');
+    expect(coordinatorLlm.chat).toHaveBeenCalledOnce();
+  });
+
+  it('non-task-bound jobs fire without task context in content', async () => {
+    const logger = pino({ level: 'silent' });
+    const bus = new EventBus(logger);
+    const schedulerService = mockSchedulerService();
+
+    const agentTaskEvents: Array<{ agentId: string; content: string }> = [];
+    bus.subscribe('agent.task', 'system', (event) => {
+      const e = event as { payload: { agentId: string; content: string } };
+      agentTaskEvents.push({ agentId: e.payload.agentId, content: e.payload.content });
+    });
+
+    const coordinatorLlm: LLMProvider = {
+      id: 'mock-coordinator',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Morning brief delivered.',
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+    new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are the coordinator.',
+      provider: coordinatorLlm,
+      bus,
+      logger,
+    }).register();
+
+    // Standard cron job: no task_id link.
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'job-cron-1',
+            agent_id: 'coordinator',
+            cron_expr: '0 9 * * *',
+            run_at: null,
+            task_payload: { skill: 'morning-brief' },
+            status: 'pending',
+            last_run_at: null,
+            next_run_at: new Date().toISOString(),
+            last_error: null,
+            consecutive_failures: 0,
+            created_by: 'system',
+            created_at: new Date().toISOString(),
+            timezone: 'UTC',
+            agent_task_id: null,
+            intent_anchor: null,
+            progress: null,
+            task_title: null,
+            run_started_at: null,
+            expected_duration_seconds: null,
+            last_run_outcome: null,
+            last_run_summary: null,
+            last_run_context: null,
+            originator: null,
+          }],
+        })
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] }),
+    };
+
+    const scheduler = new Scheduler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pool: pool as any,
+      bus,
+      logger,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      schedulerService: schedulerService as any,
+    });
+
+    scheduler.start();
+    await scheduler.pollDueJobs();
+
+    await vi.waitFor(() => {
+      expect(schedulerService.completeJobRun).toHaveBeenCalled();
+    });
+
+    scheduler.stop();
+
+    expect(agentTaskEvents).toHaveLength(1);
+    expect(agentTaskEvents[0]!.agentId).toBe('coordinator');
+
+    const content = JSON.parse(agentTaskEvents[0]!.content) as Record<string, unknown>;
+    // Non-task-bound: raw payload with no task_id injected.
+    expect(content.skill).toBe('morning-brief');
+    expect(content.task_id).toBeUndefined();
+  });
+});

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -64,6 +64,7 @@ function fakeDbRow(overrides: Record<string, unknown> = {}) {
     agent_task_id: null,
     intent_anchor: null,
     progress: null,
+    task_title: null,
     run_started_at: null,
     expected_duration_seconds: null,
     ...overrides,
@@ -404,6 +405,88 @@ describe('Scheduler', () => {
 
       const content: string = (taskEvent as { payload: { content: string } }).payload.content;
       expect(content).not.toContain('[Prior run context');
+    });
+  });
+
+  // -- task-bound dispatch routing (issue 4) --
+
+  describe('task-bound dispatch routing', () => {
+    it('routes task-bound fire to agentId (which is source_agent_id for task-wake jobs)', async () => {
+      // task-create stores source_agent_id as scheduled_jobs.agent_id, so job.agentId
+      // already carries the correct routing target for task-wake jobs.
+      const row = fakeDbRow({
+        agent_id: 'meeting-debrief',
+        agent_task_id: 'task-abc',
+        task_title: 'Board prep follow-up',
+        progress: { notes: [] },
+      });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { agentId: string } }];
+      expect(taskEvent.payload.agentId).toBe('meeting-debrief');
+    });
+
+    it('includes task_id and title in content bundle for task-bound fires', async () => {
+      const row = fakeDbRow({
+        agent_id: 'meeting-debrief',
+        agent_task_id: 'task-abc',
+        task_title: 'Board prep follow-up',
+        progress: { notes: [{ at: '2026-06-01', note: 'started' }] },
+        task_payload: { type: 'task-wake' },
+      });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { content: string } }];
+      const content = JSON.parse(taskEvent.payload.content) as Record<string, unknown>;
+      expect(content.task_id).toBe('task-abc');
+      expect(content.title).toBe('Board prep follow-up');
+      expect(content.progress).toEqual({ notes: [{ at: '2026-06-01', note: 'started' }] });
+      expect(content.task_payload).toEqual({ type: 'task-wake' });
+      // intent_anchor stays in the event payload, not content
+      expect(content.intent_anchor).toBeUndefined();
+    });
+
+    it('omits title from content bundle when task_title is null', async () => {
+      const row = fakeDbRow({
+        agent_task_id: 'task-def',
+        task_title: null,
+        progress: { notes: [] },
+      });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { content: string } }];
+      const content = JSON.parse(taskEvent.payload.content) as Record<string, unknown>;
+      expect(content.task_id).toBe('task-def');
+      expect(content.title).toBeUndefined();
+    });
+
+    it('uses raw task_payload as content for non-task-bound jobs (no task_id or title)', async () => {
+      const row = fakeDbRow({
+        agent_id: 'coordinator',
+        agent_task_id: null,
+        task_title: null,
+        task_payload: { skill: 'morning-brief' },
+      });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { content: string; agentId: string } }];
+      expect(taskEvent.payload.agentId).toBe('coordinator');
+      const content = JSON.parse(taskEvent.payload.content) as Record<string, unknown>;
+      // Non-task-bound: raw payload, no task_id
+      expect(content.task_id).toBeUndefined();
+      expect(content.skill).toBe('morning-brief');
     });
   });
 

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -67,6 +67,9 @@ function fakeDbRow(overrides: Record<string, unknown> = {}) {
     task_title: null,
     run_started_at: null,
     expected_duration_seconds: null,
+    last_run_outcome: null,
+    last_run_summary: null,
+    last_run_context: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## **User description**
## Summary

- **Scheduler dispatch branch** — when `scheduled_jobs.task_id IS NOT NULL`, `fireJob` enriches the `agent.task` content bundle with `task_id`, `title`, `progress`, and `task_payload` so the receiving specialist has full execution context.
- **Routing fix in `task-repo.updateTask`** — wake-up replacement jobs now store `current.sourceAgentId ?? callerAgentId ?? current.agentId` as `agent_id`, ensuring coordinator-reschedules during backlog sweep still route to the specialist (not coordinator).
- **`t.title AS task_title`** — added to all `scheduled_jobs ⟕ tasks` SQL joins (`pollDueJobs`, `getJob`, `listJobs`) and the `JobRow`/`DbJobRow`/`mapJobRow` types.
- **Tests** — 4 new unit tests in `scheduler.test.ts` (routing, content bundle, title-null, non-task-bound regression) + new `tests/integration/scheduler-task-dispatch.test.ts` with 3 integration tests using real EventBus + real AgentRuntime (mock LLM, mock pool).

Closes #837

## Test plan

- [ ] `pnpm run typecheck` — clean
- [ ] `npx vitest run tests/unit/scheduler/scheduler.test.ts tests/integration/scheduler-task-dispatch.test.ts` — 169 passed
- [ ] Existing non-task-bound scheduler job tests pass (covered in the same run)
- [ ] Integration test 1: specialist agent (not coordinator) receives fire with `task_id`, `title`, `progress` in content
- [ ] Integration test 2: CEO-created task (agent_id = coordinator) routes to coordinator
- [ ] Integration test 3: non-task-bound cron job fires with raw payload, no `task_id`


___

## **CodeAnt-AI Description**
**Route task wake-ups to the right agent and include task context**

### What Changed
- Task wake-up jobs now go back to the task’s source agent instead of the coordinator when a wake-up is rescheduled.
- Fired task-bound jobs now include the task ID, title, progress, and original payload so the receiving agent has full context.
- Job lookup results now carry the task title, and non-task-bound jobs keep using their raw payload unchanged.

### Impact
`✅ Fewer task wake-ups sent to the wrong agent`
`✅ Clearer task context for resumed work`
`✅ Less missing information in scheduled job runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task-scheduled wake-up notifications now include complete task metadata (ID, title, and progress).
  * Improved task-wake routing to correctly target the source agent when scheduling wake-ups.

* **Bug Fixes**
  * Fixed task-wake rescheduling to preserve the original source agent's routing target when reschedules occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->