### PR TITLE
fix: scope Scorecard write permissions to job level

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,15 +9,19 @@ on:
   # Required for SARIF upload when triggered by schedule/push
   workflow_dispatch:
 
+# Minimal top-level permissions; write permissions scoped to the job because
+# the Scorecard API rejects workflows where security-events: write is global.
 permissions:
   contents: read
-  security-events: write  # for SARIF upload
-  id-token: write         # for publishing results to OpenSSF API
 
 jobs:
   scorecard:
     name: Scorecard Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # for SARIF upload
+      id-token: write         # for publishing results to OpenSSF API
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## **User description**
## Summary

- Moves `security-events: write` and `id-token: write` from the global `permissions:` block to the `scorecard` job's `permissions:` block
- Leaves only `contents: read` at the top level

## Why

The first Scorecard run (after #909 merged) failed at publish time with:

```
error: workflow verification failed: global perm is set to write:
permission for security-events is set to write
```

The OpenSSF Scorecard API performs its own workflow-verification step before accepting results. It rejects any workflow that declares write permissions globally, even if those permissions are functionally scoped to a single job. Write permissions must be declared at the job level.

The scan itself completed (score: 5.6/10) and SARIF was generated, but results could not be published to securityscorecards.dev and the badge could not go live.

## Test plan

- [ ] Merge triggers a push event → Scorecard workflow runs
- [ ] Run completes without the 400 error from securityscorecards.dev
- [ ] Badge at `https://api.securityscorecards.dev/projects/github.com/josephfung/curia/badge` becomes live
- [ ] Results visible at `https://securityscorecards.dev/viewer/?uri=github.com/josephfung/curia`
- [ ] SARIF appears in GitHub Security tab under Scorecard category

Closes #565 (follow-up fix after #909).


___

## **CodeAnt-AI Description**
**Add OpenSSF Scorecard checks and publish the results**

### What Changed
- Added a weekly and push-triggered Scorecard workflow to scan the repository for supply-chain security issues
- Scorecard results now publish to the GitHub Security tab and to securityscorecards.dev
- Added an OpenSSF Scorecard badge to the README so the current score is visible from the project page
- Scoped the workflow’s write access to the Scorecard job so publishing works correctly

### Impact
`✅ Visible supply-chain security score`
`✅ Weekly security checks without manual runs`
`✅ Live badge and Security tab results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
