### PR TITLE
chore: guard pnpm-workspace.yaml allowBuilds against placeholder values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,12 @@ Two patterns that pass local checks but fail CI regularly:
 - Integration tests use real Postgres (via Docker), not mocks
 - Tests live next to the code they test, or in `tests/unit/` and `tests/integration/`
 
+### pnpm-workspace.yaml — do not edit during worktree setup
+
+**Never edit `pnpm-workspace.yaml` to resolve `pnpm install` output about build script approvals.** The `allowBuilds` values are already correct in the repo. When `pnpm install` warns about packages needing build approval, those warnings are informational — the existing entries handle them. If pnpm adds a new entry for a genuinely new dependency, set its value explicitly to `true` or `false` (never placeholder text). A pre-commit hook enforces this: any `allowBuilds` value that is not a boolean will block the commit.
+
+If you need to approve new build scripts interactively, use `pnpm approve-builds` — do not hand-edit this file.
+
 ## Key Files
 
 - `src/index.ts` — bootstrap orchestrator, wires everything in dependency order


### PR DESCRIPTION
## **User description**
## Summary

- Adds a pre-commit hook (`.git/hooks/pre-commit`) that rejects commits where any `allowBuilds` value in `pnpm-workspace.yaml` is not a boolean
- Adds a note to `CLAUDE.md` explaining why agents should not edit this file during worktree setup

## Background

LLM agents running `pnpm install` in a fresh worktree see pnpm v11's build-script approval warnings and try to "fix" `pnpm-workspace.yaml` by setting `allowBuilds` values — but since they don't know the correct values, write placeholder text (`set this to true or false`). This has caused CI failures when committed. The hook catches it at commit time regardless of cause; the CLAUDE.md note prevents the behaviour at the instruction layer.

The hook is installed in `.git/hooks/` (git infrastructure, not tracked source), so it is automatically shared across all worktrees without needing a commit.

## Test plan

- [x] Manually verify hook blocks a commit with `allowBuilds: esbuild: set this to true or false`
- [x] Verify hook passes when all values are `true`/`false`
- [x] CLAUDE.md note is clear and actionable


___

## **CodeAnt-AI Description**
**Warn agents not to edit `pnpm-workspace.yaml` during worktree setup**

### What Changed
- Adds a clear instruction to leave `pnpm-workspace.yaml` alone when `pnpm install` shows build approval warnings
- Explains that existing `allowBuilds` entries are already correct, and that any new dependency should be set to `true` or `false` instead of placeholder text
- Points users to `pnpm approve-builds` for interactive approval instead of editing the file by hand

### Impact
`✅ Fewer accidental pnpm workspace edits`
`✅ Fewer broken commits from placeholder values`
`✅ Clearer guidance for build approval warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
