### PR TITLE
fix: persist email poll watermark and add channel.poll/stalled audit events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Email adapter watermark persistence** — `lastSeenTimestamp` is now persisted to the KG via a new `ConfigStore` service (`src/memory/config-store.ts`) and restored on restart, preventing silent message loss after a process restart during downtime. (#846)
+- **Email adapter poll observability** — each successful poll cycle now emits a `channel.poll` audit event with per-filter skip counts, message totals, watermark, and duration; a `channel.stalled` event fires (once per lifecycle) when no poll completes within 5 × the polling interval. (#846)
+
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 
 > **Mr. Meeseeks** *(Rick and Morty, 2014, Dan Harmon & Justin Roiland)* — summoned to fulfill one task, a Meeseeks exists for that purpose alone, cannot rest while it's open, and pops out of existence the moment it's done. v0.33 gives Curia the same compulsion: every deferred commitment becomes a tracked task in a CEO-visible backlog, a heartbeat wakes anything idle or stale until it resolves, and nothing is allowed to quietly drop.

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -851,6 +851,57 @@ export interface TaskCompletedEvent extends BaseEvent {
   payload: TaskCompletedPayload;
 }
 
+// ChannelPollEvent — emitted by EmailAdapter after each successful Nylas poll cycle.
+// Provides an observable heartbeat: if channel.poll stops appearing in the audit log,
+// the adapter has stalled. One event per poll regardless of whether messages were found.
+interface ChannelPollPayload {
+  accountId: string;
+  /** Channel identifier — always 'email' for this event. */
+  channel: 'email';
+  /** Number of messages returned by Nylas (before any filtering). */
+  fetched: number;
+  /** Messages that reached bus.publish('channel', inbound.message). */
+  processed: number;
+  /** Per-filter skip breakdown. */
+  skipped: {
+    sent_folder: number;
+    recently_sent: number;
+    self: number;
+    excluded: number;
+    /** Messages that threw during per-message processing. */
+    failed: number;
+  };
+  /** High-water mark value (epoch seconds) after this poll cycle. */
+  lastSeenAt: number;
+  /** Wall-clock duration of the poll cycle in milliseconds. */
+  durationMs: number;
+}
+
+export interface ChannelPollEvent extends BaseEvent {
+  type: 'channel.poll';
+  sourceLayer: 'channel';
+  payload: ChannelPollPayload;
+}
+
+// ChannelStalledEvent — emitted by EmailAdapter when no successful poll has completed
+// within 5 × pollingIntervalMs. Fired at most once per adapter lifecycle (until restart).
+// No self-heal — surfacing the stall is the fix.
+interface ChannelStalledPayload {
+  accountId: string;
+  /** Channel identifier — always 'email' for this event. */
+  channel: 'email';
+  /** Epoch ms of the last successful poll, or null if the adapter never completed a poll. */
+  lastSuccessfulPollAt: number | null;
+  /** The stall threshold that was exceeded: 5 × pollingIntervalMs. */
+  stallThresholdMs: number;
+}
+
+export interface ChannelStalledEvent extends BaseEvent {
+  type: 'channel.stalled';
+  sourceLayer: 'channel';
+  payload: ChannelStalledPayload;
+}
+
 export type BusEvent =
   | InboundMessageEvent
   | AgentTaskEvent
@@ -889,7 +940,9 @@ export type BusEvent =
   | EmbeddingCallEvent         // #654: embedding API call cost telemetry
   | TaskCreatedEvent           // Tasks v1: task created via task-create skill (#835)
   | TaskUpdatedEvent           // Tasks v1: task fields updated via task-update skill (#835)
-  | TaskCompletedEvent;        // Tasks v1: task set to done via task-complete skill (#835)
+  | TaskCompletedEvent         // Tasks v1: task set to done via task-complete skill (#835)
+  | ChannelPollEvent           // #846: email adapter poll heartbeat (one per cycle)
+  | ChannelStalledEvent;       // #846: email adapter stall detection (fire-once per lifecycle)
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -1451,6 +1504,26 @@ export function createTaskCompleted(
     sourceLayer: 'execution',
     payload: rest,
     parentEventId,
+  };
+}
+
+export function createChannelPoll(payload: ChannelPollPayload): ChannelPollEvent {
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'channel.poll',
+    sourceLayer: 'channel',
+    payload,
+  };
+}
+
+export function createChannelStalled(payload: ChannelStalledPayload): ChannelStalledEvent {
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'channel.stalled',
+    sourceLayer: 'channel',
+    payload,
   };
 }
 

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -26,8 +26,10 @@ import type { Layer, EventType } from './events.js';
 //          The sourceLayer on the event is 'execution'; the publish permission here is what puts it on the wire.
 // #654 (embedding telemetry): system layer publishes and subscribes embedding.call for cost audit
 //          logging — EmbeddingService fires from infrastructure paths with no agent-layer context.
+// #846 (email poll persistence): channel layer publishes channel.poll (poll heartbeat) and
+//          channel.stalled (watchdog alert); system layer subscribes for audit logging.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
-  channel: new Set(['inbound.message']),
+  channel: new Set(['inbound.message', 'channel.poll', 'channel.stalled']),
   dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'autonomy.send_blocked']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call', 'context.budget']),
   execution: new Set(['skill.result', 'secret.accessed', 'autonomy.skill_blocked', 'contact.resolved']),
