### PR TITLE
fix: bump dependencies to clear Trivy/CodeQL CVE alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 - **Contact email validation** — rewrote the `primaryEmail` format regex to remove polynomial-time backtracking (ReDoS) on attacker-controlled input. (#898, CodeQL js/polynomial-redos)
 - **KG chat history rate limit** — `GET /api/kg/chat/history` now carries the same 60/min per-IP cap as every other KG route; it was the lone DB-backed endpoint left on the looser global limit. (#901, CodeQL js/missing-rate-limiting)
+- **Base image OS patches** — runtime Dockerfile stage now runs `apt-get upgrade`, pulling Debian 12 fixes for `libgnutls30`/`libgcrypt20` and clearing 13 Trivy CVEs including two criticals (CVE-2026-33845, CVE-2026-42010).
+- **npm bundled deps** — runtime image bumps global npm to latest, clearing the flagged `picomatch`/`brace-expansion`/`ip-address` copies it carries (npm is never invoked at runtime).
+- **`uuid` pinned to v11** — forces `nylas`'s transitive `uuid@8.3.2` up to `^11.1.1` (CVE-2026-41907); v11 is the last major that still ships the CommonJS build the Nylas SDK requires.
+- **pnpm overrides moved to `pnpm-workspace.yaml`** — pnpm v10+ ignores `pnpm.overrides` in package.json, so the existing pins (qs, ip-address, vite, fast-uri, hono) had silently stopped applying; relocated to the supported file.
 
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,12 @@ Two patterns that pass local checks but fail CI regularly:
 
 If you need to approve new build scripts interactively, use `pnpm approve-builds` — do not hand-edit this file.
 
+### Dependency overrides live in pnpm-workspace.yaml — NOT package.json
+
+**pnpm v10+ reads the `overrides` map only from `pnpm-workspace.yaml`. A `pnpm.overrides` block in `package.json` is silently ignored** — no warning, no error, it just does nothing. (We learned this the hard way: five security pins sat dead in `package.json` and only "worked" because natural resolution happened to satisfy their floors.) The same applies to other `package.json#pnpm.*` settings such as `onlyBuiltDependencies`, which is superseded by `allowBuilds` here.
+
+When you need to pin a transitive dependency (e.g. to clear a CVE), add it to the `overrides:` block in `pnpm-workspace.yaml`, run `pnpm install`, and confirm the change actually took effect: the regenerated lockfile must contain a top-level `overrides:` section and `pnpm why <pkg>` must show the forced version. If `pnpm install` reports "Already up to date" after editing an override, pnpm did not see your change — you almost certainly edited the wrong file.
+
 ## Key Files
 
 - `src/index.ts` — bootstrap orchestrator, wires everything in dependency order

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,24 @@ FROM node:22-slim
 # uvx is needed to spawn workspace-mcp as an MCP stdio subprocess.
 COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+# apt-get upgrade pulls the latest Debian 12 security patches for packages baked
+# into the node:22-slim base layer (e.g. libgnutls30, libgcrypt20). Without it the
+# image ships whatever versions were frozen when the base image was built, which
+# Trivy flags as known CVEs even though Debian has already published fixes.
+# Run upgrade before installing curl so curl is installed from the patched lists.
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+# The global npm bundled in the base image carries its own transitive deps that
+# Trivy flags (picomatch, brace-expansion, ip-address). npm is never invoked at
+# runtime here — we use corepack/pnpm at build and tsx to run — but bumping it
+# pulls patched bundled deps (npm 11.16.0 ships picomatch 4.0.4, brace-expansion
+# 5.0.6, ip-address 10.2.0) and clears the findings rather than leaving stale
+# copies in the image. Pinned (not @latest) so rebuilds can't silently regress
+# the cleared CVEs; bump deliberately when a newer npm is needed.
+RUN npm install -g npm@11.16.0
 
 # Create a non-root system user/group for the runtime process.
 # UIDs/GIDs are pinned (not dynamic) so docker-compose tmpfs uid= options

--- a/package.json
+++ b/package.json
@@ -64,14 +64,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ],
-    "overrides": {
-      "hono": ">=4.12.18",
-      "fast-uri": ">=3.1.2",
-      "vite": ">=8.0.5",
-      "qs": ">=6.15.2",
-      "ip-address": ">=10.1.1"
-    }
+    ]
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono: '>=4.12.18'
+  fast-uri: '>=3.1.2'
+  vite: '>=8.0.5'
+  qs: '>=6.15.2'
+  ip-address: '>=10.1.1'
+  uuid: ^11.1.1
+
 importers:
 
   .:
