### PR TITLE
chore: replace intent_anchor-for-cron with task/scheduling split in coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+- **coordinator** — replaced the `intent_anchor`-for-cron-jobs instruction with the new task/scheduling split: `task-create` for deferred CEO-visible work, `scheduler-create` (no `intent_anchor`) for operational sweeps. Adds backlog-awareness and defer-don't-drop rules. (#)
+
 ### Added
 - **Tasks console UI** — list view with owner/status/priority model: owner dropdown filter, age column, default priority sort, status lifecycle controls (terminal-state guard), contact name resolution for `waiting_on_contact_id`, next scheduled wake-up time in drawer, and parent/blocked-by task links. (#870)
 - **Tasks v1 scheduler dispatch** — task-wake fires route to `scheduled_jobs.agent_id` and include `task_id`, `title`, `progress` in the content bundle; `updateTask()` now writes the wake-up job's `agent_id` using `source_agent_id ?? tasks.agent_id ?? callerAgentId` so coordinator-triggered reschedules preserve the specialist's routing target. (#837)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.5.0"
+version: "0.5.1"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -305,29 +305,27 @@ system_prompt: |
   - Use decay-warnings-list directly if the CEO asks to see all pending warnings
     ("show me what's going stale", "what needs my review").
 
-  ## Scheduled Tasks
-  When the CEO asks you to set up a recurring task (e.g. "check X every week",
-  "remind me every Monday"), use scheduler-create with a cron_expr.
+  ## Scheduling and Task Management
 
-  **Always provide intent_anchor for recurring (cron_expr) jobs.** Write one or
-  two sentences describing what the task is meant to accomplish and why — the
-  original mandate. This is the anchor that prevents drift across multiple
-  executions.
+  Two distinct tools for two distinct needs — do not mix them.
 
-  Rules for writing a good intent_anchor:
-  - Describe *intent*, not *implementation*: what should be achieved, not which
-    tools to call
-  - Good: "Run weekly contacts dedup scan and present any probable/certain
-    duplicate pairs to the CEO for review."
-  - Bad: "Call contact-find-duplicates with min_confidence probable then loop
-    through pairs calling contact-merge dry_run: true."
+  **Deferred or CEO-visible work — use `task-create`:**
+  When the CEO says "remind me to…", "track this", "follow up with X next week",
+  or when you uncover work that cannot happen right now. Pass `wake_at` for a
+  one-shot wakeup — the skill creates the schedule row internally. Set `owner`
+  based on accountability: `'ceo'` if the CEO must act, `'curia'` if it is yours
+  to advance, `'external'` if you are waiting on someone else.
 
-  **Do NOT provide intent_anchor for one-shot (run_at) jobs.** A one-shot job
-  fires once and is done — there is no multi-burst drift risk.
+  **Recurring operational sweeps — use `scheduler-create`:**
+  When setting up something that repeats on a cron ("check X every week",
+  "remind me every Monday"). Provide only `cron_expr` and `task`. Do not pass
+  `intent_anchor` — that field is not used for operational sweeps.
 
-  **The anchor should be stable.** If the CEO fundamentally changes what a
-  recurring task should do, cancel the old job and create a new one with a
-  fresh anchor. Do not treat it as an update to the existing job.
+  **Backlog awareness:** Before answering "what's open?", "what's waiting on me?",
+  or "what are you working on?", call `task-list`.
+
+  **Decide, don't drop.** When new work arrives and you cannot act now, queue it
+  with `task-create` and briefly tell the CEO what you queued and why.
 
 
   ## Email


### PR DESCRIPTION
## **User description**
## Summary

- Replaces the coordinator's `intent_anchor`-for-cron-jobs instruction with the two-flow model from the tasks-and-backlog design (§4.3, §10).
- Adds backlog-awareness rule and decide-don't-drop rule.
- Bumps coordinator version `0.5.0` → `0.5.1`.

Per design §10, `intent_anchor` on declarative cron schedules is being phased out. Operational sweeps don't need a linked `tasks` row; that coupling was identified as a design smell. The new instruction makes the split explicit: `task-create` for deferred CEO-visible work, `scheduler-create` (no `intent_anchor`) for recurring operational sweeps.

The 4 stale `tasks` rows that the old instruction created in production have been removed directly — the backing `scheduled_jobs` rows continue running with `task_id = NULL` as intended.

## Test plan

- [ ] Coordinator smoke test: "check X every week" → `scheduler-create` called with no `intent_anchor`
- [ ] Coordinator smoke test: "remind me to call Steve Friday at 9am" → `task-create` called with `wake_at` and appropriate `owner`
- [ ] Coordinator smoke test: "what's open?" → `task-list` called before answering
- [ ] Verify no regression in coordinator's existing scheduled jobs (approval-expiry sweep, pending-actions digest)


___

## **CodeAnt-AI Description**
**Split recurring scheduling from deferred task handling in the coordinator**

### What Changed
- Recurring cron-based work now uses `scheduler-create` without an intent anchor
- Deferred or CEO-visible work now uses `task-create`, including one-shot follow-ups and items that cannot be handled right away
- The coordinator now checks the task list before answering questions about open or waiting work
- New guidance tells the coordinator to queue new work instead of ignoring it when it cannot act immediately
- The coordinator version was updated to 0.5.1, and the changelog was updated to match the new behavior

### Impact
`✅ Clearer scheduling behavior`
`✅ Fewer wrong task assignments`
`✅ Better answers about open work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
