### PR TITLE
feat(console): promote Agents & Skills to top-level pages with search, pagination, and new columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`⚠️ Stuck` label** — ceo-inbox now applies this label when triage cannot complete for a message (unrecognised classification value, required skill failure, or error budget boundary hit), making failures visible in the Gmail sidebar.
 
 ### Changed
+- **Skills & Agents console pages** — promoted from Settings sub-sections to standalone top-level pages (`/skills`, `/agents`) that mirror the Contacts/Tasks layout with search and pagination. Agents now lists model tier and memory scopes; Skills lists action risk and sensitivity. Memory scopes are now surfaced through the registry API metadata. Old `/settings/skills` and `/settings/agents` URLs redirect. (#541)
 - **`web-search`** — first consumer of `install.requires_secrets`; declares `tavily_api_key` as an install-time gate, so the Tavily key is now provisioned via the console vault and the not-configured error points operators there. (#943)
 - **Skill/agent loading** — now gated on the registry; only enabled items are registered. `skill.json` and agent YAML schemas gain optional, inert `install`/`uninstall` blocks. `allowed_callers` validation now treats all discovered agents (enabled or disabled) as known. (#541)
 - **`secret.accessed` event** — gains an optional `source: 'vault' | 'env'` field showing where each secret resolved from. Backward-compatible; existing consumers compile unchanged. (#542)

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -11,6 +11,8 @@ import {
   IconChecklist,
   IconClock,
   IconSettings,
+  IconWand,
+  IconAutonomy,
   IconChevron,
 } from './Icons';
 
@@ -28,6 +30,8 @@ const ROUTES: Record<string, string> = {
   contacts: '/contacts',
   tasks:    '/tasks',
   jobs:     '/jobs',
+  skills:   '/skills',
+  agents:   '/agents',
   settings: '/settings/workspace',
 };
 
@@ -66,7 +70,11 @@ function getInitials(name: string | null): string {
 
 export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
   const [memoryOpen, setMemoryOpen] = useState(true);
-  const [settingsOpen, setSettingsOpen] = useState(activeView === 'settings');
+  // Expand the Settings group when on any of its pages (Skills/Agents are now
+  // standalone pages but still live under the sidebar's Settings group).
+  const [settingsOpen, setSettingsOpen] = useState(
+    activeView === 'settings' || activeView === 'skills' || activeView === 'agents',
+  );
   const [principalName, setPrincipalName] = useState<string | null>(null);
   const { setOpen } = useMobileMenu();
   const navigate = useNavigate();
@@ -166,13 +174,26 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
           {settingsOpen && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 2, marginTop: 2 }}>
               <button
+                className={`nav-sub-item${activeView === 'skills' ? ' active' : ''}`}
+                onClick={() => go('skills')}
+              >
+                <IconWand />
+                Skills
+              </button>
+              <button
+                className={`nav-sub-item${activeView === 'agents' ? ' active' : ''}`}
+                onClick={() => go('agents')}
+              >
+                <IconAutonomy />
+                Agents
+              </button>
+              <button
                 className={`nav-sub-item${activeView === 'settings' ? ' active' : ''}`}
                 onClick={() => go('settings')}
               >
                 <IconSettings />
                 Workspace
               </button>
-
             </div>
           )}
         </div>

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -1,6 +1,9 @@
-import { useState, useEffect, useCallback } from 'react';
-import { SettingsLayout } from './SettingsPage.js';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { MobileMenuContext } from '../context/MobileMenu.js';
+import { Sidebar } from '../components/Sidebar.js';
+import { Topbar, TopbarSearch } from '../components/Topbar.js';
 import { apiFetch } from '../api.js';
+import { useTheme } from '../hooks/useTheme.js';
 
 // ── Types (mirror src/registry/types.ts RegistryEntry) ──────────────────────
 type DerivedState = 'uninstalled' | 'installed' | 'enabled' | 'ghost';
@@ -14,6 +17,7 @@ interface ManifestMetadata {
   capabilities?: string[];
   role?: string;
   modelTier?: string;
+  memoryScopes?: string[];
   // PR2 (#939): vault keys a skill declares in install.requires_secrets. Cross-referenced
   // against GET /api/vault/status to show configured/missing status and gate install/enable.
   requiresSecrets?: string[];
@@ -237,16 +241,28 @@ function RegistryDrawer({ entry, kindPath, onClose, onChanged }: {
                 <div>{entry.metadata.version}</div>
               </div>
               {entry.kind === 'skill' && (
-                <div className="form-field">
-                  <label>Action risk</label>
-                  <div>{String(entry.metadata.actionRisk ?? '—')}</div>
-                </div>
+                <>
+                  <div className="form-field">
+                    <label>Action risk</label>
+                    <div>{String(entry.metadata.actionRisk ?? '—')}</div>
+                  </div>
+                  <div className="form-field">
+                    <label>Sensitivity</label>
+                    <div>{entry.metadata.sensitivity ?? '—'}</div>
+                  </div>
+                </>
               )}
               {entry.kind === 'agent' && (
-                <div className="form-field">
-                  <label>Role / model</label>
-                  <div>{entry.metadata.role ?? '—'} / {entry.metadata.modelTier ?? '—'}</div>
-                </div>
+                <>
+                  <div className="form-field">
+                    <label>Role / model</label>
+                    <div>{entry.metadata.role ?? '—'} / {entry.metadata.modelTier ?? '—'}</div>
+                  </div>
+                  <div className="form-field">
+                    <label>Memory scopes</label>
+                    <div>{entry.metadata.memoryScopes?.join(', ') || '—'}</div>
+                  </div>
+                </>
               )}
               {entry.metadata.capabilities && (
                 <div className="form-field">
@@ -359,13 +375,73 @@ function RegistryDrawer({ entry, kindPath, onClose, onChanged }: {
   );
 }
 
-// ── Section (table + drawer) ─────────────────────────────────────────────────
+// ── Pagination ───────────────────────────────────────────────────────────────
+//
+// Local copy of the Contacts/Tasks pagination control — the codebase keeps one
+// per records page rather than sharing a single component.
 
-function RegistrySection({ kind }: { kind: 'skill' | 'agent' }) {
+interface PaginationProps {
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  onPage: (p: number) => void;
+  onPageSize: (n: number) => void;
+}
+
+function Pagination({ total, page, pageSize, totalPages, onPage, onPageSize }: PaginationProps) {
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, total);
+
+  const pages: number[] = [];
+  for (let i = 1; i <= totalPages; i++) pages.push(i);
+
+  return (
+    <div className="records-pagination">
+      <div className="records-pagination-info">
+        Showing <strong style={{ color: 'var(--app-fg)' }}>{start}–{end}</strong> of {total}
+      </div>
+      <div className="records-page-size">
+        Rows
+        <select value={pageSize} onChange={e => onPageSize(Number(e.target.value))}>
+          <option value="10">10</option>
+          <option value="25">25</option>
+          <option value="50">50</option>
+        </select>
+      </div>
+      <div className="records-pagination-controls">
+        <button className="records-page-btn" onClick={() => onPage(page - 1)} disabled={page <= 1}>‹</button>
+        {pages.map(p => (
+          <button key={p} className={`records-page-btn${p === page ? ' active' : ''}`} onClick={() => onPage(p)}>{p}</button>
+        ))}
+        <button className="records-page-btn" onClick={() => onPage(page + 1)} disabled={page >= totalPages}>›</button>
+      </div>
+    </div>
+  );
+}
+
+// ── Standalone registry page (Skills / Agents) ───────────────────────────────
+//
+// Mirrors the Contacts/Tasks layout: its own sidebar + topbar (with search), a
+// records table, and pagination. Skills and Agents used to render inside the
+// settings shell; they are now top-level pages reachable directly from the
+// sidebar's Settings group.
+
+function RegistryPage({ kind }: { kind: 'skill' | 'agent' }) {
   const kindPath = kind === 'skill' ? 'skills' : 'agents';
+  const [theme, setTheme] = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
   const [entries, setEntries] = useState<RegistryEntry[]>([]);
   const [selected, setSelected] = useState<RegistryEntry | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  useEffect(() => {
+    document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
+  }, [mobileOpen]);
 
   const load = useCallback(async () => {
     try {
@@ -387,81 +463,154 @@ function RegistrySection({ kind }: { kind: 'skill' | 'agent' }) {
 
   useEffect(() => { void load(); }, [load]);
 
+  // Search filters on name + description; pagination is applied to the result.
+  const filtered = useMemo(() => {
+    if (!search) return entries;
+    const q = search.toLowerCase();
+    return entries.filter(e =>
+      (e.name + ' ' + (e.metadata?.description ?? '')).toLowerCase().includes(q),
+    );
+  }, [entries, search]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pageRows = filtered.slice((safePage - 1) * pageSize, safePage * pageSize);
+
+  const title = kind === 'skill' ? 'Skills' : 'Agents';
+  // Name, State, two kind-specific columns, Version.
+  const colCount = 5;
+
   return (
-    <>
-      <div className="settings-page-header">
-        <h2 className="settings-page-title">
-          {kind === 'skill' ? 'Skills' : 'Agents'}
-        </h2>
-        <p className="settings-page-sub">
-          Install, enable, and disable {kind === 'skill' ? 'skills' : 'agents'}.
-          Changes take effect on the next restart.
-        </p>
-      </div>
-
-      {loadError && <p className="autonomy-error">{loadError}</p>}
-
-      <div className="records-layout">
-        <div className="records-table-wrap">
-          <table className="records-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>State</th>
-                <th>Version</th>
-              </tr>
-            </thead>
-            <tbody>
-              {entries.map(e => (
-                <tr
-                  key={e.name}
-                  className={selected?.name === e.name ? 'active' : undefined}
-                  onClick={() => setSelected(e)}
-                  style={{ cursor: 'pointer' }}
-                >
-                  {/* Warn icon if the manifest failed to parse */}
-                  <td>{e.name}{e.manifestError ? ' ⚠' : ''}</td>
-                  <td>
-                    <span className={`status-pill ${STATE_PILL[e.state]}`}>
-                      {/* Extra warning on ghost: manifest is gone but DB row lingers */}
-                      {e.state}{e.state === 'ghost' ? ' ⚠' : ''}
-                    </span>
-                  </td>
-                  <td>{e.metadata?.version ?? '—'}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        {selected && (
-          <RegistryDrawer
-            key={selected.name}
-            entry={selected}
-            kindPath={kindPath}
-            onClose={() => setSelected(null)}
-            onChanged={() => { void load(); }}
+    <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
+      <div className="app-root">
+        <Sidebar activeView={kindPath} theme={theme} onThemeChange={setTheme} />
+        {mobileOpen && (
+          <div
+            className="sidebar-backdrop"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden="true"
           />
         )}
+        <main className="main">
+          <Topbar crumb="Settings" title={title}>
+            <TopbarSearch
+              placeholder={`Search ${kindPath}…`}
+              value={search}
+              onChange={v => { setSearch(v); setPage(1); }}
+            />
+          </Topbar>
+
+          {loadError ? (
+            <div style={{ padding: 32, color: 'var(--app-destructive)', fontSize: 13 }}>{loadError}</div>
+          ) : (
+            <>
+              {/* Mobile search — TopbarSearch is hidden below 768px by the shared stylesheet */}
+              <div className="contacts-mobile-search">
+                <input
+                  type="text"
+                  placeholder={`Search ${kindPath}…`}
+                  value={search}
+                  onChange={e => { setSearch(e.target.value); setPage(1); }}
+                />
+              </div>
+
+              <div className="records-layout">
+                <div className="records-main">
+                  <div className="records-table-wrap">
+                    <table className="records-table">
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>State</th>
+                          {kind === 'agent' ? (
+                            <>
+                              <th>Model tier</th>
+                              <th>Memory scopes</th>
+                            </>
+                          ) : (
+                            <>
+                              <th>Action risk</th>
+                              <th>Sensitivity</th>
+                            </>
+                          )}
+                          <th>Version</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {pageRows.map(e => (
+                          <tr
+                            key={e.name}
+                            className={selected?.name === e.name ? 'active' : undefined}
+                            onClick={() => setSelected(e)}
+                            style={{ cursor: 'pointer' }}
+                          >
+                            {/* Warn icon if the manifest failed to parse */}
+                            <td>{e.name}{e.manifestError ? ' ⚠' : ''}</td>
+                            <td>
+                              <span className={`status-pill ${STATE_PILL[e.state]}`}>
+                                {/* Extra warning on ghost: manifest is gone but DB row lingers */}
+                                {e.state}{e.state === 'ghost' ? ' ⚠' : ''}
+                              </span>
+                            </td>
+                            {kind === 'agent' ? (
+                              <>
+                                <td>{e.metadata?.modelTier ?? '—'}</td>
+                                <td>{e.metadata?.memoryScopes?.join(', ') || '—'}</td>
+                              </>
+                            ) : (
+                              <>
+                                {/* actionRisk may be 0 (a valid risk score), so guard on null, not falsy. */}
+                                <td>{e.metadata?.actionRisk != null ? String(e.metadata.actionRisk) : '—'}</td>
+                                <td>{e.metadata?.sensitivity ?? '—'}</td>
+                              </>
+                            )}
+                            <td>{e.metadata?.version ?? '—'}</td>
+                          </tr>
+                        ))}
+                        {pageRows.length === 0 && (
+                          <tr>
+                            <td colSpan={colCount} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                              No {kindPath} match.
+                            </td>
+                          </tr>
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                  <Pagination
+                    total={filtered.length}
+                    page={safePage}
+                    pageSize={pageSize}
+                    totalPages={totalPages}
+                    onPage={setPage}
+                    onPageSize={n => { setPageSize(n); setPage(1); }}
+                  />
+                </div>
+
+                {selected && (
+                  <RegistryDrawer
+                    key={selected.name}
+                    entry={selected}
+                    kindPath={kindPath}
+                    onClose={() => setSelected(null)}
+                    onChanged={() => { void load(); }}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        </main>
       </div>
-    </>
+    </MobileMenuContext.Provider>
   );
 }
 
-// ── Exported page components (one per child route) ───────────────────────────
+// ── Exported page components (one per route) ─────────────────────────────────
 
 export function SkillsPage() {
-  return (
-    <SettingsLayout activeSection="skills">
-      <RegistrySection kind="skill" />
-    </SettingsLayout>
-  );
+  return <RegistryPage kind="skill" />;
 }
 
 export function AgentsPage() {
-  return (
-    <SettingsLayout activeSection="agents">
-      <RegistrySection kind="agent" />
-    </SettingsLayout>
-  );
+  return <RegistryPage kind="agent" />;
 }

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -410,11 +410,11 @@ function Pagination({ total, page, pageSize, totalPages, onPage, onPageSize }: P
         </select>
       </div>
       <div className="records-pagination-controls">
-        <button className="records-page-btn" onClick={() => onPage(page - 1)} disabled={page <= 1}>‹</button>
+        <button className="records-page-btn" aria-label="Previous page" onClick={() => onPage(page - 1)} disabled={page <= 1}>‹</button>
         {pages.map(p => (
-          <button key={p} className={`records-page-btn${p === page ? ' active' : ''}`} onClick={() => onPage(p)}>{p}</button>
+          <button key={p} className={`records-page-btn${p === page ? ' active' : ''}`} aria-label={`Page ${p}`} aria-current={p === page ? 'page' : undefined} onClick={() => onPage(p)}>{p}</button>
         ))}
-        <button className="records-page-btn" onClick={() => onPage(page + 1)} disabled={page >= totalPages}>›</button>
+        <button className="records-page-btn" aria-label="Next page" onClick={() => onPage(page + 1)} disabled={page >= totalPages}>›</button>
       </div>
     </div>
   );

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -314,13 +314,13 @@ function AutonomySection() {
 
 // ── Settings layout ───────────────────────────────────────────────────────────
 
-// The settings nav sections. Only 'autonomy' is functional; others are stubs
-// for future PRs. Rendered as <Link> elements so the URL changes on click and
-// back/forward navigation works correctly within the settings shell.
+// The settings nav sections. Only 'autonomy' is functional; 'workspace' is a stub
+// for a future PR. Skills and Agents used to live here but are now standalone
+// top-level pages (see RegistrySettings.tsx) reachable from the sidebar directly.
+// Rendered as <Link> elements so the URL changes on click and back/forward
+// navigation works correctly within the settings shell.
 const SETTINGS_SECTIONS = [
   { id: 'autonomy',  label: 'Autonomy',    href: '/settings/autonomy' },
-  { id: 'skills',   label: 'Skills',      href: '/settings/skills' },
-  { id: 'agents',   label: 'Agents',      href: '/settings/agents' },
   { id: 'workspace', label: 'Workspace',   href: '/settings/workspace' },
 ];
 

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -109,16 +109,19 @@ const workspaceRoute = createRoute({
   component: WorkspacePage,
 });
 
-const skillsSettingsRoute = createRoute({
+// Skills and Agents are now standalone top-level pages (peer to Contacts/Tasks),
+// no longer rendered inside the settings shell. The two routes below preserve the
+// old /settings/skills and /settings/agents URLs by redirecting to the new paths.
+const skillsSettingsRedirect = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/skills',
-  component: SkillsPage,
+  beforeLoad: () => { throw redirect({ to: '/skills' }); },
 });
 
-const agentsSettingsRoute = createRoute({
+const agentsSettingsRedirect = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/agents',
-  component: AgentsPage,
+  beforeLoad: () => { throw redirect({ to: '/agents' }); },
 });
 
 const loginRoute = createRoute({
@@ -145,6 +148,18 @@ const tasksRoute = createRoute({
   component: TasksPage,
 });
 
+const skillsRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/skills',
+  component: SkillsPage,
+});
+
+const agentsRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/agents',
+  component: AgentsPage,
+});
+
 const kgRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: '/kg',
@@ -163,8 +178,10 @@ const routeTree = rootRoute.addChildren([
     contactsRoute,
     jobsRoute,
     tasksRoute,
+    skillsRoute,
+    agentsRoute,
     kgRoute,
-    settingsRoute.addChildren([autonomyRoute, workspaceRoute, skillsSettingsRoute, agentsSettingsRoute]),
+    settingsRoute.addChildren([autonomyRoute, workspaceRoute, skillsSettingsRedirect, agentsSettingsRedirect]),
   ]),
   loginRoute,
 ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1509,7 +1509,7 @@ async function main(): Promise<void> {
     agentDiscovery.map(d => ({
       name: d.name,
       metadata: d.config
-        ? { name: d.config.name, description: d.config.description ?? d.config.name, version: d.config.version ?? '0.0.0', role: d.config.role, modelTier: d.config.model?.tier }
+        ? { name: d.config.name, description: d.config.description ?? d.config.name, version: d.config.version ?? '0.0.0', role: d.config.role, modelTier: d.config.model?.tier, memoryScopes: d.config.memory?.scopes }
         : null,
       error: d.error,
     })),

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -36,6 +36,8 @@ export interface ManifestMetadata {
   // agents
   role?: string;
   modelTier?: string;
+  /** Isolated memory scopes the agent reads/writes (agents/<name>.yaml → memory.scopes). */
+  memoryScopes?: string[];
 }
 
 /** One on-disk item found during discovery. `metadata` is null when the manifest


### PR DESCRIPTION
## **User description**
## Summary

Reworks the console's Agents and Skills registry pages, which were originally buried inside the Settings shell with a poor layout. They are now standalone top-level pages that mirror the Contacts/Tasks experience.

### Navigation
- Agents and Skills are now top-level pages at `/agents` and `/skills`, listed in the sidebar's **Settings** group as peers to **Workspace**.
- Removed them from the in-page settings sub-nav (`SETTINGS_SECTIONS`); they no longer render inside the `settings-nav` / `settings-content` shell.
- Old `/settings/agents` and `/settings/skills` URLs redirect to the new paths.
- The Settings sidebar group auto-expands when you're on either page.

### Layout
- Both pages now emulate the Contacts/Tasks layout: own sidebar + topbar with a **search bar** (filters on name + description), a records table, and **pagination** (10/25/50 rows). The detail drawer and install/enable/disable/uninstall actions are unchanged.

### New columns (plain text)
- **Agents:** model tier, memory scopes.
- **Skills:** action risk, sensitivity.
- The same two new fields per kind are also reflected in the detail drawer.

### Backend
- Memory scopes weren't passed through the registry API. Added `memoryScopes?: string[]` to `ManifestMetadata` and mapped `memory.scopes` from agent YAML at bootstrap (`src/index.ts`). The other three columns were already surfaced.

## Test plan
- Backend typecheck (`tsc --noEmit`): clean.
- Console typecheck: clean. Production `vite build`: succeeds.
- Registry unit tests: 22/22 pass.
- Pre-PR `code-reviewer` and `silent-failure-hunter` reviews: no high-priority findings.

## Notes
- `actionRisk` can legitimately be `0`, so the table cell guards on `!= null` rather than a falsy check.
- Out of scope (pre-existing): the `⚠` manifest-error glyph has no accessible hover text, and `SettingsLayout` hardcodes the topbar title to "Workspace".


___

## **CodeAnt-AI Description**
**Move Skills and Agents to standalone console pages**

### What Changed
- Skills and Agents now open as top-level pages at `/skills` and `/agents` instead of inside the Settings shell
- The sidebar Settings group now includes direct links to Skills, Agents, and Workspace, and stays expanded on those pages
- Old Skills and Agents settings URLs now redirect to the new pages
- Both pages now include search, pagination, and a table with the new columns shown in the drawer too
- Agents now show memory scopes, and Skills now show action risk and sensitivity
- Agent memory scopes are now available from the registry data, so they appear in the console

### Impact
`✅ Faster access to Skills and Agents`
`✅ Easier browsing of large registries`
`✅ Clearer agent and skill details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
