### PR TITLE
feat: add seed-vault script (step 1 of #911, deploy-and-seed before #922)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "render-coordinator-prompt": "tsx --env-file=.env scripts/render-coordinator-prompt.ts",
     "redteam": "promptfoo redteam run --config tests/redteam/promptfooconfig.yaml --env-file .env",
     "redteam:report": "promptfoo view",
-    "backfill:contact-attributes": "tsx --env-file=.env scripts/backfill-contact-attributes.ts"
+    "backfill:contact-attributes": "tsx --env-file=.env scripts/backfill-contact-attributes.ts",
+    "seed-vault": "tsx --env-file=.env scripts/seed-vault.ts"
   },
   "license": "MIT",
   "dependencies": {

--- a/scripts/seed-vault.ts
+++ b/scripts/seed-vault.ts
@@ -1,0 +1,146 @@
+// seed-vault.ts — one-time / idempotent migration of plaintext env secrets into
+// the encrypted vault (#911). The vault `set()` is an upsert, so re-running is safe.
+//
+// Run for a manual migration (reads the current .env):
+//   pnpm run seed-vault
+// Add a single secret later (transient env var, then run):
+//   NYLAS_API_KEY=nyk_... pnpm run seed-vault
+//
+// Invoked by scripts/setup.sh after migrations for fresh installs.
+import { pathToFileURL } from 'node:url';
+import pg from 'pg';
+import pino from 'pino';
+import { loadEncryptionKey } from '../src/secrets/crypto.js';
+import { SecretsService } from '../src/secrets/secrets-service.js';
+
+const logger = pino({ name: 'seed-vault' });
+
+// Canonical list of secrets migrated into the vault (#911). Each vault key is
+// snake_case; its env var is the UPPER_SNAKE_CASE form (the same name.toUpperCase()
+// convention used by the execution layer's ctx.secret() and by applyVaultSecrets()).
+// Order is irrelevant — set() is an upsert.
+export const SEED_SECRET_NAMES = [
+  // bootstrap/config-scoped (resolved at boot by applyVaultSecrets)
+  'anthropic_api_key',
+  'openai_api_key',
+  'openrouter_api_key',
+  'api_token',
+  'web_app_bootstrap_secret',
+  'nylas_api_key',
+  'nylas_grant_id',
+  'nylas_self_email',
+  'signal_phone_number',
+  // skill-scoped (resolved at call time by ctx.secret)
+  'ceo_nylas_grant_id',
+  'ceo_self_email',
+  'tavily_api_key',
+] as const;
+
+// The subset of secrets that MUST exist in the vault for a working install. Their
+// absence is not "feature off" — it's a broken deploy: anthropic_api_key powers all
+// agents, api_token gates HTTP auth (a missing token disables auth entirely, see
+// src/channels/http/auth.ts and the boot guard in src/index.ts), and
+// web_app_bootstrap_secret gates web login. setup.sh runs verifyRequiredSecrets() after
+// seeding so a partial/failed seed fails loudly instead of producing a half-configured
+// (and possibly auth-disabled) install (#911).
+export const REQUIRED_SECRET_NAMES = [
+  'anthropic_api_key',
+  'api_token',
+  'web_app_bootstrap_secret',
+] as const;
+
+/**
+ * Confirm each required secret has a row in the vault. Returns the names of any that are
+ * missing so the caller can fail loudly. Reads via SecretsService.get, so a present-but-
+ * undecryptable row surfaces as a thrown error rather than a false "present".
+ */
+export async function verifyRequiredSecrets(
+  secrets: SecretsService,
+  log: pino.Logger,
+): Promise<string[]> {
+  const missing: string[] = [];
+  for (const name of REQUIRED_SECRET_NAMES) {
+    // Treat an empty value as missing, not present. An empty api_token would pass a bare
+    // null-check but disables HTTP auth — validateBearerToken() treats "" as "no token
+    // configured" — so an unusable vault state must fail loudly here, matching the
+    // falsy-check boot guard in src/index.ts.
+    const value = await secrets.get(name);
+    if (value === null || value === '') missing.push(name);
+  }
+  if (missing.length > 0) {
+    log.error({ missing }, 'Required secrets missing from vault');
+  } else {
+    log.info({ required: REQUIRED_SECRET_NAMES }, 'Required secrets present in vault');
+  }
+  return missing;
+}
+
+/**
+ * Read each migrated secret from `env` (by its UPPER_SNAKE_CASE name) and upsert any
+ * present, non-empty value into the vault. Absent/empty values are skipped, never
+ * cleared — this is additive so a partial env (e.g. no Signal configured) is fine.
+ * Never logs secret values, only their names.
+ */
+export async function seedVault(
+  secrets: SecretsService,
+  env: NodeJS.ProcessEnv,
+  log: pino.Logger,
+): Promise<{ seeded: string[]; skipped: string[] }> {
+  const seeded: string[] = [];
+  const skipped: string[] = [];
+  for (const name of SEED_SECRET_NAMES) {
+    const value = env[name.toUpperCase()];
+    if (value === undefined || value === '') {
+      skipped.push(name);
+      continue;
+    }
+    await secrets.set(name, value);
+    seeded.push(name);
+  }
+  log.info({ seeded, skipped }, 'Vault seeding complete');
+  return { seeded, skipped };
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    logger.error('seed-vault: DATABASE_URL is not set');
+    process.exit(1);
+    throw new Error('unreachable'); // guards against process.exit mocks (mirrors the key branch below)
+  }
+  let key: Buffer;
+  try {
+    key = loadEncryptionKey();
+  } catch (err) {
+    logger.error({ err }, 'seed-vault: SECRET_ENCRYPTION_KEY is missing or invalid');
+    process.exit(1);
+    throw new Error('unreachable'); // guards against process.exit mocks
+  }
+  const pool = new pg.Pool({ connectionString: databaseUrl });
+  const secrets = new SecretsService(pool, key, logger);
+  seedVault(secrets, process.env, logger)
+    .then(async () => {
+      // setup.sh sets SEED_VAULT_VERIFY=1 so a partial/failed seed (e.g. the resume path
+      // where api_token was never persisted) fails the install loudly instead of booting
+      // with auth disabled. Ad-hoc single-secret runs (no flag) skip the required check.
+      if (process.env.SEED_VAULT_VERIFY === '1') {
+        const missing = await verifyRequiredSecrets(secrets, logger);
+        if (missing.length > 0) {
+          logger.error(
+            { missing },
+            'seed-vault: required secrets are not in the vault after seeding — install is incomplete',
+          );
+          await pool.end();
+          process.exit(1);
+        }
+      }
+      await pool.end();
+      process.exit(0);
+    })
+    .catch(async (err) => {
+      logger.error({ err }, 'seed-vault: fatal error');
+      await pool.end();
+      process.exit(1);
+    });
+}

