### PR TITLE
feat: gate web-search behind install.requires_secrets (#943)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`⚠️ Stuck` label** — ceo-inbox now applies this label when triage cannot complete for a message (unrecognised classification value, required skill failure, or error budget boundary hit), making failures visible in the Gmail sidebar.
 
 ### Changed
+- **`web-search`** — first consumer of `install.requires_secrets`; declares `tavily_api_key` as an install-time gate, so the Tavily key is now provisioned via the console vault and the not-configured error points operators there. (#943)
 - **Skill/agent loading** — now gated on the registry; only enabled items are registered. `skill.json` and agent YAML schemas gain optional, inert `install`/`uninstall` blocks. `allowed_callers` validation now treats all discovered agents (enabled or disabled) as known. (#541)
 - **`secret.accessed` event** — gains an optional `source: 'vault' | 'env'` field showing where each secret resolved from. Backward-compatible; existing consumers compile unchanged. (#542)
 - **coordinator prompt** — when replying to an external contact and a simultaneous principal update is needed, Curia now sends two separate messages rather than mixing both in one body. Closes #851.

--- a/config/registry-defaults.yaml
+++ b/config/registry-defaults.yaml
@@ -84,7 +84,9 @@ skills:
   - list-pending-actions
   - approval-expiry-sweep
   - pending-actions-digest
-  # NOTE: web-search excluded — requires Tavily API key (secrets: [tavily_api_key])
+  # NOTE: web-search excluded — gated by install.requires_secrets: [tavily_api_key].
+  #        Stays admin-enabled: an operator provisions the Tavily key in the console
+  #        (Settings → Skills → web-search), which lifts the gate and lets them install/enable it.
   # NOTE: calendar-* excluded — require Google Calendar credentials; enable after calendar setup
   # NOTE: ceo-inbox-* excluded — companion to the ceo-inbox agent; enable alongside it
   # NOTE: KG skills (extract-facts, extract-relationships, query-relationships, delete-relationship)

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -351,7 +351,7 @@ from `.env`.
 | `NYLAS_GRANT_ID` | Tier 2 | vault | Email grant (connected account) |
 | `NYLAS_SELF_EMAIL` | Tier 2 | vault | Address Curia reads and sends from |
 | `SIGNAL_PHONE_NUMBER` | Tier 3 | vault | Enables Signal channel |
-| `TAVILY_API_KEY` | Tier 3 | vault | Enables `web-search` skill |
+| `TAVILY_API_KEY` | Tier 3 | vault | Gates `web-search` (`install.requires_secrets`). Provision `tavily_api_key` via the console (Settings → Skills → web-search); the env var is a fallback only and should be unset in production. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Optional | `.env` | Path to service account JSON for Google Drive |
 | `CURIA_TEMPFILE_DIR` | Optional | `.env` | Base directory under which the `file-parse` skill resolves `temp_file_url` inputs. The skill rejects paths that escape this directory. Defaults to the OS temp dir when unset. |
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -218,6 +218,8 @@ TAVILY_API_KEY=tvly-... pnpm run seed-vault
 
 `ctx.secret('tavily_api_key')` resolves **vault-first** with a `TAVILY_API_KEY` env-var fallback. In production the vault is the single source of truth — do **not** leave `TAVILY_API_KEY` set in the deploy environment, since a lingering env var would mask whether the vault entry is actually being used.
 
+> **Revocation caveat:** the install/enable gate checks the **vault only**, but the runtime resolver falls back to the env var. So if `TAVILY_API_KEY` is still set, *deleting `tavily_api_key` from the vault does not revoke web-search* — the skill keeps working off the env var, and only the `secret.accessed` event (`source: env`) reveals it. Treat removing the env var as a prerequisite for vault-based key rotation/revocation, not just initial setup.
+
 ### Signal
 
 Signal messaging runs via [signal-cli](https://github.com/AsamK/signal-cli). The socket path is wired up automatically by Docker Compose — the only thing you need to set is your phone number.

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -201,13 +201,22 @@ Adds web research capability and (when available) Signal messaging.
 
 Powers the `web-search` skill, which lets agents research topics and look up current information.
 
-Sign up at [tavily.com](https://tavily.com) and seed your API key into the vault:
+`web-search` is **excluded from the default core set** and is **gated by `install.requires_secrets: [tavily_api_key]`** — it cannot be installed or enabled until the Tavily key exists in the vault. This makes it the reference flow for provisioning a skill secret through the console.
+
+**Provision via the console (recommended):**
+
+1. Sign up at [tavily.com](https://tavily.com) and copy your API key (`tvly-...`).
+2. In the console, open **Settings → Skills → web-search → Required secrets**. `tavily_api_key` shows as **missing** and **Install & enable** is disabled.
+3. Paste the key inline. It is stored encrypted in the vault; the status flips to **configured** and the button enables.
+4. Click **Install & enable**. Enforcement is **restart-based** — the skill registers and becomes usable on the next process restart.
+
+**Alternative (dev shortcut):** seed the key into the vault directly, then enable web-search in the console:
 
 ```bash
 TAVILY_API_KEY=tvly-... pnpm run seed-vault
 ```
 
-No restart required if Curia is already running — the skill resolves the key from the vault on next use.
+`ctx.secret('tavily_api_key')` resolves **vault-first** with a `TAVILY_API_KEY` env-var fallback. In production the vault is the single source of truth — do **not** leave `TAVILY_API_KEY` set in the deploy environment, since a lingering env var would mask whether the vault entry is actually being used.
 
 ### Signal
 

--- a/skills/web-search/handler.ts
+++ b/skills/web-search/handler.ts
@@ -57,14 +57,19 @@ export class WebSearchHandler implements SkillHandler {
     }
 
     // Resolve API key — declared in manifest so secret() will allow it.
-    // If the env var is not set, secret() throws — we surface that as a
-    // user-readable error rather than letting the exception propagate.
+    // ctx.secret() reads the vault first and falls back to the TAVILY_API_KEY
+    // env var; if neither has it, it throws. We surface that as a user-readable
+    // error rather than letting the exception propagate. The guidance points at
+    // the console/vault (the source of truth) rather than the env var fallback.
     let apiKey: string;
     try {
       apiKey = ctx.secret('tavily_api_key');
     } catch (err) {
       ctx.log.error({ err }, 'Failed to resolve Tavily API key');
-      return { success: false, error: 'Tavily API key not configured — set TAVILY_API_KEY in the environment' };
+      return {
+        success: false,
+        error: 'Tavily API key not configured — add tavily_api_key in the console under Settings → Skills → web-search → Required secrets',
+      };
     }
 
     if (searchDepth !== undefined && searchDepth !== 'basic' && searchDepth !== 'advanced') {

--- a/skills/web-search/handler.ts
+++ b/skills/web-search/handler.ts
@@ -66,6 +66,18 @@ export class WebSearchHandler implements SkillHandler {
       apiKey = ctx.secret('tavily_api_key');
     } catch (err) {
       ctx.log.error({ err }, 'Failed to resolve Tavily API key');
+      // ctx.secret() throws for two very different reasons, and they need
+      // different remediation. A genuinely-missing secret is a plain Error; a
+      // vault READ failure (DB down, decrypt error) is wrapped with a `cause` by
+      // the execution layer (src/skills/execution.ts). Reporting an outage as
+      // "not configured" would send operators to the console to re-enter a key
+      // that is already there — so only the missing case points to the console.
+      if (err instanceof Error && err.cause !== undefined) {
+        return {
+          success: false,
+          error: 'Web search unavailable: failed to read the Tavily API key from the secrets vault (operational error, not a missing key). Check vault/database connectivity.',
+        };
+      }
       return {
         success: false,
         error: 'Tavily API key not configured — add tavily_api_key in the console under Settings → Skills → web-search → Required secrets',

--- a/skills/web-search/skill.json
+++ b/skills/web-search/skill.json
@@ -1,9 +1,10 @@
 {
   "name": "web-search",
   "description": "Search the web using Tavily. Returns structured results with title, URL, snippet, and (for advanced depth) extracted page content. For simple lookups, one search is enough. For research tasks, call multiple times with different queries — each covering a different angle — before forming a conclusion.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "none",
+  "install": { "requires_secrets": ["tavily_api_key"] },
   "inputs": {
     "query": "string",
     "maxResults": "number?",

--- a/tests/unit/skills/web-search.test.ts
+++ b/tests/unit/skills/web-search.test.ts
@@ -46,7 +46,12 @@ describe('WebSearchHandler', () => {
     };
     const result = await handler.execute(ctx);
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('API key');
+    if (!result.success) {
+      expect(result.error).toContain('API key');
+      // Guidance must lead the operator to the console/vault, not the env var.
+      expect(result.error).toContain('Skills');
+      expect(result.error).not.toContain('TAVILY_API_KEY');
+    }
   });
 
   it('returns structured results on success', async () => {

--- a/tests/unit/skills/web-search.test.ts
+++ b/tests/unit/skills/web-search.test.ts
@@ -41,6 +41,7 @@ describe('WebSearchHandler', () => {
   it('returns failure when API key is missing', async () => {
     const ctx: SkillContext = {
       input: { query: 'test' },
+      // A genuinely-missing secret throws a plain Error with no `cause`.
       secret: () => { throw new Error('Secret not set'); },
       log: logger,
     };
@@ -51,6 +52,28 @@ describe('WebSearchHandler', () => {
       // Guidance must lead the operator to the console/vault, not the env var.
       expect(result.error).toContain('Skills');
       expect(result.error).not.toContain('TAVILY_API_KEY');
+    }
+  });
+
+  it('surfaces vault read failures as operational errors, not missing-secret guidance', async () => {
+    const ctx: SkillContext = {
+      input: { query: 'test' },
+      // The execution layer wraps a vault read failure in an Error with a `cause`
+      // (see src/skills/execution.ts). That is an outage, not a misconfiguration —
+      // operators must not be sent to the console to "add the key".
+      secret: () => {
+        throw new Error("Vault read failed for secret 'tavily_api_key': DB connection refused", {
+          cause: new Error('DB connection refused'),
+        });
+      },
+      log: logger,
+    };
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('vault');
+      expect(result.error).not.toContain('not configured');
+      expect(result.error).not.toContain('Settings');
     }
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Makes the `web-search` skill the **first real consumer** of the `install.requires_secrets` install-time secrets gate shipped in #939/#942. Until now no skill declared the gate, so the feature was inert in production. This turns it into a working end-to-end flow: *open web-search → enter the Tavily key in the console → install & enable → search works.*

Closes #943

## Changes

- **`skills/web-search/skill.json`** — declares `"install": { "requires_secrets": ["tavily_api_key"] }`; version bumped `1.0.0 → 1.1.0` (new manifest capability, per the versioning table). Validated against the real `skill-manifest.schema.json`.
- **`skills/web-search/handler.ts`** — not-configured error now directs operators to the console/vault (*Settings → Skills → web-search → Required secrets*) instead of `TAVILY_API_KEY`. The env-var fallback stays as a mechanism.
- **`config/registry-defaults.yaml`** — exclusion comment now references the gate; web-search stays out of the core set (admin-enabled once the key is provisioned).
- **`docs/dev/setup.md` + `docs/dev/configuration.md`** — document the console provisioning flow, that `TAVILY_API_KEY` should be unset in production, and (from review) that vault deletion does **not** revoke the skill while the env var persists.
- **`tests/unit/skills/web-search.test.ts`** — assert the new error guidance points to the console and no longer names the env var.
- **CHANGELOG** — entry under Changed.

## Verification

- Typecheck clean.
- `tests/unit/skills/web-search.test.ts` + `src/registry/registry-service.test.ts`: 28 passed.
- Startup validator tests: 15 passed. Real web-search manifest validates against the AJV schema.

## Deploy-time acceptance criteria (verified on the live deploy, not in this PR)

The UI/runtime behavior (drawer shows `tavily_api_key` missing/red, **Install & enable** disabled with tooltip, inline entry stores encrypted, 400 on the negative path, vault precedence with `TAVILY_API_KEY` unset → `secret.accessed source: vault`) is all existing #939/#942 infrastructure that this PR triggers. Steps to verify after deploy:

1. Deploy → web-search drawer shows the key as missing, button disabled.
2. Enter the key inline → stored encrypted in the vault, status green, button enables.
3. Install & enable, then restart → web-search registers, live query returns results.
4. Remove `TAVILY_API_KEY` from the deploy env, restart → search still works, audit shows `source: vault`.

## Notes / follow-up

- A review surfaced that the install gate is **vault-only** while the runtime resolver falls back to the env var, so a stale `TAVILY_API_KEY` masks vault-based revocation. Documented here; a code-level mitigation (enable-time warning when a gated secret resolves from env but is absent from the vault) is a reasonable follow-up but out of scope for this issue.
- Out of scope per the issue: `uninstall`-block vault cleanup and `requires_config` (PR3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Web-search skill now implements a secure installation gate requiring Tavily API key provisioning through the console vault.

* **Improvements**
  * Updated error messaging to guide operators to Settings → Skills → web-search for required secret configuration, replacing environment variable references.

* **Documentation**
  * Expanded setup guidance for Tavily integration, clarifying console-based provisioning workflow and vault-first configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Gate web search behind a required secret and show the right error when the secret is missing**

### What Changed
- Web search now requires the Tavily key before it can be installed or enabled, and the console guides operators to add it under Settings → Skills → web-search → Required secrets
- If the key is missing, the error now points to the console/vault instead of the environment variable
- If the vault cannot be read, web search now reports an operational vault problem instead of telling operators to re-enter a key that is already present
- Setup and configuration docs now explain the console-based setup flow, the production expectation for the env var, and the revocation caveat when an env var still exists

### Impact
`✅ Fewer failed web-search setups`
`✅ Clearer secret provisioning in the console`
`✅ Fewer misdirected fixes during vault outages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