@@ -79,7 +87,7 @@ importers:
         version: 6.40.0(ws@8.21.0)(zod@4.4.3)
       openredaction:
         specifier: ^1.1.2
-        version: 1.1.2(pdf-parse@2.4.5)
+        version: 1.1.2(pdf-parse@2.4.5)(react@19.2.7)
       pdf-parse:
         specifier: ^2.4.5
         version: 2.4.5
@@ -148,7 +156,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.16
+        specifier: '>=8.0.5'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
@@ -167,7 +175,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-react-oxc':
         specifier: ^0.4.3
-        version: 0.4.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4))
+        version: 0.4.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -178,8 +186,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)
+        specifier: '>=8.0.5'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
 
 packages:
 
@@ -966,7 +974,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.18'
 
   '@huggingface/jinja@0.5.9':
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
@@ -2277,7 +2285,7 @@ packages:
     resolution: {integrity: sha512-eJv6hHOIOVXzA4b2lZwccu/7VNmk9372fGOqsx5tNxiJHLtFBokyCTQUhlgjjXxl7guLPauHp0TqGTVyn1HvQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^6.3.0 || ^7.0.0
+      vite: '>=8.0.5'
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -2286,7 +2294,7 @@ packages:
     resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=8.0.5'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -5126,13 +5134,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@13.0.2:
-    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vary@1.1.2:
@@ -5202,7 +5205,7 @@ packages:
       '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=8.0.5'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -7582,10 +7585,10 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react-oxc@0.4.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4))':
+  '@vitejs/plugin-react-oxc@0.4.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.47
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -9424,7 +9427,7 @@ snapshots:
       stopwords-iso: 1.1.0
       sylvester: 0.0.21
       underscore: 1.13.8
-      uuid: 13.0.2
+      uuid: 11.1.1
       wordnet-db: 3.1.14
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -9518,7 +9521,7 @@ snapshots:
       form-data-encoder: 4.1.0
       formdata-node: 6.0.3
       mime-types: 2.1.35
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   object-assign@4.1.1: {}
 
@@ -9600,9 +9603,10 @@ snapshots:
 
   opener@1.5.2: {}
 
-  openredaction@1.1.2(pdf-parse@2.4.5):
+  openredaction@1.1.2(pdf-parse@2.4.5)(react@19.2.7):
     optionalDependencies:
       pdf-parse: 2.4.5
+      react: 19.2.7
 
   optionator@0.9.4:
     dependencies:
@@ -10829,10 +10833,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@13.0.2:
-    optional: true
-
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   vary@1.1.2: {}
 
@@ -10852,7 +10853,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4):
+  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10864,6 +10865,7 @@ snapshots:
       esbuild: 0.28.0
       fsevents: 2.3.3
       tsx: 4.22.4
+      yaml: 2.9.0
 
   vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,20 @@ packages:
 # pnpm default changes.
 blockExoticSubdeps: true
 
+# Dependency version overrides. pnpm v10+ reads `overrides` ONLY from this file —
+# a `pnpm.overrides` block in package.json is silently ignored. These pins force
+# transitive deps onto patched versions to clear known CVEs.
+#   - uuid: nylas@8.1.2 pins uuid@8.3.2 (CVE-2026-41907). uuid@11 is the last major
+#     that still ships a CommonJS build, which the CJS Nylas SDK requires; uuid@12+
+#     is ESM-only and would break `require('uuid')`.
+overrides:
+  hono: '>=4.12.18'
+  fast-uri: '>=3.1.2'
+  vite: '>=8.0.5'
+  qs: '>=6.15.2'
+  ip-address: '>=10.1.1'
+  uuid: '^11.1.1'
+
 # esbuild requires a postinstall step to download the platform binary.
 # Both versions (used by vite and tsup) are approved here.
 # promptfoo brings in several native-module packages; only esbuild actually needs


