### PR TITLE
fix: bind HTTP API before channel adapters to prevent health check failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`contact-list` skill** — new `offset` input (v1.2.0) enables cursor-based pagination; `offset > 0` requires `limit` to prevent unbounded result sets. Public API surface change.
 
 ### Fixed
-- **Startup health check** — HTTP API now binds before channel adapters start, so the health check passes within seconds instead of after the initial email catch-up completes (which could block for minutes on a long backlog). Fixes Docker deploy failures where `curia-curia-1` was marked unhealthy before `/api/health` was reachable.
+- **Startup health check** — HTTP API now binds before channel adapters start, so the health check passes within seconds instead of after the initial email catch-up completes (which could block for minutes on a long backlog). Fixes Docker deploy failures where `curia-curia-1` was marked unhealthy before `/api/health` was reachable. Channel adapter startup is now wrapped in a `try/catch` that invokes graceful shutdown (exit 1) rather than letting an adapter failure propagate to the bare `main().catch` path.
 
 - **`contact-list` skill** — rejects lifecycle status values passed as `role` (e.g. `role: "provisional"`) with a clear redirect to the `status` parameter, preventing silent zero-result sweeps. Manifest description of `role` updated to clarify it filters by job title, not lifecycle state.
 - **Dispatcher reply-lock** — suppresses duplicate `outbound.message` when a human-facing reply skill (`email-reply` or `email-send`) already fired successfully during the same task. Emits `outbound.suppressed_duplicate` audit event instead. Covers both the direct-coordinator and delegated-specialist cases. (#847)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`contact-list` skill** — new `offset` input (v1.2.0) enables cursor-based pagination; `offset > 0` requires `limit` to prevent unbounded result sets. Public API surface change.
 
 ### Fixed
+- **Startup health check** — HTTP API now binds before channel adapters start, so the health check passes within seconds instead of after the initial email catch-up completes (which could block for minutes on a long backlog). Fixes Docker deploy failures where `curia-curia-1` was marked unhealthy before `/api/health` was reachable.
 
 - **`contact-list` skill** — rejects lifecycle status values passed as `role` (e.g. `role: "provisional"`) with a clear redirect to the `status` parameter, preventing silent zero-result sweeps. Manifest description of `role` updated to clarify it filters by job title, not lifecycle state.
 - **Dispatcher reply-lock** — suppresses duplicate `outbound.message` when a human-facing reply skill (`email-reply` or `email-send`) already fired successfully during the same task. Emits `outbound.suppressed_duplicate` audit event instead. Covers both the direct-coordinator and delegated-specialist cases. (#847)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1653,44 +1653,12 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Start all email adapters AFTER the dispatcher is registered so inbound.message
-  // events always have a subscriber. Starting before registration would drop emails
-  // arriving during the startup window (each adapter advances its own high-water mark
-  // on poll, so dropped messages are never retried).
-  //
-  // In setup-required mode we skip external adapters entirely — without a principal
-  // contact there is no recipient policy, no autonomy-bypass identity match, and no
-  // sane fallback for received emails. The operator restarts after completing setup
-  // to bring these up for real.
-  if (!setupRequiredAtBoot) {
-    for (const adapter of emailAdapters) {
-      await adapter.start();
-    }
-    if (emailAdapters.length > 0) {
-      logger.info({ count: emailAdapters.length }, 'Email channel adapter(s) started');
-    }
-  } else if (emailAdapters.length > 0) {
-    logger.warn(
-      { count: emailAdapters.length },
-      'SETUP-REQUIRED mode: skipping email adapter startup — restart after setup to enable',
-    );
-  }
-
-  // Start the Signal adapter AFTER the dispatcher is registered — same ordering rule as email.
-  // SignalAdapter.start() connects to the signal-cli socket and registers the inbound listener.
-  // If signal-cli is not yet running (e.g., cold start with both containers starting simultaneously),
-  // the RPC client's exponential backoff will retry until the socket is available.
-  //
-  // Skipped in setup-required mode for the same reason as email — see above.
-  if (signalAdapter && !setupRequiredAtBoot) {
-    await signalAdapter.start();
-    logger.info('Signal channel adapter started');
-  } else if (signalAdapter && setupRequiredAtBoot) {
-    logger.warn('SETUP-REQUIRED mode: skipping Signal adapter startup — restart after setup to enable');
-  }
-
   // Graceful shutdown — stop accepting new input first, then close connections.
-  const shutdown = async () => {
+  // Accepts exitCode so startup-failure teardown can exit(1) while SIGTERM/SIGINT
+  // exit(0). Defined before channel adapter startup so that a failure in
+  // adapter.start() (after HTTP has already bound) can call shutdown(1) and ensure
+  // the HTTP server, pool, and other already-started resources are closed cleanly.
+  const shutdown = async (exitCode = 0) => {
     logger.info('Shutting down...');
     for (const adapter of emailAdapters) {
       try {
@@ -1769,7 +1737,7 @@ async function main(): Promise<void> {
     } catch (err) {
       logger.error({ err }, 'Error closing database pool during shutdown');
     }
-    process.exit(0);
+    process.exit(exitCode);
   };
 
   process.on('SIGTERM', () => void shutdown());
@@ -1779,6 +1747,48 @@ async function main(): Promise<void> {
   // handler and would terminate uncleanly without draining the DB pool, stopping
   // the scheduler, or gracefully closing the HTTP server.
   process.on('SIGINT', () => void shutdown());
+
+  // Start channel adapters AFTER the dispatcher is registered so inbound.message events
+  // always have a subscriber. Starting before registration would drop messages arriving
+  // during the startup window (each adapter advances its own high-water mark on poll,
+  // so dropped messages are never retried).
+  //
+  // Wrapped in try/catch: if a channel adapter throws after HTTP has already bound,
+  // shutdown() cleans up the HTTP server, pool, scheduler, and other started resources
+  // before the process exits. Without this, the error propagates to main().catch which
+  // calls process.exit(1) without any teardown.
+  //
+  // Skipped entirely in setup-required mode — without a principal contact there is no
+  // recipient policy, no autonomy-bypass identity match, and no sane fallback for
+  // received messages. The operator restarts after completing setup to bring these up.
+  try {
+    if (!setupRequiredAtBoot) {
+      for (const adapter of emailAdapters) {
+        await adapter.start();
+      }
+      if (emailAdapters.length > 0) {
+        logger.info({ count: emailAdapters.length }, 'Email channel adapter(s) started');
+      }
+    } else if (emailAdapters.length > 0) {
+      logger.warn(
+        { count: emailAdapters.length },
+        'SETUP-REQUIRED mode: skipping email adapter startup — restart after setup to enable',
+      );
+    }
+
+    // SignalAdapter.start() connects to the signal-cli socket and registers the inbound listener.
+    // If signal-cli is not yet running (e.g., cold start with both containers starting simultaneously),
+    // the RPC client's exponential backoff will retry until the socket is available.
+    if (signalAdapter && !setupRequiredAtBoot) {
+      await signalAdapter.start();
+      logger.info('Signal channel adapter started');
+    } else if (signalAdapter && setupRequiredAtBoot) {
+      logger.warn('SETUP-REQUIRED mode: skipping Signal adapter startup — restart after setup to enable');
+    }
+  } catch (err) {
+    logger.fatal({ err }, 'Fatal error during channel adapter startup — invoking shutdown');
+    await shutdown(1);
+  }
 
   // 8. CLI channel — only started when stdin is an interactive TTY (i.e., local dev).
   // In Docker / production, stdin is closed or a pipe: readline receives EOF

--- a/src/index.ts
+++ b/src/index.ts
@@ -1620,6 +1620,39 @@ async function main(): Promise<void> {
   const bullpenDispatcher = new BullpenDispatcher(bus, logger, bullpenService);
   bullpenDispatcher.register();
 
+  // HTTP API channel — started BEFORE channel adapters so the health check endpoint
+  // is available immediately. Channel adapters (email, Signal) run their initial
+  // poll synchronously and block on agent task processing; starting HTTP last meant
+  // the health check fired during a multi-minute catch-up and marked the container
+  // unhealthy before the API was even bound. All HTTP adapter dependencies (bus,
+  // pool, services, registries) are fully initialized by this point.
+  const httpAdapter = new HttpAdapter({
+    bus,
+    logger,
+    pool,
+    agentRegistry,
+    port: config.httpPort,
+    apiToken: config.apiToken,
+    webAppBootstrapSecret: config.webAppBootstrapSecret,
+    appOrigin: config.appOrigin,
+    agentNames: agentConfigs.map(c => c.name),
+    skillNames: skillRegistry.list().map(s => s.manifest.name),
+    schedulerService,
+    identityService: officeIdentityService,
+    executiveProfileService,
+    contactService,
+    autonomyService,
+    setupRequiredAtBoot,
+    bootStartedAt,
+  });
+
+  try {
+    await httpAdapter.start();
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to start HTTP API');
+    process.exit(1);
+  }
+
   // Start all email adapters AFTER the dispatcher is registered so inbound.message
   // events always have a subscriber. Starting before registration would drop emails
   // arriving during the startup window (each adapter advances its own high-water mark
@@ -1654,35 +1687,6 @@ async function main(): Promise<void> {
     logger.info('Signal channel adapter started');
   } else if (signalAdapter && setupRequiredAtBoot) {
     logger.warn('SETUP-REQUIRED mode: skipping Signal adapter startup — restart after setup to enable');
-  }
-
-  // HTTP API channel — REST + SSE endpoints for external clients.
-  // Runs alongside the CLI channel so both can be used simultaneously.
-  const httpAdapter = new HttpAdapter({
-    bus,
-    logger,
-    pool,
-    agentRegistry,
-    port: config.httpPort,
-    apiToken: config.apiToken,
-    webAppBootstrapSecret: config.webAppBootstrapSecret,
-    appOrigin: config.appOrigin,
-    agentNames: agentConfigs.map(c => c.name),
-    skillNames: skillRegistry.list().map(s => s.manifest.name),
-    schedulerService,
-    identityService: officeIdentityService,
-    executiveProfileService,
-    contactService,
-    autonomyService,
-    setupRequiredAtBoot,
-    bootStartedAt,
-  });
-
-  try {
-    await httpAdapter.start();
-  } catch (err) {
-    logger.fatal({ err }, 'Failed to start HTTP API');
-    process.exit(1);
   }
 
   // Graceful shutdown — stop accepting new input first, then close connections.


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause:** `EmailAdapter.start()` runs its initial poll synchronously and blocks the `main()` async function until the coordinator agent finishes processing any queued emails. A pending 3-minute research task on restart delayed `httpAdapter.start()` by ~194s — past the 60s `start_period` window — causing Docker Compose to mark the container unhealthy and the deploy to report failure.
- **Fix:** Move `httpAdapter.start()` before the channel adapter loops so `/api/health` is reachable within ~12s of container start, well inside the health check window. All `HttpAdapter` dependencies are fully initialized by this point.
- **Current status:** Prod is running fine (0 restarts, healthy) — the container kept going after the deploy reported failure.

## Test plan

- [ ] Verify typecheck passes (`pnpm run typecheck`)
- [ ] Deploy to prod and confirm `docker compose up` completes without health check error
- [ ] Check `docker logs curia-curia-1` shows `HTTP API listening` within ~15s of startup
- [ ] Confirm `curl https://office.josephfung.ca/api/health` returns `200 ok`

## Follow-up issues

Two findings from code review that don't block this fix but are worth tracking:

1. **Graceful shutdown on adapter start failure** — if a channel adapter's `start()` throws after HTTP is bound, the process exits via `main().catch` without calling `httpAdapter.stop()`. Pre-existing for signal adapter; now also applies to email. In practice both adapters handle errors internally and won't propagate — but should be hardened.
2. **Health endpoint doesn't expose adapter readiness** — `/api/health` returns `200 ok` as soon as HTTP binds, before email/signal adapters have completed their initial poll. No channel state is reflected in the response body. A consumer can't distinguish "HTTP up, channels initializing" from "fully ready."


___

## **CodeAnt-AI Description**
**Bind the HTTP API earlier so health checks pass during startup**

### What Changed
- The HTTP API now starts before email and Signal adapters begin their initial catch-up work, so `/api/health` becomes available quickly after boot.
- This prevents long message backlogs from delaying the API bind long enough for Docker health checks to fail the container.
- The release notes now call out the startup health check fix.

### Impact
`✅ Fewer unhealthy deploys`
`✅ Faster startup health checks`
`✅ Clearer container health during boot`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
