### PR TITLE
fix: batch provisional contact promotion sweep to drain pool over multiple runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 - **KG graph** — various visual improvements: physics-aware layout, better hub sizing, principal-node default view, and viewport centering on focal nodes. (#861)
-
-### Changed
-
 - **`contact-list` skill** — new `offset` input (v1.2.0) enables cursor-based pagination; `offset > 0` requires `limit` to prevent unbounded result sets. Public API surface change.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 - **KG graph** — various visual improvements: physics-aware layout, better hub sizing, principal-node default view, and viewport centering on focal nodes. (#861)
 
+### Changed
+
+- **`contact-list` skill** — new `offset` input (v1.2.0) enables cursor-based pagination; `offset > 0` requires `limit` to prevent unbounded result sets. Public API surface change.
+
 ### Fixed
 
 - **`ceo-inbox` watermark ownership** — moves `last_processed_at` management to `ceo-inbox-list` via `ConfigStore`; clamps future timestamps to `now()` and falls back to 24h lookback. (#866)
+- **Provisional contact promotion sweep** — batched to 10 contacts per daily run using `offset` pagination and a persisted `next_offset` cursor in `last_run_context`, preventing turn-budget exhaustion on large pools. Contacts agent `error_budget.max_turns` raised to 30. (#884)
+- **Scheduler task payload** — `scheduler_job_id` is now injected into every fired job's task content so agents can call `scheduler-report` without guessing their own job ID.
 - **Email adapter watermark persistence** — `lastSeenTimestamp` is now persisted to the KG via a new `ConfigStore` service (`src/memory/config-store.ts`) and restored on restart, preventing silent message loss after a process restart during downtime. (#846)
 - **Email adapter poll observability** — each successful poll cycle now emits a `channel.poll` audit event with per-filter skip counts, message totals, watermark, and duration; a `channel.stalled` event fires (once per lifecycle) when no poll completes within 5 × the polling interval. (#846)
 

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -284,7 +284,8 @@ schedule:
       2. Call ceo-inbox-list with folder: "SENT", unread_only: false,
          received_after_hours: 2160 (90 days), limit: 50. Collect all email
          addresses from the "to" and "cc" arrays across all returned messages.
-         Deduplicate into a set.
+         Normalize each address (trim whitespace and convert to lowercase) before
+         adding to the set. Deduplicate into a set.
          Note: ceo-inbox-list is capped at 50 messages per call by the skill
          definition. For high-volume inboxes this may miss older provisional
          contacts.
@@ -296,17 +297,23 @@ schedule:
          "Promotion Sweep — Principal Context" section in your system prompt) as
          contactId so the skill can resolve all calendars registered to the
          principal. Collect all attendee email addresses from non-cancelled
-         events. Deduplicate into a set.
+         events. Normalize each address (trim whitespace and convert to lowercase)
+         before adding to the set. Deduplicate into a set.
          If the call fails (skill error, calendar not connected, API unavailable),
          record the error message and treat the calendar attendee set as empty —
          calendar enrichment is best-effort and must not abort the sweep.
 
       4. For each provisional contact in the batch from step 1:
-         - Use contact-lookup (by: "name") to get their channel identities
-           (email addresses).
+         - Use contact-lookup (by: "name", query: the contact's display_name from
+           the step 1 result) to get their channel identities (email addresses).
+           The step 1 result includes a contact_id for each contact — if the
+           lookup returns more than one contact, use the one whose contact_id
+           matches the step 1 record. This prevents duplicate display names from
+           routing a promotion to the wrong contact.
          - If a contact has no email identity, skip them.
-         - Check whether their email appears in the Sent folder set (step 2) or
-           the calendar attendee set (step 3).
+         - Normalize the contact's email address (trim whitespace and lowercase)
+           before checking membership in the Sent folder set (step 2) or the
+           calendar attendee set (step 3).
          - If found in Sent folder: call contact-register with channel: "email",
            identifier: their email address, displayName: their display name,
            messageTimestamp: the current ISO 8601 time, ceo_has_sent: true.

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -276,6 +276,10 @@ schedule:
       1. Call contact-list with status: "provisional", limit: 10,
          offset: next_offset. If count is 0 (no contacts in this batch), skip
          directly to step 5 — reset the cursor to 0 for the next run.
+         @TODO: promotions during a sweep shrink the pool, so some contacts
+         may be skipped by the offset and not checked until the cursor wraps
+         back to 0. This is an accepted limitation of offset-based pagination
+         over a live set. A keyset cursor (by created_at) would be more precise.
 
       2. Call ceo-inbox-list with folder: "SENT", unread_only: false,
          received_after_hours: 2160 (90 days), limit: 50. Collect all email

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -1,5 +1,5 @@
 name: contacts
-version: "0.1.0"
+version: "0.2.0"
 role: specialist
 description: >
   Contact domain specialist — briefings, CRUD, deduplication, relationship management,
@@ -7,6 +7,8 @@ description: >
 model:
   tier: fast  # structured CRUD + briefings, no judgment calls, never user-facing
 allow_discovery: false
+error_budget:
+  max_turns: 30  # batched promotion sweep: up to 1 list + 10 lookups + 10 registers + 1 report = ~22 turns worst case
 system_prompt: |
   ## Role
   You are the Contact Specialist. You own the full contact domain for the executive
@@ -256,51 +258,71 @@ schedule:
 
   - cron: "0 8 * * *"   # Daily at 8 AM
     task: >
-      Run the provisional contact promotion sweep. Your goal is to auto-promote provisional
-      contacts to confirmed based on engagement signals from the CEO's Sent folder and calendar.
-      The curia_outbound signal (Curia itself has emailed this contact) fires automatically
-      inside contact-register — no explicit check needed for it.
+      Run one batch of the provisional contact promotion sweep. Your goal is to
+      auto-promote provisional contacts to confirmed based on engagement signals
+      from the CEO's Sent folder and calendar. Each run processes up to 10
+      contacts; subsequent runs pick up where the last one left off.
+
+      Before you begin, extract two values from your context:
+      - scheduler_job_id: read from the "scheduler_job_id" field in the JSON
+        task payload you received (used to call scheduler-report at the end).
+      - next_offset: read from the "next_offset" field in the "Agent context"
+        block of the prior run context (the "[Prior run context — ...]" section
+        at the top of your message). Default to 0 if there is no prior run
+        context or no "next_offset" field.
 
       Steps:
 
-      1. Call contact-list with status: "provisional" to get all provisional contacts.
-         If the count is zero, exit and report that no provisional contacts need promotion.
+      1. Call contact-list with status: "provisional", limit: 10,
+         offset: next_offset. If count is 0 (no contacts in this batch), skip
+         directly to step 5 — reset the cursor to 0 for the next run.
 
       2. Call ceo-inbox-list with folder: "SENT", unread_only: false,
-         received_after_hours: 2160 (90 days), limit: 50. Collect all email addresses
-         from the "to" and "cc" arrays across all returned messages. Deduplicate into a set.
-         Note: ceo-inbox-list is capped at 50 messages per call by the skill definition.
-         For high-volume inboxes this may miss older provisional contacts.
-         @TODO: add pagination support to ceo-inbox-list to scan beyond 50 messages.
+         received_after_hours: 2160 (90 days), limit: 50. Collect all email
+         addresses from the "to" and "cc" arrays across all returned messages.
+         Deduplicate into a set.
+         Note: ceo-inbox-list is capped at 50 messages per call by the skill
+         definition. For high-volume inboxes this may miss older provisional
+         contacts.
+         @TODO: add pagination support to ceo-inbox-list to scan beyond 50
+         messages.
 
       3. Call calendar-list-events with a wide date range: timeMin 90 days ago,
          timeMax 90 days from now. Pass the principal's contact ID (from the
          "Promotion Sweep — Principal Context" section in your system prompt) as
-         contactId so the skill can resolve all calendars registered to the principal.
-         Collect all attendee email addresses from non-cancelled events. Deduplicate
-         into a set.
+         contactId so the skill can resolve all calendars registered to the
+         principal. Collect all attendee email addresses from non-cancelled
+         events. Deduplicate into a set.
          If the call fails (skill error, calendar not connected, API unavailable),
          record the error message and treat the calendar attendee set as empty —
          calendar enrichment is best-effort and must not abort the sweep.
 
-      4. For each provisional contact from step 1:
-         - Use contact-lookup (by: "name") to get their channel identities (email addresses).
+      4. For each provisional contact in the batch from step 1:
+         - Use contact-lookup (by: "name") to get their channel identities
+           (email addresses).
          - If a contact has no email identity, skip them.
          - Check whether their email appears in the Sent folder set (step 2) or
            the calendar attendee set (step 3).
          - If found in Sent folder: call contact-register with channel: "email",
            identifier: their email address, displayName: their display name,
            messageTimestamp: the current ISO 8601 time, ceo_has_sent: true.
-         - If found in calendar only (not in Sent folder): call contact-register with
-           channel: "email", identifier: their email address, displayName: their display
-           name, messageTimestamp: the current ISO 8601 time, calendar_accepted: true.
-         - contact-register automatically checks the curia_outbound signal for every call.
+         - If found in calendar only (not in Sent folder): call contact-register
+           with channel: "email", identifier: their email address,
+           displayName: their display name, messageTimestamp: the current ISO
+           8601 time, calendar_accepted: true.
+         - contact-register automatically checks the curia_outbound signal for
+           every call.
 
-      5. Report a clear summary: how many provisional contacts were checked, how many
-         were promoted, which signal triggered each promotion (curia_outbound,
-         ceo_has_sent, or calendar_accepted), how many provisional contacts remain,
-         and whether the calendar call in step 3 succeeded or failed. If it failed,
-         include the error message so operators can distinguish a transient outage
-         from a permanent misconfiguration (e.g. no calendar registered for the
-         principal).
+      5. Compute the cursor for the next run:
+         - If the batch from step 1 returned fewer than 10 contacts (end of
+           pool), set next_offset to 0 (wrap around for next cycle).
+         - Otherwise, set next_offset to (current next_offset + 10).
+
+      6. Call scheduler-report with:
+         - job_id: the scheduler_job_id you extracted before step 1
+         - summary: how many contacts were checked in this batch, how many were
+           promoted and by which signal (curia_outbound, ceo_has_sent,
+           calendar_accepted), whether the calendar call succeeded or failed,
+           and the next offset so operators can track progress.
+         - context: { "next_offset": <computed value from step 5> }
     expectedDurationSeconds: 540

--- a/skills/contact-list/handler.test.ts
+++ b/skills/contact-list/handler.test.ts
@@ -144,7 +144,7 @@ describe('ContactListHandler', () => {
   });
 
   it('offset skips leading contacts', async () => {
-    const ctx = makeCtx({ offset: 2 });
+    const ctx = makeCtx({ offset: 2, limit: 10 });
     const result = await handler.execute(ctx);
     expect(result.success).toBe(true);
     // allContacts sorted by createdAt: alice, bob, carol, dave — offset 2 skips alice+bob
@@ -155,7 +155,7 @@ describe('ContactListHandler', () => {
   });
 
   it('offset past end returns empty array', async () => {
-    const ctx = makeCtx({ offset: 10 });
+    const ctx = makeCtx({ offset: 10, limit: 10 });
     const result = await handler.execute(ctx);
     expect(result.success).toBe(true);
     expect(getContacts(result)).toHaveLength(0);
@@ -248,7 +248,7 @@ describe('ContactListHandler', () => {
   });
 
   it('rejects combining role with offset', async () => {
-    const ctx = makeCtx({ role: 'CFO', offset: 5 });
+    const ctx = makeCtx({ role: 'CFO', offset: 5, limit: 10 });
     const result = await handler.execute(ctx);
     expect(result.success).toBe(false);
     expect(result.error).toContain('Cannot combine role');
@@ -259,6 +259,20 @@ describe('ContactListHandler', () => {
     const result = await handler.execute(ctx);
     expect(result.success).toBe(false);
     expect(result.error).toContain('non-negative integer');
+  });
+
+  it('rejects offset > 0 without limit (unbounded pagination guard)', async () => {
+    const ctx = makeCtx({ offset: 5 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Offset requires limit');
+  });
+
+  it('allows offset=0 without limit (same as no offset)', async () => {
+    const ctx = makeCtx({ offset: 0 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(4);
   });
 
   it('rejects non-integer offset', async () => {

--- a/skills/contact-list/handler.test.ts
+++ b/skills/contact-list/handler.test.ts
@@ -1,6 +1,6 @@
 // handler.test.ts — tests for contact-list skill.
-// Covers: no filters, status filter, limit, status+limit, role (existing),
-// invalid status, invalid limit.
+// Covers: no filters, status filter, limit, offset, status+limit+offset, role (existing),
+// invalid status, invalid limit, invalid offset.
 import { describe, it, expect, vi } from 'vitest';
 import { ContactListHandler } from './handler.js';
 import type { SkillContext, SkillResult } from '../../src/skills/types.js';
@@ -38,16 +38,16 @@ function makeCtx(input: Record<string, unknown> = {}, contacts: Contact[] = allC
     input,
     log: createSilentLogger(),
     contactService: {
-      listContacts: vi.fn().mockImplementation((filters?: { status?: string; limit?: number }) => {
+      listContacts: vi.fn().mockImplementation((filters?: { status?: string; limit?: number; offset?: number }) => {
         let results = [...contacts];
         if (filters?.status) {
           results = results.filter((c) => c.status === filters.status);
         }
         // Sort ascending by createdAt to match real backend
         results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
-        if (filters?.limit != null) {
-          results = results.slice(0, filters.limit);
-        }
+        const offset = filters?.offset ?? 0;
+        const end = filters?.limit != null ? offset + filters.limit : undefined;
+        results = results.slice(offset, end);
         return Promise.resolve(results);
       }),
       findContactByRole: vi.fn().mockResolvedValue([]),
@@ -74,6 +74,7 @@ describe('ContactListHandler', () => {
     expect(ctx.contactService!.listContacts).toHaveBeenCalledWith({
       status: undefined,
       limit: undefined,
+      offset: undefined,
     });
   });
 
@@ -131,6 +132,54 @@ describe('ContactListHandler', () => {
     const contacts = getContacts(result);
     expect(contacts).toHaveLength(1);
     expect(contacts[0].status).toBe('provisional');
+  });
+
+  // --- Offset pagination ---
+
+  it('offset=0 returns same results as no offset', async () => {
+    const ctx = makeCtx({ offset: 0 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(4);
+  });
+
+  it('offset skips leading contacts', async () => {
+    const ctx = makeCtx({ offset: 2 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    // allContacts sorted by createdAt: alice, bob, carol, dave — offset 2 skips alice+bob
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(2);
+    expect(contacts[0]!.display_name).toBe('Carol');
+    expect(contacts[1]!.display_name).toBe('Dave');
+  });
+
+  it('offset past end returns empty array', async () => {
+    const ctx = makeCtx({ offset: 10 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(0);
+  });
+
+  it('two consecutive limit+offset pages return disjoint sets', async () => {
+    const ctx1 = makeCtx({ limit: 2, offset: 0 });
+    const ctx2 = makeCtx({ limit: 2, offset: 2 });
+    const page1 = getContacts(await handler.execute(ctx1)).map((c) => c.contact_id);
+    const page2 = getContacts(await handler.execute(ctx2)).map((c) => c.contact_id);
+    expect(page1).toHaveLength(2);
+    expect(page2).toHaveLength(2);
+    expect(page1.some((id) => page2.includes(id))).toBe(false);
+    expect([...page1, ...page2].sort()).toEqual(['a1', 'b2', 'c3', 'd4'].sort());
+  });
+
+  it('offset with status filter paginates within filtered results', async () => {
+    // Only bob and carol are provisional; offset 1 should return just carol
+    const ctx = makeCtx({ status: 'provisional', limit: 10, offset: 1 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0]!.display_name).toBe('Carol');
   });
 
   // --- Role filter (existing behavior, regression check) ---
@@ -196,6 +245,27 @@ describe('ContactListHandler', () => {
     const result = await handler.execute(ctx);
     expect(result.success).toBe(false);
     expect(result.error).toContain('Cannot combine role');
+  });
+
+  it('rejects combining role with offset', async () => {
+    const ctx = makeCtx({ role: 'CFO', offset: 5 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Cannot combine role');
+  });
+
+  it('rejects negative offset', async () => {
+    const ctx = makeCtx({ offset: -1 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('non-negative integer');
+  });
+
+  it('rejects non-integer offset', async () => {
+    const ctx = makeCtx({ offset: 1.5 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('non-negative integer');
   });
 
   // --- Output shape ---

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -38,6 +38,11 @@ export class ContactListHandler implements SkillHandler {
       if (typeof offset !== 'number' || !Number.isInteger(offset) || offset < 0) {
         return { success: false, error: 'Offset must be a non-negative integer' };
       }
+      // Require limit when offset > 0 to prevent accidentally returning an unbounded
+      // result set starting from the middle of the table.
+      if (offset > 0 && limit == null) {
+        return { success: false, error: 'Offset requires limit to be set. Use limit together with offset for pagination.' };
+      }
     }
 
     // Role uses a separate query path that doesn't support status/limit/offset — reject the combination
@@ -81,7 +86,7 @@ export class ContactListHandler implements SkillHandler {
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, role, status, limit }, 'Failed to list contacts');
+      ctx.log.error({ err, role, status, limit, offset }, 'Failed to list contacts');
       return { success: false, error: `Failed to list contacts: ${message}` };
     }
   }

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -12,7 +12,8 @@ const VALID_STATUSES: readonly ContactStatus[] = ['confirmed', 'provisional', 'b
 
 export class ContactListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { role, status, limit, offset } = ctx.input as {
+    // Cast through unknown per repo convention for narrowing from Record<string, unknown>
+    const { role, status, limit, offset } = ctx.input as unknown as {
       role?: string;
       status?: string;
       limit?: number;

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -12,10 +12,11 @@ const VALID_STATUSES: readonly ContactStatus[] = ['confirmed', 'provisional', 'b
 
 export class ContactListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { role, status, limit } = ctx.input as {
+    const { role, status, limit, offset } = ctx.input as {
       role?: string;
       status?: string;
       limit?: number;
+      offset?: number;
     };
 
     // Input validation
@@ -33,10 +34,16 @@ export class ContactListHandler implements SkillHandler {
       }
     }
 
-    // Role uses a separate query path that doesn't support status/limit — reject the combination
+    if (offset != null) {
+      if (typeof offset !== 'number' || !Number.isInteger(offset) || offset < 0) {
+        return { success: false, error: 'Offset must be a non-negative integer' };
+      }
+    }
+
+    // Role uses a separate query path that doesn't support status/limit/offset — reject the combination
     // rather than silently dropping filters.
-    if (role && typeof role === 'string' && (status != null || limit != null)) {
-      return { success: false, error: 'Cannot combine role filter with status or limit. Use role alone, or status/limit without role.' };
+    if (role && typeof role === 'string' && (status != null || limit != null || offset != null)) {
+      return { success: false, error: 'Cannot combine role filter with status, limit, or offset. Use role alone, or status/limit/offset without role.' };
     }
 
     // contactService is a universal service — always injected by ExecutionLayer
@@ -47,7 +54,7 @@ export class ContactListHandler implements SkillHandler {
       };
     }
 
-    ctx.log.info({ role: role ?? '(all)', status: status ?? '(all)', limit: limit ?? '(none)' }, 'Listing contacts');
+    ctx.log.info({ role: role ?? '(all)', status: status ?? '(all)', limit: limit ?? '(none)', offset: offset ?? 0 }, 'Listing contacts');
 
     try {
       // Role filter uses the dedicated findContactByRole path (no change from existing behavior)
@@ -56,6 +63,7 @@ export class ContactListHandler implements SkillHandler {
         : await ctx.contactService.listContacts({
             status: status as ContactStatus | undefined,
             limit,
+            offset,
           });
 
       return {

--- a/skills/contact-list/skill.json
+++ b/skills/contact-list/skill.json
@@ -1,13 +1,14 @@
 {
   "name": "contact-list",
-  "description": "List contacts, optionally filtered by role or status, with optional result limit.",
-  "version": "1.1.0",
+  "description": "List contacts, optionally filtered by role or status, with optional result limit and offset for pagination.",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "role": "string?",
     "status": "string? (confirmed | provisional | blocked)",
-    "limit": "number?"
+    "limit": "number?",
+    "offset": "number? (skip this many contacts; use with limit for cursor-based pagination)"
   },
   "outputs": {
     "contacts": "array",

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1657,7 +1657,10 @@ class InMemoryContactBackend implements ContactServiceBackend {
     // Sort by createdAt ascending to match Postgres ORDER BY created_at ASC
     results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
-    const offset = filters?.offset ?? 0;
+    // Mirror the Postgres path: only apply offset when > 0 so negative values
+    // (which the handler rejects, but the backend should also handle safely)
+    // never produce Array.slice(negative) semantics that differ from Postgres.
+    const offset = filters?.offset != null && filters.offset > 0 ? filters.offset : 0;
     const end = filters?.limit != null ? offset + filters.limit : undefined;
     results = results.slice(offset, end);
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -55,7 +55,7 @@ interface ContactServiceBackend {
   findContactByKgNodeId(kgNodeId: string): Promise<Contact | null>;
   findContactByRole(role: string): Promise<Contact[]>;
   findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null>;
-  listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]>;
+  listContacts(filters?: { status?: ContactStatus; limit?: number; offset?: number }): Promise<Contact[]>;
   updateContact(contact: Contact): Promise<void>;
   createIdentity(identity: ChannelIdentity): Promise<void>;
   getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]>;
@@ -348,8 +348,8 @@ export class ContactService {
     return this.backend.findContactBySystemRole(systemRole);
   }
 
-  /** List contacts, optionally filtered by status and/or capped by limit. */
-  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+  /** List contacts, optionally filtered by status and/or capped by limit with offset for pagination. */
+  async listContacts(filters?: { status?: ContactStatus; limit?: number; offset?: number }): Promise<Contact[]> {
     return this.backend.listContacts(filters);
   }
 
@@ -1071,7 +1071,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     return this.rowToContact(row);
   }
 
-  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+  async listContacts(filters?: { status?: ContactStatus; limit?: number; offset?: number }): Promise<Contact[]> {
     const conditions: string[] = [];
     const params: unknown[] = [];
 
@@ -1086,6 +1086,11 @@ class PostgresContactBackend implements ContactServiceBackend {
     if (filters?.limit != null) {
       params.push(filters.limit);
       sql += ` LIMIT $${params.length}`;
+    }
+
+    if (filters?.offset != null && filters.offset > 0) {
+      params.push(filters.offset);
+      sql += ` OFFSET $${params.length}`;
     }
 
     const result = await this.pool.query<ContactRow>(sql, params);
@@ -1640,7 +1645,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return null;
   }
 
-  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+  async listContacts(filters?: { status?: ContactStatus; limit?: number; offset?: number }): Promise<Contact[]> {
     let results = [...this.contacts.values()];
 
     if (filters?.status != null) {
@@ -1650,9 +1655,9 @@ class InMemoryContactBackend implements ContactServiceBackend {
     // Sort by createdAt ascending to match Postgres ORDER BY created_at ASC
     results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
-    if (filters?.limit != null) {
-      results = results.slice(0, filters.limit);
-    }
+    const offset = filters?.offset ?? 0;
+    const end = filters?.limit != null ? offset + filters.limit : undefined;
+    results = results.slice(offset, end);
 
     return results;
   }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1088,6 +1088,8 @@ class PostgresContactBackend implements ContactServiceBackend {
       sql += ` LIMIT $${params.length}`;
     }
 
+    // Skip OFFSET 0 — it is a no-op in Postgres and saves a parameter slot.
+    // InMemory backend uses slice(offset, end) which also handles 0 correctly.
     if (filters?.offset != null && filters.offset > 0) {
       params.push(filters.offset);
       sql += ` OFFSET $${params.length}`;

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -355,7 +355,9 @@ export class Scheduler {
         task_payload: job.taskPayload,
       });
     } else {
-      content = JSON.stringify({ scheduler_job_id: job.id, ...job.taskPayload });
+      // scheduler_job_id is placed last so it always wins if taskPayload coincidentally
+      // contains the same key (e.g. a manually-crafted job row).
+      content = JSON.stringify({ ...job.taskPayload, scheduler_job_id: job.id });
     }
 
     // Prepend prior-run context so the agent knows what happened last time

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -341,19 +341,21 @@ export class Scheduler {
       return;
     }
 
-    // Build the agent.task content. For task-bound jobs, include task_id, title,
-    // progress, and the original task payload so the receiving specialist has full
-    // context. Intent anchor is passed in the event payload (not content) so the
-    // runtime injects it into the system prompt as a non-negotiable behavioral
-    // instruction. For non-task-bound jobs the payload is used as-is.
-    let content = JSON.stringify(job.taskPayload);
+    // Build the agent.task content. The scheduler_job_id is always injected so
+    // agents can call scheduler-report to persist their cursor/context for the
+    // next run. For task-bound jobs, include task_id, title, and progress as
+    // well. For non-task-bound jobs the payload fields are spread at the top level.
+    let content: string;
     if (job.agentTaskId) {
       content = JSON.stringify({
+        scheduler_job_id: job.id,
         task_id: job.agentTaskId,
         ...(job.taskTitle !== null && { title: job.taskTitle }),
         progress: job.progress ?? {},
         task_payload: job.taskPayload,
       });
+    } else {
+      content = JSON.stringify({ scheduler_job_id: job.id, ...job.taskPayload });
     }
 
     // Prepend prior-run context so the agent knows what happened last time


### PR DESCRIPTION
## **User description**
## Summary

Closes #884

The contacts agent's daily promotion sweep (`b577d7c6`, cron `0 8 * * *`) was exhausting its 20-turn budget every run by trying to process all 173 provisional contacts in a single shot. This batches the work at 10 contacts per run using cursor-based offset pagination, draining the pool over successive daily runs.

- **`contact-list` skill** (v1.2.0): new `offset` input for cursor-based pagination; `offset > 0` requires `limit` to prevent unbounded result sets
- **`contact-service.ts`**: `listContacts` interface and both backends (Postgres + InMemory) extended with `offset`
- **`scheduler.ts`**: `scheduler_job_id` now injected into every fired job's task payload so agents can call `scheduler-report` without guessing their own job ID; injected last so it always wins over any matching payload key
- **`contacts.yaml`**: `error_budget.max_turns` raised to 30; daily sweep rewritten to call `contact-list` with `limit: 10, offset: next_offset`, persist the cursor via `scheduler-report`, and advance or wrap the cursor each run
- **82 unit tests** covering offset pagination, the unbounded-offset guard, and cursor edge cases

**Known limitation (documented in YAML):** OFFSET-based pagination over a live set means promotions during a sweep can shift remaining rows left, causing a small number of contacts to be skipped until the cursor wraps back to 0. They're never permanently stranded, just delayed by one cycle. A keyset cursor (by `created_at`) would be more precise but is a larger change.

## Test plan

- [ ] `pnpm run typecheck` — clean
- [ ] `pnpm run test` — 82 contact-list handler tests pass; full suite clean except pre-existing DB-connectivity failures
- [ ] Run `SELECT COUNT(*) FROM contacts WHERE status = 'provisional'` on prod to confirm pool size; watch daily job logs over next few runs to confirm turn count drops to ~15-22 per run and cursor advances by 10 each day
- [ ] After the cursor wraps back to 0 (once per full sweep cycle), verify no contacts were permanently skipped by confirming the promotion count converges


___

## **CodeAnt-AI Description**
**Batch provisional contact promotion and add pagination to contact listing**

### What Changed
- The daily provisional contact promotion sweep now runs in smaller batches instead of trying to process every provisional contact at once.
- The contact list tool now supports an `offset` input for paging through results, with checks to prevent unsafe offset-only requests.
- The scheduler now includes the job ID in every task payload so the contacts agent can save its progress for the next run.
- The contacts agent’s daily sweep now reads and stores a `next_offset` cursor, then reports the updated progress after each run.

### Impact
`✅ Fewer daily sweep timeouts`
`✅ Steadier provisional contact promotion`
`✅ Safer contact list paging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cursor-based pagination support with `offset` parameter for contact list queries
  * Scheduler now includes job identifiers in agent task payloads for better tracking

* **Improvements**
  * Contact promotion sweep now processes contacts in batches of 10 per day for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->