### PR TITLE
chore: allow Trivy image scan to run on workflow_dispatch

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,6 +1,10 @@
 name: Trivy
 
 on:
+  # Manual trigger so the image scan can be run on demand — e.g. to verify a
+  # base-image / dependency CVE fix immediately instead of waiting for the
+  # weekly schedule. See the trivy-image job's `if` guard below.
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -46,7 +50,9 @@ jobs:
   trivy-image:
     name: Docker Image Scan
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    # Image build+scan is expensive, so it's skipped on every push/PR. It runs on
+    # the weekly schedule and on manual dispatch (for on-demand fix verification).
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **npm bundled deps** — runtime image bumps global npm to latest, clearing the flagged `picomatch`/`brace-expansion`/`ip-address` copies it carries (npm is never invoked at runtime).
 - **`uuid` pinned to v11** — forces `nylas`'s transitive `uuid@8.3.2` up to `^11.1.1` (CVE-2026-41907); v11 is the last major that still ships the CommonJS build the Nylas SDK requires.
 - **pnpm overrides moved to `pnpm-workspace.yaml`** — pnpm v10+ ignores `pnpm.overrides` in package.json, so the existing pins (qs, ip-address, vite, fast-uri, hono) had silently stopped applying; relocated to the supported file.
+- **On-demand Trivy image scan** — the container vulnerability scan now supports `workflow_dispatch`, so base-image/dependency CVE fixes can be re-verified immediately instead of waiting for the weekly schedule.
 
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 


### PR DESCRIPTION
## **User description**
## Summary

Lets the Trivy **container image scan** be triggered manually, not just weekly.

The `trivy-image` job (which builds the Docker image and scans it — the source of all the OS-package, npm-bundled, and app-dependency CVE alerts like libgnutls30, picomatch, uuid) was gated to `if: github.event_name == 'schedule'`, and the workflow had no `workflow_dispatch` trigger. So after fixing a base-image/dependency CVE there was **no way to re-scan the image on demand** — you had to wait for the weekly Wednesday 08:00 UTC run to confirm the fix.

## Changes
- Add `workflow_dispatch` to `trivy.yml` triggers.
- Extend the `trivy-image` job guard to `github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`.

`trivy-fs` behaviour is unchanged (still runs on push/PR/schedule). The image scan stays off push/PR (it's an expensive build) but is now runnable from the Actions tab or `gh workflow run trivy.yml`.

## Motivation
Directly enables verifying #903 (uuid, OS patches, npm bundled deps) without waiting up to a week. No untrusted input is used in any `run:` step, so this introduces no workflow-injection surface.

## Testing
- YAML validated; triggers parse as `[workflow_dispatch, push, pull_request, schedule]` and the job guard resolves correctly.


___

## **CodeAnt-AI Description**
**Run the Trivy image scan on demand**

### What Changed
- The container vulnerability scan can now be started manually from the Actions page
- The image scan still skips push and pull request runs, but now works for both the weekly schedule and manual runs
- The changelog now notes that base-image and dependency CVE fixes can be rechecked immediately

### Impact
`✅ Faster CVE verification`
`✅ No waiting for the weekly scan to confirm fixes`
`✅ Fewer delayed security follow-ups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
