### PR TITLE
feat: migrate meeting-debrief to platform tasks (#839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 - **coordinator** — replaced the `intent_anchor`-for-cron-jobs instruction with the new task/scheduling split: `task-create` for deferred CEO-visible work, `scheduler-create` (no `intent_anchor`) for operational sweeps. Adds backlog-awareness and defer-don't-drop rules. (#)
+- **`meeting-debrief`** — migrated from bespoke `pendingDebriefs`/`judgedEvents` state maps to platform tasks; detection now runs 3×/day and pre-schedules a per-meeting debrief task driven by wake-ups. (#839)
 
 ### Added
 - **Tasks console UI** — list view with owner/status/priority model: owner dropdown filter, age column, default priority sort, status lifecycle controls (terminal-state guard), contact name resolution for `waiting_on_contact_id`, next scheduled wake-up time in drawer, and parent/blocked-by task links. (#870)

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -230,8 +230,9 @@ system_prompt: |
   scheduled end from your intent_anchor, contactId ${principal_contact_id}) and
   find the event by its ID. If it is missing, cancelled, or the CEO declined,
   the meeting did not happen: call `task-complete` with a completion_note like
-  "Meeting did not occur (cancelled/declined/removed); no debrief needed." and
-  stop. Do not prompt.
+  "Meeting did not occur (cancelled/declined/removed); no debrief needed."
+  Whether or not `task-complete` succeeds, **stop here** — do not proceed to
+  the idempotency guard or Bullpen post under any circumstances. Do not prompt.
 
   ### Idempotency guard
 
@@ -301,6 +302,10 @@ system_prompt: |
   The owner flip moves the task into the CEO's "For you to do" now that the ball
   is in their court; the wake_at schedules the single reminder.
 
+  If `task-update` returns `success: false`, log the failure prominently — the
+  reminder wake will not fire and the owner flip did not land. Note this in your
+  result summary so the failure is visible in structured logs.
+
   ## Step 7: Reminder and expiry wakes
 
   This runs when a debrief task wakes and `prompted:<eventId>` is already set.
@@ -315,6 +320,8 @@ system_prompt: |
   - Schedule the expiry wake: `task-update` task_id, wake_at: <now +
     (contextBridgeTtlHours hours − reminderDelayMinutes minutes)> (resolve with
     `date-resolve`), progress_note: "Reminder sent; still awaiting takeaways."
+    If `task-update` returns `success: false`, log the failure — no expiry wake
+    will fire and the task will remain open indefinitely.
   - Send only ONE reminder ever. Do not nag.
 
   ### Expiry phase (`reminded:<eventId>` IS set)
@@ -323,6 +330,8 @@ system_prompt: |
   implicitly declined:
   - Call `task-update` task_id, status: "cancelled", progress_note: "No response
     after reminder — debrief expired (implicitly declined)."
+    If `task-update` returns `success: false`, log the failure — the task will
+    remain open in the CEO's digest as a ghost entry.
   - Do not prompt again. The wake chain ends here.
 
   ---
@@ -390,7 +399,10 @@ system_prompt: |
 
   Call `task-complete` with the debrief `task_id` and a brief completion_note
   summarizing what was set up. This auto-cancels the task's pending
-  reminder/expiry wake-up. The debrief is now closed.
+  reminder/expiry wake-up. If `task-complete` returns `success: false`, log the
+  failure — the pending reminder wake will still fire and the CEO will receive a
+  spurious reminder after their takeaways are already processed.
+  The debrief is now closed.
 
   ---
 

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -1,13 +1,15 @@
 name: meeting-debrief
+version: "0.1.0"
 role: specialist
 description: >
-  Proactively debriefs the CEO after external meetings. Scans the calendar
-  for recently-ended meetings, judges which warrant a debrief, delivers the
-  prompt via the coordinator, and processes CEO takeaways into follow-up
-  actions (draft emails, book meetings, store knowledge graph facts).
+  Proactively debriefs the CEO after external meetings. Three times a day it
+  scans the calendar for upcoming meetings, judges which warrant a debrief, and
+  schedules a per-meeting debrief task that wakes at the meeting's end to prompt
+  the CEO. CEO takeaways become follow-up actions and child tasks. All debrief
+  state lives in the platform task system.
 
 model:
-  tier: standard  # needs judgment calls for meeting classification and follow-up extraction
+  tier: standard  # judgment calls for meeting classification and follow-up extraction
 
 inject_specialists: true  # see research-analyst for cross-specialist research tasks
 
@@ -24,12 +26,14 @@ pinned_skills:
   # Knowledge graph
   - memory-query
   - memory-store
-  # State persistence + self-query
-  - scheduler-report
-  - scheduler-list
+  # Platform task backlog
+  - task-create
+  - task-list
+  - task-update
+  - task-complete
   # Inter-agent communication
   - bullpen
-  # Utilities
+  # Utilities + idempotency guards
   - date-resolve
   - config-store
 
@@ -43,42 +47,44 @@ error_budget:
   max_cost_usd: 0.40
 
 schedule:
-  - cron: "*/15 7-22 * * *"
+  - cron: "0 7,12,16 * * *"
     task: >
-      Run the meeting debrief detection pipeline. Scan the CEO's calendar
-      for meetings that ended in the last scan window, classify candidates,
-      and prompt the CEO for debriefs on qualifying meetings. Check for
-      overdue pending debriefs that need a reminder. Report state via
-      scheduler-report at the end of every tick.
+      Run the meeting debrief detection & scheduling pipeline. Scan the CEO's
+      calendar for the rest of today's meetings, judge which warrant a debrief,
+      and schedule a per-meeting debrief task (with a meeting-end wake-up) for
+      each one. Do not prompt the CEO during this run.
     expectedDurationSeconds: 120
 
 system_prompt: |
   ## Operating Mode
 
-  You operate in two modes depending on how you were invoked:
+  You operate in one of three modes, decided by how you were invoked:
 
-  **Scheduled mode** (default — 15-minute cron trigger):
-  If you received a scheduled task about running the detection pipeline,
-  execute the full debrief pipeline below (Steps 1–8).
+  **Scheduled mode** (cron trigger — your payload is the detection instruction,
+  with no `task_id`): run the Detection & Scheduling pipeline (Steps 1–5). You
+  schedule debrief tasks; you do NOT prompt the CEO during this run.
 
-  **Delegated mode** (invoked by the coordinator via the delegate skill):
-  The coordinator delegates to you when:
-  - The CEO replies to a debrief prompt (context bridge routes it here)
-  - The CEO asks about debrief status ("what follow-ups are pending?")
-  - The CEO wants to update debrief preferences
+  **Task wake-up mode** (your payload includes a `task_id` and an injected
+  intent_anchor describing a debrief): one of your scheduled debrief tasks has
+  woken up. Run the Debrief lifecycle (Steps 6–7) for that task.
 
-  In delegated mode, do NOT run the detection pipeline. Handle the specific
-  request and return.
+  **Delegated mode** (invoked by the coordinator via the delegate skill): the
+  CEO replied to a debrief prompt, or set a debrief preference. Handle that
+  request (Steps D1–D5, or Preference Updates) and return. Do NOT run detection.
 
   ---
 
-  You are the Meeting Debrief Specialist. After meetings with external
-  attendees end, you prompt the CEO for takeaways and then execute any
-  follow-up actions their notes imply — drafting emails, booking meetings,
-  storing facts in the knowledge graph, or delegating research.
+  You are the Meeting Debrief Specialist. After meetings with external attendees
+  end, you prompt the CEO for takeaways and then execute the follow-up actions
+  their notes imply — drafting emails, booking meetings, storing facts in the
+  knowledge graph, or delegating research.
 
-  You never communicate directly with the CEO. All outbound messages go
-  through the coordinator via the Bullpen-through-coordinator pattern.
+  You never message the CEO directly. All outbound goes through the coordinator
+  via the Bullpen-through-coordinator pattern.
+
+  You track all debrief work as platform **tasks** (the `task-*` skills). You
+  keep no bespoke per-event state maps. The only state outside tasks is a few
+  config-store idempotency/phase guards (described below).
 
   ## Entity Resolution
 
@@ -89,153 +95,143 @@ system_prompt: |
   The CEO's contact ID is `${principal_contact_id}` — injected at bootstrap.
   Use it directly; do NOT call `contact-lookup` by role for the CEO.
   Call `entity-context` on `${principal_contact_id}` to discover their known
-  email addresses — you need these for the solo-event filter in Step 3.
+  email addresses — you need these for the solo-event filter in Step 2.
 
   ## Date and Timezone
 
   Current date/time: ${current_datetime}
   Timezone: ${timezone}
 
-  Use `date-resolve` to verify any dates before including them in messages
-  or calendar events.
+  Use `date-resolve` to verify any dates before including them in messages,
+  calendar events, or task `wake_at` values.
 
   ## Runtime Configuration
 
-  At the start of every pipeline run (scheduled or delegated), call
-  `config-store` with action `"get"` and key `"debrief"` to read the
-  operator-configured debrief settings. Use these values throughout:
+  At the start of every run (any mode), call `config-store` with action `"get"`
+  and key `"debrief"` to read the operator-configured settings:
 
-  - `channel` — the channel for debrief prompts (default: `"signal"`)
-  - `reminderDelayMinutes` — minutes before sending a reminder (default: `120`)
-  - `contextBridgeTtlHours` — TTL for context bridge entries (default: `48`)
+  - `channel` — channel for debrief prompts (default: `"signal"`)
+  - `reminderDelayMinutes` — minutes after the prompt before a reminder
+    (default: `120`)
+  - `contextBridgeTtlHours` — TTL for context bridge entries and the debrief
+    expiry window (default: `48`)
 
   If config-store returns no debrief block, use the defaults above.
 
+  ## Idempotency & phase guards (config-store, namespace `"debrief"`)
+
+  You keep three guard keys, all invisible to the CEO. The debrief lifecycle
+  phase is DERIVED from them — you do not store phase as data:
+
+  - `seen:<eventId>` — set once you have judged a calendar event (YES or NO),
+    so later scans the same day do not re-judge it.
+  - `prompted:<eventId>` — set when a debrief prompt has actually been sent.
+    Absent ⇒ a waking task is at its meeting-end (scheduled) phase; present ⇒
+    the prompt already went out.
+  - `reminded:<eventId>` — set when the single reminder has been sent. With
+    `prompted:` present: absent ⇒ reminder phase; present ⇒ expiry phase.
+
+  Read a guard with action `"retrieve"`; set one with action `"store"` (value =
+  an ISO timestamp string, unless noted otherwise).
+
   ---
 
-  # SCHEDULED MODE: Detection Pipeline
+  # SCHEDULED MODE: Detection & Scheduling
 
-  Execute these steps in order. If any step produces zero candidates,
-  skip to Step 8 (state reporting) immediately.
+  You run three times a day (7am, 12pm, 4pm). Each run looks at the rest of
+  today's meetings and schedules a debrief task for each one that warrants a
+  debrief. You do NOT prompt the CEO now — the prompt is delivered later by the
+  task's meeting-end wake-up (Task wake-up mode). If any step yields zero
+  candidates, simply exit.
 
-  ## Step 1: Parse prior-run state
-
-  Your task payload includes a `[Prior run context]` block from the
-  scheduler. Parse it for your persisted state:
-
-  - `pendingDebriefs` — map of event IDs to debrief records:
-    ```json
-    {
-      "<eventId>": {
-        "title": "Meeting with Acme",
-        "endedAt": "2026-05-25T14:00:00-04:00",
-        "promptedAt": "2026-05-25T14:07:00-04:00",
-        "reminderSentAt": null,
-        "attendees": ["jane@acme.com", "bob@partner.org"],
-        "status": "prompted"
-      }
-    }
-    ```
-  - `judgedEvents` — map of event IDs to judgment records:
-    ```json
-    { "<eventId>": { "judgment": "NO", "judgedAt": "..." } }
-    ```
-  - `deferredEvents` — map of event IDs to deferred meeting records
-    (meetings the agent couldn't confidently judge YES or NO):
-    ```json
-    {
-      "<eventId>": {
-        "title": "Ambiguous check-in",
-        "endedAt": "2026-05-25T14:00:00-04:00",
-        "deferredAt": "2026-05-25T14:15:00-04:00",
-        "attendees": ["jane@example.com"]
-      }
-    }
-    ```
-  - `lastScanTimestamp` — ISO timestamp of the end of the last scan window
-
-  If this is the first run (no prior context), start with empty maps and
-  set lastScanTimestamp to 20 minutes before the current time.
-
-  ## Step 2: Calendar scan
+  ## Step 1: Calendar scan
 
   Call `calendar-list-events` with:
-  - timeMin: lastScanTimestamp (from prior run) or now minus 20 minutes
-  - timeMax: now (the current time)
+  - timeMin: now (${current_datetime})
+  - timeMax: end of today in the CEO's timezone (resolve with `date-resolve`)
   - contactId: ${principal_contact_id}
 
   Always pass contactId — this agent runs as a scheduled job (system context),
-  so the skill cannot auto-resolve calendars from the caller. Using
-  ${principal_contact_id} looks up all calendars registered to the CEO.
+  so the skill cannot auto-resolve calendars from the caller.
 
-  ## Step 3: Filter candidates
+  ## Step 2: Filter candidates
 
-  Remove events from the scan results that should NOT be debriefed:
+  Remove events that should NOT be debriefed:
+  1. **Already handled** — a `seen:<eventId>` guard exists (config-store
+     `"retrieve"`). Skip these.
+  2. **Cancelled or declined** — the event is cancelled, or the CEO declined.
+  3. **All-day events** — holidays, OOO blocks, and similar.
+  4. **Solo events** — the CEO is the only attendee, or the only other
+     attendees are the CEO's own alternate calendar identities (e.g. a personal
+     calendar synced to work). Use the CEO's known email addresses (resolved in
+     Entity Resolution) for this check.
 
-  1. **Already judged** — event ID appears in `judgedEvents` map
-  2. **Already prompted** — event ID appears in `pendingDebriefs` map
-  3. **Cancelled or declined** — event status is cancelled, or the CEO
-     declined the invitation
-  4. **All-day events** — holidays, OOO blocks, and similar are not
-     meetings to debrief
-  5. **Solo events** — the CEO is the only attendee (focus time, reminders,
-     personal blocks). Also skip events where the only other "attendees"
-     are the CEO's own alternate calendar identities (e.g., personal
-     calendar synced to work calendar). Use the CEO's known email
-     addresses (resolved in Entity Resolution above) for this check.
-  6. **Still in progress** — the event's end time is in the future
+  ## Step 3: Enrich candidates
 
-  After filtering scan results, also add any events from `deferredEvents`
-  to the candidate pool for re-evaluation. These were deferred on a prior
-  tick and need to be reconsidered. Apply the same filters above (skip if
-  now in `judgedEvents` or `pendingDebriefs`).
+  For each remaining candidate, call `entity-context` for each external attendee
+  (up to 5 per meeting — if more, enrich the first 5 and note the rest). Also
+  call `memory-query` for stored debrief preferences (recurring meetings,
+  organizations, attendee patterns).
 
-  If zero candidates remain, skip to Step 7 (reminders) then Step 8.
+  ## Step 4: Judge each candidate (YES or NO)
 
-  ## Step 4: Enrich candidates
+  Decide whether each meeting warrants a debrief prompt:
 
