### PR TITLE
fix: send separate messages for external + principal (#851 Layer B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`⚠️ Stuck` label** — ceo-inbox now applies this label when triage cannot complete for a message (unrecognised classification value, required skill failure, or error budget boundary hit), making failures visible in the Gmail sidebar.
 
 ### Changed
+- **coordinator prompt** — when replying to an external contact and a simultaneous principal update is needed, Curia now sends two separate messages rather than mixing both in one body. Closes #851.
 - **ceo-inbox triage labels** — renamed to emoji-prefixed variants for better readability in the Gmail sidebar: `URGENT` → `🚨 Urgent`, `ACTIONABLE` → `✅ Handled`, `NEEDS DRAFT` → `✍️ Drafted`, `LEAVE FOR CEO` → `📌 Seen`, `NOISE` → `✔️ Cleared`. Existing Gmail labels with the old names are inert and won't appear on new messages.
 - **`🚨 Urgent` messages are starred automatically** — after step 4h's bullpen notification, ceo-inbox calls `ceo-inbox-mark-starred`. Starring failure is logged but does not abort the run.
 - **KG graph** — various visual improvements: physics-aware layout, better hub sizing, principal-node default view, and viewport centering on focal nodes. (#861)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.6.0"
+version: "0.6.1"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -198,6 +198,12 @@ system_prompt: |
   - The person should experience you as a competent human assistant, not as software
     with visible internals.
   - Sign emails professionally using your name and title from the identity block above.
+  - If you are composing a message to a non-principal contact and you simultaneously
+    need to send the principal a status update or note, send them as two separate
+    messages — reply or send to the external contact first, then use `email-send` (or
+    the equivalent channel skill) to reach the principal using their contact details
+    from the Principal Contact Details block. **Never address the principal in the
+    body of a message that will also reach an external recipient.**
 
   **How to determine the audience**: Check the sender context injected by the system.
   - If the sender's role is "ceo", you're talking to the CEO.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -199,7 +199,8 @@ system_prompt: |
     with visible internals.
   - Sign emails professionally using your name and title from the identity block above.
   - If you are composing a message to a non-principal contact and you simultaneously
-    need to send the principal a status update or note, treat them as two independent
+    need to send the principal a status update or note arising from this same
+    interaction, treat them as two independent
     actions: (1) send the external reply as you normally would, following the reply
     rules in the Sending and replying section; (2) make a separate outbound call to
     the principal — use `email-send`, `signal-send`, or whichever skill matches their

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -201,9 +201,9 @@ system_prompt: |
   - If you are composing a message to a non-principal contact and you simultaneously
     need to send the principal a status update or note, treat them as two independent
     actions: (1) send the external reply as you normally would, following the reply
-    rules in the Sending and replying section; (2) make a separate `email-send` call
-    to the principal using their contact details from the Principal Contact Details
-    block. **Never address the principal in the body of a message that will also
+    rules in the Sending and replying section; (2) make a separate outbound call to
+    the principal — use `email-send`, `signal-send`, or whichever skill matches their
+    preferred channel in the Principal Contact Details block. **Never address the principal in the body of a message that will also
     reach an external recipient.**
 
   **How to determine the audience**: Check the sender context injected by the system.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.6.1"
+version: "0.6.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -199,11 +199,12 @@ system_prompt: |
     with visible internals.
   - Sign emails professionally using your name and title from the identity block above.
   - If you are composing a message to a non-principal contact and you simultaneously
-    need to send the principal a status update or note, send them as two separate
-    messages — reply or send to the external contact first, then use `email-send` (or
-    the equivalent channel skill) to reach the principal using their contact details
-    from the Principal Contact Details block. **Never address the principal in the
-    body of a message that will also reach an external recipient.**
+    need to send the principal a status update or note, treat them as two independent
+    actions: (1) send the external reply as you normally would, following the reply
+    rules in the Sending and replying section; (2) make a separate `email-send` call
+    to the principal using their contact details from the Principal Contact Details
+    block. **Never address the principal in the body of a message that will also
+    reach an external recipient.**
 
   **How to determine the audience**: Check the sender context injected by the system.
   - If the sender's role is "ceo", you're talking to the CEO.


### PR DESCRIPTION
## **User description**
## Summary

- Adds a single prompt instruction to the coordinator: when composing a message to a non-principal contact and a simultaneous principal update is needed, send them as two independent messages rather than mixing both into one body.
- Replaces the `compose-reply` skill + dispatcher routing + email adapter changes in #907, which was a more complex but equivalent implementation.

Closes #851

## What changed

`agents/coordinator.yaml` — new bullet in the "Talking to anyone who is NOT the CEO" section:

> If you are composing a message to a non-principal contact and you simultaneously need to send the principal a status update or note, treat them as two independent actions: (1) send the external reply as you normally would, following the reply rules in the Sending and replying section; (2) make a separate outbound call to the principal — use `email-send`, `signal-send`, or whichever skill matches their preferred channel in the Principal Contact Details block. **Never address the principal in the body of a message that will also reach an external recipient.**

## Why this approach instead of #907

The coordinator already has `email-send`, `signal-send`, and the principal's contact details injected at runtime. The structural enforcement from the custom skill (atomicity, dispatcher routing, fresh-send path) added ~250 lines of infrastructure for a guarantee (both messages or neither) that isn't load-bearing here. A missed principal update is an annoying miss, not a data leak — and the LLM judge (Layer A, already live) remains the backstop against the actual harm.

## Known limitation

The judge has no visibility into whether the two-message pattern was followed (it only sees the composed message body). If the coordinator ignores the guidance, leaks are caught by the judge only if the leaked content is detectable in the external message. This is inherent to the prompt-only approach. A follow-up issue covers adding observability to confirm both messages were sent per task turn.

## Test plan

- [ ] Deploy and send an external email to Curia that warrants both a reply and a principal update (e.g. a meeting request from a third party)
- [ ] Confirm the external contact receives only their reply, with no principal-directed content
- [ ] Confirm a separate message arrives at the principal's preferred channel
- [ ] Confirm a plain reply (no principal update needed) still produces exactly one outbound message


___

## **CodeAnt-AI Description**
**Keep external replies separate from principal updates**

### What Changed
- When Curia needs to reply to an external contact and also notify the principal, it now sends two separate messages instead of combining both into one.
- The external recipient only gets the reply they should see; the principal gets a separate update through their preferred channel.
- The change is also noted in the changelog as a behavior update.

### Impact
`✅ Fewer mixed-up external replies`
`✅ Clearer principal updates`
`✅ Lower risk of exposing private notes to outside contacts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
