### PR TITLE
chore(security): pin all GitHub Actions uses: to commit SHAs (#566)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: "pnpm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,19 +30,19 @@ jobs:
         language: [javascript-typescript]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       sbom_outcome: ${{ steps.sbom.outcome }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -35,7 +35,7 @@ jobs:
         id: sbom
         # Non-fatal: SBOM generation must never block CI or a release.
         continue-on-error: true
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           format: spdx-json
           output-file: sbom.spdx.json
@@ -56,7 +56,7 @@ jobs:
       actions: read    # download-artifact: not required for same-run, but explicit on this CI-untested path
     steps:
       - name: Download SBOM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sbom-${{ github.sha }}.spdx.json
           path: ./sbom-download

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,19 +23,19 @@ jobs:
       security-events: write  # for SARIF upload
       id-token: write         # for publishing results to OpenSSF API
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false  # required by Scorecard
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard.sarif
           results_format: sarif
           publish_results: true  # publishes to OpenSSF API for badge
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: scorecard.sarif
           category: scorecard

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,9 +17,9 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0 # full history for diff-aware scanning
-      - uses: gitleaks/gitleaks-action@v3
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,7 +25,7 @@ jobs:
       image: semgrep/semgrep
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run Semgrep
         # continue-on-error so Semgrep's issue-found exit code (1) doesn't
@@ -47,7 +47,7 @@ jobs:
             --exclude 'tests/**/*.snap'
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: semgrep.sarif
         # Upload even when Semgrep finds issues so alerts appear in Security tab

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -29,12 +29,12 @@ jobs:
       contents: read
       security-events: write  # Upload SARIF step writes to the Security tab
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -46,7 +46,7 @@ jobs:
           exit-code: '0'  # findings surfaced via SARIF, not exit code
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs
@@ -62,7 +62,7 @@ jobs:
       contents: read
       security-events: write  # Upload SARIF step writes to the Security tab
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -70,7 +70,7 @@ jobs:
         run: docker build -t curia:scan .
 
       - name: Run Trivy image scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'image'
           image-ref: 'curia:scan'
@@ -81,7 +81,7 @@ jobs:
           exit-code: '0'  # findings surfaced via SARIF, not exit code
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **On-demand Trivy image scan** — the container vulnerability scan now supports `workflow_dispatch`, so base-image/dependency CVE fixes can be re-verified immediately instead of waiting for the weekly schedule.
 - **Least-privilege workflow tokens** — security workflows default `GITHUB_TOKEN` to read-only, granting write scopes per-job. Clears 4 Scorecard `TokenPermissionsID` alerts. (#921)
 - **Secrets migrated out of `.env` into the vault** — application secrets resolve from the encrypted vault only (no env fallback); just the four DB/encryption bootstrap values stay in `.env`. See ADR-021. (#911)
+- **GitHub Actions SHA pinning** — all `uses:` refs across 7 workflows pinned to full 40-char commit SHAs with `# vX` version comments; Dependabot already handles updates. Clears 24 Scorecard `PinnedDependenciesID` alerts. Closes #566.
 
 ## [0.33.0] — 2026-06-04 — "Mr. Meeseeks"
 


### PR DESCRIPTION
## **User description**
## Summary

- Replaced all mutable tag refs (`actions/checkout@v6`, etc.) with full 40-char commit SHAs across 7 workflows: `ci.yml`, `codeql.yml`, `sbom.yml`, `scorecard.yml`, `secret-scan.yml`, `semgrep.yml`, `trivy.yml`.
- Each pin includes a trailing `# vX` comment to preserve readability and enable Dependabot to track updates.
- Dependabot's existing `github-actions` ecosystem entry in `.github/dependabot.yml` handles future SHA bumps — no config change needed.

Closes #566.

## SHA inventory

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `df4cb1c069e1874edd31b4311f1884172cec0e10` | v6 |
| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6 |
| `actions/download-artifact` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4 |
| `pnpm/action-setup` | `0e279bb959325dab635dd2c09392533439d90093` | v6 |
| `github/codeql-action/{init,autobuild,analyze,upload-sarif}` | `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` | v4 |
| `aquasecurity/trivy-action` | `ed142fd0673e97e23eac54620cfb913e5ce36c25` | v0.36.0 |
| `ossf/scorecard-action` | `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` | v2.4.3 |
| `gitleaks/gitleaks-action` | `e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e` | v3 |
| `anchore/sbom-action` | `e22c389904149dbc22b58101806040fa8d37a610` | v0 |

Annotated tags were dereferenced to their underlying commit SHAs (pnpm/action-setup, codeql-action, scorecard-action, trivy-action).

## Out of scope

`semgrep.yml` line 25 uses `image: semgrep/semgrep` (floating container image). Docker image digest pinning is tracked separately in #925 and is explicitly excluded from this issue.

## Test plan

- [ ] Verify `grep -rE 'uses:.*@v[0-9]' .github/workflows/` returns nothing
- [ ] Confirm Dependabot config still includes `package-ecosystem: github-actions`
- [ ] All workflows pass CI on this PR (actions resolve from their SHAs)
- [ ] 24 `PinnedDependenciesID` Scorecard alerts resolve on next weekly run after merge


___

## **CodeAnt-AI Description**
**Lock GitHub Actions to fixed versions across security workflows**

### What Changed
- All GitHub Actions used in CI and security workflows are now pinned to exact versions instead of floating tags
- The affected workflows keep the same scan, build, and upload behavior while reducing the chance of unexpected action changes
- The changelog now notes the pinning update and the OpenSSF Scorecard alerts it clears

### Impact
`✅ Fewer workflow breakages from upstream action updates`
`✅ Lower supply-chain risk in CI and security scans`
`✅ Clears OpenSSF Scorecard pinned-dependency alerts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
