### PR TITLE
feat(ceo-inbox): join task system — reification, resume mode, overflow shedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Changed
-- **`ceo-inbox`** — joins the task system (`enable_task_management: true`): reification in the NEEDS DRAFT path prevents bare forward commitments without a backing task; resume mode drafts the complete reply when a deferred follow-up task wakes; overflow load-shedding above 10 unread defers the tail as `inbox-overflow` tasks so LLM time per burst no longer scales linearly. (#840, design 2026-06-04 §8)
-
 ### Added
 - **`enable_task_management`** — declarative agent capability that auto-pins the task skills, injects the executor/reification discipline block, and marks an agent heartbeat-eligible. (design 2026-06-04 §6)
 - **`BacklogHeartbeat`** — deterministic hourly System component that wakes idle/stale tasks by enqueuing one-shot scheduler jobs, one per owning agent, globally capped. (design 2026-06-04 §3)
 
 ### Changed
+- **`ceo-inbox`** — joins the task system (`enable_task_management: true`): reification in the NEEDS DRAFT path prevents bare forward commitments without a backing task; resume mode drafts the complete reply when a deferred follow-up task wakes; overflow load-shedding above 10 unread defers the tail as `inbox-overflow` tasks so LLM time per burst no longer scales linearly. (#840, design 2026-06-04 §8)
 - **coordinator** — task management now arrives via `enable_task_management: true` (replacing manual `task-*` pins); added a bounded `error_budget` for project bursts.
 - **coordinator** — replaced the `intent_anchor`-for-cron-jobs instruction with the new task/scheduling split: `task-create` for deferred CEO-visible work, `scheduler-create` (no `intent_anchor`) for operational sweeps. Adds backlog-awareness and defer-don't-drop rules. (#)
 - **`meeting-debrief`** — migrated from bespoke `pendingDebriefs`/`judgedEvents` state maps to platform tasks; detection now runs 3×/day and pre-schedules a per-meeting debrief task driven by wake-ups. (#839)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+- **`ceo-inbox`** — joins the task system (`enable_task_management: true`): reification in the NEEDS DRAFT path prevents bare forward commitments without a backing task; resume mode drafts the complete reply when a deferred follow-up task wakes; overflow load-shedding above 10 unread defers the tail as `inbox-overflow` tasks so LLM time per burst no longer scales linearly. (#840, design 2026-06-04 §8)
+
 ### Added
 - **`enable_task_management`** — declarative agent capability that auto-pins the task skills, injects the executor/reification discipline block, and marks an agent heartbeat-eligible. (design 2026-06-04 §6)
 - **`BacklogHeartbeat`** — deterministic hourly System component that wakes idle/stale tasks by enqueuing one-shot scheduler jobs, one per owning agent, globally capped. (design 2026-06-04 §3)

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.3.0"
+version: "0.4.0"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -38,6 +38,7 @@ pinned_skills:
   - scheduler-report
 
 allow_discovery: false
+enable_task_management: true
 
 memory:
   scopes: [ceo-inbox]
@@ -68,6 +69,22 @@ system_prompt: |
   an email from Jim", "draft a new email to alice@example.com about the
   partnership"), handle that request directly using your pinned skills.
   Do NOT run the triage protocol. Respond to the specific request and return.
+
+  **Resume mode** (woken by the scheduler to advance a deferred follow-up task):
+  If you receive a scheduled wake that includes a task id, title, and progress
+  notes in the context, you are resuming a deferred follow-up. Do NOT run the
+  full triage protocol. Instead:
+  1. Read the task's progress notes to identify the original email thread and the
+     outstanding dependency (e.g. a document the CEO needs to send, a piece of
+     information that was unavailable).
+  2. Search the inbox for the dependency or any relevant update using
+     ceo-inbox-search.
+  3. If the dependency is now available: draft the complete reply using the voice
+     profile (call executive-profile-get) and the NEEDS DRAFT drafting rules.
+     Then call task-complete with a brief completion note.
+  4. If the dependency is still unavailable: update the task status to 'waiting'
+     via task-update, add a progress note, and set a new wake_at if appropriate.
+     Do not re-send an interim acknowledgment; the original was already sent.
 
   **Composing a new email (cold outreach):** When the coordinator asks you to
   draft a new email to someone (not a reply to an existing thread), use
@@ -215,7 +232,35 @@ system_prompt: |
   - received_after_hours: 24
 
   If the count is 0, skip to step 6 (save the high-water mark).
-  If there are messages, process each one oldest-first.
+
+  **Overflow check (> 10 unread):** If the list returns more than 10 unread
+  messages, you are in overflow mode and must shed load before triaging:
+
+  1. Identify the top 5 messages by urgency using subject, sender, and snippet
+     alone (do not read full bodies at this stage). Prefer apparent URGENT
+     candidates (time-sensitive asks from known contacts), then ACTIONABLE, then
+     NEEDS DRAFT, then others. Within a tier, prefer older messages.
+  2. Process only those top 5 through the full triage protocol (steps 4-6).
+  3. For each remaining message beyond the top 5 (oldest first), create a
+     deferred inbox-overflow task, then mark it as read so it does not
+     re-appear in the next run:
+     - Call task-create with:
+       - title: "<sender name>: <subject>" (one line from the list output)
+       - description: one short sentence summarizing what the email is about
+       - owner: 'ceo'
+       - tags: ['inbox-overflow']
+       - priority: 0-100 based on urgency signals from subject and snippet
+     - Call ceo-inbox-mark-read with the message_id.
+     - Call config-store to save the high-water mark for this message (same
+       step 6 logic as for fully processed messages, so the window advances).
+  4. After handling all overflow messages, proceed to step 4 to triage the
+     top 5 only.
+
+  LLM time per burst must not scale linearly past 10 — if the inbox grows to
+  50 unread, you process 5 inline and create 45 tasks. The CEO sees the deferred
+  items in the next digest's "For you to do" section.
+
+  If the count is ≤ 10, process each message oldest-first (no change).
 
   ## Step 4: For each message, triage
 
@@ -315,6 +360,39 @@ system_prompt: |
       is unavailable, treat it as no match: acknowledge the gap naturally or
       omit the factual claim — do not fabricate details. You may call
       memory-query zero or more times per email.
+    - **Reification check.** Before drafting any reply that would contain a
+      forward commitment ("I'll follow up with the document", "we'll get that
+      to you", "the CEO will send X"):
+
+      1. Try to resolve the dependency now. Search the inbox using
+         ceo-inbox-search, check referenced attachments, or review the thread.
+         If you find it, draft a complete reply with no forward promise —
+         this is the preferred outcome.
+
+      2. If the dependency is not available, decide who can obtain it:
+
+         - **Curia can chase it** (it lives in another thread, another inbox
+           tool, or can be retrieved by a specialist): draft an interim
+           acknowledgment that says "I'll get that to you" — not "the CEO
+           will follow up". Then call task-create:
+           - owner: 'curia'
+           - tags: ['inbox-follow-up']
+           - description: the email thread context and what is needed
+           - wake_at: a reasonable deadline (e.g. 24h)
+
+         - **Only the CEO can provide it** (the CEO's personal content, a
+           decision only the CEO can make, the CEO's own document): draft an
+           interim acknowledgment. Then call task-create:
+           - owner: 'ceo'
+           - tags: ['inbox-follow-up']
+           - description: the email thread context and what the CEO needs to do
+           In the Response Format, note the pending CEO action so it surfaces
+           in the next digest.
+
+      3. A bare "the CEO will follow up with [X]" draft is **not permitted**
+         unless a backing task has been created via step 2 above. This
+         invariant is non-negotiable: never send a promise without a task.
+
     - Before drafting, evaluate these conditions and classify as LEAVE FOR CEO if any apply:
         1. More than 10 CC recipients on the thread — do not draft, too wide a distribution.
         2. Negotiation terms, salary, legal, or personal health content — classify as LEAVE FOR CEO.
@@ -444,8 +522,9 @@ system_prompt: |
     ceo-inbox-archive with the message_id.
   - **NEEDS DRAFT**: Execute the full NEEDS DRAFT procedure from step 4e
     (read full message, check for prior replies, memory-query for context,
-    evaluate LEAVE FOR CEO guard conditions, then draft using voice profile
-    and scheduling rules). Call ceo-inbox-archive with the message_id.
+    reification check, evaluate LEAVE FOR CEO guard conditions, then draft
+    using voice profile and scheduling rules). Call ceo-inbox-archive with
+    the message_id.
   - **LEAVE FOR CEO**: No action. Do not archive, draft, or notify.
   - **NOISE**: Call ceo-inbox-archive with the message_id.
 
@@ -458,6 +537,9 @@ system_prompt: |
   with the message_id after processing. This keeps the CEO's unread count
   clean. Do NOT mark LEAVE FOR CEO or URGENT messages as read — the CEO
   may use unread status as their own tracking.
+
+  Note: overflow-deferred messages are already marked read during the step 3
+  overflow loop — do not mark them again here.
 
   ## Step 6: Save the high-water mark
 
@@ -499,6 +581,8 @@ system_prompt: |
     Decision tagging: ON | OFF
     Rules loaded: N active (M total)
     Rules applied: N matches across all messages
+    Overflow tasks created: N (omit line if 0)
+    Follow-up tasks created: N — owner=curia|ceo (omit line if 0)
 
   ## Date Verification
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -561,6 +561,12 @@ system_prompt: |
   - key: last_processed_at
   - value: <the message's date timestamp from ceo-inbox-list, as a string>
 
+  **Monotonicity guard:** Only store the new value if it is strictly greater than
+  the currently-stored value. Never let last_processed_at move backwards —
+  overflow messages are processed oldest-first and urgency-ranked top-5 may be
+  older than overflow tail messages, so a naïve per-message write can regress
+  the window and cause re-triage of already-handled messages on the next run.
+
   This ensures that if the run is interrupted mid-batch, the next run
   resumes from where you left off instead of re-processing messages
   that already received drafts or actions.

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -78,12 +78,17 @@ system_prompt: |
      outstanding dependency (e.g. a document the CEO needs to send, a piece of
      information that was unavailable).
   2. Search the inbox for the dependency or any relevant update using
-     ceo-inbox-search.
+     ceo-inbox-search. If ceo-inbox-search fails, call task-update to set status
+     'waiting', add a progress note ("Search failed; retrying"), and set a new
+     wake_at (e.g. 24h). Do not draft. Exit.
   3. If the dependency is now available: draft the complete reply using the voice
      profile (call executive-profile-get) and the NEEDS DRAFT drafting rules.
-     Then call task-complete with a brief completion note.
-  4. If the dependency is still unavailable: update the task status to 'waiting'
-     via task-update, add a progress note, and set a new wake_at if appropriate.
+     Then call task-complete with a brief completion note. If task-complete fails,
+     log it in the Response Format ("task-complete FAILED — draft was saved but
+     task remains open") and do not retry; the draft is already created.
+  4. If the dependency is still unavailable: call task-update to set status
+     'waiting', add a progress note, and set a new wake_at. If task-update fails,
+     log it in the Response Format ("task-update FAILED — task may be stale").
      Do not re-send an interim acknowledgment; the original was already sent.
 
   **Composing a new email (cold outreach):** When the coordinator asks you to
@@ -250,6 +255,11 @@ system_prompt: |
        - owner: 'ceo'
        - tags: ['inbox-overflow']
        - priority: 0-100 based on urgency signals from subject and snippet
+     - If task-create fails: do NOT call ceo-inbox-mark-read and do NOT
+       advance the HWM for this message. Log the failure:
+         Overflow task FAILED for "<sender>: <subject>" — <error>
+       The message will remain unread and be re-evaluated on the next run.
+       Continue to the next overflow message.
      - Call ceo-inbox-mark-read with the message_id.
      - Call config-store to save the high-water mark for this message (same
        step 6 logic as for fully processed messages, so the window advances).
@@ -360,42 +370,43 @@ system_prompt: |
       is unavailable, treat it as no match: acknowledge the gap naturally or
       omit the factual claim — do not fabricate details. You may call
       memory-query zero or more times per email.
-    - **Reification check.** Before drafting any reply that would contain a
-      forward commitment ("I'll follow up with the document", "we'll get that
-      to you", "the CEO will send X"):
-
-      1. Try to resolve the dependency now. Search the inbox using
-         ceo-inbox-search, check referenced attachments, or review the thread.
-         If you find it, draft a complete reply with no forward promise —
-         this is the preferred outcome.
-
-      2. If the dependency is not available, decide who can obtain it:
-
-         - **Curia can chase it** (it lives in another thread, another inbox
-           tool, or can be retrieved by a specialist): draft an interim
-           acknowledgment that says "I'll get that to you" — not "the CEO
-           will follow up". Then call task-create:
-           - owner: 'curia'
-           - tags: ['inbox-follow-up']
-           - description: the email thread context and what is needed
-           - wake_at: a reasonable deadline (e.g. 24h)
-
-         - **Only the CEO can provide it** (the CEO's personal content, a
-           decision only the CEO can make, the CEO's own document): draft an
-           interim acknowledgment. Then call task-create:
-           - owner: 'ceo'
-           - tags: ['inbox-follow-up']
-           - description: the email thread context and what the CEO needs to do
-           In the Response Format, note the pending CEO action so it surfaces
-           in the next digest.
-
-      3. A bare "the CEO will follow up with [X]" draft is **not permitted**
-         unless a backing task has been created via step 2 above. This
-         invariant is non-negotiable: never send a promise without a task.
-
     - Before drafting, evaluate these conditions and classify as LEAVE FOR CEO if any apply:
         1. More than 10 CC recipients on the thread — do not draft, too wide a distribution.
         2. Negotiation terms, salary, legal, or personal health content — classify as LEAVE FOR CEO.
+    - **Reification check.** Only reached if the message survived the LEAVE FOR CEO
+      guard above. Before drafting any reply that would contain a forward commitment
+      ("I'll follow up with the document", "we'll get that to you", "the CEO will
+      send X"):
+
+      1. Try to resolve the dependency now. Search the inbox using ceo-inbox-search,
+         check referenced attachments, or review the thread. If you find it, draft a
+         complete reply with no forward promise — this is the preferred outcome.
+         Skip steps 2-3 below.
+
+      2. If the dependency is not available, decide who can obtain it, then call
+         task-create:
+
+         - **Curia can chase it** (it lives in another thread, another inbox
+           tool, or can be retrieved by a specialist): call task-create with
+           `owner='curia'`, `tags=['inbox-follow-up']`, a description containing
+           the email thread context and what is needed, and `wake_at` set to a
+           reasonable deadline (e.g. 24h). If task-create succeeds, draft an
+           interim acknowledgment that says "I'll get that to you" — not "the
+           CEO will follow up".
+
+         - **Only the CEO can provide it** (the CEO's personal content, a decision
+           only the CEO can make, the CEO's own document): call task-create with
+           `owner='ceo'`, `tags=['inbox-follow-up']`, and a description containing
+           what the CEO needs to do. If task-create succeeds, draft an interim
+           acknowledgment. Note the pending CEO action in the Response Format.
+
+      3. **task-create failure:** If task-create fails, you must NOT draft the
+         interim acknowledgment. A promise must never be sent without a backing
+         task. Instead, reclassify this message as LEAVE FOR CEO. Log the failure:
+           Reification task FAILED for <subject> — <error>
+           Message reclassified to LEAVE FOR CEO (promise cannot be backed).
+         Do not archive. The CEO will handle it manually.
+
     - Call ceo-inbox-draft-reply with reply_to_message_id and body.
     - The skill automatically builds a reply-all recipient list (original sender in To,
       everyone else in CC, minus the CEO's own address). The returned { to, cc } shows
@@ -522,7 +533,7 @@ system_prompt: |
     ceo-inbox-archive with the message_id.
   - **NEEDS DRAFT**: Execute the full NEEDS DRAFT procedure from step 4e
     (read full message, check for prior replies, memory-query for context,
-    reification check, evaluate LEAVE FOR CEO guard conditions, then draft
+    evaluate LEAVE FOR CEO guard conditions, reification check, then draft
     using voice profile and scheduling rules). Call ceo-inbox-archive with
     the message_id.
   - **LEAVE FOR CEO**: No action. Do not archive, draft, or notify.


### PR DESCRIPTION
## **User description**
## Summary

Closes #840

- **`enable_task_management: true`** on `ceo-inbox` — auto-pins the four `task-*` skills and injects the executor-discipline block. Closes the dangling-commitment failure mode.
- **Reification in NEEDS DRAFT** — before drafting any forward commitment, the agent first tries to resolve the dependency; falls back to creating a backing `task-create` call (`owner=curia` or `owner=ceo`) before sending an interim ack. Sending a bare "CEO will follow up" without a backing task is explicitly blocked; if `task-create` fails the message is reclassified to LEAVE FOR CEO.
- **Resume mode** — when the scheduler wakes ceo-inbox for a deferred follow-up task, it searches the inbox for the now-available dependency and drafts the complete reply, then calls `task-complete`. Failure handling on each step prevents infinite retry loops.
- **Overflow load-shedding** — above 10 unread, the top 5 by urgency are triaged inline; the rest are deferred as `inbox-overflow` tasks (`owner=ceo`) so LLM time per burst no longer scales linearly. `task-create` failure in the overflow loop preserves the message as unread for the next run (no silent loss).

Design: `docs/wip/2026-06-04-task-execution-heartbeat-design.md` §8, §11 item 4.

## Files changed

- `agents/ceo-inbox.yaml` — version bump `0.3.0 → 0.4.0`, `enable_task_management: true`, prompt additions for resume mode, overflow, and reification
- `CHANGELOG.md` — `[Unreleased]` → Changed entry

## Test plan

- [ ] Typecheck passes (`pnpm run typecheck`)
- [ ] Existing unit tests green (`pnpm test` — 3108 pass, 2 pre-existing DB integration failures unrelated to this change)
- [ ] Smoke: inbound email requesting a document Curia lacks → no bare "CEO will follow up" without a backing task
- [ ] Smoke: > 10 unread in staging → top 5 triaged inline, rest appear as `inbox-overflow` tasks in next digest
- [ ] Smoke: follow-up task wakes ceo-inbox → complete reply drafted and task closed


___

## **CodeAnt-AI Description**
Join the CEO inbox agent to the task system for follow-ups, deferred replies, and overflow handling

### What Changed
- The CEO inbox now creates backing tasks before sending any reply that would otherwise make an unbacked promise, so it no longer sends a bare “we’ll follow up” message.
- When a deferred follow-up task wakes the agent, it now searches for the missing information, drafts the full reply if it is available, and closes the task; if the search or task update fails, it records the failure and waits for a later retry instead of looping.
- When unread mail grows past 10, the agent now handles only the 5 most urgent messages immediately and turns the rest into deferred overflow tasks, keeping the inbox from slowing down as unread volume rises.
- If overflow task creation fails, the message stays unread for the next run instead of being silently skipped.

### Impact
`✅ Fewer unanswered follow-ups`
`✅ Fewer broken reply promises`
`✅ Faster inbox triage during email bursts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 0.4.0

* **New Features**
  * Task management is now enabled for improved workflow handling.
  * Resume mode automatically advances deferred follow-up tasks when dependencies become available.
  * Inbox overflow mode activates when more than 10 unread messages are present, prioritizing top items and deferring the rest as tasks.
  * Enhanced reification checks prevent commitments unless proper dependencies can be resolved, with automatic task creation when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->