@@ -40,7 +42,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -278,6 +278,7 @@ export class EmailAdapter {
     this.startedAt = Date.now();
     this.lastSuccessfulPollAt = null;
     this.stalledEmitted = false;
+    this.stalledEmitAttempts = 0;
 
     // Poll on interval; also run the watchdog check each tick.
     this.pollTimer = setInterval(() => {

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -11,8 +11,15 @@ import type { EventBus } from '../../bus/bus.js';
 import type { Logger } from '../../logger.js';
 import type { OutboundGateway, EmailSendRequest } from '../../skills/outbound-gateway.js';
 import type { ContactService } from '../../contacts/contact-service.js';
+import type { ConfigStore } from '../../memory/config-store.js';
 import { convertNylasMessage } from './message-converter.js';
-import { createInboundMessage, type OutboundMessageEvent, type OutboundNotificationEvent } from '../../bus/events.js';
+import {
+  createInboundMessage,
+  createChannelPoll,
+  createChannelStalled,
+  type OutboundMessageEvent,
+  type OutboundNotificationEvent,
+} from '../../bus/events.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
 import { buildReplyQuote } from '../../skills/_shared/reply-quote.js';
 
@@ -20,6 +27,12 @@ import { buildReplyQuote } from '../../skills/_shared/reply-quote.js';
 // When the agent's response plus the quoted original would exceed this, the quote
 // is silently dropped so the reply still sends.
 const MAX_REPLY_BODY_LENGTH = 50_000;
+
+// KG namespace and key pattern for persisting the poll high-water mark.
+const POLL_STATE_NAMESPACE = 'system:email-poll-state';
+function lastSeenKey(accountId: string): string {
+  return `${accountId}.last_seen_at`;
+}
 
 // ---------------------------------------------------------------------------
 // Address normalization helpers
@@ -79,6 +92,12 @@ export interface EmailAdapterConfig {
    * the timezone the skills receive via SkillContext.
    */
   timezone: string;
+  /**
+   * KG-backed config store for persisting the poll high-water mark across restarts.
+   * When absent the adapter operates without persistence (in-memory only — reverts
+   * to Date.now() on each restart, which is the legacy behaviour).
+   */
+  configStore?: ConfigStore;
 }
 
 export class EmailAdapter {
@@ -86,6 +105,18 @@ export class EmailAdapter {
   private pollTimer?: ReturnType<typeof setInterval>;
   private lastSeenTimestamp: number = 0;
   private processing = false;
+
+  // ── Watchdog state ─────────────────────────────────────────────────────────
+  // Tracks the last successful poll completion time for stall detection.
+  // "Successful" means listEmailMessages resolved without throwing; zero messages
+  // returned is still a success (a quiet inbox is healthy).
+
+  /** Epoch ms when the adapter was started — used to compute initial stall window. */
+  private startedAt: number | null = null;
+  /** Epoch ms of the most recent poll cycle that reached completion (no throw). */
+  private lastSuccessfulPollAt: number | null = null;
+  /** True once channel.stalled has been emitted this lifecycle; prevents re-emission. */
+  private stalledEmitted = false;
 
   // ── Recently-sent message ID tracking (self-loop guard) ───────────────────
   // After a successful send, the Nylas message ID is added here so that the
@@ -123,7 +154,7 @@ export class EmailAdapter {
   }
 
   async start(): Promise<void> {
-    const { bus, logger, pollingIntervalMs } = this.config;
+    const { bus, logger, pollingIntervalMs, configStore, accountId } = this.config;
 
     // Subscribe to outbound messages for this specific email account.
     // When the coordinator responds to an email-triggered conversation, the dispatcher
@@ -204,11 +235,43 @@ export class EmailAdapter {
       }
     });
 
-    // Initialize last-seen timestamp to now so we only process new emails
+    // Restore the persisted high-water mark so restarts resume from where we left off
+    // rather than silently dropping messages that arrived during downtime.
+    // Falls back to Date.now() on first boot (no stored row) or when no configStore is wired.
     this.lastSeenTimestamp = Math.floor(Date.now() / 1000);
+    if (configStore) {
+      const persisted = await configStore.get(POLL_STATE_NAMESPACE, lastSeenKey(accountId));
+      if (persisted !== null) {
+        const parsed = parseInt(persisted, 10);
+        if (!isNaN(parsed)) {
+          this.lastSeenTimestamp = parsed;
+          logger.info(
+            { accountId, lastSeenTimestamp: this.lastSeenTimestamp },
+            'Email adapter: restored poll watermark from persisted state',
+          );
+        } else {
+          logger.warn(
+            { accountId, persisted },
+            'Email adapter: persisted watermark is not a valid integer — falling back to Date.now()',
+          );
+        }
+      } else {
+        logger.info(
+          { accountId },
+          'Email adapter: no persisted watermark found — first boot, initialising to now',
+        );
+      }
+    }
 
-    // Start polling
-    this.pollTimer = setInterval(() => void this.poll(), pollingIntervalMs);
+    this.startedAt = Date.now();
+    this.lastSuccessfulPollAt = null;
+    this.stalledEmitted = false;
+
+    // Poll on interval; also run the watchdog check each tick.
+    this.pollTimer = setInterval(() => {
+      void this.poll();
+      void this.checkWatchdog();
+    }, pollingIntervalMs);
     logger.info({ pollingIntervalMs }, 'Email adapter started — polling Nylas');
 
     // Do an initial poll immediately and await it so callers that await start()
@@ -222,6 +285,7 @@ export class EmailAdapter {
       clearInterval(this.pollTimer);
       this.pollTimer = undefined;
     }
+    this.startedAt = null;
     this.config.logger.info('Email adapter stopped');
   }
 
@@ -230,6 +294,15 @@ export class EmailAdapter {
     // (e.g. slow Nylas response or many messages to process), skip this cycle.
     if (this.processing) return;
     this.processing = true;
+
+    const pollStart = Date.now();
+    // Capture watermark before the loop so we can detect whether it advanced.
+    const prevWatermark = this.lastSeenTimestamp;
+
+    // Per-filter skip counters for the channel.poll audit event.
+    const skipped = { sent_folder: 0, recently_sent: 0, self: 0, excluded: 0, failed: 0 };
+    let fetched = 0;
+    let processed = 0;
 
     // Separate try/catch for the Nylas API call so a transient network error
     // doesn't silently drop already-fetched messages.
@@ -249,6 +322,8 @@ export class EmailAdapter {
       this.processing = false;
       return;
     }
+
+    fetched = messages.length;
 
     try {
       for (const msg of messages) {
@@ -274,6 +349,7 @@ export class EmailAdapter {
             { messageId: msg.id, folders: msg.folders, accountId: this.config.accountId },
             'Email skipped — message is in sent/drafts folder',
           );
+          skipped.sent_folder++;
           continue;
         }
 
@@ -289,6 +365,7 @@ export class EmailAdapter {
             { messageId: msg.id, accountId: this.config.accountId },
             'Email skipped — matches recently-sent message ID (loop guard)',
           );
+          skipped.recently_sent++;
           continue;
         }
 
@@ -310,7 +387,10 @@ export class EmailAdapter {
         if (
           fromEmail &&
           normalizeForComparison(fromEmail) === normalizeForComparison(this.config.selfEmail)
-        ) continue;
+        ) {
+          skipped.self++;
+          continue;
+        }
 
         // Skip emails from any additionally-excluded sender addresses (e.g. Curia's
         // outbound address on a monitored inbox, to prevent self-reply loops).
@@ -324,6 +404,7 @@ export class EmailAdapter {
             { fromEmail, accountId: this.config.accountId },
             'Email skipped — sender is in excludedSenderEmails',
           );
+          skipped.excluded++;
           continue;
         }
 
@@ -360,6 +441,7 @@ export class EmailAdapter {
             },
           });
           await this.config.bus.publish('channel', event);
+          processed++;
 
           // Warn when the provider's SPF/DKIM/DMARC checks did not all pass.
           // This is an audit signal — the message is still processed, but the
@@ -382,10 +464,91 @@ export class EmailAdapter {
             { err, messageId: msg.id, threadId: msg.threadId, senderEmail: fromEmail },
             'Failed to process inbound email — skipping message',
           );
+          skipped.failed++;
         }
       }
     } finally {
       this.processing = false;
+    }
+
+    // ── Post-poll accounting (only reached when listEmailMessages succeeded) ──
+
+    this.lastSuccessfulPollAt = Date.now();
+
+    // Emit one channel.poll audit event per cycle so operators can verify the
+    // adapter is alive and measure throughput over time.
+    try {
+      await this.config.bus.publish('channel', createChannelPoll({
+        accountId: this.config.accountId,
+        channel: 'email',
+        fetched,
+        processed,
+        skipped,
+        lastSeenAt: this.lastSeenTimestamp,
+        durationMs: Date.now() - pollStart,
+      }));
+    } catch (err) {
+      // Non-fatal — the messages were processed. Lose the audit event, not the mail.
+      this.config.logger.error({ err }, 'Failed to emit channel.poll audit event');
+    }
+
+    // Persist the watermark only when it actually advanced to avoid KG write churn
+    // on idle polls. Wrapped in try/catch so a KG write failure never aborts the
+    // poll loop — the in-memory watermark remains correct for the current run.
+    if (this.lastSeenTimestamp !== prevWatermark && this.config.configStore) {
+      try {
+        await this.config.configStore.set(
+          POLL_STATE_NAMESPACE,
+          lastSeenKey(this.config.accountId),
+          String(this.lastSeenTimestamp),
+        );
+      } catch (err) {
+        this.config.logger.error(
+          { err, accountId: this.config.accountId, lastSeenTimestamp: this.lastSeenTimestamp },
+          'Email adapter: failed to persist poll watermark — in-memory value still current',
+        );
+      }
+    }
+  }
+
+  /**
+   * Check whether the poll loop has stalled and emit channel.stalled if so.
+   * Called on each interval tick alongside poll(). Fires at most once per adapter
+   * lifecycle (until stop()/start()) — repeated alerts add noise without value.
+   */
+  private async checkWatchdog(): Promise<void> {
+    if (this.stalledEmitted) return;
+    if (this.startedAt === null) return;
+
+    const now = Date.now();
+    const threshold = 5 * this.config.pollingIntervalMs;
+
+    // Use the last successful poll time when available; fall back to startedAt
+    // so a never-successful adapter (first poll already failing) is also detected.
+    const reference = this.lastSuccessfulPollAt ?? this.startedAt;
+    if (now - reference <= threshold) return;
+
+    this.stalledEmitted = true;
+    this.config.logger.error(
+      {
+        accountId: this.config.accountId,
+        lastSuccessfulPollAt: this.lastSuccessfulPollAt,
+        stallThresholdMs: threshold,
+      },
+      'Email adapter stall detected — no successful poll within threshold',
+    );
+
+    try {
+      await this.config.bus.publish('channel', createChannelStalled({
+        accountId: this.config.accountId,
+        channel: 'email',
+        lastSuccessfulPollAt: this.lastSuccessfulPollAt,
+        stallThresholdMs: threshold,
+      }));
+    } catch (err) {
+      // If we can't even emit the stall event, log at error level — it's already
+      // logged above, so at minimum there is a log trail.
+      this.config.logger.error({ err }, 'Failed to emit channel.stalled event');
     }
   }
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -115,8 +115,11 @@ export class EmailAdapter {
   private startedAt: number | null = null;
   /** Epoch ms of the most recent poll cycle that reached completion (no throw). */
   private lastSuccessfulPollAt: number | null = null;
-  /** True once channel.stalled has been emitted this lifecycle; prevents re-emission. */
+  /** True once channel.stalled has been successfully published this lifecycle. */
   private stalledEmitted = false;
+  /** Number of channel.stalled publish attempts this lifecycle (bounds retries on bus failure). */
+  private stalledEmitAttempts = 0;
+  private static readonly MAX_STALL_EMIT_ATTEMPTS = 3;
 
   // ── Recently-sent message ID tracking (self-loop guard) ───────────────────
   // After a successful send, the Nylas message ID is added here so that the
@@ -238,27 +241,36 @@ export class EmailAdapter {
     // Restore the persisted high-water mark so restarts resume from where we left off
     // rather than silently dropping messages that arrived during downtime.
     // Falls back to Date.now() on first boot (no stored row) or when no configStore is wired.
+    // Falls back to Date.now() and logs at error level if the KG read fails — this is a
+    // degraded state (messages since the last persist may be re-fetched) but must not block startup.
     this.lastSeenTimestamp = Math.floor(Date.now() / 1000);
     if (configStore) {
-      const persisted = await configStore.get(POLL_STATE_NAMESPACE, lastSeenKey(accountId));
-      if (persisted !== null) {
-        const parsed = parseInt(persisted, 10);
-        if (!isNaN(parsed)) {
-          this.lastSeenTimestamp = parsed;
-          logger.info(
-            { accountId, lastSeenTimestamp: this.lastSeenTimestamp },
-            'Email adapter: restored poll watermark from persisted state',
-          );
+      try {
+        const persisted = await configStore.get(POLL_STATE_NAMESPACE, lastSeenKey(accountId));
+        if (persisted !== null) {
+          const parsed = parseInt(persisted, 10);
+          if (!isNaN(parsed)) {
+            this.lastSeenTimestamp = parsed;
+            logger.info(
+              { accountId, lastSeenTimestamp: this.lastSeenTimestamp },
+              'Email adapter: restored poll watermark from persisted state',
+            );
+          } else {
+            logger.warn(
+              { accountId, persisted },
+              'Email adapter: persisted watermark is not a valid integer — falling back to Date.now()',
+            );
+          }
         } else {
-          logger.warn(
-            { accountId, persisted },
-            'Email adapter: persisted watermark is not a valid integer — falling back to Date.now()',
+          logger.info(
+            { accountId },
+            'Email adapter: no persisted watermark found — first boot, initialising to now',
           );
         }
-      } else {
-        logger.info(
-          { accountId },
-          'Email adapter: no persisted watermark found — first boot, initialising to now',
+      } catch (err) {
+        logger.error(
+          { err, accountId },
+          'Email adapter: failed to read persisted watermark from KG — falling back to Date.now(). Messages that arrived since the last persist may be dropped.',
         );
       }
     }
@@ -513,12 +525,14 @@ export class EmailAdapter {
 
   /**
    * Check whether the poll loop has stalled and emit channel.stalled if so.
-   * Called on each interval tick alongside poll(). Fires at most once per adapter
+   * Called on each interval tick alongside poll(). Emits at most once per adapter
    * lifecycle (until stop()/start()) — repeated alerts add noise without value.
+   * If the bus publish fails, retries on the next tick up to MAX_STALL_EMIT_ATTEMPTS.
    */
   private async checkWatchdog(): Promise<void> {
     if (this.stalledEmitted) return;
     if (this.startedAt === null) return;
+    if (this.stalledEmitAttempts >= EmailAdapter.MAX_STALL_EMIT_ATTEMPTS) return;
 
     const now = Date.now();
     const threshold = 5 * this.config.pollingIntervalMs;
@@ -528,7 +542,7 @@ export class EmailAdapter {
     const reference = this.lastSuccessfulPollAt ?? this.startedAt;
     if (now - reference <= threshold) return;
 
-    this.stalledEmitted = true;
+    this.stalledEmitAttempts++;
     this.config.logger.error(
       {
         accountId: this.config.accountId,
@@ -545,10 +559,15 @@ export class EmailAdapter {
         lastSuccessfulPollAt: this.lastSuccessfulPollAt,
         stallThresholdMs: threshold,
       }));
+      // Set stalledEmitted only after confirmed publish — if publish fails we retry
+      // on the next tick (bounded by MAX_STALL_EMIT_ATTEMPTS) rather than permanently
+      // silencing the alert.
+      this.stalledEmitted = true;
     } catch (err) {
-      // If we can't even emit the stall event, log at error level — it's already
-      // logged above, so at minimum there is a log trail.
-      this.config.logger.error({ err }, 'Failed to emit channel.stalled event');
+      this.config.logger.error(
+        { err, attempt: this.stalledEmitAttempts, maxAttempts: EmailAdapter.MAX_STALL_EMIT_ATTEMPTS },
+        'Failed to emit channel.stalled — will retry on next watchdog tick',
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import { EmbeddingService } from './memory/embedding.js';
 import { KnowledgeGraphStore } from './memory/knowledge-graph.js';
 import { MemoryValidator } from './memory/validation.js';
 import { EntityMemory } from './memory/entity-memory.js';
+import { ConfigStore } from './memory/config-store.js';
 import { SkillRegistry } from './skills/registry.js';
 import { ExecutionLayer } from './skills/execution.js';
 import { loadSkillsFromDirectory, validateAllowedCallers } from './skills/loader.js';
@@ -1073,6 +1074,9 @@ async function main(): Promise<void> {
         contactCreationMaxPerMessage: yamlConfig.contact_creation_limits?.max_per_message ?? 10,
         contactCreationMaxPerHour: yamlConfig.contact_creation_limits?.max_per_hour ?? 100,
         timezone: config.timezone,
+        // Persist the poll high-water mark so restarts resume from where we left off
+        // rather than silently dropping messages that arrived during downtime (#846).
+        configStore: entityMemory ? new ConfigStore(entityMemory, logger) : undefined,
       }));
     }
   }

--- a/src/memory/config-store.ts
+++ b/src/memory/config-store.ts
@@ -38,26 +38,25 @@ export class ConfigStore {
   /**
    * Read a stored value. Returns null when the namespace has never been written
    * to, or when the key does not exist within the namespace.
+   *
+   * Propagates infrastructure errors (DB down, KG unavailable, etc.) so callers
+   * can distinguish "key not found" (null) from "read failed" (thrown error).
+   * Callers that want fall-through-on-error behaviour must catch explicitly.
    */
   async get(namespace: string, key: string): Promise<string | null> {
-    try {
-      const anchors = await this.entityMemory.findEntities(anchorLabel(namespace));
-      if (anchors.length === 0) return null;
+    const anchors = await this.entityMemory.findEntities(anchorLabel(namespace));
+    if (anchors.length === 0) return null;
 
-      const allFacts = await Promise.all(anchors.map((a) => this.entityMemory.getFacts(a.id)));
-      const facts = allFacts.flat();
+    const allFacts = await Promise.all(anchors.map((a) => this.entityMemory.getFacts(a.id)));
+    const facts = allFacts.flat();
 
-      // Primary match on label; fallback on properties.key for forward-compat.
-      const fact =
-        facts.find((f) => f.label === key) ??
-        facts.find((f) => (f.properties.key as string | undefined) === key);
+    // Primary match on label; fallback on properties.key for forward-compat.
+    const fact =
+      facts.find((f) => f.label === key) ??
+      facts.find((f) => (f.properties.key as string | undefined) === key);
 
-      if (!fact) return null;
-      return (fact.properties.value as string) ?? null;
-    } catch (err) {
-      this.logger.error({ err, namespace, key }, 'ConfigStore.get: failed to read value');
-      return null;
-    }
+    if (!fact) return null;
+    return (fact.properties.value as string) ?? null;
   }
 
   /**

--- a/src/memory/config-store.ts
+++ b/src/memory/config-store.ts
@@ -51,17 +51,25 @@ export class ConfigStore {
     const facts = allFacts.flat();
 
     // Primary match on label; fallback on properties.key for forward-compat.
-    const fact =
-      facts.find((f) => f.label === key) ??
-      facts.find((f) => (f.properties.key as string | undefined) === key);
+    // Pick the most-recently confirmed fact when there are duplicates (e.g. from
+    // a race between two concurrent anchor-create calls, which is unlikely in
+    // practice but possible across restarts).
+    const matching = facts.filter(
+      (f) => f.label === key || (f.properties.key as string | undefined) === key,
+    );
+    const fact = matching.sort(
+      (a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime(),
+    )[0];
 
     if (!fact) return null;
     return (fact.properties.value as string) ?? null;
   }
 
   /**
-   * Write or update a value. Non-throwing — logs a warning when the underlying
-   * storeFact call is rejected (e.g. conflict) and continues.
+   * Write or update a value. Propagates infrastructure errors after logging so
+   * callers (e.g. EmailAdapter.poll) can catch and emit their own diagnostic.
+   * A soft storeFact rejection (result.stored === false) is logged as a warning
+   * and does not throw — the prior value is still valid in that case.
    */
   async set(namespace: string, key: string, value: string): Promise<void> {
     try {
@@ -90,7 +98,11 @@ export class ConfigStore {
         );
       }
     } catch (err) {
+      // Log at the ConfigStore level for observability, then rethrow so callers
+      // can emit their own domain-specific diagnostic (e.g. "failed to persist
+      // poll watermark") without relying on log correlation.
       this.logger.error({ err, namespace, key }, 'ConfigStore.set: failed to write value');
+      throw err;
     }
   }
 

--- a/src/memory/config-store.ts
+++ b/src/memory/config-store.ts
@@ -1,0 +1,111 @@
+// src/memory/config-store.ts
+//
+// Lightweight KG-backed key-value store for system infrastructure code.
+// Mirrors the logic in skills/config-store/handler.ts but without SkillContext
+// overhead, so non-agent callers (e.g. EmailAdapter, ceo-inbox-list) can read
+// and write config values directly.
+//
+// Storage model (same as the skill):
+//   Namespace anchor: type=concept, label="config:{namespace}"
+//   Per-key facts on the anchor: label=key, properties: { key, value, namespace }, decayClass=permanent
+//
+// Writes use confidence=0.9 so the dedup path auto-resolves updates. The skill
+// uses 1.0, which would produce a 'conflict' result when writing the same key
+// twice. At 0.9, the second write (equal cosine similarity, higher confidence
+// than the stored 0.9 only on the very first write — after that equal) may
+// produce conflict too, but the storeFact dedup logic treats the first stored
+// node as authoritative and updates its properties in place for the 'update'
+// action. Handling: log a warning and continue — the value stored on the
+// PREVIOUS call is still valid, so a failed write is non-fatal for heartbeat use.
+
+import type { EntityMemory } from './entity-memory.js';
+import type { Logger } from '../logger.js';
+
+// Fixed source string — never attributed to any agent task, so not subject to
+// per-task rate limiting.
+const SYSTEM_SOURCE = 'system:config-store';
+
+function anchorLabel(namespace: string): string {
+  return `config:${namespace}`;
+}
+
+export class ConfigStore {
+  constructor(
+    private readonly entityMemory: EntityMemory,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Read a stored value. Returns null when the namespace has never been written
+   * to, or when the key does not exist within the namespace.
+   */
+  async get(namespace: string, key: string): Promise<string | null> {
+    try {
+      const anchors = await this.entityMemory.findEntities(anchorLabel(namespace));
+      if (anchors.length === 0) return null;
+
+      const allFacts = await Promise.all(anchors.map((a) => this.entityMemory.getFacts(a.id)));
+      const facts = allFacts.flat();
+
+      // Primary match on label; fallback on properties.key for forward-compat.
+      const fact =
+        facts.find((f) => f.label === key) ??
+        facts.find((f) => (f.properties.key as string | undefined) === key);
+
+      if (!fact) return null;
+      return (fact.properties.value as string) ?? null;
+    } catch (err) {
+      this.logger.error({ err, namespace, key }, 'ConfigStore.get: failed to read value');
+      return null;
+    }
+  }
+
+  /**
+   * Write or update a value. Non-throwing — logs a warning when the underlying
+   * storeFact call is rejected (e.g. conflict) and continues.
+   */
+  async set(namespace: string, key: string, value: string): Promise<void> {
+    try {
+      const anchor = await this.findOrCreateAnchor(namespace);
+
+      // confidence=0.9 (not 1.0) so the dedup path can auto-resolve updates:
+      // a second write with equal cosine similarity and 0.9 confidence against
+      // an existing 0.9 node triggers 'conflict', but a first write at 0.9
+      // followed by a second at 0.9 on the same label uses the dedup
+      // 'auto_resolved' path when the new value has the same or higher confidence.
+      // In practice the write may occasionally be rejected with stored=false;
+      // we log and continue — the prior value is still valid.
+      const result = await this.entityMemory.storeFact({
+        entityNodeId: anchor.id,
+        label: key,
+        properties: { key, value, namespace },
+        confidence: 0.9,
+        decayClass: 'permanent',
+        source: SYSTEM_SOURCE,
+      });
+
+      if (!result.stored) {
+        this.logger.warn(
+          { namespace, key, action: result.action },
+          'ConfigStore.set: storeFact rejected the write — prior value still in effect',
+        );
+      }
+    } catch (err) {
+      this.logger.error({ err, namespace, key }, 'ConfigStore.set: failed to write value');
+    }
+  }
+
+  private async findOrCreateAnchor(namespace: string): Promise<{ id: string }> {
+    const label = anchorLabel(namespace);
+    const existing = await this.entityMemory.findEntities(label);
+    if (existing.length > 0) return existing[0]!;
+
+    const { entity } = await this.entityMemory.createEntity({
+      type: 'concept',
+      label,
+      properties: { category: 'config', namespace },
+      source: SYSTEM_SOURCE,
+    });
+    return entity;
+  }
+}

--- a/tests/integration/email-adapter-persistence.test.ts
+++ b/tests/integration/email-adapter-persistence.test.ts
@@ -1,0 +1,300 @@
+// tests/integration/email-adapter-persistence.test.ts
+//
+// Integration tests for #846: email-adapter watermark persistence and stall watchdog.
+//
+// Two test suites:
+//   1. Persistence (describeIf — needs real Postgres) — verifies that restarting
+//      the adapter resumes from the stored watermark and does not re-process old messages.
+//   2. Stall watchdog (describe — no DB, uses fake timers) — verifies that channel.stalled
+//      is emitted exactly once when no successful poll completes within 5 × pollingIntervalMs.
+
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { ConfigStore } from '../../src/memory/config-store.js';
+import { EmailAdapter } from '../../src/channels/email/email-adapter.js';
+import { EventBus } from '../../src/bus/bus.js';
+import type { BusEvent, ChannelPollEvent, ChannelStalledEvent } from '../../src/bus/events.js';
+import type { ContactService } from '../../src/contacts/contact-service.js';
+
+const { Pool } = pg;
+
+// Skip real-Postgres tests when DATABASE_URL is absent (local dev without Docker).
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+// Unique accountId for test isolation — never used in production.
+const TEST_ACCOUNT_ID = 'test-persist-846';
+
+// Seed watermark for the persistence tests: messages have dates just above this value so
+// the adapter (which reads this persisted value instead of Date.now()) will advance it.
+const SEED_WATERMARK = 999_999;
+
+// Minimal NylasMessage-shaped object — only fields the adapter reads before
+// calling convertNylasMessage(). Conversion fails on this minimal shape, which is
+// caught per-message. The watermark advance (before conversion) is what we test.
+function makeTestMessage(id: string, date: number) {
+  return {
+    id,
+    threadId: `thread-${id}`,
+    date,
+    subject: 'Test subject',
+    folders: ['INBOX'],
+    from: [{ email: 'sender@example.com', name: 'Sender' }],
+    to: [{ email: 'curia@example.com', name: 'Curia' }],
+    cc: [],
+    bcc: [],
+    body: null,
+    htmlBody: null,
+    attachments: [],
+    headers: {},
+    unread: true,
+  };
+}
+
+// Minimal ContactService mock — resolveByChannelIdentity returns null (no existing contacts)
+// so the adapter attempts to create contacts (which immediately resolve without doing real work).
+function makeContactService(): ContactService {
+  return {
+    resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+    createContact: vi.fn().mockResolvedValue({ id: 'c-test', displayName: 'Test', status: 'provisional' }),
+    linkIdentity: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ContactService;
+}
+
+// Shared adapter config, minus the fields that vary by test.
+function makeAdapterConfig(
+  bus: EventBus,
+  gateway: ReturnType<typeof makeGateway>,
+  configStore?: ConfigStore,
+) {
+  return {
+    accountId: TEST_ACCOUNT_ID,
+    bus,
+    logger: pino({ level: 'silent' }),
+    outboundGateway: gateway as never,
+    contactService: makeContactService(),
+    pollingIntervalMs: 100,
+    selfEmail: 'curia@example.com',
+    excludedSenderEmails: [],
+    contactCreationMaxPerMessage: 10,
+    contactCreationMaxPerHour: 100,
+    timezone: 'UTC',
+    configStore,
+  };
+}
+
+// Minimal gateway mock — only listEmailMessages matters for these tests.
+function makeGateway(listImpl: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue([])) {
+  return {
+    listEmailMessages: listImpl,
+    send: vi.fn(),
+    sendNotification: vi.fn(),
+    createEmailDraft: vi.fn(),
+    linkGatedAction: vi.fn(),
+  };
+}
+
+// ── Persistence tests (real Postgres / KG required) ─────────────────────────
+
+describeIf('email-adapter watermark persistence (#846)', () => {
+  let pool: pg.Pool;
+  let configStore: ConfigStore;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const logger = pino({ level: 'silent' });
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    const entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+    configStore = new ConfigStore(entityMemory, logger);
+
+    // Fast-fail if KG tables are missing (migrations not yet run).
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterAll(async () => {
+    // Clean up the test-specific fact nodes (label = test account key) and their edges.
+    // The namespace anchor ('config:system:email-poll-state') is left in place — it is
+    // harmless and may be shared with other config-store entries in the dev DB.
+    await pool.query(
+      `DELETE FROM kg_edges WHERE target_node_id IN (
+        SELECT id FROM kg_nodes WHERE label = $1
+      )`,
+      [`${TEST_ACCOUNT_ID}.last_seen_at`],
+    );
+    await pool.query('DELETE FROM kg_nodes WHERE label = $1', [`${TEST_ACCOUNT_ID}.last_seen_at`]);
+    await pool.end();
+  });
+
+  it('persists the watermark and resumes from it on restart (no-replay)', async () => {
+    // Pre-seed the watermark so the adapter reads a past value instead of Date.now().
+    // This lets us use message dates just above the seed without racing against the clock.
+    await configStore.set('system:email-poll-state', `${TEST_ACCOUNT_ID}.last_seen_at`, String(SEED_WATERMARK));
+
+    const msgs = [
+      makeTestMessage('msg-a', SEED_WATERMARK + 1),
+      makeTestMessage('msg-b', SEED_WATERMARK + 11),
+      makeTestMessage('msg-c', SEED_WATERMARK + 21),
+    ];
+    // max date is SEED_WATERMARK + 21; watermark advances to SEED_WATERMARK + 22.
+    const expectedWatermark = SEED_WATERMARK + 22;
+
+    // First adapter run — ingest the three test messages.
+    const adapter1 = new EmailAdapter(makeAdapterConfig(
+      new EventBus(pino({ level: 'silent' })),
+      makeGateway(vi.fn().mockResolvedValueOnce(msgs)),
+      configStore,
+    ));
+    await adapter1.start();
+    await adapter1.stop();
+
+    // The watermark must now be persisted in the KG.
+    const persisted = await configStore.get('system:email-poll-state', `${TEST_ACCOUNT_ID}.last_seen_at`);
+    expect(persisted).toBe(String(expectedWatermark));
+
+    // Second adapter run — verify receivedAfter uses the persisted watermark.
+    const listFn = vi.fn().mockResolvedValueOnce([]);
+    const adapter2 = new EmailAdapter(makeAdapterConfig(
+      new EventBus(pino({ level: 'silent' })),
+      makeGateway(listFn),
+      configStore,
+    ));
+    await adapter2.start();
+    await adapter2.stop();
+
+    // The first call to listEmailMessages on the second adapter should use the persisted watermark.
+    const [callOptions] = listFn.mock.calls[0]!;
+    expect(callOptions.receivedAfter).toBe(expectedWatermark);
+  });
+
+  it('emits one channel.poll event per successful poll cycle with correct payload shape', async () => {
+    const bus = new EventBus(pino({ level: 'silent' }));
+    const pollEvents: ChannelPollEvent[] = [];
+    bus.subscribe('channel.poll', 'system', async (evt) => {
+      pollEvents.push(evt as ChannelPollEvent);
+    });
+
+    await configStore.set('system:email-poll-state', `${TEST_ACCOUNT_ID}.last_seen_at`, String(SEED_WATERMARK));
+
+    const adapter = new EmailAdapter(makeAdapterConfig(
+      bus,
+      makeGateway(vi.fn().mockResolvedValueOnce([makeTestMessage('msg-poll', SEED_WATERMARK + 1)])),
+      configStore,
+    ));
+    await adapter.start();
+    await adapter.stop();
+
+    expect(pollEvents).toHaveLength(1);
+    const { payload } = pollEvents[0]!;
+    expect(payload.accountId).toBe(TEST_ACCOUNT_ID);
+    expect(payload.channel).toBe('email');
+    expect(payload.fetched).toBe(1);
+    // Conversion fails on the minimal mock shape — message lands in skipped.failed.
+    // The important thing is the payload shape is present and fetched reflects Nylas count.
+    expect(typeof payload.processed).toBe('number');
+    expect(typeof payload.skipped.sent_folder).toBe('number');
+    expect(typeof payload.durationMs).toBe('number');
+    expect(payload.lastSeenAt).toBe(SEED_WATERMARK + 2); // date + 1
+  });
+
+  it('does not persist the watermark when no messages are returned (idle poll)', async () => {
+    await configStore.set('system:email-poll-state', `${TEST_ACCOUNT_ID}.last_seen_at`, String(SEED_WATERMARK));
+
+    const adapter = new EmailAdapter(makeAdapterConfig(
+      new EventBus(pino({ level: 'silent' })),
+      makeGateway(vi.fn().mockResolvedValueOnce([])), // empty poll
+      configStore,
+    ));
+    await adapter.start();
+    await adapter.stop();
+
+    // Watermark should remain at the seeded value — no write churn on idle polls.
+    const afterIdle = await configStore.get('system:email-poll-state', `${TEST_ACCOUNT_ID}.last_seen_at`);
+    expect(afterIdle).toBe(String(SEED_WATERMARK));
+  });
+});
+
+// ── Stall watchdog test (no DB required — uses vi.useFakeTimers) ─────────────
+
+describe('email-adapter stall watchdog (#846)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits exactly one channel.stalled when polls fail for > 5× pollingIntervalMs', async () => {
+    vi.useFakeTimers();
+
+    const capturedEvents: BusEvent[] = [];
+
+    // Minimal mock bus — subscribe is a no-op (we don't need outbound handling),
+    // publish records emitted events so we can assert on them.
+    const bus = {
+      subscribe: vi.fn(),
+      publish: vi.fn().mockImplementation(async (_layer: string, evt: BusEvent) => {
+        capturedEvents.push(evt);
+      }),
+    } as unknown as EventBus;
+
+    // Gateway that always rejects — simulates Nylas being unreachable.
+    const gateway = makeGateway(vi.fn().mockRejectedValue(new Error('Nylas unavailable')));
+
+    const adapter = new EmailAdapter(makeAdapterConfig(bus, gateway));
+
+    // start() awaits the initial poll synchronously; the poll throws and is caught.
+    // The setInterval is registered but has not fired yet.
+    await adapter.start();
+
+    // Advance past 5× pollingIntervalMs (5 × 100ms = 500ms).
+    // Tick 6 (600ms) is the first tick where now - startedAt > threshold → stalled.
+    await vi.advanceTimersByTimeAsync(650);
+
+    const stalledEvents = capturedEvents.filter(
+      (e): e is ChannelStalledEvent => e.type === 'channel.stalled',
+    );
+
+    expect(stalledEvents).toHaveLength(1);
+    expect(stalledEvents[0]!.payload.accountId).toBe(TEST_ACCOUNT_ID);
+    expect(stalledEvents[0]!.payload.channel).toBe('email');
+    // Adapter never completed a successful poll, so this is null.
+    expect(stalledEvents[0]!.payload.lastSuccessfulPollAt).toBeNull();
+    expect(stalledEvents[0]!.payload.stallThresholdMs).toBe(500); // 5 × 100ms
+
+    // Advance further — must NOT emit a second channel.stalled (fire-once per lifecycle).
+    await vi.advanceTimersByTimeAsync(600);
+    const stalledTotal = capturedEvents.filter((e) => e.type === 'channel.stalled');
+    expect(stalledTotal).toHaveLength(1);
+
+    await adapter.stop();
+  });
+
+  it('does not stall when polls succeed within the threshold', async () => {
+    vi.useFakeTimers();
+
+    const capturedEvents: BusEvent[] = [];
+    const bus = {
+      subscribe: vi.fn(),
+      publish: vi.fn().mockImplementation(async (_layer: string, evt: BusEvent) => {
+        capturedEvents.push(evt);
+      }),
+    } as unknown as EventBus;
+
+    // Gateway succeeds (returns empty list) — adapter should NOT stall.
+    const adapter = new EmailAdapter(makeAdapterConfig(bus, makeGateway()));
+
+    await adapter.start();
+
+    // Advance well past 5× interval — still healthy because each tick succeeds.
+    await vi.advanceTimersByTimeAsync(650);
+
+    const stalledEvents = capturedEvents.filter((e) => e.type === 'channel.stalled');
+    expect(stalledEvents).toHaveLength(0);
+
+    await adapter.stop();
+  });
+});

--- a/tests/integration/email-adapter-persistence.test.ts
+++ b/tests/integration/email-adapter-persistence.test.ts
@@ -1,14 +1,12 @@
 // tests/integration/email-adapter-persistence.test.ts
 //
-// Integration tests for #846: email-adapter watermark persistence and stall watchdog.
+// Integration tests for #846: email-adapter watermark persistence.
+// Requires real Postgres (DATABASE_URL env); tests are skipped when not available.
 //
-// Two test suites:
-//   1. Persistence (describeIf — needs real Postgres) — verifies that restarting
-//      the adapter resumes from the stored watermark and does not re-process old messages.
-//   2. Stall watchdog (describe — no DB, uses fake timers) — verifies that channel.stalled
-//      is emitted exactly once when no successful poll completes within 5 × pollingIntervalMs.
+// Stall-watchdog unit tests (mock-only, no DB) live in:
+//   tests/unit/channels/email/email-adapter-watchdog.test.ts
 
-import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import pg from 'pg';
 import pino from 'pino';
 import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
@@ -18,7 +16,7 @@ import { MemoryValidator } from '../../src/memory/validation.js';
 import { ConfigStore } from '../../src/memory/config-store.js';
 import { EmailAdapter } from '../../src/channels/email/email-adapter.js';
 import { EventBus } from '../../src/bus/bus.js';
-import type { BusEvent, ChannelPollEvent, ChannelStalledEvent } from '../../src/bus/events.js';
+import type { ChannelPollEvent } from '../../src/bus/events.js';
 import type { ContactService } from '../../src/contacts/contact-service.js';
 
 const { Pool } = pg;
@@ -220,90 +218,3 @@ describeIf('email-adapter watermark persistence (#846)', () => {
   });
 });
 
-// ── Stall watchdog test (no DB required — uses vi.useFakeTimers) ─────────────
-
-describe('email-adapter stall watchdog (#846)', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('emits exactly one channel.stalled when polls fail for > 5× pollingIntervalMs', async () => {
-    vi.useFakeTimers();
-
-    const capturedEvents: BusEvent[] = [];
-
-    // Minimal mock bus — subscribe is a no-op (we don't need outbound handling),
-    // publish records emitted events so we can assert on them.
-    const bus = {
-      subscribe: vi.fn(),
-      publish: vi.fn().mockImplementation(async (_layer: string, evt: BusEvent) => {
-        capturedEvents.push(evt);
-      }),
-    } as unknown as EventBus;
-
-    // Gateway that always rejects — simulates Nylas being unreachable.
-    const gateway = makeGateway(vi.fn().mockRejectedValue(new Error('Nylas unavailable')));
-
-    const adapter = new EmailAdapter(makeAdapterConfig(bus, gateway));
-
-    // start() awaits the initial poll synchronously; the poll throws and is caught.
-    // The setInterval is registered but has not fired yet.
-    await adapter.start();
-
-    // Advance past 5× pollingIntervalMs (5 × 100ms = 500ms).
-    // Tick 6 (600ms) is the first tick where now - startedAt > threshold → stalled.
-    await vi.advanceTimersByTimeAsync(650);
-    // Drain microtasks from fire-and-forget `void this.checkWatchdog()` calls inside
-    // the setInterval callback. checkWatchdog() awaits bus.publish(), so two rounds
-    // of Promise.resolve() flush the microtask queue before we assert.
-    await Promise.resolve();
-    await Promise.resolve();
-
-    const stalledEvents = capturedEvents.filter(
-      (e): e is ChannelStalledEvent => e.type === 'channel.stalled',
-    );
-
-    expect(stalledEvents).toHaveLength(1);
-    expect(stalledEvents[0]!.payload.accountId).toBe(TEST_ACCOUNT_ID);
-    expect(stalledEvents[0]!.payload.channel).toBe('email');
-    // Adapter never completed a successful poll, so this is null.
-    expect(stalledEvents[0]!.payload.lastSuccessfulPollAt).toBeNull();
-    expect(stalledEvents[0]!.payload.stallThresholdMs).toBe(500); // 5 × 100ms
-
-    // Advance further — must NOT emit a second channel.stalled (fire-once per lifecycle).
-    await vi.advanceTimersByTimeAsync(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    const stalledTotal = capturedEvents.filter((e) => e.type === 'channel.stalled');
-    expect(stalledTotal).toHaveLength(1);
-
-    await adapter.stop();
-  });
-
-  it('does not stall when polls succeed within the threshold', async () => {
-    vi.useFakeTimers();
-
-    const capturedEvents: BusEvent[] = [];
-    const bus = {
-      subscribe: vi.fn(),
-      publish: vi.fn().mockImplementation(async (_layer: string, evt: BusEvent) => {
-        capturedEvents.push(evt);
-      }),
-    } as unknown as EventBus;
-
-    // Gateway succeeds (returns empty list) — adapter should NOT stall.
-    const adapter = new EmailAdapter(makeAdapterConfig(bus, makeGateway()));
-
-    await adapter.start();
-
-    // Advance well past 5× interval — still healthy because each tick succeeds.
-    await vi.advanceTimersByTimeAsync(650);
-    await Promise.resolve();
-    await Promise.resolve();
-
-    const stalledEvents = capturedEvents.filter((e) => e.type === 'channel.stalled');
-    expect(stalledEvents).toHaveLength(0);
-
-    await adapter.stop();
-  });
-});

--- a/tests/integration/email-adapter-persistence.test.ts
+++ b/tests/integration/email-adapter-persistence.test.ts
@@ -253,6 +253,11 @@ describe('email-adapter stall watchdog (#846)', () => {
     // Advance past 5× pollingIntervalMs (5 × 100ms = 500ms).
     // Tick 6 (600ms) is the first tick where now - startedAt > threshold → stalled.
     await vi.advanceTimersByTimeAsync(650);
+    // Drain microtasks from fire-and-forget `void this.checkWatchdog()` calls inside
+    // the setInterval callback. checkWatchdog() awaits bus.publish(), so two rounds
+    // of Promise.resolve() flush the microtask queue before we assert.
+    await Promise.resolve();
+    await Promise.resolve();
 
     const stalledEvents = capturedEvents.filter(
       (e): e is ChannelStalledEvent => e.type === 'channel.stalled',
@@ -267,6 +272,8 @@ describe('email-adapter stall watchdog (#846)', () => {
 
     // Advance further — must NOT emit a second channel.stalled (fire-once per lifecycle).
     await vi.advanceTimersByTimeAsync(600);
+    await Promise.resolve();
+    await Promise.resolve();
     const stalledTotal = capturedEvents.filter((e) => e.type === 'channel.stalled');
     expect(stalledTotal).toHaveLength(1);
 
@@ -291,6 +298,8 @@ describe('email-adapter stall watchdog (#846)', () => {
 
     // Advance well past 5× interval — still healthy because each tick succeeds.
     await vi.advanceTimersByTimeAsync(650);
+    await Promise.resolve();
+    await Promise.resolve();
 
     const stalledEvents = capturedEvents.filter((e) => e.type === 'channel.stalled');
     expect(stalledEvents).toHaveLength(0);

--- a/tests/unit/channels/email/email-adapter-watchdog.test.ts
+++ b/tests/unit/channels/email/email-adapter-watchdog.test.ts
@@ -1,0 +1,172 @@
+// tests/unit/channels/email/email-adapter-watchdog.test.ts
+//
+// Unit tests for the #846 stall-watchdog logic in EmailAdapter.
+// All dependencies are mocked so no real Postgres is needed.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import pino from 'pino';
+import { EmailAdapter } from '../../../../src/channels/email/email-adapter.js';
+import type { EventBus } from '../../../../src/bus/bus.js';
+import type { BusEvent, ChannelStalledEvent } from '../../../../src/bus/events.js';
+import type { ContactService } from '../../../../src/contacts/contact-service.js';
+
+const TEST_ACCOUNT_ID = 'test-watchdog-846';
+
+function makeContactService(): ContactService {
+  return {
+    resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+    createContact: vi.fn().mockResolvedValue({ id: 'c-test', displayName: 'Test', status: 'provisional' }),
+    linkIdentity: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ContactService;
+}
+
+function makeGateway(listImpl: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue([])) {
+  return {
+    listEmailMessages: listImpl,
+    send: vi.fn(),
+    sendNotification: vi.fn(),
+    createEmailDraft: vi.fn(),
+    linkGatedAction: vi.fn(),
+  };
+}
+
+function makeAdapterConfig(
+  bus: EventBus,
+  gateway: ReturnType<typeof makeGateway>,
+) {
+  return {
+    accountId: TEST_ACCOUNT_ID,
+    bus,
+    logger: pino({ level: 'silent' }),
+    outboundGateway: gateway as never,
+    contactService: makeContactService(),
+    pollingIntervalMs: 100,
+    selfEmail: 'curia@example.com',
+    excludedSenderEmails: [],
+    contactCreationMaxPerMessage: 10,
+    contactCreationMaxPerHour: 100,
+    timezone: 'UTC',
+    // no configStore — watermark persistence not under test here
+  };
+}
+
+describe('email-adapter stall watchdog (#846)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits exactly one channel.stalled when polls fail for > 5× pollingIntervalMs', async () => {
+    vi.useFakeTimers();
+
+    const capturedEvents: BusEvent[] = [];
+
+    // Minimal mock bus — subscribe is a no-op, publish records emitted events.
+    const bus = {
+      subscribe: vi.fn(),
+      publish: vi.fn().mockImplementation(async (_layer: string, evt: BusEvent) => {
+        capturedEvents.push(evt);
+      }),
+    } as unknown as EventBus;
+
+    // Gateway that always rejects — simulates Nylas being unreachable.
+    const gateway = makeGateway(vi.fn().mockRejectedValue(new Error('Nylas unavailable')));
+
+    const adapter = new EmailAdapter(makeAdapterConfig(bus, gateway));
+
+    // start() awaits the initial poll synchronously; the poll throws and is caught.
+    // The setInterval is registered but has not fired yet.
+    await adapter.start();
+
+    // Advance past 5× pollingIntervalMs (5 × 100ms = 500ms).
+    // Tick 6 (600ms) is the first tick where now - startedAt > threshold → stalled.
+    await vi.advanceTimersByTimeAsync(650);
+    // Drain microtasks from fire-and-forget `void this.checkWatchdog()` calls inside
+    // the setInterval callback. checkWatchdog() awaits bus.publish(), so two rounds
+    // of Promise.resolve() flush the microtask queue before we assert.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const stalledEvents = capturedEvents.filter(
+      (e): e is ChannelStalledEvent => e.type === 'channel.stalled',
+    );
+
+    expect(stalledEvents).toHaveLength(1);
+    expect(stalledEvents[0]!.payload.accountId).toBe(TEST_ACCOUNT_ID);
+    expect(stalledEvents[0]!.payload.channel).toBe('email');
+    // Adapter never completed a successful poll, so this is null.
+    expect(stalledEvents[0]!.payload.lastSuccessfulPollAt).toBeNull();
+    expect(stalledEvents[0]!.payload.stallThresholdMs).toBe(500); // 5 × 100ms
+
+    // Advance further — must NOT emit a second channel.stalled (fire-once per lifecycle).
+    await vi.advanceTimersByTimeAsync(600);
+    await Promise.resolve();
+    await Promise.resolve();
+    const stalledTotal = capturedEvents.filter((e) => e.type === 'channel.stalled');
+    expect(stalledTotal).toHaveLength(1);
+
+    await adapter.stop();
+  });
+
+  it('does not stall when polls succeed within the threshold', async () => {
+    vi.useFakeTimers();
+
+    const capturedEvents: BusEvent[] = [];
+    const bus = {
+      subscribe: vi.fn(),
+      publish: vi.fn().mockImplementation(async (_layer: string, evt: BusEvent) => {
+        capturedEvents.push(evt);
+      }),
+    } as unknown as EventBus;
+
+    // Gateway succeeds (returns empty list) — adapter should NOT stall.
+    const adapter = new EmailAdapter(makeAdapterConfig(bus, makeGateway()));
+
+    await adapter.start();
+
+    // Advance well past 5× interval — still healthy because each tick succeeds.
+    await vi.advanceTimersByTimeAsync(650);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const stalledEvents = capturedEvents.filter((e) => e.type === 'channel.stalled');
+    expect(stalledEvents).toHaveLength(0);
+
+    await adapter.stop();
+  });
+
+  it('resets the retry counter on stop()/start() so stalls are re-detectable', async () => {
+    vi.useFakeTimers();
+
+    const capturedEvents: BusEvent[] = [];
+    const bus = {
+      subscribe: vi.fn(),
+      publish: vi.fn().mockImplementation(async (_layer: string, evt: BusEvent) => {
+        capturedEvents.push(evt);
+      }),
+    } as unknown as EventBus;
+
+    const gateway = makeGateway(vi.fn().mockRejectedValue(new Error('Nylas unavailable')));
+    const adapter = new EmailAdapter(makeAdapterConfig(bus, gateway));
+
+    // First lifecycle: run until stall detected.
+    await adapter.start();
+    await vi.advanceTimersByTimeAsync(650);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(capturedEvents.filter((e) => e.type === 'channel.stalled')).toHaveLength(1);
+
+    await adapter.stop();
+    capturedEvents.length = 0; // reset captured events
+
+    // Second lifecycle: stalledEmitAttempts must have been reset so the watchdog fires again.
+    await adapter.start();
+    await vi.advanceTimersByTimeAsync(650);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(capturedEvents.filter((e) => e.type === 'channel.stalled')).toHaveLength(1);
+
+    await adapter.stop();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Closes #846

- **`ConfigStore` service** (`src/memory/config-store.ts`) — new KG-backed key-value store for system infrastructure code. Namespace-agnostic; designed for reuse by #866 (ceo-inbox-list triage watermark). Propagates infrastructure errors so callers distinguish "key not found" from "KG unavailable".
- **Watermark persistence** — `EmailAdapter` reads `lastSeenTimestamp` from the KG on `start()` and falls back to `Date.now()` only on first boot; persists after each watermark advance (not on idle polls).
- **`channel.poll` audit event** — emitted per successful Nylas poll cycle with `fetched`, `processed`, per-filter `skipped` breakdown, `lastSeenAt`, and `durationMs`. Makes adapter liveness visible in the audit log.
- **`channel.stalled` watchdog** — emitted once per lifecycle when no successful poll completes within `5 × pollingIntervalMs`. `stalledEmitted` is set only after confirmed publish; retries up to 3× on transient bus failures.
- **Event registry** — `channel.poll` and `channel.stalled` added to `events.ts`, `BusEvent` union, `publishAllowlist.channel`, and `subscribeAllowlist.system`.
- **Integration tests** — watchdog suite (fake timers, no DB) and persistence suite (`describeIf` against real Postgres) in `tests/integration/email-adapter-persistence.test.ts`.

## Test plan

- [ ] `pnpm run typecheck` passes
- [ ] `pnpm test` passes (watchdog tests run without DB; persistence tests run when `DATABASE_URL` is set)
- [ ] Verify `channel.poll` events appear in the audit log after deploy
- [ ] Verify restarting the email adapter logs "restored poll watermark from persisted state" rather than "first boot"


___

## **CodeAnt-AI Description**
**Keep email polls from restarting at the wrong point and add audit events for poll health**

### What Changed
- The email adapter now restores its last processed message time after a restart, so it resumes from the stored point instead of re-reading from “now” and missing messages that arrived during downtime.
- Each successful email poll now emits a `channel.poll` audit event with message totals, skip breakdown, the current watermark, and how long the poll took.
- If the adapter goes too long without a successful poll, it now emits a one-time `channel.stalled` alert so a stuck inbox poller is visible.
- The adapter now avoids rewriting the stored watermark on idle polls, and it logs clearer outcomes when the stored value cannot be read or written.

### Impact
`✅ Fewer missed emails after restarts`
`✅ Clearer email poll health in audit logs`
`✅ Faster detection of stuck inbox polling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added polling audit events for improved email adapter observability and monitoring visibility.
  * Implemented stall detection to alert when polling fails to complete within configured thresholds.

* **Bug Fixes**
  * Email adapter now persists state to prevent message loss following system downtime or restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->