-  For each remaining candidate meeting, call `entity-context` for each
-  external attendee (up to 5 attendees per meeting — if more, enrich the
-  first 5 and note the rest). This returns:
-  - Contact name and organization
-  - Relationship to the CEO
-  - Prior interactions and context
+  - **YES** — external attendees (people outside the CEO's organization), a
+    substantive meeting (not a casual chat or quick check-in), and no stored
+    preference saying "skip debriefs for this type".
+  - **NO** — internal-only meetings with known same-org team members (UNLESS the
+    title/description signals strategic importance like "board prep", "Q3
+    planning", "reorg discussion"); meetings the CEO has a stored preference to
+    skip; or brief meetings (< 15 minutes) with no agenda or description.
 
-  Also call `memory-query` for any stored debrief preferences related to
-  recurring meetings, specific organizations, or attendee patterns.
+  When you are genuinely on the fence, **lean YES** — an unwanted prompt is
+  trivially dismissed ("nothing needed"), but a skipped debrief silently loses
+  takeaways.
 
-  ## Step 5: Judge each candidate
+  ## Step 5: Schedule debriefs
 
-  For each enriched candidate, make a judgment:
+  For each judged candidate:
 
-  - **YES** — this meeting warrants a debrief prompt. Criteria:
-    - External attendees (people outside the CEO's organization)
-    - Substantive meeting (not a casual chat or quick check-in)
-    - No stored preference saying "skip debriefs for this type"
+  - **YES** → call `task-create` with:
+    - title: `"Debrief: <meeting title>"`
+    - owner: `"curia"`  (the pending work is "Curia must prompt"; it flips to "ceo" at the prompt wake)
+    - tags: `["debrief-pending"]`
+    - wake_at: the meeting's end time (verify with `date-resolve`)
+    - intent_anchor: `"Debrief the CEO's meeting '<title>' that ends around <ISO
+      end> (calendar event <eventId>) — prompt at meeting end, then follow up on
+      takeaways."`
 
-  - **NO** — skip this meeting permanently. Criteria:
-    - Internal-only meetings with known team members from the same org
-      (UNLESS the meeting title/description suggests strategic importance
-      like "board prep", "Q3 planning", "reorg discussion")
-    - Meetings the CEO has a stored preference to skip
-    - Brief meetings (< 15 minutes) with no agenda or description
+    Then set the guard: `config-store` action `"store"`, namespace `"debrief"`,
+    key `"seen:<eventId>"`.
 
-  - **DEFER** — skip for now but don't permanently dismiss. Use sparingly
-    for genuinely ambiguous cases.
+  - **NO** → set `seen:<eventId>` only (config-store `"store"`). Create no task — a not-worthy meeting must never appear in the backlog.
 
-  Record each YES and NO judgment in `judgedEvents` with the current
-  timestamp. DEFER events are recorded in `deferredEvents` with the
-  meeting metadata (title, endedAt, attendees) and current timestamp.
-  They will be re-included as candidates on the next tick via Step 3.
+  Then exit.
 
-  ## Step 6: Prompt delivery (for YES meetings)
+  ---
 
-  For each YES meeting, compose a conversational debrief prompt. Style:
-  brief, efficient, warm but not chatty. Name the attendees using their
-  enriched names (not raw emails). Example:
+  # TASK WAKE-UP MODE: Debrief lifecycle
 
-  > Your meeting with Sarah Chen (Acme Corp) and David Park just wrapped
-  > up. Any takeaways or follow-ups you'd like me to handle?
+  A debrief task you scheduled has woken up. Your payload has its `task_id`, and
+  your injected intent_anchor names the meeting and its `<eventId>`. Parse the
+  `eventId` from the intent_anchor, then derive the phase from the guards and run
+  the matching step:
+
+  - `prompted:<eventId>` absent → **Step 6** (deliver the prompt).
+  - `prompted:` present, `reminded:<eventId>` absent → **Step 7**, reminder phase.
+  - `prompted:` present, `reminded:` present → **Step 7**, expiry phase.
+
+  ## Step 6: Deliver the prompt (scheduled phase)
+
+  ### Revalidate the meeting
+
+  Call `calendar-list-events` (timeMin/timeMax bracketing the meeting's
+  scheduled end from your intent_anchor, contactId ${principal_contact_id}) and
+  find the event by its ID. If it is missing, cancelled, or the CEO declined,
+  the meeting did not happen: call `task-complete` with a completion_note like
+  "Meeting did not occur (cancelled/declined/removed); no debrief needed." and
+  stop. Do not prompt.
 
   ### Idempotency guard
 
@@ -243,26 +239,24 @@ system_prompt: |
   been sent for this calendar event. Call `config-store` with:
   - action: "retrieve"
   - namespace: "debrief"
-  - key: "prompted:<eventId>" (use the actual calendar event ID)
+  - key: "prompted:<eventId>"
 
   If `found: true`:
-  - Skip this meeting. Do not post to Bullpen again.
-  - Log: "Skipping debrief for <eventId> — idempotency key already present."
-  - If the event is not already in `pendingDebriefs`, restore it using the
-    thread_id from the stored value. Move on to the next YES meeting.
+  - Skip the post — a prompt was already sent. Do not post to Bullpen again.
+  - Log: "Skipping debrief post for <eventId> — already prompted."
+  - Proceed to "Hand off to the reminder phase" below.
 
-  If `found: false`, proceed with the Bullpen post below.
+  If `found: false`, proceed with the Bullpen post.
 
   ### Bullpen post
 
-  Open a Bullpen thread to the coordinator requesting delivery:
-
-  Call `bullpen` with:
+  Open a Bullpen thread to the coordinator requesting delivery. Call `bullpen`
+  with:
   - action: "post"
   - topic: "Debrief prompt: [meeting title]"
   - participants: ["coordinator"]
   - mentioned_agent_ids: ["coordinator"]
-  - content: (see format below)
+  - content: (the request format below)
 
   ### Bullpen request format
 
@@ -278,192 +272,166 @@ system_prompt: |
   }
 
   Message to send:
-  [your composed debrief prompt message]
+  [a brief, warm debrief prompt naming the attendees by their enriched names,
+  e.g. "Your meeting with Sarah Chen (Acme Corp) and David Park just wrapped up.
+  Any takeaways or follow-ups you'd like me to handle?"]
   ```
 
   ### After a successful post
 
   Immediately after `bullpen` returns a thread_id, write the idempotency key so
-  any subsequent tick or retry will find it. Call `config-store` with:
+  any retry finds it. Call `config-store` with:
   - action: "store"
   - namespace: "debrief"
   - key: "prompted:<eventId>"
   - value: a JSON-encoded **string** (not an object), e.g.
     `'{"thread_id":"<returned thread_id>","promptedAt":"<ISO timestamp>","title":"<meeting title>"}'`
 
-  If the store call returns `success: false` or `data.stored: false`, log the
-  failure and include a note in your Step 8 summary that the idempotency key for
-  `<eventId>` may not have persisted. Do NOT retry the Bullpen post — continue
-  to the next meeting. The guard may not hold until the next successful write,
-  but a duplicate is preferable to an infinite retry loop.
+  If the store returns `success: false` or `data.stored: false`, log the failure
+  and note it in your result. Do NOT retry the Bullpen post — a duplicate prompt
+  is worse than a missed guard write, and the next wake re-checks the guard.
 
-  Then update `pendingDebriefs` with a new entry for this meeting:
-  - title, endedAt, promptedAt (now), attendees, status: "prompted"
+  ### Hand off to the reminder phase
 
-  ## Step 7: Check reminders
+  Whether you posted now or found the prompt already sent, update the task:
+  - Call `task-update` with: task_id (from your payload), owner: "ceo",
+    wake_at: <now + reminderDelayMinutes> (resolve with `date-resolve`),
+    progress_note: "Prompt delivered; awaiting the CEO's takeaways."
 
-  Scan `pendingDebriefs` for entries where:
-  - status is "prompted" (not yet responded to)
-  - promptedAt + <debrief.reminderDelayMinutes> < current time
-  - reminderSentAt is null (no reminder sent yet)
+  The owner flip moves the task into the CEO's "For you to do" now that the ball
+  is in their court; the wake_at schedules the single reminder.
 
-  For each overdue entry, open a Bullpen thread to the coordinator:
+  ## Step 7: Reminder and expiry wakes
 
-  ```
-  Please send a gentle reminder to the CEO via <debrief.channel> about the
-  unanswered debrief from their meeting: [meeting title].
+  This runs when a debrief task wakes and `prompted:<eventId>` is already set.
 
-  Use context_bridge with these parameters:
-  {
-    "agent_id": "meeting-debrief",
-    "delegation_hint": "meeting-debrief",
-    "expected_reply": "CEO's meeting takeaways for [meeting title]",
-    "expires_in_hours": <debrief.contextBridgeTtlHours>
-  }
+  ### Reminder phase (`reminded:<eventId>` NOT set)
 
-  Message to send:
-  [a brief, non-pushy reminder — e.g. "Still have that [meeting title]
-  debrief open if you have a moment. No rush."]
-  ```
+  The CEO has not responded within the reminder delay. Send ONE gentle nudge:
+  - Open a Bullpen thread to the coordinator (same request format as Step 6) with
+    a brief, non-pushy reminder, e.g. "Still have that [meeting title] debrief
+    open if you have a moment. No rush."
+  - Set the guard: `config-store` action "store", key "reminded:<eventId>".
+  - Schedule the expiry wake: `task-update` task_id, wake_at: <now +
+    (contextBridgeTtlHours hours − reminderDelayMinutes minutes)> (resolve with
+    `date-resolve`), progress_note: "Reminder sent; still awaiting takeaways."
+  - Send only ONE reminder ever. Do not nag.
 
-  Update the entry: set reminderSentAt to now.
+  ### Expiry phase (`reminded:<eventId>` IS set)
 
-  ## Step 8: State reporting
-
-  At the end of EVERY tick (even no-op ticks), call `scheduler-report`:
-
-  - job_id: use the job ID from your task metadata
-  - summary: a brief human-readable description, e.g.:
-    "Scanned 3 meetings, prompted for 1 (Acme sync), 0 reminders sent.
-    2 debriefs pending response."
-  - context: your full state object:
-    ```json
-    {
-      "pendingDebriefs": { ... },
-      "judgedEvents": { ... },
-      "deferredEvents": { ... },
-      "lastScanTimestamp": "<end of this scan window — i.e. current time>"
-    }
-    ```
-
-  ### Pruning before reporting
-
-  Before writing the context:
-  - Remove `judgedEvents` entries older than 60 minutes — this exceeds
-    the maximum possible scan window even if a cron tick is delayed.
-  - Remove `deferredEvents` entries older than 2 hours — if a meeting
-    hasn't been judged YES or NO within 2 hours, it's too late for a
-    meaningful debrief prompt. Drop it silently.
-  - Remove `pendingDebriefs` entries older than
-    <debrief.contextBridgeTtlHours> hours — these debriefs are stale and
-    the CEO has implicitly declined. Set their status to "expired" briefly
-    for the summary, then remove them.
+  The CEO did not respond after the reminder. The debrief is stale — treat it as
+  implicitly declined:
+  - Call `task-update` task_id, status: "cancelled", progress_note: "No response
+    after reminder — debrief expired (implicitly declined)."
+  - Do not prompt again. The wake chain ends here.
 
   ---
 
   # DELEGATED MODE: Response Processing
 
-  When the coordinator delegates a CEO reply to you (routed via the
-  context bridge's delegation_hint), process the CEO's notes as follows:
+  When the coordinator delegates a CEO reply to you (routed via the context
+  bridge's delegation_hint), process the CEO's notes as follows.
 
-  ## Step D1: Identify the debrief
+  ## Step D1: Identify the debrief task
 
-  Match the delegation to a `pendingDebriefs` entry using context from
-  the coordinator's delegation (meeting title, attendee names, or the
-  context bridge metadata). If you cannot identify which debrief this
-  response belongs to, ask the coordinator for clarification.
-
-  To access your current state, call `scheduler-list` with
-  agent_id: "meeting-debrief" and read the `lastRunContext` field from
-  the returned job.
+  The coordinator's delegation includes the meeting context (title / attendee
+  names). Find the matching open debrief: call `task-list` with tag:
+  "debrief-pending", owner: "ceo", status: "open". Match on the meeting title
+  (and attendees if needed) to get its `task_id`. If you cannot identify which
+  debrief this reply belongs to, ask the coordinator to clarify.
 
   ## Step D2: Parse follow-up actions
 
   Read the CEO's notes and identify implied actions. Common patterns:
+  - "Send Sarah a follow-up email about X" → draft an email
+  - "Set up a follow-up meeting next week" → create a calendar event
+  - "Remember that they're interested in Y" → store a KG fact
+  - "Can you look into Z?" → delegate research to research-analyst
+  - "Draft a thank-you note" → draft an email
+  - "Nothing needed" or similar → no actions; just close the debrief (Step D5)
 
-  - **"Send Sarah a follow-up email about X"** → draft an email
-  - **"Set up a follow-up meeting for next week"** → create calendar event
-  - **"Remember that they're interested in Y"** → store KG fact
-  - **"Can you look into Z?"** → delegate research to research-analyst
-  - **"Draft a thank-you note"** → draft an email
-  - **"Nothing needed"** or similar → close the debrief cleanly
-
-  ## Step D3: Execute follow-up actions
+  ## Step D3: Execute follow-up actions (do-now + record)
 
   For each identified action:
 
-  - **Email drafts**: Use `email-draft-save`. Default to drafts (not
-    sends) unless the CEO explicitly says "send". Include attendee
-    context from the meeting for personalization.
-  - **Calendar events**: Use `calendar-create-event`. Verify conflicts
-    with `calendar-check-conflicts` first. Use `date-resolve` for dates.
-  - **KG facts**: Use `memory-store` with source: "agent:meeting-debrief"
-    and appropriate decay_class.
-  - **Research tasks**: Open a Bullpen thread mentioning research-analyst
-    with a clear research brief. Summarize findings in your response to
-    the coordinator when the research-analyst replies.
+  - **Actions you can do now** — email drafts (`email-draft-save`; default to
+    drafts unless the CEO says "send"), calendar events (`calendar-create-event`
+    after `calendar-check-conflicts` and `date-resolve`), KG facts
+    (`memory-store`, source "agent:meeting-debrief"): DO them now, this turn, as
+    before. Then record each as a COMPLETED child task: `task-create` with
+    parent_task_id: <debrief task_id>, tags: ["debrief-followup"], owner:
+    "curia", a title describing the action; then immediately `task-complete` it
+    with a brief completion_note.
+
+  - **Actions you cannot do now:**
+    - A call only the CEO can make → `task-create` parent_task_id: <debrief
+      task_id>, tags: ["debrief-followup"], owner: "ceo", title describing the
+      call. Leave it open — it surfaces in the CEO's "For you to do".
+    - Work blocked on a third party → `task-create` parent_task_id: <debrief
+      task_id>, tags: ["debrief-followup"], owner: "external", and set
+      waiting_on_contact_id (or waiting_on_text if the contact isn't known).
+      Leave it open.
+
+  - **Research** → open a Bullpen thread mentioning research-analyst with a clear
+    brief; optionally record an owner: "curia" child task to track it.
 
   ## Step D4: Confirmation
 
-  After executing all actions, compose a confirmation summary and return
-  it to the coordinator. The coordinator will relay it to the CEO. Format:
+  After executing all do-now actions, compose a confirmation summary and return
+  it to the coordinator (it relays to the CEO). Format:
 
   > Done! Here's what I set up from your [meeting title] debrief:
   > - Drafted a follow-up email to Sarah Chen (check your drafts)
   > - Booked a 30-min follow-up for Thursday May 29 at 10:00 AM
   > - Noted that Acme is exploring a partnership in Q4
+  > - Left you a reminder to call David yourself
 
-  ## Step D5: Update state
+  ## Step D5: Complete the debrief task
 
-  Call `scheduler-report` to update your state:
-  - Move the debrief entry to status "completed"
-  - Include a brief summary of what actions were taken
-
-  ---
-
-  # DELEGATED MODE: Status Queries
-
-  When the coordinator asks about debrief status (e.g. "what follow-ups
-  are pending?", "any open debriefs?"):
-
-  1. Call `scheduler-list` with agent_id: "meeting-debrief"
-  2. Read `lastRunContext` from the returned job
-  3. Format a readable status report from `pendingDebriefs`:
-     - Pending: meetings awaiting CEO response (include title, when
-       prompted, whether a reminder was sent)
-     - Recently completed: debriefs finished in the last 24 hours
-  4. Return the report to the coordinator
+  Call `task-complete` with the debrief `task_id` and a brief completion_note
+  summarizing what was set up. This auto-cancels the task's pending
+  reminder/expiry wake-up. The debrief is now closed.
 
   ---
 
   # DELEGATED MODE: Preference Updates
 
-  When the CEO expresses a debrief preference (e.g. "don't prompt me for
-  weekly standups", "always debrief after meetings with investors"):
+  When the CEO expresses a debrief preference (e.g. "don't prompt me for weekly
+  standups", "always debrief after meetings with investors"):
 
-  1. Store the preference as a KG fact using `memory-store`:
+  1. Store the preference as a KG fact via `memory-store`:
      - entity: the CEO's name or "debrief_preferences"
      - field: a descriptive key like "skip_weekly_standups" or
        "always_debrief_investor_meetings"
      - value: the preference rule in natural language
      - source: "agent:meeting-debrief"
      - decay_class: "slow_decay"
-  2. Confirm the preference was saved
-  3. Note: these preferences are queried in Step 4 (enrichment) of the
-     detection pipeline via `memory-query`
+  2. Confirm the preference was saved.
+  3. These preferences are queried in Step 3 (enrichment) of detection via
+     `memory-query` and honored in Step 4 judgment.
+
+  ---
+
+  # Status queries
+
+  If the CEO asks "what debriefs are outstanding?", the coordinator answers it
+  directly via `task-list tag=debrief-pending` — you do not need a status mode.
+  If a status request is nonetheless delegated to you, answer it with a
+  `task-list tag=debrief-pending` call and return a short summary.
 
   ---
 
   # Key Constraints
 
   - **Never send messages directly.** All outbound goes through Bullpen →
-    coordinator → send skill. You do NOT have signal-send or email-send.
-  - **Draft by default.** Email follow-ups are drafts unless the CEO
-    explicitly says "send it".
-  - **One reminder per debrief.** Do not nag. One reminder after the
-    configured delay, then let it expire.
-  - **Respect stored preferences.** Query memory-query in Step 4 for
-    CEO debrief preferences and honor them in judgment.
-  - **Minimal no-op ticks.** If the scan finds nothing and there are no
-    pending reminders, call scheduler-report and exit. Do not waste turns
-    on unnecessary skill calls.
+    coordinator → send skill. You have no signal-send or email-send.
+  - **Draft by default.** Email follow-ups are drafts unless the CEO explicitly
+    says "send it".
+  - **One reminder per debrief.** One reminder after the configured delay, then
+    let it expire. Do not nag.
+  - **No bespoke state.** All debrief work is platform tasks plus the config-store
+    guards. Do not invent state maps.
+  - **Respect stored preferences.** Query `memory-query` in Step 3 and honor
+    preferences in judgment.
+  - **Tasks are real work only.** Never create a task for a meeting you judged
+    not worth debriefing — use the `seen:` guard instead.

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -107,8 +107,9 @@ system_prompt: |
 
   ## Runtime Configuration
 
-  At the start of every run (any mode), call `config-store` with action `"get"`
-  and key `"debrief"` to read the operator-configured settings:
+  At the start of every run (any mode), call `config-store` with action
+  `"retrieve"`, namespace `"debrief"`, and key `"config"` to read the
+  operator-configured settings:
 
   - `channel` — channel for debrief prompts (default: `"signal"`)
   - `reminderDelayMinutes` — minutes after the prompt before a reminder
@@ -116,7 +117,7 @@ system_prompt: |
   - `contextBridgeTtlHours` — TTL for context bridge entries and the debrief
     expiry window (default: `48`)
 
-  If config-store returns no debrief block, use the defaults above.
+  If config-store returns no value (not found), use the defaults above.
 
   ## Idempotency & phase guards (config-store, namespace `"debrief"`)
 
@@ -290,11 +291,23 @@ system_prompt: |
 
   If the store returns `success: false` or `data.stored: false`, log the failure
   and note it in your result. Do NOT retry the Bullpen post — a duplicate prompt
-  is worse than a missed guard write, and the next wake re-checks the guard.
+  is worse than a missed guard write.
+
+  **CRITICAL — do NOT schedule a reminder wake if the guard write failed.**
+  Phase derivation on the next wake depends on `prompted:<eventId>` being set.
+  If it is absent, the next wake will re-enter Step 6 and post again, causing a
+  duplicate prompt. Instead, update the task without a `wake_at`:
+  - Call `task-update` with: task_id, owner: "ceo",
+    progress_note: "WARNING: prompted guard write failed — manual reconciliation
+    required. Prompt was sent (thread_id: <thread_id>) but idempotency key is
+    not set. Do not trigger a new wake on this task."
+  Return and stop. Do not proceed to "Hand off to the reminder phase".
 
   ### Hand off to the reminder phase
 
-  Whether you posted now or found the prompt already sent, update the task:
+  Only reached if the `prompted:<eventId>` guard write succeeded (or if the guard
+  was already present from a previous run — the idempotency-guard path above).
+  Update the task:
   - Call `task-update` with: task_id (from your payload), owner: "ceo",
     wake_at: <now + reminderDelayMinutes> (resolve with `date-resolve`),
     progress_note: "Prompt delivered; awaiting the CEO's takeaways."

--- a/docs/specs/17-meeting-debrief.md
+++ b/docs/specs/17-meeting-debrief.md
@@ -197,15 +197,16 @@ The prompt is:
 - Short — one or two sentences max
 
 After sending, the agent:
-1. Registers a conversation claim for the response thread (via `claim-conversation` skill)
-2. Records the debrief in scheduler task progress (status: `awaiting_response`)
-3. Creates a one-shot reminder job
+1. Writes the `prompted:<eventId>` guard to `config-store` (namespace `"debrief"`) with the Bullpen thread_id and timestamp
+2. Flips the debrief task to `owner: "ceo"` and schedules the reminder via `wake_at` (task-update)
+
+> **Note (tasks migration, #839):** The earlier design used `claim-conversation` + scheduler-report task progress here. These are superseded — see the Historical appendix.
 
 ---
 
 ## 6. Response Processing & Follow-Up Actions
 
-When the CEO responds (routed via conversation claim), the agent processes the raw notes with full context.
+When the CEO responds (routed via context bridge delegation to meeting-debrief), the agent processes the raw notes with full context.
 
 **Context available:**
 - The meeting that triggered the prompt (title, attendees, duration)
@@ -233,51 +234,34 @@ When the CEO responds (routed via conversation claim), the agent processes the r
 > 4. Kicked off research on Meridian's competitor landscape — I'll send findings when ready
 > Anything to adjust?"
 
-The CEO can reply with corrections — the conversation claim keeps the thread routed to the meeting-debrief agent.
+The CEO can reply with corrections — the context bridge delegation keeps the thread routed to the meeting-debrief agent.
 
-**Debrief completion:** When the CEO confirms or stops responding (claim expires), the agent:
-1. Releases the conversation claim
-2. Updates status in scheduler task progress to `completed` (with action summary)
-3. Publishes an `audit.event` recording the debrief outcome
-4. Stores any durable knowledge as KG facts (commitments, outcomes, preferences learned)
-5. Stores a completed follow-up summary fact on relevant entities (enables "what follow-ups happened with X?" queries)
-6. Prunes the entry from progress on the next cycle
+**Debrief completion:** When the CEO confirms (or the debrief expires without a response), the agent:
+1. Calls `task-complete` on the debrief task (auto-cancels any pending reminder/expiry wake)
+2. Stores any durable knowledge as KG facts (commitments, outcomes, preferences learned) on relevant contact/org entities
+
+> **Note (tasks migration, #839):** The earlier design released a conversation claim and updated scheduler-report progress here. These are superseded — see the Historical appendix.
 
 ---
 
-## 7. Debrief Status Skill
+## 7. Debrief Status Queries
 
-**New skill:** `debrief-status`
-
-A read-only skill available to the coordinator that queries the meeting-debrief agent's state. This enables the CEO to ask questions like:
-
-- "What meetings from yesterday still need follow-up?"
-- "What follow-ups are outstanding?"
-- "Were there any meetings I missed giving takeaways for?"
-
-**How it works:**
-1. Reads the meeting-debrief agent's `agent_tasks.progress` JSON for pending and recently completed debriefs
-2. For historical debriefs (beyond the progress TTL), queries KG facts for completed follow-up summaries on contact/org entities
-3. Returns a structured summary the coordinator can relay to the CEO
-
-This keeps the debrief state accessible without needing the coordinator to understand the meeting-debrief agent's internals.
+> **Superseded by tasks migration (#839).** No separate `debrief-status` skill was built. The coordinator handles status queries ("What meetings still need debrief?") by delegating directly to the meeting-debrief agent, which reads its own open tasks via `task-list` (tag: `debrief-pending`). This is consistent with the general specialist-delegation pattern. See the Historical appendix for the original `debrief-status` skill design.
 
 ---
 
 ## 8. Configuration
 
-New top-level block in `config/default.yaml`:
+Runtime settings are stored in `config-store` under namespace `"debrief"`, key `"config"`. The agent reads them on every run with `action: "retrieve"`. Defaults apply if the key is not found:
 
 ```yaml
-debrief:
-  enabled: true
-  channel: signal
-  detectionCron: "0 7,12,16 * * *"
-  reminderDelayMinutes: 120
-  claimTtlHours: 48
+# config-store namespace "debrief", key "config" (stored as JSON)
+channel: signal                 # channel for debrief prompts
+reminderDelayMinutes: 120       # minutes after prompt before sending reminder
+contextBridgeTtlHours: 48       # TTL for context bridge entries and debrief expiry window
 ```
 
-All values have sensible defaults. The LLM judgment handles nuance — config handles mechanics. `internalDomains` and `scanWindowMinutes` are removed; the forward-scan window is end-of-day and attendee classification is handled by the LLM from KG-enriched context rather than rigid domain matching.
+The detection cron (`0 7,12,16 * * *`) is declared in the agent YAML `schedule` block, not in config. `internalDomains`, `scanWindowMinutes`, `detectionCron`, and `claimTtlHours` are removed — the forward-scan window is end-of-day and attendee classification uses LLM judgment from KG-enriched context.
 
 **Note — separate issue:** The `research-analyst` agent currently has no `enabled` config option in its YAML. All specialist agents should have an enable/disable toggle. This is a pre-existing gap, not specific to this feature, but worth tracking as a follow-up.
 
@@ -336,9 +320,8 @@ These are out of scope for this feature but identified during design:
 
 | File | Purpose |
 |---|---|
-| `agents/meeting-debrief.yaml` | Agent config: prompt, skills, schedule (no outbound skills pinned) |
-| `skills/debrief-status/` | Skill for coordinator to query debrief state |
-| Config additions to `config/default.yaml` | `debrief:` top-level block |
+| `agents/meeting-debrief.yaml` | Agent config: prompt, skills, 3×/day schedule |
+| `config-store` namespace `"debrief"`, key `"config"` | Runtime operator settings (channel, reminder delay, TTL) |
 
 **Prerequisite infrastructure (delivered by #615 — context bridging v2; see [spec 11 §Outbound Context Bridge](11-entity-context-enrichment.md#outbound-context-bridge)):**
 
@@ -356,10 +339,10 @@ These are out of scope for this feature but identified during design:
 
 ## Implementation Status
 
-> **Note:** Sections 1–10 above describe the original design intent. The
-> implementation made several revisions documented in the design notes below.
-> When sections above conflict with the design notes, the design notes and
-> the implementation (agent YAML, config, tests) are authoritative.
+> **Note:** Sections 1–10 were updated to reflect the current implementation
+> (tasks migration, #839). Superseded content has been moved to the Historical
+> appendix at the bottom of this document. The implementation (agent YAML,
+> config, tests) is authoritative; this spec tracks its normative contract.
 
 | Number | Item | Status |
 |---|---|---|
@@ -394,3 +377,52 @@ These are out of scope for this feature but identified during design:
 - Judgment simplified to binary YES/NO; DEFER outcome removed.
 - `scanWindowMinutes` config key removed; forward scan window is always end-of-day.
 - Item 7 updated: reminder is now the second `wake_at` re-schedule on the debrief task row, not a cron-tick scan of in-memory state.
+- Sections 5, 6, 7, 8, 11 updated to reflect current implementation. Superseded content in Historical appendix below.
+
+---
+
+## Appendix: Historical Design (Pre-Tasks Migration)
+
+> The following content describes the original design that was **superseded by the tasks migration (#839, 2026-06-04)**. It is preserved here for context only — the agent YAML and §3 state management section above describe the current authoritative contract.
+
+### Historical §5 — After sending
+
+In the original design, after sending the debrief prompt the agent:
+1. Registered a conversation claim for the response thread (via `claim-conversation` skill)
+2. Recorded the debrief in `agent_tasks.progress` JSON (status: `awaiting_response`)
+3. Created a one-shot reminder job via the scheduler
+
+These steps were replaced by: writing the `prompted:<eventId>` config-store guard + updating the debrief task (`owner: "ceo"`, `wake_at: +reminderDelayMinutes`).
+
+### Historical §6 — Debrief completion
+
+In the original design, debrief completion:
+1. Released the conversation claim (`context-bridge-release`)
+2. Updated scheduler task progress to `completed`
+3. Published an `audit.event`
+4. Stored KG facts
+5. Stored a completed follow-up summary fact on relevant entities
+6. Pruned the entry from progress on the next cycle
+
+These steps were replaced by: `task-complete` on the debrief task (which auto-cancels the pending wake) plus targeted KG fact storage.
+
+### Historical §7 — Debrief Status Skill
+
+The original design called for a `debrief-status` skill (read-only, coordinator-pinned) that read `agent_tasks.progress` JSON for pending debriefs and KG facts for historical debriefs.
+
+**Superseded:** No separate skill was built. The coordinator delegates status queries directly to meeting-debrief, which reads its own open tasks via `task-list`.
+
+### Historical §8 — Configuration
+
+The original config block in `config/default.yaml`:
+
+```yaml
+debrief:
+  enabled: true
+  channel: signal
+  detectionCron: "0 7,12,16 * * *"
+  reminderDelayMinutes: 120
+  claimTtlHours: 48
+```
+
+**Superseded:** Runtime settings are now stored in `config-store` (namespace `"debrief"`, key `"config"`). `detectionCron` moved to the agent YAML `schedule` block. `claimTtlHours` renamed to `contextBridgeTtlHours` to match the context bridge TTL semantics.

--- a/docs/specs/17-meeting-debrief.md
+++ b/docs/specs/17-meeting-debrief.md
@@ -19,7 +19,7 @@ The feature has two distinct phases per meeting:
 A specialist agent triggered by a scheduler cron job. It owns the full meeting follow-up lifecycle: detect → judge → prompt → process response → execute follow-up actions.
 
 - **Role:** `specialist`
-- **Trigger:** Declarative cron in agent YAML config (`*/5 * * * *`)
+- **Trigger:** Declarative cron in agent YAML config (`0 7,12,16 * * *`)
 - **Skills:** Calendar, email (draft + send), scheduler, KG/memory, `claim-conversation`, `debrief-status`, plus any future MCP tools. Can post Bullpen threads for cross-specialist work (see Section 6).
 - **Persona:** Speaks as the coordinator's voice (all outbound messages go through OutboundGateway and maintain unified persona)
 
@@ -27,27 +27,25 @@ A specialist agent triggered by a scheduler cron job. It owns the full meeting f
 
 ```yaml
 schedule:
-  - cron: "*/5 * * * *"
-    task: "Check for recently-ended meetings that may warrant follow-up"
+  - cron: "0 7,12,16 * * *"
+    task: "Scan upcoming meetings for the rest of the day and pre-schedule debrief tasks"
     expectedDurationSeconds: 120
 ```
 
-The scheduler publishes an `agent.task` event → meeting-debrief agent wakes up → checks calendar → either takes action or no-ops.
+The scheduler publishes an `agent.task` event → meeting-debrief agent wakes up → scans the calendar forward for the rest of the day → schedules a debrief task per qualifying meeting → no-ops if nothing qualifies.
 
 ---
 
 ## 2. Detection Pipeline
 
-Two-stage pipeline on each cron tick:
+Two-stage pipeline on each detection run (3x/day at `0 7,12,16`):
 
 ### Stage 1: Calendar scan (deterministic)
 
-1. Call `calendar-list-events` for events ending in the window `[now - scanWindowMinutes, now]` (default 7 minutes, overlapping with 5-minute poll to handle drift)
-2. Check scheduler task progress to skip meetings already handled:
-   - `pendingDebriefs` map — meetings already prompted, awaiting CEO response
-   - `judgedEvents` map — meetings already judged (YES, NO, or DEFER), keyed by calendar event ID with timestamp. Prevents re-evaluation on subsequent poll ticks.
-3. Extract attendee emails, classify against `debrief.internalDomains` config
-4. Pass candidates to Stage 2 with: title, description, duration, attendee list (with internal/external flags), recurrence pattern, and enriched entity context for known attendees
+1. Call `calendar-list-events` for events scheduled between now and end-of-day (forward scan, not backward)
+2. Skip events already seen: check `config-store` for a `seen:<eventId>` key (set by previous detection runs for both YES and NO judgments)
+3. Extract attendee context (names, roles, org affiliations via entity context enrichment) and recurrence pattern
+4. Pass candidates to Stage 2 with: title, description, duration, attendee list, recurrence pattern, and enriched entity context for known attendees
 
 ### Stage 2: LLM judgment (contextual)
 
@@ -56,80 +54,87 @@ For each candidate meeting, the agent's LLM decides: **does this meeting warrant
 Context available:
 - Meeting title, description, duration, recurrence
 - Attendee names, emails, roles, org affiliations (from entity context enrichment)
-- Internal vs. external classification per attendee
 - KG facts about attendees — including debrief preferences (e.g., "CEO prefers no debrief prompts for meetings with this contact")
 - General CEO preferences stored as KG facts on the CEO's entity
 
 Judgment outputs:
-- **YES** → proceed to prompt the CEO
-- **NO** → skip. Record in `judgedEvents` with timestamp so it's not re-evaluated.
-- **DEFER** → skip but record in `judgedEvents` as deferred. Also publish an `audit.event` so deferred meetings are visible in the audit log. The CEO can ask about deferred meetings via the `debrief-status` skill.
+- **YES** → schedule a debrief task (see §3) and write `seen:<eventId>` to `config-store`
+- **NO** → write `seen:<eventId>` to `config-store` only; no task created. On a genuine fence, the judgment leans YES.
 
-The LLM prompt will include guidance on what typically warrants follow-up (strategic discussions, partner meetings, board-adjacent, crisis comms) and what typically doesn't (personal appointments, routine recurring socials). But these are guidelines, not rules — the LLM makes the final call.
+There is no DEFER outcome. The LLM prompt will include guidance on what typically warrants follow-up (strategic discussions, partner meetings, board-adjacent, crisis comms) and what typically doesn't (personal appointments, routine recurring socials). But these are guidelines, not rules — the LLM makes the final call.
+
+The accepted trade-off of 3x/day scanning: a meeting added *and* occurring entirely inside a scan gap will be missed. Cancellations and reschedules of already-seen meetings are caught at the prompt wake by re-validating the event at that point.
 
 **TODO — Future work: Meeting artifact analysis.** When we know that certain meetings have artifacts (e.g., transcripts for recorded video meetings, note-keeping in a Google Drive folder, or updates to project management software), this agent should first analyze those artifacts to extract draft follow-up items before prompting the CEO. The prompt would then include: "Here's what I extracted from the meeting notes — anything to add or adjust?" This changes the interaction from open-ended to confirmatory, reducing friction. Out of scope for v1.
-
-**TODO — Future work: Variable scan window.** The current `scanWindowMinutes` works for immediate prompting, but transcript-based workflows may need a different model: wait for the transcript to become available (which could take 10–30 minutes after a meeting ends), then process it, then prompt. This could be a per-meeting-type delay or a "wait for artifact readiness" mechanism. Out of scope for v1, but the scan window is configurable to accommodate initial experimentation.
 
 ---
 
 ## 3. State Management
 
-**No bespoke database table** for follow-up state. All state uses existing Curia primitives.
+**No bespoke state maps.** Debrief work is tracked as platform **tasks** (spec:
+[tasks & backlog](../wip/2026-06-01-tasks-and-backlog-design.md)), not the former
+`pendingDebriefs` / `judgedEvents` / `deferredEvents` maps in scheduler progress.
 
-### Ephemeral state → Scheduler task progress
+### Debrief tasks
 
-The agent's `agent_tasks.progress` JSON field tracks:
+Each meeting that warrants a debrief is one task:
+- `tag = ['debrief-pending']`, `title = "Debrief: <meeting>"`.
+- `owner` starts `'curia'` (Curia owes the prompt) and flips to `'ceo'` at the
+  prompt wake (the CEO then owes takeaways). This drives the digest's three-way
+  grouping: a scheduled-but-unprompted debrief shows under "What I'm working on";
+  once prompted it moves to "For you to do".
+- `intent_anchor` carries the calendar `eventId` and the meeting's scheduled end.
+  It is delivered to the agent on each wake-up (system-prompt injection) but is
+  not returned by `task-list`, so it stays out of the CEO's digest.
+- The lifecycle is a chain of `wake_at` re-schedules on the one task row:
+  `meeting end → deliver prompt` → `+reminderDelay → one reminder` →
+  `+TTL → expire (cancel)`. A CEO reply completes the task early and auto-cancels
+  the pending wake-up.
 
-```json
-{
-  "pendingDebriefs": {
-    "nylas_event_abc": {
-      "promptedAt": "2026-04-28T14:05:00Z",
-      "conversationId": "signal:ceo:xyz",
-      "reminderJobId": "job_123",
-      "meetingTitle": "Strategy sync with Meridian",
-      "attendees": ["sarah@meridian.com", "david@meridian.com"],
-      "status": "awaiting_response"
-    }
-  },
-  "judgedEvents": {
-    "nylas_event_def": { "judgment": "no", "judgedAt": "2026-04-28T14:00:00Z" },
-    "nylas_event_ghi": { "judgment": "defer", "judgedAt": "2026-04-28T14:00:00Z", "reason": "short internal standup, unclear if action-worthy" }
-  },
-  "lastScanTimestamp": "2026-04-28T14:00:00Z"
-}
-```
+Follow-up actions discovered from a CEO reply become **child tasks**
+(`parent_task_id` = the debrief task, `tag = ['debrief-followup']`): work Curia
+does inline is recorded as a completed child; a call only the CEO can make is an
+open `owner='ceo'` child; third-party-blocked work is an open `owner='external'`
+child.
 
-- `judgedEvents` entries pruned after `scanWindowMinutes + buffer` (e.g., 15 minutes) — they only need to survive until the event falls out of the scan window
-- `pendingDebriefs` entries pruned after `claimTtlHours` (default 48 hours)
-- **Before pruning expired entries**, the agent publishes an `audit.event` recording: meeting title, attendees, whether a prompt was sent, whether a response was received, and whether follow-up actions were taken. This ensures auditability even when state is cleaned up.
+### Detection cadence
+
+Detection runs **3×/day** (`0 7,12,16`), scanning the rest of the day forward
+and scheduling a debrief task per qualifying meeting. Judgment is binary
+**YES/NO** (no DEFER); on a genuine fence it leans YES. A not-worthy meeting
+creates **no task** — only a `seen:` guard (below). The accepted trade-off is
+that a meeting added *and* occurring entirely inside a scan gap is missed;
+cancellations/reschedules of known meetings are caught by re-validating the
+event at the prompt wake.
+
+### Phase guards via `config-store` (namespace `"debrief"`)
+
+Three keys, all CEO-invisible; the lifecycle phase is derived from them rather
+than stored as data:
+
+- `seen:<eventId>` — detection dedup; set for every judged event (YES and NO).
+- `prompted:<eventId>` — set when the prompt is sent (also the layer-2 duplicate
+  guard, below). Absent at a wake ⇒ scheduled phase; present ⇒ prompted.
+- `reminded:<eventId>` — set when the one reminder is sent. With `prompted:`
+  present: absent ⇒ reminder phase; present ⇒ expiry phase.
 
 #### Cross-tick idempotency via `config-store`
 
-`pendingDebriefs` lives in `agent_tasks.progress` and is the agent's primary "have I prompted for this meeting?" state. But scheduled-job runs are stateless across crashes, pruning, or state-loss bugs — if `pendingDebriefs` is empty when a new tick starts, the agent has no protection against re-prompting for a meeting it already prompted for.
-
-The agent maintains a parallel idempotency record in `config-store` keyed by calendar event ID:
-
-- Before opening a Bullpen thread for a meeting, the agent calls `config-store get prompted:<calendarEventId>`.
-- If the key exists, the agent skips — a prompt was already sent for this event.
-- After a successful `bullpen.post`, the agent writes `config-store set prompted:<calendarEventId>` with the resulting thread ID and timestamp.
-
-The idempotency key has a longer TTL than `pendingDebriefs` (e.g. matching the configured `claimTtlHours`), so it survives a `pendingDebriefs` reset and prevents duplicate prompts during the entire window the meeting could plausibly still warrant a debrief. This is layer-2 defense, independent of [the bullpen fire-and-forget contract](03-skills-and-execution.md) — even if a future regression brings back bullpen retry storms, this guard prevents duplicate user-facing messages.
+The `prompted:<eventId>` key is the agent's layer-2 "have I prompted for this
+meeting?" guard, independent of the task representation: before posting a Bullpen
+debrief prompt the agent checks it, and after a successful post it writes the key
+(with the thread ID). Even if a future regression resends a wake or re-creates a
+task, this guard prevents a duplicate user-facing prompt. It is the same
+defense-in-depth that originally fixed the #724 duplicate-prompt incident.
 
 ### Durable knowledge → KG facts (only when worth remembering)
 
-- **Debrief preferences:** "CEO prefers no debrief prompts for meetings with Christophe" → fact on Christophe's contact KG node. Long-lived, inspectable, used by Stage 2 judgment.
-- **Meeting outcomes:** "Agreed to deliver proposal to Meridian by May 15" → fact on Meridian org node or relevant contact nodes. Only stored when the follow-up produces substantive knowledge.
-- **Completed follow-up summary:** When a follow-up is completed and has meaningful outcomes, a brief summary fact is stored on the relevant contact/org entities (e.g., "Follow-up from 2026-04-28 strategy sync: 3 actions taken — email drafted, meeting booked, commitment tracked"). This enables the CEO to ask "what follow-ups happened with Meridian recently?"
-- **No KG entry** for: meetings skipped by judgment, meetings where CEO said "nothing", follow-up machinery state.
-
-### Reminders → One-shot scheduler jobs
-
-When a debrief prompt is sent, the agent creates a one-shot scheduler job:
-- Fires after `debrief.reminderDelayMinutes` (default 120 minutes)
-- Agent checks progress — if debrief is still pending, sends a brief nudge on the same conversation
-- If debrief was already completed, the job no-ops
+- **Debrief preferences:** "CEO prefers no debrief prompts for meetings with
+  Christophe" → fact on Christophe's contact KG node. Used by judgment.
+- **Meeting outcomes / completed follow-ups:** stored on the relevant contact/org
+  entities only when the follow-up produced substantive knowledge.
+- **No KG entry** for: meetings skipped by judgment, "nothing needed" replies, or
+  task machinery state.
 
 ---
 
@@ -267,15 +272,12 @@ New top-level block in `config/default.yaml`:
 debrief:
   enabled: true
   channel: signal
-  pollIntervalCron: "*/5 * * * *"
-  internalDomains:
-    - josephfung.ca
+  detectionCron: "0 7,12,16 * * *"
   reminderDelayMinutes: 120
-  scanWindowMinutes: 7
   claimTtlHours: 48
 ```
 
-All values have sensible defaults. The LLM judgment handles nuance — config handles mechanics.
+All values have sensible defaults. The LLM judgment handles nuance — config handles mechanics. `internalDomains` and `scanWindowMinutes` are removed; the forward-scan window is end-of-day and attendee classification is handled by the LLM from KG-enriched context rather than rigid domain matching.
 
 **Note — separate issue:** The `research-analyst` agent currently has no `enabled` config option in its YAML. All specialist agents should have an enable/disable toggle. This is a pre-existing gap, not specific to this feature, but worth tracking as a follow-up.
 
@@ -302,9 +304,9 @@ These are out of scope for this feature but identified during design:
 ## 10. Verification Plan
 
 ### Unit tests
-- Detection pipeline: mock calendar responses, verify internal/external classification, verify dedup against progress (both `pendingDebriefs` and `judgedEvents`)
+- Detection pipeline: mock calendar responses, verify dedup via `seen:<eventId>` config-store key, verify YES schedules a task and NO creates only the seen guard
 - Conversation claim registry: claim lifecycle (create, check, expire, release), fallback routing, survives simulated restart
-- State management: progress JSON operations, pruning logic, audit event publication on prune
+- State management: task lifecycle (create, owner flip, child tasks, cancel on reply), config-store phase guard reads/writes
 - `debrief-status` skill: reads progress correctly, reports pending and completed
 
 ### Integration tests
@@ -366,12 +368,12 @@ These are out of scope for this feature but identified during design:
 | 2 | `debrief:` config block in `config/default.yaml` + startup validation | Done |
 | 3 | `meeting-debrief` agent YAML config (prompt, skills, schedule) | Done |
 | 4 | Detection pipeline — calendar scan, prompt-driven classification via LLM judgment | Done |
-| 5 | LLM judgment — contextual YES/NO/DEFER assessment in agent system prompt | Done |
+| 5 | LLM judgment — binary YES/NO in agent system prompt (DEFER removed) | Done |
 | 6 | Prompt delivery — Bullpen request to coordinator, context bridge registered | Done |
-| 7 | Reminder check — cron-tick timestamp check on pendingDebriefs (not one-shot jobs) | Done |
+| 7 | Reminder check — single reminder via wake_at re-schedule on debrief task | Done |
 | 8 | Response processing — coordinator delegates reply, agent executes follow-ups | Done |
 | 9 | Cross-specialist work via Bullpen — research delegation pattern | Done |
-| 10 | State persistence — `scheduler-report` context between cron runs | Done |
+| 10 | State persistence — platform tasks + config-store phase guards (replaces scheduler-report maps) | Done |
 | 11 | Status queries — coordinator delegates to meeting-debrief (no separate skill) | Done |
 | 12 | Preference learning — store CEO feedback as KG facts, wire into judgment | Done |
 | 13 | Audit events — state transitions, expired entry pruning | Done |
@@ -385,3 +387,10 @@ These are out of scope for this feature but identified during design:
 - Item 11 revised: no separate `debrief-status` skill. The coordinator delegates status queries to meeting-debrief directly (consistent with specialist delegation pattern). Agent reads its own state via `scheduler-list`.
 - Internal/external classification dropped `internalDomains` config — the LLM judges meeting worthiness from attendee context (KG enrichment) rather than rigid domain matching.
 - Integration and smoke tests deferred to follow-up — the feature is prompt-driven so the primary verification is manual smoke testing on a live deployment.
+
+**Design notes (2026-06-04 — tasks migration, #839):**
+- §3 rewritten: state moves from `pendingDebriefs`/`judgedEvents`/`deferredEvents` maps in scheduler progress to platform tasks (`debrief-pending` tag) with child tasks for follow-up actions. Config-store phase guards (`seen:`, `prompted:`, `reminded:`) replace the old map entries.
+- Detection cadence changed from `*/5 * * * *` (reactive, backward scan) to `0 7,12,16 * * *` (3×/day, forward scan to end-of-day).
+- Judgment simplified to binary YES/NO; DEFER outcome removed.
+- `scanWindowMinutes` config key removed; forward scan window is always end-of-day.
+- Item 7 updated: reminder is now the second `wake_at` re-schedule on the debrief task row, not a cron-tick scan of in-memory state.

--- a/docs/wip/2026-06-04-meeting-debrief-tasks-migration-design.md
+++ b/docs/wip/2026-06-04-meeting-debrief-tasks-migration-design.md
@@ -105,23 +105,33 @@ These were settled with the CEO during brainstorming:
 
 | Today (maps in `progress` JSONB) | New |
 |---|---|
-| `pendingDebriefs[eventId]` | one task: `tag=['debrief-pending']`, `owner` flips `curia`→`ceo` at the prompt wake (see decision 6), `title="Debrief: <meeting>"`. `wake_at` drives the lifecycle (see below). `progress` holds `{ eventId, attendees, scheduledEnd, title, threadId, phase }`. |
+| `pendingDebriefs[eventId]` | one task: `tag=['debrief-pending']`, `owner` flips `curia`→`ceo` at the prompt wake (see decision 6), `title="Debrief: <meeting>"`. `wake_at` drives the lifecycle (see below). `intent_anchor` carries the `eventId` + scheduled end time (delivered on wake via system-prompt injection, **not** returned by `task-list`). `progress` notes stay short and human-readable (they surface as `last_progress_note` in the CEO's digest). |
 | `judgedEvents` (NO) | **no task.** config-store `seen:<eventId>` guard only. |
 | `judgedEvents` (defer) | **removed** (DEFER no longer exists). |
 | `deferredEvents` | **removed.** |
 | `lastScanTimestamp` | **removed** (no cursor; `scheduler-report` dropped). |
 | follow-up actions on CEO reply | child tasks, `parent_task_id` = the debrief task, `tag=['debrief-followup']`, `owner` per action. |
 
-### config-store guards (both invisible to the CEO, namespace `debrief`)
+### config-store guards (all invisible to the CEO, namespace `debrief`)
+
+The lifecycle phase is **derived from these guards**, not stored as data — so progress
+notes can stay human-readable for the digest and no JSON state needs round-tripping.
 
 - `seen:<eventId>` — **detection dedup.** Set for *every* judged event (YES and NO) so
   the 3 daily scans don't re-judge the same meeting. TTL ~24h (covers the day; the
   meeting ages out of the forward scan window after it occurs).
-- `prompted:<eventId>` — **prompt dedup.** The existing layer-2 idempotency guard
-  (spec 17 §3.1). Set when the Bullpen prompt actually goes out. Survives task loss and
-  prevents duplicate user-facing prompts. **This guard and its `## Step 6` placement are
-  pinned by `tests/unit/agent.meeting-debrief-idempotency.test.ts` and must be preserved
-  verbatim in structure.**
+- `prompted:<eventId>` — **prompt dedup + phase signal.** The existing layer-2 idempotency
+  guard (spec 17 §3.1). Set when the Bullpen prompt actually goes out. Absence ⇒ the wake
+  is the meeting-end (scheduled) phase; presence ⇒ the prompt already went out. Survives
+  task loss and prevents duplicate user-facing prompts. **This guard and its `## Step 6`
+  placement are pinned by `tests/unit/agent.meeting-debrief-idempotency.test.ts` and must
+  be preserved verbatim in structure.**
+- `reminded:<eventId>` — **phase signal.** Set when the single reminder has been sent.
+  With `prompted:` present: absence ⇒ this wake is the reminder phase; presence ⇒ this
+  wake is the expiry phase. TTL ~ `contextBridgeTtlHours`.
+
+**Phase derivation at a debrief wake** (eventId parsed from `intent_anchor`):
+`prompted?` no → **scheduled** · yes + `reminded?` no → **reminder** · yes + yes → **expiry**.
 
 ---
 
@@ -146,9 +156,12 @@ The agent distinguishes modes by its invocation payload:
    for stored debrief preferences).
 5. **Judge each (binary YES/NO, lean YES on the fence — criteria preserved):**
    - **YES** → `task-create` `{ title:"Debrief: <meeting>", owner:'curia',
-     tags:['debrief-pending'], wake_at: <meeting end>, description/progress: event
-     metadata + phase:'scheduled' }`. (owner='curia' — the pending work is "Curia must
-     prompt"; it flips to 'ceo' at the prompt wake.) Then set `seen:<eventId>`.
+     tags:['debrief-pending'], wake_at: <meeting end>, intent_anchor:"Debrief the CEO's
+     meeting '<title>' that ends around <ISO end> (calendar event <eventId>) — prompt at
+     meeting end, then follow up on takeaways." }`. (owner='curia' — the pending work is
+     "Curia must prompt"; it flips to 'ceo' at the prompt wake. The eventId lives in
+     `intent_anchor` so it's delivered on wake but stays out of the digest.) Then set
+     `seen:<eventId>`.
    - **NO** → set `seen:<eventId>` only. No task, no prompt.
 6. Exit. No `scheduler-report`.
 
@@ -157,22 +170,26 @@ The agent distinguishes modes by its invocation payload:
 
 ### Mode 2 — Task wake-up (debrief task fires)
 
-Read `progress.phase` from the delivered task context and branch:
+Parse the `eventId` from the injected `intent_anchor`, then derive the phase from the
+config-store guards (see above) and branch:
 
-- **`scheduled`** (meeting-end wake):
-  1. Re-fetch the event by `eventId`. If cancelled / declined / no longer present →
-     `task-complete` (note "meeting did not occur"), stop.
+- **scheduled** (`prompted:` absent — the meeting-end wake):
+  1. Re-fetch the event by `eventId` (`calendar-list-events` around its scheduled time).
+     If cancelled / declined / no longer present → `task-complete`
+     (note "meeting did not occur"), stop.
   2. Still valid → run the **config-store `prompted:` idempotency guard** then the
      Bullpen post to the coordinator (the pinned `## Step 6` block, unchanged in
      structure: check `prompted:<eventId>` → post → store key with `thread_id` → no
      retry on store failure).
-  3. `task-update owner='ceo' wake_at=<now + reminderDelayMinutes>`, set
-     `progress.phase='prompted'` (and `promptedAt`, `threadId`). The owner flip moves the
-     task into the CEO's "For you to do" now that the ball is in their court.
-- **`prompted`** (reminder wake): send one gentle reminder via Bullpen.
-  `task-update wake_at=<promptedAt + contextBridgeTtlHours>`, `progress.phase='reminded'`.
-- **`reminded`** (expiry wake): `task-update status='cancelled'`
-  (note "no CEO response — implicitly declined"). The wake chain ends.
+  3. `task-update owner='ceo' wake_at=<now + reminderDelayMinutes>
+     progress_note="Prompt delivered; awaiting the CEO's takeaways."` The owner flip moves
+     the task into the CEO's "For you to do" now that the ball is in their court.
+- **reminder** (`prompted:` present, `reminded:` absent): send one gentle reminder via
+  Bullpen; set `reminded:<eventId>`; `task-update wake_at=<now + (TTL − reminderDelay)>
+  progress_note="Reminder sent; still awaiting takeaways."`
+- **expiry** (`prompted:` and `reminded:` present): `task-update status='cancelled'
+  progress_note="No response after reminder — debrief expired (implicitly declined)."`
+  The wake chain ends.
 
 A CEO reply at any point short-circuits this chain (Mode 3 completes the task, which
 auto-cancels the pending wake-up).

--- a/docs/wip/2026-06-04-meeting-debrief-tasks-migration-design.md
+++ b/docs/wip/2026-06-04-meeting-debrief-tasks-migration-design.md
@@ -80,13 +80,32 @@ These were settled with the CEO during brainstorming:
    task tag the agent creates is `debrief-pending` (plus `debrief-followup` children).
    Tasks now *only ever* represent real debrief work.
 
+6. **`owner` flips `curia` → `ceo` across the lifecycle.** `owner` means *who must act
+   next* (todo-list semantics), and a debrief task has two phases:
+   - **Before the prompt is sent** (scheduled → meeting-end wake): the pending work is
+     "Curia must deliver the debrief prompt" → `owner='curia'`.
+   - **After the prompt is sent** (awaiting takeaways): the pending work is "the CEO must
+     reply" → `owner='ceo'`.
+
+   So at the prompt wake the agent flips `owner` to `ceo`. This also fixes a digest bug:
+   creating with `owner='ceo'` would surface a debrief in the CEO's "For you to do"
+   *before the meeting ended and before they were ever asked*. With the flip it appears
+   in "For you to do" only once actually prompted — which is the AC's intent.
+
+   | Phase | `owner` | `status` | digest section |
+   |---|---|---|---|
+   | created (scheduled) | `curia` | open | "What I'm working on" |
+   | prompted / reminded | `ceo` | open | "For you to do" |
+   | CEO replies | — | done | — |
+   | expires | — | cancelled | — |
+
 ---
 
 ## State mapping
 
 | Today (maps in `progress` JSONB) | New |
 |---|---|
-| `pendingDebriefs[eventId]` | one task: `tag=['debrief-pending']`, `owner='ceo'`, `title="Debrief: <meeting>"`. `wake_at` drives the lifecycle (see below). `progress` holds `{ eventId, attendees, scheduledEnd, title, threadId, phase }`. |
+| `pendingDebriefs[eventId]` | one task: `tag=['debrief-pending']`, `owner` flips `curia`→`ceo` at the prompt wake (see decision 6), `title="Debrief: <meeting>"`. `wake_at` drives the lifecycle (see below). `progress` holds `{ eventId, attendees, scheduledEnd, title, threadId, phase }`. |
 | `judgedEvents` (NO) | **no task.** config-store `seen:<eventId>` guard only. |
 | `judgedEvents` (defer) | **removed** (DEFER no longer exists). |
 | `deferredEvents` | **removed.** |
@@ -126,9 +145,10 @@ The agent distinguishes modes by its invocation payload:
 4. Enrich remaining candidates (`entity-context` per external attendee; `memory-query`
    for stored debrief preferences).
 5. **Judge each (binary YES/NO, lean YES on the fence — criteria preserved):**
-   - **YES** → `task-create` `{ title:"Debrief: <meeting>", owner:'ceo',
+   - **YES** → `task-create` `{ title:"Debrief: <meeting>", owner:'curia',
      tags:['debrief-pending'], wake_at: <meeting end>, description/progress: event
-     metadata + phase:'scheduled' }`. Then set `seen:<eventId>`.
+     metadata + phase:'scheduled' }`. (owner='curia' — the pending work is "Curia must
+     prompt"; it flips to 'ceo' at the prompt wake.) Then set `seen:<eventId>`.
    - **NO** → set `seen:<eventId>` only. No task, no prompt.
 6. Exit. No `scheduler-report`.
 
@@ -146,8 +166,9 @@ Read `progress.phase` from the delivered task context and branch:
      Bullpen post to the coordinator (the pinned `## Step 6` block, unchanged in
      structure: check `prompted:<eventId>` → post → store key with `thread_id` → no
      retry on store failure).
-  3. `task-update wake_at=<now + reminderDelayMinutes>`, set `progress.phase='prompted'`
-     (and `promptedAt`, `threadId`).
+  3. `task-update owner='ceo' wake_at=<now + reminderDelayMinutes>`, set
+     `progress.phase='prompted'` (and `promptedAt`, `threadId`). The owner flip moves the
+     task into the CEO's "For you to do" now that the ball is in their court.
 - **`prompted`** (reminder wake): send one gentle reminder via Bullpen.
   `task-update wake_at=<promptedAt + contextBridgeTtlHours>`, `progress.phase='reminded'`.
 - **`reminded`** (expiry wake): `task-update status='cancelled'`
@@ -196,6 +217,25 @@ fact via `memory-store`; queried during enrichment (Mode 1 step 4).
   description to "scan the rest of today's meetings and schedule debriefs".
 - **Bump** `version` (minor — new capability surface).
 
+## Documentation changes (in this PR)
+
+- **Rewrite `docs/specs/17-meeting-debrief.md` §3 (State Management)** to describe the
+  tasks model: `debrief-pending` tasks, the wake-up lifecycle, the `owner` flip, and the
+  two config-store guards (`seen:` / `prompted:`). Update the detection-pipeline section
+  to reflect the 3×/day pre-scheduling cadence and binary YES/NO judgment. Keep the
+  cross-tick idempotency (`prompted:`) subsection. (Per CEO direction, spec 17 is updated
+  here, not punted to a later doc PR.)
+- **CHANGELOG.md** — entry under `[Unreleased] → Changed`.
+
+## Follow-ups (separate issues, not this PR)
+
+- **Explicit target `agent_id` on `task-create`** so the coordinator / ceo-inbox can
+  schedule wake-ups *into* a specialist (not just self-routing). Includes the
+  permission/gating design question (should any agent inject wakes into any other?).
+  Draft a new issue.
+- *(Optional, low priority)* add `description` to `task-list` output to make single-row
+  reads first-class without a `task-get` skill. Not needed for this migration.
+
 ---
 
 ## Verification
@@ -229,9 +269,9 @@ file-parsing pattern as the idempotency test):
 
 ## Out of scope
 
-- Changes to spec 17 itself (a follow-up doc PR updates it once this is proven in prod).
 - The digest "For you to do" rendering (issue 5, already landed) — debrief-pending tasks
-  with `owner='ceo'` flow into it automatically.
+  flow into it automatically once their `owner` flips to `ceo`.
+- Changes to the `task-*` skill APIs (see Follow-ups).
 - Backfill/migration of any in-flight `pendingDebriefs` state in prod. Debriefs are
   short-lived; existing in-flight prompts age out under the old code before/with this
   change. No data migration step.

--- a/docs/wip/2026-06-04-meeting-debrief-tasks-migration-design.md
+++ b/docs/wip/2026-06-04-meeting-debrief-tasks-migration-design.md
@@ -1,0 +1,245 @@
+# Design: Migrate `meeting-debrief` to the Tasks system (#839)
+
+**Status:** Design, pre-implementation
+**Date:** 2026-06-04
+**Issue:** [#839](https://github.com/josephfung/curia/issues/839) — Tasks v1 (6/7)
+**Companion docs:** [tasks & backlog design](2026-06-01-tasks-and-backlog-design.md) (§7, §9 issue 6), [spec 17 — meeting-debrief](../specs/17-meeting-debrief.md), [spec 07 — scheduler](../specs/07-scheduler.md)
+
+---
+
+## Context
+
+Issue 6 of the Tasks & Backlog v1 rollout is the **proof case** for the abstraction.
+The `meeting-debrief` agent currently invents its own task model: three maps
+(`pendingDebriefs`, `judgedEvents`, `deferredEvents`) plus a `lastScanTimestamp`
+cursor, all persisted into the scheduler job's `progress` JSONB via `scheduler-report`
+(spec 17 §3). If the new platform task system can't cleanly absorb this, the
+abstraction is wrong and we revisit before building more on top of it.
+
+A key fact discovered during design: **`meeting-debrief` has no TypeScript handler.**
+The entire state machine lives in the agent's `system_prompt` in
+`agents/meeting-debrief.yaml`. So this migration is a **prompt rewrite**, not a code
+refactor. The issue's acceptance criterion "net negative LOC in
+`src/agents/meeting-debrief/`" refers to a directory that does not exist; we satisfy
+its **intent** — the agent definition gets meaningfully shorter and the bespoke
+state-tracking is deleted.
+
+The task system (issues 1–5) has landed on `main`. Two mechanics were verified:
+
+1. A `wake_at` task created by an agent schedules a one-shot `scheduled_jobs` row whose
+   `agent_id` is the creating agent. On fire it routes **back to that agent** with
+   content `{ task_id, title, progress, task_payload }`. So per-event detail stored in
+   the task's `progress` is delivered on wake. The reminder/expiry/scheduled-prompt
+   chain can therefore be modelled entirely as wake-ups on one task row.
+2. `task-list` returns only `title, tags, status, owner, priority, last_progress_note,
+   next_wake_at` — **not** `progress`, `description`, or the calendar `eventId`. The
+   design must not depend on reading event identifiers back out of `task-list`.
+
+---
+
+## Decisions (this design supersedes the issue's literal wording where noted)
+
+These were settled with the CEO during brainstorming:
+
+1. **Detection moves from polling to pre-scheduling.** Today the agent fires every 15
+   minutes (`*/15 7-22 * * *` ≈ 96 invocations/day), scanning for meetings that just
+   ended. Instead it runs **3×/day** (`0 7,12,16 * * *`), scans the rest of the day's
+   meetings, judges each, and schedules a debrief task with `wake_at` = the meeting's
+   end time. Each debrief then prompts exactly when its meeting ends, via a wake-up.
+   - **Rationale:** ~96 → 3 invocations/day; precise prompt timing; leans fully into
+     the tasks/wake-up primitive (stronger proof of the abstraction).
+   - **Accepted trade-off:** a meeting *added and occurring entirely inside a scan gap*
+     (e.g. booked 1pm for 1:30pm with scans at 7/12/16) is missed. Debriefs are
+     proactive nice-to-haves, not critical paths; this is acceptable. Cancellations,
+     reschedules, and declines of *known* meetings are handled by re-validating the
+     event at the prompt wake (we hold the `eventId`).
+
+2. **The scan cursor is dropped entirely.** Under forward-looking scanning
+   (now → end of day) deduplicated by a config-store guard, there is no backward window
+   to remember. `scheduler-report` is removed from the agent. (This goes further than
+   the brainstorming's interim "keep cursor only"; pre-scheduling made the cursor
+   obsolete.) The cron's own `next_run_at` is computed from `cron_expr` and does not
+   depend on `scheduler-report`.
+
+3. **Judgment is binary YES/NO — DEFER is removed.** Re-judging a meeting yields almost
+   no new signal (the calendar entry and enrichment are static), so DEFER mostly
+   re-resolved to the same answer while inviting the model to reflexively punt borderline
+   calls — pure churn. On a genuine fence the model **leans YES** (an unwanted prompt is
+   trivially dismissed; a skipped debrief silently loses takeaways). The underlying
+   YES/NO *criteria* in the judgment step are preserved verbatim; only the DEFER output
+   option is removed. (The issue marked judgment-logic changes out of scope; collapsing
+   3-way → 2-way is a deliberate, owner-approved exception.)
+
+4. **A not-debrief-worthy (NO) meeting creates no task.** Recording a completed task for
+   every skipped meeting would flood the backlog with noise (most meetings are NO).
+   Instead a lightweight config-store guard marks the event as handled so later daily
+   scans don't re-judge it. (This supersedes the issue's "judgment='no' → immediately
+   task-complete" wording.)
+
+5. **Consequence of 3 + 4:** there are **no `debrief-judged` tasks at all**. The only
+   task tag the agent creates is `debrief-pending` (plus `debrief-followup` children).
+   Tasks now *only ever* represent real debrief work.
+
+---
+
+## State mapping
+
+| Today (maps in `progress` JSONB) | New |
+|---|---|
+| `pendingDebriefs[eventId]` | one task: `tag=['debrief-pending']`, `owner='ceo'`, `title="Debrief: <meeting>"`. `wake_at` drives the lifecycle (see below). `progress` holds `{ eventId, attendees, scheduledEnd, title, threadId, phase }`. |
+| `judgedEvents` (NO) | **no task.** config-store `seen:<eventId>` guard only. |
+| `judgedEvents` (defer) | **removed** (DEFER no longer exists). |
+| `deferredEvents` | **removed.** |
+| `lastScanTimestamp` | **removed** (no cursor; `scheduler-report` dropped). |
+| follow-up actions on CEO reply | child tasks, `parent_task_id` = the debrief task, `tag=['debrief-followup']`, `owner` per action. |
+
+### config-store guards (both invisible to the CEO, namespace `debrief`)
+
+- `seen:<eventId>` — **detection dedup.** Set for *every* judged event (YES and NO) so
+  the 3 daily scans don't re-judge the same meeting. TTL ~24h (covers the day; the
+  meeting ages out of the forward scan window after it occurs).
+- `prompted:<eventId>` — **prompt dedup.** The existing layer-2 idempotency guard
+  (spec 17 §3.1). Set when the Bullpen prompt actually goes out. Survives task loss and
+  prevents duplicate user-facing prompts. **This guard and its `## Step 6` placement are
+  pinned by `tests/unit/agent.meeting-debrief-idempotency.test.ts` and must be preserved
+  verbatim in structure.**
+
+---
+
+## Operating modes (three)
+
+The agent distinguishes modes by its invocation payload:
+
+- **Scheduled detection** — cron fire, no `task_id` in the payload.
+- **Task wake-up** — fired with a `task_id` and the task's `progress` (which carries
+  `phase`).
+- **Delegated** — invoked by the coordinator via `delegate` (CEO reply or preference
+  update).
+
+### Mode 1 — Scheduled detection (`0 7,12,16 * * *`)
+
+1. Read config (`config-store get debrief`) for channel / reminder delay / TTL.
+2. `calendar-list-events` from **now → end of day** (CEO timezone), `contactId =
+   ${principal_contact_id}`.
+3. Filter out: all-day events, solo events (CEO-only / alternate identities),
+   cancelled/declined, and any event with a `seen:<eventId>` guard already set.
+4. Enrich remaining candidates (`entity-context` per external attendee; `memory-query`
+   for stored debrief preferences).
+5. **Judge each (binary YES/NO, lean YES on the fence — criteria preserved):**
+   - **YES** → `task-create` `{ title:"Debrief: <meeting>", owner:'ceo',
+     tags:['debrief-pending'], wake_at: <meeting end>, description/progress: event
+     metadata + phase:'scheduled' }`. Then set `seen:<eventId>`.
+   - **NO** → set `seen:<eventId>` only. No task, no prompt.
+6. Exit. No `scheduler-report`.
+
+> Note: the prompt is **not** sent at detection time — only the scheduled task is
+> created. The prompt is sent later, at the meeting-end wake, after re-validation.
+
+### Mode 2 — Task wake-up (debrief task fires)
+
+Read `progress.phase` from the delivered task context and branch:
+
+- **`scheduled`** (meeting-end wake):
+  1. Re-fetch the event by `eventId`. If cancelled / declined / no longer present →
+     `task-complete` (note "meeting did not occur"), stop.
+  2. Still valid → run the **config-store `prompted:` idempotency guard** then the
+     Bullpen post to the coordinator (the pinned `## Step 6` block, unchanged in
+     structure: check `prompted:<eventId>` → post → store key with `thread_id` → no
+     retry on store failure).
+  3. `task-update wake_at=<now + reminderDelayMinutes>`, set `progress.phase='prompted'`
+     (and `promptedAt`, `threadId`).
+- **`prompted`** (reminder wake): send one gentle reminder via Bullpen.
+  `task-update wake_at=<promptedAt + contextBridgeTtlHours>`, `progress.phase='reminded'`.
+- **`reminded`** (expiry wake): `task-update status='cancelled'`
+  (note "no CEO response — implicitly declined"). The wake chain ends.
+
+A CEO reply at any point short-circuits this chain (Mode 3 completes the task, which
+auto-cancels the pending wake-up).
+
+### Mode 3 — Delegated (CEO reply)
+
+1. **Identify the debrief:** `task-list tag='debrief-pending' owner='ceo' status='open'`,
+   match on meeting title / attendee names / context-bridge metadata → get `task_id`.
+   If ambiguous, ask the coordinator to clarify.
+2. **Parse follow-up actions** from the CEO's notes (unchanged taxonomy: email draft,
+   calendar event, KG fact, research delegation, "nothing needed").
+3. **Execute — do-now + record:**
+   - Curia-doable actions (drafts via `email-draft-save`, bookings via
+     `calendar-create-event`, facts via `memory-store`) run **inline this burst**, as
+     today. Record each as a **child task** (`parent_task_id`, `tag=['debrief-followup']`)
+     created and immediately `task-complete`d.
+   - Actions Curia can't do now → **open** child tasks: CEO-only calls → `owner='ceo'`;
+     third-party-blocked work → `owner='external'` (+ `waiting_on_contact_id`/`_text`).
+     These surface in the digest.
+4. **Confirm** to the coordinator (it relays to the CEO), as today.
+5. `task-complete` the **parent** debrief task (auto-cancels its pending wake-up).
+
+**Status queries** ("what debriefs are outstanding?") are answered by the
+**coordinator's `task-list tag=debrief-pending`** — there is no meeting-debrief
+status sub-mode (per the AC; an earlier `debrief-status` skill idea was already
+rejected in spec 17).
+
+**Preference updates** (e.g. "don't debrief weekly standups") are unchanged: store a KG
+fact via `memory-store`; queried during enrichment (Mode 1 step 4).
+
+---
+
+## Manifest changes (`agents/meeting-debrief.yaml`)
+
+- **Add** to `pinned_skills`: `task-create`, `task-list`, `task-update`, `task-complete`.
+- **Remove** from `pinned_skills`: `scheduler-list`, `scheduler-report` (no longer used —
+  state lives in tasks + config-store).
+- **Keep:** `config-store` (guards), `calendar-list-events`, `calendar-create-event`,
+  `calendar-check-conflicts`, `entity-context`, `contact-lookup`, `email-draft-save`,
+  `memory-query`, `memory-store`, `bullpen`, `date-resolve`.
+- **Change** `schedule.cron`: `*/15 7-22 * * *` → `0 7,12,16 * * *`; update the task
+  description to "scan the rest of today's meetings and schedule debriefs".
+- **Bump** `version` (minor — new capability surface).
+
+---
+
+## Verification
+
+### Existing tests (must pass unmodified)
+- `tests/unit/agent.meeting-debrief-idempotency.test.ts` — pins `## Step 6`/`## Step 7`
+  headings and the `prompted:` guard ordering (check → post → store → no-retry,
+  `thread_id` in value). The redesigned prompt **keeps** Step 6 as the prompt-delivery
+  block (now executed at the meeting-end wake) with the guard intact, and a `## Step 7`
+  heading immediately after.
+- `tests/unit/config.debrief.test.ts` — config loading; unaffected.
+
+### New test
+`tests/unit/agent.meeting-debrief-tasks.test.ts` (prompt-structure assertions, same
+file-parsing pattern as the idempotency test):
+- Three operating modes are present (detection / task wake-up / delegated).
+- No references remain to `pendingDebriefs`, `judgedEvents`, `deferredEvents`,
+  `lastScanTimestamp`, `scheduler-report`, or `scheduler-list`.
+- The four `task-*` skills are pinned; `scheduler-report`/`scheduler-list` are not.
+- `schedule.cron` is `0 7,12,16 * * *`.
+- Detection creates no task for NO outcomes (guard-only) — asserted by prompt text
+  referencing `seen:` and "no task" for the NO branch.
+
+### Other
+- `pnpm --prefix <worktree> run typecheck` clean (no `.ts` logic changes expected;
+  only the new test file).
+- Net-negative LOC in the agent definition (bespoke state-tracking deleted).
+- Full suite green.
+
+---
+
+## Out of scope
+
+- Changes to spec 17 itself (a follow-up doc PR updates it once this is proven in prod).
+- The digest "For you to do" rendering (issue 5, already landed) — debrief-pending tasks
+  with `owner='ceo'` flow into it automatically.
+- Backfill/migration of any in-flight `pendingDebriefs` state in prod. Debriefs are
+  short-lived; existing in-flight prompts age out under the old code before/with this
+  change. No data migration step.
+
+## Open question (resolve during implementation, non-blocking)
+
+- Confirm dropping the per-tick `scheduler-report` call does not affect the recurring
+  cron job's rescheduling or error-budget accounting. Expectation: `next_run_at` is
+  derived from `cron_expr`; `scheduler-report` only persisted context + outcome. If it
+  turns out to be load-bearing, keep a single minimal `scheduler-report` call with an
+  empty context (no cursor) — does not change the state model.

--- a/docs/wip/2026-06-04-meeting-debrief-tasks-migration.md
+++ b/docs/wip/2026-06-04-meeting-debrief-tasks-migration.md
@@ -1,0 +1,795 @@
+# Meeting-Debrief Tasks Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the `meeting-debrief` agent from its bespoke `pendingDebriefs`/`judgedEvents`/`deferredEvents` state maps to the platform tasks system, converting detection from a 15-minute poll to a 3×/day pre-scheduling model where each debrief is a task driven by wake-ups.
+
+**Architecture:** `meeting-debrief` has no TypeScript handler — its entire state machine is the `system_prompt` in `agents/meeting-debrief.yaml`. This is therefore a **prompt rewrite plus documentation/test changes**. Debrief work becomes `debrief-pending` tasks; their lifecycle (prompt → reminder → expiry) is a chain of `wake_at` re-schedules on one task row; the lifecycle phase is derived from config-store guards (`seen:` / `prompted:` / `reminded:`); the calendar `eventId` rides in `intent_anchor` (delivered on wake, hidden from the digest); `owner` flips `curia`→`ceo` at the prompt wake.
+
+**Tech Stack:** YAML agent definition, Vitest unit tests (file-parsing style via `js-yaml`), Markdown specs. No runtime TypeScript logic changes.
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks` (branch `feat/debrief-tasks-migration`). All `pnpm`/`git` commands below use `--prefix`/`-C` against this path per the no-chaining hook.
+
+**Design reference:** [docs/wip/2026-06-04-meeting-debrief-tasks-migration-design.md](2026-06-04-meeting-debrief-tasks-migration-design.md)
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `tests/unit/agent.meeting-debrief-tasks.test.ts` | **Create** | Structural assertions on the rewritten prompt (three modes, task skills pinned, no bespoke-state tokens, cron, NO→no-task, binary YES-lean, owner flip). |
+| `agents/meeting-debrief.yaml` | **Rewrite** `system_prompt`, `pinned_skills`, `schedule.cron`; add `version` | The migration itself. |
+| `tests/unit/agent.meeting-debrief-idempotency.test.ts` | **Unchanged** (must still pass) | #724 regression guard — pins the `## Step 6` idempotency block. |
+| `docs/specs/17-meeting-debrief.md` | **Modify** §3 + detection-pipeline section | Make the spec reflect the tasks model + 3×/day cadence. |
+| `CHANGELOG.md` | **Modify** `[Unreleased] → Changed` | Record the change. |
+
+---
+
+## Task 1: Structural test for the migrated prompt (TDD — write it failing first)
+
+**Files:**
+- Create: `tests/unit/agent.meeting-debrief-tasks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/agent.meeting-debrief-tasks.test.ts` with exactly this content:
+
+```ts
+// tests/unit/agent.meeting-debrief-tasks.test.ts
+//
+// Guards the #839 migration: meeting-debrief tracks debrief work as platform
+// tasks (not bespoke pendingDebriefs/judgedEvents maps), runs detection 3x/day,
+// and judges meetings YES/NO (no DEFER). Parses the agent YAML, asserts on its
+// structure. Companion to agent.meeting-debrief-idempotency.test.ts.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+
+let parsed: Record<string, unknown>;
+let prompt: string;
+let pinnedSkills: string[];
+
+beforeAll(() => {
+  const agentPath = path.resolve(import.meta.dirname, '../../agents/meeting-debrief.yaml');
+  let raw: string;
+  try {
+    raw = fs.readFileSync(agentPath, 'utf-8');
+  } catch (err) {
+    throw new Error(
+      `Cannot load meeting-debrief.yaml from ${agentPath}: ${(err as Error).message}. ` +
+      `Is the test running from the repo root?`,
+    );
+  }
+  parsed = yaml.load(raw) as Record<string, unknown>;
+  if (typeof parsed.system_prompt !== 'string') {
+    throw new Error('meeting-debrief.yaml is missing a system_prompt string field');
+  }
+  prompt = parsed.system_prompt;
+  pinnedSkills = (parsed.pinned_skills as string[]) ?? [];
+});
+
+describe('meeting-debrief tasks migration (#839)', () => {
+  it('declares all three operating modes', () => {
+    expect(prompt).toMatch(/Scheduled mode/);
+    expect(prompt).toMatch(/Task wake-up mode/i);
+    expect(prompt).toMatch(/Delegated mode/i);
+  });
+
+  it('pins the four task-* skills', () => {
+    for (const skill of ['task-create', 'task-list', 'task-update', 'task-complete']) {
+      expect(pinnedSkills).toContain(skill);
+    }
+  });
+
+  it('no longer pins scheduler-report or scheduler-list', () => {
+    expect(pinnedSkills).not.toContain('scheduler-report');
+    expect(pinnedSkills).not.toContain('scheduler-list');
+  });
+
+  it('removes all bespoke state-map references from the prompt', () => {
+    for (const token of [
+      'pendingDebriefs',
+      'judgedEvents',
+      'deferredEvents',
+      'lastScanTimestamp',
+    ]) {
+      expect(prompt).not.toContain(token);
+    }
+  });
+
+  it('runs detection 3x/day via cron', () => {
+    const schedule = parsed.schedule as Array<{ cron?: string }> | undefined;
+    expect(schedule).toBeDefined();
+    expect(schedule!.length).toBeGreaterThan(0);
+    expect(schedule![0]!.cron).toBe('0 7,12,16 * * *');
+  });
+
+  it('creates no task for not-worthy meetings (guard-only)', () => {
+    expect(prompt).toMatch(/seen:/);
+    expect(prompt).toMatch(/[Cc]reate no task/);
+  });
+
+  it('keeps binary judgment with a YES lean and removes DEFER', () => {
+    expect(prompt).toMatch(/lean YES/i);
+    expect(prompt).not.toMatch(/\bDEFER\b/);
+  });
+
+  it('flips owner to ceo at the prompt wake', () => {
+    expect(prompt).toMatch(/flips? to .?ceo/i);
+  });
+
+  it('declares a version field', () => {
+    expect(typeof parsed.version).toBe('string');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks exec vitest run tests/unit/agent.meeting-debrief-tasks.test.ts`
+
+Expected: FAIL — the current YAML still contains `pendingDebriefs`/`judgedEvents`, has the `*/15 7-22 * * *` cron, pins `scheduler-report`/`scheduler-list`, has no `version`, and lacks the new mode/owner-flip wording.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks add tests/unit/agent.meeting-debrief-tasks.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks commit -m "test: structural test for meeting-debrief tasks migration (#839)"
+```
+
+---
+
+## Task 2: Rewrite `agents/meeting-debrief.yaml`
+
+**Files:**
+- Modify (full rewrite): `agents/meeting-debrief.yaml`
+
+- [ ] **Step 1: Replace the entire file with the content below**
+
+Use the Write tool to overwrite `agents/meeting-debrief.yaml` with **exactly** this:
+
+```yaml
+name: meeting-debrief
+version: "0.1.0"
+role: specialist
+description: >
+  Proactively debriefs the CEO after external meetings. Three times a day it
+  scans the calendar for upcoming meetings, judges which warrant a debrief, and
+  schedules a per-meeting debrief task that wakes at the meeting's end to prompt
+  the CEO. CEO takeaways become follow-up actions and child tasks. All debrief
+  state lives in the platform task system.
+
+model:
+  tier: standard  # judgment calls for meeting classification and follow-up extraction
+
+inject_specialists: true  # see research-analyst for cross-specialist research tasks
+
+pinned_skills:
+  # Calendar scanning
+  - calendar-list-events
+  # Entity enrichment for attendees
+  - entity-context
+  - contact-lookup
+  # Follow-up actions (delegated mode)
+  - email-draft-save
+  - calendar-create-event
+  - calendar-check-conflicts
+  # Knowledge graph
+  - memory-query
+  - memory-store
+  # Platform task backlog
+  - task-create
+  - task-list
+  - task-update
+  - task-complete
+  # Inter-agent communication
+  - bullpen
+  # Utilities + idempotency guards
+  - date-resolve
+  - config-store
+
+allow_discovery: false
+
+memory:
+  scopes: [meeting-debrief]
+
+error_budget:
+  max_turns: 25
+  max_cost_usd: 0.40
+
+schedule:
+  - cron: "0 7,12,16 * * *"
+    task: >
+      Run the meeting debrief detection & scheduling pipeline. Scan the CEO's
+      calendar for the rest of today's meetings, judge which warrant a debrief,
+      and schedule a per-meeting debrief task (with a meeting-end wake-up) for
+      each one. Do not prompt the CEO during this run.
+    expectedDurationSeconds: 120
+
+system_prompt: |
+  ## Operating Mode
+
+  You operate in one of three modes, decided by how you were invoked:
+
+  **Scheduled mode** (cron trigger — your payload is the detection instruction,
+  with no `task_id`): run the Detection & Scheduling pipeline (Steps 1–5). You
+  schedule debrief tasks; you do NOT prompt the CEO during this run.
+
+  **Task wake-up mode** (your payload includes a `task_id` and an injected
+  intent_anchor describing a debrief): one of your scheduled debrief tasks has
+  woken up. Run the Debrief lifecycle (Steps 6–7) for that task.
+
+  **Delegated mode** (invoked by the coordinator via the delegate skill): the
+  CEO replied to a debrief prompt, or set a debrief preference. Handle that
+  request (Steps D1–D5, or Preference Updates) and return. Do NOT run detection.
+
+  ---
+
+  You are the Meeting Debrief Specialist. After meetings with external attendees
+  end, you prompt the CEO for takeaways and then execute the follow-up actions
+  their notes imply — drafting emails, booking meetings, storing facts in the
+  knowledge graph, or delegating research.
+
+  You never message the CEO directly. All outbound goes through the coordinator
+  via the Bullpen-through-coordinator pattern.
+
+  You track all debrief work as platform **tasks** (the `task-*` skills). You
+  keep no bespoke per-event state maps. The only state outside tasks is a few
+  config-store idempotency/phase guards (described below).
+
+  ## Entity Resolution
+
+  When given only a name (no pre-resolved IDs):
+  1. Call `contact-lookup` to resolve to a contact ID.
+  2. Call `entity-context` with the contact ID for enrichment.
+
+  The CEO's contact ID is `${principal_contact_id}` — injected at bootstrap.
+  Use it directly; do NOT call `contact-lookup` by role for the CEO.
+  Call `entity-context` on `${principal_contact_id}` to discover their known
+  email addresses — you need these for the solo-event filter in Step 2.
+
+  ## Date and Timezone
+
+  Current date/time: ${current_datetime}
+  Timezone: ${timezone}
+
+  Use `date-resolve` to verify any dates before including them in messages,
+  calendar events, or task `wake_at` values.
+
+  ## Runtime Configuration
+
+  At the start of every run (any mode), call `config-store` with action `"get"`
+  and key `"debrief"` to read the operator-configured settings:
+
+  - `channel` — channel for debrief prompts (default: `"signal"`)
+  - `reminderDelayMinutes` — minutes after the prompt before a reminder
+    (default: `120`)
+  - `contextBridgeTtlHours` — TTL for context bridge entries and the debrief
+    expiry window (default: `48`)
+
+  If config-store returns no debrief block, use the defaults above.
+
+  ## Idempotency & phase guards (config-store, namespace `"debrief"`)
+
+  You keep three guard keys, all invisible to the CEO. The debrief lifecycle
+  phase is DERIVED from them — you do not store phase as data:
+
+  - `seen:<eventId>` — set once you have judged a calendar event (YES or NO),
+    so later scans the same day do not re-judge it.
+  - `prompted:<eventId>` — set when a debrief prompt has actually been sent.
+    Absent ⇒ a waking task is at its meeting-end (scheduled) phase; present ⇒
+    the prompt already went out.
+  - `reminded:<eventId>` — set when the single reminder has been sent. With
+    `prompted:` present: absent ⇒ reminder phase; present ⇒ expiry phase.
+
+  Read a guard with action `"retrieve"`; set one with action `"store"` (value =
+  an ISO timestamp string, unless noted otherwise).
+
+  ---
+
+  # SCHEDULED MODE: Detection & Scheduling
+
+  You run three times a day (7am, 12pm, 4pm). Each run looks at the rest of
+  today's meetings and schedules a debrief task for each one that warrants a
+  debrief. You do NOT prompt the CEO now — the prompt is delivered later by the
+  task's meeting-end wake-up (Task wake-up mode). If any step yields zero
+  candidates, simply exit.
+
+  ## Step 1: Calendar scan
+
+  Call `calendar-list-events` with:
+  - timeMin: now (${current_datetime})
+  - timeMax: end of today in the CEO's timezone (resolve with `date-resolve`)
+  - contactId: ${principal_contact_id}
+
+  Always pass contactId — this agent runs as a scheduled job (system context),
+  so the skill cannot auto-resolve calendars from the caller.
+
+  ## Step 2: Filter candidates
+
+  Remove events that should NOT be debriefed:
+  1. **Already handled** — a `seen:<eventId>` guard exists (config-store
+     `"retrieve"`). Skip these.
+  2. **Cancelled or declined** — the event is cancelled, or the CEO declined.
+  3. **All-day events** — holidays, OOO blocks, and similar.
+  4. **Solo events** — the CEO is the only attendee, or the only other
+     attendees are the CEO's own alternate calendar identities (e.g. a personal
+     calendar synced to work). Use the CEO's known email addresses (resolved in
+     Entity Resolution) for this check.
+
+  ## Step 3: Enrich candidates
+
+  For each remaining candidate, call `entity-context` for each external attendee
+  (up to 5 per meeting — if more, enrich the first 5 and note the rest). Also
+  call `memory-query` for stored debrief preferences (recurring meetings,
+  organizations, attendee patterns).
+
+  ## Step 4: Judge each candidate (YES or NO)
+
+  Decide whether each meeting warrants a debrief prompt:
+
+  - **YES** — external attendees (people outside the CEO's organization), a
+    substantive meeting (not a casual chat or quick check-in), and no stored
+    preference saying "skip debriefs for this type".
+  - **NO** — internal-only meetings with known same-org team members (UNLESS the
+    title/description signals strategic importance like "board prep", "Q3
+    planning", "reorg discussion"); meetings the CEO has a stored preference to
+    skip; or brief meetings (< 15 minutes) with no agenda or description.
+
+  When you are genuinely on the fence, **lean YES** — an unwanted prompt is
+  trivially dismissed ("nothing needed"), but a skipped debrief silently loses
+  takeaways.
+
+  ## Step 5: Schedule debriefs
+
+  For each judged candidate:
+
+  - **YES** → call `task-create` with:
+    - title: `"Debrief: <meeting title>"`
+    - owner: `"curia"`  (the pending work is "Curia must prompt"; it flips to
+      `"ceo"` at the prompt wake)
+    - tags: `["debrief-pending"]`
+    - wake_at: the meeting's end time (verify with `date-resolve`)
+    - intent_anchor: `"Debrief the CEO's meeting '<title>' that ends around <ISO
+      end> (calendar event <eventId>) — prompt at meeting end, then follow up on
+      takeaways."`
+
+    Then set the guard: `config-store` action `"store"`, namespace `"debrief"`,
+    key `"seen:<eventId>"`.
+
+  - **NO** → set `seen:<eventId>` only (config-store `"store"`). **Create no
+    task** — a not-worthy meeting must never appear in the backlog.
+
+  Then exit.
+
+  ---
+
+  # TASK WAKE-UP MODE: Debrief lifecycle
+
+  A debrief task you scheduled has woken up. Your payload has its `task_id`, and
+  your injected intent_anchor names the meeting and its `<eventId>`. Parse the
+  `eventId` from the intent_anchor, then derive the phase from the guards and run
+  the matching step:
+
+  - `prompted:<eventId>` absent → **Step 6** (deliver the prompt).
+  - `prompted:` present, `reminded:<eventId>` absent → **Step 7**, reminder phase.
+  - `prompted:` present, `reminded:` present → **Step 7**, expiry phase.
+
+  ## Step 6: Deliver the prompt (scheduled phase)
+
+  ### Revalidate the meeting
+
+  Call `calendar-list-events` (timeMin/timeMax bracketing the meeting's
+  scheduled end from your intent_anchor, contactId ${principal_contact_id}) and
+  find the event by its ID. If it is missing, cancelled, or the CEO declined,
+  the meeting did not happen: call `task-complete` with a completion_note like
+  "Meeting did not occur (cancelled/declined/removed); no debrief needed." and
+  stop. Do not prompt.
+
+  ### Idempotency guard
+
+  Before opening a Bullpen thread, check whether a debrief prompt has already
+  been sent for this calendar event. Call `config-store` with:
+  - action: "retrieve"
+  - namespace: "debrief"
+  - key: "prompted:<eventId>"
+
+  If `found: true`:
+  - Skip the post — a prompt was already sent. Do not post to Bullpen again.
+  - Log: "Skipping debrief post for <eventId> — already prompted."
+  - Proceed to "Hand off to the reminder phase" below.
+
+  If `found: false`, proceed with the Bullpen post.
+
+  ### Bullpen post
+
+  Open a Bullpen thread to the coordinator requesting delivery. Call `bullpen`
+  with:
+  - action: "post"
+  - topic: "Debrief prompt: [meeting title]"
+  - participants: ["coordinator"]
+  - mentioned_agent_ids: ["coordinator"]
+  - content: (the request format below)
+
+  ### Bullpen request format
+
+  ```
+  Please send this debrief prompt to the CEO via <debrief.channel>.
+
+  Use context_bridge with these parameters:
+  {
+    "agent_id": "meeting-debrief",
+    "delegation_hint": "meeting-debrief",
+    "expected_reply": "CEO's meeting takeaways and follow-up instructions for [meeting title]",
+    "expires_in_hours": <debrief.contextBridgeTtlHours>
+  }
+
+  Message to send:
+  [a brief, warm debrief prompt naming the attendees by their enriched names,
+  e.g. "Your meeting with Sarah Chen (Acme Corp) and David Park just wrapped up.
+  Any takeaways or follow-ups you'd like me to handle?"]
+  ```
+
+  ### After a successful post
+
+  Immediately after `bullpen` returns a thread_id, write the idempotency key so
+  any retry finds it. Call `config-store` with:
+  - action: "store"
+  - namespace: "debrief"
+  - key: "prompted:<eventId>"
+  - value: a JSON-encoded **string** (not an object), e.g.
+    `'{"thread_id":"<returned thread_id>","promptedAt":"<ISO timestamp>","title":"<meeting title>"}'`
+
+  If the store returns `success: false` or `data.stored: false`, log the failure
+  and note it in your result. Do NOT retry the Bullpen post — a duplicate prompt
+  is worse than a missed guard write, and the next wake re-checks the guard.
+
+  ### Hand off to the reminder phase
+
+  Whether you posted now or found the prompt already sent, update the task:
+  - Call `task-update` with: task_id (from your payload), owner: "ceo",
+    wake_at: <now + reminderDelayMinutes> (resolve with `date-resolve`),
+    progress_note: "Prompt delivered; awaiting the CEO's takeaways."
+
+  The owner flip moves the task into the CEO's "For you to do" now that the ball
+  is in their court; the wake_at schedules the single reminder.
+
+  ## Step 7: Reminder and expiry wakes
+
+  This runs when a debrief task wakes and `prompted:<eventId>` is already set.
+
+  ### Reminder phase (`reminded:<eventId>` NOT set)
+
+  The CEO has not responded within the reminder delay. Send ONE gentle nudge:
+  - Open a Bullpen thread to the coordinator (same request format as Step 6) with
+    a brief, non-pushy reminder, e.g. "Still have that [meeting title] debrief
+    open if you have a moment. No rush."
+  - Set the guard: `config-store` action "store", key "reminded:<eventId>".
+  - Schedule the expiry wake: `task-update` task_id, wake_at: <now +
+    (contextBridgeTtlHours hours − reminderDelayMinutes minutes)> (resolve with
+    `date-resolve`), progress_note: "Reminder sent; still awaiting takeaways."
+  - Send only ONE reminder ever. Do not nag.
+
+  ### Expiry phase (`reminded:<eventId>` IS set)
+
+  The CEO did not respond after the reminder. The debrief is stale — treat it as
+  implicitly declined:
+  - Call `task-update` task_id, status: "cancelled", progress_note: "No response
+    after reminder — debrief expired (implicitly declined)."
+  - Do not prompt again. The wake chain ends here.
+
+  ---
+
+  # DELEGATED MODE: Response Processing
+
+  When the coordinator delegates a CEO reply to you (routed via the context
+  bridge's delegation_hint), process the CEO's notes as follows.
+
+  ## Step D1: Identify the debrief task
+
+  The coordinator's delegation includes the meeting context (title / attendee
+  names). Find the matching open debrief: call `task-list` with tag:
+  "debrief-pending", owner: "ceo", status: "open". Match on the meeting title
+  (and attendees if needed) to get its `task_id`. If you cannot identify which
+  debrief this reply belongs to, ask the coordinator to clarify.
+
+  ## Step D2: Parse follow-up actions
+
+  Read the CEO's notes and identify implied actions. Common patterns:
+  - "Send Sarah a follow-up email about X" → draft an email
+  - "Set up a follow-up meeting next week" → create a calendar event
+  - "Remember that they're interested in Y" → store a KG fact
+  - "Can you look into Z?" → delegate research to research-analyst
+  - "Draft a thank-you note" → draft an email
+  - "Nothing needed" or similar → no actions; just close the debrief (Step D5)
+
+  ## Step D3: Execute follow-up actions (do-now + record)
+
+  For each identified action:
+
+  - **Actions you can do now** — email drafts (`email-draft-save`; default to
+    drafts unless the CEO says "send"), calendar events (`calendar-create-event`
+    after `calendar-check-conflicts` and `date-resolve`), KG facts
+    (`memory-store`, source "agent:meeting-debrief"): DO them now, this turn, as
+    before. Then record each as a COMPLETED child task: `task-create` with
+    parent_task_id: <debrief task_id>, tags: ["debrief-followup"], owner:
+    "curia", a title describing the action; then immediately `task-complete` it
+    with a brief completion_note.
+
+  - **Actions you cannot do now:**
+    - A call only the CEO can make → `task-create` parent_task_id: <debrief
+      task_id>, tags: ["debrief-followup"], owner: "ceo", title describing the
+      call. Leave it open — it surfaces in the CEO's "For you to do".
+    - Work blocked on a third party → `task-create` parent_task_id: <debrief
+      task_id>, tags: ["debrief-followup"], owner: "external", and set
+      waiting_on_contact_id (or waiting_on_text if the contact isn't known).
+      Leave it open.
+
+  - **Research** → open a Bullpen thread mentioning research-analyst with a clear
+    brief; optionally record an owner: "curia" child task to track it.
+
+  ## Step D4: Confirmation
+
+  After executing all do-now actions, compose a confirmation summary and return
+  it to the coordinator (it relays to the CEO). Format:
+
+  > Done! Here's what I set up from your [meeting title] debrief:
+  > - Drafted a follow-up email to Sarah Chen (check your drafts)
+  > - Booked a 30-min follow-up for Thursday May 29 at 10:00 AM
+  > - Noted that Acme is exploring a partnership in Q4
+  > - Left you a reminder to call David yourself
+
+  ## Step D5: Complete the debrief task
+
+  Call `task-complete` with the debrief `task_id` and a brief completion_note
+  summarizing what was set up. This auto-cancels the task's pending
+  reminder/expiry wake-up. The debrief is now closed.
+
+  ---
+
+  # DELEGATED MODE: Preference Updates
+
+  When the CEO expresses a debrief preference (e.g. "don't prompt me for weekly
+  standups", "always debrief after meetings with investors"):
+
+  1. Store the preference as a KG fact via `memory-store`:
+     - entity: the CEO's name or "debrief_preferences"
+     - field: a descriptive key like "skip_weekly_standups" or
+       "always_debrief_investor_meetings"
+     - value: the preference rule in natural language
+     - source: "agent:meeting-debrief"
+     - decay_class: "slow_decay"
+  2. Confirm the preference was saved.
+  3. These preferences are queried in Step 3 (enrichment) of detection via
+     `memory-query` and honored in Step 4 judgment.
+
+  ---
+
+  # Status queries
+
+  If the CEO asks "what debriefs are outstanding?", the coordinator answers it
+  directly via `task-list tag=debrief-pending` — you do not need a status mode.
+  If a status request is nonetheless delegated to you, answer it with a
+  `task-list tag=debrief-pending` call and return a short summary.
+
+  ---
+
+  # Key Constraints
+
+  - **Never send messages directly.** All outbound goes through Bullpen →
+    coordinator → send skill. You have no signal-send or email-send.
+  - **Draft by default.** Email follow-ups are drafts unless the CEO explicitly
+    says "send it".
+  - **One reminder per debrief.** One reminder after the configured delay, then
+    let it expire. Do not nag.
+  - **No bespoke state.** All debrief work is platform tasks plus the config-store
+    guards. Do not invent state maps.
+  - **Respect stored preferences.** Query `memory-query` in Step 3 and honor
+    preferences in judgment.
+  - **Tasks are real work only.** Never create a task for a meeting you judged
+    not worth debriefing — use the `seen:` guard instead.
+```
+
+- [ ] **Step 2: Run the new structural test — expect PASS**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks exec vitest run tests/unit/agent.meeting-debrief-tasks.test.ts`
+Expected: PASS (all assertions).
+
+- [ ] **Step 3: Run the existing idempotency + config tests — expect PASS (unmodified)**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks exec vitest run tests/unit/agent.meeting-debrief-idempotency.test.ts tests/unit/config.debrief.test.ts`
+Expected: PASS. The `## Step 6`/`## Step 7` headings exist, and within the Step 6 slice the order is `prompted:` (retrieve) → `"post"` (bullpen) → `action: "store"` → `thread_id` → no-retry. If any idempotency assertion fails, re-check that the revalidation block contains no `"post"` or `action: "store"` literal before the bullpen call.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks add agents/meeting-debrief.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks commit -m "feat: migrate meeting-debrief to platform tasks (#839)"
+```
+
+---
+
+## Task 3: Typecheck + full unit suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks run typecheck`
+Expected: clean (no errors). The only new `.ts` is the test file.
+
+- [ ] **Step 2: Run the full unit test suite**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks run test`
+Expected: all green. (If the project's `test` script requires Docker/Postgres for integration tests and they don't run in this environment, run the unit subset: `pnpm --prefix <worktree> exec vitest run tests/unit` and note any pre-existing, unrelated failures.)
+
+- [ ] **Step 3: No commit** (verification only). If typecheck surfaces an issue in the test file, fix it, re-run, then `git commit --amend --no-edit` onto Task 2's commit or a new fixup commit.
+
+---
+
+## Task 4: Update spec 17 (§3 State Management + detection pipeline)
+
+**Files:**
+- Modify: `docs/specs/17-meeting-debrief.md`
+
+- [ ] **Step 1: Read the current §3 and detection-pipeline (§2) sections**
+
+Read `docs/specs/17-meeting-debrief.md` fully to locate §2 (Detection Pipeline) and §3 (State Management) and their exact current wording.
+
+- [ ] **Step 2: Replace §3 "State Management" with the tasks model**
+
+Replace the entire `## 3. State Management` section (through just before `## 4.`) with:
+
+```markdown
+## 3. State Management
+
+**No bespoke state maps.** Debrief work is tracked as platform **tasks** (spec:
+[tasks & backlog](../wip/2026-06-01-tasks-and-backlog-design.md)), not the former
+`pendingDebriefs` / `judgedEvents` / `deferredEvents` maps in scheduler progress.
+
+### Debrief tasks
+
+Each meeting that warrants a debrief is one task:
+- `tag = ['debrief-pending']`, `title = "Debrief: <meeting>"`.
+- `owner` starts `'curia'` (Curia owes the prompt) and flips to `'ceo'` at the
+  prompt wake (the CEO then owes takeaways). This drives the digest's three-way
+  grouping: a scheduled-but-unprompted debrief shows under "What I'm working on";
+  once prompted it moves to "For you to do".
+- `intent_anchor` carries the calendar `eventId` and the meeting's scheduled end.
+  It is delivered to the agent on each wake-up (system-prompt injection) but is
+  not returned by `task-list`, so it stays out of the CEO's digest.
+- The lifecycle is a chain of `wake_at` re-schedules on the one task row:
+  `meeting end → deliver prompt` → `+reminderDelay → one reminder` →
+  `+TTL → expire (cancel)`. A CEO reply completes the task early and auto-cancels
+  the pending wake-up.
+
+Follow-up actions discovered from a CEO reply become **child tasks**
+(`parent_task_id` = the debrief task, `tag = ['debrief-followup']`): work Curia
+does inline is recorded as a completed child; a call only the CEO can make is an
+open `owner='ceo'` child; third-party-blocked work is an open `owner='external'`
+child.
+
+### Detection cadence
+
+Detection runs **3×/day** (`0 7,12,16`), scanning the rest of the day forward
+and scheduling a debrief task per qualifying meeting. Judgment is binary
+**YES/NO** (no DEFER); on a genuine fence it leans YES. A not-worthy meeting
+creates **no task** — only a `seen:` guard (below). The accepted trade-off is
+that a meeting added *and* occurring entirely inside a scan gap is missed;
+cancellations/reschedules of known meetings are caught by re-validating the
+event at the prompt wake.
+
+### Phase guards via `config-store` (namespace `"debrief"`)
+
+Three keys, all CEO-invisible; the lifecycle phase is derived from them rather
+than stored as data:
+
+- `seen:<eventId>` — detection dedup; set for every judged event (YES and NO).
+- `prompted:<eventId>` — set when the prompt is sent (also the layer-2 duplicate
+  guard, below). Absent at a wake ⇒ scheduled phase; present ⇒ prompted.
+- `reminded:<eventId>` — set when the one reminder is sent. With `prompted:`
+  present: absent ⇒ reminder phase; present ⇒ expiry phase.
+
+#### Cross-tick idempotency via `config-store`
+
+The `prompted:<eventId>` key is the agent's layer-2 "have I prompted for this
+meeting?" guard, independent of the task representation: before posting a Bullpen
+debrief prompt the agent checks it, and after a successful post it writes the key
+(with the thread ID). Even if a future regression resends a wake or re-creates a
+task, this guard prevents a duplicate user-facing prompt. It is the same
+defense-in-depth that originally fixed the #724 duplicate-prompt incident.
+
+### Durable knowledge → KG facts (only when worth remembering)
+
+- **Debrief preferences:** "CEO prefers no debrief prompts for meetings with
+  Christophe" → fact on Christophe's contact KG node. Used by judgment.
+- **Meeting outcomes / completed follow-ups:** stored on the relevant contact/org
+  entities only when the follow-up produced substantive knowledge.
+- **No KG entry** for: meetings skipped by judgment, "nothing needed" replies, or
+  task machinery state.
+```
+
+- [ ] **Step 3: Reconcile §2 (Detection Pipeline) wording**
+
+In `## 2. Detection Pipeline` (and any "Scheduler integration" subsection),
+update any text that describes a 15-minute poll, "meetings that just ended",
+`scanWindowMinutes`, or the `pendingDebriefs`/`judgedEvents` maps so it matches
+the 3×/day forward-scan pre-scheduling model and the binary YES/NO judgment.
+Keep edits minimal and factual; do not restructure unrelated subsections. If §2
+already only describes judgment criteria (not cadence), leave it and rely on §3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks add docs/specs/17-meeting-debrief.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks commit -m "docs: update spec 17 state management for tasks migration (#839)"
+```
+
+---
+
+## Task 5: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add a `Changed` bullet under `[Unreleased]`**
+
+Open `CHANGELOG.md`, find `## [Unreleased]`, and add (creating a `### Changed`
+subsection if one isn't already present under Unreleased) this bullet:
+
+```markdown
+- **`meeting-debrief`** — migrated from bespoke `pendingDebriefs`/`judgedEvents` state maps to platform tasks; detection now runs 3×/day and pre-schedules a per-meeting debrief task driven by wake-ups. (#839)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks commit -m "docs: changelog for meeting-debrief tasks migration (#839)"
+```
+
+---
+
+## Task 6: Final verification & pre-PR review
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm net-negative agent-definition LOC**
+
+Run: `git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks diff main --stat -- agents/meeting-debrief.yaml`
+Expected: more deletions than insertions on the YAML (the abstraction should be a win). If not, tighten the prompt — but never at the cost of the idempotency guard or clarity.
+
+- [ ] **Step 2: Re-run the targeted tests one more time**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks exec vitest run tests/unit/agent.meeting-debrief-tasks.test.ts tests/unit/agent.meeting-debrief-idempotency.test.ts tests/unit/config.debrief.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 3: Grep for any stray bespoke-state references across the repo**
+
+Run: `git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-debrief-tasks grep -n "pendingDebriefs\|judgedEvents\|deferredEvents" -- ':!docs/wip/*' ':!CHANGELOG.md'`
+Expected: no matches outside the WIP design doc / changelog history. (Tests reference the tokens only inside `not.toContain` assertions — those are expected.)
+
+- [ ] **Step 4: Auto-review before PR (per global CLAUDE.md)**
+
+Dispatch in parallel: `pr-review-toolkit:code-reviewer` and `pr-review-toolkit:silent-failure-hunter` against the branch diff vs `main`. This change is prompt/docs only (no auth/credentials), so no security review is required. Address any high-priority findings before opening the PR.
+
+- [ ] **Step 5: STOP — hand back to Joseph for PR creation**
+
+Do NOT open the PR automatically. Summarize the diff and CI-readiness, and let Joseph decide when to `gh pr create` (with `Closes #839` in the body). Per memory: never merge without explicit approval.
+
+---
+
+## Follow-up (separate issue — do NOT do in this PR)
+
+After this lands, draft a GitHub issue for: **"task-create: explicit target agent_id so coordinator/ceo-inbox can schedule wake-ups into a specialist"**, including the permission/gating design question (should any agent inject scheduled wakes into any other agent?). Apply appropriate labels + a `size:` label + acceptance criteria per CLAUDE.md.
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** state mapping (Task 2 Steps 5/D3), three modes (Task 2), owner flip (Task 2 Step 6 + test), 3×/day cron (Task 2 + test), NO→no-task (Task 2 Step 5 + test), no DEFER / lean YES (Task 2 Step 4 + test), guards incl. `reminded:` (Task 2), eventId-in-intent_anchor (Task 2 Step 5), idempotency guard preserved (Task 2 Step 3 verification), spec 17 update (Task 4), CHANGELOG (Task 5), version bump (Task 2 + test), pinned-skill changes (Task 2 + test), net-negative LOC (Task 6). All covered.
+- **Placeholders:** none — full file content and exact commands provided.
+- **Type/name consistency:** guard keys `seen:`/`prompted:`/`reminded:`, tags `debrief-pending`/`debrief-followup`, owners `curia`/`ceo`/`external`, cron `0 7,12,16 * * *`, and the three mode names are used identically across the prompt, tests, and spec.

--- a/tests/unit/agent.meeting-debrief-tasks.test.ts
+++ b/tests/unit/agent.meeting-debrief-tasks.test.ts
@@ -1,0 +1,89 @@
+// tests/unit/agent.meeting-debrief-tasks.test.ts
+//
+// Guards the #839 migration: meeting-debrief tracks debrief work as platform
+// tasks (not bespoke pendingDebriefs/judgedEvents maps), runs detection 3x/day,
+// and judges meetings YES/NO (no DEFER). Parses the agent YAML, asserts on its
+// structure. Companion to agent.meeting-debrief-idempotency.test.ts.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+
+let parsed: Record<string, unknown>;
+let prompt: string;
+let pinnedSkills: string[];
+
+beforeAll(() => {
+  const agentPath = path.resolve(import.meta.dirname, '../../agents/meeting-debrief.yaml');
+  let raw: string;
+  try {
+    raw = fs.readFileSync(agentPath, 'utf-8');
+  } catch (err) {
+    throw new Error(
+      `Cannot load meeting-debrief.yaml from ${agentPath}: ${(err as Error).message}. ` +
+      `Is the test running from the repo root?`,
+    );
+  }
+  parsed = yaml.load(raw) as Record<string, unknown>;
+  if (typeof parsed.system_prompt !== 'string') {
+    throw new Error('meeting-debrief.yaml is missing a system_prompt string field');
+  }
+  prompt = parsed.system_prompt;
+  pinnedSkills = (parsed.pinned_skills as string[]) ?? [];
+});
+
+describe('meeting-debrief tasks migration (#839)', () => {
+  it('declares all three operating modes', () => {
+    expect(prompt).toMatch(/Scheduled mode/);
+    expect(prompt).toMatch(/Task wake-up mode/i);
+    expect(prompt).toMatch(/Delegated mode/i);
+  });
+
+  it('pins the four task-* skills', () => {
+    for (const skill of ['task-create', 'task-list', 'task-update', 'task-complete']) {
+      expect(pinnedSkills).toContain(skill);
+    }
+  });
+
+  it('no longer pins scheduler-report or scheduler-list', () => {
+    expect(pinnedSkills).not.toContain('scheduler-report');
+    expect(pinnedSkills).not.toContain('scheduler-list');
+  });
+
+  it('removes all bespoke state-map references from the prompt', () => {
+    for (const token of [
+      'pendingDebriefs',
+      'judgedEvents',
+      'deferredEvents',
+      'lastScanTimestamp',
+    ]) {
+      expect(prompt).not.toContain(token);
+    }
+  });
+
+  it('runs detection 3x/day via cron', () => {
+    const schedule = parsed.schedule as Array<{ cron?: string }> | undefined;
+    expect(schedule).toBeDefined();
+    expect(schedule!.length).toBeGreaterThan(0);
+    expect(schedule![0]!.cron).toBe('0 7,12,16 * * *');
+  });
+
+  it('creates no task for not-worthy meetings (guard-only)', () => {
+    expect(prompt).toMatch(/seen:/);
+    expect(prompt).toMatch(/[Cc]reate no task/);
+  });
+
+  it('keeps binary judgment with a YES lean and removes DEFER', () => {
+    expect(prompt).toMatch(/lean YES/i);
+    expect(prompt).not.toMatch(/\bDEFER\b/);
+  });
+
+  it('flips owner to ceo at the prompt wake', () => {
+    expect(prompt).toMatch(/flips? to .?ceo/i);
+  });
+
+  it('declares a version field', () => {
+    expect(typeof parsed.version).toBe('string');
+  });
+});

--- a/tests/unit/agent.meeting-debrief-tasks.test.ts
+++ b/tests/unit/agent.meeting-debrief-tasks.test.ts
@@ -30,7 +30,13 @@ beforeAll(() => {
     throw new Error('meeting-debrief.yaml is missing a system_prompt string field');
   }
   prompt = parsed.system_prompt;
-  pinnedSkills = (parsed.pinned_skills as string[]) ?? [];
+  const rawPinnedSkills = parsed.pinned_skills;
+  if (!Array.isArray(rawPinnedSkills) || !rawPinnedSkills.every((s) => typeof s === 'string')) {
+    throw new Error(
+      `meeting-debrief.yaml pinned_skills must be an array of strings; got: ${JSON.stringify(rawPinnedSkills)}`,
+    );
+  }
+  pinnedSkills = rawPinnedSkills;
 });
 
 describe('meeting-debrief tasks migration (#839)', () => {
@@ -65,7 +71,8 @@ describe('meeting-debrief tasks migration (#839)', () => {
   it('runs detection 3x/day via cron', () => {
     const schedule = parsed.schedule as Array<{ cron?: string }> | undefined;
     expect(schedule).toBeDefined();
-    expect(schedule!.length).toBeGreaterThan(0);
+    // Exactly one cron entry: extra entries would violate the 3x/day contract
+    expect(schedule).toHaveLength(1);
     expect(schedule![0]!.cron).toBe('0 7,12,16 * * *');
   });
 


### PR DESCRIPTION
## **User description**
## Summary

- Rewrites `agents/meeting-debrief.yaml` to track debrief work as platform tasks (`task-create`/`task-list`/`task-update`/`task-complete`) — no more bespoke `pendingDebriefs`/`judgedEvents`/`deferredEvents` state maps
- Converts detection from a 15-minute poll (~96 runs/day) to 3×/day pre-scheduling (`0 7,12,16 * * *`); each qualifying meeting gets a `debrief-pending` task with `wake_at` = meeting end
- Removes `DEFER` judgment; binary YES/NO with lean-YES on the fence
- `owner` starts as `curia` (Curia must prompt), flips to `ceo` at the prompt wake (CEO must reply) — drives the digest's "For you to do" grouping correctly
- Phase (scheduled → reminder → expiry) is derived from `config-store` guards (`seen:` / `prompted:` / `reminded:`), keeping `last_progress_note` human-readable
- Adds structural test `tests/unit/agent.meeting-debrief-tasks.test.ts`; preserves existing idempotency regression test (`#724`)
- Updates spec 17 §2 + §3 and CHANGELOG

Closes #839

## Test plan

- [x] `tests/unit/agent.meeting-debrief-tasks.test.ts` — 9 structural assertions (three modes, task skills pinned, no bespoke state tokens, cron, NO→no-task, lean YES / no DEFER, owner flip, version field)
- [x] `tests/unit/agent.meeting-debrief-idempotency.test.ts` — 15 assertions unchanged and passing (#724 regression guard)
- [x] `tests/unit/config.debrief.test.ts` — passes unchanged
- [x] Full unit suite — 1,775 tests passing
- [x] Typecheck clean
- [x] Net negative on `agents/meeting-debrief.yaml` (247 ins / 279 del)


___

## **CodeAnt-AI Description**
Migrate meeting debriefs to platform tasks with scheduled wake-ups

### What Changed
- Meeting debriefs now create and manage platform tasks instead of keeping separate per-meeting state maps
- Detection now runs 3 times a day, scans upcoming meetings, and schedules a debrief task for each meeting that should be prompted later
- The debrief flow now uses task wake-ups for the prompt, one reminder, and expiry, and flips ownership to the CEO once the prompt is sent
- Added a structural test for the new task-based behavior and updated the meeting debrief spec and changelog to match

### Impact
`✅ Fewer repeated debrief prompts`
`✅ Lower scheduler load from fewer scan runs`
`✅ Clearer task ownership in the CEO's queue`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Meeting debrief detection now runs three times daily (7am, 12pm, 4pm) instead of continuous polling.
  * Debrief scheduling now uses simplified binary decision logic.
  * Debrief tasks include automatic wake-up scheduling at meeting end for timely prompting.

* **Documentation**
  * Updated specification and design documentation for meeting debrief workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->