### PR TITLE
fix: suppress duplicate outbound.message via dispatcher reply-lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Dispatcher reply-lock** — suppresses duplicate `outbound.message` when a human-facing reply skill (`email-reply` or `email-send`) already fired successfully during the same task. Emits `outbound.suppressed_duplicate` audit event instead. Covers both the direct-coordinator and delegated-specialist cases. (#847)
 - **`ceo-inbox` watermark ownership** — moves `last_processed_at` management to `ceo-inbox-list` via `ConfigStore`; clamps future timestamps to `now()` and falls back to 24h lookback. (#866)
 - **Provisional contact promotion sweep** — batched to 10 contacts per daily run using `offset` pagination and a persisted `next_offset` cursor in `last_run_context`, preventing turn-budget exhaustion on large pools. Contacts agent `error_budget.max_turns` raised to 30. (#884)
 - **Scheduler task payload** — `scheduler_job_id` is now injected into every fired job's task content so agents can call `scheduler-report` without guessing their own job ID.

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -155,6 +155,17 @@ interface OutboundBlockedPayload {
   findings: Array<{ rule: string; detail: string }>;
 }
 
+// OutboundSuppressedDuplicatePayload — emitted by the dispatch layer when an agent.response
+// would have produced an outbound.message, but a human-facing reply skill (email-reply or
+// email-send) already fired successfully during the same task. The agent.response payload
+// is preserved in audit_log; only the wire-level send is suppressed. See #847.
+interface OutboundSuppressedDuplicatePayload {
+  routingTaskId: string;   // agent.task event ID whose routing entry triggered the suppression
+  agentId: string;
+  conversationId: string;
+  reason: 'human_reply_already_sent';
+}
+
 // OutboundNotificationPayload — published by the dispatch layer (via OutboundGateway.sendNotification)
 // when a system-level CEO alert needs to be sent. Routing through the bus ensures the notification
 // goes through the same safety pipeline as regular outbound messages, closing the prior direct
@@ -589,6 +600,16 @@ export interface OutboundPiiRedactedEvent extends BaseEvent {
   payload: OutboundPiiRedactedPayload;
 }
 
+// OutboundSuppressedDuplicateEvent — published by the dispatch layer when handleAgentResponse
+// would produce an outbound.message but the reply-lock flag is set (a human-facing reply skill
+// already succeeded during the same task). Provides a full audit trail without triggering
+// a duplicate send. See #847.
+export interface OutboundSuppressedDuplicateEvent extends BaseEvent {
+  type: 'outbound.suppressed_duplicate';
+  sourceLayer: 'dispatch';
+  payload: OutboundSuppressedDuplicatePayload;
+}
+
 // OutboundNotificationEvent — published by the dispatch layer when a system-level CEO
 // notification needs to be sent (blocked-content alert, group-held alert, etc.).
 // Channel adapters subscribe to route it through the outbound safety pipeline.
@@ -923,6 +944,7 @@ export type BusEvent =
   | OutboundBlockedEvent  // Outbound content filter: message blocked before delivery (#38)
   | OutboundDeliveredEvent // Outbound delivery: wire-level send succeeded (#729)
   | OutboundPiiRedactedEvent // Outbound PII redaction: PII scrubbed before delivery (#249)
+  | OutboundSuppressedDuplicateEvent  // #847: duplicate reply suppressed by reply-lock
   | OutboundNotificationEvent // System notifications routed through safety pipeline (#206)
   | ScheduleCreatedEvent   // Scheduler: job created
   | ScheduleFiredEvent     // Scheduler: job fired
@@ -1051,6 +1073,22 @@ export function createOutboundPiiRedacted(
     id: randomUUID(),
     timestamp: new Date(),
     type: 'outbound.pii-redacted',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createOutboundSuppressedDuplicate(
+  // parentEventId is required — suppression must trace back to the agent.response that was
+  // suppressed, mirroring the causal position outbound.message would have occupied.
+  payload: OutboundSuppressedDuplicatePayload & { parentEventId: string },
+): OutboundSuppressedDuplicateEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'outbound.suppressed_duplicate',
     sourceLayer: 'dispatch',
     payload: rest,
     parentEventId,

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -28,21 +28,27 @@ import type { Layer, EventType } from './events.js';
 //          logging — EmbeddingService fires from infrastructure paths with no agent-layer context.
 // #846 (email poll persistence): channel layer publishes channel.poll (poll heartbeat) and
 //          channel.stalled (watchdog alert); system layer subscribes for audit logging.
+// #847 (dispatcher reply-lock): dispatch layer publishes outbound.suppressed_duplicate when
+//          a human-facing reply skill already fired during the same task; dispatch layer
+//          subscribes to skill.result to detect the reply and set the reply-lock flag.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message', 'channel.poll', 'channel.stalled']),
-  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'autonomy.send_blocked']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'autonomy.send_blocked']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call', 'context.budget']),
   execution: new Set(['skill.result', 'secret.accessed', 'autonomy.skill_blocked', 'contact.resolved']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
+// skill.result subscribe for 'dispatch': used by Dispatcher reply-lock (#847) to detect successful
+//          email-reply / email-send calls and set humanReplySent on the routing entry before
+//          handleAgentResponse fires.
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['outbound.message', 'outbound.blocked', 'outbound.notification', 'message.held', 'message.rejected']),
-  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
+  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss', 'skill.result']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -1,6 +1,6 @@
 import type { EventBus } from '../bus/bus.js';
-import type { InboundMessageEvent, AgentResponseEvent, AgentErrorEvent } from '../bus/events.js';
-import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown, createMessageHeld, createMessageRejected, createConversationCheckpoint } from '../bus/events.js';
+import type { InboundMessageEvent, AgentResponseEvent, AgentErrorEvent, SkillResultEvent } from '../bus/events.js';
+import { createAgentTask, createOutboundMessage, createOutboundSuppressedDuplicate, createContactResolved, createContactUnknown, createMessageHeld, createMessageRejected, createConversationCheckpoint } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { ContactService } from '../contacts/contact-service.js';
@@ -119,6 +119,9 @@ export class Dispatcher {
       conversationId: string;
       senderId: string;
       accountId?: string;
+      /** Set to true when a human-facing reply skill (email-reply, email-send) succeeds
+       *  during this task. handleAgentResponse suppresses outbound.message when true. */
+      humanReplySent: boolean;
     }
   >();
   /** Key: `${conversationId}:${agentId}` — reset on every agent.response */
@@ -182,6 +185,12 @@ export class Dispatcher {
     // agent.error → log for awareness (the runtime also sends agent.response for user notification)
     this.bus.subscribe('agent.error', 'dispatch', async (event) => {
       await this.handleAgentError(event as AgentErrorEvent);
+    });
+
+    // skill.result → reply-lock: detect successful email-reply / email-send calls so
+    // handleAgentResponse can suppress the duplicate outbound.message. See #847.
+    this.bus.subscribe('skill.result', 'dispatch', async (event) => {
+      await this.handleSkillResult(event as SkillResultEvent);
     });
 
     this.logger.info(
@@ -819,6 +828,7 @@ export class Dispatcher {
       conversationId: payload.conversationId,
       senderId: payload.senderId,
       accountId: payload.accountId,
+      humanReplySent: false,
     });
 
     await this.bus.publish('dispatch', taskEvent);
@@ -833,6 +843,72 @@ export class Dispatcher {
       { agentId: event.payload.agentId, errorType: event.payload.errorType, source: event.payload.source },
       'Agent error reported',
     );
+  }
+
+  /**
+   * Reply-lock: detect when a human-facing reply skill fires successfully during a task
+   * and mark the routing entry so handleAgentResponse can suppress the duplicate outbound.
+   *
+   * The skill.result event carries conversationId but not the agent.task ID directly,
+   * so we scan the routing map for an entry with a matching conversationId and senderId.
+   * This works for both the direct-coordinator case (coordinator calls email-reply) and
+   * the delegated-specialist case (T2125 calls email-reply; coordinator's routing entry
+   * shares the same conversationId). See #847.
+   *
+   * NOTE: This relies on single-process in-order event delivery — skill.result must be
+   * delivered to all subscribers (including this handler) before agent.response is
+   * delivered. The bus processes subscribers sequentially within a single Node.js
+   * event loop; multi-process deployments would require a persistent lock instead.
+   */
+  private async handleSkillResult(event: SkillResultEvent): Promise<void> {
+    const { skillName, conversationId, result } = event.payload;
+
+    if (skillName !== 'email-reply' && skillName !== 'email-send') return;
+    if (!result.success) return;
+
+    // Extract outbound recipients from result.data.
+    // email-reply returns { to: string } (single address).
+    // email-send returns { to: string } where the value may be comma-joined for multiple recipients.
+    const data = result.data as unknown as Record<string, unknown>;
+    const toRaw = typeof data?.to === 'string' ? data.to : undefined;
+    if (!toRaw) {
+      // The skill contract (to: string) was not met — log a warning so duplicate sends are
+      // observable. The lock fails open: outbound.message will still be published.
+      this.logger.warn(
+        { skillName, conversationId },
+        'Dispatcher reply-lock: skill result missing expected { to: string } field — reply-lock NOT set, duplicate send may occur',
+      );
+      return;
+    }
+
+    // Parse comma-separated recipients and normalise to lowercase for case-insensitive matching.
+    const recipients = toRaw.split(',').map((addr) => addr.trim().toLowerCase());
+
+    // Find every routing entry for this conversation where the reply target includes the
+    // original inbound sender. Multiple entries for the same conversationId are possible
+    // but rare; we set the flag on all of them to be safe.
+    let matched = false;
+    for (const [taskId, routing] of this.taskRouting.entries()) {
+      if (
+        routing.conversationId === conversationId &&
+        recipients.includes(routing.senderId.toLowerCase())
+      ) {
+        routing.humanReplySent = true;
+        matched = true;
+        this.logger.debug(
+          { taskId, conversationId, skillName },
+          'Dispatcher reply-lock: human-facing reply detected — outbound.message will be suppressed',
+        );
+      }
+    }
+
+    if (!matched) {
+      // Expected for bullpen tasks or when the routing entry was already cleaned up.
+      this.logger.debug(
+        { skillName, conversationId, routingMapSize: this.taskRouting.size },
+        'Dispatcher reply-lock: no routing entry matched skill result — no lock set',
+      );
+    }
   }
 
   private async handleAgentResponse(event: AgentResponseEvent): Promise<void> {
@@ -852,6 +928,26 @@ export class Dispatcher {
     }
 
     this.taskRouting.delete(event.parentEventId!);
+
+    // Reply-lock: if a human-facing reply skill (email-reply, email-send) already fired
+    // successfully during this task, suppress the outbound.message to prevent a duplicate
+    // send. Emit outbound.suppressed_duplicate for the audit trail. See #847.
+    if (routing.humanReplySent) {
+      this.logger.info(
+        { agentId: event.payload.agentId, conversationId: routing.conversationId, routingTaskId: event.parentEventId },
+        'Dispatcher reply-lock: suppressing duplicate outbound.message — human-facing reply already sent',
+      );
+      const suppressed = createOutboundSuppressedDuplicate({
+        routingTaskId: event.parentEventId!,
+        agentId: event.payload.agentId,
+        conversationId: routing.conversationId,
+        reason: 'human_reply_already_sent',
+        parentEventId: event.id,
+      });
+      await this.bus.publish('dispatch', suppressed);
+      this.scheduleCheckpoint(routing.conversationId, event.payload.agentId, routing.channelId);
+      return;
+    }
 
     // Publish outbound.message to the bus — the email adapter will pick it up
     // and route it through OutboundGateway (blocked-contact check + content filter).

--- a/tests/integration/dispatcher-reply-lock.test.ts
+++ b/tests/integration/dispatcher-reply-lock.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Integration tests for the dispatcher reply-lock feature (#847).
+ *
+ * These tests exercise the full in-process flow: skill.result fires → reply-lock
+ * flag is set on the routing entry → handleAgentResponse sees the flag and
+ * suppresses the duplicate outbound.message.
+ *
+ * Two cases per the acceptance criteria:
+ *   1. Direct-coordinator: coordinator itself calls email-reply, then agent.response fires.
+ *   2. Delegated-specialist: T2125 (specialist) calls email-reply inside the same
+ *      conversation; coordinator's agent.response is suppressed via conversationId match.
+ *
+ * No database required — the reply-lock operates entirely in the in-memory taskRouting map.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Dispatcher } from '../../src/dispatch/dispatcher.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import type { Logger } from '../../src/logger.js';
+import {
+  createAgentResponse,
+  createSkillResult,
+  type BusEvent,
+  type OutboundMessageEvent,
+  type OutboundSuppressedDuplicateEvent,
+} from '../../src/bus/events.js';
+
+function isOutboundMessage(e: BusEvent): e is OutboundMessageEvent {
+  return e.type === 'outbound.message';
+}
+
+function isOutboundSuppressedDuplicate(e: BusEvent): e is OutboundSuppressedDuplicateEvent {
+  return e.type === 'outbound.suppressed_duplicate';
+}
+
+function makeStubs() {
+  const publishedEvents: BusEvent[] = [];
+  const subscribeHandlers = new Map<string, (event: BusEvent) => void | Promise<void>>();
+
+  const bus = {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: BusEvent) => void | Promise<void>) => {
+      subscribeHandlers.set(eventType, handler);
+    }),
+    publish: vi.fn(async (_layer: string, event: BusEvent) => {
+      publishedEvents.push(event);
+    }),
+  } as unknown as EventBus;
+
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  } as unknown as Logger;
+
+  const dispatcher = new Dispatcher({ bus, logger });
+
+  return { dispatcher, publishedEvents, subscribeHandlers };
+}
+
+/** Seeds the routing map (without humanReplySent so handleSkillResult must set it). */
+function seedRouting(
+  dispatcher: Dispatcher,
+  taskEventId: string,
+  { conversationId = 'email:thread-abc', senderId = 'external@example.com' }: {
+    conversationId?: string;
+    senderId?: string;
+  } = {},
+) {
+  (dispatcher as unknown as {
+    taskRouting: Map<string, { channelId: string; conversationId: string; senderId: string; humanReplySent: boolean }>;
+  }).taskRouting.set(taskEventId, {
+    channelId: 'email',
+    conversationId,
+    senderId,
+    humanReplySent: false,
+  });
+}
+
+async function fireSkillResult(
+  subscribeHandlers: Map<string, (event: BusEvent) => void | Promise<void>>,
+  {
+    agentId,
+    conversationId,
+    skillName,
+    to,
+    invokeEventId = 'invoke-1',
+  }: {
+    agentId: string;
+    conversationId: string;
+    skillName: string;
+    to: string;
+    invokeEventId?: string;
+  },
+) {
+  const event = createSkillResult({
+    agentId,
+    conversationId,
+    skillName,
+    result: { success: true, data: { message_id: 'msg-1', to, subject: 'Re: Test' } },
+    durationMs: 100,
+    parentEventId: invokeEventId,
+  });
+  const handler = subscribeHandlers.get('skill.result');
+  if (!handler) throw new Error('No skill.result handler registered');
+  await handler(event);
+}
+
+async function fireAgentResponse(
+  subscribeHandlers: Map<string, (event: BusEvent) => void | Promise<void>>,
+  { taskEventId, conversationId = 'email:thread-abc', agentId = 'coordinator' }: {
+    taskEventId: string;
+    conversationId?: string;
+    agentId?: string;
+  },
+) {
+  const event = createAgentResponse({ agentId, conversationId, content: 'ok', parentEventId: taskEventId });
+  const handler = subscribeHandlers.get('agent.response');
+  if (!handler) throw new Error('No agent.response handler registered');
+  await handler(event);
+}
+
+describe('Dispatcher reply-lock — integration', () => {
+  describe('Case 1: direct-coordinator calls email-reply', () => {
+    it('suppresses outbound.message when coordinator called email-reply during the task', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      seedRouting(dispatcher, 'task-coord', {
+        conversationId: 'email:thread-abc',
+        senderId: 'client@example.com',
+      });
+
+      // Coordinator called email-reply — skill.result fires before agent.response
+      await fireSkillResult(subscribeHandlers, {
+        agentId: 'coordinator',
+        conversationId: 'email:thread-abc',
+        skillName: 'email-reply',
+        to: 'client@example.com',
+      });
+
+      // Coordinator wrap-up: agent.response fires
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-coord',
+        conversationId: 'email:thread-abc',
+        agentId: 'coordinator',
+      });
+
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(0);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(1);
+    });
+
+    it('does NOT suppress when the skill failed', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      seedRouting(dispatcher, 'task-coord-fail', {
+        conversationId: 'email:conv-fail',
+        senderId: 'client@example.com',
+      });
+
+      // email-reply failed — should not trigger reply-lock
+      const failEvent = createSkillResult({
+        agentId: 'coordinator',
+        conversationId: 'email:conv-fail',
+        skillName: 'email-reply',
+        result: { success: false, error: 'Gateway rejected' },
+        durationMs: 50,
+        parentEventId: 'invoke-fail',
+      });
+      const skillHandler = subscribeHandlers.get('skill.result');
+      if (!skillHandler) throw new Error('No skill.result handler registered');
+      await skillHandler(failEvent);
+
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-coord-fail',
+        conversationId: 'email:conv-fail',
+      });
+
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(1);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(0);
+    });
+
+    it('does NOT suppress when a different conversation sent email-reply', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      seedRouting(dispatcher, 'task-coord-other', {
+        conversationId: 'email:thread-abc',
+        senderId: 'client@example.com',
+      });
+
+      // email-reply in a DIFFERENT conversation — should not affect this routing entry
+      await fireSkillResult(subscribeHandlers, {
+        agentId: 'coordinator',
+        conversationId: 'email:thread-different',
+        skillName: 'email-reply',
+        to: 'client@example.com',
+      });
+
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-coord-other',
+        conversationId: 'email:thread-abc',
+      });
+
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(1);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(0);
+    });
+
+    it('does NOT suppress when email-reply went to a different recipient', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      seedRouting(dispatcher, 'task-coord-diff-recip', {
+        conversationId: 'email:thread-abc',
+        senderId: 'client@example.com',
+      });
+
+      // email-reply to a different person in the same conversation
+      await fireSkillResult(subscribeHandlers, {
+        agentId: 'coordinator',
+        conversationId: 'email:thread-abc',
+        skillName: 'email-reply',
+        to: 'someone-else@example.com',
+      });
+
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-coord-diff-recip',
+        conversationId: 'email:thread-abc',
+      });
+
+      // Not suppressed — reply was to a different address than senderId
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(1);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(0);
+    });
+
+    it('works with email-send (single recipient)', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      seedRouting(dispatcher, 'task-send', {
+        conversationId: 'email:thread-send',
+        senderId: 'client@example.com',
+      });
+
+      await fireSkillResult(subscribeHandlers, {
+        agentId: 'coordinator',
+        conversationId: 'email:thread-send',
+        skillName: 'email-send',
+        to: 'client@example.com',
+      });
+
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-send',
+        conversationId: 'email:thread-send',
+      });
+
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(0);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(1);
+    });
+
+    it('works with email-send when senderId is one of multiple comma-joined recipients', async () => {
+      // email-send returns { to: "addr1, addr2" } when there are multiple recipients.
+      // The reply-lock must still fire when senderId is among them.
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      seedRouting(dispatcher, 'task-send-multi', {
+        conversationId: 'email:thread-multi',
+        senderId: 'client@example.com',
+      });
+
+      await fireSkillResult(subscribeHandlers, {
+        agentId: 'coordinator',
+        conversationId: 'email:thread-multi',
+        skillName: 'email-send',
+        // Simulate email-send returning comma-joined recipients
+        to: 'client@example.com, ops@example.com',
+      });
+
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-send-multi',
+        conversationId: 'email:thread-multi',
+      });
+
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(0);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(1);
+    });
+  });
+
+  describe('Case 2: delegated specialist (T2125-style) calls email-reply', () => {
+    it('suppresses coordinator wrap-up when specialist sent reply in same conversation', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      // Only the coordinator's task has a routing entry (specialist task was spawned internally)
+      seedRouting(dispatcher, 'task-coordinator', {
+        conversationId: 'email:reconciliation-thread',
+        senderId: 'reconciliation@client.com',
+      });
+
+      // T2125 specialist calls email-reply — skill.result fires with specialist agentId
+      // but same conversationId as the coordinator's routing entry
+      await fireSkillResult(subscribeHandlers, {
+        agentId: 'T2125-expense-tracker',
+        conversationId: 'email:reconciliation-thread',
+        skillName: 'email-reply',
+        to: 'reconciliation@client.com',
+      });
+
+      // Coordinator wrap-up agent.response fires after specialist finishes
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-coordinator',
+        conversationId: 'email:reconciliation-thread',
+        agentId: 'coordinator',
+      });
+
+      // Coordinator's outbound.message should be suppressed
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(0);
+
+      const suppressed = publishedEvents.filter(isOutboundSuppressedDuplicate);
+      expect(suppressed).toHaveLength(1);
+      expect(suppressed[0]!.payload.reason).toBe('human_reply_already_sent');
+      expect(suppressed[0]!.payload.routingTaskId).toBe('task-coordinator');
+      expect(suppressed[0]!.payload.agentId).toBe('coordinator');
+      expect(suppressed[0]!.payload.conversationId).toBe('email:reconciliation-thread');
+    });
+
+    it('does not interfere with a second independent conversation', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      // Two routing entries for two different conversations
+      seedRouting(dispatcher, 'task-A', {
+        conversationId: 'email:conv-A',
+        senderId: 'alice@example.com',
+      });
+      seedRouting(dispatcher, 'task-B', {
+        conversationId: 'email:conv-B',
+        senderId: 'bob@example.com',
+      });
+
+      // Specialist fires email-reply for conv-A only
+      await fireSkillResult(subscribeHandlers, {
+        agentId: 'specialist',
+        conversationId: 'email:conv-A',
+        skillName: 'email-reply',
+        to: 'alice@example.com',
+      });
+
+      // Both coordinators respond
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-A',
+        conversationId: 'email:conv-A',
+      });
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-B',
+        conversationId: 'email:conv-B',
+      });
+
+      // Only conv-A is suppressed; conv-B fires normally
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(1);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(1);
+
+      const outbound = publishedEvents.filter(isOutboundMessage)[0]!;
+      expect(outbound.payload.conversationId).toBe('email:conv-B');
+    });
+  });
+
+  describe('unchanged behavior when no reply skill fires', () => {
+    it('publishes outbound.message normally when no email-reply was called', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      seedRouting(dispatcher, 'task-normal', {
+        conversationId: 'email:thread-normal',
+        senderId: 'user@example.com',
+      });
+
+      // No skill.result fires — coordinator responds via agent.response only
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-normal',
+        conversationId: 'email:thread-normal',
+      });
+
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(1);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(0);
+    });
+
+    it('non-email skills (e.g. list-calendar) do not trigger reply-lock', async () => {
+      const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+      dispatcher.register();
+
+      seedRouting(dispatcher, 'task-calendar', {
+        conversationId: 'email:thread-cal',
+        senderId: 'user@example.com',
+      });
+
+      await fireSkillResult(subscribeHandlers, {
+        agentId: 'coordinator',
+        conversationId: 'email:thread-cal',
+        skillName: 'list-calendar',
+        to: 'user@example.com',
+      });
+
+      await fireAgentResponse(subscribeHandlers, {
+        taskEventId: 'task-calendar',
+        conversationId: 'email:thread-cal',
+      });
+
+      expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(1);
+      expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/dispatch/dispatcher-reply-lock.test.ts
+++ b/tests/unit/dispatch/dispatcher-reply-lock.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { Logger } from '../../../src/logger.js';
+import {
+  createAgentResponse,
+  type BusEvent,
+  type OutboundMessageEvent,
+  type OutboundSuppressedDuplicateEvent,
+} from '../../../src/bus/events.js';
+
+function isOutboundMessage(e: BusEvent): e is OutboundMessageEvent {
+  return e.type === 'outbound.message';
+}
+
+function isOutboundSuppressedDuplicate(e: BusEvent): e is OutboundSuppressedDuplicateEvent {
+  return e.type === 'outbound.suppressed_duplicate';
+}
+
+function makeStubs() {
+  const publishedEvents: BusEvent[] = [];
+  const subscribeHandlers = new Map<string, (event: BusEvent) => void | Promise<void>>();
+
+  const bus = {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: BusEvent) => void | Promise<void>) => {
+      subscribeHandlers.set(eventType, handler);
+    }),
+    publish: vi.fn(async (_layer: string, event: BusEvent) => {
+      publishedEvents.push(event);
+    }),
+  } as unknown as EventBus;
+
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  } as unknown as Logger;
+
+  const dispatcher = new Dispatcher({ bus, logger });
+
+  return { dispatcher, bus, publishedEvents, subscribeHandlers };
+}
+
+/** Seeds the routing map with humanReplySent set to the given value. */
+function seedRouting(
+  dispatcher: Dispatcher,
+  taskEventId: string,
+  opts: { channelId?: string; conversationId?: string; senderId?: string; humanReplySent?: boolean } = {},
+) {
+  (dispatcher as unknown as {
+    taskRouting: Map<string, { channelId: string; conversationId: string; senderId: string; humanReplySent: boolean }>;
+  }).taskRouting.set(taskEventId, {
+    channelId: opts.channelId ?? 'email',
+    conversationId: opts.conversationId ?? 'email:thread-abc',
+    senderId: opts.senderId ?? 'sender@example.com',
+    humanReplySent: opts.humanReplySent ?? false,
+  });
+}
+
+async function fireAgentResponse(
+  subscribeHandlers: Map<string, (event: BusEvent) => void | Promise<void>>,
+  { taskEventId, conversationId = 'email:thread-abc', agentId = 'coordinator', content = 'ok' }: {
+    taskEventId: string;
+    conversationId?: string;
+    agentId?: string;
+    content?: string;
+  },
+) {
+  const event = createAgentResponse({ agentId, conversationId, content, parentEventId: taskEventId });
+  const handler = subscribeHandlers.get('agent.response');
+  if (!handler) throw new Error('No agent.response handler registered');
+  await handler(event);
+}
+
+describe('Dispatcher reply-lock — handleAgentResponse', () => {
+  it('publishes outbound.message when humanReplySent is false', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-1', { humanReplySent: false });
+    await fireAgentResponse(subscribeHandlers, { taskEventId: 'task-1' });
+
+    expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(1);
+    expect(publishedEvents.filter(isOutboundSuppressedDuplicate)).toHaveLength(0);
+  });
+
+  it('suppresses outbound.message and emits outbound.suppressed_duplicate when humanReplySent is true', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-2', { humanReplySent: true });
+    await fireAgentResponse(subscribeHandlers, { taskEventId: 'task-2', agentId: 'coordinator' });
+
+    expect(publishedEvents.filter(isOutboundMessage)).toHaveLength(0);
+
+    const suppressed = publishedEvents.filter(isOutboundSuppressedDuplicate);
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0]!.payload.reason).toBe('human_reply_already_sent');
+    expect(suppressed[0]!.payload.agentId).toBe('coordinator');
+    expect(suppressed[0]!.payload.conversationId).toBe('email:thread-abc');
+    expect(suppressed[0]!.payload.routingTaskId).toBe('task-2');
+    // parentEventId of suppressed event points to the agent.response (not the task)
+    expect(suppressed[0]!.parentEventId).toBeDefined();
+  });
+
+  it('outbound.suppressed_duplicate payload has correct structure', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-3', {
+      conversationId: 'email:conv-xyz',
+      humanReplySent: true,
+    });
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-3',
+      conversationId: 'email:conv-xyz',
+      agentId: 'curia',
+    });
+
+    const suppressed = publishedEvents.filter(isOutboundSuppressedDuplicate);
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0]!.type).toBe('outbound.suppressed_duplicate');
+    expect(suppressed[0]!.sourceLayer).toBe('dispatch');
+    expect(suppressed[0]!.id).toBeDefined();
+    expect(suppressed[0]!.timestamp).toBeDefined();
+  });
+
+  it('routing entry is deleted after suppression (no double-processing)', async () => {
+    const { dispatcher, subscribeHandlers } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-4', { humanReplySent: true });
+    await fireAgentResponse(subscribeHandlers, { taskEventId: 'task-4' });
+
+    const taskRouting = (dispatcher as unknown as {
+      taskRouting: Map<string, unknown>;
+    }).taskRouting;
+    expect(taskRouting.has('task-4')).toBe(false);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Adds `humanReplySent: boolean` to the dispatcher's routing entry, defaulting to `false`
- Dispatcher now subscribes to `skill.result` events; when `email-reply` or `email-send` succeeds with a recipient matching `routing.senderId`, the flag is set
- `handleAgentResponse` checks the flag before publishing `outbound.message`; when true, emits `outbound.suppressed_duplicate` audit event instead
- Covers the direct-coordinator case and the delegated-specialist case (specialist fires in same `conversationId`)
- Multi-recipient `email-send` handled correctly by parsing the comma-joined `to` field

## Test plan

- [x] `tests/unit/dispatch/dispatcher-reply-lock.test.ts` — unit tests for `handleAgentResponse` with flag set/unset
- [x] `tests/integration/dispatcher-reply-lock.test.ts` — full flow: direct-coordinator, delegated-specialist, multi-recipient email-send, non-matching conversations, non-email skills
- [x] All 14 new tests pass; typecheck clean

Closes #847


___

## **CodeAnt-AI Description**
Prevent duplicate email sends when a reply skill already handled the conversation

### What Changed
- When a human-facing reply is already sent with `email-reply` or `email-send`, the dispatcher now suppresses the follow-up outbound message instead of sending a duplicate
- The same protection works when a specialist sends the reply during the task and the coordinator later wraps up the conversation
- If the reply skill fails, targets the wrong conversation, or is not an email reply, the normal outbound message still goes through
- The dispatcher now records a dedicated audit event when a duplicate send is suppressed

### Impact
`✅ Fewer duplicate email sends`
`✅ Cleaner handoff between specialist and coordinator replies`
`✅ Clearer audit trail for suppressed outbound messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a reply-lock mechanism that automatically suppresses duplicate email replies when email response skills execute successfully within a task. Audit events are recorded for all suppressed duplicates to maintain operational visibility. This prevents redundant outbound messages in coordinated messaging workflows, with support for both direct-coordinator and delegated-specialist coordination patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->