### PR TITLE
fix: scope GITHUB_TOKEN to least privilege in security workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,10 +6,10 @@ on:
     # Weekly full scan — Wednesday 6am UTC (off-peak)
     - cron: '0 6 * * 3'
 
+# Least privilege: workflow token defaults to read-only; the analyze job grants
+# the write/read scopes CodeQL needs at the job level (Scorecard TokenPermissionsID).
 permissions:
-  security-events: write
   contents: read
-  actions: read
 
 env:
   # Opt in to Node.js 24 runtime before it becomes the forced default on 2026-06-02.
@@ -19,6 +19,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # CodeQL uploads analysis results to the Security tab
+      contents: read
+      actions: read           # CodeQL reads workflow run metadata
 
     strategy:
       fail-fast: false

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -6,9 +6,10 @@ on:
   release:
     types: [published]
 
-# Default read-only. The sbom job overrides to write because GitHub Actions
-# doesn't allow per-event permission scoping within a single job, and the
-# release upload step requires contents:write.
+# Least privilege: default the workflow token to read-only. Generation never
+# needs write; only the release-attachment job does, and it runs solely on
+# release events — so the write scope is isolated there instead of being held
+# by every push-triggered run (Scorecard TokenPermissionsID).
 permissions:
   contents: read
 
@@ -16,11 +17,15 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  sbom:
+  generate:
     name: Generate SBOM
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+    # Surface the generation step's outcome so the release job can skip cleanly
+    # when generation failed (continue-on-error swallows the failure here).
+    outputs:
+      sbom_outcome: ${{ steps.sbom.outcome }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -39,9 +44,24 @@ jobs:
           upload-artifact: true
           upload-artifact-retention: 90
 
+  attach-release:
+    name: Attach SBOM to release
+    runs-on: ubuntu-latest
+    needs: generate
+    # Only on a published release, and only if generation actually succeeded.
+    # This is the sole path that needs write access to the repo.
+    if: github.event_name == 'release' && needs.generate.outputs.sbom_outcome == 'success'
+    permissions:
+      contents: write  # gh release upload attaches an asset to the release
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sbom-${{ github.sha }}.spdx.json
+
       - name: Attach SBOM to release
-        if: github.event_name == 'release' && steps.sbom.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}  # gh needs repo context (no checkout in this job)
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: gh release upload "$RELEASE_TAG" sbom.spdx.json --clobber

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -58,10 +58,23 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: sbom-${{ github.sha }}.spdx.json
+          path: ./sbom-download
 
       - name: Attach SBOM to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}  # gh needs repo context (no checkout in this job)
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$RELEASE_TAG" sbom.spdx.json --clobber
+        run: |
+          # anchore/sbom-action stores the file inside the artifact under the
+          # artifact name (sbom-<sha>.spdx.json), not the output-file name, so
+          # resolve it dynamically rather than assuming a fixed path. Fail loudly
+          # if it's missing instead of attaching nothing to the release.
+          FILE=$(find ./sbom-download -name '*.spdx.json' | head -n1)
+          if [ -z "$FILE" ]; then
+            echo "::error::SBOM artifact downloaded but no .spdx.json file found inside it" >&2
+            exit 1
+          fi
+          # Copy to a stable name so the release asset is always `sbom.spdx.json`.
+          cp "$FILE" sbom.spdx.json
+          gh release upload "$RELEASE_TAG" sbom.spdx.json --clobber

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -53,6 +53,7 @@ jobs:
     if: github.event_name == 'release' && needs.generate.outputs.sbom_outcome == 'success'
     permissions:
       contents: write  # gh release upload attaches an asset to the release
+      actions: read    # download-artifact: not required for same-run, but explicit on this CI-untested path
     steps:
       - name: Download SBOM artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,14 +8,19 @@ on:
   schedule:
     - cron: '0 7 * * 3'  # Weekly, Wednesday — staggered from CodeQL (06:00)
 
+# Least privilege: workflow token defaults to read-only; the scan job grants
+# `security-events: write` at the job level for the SARIF upload (Scorecard
+# TokenPermissionsID).
 permissions:
   contents: read
-  security-events: write  # required for SARIF upload
 
 jobs:
   semgrep:
     name: Semgrep Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # required for SARIF upload
     container:
       image: semgrep/semgrep
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,9 +12,11 @@ on:
   schedule:
     - cron: '0 8 * * 3'  # Weekly, Wednesday — staggered from CodeQL (06:00) and Semgrep (07:00)
 
+# Least privilege: the workflow token defaults to read-only. Each job that
+# uploads SARIF grants `security-events: write` at the job level, so the write
+# scope exists only where it's used (Scorecard TokenPermissionsID).
 permissions:
   contents: read
-  security-events: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -23,6 +25,9 @@ jobs:
   trivy-fs:
     name: Filesystem Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # Upload SARIF step writes to the Security tab
     steps:
       - uses: actions/checkout@v6
         with:
