### PR TITLE
fix: raise deepseek/deepseek-v4-pro maxOutputTokens to 32k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`deepseek/deepseek-v4-pro` output token cap** — raised `maxOutputTokens` from 8192 to 32768; the old value caused long-form writing tasks (e.g. essay drafts via `import_to_google_doc`) to produce truncated JSON tool call arguments and non-retryable errors. (#934)
+
 ### Added
 - **Skill/Agent registry** — DB-gated install/enable lifecycle for skills and agents (`skill_registry`/`agent_registry` tables, startup reconciliation of a trusted core set, one-shot prod backfill). Only enabled items load at runtime. (#541)
 - **Skills & Agents settings** — manage install/enable/disable state from Workspace Settings. (#541)

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -114,7 +114,10 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       outputPerMToken: 0.87,
     },
     capabilities: ['coding', 'reasoning'],
-    maxOutputTokens: 8_192,
+    // 8_192 was too low — long-form writing tasks (e.g. import_to_google_doc with
+    // a full essay body) exceeded it, producing truncated JSON tool call arguments.
+    // DeepSeek V4 Pro on OpenRouter supports up to 64k output tokens (#934).
+    maxOutputTokens: 32_768,
   },
   'openai/gpt-4o': {
     provider: 'openrouter',


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause:** `maxOutputTokens: 8_192` for `deepseek/deepseek-v4-pro` was too low for long-form writing. When the coordinator called `import_to_google_doc` with a full essay body as the `content` JSON argument, the model hit the token ceiling mid-string and stopped, leaving malformed JSON. The runtime treated this as non-retryable and sent the user "unable to process".
- **Fix:** Raise `maxOutputTokens` to `32_768`. DeepSeek V4 Pro on OpenRouter supports up to 64k output tokens; 32k is a conservative but sufficient ceiling for essay-length content.

Closes #934

## Test plan

- [ ] Typecheck passes (`pnpm run typecheck`)
- [ ] Unit tests pass (`pnpm run test`)
- [ ] Smoke test: send Curia an email asking it to edit/write a long essay and confirm it successfully creates a Google Doc without a "unable to process" error


___

## **CodeAnt-AI Description**
**Raise DeepSeek V4 Pro output limit for long writing tasks**

### What Changed
- Increased the output limit for `deepseek/deepseek-v4-pro` so long essay drafts can finish without being cut off
- Prevents truncated JSON tool call arguments that could stop Google Doc creation with a non-retryable error

### Impact
`✅ Fewer failed essay imports`
`✅ Fewer "unable to process" errors`
`✅ More reliable Google Doc creation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
