### PR TITLE
docs: spec 19 (Tasks & Backlog) + v0.33 spec refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **SBOM generation** — SPDX JSON Software Bill of Materials generated on every push to `main` and attached to each GitHub release as a release asset; failure is non-fatal. (#564)
 - **`drive-download-file`** — new skill that downloads a Google Drive file (native or Google-native export) to TempFileStore and returns a `file://` URL, enabling Drive files to be attached to outbound emails. Closes #857.
 - **`pending-actions-digest`** — daily digest now surfaces the task backlog: for-you-to-do, waiting-on-others, and what-I'm-working-on. (#838)
+- **Spec 19 — Tasks & Backlog** — new consolidated spec for the `tasks` table, `task-*` skills, `enable_task_management`, the BacklogHeartbeat, and digest backlog sections. Specs 02/04/07/08/09/17 and the `adding-an-agent` dev guide updated for the `agent_tasks → tasks` rename, canonical contact attributes, and outbound email attachments.
 
 ### Changed
 - **Console tasks view** — updated to match the migrated `tasks` schema: drops `scheduled_job_id`, adds all new columns (`title`, `owner`, `priority`, `due_at`, `source`, `tags`, `description`, FK references), extends status filters with new task-lifecycle values, and updates the scheduled-jobs view to display the linked `task_id`. (#869)

--- a/docs/dev/adding-an-agent.md
+++ b/docs/dev/adding-an-agent.md
@@ -65,6 +65,10 @@ allow_discovery: true          # if true, agent can search the skill registry at
                                # "normal" sensitivity skills auto-approve; "elevated" ones
                                # require one-time human approval per agent-skill pair
 
+enable_task_management: false  # if true, auto-pins the task-* skills, injects the
+                               # task-management discipline block, and makes the agent
+                               # heartbeat-eligible (see the field reference below)
+
 # ------------------------------------------------------------------
 # Memory (optional)
 # ------------------------------------------------------------------
@@ -137,7 +141,7 @@ The LLM instructions for this agent. Written in plain text. Key points:
 
 - The runtime injects additional context automatically (current date/time, autonomy band, memory context) — you do not need to add boilerplate for these
 - The Coordinator's system prompt uses `${office_identity_block}` to receive the compiled identity (name, tone, constraints, etc.) from `OfficeIdentityService`. Specialist agents do not need this — identity is a Coordinator concern.
-- Write for a single-turn task frame. For persistent tasks, the `intent_anchor` is injected separately to prevent drift.
+- Write for a single-turn task frame. For deferred or multi-step work, use the task system (`enable_task_management`, see below and [spec 19](../specs/19-tasks-and-backlog.md)) — `task-create` for CEO-visible work, `scheduler-create` for operational sweeps. When a task wakes the agent, its `intent_anchor`, title, and progress are supplied as context so the agent resumes where it left off.
 
 ### `pinned_skills` (optional)
 
@@ -156,9 +160,10 @@ Current built-in skills include (see `skills/` for the full list):
 
 | Category | Skills |
 |---|---|
-| **Email** | `email-send`, `email-reply` |
+| **Email** | `email-send`, `email-reply` (both accept `attachments`); `drive-download-file` (fetch a Drive file to a `file://` URL for attaching) |
+| **Tasks** | `task-create`, `task-list`, `task-update`, `task-complete` — usually auto-pinned via `enable_task_management` (see below); see [spec 19](../specs/19-tasks-and-backlog.md) |
 | **Calendar** | `calendar-list-events`, `calendar-create-event`, `calendar-update-event`, `calendar-delete-event`, `calendar-find-free-time`, `calendar-check-conflicts`, `calendar-list-calendars`, `calendar-register` |
-| **Contacts** | `contact-lookup`, `contact-create`, `contact-list`, `contact-link-identity`, `contact-unlink-identity`, `contact-set-role`, `contact-grant-permission`, `contact-revoke-permission` |
+| **Contacts** | `contact-lookup`, `contact-create`, `contact-list`, `contact-update` (canonical attributes), `contact-link-identity`, `contact-unlink-identity`, `contact-set-role`, `contact-grant-permission`, `contact-revoke-permission` |
 | **Web** | `web-fetch`, `web-search`, `web-browser` |
 | **Scheduling** | `scheduler-create`, `scheduler-list`, `scheduler-cancel` |
 | **Delegation** | `delegate` |
@@ -166,6 +171,8 @@ Current built-in skills include (see `skills/` for the full list):
 | **Context** | `entity-context`, `context-for-email`, `held-messages-list`, `held-messages-process` |
 | **Templates** | `template-doc-request` |
 | **Config** | `config-store` — generic key-value agent config; namespace-scoped, KG-backed, permanent decay |
+
+This table is hand-maintained — run `ls skills/` for the authoritative current set.
 
 #### Using `config-store` for persistent agent config
 
@@ -216,6 +223,26 @@ When `true`, the agent can call the skill registry at runtime to find and reques
 - `sensitivity: "elevated"` skills → requires one-time human approval per agent-skill pair, persisted in `skill_approvals` table
 
 Turn this on for general-purpose agents (like the Coordinator) that may encounter novel tasks. Keep it `false` for focused specialist agents to prevent scope creep.
+
+### `enable_task_management` (optional, default: `false`)
+
+A single declarative capability flag that bundles the platform task system onto an agent.
+When `true`, the runtime:
+
+1. **Auto-pins** `task-create`, `task-list`, `task-update`, `task-complete` (merged and
+   deduped with your explicit `pinned_skills` — you do not list them yourself).
+2. **Auto-injects** the shared `task-management` discipline block (the advance-until-blocked
+   loop, the no-dangling-commitment invariant, and the project-decomposition rule) at a
+   fixed slot in the effective system prompt. The block is platform code, so every enabled
+   agent gets the identical, current rules.
+3. **Marks the agent heartbeat-eligible** — the `BacklogHeartbeat` only wakes agents that
+   have this flag set.
+
+Enable it on agents that uncover deferrable, multi-step work (the Coordinator and
+`ceo-inbox` ship with it on). Leave it `false` for pure act-and-return specialists. An agent
+that needs only read-only `task-list` access can still pin that one skill manually without
+the flag — it just won't be heartbeat-eligible or get the injected block. See
+[spec 19 — Tasks & Backlog](../specs/19-tasks-and-backlog.md) for the full design.
 
 ### `memory` (optional)
 

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -16,7 +16,7 @@
 | 06 | [Audit & Security](06-audit-and-security.md) | Audit log, redaction, tool sanitization, intent drift, security | 25 of 27 Done |
 | 07 | [Scheduler](07-scheduler.md) | Job model, cron, one-shot, persistent tasks, burst execution, stale-job cleanup | 21 of 22 Done |
 | 08 | [Operations](08-operations.md) | Config, deployment, health checks, logging, project structure, container security | 17 of 18 Done |
-| 09 | [Contacts & Identity](09-contacts-and-identity.md) | Contact resolution, identity verification, unknown sender policy, authorization, channel identity linking | 12 of 17 Done |
+| 09 | [Contacts & Identity](09-contacts-and-identity.md) | Contact resolution, identity verification, unknown sender policy, authorization, channel identity linking, canonical attributes | 12 of 17 Done |
 | 10 | [Audit Log Hardening](10-audit-log-hardening.md) | Structured audit fields, LLM provenance, tamper evidence, source attribution, HITL records | 2 of 17 Done |
 | 11 | [Entity Context Enrichment](11-entity-context-enrichment.md) | Entity model, KG-backed sender/entity profiles, context assembly, agent self-identity, skill convention, delegation-aware outbound context bridge | 23 of 30 Done |
 | 12 | [Knowledge Graph Web Explorer](12-knowledge-graph-web-explorer.md) | Knowledge graph browser, relationship visualization, entity memory viewer | ✅ 5 of 5 Done |
@@ -26,6 +26,7 @@
 | 16 | [Smoke Test Framework](16-smoke-test-framework.md) | Chat-based test cases, LLM-as-judge evaluation, HTML reports | 8 of 18 Done |
 | 17 | [Meeting Debrief](17-meeting-debrief.md) | Proactive debrief agent, detection pipeline, follow-up execution via Bullpen-through-coordinator | 15 of 17 Done |
 | 18 | [Onboarding](18-onboarding.md) | Single-command host bootstrap, React form wizard at `/setup`, in-chat `setup-wizard` specialist | ✅ 15 of 15 Done |
+| 19 | [Tasks & Backlog](19-tasks-and-backlog.md) | `tasks` table (promoted from `agent_tasks`), `task-*` skills, `enable_task_management`, BacklogHeartbeat, digest backlog sections, project decomposition | ✅ Shipped (v0.33) |
 
 ---
 

--- a/docs/specs/02-agent-system.md
+++ b/docs/specs/02-agent-system.md
@@ -196,7 +196,7 @@ This is everything needed to render agents as characters in a visual office: who
 Agent receives message, responds, done. Working memory for the conversation is kept for a configurable TTL (default: 1 hour of inactivity).
 
 ### Persistent Tasks
-Long-running work creates a **task record** in Postgres (`agent_tasks` table). The scheduler wakes the agent in bursts — it loads progress from working memory, does a chunk of work, saves progress, sets `next_run`. Like a cron job with state.
+Long-running work creates a **task record** in Postgres (the `tasks` table; renamed from `agent_tasks` in v0.33 — see [spec 19 — Tasks & Backlog](19-tasks-and-backlog.md)). The scheduler wakes the agent in bursts — it loads progress from working memory, does a chunk of work, saves progress, sets `next_run`. Like a cron job with state. Task management is also exposed to agents declaratively via the `enable_task_management` capability (spec 19 §4).
 
 Each persistent task carries:
 - `intent_anchor` — the original task description, included in every burst's system prompt to prevent drift

--- a/docs/specs/04-channels.md
+++ b/docs/specs/04-channels.md
@@ -59,7 +59,8 @@ Interactive terminal for local dev and testing. Reads from stdin, writes to stdo
 - **Outbound:** Sends via Nylas Send API
 - **Conversation ID:** derived from Nylas thread ID (`email:<threadId>`)
 - **Participant extraction:** From/To/CC addresses are extracted and auto-create contacts
-- **Attachments:** parsed and passed through as `Attachment[]`
+- **Attachments (inbound):** parsed and passed through as `Attachment[]`
+- **Attachments (outbound, v0.33):** all five outbound email skills (`email-send`, `email-reply`, `email-draft-save`, `ceo-inbox-draft-compose`, `ceo-inbox-draft-reply`) accept an `attachments` input. Files are read from `file://` URLs backed by `TempFileStore`, validated, and forwarded to Nylas (multipart `FormData` on the CEO-inbox path; `Buffer` content via the Nylas SDK on the Curia-outbound path), capped at 20 MB total / 10 attachments. The `drive-download-file` skill bridges Google Drive → `TempFileStore`, returning a `file://` URL so Drive files can be attached.
 - Secrets: `NYLAS_API_KEY`, `NYLAS_GRANT_ID`, `NYLAS_SELF_EMAIL`
 - Nylas abstracts away provider differences (Gmail, Outlook, IMAP) and handles OAuth
 

--- a/docs/specs/07-scheduler.md
+++ b/docs/specs/07-scheduler.md
@@ -102,6 +102,14 @@ The `FOR UPDATE SKIP LOCKED` pattern ensures that if the scheduler loop overlaps
 
 ## Persistent Tasks
 
+> **Superseded by [spec 19 — Tasks & Backlog](19-tasks-and-backlog.md) (v0.33).** The
+> `agent_tasks` table below was renamed and promoted to `tasks` (migration 049). The
+> back-FK `agent_tasks.scheduled_job_id` was **dropped** and replaced by a one-way forward
+> FK `scheduled_jobs.task_id`, so the scheduler now reads only `scheduled_jobs` and the
+> dispatch step routes task-bound fires to `tasks.source_agent_id`. The burst-execution
+> model described here still holds; the table name, FK direction, and column set are as
+> documented in spec 19. The original design is retained below for historical context.
+
 Long-running agent work uses the scheduler for burst execution:
 
 ```sql
@@ -211,7 +219,7 @@ Declarative job identity includes both the declaring agent (`source_agent_id`) a
 
 #### `intent_anchor` (optional)
 
-When `intent_anchor` is set on a declarative schedule entry, the scheduler creates a linked `agent_tasks` row at startup. This enables drift detection for the job — exactly the same mechanism used by runtime-created jobs with `intent_anchor`. The anchor should express the stable original goal of the recurring task in plain language.
+When `intent_anchor` is set on a declarative schedule entry, the scheduler creates a linked `tasks` row at startup (the table formerly named `agent_tasks`; see [spec 19](19-tasks-and-backlog.md)). This enables drift detection for the job — exactly the same mechanism used by runtime-created jobs with `intent_anchor`. The anchor should express the stable original goal of the recurring task in plain language.
 
 Without `intent_anchor`, the job runs normally but the drift detector never fires for it (the `agentTaskId` and `intentAnchor` fields remain `null` on the job row). Jobs without an `intent_anchor` are unaffected by this field's addition.
 
@@ -264,7 +272,7 @@ Four skills available to agents:
 | `scheduled_jobs` table (cron, one-shot, status, error tracking) | Done |
 | `scheduled_jobs` timezone column (per-job override) | Done |
 | `scheduled_jobs` prior run context columns (`last_run_outcome`, `last_run_summary`, `last_run_context`) | Done |
-| `agent_tasks` table (persistent tasks linked to `scheduled_jobs`) | Done |
+| `tasks` table (formerly `agent_tasks`; forward FK `scheduled_jobs.task_id`, see [spec 19](19-tasks-and-backlog.md)) | Done |
 | `SchedulerService` class (job CRUD, shared by loop and skills) | Done |
 | Scheduler loop (30s poll, `FOR UPDATE SKIP LOCKED`, failure tracking) | Done |
 | Declarative schedules from agent YAML config (upserted at startup) | Done |

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -226,19 +226,15 @@ This is a conscious decision to defer retention infrastructure. The trigger to r
 
 ## Database Migrations
 
-Using `node-pg-migrate` with plain SQL migration files:
+Using `node-pg-migrate` with plain SQL migration files in `src/db/migrations/`, numbered
+sequentially with a three-digit prefix (`NNN_<description>.sql`). Run `ls src/db/migrations/`
+for the authoritative, current list rather than relying on a snapshot here — the set grows
+with every schema change (recent examples: `048_add_contact_canonical_attributes.sql`,
+`049_promote_agent_tasks_to_tasks.sql`).
 
-```
-src/db/migrations/
-  001_create_audit_log.sql
-  002_create_kg_nodes.sql
-  003_create_kg_edges.sql
-  004_create_working_memory.sql
-  005_create_bullpen.sql
-  006_create_scheduled_jobs.sql
-  007_create_agent_tasks.sql
-  008_create_skill_approvals.sql
-```
+> **Prefix uniqueness is load-bearing.** `node-pg-migrate` sorts alphabetically within a
+> prefix, so two branches landing the same number cause a `checkOrder` failure on startup.
+> See the migration-numbering note in [CLAUDE.md](../../CLAUDE.md).
 
 Migrations run automatically on startup (before the bus starts accepting events). Failed migrations prevent startup with a clear error.
 

--- a/docs/specs/09-contacts-and-identity.md
+++ b/docs/specs/09-contacts-and-identity.md
@@ -19,6 +19,19 @@ CREATE TABLE contacts (
   display_name    TEXT NOT NULL,
   role            TEXT,
   notes           TEXT,
+  -- Canonical attributes (migration 048; see "Canonical Attributes" below)
+  preferred_name  TEXT,
+  title           TEXT,
+  organization    TEXT,
+  primary_email   TEXT,    -- CHECK: email format
+  primary_phone   TEXT,    -- CHECK: E.164 (^\+[1-9][0-9]{6,14}$)
+  timezone        TEXT,    -- IANA tz string, e.g. America/New_York
+  locale          TEXT,    -- CHECK: BCP 47, e.g. en-US
+  location        TEXT,
+  pronouns        TEXT,
+  linkedin_url    TEXT,    -- CHECK: starts with http(s)://
+  bio             TEXT,    -- CHECK: <= 500 chars
+  birthday        TEXT,    -- CHECK: YYYY-MM-DD or --MM-DD (year omitted)
   created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -31,6 +44,7 @@ CREATE INDEX idx_contacts_role ON contacts (role) WHERE role IS NOT NULL;
 - `role` — denormalized from the KG for fast access during authorization checks. Kept in sync when the KG node's role property changes.
 - `kg_node_id` — links to the `kg_nodes` person node that holds structured name fields (`given_name`, `family_name`, `preferred_name`, `pronouns`, `title`), relationships, and temporal metadata.
 - `notes` — CEO's freeform notes about the contact ("prefers text over email", "travels a lot in Q4").
+- **Canonical attributes** (`preferred_name` … `birthday`) — 12 structured profile fields persisted directly on the contact row (see the dedicated section below).
 
 ### contact_channel_identities
 
@@ -94,6 +108,59 @@ CREATE INDEX idx_cao_contact_perm ON contact_auth_overrides (contact_id, permiss
 - `revoked_at` — soft-delete timestamp. When an override is revoked, the row is preserved with `revoked_at` set for audit history. Only rows with `revoked_at IS NULL` are active.
 - `UNIQUE(contact_id, permission)` — prevents contradictory overrides for the same contact and permission. Updating an override upserts the existing row.
 - Overrides always win over role defaults.
+
+---
+
+## Canonical Attributes
+
+Historically everything the system "knew" about a person lived as `kg_nodes` of
+`type='fact'`, surfaced as confidence-scored bullet points. That invited two failures:
+agents **hallucinated** values (calendar IDs, addresses) when the fact list was thin, and
+specialists (calendar, email composition, research) each re-parsed fact bullets for the
+same handful of attributes. v0.33 promotes 12 commonly-needed attributes to first-class,
+nullable `TEXT` columns on the `contacts` row (migration `048_add_contact_canonical_attributes.sql`).
+
+| Column | Notes |
+|---|---|
+| `preferred_name` | Short/familiar form; falls back to `display_name`. |
+| `title` | Current job title. |
+| `organization` | Current employer (free-text). |
+| `primary_email` | Lowercased; app-layer validated against `contact_channel_identities`. DB CHECK enforces email format. |
+| `primary_phone` | E.164 (`^\+[1-9][0-9]{6,14}$`). |
+| `timezone` | IANA tz string (e.g. `America/New_York`). |
+| `locale` | BCP 47 (e.g. `en-US`). |
+| `location` | City/region (free-text). |
+| `pronouns` | Free-text. |
+| `linkedin_url` | Must start with `http(s)://`. |
+| `bio` | Short narrative, ≤ 500 chars. |
+| `birthday` | `YYYY-MM-DD`, or `--MM-DD` when the year is omitted. |
+
+### Writing canonical attributes
+
+There are three write paths, all converging on `ContactService`:
+
+1. **`contact-update` skill** — the direct path for an agent to set canonical attributes
+   (`action_risk: low`). Pinned to coordinator, ceo-inbox, research-analyst, and contacts.
+   Normalizes phone numbers to E.164.
+2. **Redirected fact writes** — `memory-store` and `extract-facts` detect a write whose
+   attribute key maps to a canonical field (the `canonical-attribute-guard`,
+   whitespace-trimmed) and redirect it to `ContactService` instead of creating a KG fact
+   node. The skill result reports a `redirected` counter and a `redirected_to_contact`
+   action with the `contact_id`. **New KG fact writes for these attributes are stopped** —
+   the column is the single source of truth.
+3. **One-time backfill** — `scripts/backfill-contact-attributes.ts`
+   (`npm run backfill:contact-attributes`) populates the columns from existing KG facts via
+   a 3-hop join with per-column highest-confidence tiebreaking. Safe to re-run (only touches
+   NULL columns).
+
+### Reading canonical attributes: entity-context
+
+`EntityContext.contact` exposes all 12 fields as structured values (see
+[spec 11 — Entity Context Enrichment](11-entity-context-enrichment.md)), so an agent reads
+a typed field rather than reasoning over a scored fact list. `context-for-email` prefers
+`contact.primaryEmail` and surfaces `contact.preferredName` for salutations. Rich, non-
+canonical knowledge about a person (relationships, history, preferences) continues to live
+in the knowledge graph.
 
 ---
 
@@ -205,9 +272,9 @@ If `findContactBySystemRole('principal')` returns nothing (fresh deployment, bef
 
 ### What is pre-resolved and what is not
 
-The platform pre-resolves only the principal's `contacts.id`. It does **not** pre-resolve verified email addresses, Signal numbers, calendar IDs, or timezone — those can change within a deployment lifetime, so bootstrap-time injection would go stale.
+The platform pre-resolves (caches at bootstrap) only the principal's `contacts.id`. It does **not** bootstrap-inject verified email addresses, Signal numbers, calendar IDs, timezone, or any other attribute — those can change within a deployment lifetime, so bootstrap-time injection would go stale.
 
-Agents that need any of those values call `entity-context` with `${principal_contact_id}` at the start of their run. This keeps the live values fresh and consolidates the "who is the principal and how do I reach them?" question into a single skill call per agent run, instead of multiple `contact-lookup`-by-role calls scattered across the agent's pipeline.
+Agents that need any of those values call `entity-context` with `${principal_contact_id}` at the start of their run. As of v0.33 the canonical attributes (including `timezone`, `primary_email`, `title`, `organization`) come back as structured fields on `EntityContext.contact` rather than as confidence-scored KG facts (see the Canonical Attributes section above) — so the agent reads a typed value instead of reasoning over a fact list. This keeps the live values fresh and consolidates the "who is the principal and how do I reach them?" question into a single skill call per agent run, instead of multiple `contact-lookup`-by-role calls scattered across the agent's pipeline.
 
 ### Why not auto-injection?
 

--- a/docs/specs/09-contacts-and-identity.md
+++ b/docs/specs/09-contacts-and-identity.md
@@ -270,20 +270,22 @@ Both placeholders are **opt-in**: only agents that reference the placeholder pay
 
 If `findContactBySystemRole('principal')` returns nothing (fresh deployment, before bootstrap), the placeholder resolves to an empty string and a one-time warning is logged. The same defense-in-depth UUID-format check used for `${agent_contact_id}` applies — any non-UUID value resolves to an empty string, so a future change to the ID source can't accidentally inject arbitrary text into the system prompt.
 
-### What is pre-resolved and what is not
+### What is injected and what is fetched on demand
 
-The platform pre-resolves (caches at bootstrap) only the principal's `contacts.id`. It does **not** bootstrap-inject verified email addresses, Signal numbers, calendar IDs, timezone, or any other attribute — those can change within a deployment lifetime, so bootstrap-time injection would go stale.
+Three distinct things, with three distinct rules:
 
-Agents that need any of those values call `entity-context` with `${principal_contact_id}` at the start of their run. As of v0.33 the canonical attributes (including `timezone`, `primary_email`, `title`, `organization`) come back as structured fields on `EntityContext.contact` rather than as confidence-scored KG facts (see the Canonical Attributes section above) — so the agent reads a typed value instead of reasoning over a fact list. This keeps the live values fresh and consolidates the "who is the principal and how do I reach them?" question into a single skill call per agent run, instead of multiple `contact-lookup`-by-role calls scattered across the agent's pipeline.
+1. **The principal's `contacts.id`** — resolved once at bootstrap and cached. Exposed to agents as the opt-in `${principal_contact_id}` placeholder (above).
+2. **The principal's verified channel identities** (email, phone, Signal, loaded from `contact_channel_identities` at startup) — appended to **every** agent's system prompt on each task as a `## Principal Contact Details` block (`principalIdentities` in `src/agents/runtime.ts`, wired in `src/index.ts`; #786). This is an authoritative, always-present source for *reaching* the principal, added precisely because relying on opt-in plus convention let the coordinator hallucinate the principal's address. It is the one piece of principal data the platform does inject universally — see the note in the next section.
+3. **Everything else** — calendar IDs, `timezone`, and the other canonical/mutable [contact attributes](#canonical-attributes) — is **not** injected. It can change within a deployment lifetime, so an agent that needs it calls `entity-context` with `${principal_contact_id}` at the start of its run. As of v0.33 the canonical attributes come back as structured fields on `EntityContext.contact` rather than confidence-scored KG facts, so the agent reads a typed value instead of reasoning over a fact list. This keeps the live values fresh and consolidates "how do I reach the principal and what do I know about them?" into a single skill call per run.
 
-### Why not auto-injection?
+### Why the contact-ID *handle* is opt-in
 
-The platform deliberately does *not* auto-inject the principal contact ID into every agent prompt. Two reasons:
+The `${principal_contact_id}` placeholder (the UUID handle, item 1 above) is deliberately **not** auto-injected into every agent prompt. Two reasons:
 
-1. **Attack surface.** Agents that have no business contacting the principal directly (specialist agents like research-analyst that should report through the coordinator) would be invited to do so. The opt-in pattern keeps the surface narrow.
-2. **Consistency.** The same opt-in pattern is established for `${agent_contact_id}`. Two placeholders with two different injection rules would be confusing.
+1. **Attack surface.** Agents that have no business resolving the principal's calendar or attributes (specialist agents like research-analyst that should report through the coordinator) are not handed a key to do so. The opt-in pattern keeps the surface narrow.
+2. **Consistency.** The same opt-in pattern is established for `${agent_contact_id}`. Two handles with two different injection rules would be confusing.
 
-The durable countermeasure to poorly-written agents that hardcode the principal's addresses is the `Reaching the principal` convention documented in `CLAUDE.md`, plus reviewer discipline — not silent injection.
+This is distinct from the `## Principal Contact Details` block (item 2 above), which **is** injected universally. The split is deliberate: the *reach-the-principal* channel identities are injected everywhere because hallucinated addresses are a correctness-and-safety problem the `Reaching the principal` convention alone did not prevent (#786), whereas the *contact-ID handle* that unlocks calendar lookups and arbitrary attribute reads stays opt-in to keep each agent's capability surface minimal.
 
 ---
 

--- a/docs/specs/17-meeting-debrief.md
+++ b/docs/specs/17-meeting-debrief.md
@@ -71,8 +71,8 @@ The accepted trade-off of 3x/day scanning: a meeting added *and* occurring entir
 
 ## 3. State Management
 
-**No bespoke state maps.** Debrief work is tracked as platform **tasks** (spec:
-[tasks & backlog](../wip/2026-06-01-tasks-and-backlog-design.md)), not the former
+**No bespoke state maps.** Debrief work is tracked as platform **tasks**
+([spec 19 — Tasks & Backlog](19-tasks-and-backlog.md)), not the former
 `pendingDebriefs` / `judgedEvents` / `deferredEvents` maps in scheduler progress.
 
 ### Debrief tasks

--- a/docs/specs/19-tasks-and-backlog.md
+++ b/docs/specs/19-tasks-and-backlog.md
@@ -1,0 +1,342 @@
+# 19 — Tasks & Backlog
+
+**Date:** 2026-06-04
+**Status:** Shipped (v0.33)
+
+## Overview
+
+Curia is good at acting on a single request but historically lost fidelity across
+sessions because there was no canonical place to track work. The Tasks system gives
+the platform a shared primitive for deferred, multi-step, and waiting work: a single
+`tasks` table, four `task-*` skills, a deterministic hourly heartbeat that keeps open
+work moving, and a CEO-visible backlog surfaced through the daily digest.
+
+It addresses four recurring failure modes:
+
+1. **No ownership distinction.** "I should do this" vs. "the CEO should do this" vs.
+   "we're waiting on someone else" were all rendered the same way. Tasks make the
+   three-way split first-class.
+2. **No persistence for larger projects.** Multi-step work either crammed into one
+   burst or fell on the floor between bursts. Tasks let an agent decompose a project,
+   advance what it can, and park the rest behind a wake condition.
+3. **Bursty specialists.** When `meeting-debrief` or `ceo-inbox` uncovered seven
+   follow-ups, the only options were "do all now" or "drop them." Deferral into a
+   queryable backlog replaces the explosion.
+4. **Everything treated as urgent.** A `priority` signal lets work be ranked rather
+   than competing for the same immediate attention.
+
+The design leans on infrastructure that already existed: the Postgres-backed scheduler
+([spec 07](07-scheduler.md)), the daily `pending-actions-digest`, the autonomy engine
+([spec 14](14-autonomy-engine.md)), and the audit trail.
+
+**Companion design docs** (the dated record of how this was designed and sequenced):
+[2026-06-01-tasks-and-backlog-design.md](../wip/2026-06-01-tasks-and-backlog-design.md),
+[2026-06-03-digest-backlog-sections-design.md](../wip/2026-06-03-digest-backlog-sections-design.md),
+[2026-06-04-meeting-debrief-tasks-migration-design.md](../wip/2026-06-04-meeting-debrief-tasks-migration-design.md),
+[2026-06-04-task-execution-heartbeat-design.md](../wip/2026-06-04-task-execution-heartbeat-design.md).
+
+---
+
+## 1. Architecture Summary
+
+- **One table.** The pre-existing `agent_tasks` table was renamed and promoted to
+  `tasks` with CEO-visible columns. There is no parallel table; existing scheduler and
+  persistent-task callers continued to work after a mechanical rename plus one column
+  migration (§2).
+- **Four skills.** `task-create`, `task-list`, `task-update`, `task-complete` — granular
+  domain skills matching the existing `calendar-*` / `ceo-inbox-*` pattern.
+- **No new specialist agent.** Task management is a platform-level capability available
+  to any agent (like memory), gated by the `enable_task_management` flag (§4).
+- **Three reactivation channels drain the backlog** (§5): an inbound event, a per-task
+  `wake_at` timer, and the deterministic `BacklogHeartbeat` backstop.
+
+### 1.1 Scheduler ↔ Tasks relationship
+
+The single most important architectural decision is the split between *when* and *what*:
+
+- **`scheduled_jobs` owns "when."** Cron and one-shot triggers, polled every 30s. No new
+  polling logic was introduced.
+- **`tasks` owns "what."** Units of CEO-visible work. The tasks table is *unaware of
+  scheduling* — no `next_attempt_at`, no `scheduled_job_id`.
+- **The bridge is a one-way forward FK, `scheduled_jobs.task_id → tasks.id`.** Most
+  `scheduled_jobs` rows have `task_id = NULL` (digests, cron-driven agents). A task-bound
+  row exists only when something asked to wake a specific task at a specific time. The
+  scheduler reads only `scheduled_jobs`, never `tasks`.
+
+The old back-FK (`agent_tasks.scheduled_job_id`, from [spec 07](07-scheduler.md)) was
+dropped in the migration; the forward direction replaces it and additionally answers the
+more frequent question — "which task does this firing job belong to?" — without a second
+query path. `due_at` on a task is a CEO-facing deliverable date, **not** a wake-up
+trigger; a wake-up is always a `scheduled_jobs` row, so the two are never double-stored.
+
+### 1.2 `owner` vs. `source_agent_id`
+
+Two distinct concepts that an earlier draft conflated:
+
+- **`owner`** — `'curia' | 'ceo' | 'external'`. CEO-visible. Drives the digest's
+  three-way grouping ("what should I do" vs. "what is Curia doing" vs. "what are we
+  waiting on").
+- **`source_agent_id`** — internal routing. The specialist that created the task and is
+  best positioned to resume it (`'meeting-debrief'`, `'ceo-inbox'`, …); may be null for
+  CEO-created tasks. A wake-up routes here (falling back to the coordinator).
+
+The two questions never consult the same field.
+
+---
+
+## 2. Data Model
+
+Migration [`049_promote_agent_tasks_to_tasks.sql`](../../src/db/migrations/049_promote_agent_tasks_to_tasks.sql)
+renames `agent_tasks → tasks`, adds CEO-visible columns, drops the back-FK, and adds the
+forward `scheduled_jobs.task_id`. Canonical contact-attribute columns landed in the
+adjacent migration `048_add_contact_canonical_attributes.sql` (see [spec 09](09-contacts-and-identity.md)).
+
+### 2.1 Columns added to `tasks`
+
+| Column | Type | Notes |
+|---|---|---|
+| `title` | `TEXT NOT NULL DEFAULT ''` | CEO-visible. Backfilled from `LEFT(intent_anchor, 255)` for pre-existing rows. |
+| `description` | `TEXT` | Optional longer detail. |
+| `owner` | `TEXT NOT NULL DEFAULT 'curia'` | `CHECK IN ('curia','ceo','external')`. |
+| `priority` | `INTEGER NOT NULL DEFAULT 50` | Higher = more urgent. Drives sort order. |
+| `due_at` | `TIMESTAMPTZ` | CEO-facing deliverable date; **not** a wake-up. |
+| `source` | `TEXT NOT NULL DEFAULT 'agent'` | `CHECK IN ('ceo','agent','scheduler','coordinator')`. |
+| `source_agent_id` | `TEXT` | Which agent can resume this task; backfilled from `agent_id`. |
+| `created_by` | `TEXT NOT NULL DEFAULT 'system'` | |
+| `parent_task_id` | `UUID REFERENCES tasks(id)` | Subtask linkage for projects. |
+| `blocked_by_task_id` | `UUID REFERENCES tasks(id)` | Single-dependency ordering. |
+| `waiting_on_contact_id` | `UUID REFERENCES contacts(id)` | Preferred way to record "waiting on a person." |
+| `waiting_on_text` | `TEXT` | Soft alternative when no contact row exists yet. |
+| `tags` | `TEXT[] NOT NULL DEFAULT '{}'` | Lightweight clustering (`'debrief-pending'`, `'inbox-overflow'`) without a goals entity. |
+
+Preserved verbatim from `agent_tasks`: `intent_anchor` (durable goal statement),
+`progress` JSONB (multi-burst execution state), `error_budget`, `conversation_id`,
+`agent_id`, timestamps.
+
+### 2.2 Status lifecycle
+
+The status `CHECK` constraint carries **both** the new task-lifecycle values and the
+legacy scheduler values, so scheduler code that predates the task skills keeps working:
+
+- **Task lifecycle:** `open`, `in_progress`, `blocked`, `waiting`, `done`, `cancelled`.
+- **Legacy (scheduler):** `active`, `pending`, `paused`, `completed`, `failed`.
+
+`waiting` vs. `blocked`: *waiting* = something outside Curia must happen (a person, a
+date, a third-party system); *blocked* = another known task must complete first.
+
+### 2.3 Indexes
+
+- `tasks_open_priority_idx` on `(priority DESC, due_at NULLS LAST) WHERE status IN ('open','in_progress')` — heartbeat and digest queries.
+- `tasks_parent_idx` on `(parent_task_id) WHERE parent_task_id IS NOT NULL` — subtask queries.
+- `scheduled_jobs_task_idx` on `(task_id) WHERE task_id IS NOT NULL` — wake-up routing.
+
+---
+
+## 3. Skills
+
+Four skills under `skills/`, each with an explicit `action_risk` per
+[CLAUDE.md](../../CLAUDE.md). Emit `task.created` / `task.updated` / `task.completed`
+bus events for audit and future subscribers.
+
+| Skill | `action_risk` | Notes |
+|---|---|---|
+| `task-create` | `low` | Auto-fills `source` / `source_agent_id` from caller context. `wake_at` is a convenience arg: when set, the skill creates the task **and** a one-shot `scheduled_jobs` row (with `task_id`) in one transaction. The wake time lives on the schedule row, not the task. |
+| `task-list` | `none` | Default sort `priority DESC, due_at ASC NULLS LAST`. Returns title, status, owner, due_at, age, last progress note, and the next pending wake-up if any. Timestamps via `toLocalIso()`. |
+| `task-update` | `low` | Appends `progress_note` to `progress`. Setting `wake_at` cancels any existing pending wake and creates a fresh one-shot. Status transitions validated (`done → open` rejected). Completing/cancelling auto-cancels pending `scheduled_jobs` rows where `task_id = ?`. |
+| `task-complete` | `low` | Sets `status='done'`, captures the note in audit + progress, auto-cancels pending wake-ups. A separate skill so the coordinator prompt can reason about completion cleanly and the audit log distinguishes completion from a generic update. |
+
+Cancellation is `status='cancelled'` (no `task-delete`, to preserve the audit trail).
+Single-row reads use `task-list` with a filter (no `task-get`). The skills are pinned to
+participating agents via `enable_task_management` (§4).
+
+---
+
+## 4. The `enable_task_management` Capability
+
+The executor discipline (§6) is behavioral; hand-injecting it into each agent prompt
+would drift the moment someone hand-builds a custom agent. Instead a single declarative
+flag on the agent YAML bundles the whole capability:
+
+```yaml
+# agents/<name>.yaml
+enable_task_management: true   # default: false
+```
+
+When `true`, the agent runtime does three things:
+
+1. **Auto-pins** `task-create`, `task-list`, `task-update`, `task-complete` (merged and
+   deduped with the agent's explicit `pinned_skills`).
+2. **Auto-injects** the single `task_management` guidance block (§6) at a fixed slot in
+   the effective system prompt (after the identity / security blocks). A fixed slot, not
+   a `${placeholder}` — for a discipline block, "flag set but author forgot the
+   placeholder" would reintroduce exactly the inconsistency this eliminates.
+3. **Marks the agent heartbeat-eligible** — only enabled agents appear in the heartbeat's
+   `source_agent_id` allow-list (§5).
+
+Shipped enabled on **`coordinator`** and **`ceo-inbox`**. The coordinator drops its
+now-redundant manual `task-*` pins and gains a bounded `error_budget` for project bursts.
+An agent may still list individual `task-*` skills in `pinned_skills` *without* the flag
+for a bespoke need (e.g. read-only `task-list`) — that agent is not heartbeat-eligible and
+gets no injected block. If a task's `source_agent_id` points at a non-enabled or null
+agent, the heartbeat routes the wake to the coordinator.
+
+The `task_management` block is platform code, versioned with the platform, so every
+opted-in agent gets the identical current rules.
+
+---
+
+## 5. The BacklogHeartbeat
+
+`BacklogHeartbeat` ([src/scheduler/backlog-heartbeat.ts](../../src/scheduler/backlog-heartbeat.ts))
+is a System-layer component started in `src/index.ts` with its own hourly tick. It runs
+one deterministic selection query over `tasks` and inserts one-shot `scheduled_jobs` wake
+rows. **It performs no LLM work and no domain reasoning** — it is the conductor, never an
+instrument. This preserves the scheduler's invariant (it reads only `scheduled_jobs`); the
+heartbeat is a separate component that reads `tasks` and *produces* `scheduled_jobs` rows,
+reusing the entire existing dispatch path.
+
+It replaces the never-built 3×/day LLM `backlog-sweep` from the original design, which
+conflated routing with doing and was itself a recurring burst of action.
+
+### 5.1 Reactivation model
+
+A parked task returns to life through three layers, fastest to slowest:
+
+1. **Event (instant).** An inbound reply or provided document wakes the blocked task via
+   the existing `context-bridge` mechanism. This is the primary driver for in-flight work.
+2. **Per-task `wake_at` (precise).** Set by the owner when parking; stored as a one-shot
+   `scheduled_jobs` row. Cancelled if the event fires first.
+3. **Heartbeat (catch-all).** The backstop for when an agent forgot to set a wake or a
+   task got orphaned. This is what guarantees nothing lingers.
+
+### 5.2 Selection: pick the agent, not the task
+
+The heartbeat wakes an **agent**, not a task. Per tick, for each eligible
+`source_agent_id` it selects that agent's single most-deserving entry-point task and
+enqueues exactly one wake. Two protections against over-waking stack:
+
+- **`blocked_by` keeps ordered chains out of the candidate set** — successors are excluded
+  until their blocker is `done`/`cancelled`, so only a chain's head is ever a candidate.
+- **One wake per agent per tick** — the woken agent pulls its own `task-list` and advances
+  several of its ready tasks in that burst, in the order it knows, bounded by its
+  `error_budget`.
+
+A global cap (`heartbeatMaxWakesPerTick`, default 5) backstops the case where many agents
+have idle work. Two candidate populations:
+
+| Population | Predicate | On wake, the owner… |
+|---|---|---|
+| **Idle-unblocked** | `owner='curia'`, `status IN ('open','in_progress')`, unblocked, no pending/running wake, `updated_at` older than `idleThresholdHours` (default 4h) | advances the work |
+| **Orphaned wait** | `owner='curia'`, `status IN ('waiting','blocked')`, `waiting_on_contact_id IS NULL`, no pending/running wake, `updated_at` older than `staleWaitThresholdHours` (default 48h) | re-evaluates: escalate, or re-park with a proper `wake_at` |
+
+Both populations are scoped to `owner='curia'` — the heartbeat never chases work the CEO or
+an external party owns. The orphaned-wait path additionally requires `waiting_on_contact_id
+IS NULL`: a task explicitly waiting on a specific person is **excluded entirely**, not merely
+delayed, so the heartbeat never re-pings a human (that nudge is the owner's job via a
+`wake_at`). The two thresholds differ deliberately — poke an in-flight task within half a
+workday, but give a forgotten timer 48h before the backstop fires.
+
+---
+
+## 6. The Executor Loop & No-Dangling-Commitment Invariant
+
+These behavioral rules live once in the injected `task_management` block, applied
+uniformly to every participating agent.
+
+**The loop:** when an agent receives or resumes a task it (1) *advances until blocked* —
+does every step it can now, stopping only at a genuine blocker (a person, the CEO's
+approval, a future date, a prior task) or when its burst budget runs low; (2) *reifies
+before it promises*; (3) *parks cleanly* — sets status, appends a progress note, and sets
+a wake (an event bridge or a `wake_at`).
+
+**The invariant:**
+
+> No outbound artifact may contain an unfulfilled forward commitment unless a task backs
+> that commitment — and the agent prefers to fulfill the commitment *before* sending.
+
+This kills the dangling-document failure (an agent promising "the CEO will follow up with
+the document" with nothing tracking the promise). The reply step is `blocked_by` the
+obtain-document step, so the default behavior is to resolve first and send a complete
+reply. The three runtime outcomes — resolve-then-reply (preferred), promise-then-self-
+fulfill, promise-then-CEO-owns-plus-notify (fallback) — are chosen by the agent at runtime;
+*how hard Curia tries before falling back* is governed by the autonomy posture (§8), not
+new logic.
+
+### 6.1 Project decomposition
+
+> If work has more than one step, or any step cannot be done right now, create a parent
+> task (`intent_anchor` = the durable goal) plus the first wave of subtasks
+> (`parent_task_id`, with `blocked_by_task_id` for ordering). Otherwise, a single task.
+
+Plan the first wave only and add subtasks as reality reveals them. For a project spanning
+specialists, the coordinator owns the parent and subtasks may carry different
+`source_agent_id`s so each wakes the right owner. The parent is itself heartbeat-eligible,
+so once its children are done the heartbeat wakes its owner to close it out — no special
+parent-rollup machinery in v1.
+
+---
+
+## 7. CEO Visibility: Digest Sections
+
+`pending-actions-digest` (daily) gained three backlog sections after the existing
+approvals block, each rendered only when non-empty and capped at 5 with a `+N more` footer:
+
+- **For you to do** — `owner='ceo'`, status `open`/`in_progress`, top 5 by priority.
+- **Waiting on others** — `owner='external'`, `status='waiting'`; resolves
+  `waiting_on_contact_id` to a display name, falling back to `waiting_on_text`.
+- **What I'm working on** — `owner='curia'`, status `open`/`in_progress`, top 5 by priority.
+
+This reuses the existing digest the CEO already reads; no parallel digest or new channel
+was introduced. Interactive controls (snooze / done / reassign) are explicitly deferred.
+
+---
+
+## 8. Integrations
+
+- **Per-task wake routing** ([spec 07](07-scheduler.md)). The scheduler dispatch step
+  branches on `scheduled_jobs.task_id`: when set, it loads the task and routes the fire to
+  `source_agent_id` (falling back to the coordinator), passing `task_id`, `title`,
+  `intent_anchor`, and `progress` as context. The polling loop, retry logic, and
+  error-budget accounting are untouched.
+- **`meeting-debrief`** ([spec 17](17-meeting-debrief.md)) was the proof case: its bespoke
+  `pendingDebriefs` / `judgedEvents` state maps were deleted in favor of platform tasks
+  (`tag='debrief-pending'`, per-meeting wake-ups). Pending debriefs now appear in the
+  digest's "For you to do."
+- **`ceo-inbox`** joins the system (`enable_task_management: true`): reification in the
+  NEEDS DRAFT path prevents bare forward commitments; resume mode drafts the complete reply
+  when a deferred follow-up task wakes; overflow load-shedding above ~10 unread defers the
+  tail as `tag='inbox-overflow'` tasks so per-burst LLM time no longer scales linearly.
+- **Autonomy** ([spec 14](14-autonomy-engine.md)). The "execute the safe stuff, escalate
+  the rest" behavior is the existing autonomy engine — `action_risk` per skill against the
+  live score. Drafting (low) just happens; outbound (medium) is gated; spending money
+  (high/critical) escalates via the pending-approval flow. This design adds zero new
+  autonomy mechanics.
+
+---
+
+## 9. Configuration
+
+`config/default.yaml`:
+
+```yaml
+tasks:
+  heartbeatIntervalMinutes: 60      # hourly tick
+  heartbeatMaxWakesPerTick: 5       # global cap; per-agent cap is always 1
+  idleThresholdHours: 4             # active idle (open/in_progress, curia-owned)
+  staleWaitThresholdHours: 48       # orphaned waits (waiting/blocked, no wake set)
+```
+
+Priority bands, default `owner='curia'`, and other nuance are handled by LLM judgment, not
+config — the LLM handles nuance, config handles mechanics.
+
+---
+
+## 10. Deferred (post-v1)
+
+Captured so future readers do not relitigate the scope decisions: a `goals` table and
+weighted progress rollup (tags carry us until a durable cluster appears); autonomous task
+generation from inferred needs; a first-class `commitments` entity (modeled today as a task
+with `owner='external'` + `waiting_on_contact_id`); DAG dependencies beyond a single
+`blocked_by_task_id`; an LLM groomer that dedupes/re-prioritizes/promotes clusters; an
+interactive digest surface; and a `last_advanced_at` column should `updated_at` prove a
+noisy proxy for real progress.


### PR DESCRIPTION
## **User description**
## Summary

Documentation updates for the **v0.33** release (all 27 milestone issues merged). Brings the in-repo architecture specs and dev guide in line with what shipped, ahead of cutting the tag.

- **New spec 19 — Tasks & Backlog** (`docs/specs/19-tasks-and-backlog.md`): canonical spec consolidating the four WIP design memos (tasks/backlog, digest sections, meeting-debrief migration, execution heartbeat). Covers the `tasks` table + lifecycle, scheduler↔tasks forward-FK split, the four `task-*` skills, `enable_task_management`, the `BacklogHeartbeat`, project decomposition, and the digest backlog sections.
- **Spec 09 — Contacts & Identity**: documents the 12 canonical contact attributes (migration 048), the `contact-update` skill, the KG-fact → `ContactService` redirect, and entity-context enrichment; fixes the stale "timezone is not pre-resolved" line.
- **Stale-reference fixes**: `agent_tasks → tasks` rename + forward FK in specs 02 and 07 (superseded-by banner on the historical section); spec 08 migration list replaced with a pointer; spec 04 documents outbound email attachments + `drive-download-file`; spec 17 points state-management at spec 19.
- **Spec index (00)**: new row for spec 19; touched scope descriptions refreshed.
- **Dev guide (`adding-an-agent.md`)**: documents `enable_task_management` (example + field reference), fixes the stale `intent_anchor` note, refreshes the built-in skills catalog table.
- **CHANGELOG**: docs note under `[Unreleased]`.

## Verification

- `grep agent_tasks docs/` returns only intentional historical/migration references.
- Factual claims (migrations 048/049, agent YAMLs, `config/default.yaml`, `backlog-heartbeat.ts`, email skills) cross-checked via code review; two findings (a dangling `§17` ref and the orphaned-wait predicate missing `owner='curia'` / `waiting_on_contact_id IS NULL`) fixed.

Part of cutting **v0.33** (companion public-docs PR in `curia-docs`). The release-cut PR (version bump, codename, CHANGELOG heading, haiku) is separate and follows after this merges.


___

## **CodeAnt-AI Description**
**Document the v0.33 tasks system and related platform changes**

### What Changed
- Added spec 19 for the new tasks and backlog flow, including the `tasks` table, task skills, task wake-ups, heartbeat behavior, and backlog sections in the daily digest
- Updated the agent setup guide to show `enable_task_management`, the task skills, the revised task workflow, canonical contact attributes, and outbound email attachments
- Refreshed older specs to match shipped behavior, including the `agent_tasks` to `tasks` rename, the new contact fields, and the updated email attachment flow

### Impact
`✅ Clearer task workflow guidance`
`✅ Fewer stale docs about tasks and contacts`
`✅ Easier agent setup for task-driven work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
