### PR TITLE
fix(contact-list): reject lifecycle status passed as role parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`contact-list` skill** — rejects lifecycle status values passed as `role` (e.g. `role: "provisional"`) with a clear redirect to the `status` parameter, preventing silent zero-result sweeps. Manifest description of `role` updated to clarify it filters by job title, not lifecycle state.
 - **Dispatcher reply-lock** — suppresses duplicate `outbound.message` when a human-facing reply skill (`email-reply` or `email-send`) already fired successfully during the same task. Emits `outbound.suppressed_duplicate` audit event instead. Covers both the direct-coordinator and delegated-specialist cases. (#847)
 - **`ceo-inbox` watermark ownership** — moves `last_processed_at` management to `ceo-inbox-list` via `ConfigStore`; clamps future timestamps to `now()` and falls back to 24h lookback. (#866)
 - **Provisional contact promotion sweep** — batched to 10 contacts per daily run using `offset` pagination and a persisted `next_offset` cursor in `last_run_context`, preventing turn-budget exhaustion on large pools. Contacts agent `error_budget.max_turns` raised to 30. (#884)

--- a/skills/contact-list/handler.test.ts
+++ b/skills/contact-list/handler.test.ts
@@ -233,14 +233,20 @@ describe('ContactListHandler', () => {
     expect(result.error).toContain('200 characters');
   });
 
-  it.each(['provisional', 'confirmed', 'blocked'])(
+  it.each([
+    // exact lowercase
+    'provisional', 'confirmed', 'blocked',
+    // casing and whitespace variants an LLM might produce
+    'Provisional', 'CONFIRMED', ' blocked',
+  ])(
     'rejects role="%s" and redirects to the status parameter',
     async (statusValue) => {
       const ctx = makeCtx({ role: statusValue });
       const result = await handler.execute(ctx);
       expect(result.success).toBe(false);
       expect(result.error).toContain('status');
-      expect(result.error).toContain(statusValue);
+      // error message includes the normalized (lowercase) form so the LLM knows what to pass
+      expect(result.error).toContain(statusValue.trim().toLowerCase());
     },
   );
 

--- a/skills/contact-list/handler.test.ts
+++ b/skills/contact-list/handler.test.ts
@@ -233,6 +233,17 @@ describe('ContactListHandler', () => {
     expect(result.error).toContain('200 characters');
   });
 
+  it.each(['provisional', 'confirmed', 'blocked'])(
+    'rejects role="%s" and redirects to the status parameter',
+    async (statusValue) => {
+      const ctx = makeCtx({ role: statusValue });
+      const result = await handler.execute(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('status');
+      expect(result.error).toContain(statusValue);
+    },
+  );
+
   it('rejects combining role with status', async () => {
     const ctx = makeCtx({ role: 'CFO', status: 'provisional' });
     const result = await handler.execute(ctx);

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -27,10 +27,12 @@ export class ContactListHandler implements SkillHandler {
 
     // Guard against a common LLM mistake: passing a lifecycle status as the role parameter.
     // The role filter searches job titles (e.g. "CEO"); lifecycle filtering uses status.
-    if (role && typeof role === 'string' && (VALID_STATUSES as readonly string[]).includes(role)) {
+    // Normalize before comparing so casing/whitespace variants ("Provisional", " blocked") are caught too.
+    const normalizedRole = typeof role === 'string' ? role.trim().toLowerCase() : undefined;
+    if (normalizedRole && (VALID_STATUSES as readonly string[]).includes(normalizedRole)) {
       return {
         success: false,
-        error: `"${role}" is a contact lifecycle status, not a job title. Use the status parameter instead: { status: "${role}" }`,
+        error: `"${role}" is a contact lifecycle status, not a job title. Use the status parameter instead: { status: "${normalizedRole}" }`,
       };
     }
 

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -25,7 +25,16 @@ export class ContactListHandler implements SkillHandler {
       return { success: false, error: 'Role must be 200 characters or fewer' };
     }
 
-    if (status != null && !VALID_STATUSES.includes(status)) {
+    // Guard against a common LLM mistake: passing a lifecycle status as the role parameter.
+    // The role filter searches job titles (e.g. "CEO"); lifecycle filtering uses status.
+    if (role && typeof role === 'string' && (VALID_STATUSES as readonly string[]).includes(role)) {
+      return {
+        success: false,
+        error: `"${role}" is a contact lifecycle status, not a job title. Use the status parameter instead: { status: "${role}" }`,
+      };
+    }
+
+    if (status != null && !(VALID_STATUSES as readonly string[]).includes(status)) {
       return { success: false, error: `Invalid status: "${status}". Must be one of: ${VALID_STATUSES.join(', ')}` };
     }
 

--- a/skills/contact-list/skill.json
+++ b/skills/contact-list/skill.json
@@ -1,11 +1,11 @@
 {
   "name": "contact-list",
   "description": "List contacts, optionally filtered by role or status, with optional result limit and offset for pagination.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
-    "role": "string?",
+    "role": "string? (filter by job title / professional role, e.g. 'CEO', 'CFO', 'Engineer'; mutually exclusive with status, limit, and offset; this is NOT a lifecycle status)",
     "status": "string? (confirmed | provisional | blocked)",
     "limit": "number?",
     "offset": "number? (skip this many contacts; use with limit for cursor-based pagination)"


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause:** When manually delegating a promotion sweep, the contacts specialist LLM called `contact-list` with `role: "provisional"` instead of `status: "provisional"`. The `role` filter queries job titles, so it returned 0 results silently. The agent then faithfully reported no provisional contacts.
- **Fix:** Guard at the top of `handler.ts` detects when a lifecycle status (`provisional`, `confirmed`, `blocked`) is passed as `role` and returns `{ success: false, error: "..." }` with an explicit redirect to the `status` parameter.
- **Prevention:** `skill.json` manifest description of `role` now clarifies it filters by job title (e.g. "CEO", "CFO"), not lifecycle state. This reduces future LLM confusion at the parameter-selection layer.
- `contact-list` version bumped `1.2.0` → `1.2.1`.

## Test plan

- [ ] `pnpm --prefix worktrees/curia-fix-contact-list-role run test skills/contact-list/handler.test.ts` — 31 tests pass (3 new: `role="provisional"`, `role="confirmed"`, `role="blocked"`)
- [ ] `pnpm --prefix worktrees/curia-fix-contact-list-role run typecheck` — clean
- [ ] Manually ask the contacts specialist to "run a promotion cycle for 10 provisional contacts" and confirm it now uses `status: "provisional"` (not `role: "provisional"`)


___

## **CodeAnt-AI Description**
**Reject status values passed as a role**

### What Changed
- If a lifecycle status like `provisional`, `confirmed`, or `blocked` is entered as `role`, the request now fails with a clear message that points to the `status` field instead.
- The role guidance now explains that it filters job titles such as `CEO` or `CFO`, not contact lifecycle state.
- Added tests to cover the mistaken `role` values and confirm they are rejected.

### Impact
`✅ Fewer zero-result contact sweeps`
`✅ Clearer parameter errors`
`✅ Less confusion between role and status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
