### PR TITLE
feat: extend pending-actions-digest with task backlog sections (#838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Tasks & Backlog v1 design** — design memo for a unified task model with deferred work, CEO-visible backlog, and a 3×/day coordinator sweep. See `docs/wip/2026-06-01-tasks-and-backlog-design.md`.
 - **SBOM generation** — SPDX JSON Software Bill of Materials generated on every push to `main` and attached to each GitHub release as a release asset; failure is non-fatal. (#564)
 - **`drive-download-file`** — new skill that downloads a Google Drive file (native or Google-native export) to TempFileStore and returns a `file://` URL, enabling Drive files to be attached to outbound emails. Closes #857.
+- **`pending-actions-digest`** — daily digest now surfaces the task backlog: for-you-to-do, waiting-on-others, and what-I'm-working-on. (#838)
 
 ### Changed
 - **Console tasks view** — updated to match the migrated `tasks` schema: drops `scheduled_job_id`, adds all new columns (`title`, `owner`, `priority`, `due_at`, `source`, `tags`, `description`, FK references), extends status filters with new task-lifecycle values, and updates the scheduled-jobs view to display the linked `task_id`. (#869)

--- a/docs/wip/2026-06-03-digest-backlog-sections-design.md
+++ b/docs/wip/2026-06-03-digest-backlog-sections-design.md
@@ -1,0 +1,192 @@
+# Design: Backlog sections in `pending-actions-digest`
+
+**Status:** Design, pre-implementation
+**Date:** 2026-06-03
+**Issue:** [josephfung/curia#838](https://github.com/josephfung/curia/issues/838) — Tasks v1 (5/7)
+**Parent design:** [2026-06-01-tasks-and-backlog-design.md](2026-06-01-tasks-and-backlog-design.md) (§6, §9 issue 5)
+
+---
+
+## 1. Context
+
+Tasks & Backlog v1 (issues 1–4) has landed: migration 049 promoted `agent_tasks` →
+`tasks` with CEO-visible columns, and the four `task-*` skills exist
+(`task-create`, `task-list`, `task-update`, `task-complete`). This issue is the
+read-side surface: let the CEO *see* the backlog in a channel they already read.
+
+### The surface decision
+
+The parent design (§6) names `src/digests/pending-actions-digest.ts` as the target.
+That path is stale. The actual module is the **code skill**
+`skills/pending-actions-digest/handler.ts`: a deterministic skill that loads
+non-expired `pending_approval` rows via `actionLogRepo`, formats a plain-text body,
+and sends a single email to the CEO via `outboundGateway`. It is triggered by the
+coordinator's declarative job `cron: "0 8 * * *"` (8am).
+
+There is a *second*, unrelated digest in this deployment: the `digest.yaml` agent in
+`curia-deploy` (5pm Toronto), an LLM agent that lists unsent **email drafts** over
+**Signal**. It is a different channel, a different payload, and LLM-rendered.
+
+**This issue extends the code skill only.** The `digest.yaml` Signal agent is
+explicitly out of scope and stays drafts-only. A future issue could let it consume
+`task-list`, but that path cannot satisfy this issue's snapshot-test acceptance
+criteria (only the deterministic code path can), so it is deliberately deferred.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+- Surface the three-way task backlog (`for-you-to-do` / `waiting-on-others` /
+  `what-I'm-working-on`) in the existing daily approvals email.
+- Keep the approvals block byte-for-byte unchanged.
+- Make the rendered body snapshot-testable via a pure function.
+
+### Non-Goals (this issue)
+- Any change to the `digest.yaml` Signal agent.
+- Interactive controls (snooze / done / reassign) — deferred to v1.5+ per parent §6.
+- A separate "backlog digest" or new channel.
+- Touching the task skills, the scheduler, or the coordinator.
+
+---
+
+## 3. Data Sources (all already exist)
+
+| Need | Source | Notes |
+|---|---|---|
+| Three task lists | `ctx.taskRepo.listTasks({ owner, statuses, limit })` | Already orders by `priority DESC, due_at ASC NULLS LAST`. |
+| Contact name for `waiting_on` | `ctx.contactService.getContact(id)` → `displayName` | Ambient on `SkillContext` (not capability-gated). Returns `Contact \| undefined`. |
+| Approvals (unchanged) | `ctx.actionLogRepo.findAllPending()` | Existing behavior, untouched. |
+
+Section → query mapping:
+
+- **For you to do** — `owner='ceo'`, `statuses=['open','in_progress']`
+- **Waiting on others** — `owner='external'`, `statuses=['waiting']`
+- **What I'm working on** — `owner='curia'`, `statuses=['open','in_progress']`
+
+Each fetched with `limit: 50` (see §5 for the `+N more` rationale).
+
+The only manifest capability change: add `"taskRepo"` to `capabilities`
+(currently `["actionLogRepo","outboundGateway"]`). `contactService` needs no
+declaration — it is populated whenever the execution layer has an instance.
+
+---
+
+## 4. Send Gate & Subject
+
+Compute all three lists first, then decide whether to send:
+
+- **Send if** `approvals.length > 0 || ceo.length > 0 || external.length > 0`.
+- **Skip** (`{ skipped: true }`, no email) when all three are empty — *even if*
+  `curia` ("what I'm working on") has items. Curia's own in-progress work never
+  triggers a send on its own; it is informational ride-along content.
+
+**Adaptive subject:**
+
+- Approvals present → `Pending approvals — N request(s) awaiting your decision`
+  (unchanged from today).
+- Zero approvals, backlog present → `Your daily brief — N item(s) need you`,
+  where **N = ceo.length + external.length** (the items that actually need the CEO;
+  "what I'm working on" is not counted).
+
+The existing graceful-skip paths are preserved verbatim: missing
+`CEO_PRIMARY_EMAIL` or absent `outboundGateway` → `{ skipped: true }`. If
+`ctx.taskRepo` is absent, the three lists are empty and the skill behaves exactly
+as today (approvals-only, no throw).
+
+---
+
+## 5. Rendering & Line Formats
+
+Body layout: **approvals block (unchanged)**, then each non-empty backlog section in
+this order: For you to do, Waiting on others, What I'm working on.
+
+Line formats (one bullet per task):
+
+| Section | Format |
+|---|---|
+| For you to do | `• <title> · due <date\|—> · age <duration>` |
+| Waiting on others | `• <title> · waiting on <name> · since <duration>` |
+| What I'm working on | `• <title> · age <duration>` |
+
+Field rules:
+
+- `<date>` — `due_at` rendered in the CEO's local timezone via the existing
+  `toLocalIso()` convention (date portion only); `—` when `due_at` is null.
+- `<duration>` (age / since) — short humanized span from `created_at`
+  (e.g. `3d`, `5h`, `2w`). New helper `humanizeAge()` next to the existing
+  `formatTimeRemaining()` in the handler module.
+- `<name>` — `getContact(waiting_on_contact_id)?.displayName`, falling back to
+  `waiting_on_text`, then `(unknown)` when both are null/unresolved.
+
+**Truncation / `+N more`:** each section caps its rendered bullets at **5**. To show
+an exact remainder, each section is fetched with `limit: 50`; render the first 5 and
+compute `N = fetched − 5`. At v1 task volumes (well under 50) this is exact. If a
+section ever returns the full 50, the footer shows `+45 more` and the handler logs a
+`warn` — so silent truncation cannot hide a runaway backlog. (Exact N is capped at
+45 by construction.)
+
+---
+
+## 6. Testability & Refactor
+
+Body construction is extracted into a **pure function**:
+
+```ts
+renderDigestBody(input: {
+  approvals: ApprovalLine[];   // already-shaped approval rows
+  ceo: TaskListRow[];
+  external: TaskListRow[];
+  curia: TaskListRow[];
+  resolveName: (id: string) => string | undefined; // contact display name
+  now: Date;                    // for deterministic age in tests
+  timezone: string;
+}): string
+```
+
+This returns the complete email body. The snapshot test seeds realistic tasks and
+asserts the rendered string directly — no gateway mocking. The existing approvals
+bullet logic moves into this function **unchanged**, and the existing
+`handler.test.ts` stays green, which is the proof that the approvals block is
+untouched.
+
+`now` and `timezone` are injected so age/date rendering is deterministic under test.
+
+---
+
+## 7. Housekeeping
+
+- `skill.json` `version` `1.0.0` → **`1.1.0`** (new capability + new output fields =
+  minor bump per CLAUDE.md).
+- Manifest `outputs`: add `tasksForCeo`, `tasksWaiting`, `tasksWorking` counts
+  alongside existing `pending` / `skipped`.
+- `CHANGELOG.md` under `[Unreleased]` → **Added**:
+  `**pending-actions-digest** — daily digest now surfaces the task backlog
+  (for-you-to-do, waiting-on-others, what-I'm-working-on). (#838)`
+- TDD: helper and pure-function tests written before the handler is wired.
+
+---
+
+## 8. Build Sequence
+
+1. `humanizeAge()` helper + unit tests.
+2. `renderDigestBody()` pure function + snapshot tests: all three sections, the
+   `+N more` truncation case, empty-section cases, and approvals-block-unchanged.
+3. Wire `taskRepo` into the handler: fetch three lists (`limit: 50`), apply the send
+   gate, build the adaptive subject, call `renderDigestBody()`.
+4. Manifest (`capabilities`, `version`, `outputs`) + CHANGELOG entry.
+5. `pnpm run typecheck` + full test suite green.
+
+---
+
+## 9. Acceptance Criteria (from issue #838)
+
+- [ ] Snapshot test renders all three sections correctly with realistic seeded data,
+      including the `+N more` truncation case.
+- [ ] Snapshot test verifies the existing approvals block is unchanged.
+- [ ] The CEO receives the next day's digest in staging with the new sections
+      populated (manual verification).
+- [ ] Owner resolution: `waiting_on_contact_id` resolves to display name when
+      present; falls back to `waiting_on_text`; renders `(unknown)` if both null.
+- [ ] No new permission / outbound surface introduced (the email send path is the
+      existing `outboundGateway.sendNotification`).

--- a/docs/wip/2026-06-03-digest-backlog-sections.md
+++ b/docs/wip/2026-06-03-digest-backlog-sections.md
@@ -1,0 +1,858 @@
+# pending-actions-digest Backlog Sections — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the `pending-actions-digest` skill so the daily CEO email also lists the task backlog in three owner-grouped sections (For you to do / Waiting on others / What I'm working on).
+
+**Architecture:** Body construction moves into a new pure module `render.ts` (snapshot-testable, no I/O). The handler fetches three task lists via the existing `taskRepo.listTasks`, resolves `waiting_on_contact_id` to display names via the ambient `contactService`, applies an expanded send gate, builds an adaptive subject, and delegates body formatting to `render.ts`. The approvals block is reproduced byte-for-byte. Backlog fetch is resilient: a task-query failure or absent `taskRepo` degrades to an approvals-only email rather than failing the digest.
+
+**Tech Stack:** TypeScript (ESM, `.js` import extensions), Vitest, Luxon (via `toLocalIso`), Postgres-backed `TaskRepo`.
+
+**Reference spec:** [2026-06-03-digest-backlog-sections-design.md](2026-06-03-digest-backlog-sections-design.md)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `skills/pending-actions-digest/render.ts` (**new**) | Pure formatting: `humanizeAge`, `formatDueDate`, `formatTimeRemaining`, `renderDigestBody`. No I/O, no clock reads — time is injected as `nowMs`. |
+| `skills/pending-actions-digest/render.test.ts` (**new**) | Unit + snapshot tests for the pure functions. |
+| `skills/pending-actions-digest/handler.ts` (**modify**) | Orchestration: fetch approvals + backlog, resolve names, send gate, adaptive subject, send. Imports formatters from `render.ts`. |
+| `skills/pending-actions-digest/handler.test.ts` (**modify**) | Update existing `toEqual(result.data)` assertions for the new count fields; add backlog-path tests. |
+| `skills/pending-actions-digest/skill.json` (**modify**) | Add `taskRepo` capability, bump version, add output fields. |
+| `CHANGELOG.md` (**modify**) | `[Unreleased] → Added` entry. |
+
+**Key types (already defined in the codebase, do not redefine):**
+- `TaskListRow` from `src/db/task-repo.ts` — extends `TaskRow` (`src/db/queries/tasks.ts`). Note: `createdAt`, `dueAt`, `updatedAt` are **ISO strings**, not `Date`. `waitingOnContactId: string | null`, `waitingOnText: string | null`, `title: string`.
+- `TaskRepo.listTasks(filters: { owner?, statuses?, limit? }): Promise<TaskListRow[]>` — already orders by `priority DESC, due_at ASC NULLS LAST`.
+- `ctx.contactService?.getContact(id): Promise<Contact | undefined>` — `Contact.displayName: string`.
+- `ctx.taskRepo?` and `ctx.timezone?: string` on `SkillContext`.
+- `toLocalIso(unixSeconds, timezone)` from `src/time/timestamp.ts` → e.g. `"2026-06-06T13:00:00.000+00:00"`.
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections` (branch `feat/digest-backlog-sections`). All `git` uses `git -C <worktree>`; all `pnpm` uses `pnpm --prefix <worktree>`.
+
+**One-time setup before Task 1:** install deps in the worktree.
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections install`
+Expected: completes; `node_modules/` populated.
+
+---
+
+## Task 1: `humanizeAge` helper
+
+**Files:**
+- Create: `skills/pending-actions-digest/render.ts`
+- Test: `skills/pending-actions-digest/render.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `skills/pending-actions-digest/render.test.ts`:
+
+```ts
+// render.test.ts — unit + snapshot tests for the pure digest renderer.
+import { describe, it, expect } from 'vitest';
+import { humanizeAge } from './render.js';
+
+// Fixed clock for deterministic spans. 2026-06-03T12:00:00.000Z.
+const NOW_MS = Date.parse('2026-06-03T12:00:00.000Z');
+
+describe('humanizeAge', () => {
+  it('renders <1h for spans under an hour', () => {
+    expect(humanizeAge('2026-06-03T11:30:00.000Z', NOW_MS)).toBe('<1h');
+  });
+
+  it('renders hours under a day', () => {
+    expect(humanizeAge('2026-06-03T07:00:00.000Z', NOW_MS)).toBe('5h');
+  });
+
+  it('renders days under two weeks', () => {
+    expect(humanizeAge('2026-05-31T12:00:00.000Z', NOW_MS)).toBe('3d');
+  });
+
+  it('renders weeks at and beyond 14 days', () => {
+    expect(humanizeAge('2026-05-20T12:00:00.000Z', NOW_MS)).toBe('2w');
+  });
+
+  it('clamps future/zero spans to <1h', () => {
+    expect(humanizeAge('2026-06-03T13:00:00.000Z', NOW_MS)).toBe('<1h');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/render.test.ts`
+Expected: FAIL — `Failed to resolve import "./render.js"` / `humanizeAge is not exported`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `skills/pending-actions-digest/render.ts`:
+
+```ts
+// render.ts — pure formatting for the pending-actions-digest email body.
+//
+// No I/O and no clock reads: the current time is injected as `nowMs` so every
+// function is deterministic and snapshot-testable. The handler supplies
+// `Date.now()` at call time (which test suites pin via vi.spyOn).
+
+const MS_HOUR = 3_600_000;
+const MS_DAY = 86_400_000;
+const MS_WEEK = 604_800_000;
+const MS_TWO_WEEKS = 14 * MS_DAY;
+
+/**
+ * Short humanized age of an ISO timestamp relative to nowMs.
+ * Buckets: <1h, Nh (<1 day), Nd (<2 weeks), Nw (>=2 weeks).
+ * Future or zero spans clamp to '<1h'.
+ */
+export function humanizeAge(sinceIso: string, nowMs: number): string {
+  const diff = nowMs - Date.parse(sinceIso);
+  if (!Number.isFinite(diff) || diff < MS_HOUR) return '<1h';
+  if (diff < MS_DAY) return `${Math.floor(diff / MS_HOUR)}h`;
+  if (diff < MS_TWO_WEEKS) return `${Math.floor(diff / MS_DAY)}d`;
+  return `${Math.floor(diff / MS_WEEK)}w`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/render.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections add skills/pending-actions-digest/render.ts skills/pending-actions-digest/render.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections commit -m "feat: add humanizeAge helper for digest backlog sections"
+```
+
+---
+
+## Task 2: `formatDueDate` helper
+
+**Files:**
+- Modify: `skills/pending-actions-digest/render.ts`
+- Test: `skills/pending-actions-digest/render.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skills/pending-actions-digest/render.test.ts`:
+
+```ts
+import { formatDueDate } from './render.js';
+
+describe('formatDueDate', () => {
+  it('renders the local date portion in the given timezone', () => {
+    expect(formatDueDate('2026-06-06T13:00:00.000Z', 'UTC')).toBe('2026-06-06');
+  });
+
+  it('renders an em-dash placeholder for null', () => {
+    expect(formatDueDate(null, 'UTC')).toBe('—');
+  });
+
+  it('shifts the date across timezone boundaries', () => {
+    // 00:30 UTC on the 7th is still 20:30 on the 6th in Toronto (UTC-4 in June).
+    expect(formatDueDate('2026-06-07T00:30:00.000Z', 'America/Toronto')).toBe('2026-06-06');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/render.test.ts`
+Expected: FAIL — `formatDueDate is not exported`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `skills/pending-actions-digest/render.ts` (imports at top, function below `humanizeAge`):
+
+```ts
+import { toLocalIso } from '../../src/time/timestamp.js';
+```
+
+```ts
+/**
+ * Render a task's CEO-facing due date (date only) in the user's timezone.
+ * Returns '—' for a null due date or an unrepresentable timestamp.
+ */
+export function formatDueDate(dueIso: string | null, timezone: string): string {
+  if (dueIso === null) return '—';
+  const ms = Date.parse(dueIso);
+  if (!Number.isFinite(ms)) return '—';
+  const local = toLocalIso(Math.floor(ms / 1000), timezone);
+  return local ? local.slice(0, 10) : '—';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/render.test.ts`
+Expected: PASS (8 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections add skills/pending-actions-digest/render.ts skills/pending-actions-digest/render.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections commit -m "feat: add formatDueDate helper for digest backlog sections"
+```
+
+---
+
+## Task 3: `formatTimeRemaining` + `renderDigestBody`
+
+This task moves the approvals-line formatting into `render.ts` (byte-identical) and adds the three backlog sections with `+N more` truncation.
+
+**Files:**
+- Modify: `skills/pending-actions-digest/render.ts`
+- Test: `skills/pending-actions-digest/render.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skills/pending-actions-digest/render.test.ts`:
+
+```ts
+import { renderDigestBody, type ApprovalInput } from './render.js';
+import type { TaskListRow } from '../../src/db/task-repo.js';
+
+// Minimal TaskListRow factory — only the fields renderDigestBody reads matter.
+function task(overrides: Partial<TaskListRow>): TaskListRow {
+  return {
+    id: 'id', agentId: 'a', intentAnchor: 'i', status: 'open',
+    progress: {}, errorBudget: {}, conversationId: null,
+    createdAt: '2026-06-01T12:00:00.000Z', updatedAt: '2026-06-01T12:00:00.000Z',
+    title: 'Untitled', description: null, owner: 'curia',
+    waitingOnContactId: null, waitingOnText: null, parentTaskId: null,
+    blockedByTaskId: null, priority: 50, dueAt: null, source: 'agent',
+    sourceAgentId: null, createdBy: 'system', tags: [], nextWakeAt: null,
+    ...overrides,
+  };
+}
+
+function approval(overrides: Partial<ApprovalInput>): ApprovalInput {
+  return {
+    description: 'Create event: Lunch', skillName: 'create-calendar-event',
+    shortRef: 'cal-1', expiresAt: new Date(NOW_MS + 7_200_000), ...overrides,
+  };
+}
+
+describe('renderDigestBody', () => {
+  it('renders approvals only, byte-identical to the legacy format, when backlog empty', () => {
+    const body = renderDigestBody({
+      approvals: [approval({}), approval({ description: 'Send weekly update', skillName: 'send-email', shortRef: 'email-2' })],
+      ceo: [], external: [], curia: [],
+      resolveName: () => undefined, nowMs: NOW_MS, timezone: 'UTC',
+    });
+    expect(body).toBe(
+      '• Create event: Lunch [create-calendar-event] — 2h remaining [cal-1]\n' +
+      '• Send weekly update [send-email] — 2h remaining [email-2]',
+    );
+  });
+
+  it('renders all three sections after the approvals block', () => {
+    const body = renderDigestBody({
+      approvals: [approval({})],
+      ceo: [task({ owner: 'ceo', title: 'Review the Acme deck', dueAt: '2026-06-06T13:00:00.000Z', createdAt: '2026-05-31T12:00:00.000Z' })],
+      external: [task({ owner: 'external', status: 'waiting', title: 'Signed NDA', waitingOnContactId: 'c1', createdAt: '2026-06-02T12:00:00.000Z' })],
+      curia: [task({ owner: 'curia', title: 'Draft the board email', createdAt: '2026-06-03T07:00:00.000Z' })],
+      resolveName: (id) => (id === 'c1' ? 'Steve Jobs' : undefined),
+      nowMs: NOW_MS, timezone: 'UTC',
+    });
+    expect(body).toBe(
+      '• Create event: Lunch [create-calendar-event] — 2h remaining [cal-1]\n' +
+      '\n' +
+      'For you to do:\n' +
+      '• Review the Acme deck · due 2026-06-06 · age 3d\n' +
+      '\n' +
+      'Waiting on others:\n' +
+      '• Signed NDA · waiting on Steve Jobs · since 1d\n' +
+      '\n' +
+      "What I'm working on:\n" +
+      '• Draft the board email · age 5h',
+    );
+  });
+
+  it('falls back to waiting_on_text then (unknown) for unresolved counterparties', () => {
+    const body = renderDigestBody({
+      approvals: [],
+      ceo: [], curia: [],
+      external: [
+        task({ owner: 'external', status: 'waiting', title: 'A', waitingOnContactId: 'gone', waitingOnText: 'the lawyer' }),
+        task({ owner: 'external', status: 'waiting', title: 'B', waitingOnContactId: null, waitingOnText: null }),
+      ],
+      resolveName: () => undefined, nowMs: NOW_MS, timezone: 'UTC',
+    });
+    expect(body).toContain('• A · waiting on the lawyer · since');
+    expect(body).toContain('• B · waiting on (unknown) · since');
+  });
+
+  it('caps a section at 5 bullets and appends a +N more footer', () => {
+    const ceo: TaskListRow[] = Array.from({ length: 9 }, (_, i) =>
+      task({ owner: 'ceo', title: `T${i}`, createdAt: '2026-06-03T07:00:00.000Z' }),
+    );
+    const body = renderDigestBody({
+      approvals: [], ceo, external: [], curia: [],
+      resolveName: () => undefined, nowMs: NOW_MS, timezone: 'UTC',
+    });
+    const lines = body.split('\n').filter((l) => l.startsWith('• '));
+    expect(lines).toHaveLength(5);
+    expect(body).toContain('+4 more');
+  });
+
+  it('returns an empty string when there is nothing to render', () => {
+    expect(renderDigestBody({
+      approvals: [], ceo: [], external: [], curia: [],
+      resolveName: () => undefined, nowMs: NOW_MS, timezone: 'UTC',
+    })).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/render.test.ts`
+Expected: FAIL — `renderDigestBody is not exported`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `skills/pending-actions-digest/render.ts`:
+
+```ts
+import type { TaskListRow } from '../../src/db/task-repo.js';
+
+// Approval line shape — the handler maps ActionLogRow → ApprovalInput.
+export interface ApprovalInput {
+  description: string | null;
+  skillName: string;
+  shortRef: string | null;
+  expiresAt: Date | null;
+}
+
+export interface RenderDigestInput {
+  approvals: ApprovalInput[];
+  ceo: TaskListRow[];
+  external: TaskListRow[];
+  curia: TaskListRow[];
+  /** Resolve a contact id to a display name; undefined if unknown/unresolved. */
+  resolveName: (contactId: string) => string | undefined;
+  nowMs: number;
+  timezone: string;
+}
+
+/**
+ * Time remaining until an approval expires. Preserves the legacy thresholds
+ * exactly: <=0 or <1h both render '<1h remaining'.
+ */
+export function formatTimeRemaining(expiresAt: Date | null, nowMs: number): string {
+  const ms = expiresAt != null ? expiresAt.getTime() - nowMs : 0;
+  if (ms <= 0 || ms < MS_HOUR) return '<1h remaining';
+  return `${Math.floor(ms / MS_HOUR)}h remaining`;
+}
+
+function approvalLine(a: ApprovalInput, nowMs: number): string {
+  return `• ${a.description ?? '(no description)'} [${a.skillName}] — ${formatTimeRemaining(a.expiresAt, nowMs)} [${a.shortRef ?? '—'}]`;
+}
+
+// Render a backlog section: heading, up to 5 bullets, optional "+N more" footer.
+// `lines` are pre-formatted bullet bodies (without the leading "• ").
+function section(heading: string, lines: string[]): string {
+  const shown = lines.slice(0, 5).map((l) => `• ${l}`);
+  if (lines.length > 5) shown.push(`+${lines.length - 5} more`);
+  return `${heading}:\n${shown.join('\n')}`;
+}
+
+/**
+ * Build the full digest email body: the approvals block (byte-identical to the
+ * legacy format) followed by each non-empty backlog section. Sections are
+ * separated by a blank line. Returns '' when there is nothing to render.
+ */
+export function renderDigestBody(input: RenderDigestInput): string {
+  const { approvals, ceo, external, curia, resolveName, nowMs, timezone } = input;
+  const blocks: string[] = [];
+
+  if (approvals.length > 0) {
+    blocks.push(approvals.map((a) => approvalLine(a, nowMs)).join('\n'));
+  }
+
+  if (ceo.length > 0) {
+    blocks.push(section('For you to do', ceo.map((t) =>
+      `${t.title} · due ${formatDueDate(t.dueAt, timezone)} · age ${humanizeAge(t.createdAt, nowMs)}`,
+    )));
+  }
+
+  if (external.length > 0) {
+    blocks.push(section('Waiting on others', external.map((t) => {
+      const name = (t.waitingOnContactId ? resolveName(t.waitingOnContactId) : undefined)
+        ?? t.waitingOnText ?? '(unknown)';
+      return `${t.title} · waiting on ${name} · since ${humanizeAge(t.createdAt, nowMs)}`;
+    })));
+  }
+
+  if (curia.length > 0) {
+    blocks.push(section("What I'm working on", curia.map((t) =>
+      `${t.title} · age ${humanizeAge(t.createdAt, nowMs)}`,
+    )));
+  }
+
+  return blocks.join('\n\n');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/render.test.ts`
+Expected: PASS (all render tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections add skills/pending-actions-digest/render.ts skills/pending-actions-digest/render.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections commit -m "feat: add renderDigestBody with backlog sections and +N more truncation"
+```
+
+---
+
+## Task 4: Wire the handler to fetch backlog and send adaptively
+
+**Files:**
+- Modify: `skills/pending-actions-digest/handler.ts`
+- Modify: `skills/pending-actions-digest/handler.test.ts`
+
+- [ ] **Step 1: Write the failing tests (backlog path + updated data shape)**
+
+In `skills/pending-actions-digest/handler.test.ts`:
+
+(a) Extend `makeCtx`'s options and context to support a task repo and contact service. Replace the `overrides` destructuring and the `ctx` object with:
+
+```ts
+function makeCtx(overrides: {
+  pendingRows?: ActionLogRow[];
+  sendResult?: boolean;
+  ceoEmail?: string;
+  noOutboundGateway?: boolean;
+  ceoTasks?: unknown[];
+  externalTasks?: unknown[];
+  curiaTasks?: unknown[];
+  listTasksError?: boolean;
+  contactName?: string;
+  noTaskRepo?: boolean;
+} = {}) {
+  const {
+    pendingRows = [],
+    sendResult = true,
+    ceoEmail = 'ceo@example.com',
+    noOutboundGateway = false,
+    ceoTasks = [],
+    externalTasks = [],
+    curiaTasks = [],
+    listTasksError = false,
+    contactName = 'Steve Jobs',
+    noTaskRepo = false,
+  } = overrides;
+
+  process.env['CEO_PRIMARY_EMAIL'] = ceoEmail;
+
+  const findAllPendingMock = vi.fn().mockResolvedValue(pendingRows);
+  const sendNotificationMock = vi.fn().mockResolvedValue(sendResult);
+  const logWarnMock = vi.fn();
+  const logErrorMock = vi.fn();
+
+  // listTasks routes by the `owner` filter so each section gets its own fixture.
+  const listTasksMock = vi.fn().mockImplementation(async (filters: { owner?: string }) => {
+    if (listTasksError) throw new Error('tasks query failed');
+    if (filters.owner === 'ceo') return ceoTasks;
+    if (filters.owner === 'external') return externalTasks;
+    if (filters.owner === 'curia') return curiaTasks;
+    return [];
+  });
+  const getContactMock = vi.fn().mockResolvedValue({ displayName: contactName });
+
+  const ctx: SkillContext = {
+    input: {},
+    secret: vi.fn().mockImplementation((name: string) => {
+      throw new Error(`secret ${name} not configured`);
+    }),
+    log: { info: vi.fn(), warn: logWarnMock, error: logErrorMock, debug: vi.fn() } as unknown as SkillContext['log'],
+    timezone: 'UTC',
+    actionLogRepo: { findAllPending: findAllPendingMock } as unknown as ActionLogRepo,
+    outboundGateway: noOutboundGateway
+      ? undefined
+      : ({ sendNotification: sendNotificationMock } as unknown as OutboundGateway),
+    taskRepo: noTaskRepo ? undefined : ({ listTasks: listTasksMock } as unknown as SkillContext['taskRepo']),
+    contactService: { getContact: getContactMock } as unknown as SkillContext['contactService'],
+  } as SkillContext;
+
+  return { ctx, findAllPendingMock, sendNotificationMock, logWarnMock, logErrorMock, listTasksMock, getContactMock };
+}
+```
+
+(b) Update the five existing `result.data` assertions to include the new count fields (all zero when no tasks are seeded). Apply these exact replacements:
+
+- "no pending rows" test → `expect(result.data).toEqual({ pending: 0, skipped: true, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });`
+- "sends a single digest notification" test → `expect(result.data).toEqual({ pending: 2, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });`
+- "CEO_PRIMARY_EMAIL is not set" test → `expect(result.data).toEqual({ pending: 1, skipped: true, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });`
+- "outboundGateway is not available" test → `expect(result.data).toEqual({ pending: 1, skipped: true, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });`
+- "sendNotification returning false" test → `expect(result.data).toEqual({ pending: 1, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });`
+
+(c) Add a task-row factory and new tests at the end of the `describe` block:
+
+```ts
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'id', agentId: 'a', intentAnchor: 'i', status: 'open',
+    progress: {}, errorBudget: {}, conversationId: null,
+    createdAt: new Date(FIXED_NOW - 3_600_000).toISOString(),
+    updatedAt: new Date(FIXED_NOW - 3_600_000).toISOString(),
+    title: 'A task', description: null, owner: 'curia',
+    waitingOnContactId: null, waitingOnText: null, parentTaskId: null,
+    blockedByTaskId: null, priority: 50, dueAt: null, source: 'agent',
+    sourceAgentId: null, createdBy: 'system', tags: [], nextWakeAt: null,
+    ...overrides,
+  };
+}
+
+it('sends a backlog-only digest with an adaptive subject when there are no approvals', async () => {
+  const handler = new PendingActionsDigestHandler();
+  const { ctx, sendNotificationMock } = makeCtx({
+    pendingRows: [],
+    ceoTasks: [makeTask({ owner: 'ceo', title: 'Review the Acme deck' })],
+    externalTasks: [makeTask({ owner: 'external', status: 'waiting', title: 'Signed NDA', waitingOnContactId: 'c1' })],
+  });
+
+  const result = await handler.execute(ctx);
+
+  expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  const payload = sendNotificationMock.mock.calls[0][0];
+  expect(payload.subject).toBe('Your daily brief — 2 item(s) need you');
+  expect(payload.body).toContain('For you to do:');
+  expect(payload.body).toContain('• Review the Acme deck');
+  expect(payload.body).toContain('Waiting on others:');
+  expect(payload.body).toContain('• Signed NDA · waiting on Steve Jobs · since');
+  expect(result.success).toBe(true);
+  if (!result.success) throw new Error('unreachable');
+  expect(result.data).toEqual({ pending: 0, skipped: false, tasksForCeo: 1, tasksWaiting: 1, tasksWorking: 0 });
+});
+
+it('keeps the approvals subject and appends backlog when approvals are present', async () => {
+  const handler = new PendingActionsDigestHandler();
+  const { ctx, sendNotificationMock } = makeCtx({
+    pendingRows: [makeRow({ id: 1, shortRef: 'cal-1' })],
+    curiaTasks: [makeTask({ owner: 'curia', title: 'Draft the board email' })],
+  });
+
+  await handler.execute(ctx);
+
+  const payload = sendNotificationMock.mock.calls[0][0];
+  expect(payload.subject).toBe('Pending approvals — 1 request(s) awaiting your decision');
+  expect(payload.body).toContain('cal-1');
+  expect(payload.body).toContain("What I'm working on:");
+  expect(payload.body).toContain('• Draft the board email');
+});
+
+it('does NOT send when only "what I\'m working on" is non-empty', async () => {
+  const handler = new PendingActionsDigestHandler();
+  const { ctx, sendNotificationMock } = makeCtx({
+    pendingRows: [],
+    curiaTasks: [makeTask({ owner: 'curia', title: 'Internal cleanup' })],
+  });
+
+  const result = await handler.execute(ctx);
+
+  expect(sendNotificationMock).not.toHaveBeenCalled();
+  expect(result.success).toBe(true);
+  if (!result.success) throw new Error('unreachable');
+  expect(result.data).toEqual({ pending: 0, skipped: true, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 1 });
+});
+
+it('degrades to an approvals-only digest when the task query fails', async () => {
+  const handler = new PendingActionsDigestHandler();
+  const { ctx, sendNotificationMock, logWarnMock } = makeCtx({
+    pendingRows: [makeRow({ id: 1, shortRef: 'cal-1' })],
+    listTasksError: true,
+  });
+
+  const result = await handler.execute(ctx);
+
+  expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  expect(logWarnMock).toHaveBeenCalled();
+  const payload = sendNotificationMock.mock.calls[0][0];
+  expect(payload.body).toContain('cal-1');
+  expect(payload.body).not.toContain('For you to do:');
+  expect(result.success).toBe(true);
+  if (!result.success) throw new Error('unreachable');
+  expect(result.data).toEqual({ pending: 1, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/handler.test.ts`
+Expected: FAIL — new tests fail (subject/body/data mismatches) and the updated `toEqual` assertions fail against the current handler's `{ pending, skipped }`-only data.
+
+- [ ] **Step 3: Rewrite the handler**
+
+Replace the entire body of `skills/pending-actions-digest/handler.ts` with:
+
+```ts
+// handler.ts — pending-actions-digest skill implementation.
+//
+// Daily CEO digest. Sends a single email summarizing: (1) outstanding approval
+// requests awaiting a decision, and (2) the task backlog grouped by owner —
+// "For you to do" (ceo), "Waiting on others" (external), and "What I'm working
+// on" (curia). Body formatting lives in render.ts (pure, snapshot-tested).
+//
+// Send gate: the email goes out when there is at least one approval, or any
+// ceo/external backlog item. "What I'm working on" alone never triggers a send.
+//
+// Non-fatal / graceful modes:
+//   - CEO_PRIMARY_EMAIL not configured → skipped: true
+//   - outboundGateway absent → skipped: true
+//   - taskRepo absent OR listTasks throws → backlog treated as empty (warn),
+//     approvals still send
+//   - sendNotification() returns false → logged at warn, not propagated
+//   - Nothing to show (no approvals, no ceo/external tasks) → skipped: true
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ActionLogRow } from '../../src/autonomy/action-log-types.js';
+import type { TaskListRow } from '../../src/db/task-repo.js';
+import { renderDigestBody, type ApprovalInput } from './render.js';
+
+// Per-section fetch cap. Sections render the top 5; the extra rows feed an exact
+// "+N more" footer (so N is capped at 45). Hitting the cap logs a warn so a
+// runaway backlog cannot be silently truncated.
+const SECTION_FETCH_LIMIT = 50;
+
+interface Backlog {
+  ceo: TaskListRow[];
+  external: TaskListRow[];
+  curia: TaskListRow[];
+}
+
+/**
+ * Fetch the three backlog sections. Resilient by design: an absent taskRepo or a
+ * failing query degrades to empty sections (with a warn) so the approvals digest
+ * still goes out rather than failing wholesale.
+ */
+async function fetchBacklog(ctx: SkillContext): Promise<Backlog> {
+  if (!ctx.taskRepo) return { ceo: [], external: [], curia: [] };
+  try {
+    const [ceo, external, curia] = await Promise.all([
+      ctx.taskRepo.listTasks({ owner: 'ceo', statuses: ['open', 'in_progress'], limit: SECTION_FETCH_LIMIT }),
+      ctx.taskRepo.listTasks({ owner: 'external', statuses: ['waiting'], limit: SECTION_FETCH_LIMIT }),
+      ctx.taskRepo.listTasks({ owner: 'curia', statuses: ['open', 'in_progress'], limit: SECTION_FETCH_LIMIT }),
+    ]);
+    for (const [label, list] of [['ceo', ceo], ['external', external], ['curia', curia]] as const) {
+      if (list.length >= SECTION_FETCH_LIMIT) {
+        ctx.log.warn({ section: label, count: list.length }, 'pending-actions-digest: section hit fetch cap; +N more is a floor');
+      }
+    }
+    return { ceo, external, curia };
+  } catch (err) {
+    // Non-fatal: log and fall back to empty backlog so approvals still send.
+    ctx.log.warn({ err }, 'pending-actions-digest: backlog fetch failed; sending approvals-only digest');
+    return { ceo: [], external: [], curia: [] };
+  }
+}
+
+/** Resolve external tasks' waiting_on_contact_id values to display names. */
+async function resolveContactNames(
+  ctx: SkillContext,
+  external: TaskListRow[],
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  if (!ctx.contactService) return names;
+  const ids = [...new Set(external.map((t) => t.waitingOnContactId).filter((x): x is string => x !== null))];
+  for (const id of ids) {
+    const contact = await ctx.contactService.getContact(id);
+    if (contact) names.set(id, contact.displayName);
+  }
+  return names;
+}
+
+export class PendingActionsDigestHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    try {
+      if (!ctx.actionLogRepo) {
+        return { success: false, error: 'pending-actions-digest requires actionLogRepo capability' };
+      }
+
+      // --- Step 1: Load approvals and backlog ---
+      const pending: ActionLogRow[] = await ctx.actionLogRepo.findAllPending();
+      const backlog = await fetchBacklog(ctx);
+
+      const counts = {
+        tasksForCeo: backlog.ceo.length,
+        tasksWaiting: backlog.external.length,
+        tasksWorking: backlog.curia.length,
+      };
+
+      // --- Step 2: Send gate ---
+      // Send when there are approvals OR the CEO owes/awaits something. "What I'm
+      // working on" (curia) alone is informational and never triggers a send.
+      const shouldSend = pending.length > 0 || backlog.ceo.length > 0 || backlog.external.length > 0;
+      if (!shouldSend) {
+        return { success: true, data: { pending: pending.length, skipped: true, ...counts } };
+      }
+
+      // --- Step 3: Delivery preconditions ---
+      // Read CEO email from env (not ctx.secret(), which throws on a missing var).
+      const ceoEmail = process.env['CEO_PRIMARY_EMAIL'] ?? '';
+      if (!ceoEmail) {
+        ctx.log.warn({ pendingCount: pending.length }, 'pending-actions-digest: CEO_PRIMARY_EMAIL not configured, skipping digest');
+        return { success: true, data: { pending: pending.length, skipped: true, ...counts } };
+      }
+      if (ctx.outboundGateway === undefined) {
+        ctx.log.warn({ pendingCount: pending.length }, 'pending-actions-digest: outboundGateway not available, skipping digest');
+        return { success: true, data: { pending: pending.length, skipped: true, ...counts } };
+      }
+
+      // --- Step 4: Build the body ---
+      const nameMap = await resolveContactNames(ctx, backlog.external);
+      const nowMs = Date.now();
+      const approvals: ApprovalInput[] = pending.map((r) => ({
+        description: r.description,
+        skillName: r.skillName,
+        shortRef: r.shortRef,
+        expiresAt: r.expiresAt,
+      }));
+
+      const body = renderDigestBody({
+        approvals,
+        ceo: backlog.ceo,
+        external: backlog.external,
+        curia: backlog.curia,
+        resolveName: (id) => nameMap.get(id),
+        nowMs,
+        timezone: ctx.timezone ?? 'UTC',
+      });
+
+      // --- Step 5: Adaptive subject ---
+      // Approvals present → urgency-forward approvals subject (unchanged).
+      // Backlog-only → daily brief framing; N counts the items that need the CEO.
+      const needsCeo = backlog.ceo.length + backlog.external.length;
+      const subject = pending.length > 0
+        ? `Pending approvals — ${pending.length} request(s) awaiting your decision`
+        : `Your daily brief — ${needsCeo} item(s) need you`;
+
+      // --- Step 6: Send ---
+      const sent = await ctx.outboundGateway.sendNotification({
+        notificationType: 'pending_actions_digest',
+        ceoEmail,
+        subject,
+        body,
+      });
+
+      if (!sent) {
+        ctx.log.warn({ pendingCount: pending.length }, 'pending-actions-digest: sendNotification returned false — CEO digest not delivered');
+      }
+
+      return { success: true, data: { pending: pending.length, skipped: false, ...counts } };
+    } catch (e) {
+      ctx.log.error({ err: e }, 'pending-actions-digest: unexpected error');
+      return { success: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/`
+Expected: PASS (all handler + render tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections add skills/pending-actions-digest/handler.ts skills/pending-actions-digest/handler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections commit -m "feat: surface task backlog in pending-actions-digest (#838)"
+```
+
+---
+
+## Task 5: Manifest + CHANGELOG
+
+**Files:**
+- Modify: `skills/pending-actions-digest/skill.json`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update the manifest**
+
+In `skills/pending-actions-digest/skill.json`: bump `version` to `"1.1.0"`, add the `taskRepo` capability, and add the three count outputs. The result:
+
+```json
+{
+  "name": "pending-actions-digest",
+  "description": "Send a daily digest of open approval requests and the task backlog awaiting CEO attention.",
+  "version": "1.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "pending": "number — count of open approval requests included in digest",
+    "skipped": "boolean — true if digest was not sent (nothing to show, or CEO_PRIMARY_EMAIL / outboundGateway not configured)",
+    "tasksForCeo": "number — open/in_progress tasks owned by the CEO",
+    "tasksWaiting": "number — external tasks in 'waiting' status",
+    "tasksWorking": "number — open/in_progress tasks owned by Curia"
+  },
+  "permissions": [],
+  "secrets": ["CEO_PRIMARY_EMAIL"],
+  "timeout": 30000,
+  "capabilities": ["actionLogRepo", "outboundGateway", "taskRepo"]
+}
+```
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## [Unreleased]` → `### Added` (create the `### Added` subsection if it does not exist), add:
+
+```markdown
+- **`pending-actions-digest`** — daily digest now surfaces the task backlog: for-you-to-do, waiting-on-others, and what-I'm-working-on. (#838)
+```
+
+- [ ] **Step 3: Verify the manifest parses**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec node -e "JSON.parse(require('fs').readFileSync('skills/pending-actions-digest/skill.json','utf8')); console.log('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections add skills/pending-actions-digest/skill.json CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections commit -m "chore: bump pending-actions-digest to 1.1.0; changelog for #838"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections run typecheck`
+Expected: no errors. (If `result.rows[0]` / array-access strictness bites in test fixtures, apply `!` per the codebase convention.)
+
+- [ ] **Step 2: Run the skill's full test suite**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/pending-actions-digest/`
+Expected: PASS — all render + handler tests green, including the legacy approvals tests (proof the approvals block is unchanged).
+
+- [ ] **Step 3: Run lint (if configured)**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections run lint`
+Expected: no errors in the changed files. (No `console.log`; pino/`ctx.log` only.)
+
+- [ ] **Step 4: Confirm no migration-ordering or unrelated breakage**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-digest-backlog-sections exec vitest run skills/ src/skills/`
+Expected: PASS — no regressions in neighbouring skill tests.
+
+---
+
+## Self-Review Notes (author checklist — completed)
+
+- **Spec coverage:** §3 data sources → Tasks 3–4; §4 send gate + adaptive subject → Task 4; §5 line formats + `+N more` → Task 3; §6 pure-function refactor → Task 3; §7 manifest/version/changelog → Task 5. AC owner-resolution fallback (`contact → text → (unknown)`) → Task 3 test. AC "approvals block unchanged" → legacy `handler.test.ts` kept green (Task 4 / Task 6 Step 2).
+- **Out of scope confirmed:** no change to `digest.yaml`, task skills, scheduler, or coordinator.
+- **Type consistency:** `ApprovalInput`, `RenderDigestInput`, `renderDigestBody`, `humanizeAge`, `formatDueDate`, `formatTimeRemaining`, `fetchBacklog`, `resolveContactNames` referenced consistently across tasks; `TaskListRow.createdAt`/`dueAt` treated as ISO strings throughout.
+- **Manual / staging verification** (AC item, post-merge, not automatable here): confirm the next day's staging digest email contains populated sections.
+```

--- a/skills/pending-actions-digest/handler.test.ts
+++ b/skills/pending-actions-digest/handler.test.ts
@@ -49,42 +49,59 @@ function makeCtx(overrides: {
   sendResult?: boolean;
   ceoEmail?: string;
   noOutboundGateway?: boolean;
+  ceoTasks?: unknown[];
+  externalTasks?: unknown[];
+  curiaTasks?: unknown[];
+  listTasksError?: boolean;
+  contactName?: string;
+  noTaskRepo?: boolean;
 } = {}) {
   const {
     pendingRows = [],
     sendResult = true,
     ceoEmail = 'ceo@example.com',
     noOutboundGateway = false,
+    ceoTasks = [],
+    externalTasks = [],
+    curiaTasks = [],
+    listTasksError = false,
+    contactName = 'Steve Jobs',
+    noTaskRepo = false,
   } = overrides;
 
-  // The handler reads CEO_PRIMARY_EMAIL from process.env directly (not ctx.secret()),
-  // so set it here. Tests that need it absent should pass ceoEmail: ''.
   process.env['CEO_PRIMARY_EMAIL'] = ceoEmail;
 
-  // Keep explicit references so tests can assert on mock calls without casts.
   const findAllPendingMock = vi.fn().mockResolvedValue(pendingRows);
   const sendNotificationMock = vi.fn().mockResolvedValue(sendResult);
   const logWarnMock = vi.fn();
   const logErrorMock = vi.fn();
 
+  // listTasks routes by the `owner` filter so each section gets its own fixture.
+  const listTasksMock = vi.fn().mockImplementation(async (filters: { owner?: string }) => {
+    if (listTasksError) throw new Error('tasks query failed');
+    if (filters.owner === 'ceo') return ceoTasks;
+    if (filters.owner === 'external') return externalTasks;
+    if (filters.owner === 'curia') return curiaTasks;
+    return [];
+  });
+  const getContactMock = vi.fn().mockResolvedValue({ displayName: contactName });
+
   const ctx: SkillContext = {
     input: {},
-    // ctx.secret() throws in production when the var is unset — mirror that here.
-    // The handler reads CEO_PRIMARY_EMAIL via process.env directly, so this stub
-    // is present for shape correctness only.
     secret: vi.fn().mockImplementation((name: string) => {
       throw new Error(`secret ${name} not configured`);
     }),
     log: { info: vi.fn(), warn: logWarnMock, error: logErrorMock, debug: vi.fn() } as unknown as SkillContext['log'],
-    actionLogRepo: {
-      findAllPending: findAllPendingMock,
-    } as unknown as ActionLogRepo,
+    timezone: 'UTC',
+    actionLogRepo: { findAllPending: findAllPendingMock } as unknown as ActionLogRepo,
     outboundGateway: noOutboundGateway
       ? undefined
       : ({ sendNotification: sendNotificationMock } as unknown as OutboundGateway),
+    taskRepo: noTaskRepo ? undefined : ({ listTasks: listTasksMock } as unknown as SkillContext['taskRepo']),
+    contactService: { getContact: getContactMock } as unknown as SkillContext['contactService'],
   } as SkillContext;
 
-  return { ctx, findAllPendingMock, sendNotificationMock, logWarnMock, logErrorMock };
+  return { ctx, findAllPendingMock, sendNotificationMock, logWarnMock, logErrorMock, listTasksMock, getContactMock };
 }
 
 // --- Lifecycle hooks ---
@@ -111,7 +128,7 @@ describe('PendingActionsDigestHandler', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
-    expect(result.data).toEqual({ pending: 0, skipped: true });
+    expect(result.data).toEqual({ pending: 0, skipped: true, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
     expect(sendNotificationMock).not.toHaveBeenCalled();
   });
 
@@ -138,7 +155,7 @@ describe('PendingActionsDigestHandler', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
-    expect(result.data).toEqual({ pending: 2, skipped: false });
+    expect(result.data).toEqual({ pending: 2, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
   });
 
   it('each entry includes shortRef, description, skillName, and time remaining', async () => {
@@ -186,7 +203,7 @@ describe('PendingActionsDigestHandler', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
-    expect(result.data).toEqual({ pending: 1, skipped: true });
+    expect(result.data).toEqual({ pending: 1, skipped: true, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
   });
 
   it('skips notification when outboundGateway is not available', async () => {
@@ -201,7 +218,7 @@ describe('PendingActionsDigestHandler', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
-    expect(result.data).toEqual({ pending: 1, skipped: true });
+    expect(result.data).toEqual({ pending: 1, skipped: true, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
   });
 
   it('handles sendNotification returning false gracefully', async () => {
@@ -215,7 +232,7 @@ describe('PendingActionsDigestHandler', () => {
     // Non-fatal — skill should still succeed and report skipped:false (the send was attempted)
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
-    expect(result.data).toEqual({ pending: 1, skipped: false });
+    expect(result.data).toEqual({ pending: 1, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
   });
 
   it('returns success:false on unexpected error', async () => {
@@ -230,5 +247,91 @@ describe('PendingActionsDigestHandler', () => {
     expect(result.success).toBe(false);
     if (result.success) throw new Error('unreachable');
     expect(result.error).toContain('DB error');
+  });
+
+  function makeTask(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'id', agentId: 'a', intentAnchor: 'i', status: 'open',
+      progress: {}, errorBudget: {}, conversationId: null,
+      createdAt: new Date(FIXED_NOW - 3_600_000).toISOString(),
+      updatedAt: new Date(FIXED_NOW - 3_600_000).toISOString(),
+      title: 'A task', description: null, owner: 'curia',
+      waitingOnContactId: null, waitingOnText: null, parentTaskId: null,
+      blockedByTaskId: null, priority: 50, dueAt: null, source: 'agent',
+      sourceAgentId: null, createdBy: 'system', tags: [], nextWakeAt: null,
+      ...overrides,
+    };
+  }
+
+  it('sends a backlog-only digest with an adaptive subject when there are no approvals', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const { ctx, sendNotificationMock } = makeCtx({
+      pendingRows: [],
+      ceoTasks: [makeTask({ owner: 'ceo', title: 'Review the Acme deck' })],
+      externalTasks: [makeTask({ owner: 'external', status: 'waiting', title: 'Signed NDA', waitingOnContactId: 'c1' })],
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    const payload = sendNotificationMock.mock.calls[0]![0];
+    expect(payload.subject).toBe('Your daily brief — 2 item(s) need you');
+    expect(payload.body).toContain('For you to do:');
+    expect(payload.body).toContain('• Review the Acme deck');
+    expect(payload.body).toContain('Waiting on others:');
+    expect(payload.body).toContain('• Signed NDA · waiting on Steve Jobs · since');
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 0, skipped: false, tasksForCeo: 1, tasksWaiting: 1, tasksWorking: 0 });
+  });
+
+  it('keeps the approvals subject and appends backlog when approvals are present', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const { ctx, sendNotificationMock } = makeCtx({
+      pendingRows: [makeRow({ id: 1, shortRef: 'cal-1' })],
+      curiaTasks: [makeTask({ owner: 'curia', title: 'Draft the board email' })],
+    });
+
+    await handler.execute(ctx);
+
+    const payload = sendNotificationMock.mock.calls[0]![0];
+    expect(payload.subject).toBe('Pending approvals — 1 request(s) awaiting your decision');
+    expect(payload.body).toContain('cal-1');
+    expect(payload.body).toContain("What I'm working on:");
+    expect(payload.body).toContain('• Draft the board email');
+  });
+
+  it('does NOT send when only "what I\'m working on" is non-empty', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const { ctx, sendNotificationMock } = makeCtx({
+      pendingRows: [],
+      curiaTasks: [makeTask({ owner: 'curia', title: 'Internal cleanup' })],
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 0, skipped: true, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 1 });
+  });
+
+  it('degrades to an approvals-only digest when the task query fails', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({
+      pendingRows: [makeRow({ id: 1, shortRef: 'cal-1' })],
+      listTasksError: true,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    expect(logWarnMock).toHaveBeenCalled();
+    const payload = sendNotificationMock.mock.calls[0]![0];
+    expect(payload.body).toContain('cal-1');
+    expect(payload.body).not.toContain('For you to do:');
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 1, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
   });
 });

--- a/skills/pending-actions-digest/handler.test.ts
+++ b/skills/pending-actions-digest/handler.test.ts
@@ -55,6 +55,7 @@ function makeCtx(overrides: {
   listTasksError?: boolean;
   contactName?: string;
   noTaskRepo?: boolean;
+  contactLookupError?: boolean;
 } = {}) {
   const {
     pendingRows = [],
@@ -67,6 +68,7 @@ function makeCtx(overrides: {
     listTasksError = false,
     contactName = 'Steve Jobs',
     noTaskRepo = false,
+    contactLookupError = false,
   } = overrides;
 
   process.env['CEO_PRIMARY_EMAIL'] = ceoEmail;
@@ -84,7 +86,9 @@ function makeCtx(overrides: {
     if (filters.owner === 'curia') return curiaTasks;
     return [];
   });
-  const getContactMock = vi.fn().mockResolvedValue({ displayName: contactName });
+  const getContactMock = contactLookupError
+    ? vi.fn().mockRejectedValue(new Error('contact lookup failed'))
+    : vi.fn().mockResolvedValue({ displayName: contactName });
 
   const ctx: SkillContext = {
     input: {},
@@ -352,5 +356,29 @@ describe('PendingActionsDigestHandler', () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
     expect(result.data).toEqual({ pending: 1, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
+  });
+
+  it('still sends the digest and falls back to (unknown) when contact lookup fails', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({
+      pendingRows: [],
+      ceoTasks: [],
+      externalTasks: [makeTask({ owner: 'external', status: 'waiting', title: 'Signed NDA', waitingOnContactId: 'c1', waitingOnText: null })],
+      curiaTasks: [],
+      contactLookupError: true,
+    });
+
+    const result = await handler.execute(ctx);
+
+    // Digest still sends despite the failed lookup
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    // A warn must be emitted for the failed lookup
+    expect(logWarnMock).toHaveBeenCalled();
+    // Body falls back to '(unknown)' since both contact and waitingOnText are null
+    const payload = sendNotificationMock.mock.calls[0]![0];
+    expect(payload.body).toContain('• Signed NDA · waiting on (unknown) · since');
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 0, skipped: false, tasksForCeo: 0, tasksWaiting: 1, tasksWorking: 0 });
   });
 });

--- a/skills/pending-actions-digest/handler.test.ts
+++ b/skills/pending-actions-digest/handler.test.ts
@@ -318,7 +318,7 @@ describe('PendingActionsDigestHandler', () => {
 
   it('degrades to an approvals-only digest when the task query fails', async () => {
     const handler = new PendingActionsDigestHandler();
-    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({
+    const { ctx, sendNotificationMock, logErrorMock } = makeCtx({
       pendingRows: [makeRow({ id: 1, shortRef: 'cal-1' })],
       listTasksError: true,
     });
@@ -326,7 +326,7 @@ describe('PendingActionsDigestHandler', () => {
     const result = await handler.execute(ctx);
 
     expect(sendNotificationMock).toHaveBeenCalledTimes(1);
-    expect(logWarnMock).toHaveBeenCalled();
+    expect(logErrorMock).toHaveBeenCalled();
     const payload = sendNotificationMock.mock.calls[0]![0];
     expect(payload.body).toContain('cal-1');
     expect(payload.body).not.toContain('For you to do:');

--- a/skills/pending-actions-digest/handler.test.ts
+++ b/skills/pending-actions-digest/handler.test.ts
@@ -334,4 +334,23 @@ describe('PendingActionsDigestHandler', () => {
     if (!result.success) throw new Error('unreachable');
     expect(result.data).toEqual({ pending: 1, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
   });
+
+  it('degrades to an approvals-only digest when taskRepo is absent', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({
+      pendingRows: [makeRow({ id: 1, shortRef: 'cal-1' })],
+      noTaskRepo: true,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    expect(logWarnMock).toHaveBeenCalled();
+    const payload = sendNotificationMock.mock.calls[0]![0];
+    expect(payload.body).toContain('cal-1');
+    expect(payload.body).not.toContain('For you to do:');
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 1, skipped: false, tasksForCeo: 0, tasksWaiting: 0, tasksWorking: 0 });
+  });
 });

--- a/skills/pending-actions-digest/handler.ts
+++ b/skills/pending-actions-digest/handler.ts
@@ -1,30 +1,81 @@
 // handler.ts — pending-actions-digest skill implementation.
 //
-// Digest skill: fetches all non-expired pending_approval rows and sends a
-// single summary email to the CEO so they can see all outstanding requests
-// in one place. Designed to be run on a daily schedule.
+// Daily CEO digest. Sends a single email summarizing: (1) outstanding approval
+// requests awaiting a decision, and (2) the task backlog grouped by owner —
+// "For you to do" (ceo), "Waiting on others" (external), and "What I'm working
+// on" (curia). Body formatting lives in render.ts (pure, snapshot-tested).
 //
-// Non-fatal failure modes:
-//   - CEO_PRIMARY_EMAIL not configured → returns skipped: true
-//   - outboundGateway absent → returns skipped: true
+// Send gate: the email goes out when there is at least one approval, or any
+// ceo/external backlog item. "What I'm working on" alone never triggers a send.
+//
+// Non-fatal / graceful modes:
+//   - CEO_PRIMARY_EMAIL not configured → skipped: true
+//   - outboundGateway absent → skipped: true
+//   - taskRepo absent OR listTasks throws → backlog treated as empty (warn),
+//     approvals still send
 //   - sendNotification() returns false → logged at warn, not propagated
-//   - No pending rows → returns skipped: true, no email sent
+//   - Nothing to show (no approvals, no ceo/external tasks) → skipped: true
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { ActionLogRow } from '../../src/autonomy/action-log-types.js';
+import type { TaskListRow } from '../../src/db/task-repo.js';
+import { renderDigestBody, type ApprovalInput } from './render.js';
+
+// Per-section fetch cap. Sections render the top 5; the extra rows feed an exact
+// "+N more" footer (so N is capped at 45). Hitting the cap logs a warn so a
+// runaway backlog cannot be silently truncated.
+const SECTION_FETCH_LIMIT = 50;
+
+interface Backlog {
+  ceo: TaskListRow[];
+  external: TaskListRow[];
+  curia: TaskListRow[];
+}
 
 /**
- * Format time remaining until expiry into a human-readable string.
- * Used to show the CEO how much time is left to act on each request.
- *
- * Thresholds:
- *   ms <= 0 or ms < 1h → '<1h remaining' (treat as critical, same label)
- *   else               → '<N>h remaining'
+ * Fetch the three backlog sections. Resilient by design: an absent taskRepo or a
+ * failing query degrades to empty sections (with a warn) so the approvals digest
+ * still goes out rather than failing wholesale.
  */
-function formatTimeRemaining(ms: number): string {
-  if (ms <= 0) return '<1h remaining';
-  if (ms < 3_600_000) return '<1h remaining';
-  return `${Math.floor(ms / 3_600_000)}h remaining`;
+async function fetchBacklog(ctx: SkillContext): Promise<Backlog> {
+  if (!ctx.taskRepo) return { ceo: [], external: [], curia: [] };
+  try {
+    const [ceo, external, curia] = await Promise.all([
+      ctx.taskRepo.listTasks({ owner: 'ceo', statuses: ['open', 'in_progress'], limit: SECTION_FETCH_LIMIT }),
+      ctx.taskRepo.listTasks({ owner: 'external', statuses: ['waiting'], limit: SECTION_FETCH_LIMIT }),
+      ctx.taskRepo.listTasks({ owner: 'curia', statuses: ['open', 'in_progress'], limit: SECTION_FETCH_LIMIT }),
+    ]);
+    // Warn if any section hit the fetch cap so truncation is visible in logs.
+    if (ceo.length >= SECTION_FETCH_LIMIT) {
+      ctx.log.warn({ section: 'ceo', count: ceo.length }, 'pending-actions-digest: section hit fetch cap; +N more is a floor');
+    }
+    if (external.length >= SECTION_FETCH_LIMIT) {
+      ctx.log.warn({ section: 'external', count: external.length }, 'pending-actions-digest: section hit fetch cap; +N more is a floor');
+    }
+    if (curia.length >= SECTION_FETCH_LIMIT) {
+      ctx.log.warn({ section: 'curia', count: curia.length }, 'pending-actions-digest: section hit fetch cap; +N more is a floor');
+    }
+    return { ceo, external, curia };
+  } catch (err) {
+    // Non-fatal: log and fall back to empty backlog so approvals still send.
+    ctx.log.warn({ err }, 'pending-actions-digest: backlog fetch failed; sending approvals-only digest');
+    return { ceo: [], external: [], curia: [] };
+  }
+}
+
+/** Resolve external tasks' waiting_on_contact_id values to display names. */
+async function resolveContactNames(
+  ctx: SkillContext,
+  external: TaskListRow[],
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  if (!ctx.contactService) return names;
+  const ids = [...new Set(external.map((t) => t.waitingOnContactId).filter((x): x is string => x !== null))];
+  for (const id of ids) {
+    const contact = await ctx.contactService.getContact(id);
+    if (contact) names.set(id, contact.displayName);
+  }
+  return names;
 }
 
 export class PendingActionsDigestHandler implements SkillHandler {
@@ -34,53 +85,65 @@ export class PendingActionsDigestHandler implements SkillHandler {
         return { success: false, error: 'pending-actions-digest requires actionLogRepo capability' };
       }
 
-      // --- Step 1: Load all non-expired pending_approval rows ---
+      // --- Step 1: Load approvals and backlog ---
       const pending: ActionLogRow[] = await ctx.actionLogRepo.findAllPending();
+      const backlog = await fetchBacklog(ctx);
 
-      // Early return when nothing to digest — avoid sending an empty email.
-      if (pending.length === 0) {
-        return { success: true, data: { pending: 0, skipped: true } };
+      const counts = {
+        tasksForCeo: backlog.ceo.length,
+        tasksWaiting: backlog.external.length,
+        tasksWorking: backlog.curia.length,
+      };
+
+      // --- Step 2: Send gate ---
+      // Send when there are approvals OR the CEO owes/awaits something. "What I'm
+      // working on" (curia) alone is informational and never triggers a send.
+      const shouldSend = pending.length > 0 || backlog.ceo.length > 0 || backlog.external.length > 0;
+      if (!shouldSend) {
+        return { success: true, data: { pending: pending.length, skipped: true, ...counts } };
       }
 
-      // --- Step 2: Read CEO email from env (not ctx.secret()) ---
-      // ctx.secret() throws on a missing variable, which would surface as skill
-      // failure rather than a clean skip. Reading from env gives us a graceful
-      // fallback path when the variable is not configured.
+      // --- Step 3: Delivery preconditions ---
+      // Read CEO email from env (not ctx.secret(), which throws on a missing var).
       const ceoEmail = process.env['CEO_PRIMARY_EMAIL'] ?? '';
-
       if (!ceoEmail) {
-        ctx.log.warn(
-          { pendingCount: pending.length },
-          'pending-actions-digest: CEO_PRIMARY_EMAIL not configured, skipping digest',
-        );
-        return { success: true, data: { pending: pending.length, skipped: true } };
+        ctx.log.warn({ pendingCount: pending.length }, 'pending-actions-digest: CEO_PRIMARY_EMAIL not configured, skipping digest');
+        return { success: true, data: { pending: pending.length, skipped: true, ...counts } };
       }
-
-      // --- Step 3: Check outbound gateway is available ---
       if (ctx.outboundGateway === undefined) {
-        ctx.log.warn(
-          { pendingCount: pending.length },
-          'pending-actions-digest: outboundGateway not available, skipping digest',
-        );
-        return { success: true, data: { pending: pending.length, skipped: true } };
+        ctx.log.warn({ pendingCount: pending.length }, 'pending-actions-digest: outboundGateway not available, skipping digest');
+        return { success: true, data: { pending: pending.length, skipped: true, ...counts } };
       }
 
-      // --- Step 4: Build bullet-list body ---
-      // Each line shows the description, originating skill, time remaining, and short
-      // reference (at end) so the CEO can quickly assess urgency without opening each request.
-      const body = pending
-        .map((r) => {
-          // expiresAt is guaranteed non-null by findAllPending() (WHERE expires_at > now()),
-          // but the type is Date | null — null-coalesce to avoid calling .getTime() on null.
-          const msRemaining = r.expiresAt != null ? r.expiresAt.getTime() - Date.now() : 0;
-          const timeRemaining = formatTimeRemaining(msRemaining);
-          return `• ${r.description ?? '(no description)'} [${r.skillName}] — ${timeRemaining} [${r.shortRef ?? '—'}]`;
-        })
-        .join('\n');
+      // --- Step 4: Build the body ---
+      const nameMap = await resolveContactNames(ctx, backlog.external);
+      const nowMs = Date.now();
+      const approvals: ApprovalInput[] = pending.map((r) => ({
+        description: r.description,
+        skillName: r.skillName,
+        shortRef: r.shortRef,
+        expiresAt: r.expiresAt,
+      }));
 
-      const subject = `Pending approvals — ${pending.length} request(s) awaiting your decision`;
+      const body = renderDigestBody({
+        approvals,
+        ceo: backlog.ceo,
+        external: backlog.external,
+        curia: backlog.curia,
+        resolveName: (id) => nameMap.get(id),
+        nowMs,
+        timezone: ctx.timezone ?? 'UTC',
+      });
 
-      // --- Step 5: Send digest notification ---
+      // --- Step 5: Adaptive subject ---
+      // Approvals present → urgency-forward approvals subject (unchanged).
+      // Backlog-only → daily brief framing; N counts the items that need the CEO.
+      const needsCeo = backlog.ceo.length + backlog.external.length;
+      const subject = pending.length > 0
+        ? `Pending approvals — ${pending.length} request(s) awaiting your decision`
+        : `Your daily brief — ${needsCeo} item(s) need you`;
+
+      // --- Step 6: Send ---
       const sent = await ctx.outboundGateway.sendNotification({
         notificationType: 'pending_actions_digest',
         ceoEmail,
@@ -89,14 +152,10 @@ export class PendingActionsDigestHandler implements SkillHandler {
       });
 
       if (!sent) {
-        // Non-fatal — the pending rows are unchanged, digest can retry next cycle.
-        ctx.log.warn(
-          { pendingCount: pending.length },
-          'pending-actions-digest: sendNotification returned false — CEO digest not delivered',
-        );
+        ctx.log.warn({ pendingCount: pending.length }, 'pending-actions-digest: sendNotification returned false — CEO digest not delivered');
       }
 
-      return { success: true, data: { pending: pending.length, skipped: false } };
+      return { success: true, data: { pending: pending.length, skipped: false, ...counts } };
     } catch (e) {
       ctx.log.error({ err: e }, 'pending-actions-digest: unexpected error');
       return { success: false, error: e instanceof Error ? e.message : String(e) };

--- a/skills/pending-actions-digest/handler.ts
+++ b/skills/pending-actions-digest/handler.ts
@@ -80,19 +80,23 @@ async function resolveContactNames(
   const names = new Map<string, string>();
   if (!ctx.contactService) return names;
   const ids = [...new Set(external.map((t) => t.waitingOnContactId).filter((x): x is string => x !== null))];
-  for (const id of ids) {
-    try {
-      const contact = await ctx.contactService.getContact(id);
-      if (contact) names.set(id, contact.displayName);
-    } catch (err) {
-      // Non-fatal: name lookup failed for this contact; render.ts falls back to
-      // waitingOnText or '(unknown)' rather than suppressing the digest.
-      ctx.log.warn(
-        { err, contactId: id },
-        'pending-actions-digest: contact name lookup failed; falling back to waitingOnText',
-      );
-    }
-  }
+  // Resolve all IDs concurrently; each failure is isolated so one bad lookup
+  // cannot suppress the others or the digest.
+  await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const contact = await ctx.contactService!.getContact(id);
+        if (contact) names.set(id, contact.displayName);
+      } catch (err) {
+        // Non-fatal: name lookup failed for this contact; render.ts falls back to
+        // waitingOnText or '(unknown)' rather than suppressing the digest.
+        ctx.log.warn(
+          { err, contactId: id },
+          'pending-actions-digest: contact name lookup failed; falling back to waitingOnText',
+        );
+      }
+    }),
+  );
   return names;
 }
 

--- a/skills/pending-actions-digest/handler.ts
+++ b/skills/pending-actions-digest/handler.ts
@@ -38,13 +38,19 @@ interface Backlog {
  * still goes out rather than failing wholesale.
  */
 async function fetchBacklog(ctx: SkillContext): Promise<Backlog> {
-  if (!ctx.taskRepo) return { ceo: [], external: [], curia: [] };
+  if (!ctx.taskRepo) {
+    ctx.log.warn({}, 'pending-actions-digest: taskRepo not available; backlog omitted from digest');
+    return { ceo: [], external: [], curia: [] };
+  }
   try {
     const [ceo, external, curia] = await Promise.all([
       ctx.taskRepo.listTasks({ owner: 'ceo', statuses: ['open', 'in_progress'], limit: SECTION_FETCH_LIMIT }),
       ctx.taskRepo.listTasks({ owner: 'external', statuses: ['waiting'], limit: SECTION_FETCH_LIMIT }),
       ctx.taskRepo.listTasks({ owner: 'curia', statuses: ['open', 'in_progress'], limit: SECTION_FETCH_LIMIT }),
     ]);
+    // Three separate checks rather than a for...of loop: TypeScript infers readonly
+    // tuple types from `as const` array literals which makes heterogeneous element
+    // access unsafe. Three explicit ifs are clearer and avoid the type gymnastics.
     // Warn if any section hit the fetch cap so truncation is visible in logs.
     if (ceo.length >= SECTION_FETCH_LIMIT) {
       ctx.log.warn({ section: 'ceo', count: ceo.length }, 'pending-actions-digest: section hit fetch cap; +N more is a floor');

--- a/skills/pending-actions-digest/handler.ts
+++ b/skills/pending-actions-digest/handler.ts
@@ -64,7 +64,10 @@ async function fetchBacklog(ctx: SkillContext): Promise<Backlog> {
     return { ceo, external, curia };
   } catch (err) {
     // Non-fatal: log and fall back to empty backlog so approvals still send.
-    ctx.log.warn({ err }, 'pending-actions-digest: backlog fetch failed; sending approvals-only digest');
+    ctx.log.error(
+      { err, errorClass: err instanceof Error ? err.constructor.name : typeof err },
+      'pending-actions-digest: backlog fetch failed; sending approvals-only digest',
+    );
     return { ceo: [], external: [], curia: [] };
   }
 }
@@ -78,8 +81,17 @@ async function resolveContactNames(
   if (!ctx.contactService) return names;
   const ids = [...new Set(external.map((t) => t.waitingOnContactId).filter((x): x is string => x !== null))];
   for (const id of ids) {
-    const contact = await ctx.contactService.getContact(id);
-    if (contact) names.set(id, contact.displayName);
+    try {
+      const contact = await ctx.contactService.getContact(id);
+      if (contact) names.set(id, contact.displayName);
+    } catch (err) {
+      // Non-fatal: name lookup failed for this contact; render.ts falls back to
+      // waitingOnText or '(unknown)' rather than suppressing the digest.
+      ctx.log.warn(
+        { err, contactId: id },
+        'pending-actions-digest: contact name lookup failed; falling back to waitingOnText',
+      );
+    }
   }
   return names;
 }

--- a/skills/pending-actions-digest/render.test.ts
+++ b/skills/pending-actions-digest/render.test.ts
@@ -1,6 +1,6 @@
 // render.test.ts — unit + snapshot tests for the pure digest renderer.
 import { describe, it, expect } from 'vitest';
-import { humanizeAge } from './render.js';
+import { humanizeAge, formatDueDate } from './render.js';
 
 // Fixed clock for deterministic spans. 2026-06-03T12:00:00.000Z.
 const NOW_MS = Date.parse('2026-06-03T12:00:00.000Z');
@@ -24,5 +24,20 @@ describe('humanizeAge', () => {
 
   it('clamps future/zero spans to <1h', () => {
     expect(humanizeAge('2026-06-03T13:00:00.000Z', NOW_MS)).toBe('<1h');
+  });
+});
+
+describe('formatDueDate', () => {
+  it('renders the local date portion in the given timezone', () => {
+    expect(formatDueDate('2026-06-06T13:00:00.000Z', 'UTC')).toBe('2026-06-06');
+  });
+
+  it('renders an em-dash placeholder for null', () => {
+    expect(formatDueDate(null, 'UTC')).toBe('—');
+  });
+
+  it('shifts the date across timezone boundaries', () => {
+    // 00:30 UTC on the 7th is still 20:30 on the 6th in Toronto (UTC-4 in June).
+    expect(formatDueDate('2026-06-07T00:30:00.000Z', 'America/Toronto')).toBe('2026-06-06');
   });
 });

--- a/skills/pending-actions-digest/render.test.ts
+++ b/skills/pending-actions-digest/render.test.ts
@@ -1,0 +1,28 @@
+// render.test.ts — unit + snapshot tests for the pure digest renderer.
+import { describe, it, expect } from 'vitest';
+import { humanizeAge } from './render.js';
+
+// Fixed clock for deterministic spans. 2026-06-03T12:00:00.000Z.
+const NOW_MS = Date.parse('2026-06-03T12:00:00.000Z');
+
+describe('humanizeAge', () => {
+  it('renders <1h for spans under an hour', () => {
+    expect(humanizeAge('2026-06-03T11:30:00.000Z', NOW_MS)).toBe('<1h');
+  });
+
+  it('renders hours under a day', () => {
+    expect(humanizeAge('2026-06-03T07:00:00.000Z', NOW_MS)).toBe('5h');
+  });
+
+  it('renders days under two weeks', () => {
+    expect(humanizeAge('2026-05-31T12:00:00.000Z', NOW_MS)).toBe('3d');
+  });
+
+  it('renders weeks at and beyond 14 days', () => {
+    expect(humanizeAge('2026-05-20T12:00:00.000Z', NOW_MS)).toBe('2w');
+  });
+
+  it('clamps future/zero spans to <1h', () => {
+    expect(humanizeAge('2026-06-03T13:00:00.000Z', NOW_MS)).toBe('<1h');
+  });
+});

--- a/skills/pending-actions-digest/render.test.ts
+++ b/skills/pending-actions-digest/render.test.ts
@@ -40,6 +40,10 @@ describe('formatDueDate', () => {
     // 00:30 UTC on the 7th is still 20:30 on the 6th in Toronto (UTC-4 in June).
     expect(formatDueDate('2026-06-07T00:30:00.000Z', 'America/Toronto')).toBe('2026-06-06');
   });
+
+  it('renders an em-dash for an invalid IANA timezone', () => {
+    expect(formatDueDate('2026-06-06T13:00:00.000Z', 'Invalid/Zone')).toBe('—');
+  });
 });
 
 import { renderDigestBody, type ApprovalInput } from './render.js';

--- a/skills/pending-actions-digest/render.test.ts
+++ b/skills/pending-actions-digest/render.test.ts
@@ -41,3 +41,98 @@ describe('formatDueDate', () => {
     expect(formatDueDate('2026-06-07T00:30:00.000Z', 'America/Toronto')).toBe('2026-06-06');
   });
 });
+
+import { renderDigestBody, type ApprovalInput } from './render.js';
+import type { TaskListRow } from '../../src/db/task-repo.js';
+
+// Minimal TaskListRow factory — only the fields renderDigestBody reads matter.
+function task(overrides: Partial<TaskListRow>): TaskListRow {
+  return {
+    id: 'id', agentId: 'a', intentAnchor: 'i', status: 'open',
+    progress: {}, errorBudget: {}, conversationId: null,
+    createdAt: '2026-06-01T12:00:00.000Z', updatedAt: '2026-06-01T12:00:00.000Z',
+    title: 'Untitled', description: null, owner: 'curia',
+    waitingOnContactId: null, waitingOnText: null, parentTaskId: null,
+    blockedByTaskId: null, priority: 50, dueAt: null, source: 'agent',
+    sourceAgentId: null, createdBy: 'system', tags: [], nextWakeAt: null,
+    ...overrides,
+  };
+}
+
+function approval(overrides: Partial<ApprovalInput>): ApprovalInput {
+  return {
+    description: 'Create event: Lunch', skillName: 'create-calendar-event',
+    shortRef: 'cal-1', expiresAt: new Date(NOW_MS + 7_200_000), ...overrides,
+  };
+}
+
+describe('renderDigestBody', () => {
+  it('renders approvals only, byte-identical to the legacy format, when backlog empty', () => {
+    const body = renderDigestBody({
+      approvals: [approval({}), approval({ description: 'Send weekly update', skillName: 'send-email', shortRef: 'email-2' })],
+      ceo: [], external: [], curia: [],
+      resolveName: () => undefined, nowMs: NOW_MS, timezone: 'UTC',
+    });
+    expect(body).toBe(
+      '• Create event: Lunch [create-calendar-event] — 2h remaining [cal-1]\n' +
+      '• Send weekly update [send-email] — 2h remaining [email-2]',
+    );
+  });
+
+  it('renders all three sections after the approvals block', () => {
+    const body = renderDigestBody({
+      approvals: [approval({})],
+      ceo: [task({ owner: 'ceo', title: 'Review the Acme deck', dueAt: '2026-06-06T13:00:00.000Z', createdAt: '2026-05-31T12:00:00.000Z' })],
+      external: [task({ owner: 'external', status: 'waiting', title: 'Signed NDA', waitingOnContactId: 'c1', createdAt: '2026-06-02T12:00:00.000Z' })],
+      curia: [task({ owner: 'curia', title: 'Draft the board email', createdAt: '2026-06-03T07:00:00.000Z' })],
+      resolveName: (id) => (id === 'c1' ? 'Steve Jobs' : undefined),
+      nowMs: NOW_MS, timezone: 'UTC',
+    });
+    expect(body).toBe(
+      '• Create event: Lunch [create-calendar-event] — 2h remaining [cal-1]\n' +
+      '\n' +
+      'For you to do:\n' +
+      '• Review the Acme deck · due 2026-06-06 · age 3d\n' +
+      '\n' +
+      'Waiting on others:\n' +
+      '• Signed NDA · waiting on Steve Jobs · since 1d\n' +
+      '\n' +
+      "What I'm working on:\n" +
+      '• Draft the board email · age 5h',
+    );
+  });
+
+  it('falls back to waiting_on_text then (unknown) for unresolved counterparties', () => {
+    const body = renderDigestBody({
+      approvals: [],
+      ceo: [], curia: [],
+      external: [
+        task({ owner: 'external', status: 'waiting', title: 'A', waitingOnContactId: 'gone', waitingOnText: 'the lawyer' }),
+        task({ owner: 'external', status: 'waiting', title: 'B', waitingOnContactId: null, waitingOnText: null }),
+      ],
+      resolveName: () => undefined, nowMs: NOW_MS, timezone: 'UTC',
+    });
+    expect(body).toContain('• A · waiting on the lawyer · since');
+    expect(body).toContain('• B · waiting on (unknown) · since');
+  });
+
+  it('caps a section at 5 bullets and appends a +N more footer', () => {
+    const ceo: TaskListRow[] = Array.from({ length: 9 }, (_, i) =>
+      task({ owner: 'ceo', title: `T${i}`, createdAt: '2026-06-03T07:00:00.000Z' }),
+    );
+    const body = renderDigestBody({
+      approvals: [], ceo, external: [], curia: [],
+      resolveName: () => undefined, nowMs: NOW_MS, timezone: 'UTC',
+    });
+    const lines = body.split('\n').filter((l) => l.startsWith('• '));
+    expect(lines).toHaveLength(5);
+    expect(body).toContain('+4 more');
+  });
+
+  it('returns an empty string when there is nothing to render', () => {
+    expect(renderDigestBody({
+      approvals: [], ceo: [], external: [], curia: [],
+      resolveName: () => undefined, nowMs: NOW_MS, timezone: 'UTC',
+    })).toBe('');
+  });
+});

--- a/skills/pending-actions-digest/render.ts
+++ b/skills/pending-actions-digest/render.ts
@@ -35,3 +35,82 @@ export function formatDueDate(dueIso: string | null, timezone: string): string {
   const local = toLocalIso(Math.floor(ms / 1000), timezone);
   return local ? local.slice(0, 10) : '—';
 }
+
+import type { TaskListRow } from '../../src/db/task-repo.js';
+
+// Approval line shape — the handler maps ActionLogRow → ApprovalInput.
+export interface ApprovalInput {
+  description: string | null;
+  skillName: string;
+  shortRef: string | null;
+  expiresAt: Date | null;
+}
+
+export interface RenderDigestInput {
+  approvals: ApprovalInput[];
+  ceo: TaskListRow[];
+  external: TaskListRow[];
+  curia: TaskListRow[];
+  /** Resolve a contact id to a display name; undefined if unknown/unresolved. */
+  resolveName: (contactId: string) => string | undefined;
+  nowMs: number;
+  timezone: string;
+}
+
+/**
+ * Time remaining until an approval expires. Preserves the legacy thresholds
+ * exactly: <=0 or <1h both render '<1h remaining'.
+ */
+export function formatTimeRemaining(expiresAt: Date | null, nowMs: number): string {
+  const ms = expiresAt != null ? expiresAt.getTime() - nowMs : 0;
+  if (ms <= 0 || ms < MS_HOUR) return '<1h remaining';
+  return `${Math.floor(ms / MS_HOUR)}h remaining`;
+}
+
+function approvalLine(a: ApprovalInput, nowMs: number): string {
+  return `• ${a.description ?? '(no description)'} [${a.skillName}] — ${formatTimeRemaining(a.expiresAt, nowMs)} [${a.shortRef ?? '—'}]`;
+}
+
+// Render a backlog section: heading, up to 5 bullets, optional "+N more" footer.
+// `lines` are pre-formatted bullet bodies (without the leading "• ").
+function section(heading: string, lines: string[]): string {
+  const shown = lines.slice(0, 5).map((l) => `• ${l}`);
+  if (lines.length > 5) shown.push(`+${lines.length - 5} more`);
+  return `${heading}:\n${shown.join('\n')}`;
+}
+
+/**
+ * Build the full digest email body: the approvals block (byte-identical to the
+ * legacy format) followed by each non-empty backlog section. Sections are
+ * separated by a blank line. Returns '' when there is nothing to render.
+ */
+export function renderDigestBody(input: RenderDigestInput): string {
+  const { approvals, ceo, external, curia, resolveName, nowMs, timezone } = input;
+  const blocks: string[] = [];
+
+  if (approvals.length > 0) {
+    blocks.push(approvals.map((a) => approvalLine(a, nowMs)).join('\n'));
+  }
+
+  if (ceo.length > 0) {
+    blocks.push(section('For you to do', ceo.map((t) =>
+      `${t.title} · due ${formatDueDate(t.dueAt, timezone)} · age ${humanizeAge(t.createdAt, nowMs)}`,
+    )));
+  }
+
+  if (external.length > 0) {
+    blocks.push(section('Waiting on others', external.map((t) => {
+      const name = (t.waitingOnContactId ? resolveName(t.waitingOnContactId) : undefined)
+        ?? t.waitingOnText ?? '(unknown)';
+      return `${t.title} · waiting on ${name} · since ${humanizeAge(t.createdAt, nowMs)}`;
+    })));
+  }
+
+  if (curia.length > 0) {
+    blocks.push(section("What I'm working on", curia.map((t) =>
+      `${t.title} · age ${humanizeAge(t.createdAt, nowMs)}`,
+    )));
+  }
+
+  return blocks.join('\n\n');
+}

--- a/skills/pending-actions-digest/render.ts
+++ b/skills/pending-actions-digest/render.ts
@@ -25,21 +25,29 @@ export function humanizeAge(sinceIso: string, nowMs: number): string {
   return `${Math.floor(diff / MS_WEEK)}w`;
 }
 
+// Pre-validate an IANA timezone string. Intl.DateTimeFormat throws on invalid
+// zone identifiers — we rely on that as the check so toLocalIso never throws.
+function isValidIanaTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en', { timeZone: tz });
+    return true;
+  } catch {
+    // intentional: Intl.DateTimeFormat throws on invalid IANA zone strings
+    return false;
+  }
+}
+
 /**
  * Render a task's CEO-facing due date (date only) in the user's timezone.
- * Returns '—' for a null due date or an unrepresentable timestamp.
+ * Returns '—' for a null due date, an unrepresentable timestamp, or an invalid timezone.
  */
 export function formatDueDate(dueIso: string | null, timezone: string): string {
   if (dueIso === null) return '—';
   const ms = Date.parse(dueIso);
   if (!Number.isFinite(ms)) return '—';
-  try {
-    const local = toLocalIso(Math.floor(ms / 1000), timezone);
-    return local ? local.slice(0, 10) : '—';
-  } catch {
-    // toLocalIso throws on invalid IANA timezone strings; degrade gracefully.
-    return '—';
-  }
+  if (!isValidIanaTimezone(timezone)) return '—';
+  const local = toLocalIso(Math.floor(ms / 1000), timezone);
+  return local ? local.slice(0, 10) : '—';
 }
 
 // Approval line shape — the handler maps ActionLogRow → ApprovalInput.

--- a/skills/pending-actions-digest/render.ts
+++ b/skills/pending-actions-digest/render.ts
@@ -33,8 +33,13 @@ export function formatDueDate(dueIso: string | null, timezone: string): string {
   if (dueIso === null) return '—';
   const ms = Date.parse(dueIso);
   if (!Number.isFinite(ms)) return '—';
-  const local = toLocalIso(Math.floor(ms / 1000), timezone);
-  return local ? local.slice(0, 10) : '—';
+  try {
+    const local = toLocalIso(Math.floor(ms / 1000), timezone);
+    return local ? local.slice(0, 10) : '—';
+  } catch {
+    // toLocalIso throws on invalid IANA timezone strings; degrade gracefully.
+    return '—';
+  }
 }
 
 // Approval line shape — the handler maps ActionLogRow → ApprovalInput.

--- a/skills/pending-actions-digest/render.ts
+++ b/skills/pending-actions-digest/render.ts
@@ -1,0 +1,23 @@
+// render.ts — pure formatting for the pending-actions-digest email body.
+//
+// No I/O and no clock reads: the current time is injected as `nowMs` so every
+// function is deterministic and snapshot-testable. The handler supplies
+// `Date.now()` at call time (which test suites pin via vi.spyOn).
+
+const MS_HOUR = 3_600_000;
+const MS_DAY = 86_400_000;
+const MS_WEEK = 604_800_000;
+const MS_TWO_WEEKS = 14 * MS_DAY;
+
+/**
+ * Short humanized age of an ISO timestamp relative to nowMs.
+ * Buckets: <1h, Nh (<1 day), Nd (<2 weeks), Nw (>=2 weeks).
+ * Future or zero spans clamp to '<1h'.
+ */
+export function humanizeAge(sinceIso: string, nowMs: number): string {
+  const diff = nowMs - Date.parse(sinceIso);
+  if (!Number.isFinite(diff) || diff < MS_HOUR) return '<1h';
+  if (diff < MS_DAY) return `${Math.floor(diff / MS_HOUR)}h`;
+  if (diff < MS_TWO_WEEKS) return `${Math.floor(diff / MS_DAY)}d`;
+  return `${Math.floor(diff / MS_WEEK)}w`;
+}

--- a/skills/pending-actions-digest/render.ts
+++ b/skills/pending-actions-digest/render.ts
@@ -4,6 +4,8 @@
 // function is deterministic and snapshot-testable. The handler supplies
 // `Date.now()` at call time (which test suites pin via vi.spyOn).
 
+import { toLocalIso } from '../../src/time/timestamp.js';
+
 const MS_HOUR = 3_600_000;
 const MS_DAY = 86_400_000;
 const MS_WEEK = 604_800_000;
@@ -20,4 +22,16 @@ export function humanizeAge(sinceIso: string, nowMs: number): string {
   if (diff < MS_DAY) return `${Math.floor(diff / MS_HOUR)}h`;
   if (diff < MS_TWO_WEEKS) return `${Math.floor(diff / MS_DAY)}d`;
   return `${Math.floor(diff / MS_WEEK)}w`;
+}
+
+/**
+ * Render a task's CEO-facing due date (date only) in the user's timezone.
+ * Returns '—' for a null due date or an unrepresentable timestamp.
+ */
+export function formatDueDate(dueIso: string | null, timezone: string): string {
+  if (dueIso === null) return '—';
+  const ms = Date.parse(dueIso);
+  if (!Number.isFinite(ms)) return '—';
+  const local = toLocalIso(Math.floor(ms / 1000), timezone);
+  return local ? local.slice(0, 10) : '—';
 }

--- a/skills/pending-actions-digest/render.ts
+++ b/skills/pending-actions-digest/render.ts
@@ -5,6 +5,7 @@
 // `Date.now()` at call time (which test suites pin via vi.spyOn).
 
 import { toLocalIso } from '../../src/time/timestamp.js';
+import type { TaskListRow } from '../../src/db/task-repo.js';
 
 const MS_HOUR = 3_600_000;
 const MS_DAY = 86_400_000;
@@ -35,8 +36,6 @@ export function formatDueDate(dueIso: string | null, timezone: string): string {
   const local = toLocalIso(Math.floor(ms / 1000), timezone);
   return local ? local.slice(0, 10) : '—';
 }
-
-import type { TaskListRow } from '../../src/db/task-repo.js';
 
 // Approval line shape — the handler maps ActionLogRow → ApprovalInput.
 export interface ApprovalInput {

--- a/skills/pending-actions-digest/skill.json
+++ b/skills/pending-actions-digest/skill.json
@@ -1,16 +1,19 @@
 {
   "name": "pending-actions-digest",
-  "description": "Send a daily digest of open approval requests awaiting CEO decision.",
-  "version": "1.0.0",
+  "description": "Send a daily digest of open approval requests and the task backlog awaiting CEO attention.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {},
   "outputs": {
-    "pending": "number — count of open requests included in digest",
-    "skipped": "boolean — true if digest was not sent (no open requests, or CEO_PRIMARY_EMAIL / outboundGateway not configured)"
+    "pending": "number — count of open approval requests included in digest",
+    "skipped": "boolean — true if digest was not sent (nothing to show, or CEO_PRIMARY_EMAIL / outboundGateway not configured)",
+    "tasksForCeo": "number — open/in_progress tasks owned by the CEO",
+    "tasksWaiting": "number — external tasks in 'waiting' status",
+    "tasksWorking": "number — open/in_progress tasks owned by Curia"
   },
   "permissions": [],
   "secrets": ["CEO_PRIMARY_EMAIL"],
   "timeout": 30000,
-  "capabilities": ["actionLogRepo", "outboundGateway"]
+  "capabilities": ["actionLogRepo", "outboundGateway", "taskRepo"]
 }


### PR DESCRIPTION
## **User description**
## Summary

- Adds three backlog sections to the daily CEO email digest: **For you to do** (owner=ceo), **Waiting on others** (owner=external, status=waiting), and **What I'm working on** (owner=curia) — each capped at 5 items with a `+N more` footer.
- Expands the send gate: email now fires when there are pending approvals **or** any ceo/external backlog items (curia-only is informational and never triggers a send on its own).
- Adaptive subject: uses the existing approvals subject when pending approvals are present; falls back to "Your daily brief — N item(s) need you" on backlog-only days.
- Body formatting extracted into a new pure module (`render.ts`) for deterministic snapshot testing. The approvals block is byte-identical to the prior implementation.

Closes #838

## Architecture

- `render.ts` — pure formatting layer: `humanizeAge`, `formatDueDate`, `formatTimeRemaining`, `renderDigestBody`. No I/O; `nowMs` injected for determinism.
- `handler.ts` — orchestration: fetches three task lists via `taskRepo.listTasks`, resolves `waiting_on_contact_id` to display names via `contactService`, applies send gate, builds adaptive subject, delegates body to `render.ts`.
- Graceful degradation throughout: absent `taskRepo`, query failure, contact lookup error, and invalid timezone all degrade locally rather than suppressing the approvals email.

## Test Plan

- [x] `render.test.ts` — 13 unit tests: all three sections, `+N more` truncation, approvals-only (byte-identical), empty-all, contact fallback chain (contactId → waitingOnText → `(unknown)`)
- [x] `handler.test.ts` — 13 tests: legacy approvals paths (proves approvals block unchanged), backlog-only adaptive subject, approvals+backlog combined, curia-only no-send gate, `listTasks` failure degradation, absent `taskRepo` degradation
- [x] 1259 total tests pass; typecheck clean
- [ ] Manual: verify next day's staging digest email contains populated sections


___

## **CodeAnt-AI Description**
**Add task backlog sections to the daily CEO digest**

### What Changed
- The daily email now includes three backlog sections: "For you to do," "Waiting on others," and "What I'm working on"
- The digest now sends when there are approvals or CEO/external backlog items, and uses a backlog-only subject when there are no approvals
- Each section shows at most 5 items and adds a `+N more` footer for longer lists
- Backlog details now include due dates, item age, and a contact name when available, with clear fallbacks when data is missing
- If task lookup or contact lookup fails, the approvals email still goes out instead of stopping the digest
- The approvals block stays unchanged, and the new body format is covered by deterministic tests

### Impact
`✅ More visible overdue work`
`✅ Fewer missed follow-ups`
`✅ Clearer daily digest emails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The daily pending-actions digest now surfaces a task backlog organized into three sections: "For you to do", "Waiting on others", and "What I'm working on"—grouped by ownership and status to help prioritize CEO attention.

* **Documentation**
  * Added design specifications for the pending-actions-digest enhancement, including rendering logic, data sources, and email send criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->