@@ -53,6 +58,9 @@ jobs:
     # Image build+scan is expensive, so it's skipped on every push/PR. It runs on
     # the weekly schedule and on manual dispatch (for on-demand fix verification).
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      security-events: write  # Upload SARIF step writes to the Security tab
     steps:
       - uses: actions/checkout@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`uuid` pinned to v11** — forces `nylas`'s transitive `uuid@8.3.2` up to `^11.1.1` (CVE-2026-41907); v11 is the last major that still ships the CommonJS build the Nylas SDK requires.
 - **pnpm overrides moved to `pnpm-workspace.yaml`** — pnpm v10+ ignores `pnpm.overrides` in package.json, so the existing pins (qs, ip-address, vite, fast-uri, hono) had silently stopped applying; relocated to the supported file.
 - **On-demand Trivy image scan** — the container vulnerability scan now supports `workflow_dispatch`, so base-image/dependency CVE fixes can be re-verified immediately instead of waiting for the weekly schedule.
-- **Least-privilege workflow tokens** — `trivy`, `semgrep`, `codeql`, and `sbom` now default `GITHUB_TOKEN` to read-only and grant write scopes only on the jobs that need them; `sbom` splits release-asset upload into its own write-scoped job that runs only on releases. Clears 4 high-severity Scorecard `TokenPermissionsID` alerts. (#921)
+- **Least-privilege workflow tokens** — security workflows default `GITHUB_TOKEN` to read-only, granting write scopes per-job. Clears 4 Scorecard `TokenPermissionsID` alerts. (#921)
 
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`uuid` pinned to v11** — forces `nylas`'s transitive `uuid@8.3.2` up to `^11.1.1` (CVE-2026-41907); v11 is the last major that still ships the CommonJS build the Nylas SDK requires.
 - **pnpm overrides moved to `pnpm-workspace.yaml`** — pnpm v10+ ignores `pnpm.overrides` in package.json, so the existing pins (qs, ip-address, vite, fast-uri, hono) had silently stopped applying; relocated to the supported file.
 - **On-demand Trivy image scan** — the container vulnerability scan now supports `workflow_dispatch`, so base-image/dependency CVE fixes can be re-verified immediately instead of waiting for the weekly schedule.
+- **Least-privilege workflow tokens** — `trivy`, `semgrep`, `codeql`, and `sbom` now default `GITHUB_TOKEN` to read-only and grant write scopes only on the jobs that need them; `sbom` splits release-asset upload into its own write-scoped job that runs only on releases. Clears 4 high-severity Scorecard `TokenPermissionsID` alerts. (#921)
 
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 


### PR DESCRIPTION
## **User description**
## Summary

Scopes `GITHUB_TOKEN` to least privilege across the four security-scanning workflows, resolving 4 high-severity OpenSSF Scorecard `TokenPermissionsID` alerts (#118, #119, #121, #122).

The pattern: the workflow-level `permissions:` now defaults to read-only (`contents: read`), and `write` scopes are granted only on the specific jobs that need them. This limits blast radius if any third-party action in these workflows is compromised.

- **`trivy.yml`** — `security-events: write` moved from workflow level to both SARIF-uploading jobs (`trivy-fs`, `trivy-image`).
- **`semgrep.yml`** — `security-events: write` moved to the `semgrep` job.
- **`codeql.yml`** — `security-events: write` / `actions: read` moved to the `analyze` job.
- **`sbom.yml`** — split into a read-only `generate` job and a write-scoped `attach-release` job that runs **only on release events**, so push-triggered runs no longer hold `contents: write`. The release job downloads the SBOM artifact and resolves its filename dynamically (the artifact's internal name differs from `output-file`), failing loudly if the SBOM is missing rather than silently shipping a release with no SBOM.

## Testing

- All four workflow YAML files validated with a YAML parser.
- Permission scopes verified against each tool's documented requirements (SARIF upload needs `security-events: write`; CodeQL needs `security-events: write` + `actions: read` + `contents: read`).
- `download-artifact@v4` ↔ `upload-artifact@v4` (used internally by `anchore/sbom-action@v0`) compatibility confirmed.
- The SBOM cross-job handoff path is exercised only on `release: published`, which push CI won't trigger — worth a sanity check on the next real release.

## Acceptance criteria (from #921)

- [x] Top-level `permissions:` in trivy/semgrep/codeql is read-only; `security-events: write` granted only at job level.
- [x] `sbom.yml` no longer grants `contents: write` on the push path; write scoped to a release-only job.
- [x] No change to scan coverage, schedules, or triggers.
- [ ] The 4 Scorecard alerts resolve on the next Scorecard run after merge. *(verified post-merge)*

Closes #921


___

## **CodeAnt-AI Description**
Reduce workflow token access and make SBOM release uploads reliable

### What Changed
- Security scans now keep the default token read-only and only grant write access in the jobs that upload scan results
- SBOM generation no longer holds write access during push runs; release uploads happen in a separate job that runs only for published releases
- SBOM release uploads now look for the generated file inside the downloaded artifact, copy it to a stable filename, and fail clearly if the file is missing

### Impact
`✅ Lower risk from leaked workflow tokens`
`✅ Fewer high-severity security alerts`
`✅ More reliable SBOM files on releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
