### PR TITLE
feat: physics-aware KG layout with principal-node focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+- **KG graph** — various visual improvements: physics-aware layout, better hub sizing, principal-node default view, and viewport centering on focal nodes. (#861)
+
 ### Fixed
 
 - **Email adapter watermark persistence** — `lastSeenTimestamp` is now persisted to the KG via a new `ConfigStore` service (`src/memory/config-store.ts`) and restored on restart, preventing silent message loss after a process restart during downtime. (#846)

--- a/apps/console/src/pages/KgPage.tsx
+++ b/apps/console/src/pages/KgPage.tsx
@@ -111,7 +111,7 @@ function idealEdgeLengthFn(edge: cytoscape.EdgeSingular): number {
 // produce soft springs so those nodes drift outward naturally.
 function edgeElasticityFn(edge: cytoscape.EdgeSingular): number {
   if (STRONG_EDGES.has(edge.data('label') as string)) return 0.9;
-  const conf = (edge.data('confidence') as number) ?? 0.5;
+  const conf = (edge.data('confidence') as number | undefined | null) ?? 0.5;
   const srcScore = DECAY_SCORE[edge.source().data('decayClass') as string] ?? 0.7;
   const tgtScore = DECAY_SCORE[edge.target().data('decayClass') as string] ?? 0.7;
   return Math.max(0.1, conf * Math.min(srcScore, tgtScore) * 0.7);
@@ -451,7 +451,7 @@ export default function KgPage() {
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
       console.error('[KgPage] hero graph load failed:', err);
-      setStatus('Failed to load graph');
+      setStatus(`Failed to load graph: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
   }, []);
 
@@ -474,7 +474,11 @@ export default function KgPage() {
 
   async function loadNeighborhood(nodeId: string) {
     const cy = cyRef.current;
-    if (!cy) return;
+    if (!cy) {
+      console.error('[KgPage] loadNeighborhood called before Cytoscape was initialized');
+      setStatus('Graph not ready — please refresh');
+      return;
+    }
     neighborhoodAbortRef.current?.abort();
     const controller = new AbortController();
     neighborhoodAbortRef.current = controller;
@@ -506,7 +510,7 @@ export default function KgPage() {
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
       console.error('[KgPage] neighborhood load failed:', err);
-      setStatus('Failed to load');
+      setStatus(`Failed to load: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
   }
 
@@ -550,7 +554,7 @@ export default function KgPage() {
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
       console.error('[KgPage] expand failed:', err);
-      setStatus('Failed to expand');
+      setStatus(`Failed to expand: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
   }
 
@@ -624,6 +628,8 @@ export default function KgPage() {
               await loadNeighborhood(principal.kgNodeId);
               return;
             }
+          } else {
+            console.error('[KgPage] principal node lookup: contacts fetch failed with status', res.status);
           }
         } catch (err) {
           console.error('[KgPage] principal node lookup failed:', err);
@@ -702,12 +708,7 @@ export default function KgPage() {
             />
           </div>
 
-          {loadError ? (
-            <div style={{ padding: 32, color: 'var(--app-destructive)', fontSize: 13 }}>
-              {loadError}
-            </div>
-          ) : (
-            <div className="kg-layout">
+          <div className="kg-layout">
               {/* Left: node list sidebar */}
               <div className="kg-sidebar">
                 <div className="kg-sidebar-search">
@@ -722,7 +723,11 @@ export default function KgPage() {
                   <button onClick={submitSearch}>Search</button>
                 </div>
                 <div className="kg-sidebar-list">
-                  {sidebarNodes.length === 0 ? (
+                  {loadError ? (
+                    <p style={{ fontSize: 12, color: 'var(--app-destructive)', margin: 0 }}>
+                      {loadError}
+                    </p>
+                  ) : sidebarNodes.length === 0 ? (
                     <p style={{ fontSize: 12, color: 'var(--app-fg-muted)', margin: 0 }}>
                       No matching nodes.
                     </p>
@@ -783,7 +788,6 @@ export default function KgPage() {
                 />
               )}
             </div>
-          )}
         </main>
       </div>
     </MobileMenuContext.Provider>

--- a/apps/console/src/pages/KgPage.tsx
+++ b/apps/console/src/pages/KgPage.tsx
@@ -70,25 +70,76 @@ const SENS_BADGE: Record<string, string> = {
   restricted:   'badge badge-kg-restricted',
 };
 
+// Edge types that represent close structural relationships — their pairs should
+// sit visually adjacent in the layout.
+const STRONG_EDGES = new Set([
+  'spouse', 'parent', 'child', 'sibling',
+  'reports_to', 'manages', 'member_of', 'founded', 'invested_in', 'advises',
+]);
+
+// Weighting factors for edge elasticity based on how quickly connected nodes
+// go stale. Permanent facts create tight springs; fast-decaying info goes soft.
+const DECAY_SCORE: Record<string, number> = {
+  permanent:  1.0,
+  slow_decay: 0.7,
+  fast_decay: 0.4,
+};
+
+// ── fCoSE physics callbacks ───────────────────────────────────────────────────
+
+// Fact nodes are children of entities; low repulsion keeps them clustered
+// nearby. High-traffic entity types need more space to avoid crowding.
+function nodeRepulsionFn(node: cytoscape.NodeSingular): number {
+  const type = node.data('type') as string;
+  if (type === 'fact') return 1_000;
+  if (type === 'person' || type === 'organization' || type === 'event') return 7_500;
+  return 4_500; // project, decision, concept — fCoSE default
+}
+
+// Fact edges stay short so attributes cluster against their parent entity.
+// Strong relationship pairs sit visually adjacent; generic edges settle at 80px.
+function idealEdgeLengthFn(edge: cytoscape.EdgeSingular): number {
+  const srcType = edge.source().data('type') as string;
+  const tgtType = edge.target().data('type') as string;
+  if (srcType === 'fact' || tgtType === 'fact') return 40;
+  if (STRONG_EDGES.has(edge.data('label') as string)) return 60;
+  return 80;
+}
+
+// Strong relationships attract hard (0.9). For others: weight by confidence
+// and the weaker decay score of the two endpoints — stale or uncertain edges
+// produce soft springs so those nodes drift outward naturally.
+function edgeElasticityFn(edge: cytoscape.EdgeSingular): number {
+  if (STRONG_EDGES.has(edge.data('label') as string)) return 0.9;
+  const conf = (edge.data('confidence') as number) ?? 0.5;
+  const srcScore = DECAY_SCORE[edge.source().data('decayClass') as string] ?? 0.7;
+  const tgtScore = DECAY_SCORE[edge.target().data('decayClass') as string] ?? 0.7;
+  return Math.max(0.1, conf * Math.min(srcScore, tgtScore) * 0.7);
+}
+
 // fcose layout options per the issue spec.
 const FCOSE_FULL = {
   name: 'fcose',
   animate: false,
   fit: true,
   nodeSeparation: 80,
-  idealEdgeLength: 120,
   randomize: true,
-} as const;
+  idealEdgeLength: idealEdgeLengthFn,
+  nodeRepulsion: nodeRepulsionFn,
+  edgeElasticity: edgeElasticityFn,
+};
 
 const FCOSE_EXPAND = {
   name: 'fcose',
   animate: true,
   fit: false,
   nodeSeparation: 80,
-  idealEdgeLength: 120,
   randomize: false,
   animationDuration: 400,
-} as const;
+  idealEdgeLength: idealEdgeLengthFn,
+  nodeRepulsion: nodeRepulsionFn,
+  edgeElasticity: edgeElasticityFn,
+};
 
 // Cytoscape's TS types don't model mapData() string expressions (the library
 // supports them at runtime but types them as numbers). Cast to satisfy the compiler.
@@ -109,8 +160,9 @@ const CY_STYLE = [
       'font-size': 10,
       'font-family': 'Manrope, system-ui, sans-serif',
       // Degree-based size: updated by updateDegrees() after every cy.add().
-      width: 'mapData(degree, 0, 15, 20, 52)',
-      height: 'mapData(degree, 0, 15, 20, 52)',
+      // Wider range than before so hub nodes stand out more dramatically.
+      width: 'mapData(degree, 0, 15, 20, 80)',
+      height: 'mapData(degree, 0, 15, 20, 80)',
       // Confidence-based opacity.
       opacity: 'mapData(confidence, 0, 1, 0.15, 1.0)',
     },
@@ -122,7 +174,8 @@ const CY_STYLE = [
   { selector: 'node[type="decision"]',     style: { 'background-color': '#C9874A' } },
   { selector: 'node[type="event"]',        style: { 'background-color': '#5E9E6B' } },
   { selector: 'node[type="concept"]',      style: { 'background-color': '#888888' } },
-  { selector: 'node[type="fact"]',         style: { 'background-color': '#444444' } },
+  // Facts are decorations, not hubs — fixed small size regardless of degree.
+  { selector: 'node[type="fact"]',         style: { 'background-color': '#444444', width: 10, height: 10 } },
   // Facts: hide label at default size; reveal on select.
   { selector: 'node[type="fact"]',         style: { 'font-size': 0 } },
   { selector: 'node[type="fact"]:selected', style: { 'font-size': 9 } },
@@ -413,7 +466,7 @@ export default function KgPage() {
     cy.add(elements);
     updateDegrees(cy);
     cy.resize();
-    cy.layout(FCOSE_FULL).run();
+    cy.layout(FCOSE_FULL as unknown as cytoscape.LayoutOptions).run();
     applyColorMode(cy, colorModeRef.current);
   }
 
@@ -435,6 +488,14 @@ export default function KgPage() {
       const data = await res.json() as { nodes: ApiKgNode[]; edges: ApiKgEdge[] };
       if (cy.destroyed()) return;
       renderGraph(cy, data);
+      // Animate the viewport to center on the focal node after the layout settles.
+      const focalEl = cy.getElementById(nodeId);
+      if (focalEl.length) {
+        cy.animate(
+          { fit: { eles: focalEl.closedNeighborhood(), padding: 80 } },
+          { duration: 300 },
+        );
+      }
       // Sync selection + URL so refresh and back-nav restore this view.
       const focused = data.nodes.find(n => n.id === nodeId) ?? null;
       setSelectedNode(focused);
@@ -473,17 +534,13 @@ export default function KgPage() {
       if (cy.destroyed()) return;
 
       if (newElements.length > 0) {
-        // Snapshot positions before adding so fcose can pin existing nodes.
-        const fixedNodeConstraint = cy.nodes().map(node => ({
-          nodeId: node.id(),
-          position: { ...node.position() },
-        }));
-
         cy.add(newElements);
         updateDegrees(cy);
         applyColorMode(cy, colorModeRef.current);
-
-        cy.layout({ ...FCOSE_EXPAND, fixedNodeConstraint } as unknown as cytoscape.LayoutOptions).run();
+        // randomize: false warms fCoSE from current positions without hard-pinning
+        // existing nodes, so the graph re-settles globally instead of squeezing
+        // new nodes into whatever gaps remain.
+        cy.layout(FCOSE_EXPAND as unknown as cytoscape.LayoutOptions).run();
       }
 
       cy.elements().removeClass('focal');
@@ -546,34 +603,33 @@ export default function KgPage() {
   useEffect(() => {
     void loadSidebarNodes(initialQ ?? '');
 
-    // Restore ?node= selection from URL (e.g. browser back/refresh).
     if (initialNode) {
-      neighborhoodAbortRef.current?.abort();
-      const controller = new AbortController();
-      neighborhoodAbortRef.current = controller;
+      // Restore ?node= from URL via loadNeighborhood, which handles render,
+      // focal class, viewport centering, and URL sync in one shot.
+      void loadNeighborhood(initialNode);
+    } else {
+      // Default view: focus on the principal's KG node so the graph opens on
+      // a meaningful starting point. Falls back to the hero graph if the
+      // principal has no linked KG node or the contacts fetch fails.
       void (async () => {
         try {
-          const res = await apiFetch(
-            `/api/kg/graph?node_id=${encodeURIComponent(initialNode)}&depth=2`,
-            { signal: controller.signal },
-          );
-          if (!res.ok) throw new Error(await errorMessage(res));
-          const data = await res.json() as { nodes: ApiKgNode[]; edges: ApiKgEdge[] };
-          const cy = cyRef.current;
-          if (cy && !cy.destroyed()) {
-            renderGraph(cy, data);
-            setStatus(`${data.nodes.length} nodes · ${data.edges.length} edges`);
+          const res = await apiFetch('/api/kg/contacts');
+          if (res.ok) {
+            const contacts = await res.json() as Array<{
+              systemRole: string | null;
+              kgNodeId: string | null;
+            }>;
+            const principal = contacts.find(c => c.systemRole === 'principal');
+            if (principal?.kgNodeId) {
+              await loadNeighborhood(principal.kgNodeId);
+              return;
+            }
           }
-          const found = data.nodes.find(n => n.id === initialNode);
-          if (found) setSelectedNode(found);
         } catch (err) {
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          console.error('[KgPage] ?node= restore failed:', err);
-          setStatus('Failed to restore node');
+          console.error('[KgPage] principal node lookup failed:', err);
         }
+        void loadHeroGraph();
       })();
-    } else {
-      void loadHeroGraph();
     }
     // Run once on mount only.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/console/src/pages/KgPage.tsx
+++ b/apps/console/src/pages/KgPage.tsx
@@ -619,10 +619,10 @@ export default function KgPage() {
         try {
           const res = await apiFetch('/api/kg/contacts');
           if (res.ok) {
-            const contacts = await res.json() as Array<{
+            const { contacts } = await res.json() as { contacts: Array<{
               systemRole: string | null;
               kgNodeId: string | null;
-            }>;
+            }> };
             const principal = contacts.find(c => c.systemRole === 'principal');
             if (principal?.kgNodeId) {
               await loadNeighborhood(principal.kgNodeId);


### PR DESCRIPTION
## **User description**
## Summary

Closes #861

- **Per-element fCoSE physics** — replaces flat scalar layout options with callbacks: fact nodes cluster tightly (low repulsion, short edges), strong-relationship pairs sit visually adjacent (high elasticity), and stale or low-confidence edges produce soft springs that let distant nodes drift apart naturally
- **Wider hub sizing** — node diameter range widened to 20–80px (was 20–52px); fact nodes fixed at 10px as decorations, not hubs
- **Expansion fix** — removes `fixedNodeConstraint` from `expandNeighborhood`; fCoSE now warm-starts from current positions and re-settles globally, eliminating overlap on high-degree nodes
- **Principal-node default view** — KG page opens on the principal's 2-hop neighborhood instead of an arbitrary hero graph; falls back if principal has no linked KG node
- **Deep-link viewport centering** — `?node=<id>` restore now animates the viewport to the focal node's neighborhood (same as sidebar-click navigation); also fixes missing `.focal` CSS class on URL restore
- **Error handling hardening** — load errors now surface the actual HTTP status/message; sidebar search errors no longer tear down the graph canvas; non-OK contacts responses are logged

## Test plan

- [ ] Open the KG page with no `?node=` param — graph should load centered on the principal's neighborhood
- [ ] Open with `?node=<id>` — graph loads that node's neighborhood, viewport centers on it, focal ring appears
- [ ] Click a node in the sidebar — neighborhood loads, viewport animates to center
- [ ] Single-tap a canvas node — graph expands in-place with animation and no positional overlap on high-degree nodes
- [ ] Fact nodes are visibly small (~10px) and cluster close to their parent entity
- [ ] High-degree hub nodes are meaningfully larger than leaf nodes
- [ ] Trigger a sidebar search failure (block the API in devtools) — error message appears in the sidebar list, the graph canvas remains intact
- [ ] Verify load failure messages include the HTTP status (e.g. "Failed to load: HTTP 404")
- [ ] Principal with no linked KG node → falls back to hero graph without error


___

## **CodeAnt-AI Description**
**KG graph now opens on the principal’s neighborhood and lays out related nodes with clearer structure**

### What Changed
- The KG page now opens on the principal contact’s 2-hop neighborhood instead of a generic starter graph, and falls back to the old hero graph if no linked KG node exists
- Opening a saved `?node=<id>` view now centers the graph on that node’s neighborhood, matching sidebar navigation
- Fact nodes stay small, hub nodes stand out more, and closely related nodes are placed nearer together while weak or stale links spread out
- Expanding a node no longer locks the old layout in place, which reduces overlap when more nodes are added
- Graph and search errors now show the actual failure message, and sidebar search errors no longer clear the graph canvas
- If the graph is not ready yet, the page now shows a clear status instead of failing silently

### Impact
`✅ Clearer KG entry point`
`✅ Easier-to-read node neighborhoods`
`✅ Fewer overlap issues during graph expansion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
