### PR TITLE
feat: task-execution heartbeat foundation (BacklogHeartbeat + enable_task_management)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **`enable_task_management`** — declarative agent capability that auto-pins the task skills, injects the executor/reification discipline block, and marks an agent heartbeat-eligible. (design 2026-06-04 §6)
+- **`BacklogHeartbeat`** — deterministic hourly System component that wakes idle/stale tasks by enqueuing one-shot scheduler jobs, one per owning agent, globally capped. (design 2026-06-04 §3)
+
 ### Changed
+- **coordinator** — task management now arrives via `enable_task_management: true` (replacing manual `task-*` pins); added a bounded `error_budget` for project bursts.
 - **coordinator** — replaced the `intent_anchor`-for-cron-jobs instruction with the new task/scheduling split: `task-create` for deferred CEO-visible work, `scheduler-create` (no `intent_anchor`) for operational sweeps. Adds backlog-awareness and defer-don't-drop rules. (#)
 - **`meeting-debrief`** — migrated from bespoke `pendingDebriefs`/`judgedEvents` state maps to platform tasks; detection now runs 3×/day and pre-schedules a per-meeting debrief task driven by wake-ups. (#839)
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.5.1"
+version: "0.6.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -641,11 +641,11 @@ pinned_skills:
   - approval-expiry-sweep
   - pending-actions-digest
   - scheduler-report
-  - task-create
-  - task-list
-  - task-update
-  - task-complete
 allow_discovery: true
+enable_task_management: true
+error_budget:
+  max_turns: 40
+  max_cost_usd: 1.00
 schedule:
   - cron: "0 * * * *"
     task: "Run the approval expiry sweep — find and expire any pending approval requests that have passed their expiry time."

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -437,3 +437,10 @@ sensitivity_rules:
       - medical record
       - home address
       - personal phone
+
+# Autonomous task execution — BacklogHeartbeat tuning (design 2026-06-04 §3, §9.1).
+tasks:
+  heartbeatIntervalMinutes: 60
+  heartbeatMaxWakesPerTick: 5
+  idleThresholdHours: 4
+  staleWaitThresholdHours: 48

--- a/docs/wip/2026-06-04-task-exec-heartbeat-foundation.md
+++ b/docs/wip/2026-06-04-task-exec-heartbeat-foundation.md
@@ -1,0 +1,1258 @@
+# Task Execution & Heartbeat — Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the platform machinery for autonomous task execution — a declarative `enable_task_management` agent capability and a deterministic hourly `BacklogHeartbeat` that wakes idle/stale tasks — with the coordinator enabled as the canary.
+
+**Architecture:** A new boolean agent-YAML flag (`enable_task_management`) auto-pins the four `task-*` skills, injects a shared executor-discipline prompt block, and registers the agent as heartbeat-eligible. A new System-layer component (`BacklogHeartbeat`) runs on a `setInterval`, selects idle/stale tasks via one deterministic SQL query (one entry-point per effective owner agent, globally capped), and inserts one-shot `scheduled_jobs` wake rows that the **existing, unchanged** scheduler dispatches to each owning agent. Execution stays distributed to owners; the heartbeat only routes.
+
+**Tech Stack:** TypeScript (ESM, Node 22+), PostgreSQL 16 (node-pg + plain-SQL migrations via node-pg-migrate), Vitest (unit + real-Postgres integration), pino logging.
+
+**Scope:** This plan covers design §3 (heartbeat) + §6 (capability flag) + enabling the coordinator. It does **not** cover ceo-inbox (#840), meeting-debrief/research-analyst onboarding, or the stretch `last_advanced_at` column — those are a follow-up plan. Reference spec: [`docs/wip/2026-06-04-task-execution-heartbeat-design.md`](2026-06-04-task-execution-heartbeat-design.md).
+
+**Conventions for every commit:** No `Co-Authored-By` / no Claude attribution (per repo CLAUDE.md). Run `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck` before each commit touching `.ts`. Integration tests require `DATABASE_URL` pointing at an **empty test database** (they `DELETE` rows); they auto-skip when it is unset.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/agents/task-management.ts` — single source of truth for the capability: the four skill names, the injected discipline block (design §6.1), and the pure `applyTaskManagement()` helper.
+- `tests/unit/agents/task-management.test.ts` — unit tests for `applyTaskManagement()`.
+- `src/scheduler/backlog-heartbeat.ts` — the `BacklogHeartbeat` System component (`start`/`stop`/`tick`).
+- `tests/unit/scheduler/backlog-heartbeat.test.ts` — unit tests (mocked deps, fake timers).
+- `tests/integration/backlog-heartbeat.test.ts` — real-Postgres end-to-end selection + enqueue.
+- `tests/integration/heartbeat-selection.test.ts` — real-Postgres tests for the selection SQL.
+
+**Modified files:**
+- `src/agents/loader.ts` — add `enable_task_management?: boolean` to `AgentYamlConfig`.
+- `src/index.ts` — apply `applyTaskManagement()` in the agent bootstrap loop; build the eligible-agents set; construct + start + stop `BacklogHeartbeat`.
+- `src/db/queries/tasks.ts` — add `selectHeartbeatCandidates()`.
+- `src/scheduler/scheduler-service.ts` — add `enqueueTaskWake()`.
+- `src/config.ts` — add the `tasks` config section to `YamlConfig` + `resolveTasksConfig()`.
+- `schemas/default-config.schema.json` — register the `tasks` object (root is `additionalProperties:false`).
+- `config/default.yaml` — add the `tasks:` block.
+- `tests/unit/config.test.ts` (or the existing config test file) — `resolveTasksConfig` defaults + parsing.
+- `agents/coordinator.yaml` — set the flag, drop redundant manual pins, add `error_budget`, bump version.
+- `CHANGELOG.md` — `[Unreleased]` entries.
+
+---
+
+## Part A — `enable_task_management` capability
+
+### Task A1: Add the flag to the agent config type
+
+**Files:**
+- Modify: `src/agents/loader.ts` (interface `AgentYamlConfig`, after the `inject_specialists?: boolean;` field, ~line 67)
+
+- [ ] **Step 1: Add the field**
+
+In `src/agents/loader.ts`, inside `export interface AgentYamlConfig { … }`, immediately after the `inject_specialists?: boolean;` line, add:
+
+```typescript
+  /** When true, the runtime auto-pins the task-* skills, injects the shared
+   *  task-management discipline block, and marks the agent heartbeat-eligible.
+   *  See docs/wip/2026-06-04-task-execution-heartbeat-design.md §6. Default: false. */
+  enable_task_management?: boolean;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add src/agents/loader.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: add enable_task_management flag to AgentYamlConfig"
+```
+
+---
+
+### Task A2: The capability module (block + skills + pure helper)
+
+**Files:**
+- Create: `src/agents/task-management.ts`
+- Test: `tests/unit/agents/task-management.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/agents/task-management.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  applyTaskManagement,
+  TASK_MANAGEMENT_SKILLS,
+  TASK_MANAGEMENT_BLOCK,
+} from '../../../src/agents/task-management.js';
+import type { AgentYamlConfig } from '../../../src/agents/loader.js';
+
+function cfg(overrides: Partial<AgentYamlConfig> = {}): AgentYamlConfig {
+  return {
+    name: 'test-agent',
+    model: { tier: 'standard' },
+    system_prompt: 'BASE PROMPT',
+    ...overrides,
+  };
+}
+
+describe('applyTaskManagement', () => {
+  it('is a no-op when the flag is absent', () => {
+    const r = applyTaskManagement(cfg(), 'BASE PROMPT', ['a', 'b']);
+    expect(r.systemPrompt).toBe('BASE PROMPT');
+    expect(r.pinnedSkills).toEqual(['a', 'b']);
+    expect(r.heartbeatEligible).toBe(false);
+  });
+
+  it('is a no-op when the flag is explicitly false', () => {
+    const r = applyTaskManagement(cfg({ enable_task_management: false }), 'BASE PROMPT', []);
+    expect(r.systemPrompt).toBe('BASE PROMPT');
+    expect(r.pinnedSkills).toEqual([]);
+    expect(r.heartbeatEligible).toBe(false);
+  });
+
+  it('appends the block, adds the four skills, and marks eligible when true', () => {
+    const r = applyTaskManagement(cfg({ enable_task_management: true }), 'BASE PROMPT', ['x']);
+    expect(r.systemPrompt).toBe(`BASE PROMPT\n\n${TASK_MANAGEMENT_BLOCK}`);
+    expect(r.pinnedSkills).toEqual(['x', ...TASK_MANAGEMENT_SKILLS]);
+    expect(r.heartbeatEligible).toBe(true);
+  });
+
+  it('does not duplicate skills already pinned', () => {
+    const base = ['task-list', 'other'];
+    const r = applyTaskManagement(cfg({ enable_task_management: true }), 'P', base);
+    // task-list kept once, the other three appended
+    expect(r.pinnedSkills.filter((s) => s === 'task-list')).toHaveLength(1);
+    expect(r.pinnedSkills).toEqual(['task-list', 'other', 'task-create', 'task-update', 'task-complete']);
+  });
+
+  it('exposes exactly the four task skills', () => {
+    expect([...TASK_MANAGEMENT_SKILLS]).toEqual(['task-create', 'task-list', 'task-update', 'task-complete']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/agents/task-management.test.ts`
+Expected: FAIL — cannot resolve `../../../src/agents/task-management.js`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/agents/task-management.ts`:
+
+```typescript
+import type { AgentYamlConfig } from './loader.js';
+
+/** The four skills every task-management-enabled agent can call. */
+export const TASK_MANAGEMENT_SKILLS = [
+  'task-create',
+  'task-list',
+  'task-update',
+  'task-complete',
+] as const;
+
+/** Single source of truth for the executor-discipline block injected into every
+ *  task-management-enabled agent's effective system prompt.
+ *  See docs/wip/2026-06-04-task-execution-heartbeat-design.md §6.1. */
+export const TASK_MANAGEMENT_BLOCK = [
+  '## Task Management',
+  '',
+  'You can defer, track, and resume work using your task skills.',
+  '',
+  '**Decide, don\'t drop.** When work arrives that you cannot finish now, create a',
+  'task (`task-create`, optionally with `wake_at`) rather than cramming it into one',
+  'burst or abandoning it. Briefly tell the CEO what you queued and why.',
+  '',
+  '**Decompose projects.** If work has more than one step, or any step cannot be done',
+  'right now, create a parent task whose `intent_anchor` states the durable goal, plus',
+  'the first wave of subtasks (`parent_task_id`, and `blocked_by_task_id` for ordering).',
+  'Plan the first wave only; add subtasks as you learn more.',
+  '',
+  '**Advance until blocked.** When you act on a task, do every step you can right now.',
+  'Stop only at a real blocker — waiting on a person, on the CEO\'s approval, on a future',
+  'date, or on a prior task — or when your turn budget runs low. Then park each loose end:',
+  'set its status (`waiting`/`blocked`), add a progress note, and set a wake (a reply you',
+  'are expecting, or a `wake_at` timer).',
+  '',
+  '**Never promise without a task.** Before you send anything that commits to a future',
+  'action ("I\'ll follow up with X", "we\'ll send that over"), make sure a task backs that',
+  'promise. Prefer to resolve the dependency first and send a complete message. Only send',
+  'an interim "I\'ll follow up" when the recipient needs an acknowledgment now — and when',
+  'you do, create the follow-up task (yours if you can chase it; the CEO\'s if only they',
+  'can, and tell them).',
+  '',
+  '**Resuming.** When you are woken to advance a task, you receive its id, title, intent,',
+  'and progress. Pick up where you left off. You may pull your other ready tasks',
+  '(`task-list`) and advance them too, in dependency order, until blocked or budget-bound.',
+].join('\n');
+
+export interface TaskManagementResult {
+  systemPrompt: string;
+  pinnedSkills: string[];
+  heartbeatEligible: boolean;
+}
+
+/** Apply the enable_task_management capability to an agent's prompt + skills.
+ *  Pure function — no side effects. When the flag is off (default), returns the
+ *  inputs unchanged and heartbeatEligible=false. */
+export function applyTaskManagement(
+  config: AgentYamlConfig,
+  systemPrompt: string,
+  pinnedSkills: string[],
+): TaskManagementResult {
+  if (!config.enable_task_management) {
+    return { systemPrompt, pinnedSkills, heartbeatEligible: false };
+  }
+  // Keep the author's explicit pins; append any task skills not already present.
+  const merged = [...pinnedSkills];
+  for (const skill of TASK_MANAGEMENT_SKILLS) {
+    if (!merged.includes(skill)) merged.push(skill);
+  }
+  return {
+    systemPrompt: `${systemPrompt}\n\n${TASK_MANAGEMENT_BLOCK}`,
+    pinnedSkills: merged,
+    heartbeatEligible: true,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/agents/task-management.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add src/agents/task-management.ts tests/unit/agents/task-management.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: add task-management capability module (block + skills + applyTaskManagement)"
+```
+
+---
+
+### Task A3: Wire the capability into bootstrap + build the eligible-agents set
+
+**Files:**
+- Modify: `src/index.ts` (agent bootstrap loop, ~lines 1302–1412)
+
+> **Note:** `src/index.ts` is the bootstrap orchestrator and is not unit-tested directly; correctness here is verified by typecheck plus the integration test in Task B6 (which needs at least one enabled agent). Keep the change minimal and mechanical.
+
+- [ ] **Step 1: Declare the eligible-agents set before the agent loop**
+
+In `src/index.ts`, locate where agents are iterated to build runtimes (the loop that computes `const agentPinnedSkills = agentConfig.pinned_skills ?? [];` near line 1302). Immediately **before** that loop begins, add:
+
+```typescript
+// Agents with enable_task_management: true — read by the BacklogHeartbeat to
+// know which source_agent_ids it may wake (and as the fallback target list).
+const taskManagementAgents = new Set<string>();
+```
+
+- [ ] **Step 2: Apply the capability inside the loop**
+
+Add the import at the top of `src/index.ts` (with the other `./agents/*` imports):
+
+```typescript
+import { applyTaskManagement } from './agents/task-management.js';
+```
+
+Inside the loop, after `systemPrompt` has been fully interpolated (after the `interpolateRuntimeContext(...)` branch ending ~line 1373) and after `const agentPinnedSkills = agentConfig.pinned_skills ?? [];`, insert:
+
+```typescript
+// Apply the enable_task_management capability: auto-pin task skills, append the
+// discipline block, and register heartbeat-eligibility. No-op when the flag is off.
+const taskMgmt = applyTaskManagement(agentConfig, systemPrompt, agentPinnedSkills);
+systemPrompt = taskMgmt.systemPrompt;
+const effectivePinnedSkills = taskMgmt.pinnedSkills;
+if (taskMgmt.heartbeatEligible) {
+  taskManagementAgents.add(agentConfig.name);
+}
+```
+
+Then change the existing tool-definition line to use `effectivePinnedSkills`:
+
+```typescript
+// was: const agentToolDefs = skillRegistry.toToolDefinitions(agentPinnedSkills);
+const agentToolDefs = skillRegistry.toToolDefinitions(effectivePinnedSkills);
+```
+
+(If `systemPrompt` is declared `const` at the interpolation site, change it to `let` so the reassignment above compiles.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck`
+Expected: PASS. (`taskManagementAgents` is unused until Task B5 — that is fine; it is a `Set` populated here and consumed there. If the linter flags unused, proceed; Task B5 consumes it in the same PR sequence. To avoid a lint break between commits, you may complete B5's wiring in the same commit as this step — see Task B5.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add src/index.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: wire enable_task_management into agent bootstrap"
+```
+
+---
+
+## Part B — `BacklogHeartbeat`
+
+### Task B1: The `tasks` config section
+
+**Files:**
+- Modify: `src/config.ts` (`YamlConfig` interface; add `resolveTasksConfig`)
+- Modify: `schemas/default-config.schema.json`
+- Modify: `config/default.yaml`
+- Test: `tests/unit/config-tasks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/config-tasks.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { resolveTasksConfig, DEFAULT_TASKS_CONFIG } from '../../src/config.js';
+
+describe('resolveTasksConfig', () => {
+  it('returns defaults when no tasks block is present', () => {
+    expect(resolveTasksConfig(undefined)).toEqual(DEFAULT_TASKS_CONFIG);
+  });
+
+  it('defaults are 60 / 5 / 4 / 48', () => {
+    expect(DEFAULT_TASKS_CONFIG).toEqual({
+      heartbeatIntervalMinutes: 60,
+      heartbeatMaxWakesPerTick: 5,
+      idleThresholdHours: 4,
+      staleWaitThresholdHours: 48,
+    });
+  });
+
+  it('overrides only the provided keys', () => {
+    expect(resolveTasksConfig({ idleThresholdHours: 2 })).toEqual({
+      heartbeatIntervalMinutes: 60,
+      heartbeatMaxWakesPerTick: 5,
+      idleThresholdHours: 2,
+      staleWaitThresholdHours: 48,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/config-tasks.test.ts`
+Expected: FAIL — `resolveTasksConfig` / `DEFAULT_TASKS_CONFIG` not exported.
+
+- [ ] **Step 3: Add the type + resolver in `src/config.ts`**
+
+In `src/config.ts`, inside the `export interface YamlConfig { … }` (near the existing `scheduler?: { … }` field, before the closing brace ~line 281), add:
+
+```typescript
+  tasks?: {
+    /** BacklogHeartbeat tick interval in minutes. Default 60. */
+    heartbeatIntervalMinutes?: number;
+    /** Max task wakes enqueued per heartbeat tick (global cap). Default 5. */
+    heartbeatMaxWakesPerTick?: number;
+    /** Hours an unblocked curia-owned task may sit untouched before the heartbeat
+     *  pokes it. Default 4. */
+    idleThresholdHours?: number;
+    /** Hours a waiting/blocked task with no pending wake may sit before the
+     *  heartbeat surfaces it as an orphaned wait. Default 48. */
+    staleWaitThresholdHours?: number;
+  };
+```
+
+Then, near the other exported config helpers/types (top-level, e.g. after the `Config` interface), add:
+
+```typescript
+export interface TasksConfig {
+  heartbeatIntervalMinutes: number;
+  heartbeatMaxWakesPerTick: number;
+  idleThresholdHours: number;
+  staleWaitThresholdHours: number;
+}
+
+export const DEFAULT_TASKS_CONFIG: TasksConfig = {
+  heartbeatIntervalMinutes: 60,
+  heartbeatMaxWakesPerTick: 5,
+  idleThresholdHours: 4,
+  staleWaitThresholdHours: 48,
+};
+
+/** Resolve the optional YAML tasks block to a fully-populated config with defaults. */
+export function resolveTasksConfig(yaml: YamlConfig['tasks']): TasksConfig {
+  return {
+    heartbeatIntervalMinutes: yaml?.heartbeatIntervalMinutes ?? DEFAULT_TASKS_CONFIG.heartbeatIntervalMinutes,
+    heartbeatMaxWakesPerTick: yaml?.heartbeatMaxWakesPerTick ?? DEFAULT_TASKS_CONFIG.heartbeatMaxWakesPerTick,
+    idleThresholdHours: yaml?.idleThresholdHours ?? DEFAULT_TASKS_CONFIG.idleThresholdHours,
+    staleWaitThresholdHours: yaml?.staleWaitThresholdHours ?? DEFAULT_TASKS_CONFIG.staleWaitThresholdHours,
+  };
+}
+```
+
+- [ ] **Step 4: Register the schema** (root is `additionalProperties:false`, so this is required or YAML load will reject the block)
+
+In `schemas/default-config.schema.json`, add to the top-level `"properties"` object:
+
+```json
+"tasks": {
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "heartbeatIntervalMinutes": { "type": "number", "minimum": 1 },
+    "heartbeatMaxWakesPerTick": { "type": "number", "minimum": 1 },
+    "idleThresholdHours": { "type": "number", "minimum": 0 },
+    "staleWaitThresholdHours": { "type": "number", "minimum": 0 }
+  }
+}
+```
+
+- [ ] **Step 5: Add the block to `config/default.yaml`**
+
+Append a top-level block:
+
+```yaml
+# Autonomous task execution — BacklogHeartbeat tuning (design 2026-06-04 §3, §9.1).
+tasks:
+  heartbeatIntervalMinutes: 60
+  heartbeatMaxWakesPerTick: 5
+  idleThresholdHours: 4
+  staleWaitThresholdHours: 48
+```
+
+- [ ] **Step 6: Run the test + the existing config tests**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/config-tasks.test.ts`
+Expected: PASS (3 tests).
+
+Run the existing config test suite to confirm the schema change did not break load:
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/config.test.ts`
+Expected: PASS (or, if no such file, run the full unit suite — see Task B6 closing command).
+
+- [ ] **Step 7: Typecheck + commit**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add src/config.ts schemas/default-config.schema.json config/default.yaml tests/unit/config-tasks.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: add tasks heartbeat config section with defaults"
+```
+
+---
+
+### Task B2: The heartbeat selection query
+
+**Files:**
+- Modify: `src/db/queries/tasks.ts` (add `selectHeartbeatCandidates`)
+- Test: `tests/integration/heartbeat-selection.test.ts` (real Postgres)
+
+> The selection logic is SQL correctness, so the meaningful test is an integration test against real Postgres. A mock-pool unit test would only assert the row mapping, which is trivial; we test the real query instead.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/integration/heartbeat-selection.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import { selectHeartbeatCandidates } from '../../src/db/queries/tasks.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'HBSel Test';
+
+/** Insert a task row directly; returns its id. `updatedAt` lets us simulate age. */
+async function seedTask(
+  pool: pg.Pool,
+  opts: {
+    title?: string;
+    status: string;
+    owner?: string;
+    sourceAgentId?: string | null;
+    blockedBy?: string | null;
+    updatedAt: Date;
+  },
+): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO tasks
+       (agent_id, title, intent_anchor, status, progress, error_budget, owner,
+        blocked_by_task_id, priority, source, source_agent_id, created_by, tags, updated_at)
+     VALUES ($1,$2,$3,$4,'{}'::jsonb,'{}'::jsonb,$5,$6,50,'agent',$7,'test','{}',$8)
+     RETURNING id`,
+    [
+      opts.sourceAgentId ?? 'coordinator',
+      `${PREFIX} ${opts.title ?? opts.status}`,
+      'seeded',
+      opts.status,
+      opts.owner ?? 'curia',
+      opts.blockedBy ?? null,
+      opts.sourceAgentId ?? null,
+      opts.updatedAt,
+    ],
+  );
+  return (rows[0] as { id: string }).id;
+}
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(`DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`, [`${PREFIX}%`]);
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+describeIf('selectHeartbeatCandidates', () => {
+  let pool: pg.Pool;
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM tasks LIMIT 0');
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  const hoursAgo = (h: number) => new Date(Date.now() - h * 3600_000);
+  const opts = { eligibleAgents: ['coordinator', 'ceo-inbox'], idleThresholdHours: 4, staleWaitThresholdHours: 48, maxWakes: 5 };
+
+  it('selects an idle, unblocked, curia-owned task older than the idle threshold', async () => {
+    const id = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(5) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).toContain(id);
+  });
+
+  it('ignores a task touched within the idle threshold', async () => {
+    await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(1) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got).toHaveLength(0);
+  });
+
+  it('excludes a task blocked by an unfinished task', async () => {
+    const blocker = await seedTask(pool, { title: 'blocker', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    await seedTask(pool, { title: 'blocked', status: 'blocked', sourceAgentId: 'ceo-inbox', blockedBy: blocker, updatedAt: hoursAgo(10) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    // only the blocker (open, idle) is eligible; the blocked child is excluded
+    expect(got.map((c) => c.id)).toEqual([blocker]);
+  });
+
+  it('includes a blocked task once its blocker is done (stale-wait path)', async () => {
+    const blocker = await seedTask(pool, { title: 'doneblocker', status: 'done', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(60) });
+    const child = await seedTask(pool, { title: 'unblocked', status: 'blocked', sourceAgentId: 'ceo-inbox', blockedBy: blocker, updatedAt: hoursAgo(60) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).toContain(child);
+  });
+
+  it('skips a task that already has a pending wake', async () => {
+    const id = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    await pool.query(
+      `INSERT INTO scheduled_jobs (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, task_id)
+       VALUES ('ceo-inbox', NULL, now(), '{}'::jsonb, 'pending', now(), 'test', $1)`,
+      [id],
+    );
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).not.toContain(id);
+  });
+
+  it('returns at most one entry per effective agent', async () => {
+    await seedTask(pool, { title: 'a', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    await seedTask(pool, { title: 'b', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(8) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.filter((c) => c.agentId === 'ceo-inbox')).toHaveLength(1);
+  });
+
+  it('routes a non-eligible / null source_agent_id to the coordinator fallback', async () => {
+    const id = await seedTask(pool, { status: 'open', sourceAgentId: null, updatedAt: hoursAgo(10) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    const row = got.find((c) => c.id === id);
+    expect(row?.agentId).toBe('coordinator');
+  });
+
+  it('does not advance a non-curia idle task (owner=ceo, open)', async () => {
+    await seedTask(pool, { status: 'open', owner: 'ceo', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `DATABASE_URL=$DATABASE_URL pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/integration/heartbeat-selection.test.ts`
+Expected: FAIL — `selectHeartbeatCandidates` is not exported. (If `DATABASE_URL` is unset the suite SKIPS; set it to your empty test DB to actually run.)
+
+- [ ] **Step 3: Implement the query**
+
+In `src/db/queries/tasks.ts`, add (import `Pool` type is already present in this module):
+
+```typescript
+export interface HeartbeatCandidate {
+  /** The task to wake. */
+  id: string;
+  /** The agent that will receive the wake — the task's source_agent_id, or the
+   *  fallback agent when source_agent_id is null or not heartbeat-eligible. */
+  agentId: string;
+}
+
+export interface SelectHeartbeatOptions {
+  /** Heartbeat-eligible agent names (enable_task_management: true). */
+  eligibleAgents: string[];
+  idleThresholdHours: number;
+  staleWaitThresholdHours: number;
+  /** Global cap on candidates returned per call. */
+  maxWakes: number;
+  /** Agent that receives wakes for null / non-eligible owners. Default 'coordinator'. */
+  fallbackAgentId?: string;
+}
+
+/** Select the heartbeat's wake candidates: one entry-point task per effective owner
+ *  agent (idle-unblocked curia work, or orphaned waits past their threshold), globally
+ *  capped, most-overdue first. Deterministic — no domain reasoning. */
+export async function selectHeartbeatCandidates(
+  pool: Pool,
+  opts: SelectHeartbeatOptions,
+): Promise<HeartbeatCandidate[]> {
+  if (opts.eligibleAgents.length === 0) return [];
+  const fallback = opts.fallbackAgentId ?? 'coordinator';
+  const { rows } = await pool.query(
+    `WITH candidates AS (
+       SELECT
+         t.id,
+         CASE WHEN t.source_agent_id = ANY($1::text[]) THEN t.source_agent_id ELSE $4 END AS effective_agent,
+         t.updated_at
+       FROM tasks t
+       WHERE t.status IN ('open','in_progress','waiting','blocked')
+         AND (t.blocked_by_task_id IS NULL OR EXISTS (
+               SELECT 1 FROM tasks b
+               WHERE b.id = t.blocked_by_task_id AND b.status IN ('done','cancelled')))
+         AND NOT EXISTS (
+               SELECT 1 FROM scheduled_jobs sj
+               WHERE sj.task_id = t.id AND sj.status = 'pending')
+         AND (
+               (t.owner = 'curia' AND t.status IN ('open','in_progress')
+                  AND t.updated_at < now() - make_interval(hours => $2))
+            OR (t.status IN ('waiting','blocked')
+                  AND t.updated_at < now() - make_interval(hours => $3))
+             )
+     ),
+     per_agent AS (
+       SELECT DISTINCT ON (effective_agent) id, effective_agent, updated_at
+       FROM candidates
+       ORDER BY effective_agent, updated_at ASC
+     )
+     SELECT id, effective_agent
+     FROM per_agent
+     ORDER BY updated_at ASC
+     LIMIT $5`,
+    [opts.eligibleAgents, opts.idleThresholdHours, opts.staleWaitThresholdHours, fallback, opts.maxWakes],
+  );
+  return rows.map((r) => {
+    const row = r as { id: string; effective_agent: string };
+    return { id: row.id, agentId: row.effective_agent };
+  });
+}
+```
+
+> Note: `make_interval(hours => $2)` binds `$2` as a numeric parameter — fully parameterized, no string interpolation (per CLAUDE.md SQL rule).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `DATABASE_URL=$DATABASE_URL pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/integration/heartbeat-selection.test.ts`
+Expected: PASS (8 tests) when `DATABASE_URL` points at the test DB.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add src/db/queries/tasks.ts tests/integration/heartbeat-selection.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: add selectHeartbeatCandidates query (idle + orphaned-wait, per-agent cap)"
+```
+
+---
+
+### Task B3: `enqueueTaskWake` on `SchedulerService`
+
+**Files:**
+- Modify: `src/scheduler/scheduler-service.ts` (add public method `enqueueTaskWake`)
+- Test: `tests/unit/scheduler/enqueue-task-wake.test.ts`
+
+> `createJob` always creates a *new* task when given an `intent_anchor`; the heartbeat must wake an **existing** task. `enqueueTaskWake` inserts a one-shot `scheduled_jobs` row with `task_id` preset, so the existing dispatch path routes it to the owning agent with full task context.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/scheduler/enqueue-task-wake.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { SchedulerService } from '../../../src/scheduler/scheduler-service.js';
+
+function mockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() };
+}
+
+describe('SchedulerService.enqueueTaskWake', () => {
+  it('inserts a one-shot pending scheduled_jobs row carrying the existing task_id', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rows: [{ id: 'job-9' }] }) };
+    const bus = { publish: vi.fn(), subscribe: vi.fn() };
+    const svc = new SchedulerService(
+      pool as unknown as import('pg').Pool,
+      bus as never,
+      mockLogger() as never,
+      'America/Toronto',
+    );
+
+    const runAt = new Date('2026-06-04T12:00:00Z');
+    const result = await svc.enqueueTaskWake({ taskId: 'task-7', agentId: 'ceo-inbox', runAt });
+
+    expect(result.jobId).toBe('job-9');
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/INSERT INTO scheduled_jobs/i);
+    expect(sql).toMatch(/task_id/);
+    // status pending, one-shot (cron NULL), task_id = the EXISTING task
+    expect(params).toContain('task-7');
+    expect(params).toContain('ceo-inbox');
+    expect(params).toContain(runAt);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/scheduler/enqueue-task-wake.test.ts`
+Expected: FAIL — `enqueueTaskWake` is not a function.
+
+- [ ] **Step 3: Implement the method**
+
+In `src/scheduler/scheduler-service.ts`, add a public method to the `SchedulerService` class. Use the same `this.pool` and the configured-timezone field set in the constructor (the 4th constructor arg, `config.timezone` — match its existing private field name; shown here as `this.defaultTimezone`):
+
+```typescript
+/** Enqueue a one-shot wake for an EXISTING task. Inserts a pending scheduled_jobs
+ *  row with task_id preset so the dispatcher routes it to `agentId` with full task
+ *  context. Used by the BacklogHeartbeat. Does not create a new task. */
+async enqueueTaskWake(params: {
+  taskId: string;
+  agentId: string;
+  runAt: Date;
+  createdBy?: string;
+}): Promise<{ jobId: string }> {
+  const { taskId, agentId, runAt, createdBy = 'heartbeat' } = params;
+  const { rows } = await this.pool.query(
+    `INSERT INTO scheduled_jobs
+       (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, timezone, task_id)
+     VALUES ($1, NULL, $2, $3, 'pending', $2, $4, $5, $6)
+     RETURNING id`,
+    [
+      agentId,
+      runAt,
+      JSON.stringify({ type: 'task-wake', task_id: taskId }),
+      createdBy,
+      this.defaultTimezone,
+      taskId,
+    ],
+  );
+  return { jobId: (rows[0] as { id: string }).id };
+}
+```
+
+> If the private timezone field has a different name, use that name. `timezone` is included because `scheduled_jobs.timezone` is non-defaulted in some migrations; passing the service default is safe for a one-shot `run_at` job.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/scheduler/enqueue-task-wake.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add src/scheduler/scheduler-service.ts tests/unit/scheduler/enqueue-task-wake.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: add SchedulerService.enqueueTaskWake for waking existing tasks"
+```
+
+---
+
+### Task B4: The `BacklogHeartbeat` component
+
+**Files:**
+- Create: `src/scheduler/backlog-heartbeat.ts`
+- Test: `tests/unit/scheduler/backlog-heartbeat.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/scheduler/backlog-heartbeat.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BacklogHeartbeat } from '../../../src/scheduler/backlog-heartbeat.js';
+import * as tasksQueries from '../../../src/db/queries/tasks.js';
+
+function mockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() };
+}
+
+function makeHeartbeat(overrides: Partial<ConstructorParameters<typeof BacklogHeartbeat>[0]> = {}) {
+  const enqueueTaskWake = vi.fn().mockResolvedValue({ jobId: 'job-x' });
+  const schedulerService = { enqueueTaskWake } as never;
+  const pool = { query: vi.fn() } as never;
+  const hb = new BacklogHeartbeat({
+    pool,
+    logger: mockLogger() as never,
+    schedulerService,
+    eligibleAgents: new Set(['coordinator', 'ceo-inbox']),
+    intervalMinutes: 60,
+    maxWakesPerTick: 5,
+    idleThresholdHours: 4,
+    staleWaitThresholdHours: 48,
+    ...overrides,
+  });
+  return { hb, enqueueTaskWake };
+}
+
+describe('BacklogHeartbeat.tick', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('enqueues one wake per selected candidate and returns the count', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([
+      { id: 't1', agentId: 'ceo-inbox' },
+      { id: 't2', agentId: 'coordinator' },
+    ]);
+    const { hb, enqueueTaskWake } = makeHeartbeat();
+    const count = await hb.tick();
+    expect(count).toBe(2);
+    expect(enqueueTaskWake).toHaveBeenCalledTimes(2);
+    expect(enqueueTaskWake).toHaveBeenCalledWith(expect.objectContaining({ taskId: 't1', agentId: 'ceo-inbox' }));
+    expect(enqueueTaskWake).toHaveBeenCalledWith(expect.objectContaining({ taskId: 't2', agentId: 'coordinator' }));
+  });
+
+  it('passes config thresholds and the eligible-agents list to the selector', async () => {
+    const spy = vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([]);
+    const { hb } = makeHeartbeat();
+    await hb.tick();
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eligibleAgents: ['coordinator', 'ceo-inbox'],
+        idleThresholdHours: 4,
+        staleWaitThresholdHours: 48,
+        maxWakes: 5,
+      }),
+    );
+  });
+
+  it('continues after a single enqueue failure', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([
+      { id: 't1', agentId: 'ceo-inbox' },
+      { id: 't2', agentId: 'coordinator' },
+    ]);
+    const { hb, enqueueTaskWake } = makeHeartbeat();
+    enqueueTaskWake.mockRejectedValueOnce(new Error('db blip'));
+    const count = await hb.tick();
+    expect(count).toBe(1); // second succeeds despite first failing
+    expect(enqueueTaskWake).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('BacklogHeartbeat start/stop', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('ticks on the configured interval and stops cleanly', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([]);
+    const { hb } = makeHeartbeat({ intervalMinutes: 60 });
+    hb.start();
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    expect(tasksQueries.selectHeartbeatCandidates).toHaveBeenCalledTimes(1);
+    hb.stop();
+    await vi.advanceTimersByTimeAsync(60 * 60_000 * 3);
+    expect(tasksQueries.selectHeartbeatCandidates).toHaveBeenCalledTimes(1); // no more after stop
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/scheduler/backlog-heartbeat.test.ts`
+Expected: FAIL — cannot resolve `backlog-heartbeat.js`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `src/scheduler/backlog-heartbeat.ts`:
+
+```typescript
+import type { Pool } from 'pg';
+import type { Logger } from 'pino';
+import type { SchedulerService } from './scheduler-service.js';
+import { selectHeartbeatCandidates } from '../db/queries/tasks.js';
+
+export interface BacklogHeartbeatOptions {
+  pool: Pool;
+  logger: Logger;
+  schedulerService: SchedulerService;
+  /** Heartbeat-eligible agent names (enable_task_management: true). */
+  eligibleAgents: Set<string>;
+  intervalMinutes: number;
+  maxWakesPerTick: number;
+  idleThresholdHours: number;
+  staleWaitThresholdHours: number;
+  /** Wake target for null / non-eligible owners. Default 'coordinator'. */
+  fallbackAgentId?: string;
+}
+
+/** System-layer component: on an hourly interval, selects idle/stale tasks and
+ *  enqueues one-shot wakes routed to each owning agent. Deterministic; does no
+ *  domain reasoning. The conductor, never an instrument. */
+export class BacklogHeartbeat {
+  private intervalHandle: NodeJS.Timeout | null = null;
+
+  constructor(private readonly opts: BacklogHeartbeatOptions) {}
+
+  start(): void {
+    if (this.intervalHandle) return;
+    const ms = this.opts.intervalMinutes * 60_000;
+    this.intervalHandle = setInterval(() => {
+      this.tick().catch((err) => {
+        this.opts.logger.error({ err }, 'BacklogHeartbeat: unhandled error in tick');
+      });
+    }, ms);
+    this.opts.logger.info({ intervalMinutes: this.opts.intervalMinutes }, 'BacklogHeartbeat started');
+  }
+
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    this.opts.logger.info('BacklogHeartbeat stopped');
+  }
+
+  /** One tick: select candidates and enqueue a wake for each. Returns the number
+   *  of wakes successfully enqueued. */
+  async tick(): Promise<number> {
+    const candidates = await selectHeartbeatCandidates(this.opts.pool, {
+      eligibleAgents: [...this.opts.eligibleAgents],
+      idleThresholdHours: this.opts.idleThresholdHours,
+      staleWaitThresholdHours: this.opts.staleWaitThresholdHours,
+      maxWakes: this.opts.maxWakesPerTick,
+      fallbackAgentId: this.opts.fallbackAgentId ?? 'coordinator',
+    });
+    if (candidates.length === 0) return 0;
+
+    const runAt = new Date();
+    let enqueued = 0;
+    for (const c of candidates) {
+      try {
+        await this.opts.schedulerService.enqueueTaskWake({ taskId: c.id, agentId: c.agentId, runAt });
+        enqueued += 1;
+      } catch (err) {
+        this.opts.logger.error({ err, taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: failed to enqueue wake');
+      }
+    }
+    this.opts.logger.info({ enqueued, considered: candidates.length }, 'BacklogHeartbeat: tick complete');
+    return enqueued;
+  }
+}
+```
+
+> If `Logger` is not exported from `pino` in this codebase, import it from the project's logger module instead (match how `scheduler.ts` types its `logger`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/scheduler/backlog-heartbeat.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add src/scheduler/backlog-heartbeat.ts tests/unit/scheduler/backlog-heartbeat.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: add BacklogHeartbeat component (tick + start/stop)"
+```
+
+---
+
+### Task B5: Bootstrap wiring (construct + start + stop)
+
+**Files:**
+- Modify: `src/index.ts` (construct after the Scheduler ~line 1177; start after `scheduler.start()` ~line 1485; stop in the shutdown handler ~lines 1652–1727)
+
+> This consumes the `taskManagementAgents` set built in Task A3 and the `resolveTasksConfig` from Task B1. If A3 left `taskManagementAgents` unused, this step makes it used — landing A3 and B5 in the same PR keeps every commit lint-clean.
+
+- [ ] **Step 1: Add imports**
+
+At the top of `src/index.ts`:
+
+```typescript
+import { BacklogHeartbeat } from './scheduler/backlog-heartbeat.js';
+import { resolveTasksConfig } from './config.js';  // if not already importing from './config.js', add resolveTasksConfig to the existing import
+```
+
+- [ ] **Step 2: Construct after the Scheduler is built**
+
+After the `const scheduler = new Scheduler({ … })` construction (~line 1177) and after `taskManagementAgents` is fully populated by the agent loop, add:
+
+```typescript
+// Autonomous task execution: the deterministic hourly heartbeat that wakes idle/stale
+// tasks. Reads the tasks table, writes one-shot scheduled_jobs rows; the scheduler
+// dispatches them. See docs/wip/2026-06-04-task-execution-heartbeat-design.md §3.
+const tasksConfig = resolveTasksConfig(yamlConfig.tasks);
+const backlogHeartbeat = new BacklogHeartbeat({
+  pool,
+  logger,
+  schedulerService,
+  eligibleAgents: taskManagementAgents,
+  intervalMinutes: tasksConfig.heartbeatIntervalMinutes,
+  maxWakesPerTick: tasksConfig.heartbeatMaxWakesPerTick,
+  idleThresholdHours: tasksConfig.idleThresholdHours,
+  staleWaitThresholdHours: tasksConfig.staleWaitThresholdHours,
+});
+```
+
+> Use the variable name that holds the loaded YAML config in this file (the exploration shows it referenced as `yamlConfig`; if it is named differently, match it). `schedulerService` and `pool` and `logger` are already in scope at this point.
+
+- [ ] **Step 3: Start it (after `scheduler.start()`)**
+
+After `scheduler.start();` (~line 1485):
+
+```typescript
+backlogHeartbeat.start();
+```
+
+- [ ] **Step 4: Stop it in the shutdown handler**
+
+In the `shutdown` function (~lines 1652–1727), alongside `scheduler.stop();`, add (before `await pool.end();`):
+
+```typescript
+backlogHeartbeat.stop();
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add src/index.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: construct, start, and stop BacklogHeartbeat in bootstrap"
+```
+
+---
+
+### Task B6: End-to-end integration test (selection → enqueue → dispatch-ready row)
+
+**Files:**
+- Test: `tests/integration/backlog-heartbeat.test.ts` (real Postgres)
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/integration/backlog-heartbeat.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import pg from 'pg';
+import { BacklogHeartbeat } from '../../src/scheduler/backlog-heartbeat.js';
+import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+import { createLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+const PREFIX = 'HBE2E Test';
+
+async function seedTask(pool: pg.Pool, o: { status: string; owner?: string; sourceAgentId?: string | null; updatedAt: Date }): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO tasks (agent_id, title, intent_anchor, status, progress, error_budget, owner, priority, source, source_agent_id, created_by, tags, updated_at)
+     VALUES ($1,$2,'seeded',$3,'{}'::jsonb,'{}'::jsonb,$4,50,'agent',$5,'test','{}',$6) RETURNING id`,
+    [o.sourceAgentId ?? 'coordinator', `${PREFIX} ${o.status}`, o.status, o.owner ?? 'curia', o.sourceAgentId ?? null, o.updatedAt],
+  );
+  return (rows[0] as { id: string }).id;
+}
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(`DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`, [`${PREFIX}%`]);
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+describeIf('BacklogHeartbeat end-to-end', () => {
+  let pool: pg.Pool;
+  const logger = createLogger('silent');
+  beforeAll(async () => { pool = new Pool({ connectionString: DATABASE_URL }); });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  it('enqueues exactly one pending wake per eligible agent, routed correctly', async () => {
+    const hoursAgo = (h: number) => new Date(Date.now() - h * 3600_000);
+    const idA = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(5) });
+    await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(6) }); // second for same agent — should NOT also wake
+    const idC = await seedTask(pool, { status: 'open', sourceAgentId: 'coordinator', updatedAt: hoursAgo(5) });
+
+    const schedulerService = new SchedulerService(pool, { publish: vi.fn(), subscribe: vi.fn() } as never, logger, 'UTC');
+    const hb = new BacklogHeartbeat({
+      pool, logger, schedulerService,
+      eligibleAgents: new Set(['coordinator', 'ceo-inbox']),
+      intervalMinutes: 60, maxWakesPerTick: 5, idleThresholdHours: 4, staleWaitThresholdHours: 48,
+    });
+
+    const enqueued = await hb.tick();
+    expect(enqueued).toBe(2); // one per agent
+
+    const { rows } = await pool.query(
+      `SELECT agent_id, task_id, status, cron_expr FROM scheduled_jobs
+       WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1) ORDER BY agent_id`,
+      [`${PREFIX}%`],
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => (r as { agent_id: string }).agent_id)).toEqual(['ceo-inbox', 'coordinator']);
+    for (const r of rows) {
+      const row = r as { status: string; cron_expr: string | null; task_id: string };
+      expect(row.status).toBe('pending');
+      expect(row.cron_expr).toBeNull(); // one-shot
+    }
+    // The two waked tasks are idA (or its sibling) and idC; a wake exists for ceo-inbox + coordinator.
+    const wakedTaskIds = rows.map((r) => (r as { task_id: string }).task_id);
+    expect(wakedTaskIds).toContain(idC);
+    expect(wakedTaskIds.some((t) => t === idA || t !== idC)).toBe(true);
+  });
+
+  it('does not re-enqueue on a second tick (pending wake dedup)', async () => {
+    await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: new Date(Date.now() - 5 * 3600_000) });
+    const schedulerService = new SchedulerService(pool, { publish: vi.fn(), subscribe: vi.fn() } as never, logger, 'UTC');
+    const hb = new BacklogHeartbeat({
+      pool, logger, schedulerService,
+      eligibleAgents: new Set(['ceo-inbox']),
+      intervalMinutes: 60, maxWakesPerTick: 5, idleThresholdHours: 4, staleWaitThresholdHours: 48,
+    });
+    expect(await hb.tick()).toBe(1);
+    expect(await hb.tick()).toBe(0); // already has a pending wake
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `DATABASE_URL=$DATABASE_URL pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/integration/backlog-heartbeat.test.ts`
+Expected: PASS (2 tests) against the test DB; SKIPPED when `DATABASE_URL` is unset.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add tests/integration/backlog-heartbeat.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "test: end-to-end BacklogHeartbeat selection + enqueue against Postgres"
+```
+
+---
+
+## Part C — Enable the coordinator (canary)
+
+### Task C1: Flip the flag on the coordinator
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+> The injected block (Task A2) supplies the executor/decomposition/reification discipline, so enabling the flag also delivers the project-execution guidance. The coordinator currently pins the four `task-*` skills manually (lines ~644–647) and has its `## Scheduling and Task Management` prose section (lines ~308–329) — the manual pins become redundant; leave the prose section in place (it covers scheduler-vs-task routing the block does not).
+
+- [ ] **Step 1: Set the flag, drop redundant manual pins, add error_budget, bump version**
+
+In `agents/coordinator.yaml`:
+
+1. Add at the top level (near `allow_discovery:`):
+
+```yaml
+enable_task_management: true
+```
+
+2. Remove the four now-redundant lines from `pinned_skills` (they are auto-pinned by the flag):
+
+```yaml
+  - task-create
+  - task-list
+  - task-update
+  - task-complete
+```
+
+3. Add a modest burst budget (the coordinator has none today) so project bursts are bounded:
+
+```yaml
+error_budget:
+  max_turns: 40
+  max_cost_usd: 1.00
+```
+
+4. Bump `version` (per CLAUDE.md: new capability → minor bump). Change `version: "0.5.1"` to `version: "0.6.0"`.
+
+- [ ] **Step 2: Verify the agent still loads + skills resolve**
+
+Run the existing agent/loader test suite (and any coordinator config test):
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/unit/agents`
+Expected: PASS. If a test asserts the coordinator's exact `pinned_skills` count, update it to reflect the four skills now arriving via the flag rather than manual pins.
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add agents/coordinator.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "feat: enable_task_management on coordinator (canary); add error_budget"
+```
+
+---
+
+### Task C2: CHANGELOG + full suite
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add `[Unreleased]` entries**
+
+Under `## [Unreleased]` → `### Added`:
+
+```markdown
+- **`enable_task_management`** — declarative agent capability that auto-pins the task skills, injects the executor/reification discipline block, and marks an agent heartbeat-eligible. (design 2026-06-04 §6)
+- **`BacklogHeartbeat`** — deterministic hourly System component that wakes idle/stale tasks by enqueuing one-shot scheduler jobs, one per owning agent, globally capped. (design 2026-06-04 §3)
+```
+
+Under `### Changed`:
+
+```markdown
+- **coordinator** — task management now arrives via `enable_task_management: true` (replacing manual `task-*` pins); added a bounded `error_budget` for project bursts.
+```
+
+- [ ] **Step 2: Run the full unit suite + typecheck**
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test`
+Expected: PASS (all existing + new unit tests; integration tests skip without `DATABASE_URL`).
+
+Run: `pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat run typecheck`
+Expected: PASS.
+
+If `DATABASE_URL` is available, run the integration tests too:
+Run: `DATABASE_URL=$DATABASE_URL pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat test -- tests/integration/heartbeat-selection.test.ts tests/integration/backlog-heartbeat.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-task-exec-heartbeat commit -m "docs: changelog for task-execution heartbeat foundation"
+```
+
+---
+
+## Self-Review (against the design spec)
+
+**Spec coverage:**
+- §3 heartbeat (deterministic enqueuer) → Tasks B2 (selection), B3 (enqueue), B4 (component), B5 (wiring), B6 (e2e). ✔
+- §3.1 pick-the-agent / per-agent=1 / global cap → B2 `DISTINCT ON (effective_agent)` + `LIMIT maxWakes`; tested in B2 + B6. ✔
+- §3.1 idle (4h) vs orphaned-wait (48h) thresholds → B1 config + B2 query predicate; tested in B2. ✔
+- §3 blocked_by exclusion + wake dedup → B2 query; tested in B2. ✔
+- §6 capability flag (skills + block + eligibility) → Tasks A1, A2, A3; tested in A2. ✔
+- §6 fixed-slot injection, default false, manual-import escape hatch → A2/A3 (append; no-op when off; merge preserves explicit pins). ✔
+- §6 disabled-owner → coordinator fallback → B2 `effective_agent` CASE; tested in B2. ✔
+- §8 coordinator enablement + error_budget → Task C1. ✔
+- §9.1 config keys → Task B1. ✔
+- §1.1 scheduler reads only scheduled_jobs → preserved: heartbeat writes scheduled_jobs, never touches the scheduler's read path. ✔
+- §9 zero new columns → no migration in this plan (stretch `last_advanced_at` deferred). ✔
+
+**Out of foundation scope (second plan):** ceo-inbox #840 (reification + resume + overflow), meeting-debrief/research-analyst onboarding, the LLM groomer, `last_advanced_at`.
+
+**Placeholder scan:** none — every code step contains complete code; every command has expected output. The two soft notes (`this.defaultTimezone` field name; `yamlConfig` variable name) are "match the existing identifier" pointers, with the concrete fallback stated.
+
+**Type consistency:** `HeartbeatCandidate { id, agentId }` is produced by `selectHeartbeatCandidates` (B2) and consumed by `BacklogHeartbeat.tick` (B4) and asserted in the B4 mock — names match. `enqueueTaskWake({ taskId, agentId, runAt })` signature matches its call in `tick`. `resolveTasksConfig` / `TasksConfig` (B1) consumed in B5. `applyTaskManagement` result shape (A2) consumed in A3.
+
+**Migration-collision check (per repo CLAUDE.md):** this plan adds **no** migration, so no `NNN_` collision risk. (If the stretch `last_advanced_at` column is later added, claim the next free number after `ls src/db/migrations/ | sort`.)

--- a/docs/wip/2026-06-04-task-execution-heartbeat-design.md
+++ b/docs/wip/2026-06-04-task-execution-heartbeat-design.md
@@ -1,0 +1,361 @@
+# Design: Task Execution & Heartbeat (v1)
+
+**Status:** Design, pre-implementation
+**Date:** 2026-06-04
+**Builds on:** [2026-06-01-tasks-and-backlog-design.md](2026-06-01-tasks-and-backlog-design.md) (Tasks & Backlog v1 — `tasks` table, `task-*` skills, digest backlog sections, per-task wake routing)
+**Supersedes / rescopes:** §4.2 (`backlog-sweep`) of the 2026-06-01 doc; rewrites issue [#840](https://github.com/josephfung/curia/issues/840)
+
+---
+
+## Context
+
+Tasks & Backlog v1 shipped the *storage and read* half of the system: the `tasks` table (migration 049), the four `task-*` skills, the digest's backlog sections (#838), the tasks console UI (#876), and the per-task wake-up routing in the scheduler (`scheduled_jobs.task_id` → dispatch to `source_agent_id` with task context). What it did **not** ship is the *execution* half. The `backlog-sweep` declared in §4.2 of that doc was never built — the migration even left an index comment referencing it (`tasks_open_priority_idx: backlog sweep and digest queries`), but no job advances open work.
+
+The result is three operational failure modes:
+
+1. **Everything-at-once (worry A).** Agents try to finish multi-step work in a single burst — burning execution budget and losing context across the turn. `ceo-inbox` is the worst case: it triages the *entire* unread backlog oldest-first in one run, with no decomposition, no prioritization, and no deferral. The only backstop is the `error_budget` cliff, which produces *partial* work with no graceful handoff.
+
+2. **Lingering work (worry B).** A task created with `owner='curia'` and no `wake_at` never advances unless the CEO pokes it. There is no heartbeat. Visibility (the digest) is not stewardship — the system *shows* open work but never *acts* on it autonomously.
+
+3. **Dangling commitments (a costly variant of A+B).** An agent emits a forward promise into an artifact — e.g. a draft reply that says "the CEO will follow up later with the document" — with **nothing tracking the promise**. Once that artifact is sent, the loop is silently open forever. The CEO never learns something was outstanding.
+
+The ambition is larger than "drain a backlog." We want Curia to **devise a work plan for a multi-step project and execute it incrementally** — advancing what it can, parking the rest behind something that will wake it, and never abandoning a commitment. The motivating example: *"book a sales kickoff with my head of sales and the whole sales team"* decomposes into plan-agenda-with-the-sales-leader → confirm-roster-and-calendars → book-venue → send-invites, where some steps are doable now, some are blocked on a human, and some are blocked on a prior step.
+
+---
+
+## Goals & Non-Goals
+
+### Goals (v1)
+
+- A **deterministic hourly heartbeat** that guarantees no open work lingers — a cheap, frequent router, not an LLM job.
+- A **shared task-management capability** turned on by a single declarative flag (`enable_task_management`), bundling the task skills + a uniform executor-discipline prompt block + heartbeat eligibility — defined **once in code** so custom agents cannot drift.
+- The **advance-until-blocked** execution loop and the **no-dangling-commitment** invariant, applied uniformly to every participating agent.
+- First-class **project decomposition** (parent task + first-wave subtasks + `blocked_by` ordering).
+- `ceo-inbox` **joins the system**: closes its document-follow-up failure mode (reification + resume) *and* sheds load on a backed-up inbox (the original #840 scope).
+
+### Non-goals (v1)
+
+- The **LLM groomer** — a periodic holistic pass that dedupes, re-prioritizes, and promotes clusters to projects. A clean seam is left; it is explicitly not built. We want to observe real failure modes first.
+- Autonomous task generation from inferred needs ("no recruiter contact in 21 days").
+- New schema columns (target: **zero**; one contingency column noted in §9).
+- Any change to the autonomy engine — we *lean on it* unchanged (§7).
+- A new UI surface or channel.
+
+---
+
+## 1. Architecture Summary
+
+The machine in one breath: **a task-owning agent, when it gets work it cannot finish in one shot, decomposes it, advances it until it hits a real blocker or its burst budget runs low, then parks each loose end as a task with the right status and a wake condition. The work comes back to life through one of three channels — an event, a per-task timer, or the heartbeat — and the owning agent resumes exactly where it left off.** Nothing is ever finished by abandonment; a task is either `done`, or parked behind something that will wake it.
+
+Two roles, cleanly split:
+
+- **The heartbeat is the conductor; it never plays an instrument.** One deterministic, code-only loop runs hourly, decides *which agents* have idle or stale work, and routes a single wake to each. It does no domain reasoning.
+- **Execution is distributed to owners.** The actual advancing of a task happens inside the owning agent's resume burst, governed by the LLM and bounded by that agent's `error_budget`.
+
+### 1.1 Data flow
+
+```
+  ┌─────────────┐   reads tasks,        ┌────────────────┐  reads scheduled_jobs,   ┌──────────────┐
+  │  HEARTBEAT  │   writes one-shot     │   SCHEDULER    │  dispatches with         │ OWNER AGENT  │
+  │ (hourly,    │──▶ scheduled_jobs ───▶│  (polls 30s,   │──▶ task context ────────▶│ (resume burst│
+  │  code-only) │   rows (run_at=now)   │   unchanged)   │  to source_agent_id      │  executes)   │
+  └─────────────┘                       └────────────────┘                          └──────────────┘
+```
+
+This preserves the separation the 2026-06-01 doc was careful about (§1.1 there): **the scheduler reads only `scheduled_jobs`, never `tasks`.** The heartbeat is a *new, separate* system component that reads `tasks` and *produces* `scheduled_jobs` rows. The scheduler remains a pure consumer of `scheduled_jobs`. The heartbeat hands work off by inserting one-shot wake rows — reusing the entire existing dispatch path that already ships.
+
+### 1.2 What this replaces
+
+The 2026-06-01 §4.2 `backlog-sweep` was an **LLM coordinator cron job, 3×/day, that itself picked and advanced 1–3 tasks**. We replace it because (a) it is too coarse for projects, (b) it conflates *routing* with *doing*, and (c) it is itself a recurring burst of action — re-introducing worry A at the system level. The new heartbeat separates the cheap deterministic routing (hourly) from the bounded LLM execution (per-agent, on wake).
+
+---
+
+## 2. Reactivation Model
+
+A parked task returns to life through three layers, fastest to slowest. The fast layers carry the common case; the heartbeat is the backstop.
+
+1. **Event (instant).** An inbound reply or a provided document wakes the blocked task immediately via the existing `context-bridge` / active-outbound-context mechanism. When the head of sales replies, "finalize agenda → unblock venue → book venue" happens in seconds, event-chained, with no cron involved. This is the primary driver for in-flight projects.
+
+2. **Per-task `wake_at` (precise).** The owner sets it when parking — "nudge the sales leader in 3 days if silent." Stored as a one-shot `scheduled_jobs` row (the `wake_at` convenience already in `task-create` / `task-update`). Event-cancellable: if the reply lands first, the wake is cancelled.
+
+3. **Heartbeat (catch-all).** The backstop for when an agent *forgot* to set a wake, or a task got orphaned. This is what guarantees nothing lingers (worry B) even when an agent misbehaves.
+
+Cron frequency is almost irrelevant to how responsive a project *feels* — events and advance-until-blocked drive responsiveness. The heartbeat exists only for stalls, which is why it can be cheap and hourly.
+
+---
+
+## 3. The Heartbeat (deterministic enqueuer)
+
+A **new system-level component** (`BacklogHeartbeat`), started in `src/index.ts` alongside the other System-layer infrastructure, with its own hourly tick. On each tick it runs one deterministic selection query over `tasks` and inserts one-shot `scheduled_jobs` wake rows. It performs **no LLM work and no domain reasoning**.
+
+### 3.1 Selection logic: pick the agent, not the task
+
+The heartbeat wakes an **agent**, not a task. Per tick, for each `source_agent_id` it selects that agent's single most-deserving candidate as the *entry point* and enqueues exactly one wake. Two protections against bursty over-wake stack here:
+
+- **Layer 1 — `blocked_by` keeps ordered chains out of the candidate set.** A properly decomposed sequence (#1 → #2 → #3) exposes only its *head*; successors carry a `blocked_by_task_id` and are excluded by definition until their blocker is `done`/`cancelled`. In-project ordering is protected by the dependency field, not by the heartbeat being clever.
+- **Layer 2 — one wake per agent per tick.** The residual risk is an agent owning many *independent* unblocked tasks (e.g. `ceo-inbox` with 8 deferred replies). One-per-agent caps this: the woken agent pulls its own `task-list` and advances several of its tasks in that single burst, **in the dependency order it knows**, bounded by its `error_budget`. The heartbeat never needs to understand sequencing because it never picks more than one entry point per agent.
+
+A **global cap** (`heartbeatMaxWakesPerTick`, default 5) backstops the day there are many agents: if more than 5 agents have idle work, take the 5 with the most-overdue entry points; the rest wait an hour.
+
+Two candidate populations, both characterized by *"not done/cancelled, no pending wake, gone quiet"*:
+
+| Population | Predicate | On wake, the owner… |
+|---|---|---|
+| **Idle-unblocked** | `owner='curia'`, `status IN ('open','in_progress')`, unblocked, no pending wake, `updated_at` older than `idleThresholdHours` (default **4h**) | advances the work (advance-until-blocked) |
+| **Orphaned wait** | `status IN ('waiting','blocked')`, no pending wake, `updated_at` older than `staleWaitThresholdHours` (default **48h**) | re-evaluates: nudge the human, escalate to the CEO, or re-park with a proper `wake_at` |
+
+The two thresholds differ deliberately: an in-flight task should be poked within half a workday, but you do not re-ping a human 4h after emailing them. The orphaned-wait row is a *safety net for a forgotten timer* — a well-behaved agent would have set its own `wake_at`, which fires first.
+
+### 3.2 Selection query (sketch)
+
+```sql
+-- One entry-point task per eligible agent, globally capped, most-overdue first.
+SELECT DISTINCT ON (t.source_agent_id) t.id, t.source_agent_id
+FROM tasks t
+WHERE t.status IN ('open','in_progress','waiting','blocked')
+  AND t.source_agent_id = ANY ($1)                 -- only task-management-enabled agents
+  -- not blocked by an unfinished task
+  AND (t.blocked_by_task_id IS NULL OR EXISTS (
+        SELECT 1 FROM tasks b WHERE b.id = t.blocked_by_task_id
+          AND b.status IN ('done','cancelled')))
+  -- no pending wake already scheduled (respects agent-set wake_at and prior heartbeat enqueues)
+  AND NOT EXISTS (
+        SELECT 1 FROM scheduled_jobs sj
+        WHERE sj.task_id = t.id AND sj.status = 'pending')
+  -- quiet past the per-status threshold
+  AND (
+        (t.owner = 'curia' AND t.status IN ('open','in_progress')
+           AND t.updated_at < now() - ($2 || ' hours')::interval)
+     OR (t.status IN ('waiting','blocked')
+           AND t.updated_at < now() - ($3 || ' hours')::interval)
+      )
+ORDER BY t.source_agent_id, t.updated_at ASC        -- per agent: oldest-touched = most deserving
+-- application layer then takes the top N (=5) of these by lateness and enqueues one wake each
+```
+
+For each selected task the heartbeat inserts a `scheduled_jobs` row: `run_at = now()`, `task_id = <task>`, `agent_id = source_agent_id` (falling back to `coordinator` if that agent is disabled), `created_by = 'heartbeat'`, and a short `task_payload` ("Resume and advance this task"). The existing scheduler fires it within 30s.
+
+### 3.3 Why `updated_at` is sufficient (for now)
+
+"Idle" = `updated_at` age; "expected wait" = an owner-set `wake_at` (a pending `scheduled_jobs` row, which the `NOT EXISTS` guard respects); "stale" = no such wake and quiet past threshold. All three are expressible from existing `tasks` fields plus `scheduled_jobs`. **No new columns.** Contingency: if `updated_at` proves a noisy proxy for "last actually advanced" (e.g. a label/tag touch bumps it spuriously), add a single `last_advanced_at` column — flagged, not built (§9).
+
+---
+
+## 4. The Executor Loop & the No-Dangling-Commitment Invariant
+
+These are *behavioral* rules shared by every participating agent. They live **once** in the injected `task_management` prompt block (§6), not copy-pasted per agent.
+
+### 4.1 The loop
+
+When an agent receives or resumes a task, it runs:
+
+1. **Advance until blocked.** Do every step you can right now. Stop only at a genuine blocker — waiting on a person, on the CEO's approval, on a future date, or on a prior task — **or** when your burst budget (`error_budget`: `max_turns` / `max_cost_usd`) runs low. This bound is what prevents the runaway burst (worry A). On a heartbeat wake you may pull your other owned, ready tasks via `task-list` and advance them too, in dependency order, until blocked or budget-bounded.
+2. **Reify before you promise** (§4.2).
+3. **Park cleanly.** For each loose end, set status (`waiting` / `blocked`), append a `progress_note`, and set a wake — an event bridge (so a reply reactivates it) *or* a `wake_at` timer (so silence reactivates it). Setting neither is permitted (the heartbeat catches it) but setting one is the discipline.
+
+### 4.2 The invariant
+
+> **No outbound artifact may contain an unfulfilled forward commitment unless a task backs that commitment — and the agent prefers to fulfill the commitment *before* sending.**
+
+This is the rule that kills the dangling-document failure. The agent decomposes the reply: "respond to sender" is `blocked_by` "obtain the document." Because advance-until-blocked cannot reach the "send reply" step until "obtain document" completes, the agent's **default** behavior is to resolve first and send a *complete* reply. The three outcomes the CEO articulated fall out at runtime depending on whether the dependency resolves, and they map to the CEO's stated preference order:
+
+| Outcome | When | Mechanism |
+|---|---|---|
+| **Resolve-then-reply** (most preferred) | the doc is findable now or after a short wait | reply step stays `blocked_by` obtain-doc; the promise is never made; a complete reply is sent once resolved |
+| **Promise-then-self-fulfill** | sender needs acknowledgment now; Curia can chase the doc | send interim reply **+** create follow-up task `owner='curia'`; resume wakes Curia to send the doc |
+| **Promise-then-CEO-owns + notify** (fallback) | sender needs acknowledgment now; only the CEO can produce the doc | send interim reply **+** create follow-up task `owner='ceo'` **+** notify the CEO; appears in the digest's "For you to do" |
+
+There is no configuration choosing among these — the agent picks at runtime. *How hard Curia tries to resolve before falling back* is governed by its autonomy posture (§7), not new logic.
+
+---
+
+## 5. Decomposition: Projects
+
+A "project" is a durable goal with a small dependency graph. The rule of thumb, baked into the `task_management` block:
+
+> **If the work has more than one step, or any step cannot be completed right now, create a parent task (`intent_anchor` = the durable goal) plus the *first wave* of subtasks (`parent_task_id`, with `blocked_by_task_id` for ordering). Otherwise, a single task.**
+
+- **Plan the first wave, not the whole tree.** Add subtasks as reality reveals them — the sales leader's agenda determines the venue size, which could not have been planned up front. Incremental planning beats a brittle complete plan.
+- **Cross-specialist ownership.** For a project spanning specialists, the **coordinator** owns the parent (`source_agent_id='coordinator'`). Subtasks may carry different `source_agent_id`s (a "confirm calendars" subtask → calendar specialist; "draft agenda" → coordinator) so each wakes the right owner.
+- **Parent completion.** When a subtask completes and unblocks the next, the resuming owner advances the chain. The parent task is itself heartbeat-eligible: once its children are done and it is idle-unblocked, the heartbeat wakes its owner to close it out (or advance the next wave). No special parent-rollup machinery in v1.
+
+### 5.1 Walkthrough: the sales kickoff
+
+1. **Intake (synchronous):** coordinator recognizes a multi-step request → creates parent `intent_anchor:"book sales kickoff"` + first-wave subtasks → advances what it can now (messages the sales leader to plan content; pulls roster + candidate calendar windows) → parks the rest (`waiting` on the sales leader; `blocked_by` agenda) → tells the CEO "kicked it off, I'll keep moving as pieces come back."
+2. **Sales leader replies (event):** wakes the agenda subtask → finalize agenda → unblocks venue → propose/book venue (escalates if it spends money, per §7) → park on approval.
+3. **Venue confirms (event):** unblocks invites → send calendar invites → parent nears `done`.
+4. **Heartbeat's role here:** *none of the driving* — events do that. It only intervenes if, say, the sales leader never replies and the agent forgot a nudge timer (orphaned wait → wake coordinator to nudge or escalate at 48h).
+
+---
+
+## 6. The `enable_task_management` Agent Capability
+
+The §4–§5 rules are *behavioral discipline*. Injecting them by hand into each agent prompt guarantees drift the moment someone hand-builds a custom agent. Instead, a single declarative toggle on the agent YAML bundles the whole capability — mirroring existing per-agent capability flags (`inject_specialists: true`, `memory: scopes: [...]`, the runtime autonomy-block injection).
+
+```yaml
+# agents/<name>.yaml
+enable_task_management: true   # default: false
+```
+
+When `true`, the agent runtime does three things:
+
+1. **Auto-pins** `task-create`, `task-list`, `task-update`, `task-complete` (merged and deduped with the agent's explicit `pinned_skills`).
+2. **Auto-injects** the single `task_management` guidance block — the §4 executor loop, the §4.2 reification invariant, the §5 decomposition rule, and the resume-mode contract — at a **fixed slot** in the effective system prompt (after the identity / security blocks). A fixed slot, not a `${placeholder}`: for a discipline block, "flag set true but author forgot the placeholder" would reintroduce exactly the inconsistency we are eliminating. Guaranteed presence beats placement control.
+3. **Marks the agent heartbeat-eligible** — only enabled agents appear in the heartbeat's `source_agent_id` allow-list (§3.2, `$1`) and need a resume mode (the block supplies it).
+
+Notes:
+
+- **Default `false`, opt-in `true`.** Enable on the agents that uncover deferrable work: `coordinator`, `ceo-inbox`, `meeting-debrief`, `research-analyst`. Leave off pure-CRUD specialists (`contacts`, `calendar`) that act-and-return.
+- **Manual import escape hatch.** An agent may still list individual `task-*` skills in `pinned_skills` without the flag, for a bespoke need (e.g. read-only `task-list` access) — the flag is a convenience bundle, not the only path. Such an agent is *not* heartbeat-eligible and gets no injected block.
+- **Disabled-owner fallback.** If a task's `source_agent_id` points at an agent that is *not* task-management-enabled (or is null), the heartbeat routes the wake to the **coordinator** — the same fallback the 2026-06-01 doc specifies for null owners.
+- **Versioning.** The `task_management` block is platform code, versioned with the platform; every opted-in agent gets the identical, current rules. Bumping the block is a platform change, surfaced in structured logs (per CLAUDE.md versioning conventions).
+
+### 6.1 The injected block (proposed content)
+
+> **Task management.** You can defer, track, and resume work using your task skills.
+>
+> **Decide, don't drop.** When work arrives that you cannot finish now, create a task (`task-create`, optionally with `wake_at`) rather than cramming or abandoning it. Briefly tell the CEO what you queued and why.
+>
+> **Decompose projects.** If work has more than one step, or any step cannot be done right now, create a parent task whose `intent_anchor` states the durable goal, plus the first wave of subtasks (`parent_task_id`, `blocked_by_task_id` for ordering). Plan the first wave only; add subtasks as you learn more.
+>
+> **Advance until blocked.** When you act on a task, do every step you can right now. Stop only at a real blocker — waiting on a person, on the CEO's approval, on a future date, or on a prior task — or when your turn budget runs low. Then park each loose end: set its status (`waiting`/`blocked`), add a progress note, and set a wake (a reply you're expecting, or a `wake_at` timer).
+>
+> **Never promise without a task.** Before you send anything that commits to a future action ("I'll follow up with X", "we'll send that over"), make sure a task backs that promise. Prefer to *resolve the dependency first* and send a complete message. Only send an interim "I'll follow up" when the recipient needs an acknowledgment now — and when you do, create the follow-up task (yours if you can chase it; the CEO's if only they can, and tell them).
+>
+> **Resuming.** When you're woken to advance a task, you'll receive its id, title, intent, and progress. Pick up where you left off. You may pull your other ready tasks (`task-list`) and advance them too, in dependency order, until blocked or budget-bound.
+
+---
+
+## 7. Autonomy Interaction
+
+The hybrid "execute the safe stuff, escalate the rest" line is **already governed by the existing autonomy engine** (spec 14) — `action_risk` on each skill against the live autonomy score. The executor loop inherits this for free:
+
+- "Draft the agenda" (`action_risk` low/none) → just do it.
+- "Email the sales leader" (`medium`, outbound) → gated by score.
+- "Book the $4k venue" (`high`/`critical`) → escalates to the CEO via the existing pending-approval flow.
+
+So *how forward-leaning the steward feels* is tuned by the CEO's autonomy posture (`get-autonomy` / `set-autonomy`), **not** by new risk logic in this design. This design adds zero new autonomy mechanics; it composes with what exists.
+
+---
+
+## 8. Agent-by-Agent Changes
+
+| Agent | Change |
+|---|---|
+| **(platform)** | New `BacklogHeartbeat` system component + deterministic router (§3). New `enable_task_management` runtime capability + injected block (§6). |
+| **coordinator** | Set `enable_task_management: true` (drops its now-redundant manual `task-*` pins). Inherits the project-execution + reification behavior via the block. Add a modest explicit `error_budget` (it has none today) so project bursts are bounded. **Remove** the never-built §4.2 `backlog-sweep` from scope (it is replaced by the heartbeat, which is *not* a coordinator cron). |
+| **ceo-inbox** (#840 rewrite) | Set `enable_task_management: true` (it currently has **zero** `task-*` skills — it cannot create a follow-up task today). Add the reification rule into the NEEDS DRAFT path (the document-follow-up case). Add task-wake resume handling (when a deferred reply task wakes, draft it). **Keep** the original #840 overflow load-shedding: above N unread, process the top-priority handful inline and defer the tail as `tag='inbox-overflow'` tasks. |
+| **meeting-debrief** | Set `enable_task_management: true`. Its bespoke per-agent state (`pendingDebriefs` / `judgedEvents`) was the original proof case (2026-06-01 §7) — it inherits the shared loop and the heartbeat for free. (Confirm migration status during planning.) |
+| **research-analyst** | Set `enable_task_management: true` for long-running queries that should defer and resume rather than block a burst. |
+
+---
+
+## 9. Schema
+
+**Target: zero new columns.** Everything the heartbeat needs is expressible from existing `tasks` fields + `scheduled_jobs` (§3.3). The status lifecycle, `owner`, `parent_task_id`, `blocked_by_task_id`, `source_agent_id`, `updated_at`, and the `wake_at`-as-`scheduled_jobs`-row convention all exist from the 2026-06-01 work.
+
+**Contingency (flagged, not built):** if `updated_at` is too noisy a proxy for "last actually advanced" (a tag/label write bumps it without real progress), add a single `last_advanced_at TIMESTAMPTZ` column, written only by `task-update` when a `progress_note` is supplied, and switch the §3.2 thresholds to it. Decide during implementation against real data; do not pre-build.
+
+### 9.1 Configuration
+
+`config/default.yaml`, `tasks.*` (supersedes the 2026-06-01 `backlogSweepCron` / `sweepBatchSize`):
+
+```yaml
+tasks:
+  heartbeatIntervalMinutes: 60      # hourly
+  heartbeatMaxWakesPerTick: 5       # global cap; per-agent cap is always 1
+  idleThresholdHours: 4             # active idle (open/in_progress, curia-owned)
+  staleWaitThresholdHours: 48       # orphaned waits (waiting/blocked, no wake set)
+```
+
+---
+
+## 10. Already Shipped vs. New
+
+To scope the work precisely:
+
+**Already shipped (reused, not rebuilt):**
+- `tasks` table + status lifecycle + ownership columns (migration 049).
+- `task-create` / `task-list` / `task-update` / `task-complete` skills, with the `wake_at` convenience.
+- Per-task wake routing: `scheduled_jobs.task_id` → dispatch to `source_agent_id` with task context ([scheduler.ts](../../src/scheduler/scheduler.ts), [scheduler-service.ts](../../src/scheduler/scheduler-service.ts)).
+- Digest backlog sections (#838); tasks console UI (#876).
+- The autonomy engine (spec 14) and `context-bridge` reply routing.
+
+**New in this design:**
+1. `BacklogHeartbeat` system component + deterministic router + selection query (§3).
+2. `enable_task_management` runtime capability: skill auto-pin + fixed-slot block injection + heartbeat-eligibility registration (§6).
+3. The `task_management` prompt block content (§6.1).
+4. Reification + advance-until-blocked behavior wired into `ceo-inbox` (#840 rewrite) and validated end-to-end.
+5. `tasks.*` config (§9.1); coordinator `error_budget`.
+
+---
+
+## 11. Issue Breakdown (suggested PR sequence)
+
+Each item is one PR, independently reviewable. Items 2 and 3 can parallelize after item 1.
+
+| # | Issue | Acceptance |
+|---|---|---|
+| 1 | **`enable_task_management` capability.** Runtime flag: auto-pin task skills (deduped), inject the `task_management` block at the fixed slot, register heartbeat-eligibility. Default `false`. | Enabling the flag on a test agent makes the four skills callable and the block present in its effective prompt; a disabled agent is unchanged; manual `task-*` pins without the flag still work and do not inject the block. Typecheck + existing tests green. |
+| 2 | **`BacklogHeartbeat` system component.** Hourly tick, deterministic selection query (§3.2), one-shot `scheduled_jobs` enqueue with dedup, per-agent=1 + global cap, disabled-owner→coordinator fallback. Config keys (§9.1). | Unit tests: idle-unblocked and orphaned-wait selection; `blocked_by` exclusion; `NOT EXISTS` wake dedup; per-agent=1; global cap. Integration: seed idle tasks across 3 agents → exactly one wake per agent, capped at 5, each routed to the correct `source_agent_id`. A task with an agent-set pending `wake_at` is **not** double-enqueued. |
+| 3 | **Coordinator onboarding.** Flip `enable_task_management: true`, drop redundant manual pins, add `error_budget`. Remove the never-built §4.2 `backlog-sweep` from any tracking. | Smoke: "book a sales kickoff…" produces a parent task + first-wave subtasks with sensible `blocked_by`; advance-until-blocked parks on the sales-leader wait; a simulated reply event advances the chain. Existing coordinator smoke tests green. |
+| 4 | **ceo-inbox: close the loop (#840 rewrite).** Flag on; reification rule in NEEDS DRAFT; task-wake resume drafting; overflow load-shedding above N unread. | The document-follow-up case: with no doc available, ceo-inbox does **not** send a bare "CEO will follow up" — it either resolves first or creates + assigns a tracked follow-up task and notifies. With > N unread in staging, top-priority handful processed inline, tail deferred as `inbox-overflow` tasks visible in the next digest. LLM time per burst no longer scales linearly past N. |
+| 5 | **(Stretch) `last_advanced_at`.** Only if item 2's `updated_at` proves noisy against real data. | Column added; `task-update` writes it on `progress_note`; heartbeat thresholds switch to it; backfill from `updated_at`. |
+
+Per CLAUDE.md, every issue needs applicable pre-existing labels, one `size:` label, and explicit acceptance criteria. Issue #840 is **rewritten** (not newly created) to item 4's scope.
+
+---
+
+## 12. Verification Plan
+
+### 12.1 Unit
+- Heartbeat selection query: each population, `blocked_by` exclusion, wake dedup, per-agent=1, global cap, threshold boundaries, disabled-owner fallback.
+- Capability wiring: flag on → skills pinned + block injected at the fixed slot; flag off → neither; manual import path unaffected.
+
+### 12.2 Integration
+- End-to-end heartbeat: seed idle/stale/blocked tasks across multiple agents → assert exactly the expected one-shot `scheduled_jobs` rows, correct routing, and that already-waked tasks are skipped.
+- Advance-until-blocked: a project task with a 3-step chain advances to the first blocker in one burst, parks, and resumes on a simulated event.
+- Cancellation: completing a task cancels its pending heartbeat-enqueued wake (existing `task-complete` cascade).
+
+### 12.3 Smoke (LLM-judge, existing framework)
+- **Dangling-commitment regression:** an inbound email requesting a document Curia does not have → assert no bare "CEO will follow up" is sent without a backing task; assert the correct one of the three §4.2 outcomes.
+- **Project decomposition:** "book a sales kickoff…" → parent + first-wave subtasks + sensible `blocked_by`; advance-until-blocked behavior; event-driven advancement on a simulated reply.
+- **Overflow:** > N unread → top handful inline, tail deferred, digest shows them.
+- **No-lingering:** an `owner='curia'` task left untouched for > 4h with no wake → the next heartbeat tick wakes its owner.
+
+### 12.4 Manual
+- Run a full day in staging with the heartbeat live; confirm hourly ticks are cheap (no LLM cost on empty ticks) and that real idle tasks get advanced without thrash.
+- Confirm existing test suite remains green after each item.
+
+---
+
+## 13. New / Modified Files Summary
+
+### New
+| File | Purpose |
+|---|---|
+| `src/tasks/heartbeat.ts` (or `src/scheduler/backlog-heartbeat.ts`) | `BacklogHeartbeat` component: hourly tick, selection query, one-shot enqueue |
+| `src/tasks/heartbeat.test.ts` | Unit tests for selection + enqueue |
+| `src/agents/task-management-block.ts` (or template asset) | The single source-of-truth `task_management` prompt block (§6.1) |
+
+### Modified
+| File | Change |
+|---|---|
+| `src/index.ts` | Start `BacklogHeartbeat` in System-layer bootstrap |
+| agent runtime loader (effective-prompt + skill assembly) | Honor `enable_task_management`: auto-pin skills, inject block at fixed slot, register heartbeat-eligibility |
+| `agents/coordinator.yaml` | `enable_task_management: true`; drop redundant `task-*` pins; add `error_budget` |
+| `agents/ceo-inbox.yaml` + `src/agents/ceo-inbox/*` | `enable_task_management: true`; reification in NEEDS DRAFT; task-wake resume; overflow load-shedding |
+| `agents/meeting-debrief.yaml`, `agents/research-analyst.yaml` | `enable_task_management: true` |
+| `config/default.yaml` | `tasks.*` keys (§9.1); remove `backlogSweepCron` / `sweepBatchSize` if present |
+| `CHANGELOG.md` | `[Unreleased]` entries per PR |
+
+---
+
+## 14. Open Questions
+
+These do not block authoring; resolve before the relevant item lands.
+
+1. **Heartbeat trigger mechanism.** Internal bootstrap timer (`setInterval`, simplest) vs. a self-scheduling system `scheduled_jobs` row dispatched to a *code* handler (more integrated, needs the scheduler to support non-agent handlers). Lean: bootstrap timer for v1.
+2. **`updated_at` noisiness.** Whether tag/label/progress-note writes bump `updated_at` enough to mask real idleness — drives whether item 5 (`last_advanced_at`) is needed. Measure in staging.
+3. **Resume-burst budget for the coordinator.** What `error_budget` (`max_turns` / `max_cost_usd`) bounds a coordinator project burst without starving a legitimately deep project? Start conservative; tune against real bursts.
+4. **Orphaned-wait escalation phrasing.** When a 48h orphaned wait wakes the owner, what is the default action — silent re-ping, or surface to the CEO? Lean: owner judgment per the block, biased toward a CEO nudge for `owner='ceo'`/`external`.

--- a/docs/wip/2026-06-04-task-execution-heartbeat-design.md
+++ b/docs/wip/2026-06-04-task-execution-heartbeat-design.md
@@ -179,7 +179,7 @@ A "project" is a durable goal with a small dependency graph. The rule of thumb, 
 - **Cross-specialist ownership.** For a project spanning specialists, the **coordinator** owns the parent (`source_agent_id='coordinator'`). Subtasks may carry different `source_agent_id`s (a "confirm calendars" subtask → calendar specialist; "draft agenda" → coordinator) so each wakes the right owner.
 - **Parent completion.** When a subtask completes and unblocks the next, the resuming owner advances the chain. The parent task is itself heartbeat-eligible: once its children are done and it is idle-unblocked, the heartbeat wakes its owner to close it out (or advance the next wave). No special parent-rollup machinery in v1.
 
-### 5.1 Walkthrough: the sales kickoff
+### 5.1 Walkthrough: the sales kickoff example
 
 1. **Intake (synchronous):** coordinator recognizes a multi-step request → creates parent `intent_anchor:"book sales kickoff"` + first-wave subtasks → advances what it can now (messages the sales leader to plan content; pulls roster + candidate calendar windows) → parks the rest (`waiting` on the sales leader; `blocked_by` agenda) → tells the CEO "kicked it off, I'll keep moving as pieces come back."
 2. **Sales leader replies (event):** wakes the agenda subtask → finalize agenda → unblocks venue → propose/book venue (escalates if it spends money, per §7) → park on approval.

--- a/schemas/agent-config.schema.json
+++ b/schemas/agent-config.schema.json
@@ -43,6 +43,7 @@
       "items": { "type": "string" }
     },
     "allow_discovery": { "type": "boolean" },
+    "enable_task_management": { "type": "boolean" },
     "memory": {
       "type": "object",
       "additionalProperties": false,

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -309,8 +309,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "heartbeatIntervalMinutes": { "type": "number", "minimum": 1 },
-        "heartbeatMaxWakesPerTick": { "type": "number", "minimum": 1 },
+        "heartbeatIntervalMinutes": { "type": "integer", "minimum": 1 },
+        "heartbeatMaxWakesPerTick": { "type": "integer", "minimum": 1 },
         "idleThresholdHours": { "type": "number", "minimum": 0 },
         "staleWaitThresholdHours": { "type": "number", "minimum": 0 }
       }

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -304,6 +304,16 @@
       "properties": {
         "defaultExpectedDurationSeconds": { "type": "integer", "minimum": 1 }
       }
+    },
+    "tasks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "heartbeatIntervalMinutes": { "type": "number", "minimum": 1 },
+        "heartbeatMaxWakesPerTick": { "type": "number", "minimum": 1 },
+        "idleThresholdHours": { "type": "number", "minimum": 0 },
+        "staleWaitThresholdHours": { "type": "number", "minimum": 0 }
+      }
     }
   },
   "definitions": {

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -65,6 +65,10 @@ export interface AgentYamlConfig {
    * know what other agents are available (e.g. to make ACTIONABLE routing decisions).
    */
   inject_specialists?: boolean;
+  /** When true, the runtime auto-pins the task-* skills, injects the shared
+   *  task-management discipline block, and marks the agent heartbeat-eligible.
+   *  See docs/wip/2026-06-04-task-execution-heartbeat-design.md §6. Default: false. */
+  enable_task_management?: boolean;
 }
 
 /**

--- a/src/agents/task-management.ts
+++ b/src/agents/task-management.ts
@@ -58,7 +58,7 @@ export function applyTaskManagement(
   pinnedSkills: string[],
 ): TaskManagementResult {
   if (!config.enable_task_management) {
-    return { systemPrompt, pinnedSkills, heartbeatEligible: false };
+    return { systemPrompt, pinnedSkills: [...pinnedSkills], heartbeatEligible: false };
   }
   // Keep the author's explicit pins; append any task skills not already present.
   const merged = [...pinnedSkills];

--- a/src/agents/task-management.ts
+++ b/src/agents/task-management.ts
@@ -1,0 +1,73 @@
+import type { AgentYamlConfig } from './loader.js';
+
+/** The four skills every task-management-enabled agent can call. */
+export const TASK_MANAGEMENT_SKILLS = [
+  'task-create',
+  'task-list',
+  'task-update',
+  'task-complete',
+] as const;
+
+/** Single source of truth for the executor-discipline block injected into every
+ *  task-management-enabled agent's effective system prompt.
+ *  See docs/wip/2026-06-04-task-execution-heartbeat-design.md §6.1. */
+export const TASK_MANAGEMENT_BLOCK = [
+  '## Task Management',
+  '',
+  'You can defer, track, and resume work using your task skills.',
+  '',
+  '**Decide, don\'t drop.** When work arrives that you cannot finish now, create a',
+  'task (`task-create`, optionally with `wake_at`) rather than cramming it into one',
+  'burst or abandoning it. Briefly tell the CEO what you queued and why.',
+  '',
+  '**Decompose projects.** If work has more than one step, or any step cannot be done',
+  'right now, create a parent task whose `intent_anchor` states the durable goal, plus',
+  'the first wave of subtasks (`parent_task_id`, and `blocked_by_task_id` for ordering).',
+  'Plan the first wave only; add subtasks as you learn more.',
+  '',
+  '**Advance until blocked.** When you act on a task, do every step you can right now.',
+  'Stop only at a real blocker — waiting on a person, on the CEO\'s approval, on a future',
+  'date, or on a prior task — or when your turn budget runs low. Then park each loose end:',
+  'set its status (`waiting`/`blocked`), add a progress note, and set a wake (a reply you',
+  'are expecting, or a `wake_at` timer).',
+  '',
+  '**Never promise without a task.** Before you send anything that commits to a future',
+  'action ("I\'ll follow up with X", "we\'ll send that over"), make sure a task backs that',
+  'promise. Prefer to resolve the dependency first and send a complete message. Only send',
+  'an interim "I\'ll follow up" when the recipient needs an acknowledgment now — and when',
+  'you do, create the follow-up task (yours if you can chase it; the CEO\'s if only they',
+  'can, and tell them).',
+  '',
+  '**Resuming.** When you are woken to advance a task, you receive its id, title, intent,',
+  'and progress. Pick up where you left off. You may pull your other ready tasks',
+  '(`task-list`) and advance them too, in dependency order, until blocked or budget-bound.',
+].join('\n');
+
+export interface TaskManagementResult {
+  systemPrompt: string;
+  pinnedSkills: string[];
+  heartbeatEligible: boolean;
+}
+
+/** Apply the enable_task_management capability to an agent's prompt + skills.
+ *  Pure function — no side effects. When the flag is off (default), returns the
+ *  inputs unchanged and heartbeatEligible=false. */
+export function applyTaskManagement(
+  config: AgentYamlConfig,
+  systemPrompt: string,
+  pinnedSkills: string[],
+): TaskManagementResult {
+  if (!config.enable_task_management) {
+    return { systemPrompt, pinnedSkills, heartbeatEligible: false };
+  }
+  // Keep the author's explicit pins; append any task skills not already present.
+  const merged = [...pinnedSkills];
+  for (const skill of TASK_MANAGEMENT_SKILLS) {
+    if (!merged.includes(skill)) merged.push(skill);
+  }
+  return {
+    systemPrompt: `${systemPrompt}\n\n${TASK_MANAGEMENT_BLOCK}`,
+    pinnedSkills: merged,
+    heartbeatEligible: true,
+  };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -765,14 +765,14 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       throw new Error(`tasks.heartbeatMaxWakesPerTick must be a positive integer, got: ${String(t.heartbeatMaxWakesPerTick)}`);
     }
     if (t.idleThresholdHours !== undefined && (
-      typeof t.idleThresholdHours !== 'number' || t.idleThresholdHours < 0
+      !Number.isFinite(t.idleThresholdHours) || t.idleThresholdHours < 0
     )) {
-      throw new Error(`tasks.idleThresholdHours must be a non-negative number, got: ${String(t.idleThresholdHours)}`);
+      throw new Error(`tasks.idleThresholdHours must be a non-negative finite number, got: ${String(t.idleThresholdHours)}`);
     }
     if (t.staleWaitThresholdHours !== undefined && (
-      typeof t.staleWaitThresholdHours !== 'number' || t.staleWaitThresholdHours < 0
+      !Number.isFinite(t.staleWaitThresholdHours) || t.staleWaitThresholdHours < 0
     )) {
-      throw new Error(`tasks.staleWaitThresholdHours must be a non-negative number, got: ${String(t.staleWaitThresholdHours)}`);
+      throw new Error(`tasks.staleWaitThresholdHours must be a non-negative finite number, got: ${String(t.staleWaitThresholdHours)}`);
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,30 @@ export interface Config {
   signalPhoneNumber: string | undefined;
 }
 
+export interface TasksConfig {
+  heartbeatIntervalMinutes: number;
+  heartbeatMaxWakesPerTick: number;
+  idleThresholdHours: number;
+  staleWaitThresholdHours: number;
+}
+
+export const DEFAULT_TASKS_CONFIG: TasksConfig = {
+  heartbeatIntervalMinutes: 60,
+  heartbeatMaxWakesPerTick: 5,
+  idleThresholdHours: 4,
+  staleWaitThresholdHours: 48,
+};
+
+/** Resolve the optional YAML tasks block to a fully-populated config with defaults. */
+export function resolveTasksConfig(yaml: YamlConfig['tasks']): TasksConfig {
+  return {
+    heartbeatIntervalMinutes: yaml?.heartbeatIntervalMinutes ?? DEFAULT_TASKS_CONFIG.heartbeatIntervalMinutes,
+    heartbeatMaxWakesPerTick: yaml?.heartbeatMaxWakesPerTick ?? DEFAULT_TASKS_CONFIG.heartbeatMaxWakesPerTick,
+    idleThresholdHours: yaml?.idleThresholdHours ?? DEFAULT_TASKS_CONFIG.idleThresholdHours,
+    staleWaitThresholdHours: yaml?.staleWaitThresholdHours ?? DEFAULT_TASKS_CONFIG.staleWaitThresholdHours,
+  };
+}
+
 /**
  * Typed shape for config/default.yaml.
  *
@@ -277,6 +301,18 @@ export interface YamlConfig {
     /** Default assumed duration in seconds for scheduled jobs that declare no expectedDurationSeconds.
      *  Used by the watchdog to compute recovery timeouts. Default: 600. */
     defaultExpectedDurationSeconds?: number;
+  };
+  tasks?: {
+    /** BacklogHeartbeat tick interval in minutes. Default 60. */
+    heartbeatIntervalMinutes?: number;
+    /** Max task wakes enqueued per heartbeat tick (global cap). Default 5. */
+    heartbeatMaxWakesPerTick?: number;
+    /** Hours an unblocked curia-owned task may sit untouched before the heartbeat
+     *  pokes it. Default 4. */
+    idleThresholdHours?: number;
+    /** Hours a waiting/blocked task with no pending wake may sit before the
+     *  heartbeat surfaces it as an orphaned wait. Default 48. */
+    staleWaitThresholdHours?: number;
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -746,6 +746,36 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     );
   }
 
+  // Validate tasks config if present.
+  // Guard against non-object roots (e.g. `tasks: 60`) for the same reason as scheduler above.
+  if (config.tasks !== undefined && (typeof config.tasks !== 'object' || Array.isArray(config.tasks) || config.tasks === null)) {
+    throw new Error(`tasks must be a YAML mapping, got: ${typeof config.tasks}`);
+  }
+  if (config.tasks !== undefined) {
+    const t = config.tasks;
+    // A zero or negative interval would cause setInterval(fn, <=0) to fire in a tight loop.
+    if (t.heartbeatIntervalMinutes !== undefined && (
+      !Number.isInteger(t.heartbeatIntervalMinutes) || t.heartbeatIntervalMinutes < 1
+    )) {
+      throw new Error(`tasks.heartbeatIntervalMinutes must be a positive integer, got: ${String(t.heartbeatIntervalMinutes)}`);
+    }
+    if (t.heartbeatMaxWakesPerTick !== undefined && (
+      !Number.isInteger(t.heartbeatMaxWakesPerTick) || t.heartbeatMaxWakesPerTick < 1
+    )) {
+      throw new Error(`tasks.heartbeatMaxWakesPerTick must be a positive integer, got: ${String(t.heartbeatMaxWakesPerTick)}`);
+    }
+    if (t.idleThresholdHours !== undefined && (
+      typeof t.idleThresholdHours !== 'number' || t.idleThresholdHours < 0
+    )) {
+      throw new Error(`tasks.idleThresholdHours must be a non-negative number, got: ${String(t.idleThresholdHours)}`);
+    }
+    if (t.staleWaitThresholdHours !== undefined && (
+      typeof t.staleWaitThresholdHours !== 'number' || t.staleWaitThresholdHours < 0
+    )) {
+      throw new Error(`tasks.staleWaitThresholdHours must be a non-negative number, got: ${String(t.staleWaitThresholdHours)}`);
+    }
+  }
+
   return config;
 }
 

--- a/src/db/queries/tasks.ts
+++ b/src/db/queries/tasks.ts
@@ -109,9 +109,11 @@ export interface SelectHeartbeatOptions {
  *
  *  Two eligibility paths:
  *  1. Idle path: owner='curia', status in (open, in_progress), not blocked,
- *     no pending wake, updated_at older than idleThresholdHours.
- *  2. Stale-wait path: status in (waiting, blocked), blocker done/cancelled or
- *     no blocker, no pending wake, updated_at older than staleWaitThresholdHours.
+ *     no pending/running wake, updated_at older than idleThresholdHours.
+ *  2. Stale-wait path: owner='curia', status in (waiting, blocked),
+ *     waiting_on_contact_id IS NULL (not blocked on a specific human),
+ *     blocker done/cancelled or no blocker, no pending/running wake,
+ *     updated_at older than staleWaitThresholdHours.
  *
  *  Results are deduplicated to one task per effective agent (most-overdue first).
  */
@@ -137,11 +139,12 @@ export async function selectHeartbeatCandidates(
                WHERE b.id = t.blocked_by_task_id AND b.status IN ('done','cancelled')))
          AND NOT EXISTS (
                SELECT 1 FROM scheduled_jobs sj
-               WHERE sj.task_id = t.id AND sj.status = 'pending')
+               WHERE sj.task_id = t.id AND sj.status IN ('pending', 'running'))
          AND (
                (t.owner = 'curia' AND t.status IN ('open','in_progress')
                   AND t.updated_at < now() - make_interval(hours => $2))
-            OR (t.status IN ('waiting','blocked')
+            OR (t.owner = 'curia' AND t.status IN ('waiting','blocked')
+                  AND t.waiting_on_contact_id IS NULL
                   AND t.updated_at < now() - make_interval(hours => $3))
              )
      ),

--- a/src/db/queries/tasks.ts
+++ b/src/db/queries/tasks.ts
@@ -82,6 +82,86 @@ export function mapTaskRow(row: DbTaskRow): TaskRow {
   };
 }
 
+// -- Heartbeat candidate selection --
+
+export interface HeartbeatCandidate {
+  /** The task to wake. */
+  id: string;
+  /** The agent that will receive the wake — the task's source_agent_id, or the
+   *  fallback agent when source_agent_id is null or not heartbeat-eligible. */
+  agentId: string;
+}
+
+export interface SelectHeartbeatOptions {
+  /** Heartbeat-eligible agent names (enable_task_management: true). */
+  eligibleAgents: string[];
+  idleThresholdHours: number;
+  staleWaitThresholdHours: number;
+  /** Global cap on candidates returned per call. */
+  maxWakes: number;
+  /** Agent that receives wakes for null / non-eligible owners. Default 'coordinator'. */
+  fallbackAgentId?: string;
+}
+
+/** Select the heartbeat's wake candidates: one entry-point task per effective owner
+ *  agent (idle-unblocked curia work, or orphaned waits past their threshold), globally
+ *  capped, most-overdue first. Deterministic — no domain reasoning.
+ *
+ *  Two eligibility paths:
+ *  1. Idle path: owner='curia', status in (open, in_progress), not blocked,
+ *     no pending wake, updated_at older than idleThresholdHours.
+ *  2. Stale-wait path: status in (waiting, blocked), blocker done/cancelled or
+ *     no blocker, no pending wake, updated_at older than staleWaitThresholdHours.
+ *
+ *  Results are deduplicated to one task per effective agent (most-overdue first).
+ */
+export async function selectHeartbeatCandidates(
+  pool: Pool,
+  opts: SelectHeartbeatOptions,
+): Promise<HeartbeatCandidate[]> {
+  if (opts.eligibleAgents.length === 0) return [];
+  const fallback = opts.fallbackAgentId ?? 'coordinator';
+  // $1 = eligibleAgents array, $2 = idleThresholdHours, $3 = staleWaitThresholdHours,
+  // $4 = fallbackAgentId, $5 = maxWakes
+  // make_interval(hours => $N) binds $N as a numeric parameter — fully parameterized.
+  const { rows } = await pool.query(
+    `WITH candidates AS (
+       SELECT
+         t.id,
+         CASE WHEN t.source_agent_id = ANY($1::text[]) THEN t.source_agent_id ELSE $4 END AS effective_agent,
+         t.updated_at
+       FROM tasks t
+       WHERE t.status IN ('open','in_progress','waiting','blocked')
+         AND (t.blocked_by_task_id IS NULL OR EXISTS (
+               SELECT 1 FROM tasks b
+               WHERE b.id = t.blocked_by_task_id AND b.status IN ('done','cancelled')))
+         AND NOT EXISTS (
+               SELECT 1 FROM scheduled_jobs sj
+               WHERE sj.task_id = t.id AND sj.status = 'pending')
+         AND (
+               (t.owner = 'curia' AND t.status IN ('open','in_progress')
+                  AND t.updated_at < now() - make_interval(hours => $2))
+            OR (t.status IN ('waiting','blocked')
+                  AND t.updated_at < now() - make_interval(hours => $3))
+             )
+     ),
+     per_agent AS (
+       SELECT DISTINCT ON (effective_agent) id, effective_agent, updated_at
+       FROM candidates
+       ORDER BY effective_agent, updated_at ASC
+     )
+     SELECT id, effective_agent
+     FROM per_agent
+     ORDER BY updated_at ASC
+     LIMIT $5`,
+    [opts.eligibleAgents, opts.idleThresholdHours, opts.staleWaitThresholdHours, fallback, opts.maxWakes],
+  );
+  return rows.map((r) => {
+    const row = r as unknown as { id: string; effective_agent: string };
+    return { id: row.id, agentId: row.effective_agent };
+  });
+}
+
 // Fetch a single task row by ID. Returns null if not found.
 export async function getTaskById(pool: Pool, taskId: string): Promise<TaskRow | null> {
   const { rows } = await pool.query(

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@
 
 import * as path from 'node:path';
 import { runner } from 'node-pg-migrate';
-import { ceoPrimaryEmailIsPlaceholder, loadConfig, loadYamlConfig, resolveChannelAccounts } from './config.js';
+import { ceoPrimaryEmailIsPlaceholder, loadConfig, loadYamlConfig, resolveChannelAccounts, resolveTasksConfig } from './config.js';
 import { createLogger } from './logger.js';
 import { HttpAdapter } from './channels/http/http-adapter.js';
 import { createPool } from './db/connection.js';
@@ -106,6 +106,7 @@ import { runReadinessChecks } from './startup/readiness.js';
 import { compileSecurityContextBlock } from './security/security-context.js';
 import { OutboundContextService } from './dispatch/outbound-context.js';
 import { applyTaskManagement } from './agents/task-management.js';
+import { BacklogHeartbeat } from './scheduler/backlog-heartbeat.js';
 
 async function main(): Promise<void> {
   // Captured at the very start of main() so the wizard's post-setup polling
@@ -1497,7 +1498,23 @@ async function main(): Promise<void> {
     // Non-fatal: watchdog will retry in 5 minutes.
     logger.error({ err }, 'Startup stuck-job recovery failed — watchdog will retry in 5 minutes');
   }
+  // Autonomous task execution: the deterministic hourly heartbeat that wakes idle/stale
+  // tasks. Reads the tasks table, writes one-shot scheduled_jobs rows; the scheduler
+  // dispatches them. See docs/wip/2026-06-04-task-execution-heartbeat-design.md §3.
+  const tasksConfig = resolveTasksConfig(yamlConfig.tasks);
+  const backlogHeartbeat = new BacklogHeartbeat({
+    pool,
+    logger,
+    schedulerService,
+    eligibleAgents: taskManagementAgents,
+    intervalMinutes: tasksConfig.heartbeatIntervalMinutes,
+    maxWakesPerTick: tasksConfig.heartbeatMaxWakesPerTick,
+    idleThresholdHours: tasksConfig.idleThresholdHours,
+    staleWaitThresholdHours: tasksConfig.staleWaitThresholdHours,
+  });
+
   scheduler.start();
+  backlogHeartbeat.start();
   logger.info('Scheduler started');
 
   // Log the scrubber status after the logger is available (patterns are loaded at module
@@ -1702,6 +1719,11 @@ async function main(): Promise<void> {
       scheduler.stop();
     } catch (err) {
       logger.error({ err }, 'Error stopping scheduler during shutdown');
+    }
+    try {
+      backlogHeartbeat.stop();
+    } catch (err) {
+      logger.error({ err }, 'Error stopping backlog heartbeat during shutdown');
     }
     if (browserService) {
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ import { runStartupValidation } from './startup/validator.js';
 import { runReadinessChecks } from './startup/readiness.js';
 import { compileSecurityContextBlock } from './security/security-context.js';
 import { OutboundContextService } from './dispatch/outbound-context.js';
+import { applyTaskManagement } from './agents/task-management.js';
 
 async function main(): Promise<void> {
   // Captured at the very start of main() so the wizard's post-setup polling
@@ -1296,6 +1297,10 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Agents with enable_task_management: true — read by the BacklogHeartbeat to
+  // know which source_agent_ids it may wake (and as the fallback target list).
+  const taskManagementAgents = new Set<string>();
+
   // Pass 2: Create AgentRuntime for each config (now all specialists are known)
   for (const agentConfig of agentConfigs) {
     // Build tool definitions from pinned skills
@@ -1308,25 +1313,6 @@ async function main(): Promise<void> {
         );
       }
     }
-    const agentToolDefs = skillRegistry.toToolDefinitions(agentPinnedSkills);
-
-    // allow_discovery: true → inject the skill-registry discovery tool into the agent's
-    // tool list. Skipped if already pinned to avoid duplicate tool definitions.
-    // The skill-registry handler is loaded by the standard file loader like any other
-    // skill; this only controls whether it appears in the LLM's tool list for this agent.
-    if (agentConfig.allow_discovery && !agentPinnedSkills.includes('skill-registry')) {
-      const discoveryToolDefs = skillRegistry.toToolDefinitions(['skill-registry']);
-      if (discoveryToolDefs.length === 0) {
-        // skill-registry is not in the registry — it either failed to load (bad manifest,
-        // missing handler) or was never registered. Error-level: a declared capability is
-        // unavailable for this agent's entire lifetime. Root cause will be in the earlier
-        // skill-loader error log; this connects the agent-level consequence to it.
-        logger.error({ agent: agentConfig.name }, 'allow_discovery is true but skill-registry is not registered — discovery unavailable; check startup logs for skill load errors');
-      } else {
-        agentToolDefs.push(...discoveryToolDefs);
-      }
-    }
-
     // For the coordinator, interpolate runtime context (specialist list, agent contact ID).
     // Date and timezone are no longer baked in here — they are appended fresh on every
     // task turn via AgentRuntime using formatTimeContextBlock() so they never go stale.
@@ -1372,6 +1358,35 @@ async function main(): Promise<void> {
       });
     }
 
+    // Apply the enable_task_management capability: auto-pin task skills, append the
+    // discipline block, and register heartbeat-eligibility. No-op when the flag is off.
+    const taskMgmt = applyTaskManagement(agentConfig, systemPrompt, agentPinnedSkills);
+    systemPrompt = taskMgmt.systemPrompt;
+    const effectivePinnedSkills = taskMgmt.pinnedSkills;
+    if (taskMgmt.heartbeatEligible) {
+      taskManagementAgents.add(agentConfig.name);
+    }
+
+    // was: const agentToolDefs = skillRegistry.toToolDefinitions(agentPinnedSkills);
+    const agentToolDefs = skillRegistry.toToolDefinitions(effectivePinnedSkills);
+
+    // allow_discovery: true → inject the skill-registry discovery tool into the agent's
+    // tool list. Skipped if already pinned to avoid duplicate tool definitions.
+    // The skill-registry handler is loaded by the standard file loader like any other
+    // skill; this only controls whether it appears in the LLM's tool list for this agent.
+    if (agentConfig.allow_discovery && !effectivePinnedSkills.includes('skill-registry')) {
+      const discoveryToolDefs = skillRegistry.toToolDefinitions(['skill-registry']);
+      if (discoveryToolDefs.length === 0) {
+        // skill-registry is not in the registry — it either failed to load (bad manifest,
+        // missing handler) or was never registered. Error-level: a declared capability is
+        // unavailable for this agent's entire lifetime. Root cause will be in the earlier
+        // skill-loader error log; this connects the agent-level consequence to it.
+        logger.error({ agent: agentConfig.name }, 'allow_discovery is true but skill-registry is not registered — discovery unavailable; check startup logs for skill load errors');
+      } else {
+        agentToolDefs.push(...discoveryToolDefs);
+      }
+    }
+
     // Resolve this agent's capability tier to a concrete model, then look up
     // the provider from the model registry. This decouples tier→model from
     // model→provider: the registry is the single source of truth for which
@@ -1400,7 +1415,7 @@ async function main(): Promise<void> {
       memory,
       entityMemory,
       executionLayer,
-      pinnedSkills: agentPinnedSkills,
+      pinnedSkills: effectivePinnedSkills,
       skillToolDefs: agentToolDefs,
       // Registry-backed context window lookups and cost estimation (DI so runtime is testable).
       modelRegistry,

--- a/src/scheduler/backlog-heartbeat.ts
+++ b/src/scheduler/backlog-heartbeat.ts
@@ -47,26 +47,44 @@ export class BacklogHeartbeat {
   /** One tick: select candidates and enqueue a wake for each. Returns the number
    *  of wakes successfully enqueued. */
   async tick(): Promise<number> {
-    const candidates = await selectHeartbeatCandidates(this.opts.pool, {
-      eligibleAgents: [...this.opts.eligibleAgents],
-      idleThresholdHours: this.opts.idleThresholdHours,
-      staleWaitThresholdHours: this.opts.staleWaitThresholdHours,
-      maxWakes: this.opts.maxWakesPerTick,
-      fallbackAgentId: this.opts.fallbackAgentId ?? 'coordinator',
-    });
+    let candidates;
+    try {
+      candidates = await selectHeartbeatCandidates(this.opts.pool, {
+        eligibleAgents: [...this.opts.eligibleAgents],
+        idleThresholdHours: this.opts.idleThresholdHours,
+        staleWaitThresholdHours: this.opts.staleWaitThresholdHours,
+        maxWakes: this.opts.maxWakesPerTick,
+        fallbackAgentId: this.opts.fallbackAgentId ?? 'coordinator',
+      });
+    } catch (err) {
+      this.opts.logger.error({ err }, 'BacklogHeartbeat: candidate selection query failed — skipping tick');
+      return 0;
+    }
     if (candidates.length === 0) return 0;
 
     const runAt = new Date();
     let enqueued = 0;
     for (const c of candidates) {
       try {
-        await this.opts.schedulerService.enqueueTaskWake({ taskId: c.id, agentId: c.agentId, runAt });
+        const { jobId } = await this.opts.schedulerService.enqueueTaskWake({ taskId: c.id, agentId: c.agentId, runAt });
+        this.opts.logger.debug({ taskId: c.id, agentId: c.agentId, jobId }, 'BacklogHeartbeat: wake enqueued');
         enqueued += 1;
       } catch (err) {
-        this.opts.logger.error({ err, taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: failed to enqueue wake');
+        // 23503 = foreign_key_violation: task was completed/deleted between selection and enqueue — benign race.
+        if ((err as { code?: string }).code === '23503') {
+          this.opts.logger.debug({ taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: task no longer exists at enqueue time — skipped');
+        } else {
+          this.opts.logger.error({ err, taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: failed to enqueue wake');
+        }
       }
     }
     this.opts.logger.info({ enqueued, considered: candidates.length }, 'BacklogHeartbeat: tick complete');
+    if (enqueued === 0 && candidates.length > 0) {
+      this.opts.logger.error(
+        { considered: candidates.length },
+        'BacklogHeartbeat: all wake enqueues failed — tasks will not advance until next tick',
+      );
+    }
     return enqueued;
   }
 }

--- a/src/scheduler/backlog-heartbeat.ts
+++ b/src/scheduler/backlog-heartbeat.ts
@@ -22,6 +22,8 @@ export interface BacklogHeartbeatOptions {
  *  domain reasoning. The conductor, never an instrument. */
 export class BacklogHeartbeat {
   private intervalHandle: NodeJS.Timeout | null = null;
+  // Prevents a slow tick from overlapping with the next interval fire.
+  private tickInFlight = false;
 
   constructor(private readonly opts: BacklogHeartbeatOptions) {}
 
@@ -29,9 +31,18 @@ export class BacklogHeartbeat {
     if (this.intervalHandle) return;
     const ms = this.opts.intervalMinutes * 60_000;
     this.intervalHandle = setInterval(() => {
-      this.tick().catch((err) => {
-        this.opts.logger.error({ err }, 'BacklogHeartbeat: unhandled error in tick');
-      });
+      if (this.tickInFlight) {
+        this.opts.logger.warn('BacklogHeartbeat: previous tick still in flight — skipping this interval');
+        return;
+      }
+      this.tickInFlight = true;
+      this.tick()
+        .catch((err) => {
+          this.opts.logger.error({ err }, 'BacklogHeartbeat: unhandled error in tick');
+        })
+        .finally(() => {
+          this.tickInFlight = false;
+        });
     }, ms);
     this.opts.logger.info({ intervalMinutes: this.opts.intervalMinutes }, 'BacklogHeartbeat started');
   }

--- a/src/scheduler/backlog-heartbeat.ts
+++ b/src/scheduler/backlog-heartbeat.ts
@@ -1,0 +1,72 @@
+import type { Pool } from 'pg';
+import type { Logger } from '../logger.js';
+import type { SchedulerService } from './scheduler-service.js';
+import { selectHeartbeatCandidates } from '../db/queries/tasks.js';
+
+export interface BacklogHeartbeatOptions {
+  pool: Pool;
+  logger: Logger;
+  schedulerService: SchedulerService;
+  /** Heartbeat-eligible agent names (enable_task_management: true). */
+  eligibleAgents: Set<string>;
+  intervalMinutes: number;
+  maxWakesPerTick: number;
+  idleThresholdHours: number;
+  staleWaitThresholdHours: number;
+  /** Wake target for null / non-eligible owners. Default 'coordinator'. */
+  fallbackAgentId?: string;
+}
+
+/** System-layer component: on an hourly interval, selects idle/stale tasks and
+ *  enqueues one-shot wakes routed to each owning agent. Deterministic; does no
+ *  domain reasoning. The conductor, never an instrument. */
+export class BacklogHeartbeat {
+  private intervalHandle: NodeJS.Timeout | null = null;
+
+  constructor(private readonly opts: BacklogHeartbeatOptions) {}
+
+  start(): void {
+    if (this.intervalHandle) return;
+    const ms = this.opts.intervalMinutes * 60_000;
+    this.intervalHandle = setInterval(() => {
+      this.tick().catch((err) => {
+        this.opts.logger.error({ err }, 'BacklogHeartbeat: unhandled error in tick');
+      });
+    }, ms);
+    this.opts.logger.info({ intervalMinutes: this.opts.intervalMinutes }, 'BacklogHeartbeat started');
+  }
+
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    this.opts.logger.info('BacklogHeartbeat stopped');
+  }
+
+  /** One tick: select candidates and enqueue a wake for each. Returns the number
+   *  of wakes successfully enqueued. */
+  async tick(): Promise<number> {
+    const candidates = await selectHeartbeatCandidates(this.opts.pool, {
+      eligibleAgents: [...this.opts.eligibleAgents],
+      idleThresholdHours: this.opts.idleThresholdHours,
+      staleWaitThresholdHours: this.opts.staleWaitThresholdHours,
+      maxWakes: this.opts.maxWakesPerTick,
+      fallbackAgentId: this.opts.fallbackAgentId ?? 'coordinator',
+    });
+    if (candidates.length === 0) return 0;
+
+    const runAt = new Date();
+    let enqueued = 0;
+    for (const c of candidates) {
+      try {
+        await this.opts.schedulerService.enqueueTaskWake({ taskId: c.id, agentId: c.agentId, runAt });
+        enqueued += 1;
+      } catch (err) {
+        this.opts.logger.error({ err, taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: failed to enqueue wake');
+      }
+    }
+    this.opts.logger.info({ enqueued, considered: candidates.length }, 'BacklogHeartbeat: tick complete');
+    return enqueued;
+  }
+}

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -877,6 +877,33 @@ export class SchedulerService {
     return { noOp: false, suspended: shouldSuspend, consecutiveFailures: newFailures };
   }
 
+  /** Enqueue a one-shot wake for an EXISTING task. Inserts a pending scheduled_jobs
+   *  row with task_id preset so the dispatcher routes it to `agentId` with full task
+   *  context. Used by the BacklogHeartbeat. Does not create a new task. */
+  async enqueueTaskWake(params: {
+    taskId: string;
+    agentId: string;
+    runAt: Date;
+    createdBy?: string;
+  }): Promise<{ jobId: string }> {
+    const { taskId, agentId, runAt, createdBy = 'heartbeat' } = params;
+    const { rows } = await this.pool.query(
+      `INSERT INTO scheduled_jobs
+         (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, timezone, task_id)
+       VALUES ($1, NULL, $2, $3, 'pending', $2, $4, $5, $6)
+       RETURNING id`,
+      [
+        agentId,
+        runAt,
+        JSON.stringify({ type: 'task-wake', task_id: taskId }),
+        createdBy,
+        this.timezone,
+        taskId,
+      ],
+    );
+    return { jobId: (rows[0] as { id: string }).id };
+  }
+
   /**
    * Write an agent-authored summary and optional structured context to the job's
    * last-run record. Called by the scheduler-report skill at the end of each job

--- a/tests/integration/backlog-heartbeat.test.ts
+++ b/tests/integration/backlog-heartbeat.test.ts
@@ -15,7 +15,9 @@ async function seedTask(pool: pg.Pool, o: { status: string; owner?: string; sour
      VALUES ($1,$2,'seeded',$3,'{}'::jsonb,'{}'::jsonb,$4,50,'agent',$5,'test','{}',$6) RETURNING id`,
     [o.sourceAgentId ?? 'coordinator', `${PREFIX} ${o.status}`, o.status, o.owner ?? 'curia', o.sourceAgentId ?? null, o.updatedAt],
   );
-  return (rows[0] as unknown as { id: string }).id;
+  const [row] = rows as Array<{ id: string }>;
+  if (!row) throw new Error('seedTask: INSERT INTO tasks returned no rows');
+  return row.id;
 }
 
 async function cleanup(pool: pg.Pool): Promise<void> {
@@ -33,7 +35,7 @@ describeIf('BacklogHeartbeat end-to-end', () => {
   it('enqueues exactly one pending wake per eligible agent, routed correctly', async () => {
     const hoursAgo = (h: number) => new Date(Date.now() - h * 3600_000);
     const idA = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(5) });
-    await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(6) }); // second for same agent — should NOT also wake
+    const idB = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(6) }); // second for same agent — should NOT also wake
     const idC = await seedTask(pool, { status: 'open', sourceAgentId: 'coordinator', updatedAt: hoursAgo(5) });
 
     const schedulerService = new SchedulerService(pool, { publish: vi.fn(), subscribe: vi.fn() } as never, logger, 'UTC');
@@ -58,10 +60,13 @@ describeIf('BacklogHeartbeat end-to-end', () => {
       expect(row.status).toBe('pending');
       expect(row.cron_expr).toBeNull(); // one-shot
     }
-    // The two waked tasks are idA (or its sibling) and idC; a wake exists for ceo-inbox + coordinator.
+    // One of the two ceo-inbox tasks (idA or idB) must be woken; idC must be woken.
     const wakedTaskIds = rows.map((r) => (r as unknown as { task_id: string }).task_id);
     expect(wakedTaskIds).toContain(idC);
-    expect(wakedTaskIds.some((t) => t === idA || t !== idC)).toBe(true);
+    // DISTINCT ON (effective_agent) picks the oldest ceo-inbox task — idB (6h) beats idA (5h).
+    expect(wakedTaskIds).toContain(idB);
+    // Paranoia: idA should NOT also be woken (only one wake per agent per tick).
+    expect(wakedTaskIds).not.toContain(idA);
   });
 
   it('does not re-enqueue on a second tick (pending wake dedup)', async () => {

--- a/tests/integration/backlog-heartbeat.test.ts
+++ b/tests/integration/backlog-heartbeat.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import pg from 'pg';
+import { BacklogHeartbeat } from '../../src/scheduler/backlog-heartbeat.js';
+import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+const PREFIX = 'HBE2E Test';
+
+async function seedTask(pool: pg.Pool, o: { status: string; owner?: string; sourceAgentId?: string | null; updatedAt: Date }): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO tasks (agent_id, title, intent_anchor, status, progress, error_budget, owner, priority, source, source_agent_id, created_by, tags, updated_at)
+     VALUES ($1,$2,'seeded',$3,'{}'::jsonb,'{}'::jsonb,$4,50,'agent',$5,'test','{}',$6) RETURNING id`,
+    [o.sourceAgentId ?? 'coordinator', `${PREFIX} ${o.status}`, o.status, o.owner ?? 'curia', o.sourceAgentId ?? null, o.updatedAt],
+  );
+  return (rows[0] as unknown as { id: string }).id;
+}
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(`DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`, [`${PREFIX}%`]);
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+describeIf('BacklogHeartbeat end-to-end', () => {
+  let pool: pg.Pool;
+  const logger = createSilentLogger();
+  beforeAll(async () => { pool = new Pool({ connectionString: DATABASE_URL }); });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  it('enqueues exactly one pending wake per eligible agent, routed correctly', async () => {
+    const hoursAgo = (h: number) => new Date(Date.now() - h * 3600_000);
+    const idA = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(5) });
+    await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(6) }); // second for same agent — should NOT also wake
+    const idC = await seedTask(pool, { status: 'open', sourceAgentId: 'coordinator', updatedAt: hoursAgo(5) });
+
+    const schedulerService = new SchedulerService(pool, { publish: vi.fn(), subscribe: vi.fn() } as never, logger, 'UTC');
+    const hb = new BacklogHeartbeat({
+      pool, logger, schedulerService,
+      eligibleAgents: new Set(['coordinator', 'ceo-inbox']),
+      intervalMinutes: 60, maxWakesPerTick: 5, idleThresholdHours: 4, staleWaitThresholdHours: 48,
+    });
+
+    const enqueued = await hb.tick();
+    expect(enqueued).toBe(2); // one per agent
+
+    const { rows } = await pool.query(
+      `SELECT agent_id, task_id, status, cron_expr FROM scheduled_jobs
+       WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1) ORDER BY agent_id`,
+      [`${PREFIX}%`],
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => (r as unknown as { agent_id: string }).agent_id)).toEqual(['ceo-inbox', 'coordinator']);
+    for (const r of rows) {
+      const row = r as unknown as { status: string; cron_expr: string | null; task_id: string };
+      expect(row.status).toBe('pending');
+      expect(row.cron_expr).toBeNull(); // one-shot
+    }
+    // The two waked tasks are idA (or its sibling) and idC; a wake exists for ceo-inbox + coordinator.
+    const wakedTaskIds = rows.map((r) => (r as unknown as { task_id: string }).task_id);
+    expect(wakedTaskIds).toContain(idC);
+    expect(wakedTaskIds.some((t) => t === idA || t !== idC)).toBe(true);
+  });
+
+  it('does not re-enqueue on a second tick (pending wake dedup)', async () => {
+    await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: new Date(Date.now() - 5 * 3600_000) });
+    const schedulerService = new SchedulerService(pool, { publish: vi.fn(), subscribe: vi.fn() } as never, logger, 'UTC');
+    const hb = new BacklogHeartbeat({
+      pool, logger, schedulerService,
+      eligibleAgents: new Set(['ceo-inbox']),
+      intervalMinutes: 60, maxWakesPerTick: 5, idleThresholdHours: 4, staleWaitThresholdHours: 48,
+    });
+    expect(await hb.tick()).toBe(1);
+    expect(await hb.tick()).toBe(0); // already has a pending wake
+  });
+});

--- a/tests/integration/heartbeat-selection.test.ts
+++ b/tests/integration/heartbeat-selection.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import { selectHeartbeatCandidates } from '../../src/db/queries/tasks.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'HBSel Test';
+
+/** Insert a task row directly; returns its id. `updatedAt` lets us simulate age. */
+async function seedTask(
+  pool: pg.Pool,
+  opts: {
+    title?: string;
+    status: string;
+    owner?: string;
+    sourceAgentId?: string | null;
+    blockedBy?: string | null;
+    updatedAt: Date;
+  },
+): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO tasks
+       (agent_id, title, intent_anchor, status, progress, error_budget, owner,
+        blocked_by_task_id, priority, source, source_agent_id, created_by, tags, updated_at)
+     VALUES ($1,$2,$3,$4,'{}'::jsonb,'{}'::jsonb,$5,$6,50,'agent',$7,'test','{}',$8)
+     RETURNING id`,
+    [
+      opts.sourceAgentId ?? 'coordinator',
+      `${PREFIX} ${opts.title ?? opts.status}`,
+      'seeded',
+      opts.status,
+      opts.owner ?? 'curia',
+      opts.blockedBy ?? null,
+      opts.sourceAgentId ?? null,
+      opts.updatedAt,
+    ],
+  );
+  return (rows[0] as { id: string }).id;
+}
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(`DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`, [`${PREFIX}%`]);
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+describeIf('selectHeartbeatCandidates', () => {
+  let pool: pg.Pool;
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM tasks LIMIT 0');
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  const hoursAgo = (h: number) => new Date(Date.now() - h * 3600_000);
+  const opts = { eligibleAgents: ['coordinator', 'ceo-inbox'], idleThresholdHours: 4, staleWaitThresholdHours: 48, maxWakes: 5 };
+
+  it('selects an idle, unblocked, curia-owned task older than the idle threshold', async () => {
+    const id = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(5) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).toContain(id);
+  });
+
+  it('ignores a task touched within the idle threshold', async () => {
+    await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(1) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got).toHaveLength(0);
+  });
+
+  it('excludes a task blocked by an unfinished task', async () => {
+    const blocker = await seedTask(pool, { title: 'blocker', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    await seedTask(pool, { title: 'blocked', status: 'blocked', sourceAgentId: 'ceo-inbox', blockedBy: blocker, updatedAt: hoursAgo(10) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    // only the blocker (open, idle) is eligible; the blocked child is excluded
+    expect(got.map((c) => c.id)).toEqual([blocker]);
+  });
+
+  it('includes a blocked task once its blocker is done (stale-wait path)', async () => {
+    const blocker = await seedTask(pool, { title: 'doneblocker', status: 'done', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(60) });
+    const child = await seedTask(pool, { title: 'unblocked', status: 'blocked', sourceAgentId: 'ceo-inbox', blockedBy: blocker, updatedAt: hoursAgo(60) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).toContain(child);
+  });
+
+  it('skips a task that already has a pending wake', async () => {
+    const id = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    await pool.query(
+      `INSERT INTO scheduled_jobs (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, task_id)
+       VALUES ('ceo-inbox', NULL, now(), '{}'::jsonb, 'pending', now(), 'test', $1)`,
+      [id],
+    );
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).not.toContain(id);
+  });
+
+  it('returns at most one entry per effective agent', async () => {
+    await seedTask(pool, { title: 'a', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    await seedTask(pool, { title: 'b', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(8) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.filter((c) => c.agentId === 'ceo-inbox')).toHaveLength(1);
+  });
+
+  it('routes a non-eligible / null source_agent_id to the coordinator fallback', async () => {
+    const id = await seedTask(pool, { status: 'open', sourceAgentId: null, updatedAt: hoursAgo(10) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    const row = got.find((c) => c.id === id);
+    expect(row?.agentId).toBe('coordinator');
+  });
+
+  it('does not advance a non-curia idle task (owner=ceo, open)', async () => {
+    await seedTask(pool, { status: 'open', owner: 'ceo', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got).toHaveLength(0);
+  });
+});

--- a/tests/integration/heartbeat-selection.test.ts
+++ b/tests/integration/heartbeat-selection.test.ts
@@ -42,16 +42,21 @@ async function seedTask(
   return row.id;
 }
 
-async function getAnyContactId(pool: pg.Pool): Promise<string> {
-  const { rows } = await pool.query<{ id: string }>('SELECT id FROM contacts LIMIT 1');
+async function seedContact(pool: pg.Pool): Promise<string> {
+  const { rows } = await pool.query<{ id: string }>(
+    `INSERT INTO contacts (display_name) VALUES ($1) RETURNING id`,
+    [`${PREFIX} contact`],
+  );
   const [row] = rows;
-  if (!row) throw new Error('getAnyContactId: contacts table is empty — seed a contact before running this test');
+  if (!row) throw new Error('seedContact: INSERT INTO contacts returned no rows');
   return row.id;
 }
 
 async function cleanup(pool: pg.Pool): Promise<void> {
   await pool.query(`DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`, [`${PREFIX}%`]);
+  // Delete tasks before contacts to avoid FK violation (tasks.waiting_on_contact_id → contacts.id).
   await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+  await pool.query(`DELETE FROM contacts WHERE display_name LIKE $1`, [`${PREFIX}%`]);
 }
 
 describeIf('selectHeartbeatCandidates', () => {
@@ -148,7 +153,7 @@ describeIf('selectHeartbeatCandidates', () => {
     // waiting on them — the heartbeat should not interrupt that wait.
     const id = await seedTask(pool, { status: 'waiting', owner: 'curia', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(60) });
     // Use a real contact ID to satisfy the FK constraint on waiting_on_contact_id.
-    const contactId = await getAnyContactId(pool);
+    const contactId = await seedContact(pool);
     await pool.query(`UPDATE tasks SET waiting_on_contact_id = $1 WHERE id = $2`, [contactId, id]);
     const got = await selectHeartbeatCandidates(pool, opts);
     expect(got.map((c) => c.id)).not.toContain(id);

--- a/tests/integration/heartbeat-selection.test.ts
+++ b/tests/integration/heartbeat-selection.test.ts
@@ -37,7 +37,16 @@ async function seedTask(
       opts.updatedAt,
     ],
   );
-  return (rows[0] as { id: string }).id;
+  const [row] = rows as Array<{ id: string }>;
+  if (!row) throw new Error('seedTask: INSERT INTO tasks returned no rows');
+  return row.id;
+}
+
+async function getAnyContactId(pool: pg.Pool): Promise<string> {
+  const { rows } = await pool.query<{ id: string }>('SELECT id FROM contacts LIMIT 1');
+  const [row] = rows;
+  if (!row) throw new Error('getAnyContactId: contacts table is empty — seed a contact before running this test');
+  return row.id;
 }
 
 async function cleanup(pool: pg.Pool): Promise<void> {
@@ -138,8 +147,9 @@ describeIf('selectHeartbeatCandidates', () => {
     // Tasks blocked on a specific human (waiting_on_contact_id IS NOT NULL) are genuinely
     // waiting on them — the heartbeat should not interrupt that wait.
     const id = await seedTask(pool, { status: 'waiting', owner: 'curia', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(60) });
-    // Set waiting_on_contact_id to a placeholder UUID
-    await pool.query(`UPDATE tasks SET waiting_on_contact_id = gen_random_uuid() WHERE id = $1`, [id]);
+    // Use a real contact ID to satisfy the FK constraint on waiting_on_contact_id.
+    const contactId = await getAnyContactId(pool);
+    await pool.query(`UPDATE tasks SET waiting_on_contact_id = $1 WHERE id = $2`, [contactId, id]);
     const got = await selectHeartbeatCandidates(pool, opts);
     expect(got.map((c) => c.id)).not.toContain(id);
   });

--- a/tests/integration/heartbeat-selection.test.ts
+++ b/tests/integration/heartbeat-selection.test.ts
@@ -114,4 +114,33 @@ describeIf('selectHeartbeatCandidates', () => {
     const got = await selectHeartbeatCandidates(pool, opts);
     expect(got).toHaveLength(0);
   });
+
+  it('skips a task whose scheduled_jobs row is already running (Fix 1: running dedup)', async () => {
+    const id = await seedTask(pool, { status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    await pool.query(
+      `INSERT INTO scheduled_jobs (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, task_id)
+       VALUES ('ceo-inbox', NULL, now(), '{}'::jsonb, 'running', now(), 'test', $1)`,
+      [id],
+    );
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).not.toContain(id);
+  });
+
+  it('does not wake a stale-wait task owned by ceo (Fix 2: owner scope)', async () => {
+    // A ceo-owned waiting task past the stale-wait threshold should not be selected —
+    // waking it would produce spurious agent invocations on CEO-managed work.
+    await seedTask(pool, { status: 'waiting', owner: 'ceo', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(60) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got).toHaveLength(0);
+  });
+
+  it('does not wake a stale-wait task that is waiting on a specific contact (Fix 2: contact scope)', async () => {
+    // Tasks blocked on a specific human (waiting_on_contact_id IS NOT NULL) are genuinely
+    // waiting on them — the heartbeat should not interrupt that wait.
+    const id = await seedTask(pool, { status: 'waiting', owner: 'curia', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(60) });
+    // Set waiting_on_contact_id to a placeholder UUID
+    await pool.query(`UPDATE tasks SET waiting_on_contact_id = gen_random_uuid() WHERE id = $1`, [id]);
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).not.toContain(id);
+  });
 });

--- a/tests/unit/agents/task-management.test.ts
+++ b/tests/unit/agents/task-management.test.ts
@@ -48,4 +48,9 @@ describe('applyTaskManagement', () => {
   it('exposes exactly the four task skills', () => {
     expect([...TASK_MANAGEMENT_SKILLS]).toEqual(['task-create', 'task-list', 'task-update', 'task-complete']);
   });
+
+  it('produces exactly the four task skills when starting from an empty pinned list', () => {
+    const r = applyTaskManagement(cfg({ enable_task_management: true }), 'P', []);
+    expect(r.pinnedSkills).toEqual([...TASK_MANAGEMENT_SKILLS]);
+  });
 });

--- a/tests/unit/agents/task-management.test.ts
+++ b/tests/unit/agents/task-management.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyTaskManagement,
+  TASK_MANAGEMENT_SKILLS,
+  TASK_MANAGEMENT_BLOCK,
+} from '../../../src/agents/task-management.js';
+import type { AgentYamlConfig } from '../../../src/agents/loader.js';
+
+function cfg(overrides: Partial<AgentYamlConfig> = {}): AgentYamlConfig {
+  return {
+    name: 'test-agent',
+    model: { tier: 'standard' },
+    system_prompt: 'BASE PROMPT',
+    ...overrides,
+  };
+}
+
+describe('applyTaskManagement', () => {
+  it('is a no-op when the flag is absent', () => {
+    const r = applyTaskManagement(cfg(), 'BASE PROMPT', ['a', 'b']);
+    expect(r.systemPrompt).toBe('BASE PROMPT');
+    expect(r.pinnedSkills).toEqual(['a', 'b']);
+    expect(r.heartbeatEligible).toBe(false);
+  });
+
+  it('is a no-op when the flag is explicitly false', () => {
+    const r = applyTaskManagement(cfg({ enable_task_management: false }), 'BASE PROMPT', []);
+    expect(r.systemPrompt).toBe('BASE PROMPT');
+    expect(r.pinnedSkills).toEqual([]);
+    expect(r.heartbeatEligible).toBe(false);
+  });
+
+  it('appends the block, adds the four skills, and marks eligible when true', () => {
+    const r = applyTaskManagement(cfg({ enable_task_management: true }), 'BASE PROMPT', ['x']);
+    expect(r.systemPrompt).toBe(`BASE PROMPT\n\n${TASK_MANAGEMENT_BLOCK}`);
+    expect(r.pinnedSkills).toEqual(['x', ...TASK_MANAGEMENT_SKILLS]);
+    expect(r.heartbeatEligible).toBe(true);
+  });
+
+  it('does not duplicate skills already pinned', () => {
+    const base = ['task-list', 'other'];
+    const r = applyTaskManagement(cfg({ enable_task_management: true }), 'P', base);
+    // task-list kept once, the other three appended
+    expect(r.pinnedSkills.filter((s) => s === 'task-list')).toHaveLength(1);
+    expect(r.pinnedSkills).toEqual(['task-list', 'other', 'task-create', 'task-update', 'task-complete']);
+  });
+
+  it('exposes exactly the four task skills', () => {
+    expect([...TASK_MANAGEMENT_SKILLS]).toEqual(['task-create', 'task-list', 'task-update', 'task-complete']);
+  });
+});

--- a/tests/unit/config-tasks.test.ts
+++ b/tests/unit/config-tasks.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTasksConfig, DEFAULT_TASKS_CONFIG } from '../../src/config.js';
+
+describe('resolveTasksConfig', () => {
+  it('returns defaults when no tasks block is present', () => {
+    expect(resolveTasksConfig(undefined)).toEqual(DEFAULT_TASKS_CONFIG);
+  });
+
+  it('defaults are 60 / 5 / 4 / 48', () => {
+    expect(DEFAULT_TASKS_CONFIG).toEqual({
+      heartbeatIntervalMinutes: 60,
+      heartbeatMaxWakesPerTick: 5,
+      idleThresholdHours: 4,
+      staleWaitThresholdHours: 48,
+    });
+  });
+
+  it('overrides only the provided keys', () => {
+    expect(resolveTasksConfig({ idleThresholdHours: 2 })).toEqual({
+      heartbeatIntervalMinutes: 60,
+      heartbeatMaxWakesPerTick: 5,
+      idleThresholdHours: 2,
+      staleWaitThresholdHours: 48,
+    });
+  });
+});

--- a/tests/unit/scheduler/backlog-heartbeat.test.ts
+++ b/tests/unit/scheduler/backlog-heartbeat.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BacklogHeartbeat } from '../../../src/scheduler/backlog-heartbeat.js';
+import * as tasksQueries from '../../../src/db/queries/tasks.js';
+
+function mockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() };
+}
+
+function makeHeartbeat(overrides: Partial<ConstructorParameters<typeof BacklogHeartbeat>[0]> = {}) {
+  const enqueueTaskWake = vi.fn().mockResolvedValue({ jobId: 'job-x' });
+  const schedulerService = { enqueueTaskWake } as never;
+  const pool = { query: vi.fn() } as never;
+  const hb = new BacklogHeartbeat({
+    pool,
+    logger: mockLogger() as never,
+    schedulerService,
+    eligibleAgents: new Set(['coordinator', 'ceo-inbox']),
+    intervalMinutes: 60,
+    maxWakesPerTick: 5,
+    idleThresholdHours: 4,
+    staleWaitThresholdHours: 48,
+    ...overrides,
+  });
+  return { hb, enqueueTaskWake };
+}
+
+describe('BacklogHeartbeat.tick', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('enqueues one wake per selected candidate and returns the count', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([
+      { id: 't1', agentId: 'ceo-inbox' },
+      { id: 't2', agentId: 'coordinator' },
+    ]);
+    const { hb, enqueueTaskWake } = makeHeartbeat();
+    const count = await hb.tick();
+    expect(count).toBe(2);
+    expect(enqueueTaskWake).toHaveBeenCalledTimes(2);
+    expect(enqueueTaskWake).toHaveBeenCalledWith(expect.objectContaining({ taskId: 't1', agentId: 'ceo-inbox' }));
+    expect(enqueueTaskWake).toHaveBeenCalledWith(expect.objectContaining({ taskId: 't2', agentId: 'coordinator' }));
+  });
+
+  it('passes config thresholds and the eligible-agents list to the selector', async () => {
+    const spy = vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([]);
+    const { hb } = makeHeartbeat();
+    await hb.tick();
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eligibleAgents: ['coordinator', 'ceo-inbox'],
+        idleThresholdHours: 4,
+        staleWaitThresholdHours: 48,
+        maxWakes: 5,
+      }),
+    );
+  });
+
+  it('continues after a single enqueue failure', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([
+      { id: 't1', agentId: 'ceo-inbox' },
+      { id: 't2', agentId: 'coordinator' },
+    ]);
+    const { hb, enqueueTaskWake } = makeHeartbeat();
+    enqueueTaskWake.mockRejectedValueOnce(new Error('db blip'));
+    const count = await hb.tick();
+    expect(count).toBe(1); // second succeeds despite first failing
+    expect(enqueueTaskWake).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('BacklogHeartbeat start/stop', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('ticks on the configured interval and stops cleanly', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([]);
+    const { hb } = makeHeartbeat({ intervalMinutes: 60 });
+    hb.start();
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    expect(tasksQueries.selectHeartbeatCandidates).toHaveBeenCalledTimes(1);
+    hb.stop();
+    await vi.advanceTimersByTimeAsync(60 * 60_000 * 3);
+    expect(tasksQueries.selectHeartbeatCandidates).toHaveBeenCalledTimes(1); // no more after stop
+  });
+});

--- a/tests/unit/scheduler/enqueue-task-wake.test.ts
+++ b/tests/unit/scheduler/enqueue-task-wake.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SchedulerService } from '../../../src/scheduler/scheduler-service.js';
+
+function mockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() };
+}
+
+describe('SchedulerService.enqueueTaskWake', () => {
+  it('inserts a one-shot pending scheduled_jobs row carrying the existing task_id', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rows: [{ id: 'job-9' }] }) };
+    const bus = { publish: vi.fn(), subscribe: vi.fn() };
+    const svc = new SchedulerService(
+      pool as unknown as import('pg').Pool,
+      bus as never,
+      mockLogger() as never,
+      'America/Toronto',
+    );
+
+    const runAt = new Date('2026-06-04T12:00:00Z');
+    const result = await svc.enqueueTaskWake({ taskId: 'task-7', agentId: 'ceo-inbox', runAt });
+
+    expect(result.jobId).toBe('job-9');
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/INSERT INTO scheduled_jobs/i);
+    expect(sql).toMatch(/task_id/);
+    // status pending, one-shot (cron NULL), task_id = the EXISTING task
+    expect(params).toContain('task-7');
+    expect(params).toContain('ceo-inbox');
+    expect(params).toContain(runAt);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- **`enable_task_management` agent flag** — set `enable_task_management: true` in an agent YAML to auto-pin the four task skills (`task-create`, `task-list`, `task-update`, `task-complete`), inject an advance-until-blocked executor discipline block into the system prompt, and register the agent as heartbeat-eligible. Single source of truth in `src/agents/task-management.ts`.
- **`BacklogHeartbeat`** — hourly system-layer component that selects idle/stale tasks with no active scheduled job and enqueues one wake per eligible agent, capped by `tasks.heartbeatMaxWakesPerTick`. Pure router: no LLM reasoning, no new tasks. One candidate per agent per tick to prevent burst spend.
- **Coordinator canary** — coordinator gets `enable_task_management: true` + `error_budget: { max_turns: 40, max_cost_usd: 1.00 }` as the first real-world test of the pattern.
- **`tasks` config block** — new `config/default.yaml` section with `heartbeatIntervalMinutes: 60`, `heartbeatMaxWakesPerTick: 5`, `idleThresholdHours: 4`, `staleWaitThresholdHours: 48`. Validated at startup.

Closes #886

Foundation for #840 — ceo-inbox NEEDS DRAFT reification, resume mode, and overflow load-shedding follow in the next PR

## Design

Full spec: `docs/wip/2026-06-04-task-execution-heartbeat-design.md`  
Implementation plan: `docs/wip/2026-06-04-task-exec-heartbeat-foundation.md`

Key invariants:
- One wake per eligible agent per tick (prevents execution bursts)
- `NOT EXISTS` guard against `pending`/`running` `scheduled_jobs` rows (dedup)
- `owner = 'curia'` scoping on all candidate paths (never wakes CEO-owned or external tasks)
- `blocked_by_task_id` exclusion (blocker must be `done`/`cancelled` first)
- No new migrations — heartbeat writes `scheduled_jobs` rows pointing at existing `tasks`

## Test Plan

- [ ] Unit: `task-management.test.ts` — 6 tests covering no-op path, skill dedup, block injection, heartbeatEligible flag
- [ ] Unit: `config-tasks.test.ts` — defaults, env override, validation rejection
- [ ] Unit: `enqueue-task-wake.test.ts` — inserts `scheduled_jobs` row with correct `task_id`
- [ ] Unit: `backlog-heartbeat.test.ts` — 4 tests: empty candidates, successful tick, partial failure, zero-enqueue error log
- [ ] Integration (requires DATABASE_URL): `heartbeat-selection.test.ts` — 11 scenarios including dedup, blocked_by, owner scoping; `backlog-heartbeat.test.ts` — end-to-end tick + DB verification
- [ ] CI green on unit suite (245 passing; 2 pre-existing failures require DATABASE_URL)


___

## **CodeAnt-AI Description**
**Add task-management support and hourly task wake-ups**

### What Changed
- Agents can now opt into task management with a single flag that auto-adds the four task skills, appends the shared task-management guidance to the system prompt, and marks the agent as eligible for heartbeat wakes.
- A new hourly heartbeat finds idle or long-waiting tasks, skips tasks that already have a wake scheduled, and enqueues a one-shot wake for each eligible agent with a cap per tick.
- The coordinator is switched to the new task-management mode, its manual task skill pins are removed, and it now has a bounded execution budget.
- New config defaults, schema support, and tests cover the new flag, heartbeat selection, enqueueing, and end-to-end wake flow.

### Impact
`✅ Fewer stuck tasks`
`✅ Faster task resumption after idle periods`
`✅ Safer coordinator task bursts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task management capability: agents can auto-manage task skills and participate in deterministic task resumption.
  * BacklogHeartbeat: periodic system process that wakes idle or stalled tasks (capped per tick).

* **Changed**
  * Coordinator configuration bumped and now routes task management via the new capability and enforces a bounded error budget for bursts.
  * New configurable task parameters for heartbeat cadence, idle/stale thresholds and per-tick wake limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

