### PR TITLE
feat: tasks console UI — owner/status/priority model (#870)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
+- **Tasks console UI** — list view with owner/status/priority model: owner dropdown filter, age column, default priority sort, status lifecycle controls (terminal-state guard), contact name resolution for `waiting_on_contact_id`, next scheduled wake-up time in drawer, and parent/blocked-by task links. (#870)
 - **Tasks v1 scheduler dispatch** — task-wake fires route to `scheduled_jobs.agent_id` and include `task_id`, `title`, `progress` in the content bundle; `updateTask()` now writes the wake-up job's `agent_id` using `source_agent_id ?? tasks.agent_id ?? callerAgentId` so coordinator-triggered reschedules preserve the specialist's routing target. (#837)
 - **Tasks v1 CRUD skills** — `task-create`, `task-list`, `task-update`, `task-complete` skills backed by a new capability-gated `TaskRepo`; promotes `agent_tasks` to a first-class `tasks` table with CEO-visible columns; adds `task.created`, `task.updated`, `task.completed` bus events. (#834, #835)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,23 +17,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Tasks console UI** — list view with owner/status/priority model: owner dropdown filter, age column, default priority sort, status lifecycle controls (terminal-state guard), contact name resolution for `waiting_on_contact_id`, next scheduled wake-up time in drawer, and parent/blocked-by task links. (#870)
 - **Tasks v1 scheduler dispatch** — task-wake fires route to `scheduled_jobs.agent_id` and include `task_id`, `title`, `progress` in the content bundle; `updateTask()` now writes the wake-up job's `agent_id` using `source_agent_id ?? tasks.agent_id ?? callerAgentId` so coordinator-triggered reschedules preserve the specialist's routing target. (#837)
 - **Tasks v1 CRUD skills** — `task-create`, `task-list`, `task-update`, `task-complete` skills backed by a new capability-gated `TaskRepo`; promotes `agent_tasks` to a first-class `tasks` table with CEO-visible columns; adds `task.created`, `task.updated`, `task.completed` bus events. (#834, #835)
-
-### Changed
-- **Console tasks view** — updated to match the migrated `tasks` schema: drops `scheduled_job_id`, adds all new columns (`title`, `owner`, `priority`, `due_at`, `source`, `tags`, `description`, FK references), extends status filters with new task-lifecycle values, and updates the scheduled-jobs view to display the linked `task_id`. (#869)
-
-### Added
 - **`contact-update` skill** — direct write path for canonical contact attributes (title, organization, phone, timezone, etc.) with E.164 phone normalization. Pinned to coordinator, ceo-inbox, research-analyst, and contacts. (#863)
 - **Contact canonical attributes** — 12 structured profile fields (`title`, `organization`, `primary_email`, etc.) persisted directly on the `contacts` row; backfill script populates from KG facts. (#829)
 - **Entity context enrichment** — `EntityContext.contact` now exposes all 12 canonical fields; canonical-attribute writes via `memory-store` and `extract-facts` redirect to `ContactService` with E.164 phone normalization; `context-for-email` prefers `contact.primaryEmail` and surfaces `contact.preferredName` for salutations. (#830)
 - **File attachments in outbound email** — all five email skills (`email-send`, `email-reply`, `email-draft-save`, `ceo-inbox-draft-compose`, `ceo-inbox-draft-reply`) now accept an `attachments` input field. Attachments are read from `file://` URLs (TempFileStore), validated, and forwarded to Nylas. The CEO inbox path uses multipart FormData; the Curia outbound path passes `Buffer` content via the Nylas SDK. 20 MB total / 10 attachment limit enforced. (#818)
-
-### Fixed
-- **`extract-facts` canonical lookup N+1** — contact lookups are now cached by KG node ID within a single `execute()` call; multiple canonical facts about the same person no longer each trigger a separate DB query. (#830)
-- **`extract-facts` + `memory-store` skill.json contracts** — output schemas now document the `redirected` counter and `redirected_to_contact` action (with `contact_id`) introduced by the canonical attribute guard. (#830)
-- **`canonical-attribute-guard` whitespace handling** — `resolveCanonicalField` now trims leading/trailing whitespace before lookup; LLM-generated attribute keys like `" timezone "` now match correctly instead of falling through to KG writes.
-- **coordinator delegation hint** — `delegation_hint` in active outbound context is now treated as a binding contract; coordinator no longer handles replies directly when a specialist is named, preventing meeting debriefs from getting stuck at `"prompted"`. (#763)
-
-### Added
 - **`ceo-inbox-draft-compose`** — compose cold-outreach drafts to CEO's Gmail Drafts via `CEO_NYLAS_GRANT_ID`. (#815)
 - **Promptfoo red team runbook** — `tests/redteam/` with promptfoo config, `scripts/render-coordinator-prompt.ts` helper, and `pnpm redteam` / `pnpm redteam:report` scripts; tests prompt injection, data exfiltration, hijacking, and ASCII smuggling against the live coordinator system prompt. (#583)
 - **Outbound audience-leak plan** — implementation plan for Stage 2 LLM judge + structured `compose-reply` skill to prevent the coordinator from sending internal reasoning to external recipients. See `docs/wip/2026-06-02-outbound-audience-leak.md`.
@@ -42,7 +29,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **SBOM generation** — SPDX JSON Software Bill of Materials generated on every push to `main` and attached to each GitHub release as a release asset; failure is non-fatal. (#564)
 - **`drive-download-file`** — new skill that downloads a Google Drive file (native or Google-native export) to TempFileStore and returns a `file://` URL, enabling Drive files to be attached to outbound emails. Closes #857.
 
+### Changed
+- **Console tasks view** — updated to match the migrated `tasks` schema: drops `scheduled_job_id`, adds all new columns (`title`, `owner`, `priority`, `due_at`, `source`, `tags`, `description`, FK references), extends status filters with new task-lifecycle values, and updates the scheduled-jobs view to display the linked `task_id`. (#869)
+
 ### Fixed
+- **`extract-facts` canonical lookup N+1** — contact lookups are now cached by KG node ID within a single `execute()` call; multiple canonical facts about the same person no longer each trigger a separate DB query. (#830)
+- **`extract-facts` + `memory-store` skill.json contracts** — output schemas now document the `redirected` counter and `redirected_to_contact` action (with `contact_id`) introduced by the canonical attribute guard. (#830)
+- **`canonical-attribute-guard` whitespace handling** — `resolveCanonicalField` now trims leading/trailing whitespace before lookup; LLM-generated attribute keys like `" timezone "` now match correctly instead of falling through to KG writes.
+- **coordinator delegation hint** — `delegation_hint` in active outbound context is now treated as a binding contract; coordinator no longer handles replies directly when a specialist is named, preventing meeting debriefs from getting stuck at `"prompted"`. (#763)
 - **`email-draft-save` unknown account error** — `OutboundGateway` now lists available accounts when unknown `accountId` is passed. (#815)
 - **Working memory TTL** — 30-day expiry on inserts; nightly purge trims expired non-archived turns. (#220)
 - **Automatic scheduled run summaries** — scheduler auto-captures `agent.response.content` as `last_run_summary` via COALESCE; agents no longer need to call `scheduler-report` explicitly. (#817)
@@ -53,9 +47,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Principal contact injection** — runtime now injects a `## Principal Contact Details` block (verified email, Signal, phone) into every agent's system prompt per-task, preventing the coordinator from hallucinating the principal's address when composing outbound messages. (#786)
 - **`fast` model tier** — repointed to `google/gemini-3.1-flash-lite` after OpenRouter removed `gemini-2.0-flash-001`; unblocks contacts, calendar, research-analyst, digest. (#812)
 - **Provisional contact sweep** — sweep step 3 now passes `${principal_contact_id}` to `calendar-list-events` (was passing nothing, causing a UUID validation error), and treats calendar failure as best-effort so Sent-folder promotions still fire. (#816)
-
-### Changed
-- None.
 
 ### Removed
 - None.

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -54,6 +54,16 @@ function formatDateTime(iso: string | null): string {
   return iso.slice(0, 16).replace('T', ' ');
 }
 
+// Format a timestamp for wake-time display, including the user's local timezone abbreviation.
+function formatWakeAt(iso: string): string {
+  const d = new Date(iso);
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(d);
+}
+
 // Returns a compact "age" string (e.g. "2d", "3h", "just now") from an ISO timestamp.
 function formatAge(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
@@ -150,10 +160,11 @@ interface DrawerProps {
 
 const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['done', 'cancelled']);
 
-const ALL_STATUSES: TaskStatus[] = [
-  'open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled',
-  'active', 'pending', 'paused', 'completed', 'failed',
-];
+// Valid task-lifecycle statuses that can be set via the UI.
+const EDITABLE_STATUSES: TaskStatus[] = ['open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled'];
+
+// Legacy scheduler statuses — only readable for old rows, not selectable as new destinations.
+const LEGACY_STATUSES = new Set<TaskStatus>(['active', 'pending', 'paused', 'completed', 'failed']);
 
 function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted, lookupTask, onNavigateTo }: DrawerProps) {
   const [agentId, setAgentId] = useState(task?.agentId ?? '');
@@ -323,7 +334,7 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted, lookupTas
             <span className={`status-pill ${task.status}`}>{task.status.replace('_', ' ')}</span>
             {task.nextWakeAt && (
               <span style={{ marginLeft: 8, fontSize: 12, color: 'var(--app-fg-muted)' }}>
-                wakes {formatDateTime(task.nextWakeAt)}
+                wakes {formatWakeAt(task.nextWakeAt)}
               </span>
             )}
           </div>
@@ -353,7 +364,12 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted, lookupTas
                 onChange={e => setStatus(e.target.value as TaskStatus)}
                 disabled={isTerminal}
               >
-                {ALL_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+                {/* If the current value is a legacy status, show it as a read-only stub so
+                    old rows remain readable, but don't include it in the selectable list. */}
+                {LEGACY_STATUSES.has(status) && (
+                  <option value={status} disabled>{status} (legacy)</option>
+                )}
+                {EDITABLE_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
               </select>
             </div>
             <div className="form-field">

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -266,11 +266,20 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted, lookupTas
     }
   }
 
-  // Render a related-task link: shows the task title (if locally resolvable) or the UUID.
-  // Clicking navigates the drawer to that task.
+  // Render a related-task link: shows the task title and navigates the drawer on click.
+  // If the task isn't in the loaded list (e.g. filtered out or outside LIMIT 500),
+  // renders a read-only UUID field instead of a dead-click button.
   function relatedTaskLink(label: string, id: string | null) {
     if (!id) return null;
     const related = lookupTask(id);
+    if (!related) {
+      return (
+        <div className="form-field">
+          <label>{label}</label>
+          <div className="form-field-readonly cell-mono" style={{ fontSize: 11, wordBreak: 'break-all' }}>{id}</div>
+        </div>
+      );
+    }
     return (
       <div className="form-field">
         <label>{label}</label>
@@ -280,7 +289,7 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted, lookupTas
           onClick={() => onNavigateTo(id)}
           title={id}
         >
-          {related ? related.title || id : id}
+          {related.title}
         </button>
       </div>
     );

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -30,9 +30,11 @@ interface Task {
   sourceAgentId: string | null;
   tags: string[];
   waitingOnContactId: string | null;
+  waitingOnContactName: string | null;
   waitingOnText: string | null;
   parentTaskId: string | null;
   blockedByTaskId: string | null;
+  nextWakeAt: string | null;
   progress: Record<string, unknown>;
   errorBudget: Record<string, unknown>;
   conversationId: string | null;
@@ -50,6 +52,16 @@ function formatDate(iso: string | null): string {
 function formatDateTime(iso: string | null): string {
   if (!iso) return '—';
   return iso.slice(0, 16).replace('T', ' ');
+}
+
+// Returns a compact "age" string (e.g. "2d", "3h", "just now") from an ISO timestamp.
+function formatAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return 'just now';
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h`;
+  if (ms < 86_400_000 * 30) return `${Math.floor(ms / 86_400_000)}d`;
+  return `${Math.floor(ms / (86_400_000 * 30))}mo`;
 }
 
 function prettyJson(value: Record<string, unknown>): string {
@@ -130,14 +142,20 @@ interface DrawerProps {
   onClose: () => void;
   onSaved: (task: Task) => void;
   onDeleted: (id: string) => void;
+  /** Resolve a task ID to a summary for display in related-task links. */
+  lookupTask: (id: string) => { id: string; title: string } | undefined;
+  /** Navigate the drawer to a related task by ID. */
+  onNavigateTo: (id: string) => void;
 }
+
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['done', 'cancelled']);
 
 const ALL_STATUSES: TaskStatus[] = [
   'open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled',
   'active', 'pending', 'paused', 'completed', 'failed',
 ];
 
-function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerProps) {
+function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted, lookupTask, onNavigateTo }: DrawerProps) {
   const [agentId, setAgentId] = useState(task?.agentId ?? '');
   const [title, setTitle] = useState(task?.title ?? '');
   const [intentAnchor, setIntentAnchor] = useState(task?.intentAnchor ?? '');
@@ -156,6 +174,9 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Whether the current task is in a terminal state (done/cancelled).
+  const isTerminal = !creating && task !== null && TERMINAL_STATUSES.has(task.status);
+
   async function handleSave() {
     if (!agentId.trim()) { setError('Agent ID is required.'); return; }
     if (!intentAnchor.trim()) { setError('Intent anchor is required.'); return; }
@@ -163,6 +184,12 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
     const parsedPriority = parseInt(priority, 10);
     if (isNaN(parsedPriority) || parsedPriority < 0 || parsedPriority > 100) {
       setError('Priority must be an integer 0–100.');
+      return;
+    }
+
+    // Block invalid status transitions for terminal tasks — mirrored from TaskRepo.
+    if (isTerminal && status !== task!.status) {
+      setError(`Cannot change status from '${task!.status}' — that status is final.`);
       return;
     }
 
@@ -239,7 +266,27 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
     }
   }
 
-  // Read-only UUID display for system-managed FK fields.
+  // Render a related-task link: shows the task title (if locally resolvable) or the UUID.
+  // Clicking navigates the drawer to that task.
+  function relatedTaskLink(label: string, id: string | null) {
+    if (!id) return null;
+    const related = lookupTask(id);
+    return (
+      <div className="form-field">
+        <label>{label}</label>
+        <button
+          type="button"
+          className="task-related-link"
+          onClick={() => onNavigateTo(id)}
+          title={id}
+        >
+          {related ? related.title || id : id}
+        </button>
+      </div>
+    );
+  }
+
+  // Render a read-only UUID field (for system-managed FKs with no link behaviour).
   function uuidField(label: string, value: string | null) {
     if (!value) return null;
     return (
@@ -263,13 +310,26 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
         </div>
         <h2 className="drawer-title-h2">{creating ? 'New task' : (task?.title || task?.agentId) ?? ''}</h2>
         {!creating && task && (
-          <div className="drawer-subtitle">{task.status}</div>
+          <div className="drawer-subtitle">
+            <span className={`status-pill ${task.status}`}>{task.status.replace('_', ' ')}</span>
+            {task.nextWakeAt && (
+              <span style={{ marginLeft: 8, fontSize: 12, color: 'var(--app-fg-muted)' }}>
+                wakes {formatDateTime(task.nextWakeAt)}
+              </span>
+            )}
+          </div>
         )}
       </div>
 
       <div className="drawer-body">
         <div className="edit-drawer-form">
           {error && <p style={{ color: 'var(--app-destructive)', margin: 0, fontSize: 13 }}>{error}</p>}
+
+          {isTerminal && (
+            <p style={{ color: 'var(--app-fg-muted)', margin: 0, fontSize: 12, fontStyle: 'italic' }}>
+              This task is in a terminal state. Status cannot be changed.
+            </p>
+          )}
 
           <div className="form-grid">
             <div className="form-field">
@@ -278,7 +338,12 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
             </div>
             <div className="form-field">
               <label htmlFor="tf-status">Status</label>
-              <select id="tf-status" value={status} onChange={e => setStatus(e.target.value as TaskStatus)}>
+              <select
+                id="tf-status"
+                value={status}
+                onChange={e => setStatus(e.target.value as TaskStatus)}
+                disabled={isTerminal}
+              >
                 {ALL_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
               </select>
             </div>
@@ -334,13 +399,20 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
             <input id="tf-conv-id" type="text" value={conversationId} onChange={e => setConversationId(e.target.value)} placeholder="UUID — optional" />
           </div>
 
-          {/* Read-only system-managed FK fields */}
+          {/* Read-only system-managed fields */}
           {!creating && (
             <>
+              {task?.waitingOnContactId && (
+                <div className="form-field">
+                  <label>Waiting on contact</label>
+                  <div className="form-field-readonly">
+                    {task.waitingOnContactName ?? task.waitingOnContactId}
+                  </div>
+                </div>
+              )}
+              {relatedTaskLink('Parent task', task?.parentTaskId ?? null)}
+              {relatedTaskLink('Blocked by', task?.blockedByTaskId ?? null)}
               {uuidField('Source agent ID', task?.sourceAgentId ?? null)}
-              {uuidField('Waiting on contact ID', task?.waitingOnContactId ?? null)}
-              {uuidField('Parent task ID', task?.parentTaskId ?? null)}
-              {uuidField('Blocked by task ID', task?.blockedByTaskId ?? null)}
             </>
           )}
 
@@ -377,7 +449,7 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerP
 
 // ── Main page ─────────────────────────────────────────────────────────────────
 
-type SortKey = 'title' | 'agentId' | 'owner' | 'priority' | 'status' | 'dueAt' | 'updatedAt';
+type SortKey = 'title' | 'agentId' | 'owner' | 'priority' | 'status' | 'dueAt' | 'updatedAt' | 'createdAt';
 
 const STATUS_FILTERS = [
   'all',
@@ -388,6 +460,8 @@ const STATUS_FILTERS = [
 ] as const;
 type StatusFilter = typeof STATUS_FILTERS[number];
 
+type OwnerFilter = 'all' | TaskOwner;
+
 export default function TasksPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -396,7 +470,9 @@ export default function TasksPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'updatedAt', dir: 'desc' });
+  const [ownerFilter, setOwnerFilter] = useState<OwnerFilter>('all');
+  // Default sort: priority DESC; due_at ASC is the tiebreaker in the sort comparator.
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'priority', dir: 'desc' });
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [editing, setEditing] = useState<Task | null>(null);
@@ -434,6 +510,7 @@ export default function TasksPage() {
   const filtered = useMemo(() => {
     let rows = tasks;
     if (statusFilter !== 'all') rows = rows.filter(t => t.status === statusFilter);
+    if (ownerFilter !== 'all') rows = rows.filter(t => t.owner === ownerFilter);
     if (search) {
       const q = search.toLowerCase();
       rows = rows.filter(t =>
@@ -446,10 +523,18 @@ export default function TasksPage() {
       const bv = (b[sort.key] ?? '') as string | number;
       if (av < bv) return -1 * dir;
       if (av > bv) return  1 * dir;
+      // Secondary tiebreaker when sorting by priority: due_at ASC NULLS LAST,
+      // mirroring the tasks_open_priority_idx sort order from the DB.
+      if (sort.key === 'priority') {
+        const da = a.dueAt ?? '￿';
+        const db = b.dueAt ?? '￿';
+        if (da < db) return -1;
+        if (da > db) return 1;
+      }
       return 0;
     });
     return rows;
-  }, [tasks, statusFilter, search, sort]);
+  }, [tasks, statusFilter, ownerFilter, search, sort]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const safePage = Math.min(page, totalPages);
@@ -458,7 +543,7 @@ export default function TasksPage() {
   function toggleSort(key: SortKey) {
     setSort(s => s.key === key
       ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
-      : { key, dir: 'asc' });
+      : { key, dir: key === 'priority' ? 'desc' : 'asc' });
   }
   const sortArrow = (key: SortKey) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
   const ariaSort = (key: SortKey): 'ascending' | 'descending' | 'none' =>
@@ -483,6 +568,21 @@ export default function TasksPage() {
     setTasks(prev => prev.filter(t => t.id !== id));
     setEditing(null);
     setCreating(false);
+  }
+
+  /** Resolve a task ID to a lightweight summary for the drawer's related-task links. */
+  function lookupTask(id: string): { id: string; title: string } | undefined {
+    const t = tasks.find(t => t.id === id);
+    return t ? { id: t.id, title: t.title || t.intentAnchor } : undefined;
+  }
+
+  /** Navigate the drawer to a different task (parent, blocked-by). */
+  function handleNavigateTo(id: string) {
+    const target = tasks.find(t => t.id === id);
+    if (target) {
+      setCreating(false);
+      setEditing(target);
+    }
   }
 
   return (
@@ -542,6 +642,21 @@ export default function TasksPage() {
                   ))}
                 </div>
                 <div className="records-toolbar-right">
+                  {/* Owner filter — compact dropdown keeps the toolbar to one row */}
+                  <label htmlFor="tasks-owner-filter" style={{ fontSize: 12, color: 'var(--app-fg-muted)' }}>
+                    Owner
+                  </label>
+                  <select
+                    id="tasks-owner-filter"
+                    className="records-filter-select"
+                    value={ownerFilter}
+                    onChange={e => { setOwnerFilter(e.target.value as OwnerFilter); setPage(1); }}
+                  >
+                    <option value="all">All</option>
+                    <option value="curia">curia</option>
+                    <option value="ceo">ceo</option>
+                    <option value="external">external</option>
+                  </select>
                   <span className="topbar-meta">{filtered.length} of {tasks.length}</span>
                 </div>
               </div>
@@ -555,11 +670,6 @@ export default function TasksPage() {
                           <th className="sortable" aria-sort={ariaSort('title')}>
                             <button className="sort-btn" onClick={() => toggleSort('title')}>
                               Title <span className="sort-arrow">{sortArrow('title')}</span>
-                            </button>
-                          </th>
-                          <th className="sortable" aria-sort={ariaSort('agentId')}>
-                            <button className="sort-btn" onClick={() => toggleSort('agentId')}>
-                              Agent <span className="sort-arrow">{sortArrow('agentId')}</span>
                             </button>
                           </th>
                           <th className="sortable" aria-sort={ariaSort('owner')}>
@@ -582,6 +692,7 @@ export default function TasksPage() {
                               Due <span className="sort-arrow">{sortArrow('dueAt')}</span>
                             </button>
                           </th>
+                          <th className="col-updated" style={{ color: 'var(--app-fg-muted)', fontSize: 11 }}>Age</th>
                           <th className="sortable col-updated" aria-sort={ariaSort('updatedAt')}>
                             <button className="sort-btn" onClick={() => toggleSort('updatedAt')}>
                               Updated <span className="sort-arrow">{sortArrow('updatedAt')}</span>
@@ -605,11 +716,11 @@ export default function TasksPage() {
                                 </span>
                               )}
                             </td>
-                            <td className="cell-mono" style={{ fontSize: 12 }}>{t.agentId}</td>
                             <td><span className={`badge badge-${t.owner}`}>{t.owner}</span></td>
                             <td><span className={`status-pill ${t.status}`}>{t.status.replace('_', ' ')}</span></td>
                             <td className="cell-mono" style={{ textAlign: 'center' }}>{t.priority}</td>
                             <td className="cell-mono col-updated">{formatDate(t.dueAt)}</td>
+                            <td className="cell-mono col-updated" style={{ color: 'var(--app-fg-muted)' }}>{formatAge(t.createdAt)}</td>
                             <td className="cell-mono col-updated">{formatDateTime(t.updatedAt)}</td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>
@@ -654,6 +765,8 @@ export default function TasksPage() {
                     onClose={() => { setEditing(null); setCreating(false); }}
                     onSaved={handleSaved}
                     onDeleted={handleDeleted}
+                    lookupTask={lookupTask}
+                    onNavigateTo={handleNavigateTo}
                   />
                 )}
               </div>

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -932,6 +932,12 @@ input:focus, textarea:focus, select:focus {
 /* Tasks: paused = blue — scoped to override the job rule above */
 .tasks-page .status-pill.paused::before { background: var(--app-blue); }
 
+/* Task-lifecycle statuses (migration 049) — no global rules defined for these above */
+.status-pill.open::before        { background: var(--app-teal); }
+.status-pill.in_progress::before { background: var(--app-blue); }
+.status-pill.waiting::before     { background: var(--app-amber); }
+.status-pill.done::before        { background: var(--app-green); }
+
 /* ── Drawer (right-anchored) ───────────────────────────────────────── */
 .drawer {
   flex: none;
@@ -1013,6 +1019,16 @@ input:focus, textarea:focus, select:focus {
 }
 .records-filter-chip:hover { color: var(--app-fg); border-color: var(--app-input-bd); }
 .records-filter-chip.active { color: var(--app-fg); border-color: var(--app-teal); background: var(--app-teal-soft); }
+
+/* Compact filter <select> used in the toolbar right slot (e.g. owner filter on Tasks page) */
+.records-filter-select {
+  height: 28px; padding: 0 6px;
+  font-size: 12px; color: var(--app-fg);
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
 
 .records-table-wrap { flex: 1; overflow: auto; background: var(--app-bg); }
 table.records-table {
@@ -1141,6 +1157,20 @@ table.records-table tbody tr.active td { background: transparent; }
   border: 1px solid var(--app-border);
   border-radius: 6px;
 }
+
+/* Clickable related-task link inside the drawer (parent/blocked-by fields) */
+.task-related-link {
+  display: block; width: 100%; text-align: left;
+  font-size: 13px; color: var(--app-teal);
+  padding: 8px 12px;
+  background: var(--app-muted);
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  transition: border-color 120ms;
+}
+.task-related-link:hover { border-color: var(--app-teal); }
 
 /* Responsive adjustments for records views */
 @media (max-width: 768px) {

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1170,7 +1170,16 @@ table.records-table tbody tr.active td { background: transparent; }
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   transition: border-color 120ms;
 }
-.task-related-link:hover { border-color: var(--app-teal); }
+.task-related-link:hover,
+.task-related-link:focus-visible {
+  border-color: var(--app-teal);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--app-teal-soft);
+}
+
+/* Dark mode: --app-teal (#478189) on --app-muted (#373737) is only 2.7:1.
+   Use --app-fg instead to meet WCAG AA at 13px. */
+[data-theme="dark"] .task-related-link { color: var(--app-fg); }
 
 /* Responsive adjustments for records views */
 @media (max-width: 768px) {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -335,9 +335,9 @@ export async function knowledgeGraphRoutes(
       t.blocked_by_task_id, t.progress, t.error_budget, t.conversation_id,
       t.created_at, t.updated_at,
       c.display_name AS waiting_on_contact_name,
-      (SELECT sj.run_at FROM scheduled_jobs sj
+      (SELECT sj.next_run_at FROM scheduled_jobs sj
        WHERE sj.task_id = t.id AND sj.status = 'pending'
-       ORDER BY sj.run_at ASC LIMIT 1) AS next_wake_at
+       ORDER BY sj.next_run_at ASC LIMIT 1) AS next_wake_at
     FROM tasks t
     LEFT JOIN contacts c ON c.id = t.waiting_on_contact_id
     ORDER BY t.updated_at DESC
@@ -633,6 +633,7 @@ export async function knowledgeGraphRoutes(
              conversation_id = $15,
              updated_at      = now()
          WHERE id = $1
+           AND ($6 = status OR status NOT IN ('done', 'cancelled'))
          RETURNING ${TASK_SELECT}`,
         [
           id,
@@ -652,10 +653,26 @@ export async function knowledgeGraphRoutes(
           conversationId,
         ],
       );
-      // Guard against concurrent deletes between the existence check and the UPDATE.
+      // Zero rows updated: either a concurrent delete or a concurrent terminal transition
+      // slipped in after our pre-check. Re-read to distinguish the two cases.
       if (!updated.rowCount) {
-        logger.warn({ taskId: id }, 'kg: PATCH tasks matched 0 rows — likely concurrent delete');
-        return reply.status(404).send({ error: 'Task not found.' });
+        const current = await pool.query<{ status: string }>(
+          `SELECT status FROM tasks WHERE id = $1`,
+          [id],
+        );
+        if (!current.rowCount) {
+          logger.warn({ taskId: id }, 'kg: PATCH tasks matched 0 rows — likely concurrent delete');
+          return reply.status(404).send({ error: 'Task not found.' });
+        }
+        const currentStatus = current.rows[0]!.status;
+        if (['done', 'cancelled'].includes(currentStatus) && typeof body.status === 'string' && body.status !== currentStatus) {
+          return reply.status(400).send({
+            error: `Cannot transition task from '${currentStatus}' — it is a terminal state.`,
+          });
+        }
+        // Neither delete nor terminal: unexpected. Surface a 500 rather than silently dropping.
+        logger.error({ taskId: id, currentStatus }, 'kg: PATCH UPDATE matched 0 rows for non-terminal task');
+        return reply.status(500).send({ error: 'Update failed unexpectedly.' });
       }
       // Re-fetch with enriched JOIN so the response includes contact name and
       // next wake-up time, keeping parity with the GET list response shape.
@@ -667,9 +684,9 @@ export async function knowledgeGraphRoutes(
           t.blocked_by_task_id, t.progress, t.error_budget, t.conversation_id,
           t.created_at, t.updated_at,
           c.display_name AS waiting_on_contact_name,
-          (SELECT sj.run_at FROM scheduled_jobs sj
+          (SELECT sj.next_run_at FROM scheduled_jobs sj
            WHERE sj.task_id = t.id AND sj.status = 'pending'
-           ORDER BY sj.run_at ASC LIMIT 1) AS next_wake_at
+           ORDER BY sj.next_run_at ASC LIMIT 1) AS next_wake_at
          FROM tasks t
          LEFT JOIN contacts c ON c.id = t.waiting_on_contact_id
          WHERE t.id = $1`,

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -537,6 +537,12 @@ export async function knowledgeGraphRoutes(
     }
     const row = existing.rows[0]! as DbTaskRow;
 
+    // Validate status value before checking transition rules so callers get
+    // "Invalid status" rather than "terminal state" for nonsense status strings.
+    if (typeof body.status === 'string' && !validTaskStatuses.includes(body.status)) {
+      return reply.status(400).send({ error: 'Invalid status.' });
+    }
+
     // Mirror the TaskRepo terminal-state guard: once a task is done or cancelled,
     // status cannot be changed via the console API either.
     const TERMINAL_STATUSES_KG = ['done', 'cancelled'];
@@ -661,6 +667,11 @@ export async function knowledgeGraphRoutes(
          WHERE t.id = $1`,
         [id],
       );
+      // Guard against concurrent deletes between the UPDATE and the re-fetch.
+      if (!enriched.rowCount) {
+        logger.warn({ taskId: id }, 'kg: PATCH enriched re-fetch matched 0 rows — concurrent delete');
+        return reply.status(404).send({ error: 'Task not found.' });
+      }
       return reply.send({
         task: serializeTask(enriched.rows[0]! as DbTaskRow),
       });

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -289,6 +289,8 @@ export async function knowledgeGraphRoutes(
   const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
   // Full DB row shape for the tasks table (all columns post-migration-049).
+  // The enriched variant (used for GET list) includes joined fields from
+  // contacts and a correlated subquery for the next scheduled wake-up time.
   type DbTaskRow = {
     id: string;
     agent_id: string;
@@ -311,13 +313,35 @@ export async function knowledgeGraphRoutes(
     conversation_id: string | null;
     created_at: string;
     updated_at: string;
+    // Enriched fields — null on rows returned by the bare UPDATE RETURNING path.
+    waiting_on_contact_name: string | null;
+    next_wake_at: string | null;
   };
 
+  // Columns used for bare SELECT / UPDATE RETURNING (no JOIN needed).
   const TASK_SELECT = `
     id, agent_id, title, intent_anchor, description, status, owner, priority,
     due_at, source, source_agent_id, tags, waiting_on_contact_id, waiting_on_text,
     parent_task_id, blocked_by_task_id, progress, error_budget, conversation_id,
     created_at, updated_at`;
+
+  // Full enriched query for the GET list: joins contacts for display name and
+  // uses a correlated subquery to surface the next pending scheduled wake-up.
+  const TASK_ENRICHED_QUERY = `
+    SELECT
+      t.id, t.agent_id, t.title, t.intent_anchor, t.description, t.status,
+      t.owner, t.priority, t.due_at, t.source, t.source_agent_id, t.tags,
+      t.waiting_on_contact_id, t.waiting_on_text, t.parent_task_id,
+      t.blocked_by_task_id, t.progress, t.error_budget, t.conversation_id,
+      t.created_at, t.updated_at,
+      c.display_name AS waiting_on_contact_name,
+      (SELECT sj.run_at FROM scheduled_jobs sj
+       WHERE sj.task_id = t.id AND sj.status = 'pending'
+       ORDER BY sj.run_at ASC LIMIT 1) AS next_wake_at
+    FROM tasks t
+    LEFT JOIN contacts c ON c.id = t.waiting_on_contact_id
+    ORDER BY t.updated_at DESC
+    LIMIT 500`;
 
   function serializeTask(row: DbTaskRow) {
     return {
@@ -334,9 +358,11 @@ export async function knowledgeGraphRoutes(
       sourceAgentId: row.source_agent_id,
       tags: row.tags ?? [],
       waitingOnContactId: row.waiting_on_contact_id,
+      waitingOnContactName: row.waiting_on_contact_name ?? null,
       waitingOnText: row.waiting_on_text,
       parentTaskId: row.parent_task_id,
       blockedByTaskId: row.blocked_by_task_id,
+      nextWakeAt: row.next_wake_at ?? null,
       progress: row.progress ?? {},
       errorBudget: row.error_budget ?? {},
       conversationId: row.conversation_id,
@@ -351,9 +377,7 @@ export async function knowledgeGraphRoutes(
   app.get('/api/kg/tasks', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     try {
-      const result = await pool.query(
-        `SELECT ${TASK_SELECT} FROM tasks ORDER BY updated_at DESC LIMIT 500`,
-      );
+      const result = await pool.query(TASK_ENRICHED_QUERY);
       return reply.send({
         tasks: result.rows.map((row) => serializeTask(row as DbTaskRow)),
       });
@@ -513,6 +537,19 @@ export async function knowledgeGraphRoutes(
     }
     const row = existing.rows[0]! as DbTaskRow;
 
+    // Mirror the TaskRepo terminal-state guard: once a task is done or cancelled,
+    // status cannot be changed via the console API either.
+    const TERMINAL_STATUSES_KG = ['done', 'cancelled'];
+    if (
+      TERMINAL_STATUSES_KG.includes(row.status) &&
+      typeof body.status === 'string' &&
+      body.status !== row.status
+    ) {
+      return reply.status(400).send({
+        error: `Cannot transition task from '${row.status}' — it is a terminal state.`,
+      });
+    }
+
     const agentId = typeof body.agentId === 'string' ? body.agentId.trim() : row.agent_id;
     const title = typeof body.title === 'string' ? body.title.trim() : row.title;
     const intentAnchor = typeof body.intentAnchor === 'string' ? body.intentAnchor.trim() : row.intent_anchor;
@@ -606,8 +643,26 @@ export async function knowledgeGraphRoutes(
         logger.warn({ taskId: id }, 'kg: PATCH tasks matched 0 rows — likely concurrent delete');
         return reply.status(404).send({ error: 'Task not found.' });
       }
+      // Re-fetch with enriched JOIN so the response includes contact name and
+      // next wake-up time, keeping parity with the GET list response shape.
+      const enriched = await pool.query(
+        `SELECT
+          t.id, t.agent_id, t.title, t.intent_anchor, t.description, t.status,
+          t.owner, t.priority, t.due_at, t.source, t.source_agent_id, t.tags,
+          t.waiting_on_contact_id, t.waiting_on_text, t.parent_task_id,
+          t.blocked_by_task_id, t.progress, t.error_budget, t.conversation_id,
+          t.created_at, t.updated_at,
+          c.display_name AS waiting_on_contact_name,
+          (SELECT sj.run_at FROM scheduled_jobs sj
+           WHERE sj.task_id = t.id AND sj.status = 'pending'
+           ORDER BY sj.run_at ASC LIMIT 1) AS next_wake_at
+         FROM tasks t
+         LEFT JOIN contacts c ON c.id = t.waiting_on_contact_id
+         WHERE t.id = $1`,
+        [id],
+      );
       return reply.send({
-        task: serializeTask(updated.rows[0]! as DbTaskRow),
+        task: serializeTask(enriched.rows[0]! as DbTaskRow),
       });
     } catch (err) {
       logger.error({ err, taskId: id }, 'kg: PATCH /api/kg/tasks/:id failed');

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -528,14 +528,22 @@ export async function knowledgeGraphRoutes(
       conversationId?: unknown;
     };
 
-    const existing = await pool.query(
-      `SELECT ${TASK_SELECT} FROM tasks WHERE id = $1`,
-      [id],
-    );
-    if (existing.rowCount === 0) {
-      return reply.status(404).send({ error: 'Task not found.' });
+    // Wrap the entire DB interaction in one try-catch so pool errors on the
+    // existence check are handled the same way as errors from the UPDATE.
+    let row: DbTaskRow;
+    try {
+      const existing = await pool.query(
+        `SELECT ${TASK_SELECT} FROM tasks WHERE id = $1`,
+        [id],
+      );
+      if (existing.rowCount === 0) {
+        return reply.status(404).send({ error: 'Task not found.' });
+      }
+      row = existing.rows[0]! as DbTaskRow;
+    } catch (err) {
+      logger.error({ err, taskId: id }, 'kg: PATCH /api/kg/tasks/:id existence check failed');
+      return reply.status(500).send({ error: 'Failed to load task.' });
     }
-    const row = existing.rows[0]! as DbTaskRow;
 
     // Validate status value before checking transition rules so callers get
     // "Invalid status" rather than "terminal state" for nonsense status strings.


### PR DESCRIPTION
## **User description**
## Summary

- **List view**: owner dropdown filter, age column, priority-DESC default sort (with due_at ASC tiebreaker), tag search works via existing title/agent/tags search
- **Detail/edit panel**: contact display name for `waiting_on_contact_id`, next scheduled wake-up time from `scheduled_jobs`, parent/blocked-by as clickable drawer navigation links (or UUID display if task not in loaded list)
- **Status lifecycle control**: terminal-state guard (done/cancelled) enforced in both frontend and backend PATCH endpoint; status dropdown disabled for terminal tasks
- **Backend**: `GET /api/kg/tasks` extended with `LEFT JOIN contacts` and correlated subquery for `next_wake_at`; PATCH re-fetches enriched task after UPDATE; existence-check wrapped in its own try-catch
- **CSS**: status-pill dot colors for `open`, `in_progress`, `waiting`, `done`; new `.records-filter-select` and `.task-related-link` styles

Closes #870

## Test plan

- [ ] Open Tasks page — list loads with priority-DESC sort by default
- [ ] Filter by status chip → correct rows shown; count badges update
- [ ] Filter by owner dropdown (curia / ceo / external / All) → correct rows shown
- [ ] Search for a tag value → matching tasks shown
- [ ] Click a row → drawer opens with all fields populated, including contact name (if set) and wake-up time (if scheduled)
- [ ] Click "Parent task" / "Blocked by" link in drawer → drawer navigates to related task
- [ ] When related task not in list (e.g. filtered out) → shows UUID read-only, not a dead button
- [ ] Edit a task in `open` status → save succeeds; status pill updates inline
- [ ] Try changing status of a `done` task → frontend shows "cannot change status" error; backend also returns 400 if PATCH attempted directly
- [ ] Status pills: `open` (teal), `in_progress` (blue), `waiting` (amber), `done` (green) all show correct dot colors
- [ ] No regressions on Contacts, Jobs, KG, or other console pages


___

## **CodeAnt-AI Description**
**Improve the Tasks console with owner filtering, clearer task details, and locked final statuses**

### What Changed
- The Tasks list now includes an owner filter, an age column, and opens sorted by highest priority first with due date used to break ties.
- Task details now show the contact name for "waiting on" tasks, the next wake-up time, and clickable parent/blocked-by links that jump to the related task when it is loaded.
- Tasks in a final state can no longer have their status changed in the drawer or through the API, and invalid status values now return a direct "Invalid status" error.
- The task list and save response now include the extra detail fields shown in the drawer, so the page stays in sync after edits.

### Impact
`✅ Faster task triage`
`✅ Fewer mistaken status changes on finished tasks`
`✅ Clearer task relationships and follow-up timing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tasks interface now includes owner filtering and age tracking
  * Email outbound support for file attachments
  * Enhanced contact management with improved field normalization

* **Bug Fixes**
  * Performance optimizations in fact extraction
  * Improved task terminal state handling
  * Whitespace trimming in canonical field resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->