### PR TITLE
feat: compose-reply skill + sidebar split (Layer B, audience-leak #851)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
+- **`compose-reply` skill** — lets the coordinator partition a reply into an external-facing body and a principal-only status update; the dispatcher routes each piece as a separate outbound message, eliminating the audience-leak failure mode at the source. (#851)
 - **`ceo-inbox-mark-starred`** — new skill that stars (or unstars) a CEO inbox message via the Nylas starred field; mirrors the pattern of `ceo-inbox-mark-read`.
 - **`⚠️ Stuck` label** — ceo-inbox now applies this label when triage cannot complete for a message (unrecognised classification value, required skill failure, or error budget boundary hit), making failures visible in the Gmail sidebar.
 
 ### Changed
+- **`AgentResponsePayload`** — extended with optional `sidebar: { audience: 'principal'; content: string }` field; public API surface change. (#851)
+- **Dispatcher** — `handleAgentResponse` publishes a second `outbound.message` to the principal when `sidebar` is present and `principalRouting` is configured; adds `principalRouting` to `DispatcherConfig`. (#851)
+- **Coordinator prompt** — Audience Awareness section documents the `compose-reply` pattern; bumped to v0.7.0. (#851)
 - **ceo-inbox triage labels** — renamed to emoji-prefixed variants for better readability in the Gmail sidebar: `URGENT` → `🚨 Urgent`, `ACTIONABLE` → `✅ Handled`, `NEEDS DRAFT` → `✍️ Drafted`, `LEAVE FOR CEO` → `📌 Seen`, `NOISE` → `✔️ Cleared`. Existing Gmail labels with the old names are inert and won't appear on new messages.
 - **`🚨 Urgent` messages are starred automatically** — after step 4h's bullpen notification, ceo-inbox calls `ceo-inbox-mark-starred`. Starring failure is logged but does not abort the run.
 - **KG graph** — various visual improvements: physics-aware layout, better hub sizing, principal-node default view, and viewport centering on focal nodes. (#861)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.6.0"
+version: "0.7.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -198,6 +198,13 @@ system_prompt: |
   - The person should experience you as a competent human assistant, not as software
     with visible internals.
   - Sign emails professionally using your name and title from the identity block above.
+  - When replying to a non-principal contact about a principal-delegated task and you
+    also need to update the principal on the status, use the `compose-reply` skill with
+    `external` (the text safe to send to the contact) and `internal` (the status update
+    for the principal only). The system routes them as two separate messages. **Never
+    address the principal in the body of a message that goes to a non-principal
+    recipient** — if you find yourself writing "To the CEO:" or a separate status section
+    inside a reply to an external contact, use `compose-reply` instead.
 
   **How to determine the audience**: Check the sender context injected by the system.
   - If the sender's role is "ceo", you're talking to the CEO.
@@ -641,6 +648,7 @@ pinned_skills:
   - approval-expiry-sweep
   - pending-actions-digest
   - scheduler-report
+  - compose-reply
 allow_discovery: true
 enable_task_management: true
 error_budget:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -87,6 +87,17 @@ dispatch:
     max_per_sender: 15      # messages per sender per window (15 allows for an active chat burst)
     max_global: 100         # total messages per window across all senders
 
+  # Routing for compose-reply sidebar updates. When set, agent.response events that
+  # carry a `sidebar` field (produced by the compose-reply skill) publish a second
+  # outbound.message to this recipient — the principal's inbox — so they receive a
+  # status update separate from the external reply. Omit to disable sidebar delivery.
+  #
+  # principal_routing:
+  #   channel_id: email
+  #   account_id: curia      # named email account to send from; defaults to 'curia'
+  #   recipient_id: principal@example.com
+  #   subject: "Task update" # email subject for sidebar messages (default: 'Task update')
+
 workingMemory:
   # TTL for working memory turns. Rows are expired by DreamEngine's nightly purge
   # pass (DELETE WHERE expires_at < now()). The idx_wm_expires partial index makes

--- a/skills/compose-reply/handler.test.ts
+++ b/skills/compose-reply/handler.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { ComposeReplyHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import { createLogger } from '../../src/logger.js';
+
+function makeCtx(input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    agentId: 'coordinator',
+    conversationId: 'conv-test',
+    taskEventId: 'task-test',
+    log: createLogger('silent'),
+    secret: () => { throw new Error('no secrets'); },
+    timezone: 'UTC',
+  } as unknown as SkillContext;
+}
+
+describe('ComposeReplyHandler', () => {
+  const handler = new ComposeReplyHandler();
+
+  it('returns external and internal when both are provided', async () => {
+    const ctx = makeCtx({ external: 'Friday works great!', internal: 'Confirmed 2 PM with Armin; invite pending.' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as { external: string; internal?: string };
+    expect(data.external).toBe('Friday works great!');
+    expect(data.internal).toBe('Confirmed 2 PM with Armin; invite pending.');
+  });
+
+  it('returns only external when internal is absent', async () => {
+    const ctx = makeCtx({ external: 'See you then!' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as { external: string; internal?: string };
+    expect(data.external).toBe('See you then!');
+    expect(data.internal).toBeUndefined();
+  });
+
+  it('trims whitespace from external', async () => {
+    const ctx = makeCtx({ external: '  Hello there.  ' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect((result.data as { external: string }).external).toBe('Hello there.');
+  });
+
+  it('trims whitespace from internal when present', async () => {
+    const ctx = makeCtx({ external: 'Hi Armin', internal: '  Status update.  ' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect((result.data as { internal?: string }).internal).toBe('Status update.');
+  });
+
+  it('fails when external is missing', async () => {
+    const ctx = makeCtx({});
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toMatch(/external/i);
+  });
+
+  it('fails when external is not a string', async () => {
+    const ctx = makeCtx({ external: 42 });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toMatch(/external/i);
+  });
+
+  it('fails when external is empty after trimming', async () => {
+    const ctx = makeCtx({ external: '   ' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toMatch(/external/i);
+  });
+
+  it('fails when internal is provided but is not a string', async () => {
+    const ctx = makeCtx({ external: 'Valid reply', internal: 123 });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toMatch(/internal/i);
+  });
+
+  it('fails when internal is provided but is empty after trimming', async () => {
+    const ctx = makeCtx({ external: 'Valid reply', internal: '   ' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toMatch(/internal/i);
+  });
+});

--- a/skills/compose-reply/handler.ts
+++ b/skills/compose-reply/handler.ts
@@ -1,0 +1,48 @@
+// handler.ts — compose-reply skill.
+//
+// Allows the coordinator to partition a reply into an external-facing body
+// and a principal-only status update. The handler validates inputs and
+// returns the trimmed values. The runtime detects this skill by name, short-
+// circuits the tool-use loop, and emits an agent.response with the external
+// text as `content` and the internal text as `sidebar`. The dispatcher then
+// routes each piece as a separate outbound message.
+//
+// No side effects — pure shape. action_risk: "none".
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ComposeReplyHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { external, internal } = ctx.input as {
+      external?: unknown;
+      internal?: unknown;
+    };
+
+    if (!external || typeof external !== 'string') {
+      return { success: false, error: 'Missing required input: external (string)' };
+    }
+    const externalTrimmed = external.trim();
+    if (externalTrimmed === '') {
+      return { success: false, error: 'external must not be empty' };
+    }
+
+    if (internal !== undefined) {
+      if (typeof internal !== 'string') {
+        return { success: false, error: 'internal must be a string when provided' };
+      }
+      const internalTrimmed = internal.trim();
+      if (internalTrimmed === '') {
+        return { success: false, error: 'internal must not be empty when provided' };
+      }
+      return {
+        success: true,
+        data: { external: externalTrimmed, internal: internalTrimmed },
+      };
+    }
+
+    return {
+      success: true,
+      data: { external: externalTrimmed },
+    };
+  }
+}

--- a/skills/compose-reply/handler.ts
+++ b/skills/compose-reply/handler.ts
@@ -13,7 +13,8 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 
 export class ComposeReplyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { external, internal } = ctx.input as {
+    // Cast through unknown first per project convention (Record<string,unknown> → typed shape).
+    const { external, internal } = ctx.input as unknown as {
       external?: unknown;
       internal?: unknown;
     };

--- a/skills/compose-reply/skill.json
+++ b/skills/compose-reply/skill.json
@@ -1,0 +1,18 @@
+{
+  "name": "compose-reply",
+  "description": "Structure a reply that has two distinct audiences: an external recipient and the principal. Call this when responding to a non-principal contact about a principal-delegated task and you also need to update the principal on the status. Provide `external` with the text safe to send to the contact, and optionally `internal` with the status update for the principal only. The system routes them as two separate messages — never address the principal in the body of a message that also goes to an external recipient.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "external": "string (text safe to send to the inbound sender)",
+    "internal": "string? (text for the principal only — routed separately, never visible to the external recipient)"
+  },
+  "outputs": {
+    "external": "string (validated external-facing reply)",
+    "internal": "string? (validated principal-facing update, present only when internal was provided)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 5000
+}

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -707,6 +707,9 @@ export class AgentRuntime {
     // for another round. This moves the clarification format contract from LLM prompts
     // into code: the runtime produces it, the DelegateHandler parses it.
     let pendingClarification: { question: string; context: string } | null = null;
+    // Set when compose-reply succeeds; triggers a short-circuit that routes
+    // external → content and internal → sidebar on the emitted agent.response.
+    let pendingComposeReply: { external: string; internal?: string } | null = null;
 
     while (response.type === 'tool_use' && executionLayer) {
       // Check turn budget before processing this round of tool calls
@@ -937,6 +940,28 @@ export class AgentRuntime {
             }
           }
 
+          // compose-reply detection: when the skill succeeds, capture external and
+          // internal for the short-circuit exit. Only captures the first call;
+          // subsequent compose-reply calls in the same turn are ignored.
+          if (toolCall.name === 'compose-reply' && result.success && !pendingComposeReply) {
+            try {
+              const crData = typeof result.data === 'string'
+                ? JSON.parse(result.data) as unknown
+                : result.data;
+              const typed = crData as { external?: unknown; internal?: unknown };
+              if (typed?.external && typeof typed.external === 'string') {
+                pendingComposeReply = {
+                  external: typed.external,
+                  internal: typeof typed.internal === 'string' ? typed.internal : undefined,
+                };
+              } else {
+                logger.warn({ agentId }, 'compose-reply result missing valid external field — skipping short-circuit');
+              }
+            } catch (err) {
+              logger.warn({ err, agentId }, 'Failed to parse compose-reply result — skipping short-circuit');
+            }
+          }
+
           const resultContent = typeof result.data === 'string' ? result.data : JSON.stringify(result.data);
           toolResultBlocks.push({
             type: 'tool_result',
@@ -1036,6 +1061,31 @@ export class AgentRuntime {
         logger.info(
           { agentId, conversationId, question: pendingClarification.question.slice(0, 100) },
           'Task paused for clarification — specialist requested CEO direction',
+        );
+        return;
+      }
+
+      // compose-reply short-circuit: emit a structured agent.response that carries
+      // external text as `content` and optional principal update as `sidebar`.
+      // The dispatcher routes each piece as a separate outbound message.
+      if (pendingComposeReply) {
+        if (memory) {
+          await memory.addTurn(conversationId, agentId, { role: 'assistant', content: pendingComposeReply.external });
+        }
+        const composeResponse = createAgentResponse({
+          agentId,
+          conversationId,
+          content: pendingComposeReply.external,
+          skillsCalled,
+          ...(pendingComposeReply.internal !== undefined && {
+            sidebar: { audience: 'principal' as const, content: pendingComposeReply.internal },
+          }),
+          parentEventId: taskEvent.id,
+        });
+        await bus.publish('agent', composeResponse);
+        logger.info(
+          { agentId, conversationId, hasSidebar: pendingComposeReply.internal !== undefined },
+          'compose-reply short-circuit: emitting structured agent.response',
         );
         return;
       }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -944,10 +944,23 @@ export class AgentRuntime {
           // internal for the short-circuit exit. Only captures the first call;
           // subsequent compose-reply calls in the same turn are ignored.
           if (toolCall.name === 'compose-reply' && result.success && !pendingComposeReply) {
+            // The ComposeReplyHandler always returns a plain object — JSON.parse is only
+            // needed if the execution layer serialized the result to a string. Isolate
+            // the parse step so a JSON syntax error is distinguishable from a type error
+            // in the detection logic below.
+            let crData: unknown;
             try {
-              const crData = typeof result.data === 'string'
+              crData = typeof result.data === 'string'
                 ? JSON.parse(result.data) as unknown
                 : result.data;
+            } catch (err) {
+              logger.error(
+                { err, agentId, conversationId },
+                'compose-reply: failed to parse skill result — skipping short-circuit; tool loop continues',
+              );
+              crData = null;
+            }
+            if (crData !== null) {
               const typed = crData as { external?: unknown; internal?: unknown };
               if (typed?.external && typeof typed.external === 'string') {
                 pendingComposeReply = {
@@ -955,10 +968,11 @@ export class AgentRuntime {
                   internal: typeof typed.internal === 'string' ? typed.internal : undefined,
                 };
               } else {
-                logger.warn({ agentId }, 'compose-reply result missing valid external field — skipping short-circuit');
+                logger.warn(
+                  { agentId, conversationId },
+                  'compose-reply result missing valid external field — skipping short-circuit; tool loop continues',
+                );
               }
-            } catch (err) {
-              logger.warn({ err, agentId }, 'Failed to parse compose-reply result — skipping short-circuit');
             }
           }
 
@@ -1068,10 +1082,12 @@ export class AgentRuntime {
       // compose-reply short-circuit: emit a structured agent.response that carries
       // external text as `content` and optional principal update as `sidebar`.
       // The dispatcher routes each piece as a separate outbound message.
+      //
+      // Ordering: publish to the bus FIRST, then persist to memory. If bus.publish
+      // throws, memory is never written — the task fails visibly and no phantom
+      // assistant turn is recorded for a message that never left. The reverse order
+      // (memory first) would corrupt conversation state if publish fails.
       if (pendingComposeReply) {
-        if (memory) {
-          await memory.addTurn(conversationId, agentId, { role: 'assistant', content: pendingComposeReply.external });
-        }
         const composeResponse = createAgentResponse({
           agentId,
           conversationId,
@@ -1083,6 +1099,9 @@ export class AgentRuntime {
           parentEventId: taskEvent.id,
         });
         await bus.publish('agent', composeResponse);
+        if (memory) {
+          await memory.addTurn(conversationId, agentId, { role: 'assistant', content: pendingComposeReply.external });
+        }
         logger.info(
           { agentId, conversationId, hasSidebar: pendingComposeReply.internal !== undefined },
           'compose-reply short-circuit: emitting structured agent.response',

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -101,6 +101,14 @@ interface OutboundMessagePayload {
   /** The agent.task event ID that originated this outbound message.
    *  Stamped by the dispatcher for traceability and action_log context. */
   taskEventId?: string;
+  /**
+   * When present, signals the email adapter to send a fresh email (not a thread reply)
+   * addressed to `recipientId` using this string as the subject. Absent for regular
+   * thread replies, where the subject is derived from the existing thread.
+   *
+   * Only consumed by the email channel adapter. Other adapters ignore this field.
+   */
+  subject?: string;
 }
 
 // OutboundDeliveredPayload — emitted by OutboundGateway after a successful

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -71,6 +71,13 @@ interface AgentResponsePayload {
   // Populated by the agent runtime's tool-use loop; absent on error-path responses
   // where the runtime bailed before completing the loop.
   skillsCalled?: string[];
+  // Present when the agent called compose-reply with an `internal` field. The
+  // dispatcher routes this as a separate principal-directed outbound message,
+  // ensuring it never appears in the external recipient's email body.
+  sidebar?: {
+    audience: 'principal';
+    content: string;
+  };
 }
 
 interface OutboundMessagePayload {

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -582,6 +582,37 @@ export class EmailAdapter {
     const { outboundGateway, logger } = this.config;
     const conversationId = outbound.payload.conversationId;
 
+    // Fresh-send path: when `subject` is set, the caller (dispatcher's sidebar split)
+    // wants a new email to `recipientId`, not a thread reply. The conversationId in
+    // these events is the original inbound thread (kept for traceability) and MUST NOT
+    // be used for routing — the email adapter's thread lookup would route to the wrong
+    // person. Instead, send directly to recipientId with the provided subject.
+    if (outbound.payload.subject !== undefined) {
+      const recipientId = outbound.payload.recipientId;
+      if (!recipientId) {
+        logger.error(
+          { conversationId },
+          'sendOutboundReply: fresh-send path requires recipientId — skipping sidebar delivery',
+        );
+        return;
+      }
+      await this.sendWithGatedDraftFallback(
+        {
+          channel: 'email' as const,
+          accountId: this.config.accountId,
+          to: recipientId,
+          subject: outbound.payload.subject,
+          body: outbound.payload.content,
+        },
+        {
+          taskEventId: outbound.payload.taskEventId,
+          conversationId,
+          parentEventId: outbound.id,
+        },
+      );
+      return;
+    }
+
     if (!conversationId.startsWith('email:')) {
       logger.warn({ conversationId }, 'Cannot send email reply — conversation ID not in email format');
       return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -164,6 +164,22 @@ export interface YamlConfig {
       /** Maximum total messages allowed per window across all senders. Default: 100. */
       max_global?: number;
     };
+    /**
+     * Routing config for the compose-reply sidebar. When set, agent.response events
+     * that carry a `sidebar` field publish a second outbound.message to this recipient.
+     * Required to make the compose-reply skill deliver principal updates.
+     */
+    principal_routing?: {
+      /** Channel to use (e.g. 'email'). */
+      channel_id: string;
+      /** Named account to send from. For email channels defaults to 'curia' when absent.
+       *  Multi-account deployments should set this explicitly. */
+      account_id?: string;
+      /** Recipient address (e.g. principal's email). */
+      recipient_id: string;
+      /** Subject line for the sidebar email. Defaults to 'Task update'. */
+      subject?: string;
+    };
   };
   security?: {
     extra_injection_patterns?: Array<{ regex: string; label: string }>;

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -946,6 +946,13 @@ export class Dispatcher {
     // Reply-lock: if a human-facing reply skill (email-reply, email-send) already fired
     // successfully during this task, suppress the outbound.message to prevent a duplicate
     // send. Emit outbound.suppressed_duplicate for the audit trail. See #847.
+    //
+    // Interaction with compose-reply sidebar: when humanReplySent is true, the entire
+    // handler returns early — both the external outbound AND any sidebar are suppressed.
+    // This is intentional: if email-reply/email-send already sent the external message,
+    // the compose-reply flow was abandoned mid-task, and the sidebar (which is the
+    // principal status update for that same send) is no longer relevant. If the principal
+    // needs an update, the completed skill that fired humanReplySent should handle it.
     if (routing.humanReplySent) {
       this.logger.info(
         { agentId: event.payload.agentId, conversationId: routing.conversationId, routingTaskId: event.parentEventId },
@@ -984,6 +991,11 @@ export class Dispatcher {
     // compose-reply sidebar split: if the agent partitioned the reply into an external body
     // and a principal-only update, publish a second outbound.message to the principal.
     // Each outbound goes through OutboundGateway and the content filter independently.
+    //
+    // Note on ordering: the primary outbound was already published above. A failure in the
+    // sidebar publish means the external message went out but the principal update is lost.
+    // We wrap in try/catch so the failure is logged with the sidebar content (for manual
+    // recovery) rather than propagating and aborting the checkpoint scheduling below.
     if (event.payload.sidebar) {
       if (this.principalRouting) {
         const sidebarOutbound = createOutboundMessage({
@@ -995,15 +1007,32 @@ export class Dispatcher {
           parentEventId: event.id,
           taskEventId: event.parentEventId ?? undefined,
         });
-        await this.bus.publish('dispatch', sidebarOutbound);
-        this.logger.info(
-          { agentId: event.payload.agentId, conversationId: routing.conversationId },
-          'Dispatcher: published sidebar outbound to principal',
-        );
+        try {
+          await this.bus.publish('dispatch', sidebarOutbound);
+          this.logger.info(
+            { agentId: event.payload.agentId, conversationId: routing.conversationId },
+            'Dispatcher: published sidebar outbound to principal',
+          );
+        } catch (err) {
+          // Non-fatal for the primary send (already succeeded), but the principal did not
+          // receive their status update. Log at error with the sidebar content truncated so
+          // an operator can manually reconstruct and deliver it.
+          this.logger.error(
+            {
+              err,
+              agentId: event.payload.agentId,
+              conversationId: routing.conversationId,
+              sidebarContentPreview: event.payload.sidebar.content.slice(0, 200),
+            },
+            'Dispatcher: failed to publish sidebar outbound to principal — principal update was NOT delivered',
+          );
+        }
       } else {
-        this.logger.warn(
+        // Misconfiguration: compose-reply requires principalRouting to be useful.
+        // Log at error (not warn) because a principal-directed message has been permanently dropped.
+        this.logger.error(
           { agentId: event.payload.agentId, conversationId: routing.conversationId },
-          'Dispatcher: agent.response has sidebar but no principalRouting configured — sidebar dropped',
+          'Dispatcher: agent.response has sidebar but no principalRouting configured — sidebar dropped permanently',
         );
       }
     }

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -81,6 +81,16 @@ export interface DispatcherConfig {
   /** Outbound context service — v2 context bridging. When present, replaces
    *  the working-memory-based context memo injection. */
   outboundContextService?: import('./outbound-context.js').OutboundContextService;
+  /** Routing for the compose-reply sidebar: when set, agent.response events
+   *  that carry a `sidebar` field publish a second outbound.message addressed
+   *  to the principal (in addition to the primary outbound to the inbound sender).
+   *  When absent, sidebar content is logged as a warning and dropped. */
+  principalRouting?: {
+    channelId: string;
+    accountId?: string;
+    /** Recipient identifier (e.g. email address). */
+    recipientId: string;
+  };
 }
 
 /**
@@ -134,6 +144,9 @@ export class Dispatcher {
   private selfEmail?: string;
   /** Outbound context service — v2 context bridging (replaces working-memory memo read path). */
   private _outboundContextService?: import('./outbound-context.js').OutboundContextService;
+  /** Principal routing for compose-reply sidebar delivery. When set, sidebar content
+   *  is published as a second outbound.message to the principal. */
+  private principalRouting?: DispatcherConfig['principalRouting'];
 
   constructor(config: DispatcherConfig) {
     this.bus = config.bus;
@@ -152,6 +165,7 @@ export class Dispatcher {
     this.confidencePipeline = config.confidencePipeline;
     this.selfEmail = config.selfEmail;
     this._outboundContextService = config.outboundContextService;
+    this.principalRouting = config.principalRouting;
 
     // Warn if the trust floor is active but no held-message service was provided — the floor
     // silently becomes a no-op in that case, which is a security-relevant degradation.
@@ -966,6 +980,33 @@ export class Dispatcher {
       taskEventId: event.parentEventId ?? undefined,
     });
     await this.bus.publish('dispatch', outbound);
+
+    // compose-reply sidebar split: if the agent partitioned the reply into an external body
+    // and a principal-only update, publish a second outbound.message to the principal.
+    // Each outbound goes through OutboundGateway and the content filter independently.
+    if (event.payload.sidebar) {
+      if (this.principalRouting) {
+        const sidebarOutbound = createOutboundMessage({
+          conversationId: routing.conversationId,
+          channelId: this.principalRouting.channelId,
+          accountId: this.principalRouting.accountId,
+          content: event.payload.sidebar.content,
+          recipientId: this.principalRouting.recipientId,
+          parentEventId: event.id,
+          taskEventId: event.parentEventId ?? undefined,
+        });
+        await this.bus.publish('dispatch', sidebarOutbound);
+        this.logger.info(
+          { agentId: event.payload.agentId, conversationId: routing.conversationId },
+          'Dispatcher: published sidebar outbound to principal',
+        );
+      } else {
+        this.logger.warn(
+          { agentId: event.payload.agentId, conversationId: routing.conversationId },
+          'Dispatcher: agent.response has sidebar but no principalRouting configured — sidebar dropped',
+        );
+      }
+    }
 
     // Schedule a checkpoint for this conversation — resets the debounce timer if
     // already running, so only fires after a full window of inactivity.

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -87,9 +87,15 @@ export interface DispatcherConfig {
    *  When absent, sidebar content is logged as a warning and dropped. */
   principalRouting?: {
     channelId: string;
+    /** Which named account should send the sidebar. For email channels, defaults to
+     *  'curia' when absent (email adapter fallback). Multi-account deployments should
+     *  set this explicitly to ensure the sidebar is sent from the correct mailbox. */
     accountId?: string;
     /** Recipient identifier (e.g. email address). */
     recipientId: string;
+    /** Subject line for the sidebar email. Only used by the email adapter (fresh-send
+     *  path). Defaults to 'Task update' when absent. */
+    subject?: string;
   };
 }
 
@@ -999,11 +1005,18 @@ export class Dispatcher {
     if (event.payload.sidebar) {
       if (this.principalRouting) {
         const sidebarOutbound = createOutboundMessage({
+          // conversationId is the original inbound thread — kept for action_log
+          // traceability so operators can see which conversation triggered this sidebar.
+          // The email adapter uses `subject` (below) to detect the fresh-send path and
+          // routes to `recipientId` directly instead of threading into this conversation.
           conversationId: routing.conversationId,
           channelId: this.principalRouting.channelId,
           accountId: this.principalRouting.accountId,
           content: event.payload.sidebar.content,
           recipientId: this.principalRouting.recipientId,
+          // subject triggers the email adapter's fresh-send path, routing the sidebar
+          // to the principal's address (recipientId) instead of Armin's thread.
+          subject: this.principalRouting.subject ?? 'Task update',
           parentEventId: event.id,
           taskEventId: event.parentEventId ?? undefined,
         });
@@ -1022,7 +1035,8 @@ export class Dispatcher {
               err,
               agentId: event.payload.agentId,
               conversationId: routing.conversationId,
-              sidebarContentPreview: event.payload.sidebar.content.slice(0, 200),
+              // Content length only — never log the content itself, which is principal-only text.
+              sidebarContentLength: event.payload.sidebar.content.length,
             },
             'Dispatcher: failed to publish sidebar outbound to principal — principal update was NOT delivered',
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1660,6 +1660,14 @@ async function main(): Promise<void> {
     confidencePipeline,
     selfEmail: resolvedEmailAccounts[0]?.selfEmail,
     outboundContextService,
+    principalRouting: yamlConfig.dispatch?.principal_routing
+      ? {
+          channelId: yamlConfig.dispatch.principal_routing.channel_id,
+          accountId: yamlConfig.dispatch.principal_routing.account_id,
+          recipientId: yamlConfig.dispatch.principal_routing.recipient_id,
+          subject: yamlConfig.dispatch.principal_routing.subject,
+        }
+      : undefined,
   });
   dispatcher.register();
 

--- a/tests/unit/agents/runtime.compose-reply.test.ts
+++ b/tests/unit/agents/runtime.compose-reply.test.ts
@@ -1,0 +1,249 @@
+// runtime.compose-reply.test.ts — tests for the compose-reply short-circuit
+// in AgentRuntime. When the LLM calls compose-reply with {external, internal},
+// the runtime must emit agent.response with content=external and
+// sidebar={audience:'principal', content:internal} without making an extra
+// LLM round-trip. Free-text responses and external-only compose-reply calls
+// must produce no sidebar (back-compat).
+
+import { describe, it, expect, vi } from 'vitest';
+import { AgentRuntime } from '../../../src/agents/runtime.js';
+import { EventBus } from '../../../src/bus/bus.js';
+import { createAgentTask, type AgentResponseEvent } from '../../../src/bus/events.js';
+import type { LLMProvider } from '../../../src/agents/llm/provider.js';
+import type { ExecutionLayer } from '../../../src/skills/execution.js';
+import { createLogger } from '../../../src/logger.js';
+
+const MOCK_PROVENANCE = {
+  requestedModel: 'mock-model',
+  actualModel: 'mock-model',
+  providerRequestId: 'msg_mock_000',
+} as const;
+
+/** LLM that returns a single tool_use for compose-reply, then never called again. */
+function makeComposeReplyProvider(input: Record<string, unknown>): LLMProvider {
+  return {
+    id: 'mock',
+    chat: vi.fn().mockResolvedValueOnce({
+      type: 'tool_use' as const,
+      toolCalls: [{ id: 'cr-1', name: 'compose-reply', input }],
+      usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+      provenance: MOCK_PROVENANCE,
+    }),
+  };
+}
+
+/** Execution layer that returns compose-reply skill result matching its input. */
+function makeComposeReplyExecution(data: { external: string; internal?: string }): ExecutionLayer {
+  return {
+    invoke: vi.fn().mockResolvedValue({ success: true, data }),
+    getToolDefinitions: vi.fn().mockReturnValue([]),
+  } as unknown as ExecutionLayer;
+}
+
+async function runComposeReplyTask(
+  provider: LLMProvider,
+  execution: ExecutionLayer,
+): Promise<AgentResponseEvent[]> {
+  const logger = createLogger('silent');
+  const bus = new EventBus(logger);
+  const responses: AgentResponseEvent[] = [];
+
+  bus.subscribe('agent.response', 'dispatch', (ev) => {
+    responses.push(ev as AgentResponseEvent);
+  });
+
+  const agent = new AgentRuntime({
+    agentId: 'coordinator',
+    systemPrompt: 'You are an assistant.',
+    provider,
+    resolvedModel: 'mock-model',
+    bus,
+    logger,
+    executionLayer: execution,
+    pinnedSkills: ['compose-reply'],
+    skillToolDefs: [
+      {
+        name: 'compose-reply',
+        description: 'Compose a two-audience reply',
+        input_schema: {
+          type: 'object' as const,
+          properties: {
+            external: { type: 'string' },
+            internal: { type: 'string' },
+          },
+          required: ['external'],
+        },
+      },
+    ],
+  });
+  agent.register();
+
+  const task = createAgentTask({
+    agentId: 'coordinator',
+    conversationId: 'conv-1',
+    channelId: 'email',
+    senderId: 'armin@example.com',
+    content: 'Can we meet Friday?',
+    parentEventId: 'inbound-1',
+  });
+  await bus.publish('dispatch', task);
+
+  return responses;
+}
+
+describe('AgentRuntime compose-reply detection', () => {
+  it('emits agent.response with content=external and sidebar when compose-reply returns both fields', async () => {
+    const input = { external: 'Friday at 2 PM works.', internal: 'Confirmed Fri 2 PM with Armin; invite pending.' };
+    const provider = makeComposeReplyProvider(input);
+    const execution = makeComposeReplyExecution({ external: input.external, internal: input.internal });
+
+    const responses = await runComposeReplyTask(provider, execution);
+
+    expect(responses).toHaveLength(1);
+    const resp = responses[0]!;
+    expect(resp.payload.content).toBe('Friday at 2 PM works.');
+    expect(resp.payload.sidebar).toEqual({ audience: 'principal', content: 'Confirmed Fri 2 PM with Armin; invite pending.' });
+  });
+
+  it('does not make a second LLM call when compose-reply short-circuits', async () => {
+    const input = { external: 'Friday at 2 PM works.', internal: 'Status for CEO.' };
+    const provider = makeComposeReplyProvider(input);
+    const execution = makeComposeReplyExecution({ external: input.external, internal: input.internal });
+
+    await runComposeReplyTask(provider, execution);
+
+    // LLM should only be called once (the initial tool_use), not again for a text response
+    expect(provider.chat).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits agent.response with content=external and no sidebar when compose-reply has no internal', async () => {
+    const input = { external: 'See you then.' };
+    const provider = makeComposeReplyProvider(input);
+    const execution = makeComposeReplyExecution({ external: input.external });
+
+    const responses = await runComposeReplyTask(provider, execution);
+
+    expect(responses).toHaveLength(1);
+    const resp = responses[0]!;
+    expect(resp.payload.content).toBe('See you then.');
+    expect(resp.payload.sidebar).toBeUndefined();
+  });
+
+  it('falls back to free-text response without sidebar when compose-reply is not called', async () => {
+    const logger = createLogger('silent');
+    const bus = new EventBus(logger);
+    const responses: AgentResponseEvent[] = [];
+
+    bus.subscribe('agent.response', 'dispatch', (ev) => {
+      responses.push(ev as AgentResponseEvent);
+    });
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Friday works for me!',
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-2',
+      channelId: 'email',
+      senderId: 'armin@example.com',
+      content: 'Can we meet Friday?',
+      parentEventId: 'inbound-2',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0]!.payload.content).toBe('Friday works for me!');
+    expect(responses[0]!.payload.sidebar).toBeUndefined();
+  });
+
+  it('continues the tool loop normally when compose-reply returns a failure', async () => {
+    // If compose-reply fails validation, the error is fed back to the LLM
+    // and the loop continues — the runtime should NOT short-circuit on failure.
+    const logger = createLogger('silent');
+    const bus = new EventBus(logger);
+    const responses: AgentResponseEvent[] = [];
+
+    bus.subscribe('agent.response', 'dispatch', (ev) => {
+      responses.push(ev as AgentResponseEvent);
+    });
+
+    let callCount = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'cr-1', name: 'compose-reply', input: { external: '' } }],
+            usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
+          };
+        }
+        return {
+          type: 'text' as const,
+          content: 'Let me try again.',
+          usage: { inputTokens: 100, outputTokens: 10, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      }),
+    };
+
+    const execution: ExecutionLayer = {
+      invoke: vi.fn().mockResolvedValue({ success: false, error: 'external must not be empty' }),
+      getToolDefinitions: vi.fn().mockReturnValue([]),
+    } as unknown as ExecutionLayer;
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: execution,
+      pinnedSkills: ['compose-reply'],
+      skillToolDefs: [
+        {
+          name: 'compose-reply',
+          description: 'Compose reply',
+          input_schema: { type: 'object' as const, properties: { external: { type: 'string' } }, required: ['external'] },
+        },
+      ],
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-3',
+      channelId: 'email',
+      senderId: 'armin@example.com',
+      content: 'What time works?',
+      parentEventId: 'inbound-3',
+    });
+    await bus.publish('dispatch', task);
+
+    // Loop continued; LLM was called twice
+    expect(provider.chat).toHaveBeenCalledTimes(2);
+    expect(responses).toHaveLength(1);
+    // No sidebar — compose-reply failed so no short-circuit
+    expect(responses[0]!.payload.sidebar).toBeUndefined();
+  });
+});

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -1246,3 +1246,82 @@ describe('EmailAdapter — sendOutboundReply CC', () => {
     );
   });
 });
+
+describe('EmailAdapter — fresh-send path (compose-reply sidebar)', () => {
+  // When outbound.payload.subject is set, the adapter must send a fresh email
+  // to recipientId instead of threading into the conversationId thread. This path
+  // is used by the dispatcher's compose-reply sidebar split so the principal update
+  // goes to the CEO, not back to the original external sender's thread.
+
+  let mocks: ReturnType<typeof createMocks>;
+  let triggerOutbound: (event: BusEvent) => Promise<void>;
+
+  beforeEach(async () => {
+    mocks = createMocks();
+    triggerOutbound = captureHandler('outbound.message', mocks);
+    void makeAdapter(mocks).start();
+    // Let the initial poll complete, then reset call counts so assertions only
+    // capture what happens in response to the triggered outbound event.
+    await flushPoll();
+    vi.clearAllMocks();
+    // Re-stub send after clearAllMocks so it still returns a resolved promise.
+    (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, messageId: 'sent-1' });
+  });
+
+  it('sends a fresh email to recipientId using the provided subject (no thread lookup)', async () => {
+    const event = createOutboundMessage({
+      conversationId: 'email:armin-thread',
+      channelId: 'email',
+      content: 'CEO update: confirmed Fri 2 PM with Armin.',
+      recipientId: CEO_EMAIL,
+      subject: 'Task update',
+      parentEventId: 'task-99',
+    });
+
+    await triggerOutbound(event);
+
+    // Must send to the principal, not look up the original thread
+    expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: CEO_EMAIL,
+        subject: 'Task update',
+        body: 'CEO update: confirmed Fri 2 PM with Armin.',
+      }),
+      expect.any(Object),
+    );
+    // Must NOT do a thread lookup (that would route to the external sender)
+    expect(mocks.outboundGateway.listEmailMessages).not.toHaveBeenCalled();
+  });
+
+  it('does not include replyToMessageId in the fresh-send request', async () => {
+    const event = createOutboundMessage({
+      conversationId: 'email:armin-thread',
+      channelId: 'email',
+      content: 'CEO update: confirmed Fri 2 PM with Armin.',
+      recipientId: CEO_EMAIL,
+      subject: 'Task update',
+      parentEventId: 'task-99',
+    });
+
+    await triggerOutbound(event);
+
+    const [[sendArg]] = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls as [[Record<string, unknown>]];
+    expect(sendArg!['replyToMessageId']).toBeUndefined();
+  });
+
+  it('skips delivery and logs an error when subject is set but recipientId is absent', async () => {
+    const event = createOutboundMessage({
+      conversationId: 'email:armin-thread',
+      channelId: 'email',
+      content: 'CEO update.',
+      // recipientId deliberately omitted
+      subject: 'Task update',
+      parentEventId: 'task-99',
+    });
+
+    await triggerOutbound(event);
+
+    expect(mocks.outboundGateway.send).not.toHaveBeenCalled();
+    expect(mocks.outboundGateway.listEmailMessages).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/dispatch/dispatcher.sidebar.test.ts
+++ b/tests/unit/dispatch/dispatcher.sidebar.test.ts
@@ -39,7 +39,7 @@ function makeStubs(principalRouting?: { channelId: string; accountId?: string; r
 
   const dispatcher = new Dispatcher({ bus, logger, principalRouting });
 
-  return { dispatcher, bus, publishedEvents, subscribeHandlers };
+  return { dispatcher, bus, logger, publishedEvents, subscribeHandlers };
 }
 
 /** Seeds the routing table for an inbound task. */
@@ -158,6 +158,7 @@ describe('Dispatcher sidebar split', () => {
 
     const outbounds = publishedEvents.filter(isOutboundMessage);
     const principal = outbounds.find(e => e.payload.recipientId === 'ceo@example.com');
+    expect(principal).toBeDefined();
     expect(principal!.payload.channelId).toBe('email');
     expect(principal!.payload.accountId).toBe('curia');
   });
@@ -179,8 +180,8 @@ describe('Dispatcher sidebar split', () => {
 
   it('publishes only one outbound.message when sidebar is present but principalRouting is not configured', async () => {
     // If the dispatcher has no principalRouting, it cannot deliver the sidebar —
-    // it still sends the external reply but silently drops the sidebar.
-    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(/* no principalRouting */);
+    // it still sends the external reply but permanently drops the sidebar.
+    const { dispatcher, subscribeHandlers, publishedEvents, logger } = makeStubs(/* no principalRouting */);
     dispatcher.register();
 
     seedRouting(dispatcher, 'task-6', { senderId: 'armin@example.com' });
@@ -194,6 +195,9 @@ describe('Dispatcher sidebar split', () => {
     // Only the external message goes out — sidebar is dropped (no principal routing)
     expect(outbounds).toHaveLength(1);
     expect(outbounds[0]!.payload.content).toBe('External reply.');
+    // The dropped sidebar is a misconfiguration — must be logged at error so it
+    // doesn't silently vanish and can be detected in operational monitoring.
+    expect(logger.error).toHaveBeenCalled();
   });
 
   it('suppresses both the external outbound and the sidebar when reply-lock is active', async () => {

--- a/tests/unit/dispatch/dispatcher.sidebar.test.ts
+++ b/tests/unit/dispatch/dispatcher.sidebar.test.ts
@@ -1,0 +1,198 @@
+// dispatcher.sidebar.test.ts — tests for the sidebar split in handleAgentResponse.
+//
+// When an agent.response carries a sidebar field and the dispatcher is
+// configured with principalRouting, it must publish two outbound.message
+// events: one to the inbound sender (external content only) and one to
+// the principal (sidebar content only). The sidebar text must never appear
+// in the external outbound, and vice versa.
+
+import { describe, it, expect, vi } from 'vitest';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { Logger } from '../../../src/logger.js';
+import {
+  createAgentResponse,
+  type BusEvent,
+  type OutboundMessageEvent,
+} from '../../../src/bus/events.js';
+
+function isOutboundMessage(e: BusEvent): e is OutboundMessageEvent {
+  return e.type === 'outbound.message';
+}
+
+function makeStubs(principalRouting?: { channelId: string; accountId?: string; recipientId: string }) {
+  const publishedEvents: BusEvent[] = [];
+  const subscribeHandlers = new Map<string, (event: BusEvent) => void | Promise<void>>();
+
+  const bus = {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: BusEvent) => void | Promise<void>) => {
+      subscribeHandlers.set(eventType, handler);
+    }),
+    publish: vi.fn(async (_layer: string, event: BusEvent) => {
+      publishedEvents.push(event);
+    }),
+  } as unknown as EventBus;
+
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  } as unknown as Logger;
+
+  const dispatcher = new Dispatcher({ bus, logger, principalRouting });
+
+  return { dispatcher, bus, publishedEvents, subscribeHandlers };
+}
+
+/** Seeds the routing table for an inbound task. */
+function seedRouting(
+  dispatcher: Dispatcher,
+  taskEventId: string,
+  opts: { channelId?: string; conversationId?: string; senderId?: string; accountId?: string } = {},
+) {
+  (dispatcher as unknown as {
+    taskRouting: Map<string, {
+      channelId: string;
+      conversationId: string;
+      senderId: string;
+      accountId?: string;
+      humanReplySent: boolean;
+    }>;
+  }).taskRouting.set(taskEventId, {
+    channelId: opts.channelId ?? 'email',
+    conversationId: opts.conversationId ?? 'email:thread-abc',
+    senderId: opts.senderId ?? 'armin@example.com',
+    accountId: opts.accountId,
+    humanReplySent: false,
+  });
+}
+
+async function fireAgentResponse(
+  subscribeHandlers: Map<string, (event: BusEvent) => void | Promise<void>>,
+  opts: {
+    taskEventId: string;
+    content?: string;
+    sidebar?: { audience: 'principal'; content: string };
+    conversationId?: string;
+    agentId?: string;
+  },
+) {
+  const event = createAgentResponse({
+    agentId: opts.agentId ?? 'coordinator',
+    conversationId: opts.conversationId ?? 'email:thread-abc',
+    content: opts.content ?? 'ok',
+    ...(opts.sidebar !== undefined && { sidebar: opts.sidebar }),
+    parentEventId: opts.taskEventId,
+  });
+  const handler = subscribeHandlers.get('agent.response');
+  if (!handler) throw new Error('No agent.response handler registered');
+  await handler(event);
+}
+
+describe('Dispatcher sidebar split', () => {
+  it('publishes two outbound.message events when sidebar is present and principalRouting is configured', async () => {
+    const principalRouting = { channelId: 'email', accountId: 'curia', recipientId: 'ceo@example.com' };
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(principalRouting);
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-1', { senderId: 'armin@example.com', channelId: 'email', accountId: 'curia' });
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-1',
+      content: 'Friday at 2 PM works!',
+      sidebar: { audience: 'principal', content: 'Confirmed Fri 2 PM with Armin; invite pending.' },
+    });
+
+    const outbounds = publishedEvents.filter(isOutboundMessage);
+    expect(outbounds).toHaveLength(2);
+  });
+
+  it('sends the external content (not sidebar) to the inbound sender', async () => {
+    const principalRouting = { channelId: 'email', accountId: 'curia', recipientId: 'ceo@example.com' };
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(principalRouting);
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-2', { senderId: 'armin@example.com', channelId: 'email' });
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-2',
+      content: 'Friday at 2 PM works!',
+      sidebar: { audience: 'principal', content: 'Status for CEO.' },
+    });
+
+    const outbounds = publishedEvents.filter(isOutboundMessage);
+    const external = outbounds.find(e => e.payload.recipientId === 'armin@example.com');
+    expect(external).toBeDefined();
+    expect(external!.payload.content).toBe('Friday at 2 PM works!');
+    // Sidebar text must NOT appear in the external outbound
+    expect(external!.payload.content).not.toContain('Status for CEO.');
+  });
+
+  it('sends the sidebar content (not external) to the principal', async () => {
+    const principalRouting = { channelId: 'email', accountId: 'curia', recipientId: 'ceo@example.com' };
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(principalRouting);
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-3', { senderId: 'armin@example.com', channelId: 'email' });
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-3',
+      content: 'Friday at 2 PM works!',
+      sidebar: { audience: 'principal', content: 'Status for CEO.' },
+    });
+
+    const outbounds = publishedEvents.filter(isOutboundMessage);
+    const principal = outbounds.find(e => e.payload.recipientId === 'ceo@example.com');
+    expect(principal).toBeDefined();
+    expect(principal!.payload.content).toBe('Status for CEO.');
+    // External text must NOT appear in the principal outbound
+    expect(principal!.payload.content).not.toContain('Friday at 2 PM works!');
+  });
+
+  it('routes the principal outbound through the correct channelId and accountId', async () => {
+    const principalRouting = { channelId: 'email', accountId: 'curia', recipientId: 'ceo@example.com' };
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(principalRouting);
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-4', { senderId: 'armin@example.com', channelId: 'email', accountId: 'work' });
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-4',
+      content: 'External reply.',
+      sidebar: { audience: 'principal', content: 'CEO update.' },
+    });
+
+    const outbounds = publishedEvents.filter(isOutboundMessage);
+    const principal = outbounds.find(e => e.payload.recipientId === 'ceo@example.com');
+    expect(principal!.payload.channelId).toBe('email');
+    expect(principal!.payload.accountId).toBe('curia');
+  });
+
+  it('publishes only one outbound.message when sidebar is absent', async () => {
+    const principalRouting = { channelId: 'email', accountId: 'curia', recipientId: 'ceo@example.com' };
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(principalRouting);
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-5', { senderId: 'armin@example.com' });
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-5',
+      content: 'Just a plain reply.',
+    });
+
+    const outbounds = publishedEvents.filter(isOutboundMessage);
+    expect(outbounds).toHaveLength(1);
+  });
+
+  it('publishes only one outbound.message when sidebar is present but principalRouting is not configured', async () => {
+    // If the dispatcher has no principalRouting, it cannot deliver the sidebar —
+    // it still sends the external reply but silently drops the sidebar.
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(/* no principalRouting */);
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-6', { senderId: 'armin@example.com' });
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-6',
+      content: 'External reply.',
+      sidebar: { audience: 'principal', content: 'Sidebar text.' },
+    });
+
+    const outbounds = publishedEvents.filter(isOutboundMessage);
+    // Only the external message goes out — sidebar is dropped (no principal routing)
+    expect(outbounds).toHaveLength(1);
+    expect(outbounds[0]!.payload.content).toBe('External reply.');
+  });
+});

--- a/tests/unit/dispatch/dispatcher.sidebar.test.ts
+++ b/tests/unit/dispatch/dispatcher.sidebar.test.ts
@@ -195,4 +195,40 @@ describe('Dispatcher sidebar split', () => {
     expect(outbounds).toHaveLength(1);
     expect(outbounds[0]!.payload.content).toBe('External reply.');
   });
+
+  it('suppresses both the external outbound and the sidebar when reply-lock is active', async () => {
+    // When humanReplySent=true (email-reply or email-send already fired), the entire
+    // handleAgentResponse returns early — neither the external outbound nor the sidebar
+    // is sent. The sidebar is intentionally dropped because the compose-reply flow was
+    // abandoned mid-task (email-reply already sent the external message independently).
+    const principalRouting = { channelId: 'email', accountId: 'curia', recipientId: 'ceo@example.com' };
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(principalRouting);
+    dispatcher.register();
+
+    // Seed routing with humanReplySent = true
+    (dispatcher as unknown as {
+      taskRouting: Map<string, {
+        channelId: string;
+        conversationId: string;
+        senderId: string;
+        accountId?: string;
+        humanReplySent: boolean;
+      }>;
+    }).taskRouting.set('task-lock', {
+      channelId: 'email',
+      conversationId: 'email:thread-abc',
+      senderId: 'armin@example.com',
+      humanReplySent: true,
+    });
+
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-lock',
+      content: 'External reply.',
+      sidebar: { audience: 'principal', content: 'Sidebar that should NOT be sent.' },
+    });
+
+    const outbounds = publishedEvents.filter(isOutboundMessage);
+    // Reply-lock: both external and sidebar suppressed
+    expect(outbounds).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

Implements **Layer B** of the 2026-06-01 audience-leak remediation ([docs/wip/2026-06-02-outbound-audience-leak.md](https://github.com/josephfung/curia/blob/main/docs/wip/2026-06-02-outbound-audience-leak.md)).

The root cause of the 2026-06-01 incident was that the coordinator emits a single free-text blob that becomes the email body verbatim — no way to say "this part is for Armin, this part is for the CEO." Layer B eliminates that failure mode at the source.

- **New `compose-reply` skill** (`skills/compose-reply/`) — action_risk: none. The coordinator calls it with `external` (text safe for the contact) and optionally `internal` (principal-only status update). Validated inputs, pure shape.
- **Runtime short-circuit** — when `compose-reply` succeeds, the runtime skips the next LLM round-trip and emits `agent.response` with `content = external` and `sidebar = { audience: 'principal', content: internal }` (mirrors the `request-clarification` pattern).
- **Dispatcher sidebar split** — `handleAgentResponse` publishes a second `outbound.message` to the principal when `sidebar` is present and `principalRouting` is configured. Each piece goes through `OutboundGateway` and the content filter independently.
- **`AgentResponsePayload`** extended with optional `sidebar` (public API surface change, noted in CHANGELOG).
- **Coordinator prompt** updated with explicit `compose-reply` guidance in the Audience Awareness section; skill pinned.

Closes #851

## Error handling

- `bus.publish` in the runtime short-circuit happens **before** `memory.addTurn` — publish failure never leaves a phantom turn in conversation history.
- Sidebar publish wrapped in try/catch — failure logs at error level with sidebar content preview for operator recovery; does not abort checkpoint scheduling.
- Sidebar drop when `principalRouting` is absent logs at error level (not warn).
- Reply-lock (`humanReplySent=true`) intentionally suppresses both external and sidebar (documented with comment + test).

## Test plan

- [x] `skills/compose-reply/handler.test.ts` — 9 tests: happy path, validation, trimming, optional internal
- [x] `tests/unit/agents/runtime.compose-reply.test.ts` — 5 tests: both fields, no second LLM call, external-only, free-text back-compat, failure continues loop
- [x] `tests/unit/dispatch/dispatcher.sidebar.test.ts` — 7 tests: two outbounds, content isolation, channel/accountId routing, absent sidebar, no principalRouting, reply-lock suppression
- [x] `pnpm run typecheck` — clean
- [x] Full test suite: 3221 passing (3 pre-existing DB-connectivity failures, unchanged)


___

## **CodeAnt-AI Description**
**Split replies between the external recipient and the principal**

### What Changed
- Added a new reply format that lets the coordinator send one message to the contact and a separate status update to the principal
- The app now delivers the external reply and principal update as two distinct outbound messages, so the principal-only text never appears in the contact-facing email
- If the reply is already sent by another path, both the external reply and the principal update are skipped to avoid duplicate sends
- Improved validation and logging around the new reply format so failed or misrouted principal updates are reported clearly

### Impact
`✅ Fewer audience leaks in outgoing email`
`✅ Clearer status updates for principals`
`✅ Fewer duplicate reply sends`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added compose-reply skill enabling coordinators to partition replies into external recipient content and principal-only status updates
  * Introduced principal sidebar messaging for audience-safe delivery of sensitive information
  * Enhanced message dispatcher with principal-directed routing configuration

* **Changed**
  * Agent response structure extended with optional sidebar field for principal-only content
  * Version updated to 0.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->