### PR DESCRIPTION
## **User description**
## Summary

Clears the 18 open dependency / base-image code-scanning alerts (Trivy + CodeQL), which fall into three buckets, each fixed differently.

### Bucket A — Debian OS packages in the runtime image (13 alerts, incl. 2 critical)
`libgnutls30` (deb12u6→u7) and `libgcrypt20` were frozen into the `node:22-slim` base layer and never upgraded. The runtime stage now runs `apt-get upgrade -y` (before installing curl, so curl comes from the patched lists), pulling Debian 12's published security fixes.

Clears: #99–#111 — including criticals **CVE-2026-33845** (#100) and **CVE-2026-42010** (#101), and highs CVE-2026-42009/3833/33846 + libgnutls30 batch.

### Bucket B — npm's own bundled deps (4 alerts)
`picomatch` / `brace-expansion` / `ip-address` living inside the global npm that ships with the base image (`usr/local/lib/node_modules/npm/...`). npm is never invoked at runtime (we use corepack/pnpm at build, tsx at run), but the stale copies still get scanned. Pinned global npm to **11.16.0**, which bundles picomatch 4.0.4, brace-expansion 5.0.6, ip-address 10.2.0 — all at/past their fix versions (verified by extracting npm 11.16.0's bundled tree). Pinned, not `@latest`, so rebuilds can't silently regress.

Clears: #112 (brace-expansion), #113 (ip-address), #114/#115 (picomatch).

### Bucket C — one real app dependency: `uuid@8.3.2` (#116, CVE-2026-41907)
Pulled in transitively by `nylas@8.1.2` (latest Nylas; still pins `uuid: ^8.3.2`). Added a pnpm override forcing `uuid: ^11.1.1`. **v11 is deliberate** — it's the last major that still ships a CommonJS build, which the CJS Nylas SDK requires; v12+ is ESM-only and would break `require('uuid')`. Lockfile now resolves a single `uuid@11.1.1` across the whole tree.

### Incidental fix: pnpm overrides were silently dead
pnpm v10+ reads `overrides` **only** from `pnpm-workspace.yaml`; the `pnpm.overrides` block in package.json is ignored. The existing pins (qs, ip-address, vite, fast-uri, hono) had quietly stopped applying — they only satisfied their floors today by luck of natural resolution. Migrated all of them (plus the new `uuid` pin) to `pnpm-workspace.yaml`, which is now reflected in the lockfile's `overrides:` block for the first time.

## Testing
- `pnpm test` — 3151 passed, 110 skipped (2 integration files fail only because `DATABASE_URL` isn't set locally; unrelated).
- `pnpm run typecheck` — clean.
- `pnpm why uuid` — single version 11.1.1; uuid@8.3.2 gone.
- Reviewed by code-reviewer + a focused supply-chain/security pass: no blocking findings; npm bundled-dep clears verified empirically.

## Notes
- These alerts clear only after CI rebuilds the image and Trivy/CodeQL re-scan `main`.
- `pnpm.onlyBuiltDependencies` in package.json is likewise superseded by `allowBuilds:` in pnpm-workspace.yaml (already present) — left in place to keep this PR scoped; can be cleaned up separately.


___

## **CodeAnt-AI Description**
Fix dependency vulnerabilities in the runtime image and lockfile

### What Changed
- Updated the runtime Docker image to install Debian security patches, clearing known OS package CVEs from the base image.
- Replaced the runtime image’s bundled npm with a pinned newer version so its scanned helper packages are no longer flagged.
- Moved dependency version pins into the supported workspace file and added a `uuid` pin so Nylas no longer pulls the vulnerable `uuid@8.3.2`.
- Kept the existing security pins for other transitive dependencies in place through the shared workspace config.

### Impact
`✅ Fewer security scan alerts`
`✅ Lower exposure to known dependency CVEs`
`✅ Cleaner container builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
