### PR TITLE
fix: move ceo-inbox watermark ownership into code (#866)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`ceo-inbox` watermark ownership** — `last_processed_at` is now read and written by `ceo-inbox-list` in code via `ConfigStore`, not by the LLM; model-fabricated timestamps can no longer blind inbox triage by drifting into the future. A future watermark is clamped to `now()`, the stored value is healed immediately, and the run falls back to the default 24h lookback so the backlog is recovered. (#866)
+- **`ceo-inbox` watermark ownership** — moves `last_processed_at` management to `ceo-inbox-list` via `ConfigStore`; clamps future timestamps to `now()` and falls back to 24h lookback. (#866)
 - **Email adapter watermark persistence** — `lastSeenTimestamp` is now persisted to the KG via a new `ConfigStore` service (`src/memory/config-store.ts`) and restored on restart, preventing silent message loss after a process restart during downtime. (#846)
 - **Email adapter poll observability** — each successful poll cycle now emits a `channel.poll` audit event with per-filter skip counts, message totals, watermark, and duration; a `channel.stalled` event fires (once per lifecycle) when no poll completes within 5 × the polling interval. (#846)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`ceo-inbox` watermark ownership** — `last_processed_at` is now read and written by `ceo-inbox-list` in code via `ConfigStore`, not by the LLM; model-fabricated timestamps can no longer blind inbox triage by drifting into the future. A future watermark is clamped to `now()`, the stored value is healed immediately, and the run falls back to the default 24h lookback so the backlog is recovered. (#866)
 - **Email adapter watermark persistence** — `lastSeenTimestamp` is now persisted to the KG via a new `ConfigStore` service (`src/memory/config-store.ts`) and restored on restart, preventing silent message loss after a process restart during downtime. (#846)
 - **Email adapter poll observability** — each successful poll cycle now emits a `channel.poll` audit event with per-filter skip counts, message totals, watermark, and duration; a `channel.stalled` event fires (once per lifecycle) when no poll completes within 5 × the polling interval. (#846)
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -398,7 +398,7 @@ system_prompt: |
     - The skill automatically builds a reply-all recipient list (original sender in To,
       everyone else in CC, minus the CEO's own address). The returned { to, cc } shows
       exactly who the draft was addressed to — include this in your response summary.
-    - Write the draft applying the voice profile retrieved in step 2: match
+    - Write the draft applying the voice profile retrieved in step 1: match
       tone, formality, writing patterns, and vocabulary preferences. Use the
       profile's sign-off if one is set; omit signing entirely if no sign-off
       is configured. Default to reply-all.
@@ -458,7 +458,7 @@ system_prompt: |
   rules first. Rules may override the classification, so you must complete
   this step before archiving, creating drafts, or opening bullpen threads:
 
-  **Standing rules:** For each active rule from step 2b, evaluate the
+  **Standing rules:** For each active rule from step 2, evaluate the
   condition against this email's full context: sender identity (from
   entity-context), subject, snippet or body, and any relationship data.
   If the condition matches, follow the instruction. Note: if entity-context
@@ -484,7 +484,7 @@ system_prompt: |
   Retain any labels already present on the message from the mail system's
   own rules, but do not add more than one triage classification label.
 
-  **Decision tagging:** If decision tagging is enabled (from step 2b),
+  **Decision tagging:** If decision tagging is enabled (from step 2),
   call ceo-inbox-label with:
   - message_id: the current message's ID
   - labels: [the final classification category, e.g. "URGENT"]

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.4.0"
+version: "0.5.0"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -10,7 +10,7 @@ description: >
   to the coordinator via the bullpen for Signal delivery.
 
 model:
-  tier: standard  # reverted from fast — Haiku botched Unix timestamp arithmetic, causing last_processed_at to drift ~40 days into the future and blinding inbox triage
+  tier: standard
 
 inject_specialists: true
 
@@ -61,7 +61,7 @@ system_prompt: |
 
   **Scheduled mode** (default — 15-minute cron trigger, 6am–11pm):
   If you received a scheduled task like "Check the CEO's inbox for unread
-  messages", execute the full triage protocol below (Steps 1-6).
+  messages", execute the full triage protocol below.
 
   **Delegated mode** (invoked via bullpen by the coordinator):
   If you received a specific request from the coordinator (e.g. "add a rule
@@ -177,17 +177,7 @@ system_prompt: |
   - `ambiguous` — do not store; note the ambiguity in the Response Format.
   - `rate_limited` — stop storing facts for this run.
 
-  ## Step 1: Read the high-water mark
-
-  Call config-store with:
-  - action: retrieve
-  - namespace: ceo_inbox
-  - key: last_processed_at
-
-  This returns the unix timestamp of the last triage run. Store it in
-  a variable for step 3.
-
-  ## Step 2: Fetch the executive voice profile
+  ## Step 1: Fetch the executive voice profile
 
   Call executive-profile-get. Store the returned summary and profile object —
   you will use them when composing any NEEDS DRAFT reply in step 4. Do not
@@ -199,7 +189,7 @@ system_prompt: |
   without signing with a name or title. In your final summary, add:
     Voice profile: UNAVAILABLE (fallback used)
 
-  ## Step 2b: Load standing rules and decision tagging config
+  ## Step 2: Load standing rules and decision tagging config
 
   Call config-store with:
   - action: retrieve
@@ -230,13 +220,11 @@ system_prompt: |
   Call ceo-inbox-list with:
   - unread_only: true
 
-  If you got a timestamp from step 1:
-  - received_after_timestamp: <the timestamp value>
+  The skill manages its own high-water mark via ConfigStore — do NOT pass
+  received_after_timestamp or received_after_hours. The watermark is read,
+  clamped if corrupted, and advanced automatically in code.
 
-  If config-store returned no value (first run):
-  - received_after_hours: 24
-
-  If the count is 0, skip to step 6 (save the high-water mark).
+  If the count is 0, exit immediately without any further output.
 
   **Overflow check (> 10 unread):** If the list returns more than 10 unread
   messages, you are in overflow mode and must shed load before triaging:
@@ -245,7 +233,7 @@ system_prompt: |
      alone (do not read full bodies at this stage). Prefer apparent URGENT
      candidates (time-sensitive asks from known contacts), then ACTIONABLE, then
      NEEDS DRAFT, then others. Within a tier, prefer older messages.
-  2. Process only those top 5 through the full triage protocol (steps 4-6).
+  2. Process only those top 5 through the full triage protocol (steps 4-5).
   3. For each remaining message beyond the top 5 (oldest first), create a
      deferred inbox-overflow task, then mark it as read so it does not
      re-appear in the next run:
@@ -255,14 +243,13 @@ system_prompt: |
        - owner: 'ceo'
        - tags: ['inbox-overflow']
        - priority: 0-100 based on urgency signals from subject and snippet
-     - If task-create fails: do NOT call ceo-inbox-mark-read and do NOT
-       advance the HWM for this message. Log the failure:
+     - If task-create fails: do NOT call ceo-inbox-mark-read. Log the failure:
          Overflow task FAILED for "<sender>: <subject>" — <error>
-       The message will remain unread and be re-evaluated on the next run.
-       Continue to the next overflow message.
+       Continue to the next overflow message. (Note: the message may not
+       re-appear in the next run because the high-water mark already advanced
+       past it at list time. Treat persistent failures as lost overflow items.)
+
      - Call ceo-inbox-mark-read with the message_id.
-     - Call config-store to save the high-water mark for this message (same
-       step 6 logic as for fully processed messages, so the window advances).
   4. After handling all overflow messages, proceed to step 4 to triage the
      top 5 only.
 
@@ -551,28 +538,6 @@ system_prompt: |
 
   Note: overflow-deferred messages are already marked read during the step 3
   overflow loop — do not mark them again here.
-
-  ## Step 6: Save the high-water mark
-
-  After processing EACH message (not at the end — after each one), call
-  config-store:
-  - action: store
-  - namespace: ceo_inbox
-  - key: last_processed_at
-  - value: <the message's date timestamp from ceo-inbox-list, as a string>
-
-  **Monotonicity guard:** Only store the new value if it is strictly greater than
-  the currently-stored value. Never let last_processed_at move backwards —
-  overflow messages are processed oldest-first and urgency-ranked top-5 may be
-  older than overflow tail messages, so a naïve per-message write can regress
-  the window and cause re-triage of already-handled messages on the next run.
-
-  This ensures that if the run is interrupted mid-batch, the next run
-  resumes from where you left off instead of re-processing messages
-  that already received drafts or actions.
-
-  Also save the timestamp if there were zero messages (use the current
-  time so the window advances).
 
   ## Available specialists
 

--- a/skills/ceo-inbox-list/handler.test.ts
+++ b/skills/ceo-inbox-list/handler.test.ts
@@ -1,16 +1,39 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CeoInboxListHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
+import type { EntityMemory } from '../../src/memory/entity-memory.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-/** Build a minimal SkillContext with the given input and an optional Nylas
- *  self-email. The Nylas client is mocked at the fetch level so we can
- *  inspect what `receivedAfter` value gets sent to the API. */
+/** Build a minimal SkillContext. The Nylas client is mocked at the fetch
+ *  level so we can inspect the `receivedAfter` query param. */
 function makeCtx(
   input: Record<string, unknown>,
-  opts: { selfEmail?: string } = {},
+  opts: { selfEmail?: string; storedWatermark?: string | null } = {},
 ): SkillContext {
+  // Build a minimal EntityMemory mock that returns the desired stored watermark.
+  let entityMemory: EntityMemory | undefined;
+  if (opts.storedWatermark !== undefined) {
+    const storedValue = opts.storedWatermark;
+    // ConfigStore.get() calls findEntities then getFacts.
+    const anchorNode = { id: 'anchor-1', label: 'config:ceo_inbox', type: 'concept', properties: {} };
+    const factNode =
+      storedValue !== null
+        ? {
+            id: 'fact-1',
+            label: 'last_processed_at',
+            properties: { key: 'last_processed_at', value: storedValue, namespace: 'ceo_inbox' },
+            temporal: { lastConfirmedAt: new Date() },
+          }
+        : undefined;
+
+    entityMemory = {
+      findEntities: vi.fn().mockResolvedValue([anchorNode]),
+      getFacts: vi.fn().mockResolvedValue(factNode ? [factNode] : []),
+      storeFact: vi.fn().mockResolvedValue({ stored: true, action: 'updated' }),
+    } as unknown as EntityMemory;
+  }
+
   return {
     input,
     secret(name: string) {
@@ -28,11 +51,10 @@ function makeCtx(
       error: vi.fn(),
       debug: vi.fn(),
     },
+    entityMemory,
   };
 }
 
-/** Capture the URL that fetch was called with and return an empty message
- *  list so the handler completes normally. */
 function mockFetchReturning(messages: unknown[] = []) {
   return vi.fn().mockResolvedValue({
     ok: true,
@@ -41,45 +63,33 @@ function mockFetchReturning(messages: unknown[] = []) {
 }
 
 function extractReceivedAfter(fetchMock: ReturnType<typeof vi.fn>): string | null {
-  const url = new URL(fetchMock.mock.calls[0][0] as string);
+  const url = new URL(fetchMock.mock.calls[0]![0] as string);
   return url.searchParams.get('received_after');
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
-describe('CeoInboxListHandler — timestamp handling', () => {
+describe('CeoInboxListHandler — watermark handling (#866)', () => {
   let handler: CeoInboxListHandler;
 
   beforeEach(() => {
     handler = new CeoInboxListHandler();
   });
 
-  it('accepts a numeric received_after_timestamp and adds +1', async () => {
-    const ts = 1_700_000_000;
-    const ctx = makeCtx({ received_after_timestamp: ts });
+  it('uses ConfigStore watermark + 1 as receivedAfter when entityMemory is wired', async () => {
+    const storedTs = 1_700_000_000;
+    const ctx = makeCtx({}, { storedWatermark: String(storedTs) });
     const fetchSpy = mockFetchReturning();
     vi.stubGlobal('fetch', fetchSpy);
 
     await handler.execute(ctx);
 
-    // The handler should pass ts + 1 to Nylas so "strictly after" semantics hold
-    expect(extractReceivedAfter(fetchSpy)).toBe(String(ts + 1));
+    expect(extractReceivedAfter(fetchSpy)).toBe(String(storedTs + 1));
   });
 
-  it('coerces a string received_after_timestamp to a number and adds +1', async () => {
-    const ts = 1_700_000_000;
-    const ctx = makeCtx({ received_after_timestamp: String(ts) });
-    const fetchSpy = mockFetchReturning();
-    vi.stubGlobal('fetch', fetchSpy);
-
-    await handler.execute(ctx);
-
-    // String "1700000000" should be coerced, not silently dropped
-    expect(extractReceivedAfter(fetchSpy)).toBe(String(ts + 1));
-  });
-
-  it('falls back to received_after_hours when timestamp is missing', async () => {
-    const ctx = makeCtx({ received_after_hours: 24 });
+  it('falls back to received_after_hours when no watermark is stored', async () => {
+    // entityMemory returns null (no stored fact) → handler uses hours fallback
+    const ctx = makeCtx({ received_after_hours: 24 }, { storedWatermark: null });
     const fetchSpy = mockFetchReturning();
     vi.stubGlobal('fetch', fetchSpy);
 
@@ -88,35 +98,49 @@ describe('CeoInboxListHandler — timestamp handling', () => {
     const after = Math.floor(Date.now() / 1_000) - 24 * 3600;
 
     const param = Number(extractReceivedAfter(fetchSpy));
-    // The hours-based fallback should NOT get the +1 offset — it's already
-    // an approximate cutoff, not a high-water mark.
     expect(param).toBeGreaterThanOrEqual(before);
     expect(param).toBeLessThanOrEqual(after + 1);
   });
 
-  it('sends no received_after when both timestamp and hours are missing', async () => {
+  it('applies the 24h hard default when entityMemory is absent and no hours supplied', async () => {
+    // No entityMemory, no received_after_hours
     const ctx = makeCtx({});
     const fetchSpy = mockFetchReturning();
     vi.stubGlobal('fetch', fetchSpy);
 
+    const before = Math.floor(Date.now() / 1_000) - 24 * 3600;
     await handler.execute(ctx);
+    const after = Math.floor(Date.now() / 1_000) - 24 * 3600;
 
-    expect(extractReceivedAfter(fetchSpy)).toBeNull();
+    const param = Number(extractReceivedAfter(fetchSpy));
+    expect(param).toBeGreaterThanOrEqual(before);
+    expect(param).toBeLessThanOrEqual(after + 1);
   });
 
-  it('ignores non-numeric, non-coercible timestamp values', async () => {
-    const ctx = makeCtx({ received_after_timestamp: 'not-a-number' });
+  it('falls back to default lookback on a future watermark and emits a warn log', async () => {
+    const futureTs = Math.floor(Date.now() / 1_000) + 29 * 24 * 3600; // 29 days in future
+    const ctx = makeCtx({}, { storedWatermark: String(futureTs) });
     const fetchSpy = mockFetchReturning();
     vi.stubGlobal('fetch', fetchSpy);
 
+    const before = Math.floor(Date.now() / 1_000) - 24 * 3600;
     await handler.execute(ctx);
+    const after = Math.floor(Date.now() / 1_000) - 24 * 3600;
 
-    // Should fall through to no filter (no hours fallback provided either)
-    expect(extractReceivedAfter(fetchSpy)).toBeNull();
+    // Must have warned about the future watermark
+    const warnCalls = (ctx.log.warn as ReturnType<typeof vi.fn>).mock.calls;
+    expect(
+      warnCalls.some((call: unknown[]) => typeof call[1] === 'string' && call[1].includes('future')),
+    ).toBe(true);
+
+    // receivedAfter must be the 24h default (not the future timestamp + 1, which would return nothing)
+    const param = Number(extractReceivedAfter(fetchSpy));
+    expect(param).toBeGreaterThanOrEqual(before);
+    expect(param).toBeLessThanOrEqual(after + 1);
   });
 
-  it('coerces a float string timestamp correctly', async () => {
-    const ctx = makeCtx({ received_after_timestamp: '1700000000.789' });
+  it('coerces a float string watermark from ConfigStore correctly', async () => {
+    const ctx = makeCtx({}, { storedWatermark: '1700000000.789' });
     const fetchSpy = mockFetchReturning();
     vi.stubGlobal('fetch', fetchSpy);
 
@@ -124,5 +148,21 @@ describe('CeoInboxListHandler — timestamp handling', () => {
 
     // Should floor the float and add +1
     expect(extractReceivedAfter(fetchSpy)).toBe(String(1_700_000_000 + 1));
+  });
+
+  it('filters out messages sent from curiaEmail', async () => {
+    const self = 'curia@example.com';
+    const ctx = makeCtx({}, { selfEmail: self, storedWatermark: null });
+    const fetchSpy = mockFetchReturning([
+      { id: 'm1', threadId: 't1', date: 1, subject: 'a', from: [{ email: self, name: 'Curia' }], to: [], cc: [], snippet: '', unread: true, folders: ['INBOX'], attachments: [] },
+      { id: 'm2', threadId: 't2', date: 2, subject: 'b', from: [{ email: 'other@x.com', name: 'Other' }], to: [], cc: [], snippet: '', unread: true, folders: ['INBOX'], attachments: [] },
+    ]);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { count: number };
+    expect(data.count).toBe(1);
   });
 });

--- a/skills/ceo-inbox-list/handler.ts
+++ b/skills/ceo-inbox-list/handler.ts
@@ -1,8 +1,15 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { CeoNylasClient } from '../_shared/ceo-nylas-client.js';
+import { ConfigStore } from '../../src/memory/config-store.js';
 
 const MAX_LIMIT = 50;
 const DEFAULT_LIMIT = 20;
+
+const WATERMARK_NAMESPACE = 'ceo_inbox';
+const WATERMARK_KEY = 'last_processed_at';
+
+// Default lookback when no persisted watermark exists (first run).
+const FIRST_RUN_HOURS = 24;
 
 export class CeoInboxListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -38,33 +45,90 @@ export class CeoInboxListHandler implements SkillHandler {
 
     const unreadOnly = input.unread_only !== false; // default true
 
-    // Date gate: received_after_timestamp (absolute, from config-store high-water
-    // mark) takes precedence over received_after_hours (relative, first-run fallback).
-    // config-store returns all values as strings, so we coerce with Number() to
-    // handle both string and number inputs from the LLM. (fix: issue #44)
-    const rawTimestamp = Number(input.received_after_timestamp);
-    const receivedAfterTimestamp =
-      Number.isFinite(rawTimestamp)
-        ? Math.floor(rawTimestamp)
-        : undefined;
-
+    // received_after_hours: first-run fallback only. The absolute watermark is
+    // now managed by this skill via ConfigStore — the LLM no longer supplies
+    // timestamps. (fix: issue #866)
     const receivedAfterHours =
       typeof input.received_after_hours === 'number' && Number.isFinite(input.received_after_hours)
         ? Math.max(1, Math.floor(input.received_after_hours))
         : undefined;
 
-    // +1 on the high-water mark converts "last processed" to "strictly after",
-    // preventing re-processing when Nylas uses inclusive >= comparison. The +1
-    // only applies to the absolute timestamp path — the hours-based fallback is
-    // already an approximate cutoff, not a precise high-water mark. (fix: issue #44)
-    const receivedAfter = receivedAfterTimestamp !== undefined
-      ? receivedAfterTimestamp + 1
-      : (receivedAfterHours !== undefined
-        ? Math.floor((Date.now() - receivedAfterHours * 3_600_000) / 1_000)
-        : undefined);
+    // ── Watermark read (code-owned, not LLM-owned) ────────────────────────────
+    //
+    // Read last_processed_at from ConfigStore. The LLM never supplies this
+    // value — model-fabricated unix timestamps drifted 29 days into the future
+    // and blinded inbox triage for ~19 hours (issue #866).
+    const nowSeconds = Math.floor(Date.now() / 1_000);
+    // effectiveWatermark: the value used to compute receivedAfter.
+    // watermarkFloor: the monotonicity floor for the advance guard; may differ from
+    // effectiveWatermark when we heal a poisoned future timestamp (we fall through
+    // to the default 24h lookback while keeping nowSeconds as the floor so the
+    // advance write doesn't regress back to a past message date).
+    let effectiveWatermark: number | undefined;
+    let watermarkFloor: number | undefined;
+    let configStore: ConfigStore | undefined;
+
+    if (ctx.entityMemory) {
+      configStore = new ConfigStore(ctx.entityMemory, ctx.log);
+      try {
+        const stored = await configStore.get(WATERMARK_NAMESPACE, WATERMARK_KEY);
+        if (stored !== null) {
+          const parsed = Math.floor(Number(stored));
+          if (Number.isFinite(parsed)) {
+            if (parsed > nowSeconds) {
+              // Defensive clamp: a future watermark is physically impossible.
+              // Treat as "no watermark" for this query (fall through to the default
+              // 24h lookback) so the current run can recover the recent backlog.
+              // Heal the stored value immediately so future runs start clean.
+              ctx.log.warn(
+                { stored, nowSeconds, deltaSeconds: parsed - nowSeconds },
+                'ceo-inbox-list: last_processed_at is in the future — healing stored value and falling back to default lookback',
+              );
+              effectiveWatermark = undefined; // use default 24h lookback for this run
+              watermarkFloor = nowSeconds; // advance guard never regresses past healed value
+              // Heal asynchronously; don't block the Nylas query on this write.
+              configStore.set(WATERMARK_NAMESPACE, WATERMARK_KEY, String(nowSeconds)).catch((err) => {
+                ctx.log.error({ err, healedTo: nowSeconds }, 'ceo-inbox-list: failed to heal future watermark in ConfigStore');
+              });
+            } else {
+              effectiveWatermark = parsed;
+              watermarkFloor = parsed;
+            }
+          }
+        }
+      } catch (err) {
+        // Config read failure is non-fatal: fall through to first-run defaults.
+        ctx.log.error(
+          { err, errorType: err instanceof Error ? err.constructor.name : typeof err },
+          'ceo-inbox-list: failed to read watermark from ConfigStore — using first-run default',
+        );
+      }
+    } else {
+      ctx.log.warn({}, 'ceo-inbox-list: entityMemory not available — watermark reads/writes skipped');
+    }
+
+    // +1 on the stored watermark converts "last processed" to "strictly after",
+    // preventing re-fetch of the last-seen message (Nylas uses inclusive >= comparison).
+    const receivedAfter =
+      effectiveWatermark !== undefined
+        ? effectiveWatermark + 1
+        : receivedAfterHours !== undefined
+          ? Math.floor((Date.now() - receivedAfterHours * 3_600_000) / 1_000)
+          : nowSeconds - FIRST_RUN_HOURS * 3_600; // hard default: last 24h
 
     ctx.log.info(
-      { limit, folder, unreadOnly, receivedAfter, source: receivedAfterTimestamp ? 'timestamp' : 'hours' },
+      {
+        limit,
+        folder,
+        unreadOnly,
+        receivedAfter,
+        source:
+          effectiveWatermark !== undefined
+            ? 'config-store'
+            : receivedAfterHours !== undefined
+              ? 'hours'
+              : 'default',
+      },
       'ceo-inbox-list: listing messages',
     );
 
@@ -90,6 +154,24 @@ export class CeoInboxListHandler implements SkillHandler {
           { filtered: raw.length - messages.length },
           'ceo-inbox-list: filtered out messages from Curia',
         );
+      }
+
+      // ── Watermark advance (code-owned, not LLM-owned) ──────────────────────
+      //
+      // Advance to max(msg.date) of returned messages. Only writes when there
+      // are messages and the new max strictly advances past the watermarkFloor
+      // (the current persisted value, or nowSeconds after a heal). A zero-message
+      // run leaves last_processed_at unchanged — nothing arrived, nothing to
+      // advance past. The watermarkFloor guard also prevents a healed nowSeconds
+      // from being overwritten by a past message date.
+      if (messages.length > 0 && configStore) {
+        // Use reduce rather than spread+Math.max to avoid a RangeError for very large arrays.
+        const maxDate = messages.reduce((max, m) => (m.date > max ? m.date : max), 0);
+        if (watermarkFloor === undefined || maxDate > watermarkFloor) {
+          configStore.set(WATERMARK_NAMESPACE, WATERMARK_KEY, String(maxDate)).catch((err) => {
+            ctx.log.error({ err, advanceTo: maxDate }, 'ceo-inbox-list: failed to advance watermark in ConfigStore');
+          });
+        }
       }
 
       return {

--- a/skills/ceo-inbox-list/handler.ts
+++ b/skills/ceo-inbox-list/handler.ts
@@ -12,6 +12,14 @@ const WATERMARK_KEY = 'last_processed_at';
 const FIRST_RUN_HOURS = 24;
 
 export class CeoInboxListHandler implements SkillHandler {
+  // Namespace is injectable so integration tests can scope their writes to a
+  // test-only namespace and avoid corrupting the production watermark.
+  private readonly ns: string;
+
+  constructor(ns = WATERMARK_NAMESPACE) {
+    this.ns = ns;
+  }
+
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const apiKey = ctx.secret('nylas_api_key');
     const grantId = ctx.secret('ceo_nylas_grant_id');
@@ -67,11 +75,15 @@ export class CeoInboxListHandler implements SkillHandler {
     let effectiveWatermark: number | undefined;
     let watermarkFloor: number | undefined;
     let configStore: ConfigStore | undefined;
+    // Set to true when a future watermark is detected and healed. When true the
+    // received_after_hours caller input is ignored — a poisoned watermark always
+    // recovers via the hard 24h default to guarantee the backlog is visible.
+    let poisonedWatermark = false;
 
     if (ctx.entityMemory) {
       configStore = new ConfigStore(ctx.entityMemory, ctx.log);
       try {
-        const stored = await configStore.get(WATERMARK_NAMESPACE, WATERMARK_KEY);
+        const stored = await configStore.get(this.ns, WATERMARK_KEY);
         if (stored !== null) {
           const parsed = Math.floor(Number(stored));
           if (Number.isFinite(parsed)) {
@@ -86,8 +98,9 @@ export class CeoInboxListHandler implements SkillHandler {
               );
               effectiveWatermark = undefined; // use default 24h lookback for this run
               watermarkFloor = nowSeconds; // advance guard never regresses past healed value
+              poisonedWatermark = true; // bypass received_after_hours override on poisoned runs
               // Heal asynchronously; don't block the Nylas query on this write.
-              configStore.set(WATERMARK_NAMESPACE, WATERMARK_KEY, String(nowSeconds)).catch((err) => {
+              configStore.set(this.ns, WATERMARK_KEY, String(nowSeconds)).catch((err) => {
                 ctx.log.error({ err, healedTo: nowSeconds }, 'ceo-inbox-list: failed to heal future watermark in ConfigStore');
               });
             } else {
@@ -109,10 +122,12 @@ export class CeoInboxListHandler implements SkillHandler {
 
     // +1 on the stored watermark converts "last processed" to "strictly after",
     // preventing re-fetch of the last-seen message (Nylas uses inclusive >= comparison).
+    // When the watermark was poisoned (future timestamp), always use the hard 24h default
+    // regardless of any received_after_hours caller input — we must recover the backlog.
     const receivedAfter =
       effectiveWatermark !== undefined
         ? effectiveWatermark + 1
-        : receivedAfterHours !== undefined
+        : !poisonedWatermark && receivedAfterHours !== undefined
           ? Math.floor((Date.now() - receivedAfterHours * 3_600_000) / 1_000)
           : nowSeconds - FIRST_RUN_HOURS * 3_600; // hard default: last 24h
 
@@ -125,9 +140,11 @@ export class CeoInboxListHandler implements SkillHandler {
         source:
           effectiveWatermark !== undefined
             ? 'config-store'
-            : receivedAfterHours !== undefined
-              ? 'hours'
-              : 'default',
+            : poisonedWatermark
+              ? 'poison-recovery'
+              : receivedAfterHours !== undefined
+                ? 'hours'
+                : 'default',
       },
       'ceo-inbox-list: listing messages',
     );
@@ -158,17 +175,19 @@ export class CeoInboxListHandler implements SkillHandler {
 
       // ── Watermark advance (code-owned, not LLM-owned) ──────────────────────
       //
-      // Advance to max(msg.date) of returned messages. Only writes when there
-      // are messages and the new max strictly advances past the watermarkFloor
-      // (the current persisted value, or nowSeconds after a heal). A zero-message
-      // run leaves last_processed_at unchanged — nothing arrived, nothing to
-      // advance past. The watermarkFloor guard also prevents a healed nowSeconds
-      // from being overwritten by a past message date.
-      if (messages.length > 0 && configStore) {
+      // Advance to max(msg.date) of the raw (pre-filter) result. Using `raw`
+      // rather than `messages` prevents a stall when every fetched message is
+      // Curia-originated: in that case `messages` would be empty, the watermark
+      // would never advance, and the same Curia messages would be re-fetched
+      // every run while newer external mail sits unseen beyond the limit window.
+      // Only writes when there are raw messages and the new max strictly advances
+      // past watermarkFloor (the persisted value, or nowSeconds after a heal).
+      // A zero-raw-message run leaves last_processed_at unchanged.
+      if (raw.length > 0 && configStore) {
         // Use reduce rather than spread+Math.max to avoid a RangeError for very large arrays.
-        const maxDate = messages.reduce((max, m) => (m.date > max ? m.date : max), 0);
+        const maxDate = raw.reduce((max, m) => (m.date > max ? m.date : max), 0);
         if (watermarkFloor === undefined || maxDate > watermarkFloor) {
-          configStore.set(WATERMARK_NAMESPACE, WATERMARK_KEY, String(maxDate)).catch((err) => {
+          configStore.set(this.ns, WATERMARK_KEY, String(maxDate)).catch((err) => {
             ctx.log.error({ err, advanceTo: maxDate }, 'ceo-inbox-list: failed to advance watermark in ConfigStore');
           });
         }

--- a/skills/ceo-inbox-list/skill.json
+++ b/skills/ceo-inbox-list/skill.json
@@ -1,15 +1,14 @@
 {
   "name": "ceo-inbox-list",
   "description": "List recent messages from the CEO's personal email inbox. Intended for use by the ceo-inbox agent — accesses the CEO's personal email, do not call from other agents.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "limit": "number? (max messages to return, 1–50, default 20)",
     "folder": "string? (Gmail folder/label to list, default 'INBOX'; use 'SENT' for the Sent folder)",
     "unread_only": "boolean? (if true, only return unread messages, default true)",
-    "received_after_hours": "number? (only return messages received in the last N hours, e.g. 24 for last day; ignored if received_after_timestamp is set)",
-    "received_after_timestamp": "number? (unix timestamp in seconds — only return messages received after this time; takes precedence over received_after_hours)"
+    "received_after_hours": "number? (first-run fallback only — only return messages received in the last N hours; ignored when a persisted watermark exists in ConfigStore)"
   },
   "outputs": {
     "messages": "array of { id, threadId, from, to, cc, subject, date, snippet, unread, folders, attachments: [{ id, filename, contentType, size }] }",
@@ -18,5 +17,5 @@
   "permissions": [],
   "secrets": ["nylas_api_key", "ceo_nylas_grant_id", "nylas_self_email"],
   "timeout": 20000,
-  "capabilities": []
+  "capabilities": ["entityMemory"]
 }

--- a/tests/integration/ceo-inbox-list-watermark.test.ts
+++ b/tests/integration/ceo-inbox-list-watermark.test.ts
@@ -22,8 +22,9 @@ const { Pool } = pg;
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIf = DATABASE_URL ? describe : describe.skip;
 
-// Keys kept separate from production and email-adapter-persistence tests.
-const WATERMARK_NAMESPACE = 'ceo_inbox';
+// Test-scoped namespace so tests cannot corrupt the production watermark even
+// when DATABASE_URL points at a shared database.
+const WATERMARK_NAMESPACE = 'ceo_inbox_test';
 const WATERMARK_KEY = 'last_processed_at';
 
 const SEED_WATERMARK = 1_000_000;
@@ -87,7 +88,9 @@ describeIf('ceo-inbox-list watermark (#866)', () => {
     const validator = new MemoryValidator(kgStore, embeddingService);
     entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
     configStore = new ConfigStore(entityMemory, logger);
-    handler = new CeoInboxListHandler();
+    // Pass the test namespace so the handler writes to an isolated scope and
+    // never touches the production ceo_inbox watermark.
+    handler = new CeoInboxListHandler(WATERMARK_NAMESPACE);
 
     await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
   });

--- a/tests/integration/ceo-inbox-list-watermark.test.ts
+++ b/tests/integration/ceo-inbox-list-watermark.test.ts
@@ -1,0 +1,199 @@
+// tests/integration/ceo-inbox-list-watermark.test.ts
+//
+// Integration tests for #866: ceo-inbox-list watermark management.
+// Verifies that last_processed_at is read and written by the skill handler
+// in code, not by the LLM, and that a future watermark is clamped and healed.
+//
+// Requires real Postgres (DATABASE_URL env); tests are skipped when not available.
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { ConfigStore } from '../../src/memory/config-store.js';
+import { CeoInboxListHandler } from '../../skills/ceo-inbox-list/handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+// Keys kept separate from production and email-adapter-persistence tests.
+const WATERMARK_NAMESPACE = 'ceo_inbox';
+const WATERMARK_KEY = 'last_processed_at';
+
+const SEED_WATERMARK = 1_000_000;
+
+// Minimal Nylas message shape — only fields the handler reads.
+function makeNylasMessage(id: string, date: number) {
+  return {
+    id,
+    threadId: `thread-${id}`,
+    date,
+    subject: 'Test',
+    from: [{ email: 'sender@example.com', name: 'Sender' }],
+    to: [{ email: 'ceo@example.com', name: 'CEO' }],
+    cc: [],
+    snippet: 'snippet',
+    unread: true,
+    folders: ['INBOX'],
+    attachments: [],
+  };
+}
+
+// Return a fetch mock that answers with the given messages list.
+function stubNylasMessages(messages: ReturnType<typeof makeNylasMessage>[]) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: messages }),
+  } as unknown as Response);
+}
+
+// Minimal SkillContext with real entityMemory wired in.
+function makeCtx(entityMemory: EntityMemory): SkillContext {
+  return {
+    input: { unread_only: true },
+    secret(name: string) {
+      if (name === 'nylas_api_key') return 'test-key';
+      if (name === 'ceo_nylas_grant_id') return 'test-grant';
+      // nylas_self_email not set — handler degrades gracefully.
+      throw new Error(`unknown secret: ${name}`);
+    },
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    entityMemory,
+  };
+}
+
+describeIf('ceo-inbox-list watermark (#866)', () => {
+  let pool: pg.Pool;
+  let entityMemory: EntityMemory;
+  let configStore: ConfigStore;
+  let handler: CeoInboxListHandler;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const logger = pino({ level: 'silent' });
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+    configStore = new ConfigStore(entityMemory, logger);
+    handler = new CeoInboxListHandler();
+
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterAll(async () => {
+    // Remove the test fact node and its edges. Leave the namespace anchor.
+    await pool.query(
+      `DELETE FROM kg_edges WHERE target_node_id IN (
+        SELECT id FROM kg_nodes WHERE label = $1
+      )`,
+      [WATERMARK_KEY],
+    );
+    await pool.query('DELETE FROM kg_nodes WHERE label = $1', [WATERMARK_KEY]);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    // Reset the stored watermark before each test.
+    await configStore.set(WATERMARK_NAMESPACE, WATERMARK_KEY, String(SEED_WATERMARK));
+  });
+
+  it('advances watermark to max(date) of returned messages', async () => {
+    const msgs = [
+      makeNylasMessage('a', SEED_WATERMARK + 10),
+      makeNylasMessage('b', SEED_WATERMARK + 30),
+      makeNylasMessage('c', SEED_WATERMARK + 20),
+    ];
+
+    vi.stubGlobal('fetch', stubNylasMessages(msgs));
+
+    const ctx = makeCtx(entityMemory);
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { count: number };
+    expect(data.count).toBe(3);
+
+    // Give the async ConfigStore write time to complete.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const stored = await configStore.get(WATERMARK_NAMESPACE, WATERMARK_KEY);
+    // Should advance to max(date) = SEED_WATERMARK + 30
+    expect(stored).toBe(String(SEED_WATERMARK + 30));
+  });
+
+  it('does not advance watermark on an empty run', async () => {
+    vi.stubGlobal('fetch', stubNylasMessages([]));
+
+    const ctx = makeCtx(entityMemory);
+    await handler.execute(ctx);
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const stored = await configStore.get(WATERMARK_NAMESPACE, WATERMARK_KEY);
+    // Watermark must remain unchanged — nothing arrived, nothing to advance past.
+    expect(stored).toBe(String(SEED_WATERMARK));
+  });
+
+  it('clamps a future watermark, returns the backlog, and heals the stored value', async () => {
+    // Poison the watermark to 29 days in the future — the exact bug from #866.
+    const nowBeforeRun = Math.floor(Date.now() / 1_000);
+    const futureTs = nowBeforeRun + 29 * 24 * 3600;
+    await configStore.set(WATERMARK_NAMESPACE, WATERMARK_KEY, String(futureTs));
+
+    // Messages with dates in the recent past (the "blind window" backlog).
+    const msgs = [
+      makeNylasMessage('d', nowBeforeRun - 3600),
+      makeNylasMessage('e', nowBeforeRun - 1800),
+    ];
+
+    vi.stubGlobal('fetch', stubNylasMessages(msgs));
+
+    const ctx = makeCtx(entityMemory);
+    const result = await handler.execute(ctx);
+
+    // The handler must return the backlog even though the stored watermark was in the future.
+    expect(result.success).toBe(true);
+    const data = result.data as { count: number };
+    expect(data.count).toBe(2);
+
+    // The warn log must have fired for the future watermark.
+    expect((ctx.log.warn as ReturnType<typeof vi.fn>).mock.calls.some(
+      (call: unknown[]) => typeof call[1] === 'string' && call[1].includes('future'),
+    )).toBe(true);
+
+    // Give the async heal write time to complete.
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Stored watermark must now be healed to ~now (not the future, not a past date).
+    // The advance guard prevents the past message dates from overwriting the healed nowSeconds.
+    const stored = await configStore.get(WATERMARK_NAMESPACE, WATERMARK_KEY);
+    const storedNum = Number(stored);
+    expect(storedNum).toBeGreaterThanOrEqual(nowBeforeRun); // healed to at least nowSeconds
+    expect(storedNum).toBeLessThanOrEqual(Math.floor(Date.now() / 1_000) + 2); // not in the future
+  });
+
+  it('passes received_after = storedWatermark + 1 to Nylas', async () => {
+    const fetchSpy = stubNylasMessages([]);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const ctx = makeCtx(entityMemory);
+    await handler.execute(ctx);
+
+    const url = new URL(fetchSpy.mock.calls[0]![0] as string);
+    const receivedAfterParam = url.searchParams.get('received_after');
+    // Must pass stored watermark + 1 for exclusive semantics.
+    expect(receivedAfterParam).toBe(String(SEED_WATERMARK + 1));
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- **`ceo-inbox-list` now owns the watermark in code.** `last_processed_at` is read and written by the skill handler via `ConfigStore` (`ctx.entityMemory`). The LLM no longer supplies timestamps to any skill — this class of bug (model-fabricated unix timestamps drifting into the future) is no longer possible.
- **Defensive clamp for future watermarks.** If `last_processed_at > now()`, the skill logs a warning, heals the stored value to `nowSeconds`, and falls back to the default 24h lookback for the current run so the recent backlog is recovered. The advance guard uses `nowSeconds` as a monotonicity floor so past message dates can't overwrite the healed value.
- **Zero-message runs leave the watermark unchanged.** Nothing arrived, so there is nothing to advance past.
- **`ceo-inbox.yaml` simplified.** Steps 1 (read high-water mark) and 6 (save high-water mark) removed. Step 3 no longer passes `received_after_timestamp` or `received_after_hours`. Overflow handling no longer calls `config-store` for watermark management. Overflow failure note updated to reflect that messages may not re-appear if the watermark already advanced past them at list time.

## Test plan

- [ ] Unit tests: `pnpm exec vitest run skills/ceo-inbox-list/handler.test.ts` — 6 tests pass
- [ ] Integration tests: `tests/integration/ceo-inbox-list-watermark.test.ts` — requires `DATABASE_URL`; covers watermark advance, empty-run no-op, future-watermark clamp/heal, and `receivedAfter = stored + 1`
- [ ] TypeScript: `pnpm run typecheck` — clean

Closes #866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CEO inbox watermark management to prevent triage drift. The system now maintains its own message tracking timestamp and automatically recovers from corrupted or future-dated values using a 24-hour default fallback.

* **Tests**
  * Added comprehensive integration tests for watermark handling and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep CEO inbox triage on the correct message window**

### What Changed
- The CEO inbox listing skill now reads and updates its own saved “last processed” timestamp, so inbox triage no longer depends on the model supplying timestamps.
- If the saved timestamp is in the future, the skill warns, repairs the saved value, and falls back to a 24-hour lookback so missed emails are picked up again.
- Runs with no new messages leave the saved timestamp unchanged, and the skill still filters out messages sent from Curia.
- The inbox skill definition and triage instructions now reflect the new behavior, and the changelog documents the fix.

### Impact
`✅ Fewer inbox blind spots`
`✅ Recovery after corrupted timestamps`
`✅ Fewer repeated triage misses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