--- a/tests/integration/seed-vault.test.ts
+++ b/tests/integration/seed-vault.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { loadEncryptionKey } from '../../src/secrets/crypto.js';
+import { SecretsService } from '../../src/secrets/secrets-service.js';
+import { seedVault, verifyRequiredSecrets, SEED_SECRET_NAMES, REQUIRED_SECRET_NAMES } from '../../scripts/seed-vault.js';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL && process.env.SECRET_ENCRYPTION_KEY ? describe : describe.skip;
+
+describeIf('seedVault', () => {
+  const logger = pino({ level: 'silent' });
+  // Construct pool/service inside hooks (not at describe-callback top level) so that
+  // `describe.skip` can collect the suite without invoking loadEncryptionKey() — which
+  // throws when SECRET_ENCRYPTION_KEY is unset. Mirrors secrets-service.test.ts.
+  let pool: pg.Pool;
+  let secrets: SecretsService;
+
+  beforeAll(() => {
+    pool = new pg.Pool({ connectionString: DATABASE_URL });
+    secrets = new SecretsService(pool, loadEncryptionKey(), logger);
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM secrets WHERE name = ANY($1)', [[...SEED_SECRET_NAMES]]);
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM secrets WHERE name = ANY($1)', [[...SEED_SECRET_NAMES]]);
+    await pool.end();
+  });
+
+  it('seeds present env values into the vault and skips absent ones', async () => {
+    const env = { NYLAS_API_KEY: 'nyk_test_123', TAVILY_API_KEY: 'tvly_test_456' };
+    const { seeded, skipped } = await seedVault(secrets, env, logger);
+
+    expect(seeded.sort()).toEqual(['nylas_api_key', 'tavily_api_key']);
+    expect(skipped).toContain('anthropic_api_key');
+    expect(await secrets.get('nylas_api_key')).toBe('nyk_test_123');
+    expect(await secrets.get('tavily_api_key')).toBe('tvly_test_456');
+    expect(await secrets.get('anthropic_api_key')).toBeNull();
+  });
+
+  it('treats empty-string env values as absent (skipped)', async () => {
+    const { seeded, skipped } = await seedVault(secrets, { NYLAS_API_KEY: '' }, logger);
+    expect(seeded).not.toContain('nylas_api_key');
+    expect(skipped).toContain('nylas_api_key');
+  });
+
+  it('is idempotent — re-running upserts the same value', async () => {
+    await seedVault(secrets, { TAVILY_API_KEY: 'tvly_v1' }, logger);
+    await seedVault(secrets, { TAVILY_API_KEY: 'tvly_v2' }, logger);
+    expect(await secrets.get('tavily_api_key')).toBe('tvly_v2');
+  });
+
+  it('verifyRequiredSecrets reports every required secret missing from an empty vault', async () => {
+    const missing = await verifyRequiredSecrets(secrets, logger);
+    expect(missing.sort()).toEqual([...REQUIRED_SECRET_NAMES].sort());
+  });
+
+  it('verifyRequiredSecrets reports the specific required secret still missing after a partial seed', async () => {
+    // Simulate the resume-path gap: anthropic + web_app_bootstrap_secret seeded, api_token never persisted.
+    await seedVault(
+      secrets,
+      { ANTHROPIC_API_KEY: 'sk-ant-x', WEB_APP_BOOTSTRAP_SECRET: 'wabs-x' },
+      logger,
+    );
+    const missing = await verifyRequiredSecrets(secrets, logger);
+    expect(missing).toEqual(['api_token']);
+  });
+
+  it('verifyRequiredSecrets treats an empty-string required secret as missing', async () => {
+    // An empty api_token row would pass a bare null-check but disables HTTP auth, so it
+    // must be reported missing — set the other two so only the empty one is flagged.
+    await seedVault(
+      secrets,
+      { ANTHROPIC_API_KEY: 'sk-ant-x', WEB_APP_BOOTSTRAP_SECRET: 'wabs-x' },
+      logger,
+    );
+    await secrets.set('api_token', '');
+    expect(await verifyRequiredSecrets(secrets, logger)).toEqual(['api_token']);
+  });
+
+  it('verifyRequiredSecrets returns empty when all required secrets are present', async () => {
+    await seedVault(
+      secrets,
+      { ANTHROPIC_API_KEY: 'sk-ant-x', API_TOKEN: 'tok-x', WEB_APP_BOOTSTRAP_SECRET: 'wabs-x' },
+      logger,
+    );
+    expect(await verifyRequiredSecrets(secrets, logger)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Adds `scripts/seed-vault.ts` (`pnpm run seed-vault`) — a one-time, idempotent script that copies plaintext env secrets into the encrypted vault (#542). This is **step 1** of #911, split out so it can ship and run against production **before** the breaking vault-only resolution change.

Part of #911. Paired with #922 (the vault-only resolution change), which should merge **after** this is deployed and prod is seeded.

## Why this is safe to deploy on its own

- The script is **not imported by the running application** — it only executes via `pnpm run seed-vault`. Deploying this PR changes **zero** runtime secret-resolution behavior.
- `secrets.set()` is an upsert, so the script is idempotent and re-runnable.
- It reads from `process.env`, encrypts via the existing `SecretsService` (AES-256-GCM), and never logs a secret value (only names, in the `seeded`/`skipped` summary).

## What it enables

After merging and deploying this, on the existing deployment:

1. Run `pnpm run seed-vault` (reads the live `.env`, upserts into the vault).
2. Verify the rows exist, and that **skill** secret reads now resolve from the vault — `ctx.secret()` has been vault-first since #542, so once seeded, `secret.accessed` events flip to `source: 'vault'` with identical values. That's the migration signal, observable **before** any breaking change.

Bootstrap/config secrets keep resolving from env until #922 lands.

It also exports `verifyRequiredSecrets()` (+ `REQUIRED_SECRET_NAMES`), used by #922's `setup.sh` to confirm required rows persisted; it's dormant here unless `SEED_VAULT_VERIFY=1` is set.

## Test plan

- `seed-vault.test.ts` (DB-gated, runs in CI against real Postgres): seed-present / skip-absent, empty-string-as-absent, idempotency, and the `verifyRequiredSecrets` cases (all-missing, partial, all-present).
- No runtime code path is touched, so existing behavior is unchanged.


___

## **CodeAnt-AI Description**
**Add a one-time script to copy env secrets into the vault before the vault-only change**

### What Changed
- Adds a `seed-vault` command that reads existing environment secrets and saves any present values into the encrypted vault
- Skips missing or empty secrets without clearing anything, so partial setups can be seeded safely and rerun without changing existing values
- Adds a required-secret check for fresh installs so setup fails when key secrets were not saved and the app would otherwise start in a broken state
- Adds tests for seeding present values, skipping absent values, rerunning safely, and reporting missing required secrets

### Impact
`✅ Safer vault migration`
`✅ Fewer half-configured installs`
`✅ Clearer setup failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a script to seed and manage encrypted secrets in the vault system with idempotent migration support and verification capabilities.

* **Tests**
  * Added integration tests for secret vault seeding functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->