### PR TITLE
fix(scheduler): revive cancelled declarative jobs on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Declarative job revival** — `upsertDeclarativeJob` now flips a `cancelled` row back to `pending` (clearing failure state) on conflict, so a still-declared schedule that a prior stale-cleanup wrongly cancelled is restored on restart instead of staying silently dead; `running`/`suspended`/`failed` are left untouched.
 - **`deepseek/deepseek-v4-pro` output token cap** — raised `maxOutputTokens` from 8192 to 32768; the old value caused long-form writing tasks (e.g. essay drafts via `import_to_google_doc`) to produce truncated JSON tool call arguments and non-retryable errors. (#934)
 
 ### Added

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -603,20 +603,33 @@ export class SchedulerService {
     ];
 
     const { rows } = await this.pool.query(sql, params);
-    const resultRow = rows[0] as {
-      id: string;
-      prior_status?: string | null;
-      prior_failures?: number | null;
-      prior_error?: string | null;
-    };
+    const resultRow = rows[0] as
+      | {
+          id: string;
+          prior_status?: string | null;
+          prior_failures?: number | null;
+          prior_error?: string | null;
+        }
+      | undefined;
+    // An INSERT ... ON CONFLICT DO UPDATE with no DO UPDATE WHERE always returns exactly
+    // one row (the inserted or the updated row), so an empty result means the statement or
+    // connection is fundamentally broken. Fail loudly rather than dereferencing undefined —
+    // loadDeclarativeJobs() catches this and logs it on the per-schedule error path.
+    if (!resultRow) {
+      throw new Error(
+        `upsertDeclarativeJob: upsert returned no row for ${sourceAgentId}/${agentId} (${schedule.cron})`,
+      );
+    }
     const jobId = resultRow.id;
+
+    const revivedFromCancelled = resultRow.prior_status === 'cancelled';
 
     // Reviving overrides a terminal 'cancelled' state, so surface it loudly — the
     // symmetric cancellation path (cancelStaleDeclarativeJobs) logs per row, and a
     // resurrection must be at least as visible. Include the failure bookkeeping the
     // upsert just wiped so the prior context survives in the logs. warn (not info)
     // because this silently undoes a deliberate cancelJob() if one was issued.
-    if (resultRow.prior_status === 'cancelled') {
+    if (revivedFromCancelled) {
       this.logger.warn(
         {
           jobId,
@@ -628,6 +641,24 @@ export class SchedulerService {
         },
         'Declarative job revived from cancelled — its YAML declaration still exists. ' +
           'If this job was deliberately stopped, remove its schedule entry from the agent YAML instead of cancelling it.',
+      );
+
+      // cancelJob() cancels a job AND cascades 'cancelled' onto its linked task (see
+      // cancelJob above). Reviving only the job would leave an intent_anchor schedule
+      // pointing at a terminal 'cancelled' task, which the task-update guards
+      // (TERMINAL_STATUSES) then reject — an inconsistent, un-editable state. So when we
+      // revive, also reactivate the linked task. Scoped to status = 'cancelled' so a task
+      // left 'active' by the stale-cleanup path, or one legitimately 'done', is untouched.
+      // (No declarative schedule sets intent_anchor today, so this is a no-op in practice,
+      // but it keeps revival symmetric with cancelJob's cascade for when they do.)
+      await this.pool.query(
+        `UPDATE tasks
+            SET status = 'active', updated_at = now()
+           FROM scheduled_jobs sj
+          WHERE sj.id = $1
+            AND tasks.id = sj.task_id
+            AND tasks.status = 'cancelled'`,
+        [jobId],
       );
     }
 

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -539,15 +539,55 @@ export class SchedulerService {
     // ('principal') and agent-decided ('agent') tasks. See issue #558.
     const originator = makeSystemOriginator();
 
+    // The `prior` CTE captures the row's state BEFORE the upsert (it reads the
+    // statement-start snapshot), so we can tell a routine refresh apart from a
+    // revival of a previously-cancelled row and log the latter loudly below.
+    // The payload predicate mirrors the ON CONFLICT key: task_payload::text is the
+    // stored jsonb canonical text, and $4::jsonb::text normalizes the incoming
+    // payload the same way, so this matches exactly the row ON CONFLICT will hit.
     const sql = `
+      WITH prior AS (
+        SELECT status AS prior_status,
+               consecutive_failures AS prior_failures,
+               last_error AS prior_error
+          FROM scheduled_jobs
+         WHERE created_by = 'system'
+           AND source_agent_id = $1
+           AND agent_id = $2
+           AND cron_expr = $3
+           AND task_payload::text = $4::jsonb::text
+      )
       INSERT INTO scheduled_jobs (source_agent_id, agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone, expected_duration_seconds, originator)
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
       ON CONFLICT (source_agent_id, agent_id, cron_expr, (task_payload::text)) WHERE created_by = 'system'
       DO UPDATE SET next_run_at = $6,
                     timezone = $8,
                     expected_duration_seconds = $9,
-                    originator = COALESCE(scheduled_jobs.originator, $10)
-      RETURNING id
+                    originator = COALESCE(scheduled_jobs.originator, $10),
+                    -- Revive a row that a prior stale-cleanup cancelled but whose YAML
+                    -- declaration still exists. Without this, the ON CONFLICT path updates
+                    -- the row in place and leaves status = 'cancelled' forever, so a still-
+                    -- declared job silently never runs again after one bad cancellation
+                    -- (e.g. the historical task_payload-normalization mismatch). Revive ONLY
+                    -- 'cancelled'; 'running', 'suspended' (failure threshold), 'paused' (drift),
+                    -- 'pending', 'failed' and 'completed' are left untouched.
+                    --
+                    -- Consequence: a deliberate cancelJob() on a still-declared declarative job
+                    -- is NOT durable across restart — it lands in 'cancelled' and is revived
+                    -- here. The supported way to permanently stop a declarative job is to remove
+                    -- its schedule entry from the agent YAML; the row then has no re-declaring
+                    -- upsert, so cancelStaleDeclarativeJobs cancels it and it stays cancelled.
+                    -- Revivals are logged at warn level below so the override is visible.
+                    --
+                    -- Reviving also clears the stale failure bookkeeping so the job starts from
+                    -- a clean slate; the wiped values are preserved in the revival log line.
+                    status = CASE WHEN scheduled_jobs.status = 'cancelled' THEN 'pending' ELSE scheduled_jobs.status END,
+                    consecutive_failures = CASE WHEN scheduled_jobs.status = 'cancelled' THEN 0 ELSE scheduled_jobs.consecutive_failures END,
+                    last_error = CASE WHEN scheduled_jobs.status = 'cancelled' THEN NULL ELSE scheduled_jobs.last_error END
+      RETURNING id,
+                (SELECT prior_status FROM prior) AS prior_status,
+                (SELECT prior_failures FROM prior) AS prior_failures,
+                (SELECT prior_error FROM prior) AS prior_error
     `;
     const params: unknown[] = [
       sourceAgentId,
@@ -563,7 +603,33 @@ export class SchedulerService {
     ];
 
     const { rows } = await this.pool.query(sql, params);
-    const jobId = (rows[0] as { id: string }).id;
+    const resultRow = rows[0] as {
+      id: string;
+      prior_status?: string | null;
+      prior_failures?: number | null;
+      prior_error?: string | null;
+    };
+    const jobId = resultRow.id;
+
+    // Reviving overrides a terminal 'cancelled' state, so surface it loudly — the
+    // symmetric cancellation path (cancelStaleDeclarativeJobs) logs per row, and a
+    // resurrection must be at least as visible. Include the failure bookkeeping the
+    // upsert just wiped so the prior context survives in the logs. warn (not info)
+    // because this silently undoes a deliberate cancelJob() if one was issued.
+    if (resultRow.prior_status === 'cancelled') {
+      this.logger.warn(
+        {
+          jobId,
+          sourceAgentId,
+          agentId,
+          cron: schedule.cron,
+          priorConsecutiveFailures: resultRow.prior_failures ?? null,
+          priorLastError: resultRow.prior_error ?? null,
+        },
+        'Declarative job revived from cancelled — its YAML declaration still exists. ' +
+          'If this job was deliberately stopped, remove its schedule entry from the agent YAML instead of cancelling it.',
+      );
+    }
 
     // If intent_anchor is set, create a linked tasks row so the drift detector can
     // fire for this job — same pattern as createJob(). The WHERE NOT EXISTS guard ensures

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -725,6 +725,74 @@ describe('SchedulerService', () => {
       expect(sql).toContain('ON CONFLICT (source_agent_id, agent_id, cron_expr, (task_payload::text)) WHERE created_by = \'system\'');
     });
 
+    it('revives a cancelled row on conflict — DO UPDATE flips cancelled back to pending and resets failure state', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-revive', prior_status: 'pending' }] });
+
+      await svc.upsertDeclarativeJob('ceo-inbox', 'ceo-inbox', {
+        cron: '*/15 6-23 * * *',
+        task: 'Check the CEO inbox',
+      });
+
+      const [sql] = pool.query.mock.calls[0] as [string];
+      // A row that a prior stale-cleanup cancelled must be revived when its YAML
+      // declaration still exists. Without this the ON CONFLICT path updates the row
+      // in place and leaves status='cancelled' forever, silently disabling a still-
+      // declared job. Only 'cancelled' is revived; running/suspended/pending/failed
+      // are left untouched so a restart never resurrects a deliberately-stopped job.
+      expect(sql).toContain(
+        "status = CASE WHEN scheduled_jobs.status = 'cancelled' THEN 'pending' ELSE scheduled_jobs.status END",
+      );
+      expect(sql).toContain(
+        "consecutive_failures = CASE WHEN scheduled_jobs.status = 'cancelled' THEN 0 ELSE scheduled_jobs.consecutive_failures END",
+      );
+      expect(sql).toContain(
+        "last_error = CASE WHEN scheduled_jobs.status = 'cancelled' THEN NULL ELSE scheduled_jobs.last_error END",
+      );
+      // The `prior` CTE + RETURNING let us detect a revival (pre-update status) so it
+      // can be logged distinctly from a routine refresh.
+      expect(sql).toContain('WITH prior AS');
+      expect(sql).toContain('task_payload::text = $4::jsonb::text');
+      expect(sql).toContain('(SELECT prior_status FROM prior) AS prior_status');
+    });
+
+    it('logs a warn when a cancelled job is revived, carrying the wiped failure context', async () => {
+      // prior_status='cancelled' means the conflicting row was previously cancelled and is
+      // now being resurrected — operators must see this, especially in case it undoes a
+      // deliberate cancelJob().
+      pool.query.mockResolvedValueOnce({
+        rows: [{ id: 'job-revived', prior_status: 'cancelled', prior_failures: 3, prior_error: 'Job timed out after 70m' }],
+      });
+
+      await svc.upsertDeclarativeJob('ceo-inbox', 'ceo-inbox', {
+        cron: '*/15 6-23 * * *',
+        task: 'Check the CEO inbox',
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: 'job-revived',
+          agentId: 'ceo-inbox',
+          priorConsecutiveFailures: 3,
+          priorLastError: 'Job timed out after 70m',
+        }),
+        expect.stringContaining('revived from cancelled'),
+      );
+    });
+
+    it('does NOT log a revival warn for a routine refresh of a non-cancelled row', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-refresh', prior_status: 'pending' }] });
+
+      await svc.upsertDeclarativeJob('ceo-inbox', 'ceo-inbox', {
+        cron: '*/15 6-23 * * *',
+        task: 'Check the CEO inbox',
+      });
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('revived from cancelled'),
+      );
+    });
+
     it('persists sourceAgentId separately from the target agent id', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-source' }] });
 

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -779,7 +779,30 @@ describe('SchedulerService', () => {
       );
     });
 
-    it('does NOT log a revival warn for a routine refresh of a non-cancelled row', async () => {
+    it('reactivates the linked task when a cancelled job is revived — symmetry with cancelJob cascade', async () => {
+      // cancelJob() cancels the job AND cascades 'cancelled' onto its linked task. Reviving
+      // the job must also reactivate that task, or an intent_anchor schedule ends up pointing
+      // at a terminal task the update guards reject.
+      pool.query.mockResolvedValueOnce({
+        rows: [{ id: 'job-revived', prior_status: 'cancelled', prior_failures: 0, prior_error: null }],
+      });
+
+      await svc.upsertDeclarativeJob('ceo-inbox', 'ceo-inbox', {
+        cron: '*/15 6-23 * * *',
+        task: 'Check the CEO inbox',
+      });
+
+      const reactivation = pool.query.mock.calls.find(
+        ([sql]) =>
+          typeof sql === 'string' && sql.includes("SET status = 'active'") && sql.includes('FROM scheduled_jobs sj'),
+      ) as [string, unknown[]] | undefined;
+      expect(reactivation).toBeDefined();
+      // Scoped to a cancelled task only — a task left 'active' or legitimately 'done' is untouched.
+      expect(reactivation![0]).toContain("tasks.status = 'cancelled'");
+      expect(reactivation![1]).toContain('job-revived');
+    });
+
+    it('does NOT log a revival warn or reactivate a task for a routine refresh of a non-cancelled row', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-refresh', prior_status: 'pending' }] });
 
       await svc.upsertDeclarativeJob('ceo-inbox', 'ceo-inbox', {
@@ -787,10 +810,10 @@ describe('SchedulerService', () => {
         task: 'Check the CEO inbox',
       });
 
-      expect(logger.warn).not.toHaveBeenCalledWith(
-        expect.anything(),
-        expect.stringContaining('revived from cancelled'),
-      );
+      // No warn at all on a routine refresh (a stricter contract than "no revival message").
+      expect(logger.warn).not.toHaveBeenCalled();
+      // And exactly one query — the upsert — with no task-reactivation follow-up.
+      expect(pool.query).toHaveBeenCalledTimes(1);
     });
 
     it('persists sourceAgentId separately from the target agent id', async () => {


### PR DESCRIPTION
## **User description**
## Summary

Declarative cron jobs (`agents/*.yaml`, `created_by='system'`) are re-upserted on every boot via `upsertDeclarativeJob`. The `ON CONFLICT ... DO UPDATE` clause refreshed `next_run_at`/`timezone`/etc. but **never touched `status`** — so any row that was ever `cancelled` stayed `cancelled` forever, even though its YAML schedule still existed. The job silently never ran again.

This bit production: **ceo-inbox** (`*/15 6-23`), **expense-tracker** (`*/30 6-17` + monthly), **security-triage** (`*/30`), and **digest** (`0 17`) were all stuck `cancelled`. The `"Declarative job upserted"` log fired for each on every boot, masking the fact that they were dead. They were originally cancelled by an earlier `cancelStaleDeclarativeJobs` run before the `task_payload` `::jsonb::text` normalization fix (whitespace/key-order mismatch); the upsert could never bring them back. Survivors (`contacts`/`coordinator`/`meeting-debrief`) escaped only because their task text changed, forcing a fresh `INSERT`.

## Change

- `DO UPDATE` now revives **only** `status = 'cancelled'` rows back to `'pending'` (and zeroes `consecutive_failures` / nulls `last_error`). `running`, `suspended` (failure threshold), `paused` (drift), `pending`, `failed`, `completed` are left untouched.
- A `prior` CTE captures the pre-update row so a resurrection is distinguishable from a routine refresh and is logged at **warn** with the wiped failure context (the symmetric cancel path already logs per-row — this restores that symmetry).
- Comment documents the consequence: a deliberate `cancelJob()` on a *still-declared* declarative job is not durable across restart; the supported permanent-stop path is removing the YAML schedule entry.

## Testing

- `tests/unit/scheduler/scheduler-service.test.ts`: revive-clause SQL assertions, the `prior` CTE/RETURNING shape, warn-on-revival (with carried failure context), and no-warn on routine refresh.
- All 146 scheduler unit tests pass; `typecheck` + `eslint` clean.

## Follow-up (not in this PR)

- A real-Postgres integration test asserting a `cancelled` declarative row flips to `pending` while a separately-seeded `suspended` row stays put would strengthen coverage beyond the SQL-string assertions (both reviewers flagged this as nice-to-have).
- The 4 prod jobs were already revived out-of-band via a targeted `UPDATE`; this PR prevents recurrence.


___

## **CodeAnt-AI Description**
**Restore cancelled declarative jobs when their YAML schedule still exists**

### What Changed
- When a declarative cron job is found again on restart, a job that was previously cancelled is now brought back to pending instead of staying stuck cancelled
- The job’s failed-run count and last error are cleared when it is revived, so it starts from a clean state
- Revived jobs are logged with a warning that shows the previous failure details; routine refreshes are not logged this way
- The changelog now calls out this recovery behavior

### Impact
`✅ Fewer silently dead scheduled jobs after restart`
`✅ Faster recovery from accidental job cancellation`
`✅ Clearer alerts when a cancelled job is restored`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Previously cancelled jobs are now automatically revived to pending status when their schedule remains actively declared, with failure-related information cleared. Jobs in running, suspended, or failed states continue operating normally. Enhanced logging tracks these job revivals for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->