### PR TITLE
fix: rate-limit GET /api/kg/chat/history (CodeQL js/missing-rate-limiting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 - **Contact email validation** — rewrote the `primaryEmail` format regex to remove polynomial-time backtracking (ReDoS) on attacker-controlled input. (#898, CodeQL js/polynomial-redos)
+- **KG chat history rate limit** — `GET /api/kg/chat/history` now carries the same 60/min per-IP cap as every other KG route; it was the lone DB-backed endpoint left on the looser global limit. (#901, CodeQL js/missing-rate-limiting)
 
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1179,7 +1179,7 @@ export async function knowledgeGraphRoutes(
    * inserted by the summarisation pass) are excluded since they are internal
    * artifacts not intended for display.
    */
-  app.get('/api/kg/chat/history', async (request, reply) => {
+  app.get('/api/kg/chat/history', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
 
     const query = request.query as {

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -1,4 +1,6 @@
 import Fastify from 'fastify';
+import type { LightMyRequestResponse } from 'fastify';
+import rateLimit from '@fastify/rate-limit';
 import type { Pool } from 'pg';
 import type { Logger } from '../../../../src/logger.js';
 import type { ContactService } from '../../../../src/contacts/contact-service.js';
@@ -219,6 +221,46 @@ describe('knowledgeGraphRoutes', () => {
       primaryEmail: 'first.last@sub.example.co.uk',
     });
     expect(response.statusCode).not.toBe(400);
+
+    await app.close();
+  });
+
+  // Regression for CodeQL #98 (js/missing-rate-limiting). GET /api/kg/chat/history
+  // reads from the working_memory table and was the only KG route missing the
+  // KG_RATE (60/min) per-route override — leaving it covered only by the looser
+  // global limit. We register @fastify/rate-limit with a deliberately high global
+  // cap (1000) so the route's own 60/min ceiling is the ONLY thing that can trip a
+  // 429: without the override all 61 requests would pass the limiter and return
+  // 401 at the secret guard; with it, the 61st is rejected by the limiter first.
+  it('rate-limits GET /api/kg/chat/history with the KG per-route cap', async () => {
+    const app = Fastify();
+    await app.register(rateLimit, { max: 1000, timeWindow: '1 minute' });
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'secret-1',
+      secureCookies: false,
+      sessions: new Map(),
+    });
+
+    // The rate-limit onRequest hook runs before the handler's assertSecret check,
+    // so it increments on every (unauthenticated) request. Fire a handful past the
+    // 60/min cap rather than pinning the assertion to the exact 61st request — the
+    // boundary index isn't what we're testing, only that the per-route cap engages.
+    const url = '/api/kg/chat/history?conversationId=c1';
+    const statuses: number[] = [];
+    for (let i = 0; i < 65; i++) {
+      const res: LightMyRequestResponse = await app.inject({ method: 'GET', url });
+      statuses.push(res.statusCode);
+    }
+
+    // The first request passes the limiter and is rejected by the secret guard —
+    // proves requests reach past the rate limiter, so a later 429 comes from the
+    // limiter and not some blanket rejection.
+    expect(statuses[0]).toBe(401);
+    // A 429 within 65 requests can only come from the route's own 60/min override:
+    // the global cap is 1000, so without KG_RATE none of these would be throttled.
+    expect(statuses).toContain(429);
 
     await app.close();
   });


### PR DESCRIPTION
## **User description**
## Summary

Closes #901. Resolves CodeQL alert **#98** (`js/missing-rate-limiting`, high).

`GET /api/kg/chat/history` reads from the `working_memory` table but was the **only** KG route missing the per-route `KG_RATE` (60 req/min per IP) override that all 13 sibling KG routes carry. It was therefore covered only by the looser global 200/min limit, leaving it more exposed to query-flood DoS against the database. CodeQL recognizes the per-route `config.rateLimit` form, which is why it flagged this one handler and none of its siblings.

The fix adds the existing `KG_RATE` route-option object to the handler — a one-line change bringing it in line with the rest of the KG API surface.

## Changes

- `src/channels/http/routes/kg.ts` — add `KG_RATE` to the `GET /api/kg/chat/history` registration.
- `tests/unit/channels/http/kg-routes.test.ts` — regression test (TDD: written failing first). Registers `@fastify/rate-limit` with a deliberately high global cap (1000) so the route's own 60/min ceiling is the only thing that can produce a `429`; fires past the cap and asserts a `429` appears while an early request still reaches the secret guard (401), proving the throttle comes from the per-route override and not a blanket rejection.
- `CHANGELOG.md` — Security entry.

## Testing

- `pnpm run typecheck` — clean.
- KG routes suite: 8/8 pass. HTTP unit suite: 50/50 pass.
- Verified the test genuinely fails without the fix (no `429` within 65 requests under the global 1000 cap).

## Note on alert #97

The sibling alert #97 (console SPA fallback `GET /*`) is **not** in this PR. That route is already covered by the global limiter; CodeQL flags it only because it doesn't credit the global `register()` form (only explicit per-route config). It's being resolved as a dismissal rather than a redundant per-route limit on static serving.


___

## **CodeAnt-AI Description**
**Add the missing rate limit to KG chat history**

### What Changed
- `GET /api/kg/chat/history` now uses the same 60 requests/minute per-IP limit as the other KG routes
- Added a regression test that confirms the route is throttled even when the global limit is set much higher
- Noted the fix in the security changelog

### Impact
`✅ Fewer database floods from chat history requests`
`✅ Consistent protection across all KG routes`
`✅ Lower risk of denial-of-service on chat history`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Security**
* The chat history endpoint now enforces a per-IP rate limit of 60 requests per minute, bringing it in line with standard protections applied to other API routes for consistency and improved security.

**Tests**
* Added comprehensive test coverage to verify that the chat history endpoint properly enforces its rate limit and returns appropriate responses when the limit is exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->