### PR TITLE
feat: ceo-inbox label refresh, ⚠️ Stuck, and star urgent (#871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **`ceo-inbox-mark-starred`** — new skill that stars (or unstars) a CEO inbox message via the Nylas starred field; mirrors the pattern of `ceo-inbox-mark-read`.
+- **`⚠️ Stuck` label** — ceo-inbox now applies this label when triage cannot complete for a message (unrecognised classification value, required skill failure, or error budget boundary hit), making failures visible in the Gmail sidebar.
+
 ### Changed
+- **ceo-inbox triage labels** — renamed to emoji-prefixed variants for better readability in the Gmail sidebar: `URGENT` → `🚨 Urgent`, `ACTIONABLE` → `✅ Handled`, `NEEDS DRAFT` → `✍️ Drafted`, `LEAVE FOR CEO` → `📌 Seen`, `NOISE` → `✔️ Cleared`. Existing Gmail labels with the old names are inert and won't appear on new messages.
+- **`🚨 Urgent` messages are starred automatically** — after step 4h's bullpen notification, ceo-inbox calls `ceo-inbox-mark-starred`. Starring failure is logged but does not abort the run.
 - **KG graph** — various visual improvements: physics-aware layout, better hub sizing, principal-node default view, and viewport centering on focal nodes. (#861)
 - **`contact-list` skill** — new `offset` input (v1.2.0) enables cursor-based pagination; `offset > 0` requires `limit` to prevent unbounded result sets. Public API surface change.
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -441,6 +441,16 @@ system_prompt: |
   **✔️ Cleared** — receipt, newsletter, automated notification, no human action needed:
     - Call ceo-inbox-archive with the message_id.
 
+  **⚠️ Stuck** — processing failed in a way that leaves the message unresolved
+    (e.g. classification returned an unrecognised value, a required skill call
+    failed with no meaningful fallback, or the error budget boundary was hit
+    mid-message):
+      - Apply the label via `ceo-inbox-label` with label `⚠️ Stuck` so the
+        CEO can see which messages need a manual look. Do NOT archive. Do NOT
+        draft. Do NOT notify via bullpen.
+      - Include a note in the per-message Response Format output explaining
+        what failed.
+
   **Important:** After choosing a classification above, do NOT execute the
   associated actions yet. Proceed through steps 4f and 4g to evaluate
   standing rules before executing any action — rules may change your
@@ -525,6 +535,8 @@ system_prompt: |
     the message_id.
   - **📌 Seen**: No action. Do not archive, draft, or notify.
   - **✔️ Cleared**: Call ceo-inbox-archive with the message_id.
+  - **⚠️ Stuck**: Call ceo-inbox-label with label `⚠️ Stuck`. Do NOT archive,
+    draft, or notify. Log what failed in the per-message Response Format.
 
   If any skill call fails, log the error in the Response Format and continue.
   Do not abort the run for a single action failure.
@@ -548,7 +560,7 @@ system_prompt: |
   For each processed message, output:
     Subject: <subject line>
     From: <sender email>
-    Classification: <🚨 Urgent|✅ Handled|✍️ Drafted|📌 Seen|✔️ Cleared>
+    Classification: <🚨 Urgent|✅ Handled|✍️ Drafted|📌 Seen|✔️ Cleared|⚠️ Stuck>
     Rationale: <one sentence>
     Actions: <list of skills called, or "none">
     Labels: <labels applied, or "none", or "FAILED — reason">
@@ -556,7 +568,7 @@ system_prompt: |
 
   After processing all messages, summarize:
     Total: N messages processed
-    Breakdown: N 🚨 Urgent, N ✅ Handled, N ✍️ Drafted, N 📌 Seen, N ✔️ Cleared
+    Breakdown: N 🚨 Urgent, N ✅ Handled, N ✍️ Drafted, N 📌 Seen, N ✔️ Cleared, N ⚠️ Stuck
     Voice profile: OK | UNAVAILABLE (fallback used)
     Entity-context: OK | FAILED for <sender email> — <one-sentence error description>
       (one line per failed sender; if all succeeded, a single "Entity-context: OK" line)

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,11 +1,11 @@
 name: ceo-inbox
-version: "0.5.0"
+version: "0.6.0"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
   inbox queries, and composing new draft emails when delegated. On its 15-minute
-  schedule, triages each unread message into five categories: URGENT, ACTIONABLE,
-  NEEDS DRAFT, LEAVE FOR CEO, or NOISE. Archives processed messages, drafts
+  schedule, triages each unread message into five categories: 🚨 Urgent, ✅ Handled,
+  ✍️ Drafted, 📌 Seen, or ✔️ Cleared. Archives processed messages, drafts
   replies and new outbound emails, labels messages, and escalates urgent items
   to the coordinator via the bullpen for Signal delivery.
 
@@ -82,7 +82,7 @@ system_prompt: |
      'waiting', add a progress note ("Search failed; retrying"), and set a new
      wake_at (e.g. 24h). Do not draft. Exit.
   3. If the dependency is now available: draft the complete reply using the voice
-     profile (call executive-profile-get) and the NEEDS DRAFT drafting rules.
+     profile (call executive-profile-get) and the ✍️ Drafted drafting rules.
      Then call task-complete with a brief completion note. If task-complete fails,
      log it in the Response Format ("task-complete FAILED — draft was saved but
      task remains open") and do not retry; the draft is already created.
@@ -102,7 +102,7 @@ system_prompt: |
 
   Note: the coordinator may delegate CEO replies that originated from an
   urgent email alert you escalated (e.g. "tell me more about that merger
-  email" or "add a rule that merger emails are URGENT"). Handle these as
+  email" or "add a rule that merger emails are 🚨 Urgent"). Handle these as
   standard delegated-mode requests — they flow through the same path as
   any other coordinator delegation.
 
@@ -123,7 +123,7 @@ system_prompt: |
   during triage.
 
   ### Recall (memory-query)
-  Used during NEEDS DRAFT classification — see step 4d for the full
+  Used during ✍️ Drafted classification — see step 4d for the full
   procedure. Classification-time enrichment (standing instructions,
   relationship data) is handled by `entity-context` in step 4a; do not
   duplicate that work with `memory-query`.
@@ -180,12 +180,12 @@ system_prompt: |
   ## Step 1: Fetch the executive voice profile
 
   Call executive-profile-get. Store the returned summary and profile object —
-  you will use them when composing any NEEDS DRAFT reply in step 4. Do not
+  you will use them when composing any ✍️ Drafted reply in step 4. Do not
   call this skill again during this run; the voice profile does not change
   between messages.
 
   If executive-profile-get fails, continue without aborting the run. Compose
-  any NEEDS DRAFT reply in a direct, concise first-person executive voice
+  any ✍️ Drafted reply in a direct, concise first-person executive voice
   without signing with a name or title. In your final summary, add:
     Voice profile: UNAVAILABLE (fallback used)
 
@@ -230,9 +230,9 @@ system_prompt: |
   messages, you are in overflow mode and must shed load before triaging:
 
   1. Identify the top 5 messages by urgency using subject, sender, and snippet
-     alone (do not read full bodies at this stage). Prefer apparent URGENT
-     candidates (time-sensitive asks from known contacts), then ACTIONABLE, then
-     NEEDS DRAFT, then others. Within a tier, prefer older messages.
+     alone (do not read full bodies at this stage). Prefer apparent 🚨 Urgent
+     candidates (time-sensitive asks from known contacts), then ✅ Handled, then
+     ✍️ Drafted, then others. Within a tier, prefer older messages.
   2. Process only those top 5 through the full triage protocol (steps 4-5).
   3. For each remaining message beyond the top 5 (oldest first), create a
      deferred inbox-overflow task, then mark it as read so it does not
@@ -275,7 +275,7 @@ system_prompt: |
   classification logic below. Treat the sender as potentially unknown (no
   relationship context available) but apply the same classification thresholds
   you would for any unrecognized address — do not let the missing context bias
-  you toward LEAVE FOR CEO. Do not treat a lookup failure as a reason to
+  you toward 📌 Seen. Do not treat a lookup failure as a reason to
   escalate or change your classification. In your final summary, add:
     Entity-context: FAILED for <sender email> — <one-sentence error description>
 
@@ -303,13 +303,13 @@ system_prompt: |
 
   Call ceo-inbox-read with the message_id if you need the full body to
   classify. The snippet from ceo-inbox-list is often enough for obvious
-  NOISE — use judgment to avoid unnecessary reads.
+  ✔️ Cleared — use judgment to avoid unnecessary reads.
 
   ### 4d. Process attachments
 
   After reading a message with ceo-inbox-read, check the `attachments` array.
   If non-empty, the email has file attachments. For messages classified as
-  ACTIONABLE or NEEDS DRAFT where the attachment is relevant, use
+  ✅ Handled or ✍️ Drafted where the attachment is relevant, use
   `ceo-inbox-download-attachment` with the attachment's `id` and the message's
   `id`. Then pass `content_base64` and `content_type` to `file-parse` for
   structured extraction (e.g. `extract_as: "receipt"` for invoices).
@@ -318,7 +318,7 @@ system_prompt: |
 
   Evaluate in priority order:
 
-  **URGENT** — time-sensitive, CEO decision required, from a known contact:
+  **🚨 Urgent** — time-sensitive, CEO decision required, from a known contact:
     - Post a Bullpen thread mentioning the coordinator with a structured
       send request. Use this exact format:
 
@@ -331,19 +331,19 @@ system_prompt: |
 
     - Do NOT archive. Do NOT draft a reply.
 
-  **ACTIONABLE** — a task a deployed specialist can handle autonomously:
+  **✅ Handled** — a task a deployed specialist can handle autonomously:
     - Check the available specialists below to understand what the team can do.
     - Open a bullpen thread mentioning the capable specialist with a clear
       handoff summary.
     - Classification note: if the only action needed is to discard the email,
-      classify as NOISE instead. If a human reply is needed, classify as NEEDS
-      DRAFT instead. ACTIONABLE is specifically for delegating a task to a
+      classify as ✔️ Cleared instead. If a human reply is needed, classify as
+      ✍️ Drafted instead. ✅ Handled is specifically for delegating a task to a
       specialist agent.
-    - Note: ACTIONABLE emails ARE archived after the specialist is notified
+    - Note: ✅ Handled emails ARE archived after the specialist is notified
       (see step 4h). Archiving is a side-effect of processing, not a reason
       to choose a different classification.
 
-  **NEEDS DRAFT** — a reply is warranted and the CEO should review before
+  **✍️ Drafted** — a reply is warranted and the CEO should review before
   sending:
     - Call ceo-inbox-read to get the full message and thread context.
     - Check whether the CEO has already replied in this thread (search for
@@ -357,10 +357,10 @@ system_prompt: |
       is unavailable, treat it as no match: acknowledge the gap naturally or
       omit the factual claim — do not fabricate details. You may call
       memory-query zero or more times per email.
-    - Before drafting, evaluate these conditions and classify as LEAVE FOR CEO if any apply:
+    - Before drafting, evaluate these conditions and classify as 📌 Seen if any apply:
         1. More than 10 CC recipients on the thread — do not draft, too wide a distribution.
-        2. Negotiation terms, salary, legal, or personal health content — classify as LEAVE FOR CEO.
-    - **Reification check.** Only reached if the message survived the LEAVE FOR CEO
+        2. Negotiation terms, salary, legal, or personal health content — classify as 📌 Seen.
+    - **Reification check.** Only reached if the message survived the 📌 Seen
       guard above. Before drafting any reply that would contain a forward commitment
       ("I'll follow up with the document", "we'll get that to you", "the CEO will
       send X"):
@@ -389,9 +389,9 @@ system_prompt: |
 
       3. **task-create failure:** If task-create fails, you must NOT draft the
          interim acknowledgment. A promise must never be sent without a backing
-         task. Instead, reclassify this message as LEAVE FOR CEO. Log the failure:
+         task. Instead, reclassify this message as 📌 Seen. Log the failure:
            Reification task FAILED for <subject> — <error>
-           Message reclassified to LEAVE FOR CEO (promise cannot be backed).
+           Message reclassified to 📌 Seen (promise cannot be backed).
          Do not archive. The CEO will handle it manually.
 
     - Call ceo-inbox-draft-reply with reply_to_message_id and body.
@@ -408,7 +408,7 @@ system_prompt: |
 
     ### Scheduling-specific drafting rules
 
-    When a NEEDS DRAFT email involves scheduling (the sender proposes days,
+    When a ✍️ Drafted email involves scheduling (the sender proposes days,
     asks the CEO to suggest a time, or is negotiating a meeting slot):
 
     1. **Be specific.** Propose a concrete date AND time (e.g. "Monday
@@ -435,10 +435,10 @@ system_prompt: |
        "pending your calendar") so the CEO knows the slot hasn't been
        verified against existing events.
 
-  **LEAVE FOR CEO** — personal, sensitive, relationship-dependent, or uncertain:
+  **📌 Seen** — personal, sensitive, relationship-dependent, or uncertain:
     - Do nothing. No archive, no draft, no notification.
 
-  **NOISE** — receipt, newsletter, automated notification, no human action needed:
+  **✔️ Cleared** — receipt, newsletter, automated notification, no human action needed:
     - Call ceo-inbox-archive with the message_id.
 
   **Important:** After choosing a classification above, do NOT execute the
@@ -449,7 +449,7 @@ system_prompt: |
 
   ### 4f. When in doubt
 
-  Prefer LEAVE FOR CEO. Use URGENT only for genuinely time-sensitive items
+  Prefer 📌 Seen. Use 🚨 Urgent only for genuinely time-sensitive items
   with a clear deadline or decision required. Do not over-notify.
 
   ### 4g. Evaluate standing rules and apply labels
@@ -467,8 +467,8 @@ system_prompt: |
   message — entity-context standing instructions take precedence.
   The instruction may:
   - Apply a label (call ceo-inbox-label)
-  - Override the classification you just made (e.g. "classify as NOISE"
-    means archive the message even if you originally chose LEAVE FOR CEO)
+  - Override the classification you just made (e.g. "classify as ✔️ Cleared"
+    means archive the message even if you originally chose 📌 Seen)
   - Delegate to a specialist (call bullpen — pass source_message_id: <the email's message_id> to prevent duplicate threads if this run is retried)
   - Take any other action available via your pinned skills
 
@@ -476,8 +476,8 @@ system_prompt: |
   report in the Response Format to reflect the override.
 
   If multiple rules match, apply only ONE classification per message —
-  pick the most cautious one (URGENT > LEAVE FOR CEO > NEEDS DRAFT >
-  ACTIONABLE > NOISE). Only the winning rule's bundled actions (archive,
+  pick the most cautious one (🚨 Urgent > 📌 Seen > ✍️ Drafted >
+  ✅ Handled > ✔️ Cleared). Only the winning rule's bundled actions (archive,
   draft, notify) take effect; discard those of any losing rules. Pure
   side-effect instructions from any matching rule that do not change the
   classification (e.g. "apply label X") still execute.
@@ -487,7 +487,7 @@ system_prompt: |
   **Decision tagging:** If decision tagging is enabled (from step 2),
   call ceo-inbox-label with:
   - message_id: the current message's ID
-  - labels: [the final classification category, e.g. "URGENT"]
+  - labels: [the final classification category, e.g. "🚨 Urgent"]
 
   This applies the classification as a Gmail label. Use the final
   classification (after any rule overrides), not the original.
@@ -509,31 +509,31 @@ system_prompt: |
   (after any overrides from step 4g). This is the authoritative action
   checklist — every action for every classification is listed here:
 
-  - **URGENT**: Open a bullpen thread mentioning the coordinator with a
+  - **🚨 Urgent**: Open a bullpen thread mentioning the coordinator with a
     structured send request (Urgency: immediate, Channel: Signal, Message,
     Context bridge with agent_id=ceo-inbox and delegation_hint). Pass
     source_message_id: <the email's message_id> to prevent duplicate threads
     if this run is retried. Do NOT archive.
-  - **ACTIONABLE**: Open a bullpen thread mentioning the capable specialist
+  - **✅ Handled**: Open a bullpen thread mentioning the capable specialist
     with a clear handoff summary. Pass source_message_id: <the email's
     message_id> to prevent duplicate threads if this run is retried. Call
     ceo-inbox-archive with the message_id.
-  - **NEEDS DRAFT**: Execute the full NEEDS DRAFT procedure from step 4e
+  - **✍️ Drafted**: Execute the full ✍️ Drafted procedure from step 4e
     (read full message, check for prior replies, memory-query for context,
-    evaluate LEAVE FOR CEO guard conditions, reification check, then draft
+    evaluate 📌 Seen guard conditions, reification check, then draft
     using voice profile and scheduling rules). Call ceo-inbox-archive with
     the message_id.
-  - **LEAVE FOR CEO**: No action. Do not archive, draft, or notify.
-  - **NOISE**: Call ceo-inbox-archive with the message_id.
+  - **📌 Seen**: No action. Do not archive, draft, or notify.
+  - **✔️ Cleared**: Call ceo-inbox-archive with the message_id.
 
   If any skill call fails, log the error in the Response Format and continue.
   Do not abort the run for a single action failure.
 
   ## Step 5: Mark as read (optional)
 
-  For NOISE, ACTIONABLE, and NEEDS DRAFT messages, call ceo-inbox-mark-read
+  For ✔️ Cleared, ✅ Handled, and ✍️ Drafted messages, call ceo-inbox-mark-read
   with the message_id after processing. This keeps the CEO's unread count
-  clean. Do NOT mark LEAVE FOR CEO or URGENT messages as read — the CEO
+  clean. Do NOT mark 📌 Seen or 🚨 Urgent messages as read — the CEO
   may use unread status as their own tracking.
 
   Note: overflow-deferred messages are already marked read during the step 3
@@ -548,7 +548,7 @@ system_prompt: |
   For each processed message, output:
     Subject: <subject line>
     From: <sender email>
-    Classification: <URGENT|ACTIONABLE|NEEDS DRAFT|LEAVE FOR CEO|NOISE>
+    Classification: <🚨 Urgent|✅ Handled|✍️ Drafted|📌 Seen|✔️ Cleared>
     Rationale: <one sentence>
     Actions: <list of skills called, or "none">
     Labels: <labels applied, or "none", or "FAILED — reason">
@@ -556,7 +556,7 @@ system_prompt: |
 
   After processing all messages, summarize:
     Total: N messages processed
-    Breakdown: N URGENT, N ACTIONABLE, N NEEDS DRAFT, N LEAVE FOR CEO, N NOISE
+    Breakdown: N 🚨 Urgent, N ✅ Handled, N ✍️ Drafted, N 📌 Seen, N ✔️ Cleared
     Voice profile: OK | UNAVAILABLE (fallback used)
     Entity-context: OK | FAILED for <sender email> — <one-sentence error description>
       (one line per failed sender; if all succeeded, a single "Entity-context: OK" line)

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -26,6 +26,7 @@ pinned_skills:
   - ceo-inbox-update-folders
   - ceo-inbox-label
   - ceo-inbox-mark-read
+  - ceo-inbox-mark-starred
   - config-store
   - bullpen
   - entity-context
@@ -502,6 +503,13 @@ system_prompt: |
   This applies the classification as a Gmail label. Use the final
   classification (after any rule overrides), not the original.
 
+  **Starring 🚨 Urgent messages:** If the final classification is `🚨 Urgent`
+  and the decision tagging label call did not fail, call
+  `ceo-inbox-mark-starred` with `message_id`. If the call fails, add
+  `Starred: FAILED — <reason>` to the per-message output and continue —
+  starring failure is non-critical and must not abort the run.
+  If the call succeeds, add `Starred: yes` to the per-message output.
+
   **Failure handling:** If ceo-inbox-label fails, log the error in the
   Response Format and continue to the next message. Do not abort the run.
   Add to the per-message output:
@@ -564,6 +572,7 @@ system_prompt: |
     Rationale: <one sentence>
     Actions: <list of skills called, or "none">
     Labels: <labels applied, or "none", or "FAILED — reason">
+    Starred: yes | FAILED — <reason>   (🚨 Urgent messages only; omit for other classifications)
     Rules matched: <rule conditions that fired, or "none">
 
   After processing all messages, summarize:

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -503,13 +503,6 @@ system_prompt: |
   This applies the classification as a Gmail label. Use the final
   classification (after any rule overrides), not the original.
 
-  **Starring 🚨 Urgent messages:** If the final classification is `🚨 Urgent`
-  and the decision tagging label call did not fail, call
-  `ceo-inbox-mark-starred` with `message_id`. If the call fails, add
-  `Starred: FAILED — <reason>` to the per-message output and continue —
-  starring failure is non-critical and must not abort the run.
-  If the call succeeds, add `Starred: yes` to the per-message output.
-
   **Failure handling:** If ceo-inbox-label fails, log the error in the
   Response Format and continue to the next message. Do not abort the run.
   Add to the per-message output:
@@ -532,6 +525,10 @@ system_prompt: |
     Context bridge with agent_id=ceo-inbox and delegation_hint). Pass
     source_message_id: <the email's message_id> to prevent duplicate threads
     if this run is retried. Do NOT archive.
+    Also call `ceo-inbox-mark-starred` with `message_id` to star the message in
+    the email client. If the call fails, log `Starred: FAILED — <reason>` in
+    the per-message output and continue — starring failure is non-critical.
+    If the call succeeds, log `Starred: yes`.
   - **✅ Handled**: Open a bullpen thread mentioning the capable specialist
     with a clear handoff summary. Pass source_message_id: <the email's
     message_id> to prevent duplicate threads if this run is retried. Call
@@ -572,7 +569,7 @@ system_prompt: |
     Rationale: <one sentence>
     Actions: <list of skills called, or "none">
     Labels: <labels applied, or "none", or "FAILED — reason">
-    Starred: yes | FAILED — <reason>   (🚨 Urgent messages only; omit for other classifications)
+    Starred: yes | FAILED — <reason> | omitted   (🚨 Urgent messages only; omit line entirely for other classifications)
     Rules matched: <rule conditions that fired, or "none">
 
   After processing all messages, summarize:

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -235,6 +235,11 @@ export class CeoNylasClient {
     await this.request<NylasApiMessage>('PUT', url, 'markAsRead', { unread: false });
   }
 
+  async markAsStarred(messageId: string, starred = true): Promise<void> {
+    const url = `${this.baseUrl}/messages/${encodeURIComponent(messageId)}`;
+    await this.request<NylasApiMessage>('PUT', url, 'markAsStarred', { starred });
+  }
+
   async updateMessageFolders(
     messageId: string,
     folders: string[],
@@ -419,6 +424,7 @@ interface NylasApiMessage {
   snippet?: string;
   date?: number;
   unread?: boolean;
+  starred?: boolean;
   folders?: string[];
   labels?: string[];
   attachments?: NylasApiAttachment[];

--- a/skills/ceo-inbox-label/skill.json
+++ b/skills/ceo-inbox-label/skill.json
@@ -1,12 +1,12 @@
 {
   "name": "ceo-inbox-label",
   "description": "Apply one or more labels to a message in the CEO's personal email inbox. Resolves label names to Gmail folder IDs, creating any labels that do not yet exist. Use this to apply decision-tagging classifications or rule-based labels. Intended for use by the ceo-inbox agent — accesses the CEO's personal email, do not call from other agents.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
     "message_id": "string (Nylas message ID to label)",
-    "labels": "string[] (label names to apply, e.g. ['URGENT', 'BOARD'])"
+    "labels": "string[] (label names to apply, e.g. ['🚨 Urgent', 'BOARD'])"
   },
   "outputs": {
     "success": "boolean",

--- a/skills/ceo-inbox-mark-starred/handler.test.ts
+++ b/skills/ceo-inbox-mark-starred/handler.test.ts
@@ -1,6 +1,6 @@
 // handler.test.ts — unit tests for ceo-inbox-mark-starred skill.
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { CeoInboxMarkStarredHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 import { createSilentLogger } from '../../src/logger.js';
@@ -17,6 +17,9 @@ function makeCtx(overrides?: Partial<SkillContext> & { input?: Record<string, un
 }
 
 describe('CeoInboxMarkStarredHandler', () => {
+  // Guarantees spy cleanup even when a test assertion throws before mockRestore()
+  afterEach(() => vi.restoreAllMocks());
+
   it('returns error when message_id is missing', async () => {
     const handler = new CeoInboxMarkStarredHandler();
     const result = await handler.execute(makeCtx({ input: {} }));
@@ -77,5 +80,50 @@ describe('CeoInboxMarkStarredHandler', () => {
     expect(body.starred).toBe(false);
 
     fetchSpy.mockRestore();
+  });
+
+  it('accepts starred="false" (string) and unstarred the message', async () => {
+    const handler = new CeoInboxMarkStarredHandler();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { id: 'msg-123', starred: false } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await handler.execute(makeCtx({ input: { message_id: 'msg-123', starred: 'false' } }));
+    expect(result.success).toBe(true);
+    expect((result as { data: Record<string, unknown> }).data).toEqual({
+      message_id: 'msg-123',
+      starred: false,
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string) as Record<string, unknown>;
+    expect(body.starred).toBe(false);
+  });
+
+  it('accepts starred="true" (string) and stars the message', async () => {
+    const handler = new CeoInboxMarkStarredHandler();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { id: 'msg-123', starred: true } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await handler.execute(makeCtx({ input: { message_id: 'msg-123', starred: 'true' } }));
+    expect(result.success).toBe(true);
+    expect((result as { data: Record<string, unknown> }).data).toEqual({
+      message_id: 'msg-123',
+      starred: true,
+    });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('returns error for non-boolean starred value', async () => {
+    const handler = new CeoInboxMarkStarredHandler();
+    const result = await handler.execute(makeCtx({ input: { message_id: 'msg-123', starred: 42 } }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('starred must be a boolean');
   });
 });

--- a/skills/ceo-inbox-mark-starred/handler.test.ts
+++ b/skills/ceo-inbox-mark-starred/handler.test.ts
@@ -1,0 +1,81 @@
+// handler.test.ts — unit tests for ceo-inbox-mark-starred skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { CeoInboxMarkStarredHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+function makeCtx(overrides?: Partial<SkillContext> & { input?: Record<string, unknown> }): SkillContext {
+  return {
+    input: { message_id: 'msg-123' },
+    secret: (_name: string) => 'test-secret',
+    log: createSilentLogger(),
+    taskMetadata: {},
+    taskEventId: undefined,
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+describe('CeoInboxMarkStarredHandler', () => {
+  it('returns error when message_id is missing', async () => {
+    const handler = new CeoInboxMarkStarredHandler();
+    const result = await handler.execute(makeCtx({ input: {} }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('message_id');
+  });
+
+  it('calls markAsStarred with starred=true by default and returns success', async () => {
+    const handler = new CeoInboxMarkStarredHandler();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { id: 'msg-123', unread: false, starred: true } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(true);
+    expect((result as { data: Record<string, unknown> }).data).toEqual({
+      message_id: 'msg-123',
+      starred: true,
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it('returns error when the Nylas API call fails', async () => {
+    const handler = new CeoInboxMarkStarredHandler();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new Error('Network failure'),
+    );
+
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('Failed to mark message as starred');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('passes starred=false when explicitly set to false', async () => {
+    const handler = new CeoInboxMarkStarredHandler();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { id: 'msg-123', starred: false } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await handler.execute(makeCtx({ input: { message_id: 'msg-123', starred: false } }));
+    expect(result.success).toBe(true);
+    expect((result as { data: Record<string, unknown> }).data).toEqual({
+      message_id: 'msg-123',
+      starred: false,
+    });
+
+    // Verify the PUT body contained starred: false
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string) as Record<string, unknown>;
+    expect(body.starred).toBe(false);
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/skills/ceo-inbox-mark-starred/handler.ts
+++ b/skills/ceo-inbox-mark-starred/handler.ts
@@ -1,0 +1,33 @@
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { CeoNylasClient } from '../_shared/ceo-nylas-client.js';
+
+export class CeoInboxMarkStarredHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const apiKey = ctx.secret('nylas_api_key');
+    const grantId = ctx.secret('ceo_nylas_grant_id');
+    const client = new CeoNylasClient(apiKey, grantId, ctx.log);
+
+    const input =
+      ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
+
+    const messageId =
+      typeof input.message_id === 'string' ? input.message_id.trim() : '';
+
+    if (!messageId) {
+      return { success: false, error: 'message_id is required' };
+    }
+
+    // Default to true (star) when the caller omits the field
+    const starred = typeof input.starred === 'boolean' ? input.starred : true;
+
+    ctx.log.info({ messageId, starred }, 'ceo-inbox-mark-starred: setting starred');
+
+    try {
+      await client.markAsStarred(messageId, starred);
+      return { success: true, data: { message_id: messageId, starred } };
+    } catch (err) {
+      ctx.log.error({ err, messageId }, 'ceo-inbox-mark-starred: failed');
+      return { success: false, error: 'Failed to mark message as starred' };
+    }
+  }
+}

--- a/skills/ceo-inbox-mark-starred/handler.ts
+++ b/skills/ceo-inbox-mark-starred/handler.ts
@@ -17,8 +17,21 @@ export class CeoInboxMarkStarredHandler implements SkillHandler {
       return { success: false, error: 'message_id is required' };
     }
 
-    // Default to true (star) when the caller omits the field
-    const starred = typeof input.starred === 'boolean' ? input.starred : true;
+    // LLM tool calls may serialize booleans as strings; accept "true"/"false" explicitly.
+    // Default to true (star) when the field is omitted; reject other non-boolean values.
+    const starredRaw = input.starred;
+    let starred: boolean;
+    if (starredRaw === undefined) {
+      starred = true;
+    } else if (typeof starredRaw === 'boolean') {
+      starred = starredRaw;
+    } else if (starredRaw === 'true') {
+      starred = true;
+    } else if (starredRaw === 'false') {
+      starred = false;
+    } else {
+      return { success: false, error: 'starred must be a boolean' };
+    }
 
     ctx.log.info({ messageId, starred }, 'ceo-inbox-mark-starred: setting starred');
 

--- a/skills/ceo-inbox-mark-starred/skill.json
+++ b/skills/ceo-inbox-mark-starred/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "ceo-inbox-mark-starred",
   "description": "Star (or unstar) a message in the CEO's personal email inbox. Sets the starred/flagged attribute on the Nylas message object, which maps to a Gmail star or Outlook flag in the email client. Call with message_id after applying the 🚨 Urgent label. Intended for use by the ceo-inbox agent — accesses the CEO's personal email, do not call from other agents.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/ceo-inbox-mark-starred/skill.json
+++ b/skills/ceo-inbox-mark-starred/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "ceo-inbox-mark-starred",
+  "description": "Star (or unstar) a message in the CEO's personal email inbox. Sets the starred/flagged attribute on the Nylas message object, which maps to a Gmail star or Outlook flag in the email client. Call with message_id after applying the 🚨 Urgent label. Intended for use by the ceo-inbox agent — accesses the CEO's personal email, do not call from other agents.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "message_id": "string (Nylas message ID to star)",
+    "starred": "boolean? (true to star, false to unstar; defaults to true if omitted)"
+  },
+  "outputs": {
+    "success": "boolean",
+    "message_id": "string",
+    "starred": "boolean (the value that was set)"
+  },
+  "permissions": [],
+  "secrets": ["nylas_api_key", "ceo_nylas_grant_id"],
+  "timeout": 10000,
+  "capabilities": []
+}


### PR DESCRIPTION
## **User description**
## Summary

Closes #871

Three improvements to the ceo-inbox triage system:

- Renamed the five triage labels to emoji variants (`🚨 Urgent`, `✅ Handled`, `✍️ Drafted`, `📌 Seen`, `✔️ Cleared`) for better readability in the Gmail sidebar.
- Added `⚠️ Stuck` label applied when ceo-inbox cannot complete triage for a message (skill failure, unrecognised classification, error budget hit). No archive, no draft, no bullpen.
- Added `ceo-inbox-mark-starred` skill; `🚨 Urgent` messages are starred unconditionally in step 4h after the bullpen notification. Starring failure is logged but non-fatal.

## Test plan

- [ ] `pnpm run typecheck` passes with zero errors
- [ ] `skills/ceo-inbox-mark-starred/handler.test.ts` — all 4 tests pass
- [ ] `agents/ceo-inbox.yaml` contains no occurrences of old plain-text label names (`URGENT`, `ACTIONABLE`, `NEEDS DRAFT`, `LEAVE FOR CEO`, `NOISE`)
- [ ] `agents/ceo-inbox.yaml` `pinned_skills` includes `ceo-inbox-mark-starred`
- [ ] `agents/ceo-inbox.yaml` version is `0.6.0`
- [ ] `skills/ceo-inbox-label/skill.json` version is `0.1.1`
- [ ] `⚠️ Stuck` appears in step 4e classification, step 4h action checklist, Response Format Classification and Breakdown lines
- [ ] Starring instruction in step 4h fires unconditionally for `🚨 Urgent` (not gated on decision tagging)


___

## **CodeAnt-AI Description**
**Refresh CEO inbox triage labels and star urgent messages automatically**

### What Changed
- Renamed the CEO inbox triage labels to emoji versions so they are easier to scan in Gmail.
- Added a new `⚠️ Stuck` label for messages that cannot be fully triaged, so unresolved failures stay visible instead of disappearing.
- `🚨 Urgent` messages are now starred automatically after escalation, and starring errors are logged without stopping triage.
- Updated the CEO inbox rules and response summary to use the new label names and report starred urgent messages.

### Impact
`✅ Clearer inbox triage labels`
`✅ Fewer missed urgent emails`
`✅ Visible handling of triage failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
