### PR TITLE
chore: migrate secrets out of .env into the encrypted vault (#911)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,16 +8,17 @@ DB_PASSWORD=your-db-password
 # at the wrong DB (or no DB at all).
 DATABASE_URL=postgres://curia:your-db-password@localhost:5432/curia
 
-# LLM Providers
-ANTHROPIC_API_KEY=sk-ant-...
-# OpenAI — used for knowledge graph embeddings (text-embedding-3-small)
-# and smoke test judge (GPT-4o). Optional: system works without it but
-# entity memory and smoke tests will be unavailable.
-OPENAI_API_KEY=sk-...
-# OpenRouter — routes non-Claude models (Gemini, DeepSeek, GPT-4o, etc.)
-# through a single API. Optional: system works without it but OpenRouter
-# models in the registry will be unavailable.
-# OPENROUTER_API_KEY=sk-or-...
+# === Secrets: managed in the encrypted vault, NOT here ===
+#
+# All API keys and tokens (Anthropic, OpenAI, OpenRouter, Nylas, Tavily, the HTTP
+# API_TOKEN, WEB_APP_BOOTSTRAP_SECRET, Signal number) live in the encrypted secrets
+# vault, not in this file. `pnpm run setup` seeds them after migrations. To add or
+# update one later, set it transiently and seed it:
+#
+#   NYLAS_API_KEY=nyk_... pnpm run seed-vault
+#
+# Only the four values needed to reach and unlock the vault — plus non-secret config
+# below — belong in .env. (Google Workspace OAuth secrets are migrated separately, #913.)
 
 # TLS (macOS only) — Node installed via nvm/fnm bundles its own CA store
 # and doesn't trust macOS system certificates. If HTTPS fetch fails with
@@ -30,7 +31,6 @@ OPENAI_API_KEY=sk-...
 
 # HTTP API
 HTTP_PORT=3000
-API_TOKEN=your-secret-token-here
 
 # Postgres host port (Docker Compose). Override only if 5432 is already bound on
 # the host — e.g. running a parallel curia stack against a sibling clone for
@@ -39,40 +39,23 @@ API_TOKEN=your-secret-token-here
 # host-side migrations connect via DATABASE_URL, not via the docker network.
 # POSTGRES_PORT=5432
 
-# Knowledge Graph web explorer
-# Secret required by /api/kg/* endpoints (sent as x-web-bootstrap-secret from the /kg UI).
-# If unset, the knowledge graph explorer API is disabled.
-WEB_APP_BOOTSTRAP_SECRET=replace-with-a-long-random-secret
-
 # Secrets vault master key — encrypts all stored credentials (AES-256-GCM). REQUIRED.
 # 32 random bytes, base64-encoded. Generate: openssl rand -base64 32
 # pnpm run setup fills this in automatically.
 SECRET_ENCRYPTION_KEY=replace-with-output-of-openssl-rand-base64-32
 
-# Nylas — unified email, calendar, and contacts API (https://nylas.com).
-# Powers the email channel adapter. Optional: system works without it
-# but email send/receive will be unavailable.
-# NYLAS_API_KEY: application API key from the Nylas dashboard
-# NYLAS_GRANT_ID: identifier for the connected email account
-# NYLAS_SELF_EMAIL: Curia's email address (filters self-sent messages, signs outbound emails)
-NYLAS_API_KEY=nyk_v0_...
-NYLAS_GRANT_ID=
-NYLAS_SELF_EMAIL=curia@yourdomain.com
-# Polling interval in milliseconds (default: 30000 = 30 seconds)
+# Nylas email polling interval in milliseconds (default: 30000 = 30 seconds).
+# Non-secret config; the Nylas API key, grant ID, and self-email live in the vault.
 # NYLAS_POLL_INTERVAL_MS=30000
 
 # === Optional: Signal Channel (signal-cli) ===
 #
-# The Signal adapter activates when both vars are set.
-# SIGNAL_PHONE_NUMBER: E.164 format, e.g. +12223334444
-#   This must be the number you registered via `signal-cli register` + `verify`.
+# The Signal phone number (E.164 format, e.g. +12223334444) — the number you
+# registered via `signal-cli register` + `verify` — is a vault-managed secret.
 # SIGNAL_SOCKET_PATH is managed by the deployment layer — do not set it here.
 #
-# IMPORTANT: Before setting these, you must seed the signal-data Docker volume
+# IMPORTANT: Before enabling Signal, you must seed the signal-data Docker volume
 # with your registered account credentials (see your deployment documentation).
-
-# SIGNAL_PHONE_NUMBER=+12223334444
-
 
 # CEO's primary email address. Optional.
 #
@@ -94,11 +77,6 @@ NYLAS_SELF_EMAIL=curia@yourdomain.com
 # Used to resolve relative dates ("next Friday") in agent prompts.
 # Override via KG entity fact when traveling (future feature).
 TIMEZONE=America/Toronto
-
-# Web search — Tavily API (https://tavily.com)
-# Powers the web-search skill for research and lookup queries.
-# Get your key from the Tavily dashboard after signing up.
-TAVILY_API_KEY=tvly-...
 
 # === Optional: Google Drive / Workspace (MCP) ===
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **pnpm overrides moved to `pnpm-workspace.yaml`** — pnpm v10+ ignores `pnpm.overrides` in package.json, so the existing pins (qs, ip-address, vite, fast-uri, hono) had silently stopped applying; relocated to the supported file.
 - **On-demand Trivy image scan** — the container vulnerability scan now supports `workflow_dispatch`, so base-image/dependency CVE fixes can be re-verified immediately instead of waiting for the weekly schedule.
 - **Least-privilege workflow tokens** — security workflows default `GITHUB_TOKEN` to read-only, granting write scopes per-job. Clears 4 Scorecard `TokenPermissionsID` alerts. (#921)
+- **Secrets migrated out of `.env` into the vault** — API keys and tokens now resolve from the encrypted vault only, with no env fallback; only the four DB/encryption bootstrap values stay in `.env`. Seeded by a new `seed-vault` script and `setup.sh`. See ADR-021. (#911)
 
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **pnpm overrides moved to `pnpm-workspace.yaml`** — pnpm v10+ ignores `pnpm.overrides` in package.json, so the existing pins (qs, ip-address, vite, fast-uri, hono) had silently stopped applying; relocated to the supported file.
 - **On-demand Trivy image scan** — the container vulnerability scan now supports `workflow_dispatch`, so base-image/dependency CVE fixes can be re-verified immediately instead of waiting for the weekly schedule.
 - **Least-privilege workflow tokens** — security workflows default `GITHUB_TOKEN` to read-only, granting write scopes per-job. Clears 4 Scorecard `TokenPermissionsID` alerts. (#921)
-- **Secrets migrated out of `.env` into the vault** — API keys and tokens now resolve from the encrypted vault only, with no env fallback; only the four DB/encryption bootstrap values stay in `.env`. Seeded by a new `seed-vault` script and `setup.sh`. See ADR-021. (#911)
+- **Secrets migrated out of `.env` into the vault** — application secrets resolve from the encrypted vault only (no env fallback); just the four DB/encryption bootstrap values stay in `.env`. See ADR-021. (#911)
 
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 

--- a/docs/adr/021-vault-only-secret-resolution.md
+++ b/docs/adr/021-vault-only-secret-resolution.md
@@ -1,0 +1,122 @@
+# ADR-021: Vault-only secret resolution (no env fallback)
+
+Date: 2026-06-08
+Status: Accepted
+
+## Context
+
+[ADR-020](020-secrets-vault.md) shipped the encrypted secrets vault (#542) with a
+deliberate env-var fallback: `ctx.secret()` and the bootstrap config readers checked
+the vault first, then fell back to `process.env`. That fallback was a rollout
+affordance — it let the vault land without simultaneously moving every secret out of
+`.env`, so a half-migrated install still booted.
+
+The fallback was always meant to be temporary. As long as it exists:
+
+- Plaintext secrets keep living in `.env`, which is the exposure ADR-020 set out to
+  remove. A compromised host still reads every credential from the process environment.
+- A value can silently diverge between the vault and `.env` — the vault has the new
+  key, `.env` still has the old one, and the fallback masks which one actually wins.
+  That is a genuine debugging hazard ("why is it still using the old key?").
+
+#911 removes the payoff: migrate every secret into the vault and delete the env
+fallback. The open question this ADR settles is **what stays in `.env`** and **how
+fresh installs avoid an empty-vault boot failure** once there's no fallback to cushion
+them.
+
+**Alternative considered — overlay with env fallback (vault-first, then `?? process.env`):**
+Keep reading the vault first but retain the env fallback indefinitely. Rejected. It
+perpetuates exactly the two problems above: plaintext lingers in `.env`, and a
+vault/env divergence stays invisible because the fallback quietly resolves it. The
+debuggability cost ("which copy am I actually using?") outweighs the small convenience
+of a soft landing on a missing secret.
+
+## Decision
+
+**Vault-only resolution. No env fallback for any secret** — except the four values
+that bootstrap the vault itself:
+
+- `DB_USER`, `DB_PASSWORD`, `DATABASE_URL` — needed to connect to the Postgres
+  instance that *hosts* the vault.
+- `SECRET_ENCRYPTION_KEY` — the AES-256-GCM key that *decrypts* the vault.
+
+A secret cannot live in the vault it unlocks, so these four remain in `.env` by
+necessity. (Non-secret config — `HTTP_PORT`, `LOG_LEVEL`, `TIMEZONE` — and identity
+config — `CEO_PRIMARY_EMAIL`, `CEO_SIGNAL_NUMBER` — also stay in `.env`, but they are
+not secrets and are out of scope here.)
+
+Every other secret resolves from the vault only. There is no `?? process.env`.
+
+**Two consumption paths:**
+
+1. **Skill secrets via `ctx.secret()`** — already vault-first from ADR-020. #911 drops
+   its env fallback so it is now vault-only. Skill reads still emit the
+   `secret.accessed` audit event with `source: 'vault'`.
+2. **Bootstrap/config secrets via `applyVaultSecrets(config, secretsService, logger)`**
+   (`src/secrets/apply-vault-secrets.ts`). It runs in `src/index.ts` immediately after
+   the vault is constructed and migrations have run, and overwrites the config secret
+   fields (Anthropic, OpenAI, OpenRouter, API token, web-app bootstrap secret, Nylas
+   trio, Signal number) from the vault. `loadConfig()` no longer reads any of these
+   from env — `applyVaultSecrets` is the single place they enter `Config`.
+
+**Seeding.** `scripts/seed-vault.ts` (`pnpm run seed-vault`) reads the current env
+values and upserts every present one into the vault (`set()` is an idempotent upsert;
+absent/empty values are skipped, never cleared). `setup.sh` runs it after migrations,
+so a fresh install seeds the vault before the app's first boot and never faces an
+empty vault. To add or update one secret later, supply it as a transient env var:
+`VAR=value pnpm run seed-vault`.
+
+**Why `ANTHROPIC_API_KEY` is not a special env exception.** It's tempting to keep
+Anthropic in `.env` since "the app is useless without it." But it doesn't need to be:
+the vault is constructed (and seeded, on fresh installs, by `setup.sh`) *before*
+`applyVaultSecrets` reads Anthropic and before any provider consumes it. The
+fresh-boot concern that would justify an exception is already solved by setup-time
+seeding, so Anthropic lives in the vault like every other secret.
+
+## Consequences
+
+**Easier / safer:**
+
+- `.env` shrinks to the four bootstrap values plus non-secret config. A compromised
+  host no longer leaks API keys from the process environment — only the encryption key
+  and DB credentials (which a host already needs to reach the data).
+- No silent vault/env divergence. There is exactly one source of truth per secret, so
+  "which copy is it using?" stops being a question.
+
+**Accepted trade-offs / risks:**
+
+- **Fresh installs must seed the vault before first boot.** Handled automatically by
+  `setup.sh` (seed runs after migrations, before `docker compose up`). A from-scratch
+  boot that skips `setup.sh` will fail closed on the first required secret.
+- **Rollout order matters for existing deployments.** With no fallback to cushion an
+  empty vault, you must run `seed-vault` (populating the vault from the live `.env`)
+  *before* deploying the vault-only code. Deploy-then-seed would crash on boot.
+- **Bootstrap (non-skill) secret reads are not audited.** This is a deliberate choice:
+  `applyVaultSecrets` runs once at boot and is not part of the per-invocation skill
+  path that the `secret.accessed` event covers. Bootstrap-only secrets are verified by
+  checking the vault row exists, not via an audit event. Skill reads still audit with
+  `source: 'vault'`.
+- **A missing required secret fails closed.** Most secrets fail at their consumer (e.g.
+  `anthropic_api_key`'s startup check). `api_token` is the exception that needed an
+  explicit boot guard: its HTTP-auth consumer (`validateBearerToken`) fails *open* —
+  no token configured means auth is disabled — so under vault-only resolution an absent
+  row would silently expose the API. `src/index.ts` therefore refuses to boot when
+  `api_token` is absent. As a second layer, `setup.sh` runs `seed-vault` with
+  `SEED_VAULT_VERIFY=1`, which confirms the required rows (`anthropic_api_key`,
+  `api_token`, `web_app_bootstrap_secret`) were actually persisted and aborts the install
+  otherwise — closing the resume-path gap where a secret could be skipped. Optional
+  secrets (OpenAI, OpenRouter, Signal) stay feature-gated by their existing `if (config.x)`
+  guards, so their absence disables a feature rather than failing the boot.
+
+## Known limitations
+
+- **Multi-account YAML email is not covered.** When `channel_accounts.email` is
+  configured in `config/local.yaml`, `resolveChannelAccounts()` (`src/config.ts`)
+  resolves each account's `nylas_grant_id` / `self_email` via `resolveEnvValue()`,
+  which reads `env:VAR` references straight from `process.env` — bypassing the vault.
+  #911 only migrates the legacy single-account path (`config.nylasGrantId`). So
+  "vault-only" is not whole-system true for multi-account YAML deployments. No such
+  deployment is live yet; routing the `env:VAR` resolver through the vault is tracked
+  as follow-up in #920.
+- **Google Workspace OAuth secrets are deferred to #913.** They are not part of #911's
+  migration and are tracked separately.

--- a/docs/adr/021-vault-only-secret-resolution.md
+++ b/docs/adr/021-vault-only-secret-resolution.md
@@ -19,7 +19,7 @@ The fallback was always meant to be temporary. As long as it exists:
   key, `.env` still has the old one, and the fallback masks which one actually wins.
   That is a genuine debugging hazard ("why is it still using the old key?").
 
-#911 removes the payoff: migrate every secret into the vault and delete the env
+Issue #911 removes the payoff: migrate every secret into the vault and delete the env
 fallback. The open question this ADR settles is **what stays in `.env`** and **how
 fresh installs avoid an empty-vault boot failure** once there's no fallback to cushion
 them.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,7 @@ Each ADR follows the [Nygard format](https://adr.github.io/):
 | [018](018-curia-initiated-approval-requests.md) | Curia-initiated approval requests via unified `autonomy_action_log` state machine | Accepted |
 | [019](019-delegation-aware-outbound-context.md) | Delegation-aware outbound context via a dedicated registry (replaces v1 context-memo) | Accepted |
 | [020](020-secrets-vault.md) | Application-layer AES-256-GCM secrets vault in PostgreSQL — structural typing, per-invocation pre-warm cache, env-var fallback for incremental migration | Accepted |
+| [021](021-vault-only-secret-resolution.md) | Vault-only secret resolution — remove the env fallback; only the four vault-bootstrap values stay in `.env`, everything else seeds via `seed-vault` | Accepted |
 
 ## Adding new ADRs
 

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -2,7 +2,7 @@
 
 Curia is configured through two complementary mechanisms:
 
-- **`.env`** — secrets and environment-specific values (API keys, database URL, port). Never committed to version control.
+- **`.env`** — bootstrap values and environment-specific config (database URL, encryption key, port). Never committed to version control. **Application secrets do not live here** — they resolve from the encrypted vault. See [Secrets](#secrets) below.
 - **`config/default.yaml`** — tuning knobs and feature flags that are safe to commit. Defaults are set here; `.env` overrides nothing in this file — the two are independent.
 
 Changes to `default.yaml` take effect on restart. Changes to `.env` also require a restart.
@@ -231,6 +231,12 @@ The `env:VAR_NAME` references are resolved from environment variables at
 startup — no credentials are stored in `local.yaml`. The actual grant IDs and
 email addresses live in `.env`.
 
+> **Note:** The multi-account `channel_accounts.email` path resolves
+> `env:VAR` references straight from `.env`, **not** from the vault — it is the
+> one path the vault-only model ([ADR-021](../adr/021-vault-only-secret-resolution.md))
+> does not yet cover. The legacy single-account Nylas secrets *are* vault-resolved.
+> Routing multi-account secrets through the vault is tracked as follow-up work (#920).
+
 For a full description of the `channel_accounts.email` schema, see the
 `channel_accounts` comment block in `config/default.yaml`.
 
@@ -283,28 +289,112 @@ Drive integration (service account setup, folder sharing, credential wiring).
 
 ---
 
+## Secrets
+
+Secrets resolve from the **encrypted vault only** — there is no env-var fallback (see
+[ADR-021](../adr/021-vault-only-secret-resolution.md)). Only four bootstrap values stay
+in `.env`, because they are needed to reach and unlock the vault itself:
+
+- `DB_USER`, `DB_PASSWORD`, `DATABASE_URL` — connect to the Postgres instance that hosts
+  the vault.
+- `SECRET_ENCRYPTION_KEY` — decrypts the vault.
+
+Every other secret (Anthropic, OpenAI, OpenRouter, API token, web-app bootstrap secret,
+Nylas trio, Signal number, Tavily) lives only in the vault.
+
+**Seeding:**
+
+- **Fresh install** — `pnpm run setup` seeds the vault automatically after migrations,
+  so the app never boots against an empty vault.
+- **Add or update one secret later** — supply it as a transient env var and run the
+  seeder: `VAR=value pnpm run seed-vault`. The seeder upserts present values; absent
+  ones are skipped, never cleared.
+
+**Missing secrets:** a missing *required* secret fails closed. Most fail at their consumer
+(e.g. `anthropic_api_key`). `api_token` is special-cased with an explicit boot guard that
+refuses to start, because its HTTP-auth consumer fails *open* (no token configured = auth
+disabled) — an absent token would otherwise silently expose the API. `setup.sh` also runs
+`seed-vault` with `SEED_VAULT_VERIFY=1`, which confirms the required rows (`anthropic_api_key`,
+`api_token`, `web_app_bootstrap_secret`) landed and aborts the install if any are missing.
+A missing *optional* secret (OpenAI, OpenRouter, Signal) disables its feature via the
+existing `if (config.x)` guards rather than failing the boot.
+
+### Migrating an existing deployment
+
+A deployment that predates the vault keeps its secrets in `.env`. Because resolution is
+vault-only with **no env fallback**, booting the new code against an empty vault would
+leave every secret unset — so the vault must be seeded **before** the new code resolves
+secrets, and `.env` is trimmed **last**. Order matters; do not reorder these steps.
+
+1. Deploy the new build to a place where `pnpm run seed-vault` can run, but **do not yet
+   restart the app on the new code**. The existing `.env` still holds every secret.
+2. With the current `.env` present, seed the vault from it:
+
+   ```
+   pnpm run seed-vault
+   ```
+
+   It reads the live env values and upserts them. Confirm the logged `seeded` list
+   contains every secret you expect; `skipped` should only hold genuinely-unset ones.
+3. Confirm the rows exist (bootstrap-only secrets are not audited, so verify by row):
+
+   ```sql
+   SELECT name FROM secrets ORDER BY name;
+   ```
+
+4. Restart the app on the new code. `applyVaultSecrets` now sources config from the vault.
+   Confirm the boot log line `Resolved bootstrap secrets from vault` shows the expected
+   `present` map, and that email / Signal / agents work.
+5. Confirm a skill read now resolves from the vault:
+
+   ```sql
+   SELECT payload->>'source' FROM events
+    WHERE type = 'secret.accessed' AND payload->>'secretName' = 'nylas_api_key'
+    ORDER BY created_at DESC LIMIT 1;   -- expect 'vault'
+   ```
+
+6. **Only now** remove the migrated secrets from `.env` (leave the four bootstrap values).
+   Restart once more and reconfirm.
+
+**Rollback:** before step 6 the old `.env` still holds every value, so redeploying the
+previous build restores env-based resolution. After step 6, re-add a value with
+`VAR=value pnpm run seed-vault` if needed.
+
+---
+
 ## Environment variables (`.env`)
 
-Environment variables control secrets and deployment-specific values that must not be committed. A full list with descriptions lives in `.env.example` at the repo root. Key variables:
+Environment variables control bootstrap values and deployment-specific config that must
+not be committed. Application secrets are **not** set here — they live in the vault (see
+[Secrets](#secrets) above). A full list with descriptions lives in `.env.example` at the
+repo root.
 
-| Variable | Required | Description |
-|---|---|---|
-| `SECRET_ENCRYPTION_KEY` | Yes | AES-256-GCM key for the secrets vault. Generate with `openssl rand -base64 32`. Changing this without running `scripts/rotate-secret-key.ts` makes stored secrets unreadable. |
-| `DATABASE_URL` | Yes | Postgres connection string |
-| `ANTHROPIC_API_KEY` | Yes | Powers all agents |
-| `API_TOKEN` | Yes | Authenticates HTTP API requests |
-| `WEB_APP_BOOTSTRAP_SECRET` | Yes | Web app login secret |
-| `TIMEZONE` | Yes | IANA timezone (e.g. `America/Toronto`) |
-| `CEO_PRIMARY_EMAIL` | Recommended | Prevents first CEO email from being held |
-| `OPENAI_API_KEY` | Tier 2 | Enables entity memory and semantic search |
-| `OPENROUTER_API_KEY` | Optional | Enables multi-model routing via OpenRouter (Gemini Flash, DeepSeek V3, GPT-4o). When set, tiers can map to OpenRouter-hosted models. |
-| `NYLAS_API_KEY` | Tier 2 | Email channel |
-| `NYLAS_GRANT_ID` | Tier 2 | Email grant (connected account) |
-| `NYLAS_SELF_EMAIL` | Tier 2 | Address Curia reads and sends from |
-| `SIGNAL_PHONE_NUMBER` | Tier 3 | Enables Signal channel |
-| `TAVILY_API_KEY` | Tier 3 | Enables `web-search` skill |
-| `GOOGLE_APPLICATION_CREDENTIALS` | Optional | Path to service account JSON for Google Drive |
-| `CURIA_TEMPFILE_DIR` | Optional | Base directory under which the `file-parse` skill resolves `temp_file_url` inputs. The skill rejects paths that escape this directory. Defaults to the OS temp dir when unset. |
+The **Stored in** column shows where each value lives: `.env` for the bootstrap and
+non-secret config that must be on the host before the vault opens, or **vault** for
+secrets that resolve from the encrypted store ([ADR-021](../adr/021-vault-only-secret-resolution.md)).
+Vault secrets are listed by their env-var name because that's the name you pass when
+seeding (`VAR=value pnpm run seed-vault`); they are read from the vault at runtime, not
+from `.env`.
+
+| Variable | Required | Stored in | Description |
+|---|---|---|---|
+| `SECRET_ENCRYPTION_KEY` | Yes | `.env` | AES-256-GCM key for the secrets vault. Generate with `openssl rand -base64 32`. Changing this without running `scripts/rotate-secret-key.ts` makes stored secrets unreadable. |
+| `DATABASE_URL` | Yes | `.env` | Postgres connection string (also reads the vault that hosts the secrets) |
+| `DB_USER` / `DB_PASSWORD` | Yes | `.env` | Postgres credentials |
+| `TIMEZONE` | Yes | `.env` | IANA timezone (e.g. `America/Toronto`) |
+| `CEO_PRIMARY_EMAIL` | Recommended | `.env` | Prevents first CEO email from being held |
+| `ANTHROPIC_API_KEY` | Yes | vault | Powers all agents |
+| `API_TOKEN` | Yes | vault | Authenticates HTTP API requests |
+| `WEB_APP_BOOTSTRAP_SECRET` | Yes | vault | Web app login secret |
+| `OPENAI_API_KEY` | Tier 2 | vault | Enables entity memory and semantic search |
+| `OPENROUTER_API_KEY` | Optional | vault | Enables multi-model routing via OpenRouter (Gemini Flash, DeepSeek V3, GPT-4o). When set, tiers can map to OpenRouter-hosted models. |
+| `NYLAS_API_KEY` | Tier 2 | vault | Email channel |
+| `NYLAS_GRANT_ID` | Tier 2 | vault | Email grant (connected account) |
+| `NYLAS_SELF_EMAIL` | Tier 2 | vault | Address Curia reads and sends from |
+| `SIGNAL_PHONE_NUMBER` | Tier 3 | vault | Enables Signal channel |
+| `TAVILY_API_KEY` | Tier 3 | vault | Enables `web-search` skill |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Optional | `.env` | Path to service account JSON for Google Drive |
+| `CURIA_TEMPFILE_DIR` | Optional | `.env` | Base directory under which the `file-parse` skill resolves `temp_file_url` inputs. The skill rejects paths that escape this directory. Defaults to the OS temp dir when unset. |
 
 See [setup.md](setup.md) for a step-by-step walkthrough of setting these up.
 

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -330,7 +330,7 @@ secrets, and `.env` is trimmed **last**. Order matters; do not reorder these ste
    restart the app on the new code**. The existing `.env` still holds every secret.
 2. With the current `.env` present, seed the vault from it:
 
-   ```
+   ```bash
    pnpm run seed-vault
    ```
 

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -319,47 +319,6 @@ disabled) — an absent token would otherwise silently expose the API. `setup.sh
 A missing *optional* secret (OpenAI, OpenRouter, Signal) disables its feature via the
 existing `if (config.x)` guards rather than failing the boot.
 
-### Migrating an existing deployment
-
-A deployment that predates the vault keeps its secrets in `.env`. Because resolution is
-vault-only with **no env fallback**, booting the new code against an empty vault would
-leave every secret unset — so the vault must be seeded **before** the new code resolves
-secrets, and `.env` is trimmed **last**. Order matters; do not reorder these steps.
-
-1. Deploy the new build to a place where `pnpm run seed-vault` can run, but **do not yet
-   restart the app on the new code**. The existing `.env` still holds every secret.
-2. With the current `.env` present, seed the vault from it:
-
-   ```bash
-   pnpm run seed-vault
-   ```
-
-   It reads the live env values and upserts them. Confirm the logged `seeded` list
-   contains every secret you expect; `skipped` should only hold genuinely-unset ones.
-3. Confirm the rows exist (bootstrap-only secrets are not audited, so verify by row):
-
-   ```sql
-   SELECT name FROM secrets ORDER BY name;
-   ```
-
-4. Restart the app on the new code. `applyVaultSecrets` now sources config from the vault.
-   Confirm the boot log line `Resolved bootstrap secrets from vault` shows the expected
-   `present` map, and that email / Signal / agents work.
-5. Confirm a skill read now resolves from the vault:
-
-   ```sql
-   SELECT payload->>'source' FROM events
-    WHERE type = 'secret.accessed' AND payload->>'secretName' = 'nylas_api_key'
-    ORDER BY created_at DESC LIMIT 1;   -- expect 'vault'
-   ```
-
-6. **Only now** remove the migrated secrets from `.env` (leave the four bootstrap values).
-   Restart once more and reconfirm.
-
-**Rollback:** before step 6 the old `.env` still holds every value, so redeploying the
-previous build restores env-based resolution. After step 6, re-add a value with
-`VAR=value pnpm run seed-vault` if needed.
-
 ---
 
 ## Environment variables (`.env`)

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -48,12 +48,16 @@ for you:
    (Nylas, OpenAI, Tavily, Signal) commented out for Tiers 2 and 3.
 5. Starts the Postgres container, waits for it to be healthy, and applies
    all database migrations.
-6. Runs `pnpm install --frozen-lockfile` if `node_modules/` is missing
+6. **Seeds the encrypted secrets vault** from the values it just generated
+   and prompted for. Secrets resolve from the vault only — there is no
+   `.env` fallback (see [ADR-021](../adr/021-vault-only-secret-resolution.md)),
+   so this runs before first boot to avoid an empty-vault failure.
+7. Runs `pnpm install --frozen-lockfile` if `node_modules/` is missing
    (skipped on re-runs).
-7. Brings up the full stack (`docker compose up -d`) and polls Curia's
+8. Brings up the full stack (`docker compose up -d`) and polls Curia's
    healthcheck so the success banner only fires once the app is actually
    responding.
-8. Appends `# SETUP_COMPLETE` to `.env` as a clean-finish marker and prints
+9. Appends `# SETUP_COMPLETE` to `.env` as a clean-finish marker and prints
    a summary box with `http://localhost:3000` and your bootstrap secret.
 
 **Save the bootstrap secret to a password manager** — the script will not
@@ -109,6 +113,31 @@ full design is documented in
 
 ---
 
+## Adding secrets after setup
+
+Tiers 2 and 3 add credentials (Nylas, OpenAI, Tavily, Signal). These are
+**secrets**, and secrets resolve from the encrypted vault only — there is no
+`.env` fallback (see [ADR-021](../adr/021-vault-only-secret-resolution.md)).
+Setting a key in `.env` alone has no effect.
+
+To add or update a secret, pass it as a transient env var to the seeder:
+
+```bash
+NYLAS_API_KEY=nyk_v0_... pnpm run seed-vault
+```
+
+The seeder upserts the value into the vault (re-running is safe; absent values
+are skipped, never cleared). You can pass several at once. Then restart Curia so
+the relevant channel or skill picks the secret up. The env-var snippets in the
+tiers below name the variables to seed.
+
+> Only the four vault-bootstrap values (`DB_USER`, `DB_PASSWORD`,
+> `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`) plus non-secret config (`TIMEZONE`,
+> `CEO_PRIMARY_EMAIL`, etc.) belong in `.env`. Everything else goes through the
+> vault.
+
+---
+
 ## Tier 2 — Recommended
 
 Adds the email channel and knowledge graph embeddings. This gives you a realistic development environment close to how Curia is actually used.
@@ -137,13 +166,16 @@ After completing the OAuth flow, the grant appears in your dashboard. Copy the *
 
 `NYLAS_SELF_EMAIL` is the address of the connected account — the address Curia reads and sends from:
 
-```env
-NYLAS_API_KEY=nyk_v0_...
-NYLAS_GRANT_ID=<grant-id-from-dashboard>
-NYLAS_SELF_EMAIL=curia@yourdomain.com
+Seed all three into the vault (see [Adding secrets after setup](#adding-secrets-after-setup)):
+
+```bash
+NYLAS_API_KEY=nyk_v0_... \
+NYLAS_GRANT_ID=<grant-id-from-dashboard> \
+NYLAS_SELF_EMAIL=curia@yourdomain.com \
+pnpm run seed-vault
 ```
 
-Restart Curia (`pnpm local`) — the email channel activates automatically when all three Nylas vars are present.
+Restart Curia (`pnpm local`) — the email channel activates automatically when all three Nylas secrets are in the vault.
 
 > **Multiple email accounts:** The three vars above wire up a single "legacy" email account. To configure multiple named accounts with per-account outbound policies (e.g. a Curia account that sends directly and a personal account that requires your approval), use `channel_accounts.email` in `config/local.yaml`. See [configuration.md](configuration.md#configlocalyaml--deployment-overrides) for details and an example.
 
@@ -151,10 +183,10 @@ Restart Curia (`pnpm local`) — the email channel activates automatically when 
 
 OpenAI's embedding model (`text-embedding-3-small`) powers entity memory and semantic search in the knowledge graph. Without it, KG lookups are exact-match only and smoke tests are unavailable.
 
-Get an API key from [platform.openai.com](https://platform.openai.com) and set it:
+Get an API key from [platform.openai.com](https://platform.openai.com) and seed it into the vault:
 
-```env
-OPENAI_API_KEY=sk-...
+```bash
+OPENAI_API_KEY=sk-... pnpm run seed-vault
 ```
 
 > **Checkpoint:** Email channel active, knowledge graph fully functional with semantic search. This is the recommended baseline for most development work.
@@ -169,13 +201,13 @@ Adds web research capability and (when available) Signal messaging.
 
 Powers the `web-search` skill, which lets agents research topics and look up current information.
 
-Sign up at [tavily.com](https://tavily.com) and copy your API key:
+Sign up at [tavily.com](https://tavily.com) and seed your API key into the vault:
 
-```env
-TAVILY_API_KEY=tvly-...
+```bash
+TAVILY_API_KEY=tvly-... pnpm run seed-vault
 ```
 
-No restart required if Curia is already running — the skill picks up the key on next use.
+No restart required if Curia is already running — the skill resolves the key from the vault on next use.
 
 ### Signal
 
@@ -185,10 +217,10 @@ Signal messaging runs via [signal-cli](https://github.com/AsamK/signal-cli). The
 
 Signal requires registering a phone number with signal-cli and seeding the `signal-data` Docker volume with the resulting credentials. Refer to your deployment documentation for the bootstrap procedure.
 
-**2. Set the env var**
+**2. Seed the phone number**
 
-```env
-SIGNAL_PHONE_NUMBER=+12223334444
+```bash
+SIGNAL_PHONE_NUMBER=+12223334444 pnpm run seed-vault
 ```
 
 That's the E.164 number you registered via `signal-cli register` + `verify`. `SIGNAL_SOCKET_PATH` is managed by the deployment layer — do not set it in `.env`.

--- a/docs/wip/2026-06-07-vault-secret-migration.md
+++ b/docs/wip/2026-06-07-vault-secret-migration.md
@@ -1,0 +1,727 @@
+# Vault Secret Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move every secret except the four that bootstrap the vault out of plaintext `.env` and into the encrypted secrets vault (#542), with vault-only resolution and no env fallback.
+
+**Architecture:** Skill secrets already resolve vault-first via `ctx.secret()` (#542), so they need only seeding + `.env` removal. Bootstrap/config secrets (read by `loadConfig()` before the vault exists) move to a new `applyVaultSecrets()` step that runs right after the vault is constructed and overwrites those config fields from the vault — vault-only, no `?? process.env`. A `seed-vault` script writes current env values into the vault and is invoked by `setup.sh` after migrations so fresh installs never face an empty vault.
+
+**Tech Stack:** TypeScript (ESM, Node 22+), PostgreSQL (pg), AES-256-GCM vault (`SecretsService`), vitest, pino, bash (`setup.sh`).
+
+**Issue:** #911. Google Workspace OAuth secrets are out of scope (split to #913).
+
+---
+
+## The four env-only values (everything else → vault)
+
+| Stays in `.env` | Why |
+|---|---|
+| `DB_USER`, `DB_PASSWORD`, `DATABASE_URL` | needed to connect to the DB that hosts the vault |
+| `SECRET_ENCRYPTION_KEY` | decrypts the vault; cannot live in it |
+
+Non-secret config (`HTTP_PORT`, `POSTGRES_PORT`, `LOG_LEVEL`, `TIMEZONE`, `NYLAS_POLL_INTERVAL_MS`, `APP_ORIGIN`, `NODE_EXTRA_CA_CERTS`) and identity config (`CEO_PRIMARY_EMAIL`, `CEO_SIGNAL_NUMBER`) also stay in `.env` — they are not secrets and are out of scope.
+
+## The 12 migrated secrets (vault name → env var, mapped by `name.toUpperCase()`)
+
+**Bootstrap/config-scoped** (resolved by `applyVaultSecrets`):
+`anthropic_api_key`, `openai_api_key`, `openrouter_api_key`, `api_token`, `web_app_bootstrap_secret`, `nylas_api_key`, `nylas_grant_id`, `nylas_self_email`, `signal_phone_number`
+
+**Skill-scoped** (resolved by existing `ctx.secret()`, no code change):
+`ceo_nylas_grant_id`, `ceo_self_email`, `tavily_api_key`
+
+The three dual-consumed secrets (`nylas_api_key`, `nylas_self_email`, `openai_api_key`) are a single vault row each, read by both paths.
+
+## CRITICAL — rollout ordering (no fallback means order matters)
+
+Because there is **no env fallback**, booting the new vault-only code against an **empty vault wipes every secret**. The vault MUST be seeded before the new code resolves secrets. Order, for both fresh installs and the existing deployment:
+
+1. Migrations run (creates/has the `secrets` table).
+2. `seed-vault` runs while the values are still available in env (fresh: prompted/generated in `setup.sh`; existing box: current `.env`).
+3. Only then does the app boot on the new `applyVaultSecrets` path.
+4. Remove the migrated vars from `.env` **after** verifying the vault is seeded.
+
+`setup.sh` enforces this for fresh installs (seed between migrate and stack-start). The existing-deployment runbook (Task 7) does it manually.
+
+## File Structure
+
+- `scripts/seed-vault.ts` — **new.** Canonical migrated-secret list + `seedVault()` (testable) + CLI entry. Reads env, upserts into the vault.
+- `tests/integration/seed-vault.test.ts` — **new.** Real-Postgres test of `seedVault()` (gated on `DATABASE_URL`, like `secrets-service.test.ts`).
+- `src/secrets/apply-vault-secrets.ts` — **new.** `applyVaultSecrets(config, secrets, logger)` overwrites the nine config secret fields from the vault (vault-only).
+- `src/secrets/apply-vault-secrets.test.ts` — **new.** Unit test with a fake `SecretsService`.
+- `src/config.ts` — **modify.** `loadConfig()` stops reading the nine secret fields from env (they become `undefined`/`''`, resolved later by `applyVaultSecrets`).
+- `tests/unit/config.test.ts` — **modify.** Drop the "loads ANTHROPIC_API_KEY from environment" test; add a test asserting `loadConfig()` no longer reads it from env.
+- `src/index.ts` — **modify.** Call `await applyVaultSecrets(config, secretsService, logger)` immediately after migrations (after line 263), before any consumer.
+- `scripts/setup.sh` — **modify.** `write_env` stops writing the three migrated generated/prompted secrets; add a seed-vault invocation after `pnpm run migrate`.
+- `package.json` — **modify.** Add `"seed-vault"` script.
+- `.env.example` — **modify.** Remove the 12 migrated secrets; document vault-only.
+- `docs/dev/setup.md`, `docs/dev/configuration.md` — **modify.** Describe vault-only resolution + how to add a secret post-setup.
+- `docs/adr/021-vault-only-secret-resolution.md` + `docs/adr/README.md` — **new/modify.** Record the no-fallback decision.
+- `CHANGELOG.md` — **modify.** `Security` entry under `[Unreleased]`.
+
+---
+
+### Task 1: `seed-vault` script + integration test
+
+**Files:**
+- Create: `scripts/seed-vault.ts`
+- Create: `tests/integration/seed-vault.test.ts`
+- Modify: `package.json` (scripts block, after line 29)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/seed-vault.test.ts`. This mirrors the gating pattern in `tests/integration/secrets-service.test.ts` (real Postgres, skipped when `DATABASE_URL` is unset).
+
+```typescript
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { loadEncryptionKey } from '../../src/secrets/crypto.js';
+import { SecretsService } from '../../src/secrets/secrets-service.js';
+import { seedVault, SEED_SECRET_NAMES } from '../../scripts/seed-vault.js';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL && process.env.SECRET_ENCRYPTION_KEY ? describe : describe.skip;
+
+describeIf('seedVault', () => {
+  const logger = pino({ level: 'silent' });
+  const pool = new pg.Pool({ connectionString: DATABASE_URL });
+  const secrets = new SecretsService(pool, loadEncryptionKey(), logger);
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM secrets WHERE name = ANY($1)', [[...SEED_SECRET_NAMES]]);
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM secrets WHERE name = ANY($1)', [[...SEED_SECRET_NAMES]]);
+    await pool.end();
+  });
+
+  it('seeds present env values into the vault and skips absent ones', async () => {
+    const env = { NYLAS_API_KEY: 'nyk_test_123', TAVILY_API_KEY: 'tvly_test_456' };
+    const { seeded, skipped } = await seedVault(secrets, env, logger);
+
+    expect(seeded.sort()).toEqual(['nylas_api_key', 'tavily_api_key']);
+    expect(skipped).toContain('anthropic_api_key');
+    expect(await secrets.get('nylas_api_key')).toBe('nyk_test_123');
+    expect(await secrets.get('tavily_api_key')).toBe('tvly_test_456');
+    expect(await secrets.get('anthropic_api_key')).toBeNull();
+  });
+
+  it('treats empty-string env values as absent (skipped)', async () => {
+    const { seeded, skipped } = await seedVault(secrets, { NYLAS_API_KEY: '' }, logger);
+    expect(seeded).not.toContain('nylas_api_key');
+    expect(skipped).toContain('nylas_api_key');
+  });
+
+  it('is idempotent — re-running upserts the same value', async () => {
+    await seedVault(secrets, { TAVILY_API_KEY: 'tvly_v1' }, logger);
+    await seedVault(secrets, { TAVILY_API_KEY: 'tvly_v2' }, logger);
+    expect(await secrets.get('tavily_api_key')).toBe('tvly_v2');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration test tests/integration/seed-vault.test.ts`
+Expected: FAIL — `Cannot find module '../../scripts/seed-vault.js'` (or the suite is skipped if `DATABASE_URL`/`SECRET_ENCRYPTION_KEY` are unset; in that case confirm it imports without a resolution error once Step 3 exists).
+
+- [ ] **Step 3: Write the script**
+
+Create `scripts/seed-vault.ts`:
+
+```typescript
+// seed-vault.ts — one-time / idempotent migration of plaintext env secrets into
+// the encrypted vault (#911). The vault `set()` is an upsert, so re-running is safe.
+//
+// Run for a manual migration (reads the current .env):
+//   pnpm run seed-vault
+// Add a single secret later (transient env var, then run):
+//   NYLAS_API_KEY=nyk_... pnpm run seed-vault
+//
+// Invoked by scripts/setup.sh after migrations for fresh installs.
+import pg from 'pg';
+import pino from 'pino';
+import { loadEncryptionKey } from '../src/secrets/crypto.js';
+import { SecretsService } from '../src/secrets/secrets-service.js';
+
+const logger = pino({ name: 'seed-vault' });
+
+// Canonical list of secrets migrated into the vault (#911). Each vault key is
+// snake_case; its env var is the UPPER_SNAKE_CASE form (the same name.toUpperCase()
+// convention used by the execution layer's ctx.secret() and by applyVaultSecrets()).
+// Order is irrelevant — set() is an upsert.
+export const SEED_SECRET_NAMES = [
+  // bootstrap/config-scoped (resolved at boot by applyVaultSecrets)
+  'anthropic_api_key',
+  'openai_api_key',
+  'openrouter_api_key',
+  'api_token',
+  'web_app_bootstrap_secret',
+  'nylas_api_key',
+  'nylas_grant_id',
+  'nylas_self_email',
+  'signal_phone_number',
+  // skill-scoped (resolved at call time by ctx.secret)
+  'ceo_nylas_grant_id',
+  'ceo_self_email',
+  'tavily_api_key',
+] as const;
+
+/**
+ * Read each migrated secret from `env` (by its UPPER_SNAKE_CASE name) and upsert any
+ * present, non-empty value into the vault. Absent/empty values are skipped, never
+ * cleared — this is additive so a partial env (e.g. no Signal configured) is fine.
+ * Never logs secret values, only their names.
+ */
+export async function seedVault(
+  secrets: SecretsService,
+  env: NodeJS.ProcessEnv,
+  log: pino.Logger,
+): Promise<{ seeded: string[]; skipped: string[] }> {
+  const seeded: string[] = [];
+  const skipped: string[] = [];
+  for (const name of SEED_SECRET_NAMES) {
+    const value = env[name.toUpperCase()];
+    if (value === undefined || value === '') {
+      skipped.push(name);
+      continue;
+    }
+    await secrets.set(name, value);
+    seeded.push(name);
+  }
+  log.info({ seeded, skipped }, 'Vault seeding complete');
+  return { seeded, skipped };
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    logger.error('seed-vault: DATABASE_URL is not set');
+    process.exit(1);
+  }
+  let key: Buffer;
+  try {
+    key = loadEncryptionKey();
+  } catch (err) {
+    logger.error({ err }, 'seed-vault: SECRET_ENCRYPTION_KEY is missing or invalid');
+    process.exit(1);
+    throw new Error('unreachable'); // guards against process.exit mocks
+  }
+  const pool = new pg.Pool({ connectionString: databaseUrl });
+  const secrets = new SecretsService(pool, key, logger);
+  seedVault(secrets, process.env, logger)
+    .then(async () => { await pool.end(); process.exit(0); })
+    .catch(async (err) => {
+      logger.error({ err }, 'seed-vault: fatal error');
+      await pool.end();
+      process.exit(1);
+    });
+}
+```
+
+Add to `package.json` scripts (after the `backfill:contact-attributes` line, keep the trailing comma rules valid):
+
+```json
+    "backfill:contact-attributes": "tsx --env-file=.env scripts/backfill-contact-attributes.ts",
+    "seed-vault": "tsx --env-file=.env scripts/seed-vault.ts"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration test tests/integration/seed-vault.test.ts`
+Expected: PASS (or SKIP if no `DATABASE_URL` — run against a local Postgres + a 32-byte `SECRET_ENCRYPTION_KEY` to actually exercise it).
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration run typecheck`
+Expected: no errors.
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration add scripts/seed-vault.ts tests/integration/seed-vault.test.ts package.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration commit -m "feat: add seed-vault script to migrate env secrets into the vault (#911)"
+```
+
+---
+
+### Task 2: `applyVaultSecrets` + bootstrap wiring + `loadConfig` env removal
+
+**Files:**
+- Create: `src/secrets/apply-vault-secrets.ts`
+- Create: `src/secrets/apply-vault-secrets.test.ts`
+- Modify: `src/config.ts:944-968` (the nine secret fields in the `loadConfig()` return)
+- Modify: `src/index.ts` (insert call after line 263)
+- Modify: `tests/unit/config.test.ts:26-31`
+
+- [ ] **Step 1: Write the failing unit test for `applyVaultSecrets`**
+
+Create `src/secrets/apply-vault-secrets.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import type { Config } from '../config.js';
+import type { SecretsService } from './secrets-service.js';
+import { applyVaultSecrets } from './apply-vault-secrets.js';
+
+const logger = pino({ level: 'silent' });
+
+// Minimal config with only the fields applyVaultSecrets touches (plus required others).
+function baseConfig(): Config {
+  return {
+    databaseUrl: 'postgres://x',
+    anthropicApiKey: undefined,
+    openaiApiKey: undefined,
+    openrouterApiKey: undefined,
+    logLevel: 'info',
+    httpPort: 3000,
+    apiToken: undefined,
+    webAppBootstrapSecret: undefined,
+    appOrigin: undefined,
+    timezone: 'UTC',
+    nylasApiKey: undefined,
+    nylasGrantId: undefined,
+    nylasPollingIntervalMs: 30000,
+    nylasSelfEmail: '',
+    ceoPrimaryEmail: undefined,
+    ceoSignalNumber: undefined,
+    signalSocketPath: undefined,
+    signalPhoneNumber: undefined,
+  };
+}
+
+function fakeSecrets(values: Record<string, string>): SecretsService {
+  return { get: vi.fn(async (name: string) => values[name] ?? null) } as unknown as SecretsService;
+}
+
+describe('applyVaultSecrets', () => {
+  it('overwrites config secret fields from the vault', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({
+      anthropic_api_key: 'sk-ant-vault',
+      api_token: 'tok-vault',
+      nylas_grant_id: 'grant-vault',
+      nylas_self_email: 'curia@vault.test',
+    });
+
+    await applyVaultSecrets(config, secrets, logger);
+
+    expect(config.anthropicApiKey).toBe('sk-ant-vault');
+    expect(config.apiToken).toBe('tok-vault');
+    expect(config.nylasGrantId).toBe('grant-vault');
+    expect(config.nylasSelfEmail).toBe('curia@vault.test');
+  });
+
+  it('sets undefined for absent secrets (no env fallback)', async () => {
+    const config = baseConfig();
+    // Even if process.env had a value, applyVaultSecrets must NOT read it.
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-env-should-be-ignored';
+    const secrets = fakeSecrets({}); // vault empty
+
+    await applyVaultSecrets(config, secrets, logger);
+
+    expect(config.anthropicApiKey).toBeUndefined();
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it('defaults nylasSelfEmail to empty string when absent (type is string, not undefined)', async () => {
+    const config = baseConfig();
+    await applyVaultSecrets(config, fakeSecrets({}), logger);
+    expect(config.nylasSelfEmail).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration test src/secrets/apply-vault-secrets.test.ts`
+Expected: FAIL — `Cannot find module './apply-vault-secrets.js'`.
+
+- [ ] **Step 3: Write `applyVaultSecrets`**
+
+Create `src/secrets/apply-vault-secrets.ts`:
+
+```typescript
+// apply-vault-secrets.ts — resolves the bootstrap/config-scoped secrets from the
+// vault and writes them onto the Config object (#911). Vault-only: there is NO env
+// fallback. loadConfig() no longer reads these from process.env; this is the single
+// place they enter Config. Must run after the vault is constructed and migrations
+// have run, and before any consumer reads config (anthropic provider, openai
+// embeddings, nylas/signal channels). Reads run concurrently; values are never logged.
+import type { Logger } from '../logger.js';
+import type { Config } from '../config.js';
+import type { SecretsService } from './secrets-service.js';
+
+export async function applyVaultSecrets(
+  config: Config,
+  secrets: SecretsService,
+  logger: Logger,
+): Promise<void> {
+  const [
+    anthropicApiKey,
+    openaiApiKey,
+    openrouterApiKey,
+    apiToken,
+    webAppBootstrapSecret,
+    nylasApiKey,
+    nylasGrantId,
+    nylasSelfEmail,
+    signalPhoneNumber,
+  ] = await Promise.all([
+    secrets.get('anthropic_api_key'),
+    secrets.get('openai_api_key'),
+    secrets.get('openrouter_api_key'),
+    secrets.get('api_token'),
+    secrets.get('web_app_bootstrap_secret'),
+    secrets.get('nylas_api_key'),
+    secrets.get('nylas_grant_id'),
+    secrets.get('nylas_self_email'),
+    secrets.get('signal_phone_number'),
+  ]);
+
+  // `?? undefined` converts the service's `null` (absent) to the Config field's
+  // `undefined`. nylasSelfEmail is typed `string`, so it defaults to '' — matching
+  // the previous `process.env.NYLAS_SELF_EMAIL ?? ''` behavior, not an env read.
+  config.anthropicApiKey = anthropicApiKey ?? undefined;
+  config.openaiApiKey = openaiApiKey ?? undefined;
+  config.openrouterApiKey = openrouterApiKey ?? undefined;
+  config.apiToken = apiToken ?? undefined;
+  config.webAppBootstrapSecret = webAppBootstrapSecret ?? undefined;
+  config.nylasApiKey = nylasApiKey ?? undefined;
+  config.nylasGrantId = nylasGrantId ?? undefined;
+  config.nylasSelfEmail = nylasSelfEmail ?? '';
+  config.signalPhoneNumber = signalPhoneNumber ?? undefined;
+
+  // Names only — never values. Lets an operator confirm what the vault supplied
+  // vs. what's absent (feature-disabled), which is the whole debuggability win.
+  const present = {
+    anthropic_api_key: anthropicApiKey !== null,
+    openai_api_key: openaiApiKey !== null,
+    openrouter_api_key: openrouterApiKey !== null,
+    api_token: apiToken !== null,
+    web_app_bootstrap_secret: webAppBootstrapSecret !== null,
+    nylas_api_key: nylasApiKey !== null,
+    nylas_grant_id: nylasGrantId !== null,
+    nylas_self_email: nylasSelfEmail !== null,
+    signal_phone_number: signalPhoneNumber !== null,
+  };
+  logger.info({ present }, 'Resolved bootstrap secrets from vault (vault-only, no env fallback)');
+}
+```
+
+- [ ] **Step 4: Run the unit test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration test src/secrets/apply-vault-secrets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Stop reading the nine secrets from env in `loadConfig()`**
+
+In `src/config.ts`, the `loadConfig()` return object (lines 944-968) currently reads each from `process.env`. Replace the nine secret lines with vault-resolved-later defaults. Edit each:
+
+```typescript
+    // Bootstrap/config secrets are resolved from the vault by applyVaultSecrets()
+    // after the vault is constructed (#911). loadConfig() no longer reads them from
+    // env — vault-only, no fallback. They are undefined here and overwritten at boot.
+    anthropicApiKey: undefined,
+    openaiApiKey: undefined,
+    openrouterApiKey: undefined,
+```
+```typescript
+    apiToken: undefined,
+    webAppBootstrapSecret: undefined,
+```
+```typescript
+    nylasApiKey: undefined,
+    nylasGrantId: undefined,
+    nylasPollingIntervalMs,
+    nylasSelfEmail: '',
+```
+```typescript
+    signalPhoneNumber: undefined,
+```
+
+Leave `databaseUrl`, `logLevel`, `httpPort`, `appOrigin`, `timezone`, `nylasPollingIntervalMs`, `ceoPrimaryEmail`, `ceoSignalNumber`, `signalSocketPath` exactly as they are (not migrated).
+
+- [ ] **Step 6: Update the config test that asserted env reading**
+
+In `tests/unit/config.test.ts`, replace the test at lines 26-31:
+
+```typescript
+  it('does not read ANTHROPIC_API_KEY from environment (vault-only, resolved by applyVaultSecrets)', () => {
+    process.env.DATABASE_URL = 'postgres://test:test@localhost:5432/test';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    const config = loadConfig();
+    expect(config.anthropicApiKey).toBeUndefined();
+  });
+```
+
+- [ ] **Step 7: Run the config test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration test tests/unit/config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Verify no stray direct `process.env` reads of migrated secrets remain**
+
+Run this and confirm the only hits are the skill `ctx.secret()` paths, `seed-vault.ts`, and tests — NOT a live consumer reading env directly (which would bypass the vault):
+
+```bash
+grep -rnE "process\.env(\.|\[['\"])(ANTHROPIC_API_KEY|OPENAI_API_KEY|OPENROUTER_API_KEY|API_TOKEN|WEB_APP_BOOTSTRAP_SECRET|NYLAS_API_KEY|NYLAS_GRANT_ID|NYLAS_SELF_EMAIL|SIGNAL_PHONE_NUMBER|CEO_NYLAS_GRANT_ID|CEO_SELF_EMAIL|TAVILY_API_KEY)" --include='*.ts' /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration/src
+```
+Expected: no consumer in `src/` reads these directly after the change (config.ts no longer does). If a hit appears (e.g. an embeddings module reading `process.env.OPENAI_API_KEY` directly), route it through `config.openaiApiKey` instead — add a follow-up step here for that file.
+
+- [ ] **Step 9: Wire `applyVaultSecrets` into bootstrap**
+
+In `src/index.ts`, add the import near the existing secrets imports (after line 99):
+
+```typescript
+import { applyVaultSecrets } from './secrets/apply-vault-secrets.js';
+```
+
+Insert the call immediately after the migration `try/catch` closes (after line 263, before the `// 3. Audit logger` comment on line 265):
+
+```typescript
+
+  // Resolve bootstrap/config secrets from the vault now that migrations have run
+  // (the `secrets` table exists) and before any consumer reads config (#911).
+  // Vault-only: a missing required secret leaves config undefined, failing closed at
+  // its consumer exactly as an unset env var did — there is no env fallback.
+  await applyVaultSecrets(config, secretsService, logger);
+```
+
+- [ ] **Step 10: Typecheck + full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration run typecheck`
+Expected: no errors.
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration test`
+Expected: green (DB-gated suites may skip without `DATABASE_URL`).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration add src/secrets/apply-vault-secrets.ts src/secrets/apply-vault-secrets.test.ts src/config.ts src/index.ts tests/unit/config.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration commit -m "feat: resolve bootstrap secrets from vault, drop env reads in loadConfig (#911)"
+```
+
+---
+
+### Task 3: `setup.sh` — seed vault after migrate; stop writing migrated secrets to `.env`
+
+**Files:**
+- Modify: `scripts/setup.sh` — `write_env` (lines 134-145) and the post-migrate flow (after line 390)
+
+- [ ] **Step 1: Trim `write_env` to only the four env-only values**
+
+Replace the `write_env` function body (lines 134-145) so it no longer writes `ANTHROPIC_API_KEY`, `API_TOKEN`, or `WEB_APP_BOOTSTRAP_SECRET` to `.env` (those now go to the vault). It keeps the anthropic key as a parameter only to pass it onward to the seed step via the caller.
+
+```bash
+write_env() {
+    # ANTHROPIC_API_KEY / API_TOKEN / WEB_APP_BOOTSTRAP_SECRET are NOT written here —
+    # they are seeded into the encrypted vault after migrations (#911). Only the four
+    # values needed to reach and unlock the vault live in .env.
+    sed \
+        -e "s|^DB_USER=.*|DB_USER=${DB_USER}|" \
+        -e "s|^DB_PASSWORD=.*|DB_PASSWORD=${DB_PASSWORD}|" \
+        -e "s|^DATABASE_URL=.*|DATABASE_URL=${DATABASE_URL}|" \
+        -e "s|^SECRET_ENCRYPTION_KEY=.*|SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY}|" \
+        "$ENV_EXAMPLE" > "$ENV_FILE"
+}
+```
+
+- [ ] **Step 2: Seed the vault after migrations, before the stack starts**
+
+Find the migrate block (lines 385-391, ends with `success "Migrations applied"`). Immediately after it, add a seed step. The generated/prompted secrets are in shell scope (`API_TOKEN`, `WEB_APP_BOOTSTRAP_SECRET` from `generate_secrets`; the Anthropic key must be threaded in — see Step 3). Export them so `seed-vault` (which reads from `process.env`) picks them up. `.env` already supplies `DATABASE_URL` + `SECRET_ENCRYPTION_KEY` via `--env-file`.
+
+```bash
+    success "Migrations applied"
+
+    # Seed the encrypted vault with the prompted/generated secrets (#911). Must run
+    # after migrations (the `secrets` table exists) and before the app boots, because
+    # the app resolves these vault-only with no env fallback. seed-vault reads values
+    # from process.env, so export them here; absent ones are simply skipped.
+    info "Seeding secrets vault..."
+    if ! ANTHROPIC_API_KEY="$SEED_ANTHROPIC_KEY" \
+         API_TOKEN="$API_TOKEN" \
+         WEB_APP_BOOTSTRAP_SECRET="$WEB_APP_BOOTSTRAP_SECRET" \
+         pnpm --prefix "$REPO_ROOT" run seed-vault; then
+        error "Vault seeding failed. See the output above."
+        hint "To retry: pnpm run setup  (choose option 2 — Resume setup)"
+        exit 1
+    fi
+    success "Secrets vault seeded"
+```
+
+- [ ] **Step 3: Thread the prompted Anthropic key to the seed step**
+
+The seed step runs inside `run_infra` (which contains the migrate block), but the Anthropic key is prompted in `main()` (line 454) and only passed to `write_env`. Make it available to the seed step via a global. In `main()`, after `anthropic_key=$(prompt_anthropic_key)` (line 454), add:
+
+```bash
+        SEED_ANTHROPIC_KEY="$anthropic_key"
+```
+
+And declare it with the other globals near the top of the script (alongside `PRESERVED_ENCRYPTION_KEY=""` at line 29):
+
+```bash
+SEED_ANTHROPIC_KEY=""
+```
+
+Note for the **resume** path (option 2): if `.env` already exists and setup is resumed, `SEED_ANTHROPIC_KEY` is empty, so `ANTHROPIC_API_KEY` is exported empty and skipped by seed-vault — correct, because a resume assumes the vault was already seeded on the original run. Document this in the runbook (Task 7).
+
+- [ ] **Step 4: Manually verify setup.sh syntax**
+
+Run: `bash -n /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration/scripts/setup.sh`
+Expected: no output (valid syntax).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration add scripts/setup.sh
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration commit -m "feat: seed vault during setup; stop writing migrated secrets to .env (#911)"
+```
+
+---
+
+### Task 4: `.env.example` cleanup
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: Remove the 12 migrated secrets and document vault-only**
+
+Edit `.env.example`:
+- Delete the assignment lines for `ANTHROPIC_API_KEY` (12), `OPENAI_API_KEY` (16), `NYLAS_API_KEY` (58), `NYLAS_GRANT_ID` (59), `NYLAS_SELF_EMAIL` (60), `API_TOKEN` (33), `WEB_APP_BOOTSTRAP_SECRET` (45), `TAVILY_API_KEY` (101). (`OPENROUTER_API_KEY`, `GOOGLE_*`, `SIGNAL_PHONE_NUMBER` are already commented out; leave Google for #913, and remove the commented `OPENROUTER_API_KEY` / `SIGNAL_PHONE_NUMBER` example lines too since they're vault-managed now.)
+- Keep `DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`, `HTTP_PORT`, `POSTGRES_PORT` (commented), `LOG_LEVEL`, `TIMEZONE`, `NYLAS_POLL_INTERVAL_MS` (commented), `CEO_PRIMARY_EMAIL` (commented), `CEO_SIGNAL_NUMBER`, `APP_ORIGIN`, `NODE_EXTRA_CA_CERTS` (commented), `SIGNAL_SOCKET_PATH` notes.
+- Convert the explanatory comment blocks (e.g. the Nylas block at 52-57, Tavily at 98-100) to point at the vault. Add a header block near the top:
+
+```bash
+# === Secrets: managed in the encrypted vault, NOT here ===
+#
+# All API keys and tokens (Anthropic, OpenAI, OpenRouter, Nylas, Tavily, the HTTP
+# API_TOKEN, WEB_APP_BOOTSTRAP_SECRET, Signal number, CEO inbox grant) live in the
+# encrypted secrets vault, not in this file. `pnpm run setup` seeds them after
+# migrations. To add or update one later, set it transiently and seed it:
+#
+#   NYLAS_API_KEY=nyk_... pnpm run seed-vault
+#
+# Only the four values below — needed to reach and unlock the vault itself — and
+# non-secret config live in .env.
+```
+
+- [ ] **Step 2: Confirm only the four secrets + non-secret config remain**
+
+Run: `grep -nE '^[A-Z]' /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration/.env.example`
+Expected: only `DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`, `LOG_LEVEL`, `TIMEZONE`, `CEO_SIGNAL_NUMBER` as active (uncommented) keys; the rest commented or removed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration add .env.example
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration commit -m "chore: remove migrated secrets from .env.example, document vault-only (#911)"
+```
+
+---
+
+### Task 5: Docs + ADR
+
+**Files:**
+- Modify: `docs/dev/setup.md`, `docs/dev/configuration.md`
+- Create: `docs/adr/021-vault-only-secret-resolution.md`
+- Modify: `docs/adr/README.md`
+
+- [ ] **Step 1: Update `docs/dev/configuration.md`**
+
+Add a "Secrets (vault-only)" section stating: secrets resolve from the encrypted vault only — there is no env fallback; the four bootstrap values (`DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`) stay in `.env`; everything else is seeded via `pnpm run setup` (fresh) or `pnpm run seed-vault` (add/update one secret with a transient env var); a missing required secret fails closed at its consumer, an optional one disables its feature.
+
+- [ ] **Step 2: Update `docs/dev/setup.md`**
+
+Note that setup auto-seeds the vault after migrations, and how to add a secret afterward (`VAR=value pnpm run seed-vault`).
+
+- [ ] **Step 3: Write the ADR**
+
+Create `docs/adr/021-vault-only-secret-resolution.md` from `docs/adr/template.md`. Context: #542 shipped the vault with an env fallback for safe rollout; #911 removes the plaintext. Decision: vault-only resolution with no env fallback for all secrets except the four that bootstrap the vault; rejected the overlay-with-env-fallback because a silent vault/env divergence is a debugging hazard and leaves plaintext on disk. Consequences: fresh installs must seed the vault before first boot (handled by setup.sh); rollout order matters for existing deployments (seed before deploying vault-only code); bootstrap secret reads are not audited (verified by row existence).
+
+- [ ] **Step 4: Add the ADR row**
+
+Add a row for ADR-021 to `docs/adr/README.md`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration add docs/dev/setup.md docs/dev/configuration.md docs/adr/021-vault-only-secret-resolution.md docs/adr/README.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration commit -m "docs: vault-only secret resolution + ADR-021 (#911)"
+```
+
+---
+
+### Task 6: CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (under `## [Unreleased]`)
+
+- [ ] **Step 1: Add a Security entry**
+
+Under `## [Unreleased]`, in a `### Security` subsection:
+
+```markdown
+- **Secrets vault migration** — API keys and tokens now resolve from the encrypted vault only (no `.env` fallback); a `seed-vault` script and `setup.sh` seed it, and only the four DB/encryption bootstrap values remain in `.env`. (#911)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-vault-migration commit -m "docs: changelog for vault secret migration (#911)"
+```
+
+---
+
+### Task 7: Existing-deployment migration runbook + live verification
+
+This task is operational — performed once against the running deployment by Joseph (devops; needs step-by-step). Capture it as a runbook section in `docs/dev/setup.md` (or a `docs/runbooks/` doc if that's the convention) and execute it with him.
+
+- [ ] **Step 1: Document the ordered migration runbook**
+
+```
+1. Deploy the new build to a place where `pnpm run seed-vault` can run, but DO NOT
+   restart the app on the new vault-only code yet. The current .env still holds all secrets.
+2. With the existing .env present, run:  pnpm run seed-vault
+   (reads current env values → upserts into the vault). Confirm the logged `seeded`
+   list contains all 12 names you expect; `skipped` should only be genuinely-unset ones.
+3. Verify the vault rows exist (bootstrap-only secrets are not audited, so check rows):
+     SELECT name FROM secrets ORDER BY name;
+4. Restart the app on the new code. applyVaultSecrets now sources config from the vault.
+   Confirm the boot log "Resolved bootstrap secrets from vault" shows the expected
+   `present` map, and that email/Signal/agents work.
+5. Confirm a skill read flips to vault in the audit log:
+     SELECT payload->>'source' FROM events
+      WHERE type='secret.accessed' AND payload->>'secretName'='nylas_api_key'
+      ORDER BY created_at DESC LIMIT 1;   -- expect 'vault'
+6. Only now, remove the 12 migrated vars from .env. Restart once more and reconfirm.
+   (Rollback: if anything is wrong before step 6, the old .env still has every value —
+   redeploy the previous build to restore env-based resolution.)
+```
+
+- [ ] **Step 2: Execute with Joseph and verify**
+
+Run the runbook against the live deployment; confirm steps 3-5 outputs. Do not delete from the live `.env` until the audit `source: 'vault'` check passes.
+
+---
+
+## Self-Review
+
+**Spec coverage (issue #911 acceptance criteria):**
+- Four env-only secrets documented → Task 4, Task 5 (ADR), Task 1 list. ✅
+- Skill secrets in vault + removed from `.env`/`.env.example` → Task 1 (seed), Task 4. ✅
+- Bootstrap secrets via `applyVaultSecrets`, removed from env; `loadConfig` no longer reads them → Task 2. ✅
+- `secret.accessed` source='vault' for skill secrets → Task 7 step 5 verification (no code change needed; #542 already emits it). ✅
+- Bootstrap-only secrets verified by row existence, unaudited → Task 7 step 3. ✅
+- seed-vault committed, registered, run by setup.sh; write_env trimmed → Task 1, Task 3. ✅
+- Setup/config docs + ADR → Task 5. ✅
+- No skill/channel regresses, suite green → Task 2 step 10, Task 7. ✅
+- `approval-expiry-sweep` bypass unaffected → CEO_PRIMARY_EMAIL stays in `.env`; no change. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code. Docs tasks (5) describe content rather than full prose — acceptable for doc edits, but the ADR/section intent is specified.
+
+**Type consistency:** `SEED_SECRET_NAMES` (Task 1) used in Task 1 test. `applyVaultSecrets(config, secrets, logger)` signature consistent across Task 2 test, impl, and the index.ts call. `seedVault(secrets, env, log)` consistent between script and test. Config field names match `src/config.ts:36-69`. ✅
+
+**Known risk flagged:** rollout ordering (seed before vault-only boot) is the one operational footgun — called out at the top and in Task 7.

--- a/scripts/seed-vault.ts
+++ b/scripts/seed-vault.ts
@@ -60,12 +60,12 @@ export async function verifyRequiredSecrets(
 ): Promise<string[]> {
   const missing: string[] = [];
   for (const name of REQUIRED_SECRET_NAMES) {
-    // Treat an empty value as missing, not present. An empty api_token would pass a bare
-    // null-check but disables HTTP auth — validateBearerToken() treats "" as "no token
-    // configured" — so an unusable vault state must fail loudly here, matching the
-    // falsy-check boot guard in src/index.ts.
+    // Treat an empty or whitespace-only value as missing, not present. An empty (or
+    // blank) api_token would pass a bare null-check but disables HTTP auth —
+    // validateBearerToken() treats "" as "no token configured" — so an unusable vault
+    // state must fail loudly here, matching the falsy-check boot guard in src/index.ts.
     const value = await secrets.get(name);
-    if (value === null || value === '') missing.push(name);
+    if (value === null || value.trim() === '') missing.push(name);
   }
   if (missing.length > 0) {
     log.error({ missing }, 'Required secrets missing from vault');
@@ -89,7 +89,12 @@ export async function seedVault(
   const seeded: string[] = [];
   const skipped: string[] = [];
   for (const name of SEED_SECRET_NAMES) {
-    const value = env[name.toUpperCase()];
+    // Trim before checking and storing: a copy-pasted value often carries a trailing
+    // newline, and a whitespace-only value (e.g. ` `) is unusable at runtime — the
+    // Anthropic client, HTTP auth, and Signal account id all reject it. Treating a
+    // blank-after-trim value as absent keeps an invalid placeholder out of the vault so
+    // verifyRequiredSecrets() and the boot guards see the true "missing" state.
+    const value = env[name.toUpperCase()]?.trim();
     if (value === undefined || value === '') {
       skipped.push(name);
       continue;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -396,19 +396,35 @@ run_infra() {
 
     # Seed the encrypted vault with the prompted/generated secrets (#911). Must run
     # after migrations (the `secrets` table exists) and before the app boots, because
-    # the app resolves these vault-only with no env fallback. seed-vault reads values
-    # from process.env, so export them here; absent ones are simply skipped. On the
-    # resume path SEED_ANTHROPIC_KEY is empty (vault already seeded on the first run),
-    # so ANTHROPIC_API_KEY is exported empty and skipped — intended.
-    # SEED_VAULT_VERIFY=1 makes seed-vault confirm the required rows (anthropic_api_key,
-    # api_token, web_app_bootstrap_secret) actually landed in the vault and exit non-zero
-    # if not — so a resume run whose first attempt never persisted them fails loudly here
-    # rather than booting an instance with HTTP auth disabled (#911).
+    # the app resolves these vault-only with no env fallback. SEED_VAULT_VERIFY=1 makes
+    # seed-vault confirm the required rows (anthropic_api_key, api_token,
+    # web_app_bootstrap_secret) actually landed in the vault and exit non-zero if not —
+    # so a run that never persisted them fails loudly here rather than booting an instance
+    # with HTTP auth disabled (#911).
+    #
+    # The bootstrap secrets are passed explicitly per setup mode rather than forwarding
+    # the ambient shell environment:
+    #   - Full install: the freshly generated/prompted values are NOT written to .env, so
+    #     the seed-vault child can only receive them through these assignments.
+    #   - Resume: the vault was already seeded on the first run, so pass NONE of them and
+    #     let seed-vault re-verify the existing rows. Forwarding them on resume would
+    #     either clobber an already-seeded ANTHROPIC_API_KEY to empty (failing
+    #     verification) or silently re-seed API_TOKEN / WEB_APP_BOOTSTRAP_SECRET from
+    #     whatever happens to be in the operator's shell — an unintended secret rotation.
+    #     (A legacy pre-vault .env still migrates: run_infra exported its plaintext
+    #     secrets above, and seed-vault reads them from the inherited process.env.)
     info "Seeding secrets vault..."
-    if ! ANTHROPIC_API_KEY="$SEED_ANTHROPIC_KEY" \
-         API_TOKEN="${API_TOKEN:-}" \
-         WEB_APP_BOOTSTRAP_SECRET="${WEB_APP_BOOTSTRAP_SECRET:-}" \
-         SEED_VAULT_VERIFY=1 \
+    seed_secret_env=()
+    if [[ "$SETUP_MODE" == "full" ]]; then
+        seed_secret_env=(
+            "ANTHROPIC_API_KEY=$SEED_ANTHROPIC_KEY"
+            "API_TOKEN=$API_TOKEN"
+            "WEB_APP_BOOTSTRAP_SECRET=$WEB_APP_BOOTSTRAP_SECRET"
+        )
+    fi
+    # ${arr[@]+"${arr[@]}"} expands safely to nothing when the array is empty, even under
+    # `set -u` on bash 3.2 (macOS default), where a bare "${arr[@]}" is an unbound error.
+    if ! env ${seed_secret_env[@]+"${seed_secret_env[@]}"} SEED_VAULT_VERIFY=1 \
          pnpm --prefix "$REPO_ROOT" run seed-vault; then
         error "Vault seeding failed or required secrets are missing. See the output above."
         hint "If this is a resume after a failed first run, re-run full setup (option 3) to regenerate and seed the bootstrap secrets."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -27,6 +27,9 @@ SETUP_MODE="full"  # "full" | "resume"
 # Global: set by handle_existing_env when the vault key should be preserved across
 # a full reset (Postgres data is NOT wiped, so existing encrypted rows must stay readable)
 PRESERVED_ENCRYPTION_KEY=""
+# Global: set by main() from the prompted Anthropic key, consumed by run_infra to
+# seed the vault (#911). Empty on the resume path (vault already seeded on first run).
+SEED_ANTHROPIC_KEY=""
 
 # Verifies docker, docker compose, node >= 22, pnpm, and openssl are available.
 # Exits 1 with an install link on the first missing tool.
@@ -129,17 +132,16 @@ generate_secrets() {
     DATABASE_URL="postgres://curia:${DB_PASSWORD}@localhost:${pg_host_port}/curia"
 }
 
-# Templates ENV_EXAMPLE into ENV_FILE, substituting generated secrets.
-# Takes the Anthropic API key as $1. Optional vars remain commented.
+# Templates ENV_EXAMPLE into ENV_FILE, substituting the four bootstrap secrets.
+# Optional vars remain commented.
 write_env() {
-    local anthropic_key="$1"
+    # ANTHROPIC_API_KEY / API_TOKEN / WEB_APP_BOOTSTRAP_SECRET are NOT written here —
+    # they are seeded into the encrypted vault after migrations (#911). Only the four
+    # values needed to reach and unlock the vault live in .env.
     sed \
         -e "s|^DB_USER=.*|DB_USER=${DB_USER}|" \
         -e "s|^DB_PASSWORD=.*|DB_PASSWORD=${DB_PASSWORD}|" \
         -e "s|^DATABASE_URL=.*|DATABASE_URL=${DATABASE_URL}|" \
-        -e "s|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${anthropic_key}|" \
-        -e "s|^API_TOKEN=.*|API_TOKEN=${API_TOKEN}|" \
-        -e "s|^WEB_APP_BOOTSTRAP_SECRET=.*|WEB_APP_BOOTSTRAP_SECRET=${WEB_APP_BOOTSTRAP_SECRET}|" \
         -e "s|^SECRET_ENCRYPTION_KEY=.*|SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY}|" \
         "$ENV_EXAMPLE" > "$ENV_FILE"
 }
@@ -355,7 +357,9 @@ wait_for_curia() {
 }
 
 # Starts Postgres, runs migrations, starts the full stack, writes SETUP_COMPLETE marker.
-# Parses .env to get DATABASE_URL, HTTP_PORT, and WEB_APP_BOOTSTRAP_SECRET for use at runtime.
+# Parses .env to get DATABASE_URL and HTTP_PORT for use at runtime. The bootstrap secret
+# is no longer stored in .env (#911) — it lives in the vault; only the full-setup path
+# holds it in-shell to display once (see print_summary's empty-secret branch on resume).
 run_infra() {
     if [[ ! -f "$ENV_FILE" ]]; then
         error ".env not found. Cannot continue setup."
@@ -390,6 +394,28 @@ run_infra() {
     fi
     success "Migrations applied"
 
+    # Seed the encrypted vault with the prompted/generated secrets (#911). Must run
+    # after migrations (the `secrets` table exists) and before the app boots, because
+    # the app resolves these vault-only with no env fallback. seed-vault reads values
+    # from process.env, so export them here; absent ones are simply skipped. On the
+    # resume path SEED_ANTHROPIC_KEY is empty (vault already seeded on the first run),
+    # so ANTHROPIC_API_KEY is exported empty and skipped — intended.
+    # SEED_VAULT_VERIFY=1 makes seed-vault confirm the required rows (anthropic_api_key,
+    # api_token, web_app_bootstrap_secret) actually landed in the vault and exit non-zero
+    # if not — so a resume run whose first attempt never persisted them fails loudly here
+    # rather than booting an instance with HTTP auth disabled (#911).
+    info "Seeding secrets vault..."
+    if ! ANTHROPIC_API_KEY="$SEED_ANTHROPIC_KEY" \
+         API_TOKEN="${API_TOKEN:-}" \
+         WEB_APP_BOOTSTRAP_SECRET="${WEB_APP_BOOTSTRAP_SECRET:-}" \
+         SEED_VAULT_VERIFY=1 \
+         pnpm --prefix "$REPO_ROOT" run seed-vault; then
+        error "Vault seeding failed or required secrets are missing. See the output above."
+        hint "If this is a resume after a failed first run, re-run full setup (option 3) to regenerate and seed the bootstrap secrets."
+        exit 1
+    fi
+    success "Secrets vault seeded"
+
     info "Starting Curia..."
     if ! docker compose --project-directory "$REPO_ROOT" up -d; then
         error "Failed to start Curia stack."
@@ -410,7 +436,9 @@ run_infra() {
     # Mark setup as complete so the idempotency menu can distinguish restart vs recovery.
     printf "\n# SETUP_COMPLETE\n" >> "$ENV_FILE"
 
-    print_summary "$WEB_APP_BOOTSTRAP_SECRET"
+    # On the resume path the bootstrap secret is not in-shell (not in .env anymore,
+    # not regenerated), so pass it defensively — print_summary degrades gracefully.
+    print_summary "${WEB_APP_BOOTSTRAP_SECRET:-}"
 }
 
 # Prints the final summary box with login URL and bootstrap secret.
@@ -429,11 +457,19 @@ print_summary() {
     printf "║%-${W}s║\n" ""
     printf "║   %-$((W-3))s║\n" "Open:    http://localhost:${port}"
     printf "║%-${W}s║\n" ""
-    printf "║   %-$((W-3))s║\n" "Bootstrap secret (save this to a password manager):"
-    printf "║   %-$((W-3))s║\n" "${secret}"
-    printf "║%-${W}s║\n" ""
-    printf "║   %-$((W-3))s║\n" "Enter it on the login page to create your account."
-    printf "║   %-$((W-3))s║\n" "You won't be shown it again here."
+    if [[ -n "$secret" ]]; then
+        # Full setup — the freshly generated secret is in hand; show it once.
+        printf "║   %-$((W-3))s║\n" "Bootstrap secret (save this to a password manager):"
+        printf "║   %-$((W-3))s║\n" "${secret}"
+        printf "║%-${W}s║\n" ""
+        printf "║   %-$((W-3))s║\n" "Enter it on the login page to create your account."
+        printf "║   %-$((W-3))s║\n" "You won't be shown it again here."
+    else
+        # Resume — the secret now lives in the vault, not .env, and isn't retrievable
+        # here. It was shown during the initial setup run.
+        printf "║   %-$((W-3))s║\n" "Bootstrap secret: stored in the encrypted vault."
+        printf "║   %-$((W-3))s║\n" "(Shown once during initial setup; not retrievable here.)"
+    fi
     printf "║%-${W}s║\n" ""
     printf "╚%s╝\n" "$border"
     echo ""
@@ -452,7 +488,8 @@ main() {
         generate_secrets
         local anthropic_key
         anthropic_key=$(prompt_anthropic_key)
-        write_env "$anthropic_key"
+        SEED_ANTHROPIC_KEY="$anthropic_key"
+        write_env
         success ".env written"
     fi
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -941,19 +941,22 @@ export function loadConfig(): Config {
 
   return {
     databaseUrl,
-    anthropicApiKey: process.env.ANTHROPIC_API_KEY,
-    openaiApiKey: process.env.OPENAI_API_KEY,
-    openrouterApiKey: process.env.OPENROUTER_API_KEY,
+    // Bootstrap/config secrets are resolved from the vault by applyVaultSecrets()
+    // after the vault is constructed (#911). loadConfig() no longer reads them from
+    // env — vault-only, no fallback. They are undefined here and overwritten at boot.
+    anthropicApiKey: undefined,
+    openaiApiKey: undefined,
+    openrouterApiKey: undefined,
     logLevel: process.env.LOG_LEVEL ?? 'info',
     httpPort,
-    apiToken: process.env.API_TOKEN,
-    webAppBootstrapSecret: process.env.WEB_APP_BOOTSTRAP_SECRET,
+    apiToken: undefined,
+    webAppBootstrapSecret: undefined,
     appOrigin: process.env.APP_ORIGIN || undefined,
     timezone,
-    nylasApiKey: process.env.NYLAS_API_KEY,
-    nylasGrantId: process.env.NYLAS_GRANT_ID,
+    nylasApiKey: undefined,
+    nylasGrantId: undefined,
     nylasPollingIntervalMs,
-    nylasSelfEmail: process.env.NYLAS_SELF_EMAIL ?? '',
+    nylasSelfEmail: '',
     // Reject the literal `.env.example` placeholder so a user who runs
     // `pnpm run setup` and never edits the generated .env doesn't get a phantom
     // CEO contact named "CEO" bound to `you@yourdomain.com` created at boot —
@@ -965,6 +968,6 @@ export function loadConfig(): Config {
     // .trim() prevents a whitespace-only value (e.g. "  ") from activating the
     // Signal adapter with a bogus socket path or phone number.
     signalSocketPath: process.env.SIGNAL_SOCKET_PATH?.trim() || undefined,
-    signalPhoneNumber: process.env.SIGNAL_PHONE_NUMBER?.trim() || undefined,
+    signalPhoneNumber: undefined,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,7 @@ import { OfficeIdentityService } from './identity/service.js';
 import { ExecutiveProfileService } from './executive/service.js';
 import { loadEncryptionKey } from './secrets/crypto.js';
 import { SecretsService } from './secrets/secrets-service.js';
+import { applyVaultSecrets } from './secrets/apply-vault-secrets.js';
 import { SensitivityClassifier } from './memory/sensitivity.js';
 import { DreamEngine } from './memory/dream-engine.js';
 import type { DecayConfig } from './memory/dream-engine.js';
@@ -259,6 +260,29 @@ async function main(): Promise<void> {
     }
   } catch (err) {
     logger.fatal({ err }, 'Database migration failed');
+    process.exit(1);
+  }
+
+  // Resolve bootstrap/config secrets from the vault now that migrations have run
+  // (the `secrets` table exists) and before any consumer reads config (#911).
+  // Vault-only: a missing required secret leaves config undefined, failing closed at
+  // its consumer exactly as an unset env var did — there is no env fallback.
+  // A vault read error (DB/decrypt failure) is a hard startup failure, surfaced
+  // with a structured fatal line to match the migration/encryption-key blocks above.
+  try {
+    await applyVaultSecrets(config, secretsService, logger);
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to resolve bootstrap secrets from vault');
+    process.exit(1);
+  }
+
+  // api_token is a REQUIRED secret with a fail-OPEN consumer: validateBearerToken()
+  // (src/channels/http/auth.ts) disables HTTP auth entirely when no token is configured
+  // — a local-dev convenience. Under vault-only resolution an absent vault row would
+  // silently expose every authenticated endpoint, so guard it explicitly here: fail
+  // closed (refuse to boot), not open (#911). Mirror the anthropic_api_key guard below.
+  if (!config.apiToken) {
+    logger.fatal('api_token is missing from the vault — refusing to boot with HTTP auth disabled. Seed it with: API_TOKEN=<value> pnpm run seed-vault');
     process.exit(1);
   }
 

--- a/src/secrets/apply-vault-secrets.test.ts
+++ b/src/secrets/apply-vault-secrets.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import type { Config } from '../config.js';
+import type { SecretsService } from './secrets-service.js';
+import { applyVaultSecrets } from './apply-vault-secrets.js';
+
+const logger = pino({ level: 'silent' });
+
+// Minimal config with only the fields applyVaultSecrets touches (plus required others).
+function baseConfig(): Config {
+  return {
+    databaseUrl: 'postgres://x',
+    anthropicApiKey: undefined,
+    openaiApiKey: undefined,
+    openrouterApiKey: undefined,
+    logLevel: 'info',
+    httpPort: 3000,
+    apiToken: undefined,
+    webAppBootstrapSecret: undefined,
+    appOrigin: undefined,
+    timezone: 'UTC',
+    nylasApiKey: undefined,
+    nylasGrantId: undefined,
+    nylasPollingIntervalMs: 30000,
+    nylasSelfEmail: '',
+    ceoPrimaryEmail: undefined,
+    ceoSignalNumber: undefined,
+    signalSocketPath: undefined,
+    signalPhoneNumber: undefined,
+  };
+}
+
+function fakeSecrets(values: Record<string, string>): SecretsService {
+  return { get: vi.fn(async (name: string) => values[name] ?? null) } as unknown as SecretsService;
+}
+
+describe('applyVaultSecrets', () => {
+  it('overwrites config secret fields from the vault', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({
+      anthropic_api_key: 'sk-ant-vault',
+      api_token: 'tok-vault',
+      nylas_grant_id: 'grant-vault',
+      nylas_self_email: 'curia@vault.test',
+    });
+
+    await applyVaultSecrets(config, secrets, logger);
+
+    expect(config.anthropicApiKey).toBe('sk-ant-vault');
+    expect(config.apiToken).toBe('tok-vault');
+    expect(config.nylasGrantId).toBe('grant-vault');
+    expect(config.nylasSelfEmail).toBe('curia@vault.test');
+  });
+
+  it('sets undefined for absent secrets (no env fallback)', async () => {
+    const config = baseConfig();
+    // Even if process.env had a value, applyVaultSecrets must NOT read it.
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-env-should-be-ignored';
+    const secrets = fakeSecrets({}); // vault empty
+
+    await applyVaultSecrets(config, secrets, logger);
+
+    expect(config.anthropicApiKey).toBeUndefined();
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it('defaults nylasSelfEmail to empty string when absent (type is string, not undefined)', async () => {
+    const config = baseConfig();
+    await applyVaultSecrets(config, fakeSecrets({}), logger);
+    expect(config.nylasSelfEmail).toBe('');
+  });
+});

--- a/src/secrets/apply-vault-secrets.ts
+++ b/src/secrets/apply-vault-secrets.ts
@@ -1,0 +1,65 @@
+// apply-vault-secrets.ts — resolves the bootstrap/config-scoped secrets from the
+// vault and writes them onto the Config object (#911). Vault-only: there is NO env
+// fallback. loadConfig() no longer reads these from process.env; this is the single
+// place they enter Config. Must run after the vault is constructed and migrations
+// have run, and before any consumer reads config (anthropic provider, openai
+// embeddings, nylas/signal channels). Reads run concurrently; values are never logged.
+import type { Logger } from '../logger.js';
+import type { Config } from '../config.js';
+import type { SecretsService } from './secrets-service.js';
+
+export async function applyVaultSecrets(
+  config: Config,
+  secrets: SecretsService,
+  logger: Logger,
+): Promise<void> {
+  const [
+    anthropicApiKey,
+    openaiApiKey,
+    openrouterApiKey,
+    apiToken,
+    webAppBootstrapSecret,
+    nylasApiKey,
+    nylasGrantId,
+    nylasSelfEmail,
+    signalPhoneNumber,
+  ] = await Promise.all([
+    secrets.get('anthropic_api_key'),
+    secrets.get('openai_api_key'),
+    secrets.get('openrouter_api_key'),
+    secrets.get('api_token'),
+    secrets.get('web_app_bootstrap_secret'),
+    secrets.get('nylas_api_key'),
+    secrets.get('nylas_grant_id'),
+    secrets.get('nylas_self_email'),
+    secrets.get('signal_phone_number'),
+  ]);
+
+  // `?? undefined` converts the service's `null` (absent) to the Config field's
+  // `undefined`. nylasSelfEmail is typed `string`, so it defaults to '' — matching
+  // the previous `process.env.NYLAS_SELF_EMAIL ?? ''` behavior, not an env read.
+  config.anthropicApiKey = anthropicApiKey ?? undefined;
+  config.openaiApiKey = openaiApiKey ?? undefined;
+  config.openrouterApiKey = openrouterApiKey ?? undefined;
+  config.apiToken = apiToken ?? undefined;
+  config.webAppBootstrapSecret = webAppBootstrapSecret ?? undefined;
+  config.nylasApiKey = nylasApiKey ?? undefined;
+  config.nylasGrantId = nylasGrantId ?? undefined;
+  config.nylasSelfEmail = nylasSelfEmail ?? '';
+  config.signalPhoneNumber = signalPhoneNumber ?? undefined;
+
+  // Names only — never values. Lets an operator confirm what the vault supplied
+  // vs. what's absent (feature-disabled), which is the whole debuggability win.
+  const present = {
+    anthropic_api_key: anthropicApiKey !== null,
+    openai_api_key: openaiApiKey !== null,
+    openrouter_api_key: openrouterApiKey !== null,
+    api_token: apiToken !== null,
+    web_app_bootstrap_secret: webAppBootstrapSecret !== null,
+    nylas_api_key: nylasApiKey !== null,
+    nylas_grant_id: nylasGrantId !== null,
+    nylas_self_email: nylasSelfEmail !== null,
+    signal_phone_number: signalPhoneNumber !== null,
+  };
+  logger.info({ present }, 'Resolved bootstrap secrets from vault (vault-only, no env fallback)');
+}

--- a/src/secrets/apply-vault-secrets.ts
+++ b/src/secrets/apply-vault-secrets.ts
@@ -35,31 +35,45 @@ export async function applyVaultSecrets(
     secrets.get('signal_phone_number'),
   ]);
 
-  // `?? undefined` converts the service's `null` (absent) to the Config field's
-  // `undefined`. nylasSelfEmail is typed `string`, so it defaults to '' — matching
-  // the previous `process.env.NYLAS_SELF_EMAIL ?? ''` behavior, not an env read.
-  config.anthropicApiKey = anthropicApiKey ?? undefined;
-  config.openaiApiKey = openaiApiKey ?? undefined;
-  config.openrouterApiKey = openrouterApiKey ?? undefined;
-  config.apiToken = apiToken ?? undefined;
-  config.webAppBootstrapSecret = webAppBootstrapSecret ?? undefined;
-  config.nylasApiKey = nylasApiKey ?? undefined;
-  config.nylasGrantId = nylasGrantId ?? undefined;
-  config.nylasSelfEmail = nylasSelfEmail ?? '';
-  config.signalPhoneNumber = signalPhoneNumber ?? undefined;
+  // Normalize each vault value: trim surrounding whitespace (copy-paste artifacts) and
+  // collapse a blank/whitespace-only result to `undefined` (absent). A whitespace-only
+  // secret is unusable at runtime — the Anthropic client and HTTP auth reject it, and a
+  // blank Signal phone number would otherwise stay truthy and wire up the channel with an
+  // invalid account id — so it must read as absent here, keeping the boot guards and the
+  // feature-on checks (`if (config.signalPhoneNumber)`) honest rather than letting a
+  // truthy-but-empty string slip through. The seeder already trims on write; this is the
+  // matching read-side guard for rows set by any other path.
+  const clean = (value: string | null): string | undefined => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+  };
+
+  config.anthropicApiKey = clean(anthropicApiKey);
+  config.openaiApiKey = clean(openaiApiKey);
+  config.openrouterApiKey = clean(openrouterApiKey);
+  config.apiToken = clean(apiToken);
+  config.webAppBootstrapSecret = clean(webAppBootstrapSecret);
+  config.nylasApiKey = clean(nylasApiKey);
+  config.nylasGrantId = clean(nylasGrantId);
+  // nylasSelfEmail is typed `string`, so it defaults to '' — matching the previous
+  // `process.env.NYLAS_SELF_EMAIL ?? ''` behavior, not an env read.
+  config.nylasSelfEmail = clean(nylasSelfEmail) ?? '';
+  config.signalPhoneNumber = clean(signalPhoneNumber);
 
   // Names only — never values. Lets an operator confirm what the vault supplied
   // vs. what's absent (feature-disabled), which is the whole debuggability win.
+  // Uses the same `clean()` as the assignments above so the log reflects what each
+  // consumer actually sees — a blank row reads as absent, not present.
   const present = {
-    anthropic_api_key: anthropicApiKey !== null,
-    openai_api_key: openaiApiKey !== null,
-    openrouter_api_key: openrouterApiKey !== null,
-    api_token: apiToken !== null,
-    web_app_bootstrap_secret: webAppBootstrapSecret !== null,
-    nylas_api_key: nylasApiKey !== null,
-    nylas_grant_id: nylasGrantId !== null,
-    nylas_self_email: nylasSelfEmail !== null,
-    signal_phone_number: signalPhoneNumber !== null,
+    anthropic_api_key: clean(anthropicApiKey) !== undefined,
+    openai_api_key: clean(openaiApiKey) !== undefined,
+    openrouter_api_key: clean(openrouterApiKey) !== undefined,
+    api_token: clean(apiToken) !== undefined,
+    web_app_bootstrap_secret: clean(webAppBootstrapSecret) !== undefined,
+    nylas_api_key: clean(nylasApiKey) !== undefined,
+    nylas_grant_id: clean(nylasGrantId) !== undefined,
+    nylas_self_email: clean(nylasSelfEmail) !== undefined,
+    signal_phone_number: clean(signalPhoneNumber) !== undefined,
   };
   logger.info({ present }, 'Resolved bootstrap secrets from vault (vault-only, no env fallback)');
 }

--- a/tests/integration/seed-vault.test.ts
+++ b/tests/integration/seed-vault.test.ts
@@ -47,6 +47,30 @@ describeIf('seedVault', () => {
     expect(skipped).toContain('nylas_api_key');
   });
 
+  it('treats whitespace-only env values as absent (skipped)', async () => {
+    const { seeded, skipped } = await seedVault(secrets, { NYLAS_API_KEY: '   ' }, logger);
+    expect(seeded).not.toContain('nylas_api_key');
+    expect(skipped).toContain('nylas_api_key');
+    expect(await secrets.get('nylas_api_key')).toBeNull();
+  });
+
+  it('trims surrounding whitespace from seeded values (copy-paste artifacts)', async () => {
+    await seedVault(secrets, { TAVILY_API_KEY: '  tvly_padded_123\n' }, logger);
+    expect(await secrets.get('tavily_api_key')).toBe('tvly_padded_123');
+  });
+
+  it('verifyRequiredSecrets treats a whitespace-only required secret as missing', async () => {
+    await seedVault(
+      secrets,
+      { ANTHROPIC_API_KEY: 'sk-ant-x', API_TOKEN: 'tok-x', WEB_APP_BOOTSTRAP_SECRET: 'wabs-x' },
+      logger,
+    );
+    // A whitespace-only row would pass a bare null-check but disables HTTP auth, so it
+    // must be reported missing — set it directly (the seeder would have skipped it).
+    await secrets.set('api_token', '   ');
+    expect(await verifyRequiredSecrets(secrets, logger)).toEqual(['api_token']);
+  });
+
   it('is idempotent — re-running upserts the same value', async () => {
     await seedVault(secrets, { TAVILY_API_KEY: 'tvly_v1' }, logger);
     await seedVault(secrets, { TAVILY_API_KEY: 'tvly_v2' }, logger);

--- a/tests/setup/test-setup-functions.sh
+++ b/tests/setup/test-setup-functions.sh
@@ -23,6 +23,19 @@ assert_true() {
     fi
 }
 
+assert_false() {
+    local desc="$1"
+    local file="$2"
+    local pattern="$3"
+    if ! grep -qF "$pattern" "$file" 2>/dev/null; then
+        echo "  ✓ $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  ✗ $desc — did not expect '$pattern' in $file"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 assert_valid_key() {
     local desc="$1"
     local key="$2"
@@ -71,6 +84,7 @@ cat > "$_tmp_example" <<'EXAMPLE_EOF'
 DB_USER=your-db-user
 DB_PASSWORD=your-db-password
 DATABASE_URL=postgres://your-db-user:your-db-password@localhost:5432/curia
+SECRET_ENCRYPTION_KEY=replace-with-a-base64-32-byte-key
 ANTHROPIC_API_KEY=sk-ant-...
 API_TOKEN=your-secret-token-here
 WEB_APP_BOOTSTRAP_SECRET=replace-with-a-long-random-secret
@@ -80,25 +94,33 @@ EXAMPLE_EOF
 
 _tmp_env=$(mktemp)
 
-# Override script globals for test isolation
+# Override script globals for test isolation. Under vault-only (#911), write_env only
+# templates the four bootstrap values into .env; ANTHROPIC_API_KEY / API_TOKEN /
+# WEB_APP_BOOTSTRAP_SECRET are seeded into the encrypted vault and must NOT appear here.
 ENV_EXAMPLE="$_tmp_example"
 ENV_FILE="$_tmp_env"
 DB_USER="curia"
 DB_PASSWORD="testpassword123abc"
+SECRET_ENCRYPTION_KEY="dGVzdC1lbmNyeXB0aW9uLWtleS0zMmJ5dGVzLWxvbmcxMjM0NQ=="
 API_TOKEN="testtoken456def"
 WEB_APP_BOOTSTRAP_SECRET="testsecret789ghi"
 DATABASE_URL="postgres://curia:testpassword123abc@localhost:5432/curia"
 
-write_env "sk-ant-testkey999"
+write_env
 
-assert_true "DB_USER=curia written"                   "$_tmp_env" "DB_USER=curia"
-assert_true "DB_PASSWORD written"                      "$_tmp_env" "DB_PASSWORD=testpassword123abc"
-assert_true "DATABASE_URL written"                     "$_tmp_env" "DATABASE_URL=postgres://curia:testpassword123abc@localhost:5432/curia"
-assert_true "ANTHROPIC_API_KEY written"                "$_tmp_env" "ANTHROPIC_API_KEY=sk-ant-testkey999"
-assert_true "API_TOKEN written"                        "$_tmp_env" "API_TOKEN=testtoken456def"
-assert_true "WEB_APP_BOOTSTRAP_SECRET written"         "$_tmp_env" "WEB_APP_BOOTSTRAP_SECRET=testsecret789ghi"
-assert_true "optional comment line preserved"          "$_tmp_env" "# NYLAS_API_KEY"
-assert_true "non-substituted var preserved"            "$_tmp_env" "LOG_LEVEL=info"
+assert_true  "DB_USER=curia written"                  "$_tmp_env" "DB_USER=curia"
+assert_true  "DB_PASSWORD written"                     "$_tmp_env" "DB_PASSWORD=testpassword123abc"
+assert_true  "DATABASE_URL written"                    "$_tmp_env" "DATABASE_URL=postgres://curia:testpassword123abc@localhost:5432/curia"
+assert_true  "SECRET_ENCRYPTION_KEY written"           "$_tmp_env" "SECRET_ENCRYPTION_KEY=dGVzdC1lbmNyeXB0aW9uLWtleS0zMmJ5dGVzLWxvbmcxMjM0NQ=="
+# Vault-only: these three are NOT written to .env (they go to the encrypted vault). The
+# live values must never be templated in, and the example placeholders stay untouched.
+assert_false "API_TOKEN live value not written to .env"    "$_tmp_env" "API_TOKEN=testtoken456def"
+assert_false "WEB_APP_BOOTSTRAP live value not in .env"    "$_tmp_env" "WEB_APP_BOOTSTRAP_SECRET=testsecret789ghi"
+assert_true  "ANTHROPIC_API_KEY placeholder left untouched" "$_tmp_env" "ANTHROPIC_API_KEY=sk-ant-..."
+assert_true  "API_TOKEN placeholder left untouched"        "$_tmp_env" "API_TOKEN=your-secret-token-here"
+assert_true  "WEB_APP_BOOTSTRAP placeholder left untouched" "$_tmp_env" "WEB_APP_BOOTSTRAP_SECRET=replace-with-a-long-random-secret"
+assert_true  "optional comment line preserved"            "$_tmp_env" "# NYLAS_API_KEY"
+assert_true  "non-substituted var preserved"              "$_tmp_env" "LOG_LEVEL=info"
 
 rm -f "$_tmp_example" "$_tmp_env"
 # Reset ENV_FILE/ENV_EXAMPLE to real paths after test

--- a/tests/unit/apply-vault-secrets.test.ts
+++ b/tests/unit/apply-vault-secrets.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import type { Config } from '../../src/config.js';
+import type { SecretsService } from '../../src/secrets/secrets-service.js';
+import { applyVaultSecrets } from '../../src/secrets/apply-vault-secrets.js';
+
+const logger = pino({ level: 'silent' });
+
+// Minimal SecretsService stub: applyVaultSecrets only calls get(name).
+function stubSecrets(values: Record<string, string | null>): SecretsService {
+  return {
+    get: async (name: string) => (name in values ? values[name] : null),
+  } as unknown as SecretsService;
+}
+
+// Bare config carrying just the fields applyVaultSecrets writes.
+function blankConfig(): Config {
+  return {
+    anthropicApiKey: undefined,
+    openaiApiKey: undefined,
+    openrouterApiKey: undefined,
+    apiToken: undefined,
+    webAppBootstrapSecret: undefined,
+    nylasApiKey: undefined,
+    nylasGrantId: undefined,
+    nylasSelfEmail: '',
+    signalPhoneNumber: undefined,
+  } as unknown as Config;
+}
+
+describe('applyVaultSecrets', () => {
+  it('writes present vault values onto config and leaves absent ones undefined', async () => {
+    const config = blankConfig();
+    await applyVaultSecrets(
+      config,
+      stubSecrets({ anthropic_api_key: 'sk-ant-x', api_token: 'tok-x' }),
+      logger,
+    );
+    expect(config.anthropicApiKey).toBe('sk-ant-x');
+    expect(config.apiToken).toBe('tok-x');
+    expect(config.signalPhoneNumber).toBeUndefined();
+    expect(config.nylasApiKey).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace from vault values', async () => {
+    const config = blankConfig();
+    await applyVaultSecrets(
+      config,
+      stubSecrets({ anthropic_api_key: '  sk-ant-x\n', signal_phone_number: ' +12223334444 ' }),
+      logger,
+    );
+    expect(config.anthropicApiKey).toBe('sk-ant-x');
+    expect(config.signalPhoneNumber).toBe('+12223334444');
+  });
+
+  it('collapses a whitespace-only value to undefined so feature/boot guards stay honest', async () => {
+    const config = blankConfig();
+    await applyVaultSecrets(
+      config,
+      // A blank signal_phone_number must NOT wire up the Signal channel; a blank
+      // api_token must trip the !config.apiToken boot guard rather than read as present.
+      stubSecrets({ signal_phone_number: '   ', api_token: ' ' }),
+      logger,
+    );
+    expect(config.signalPhoneNumber).toBeUndefined();
+    expect(config.apiToken).toBeUndefined();
+  });
+
+  it('defaults nylasSelfEmail to an empty string, never undefined', async () => {
+    const config = blankConfig();
+    await applyVaultSecrets(config, stubSecrets({}), logger);
+    expect(config.nylasSelfEmail).toBe('');
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -23,11 +23,11 @@ describe('loadConfig', () => {
     expect(() => loadConfig()).toThrow('DATABASE_URL');
   });
 
-  it('loads ANTHROPIC_API_KEY from environment', () => {
+  it('does not read ANTHROPIC_API_KEY from environment (vault-only, resolved by applyVaultSecrets)', () => {
     process.env.DATABASE_URL = 'postgres://test:test@localhost:5432/test';
     process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
     const config = loadConfig();
-    expect(config.anthropicApiKey).toBe('sk-ant-test');
+    expect(config.anthropicApiKey).toBeUndefined();
   });
 
   it('defaults LOG_LEVEL to info', () => {


### PR DESCRIPTION
> **Step 2 of a two-PR split — now rebased.** #924 (the `seed-vault` script) is merged, and this branch has been rebased onto `main`, so it now contains **only the vault-only delta** (the seeder no longer appears in the diff). Single clean commit.
>
> **Merge ordering still applies:** the prod vault must be seeded (via the now-deployed #924) and verified **before** this merges — deploying vault-only resolution against an un-seeded vault fails closed on every secret. Sequence: seed prod → verify `source: 'vault'` → merge + deploy this → trim prod `.env` last.

---

## Summary

Migrates secrets out of plaintext `.env` into the encrypted vault (#542), with a **vault-only** resolution model — no env fallback. Closes #911.

Only **four** values stay in `.env`, because they bootstrap the vault itself: `DB_USER`, `DB_PASSWORD`, `DATABASE_URL` (reach the DB that hosts the vault) and `SECRET_ENCRYPTION_KEY` (decrypts it). Every other secret lives only in the vault.

### How it works
- **Skill secrets** (`ctx.secret()`) already resolved vault-first in #542 — they're just seeded and removed from `.env` (no code change).
- **Bootstrap/config secrets** now resolve via a new `applyVaultSecrets(config, secretsService, logger)` that runs right after the vault is constructed in `src/index.ts`, before any consumer. `loadConfig()` no longer reads them from env. Vault-only, no `?? process.env`.
- **`scripts/seed-vault.ts`** (`pnpm run seed-vault`) seeds the vault from current env values (idempotent upsert). `setup.sh` runs it after migrations so fresh installs never boot an empty vault, and `write_env` now writes only the four bootstrap values.

### Security hardening (caught in the pre-PR review)
The HTTP bearer-auth consumer (`validateBearerToken`) **fails open** — a missing token disables auth entirely. Under vault-only resolution an absent `api_token` row would silently expose the API, so:
- `src/index.ts` now **refuses to boot** when `api_token` is absent (fail closed), and
- `setup.sh` runs seeding with `SEED_VAULT_VERIFY=1`, which confirms the required rows (`anthropic_api_key`, `api_token`, `web_app_bootstrap_secret`) actually persisted and aborts the install otherwise — closing a resume-path gap where a secret could be silently skipped.

### ⚠️ Rollout ordering (do NOT merge-and-deploy blindly)
Because there is no env fallback, deploying this against an **un-seeded** prod vault would fail closed on every secret. The existing deployment must be migrated in order: **seed the prod vault from the live `.env` first, verify, deploy this code, then trim prod `.env` last.** Full runbook in `docs/dev/configuration.md` → "Migrating an existing deployment".

## Out of scope (follow-ups filed)
- Google Workspace OAuth secrets — #913 (second consumer: the MCP subprocess)
- Multi-account YAML `resolveEnvValue` path still reads env — #920

## Test plan
- `pnpm run typecheck` — clean
- `pnpm test` — green (3220 passing; the 2 failing `autonomy-*` tests are pre-existing DB-required tests that fail identically on `main` without `DATABASE_URL`, and this branch touches no autonomy files)
- New: `apply-vault-secrets.test.ts` (vault-only resolution, no env fallback), `seed-vault.test.ts` (seed/skip/idempotent + required-secret verification)
- Reviews: spec + quality per task, final holistic review, silent-failure hunter (2 criticals found and fixed, re-verified resolved), security review (signed off — no secret reaches any log; crypto/access model unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated setup and configuration guides to reflect vault-based secret management instead of environment files for improved security.
  * Added comprehensive migration guidance for existing deployments and operational procedures for managing secrets.

* **Chores**
  * Enhanced setup process to automatically seed application secrets into an encrypted vault; only bootstrap configuration values now remain in environment files.
  * Improved security posture by centralizing secret storage and removing credentials from configuration templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->