### PR TITLE
feat: database-layer registry for channels with credential management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Channel credential vault writes** — the `PUT /api/vault/secrets/:name` scope guard now also accepts valid channel credential keys (`channel.<channel>.<field>`) derived from `CHANNEL_CATALOG`, so the Channels console can save credentials end-to-end; arbitrary/bogus `channel.*` names are still rejected.
 - **Declarative job revival** — `upsertDeclarativeJob` now flips a `cancelled` row back to `pending` (clearing failure state) on conflict, so a still-declared schedule that a prior stale-cleanup wrongly cancelled is restored on restart instead of staying silently dead; `running`/`suspended`/`failed` are left untouched.
 - **`deepseek/deepseek-v4-pro` output token cap** — raised `maxOutputTokens` from 8192 to 32768; the old value caused long-form writing tasks (e.g. essay drafts via `import_to_google_doc`) to produce truncated JSON tool call arguments and non-retryable errors. (#934)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`deepseek/deepseek-v4-pro` output token cap** — raised `maxOutputTokens` from 8192 to 32768; the old value caused long-form writing tasks (e.g. essay drafts via `import_to_google_doc`) to produce truncated JSON tool call arguments and non-retryable errors. (#934)
 
 ### Added
+- **Channel registry** — database-backed install/enable lifecycle for channels with credentials in the secrets vault (vault-first, env/config fallback); new `Channel` interface, `Channels` console page, and always-on HTTP/CLI safeguard. (#543)
 - **`install.requires_secrets`** — skills can declare vault keys that must be configured before they install/enable; `RegistryService` rejects install/enable when any are missing, and the Skills drawer shows per-secret status with inline entry (e.g. enter a Tavily key when enabling web-search). Adds `SecretsService.list()` and `/api/vault/*` routes. Closes #939.
 - **Skill/Agent registry** — DB-gated install/enable lifecycle for skills and agents (`skill_registry`/`agent_registry` tables, startup reconciliation of a trusted core set, one-shot prod backfill). Only enabled items load at runtime. (#541)
 - **Skills & Agents settings** — manage install/enable/disable state from Workspace Settings. (#541)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,11 @@ When you need to pin a transitive dependency (e.g. to clear a CVE), add it to th
 ## Adding Things
 
 ### New Channel Adapter
-1. Create `src/channels/<name>/` implementing `ChannelAdapter` interface
-2. Register as `layer: "channel"` with the bus
-3. Add config section to `config/default.yaml`
-4. Write tests
+1. Create `src/channels/<name>/` implementing the `Channel` interface from `src/channels/channel.ts` (`name`, `isToggleable`, `start()`, `stop()`)
+2. Add a `ChannelDescriptor` to `src/channels/catalog.ts` (credential fields + required secret keys)
+3. Register as `layer: "channel"` with the bus
+4. Add config section to `config/default.yaml`
+5. Write tests
 
 ### New Skill
 1. Create `skills/<name>/skill.json` (manifest) + `handler.ts`

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -32,6 +32,7 @@ const ROUTES: Record<string, string> = {
   jobs:     '/jobs',
   skills:   '/skills',
   agents:   '/agents',
+  channels: '/channels',
   settings: '/settings/workspace',
 };
 
@@ -73,7 +74,7 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
   // Expand the Settings group when on any of its pages (Skills/Agents are now
   // standalone pages but still live under the sidebar's Settings group).
   const [settingsOpen, setSettingsOpen] = useState(
-    activeView === 'settings' || activeView === 'skills' || activeView === 'agents',
+    activeView === 'settings' || activeView === 'skills' || activeView === 'agents' || activeView === 'channels',
   );
   const [principalName, setPrincipalName] = useState<string | null>(null);
   const { setOpen } = useMobileMenu();
@@ -186,6 +187,13 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
               >
                 <IconAutonomy />
                 Agents
+              </button>
+              <button
+                className={`nav-sub-item${activeView === 'channels' ? ' active' : ''}`}
+                onClick={() => go('channels')}
+              >
+                <IconWand />
+                Channels
               </button>
               <button
                 className={`nav-sub-item${activeView === 'settings' ? ' active' : ''}`}

--- a/apps/console/src/pages/ChannelSettings.tsx
+++ b/apps/console/src/pages/ChannelSettings.tsx
@@ -1,0 +1,420 @@
+import { useState, useEffect, useCallback } from 'react';
+import { MobileMenuContext } from '../context/MobileMenu.js';
+import { Sidebar } from '../components/Sidebar.js';
+import { Topbar } from '../components/Topbar.js';
+import { apiFetch } from '../api.js';
+import { useTheme } from '../hooks/useTheme.js';
+
+// ── Types (mirror src/channels/credential-resolver.ts CredentialFieldStatus and
+//    src/registry/channel-registry-types.ts ChannelRegistryEntry) ──────────────
+type ChannelState = 'uninstalled' | 'installed' | 'enabled';
+type CredentialSource = 'vault' | 'env' | 'config' | 'missing';
+
+interface CredentialFieldStatus {
+  key: string;
+  label: string;
+  secret: boolean;
+  configured: boolean;
+  source: CredentialSource;
+}
+
+interface ChannelEntry {
+  name: string;
+  description: string;
+  state: ChannelState;
+  isToggleable: boolean;
+  credentialFields: CredentialFieldStatus[];
+  requiredResolvable: boolean;
+  installedAt: string | null;
+  installedBy: string | null;
+  enabledAt: string | null;
+  enabledBy: string | null;
+}
+
+// Map each derived state to one of the existing .status-pill modifier classes
+// (app.css), matching how RegistrySettings reuses them:
+//   enabled     → confirmed (green)
+//   installed   → provisional (amber)
+//   uninstalled → no modifier (neutral)
+const STATE_PILL: Record<ChannelState, string> = {
+  enabled:     'confirmed',
+  installed:   'provisional',
+  uninstalled: '',
+};
+
+const STATE_LABEL: Record<ChannelState, string> = {
+  uninstalled: 'not installed',
+  installed:   'installed',
+  enabled:     'enabled',
+};
+
+// Safe error message extraction — guards against non-JSON error bodies.
+async function errorMessage(res: Response): Promise<string> {
+  const ct = res.headers.get('content-type') ?? '';
+  if (ct.includes('application/json')) {
+    try {
+      const d = await res.json() as { error?: string };
+      if (d.error) return d.error;
+    } catch { /* fall through to HTTP status */ }
+  }
+  return `HTTP ${res.status}`;
+}
+
+// ── Credential row (status + inline entry) ───────────────────────────────────
+//
+// One credential field. Shows a configured/missing pill plus the resolution source,
+// and a masked-or-plain input + Save that PUTs the value to the vault under
+// channel.<channel>.<key>. On success it calls onSaved so the page re-reads channel
+// status and re-evaluates the Enable gate.
+
+function CredentialRow({ channel, field, onSaved }: {
+  channel: string;
+  field: CredentialFieldStatus;
+  onSaved: () => void;
+}) {
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const save = useCallback(async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      // Credentials are stored in the secrets vault under channel.<name>.<key>.
+      const vaultKey = `channel.${channel}.${field.key}`;
+      const res = await apiFetch(`/api/vault/secrets/${encodeURIComponent(vaultKey)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      setValue(''); // don't keep the credential in component state after a successful save
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to save credential');
+    } finally {
+      setBusy(false);
+    }
+  }, [channel, field.key, value, onSaved]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span className={`status-pill ${field.configured ? 'confirmed' : 'blocked'}`}>
+          {field.configured ? `configured (${field.source})` : 'missing'}
+        </span>
+        <code style={{ fontSize: 13 }}>{field.label}</code>
+      </div>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <input
+          type={field.secret ? 'password' : 'text'}
+          autoComplete="off"
+          value={value}
+          placeholder={field.configured ? 'Enter a new value to replace' : `Enter ${field.label}`}
+          aria-label={`Value for ${field.label}`}
+          onChange={e => setValue(e.target.value)}
+          style={{ flex: 1 }}
+        />
+        <button
+          type="button"
+          className="btn btn-secondary btn-sm"
+          disabled={busy || value.length === 0}
+          onClick={() => void save()}
+        >
+          Save
+        </button>
+      </div>
+      {err && <p className="autonomy-error" style={{ margin: 0 }}>{err}</p>}
+    </div>
+  );
+}
+
+// ── Detail drawer ────────────────────────────────────────────────────────────
+
+function ChannelDrawer({ entry, onClose, onChanged }: {
+  entry: ChannelEntry;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Perform a mutating lifecycle call on the channel and refresh the list on success.
+  // method+suffix mirrors the registry routes: POST .../install|enable|disable, DELETE base.
+  const act = useCallback(async (method: 'POST' | 'DELETE', suffix: string) => {
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await apiFetch(
+        `/api/registry/channels/${encodeURIComponent(entry.name)}${suffix}`,
+        { method },
+      );
+      if (!res.ok) throw new Error(await errorMessage(res));
+      onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Action failed');
+    } finally {
+      setBusy(false);
+    }
+  }, [entry.name, onChanged]);
+
+  const confirmUninstall = () => {
+    if (window.confirm(`Uninstall "${entry.name}"? This clears its stored credentials and removes its registry row.`)) {
+      void act('DELETE', '');
+    }
+  };
+
+  // Non-toggleable channels (http, cli) are always on: no credential form, no
+  // lifecycle actions, and the Enable gate doesn't apply.
+  const locked = !entry.isToggleable;
+
+  return (
+    <aside className="drawer">
+      <div className="drawer-header">
+        <div className="drawer-header-top">
+          <span>channel</span>
+          <button
+            type="button"
+            className="drawer-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="6" y1="6" x2="18" y2="18" /><line x1="18" y1="6" x2="6" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <h2 className="drawer-title-h2">{entry.name}</h2>
+      </div>
+
+      <div className="drawer-body">
+        <div className="edit-drawer-form">
+          <p className="settings-page-sub" style={{ margin: 0 }}>
+            Enabling or disabling takes effect on the next restart.
+          </p>
+
+          {err && <p className="autonomy-error">{err}</p>}
+
+          <div className="form-field">
+            <label>State</label>
+            {locked ? (
+              <span className="status-pill confirmed">Always on</span>
+            ) : (
+              <span className={`status-pill ${STATE_PILL[entry.state]}`}>{STATE_LABEL[entry.state]}</span>
+            )}
+          </div>
+
+          <div className="form-field">
+            <label>Description</label>
+            <div>{entry.description}</div>
+          </div>
+
+          {/* Credential form — only for toggleable channels that declare fields.
+              Always-on channels (http, cli) have no credentials. */}
+          {!locked && entry.credentialFields.length > 0 && (
+            <div className="form-field">
+              <label>Credentials</label>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {entry.credentialFields.map(field => (
+                  <CredentialRow
+                    key={field.key}
+                    channel={entry.name}
+                    field={field}
+                    onSaved={onChanged}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="form-field">
+            <label>Installed</label>
+            <div>
+              {entry.installedAt
+                ? `${entry.installedAt} by ${entry.installedBy}`
+                : '—'}
+            </div>
+          </div>
+          <div className="form-field">
+            <label>Enabled</label>
+            <div>
+              {entry.enabledAt
+                ? `${entry.enabledAt} by ${entry.enabledBy}`
+                : '—'}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Lifecycle actions — hidden entirely for non-toggleable channels. */}
+      {!locked && (
+        <div className="drawer-footer">
+          {/* Install — only when not yet in the registry. */}
+          {entry.state === 'uninstalled' && (
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              disabled={busy}
+              onClick={() => void act('POST', '/install')}
+            >
+              Install
+            </button>
+          )}
+
+          {/* Enable — only for installed (but not yet enabled) channels. Gated on
+              required credentials resolving, mirroring the service-level guard. */}
+          {entry.state === 'installed' && (
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={busy || !entry.requiredResolvable}
+              title={entry.requiredResolvable ? undefined : 'Configure the required credentials first'}
+              onClick={() => void act('POST', '/enable')}
+            >
+              Enable
+            </button>
+          )}
+
+          {/* Disable — only for currently-enabled channels. */}
+          {entry.state === 'enabled' && (
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              disabled={busy}
+              onClick={() => void act('POST', '/disable')}
+            >
+              Disable
+            </button>
+          )}
+
+          {/* Uninstall — available for any channel that has a registry row. */}
+          {entry.state !== 'uninstalled' && (
+            <button
+              type="button"
+              className="btn btn-danger btn-sm"
+              disabled={busy}
+              onClick={confirmUninstall}
+            >
+              Uninstall
+            </button>
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+// ── Channels page ─────────────────────────────────────────────────────────────
+//
+// Mirrors the RegistrySettings (Skills/Agents) layout: its own sidebar + topbar, a
+// records table of channels with state pills, and a detail drawer with a credential
+// form + lifecycle actions. The catalog is small (four channels), so there is no
+// search or pagination.
+
+export function ChannelsPage() {
+  const [theme, setTheme] = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const [entries, setEntries] = useState<ChannelEntry[]>([]);
+  const [selected, setSelected] = useState<ChannelEntry | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
+  }, [mobileOpen]);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiFetch('/api/registry/channels');
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as { channels: ChannelEntry[] };
+      const list = data.channels ?? [];
+      setEntries(list);
+      setLoadError(null); // clear any prior error on successful reload
+      // Keep the drawer in sync with the freshly-loaded state so action buttons and
+      // credential pills reflect the true current state after a transition.
+      setSelected(prev =>
+        prev ? list.find(e => e.name === prev.name) ?? null : null,
+      );
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Failed to load');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  return (
+    <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
+      <div className="app-root">
+        <Sidebar activeView="channels" theme={theme} onThemeChange={setTheme} />
+        {mobileOpen && (
+          <div
+            className="sidebar-backdrop"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden="true"
+          />
+        )}
+        <main className="main">
+          <Topbar crumb="Settings" title="Channels" />
+
+          {loadError ? (
+            <div style={{ padding: 32, color: 'var(--app-destructive)', fontSize: 13 }}>{loadError}</div>
+          ) : (
+            <div className="records-layout">
+              <div className="records-main">
+                <div className="records-table-wrap">
+                  <table className="records-table">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>State</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {entries.map(e => (
+                        <tr
+                          key={e.name}
+                          className={selected?.name === e.name ? 'active' : undefined}
+                          onClick={() => setSelected(e)}
+                          style={{ cursor: 'pointer' }}
+                        >
+                          <td>{e.name}</td>
+                          <td>
+                            {/* Non-toggleable channels (http, cli) are always on. */}
+                            {e.isToggleable ? (
+                              <span className={`status-pill ${STATE_PILL[e.state]}`}>{STATE_LABEL[e.state]}</span>
+                            ) : (
+                              <span className="status-pill confirmed">Always on</span>
+                            )}
+                          </td>
+                          <td>{e.description}</td>
+                        </tr>
+                      ))}
+                      {entries.length === 0 && (
+                        <tr>
+                          <td colSpan={3} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                            No channels.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              {selected && (
+                <ChannelDrawer
+                  key={selected.name}
+                  entry={selected}
+                  onClose={() => setSelected(null)}
+                  onChanged={() => { void load(); }}
+                />
+              )}
+            </div>
+          )}
+        </main>
+      </div>
+    </MobileMenuContext.Provider>
+  );
+}

--- a/apps/console/src/pages/ChannelSettings.tsx
+++ b/apps/console/src/pages/ChannelSettings.tsx
@@ -55,7 +55,11 @@ async function errorMessage(res: Response): Promise<string> {
     try {
       const d = await res.json() as { error?: string };
       if (d.error) return d.error;
-    } catch { /* fall through to HTTP status */ }
+    } catch (err) {
+      // Malformed JSON body — log (don't swallow) and fall through to the HTTP status,
+      // which is still a useful message for the caller.
+      console.error('[errorMessage] failed to parse JSON error body:', err);
+    }
   }
   return `HTTP ${res.status}`;
 }

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -23,6 +23,9 @@ const SkillsPage = lazy(() =>
 const AgentsPage = lazy(() =>
   import('./pages/RegistrySettings').then(m => ({ default: m.AgentsPage })),
 );
+const ChannelsPage = lazy(() =>
+  import('./pages/ChannelSettings').then(m => ({ default: m.ChannelsPage })),
+);
 const WizardPage = lazy(() => import('./pages/WizardPage'));
 const ContactsPage = lazy(() => import('./pages/ContactsPage'));
 const JobsPage = lazy(() => import('./pages/JobsPage'));
@@ -160,6 +163,12 @@ const agentsRoute = createRoute({
   component: AgentsPage,
 });
 
+const channelsRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/channels',
+  component: ChannelsPage,
+});
+
 const kgRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: '/kg',
@@ -180,6 +189,7 @@ const routeTree = rootRoute.addChildren([
     tasksRoute,
     skillsRoute,
     agentsRoute,
+    channelsRoute,
     kgRoute,
     settingsRoute.addChildren([autonomyRoute, workspaceRoute, skillsSettingsRedirect, agentsSettingsRedirect]),
   ]),

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,6 +22,10 @@ channels:
 
 # Multi-account email configuration (spec §03-email-channel.md).
 #
+# Note: email credentials may now also be supplied via the secrets vault (keys
+# `channel.email.*`) and managed in the Channels console page. The config path
+# below remains supported and is preferred for multi-account setups.
+#
 # channel_accounts.email defines one or more named Nylas-backed email accounts.
 # Each account has its own grant ID and self-email address. All accounts send
 # directly via the OutboundGateway (autonomy-gated).

--- a/docs/wip/2026-06-12-channel-policy-registry-issue.md
+++ b/docs/wip/2026-06-12-channel-policy-registry-issue.md
@@ -1,7 +1,8 @@
-# DRAFT ISSUE — review before filing on GitHub
+# Channel policy issue — FILED as #962
 
 > Spun out of #543 (channel registry). This captures the **channel policy** concern
-> deliberately deferred from that issue. Review, then file with `gh issue create`.
+> deliberately deferred from that issue.
+> **Filed:** https://github.com/josephfung/curia/issues/962
 
 **Suggested title:** `feat: DB-backed channel policy (trust / unknown_sender / threaded) with yaml defaults`
 

--- a/docs/wip/2026-06-12-channel-policy-registry-issue.md
+++ b/docs/wip/2026-06-12-channel-policy-registry-issue.md
@@ -1,0 +1,92 @@
+# DRAFT ISSUE — review before filing on GitHub
+
+> Spun out of #543 (channel registry). This captures the **channel policy** concern
+> deliberately deferred from that issue. Review, then file with `gh issue create`.
+
+**Suggested title:** `feat: DB-backed channel policy (trust / unknown_sender / threaded) with yaml defaults`
+
+**Suggested labels:** `channels`, `autonomy`, `governance`, `enhancement`, `web-ui`, `P4`, `size:L`
+
+**Suggested milestone:** _(none — schedule after #543 lands)_
+
+---
+
+## Summary
+
+Move channel **policy** settings — currently static defaults in
+`config/channel-trust.yaml` — into a runtime-configurable model: yaml provides the
+default, an optional DB value overrides it, and (for `trust` / `unknown_sender`) the web
+console can edit it. Split `threaded` out as an adapter *capability* expressed on the
+`Channel` interface rather than as policy.
+
+This complements the channel **registry** (#543), which handles channel *lifecycle*
+(install/enable) and *credentials*. Policy is a separate, dispatch-layer concern and was
+intentionally kept out of the registry.
+
+## Motivation
+
+`config/channel-trust.yaml` defines, per channel:
+
+- `trust` — caps the maximum sensitivity of actions a message from this channel can trigger.
+- `unknown_sender` — what to do with messages from unrecognized senders
+  (`allow` / `hold_and_notify` / `ignore`).
+- `threaded` — whether the channel renders replies as threads.
+
+These are consumed in the **dispatch layer** (`src/contacts/config-loader.ts` →
+`src/dispatch/trust-scorer.ts`, `src/dispatch/dispatcher.ts`). Today they can only be
+changed by editing yaml and restarting. Operators have no runtime control and no audit
+trail of policy changes.
+
+## Design sketch
+
+### 1. `threaded` → `Channel` interface (do this first)
+
+`threaded` is a property of the adapter/channel capability, not a security policy. Add
+`readonly threaded: boolean` to the `Channel` interface (introduced in #543) and source
+it from the adapter, removing `threaded` from the policy concern.
+
+### 2. Policy resolution: yaml default ▸ DB override
+
+- Keep `config/channel-trust.yaml` as the **default** source.
+- Add a `channel_policy` store (table) holding only operator overrides:
+  `channel_name`, `trust?`, `unknown_sender?`, `updated_at`, `updated_by`.
+- Resolution: DB override (if present) wins over yaml default, per field.
+- Membership note: `channel-trust.yaml` includes `web` (the KG app, authenticated by the
+  bootstrap secret) which has **no startable adapter** and is **not** in the registry
+  catalog. Policy membership ≠ registry membership — the policy store must cover `web`
+  too.
+
+### 3. Security: trust is sensitive — write an ADR
+
+Making `trust` runtime-editable means a console compromise could **escalate** a channel's
+trust level and, with it, the maximum action sensitivity reachable from that channel.
+Before building this:
+
+- Write an ADR (`docs/adr/`) covering the trust-escalation threat, who may edit policy,
+  and the required audit trail.
+- Every policy change must emit an audit event (actor, channel, field, old → new).
+- Consider whether `trust` edits need a stricter gate than `unknown_sender` (e.g. an
+  approval step, or read-only in the UI with edits only via a privileged path).
+
+### 4. Web console
+
+Add policy controls to the channel detail drawer (built in #543): per-channel `trust`
+and `unknown_sender` selectors showing the effective value and its source (yaml default
+vs DB override), with a reset-to-default action.
+
+## Acceptance criteria
+
+- [ ] `threaded` moved to the `Channel` interface; `config/channel-trust.yaml` no longer carries it; dispatch reads it from the adapter/channel.
+- [ ] `channel_policy` store created via migration, holding per-channel `trust` / `unknown_sender` overrides.
+- [ ] Policy resolution = DB override ▸ yaml default, per field; covers `web` as well as the four adapters.
+- [ ] Dispatch layer (`trust-scorer.ts`, `dispatcher.ts`) reads resolved policy, not raw yaml.
+- [ ] Every policy change emits an audit event (actor, channel, field, old → new value).
+- [ ] ADR written documenting the trust-escalation threat model and the chosen edit/gate model.
+- [ ] Web console drawer shows effective `trust` / `unknown_sender` + source, with edit + reset-to-default.
+- [ ] Existing deployments behave identically until an operator sets an override (yaml defaults preserved).
+
+## Out of scope
+
+- Per-sender or per-contact policy overrides (channel-level only).
+- Changing the trust-scoring algorithm itself.
+- Channel lifecycle / credentials (covered by #543).

--- a/docs/wip/2026-06-12-channel-registry-design.md
+++ b/docs/wip/2026-06-12-channel-registry-design.md
@@ -1,0 +1,314 @@
+# Channel Registry — Design
+
+**Date:** 2026-06-12
+**Issue:** [#543 — feat: database-layer registry for channels with credential management](https://github.com/josephfung/curia/issues/543)
+**Depends on:** #542 (secrets vault) — **merged** (`050_create_secrets_vault.sql`, `src/secrets/secrets-service.ts`)
+**Status:** Design approved, pending spec review
+
+---
+
+## 1. Summary
+
+Add a database-backed registry that governs the install/enable lifecycle of Curia's
+channels, paralleling the existing skills/agents registry (#541). Channel credentials
+move into the encrypted secrets vault under a `channel.<name>.<field>` naming
+convention, resolved **vault-first with env/config fallback** so running deployments
+are untouched. A formal `Channel` TypeScript interface replaces the current duck-typed
+adapter pattern, and the web console gains a **Channels** management page mirroring the
+Skills/Agents list+drawer pattern.
+
+This is a channel-layer **lifecycle + credentials** concern only. Two pieces from the
+original issue are deliberately deferred (see §10): the in-app OAuth flow, and
+DB-backed channel *policy* (trust / unknown_sender / threaded).
+
+---
+
+## 2. Key decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Defer in-app OAuth** to a follow-up issue | No in-app OAuth flow exists anywhere in the codebase, and none of the four current channels need one (Nylas = externally-obtained grant ID; Signal = socket path + phone number). Building a generic OAuth redirect/callback subsystem with no consumer is speculative. |
+| D2 | **Separate `ChannelRegistryService`** + `channel_registry` table | Channels differ structurally from skills/agents: code-defined (not disk-manifest-discovered), carry an `is_toggleable` flag, and HTTP/CLI must always start. Cleaner than forcing channel-specific conditionals into the shared `RegistryService`. |
+| D3 | **Vault-first, env/config fallback** | Credentials resolve from the vault first, then existing env var, then `config/default.yaml`. Reconcile auto-seeds enabled rows for channels whose credentials already resolve, so existing installs light up unchanged. No forced migration. |
+| D4 | **Policy stays out of the registry** (deferred) | `trust` / `unknown_sender` are dispatch-layer security policy (consumed by `trust-scorer.ts`, `dispatcher.ts` via `contacts/config-loader.ts`), not channel-layer lifecycle. Mixing them couples two layers across a security boundary and is security-sensitive enough to warrant its own design + ADR. See §10 and the follow-up issue draft. |
+
+---
+
+## 3. Architecture overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Web Console (apps/console)                                      │
+│   Channels page → list + detail drawer (credential form)        │
+└───────────────┬──────────────────────────────────────────────┘
+                │ REST  /api/registry/channels/*   +   PUT /api/vault/secrets/:name
+┌───────────────▼──────────────────────────────────────────────┐
+│ Backend (src)                                                   │
+│   ChannelRegistryService ──► channel_registry table            │
+│         │                                                       │
+│         ├── catalog (src/channels/catalog.ts)  ← source of truth│
+│         │      for which channels exist + their cred fields     │
+│         ├── credential resolution (vault ▸ env ▸ config)        │
+│         │      └── SecretsService (vault)                       │
+│         └── startup loader (index.ts): start enabled channels   │
+│                                                                 │
+│   Channel interface ◄── email / signal / http / cli adapters    │
+└────────────────────────────────────────────────────────────────┘
+```
+
+The **catalog** is the static, code-defined list of known channels and is the single
+source of truth for: which channels exist, whether each is toggleable, what credential
+fields it needs, and which of those are required to enable it. The `channel_registry`
+table holds only the *mutable lifecycle state* (installed/enabled + timestamps/actors).
+
+---
+
+## 4. The `Channel` interface + catalog
+
+### 4.1 Interface
+
+Replaces the implicit duck-typed pattern (today adapters only expose `start()`; there is
+no `ChannelAdapter` interface in code despite CLAUDE.md referencing one).
+
+```typescript
+// src/channels/channel.ts
+export interface Channel {
+  readonly name: string;          // 'email' | 'signal' | 'http' | 'cli'
+  readonly isToggleable: boolean; // false for http, cli
+  start(): Promise<void>;
+  stop(): Promise<void>;          // graceful shutdown
+}
+```
+
+All four adapters implement it. Changes per adapter:
+- **CLI**: `start()` becomes `async` (currently synchronous); add `stop()`.
+- **Email / Signal / HTTP**: add `stop()` (graceful teardown of poller / RPC socket /
+  Fastify server). No change to message handling.
+
+`stop()` is wired into the existing process-shutdown path. Because hot-reload is out of
+scope (§10), enabling/disabling a channel via the UI takes effect at the **next
+restart** — `stop()` is used for clean shutdown, not live toggling.
+
+### 4.2 Catalog
+
+```typescript
+// src/channels/catalog.ts
+export interface ChannelCredentialField {
+  key: string;            // vault suffix, e.g. 'nylas_grant_id'
+  label: string;          // form label
+  secret: boolean;        // render as password input + never echo back
+  envFallback?: string;   // legacy env var checked during resolution, e.g. 'NYLAS_API_KEY'
+  configPath?: string;    // dotted path into config/default.yaml, for back-compat resolution
+}
+
+export interface ChannelDescriptor {
+  name: string;
+  description: string;
+  isToggleable: boolean;
+  credentialFields: ChannelCredentialField[]; // [] for http/cli
+  requiredSecretKeys: string[];               // subset of field keys required before enable
+}
+
+export const CHANNEL_CATALOG: ChannelDescriptor[] = [ /* email, signal, http, cli */ ];
+```
+
+Representative field definitions:
+
+| Channel | Fields (`key`) | Required | envFallback / configPath |
+|---|---|---|---|
+| `email` | `nylas_api_key`, `nylas_grant_id`, `nylas_self_email` | all three | `NYLAS_API_KEY`; `channel_accounts.email[]` (see §6) |
+| `signal` | `socket_path`, `phone_number` | both | `SIGNAL_SOCKET_PATH`, `SIGNAL_PHONE_NUMBER` |
+| `http` | — | — | `isToggleable: false` |
+| `cli` | — | — | `isToggleable: false` |
+
+Vault keys follow the issue's convention: `channel.<name>.<field.key>`
+(e.g. `channel.email.nylas_grant_id`, `channel.signal.phone_number`).
+
+---
+
+## 5. Data model
+
+`channel_registry` mirrors `skill_registry`/`agent_registry`, plus an `is_toggleable`
+column.
+
+```sql
+-- src/db/migrations/052_create_channel_registry.sql
+-- (verify 052 is still the next free prefix at implementation time; renumber if a
+--  collision landed first — see CLAUDE.md migration-numbering hazard)
+CREATE TABLE channel_registry (
+  name          TEXT PRIMARY KEY,           -- matches catalog descriptor name
+  enabled       BOOLEAN     NOT NULL DEFAULT false,
+  is_toggleable BOOLEAN     NOT NULL DEFAULT true,
+  installed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  installed_by  TEXT        NOT NULL DEFAULT 'system',
+  enabled_at    TIMESTAMPTZ,                -- set when enabled=true, cleared on disable
+  enabled_by    TEXT,
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+**Derived state** (not stored as an enum):
+
+| State | Condition |
+|---|---|
+| `uninstalled` | catalog entry exists, no DB row |
+| `installed` (disabled) | DB row, `enabled = false` |
+| `enabled` | DB row, `enabled = true`, `enabled_at` set |
+
+"Not present" never applies — the catalog always lists all four channels.
+
+---
+
+## 6. Credential resolution
+
+A single helper resolves each credential field across sources, vault-first:
+
+```typescript
+// resolveChannelCredential(descriptor, field) →
+//   vault.get(`channel.${name}.${field.key}`)
+//     ?? process.env[field.envFallback]
+//     ?? lookup(config, field.configPath)
+//     ?? null
+```
+
+- The existing **multi-account email** path (`config/default.yaml` →
+  `channel_accounts.email[]`, shared `NYLAS_API_KEY`) is **preserved unchanged**. The
+  vault/UI path is the single-account setup for fresh installs.
+- A channel's credentials are considered **resolvable** if every `requiredSecretKeys`
+  field resolves from *any* source. The UI surfaces *where* each field resolved from
+  (vault / environment / config / missing) so an operator understands the live state
+  without the registry having to import existing env/config values.
+- `secret: true` fields are write-only over the API: the form can submit a new value
+  (`PUT /api/vault/secrets/channel.<name>.<key>`) but the value is never echoed back;
+  status is reported as configured/missing only.
+
+---
+
+## 7. Startup behaviour (in `src/index.ts`, after DB + vault are ready)
+
+1. **Reconcile.** For each catalog channel with no DB row whose required credentials
+   already resolve (vault or env/config), insert an `enabled` row — existing
+   deployments come up unchanged. HTTP and CLI rows are always ensured present with
+   `is_toggleable = false, enabled = true`.
+2. **Load.** Start only channels with `enabled = true`. HTTP and CLI always start
+   regardless of DB state (operator-lockout safeguard).
+3. **Missing secrets.** If an `enabled` channel's required credentials do not resolve,
+   log a warning and skip starting that adapter — **never crash**.
+
+Adapter instantiation order is unchanged from today (adapters start after the
+`OutboundGateway` and dispatcher are wired). Started adapters are tracked in a map keyed
+by channel name so `stop()` can be called on shutdown.
+
+---
+
+## 8. Backend API
+
+New routes backed by `ChannelRegistryService`, alongside the existing registry routes,
+same auth (session cookie / `x-web-bootstrap-secret`):
+
+```
+GET    /api/registry/channels                    list catalog ⨝ DB ⨝ resolution status
+POST   /api/registry/channels/:name/install      create row (enabled=false)
+POST   /api/registry/channels/:name/enable        gated: required creds must resolve
+POST   /api/registry/channels/:name/disable        409 if !is_toggleable
+DELETE /api/registry/channels/:name                 clears channel.<name>.* vault keys; 409 if !is_toggleable
+```
+
+Credential writes reuse the existing `PUT /api/vault/secrets/:name` endpoint.
+
+`ChannelRegistryService` public API:
+
+```typescript
+class ChannelRegistryService {
+  list(): Promise<ChannelRegistryEntry[]>;           // catalog + row + resolution status + derived state
+  install(name: string, actor: string): Promise<ChannelRegistryEntry>;
+  enable(name: string, actor: string): Promise<ChannelRegistryEntry>;   // throws if required creds unresolved
+  disable(name: string, actor: string): Promise<ChannelRegistryEntry>;  // throws if !is_toggleable
+  uninstall(name: string, actor: string): Promise<void>;                // clears vault keys; throws if !is_toggleable
+}
+```
+
+---
+
+## 9. Frontend (`apps/console`)
+
+A **Channels** entry in the Settings sidebar group (peer to Skills/Agents), reusing the
+`RegistrySettings`/drawer components:
+
+- **List view:** one row per catalog channel; state pill (uninstalled / installed /
+  enabled); enable/disable toggle, **locked + greyed for `http` and `cli`**.
+- **Detail drawer:** channel name, description, derived state; a credential form
+  generated from the catalog's `credentialFields` (password inputs for `secret` fields,
+  showing configured/missing + source per field); Install / Enable–Disable /
+  Uninstall (confirm-required) controls. Enable is disabled until required creds resolve.
+
+No net-new visual design — the existing registry components are reused.
+
+---
+
+## 10. Out of scope (this issue)
+
+Carried over from the issue, plus deferrals from design:
+
+- **In-app OAuth flow** (D1). No in-app OAuth exists yet and no current channel needs
+  one. Split into its own follow-up issue, to be built when a channel actually requires
+  it. The catalog/drawer are structured so an OAuth field type can be added later
+  without reshaping the registry.
+- **DB-backed channel policy — `trust` / `unknown_sender` / `threaded`** (D4).
+  Currently defaulted in `config/channel-trust.yaml` and consumed by the **dispatch
+  layer** (`src/contacts/config-loader.ts` → `src/dispatch/trust-scorer.ts`,
+  `dispatcher.ts`). Deferred to a separate, lower-priority issue because:
+  - it's a different layer/concern from channel lifecycle;
+  - making `trust` runtime-editable from the console is security-sensitive (console
+    compromise → trust escalation) and deserves its own design + ADR;
+  - membership differs — `channel-trust.yaml` includes `web` (the KG app, bootstrap-secret
+    authenticated), which has no startable adapter and is not in the registry catalog;
+  - `threaded` is an adapter *capability*, not a policy — its natural home is a
+    `readonly threaded` property on the `Channel` interface, which that follow-up should
+    do first.
+
+  **Drafted as a follow-up issue:** see
+  [`docs/wip/2026-06-12-channel-policy-registry-issue.md`](./2026-06-12-channel-policy-registry-issue.md)
+  (review before filing on GitHub).
+- **Hot-reload** of channel adapters without restart. Enable/disable applies at next
+  restart.
+- **Multi-account management in the UI.** The existing config-driven multi-account email
+  path is retained; the UI/vault handles the single-account case only.
+- **OAuth token-refresh UI** (moot once OAuth itself is deferred).
+
+---
+
+## 11. Testing (TDD — tests first)
+
+- **`ChannelRegistryService`**: install → enable → disable → uninstall lifecycle;
+  enable gating when required creds unresolved (rejects); `is_toggleable` locks
+  (disable/uninstall of http/cli → error); uninstall clears `channel.<name>.*` vault keys.
+- **Credential resolution**: precedence (vault ▸ env ▸ config); per-field source
+  reporting; required-set resolvable logic.
+- **Reconcile**: seeds `enabled` rows for channels with resolvable creds; http/cli always
+  present, locked, enabled; does not overwrite operator-set state on subsequent boots.
+- **Startup loader**: only `enabled` channels start; http/cli always start; an `enabled`
+  channel with missing required creds logs a warning and is skipped (no crash).
+- **Routes**: auth required; `is_toggleable` 409s; enable-gating 4xx.
+- **Interface conformance**: all four adapters implement `Channel` (`start`/`stop`,
+  `name`, `isToggleable`).
+
+Integration tests use real Postgres per project convention.
+
+---
+
+## 12. Acceptance criteria (adjusted for deferrals)
+
+- [ ] `channel_registry` table created via migration.
+- [ ] `Channel` TypeScript interface defined; all four adapters implement it (incl. `stop()`).
+- [ ] At startup, only `enabled = true` channels start, except HTTP and CLI which always start.
+- [ ] HTTP and CLI appear in the registry with `is_toggleable = false` and cannot be disabled/uninstalled.
+- [ ] Channel credentials stored in the secrets vault under `channel.<name>.<field>`.
+- [ ] Credential resolution is vault-first with env/config fallback; existing deployments start unchanged.
+- [ ] An enabled channel with missing required credentials produces a startup warning (not a crash) and does not start.
+- [ ] Web console shows a Channels list with state indicators and enable/disable toggles (locked for HTTP/CLI).
+- [ ] Detail drawer shows a credential form appropriate to each channel, with per-field configured/missing status.
+- [ ] Static credential install: form submission → vault → channel marked installed.
+- [ ] Uninstall clears the channel's vault entries and removes the registry row (confirm required).
+- [ ] **Deferred** (tracked in follow-up issues): in-app OAuth flow; DB-backed channel policy.
+```

--- a/docs/wip/2026-06-12-channel-registry-design.md
+++ b/docs/wip/2026-06-12-channel-registry-design.md
@@ -267,9 +267,9 @@ Carried over from the issue, plus deferrals from design:
     `readonly threaded` property on the `Channel` interface, which that follow-up should
     do first.
 
-  **Drafted as a follow-up issue:** see
-  [`docs/wip/2026-06-12-channel-policy-registry-issue.md`](./2026-06-12-channel-policy-registry-issue.md)
-  (review before filing on GitHub).
+  **Filed as follow-up issue
+  [#962](https://github.com/josephfung/curia/issues/962)** (draft at
+  [`docs/wip/2026-06-12-channel-policy-registry-issue.md`](./2026-06-12-channel-policy-registry-issue.md)).
 - **Hot-reload** of channel adapters without restart. Enable/disable applies at next
   restart.
 - **Multi-account management in the UI.** The existing config-driven multi-account email

--- a/docs/wip/2026-06-12-channel-registry.md
+++ b/docs/wip/2026-06-12-channel-registry.md
@@ -1863,4 +1863,17 @@ git -C "$WT" commit -m "docs: document channel registry (changelog, config, CLAU
 - **Spec coverage:** every acceptance criterion in the design maps to a task — table (T5), interface (T1/T3), startup gating + always-on http/cli (T9/T11), vault naming + resolution (T2/T4), missing-cred warning-not-crash (T9/T11), console list + drawer + form (T12/T13), static install via form→vault (T12), uninstall clears vault + row (T8/T12). OAuth and policy are explicitly out of scope (#962).
 - **Type consistency:** `channelCredentialStatus` / `ChannelCredentialStatus` / `CredentialStatusFn` / `ChannelRegistryEntry` / `ChannelGuardError` names are used identically across Tasks 4, 6, 8, 9, 11. Repo method `install(name, actor, isToggleable)` signature is consistent in the interface (T6), impl (T7), service calls (T8), and reconcile (T9).
 - **Known soft spots (flagged inline for the implementer):** EmailAdapter `stop()` timer-field name (T3c); exact auth helper exports for routes (T10); `DbPool` import path (T7); `requiredHint` placeholder + class names in the console page (T12). Each is called out at its step.
+
+---
+
+## Discovered during implementation
+
+Issues found by code review that the plan did not anticipate, and how they were resolved:
+
+- **Vault write scope guard rejected channel keys (gap in T10/T12).** The console saves credentials via `PUT /api/vault/secrets/:name`, but that route's existing scope guard (`registryService.declaredSecretNames()`, from #939) only permits *skill*-declared secret names. Channel keys (`channel.<name>.<key>`) are not skill-declared, so a real save would have returned 400 and the credential-install acceptance criterion would not have worked end to end. **Resolved** by an added unit ("Unit V"): widened the guard in `src/channels/http/routes/vault.ts` to also accept exact channel credential keys derived from `CHANNEL_CATALOG` (skill-declared **or** known-channel-key), preserving the "no arbitrary `channel.*` writes" protection, with a new `vault.test.ts` proving both accept and reject paths. Commit `8dd8dd7f`.
+- **Plan's `disable()` SQL bound an extra parameter (T7).** The plan's repo `disable` bound `[name, actor]` for a `$1`-only query, which throws at runtime. Fixed to bind `[name]` (param kept as `_actor` for interface symmetry), matching the sibling `registry-repo.ts`.
+- **`DbPool` import path (T7).** The real export is `../db/connection.js`, not the plan's guessed `../db/pool.js`.
+- **Auth helpers for routes (T10).** The real auth primitive is `assertSecret` from `../session-auth.js` (wrapped in a local `requireAuth` closure), and `AUTH_RATE` is a local const — not importable from `registry.ts` as the plan sketch assumed.
+- **Console page patterns (T12).** RegistrySettings uses concrete class names (`records-layout`, `status-pill`, `drawer-footer`, etc.) and a `SecretRow`-style subcomponent; the plan's placeholder class names were replaced with the real ones.
+- **EmailAdapter/HTTP `stop()` already existed (T3).** Both adapters already had working `stop()` implementations; only the `Channel` interface members (`name`, `isToggleable`) needed adding.
 ```

--- a/docs/wip/2026-06-12-channel-registry.md
+++ b/docs/wip/2026-06-12-channel-registry.md
@@ -1,0 +1,1866 @@
+# Channel Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a database-backed install/enable registry for Curia's channels, with credentials in the secrets vault (vault-first, env/config fallback), a formal `Channel` interface, and a Channels management page in the console.
+
+**Architecture:** A code-defined `CHANNEL_CATALOG` is the source of truth for which channels exist and what credentials each needs. A new `channel_registry` table holds mutable lifecycle state (enabled + `is_toggleable` + timestamps). `ChannelRegistryService` (mirroring `RegistryService`) drives install/enable/disable/uninstall; `reconcileChannelRegistry` seeds enabled rows for channels whose credentials already resolve. At startup, only enabled+resolvable channels construct/start their adapters — except HTTP and CLI, which always start and cannot be toggled.
+
+**Tech Stack:** TypeScript (ESM, Node 22), PostgreSQL + node-pg-migrate, Fastify, Vitest, React + TanStack Router (apps/console).
+
+**Spec:** `docs/wip/2026-06-12-channel-registry-design.md`. **Follow-up (out of scope):** #962 (channel policy).
+
+---
+
+## Conventions for every command in this plan
+
+- `WT` = `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-registry` (the worktree you are working in).
+- Typecheck: `pnpm --prefix "$WT" run typecheck`
+- Run one test file: `pnpm --prefix "$WT" test <path>` (vitest takes a path filter).
+- Integration tests need Postgres: ensure `DATABASE_URL` is exported (it's in the symlinked `.env`; the integration `describeIf` skips when unset, so confirm it's set before relying on those tests).
+- **Before starting:** run `pnpm --prefix "$WT" install` once so `node_modules` exists in the worktree.
+- Commit after each task with the message shown. Conventional commits, no `Co-Authored-By`, no Claude attribution.
+
+---
+
+## File structure
+
+**New files:**
+- `src/db/migrations/052_create_channel_registry.sql` — table + updated_at trigger.
+- `src/channels/channel.ts` — the `Channel` interface.
+- `src/channels/catalog.ts` — `ChannelCredentialField`, `ChannelDescriptor`, `CHANNEL_CATALOG`.
+- `src/channels/credential-resolver.ts` — vault-first credential resolution + per-field status.
+- `src/registry/channel-registry-types.ts` — row/entry/repo types + `ChannelGuardError`.
+- `src/registry/channel-registry-repo.ts` — Postgres `ChannelRegistryRepo`.
+- `src/registry/channel-registry-service.ts` — `ChannelRegistryService`.
+- `src/registry/channel-reconcile.ts` — `reconcileChannelRegistry`.
+- `src/channels/http/routes/channel-registry.ts` — `/api/registry/channels/*` routes.
+- `apps/console/src/pages/ChannelSettings.tsx` — Channels page (list + drawer + credential form).
+- Tests alongside each (`*.test.ts`) and integration tests under `tests/integration/`.
+
+**Modified files:**
+- `src/channels/cli/cli-adapter.ts`, `signal/signal-adapter.ts`, `email/email-adapter.ts`, `http/http-adapter.ts` — implement `Channel`.
+- `src/channels/http/http-adapter.ts` — register channel-registry routes; add `channelRegistryService` to config.
+- `src/index.ts` — construct repo/service, reconcile, gate adapter construction on enabled state, pass service to HTTP adapter.
+- `apps/console/src/components/Sidebar.tsx`, `apps/console/src/router.tsx` — Channels nav + route.
+- `CHANGELOG.md`, `config/default.yaml` (doc comment), `CLAUDE.md` ("New Channel Adapter" now references the real interface).
+
+---
+
+## Task 1: `Channel` interface
+
+**Files:**
+- Create: `src/channels/channel.ts`
+
+No test (type-only declaration; conformance is verified in Task 3).
+
+- [ ] **Step 1: Create the interface**
+
+```typescript
+// src/channels/channel.ts
+// Formal contract every channel adapter implements. Replaces the previous duck-typed
+// pattern (adapters historically exposed only start()). `isToggleable` is false for the
+// always-on safeguard channels (http, cli) which must never be disabled from the UI.
+
+export interface Channel {
+  /** Stable identifier: 'email' | 'signal' | 'http' | 'cli'. Matches the catalog + registry row. */
+  readonly name: string;
+  /** False for http and cli — they always start and cannot be disabled/uninstalled. */
+  readonly isToggleable: boolean;
+  start(): Promise<void>;
+  /** Graceful teardown (used on process shutdown). Idempotent. */
+  stop(): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --prefix "$WT" run typecheck`
+Expected: PASS (no consumers yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C "$WT" add src/channels/channel.ts
+git -C "$WT" commit -m "feat(channels): add formal Channel interface"
+```
+
+---
+
+## Task 2: Channel catalog
+
+**Files:**
+- Create: `src/channels/catalog.ts`
+- Test: `src/channels/catalog.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/channels/catalog.test.ts
+import { describe, it, expect } from 'vitest';
+import { CHANNEL_CATALOG, getChannelDescriptor } from './catalog.js';
+
+describe('CHANNEL_CATALOG', () => {
+  it('contains exactly the four known channels', () => {
+    expect(CHANNEL_CATALOG.map(c => c.name).sort()).toEqual(['cli', 'email', 'http', 'signal']);
+  });
+
+  it('marks http and cli as non-toggleable with no credential fields', () => {
+    for (const name of ['http', 'cli']) {
+      const d = getChannelDescriptor(name)!;
+      expect(d.isToggleable).toBe(false);
+      expect(d.credentialFields).toEqual([]);
+      expect(d.requiredSecretKeys).toEqual([]);
+    }
+  });
+
+  it('marks email and signal as toggleable with required credential fields', () => {
+    const email = getChannelDescriptor('email')!;
+    expect(email.isToggleable).toBe(true);
+    expect(email.requiredSecretKeys).toEqual(['nylas_api_key', 'nylas_grant_id', 'nylas_self_email']);
+
+    const signal = getChannelDescriptor('signal')!;
+    expect(signal.isToggleable).toBe(true);
+    expect(signal.requiredSecretKeys).toEqual(['socket_path', 'phone_number']);
+  });
+
+  it('every requiredSecretKey corresponds to a declared field', () => {
+    for (const d of CHANNEL_CATALOG) {
+      const fieldKeys = new Set(d.credentialFields.map(f => f.key));
+      for (const req of d.requiredSecretKeys) expect(fieldKeys.has(req)).toBe(true);
+    }
+  });
+
+  it('getChannelDescriptor returns undefined for unknown channels', () => {
+    expect(getChannelDescriptor('telegram')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix "$WT" test src/channels/catalog.test.ts`
+Expected: FAIL ("Cannot find module './catalog.js'").
+
+- [ ] **Step 3: Implement the catalog**
+
+```typescript
+// src/channels/catalog.ts
+// Static, code-defined source of truth for which channels exist, whether each is
+// toggleable, and what credentials it needs. The channel_registry table holds only
+// mutable lifecycle state; this catalog supplies everything structural.
+
+export interface ChannelCredentialField {
+  /** Vault key suffix: stored as `channel.<channel>.<key>`. */
+  key: string;
+  /** Human label for the credential form. */
+  label: string;
+  /** Render as a password input and never echo the value back over the API. */
+  secret: boolean;
+  /** Legacy env var checked during resolution (back-compat with pre-vault deployments). */
+  envFallback?: string;
+}
+
+export interface ChannelDescriptor {
+  name: string;
+  description: string;
+  /** False for http, cli — always-on, cannot be disabled/uninstalled. */
+  isToggleable: boolean;
+  credentialFields: ChannelCredentialField[];
+  /** Subset of credentialFields[].key that must resolve before the channel can be enabled. */
+  requiredSecretKeys: string[];
+}
+
+export const CHANNEL_CATALOG: ChannelDescriptor[] = [
+  {
+    name: 'email',
+    description: 'Email channel via Nylas. Polls a connected mailbox and replies in-thread.',
+    isToggleable: true,
+    credentialFields: [
+      { key: 'nylas_api_key', label: 'Nylas API key', secret: true, envFallback: 'NYLAS_API_KEY' },
+      { key: 'nylas_grant_id', label: 'Nylas grant ID', secret: true, envFallback: 'NYLAS_GRANT_ID' },
+      { key: 'nylas_self_email', label: 'Mailbox address', secret: false, envFallback: 'NYLAS_SELF_EMAIL' },
+    ],
+    requiredSecretKeys: ['nylas_api_key', 'nylas_grant_id', 'nylas_self_email'],
+  },
+  {
+    name: 'signal',
+    description: 'Signal channel via signal-cli JSON-RPC over a Unix socket.',
+    isToggleable: true,
+    credentialFields: [
+      { key: 'socket_path', label: 'signal-cli socket path', secret: false, envFallback: 'SIGNAL_SOCKET_PATH' },
+      { key: 'phone_number', label: 'Phone number (E.164)', secret: false, envFallback: 'SIGNAL_PHONE_NUMBER' },
+    ],
+    requiredSecretKeys: ['socket_path', 'phone_number'],
+  },
+  {
+    name: 'http',
+    description: 'HTTP API channel. Always on — serves the web console and API.',
+    isToggleable: false,
+    credentialFields: [],
+    requiredSecretKeys: [],
+  },
+  {
+    name: 'cli',
+    description: 'Local CLI channel. Always on in interactive sessions; cannot be disabled.',
+    isToggleable: false,
+    credentialFields: [],
+    requiredSecretKeys: [],
+  },
+];
+
+export function getChannelDescriptor(name: string): ChannelDescriptor | undefined {
+  return CHANNEL_CATALOG.find(c => c.name === name);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --prefix "$WT" test src/channels/catalog.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$WT" add src/channels/catalog.ts src/channels/catalog.test.ts
+git -C "$WT" commit -m "feat(channels): add channel catalog descriptor"
+```
+
+---
+
+## Task 3: Adapters implement `Channel`
+
+Make all four adapters satisfy the interface. CLI's `start()` becomes `async`; email/http gain `stop()`; all gain `readonly name` + `readonly isToggleable`.
+
+**Files:**
+- Modify: `src/channels/cli/cli-adapter.ts`
+- Modify: `src/channels/signal/signal-adapter.ts`
+- Modify: `src/channels/email/email-adapter.ts`
+- Modify: `src/channels/http/http-adapter.ts`
+- Test: `src/channels/channel-conformance.test.ts`
+
+- [ ] **Step 1: Write the failing conformance test**
+
+```typescript
+// src/channels/channel-conformance.test.ts
+// Compile-time + light runtime check that each adapter satisfies the Channel interface.
+// We assert the static shape (name, isToggleable, start, stop) without constructing the
+// adapters (which need live deps) by using `satisfies`-style type assertions in a typed
+// helper plus a runtime prototype check.
+import { describe, it, expect } from 'vitest';
+import type { Channel } from './channel.js';
+import { CliAdapter } from './cli/cli-adapter.js';
+import { SignalAdapter } from './signal/signal-adapter.js';
+import { EmailAdapter } from './email/email-adapter.js';
+import { HttpAdapter } from './http/http-adapter.js';
+
+// Type-level assertion: each class's instance type must be assignable to Channel.
+// If an adapter is missing a member, this file fails to typecheck.
+type AssertChannel<T extends Channel> = T;
+type _Cli = AssertChannel<CliAdapter>;
+type _Signal = AssertChannel<SignalAdapter>;
+type _Email = AssertChannel<EmailAdapter>;
+type _Http = AssertChannel<HttpAdapter>;
+
+describe('channel adapters implement Channel', () => {
+  it('expose start and stop on their prototypes', () => {
+    for (const cls of [CliAdapter, SignalAdapter, EmailAdapter, HttpAdapter]) {
+      expect(typeof cls.prototype.start).toBe('function');
+      expect(typeof cls.prototype.stop).toBe('function');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix "$WT" test src/channels/channel-conformance.test.ts`
+Expected: FAIL — typecheck errors (CLI `start` returns `void` not `Promise<void>`; missing `name`/`isToggleable`; email/http missing `stop`).
+
+- [ ] **Step 3a: CLI adapter — implement Channel**
+
+In `src/channels/cli/cli-adapter.ts`, change the class to declare `implements Channel`, add the two readonly members, and make `start()` async. Import the interface.
+
+```typescript
+// at top, add:
+import type { Channel } from '../channel.js';
+
+// change the class declaration line to:
+export class CliAdapter implements Channel {
+  readonly name = 'cli';
+  readonly isToggleable = false;
+  // ...existing private fields unchanged...
+
+  // change start() signature from `start(): void {` to:
+  async start(): Promise<void> {
+    // ...existing body unchanged...
+  }
+
+  // change stop() from `stop(): void {` to async to match the interface:
+  async stop(): Promise<void> {
+    this.rl?.close();
+  }
+}
+```
+
+Note: the existing call site `cli.start()` in `index.ts` (around line 2017) does not await — that's fine, `start()` resolves synchronously. Leave it (Task 11 leaves CLI start as-is).
+
+- [ ] **Step 3b: Signal adapter — implement Channel**
+
+In `src/channels/signal/signal-adapter.ts` (`start()` and `stop()` already async):
+
+```typescript
+import type { Channel } from '../channel.js';
+
+export class SignalAdapter implements Channel {
+  readonly name = 'signal';
+  readonly isToggleable = true;
+  // ...existing fields/methods unchanged (start/stop already match)...
+}
+```
+
+- [ ] **Step 3c: Email adapter — implement Channel + add stop()**
+
+In `src/channels/email/email-adapter.ts`. The adapter polls on a timer; `stop()` must halt the poll loop. Add a stop flag + clear the timer handle that `start()` schedules.
+
+```typescript
+import type { Channel } from '../channel.js';
+
+export class EmailAdapter implements Channel {
+  readonly name = 'email';
+  readonly isToggleable = true;
+  // Add if not already present:
+  private stopped = false;
+  private pollTimer?: NodeJS.Timeout;
+
+  // ...existing constructor/start...
+  // In start()'s polling scheduler, capture the timer handle into this.pollTimer
+  // (e.g. `this.pollTimer = setTimeout(...)`) and check `if (this.stopped) return;`
+  // before scheduling the next poll.
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.pollTimer) clearTimeout(this.pollTimer);
+  }
+}
+```
+
+> Implementer note: open `email-adapter.ts`, find where the next poll is scheduled (the `setTimeout`/`setInterval` in the poll loop), assign its handle to `this.pollTimer`, and guard re-scheduling with `this.stopped`. If a timer field already exists, reuse it instead of adding `pollTimer`.
+
+- [ ] **Step 3d: HTTP adapter — implement Channel + add stop()**
+
+In `src/channels/http/http-adapter.ts` (it holds the Fastify instance as `this.app`):
+
+```typescript
+import type { Channel } from '../channel.js';
+
+export class HttpAdapter implements Channel {
+  readonly name = 'http';
+  readonly isToggleable = false;
+  // ...existing fields/start unchanged...
+
+  async stop(): Promise<void> {
+    await this.app.close();
+  }
+}
+```
+
+- [ ] **Step 4: Run test + typecheck to verify pass**
+
+Run: `pnpm --prefix "$WT" run typecheck`
+Run: `pnpm --prefix "$WT" test src/channels/channel-conformance.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing adapter tests to confirm no regressions**
+
+Run: `pnpm --prefix "$WT" test src/channels/`
+Expected: PASS (CLI `start()` now async — verify no existing CLI test asserts a synchronous return; if one does, `await` it).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "$WT" add src/channels/cli/cli-adapter.ts src/channels/signal/signal-adapter.ts src/channels/email/email-adapter.ts src/channels/http/http-adapter.ts src/channels/channel-conformance.test.ts
+git -C "$WT" commit -m "feat(channels): adapters implement the Channel interface"
+```
+
+---
+
+## Task 4: Credential resolver
+
+Resolves each credential vault-first, then env fallback. Config-based resolution (multi-account email) is supplied by the caller as a set of already-satisfied keys, keeping this module pure and testable.
+
+**Files:**
+- Create: `src/channels/credential-resolver.ts`
+- Test: `src/channels/credential-resolver.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/channels/credential-resolver.test.ts
+import { describe, it, expect } from 'vitest';
+import { channelCredentialStatus } from './credential-resolver.js';
+import type { ChannelDescriptor } from './catalog.js';
+
+const signal: ChannelDescriptor = {
+  name: 'signal', description: '', isToggleable: true,
+  credentialFields: [
+    { key: 'socket_path', label: 'Socket', secret: false, envFallback: 'SIGNAL_SOCKET_PATH' },
+    { key: 'phone_number', label: 'Phone', secret: false, envFallback: 'SIGNAL_PHONE_NUMBER' },
+  ],
+  requiredSecretKeys: ['socket_path', 'phone_number'],
+};
+
+const fakeSecrets = (present: Record<string, string>) => ({
+  async get(name: string) { return present[name] ?? null; },
+});
+
+describe('channelCredentialStatus', () => {
+  it('resolves from the vault first', async () => {
+    const secrets = fakeSecrets({ 'channel.signal.socket_path': '/run/sig.sock', 'channel.signal.phone_number': '+15551234567' });
+    const res = await channelCredentialStatus({ secrets, env: {} }, signal);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.map(f => f.source)).toEqual(['vault', 'vault']);
+  });
+
+  it('falls back to env when vault is empty', async () => {
+    const secrets = fakeSecrets({});
+    const env = { SIGNAL_SOCKET_PATH: '/run/sig.sock', SIGNAL_PHONE_NUMBER: '+15551234567' };
+    const res = await channelCredentialStatus({ secrets, env }, signal);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.map(f => f.source)).toEqual(['env', 'env']);
+  });
+
+  it('reports missing when neither vault nor env nor config provides a required key', async () => {
+    const res = await channelCredentialStatus({ secrets: fakeSecrets({}), env: {} }, signal);
+    expect(res.requiredResolvable).toBe(false);
+    expect(res.fields.find(f => f.key === 'socket_path')!.source).toBe('missing');
+  });
+
+  it('treats caller-supplied config keys as satisfied', async () => {
+    const res = await channelCredentialStatus(
+      { secrets: fakeSecrets({}), env: {}, configResolvedKeys: new Set(['socket_path', 'phone_number']) },
+      signal,
+    );
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.map(f => f.source)).toEqual(['config', 'config']);
+  });
+
+  it('a channel with no required keys is always resolvable', async () => {
+    const http: ChannelDescriptor = { name: 'http', description: '', isToggleable: false, credentialFields: [], requiredSecretKeys: [] };
+    const res = await channelCredentialStatus({ secrets: fakeSecrets({}), env: {} }, http);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix "$WT" test src/channels/credential-resolver.test.ts`
+Expected: FAIL ("Cannot find module './credential-resolver.js'").
+
+- [ ] **Step 3: Implement the resolver**
+
+```typescript
+// src/channels/credential-resolver.ts
+// Vault-first credential resolution for channels. Precedence per field:
+//   vault  (channel.<name>.<key>)  ▸  env (field.envFallback)  ▸  config (caller-supplied)  ▸  missing
+// Config resolution lives in the caller (index.ts) because it depends on already-parsed
+// config shapes (e.g. multi-account email); the caller passes the satisfied key names in.
+import type { ChannelDescriptor } from './catalog.js';
+
+export type CredentialSource = 'vault' | 'env' | 'config' | 'missing';
+
+export interface CredentialFieldStatus {
+  key: string;
+  label: string;
+  secret: boolean;
+  configured: boolean;
+  source: CredentialSource;
+}
+
+export interface CredentialResolverDeps {
+  /** Narrow view of the vault — only get() is needed. */
+  secrets: { get(name: string): Promise<string | null> };
+  /** Defaults to process.env. Injected in tests. */
+  env?: Record<string, string | undefined>;
+  /** Required keys the caller considers satisfied via config/default.yaml (e.g. email accounts). */
+  configResolvedKeys?: Set<string>;
+}
+
+export interface ChannelCredentialStatus {
+  fields: CredentialFieldStatus[];
+  /** True when every requiredSecretKeys entry resolves from some source. */
+  requiredResolvable: boolean;
+}
+
+export async function channelCredentialStatus(
+  deps: CredentialResolverDeps,
+  descriptor: ChannelDescriptor,
+): Promise<ChannelCredentialStatus> {
+  const env = deps.env ?? process.env;
+  const configKeys = deps.configResolvedKeys ?? new Set<string>();
+  const fields: CredentialFieldStatus[] = [];
+
+  for (const field of descriptor.credentialFields) {
+    const vaultVal = await deps.secrets.get(`channel.${descriptor.name}.${field.key}`);
+    let source: CredentialSource;
+    if (vaultVal) source = 'vault';
+    else if (field.envFallback && env[field.envFallback]) source = 'env';
+    else if (configKeys.has(field.key)) source = 'config';
+    else source = 'missing';
+
+    fields.push({ key: field.key, label: field.label, secret: field.secret, configured: source !== 'missing', source });
+  }
+
+  const byKey = new Map(fields.map(f => [f.key, f]));
+  const requiredResolvable = descriptor.requiredSecretKeys.every(k => byKey.get(k)?.configured === true);
+  return { fields, requiredResolvable };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --prefix "$WT" test src/channels/credential-resolver.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$WT" add src/channels/credential-resolver.ts src/channels/credential-resolver.test.ts
+git -C "$WT" commit -m "feat(channels): add vault-first credential resolver"
+```
+
+---
+
+## Task 5: Migration — `channel_registry` table
+
+**Files:**
+- Create: `src/db/migrations/052_create_channel_registry.sql`
+- Test: `tests/integration/channel-registry-repo.test.ts` (the table-exists assertion lands here in Task 7; this task adds a minimal migration-applied check)
+
+- [ ] **Step 1: Confirm 052 is the next free prefix**
+
+Run: `ls "$WT/src/db/migrations" | sort | tail -4`
+Expected: highest is `051_create_skill_agent_registry.sql`. If a `052_*` already exists (a branch landed first), use the next free number everywhere in this plan instead.
+
+- [ ] **Step 2: Write the migration**
+
+```sql
+-- src/db/migrations/052_create_channel_registry.sql
+-- Up Migration
+-- Database-backed registry that gates channel adapter startup on an install/enable
+-- lifecycle (spec: docs/wip/2026-06-12-channel-registry-design.md, #543). Mirrors
+-- skill_registry/agent_registry, plus is_toggleable: false for http/cli, which always
+-- start and cannot be disabled (operator-lockout safeguard). Credentials live in the
+-- secrets vault (channel.<name>.<field>); this table stores only lifecycle state.
+
+CREATE TABLE channel_registry (
+  name          TEXT PRIMARY KEY,                 -- matches a CHANNEL_CATALOG descriptor name
+  enabled       BOOLEAN     NOT NULL DEFAULT false,
+  is_toggleable BOOLEAN     NOT NULL DEFAULT true, -- false for http, cli
+  installed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  installed_by  TEXT        NOT NULL DEFAULT 'system',
+  enabled_at    TIMESTAMPTZ,                       -- set when enabled flips true, cleared on disable
+  enabled_by    TEXT,
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION channel_registry_set_updated_at()
+  RETURNS trigger LANGUAGE plpgsql AS $$
+  BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+  END;
+$$;
+
+CREATE TRIGGER channel_registry_updated_at
+  BEFORE UPDATE ON channel_registry
+  FOR EACH ROW EXECUTE FUNCTION channel_registry_set_updated_at();
+
+-- Down Migration
+DROP TRIGGER IF EXISTS channel_registry_updated_at ON channel_registry;
+DROP FUNCTION IF EXISTS channel_registry_set_updated_at();
+DROP TABLE IF EXISTS channel_registry;
+```
+
+- [ ] **Step 3: Apply migrations against the dev DB and verify the table exists**
+
+Run: `pnpm --prefix "$WT" run migrate` (if a migrate script exists; otherwise the table is created at app startup — start the app once, or run the project's migration command). Then verify:
+Run: `psql "$DATABASE_URL" -c "\\d channel_registry"`
+Expected: the table with columns `name, enabled, is_toggleable, installed_at, installed_by, enabled_at, enabled_by, updated_at`.
+
+> If unsure of the migrate command, check `package.json` scripts for `migrate`/`db:migrate`. The app also runs migrations on boot (`src/index.ts` runner), so launching the app once applies it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "$WT" add src/db/migrations/052_create_channel_registry.sql
+git -C "$WT" commit -m "feat(db): add channel_registry table migration"
+```
+
+---
+
+## Task 6: Channel registry types
+
+**Files:**
+- Create: `src/registry/channel-registry-types.ts`
+
+No standalone test (types + a trivial error class; exercised by Tasks 7–8).
+
+- [ ] **Step 1: Create the types**
+
+```typescript
+// src/registry/channel-registry-types.ts
+// Types for the channel registry. Mirrors registry/types.ts but channels are
+// code-defined (CHANNEL_CATALOG), carry is_toggleable, and never reach a 'ghost' state.
+import type { CredentialFieldStatus } from '../channels/credential-resolver.js';
+
+export type ChannelDerivedState = 'uninstalled' | 'installed' | 'enabled';
+
+/** A row in channel_registry, mapped to camelCase. */
+export interface ChannelRegistryRow {
+  name: string;
+  enabled: boolean;
+  isToggleable: boolean;
+  installedAt: string;
+  installedBy: string;
+  enabledAt: string | null;
+  enabledBy: string | null;
+  updatedAt: string;
+}
+
+/** A fully-resolved entry the API returns: catalog × row × credential status → state. */
+export interface ChannelRegistryEntry {
+  name: string;
+  description: string;
+  state: ChannelDerivedState;
+  isToggleable: boolean;
+  credentialFields: CredentialFieldStatus[];
+  requiredResolvable: boolean;
+  installedAt: string | null;
+  installedBy: string | null;
+  enabledAt: string | null;
+  enabledBy: string | null;
+}
+
+/** Thrown for expected guard rejections (unknown channel, not-installed enable,
+ *  disable/uninstall of a non-toggleable channel, missing-credential enable).
+ *  Routes catch this specifically to return HTTP 400. */
+export class ChannelGuardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChannelGuardError';
+  }
+}
+
+/** DB-access contract. Postgres impl is ChannelRegistryRepo; tests use an in-memory fake. */
+export interface IChannelRegistryRepo {
+  listRows(): Promise<ChannelRegistryRow[]>;
+  getRow(name: string): Promise<ChannelRegistryRow | null>;
+  /** Insert enabled=false with the given is_toggleable if absent; return existing row if present. */
+  install(name: string, actor: string, isToggleable: boolean): Promise<ChannelRegistryRow>;
+  enable(name: string, actor: string): Promise<ChannelRegistryRow>;
+  disable(name: string, actor: string): Promise<ChannelRegistryRow>;
+  uninstall(name: string): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `pnpm --prefix "$WT" run typecheck`
+Expected: PASS.
+
+```bash
+git -C "$WT" add src/registry/channel-registry-types.ts
+git -C "$WT" commit -m "feat(registry): add channel registry types"
+```
+
+---
+
+## Task 7: `ChannelRegistryRepo` (Postgres)
+
+**Files:**
+- Create: `src/registry/channel-registry-repo.ts`
+- Test: `tests/integration/channel-registry-repo.test.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```typescript
+// tests/integration/channel-registry-repo.test.ts
+// Requires Postgres with migration 052 applied. Skips when DATABASE_URL is unset.
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import { ChannelRegistryRepo } from '../../src/registry/channel-registry-repo.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('ChannelRegistryRepo', () => {
+  let pool: pg.Pool;
+  let repo: ChannelRegistryRepo;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM channel_registry LIMIT 0'); // fails loudly if migration 052 not applied
+    repo = new ChannelRegistryRepo(pool);
+  });
+  afterAll(async () => { await pool.end(); });
+  beforeEach(async () => { await pool.query('DELETE FROM channel_registry'); });
+
+  it('install inserts a disabled row carrying is_toggleable', async () => {
+    const row = await repo.install('signal', 'tester', true);
+    expect(row.enabled).toBe(false);
+    expect(row.isToggleable).toBe(true);
+    expect(row.installedBy).toBe('tester');
+    expect(row.enabledAt).toBeNull();
+  });
+
+  it('install is idempotent and preserves is_toggleable of the existing row', async () => {
+    await repo.install('http', 'system', false);
+    const again = await repo.install('http', 'someone', true); // should NOT flip to toggleable
+    expect(again.isToggleable).toBe(false);
+  });
+
+  it('enable then disable toggles enabled + enabled_at', async () => {
+    await repo.install('signal', 'tester', true);
+    const enabled = await repo.enable('signal', 'admin');
+    expect(enabled.enabled).toBe(true);
+    expect(enabled.enabledAt).not.toBeNull();
+    const disabled = await repo.disable('signal', 'admin');
+    expect(disabled.enabled).toBe(false);
+    expect(disabled.enabledAt).toBeNull();
+  });
+
+  it('uninstall removes the row', async () => {
+    await repo.install('signal', 'tester', true);
+    await repo.uninstall('signal');
+    expect(await repo.getRow('signal')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix "$WT" test tests/integration/channel-registry-repo.test.ts`
+Expected: FAIL ("Cannot find module .../channel-registry-repo.js"). (If `DATABASE_URL` is unset the suite skips — set it first so the test actually runs.)
+
+- [ ] **Step 3: Implement the repo**
+
+```typescript
+// src/registry/channel-registry-repo.ts
+// Postgres-backed channel_registry access. Parameterized queries only.
+import type { DbPool } from '../db/pool.js';
+import type { ChannelRegistryRow, IChannelRegistryRepo } from './channel-registry-types.js';
+
+const COLS = 'name, enabled, is_toggleable, installed_at, installed_by, enabled_at, enabled_by, updated_at';
+
+interface DbChannelRow {
+  name: string;
+  enabled: boolean;
+  is_toggleable: boolean;
+  installed_at: string;
+  installed_by: string;
+  enabled_at: string | null;
+  enabled_by: string | null;
+  updated_at: string;
+}
+
+function mapRow(r: DbChannelRow): ChannelRegistryRow {
+  return {
+    name: r.name,
+    enabled: r.enabled,
+    isToggleable: r.is_toggleable,
+    installedAt: r.installed_at,
+    installedBy: r.installed_by,
+    enabledAt: r.enabled_at,
+    enabledBy: r.enabled_by,
+    updatedAt: r.updated_at,
+  };
+}
+
+export class ChannelRegistryRepo implements IChannelRegistryRepo {
+  constructor(private readonly pool: DbPool) {}
+
+  async listRows(): Promise<ChannelRegistryRow[]> {
+    const { rows } = await this.pool.query<DbChannelRow>(`SELECT ${COLS} FROM channel_registry`);
+    return rows.map(mapRow);
+  }
+
+  async getRow(name: string): Promise<ChannelRegistryRow | null> {
+    const { rows } = await this.pool.query<DbChannelRow>(`SELECT ${COLS} FROM channel_registry WHERE name = $1`, [name]);
+    return rows[0] ? mapRow(rows[0]) : null;
+  }
+
+  async install(name: string, actor: string, isToggleable: boolean): Promise<ChannelRegistryRow> {
+    // Insert a disabled row; if it already exists, leave it untouched (incl. is_toggleable)
+    // and return it. The no-op SET makes ON CONFLICT return the existing row via RETURNING.
+    const { rows } = await this.pool.query<DbChannelRow>(
+      `INSERT INTO channel_registry (name, enabled, is_toggleable, installed_by)
+       VALUES ($1, false, $3, $2)
+       ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+       RETURNING ${COLS}`,
+      [name, actor, isToggleable],
+    );
+    return mapRow(rows[0]!);
+  }
+
+  async enable(name: string, actor: string): Promise<ChannelRegistryRow> {
+    const { rows } = await this.pool.query<DbChannelRow>(
+      `UPDATE channel_registry
+          SET enabled = true, enabled_at = now(), enabled_by = $2, updated_at = now()
+        WHERE name = $1
+        RETURNING ${COLS}`,
+      [name, actor],
+    );
+    if (!rows[0]) throw new Error(`enable: no channel_registry row for '${name}'`);
+    return mapRow(rows[0]);
+  }
+
+  async disable(name: string, actor: string): Promise<ChannelRegistryRow> {
+    const { rows } = await this.pool.query<DbChannelRow>(
+      `UPDATE channel_registry
+          SET enabled = false, enabled_at = NULL, enabled_by = NULL, updated_at = now()
+        WHERE name = $1
+        RETURNING ${COLS}`,
+      [name, actor],
+    );
+    if (!rows[0]) throw new Error(`disable: no channel_registry row for '${name}'`);
+    return mapRow(rows[0]);
+  }
+
+  async uninstall(name: string): Promise<void> {
+    await this.pool.query(`DELETE FROM channel_registry WHERE name = $1`, [name]);
+  }
+}
+```
+
+> Implementer note: confirm the `DbPool` type import path. Check how `src/registry/registry-repo.ts` imports its pool type and mirror it exactly (it may be `import type { DbPool } from '../db/pool.js'` or a `pg.Pool` alias). The `enable`/`disable` params keep `actor` even though `disable` clears `enabled_by` — `actor` is unused there but kept for interface symmetry; prefix with `_` only if the linter complains.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --prefix "$WT" test tests/integration/channel-registry-repo.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `pnpm --prefix "$WT" run typecheck`
+
+```bash
+git -C "$WT" add src/registry/channel-registry-repo.ts tests/integration/channel-registry-repo.test.ts
+git -C "$WT" commit -m "feat(registry): add ChannelRegistryRepo"
+```
+
+---
+
+## Task 8: `ChannelRegistryService`
+
+**Files:**
+- Create: `src/registry/channel-registry-service.ts`
+- Test: `src/registry/channel-registry-service.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/registry/channel-registry-service.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ChannelRegistryService } from './channel-registry-service.js';
+import { ChannelGuardError } from './channel-registry-types.js';
+import type { IChannelRegistryRepo, ChannelRegistryRow } from './channel-registry-types.js';
+import type { ChannelDescriptor } from '../channels/catalog.js';
+import type { ChannelCredentialStatus } from '../channels/credential-resolver.js';
+
+class FakeRepo implements IChannelRegistryRepo {
+  rows = new Map<string, ChannelRegistryRow>();
+  async listRows() { return [...this.rows.values()]; }
+  async getRow(n: string) { return this.rows.get(n) ?? null; }
+  async install(name: string, actor: string, isToggleable: boolean) {
+    const existing = this.rows.get(name);
+    if (existing) return existing;
+    const row: ChannelRegistryRow = { name, enabled: false, isToggleable, installedAt: 't0', installedBy: actor, enabledAt: null, enabledBy: null, updatedAt: 't0' };
+    this.rows.set(name, row); return row;
+  }
+  async enable(name: string, actor: string) {
+    const row = this.rows.get(name); if (!row) throw new Error('no row');
+    const next = { ...row, enabled: true, enabledAt: 't1', enabledBy: actor }; this.rows.set(name, next); return next;
+  }
+  async disable(name: string, _actor: string) {
+    const row = this.rows.get(name); if (!row) throw new Error('no row');
+    const next = { ...row, enabled: false, enabledAt: null, enabledBy: null }; this.rows.set(name, next); return next;
+  }
+  async uninstall(name: string) { this.rows.delete(name); }
+}
+
+const CATALOG: ChannelDescriptor[] = [
+  { name: 'signal', description: 'sig', isToggleable: true,
+    credentialFields: [{ key: 'phone_number', label: 'Phone', secret: false }], requiredSecretKeys: ['phone_number'] },
+  { name: 'http', description: 'http', isToggleable: false, credentialFields: [], requiredSecretKeys: [] },
+];
+
+// Credential status fn: signal resolvable iff `signalReady`, http always resolvable.
+const statusFn = (signalReady: boolean) =>
+  async (d: ChannelDescriptor): Promise<ChannelCredentialStatus> => {
+    if (d.name === 'signal') {
+      return { requiredResolvable: signalReady, fields: [{ key: 'phone_number', label: 'Phone', secret: false, configured: signalReady, source: signalReady ? 'vault' : 'missing' }] };
+    }
+    return { requiredResolvable: true, fields: [] };
+  };
+
+describe('ChannelRegistryService', () => {
+  let repo: FakeRepo;
+  beforeEach(() => { repo = new FakeRepo(); });
+
+  it('list derives state: no row → uninstalled, row+disabled → installed, row+enabled → enabled', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true));
+    let entries = await svc.list();
+    expect(entries.find(e => e.name === 'signal')!.state).toBe('uninstalled');
+    await svc.install('signal', 'a');
+    entries = await svc.list();
+    expect(entries.find(e => e.name === 'signal')!.state).toBe('installed');
+    await svc.enable('signal', 'a');
+    entries = await svc.list();
+    expect(entries.find(e => e.name === 'signal')!.state).toBe('enabled');
+  });
+
+  it('list surfaces isToggleable and credential field status from the catalog + resolver', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(false));
+    const entries = await svc.list();
+    const http = entries.find(e => e.name === 'http')!;
+    expect(http.isToggleable).toBe(false);
+    const signal = entries.find(e => e.name === 'signal')!;
+    expect(signal.requiredResolvable).toBe(false);
+    expect(signal.credentialFields[0]!.source).toBe('missing');
+  });
+
+  it('enable is rejected when required credentials do not resolve', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(false));
+    await svc.install('signal', 'a');
+    await expect(svc.enable('signal', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+  });
+
+  it('enable of a not-installed channel is rejected', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true));
+    await expect(svc.enable('signal', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+  });
+
+  it('install/enable/disable of an unknown channel is rejected', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true));
+    await expect(svc.install('telegram', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+  });
+
+  it('disable and uninstall of a non-toggleable channel are rejected', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true));
+    await repo.install('http', 'system', false);
+    await repo.enable('http', 'system');
+    await expect(svc.disable('http', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+    await expect(svc.uninstall('http', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+  });
+
+  it('uninstall clears the channel vault keys and removes the row', async () => {
+    const deleted: string[] = [];
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true), { delete: async (n: string) => { deleted.push(n); } });
+    await svc.install('signal', 'a');
+    await svc.uninstall('signal', 'a');
+    expect(deleted).toContain('channel.signal.phone_number');
+    expect(await repo.getRow('signal')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix "$WT" test src/registry/channel-registry-service.test.ts`
+Expected: FAIL ("Cannot find module './channel-registry-service.js'").
+
+- [ ] **Step 3: Implement the service**
+
+```typescript
+// src/registry/channel-registry-service.ts
+// Drives the channel install/enable lifecycle. Channels are code-defined (CHANNEL_CATALOG),
+// so there is no on-disk discovery and no 'ghost' state. enable() is gated on the channel's
+// required credentials resolving (vault/env/config); disable()/uninstall() are blocked for
+// non-toggleable channels (http, cli).
+import type { ChannelDescriptor } from '../channels/catalog.js';
+import type { ChannelCredentialStatus } from '../channels/credential-resolver.js';
+import {
+  ChannelGuardError,
+  type ChannelRegistryEntry,
+  type IChannelRegistryRepo,
+} from './channel-registry-types.js';
+
+/** Resolves the live credential status for a descriptor (vault/env/config). Injected so the
+ *  service stays decoupled from the vault + config wiring and is trivially fakeable in tests. */
+export type CredentialStatusFn = (descriptor: ChannelDescriptor) => Promise<ChannelCredentialStatus>;
+
+export class ChannelRegistryService {
+  constructor(
+    private readonly repo: IChannelRegistryRepo,
+    private readonly catalog: ChannelDescriptor[],
+    private readonly credentialStatus: CredentialStatusFn,
+    /** Used by uninstall() to clear the channel's vault keys. Optional in tests. */
+    private readonly secrets?: { delete(name: string): Promise<void> },
+  ) {}
+
+  private descriptor(name: string): ChannelDescriptor {
+    const d = this.catalog.find(c => c.name === name);
+    if (!d) throw new ChannelGuardError(`Unknown channel '${name}'.`);
+    return d;
+  }
+
+  async list(): Promise<ChannelRegistryEntry[]> {
+    const rows = await this.repo.listRows();
+    const rowByName = new Map(rows.map(r => [r.name, r]));
+    const entries: ChannelRegistryEntry[] = [];
+
+    for (const d of this.catalog) {
+      const row = rowByName.get(d.name);
+      const status = await this.credentialStatus(d);
+      const state = !row ? 'uninstalled' : row.enabled ? 'enabled' : 'installed';
+      entries.push({
+        name: d.name,
+        description: d.description,
+        state,
+        isToggleable: d.isToggleable,
+        credentialFields: status.fields,
+        requiredResolvable: status.requiredResolvable,
+        installedAt: row?.installedAt ?? null,
+        installedBy: row?.installedBy ?? null,
+        enabledAt: row?.enabledAt ?? null,
+        enabledBy: row?.enabledBy ?? null,
+      });
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    return entries;
+  }
+
+  async install(name: string, actor: string): Promise<ChannelRegistryEntry> {
+    const d = this.descriptor(name);
+    await this.repo.install(name, actor, d.isToggleable);
+    return this.entry(name);
+  }
+
+  async enable(name: string, actor: string): Promise<ChannelRegistryEntry> {
+    const d = this.descriptor(name);
+    const row = await this.repo.getRow(name);
+    if (!row) throw new ChannelGuardError(`Cannot enable '${name}': not installed. Install it first.`);
+    const status = await this.credentialStatus(d);
+    if (!status.requiredResolvable) {
+      throw new ChannelGuardError(`Cannot enable '${name}': required credentials are not configured.`);
+    }
+    await this.repo.enable(name, actor);
+    return this.entry(name);
+  }
+
+  async disable(name: string, actor: string): Promise<ChannelRegistryEntry> {
+    const d = this.descriptor(name);
+    if (!d.isToggleable) throw new ChannelGuardError(`Channel '${name}' cannot be disabled.`);
+    const row = await this.repo.getRow(name);
+    if (!row) throw new ChannelGuardError(`Cannot disable '${name}': no registry row.`);
+    await this.repo.disable(name, actor);
+    return this.entry(name);
+  }
+
+  async uninstall(name: string, _actor: string): Promise<void> {
+    const d = this.descriptor(name);
+    if (!d.isToggleable) throw new ChannelGuardError(`Channel '${name}' cannot be uninstalled.`);
+    // Clear the channel's vault keys (best-effort; delete is a no-op if the key is absent).
+    if (this.secrets) {
+      for (const field of d.credentialFields) {
+        await this.secrets.delete(`channel.${name}.${field.key}`);
+      }
+    }
+    await this.repo.uninstall(name);
+  }
+
+  private async entry(name: string): Promise<ChannelRegistryEntry> {
+    const entries = await this.list();
+    const found = entries.find(e => e.name === name);
+    if (!found) throw new Error(`entry: '${name}' not in catalog after mutation`);
+    return found;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --prefix "$WT" test src/registry/channel-registry-service.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `pnpm --prefix "$WT" run typecheck`
+
+```bash
+git -C "$WT" add src/registry/channel-registry-service.ts src/registry/channel-registry-service.test.ts
+git -C "$WT" commit -m "feat(registry): add ChannelRegistryService"
+```
+
+---
+
+## Task 9: `reconcileChannelRegistry`
+
+Seeds the registry at startup: http/cli always present + enabled (locked); toggleable channels with resolvable credentials and no existing row get installed + enabled.
+
+**Files:**
+- Create: `src/registry/channel-reconcile.ts`
+- Test: `src/registry/channel-reconcile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/registry/channel-reconcile.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { reconcileChannelRegistry } from './channel-reconcile.js';
+import type { IChannelRegistryRepo, ChannelRegistryRow } from './channel-registry-types.js';
+import type { ChannelDescriptor } from '../channels/catalog.js';
+import type { ChannelCredentialStatus } from '../channels/credential-resolver.js';
+
+class FakeRepo implements IChannelRegistryRepo {
+  rows = new Map<string, ChannelRegistryRow>();
+  async listRows() { return [...this.rows.values()]; }
+  async getRow(n: string) { return this.rows.get(n) ?? null; }
+  async install(name: string, actor: string, isToggleable: boolean) {
+    const e = this.rows.get(name); if (e) return e;
+    const row: ChannelRegistryRow = { name, enabled: false, isToggleable, installedAt: 't0', installedBy: actor, enabledAt: null, enabledBy: null, updatedAt: 't0' };
+    this.rows.set(name, row); return row;
+  }
+  async enable(name: string, actor: string) { const r = this.rows.get(name)!; const n = { ...r, enabled: true, enabledAt: 't1', enabledBy: actor }; this.rows.set(name, n); return n; }
+  async disable(name: string, _a: string) { const r = this.rows.get(name)!; const n = { ...r, enabled: false, enabledAt: null, enabledBy: null }; this.rows.set(name, n); return n; }
+  async uninstall(name: string) { this.rows.delete(name); }
+}
+
+const silentLogger = { info() {}, warn() {}, error() {}, debug() {} } as any;
+
+const CATALOG: ChannelDescriptor[] = [
+  { name: 'email', description: '', isToggleable: true, credentialFields: [], requiredSecretKeys: ['x'] },
+  { name: 'signal', description: '', isToggleable: true, credentialFields: [], requiredSecretKeys: ['y'] },
+  { name: 'http', description: '', isToggleable: false, credentialFields: [], requiredSecretKeys: [] },
+  { name: 'cli', description: '', isToggleable: false, credentialFields: [], requiredSecretKeys: [] },
+];
+
+// resolvable: only 'email'
+const statusFn = async (d: ChannelDescriptor): Promise<ChannelCredentialStatus> =>
+  ({ requiredResolvable: d.name === 'email' || !d.isToggleable, fields: [] });
+
+describe('reconcileChannelRegistry', () => {
+  let repo: FakeRepo;
+  beforeEach(() => { repo = new FakeRepo(); });
+
+  it('always enrolls http and cli as enabled + non-toggleable', async () => {
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    for (const name of ['http', 'cli']) {
+      const row = repo.rows.get(name)!;
+      expect(row.enabled).toBe(true);
+      expect(row.isToggleable).toBe(false);
+    }
+  });
+
+  it('enrolls a toggleable channel as enabled only when its credentials resolve', async () => {
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    expect(repo.rows.get('email')!.enabled).toBe(true);   // resolvable
+    expect(repo.rows.get('signal')).toBeUndefined();       // not resolvable → no row
+  });
+
+  it('respects existing admin state and does not overwrite it', async () => {
+    await repo.install('email', 'admin', true); // installed but deliberately left disabled
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    expect(repo.rows.get('email')!.enabled).toBe(false);   // left as-is
+  });
+
+  it('re-enables http/cli if a prior run left them disabled (safeguard)', async () => {
+    await repo.install('http', 'system', false); // disabled row exists
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    expect(repo.rows.get('http')!.enabled).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix "$WT" test src/registry/channel-reconcile.test.ts`
+Expected: FAIL ("Cannot find module './channel-reconcile.js'").
+
+- [ ] **Step 3: Implement reconcile**
+
+```typescript
+// src/registry/channel-reconcile.ts
+// Startup reconciliation for the channel registry:
+//   - http/cli (non-toggleable) are ALWAYS present and enabled — operator-lockout safeguard.
+//   - toggleable channels with no row whose credentials resolve are installed + enabled, so
+//     existing deployments light up unchanged. Existing admin state is never overwritten.
+import type { Logger } from 'pino';
+import type { ChannelDescriptor } from '../channels/catalog.js';
+import type { CredentialStatusFn } from './channel-registry-service.js';
+import type { IChannelRegistryRepo } from './channel-registry-types.js';
+
+export interface ReconcileChannelDeps {
+  repo: IChannelRegistryRepo;
+  catalog: ChannelDescriptor[];
+  credentialStatus: CredentialStatusFn;
+  logger: Logger;
+}
+
+export async function reconcileChannelRegistry(deps: ReconcileChannelDeps): Promise<void> {
+  const { repo, catalog, credentialStatus, logger } = deps;
+  const existing = new Map((await repo.listRows()).map(r => [r.name, r]));
+
+  for (const d of catalog) {
+    const row = existing.get(d.name);
+
+    // Always-on channels: ensure present + enabled, regardless of prior state.
+    if (!d.isToggleable) {
+      if (!row) {
+        await repo.install(d.name, 'reconciliation', false);
+        await repo.enable(d.name, 'reconciliation');
+        logger.info({ channel: d.name }, 'channel registry: enrolled always-on channel as enabled');
+      } else if (!row.enabled) {
+        await repo.enable(d.name, 'reconciliation');
+        logger.warn({ channel: d.name }, 'channel registry: re-enabled always-on channel that was disabled');
+      }
+      continue;
+    }
+
+    // Toggleable channels: respect any existing admin state.
+    if (row) continue;
+
+    const status = await credentialStatus(d);
+    if (status.requiredResolvable) {
+      await repo.install(d.name, 'reconciliation', true);
+      await repo.enable(d.name, 'reconciliation');
+      logger.info({ channel: d.name }, 'channel registry: enrolled channel with resolvable credentials as enabled');
+    } else {
+      logger.info({ channel: d.name }, 'channel registry: channel has no credentials; left uninstalled');
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --prefix "$WT" test src/registry/channel-reconcile.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `pnpm --prefix "$WT" run typecheck`
+
+```bash
+git -C "$WT" add src/registry/channel-reconcile.ts src/registry/channel-reconcile.test.ts
+git -C "$WT" commit -m "feat(registry): add channel registry reconciliation"
+```
+
+---
+
+## Task 10: HTTP routes `/api/registry/channels/*`
+
+**Files:**
+- Create: `src/channels/http/routes/channel-registry.ts`
+- Modify: `src/channels/http/http-adapter.ts` (register routes + extend config type)
+- Test: `src/channels/http/routes/channel-registry.test.ts`
+
+> First read `src/channels/http/routes/registry.ts` in full to copy the exact `requireAuth`, `AUTH_RATE`, options-type, and `app.register` plugin shape used there. The handlers below follow that pattern; match the real helper names/imports from that file.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/channels/http/routes/channel-registry.test.ts
+// Spins up a Fastify instance with the channel-registry routes and a fake service,
+// bypassing auth via the bootstrap-secret header (mirror how registry.test.ts authenticates).
+import { describe, it, expect, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { channelRegistryRoutes } from './channel-registry.js';
+import { ChannelGuardError } from '../../../registry/channel-registry-types.js';
+
+const BOOTSTRAP = 'test-bootstrap-secret';
+
+function fakeService(overrides: Record<string, any> = {}) {
+  return {
+    list: async () => [{ name: 'signal', description: '', state: 'uninstalled', isToggleable: true, credentialFields: [], requiredResolvable: false, installedAt: null, installedBy: null, enabledAt: null, enabledBy: null }],
+    install: async () => ({ name: 'signal', state: 'installed' }),
+    enable: async () => ({ name: 'signal', state: 'enabled' }),
+    disable: async () => ({ name: 'signal', state: 'installed' }),
+    uninstall: async () => {},
+    ...overrides,
+  };
+}
+
+async function build(service: any): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(channelRegistryRoutes, { channelRegistryService: service, webAppBootstrapSecret: BOOTSTRAP, sessions: { /* minimal stub matching registry.ts */ } as any });
+  return app;
+}
+
+const auth = { 'x-web-bootstrap-secret': BOOTSTRAP };
+
+describe('channel registry routes', () => {
+  let app: FastifyInstance;
+  afterEach?.(async () => { await app?.close(); });
+
+  it('GET /api/registry/channels returns the list', async () => {
+    app = await build(fakeService());
+    const res = await app.inject({ method: 'GET', url: '/api/registry/channels', headers: auth });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().channels[0].name).toBe('signal');
+  });
+
+  it('POST enable maps ChannelGuardError to 400', async () => {
+    app = await build(fakeService({ enable: async () => { throw new ChannelGuardError('nope'); } }));
+    const res = await app.inject({ method: 'POST', url: '/api/registry/channels/signal/enable', headers: auth });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('nope');
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    app = await build(fakeService());
+    const res = await app.inject({ method: 'GET', url: '/api/registry/channels' });
+    expect(res.statusCode).toBe(401);
+  });
+});
+```
+
+> The exact auth stub (`sessions`) and the unauth status code (401 vs 403) must match `registry.ts`/`requireAuth`. Adjust the test's `sessions` stub and expected unauth code to whatever `registry.ts` uses; read it first.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --prefix "$WT" test src/channels/http/routes/channel-registry.test.ts`
+Expected: FAIL ("Cannot find module './channel-registry.js'").
+
+- [ ] **Step 3: Implement the routes**
+
+```typescript
+// src/channels/http/routes/channel-registry.ts
+// REST surface for the channel registry, mirroring routes/registry.ts. Session-authed
+// (or bootstrap-secret). ChannelGuardError → 400; anything else → 500.
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { ChannelGuardError } from '../../../registry/channel-registry-types.js';
+import type { ChannelRegistryService } from '../../../registry/channel-registry-service.js';
+// Reuse the SAME auth helpers/rate config registry.ts uses. Import them from there or the
+// shared module registry.ts imports from — do not re-implement auth.
+import { requireAuth, AUTH_RATE, type SessionStore } from './registry.js'; // adjust to real exports
+
+const ACTOR = 'web-console';
+
+export interface ChannelRegistryRouteOptions {
+  channelRegistryService: ChannelRegistryService;
+  webAppBootstrapSecret: string;
+  sessions: SessionStore; // match registry.ts's type
+}
+
+export async function channelRegistryRoutes(
+  app: FastifyInstance,
+  options: ChannelRegistryRouteOptions,
+): Promise<void> {
+  const { channelRegistryService: svc } = options;
+
+  app.get('/api/registry/channels', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+    try {
+      return reply.send({ channels: await svc.list() });
+    } catch (err) {
+      request.log.error({ err }, 'GET /api/registry/channels failed');
+      return reply.status(500).send({ error: 'Failed to list channels. Check server logs.' });
+    }
+  });
+
+  const action = (op: 'install' | 'enable' | 'disable' | 'uninstall') =>
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!requireAuth(request, reply)) return;
+      const { name } = request.params as { name: string };
+      try {
+        if (op === 'uninstall') {
+          await svc.uninstall(name, ACTOR);
+          return reply.send({ ok: true });
+        }
+        const entry =
+          op === 'install' ? await svc.install(name, ACTOR)
+          : op === 'enable' ? await svc.enable(name, ACTOR)
+          : await svc.disable(name, ACTOR);
+        return reply.send({ entry });
+      } catch (err) {
+        if (err instanceof ChannelGuardError) {
+          request.log.info({ err, name, op }, `channel ${op} rejected: guard`);
+          return reply.status(400).send({ error: err.message });
+        }
+        request.log.error({ err, name, op }, `channel ${op} failed unexpectedly`);
+        return reply.status(500).send({ error: 'Operation failed. Check server logs.' });
+      }
+    };
+
+  app.post('/api/registry/channels/:name/install', AUTH_RATE, action('install'));
+  app.post('/api/registry/channels/:name/enable', AUTH_RATE, action('enable'));
+  app.post('/api/registry/channels/:name/disable', AUTH_RATE, action('disable'));
+  app.delete('/api/registry/channels/:name', AUTH_RATE, action('uninstall'));
+}
+```
+
+> If `requireAuth`/`AUTH_RATE`/`SessionStore` are not exported from `registry.ts`, find their real source module (they may live in a shared `http/auth.ts` or similar) and import from there. Keeping a single auth implementation is required — do not duplicate it.
+
+- [ ] **Step 4: Register the routes in `http-adapter.ts`**
+
+In `src/channels/http/http-adapter.ts`, extend the config type with `channelRegistryService?` and register the routes next to the existing registry routes (the block around lines 308–327). Add:
+
+```typescript
+import { channelRegistryRoutes } from './routes/channel-registry.js';
+// ...in HttpAdapterConfig: add
+//   channelRegistryService?: ChannelRegistryService;
+// ...in the registry-routes registration block, after the vaultRoutes register:
+    if (webAppBootstrapSecret && this.config.channelRegistryService) {
+      await this.app.register(channelRegistryRoutes, {
+        channelRegistryService: this.config.channelRegistryService,
+        webAppBootstrapSecret,
+        sessions,
+      });
+    }
+```
+
+Add the `ChannelRegistryService` type import at the top of `http-adapter.ts`.
+
+- [ ] **Step 5: Run test + typecheck**
+
+Run: `pnpm --prefix "$WT" test src/channels/http/routes/channel-registry.test.ts`
+Run: `pnpm --prefix "$WT" run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "$WT" add src/channels/http/routes/channel-registry.ts src/channels/http/routes/channel-registry.test.ts src/channels/http/http-adapter.ts
+git -C "$WT" commit -m "feat(channels): add channel registry HTTP routes"
+```
+
+---
+
+## Task 11: Startup wiring in `index.ts`
+
+Construct the repo + service, reconcile, gate adapter construction on enabled state, and pass the service to the HTTP adapter. **This task has no new unit test** — it's integration glue; verify by booting the app and by the existing startup tests. Make the smallest edits that wire the pieces.
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Read the adapter-construction region**
+
+Open `src/index.ts` and locate:
+- the email adapter construction loop (~lines 1251–1277),
+- the signal adapter construction (~lines 1281–1291),
+- the CLI start (~lines 2016–2022),
+- where `secretsService`, `resolvedEmailAccounts`, `nylasClientMap`, `signalRpcClient`, `config.signalPhoneNumber`, and the DB `pool` are already in scope (all before line 1251).
+
+- [ ] **Step 2: Insert the channel-registry setup block before adapter construction**
+
+Immediately **before** the email construction loop (~line 1251), insert:
+
+```typescript
+  // ── Channel registry ───────────────────────────────────────────────────────
+  // Decide which channels start, from DB lifecycle state + resolvable credentials.
+  // Credentials resolve vault-first, then env, then config (multi-account email).
+  const channelRegistryRepo = new ChannelRegistryRepo(pool);
+
+  // Config-satisfied keys per channel (the messy, config-shape-aware part lives here,
+  // keeping the resolver pure). Email is satisfied via config when ≥1 account resolved.
+  const channelConfigKeys = (descriptor: ChannelDescriptor): Set<string> => {
+    if (descriptor.name === 'email' && resolvedEmailAccounts.length > 0) {
+      return new Set(['nylas_api_key', 'nylas_grant_id', 'nylas_self_email']);
+    }
+    return new Set<string>();
+  };
+
+  const channelCredentialStatusFn = (descriptor: ChannelDescriptor) =>
+    channelCredentialStatus(
+      { secrets: secretsService, configResolvedKeys: channelConfigKeys(descriptor) },
+      descriptor,
+    );
+
+  try {
+    await reconcileChannelRegistry({
+      repo: channelRegistryRepo,
+      catalog: CHANNEL_CATALOG,
+      credentialStatus: channelCredentialStatusFn,
+      logger,
+    });
+  } catch (err) {
+    logger.fatal({ err }, 'Channel registry reconciliation failed');
+    process.exit(1);
+  }
+
+  // Compute the set of channels that should actually start this boot: enabled in the DB
+  // AND credentials currently resolvable. Non-toggleable channels (http/cli) always start.
+  const channelRows = await channelRegistryRepo.listRows();
+  const enabledByName = new Map(channelRows.map(r => [r.name, r.enabled]));
+  const channelShouldStart = new Set<string>();
+  for (const descriptor of CHANNEL_CATALOG) {
+    if (!descriptor.isToggleable) { channelShouldStart.add(descriptor.name); continue; }
+    if (!enabledByName.get(descriptor.name)) continue;
+    const status = await channelCredentialStatusFn(descriptor);
+    if (status.requiredResolvable) {
+      channelShouldStart.add(descriptor.name);
+    } else {
+      // Enabled but credentials no longer resolve: warn and skip — never crash (spec §7).
+      logger.warn({ channel: descriptor.name }, 'channel enabled but required credentials missing; not starting');
+    }
+  }
+
+  // Service backing /api/registry/channels/* (delete wired for uninstall vault cleanup).
+  const channelRegistryService = new ChannelRegistryService(
+    channelRegistryRepo,
+    CHANNEL_CATALOG,
+    channelCredentialStatusFn,
+    secretsService,
+  );
+  // ───────────────────────────────────────────────────────────────────────────
+```
+
+Add the imports at the top of `index.ts`:
+
+```typescript
+import { CHANNEL_CATALOG, type ChannelDescriptor } from './channels/catalog.js';
+import { channelCredentialStatus } from './channels/credential-resolver.js';
+import { ChannelRegistryRepo } from './registry/channel-registry-repo.js';
+import { ChannelRegistryService } from './registry/channel-registry-service.js';
+import { reconcileChannelRegistry } from './registry/channel-reconcile.js';
+```
+
+- [ ] **Step 3: Gate email construction on `channelShouldStart`**
+
+In the email construction loop, add the gate. Change the loop guard:
+
+```typescript
+  if (outboundGateway && channelShouldStart.has('email')) {
+    for (const account of resolvedEmailAccounts) {
+      // ...unchanged body...
+    }
+  }
+```
+
+- [ ] **Step 4: Gate signal construction on `channelShouldStart`**
+
+```typescript
+  if (outboundGateway && signalRpcClient && config.signalPhoneNumber && channelShouldStart.has('signal')) {
+    signalAdapter = new SignalAdapter({ /* ...unchanged... */ });
+  }
+```
+
+(CLI and HTTP are non-toggleable and always in `channelShouldStart`; leave their existing construction/start untouched.)
+
+- [ ] **Step 5: Pass `channelRegistryService` to the HTTP adapter config**
+
+Find where `new HttpAdapter({ ... })` is constructed and add `channelRegistryService,` to its config object (alongside the existing `registryService` / `secretsService` fields).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --prefix "$WT" run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Boot smoke test**
+
+Start the app once against the dev DB (use the project's dev run command, e.g. `pnpm --prefix "$WT" run dev`), watching `curia.log`/stdout. Confirm:
+- migration 052 applies,
+- a `channel registry: enrolled ...` line appears for http/cli (and email/signal if their creds resolve),
+- the process does not crash if a toggleable channel lacks credentials (warning, not fatal).
+Stop the app.
+
+- [ ] **Step 8: Run the broader test suite for regressions**
+
+Run: `pnpm --prefix "$WT" test src/`
+Expected: PASS (investigate any startup-related test that asserts adapters always construct — update it to seed/enable the channel or assert the new gated behavior).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git -C "$WT" add src/index.ts
+git -C "$WT" commit -m "feat(channels): gate adapter startup on the channel registry"
+```
+
+---
+
+## Task 12: Console — Channels page
+
+A page mirroring `RegistrySettings.tsx`: list of channels with state pills + a drawer with a credential form (fields from `credentialFields`) and Install/Enable/Disable/Uninstall actions. Toggle/actions locked for non-toggleable channels.
+
+**Files:**
+- Create: `apps/console/src/pages/ChannelSettings.tsx`
+
+> Read `apps/console/src/pages/RegistrySettings.tsx` in full first and reuse its layout primitives (the page shell, drawer, state-pill styles, `apiFetch`, `errorMessage`). The component below is the channel-specific core; wrap it in the same page chrome RegistrySettings uses so styling is consistent.
+
+- [ ] **Step 1: Implement the page**
+
+```tsx
+// apps/console/src/pages/ChannelSettings.tsx
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../api.js';
+
+interface CredentialFieldStatus {
+  key: string; label: string; secret: boolean; configured: boolean;
+  source: 'vault' | 'env' | 'config' | 'missing';
+}
+interface ChannelEntry {
+  name: string; description: string;
+  state: 'uninstalled' | 'installed' | 'enabled';
+  isToggleable: boolean;
+  credentialFields: CredentialFieldStatus[];
+  requiredResolvable: boolean;
+}
+
+const STATE_LABEL: Record<ChannelEntry['state'], string> = {
+  uninstalled: 'Not installed', installed: 'Installed (disabled)', enabled: 'Enabled',
+};
+
+export function ChannelsPage() {
+  const [entries, setEntries] = useState<ChannelEntry[]>([]);
+  const [selected, setSelected] = useState<ChannelEntry | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [draft, setDraft] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiFetch('/api/registry/channels');
+      if (!res.ok) throw new Error(`Failed to load (${res.status})`);
+      const data = await res.json() as { channels: ChannelEntry[] };
+      setEntries(data.channels);
+      setLoadError(null);
+      setSelected(prev => prev ? data.channels.find(c => c.name === prev.name) ?? null : null);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Failed to load');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const act = useCallback(async (method: 'POST' | 'DELETE', path: string) => {
+    if (!selected) return;
+    setBusy(true);
+    try {
+      const res = await apiFetch(`/api/registry/channels/${selected.name}${path}`, { method });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(body.error ?? `Request failed (${res.status})`);
+      }
+      await load();
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Action failed');
+    } finally {
+      setBusy(false);
+    }
+  }, [selected, load]);
+
+  // Save a credential to the vault under channel.<name>.<key>, then reload status.
+  const saveCredential = useCallback(async (channel: string, key: string, value: string) => {
+    setBusy(true);
+    try {
+      const res = await apiFetch(`/api/vault/secrets/channel.${channel}.${key}`, {
+        method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ value }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(body.error ?? `Save failed (${res.status})`);
+      }
+      setDraft(d => ({ ...d, [key]: '' }));
+      await load();
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setBusy(false);
+    }
+  }, [load]);
+
+  return (
+    <div className="registry-page">
+      <h1>Channels</h1>
+      {loadError && <div className="error-banner">{loadError}</div>}
+      <ul className="registry-list">
+        {entries.map(e => (
+          <li key={e.name}>
+            <button className={`registry-row${selected?.name === e.name ? ' active' : ''}`} onClick={() => setSelected(e)}>
+              <span className="registry-name">{e.name}</span>
+              <span className={`state-pill state-${e.state}`}>{STATE_LABEL[e.state]}</span>
+              {!e.isToggleable && <span className="state-pill state-locked">Always on</span>}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {selected && (
+        <aside className="registry-drawer">
+          <h2>{selected.name}</h2>
+          <p>{selected.description}</p>
+          <p className="muted">State: {STATE_LABEL[selected.state]}{!selected.isToggleable && ' (cannot be disabled)'}</p>
+
+          {/* Credential form — only for toggleable channels with fields */}
+          {selected.isToggleable && selected.credentialFields.length > 0 && (
+            <div className="credential-form">
+              <h3>Credentials</h3>
+              {selected.credentialFields.map(f => (
+                <div key={f.key} className="credential-field">
+                  <label>{f.label}</label>
+                  <span className={`source-pill source-${f.source}`}>
+                    {f.configured ? `configured (${f.source})` : 'missing'}
+                  </span>
+                  <div className="credential-entry">
+                    <input
+                      type={f.secret ? 'password' : 'text'}
+                      value={draft[f.key] ?? ''}
+                      placeholder={f.configured ? '•••• (set — enter to replace)' : 'enter value'}
+                      onChange={ev => setDraft(d => ({ ...d, [f.key]: ev.target.value }))}
+                    />
+                    <button className="btn btn-sm" disabled={busy || !(draft[f.key]?.length)} onClick={() => void saveCredential(selected.name, f.key, draft[f.key]!)}>
+                      Save
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Lifecycle actions — hidden entirely for non-toggleable channels */}
+          {selected.isToggleable && (
+            <div className="registry-actions">
+              {selected.state === 'uninstalled' && (
+                <button className="btn btn-secondary btn-sm" disabled={busy} onClick={() => void act('POST', '/install')}>Install</button>
+              )}
+              {selected.state === 'installed' && (
+                <button className="btn btn-primary btn-sm" disabled={busy || !selected.requiredResolvable}
+                        title={selected.requiredResolvable ? '' : 'Configure required credentials first'}
+                        onClick={() => void act('POST', '/enable')}>Enable</button>
+              )}
+              {selected.state === 'enabled' && (
+                <button className="btn btn-secondary btn-sm" disabled={busy} onClick={() => void act('POST', '/disable')}>Disable</button>
+              )}
+              {selected.state !== 'uninstalled' && (
+                <button className="btn btn-danger btn-sm" disabled={busy}
+                        onClick={() => { if (confirm(`Uninstall ${selected.name}? This clears its stored credentials.`)) void act('DELETE', ''); }}>
+                  Uninstall
+                </button>
+              )}
+            </div>
+          )}
+        </aside>
+      )}
+    </div>
+  );
+}
+```
+
+> Fix-ups while implementing: reuse RegistrySettings' actual class names if they differ from the ones above so the styling matches. The important contract is the API calls and the locked behavior for non-toggleable channels (no actions, no credential form). Required-field marking is intentionally omitted — the Enable button already enforces resolvability.
+
+- [ ] **Step 2: Typecheck the console app**
+
+Run: `pnpm --prefix "$WT/apps/console" run typecheck` (or the console's typecheck script; check `apps/console/package.json`).
+Expected: PASS after you resolve the `requiredHint` placeholder.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C "$WT" add apps/console/src/pages/ChannelSettings.tsx
+git -C "$WT" commit -m "feat(console): add Channels management page"
+```
+
+---
+
+## Task 13: Console — nav + route
+
+**Files:**
+- Modify: `apps/console/src/router.tsx`
+- Modify: `apps/console/src/components/Sidebar.tsx`
+
+- [ ] **Step 1: Add the route**
+
+In `apps/console/src/router.tsx`, mirror the skills/agents routes (around lines 151–161 and the route tree at 173–187):
+
+```tsx
+import { ChannelsPage } from './pages/ChannelSettings.js'; // add with the other page imports
+
+const channelsRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/channels',
+  component: ChannelsPage,
+});
+```
+
+Add `channelsRoute` to the `authedRoute.addChildren([...])` array next to `skillsRoute, agentsRoute`.
+
+- [ ] **Step 2: Add the sidebar entry**
+
+In `apps/console/src/components/Sidebar.tsx`, add a nav-sub-item in the Settings group next to Skills/Agents (around lines 176–189). Use any existing icon import (e.g. reuse one already imported, or `IconWand`):
+
+```tsx
+              <button
+                className={`nav-sub-item${activeView === 'channels' ? ' active' : ''}`}
+                onClick={() => go('channels')}
+              >
+                <IconWand />
+                Channels
+              </button>
+```
+
+Ensure `'channels'` is a valid value for whatever `activeView`/`go()` typing the sidebar uses (check the `ROUTES`/view-name union near the top of `Sidebar.tsx` and add `channels: '/channels'` if a `ROUTES` map exists).
+
+- [ ] **Step 3: Typecheck + build the console**
+
+Run: `pnpm --prefix "$WT/apps/console" run typecheck`
+Run: `pnpm --prefix "$WT/apps/console" run build`
+Expected: PASS.
+
+- [ ] **Step 4: Manual smoke (optional but recommended)**
+
+Run the console dev server + backend, log in, open Settings → Channels. Confirm: list shows all four channels; http/cli show "Always on" with no actions; signal/email show credential fields with source pills; entering a credential + Save persists and the source pill flips to "configured (vault)"; Enable is disabled until required creds resolve.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$WT" add apps/console/src/router.tsx apps/console/src/components/Sidebar.tsx
+git -C "$WT" commit -m "feat(console): add Channels nav entry and route"
+```
+
+---
+
+## Task 14: Docs — CHANGELOG, config comment, CLAUDE.md
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `config/default.yaml` (doc comment only)
+- Modify: `CLAUDE.md` ("New Channel Adapter" section)
+
+- [ ] **Step 1: CHANGELOG entry**
+
+Under `## [Unreleased]` → `### Added`:
+
+```markdown
+- **Channel registry** — database-backed install/enable lifecycle for channels with credentials in the secrets vault (vault-first, env/config fallback); new `Channel` interface, `Channels` console page, and always-on HTTP/CLI safeguard. (#543)
+```
+
+- [ ] **Step 2: config/default.yaml comment**
+
+Add a short comment above `channel_accounts.email` noting credentials may now also be supplied via the vault (`channel.email.*`) and managed in the console; the config path remains supported for multi-account setups.
+
+- [ ] **Step 3: CLAUDE.md — update "New Channel Adapter"**
+
+Update step 1 of "Adding Things → New Channel Adapter" to reference the now-real interface: "Create `src/channels/<name>/` implementing the `Channel` interface from `src/channels/channel.ts` (`name`, `isToggleable`, `start()`, `stop()`)", and add a step: "Add a `ChannelDescriptor` to `src/channels/catalog.ts` (credential fields + required secret keys)."
+
+- [ ] **Step 4: Typecheck (sanity) + commit**
+
+```bash
+git -C "$WT" add CHANGELOG.md config/default.yaml CLAUDE.md
+git -C "$WT" commit -m "docs: document channel registry (changelog, config, CLAUDE.md)"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] Full typecheck: `pnpm --prefix "$WT" run typecheck` → PASS
+- [ ] Backend tests: `pnpm --prefix "$WT" test src/ tests/` → PASS (integration tests need `DATABASE_URL`)
+- [ ] Console typecheck + build: `pnpm --prefix "$WT/apps/console" run typecheck` and `run build` → PASS
+- [ ] Migration prefix still unique: `ls "$WT/src/db/migrations" | sort` → no duplicate `052_`
+- [ ] Boot smoke test passes (Task 11 Step 7): http/cli enrolled, no crash on missing channel creds
+- [ ] Run the auto-review subagents (code-reviewer + silent-failure-hunter) per global workflow; address high-priority findings
+- [ ] PR body includes `Closes #543` and references follow-up #962
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** every acceptance criterion in the design maps to a task — table (T5), interface (T1/T3), startup gating + always-on http/cli (T9/T11), vault naming + resolution (T2/T4), missing-cred warning-not-crash (T9/T11), console list + drawer + form (T12/T13), static install via form→vault (T12), uninstall clears vault + row (T8/T12). OAuth and policy are explicitly out of scope (#962).
+- **Type consistency:** `channelCredentialStatus` / `ChannelCredentialStatus` / `CredentialStatusFn` / `ChannelRegistryEntry` / `ChannelGuardError` names are used identically across Tasks 4, 6, 8, 9, 11. Repo method `install(name, actor, isToggleable)` signature is consistent in the interface (T6), impl (T7), service calls (T8), and reconcile (T9).
+- **Known soft spots (flagged inline for the implementer):** EmailAdapter `stop()` timer-field name (T3c); exact auth helper exports for routes (T10); `DbPool` import path (T7); `requiredHint` placeholder + class names in the console page (T12). Each is called out at its step.
+```

--- a/src/channels/catalog.test.ts
+++ b/src/channels/catalog.test.ts
@@ -1,0 +1,39 @@
+// src/channels/catalog.test.ts
+import { describe, it, expect } from 'vitest';
+import { CHANNEL_CATALOG, getChannelDescriptor } from './catalog.js';
+
+describe('CHANNEL_CATALOG', () => {
+  it('contains exactly the four known channels', () => {
+    expect(CHANNEL_CATALOG.map(c => c.name).sort()).toEqual(['cli', 'email', 'http', 'signal']);
+  });
+
+  it('marks http and cli as non-toggleable with no credential fields', () => {
+    for (const name of ['http', 'cli']) {
+      const d = getChannelDescriptor(name)!;
+      expect(d.isToggleable).toBe(false);
+      expect(d.credentialFields).toEqual([]);
+      expect(d.requiredSecretKeys).toEqual([]);
+    }
+  });
+
+  it('marks email and signal as toggleable with required credential fields', () => {
+    const email = getChannelDescriptor('email')!;
+    expect(email.isToggleable).toBe(true);
+    expect(email.requiredSecretKeys).toEqual(['nylas_api_key', 'nylas_grant_id', 'nylas_self_email']);
+
+    const signal = getChannelDescriptor('signal')!;
+    expect(signal.isToggleable).toBe(true);
+    expect(signal.requiredSecretKeys).toEqual(['socket_path', 'phone_number']);
+  });
+
+  it('every requiredSecretKey corresponds to a declared field', () => {
+    for (const d of CHANNEL_CATALOG) {
+      const fieldKeys = new Set(d.credentialFields.map(f => f.key));
+      for (const req of d.requiredSecretKeys) expect(fieldKeys.has(req)).toBe(true);
+    }
+  });
+
+  it('getChannelDescriptor returns undefined for unknown channels', () => {
+    expect(getChannelDescriptor('telegram')).toBeUndefined();
+  });
+});

--- a/src/channels/catalog.ts
+++ b/src/channels/catalog.ts
@@ -1,0 +1,67 @@
+// src/channels/catalog.ts
+// Static, code-defined source of truth for which channels exist, whether each is
+// toggleable, and what credentials it needs. The channel_registry table holds only
+// mutable lifecycle state; this catalog supplies everything structural.
+
+export interface ChannelCredentialField {
+  /** Vault key suffix: stored as `channel.<channel>.<key>`. */
+  key: string;
+  /** Human label for the credential form. */
+  label: string;
+  /** Render as a password input and never echo the value back over the API. */
+  secret: boolean;
+  /** Legacy env var checked during resolution (back-compat with pre-vault deployments). */
+  envFallback?: string;
+}
+
+export interface ChannelDescriptor {
+  name: string;
+  description: string;
+  /** False for http, cli — always-on, cannot be disabled/uninstalled. */
+  isToggleable: boolean;
+  credentialFields: ChannelCredentialField[];
+  /** Subset of credentialFields[].key that must resolve before the channel can be enabled. */
+  requiredSecretKeys: string[];
+}
+
+export const CHANNEL_CATALOG: ChannelDescriptor[] = [
+  {
+    name: 'email',
+    description: 'Email channel via Nylas. Polls a connected mailbox and replies in-thread.',
+    isToggleable: true,
+    credentialFields: [
+      { key: 'nylas_api_key', label: 'Nylas API key', secret: true, envFallback: 'NYLAS_API_KEY' },
+      { key: 'nylas_grant_id', label: 'Nylas grant ID', secret: true, envFallback: 'NYLAS_GRANT_ID' },
+      { key: 'nylas_self_email', label: 'Mailbox address', secret: false, envFallback: 'NYLAS_SELF_EMAIL' },
+    ],
+    requiredSecretKeys: ['nylas_api_key', 'nylas_grant_id', 'nylas_self_email'],
+  },
+  {
+    name: 'signal',
+    description: 'Signal channel via signal-cli JSON-RPC over a Unix socket.',
+    isToggleable: true,
+    credentialFields: [
+      { key: 'socket_path', label: 'signal-cli socket path', secret: false, envFallback: 'SIGNAL_SOCKET_PATH' },
+      { key: 'phone_number', label: 'Phone number (E.164)', secret: false, envFallback: 'SIGNAL_PHONE_NUMBER' },
+    ],
+    requiredSecretKeys: ['socket_path', 'phone_number'],
+  },
+  {
+    name: 'http',
+    description: 'HTTP API channel. Always on — serves the web console and API.',
+    isToggleable: false,
+    credentialFields: [],
+    requiredSecretKeys: [],
+  },
+  {
+    name: 'cli',
+    description: 'Local CLI channel. Always on in interactive sessions; cannot be disabled.',
+    isToggleable: false,
+    credentialFields: [],
+    requiredSecretKeys: [],
+  },
+];
+
+export function getChannelDescriptor(name: string): ChannelDescriptor | undefined {
+  return CHANNEL_CATALOG.find(c => c.name === name);
+}

--- a/src/channels/channel-conformance.test.ts
+++ b/src/channels/channel-conformance.test.ts
@@ -1,0 +1,30 @@
+// src/channels/channel-conformance.test.ts
+// Compile-time + light runtime check that each adapter satisfies the Channel interface.
+// We assert the static shape (name, isToggleable, start, stop) without constructing the
+// adapters (which need live deps) by using `satisfies`-style type assertions in a typed
+// helper plus a runtime prototype check.
+import { describe, it, expect } from 'vitest';
+import type { Channel } from './channel.js';
+import { CliAdapter } from './cli/cli-adapter.js';
+import { SignalAdapter } from './signal/signal-adapter.js';
+import { EmailAdapter } from './email/email-adapter.js';
+import { HttpAdapter } from './http/http-adapter.js';
+
+// Type-level assertion: each class's instance type must be assignable to Channel.
+// If an adapter is missing a member, this file fails to typecheck.
+// The aliases are `export`ed so the repo's `noUnusedLocals` rule doesn't flag them
+// as unused — the assertion lives purely in the `T extends Channel` constraint.
+type AssertChannel<T extends Channel> = T;
+export type _Cli = AssertChannel<CliAdapter>;
+export type _Signal = AssertChannel<SignalAdapter>;
+export type _Email = AssertChannel<EmailAdapter>;
+export type _Http = AssertChannel<HttpAdapter>;
+
+describe('channel adapters implement Channel', () => {
+  it('expose start and stop on their prototypes', () => {
+    for (const cls of [CliAdapter, SignalAdapter, EmailAdapter, HttpAdapter]) {
+      expect(typeof cls.prototype.start).toBe('function');
+      expect(typeof cls.prototype.stop).toBe('function');
+    }
+  });
+});

--- a/src/channels/channel.ts
+++ b/src/channels/channel.ts
@@ -1,0 +1,14 @@
+// src/channels/channel.ts
+// Formal contract every channel adapter implements. Replaces the previous duck-typed
+// pattern (adapters historically exposed only start()). `isToggleable` is false for the
+// always-on safeguard channels (http, cli) which must never be disabled from the UI.
+
+export interface Channel {
+  /** Stable identifier: 'email' | 'signal' | 'http' | 'cli'. Matches the catalog + registry row. */
+  readonly name: string;
+  /** False for http and cli — they always start and cannot be disabled/uninstalled. */
+  readonly isToggleable: boolean;
+  start(): Promise<void>;
+  /** Graceful teardown (used on process shutdown). Idempotent. */
+  stop(): Promise<void>;
+}

--- a/src/channels/cli/cli-adapter.ts
+++ b/src/channels/cli/cli-adapter.ts
@@ -3,6 +3,7 @@ import type { EventBus } from '../../bus/bus.js';
 import { createInboundMessage } from '../../bus/events.js';
 import type { OutboundMessageEvent } from '../../bus/events.js';
 import type { Logger } from '../../logger.js';
+import type { Channel } from '../channel.js';
 
 /**
  * CLI channel adapter — interactive terminal I/O for local development and testing.
@@ -14,7 +15,9 @@ import type { Logger } from '../../logger.js';
  * (channel → dispatch → agent → dispatch → channel) can be exercised without
  * a real messaging platform.
  */
-export class CliAdapter {
+export class CliAdapter implements Channel {
+  readonly name = 'cli';
+  readonly isToggleable = false;
   private bus: EventBus;
   private logger: Logger;
   private rl?: readline.Interface;
@@ -26,7 +29,7 @@ export class CliAdapter {
     this.onExit = onExit;
   }
 
-  start(): void {
+  async start(): Promise<void> {
     // Subscribe to outbound messages directed at the CLI channel.
     this.bus.subscribe('outbound.message', 'channel', (event) => {
       if (event.type === 'outbound.message' && event.payload.channelId === 'cli') {
@@ -94,7 +97,7 @@ export class CliAdapter {
     this.rl?.prompt();
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.rl?.close();
   }
 }

--- a/src/channels/cli/cli-adapter.ts
+++ b/src/channels/cli/cli-adapter.ts
@@ -73,7 +73,7 @@ export class CliAdapter implements Channel {
       }
 
       if (content === '/quit' || content === '/exit') {
-        this.stop();
+        void this.stop();
         return;
       }
 

--- a/src/channels/credential-resolver.test.ts
+++ b/src/channels/credential-resolver.test.ts
@@ -1,0 +1,56 @@
+// src/channels/credential-resolver.test.ts
+import { describe, it, expect } from 'vitest';
+import { channelCredentialStatus } from './credential-resolver.js';
+import type { ChannelDescriptor } from './catalog.js';
+
+const signal: ChannelDescriptor = {
+  name: 'signal', description: '', isToggleable: true,
+  credentialFields: [
+    { key: 'socket_path', label: 'Socket', secret: false, envFallback: 'SIGNAL_SOCKET_PATH' },
+    { key: 'phone_number', label: 'Phone', secret: false, envFallback: 'SIGNAL_PHONE_NUMBER' },
+  ],
+  requiredSecretKeys: ['socket_path', 'phone_number'],
+};
+
+const fakeSecrets = (present: Record<string, string>) => ({
+  async get(name: string) { return present[name] ?? null; },
+});
+
+describe('channelCredentialStatus', () => {
+  it('resolves from the vault first', async () => {
+    const secrets = fakeSecrets({ 'channel.signal.socket_path': '/run/sig.sock', 'channel.signal.phone_number': '+15551234567' });
+    const res = await channelCredentialStatus({ secrets, env: {} }, signal);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.map(f => f.source)).toEqual(['vault', 'vault']);
+  });
+
+  it('falls back to env when vault is empty', async () => {
+    const secrets = fakeSecrets({});
+    const env = { SIGNAL_SOCKET_PATH: '/run/sig.sock', SIGNAL_PHONE_NUMBER: '+15551234567' };
+    const res = await channelCredentialStatus({ secrets, env }, signal);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.map(f => f.source)).toEqual(['env', 'env']);
+  });
+
+  it('reports missing when neither vault nor env nor config provides a required key', async () => {
+    const res = await channelCredentialStatus({ secrets: fakeSecrets({}), env: {} }, signal);
+    expect(res.requiredResolvable).toBe(false);
+    expect(res.fields.find(f => f.key === 'socket_path')!.source).toBe('missing');
+  });
+
+  it('treats caller-supplied config keys as satisfied', async () => {
+    const res = await channelCredentialStatus(
+      { secrets: fakeSecrets({}), env: {}, configResolvedKeys: new Set(['socket_path', 'phone_number']) },
+      signal,
+    );
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.map(f => f.source)).toEqual(['config', 'config']);
+  });
+
+  it('a channel with no required keys is always resolvable', async () => {
+    const http: ChannelDescriptor = { name: 'http', description: '', isToggleable: false, credentialFields: [], requiredSecretKeys: [] };
+    const res = await channelCredentialStatus({ secrets: fakeSecrets({}), env: {} }, http);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields).toEqual([]);
+  });
+});

--- a/src/channels/credential-resolver.ts
+++ b/src/channels/credential-resolver.ts
@@ -22,6 +22,9 @@ export interface CredentialResolverDeps {
   env?: Record<string, string | undefined>;
   /** Required keys the caller considers satisfied via config/default.yaml (e.g. email accounts). */
   configResolvedKeys?: Set<string>;
+  /** Optional logger. A vault read failure is treated as 'missing' (so env/config
+   *  fallback still applies) but is logged here rather than swallowed. Omitted in tests. */
+  logger?: { warn(obj: unknown, msg: string): void };
 }
 
 export interface ChannelCredentialStatus {
@@ -39,7 +42,18 @@ export async function channelCredentialStatus(
   const fields: CredentialFieldStatus[] = [];
 
   for (const field of descriptor.credentialFields) {
-    const vaultVal = await deps.secrets.get(`channel.${descriptor.name}.${field.key}`);
+    // Vault read is isolated per field: a transient vault failure must not abort the
+    // whole resolution and falsely report a channel as broken. On error we treat the
+    // vault value as absent and fall through to env/config precedence.
+    let vaultVal: string | null = null;
+    try {
+      vaultVal = await deps.secrets.get(`channel.${descriptor.name}.${field.key}`);
+    } catch (err) {
+      deps.logger?.warn(
+        { err, channel: descriptor.name, key: field.key },
+        'channel credential vault read failed; treating as missing and falling back to env/config',
+      );
+    }
     let source: CredentialSource;
     if (vaultVal) source = 'vault';
     else if (field.envFallback && env[field.envFallback]) source = 'env';

--- a/src/channels/credential-resolver.ts
+++ b/src/channels/credential-resolver.ts
@@ -1,0 +1,55 @@
+// src/channels/credential-resolver.ts
+// Vault-first credential resolution for channels. Precedence per field:
+//   vault  (channel.<name>.<key>)  ▸  env (field.envFallback)  ▸  config (caller-supplied)  ▸  missing
+// Config resolution lives in the caller (index.ts) because it depends on already-parsed
+// config shapes (e.g. multi-account email); the caller passes the satisfied key names in.
+import type { ChannelDescriptor } from './catalog.js';
+
+export type CredentialSource = 'vault' | 'env' | 'config' | 'missing';
+
+export interface CredentialFieldStatus {
+  key: string;
+  label: string;
+  secret: boolean;
+  configured: boolean;
+  source: CredentialSource;
+}
+
+export interface CredentialResolverDeps {
+  /** Narrow view of the vault — only get() is needed. */
+  secrets: { get(name: string): Promise<string | null> };
+  /** Defaults to process.env. Injected in tests. */
+  env?: Record<string, string | undefined>;
+  /** Required keys the caller considers satisfied via config/default.yaml (e.g. email accounts). */
+  configResolvedKeys?: Set<string>;
+}
+
+export interface ChannelCredentialStatus {
+  fields: CredentialFieldStatus[];
+  /** True when every requiredSecretKeys entry resolves from some source. */
+  requiredResolvable: boolean;
+}
+
+export async function channelCredentialStatus(
+  deps: CredentialResolverDeps,
+  descriptor: ChannelDescriptor,
+): Promise<ChannelCredentialStatus> {
+  const env = deps.env ?? process.env;
+  const configKeys = deps.configResolvedKeys ?? new Set<string>();
+  const fields: CredentialFieldStatus[] = [];
+
+  for (const field of descriptor.credentialFields) {
+    const vaultVal = await deps.secrets.get(`channel.${descriptor.name}.${field.key}`);
+    let source: CredentialSource;
+    if (vaultVal) source = 'vault';
+    else if (field.envFallback && env[field.envFallback]) source = 'env';
+    else if (configKeys.has(field.key)) source = 'config';
+    else source = 'missing';
+
+    fields.push({ key: field.key, label: field.label, secret: field.secret, configured: source !== 'missing', source });
+  }
+
+  const byKey = new Map(fields.map(f => [f.key, f]));
+  const requiredResolvable = descriptor.requiredSecretKeys.every(k => byKey.get(k)?.configured === true);
+  return { fields, requiredResolvable };
+}

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -22,6 +22,7 @@ import {
 } from '../../bus/events.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
 import { buildReplyQuote } from '../../skills/_shared/reply-quote.js';
+import type { Channel } from '../channel.js';
 
 // Mirrors MAX_BODY_LENGTH in skills/email-send/handler.ts and skills/email-reply/handler.ts.
 // When the agent's response plus the quoted original would exceed this, the quote
@@ -100,8 +101,14 @@ export interface EmailAdapterConfig {
   configStore?: ConfigStore;
 }
 
-export class EmailAdapter {
+export class EmailAdapter implements Channel {
+  readonly name = 'email';
+  readonly isToggleable = true;
   private config: EmailAdapterConfig;
+  // Existing setInterval handle — cleared in stop() to halt the poll loop. The
+  // overlap guard (`processing`) plus clearing this interval are sufficient to
+  // stop polling; no separate `stopped` flag is needed because polls are driven
+  // by a single repeating interval rather than per-poll re-scheduling.
   private pollTimer?: ReturnType<typeof setInterval>;
   private lastSeenTimestamp: number = 0;
   private processing = false;

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -43,6 +43,7 @@ import type { ExecutiveProfileService } from '../../executive/service.js';
 import type { ContactService } from '../../contacts/contact-service.js';
 import type { AutonomyService } from '../../autonomy/autonomy-service.js';
 import { type SessionStore } from './session-auth.js';
+import type { Channel } from '../channel.js';
 
 export interface HttpAdapterConfig {
   bus: EventBus;
@@ -80,7 +81,9 @@ export interface HttpAdapterConfig {
   bootStartedAt: string;
 }
 
-export class HttpAdapter {
+export class HttpAdapter implements Channel {
+  readonly name = 'http';
+  readonly isToggleable = false;
   private app: FastifyInstance;
   private config: HttpAdapterConfig;
   private eventRouter: EventRouter;

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -36,6 +36,7 @@ import { identityRoutes } from './routes/identity.js';
 import { executiveRoutes } from './routes/executive.js';
 import { autonomyRoutes } from './routes/autonomy.js';
 import { registryRoutes } from './routes/registry.js';
+import { channelRegistryRoutes } from './routes/channel-registry.js';
 import { vaultRoutes } from './routes/vault.js';
 import { setupRoutes } from './routes/setup.js';
 import type { OfficeIdentityService } from '../../identity/service.js';
@@ -62,6 +63,9 @@ export interface HttpAdapterConfig {
   contactService: ContactService;
   autonomyService?: AutonomyService;
   registryService?: import('../../registry/registry-service.js').RegistryService;
+  /** Backs the /api/registry/channels/* routes (channel install/enable lifecycle). Mounted
+   *  only when webAppBootstrapSecret is also configured. */
+  channelRegistryService?: import('../../registry/channel-registry-service.js').ChannelRegistryService;
   /** Backs the /api/vault/* routes (secrets status + skill-secret entry). Mounted only
    *  alongside registryService, which scopes which secret names may be written. */
   secretsService?: import('../../secrets/secrets-service.js').SecretsService;
@@ -327,6 +331,17 @@ export class HttpAdapter implements Channel {
           sessions,
         });
       }
+    }
+
+    // Channel registry routes — the channel install/enable lifecycle for the console UI.
+    // Independent of the skill/agent registryService, so guarded only on the bootstrap
+    // secret + its own service.
+    if (webAppBootstrapSecret && this.config.channelRegistryService) {
+      await this.app.register(channelRegistryRoutes, {
+        channelRegistryService: this.config.channelRegistryService,
+        webAppBootstrapSecret,
+        sessions,
+      });
     }
 
     // Only register KG routes when the secret is configured — if unset, the routes

--- a/src/channels/http/routes/channel-registry.test.ts
+++ b/src/channels/http/routes/channel-registry.test.ts
@@ -1,0 +1,125 @@
+// channel-registry.test.ts — exercises the channel registry HTTP routes against a fake
+// service. Auth is satisfied via the x-web-bootstrap-secret header path of assertSecret
+// (same path registry.ts uses); sessions is a real empty Map per session-auth's SessionStore.
+import { describe, it, expect, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { channelRegistryRoutes } from './channel-registry.js';
+import { ChannelGuardError } from '../../../registry/channel-registry-types.js';
+import type { ChannelRegistryService } from '../../../registry/channel-registry-service.js';
+import type { ChannelRegistryEntry } from '../../../registry/channel-registry-types.js';
+
+const BOOTSTRAP = 'test-bootstrap-secret';
+
+const sampleEntry: ChannelRegistryEntry = {
+  name: 'signal',
+  description: '',
+  state: 'uninstalled',
+  isToggleable: true,
+  credentialFields: [],
+  requiredResolvable: false,
+  installedAt: null,
+  installedBy: null,
+  enabledAt: null,
+  enabledBy: null,
+};
+
+// Build a fake ChannelRegistryService. Only the methods the routes call are implemented;
+// cast through the interface so the test stays honest about the shape it depends on.
+function fakeService(overrides: Partial<ChannelRegistryService> = {}): ChannelRegistryService {
+  const base: Partial<ChannelRegistryService> = {
+    list: async () => [sampleEntry],
+    install: async () => ({ ...sampleEntry, state: 'installed' }),
+    enable: async () => ({ ...sampleEntry, state: 'enabled' }),
+    disable: async () => ({ ...sampleEntry, state: 'installed' }),
+    uninstall: async () => {},
+    ...overrides,
+  };
+  return base as ChannelRegistryService;
+}
+
+async function build(service: ChannelRegistryService): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(channelRegistryRoutes, {
+    channelRegistryService: service,
+    webAppBootstrapSecret: BOOTSTRAP,
+    sessions: new Map(),
+  });
+  return app;
+}
+
+const auth = { 'x-web-bootstrap-secret': BOOTSTRAP };
+
+describe('channel registry routes', () => {
+  let app: FastifyInstance;
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('GET /api/registry/channels returns the list', async () => {
+    app = await build(fakeService());
+    const res = await app.inject({ method: 'GET', url: '/api/registry/channels', headers: auth });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().channels[0].name).toBe('signal');
+  });
+
+  it('POST install returns the updated entry', async () => {
+    app = await build(fakeService());
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/registry/channels/signal/install',
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().entry.state).toBe('installed');
+  });
+
+  it('DELETE uninstall returns ok', async () => {
+    app = await build(fakeService());
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/registry/channels/signal',
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+  });
+
+  it('POST enable maps ChannelGuardError to 400', async () => {
+    app = await build(
+      fakeService({
+        enable: async () => {
+          throw new ChannelGuardError('nope');
+        },
+      }),
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/registry/channels/signal/enable',
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('nope');
+  });
+
+  it('maps unexpected errors to 500', async () => {
+    app = await build(
+      fakeService({
+        install: async () => {
+          throw new Error('db exploded');
+        },
+      }),
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/registry/channels/signal/install',
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    app = await build(fakeService());
+    const res = await app.inject({ method: 'GET', url: '/api/registry/channels' });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/src/channels/http/routes/channel-registry.ts
+++ b/src/channels/http/routes/channel-registry.ts
@@ -1,0 +1,86 @@
+// channel-registry.ts — HTTP routes for the channel registry management UI.
+// Session-cookie or x-web-bootstrap-secret auth (same pattern as registry.ts/vault.ts).
+// Only mounted when webAppBootstrapSecret + channelRegistryService are configured.
+//
+//   GET    /api/registry/channels                 — list all channels with derived state
+//   POST   /api/registry/channels/:name/install
+//   POST   /api/registry/channels/:name/enable
+//   POST   /api/registry/channels/:name/disable
+//   DELETE /api/registry/channels/:name           — uninstall
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { ChannelRegistryService } from '../../../registry/channel-registry-service.js';
+import { ChannelGuardError } from '../../../registry/channel-registry-types.js';
+import { assertSecret, type SessionStore } from '../session-auth.js';
+
+export interface ChannelRegistryRouteOptions {
+  channelRegistryService: ChannelRegistryService;
+  webAppBootstrapSecret: string;
+  sessions: SessionStore;
+}
+
+const ACTOR = 'web-console'; // no per-user identity in the console today (same as registry routes)
+
+export async function channelRegistryRoutes(
+  app: FastifyInstance,
+  options: ChannelRegistryRouteOptions,
+): Promise<void> {
+  const { channelRegistryService: svc, webAppBootstrapSecret, sessions } = options;
+
+  // Stricter per-route rate limit: 30 req/min per IP. These routes check credentials on
+  // every call — still brute-force-sensitive. Mirrors registry.ts's AUTH_RATE.
+  const AUTH_RATE = { config: { rateLimit: { max: 30, timeWindow: '1 minute' } } };
+
+  // Auth helper — validates session cookie or bootstrap secret on every request.
+  function requireAuth(request: FastifyRequest, reply: FastifyReply): boolean {
+    return assertSecret(request, reply, webAppBootstrapSecret, sessions);
+  }
+
+  // -- GET /api/registry/channels — list all channels with derived state --
+
+  app.get('/api/registry/channels', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+    try {
+      return reply.send({ channels: await svc.list() });
+    } catch (err) {
+      request.log.error({ err }, 'GET /api/registry/channels failed');
+      return reply.status(500).send({ error: 'Failed to list channels. Check server logs.' });
+    }
+  });
+
+  // -- POST state-change actions: install, enable, disable; DELETE uninstall --
+  //
+  // A single factory handles all four so the auth + error-handling pattern isn't repeated.
+  // ChannelGuardError (unknown channel, not-installed enable, unresolvable creds, non-toggleable
+  // disable/uninstall) are caller errors → 400. All other errors are infrastructure → 500.
+  const action = (op: 'install' | 'enable' | 'disable' | 'uninstall') =>
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!requireAuth(request, reply)) return;
+      const { name } = request.params as { name: string };
+      try {
+        if (op === 'uninstall') {
+          await svc.uninstall(name, ACTOR);
+          return reply.send({ ok: true });
+        }
+        const entry =
+          op === 'install' ? await svc.install(name, ACTOR)
+          : op === 'enable' ? await svc.enable(name, ACTOR)
+          : await svc.disable(name, ACTOR);
+        return reply.send({ entry });
+      } catch (err) {
+        if (err instanceof ChannelGuardError) {
+          // Expected validation rejection — bad request from the caller.
+          request.log.info({ err, name, op }, `channel ${op} rejected: guard`);
+          return reply.status(400).send({ error: err.message });
+        }
+        // Unexpected failure — DB error, invariant violation, etc.
+        request.log.error({ err, name, op }, `channel ${op} failed unexpectedly`);
+        return reply.status(500).send({ error: 'Operation failed. Check server logs.' });
+      }
+    };
+
+  app.post('/api/registry/channels/:name/install', AUTH_RATE, action('install'));
+  app.post('/api/registry/channels/:name/enable', AUTH_RATE, action('enable'));
+  app.post('/api/registry/channels/:name/disable', AUTH_RATE, action('disable'));
+  app.delete('/api/registry/channels/:name', AUTH_RATE, action('uninstall'));
+}

--- a/src/channels/http/routes/vault.test.ts
+++ b/src/channels/http/routes/vault.test.ts
@@ -1,0 +1,135 @@
+// vault.test.ts — exercises the secrets-vault HTTP routes against fake services.
+// Auth is satisfied via the x-web-bootstrap-secret header path of assertSecret (same
+// pattern as channel-registry.test.ts); sessions is a real empty Map per SessionStore.
+//
+// The scope guard on PUT /api/vault/secrets/:name accepts a name only if it is EITHER a
+// skill-declared secret OR a valid channel credential key from CHANNEL_CATALOG. These tests
+// prove both accept paths and the reject paths (arbitrary names and bogus channel keys).
+import { describe, it, expect, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { vaultRoutes, type VaultSecretsPort } from './vault.js';
+import type { RegistryService } from '../../../registry/registry-service.js';
+
+const BOOTSTRAP = 'test-bootstrap-secret';
+
+// A skill-declared secret used to prove the original scope-guard path still works.
+const DECLARED_SECRET = 'some_skill_secret';
+
+/** Records set() calls so tests can assert the secret was actually written. */
+interface RecordingSecrets extends VaultSecretsPort {
+  sets: Array<{ name: string; value: string }>;
+}
+
+function fakeSecrets(): RecordingSecrets {
+  const sets: Array<{ name: string; value: string }> = [];
+  return {
+    sets,
+    list: async () => sets.map(s => s.name),
+    set: async (name: string, value: string) => {
+      sets.push({ name, value });
+    },
+  };
+}
+
+// Minimal RegistryService fake — only declaredSecretNames() is called by these routes.
+function fakeRegistry(declared: string[] = [DECLARED_SECRET]): RegistryService {
+  const base: Partial<RegistryService> = {
+    declaredSecretNames: () => declared,
+  };
+  return base as RegistryService;
+}
+
+async function build(
+  secretsService: VaultSecretsPort,
+  registryService: RegistryService,
+): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(vaultRoutes, {
+    secretsService,
+    registryService,
+    webAppBootstrapSecret: BOOTSTRAP,
+    sessions: new Map(),
+  });
+  return app;
+}
+
+const auth = { 'x-web-bootstrap-secret': BOOTSTRAP };
+
+function put(app: FastifyInstance, name: string, body: unknown) {
+  return app.inject({
+    method: 'PUT',
+    url: `/api/vault/secrets/${name}`,
+    headers: auth,
+    payload: body as object,
+  });
+}
+
+describe('vault routes', () => {
+  let app: FastifyInstance;
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('accepts a valid channel credential key and writes it', async () => {
+    const secrets = fakeSecrets();
+    app = await build(secrets, fakeRegistry());
+    const res = await put(app, 'channel.email.nylas_api_key', { value: 'nk_live_abc' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+    expect(secrets.sets).toEqual([{ name: 'channel.email.nylas_api_key', value: 'nk_live_abc' }]);
+  });
+
+  it('accepts a skill-declared secret (existing behavior preserved)', async () => {
+    const secrets = fakeSecrets();
+    app = await build(secrets, fakeRegistry([DECLARED_SECRET]));
+    const res = await put(app, DECLARED_SECRET, { value: 'shhh' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+    expect(secrets.sets).toEqual([{ name: DECLARED_SECRET, value: 'shhh' }]);
+  });
+
+  it('rejects an arbitrary undeclared name with 400', async () => {
+    const secrets = fakeSecrets();
+    app = await build(secrets, fakeRegistry());
+    const res = await put(app, 'random_key', { value: 'x' });
+    expect(res.statusCode).toBe(400);
+    expect(secrets.sets).toEqual([]);
+  });
+
+  it('rejects a bogus channel key not in the catalog with 400', async () => {
+    const secrets = fakeSecrets();
+    app = await build(secrets, fakeRegistry());
+    const res = await put(app, 'channel.email.not_a_field', { value: 'x' });
+    expect(res.statusCode).toBe(400);
+    expect(secrets.sets).toEqual([]);
+  });
+
+  it('rejects a channel credential key for a channel with no fields with 400', async () => {
+    // 'telegram' is not a channel at all; proves we don't accept arbitrary channel.* names.
+    const secrets = fakeSecrets();
+    app = await build(secrets, fakeRegistry());
+    const res = await put(app, 'channel.telegram.x', { value: 'x' });
+    expect(res.statusCode).toBe(400);
+    expect(secrets.sets).toEqual([]);
+  });
+
+  it('rejects an empty value with 400 even for a valid channel key', async () => {
+    const secrets = fakeSecrets();
+    app = await build(secrets, fakeRegistry());
+    const res = await put(app, 'channel.email.nylas_api_key', { value: '' });
+    expect(res.statusCode).toBe(400);
+    expect(secrets.sets).toEqual([]);
+  });
+
+  it('rejects unauthenticated requests with 401', async () => {
+    const secrets = fakeSecrets();
+    app = await build(secrets, fakeRegistry());
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/vault/secrets/channel.email.nylas_api_key',
+      payload: { value: 'x' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(secrets.sets).toEqual([]);
+  });
+});

--- a/src/channels/http/routes/vault.ts
+++ b/src/channels/http/routes/vault.ts
@@ -12,6 +12,23 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { RegistryService } from '../../../registry/registry-service.js';
 import { assertSecret, type SessionStore } from '../session-auth.js';
+import { CHANNEL_CATALOG } from '../../catalog.js';
+
+// Allow-set of valid channel credential vault keys, derived once from the static catalog.
+// A channel credential is stored as `channel.<channel>.<field.key>`; only the exact
+// (channel, field) pairs the catalog declares are writable here. This mirrors the
+// skill-declared-secret scope guard: the channel console can configure known credentials,
+// but no arbitrary `channel.*` name may be written (e.g. `channel.email.bogus` is rejected).
+const CHANNEL_CREDENTIAL_KEYS: ReadonlySet<string> = new Set(
+  CHANNEL_CATALOG.flatMap(descriptor =>
+    descriptor.credentialFields.map(field => `channel.${descriptor.name}.${field.key}`),
+  ),
+);
+
+/** True iff `name` is a valid channel credential key declared by the catalog. */
+function isChannelCredentialKey(name: string): boolean {
+  return CHANNEL_CREDENTIAL_KEYS.has(name);
+}
 
 /** The narrow slice of SecretsService these routes need — list names + set a string value. */
 export interface VaultSecretsPort {
@@ -74,13 +91,18 @@ export async function vaultRoutes(
       return reply.status(400).send({ error: `Secret value exceeds ${MAX_SECRET_VALUE_LENGTH} characters.` });
     }
 
-    // Scope guard: only secrets some skill declares may be set here. This is the line
-    // between "configure a skill's secret" and "write any key into the vault".
-    if (!registryService.declaredSecretNames().includes(name)) {
-      request.log.info({ name }, 'vault set rejected: name not declared by any skill');
+    // Scope guard: a name may be set only if it is EITHER a secret some skill declares
+    // OR a valid channel credential key from the catalog. This is the line between
+    // "configure a declared secret / known channel credential" and "write any key into
+    // the vault". Arbitrary `channel.*` names that aren't in the catalog are still rejected.
+    const isSkillDeclared = registryService.declaredSecretNames().includes(name);
+    if (!isSkillDeclared && !isChannelCredentialKey(name)) {
+      request.log.info({ name }, 'vault set rejected: name not declared by any skill or channel');
       return reply.status(400).send({
-        error: `'${name}' is not a required secret declared by any skill. ` +
-          `Only secrets a skill lists in install.requires_secrets can be set here.`,
+        error: `'${name}' is not a required secret declared by any skill, ` +
+          `nor a known channel credential. Only secrets a skill lists in ` +
+          `install.requires_secrets, or channel credentials defined in the channel catalog, ` +
+          `can be set here.`,
       });
     }
 

--- a/src/channels/signal/signal-adapter.ts
+++ b/src/channels/signal/signal-adapter.ts
@@ -22,6 +22,7 @@ import { convertSignalEnvelope } from './message-converter.js';
 import { checkGroupMemberTrust } from './group-trust.js';
 import { createInboundMessage } from '../../bus/events.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
+import type { Channel } from '../channel.js';
 
 export interface SignalAdapterConfig {
   bus: EventBus;
@@ -51,7 +52,9 @@ export interface SignalAdapterConfig {
   ceoEmail?: string;
 }
 
-export class SignalAdapter {
+export class SignalAdapter implements Channel {
+  readonly name = 'signal';
+  readonly isToggleable = true;
   private readonly config: SignalAdapterConfig;
   private readonly log: Logger;
   // Bound handler so we can remove it in stop() without losing the reference.

--- a/src/db/migrations/052_create_channel_registry.sql
+++ b/src/db/migrations/052_create_channel_registry.sql
@@ -1,0 +1,35 @@
+-- src/db/migrations/052_create_channel_registry.sql
+-- Up Migration
+-- Database-backed registry that gates channel adapter startup on an install/enable
+-- lifecycle (spec: docs/wip/2026-06-12-channel-registry-design.md, #543). Mirrors
+-- skill_registry/agent_registry, plus is_toggleable: false for http/cli, which always
+-- start and cannot be disabled (operator-lockout safeguard). Credentials live in the
+-- secrets vault (channel.<name>.<field>); this table stores only lifecycle state.
+
+CREATE TABLE channel_registry (
+  name          TEXT PRIMARY KEY,                 -- matches a CHANNEL_CATALOG descriptor name
+  enabled       BOOLEAN     NOT NULL DEFAULT false,
+  is_toggleable BOOLEAN     NOT NULL DEFAULT true, -- false for http, cli
+  installed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  installed_by  TEXT        NOT NULL DEFAULT 'system',
+  enabled_at    TIMESTAMPTZ,                       -- set when enabled flips true, cleared on disable
+  enabled_by    TEXT,
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION channel_registry_set_updated_at()
+  RETURNS trigger LANGUAGE plpgsql AS $$
+  BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+  END;
+$$;
+
+CREATE TRIGGER channel_registry_updated_at
+  BEFORE UPDATE ON channel_registry
+  FOR EACH ROW EXECUTE FUNCTION channel_registry_set_updated_at();
+
+-- Down Migration
+DROP TRIGGER IF EXISTS channel_registry_updated_at ON channel_registry;
+DROP FUNCTION IF EXISTS channel_registry_set_updated_at();
+DROP TABLE IF EXISTS channel_registry;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1262,16 +1262,22 @@ async function main(): Promise<void> {
   // keeping the resolver pure). Email is satisfied via config when ≥1 account resolved.
   const channelConfigKeys = (descriptor: ChannelDescriptor): Set<string> => {
     if (descriptor.name === 'email' && resolvedEmailAccounts.length > 0) {
-      // All of email's required creds come from config/default.yaml accounts (vault/env not needed).
-      // Derive from the descriptor so this stays in sync if the catalog's required-key list changes.
-      return new Set(descriptor.requiredSecretKeys);
+      // Email's runtime creds come from config/default.yaml accounts. Only mark a key
+      // as config-resolved when it is actually present, so registry state reflects what
+      // the adapter can really boot with (the API key in particular is global config,
+      // not per-account, so a resolved account does not by itself imply a key exists).
+      const keys = new Set<string>();
+      keys.add('nylas_grant_id');
+      keys.add('nylas_self_email');
+      if (config.nylasApiKey) keys.add('nylas_api_key');
+      return keys;
     }
     return new Set<string>();
   };
 
   const channelCredentialStatusFn = (descriptor: ChannelDescriptor) =>
     channelCredentialStatus(
-      { secrets: secretsService, configResolvedKeys: channelConfigKeys(descriptor) },
+      { secrets: secretsService, configResolvedKeys: channelConfigKeys(descriptor), logger },
       descriptor,
     );
 
@@ -2081,7 +2087,14 @@ async function main(): Promise<void> {
   // input while the CLI remains available for local development sessions.
   if (process.stdin.isTTY) {
     const cli = new CliAdapter(bus, logger, () => void shutdown());
-    cli.start();
+    // start() is async but performs only synchronous setup (no awaits), so the readline
+    // interface is ready for prompt() immediately below. Attach a .catch() so a setup
+    // failure (e.g. an unauthorized bus.subscribe) is logged and shut down fatally rather
+    // than surfacing as an unhandled promise rejection.
+    void cli.start().catch((err) => {
+      logger.fatal({ err }, 'CLI adapter failed to start — invoking shutdown');
+      void shutdown(1);
+    });
     // Print welcome directly to stdout (logger writes to curia.log in dev mode)
     process.stdout.write('\nCuria is ready. Type a message, /quit to exit, or Ctrl+C.\n\n');
     cli.prompt();

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,11 @@ import { RegistryRepo } from './registry/registry-repo.js';
 import { RegistryService } from './registry/registry-service.js';
 import { reconcileRegistries, type RegistryDefaults } from './registry/reconcile.js';
 import type { Discovery, RegistryRow } from './registry/types.js';
+import { CHANNEL_CATALOG, type ChannelDescriptor } from './channels/catalog.js';
+import { channelCredentialStatus } from './channels/credential-resolver.js';
+import { ChannelRegistryRepo } from './registry/channel-registry-repo.js';
+import { ChannelRegistryService } from './registry/channel-registry-service.js';
+import { reconcileChannelRegistry } from './registry/channel-reconcile.js';
 
 async function main(): Promise<void> {
   // Captured at the very start of main() so the wizard's post-setup polling
@@ -1248,11 +1253,69 @@ async function main(): Promise<void> {
     logger.warn('Outbound gateway NOT initialized — outboundFilter not ready (coordinator config missing?). Outbound send skills will be unavailable.');
   }
 
+  // ── Channel registry ───────────────────────────────────────────────────────
+  // Decide which channels start, from DB lifecycle state + resolvable credentials.
+  // Credentials resolve vault-first, then env, then config (multi-account email).
+  const channelRegistryRepo = new ChannelRegistryRepo(pool);
+
+  // Config-satisfied keys per channel (the messy, config-shape-aware part lives here,
+  // keeping the resolver pure). Email is satisfied via config when ≥1 account resolved.
+  const channelConfigKeys = (descriptor: ChannelDescriptor): Set<string> => {
+    if (descriptor.name === 'email' && resolvedEmailAccounts.length > 0) {
+      return new Set(['nylas_api_key', 'nylas_grant_id', 'nylas_self_email']);
+    }
+    return new Set<string>();
+  };
+
+  const channelCredentialStatusFn = (descriptor: ChannelDescriptor) =>
+    channelCredentialStatus(
+      { secrets: secretsService, configResolvedKeys: channelConfigKeys(descriptor) },
+      descriptor,
+    );
+
+  try {
+    await reconcileChannelRegistry({
+      repo: channelRegistryRepo,
+      catalog: CHANNEL_CATALOG,
+      credentialStatus: channelCredentialStatusFn,
+      logger,
+    });
+  } catch (err) {
+    logger.fatal({ err }, 'Channel registry reconciliation failed');
+    process.exit(1);
+  }
+
+  // Compute the set of channels that should actually start this boot: enabled in the DB
+  // AND credentials currently resolvable. Non-toggleable channels (http/cli) always start.
+  const channelRows = await channelRegistryRepo.listRows();
+  const enabledByName = new Map(channelRows.map(r => [r.name, r.enabled]));
+  const channelShouldStart = new Set<string>();
+  for (const descriptor of CHANNEL_CATALOG) {
+    if (!descriptor.isToggleable) { channelShouldStart.add(descriptor.name); continue; }
+    if (!enabledByName.get(descriptor.name)) continue;
+    const status = await channelCredentialStatusFn(descriptor);
+    if (status.requiredResolvable) {
+      channelShouldStart.add(descriptor.name);
+    } else {
+      // Enabled but credentials no longer resolve: warn and skip — never crash (spec §7).
+      logger.warn({ channel: descriptor.name }, 'channel enabled but required credentials missing; not starting');
+    }
+  }
+
+  // Service backing /api/registry/channels/* (delete wired for uninstall vault cleanup).
+  const channelRegistryService = new ChannelRegistryService(
+    channelRegistryRepo,
+    CHANNEL_CATALOG,
+    channelCredentialStatusFn,
+    secretsService,
+  );
+  // ───────────────────────────────────────────────────────────────────────────
+
   // Construct one EmailAdapter per resolved account (but don't start any yet —
   // adapters must not poll until the dispatcher is registered, otherwise inbound.message
   // events have no subscriber and are permanently dropped because each adapter advances
   // its own high-water mark on poll).
-  if (outboundGateway) {
+  if (outboundGateway && channelShouldStart.has('email')) {
     for (const account of resolvedEmailAccounts) {
       if (!nylasClientMap.has(account.name)) continue; // skip accounts with no client (NYLAS_API_KEY missing)
 
@@ -1278,7 +1341,7 @@ async function main(): Promise<void> {
 
   // Construct the Signal adapter (but don't start it yet — same ordering rule as email:
   // dispatcher must be registered first so inbound.message always has a subscriber).
-  if (outboundGateway && signalRpcClient && config.signalPhoneNumber) {
+  if (outboundGateway && signalRpcClient && config.signalPhoneNumber && channelShouldStart.has('signal')) {
     signalAdapter = new SignalAdapter({
       bus,
       logger,
@@ -1859,6 +1922,7 @@ async function main(): Promise<void> {
     contactService,
     autonomyService,
     registryService,
+    channelRegistryService,
     secretsService,
     setupRequiredAtBoot,
     bootStartedAt,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1262,7 +1262,9 @@ async function main(): Promise<void> {
   // keeping the resolver pure). Email is satisfied via config when ≥1 account resolved.
   const channelConfigKeys = (descriptor: ChannelDescriptor): Set<string> => {
     if (descriptor.name === 'email' && resolvedEmailAccounts.length > 0) {
-      return new Set(['nylas_api_key', 'nylas_grant_id', 'nylas_self_email']);
+      // All of email's required creds come from config/default.yaml accounts (vault/env not needed).
+      // Derive from the descriptor so this stays in sync if the catalog's required-key list changes.
+      return new Set(descriptor.requiredSecretKeys);
     }
     return new Set<string>();
   };

--- a/src/registry/channel-reconcile.test.ts
+++ b/src/registry/channel-reconcile.test.ts
@@ -1,0 +1,65 @@
+// src/registry/channel-reconcile.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { reconcileChannelRegistry } from './channel-reconcile.js';
+import type { IChannelRegistryRepo, ChannelRegistryRow } from './channel-registry-types.js';
+import type { ChannelDescriptor } from '../channels/catalog.js';
+import type { ChannelCredentialStatus } from '../channels/credential-resolver.js';
+
+class FakeRepo implements IChannelRegistryRepo {
+  rows = new Map<string, ChannelRegistryRow>();
+  async listRows() { return [...this.rows.values()]; }
+  async getRow(n: string) { return this.rows.get(n) ?? null; }
+  async install(name: string, actor: string, isToggleable: boolean) {
+    const e = this.rows.get(name); if (e) return e;
+    const row: ChannelRegistryRow = { name, enabled: false, isToggleable, installedAt: 't0', installedBy: actor, enabledAt: null, enabledBy: null, updatedAt: 't0' };
+    this.rows.set(name, row); return row;
+  }
+  async enable(name: string, actor: string) { const r = this.rows.get(name)!; const n = { ...r, enabled: true, enabledAt: 't1', enabledBy: actor }; this.rows.set(name, n); return n; }
+  async disable(name: string, _a: string) { const r = this.rows.get(name)!; const n = { ...r, enabled: false, enabledAt: null, enabledBy: null }; this.rows.set(name, n); return n; }
+  async uninstall(name: string) { this.rows.delete(name); }
+}
+
+const silentLogger = { info() {}, warn() {}, error() {}, debug() {} } as any;
+
+const CATALOG: ChannelDescriptor[] = [
+  { name: 'email', description: '', isToggleable: true, credentialFields: [], requiredSecretKeys: ['x'] },
+  { name: 'signal', description: '', isToggleable: true, credentialFields: [], requiredSecretKeys: ['y'] },
+  { name: 'http', description: '', isToggleable: false, credentialFields: [], requiredSecretKeys: [] },
+  { name: 'cli', description: '', isToggleable: false, credentialFields: [], requiredSecretKeys: [] },
+];
+
+// resolvable: only 'email'
+const statusFn = async (d: ChannelDescriptor): Promise<ChannelCredentialStatus> =>
+  ({ requiredResolvable: d.name === 'email' || !d.isToggleable, fields: [] });
+
+describe('reconcileChannelRegistry', () => {
+  let repo: FakeRepo;
+  beforeEach(() => { repo = new FakeRepo(); });
+
+  it('always enrolls http and cli as enabled + non-toggleable', async () => {
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    for (const name of ['http', 'cli']) {
+      const row = repo.rows.get(name)!;
+      expect(row.enabled).toBe(true);
+      expect(row.isToggleable).toBe(false);
+    }
+  });
+
+  it('enrolls a toggleable channel as enabled only when its credentials resolve', async () => {
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    expect(repo.rows.get('email')!.enabled).toBe(true);   // resolvable
+    expect(repo.rows.get('signal')).toBeUndefined();       // not resolvable → no row
+  });
+
+  it('respects existing admin state and does not overwrite it', async () => {
+    await repo.install('email', 'admin', true); // installed but deliberately left disabled
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    expect(repo.rows.get('email')!.enabled).toBe(false);   // left as-is
+  });
+
+  it('re-enables http/cli if a prior run left them disabled (safeguard)', async () => {
+    await repo.install('http', 'system', false); // disabled row exists
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    expect(repo.rows.get('http')!.enabled).toBe(true);
+  });
+});

--- a/src/registry/channel-reconcile.test.ts
+++ b/src/registry/channel-reconcile.test.ts
@@ -4,6 +4,7 @@ import { reconcileChannelRegistry } from './channel-reconcile.js';
 import type { IChannelRegistryRepo, ChannelRegistryRow } from './channel-registry-types.js';
 import type { ChannelDescriptor } from '../channels/catalog.js';
 import type { ChannelCredentialStatus } from '../channels/credential-resolver.js';
+import { createLogger } from '../logger.js';
 
 class FakeRepo implements IChannelRegistryRepo {
   rows = new Map<string, ChannelRegistryRow>();
@@ -19,7 +20,7 @@ class FakeRepo implements IChannelRegistryRepo {
   async uninstall(name: string) { this.rows.delete(name); }
 }
 
-const silentLogger = { info() {}, warn() {}, error() {}, debug() {} } as any;
+const silentLogger = createLogger('silent');
 
 const CATALOG: ChannelDescriptor[] = [
   { name: 'email', description: '', isToggleable: true, credentialFields: [], requiredSecretKeys: ['x'] },

--- a/src/registry/channel-reconcile.ts
+++ b/src/registry/channel-reconcile.ts
@@ -1,0 +1,50 @@
+// src/registry/channel-reconcile.ts
+// Startup reconciliation for the channel registry:
+//   - http/cli (non-toggleable) are ALWAYS present and enabled — operator-lockout safeguard.
+//   - toggleable channels with no row whose credentials resolve are installed + enabled, so
+//     existing deployments light up unchanged. Existing admin state is never overwritten.
+import type { Logger } from 'pino';
+import type { ChannelDescriptor } from '../channels/catalog.js';
+import type { CredentialStatusFn } from './channel-registry-service.js';
+import type { IChannelRegistryRepo } from './channel-registry-types.js';
+
+export interface ReconcileChannelDeps {
+  repo: IChannelRegistryRepo;
+  catalog: ChannelDescriptor[];
+  credentialStatus: CredentialStatusFn;
+  logger: Logger;
+}
+
+export async function reconcileChannelRegistry(deps: ReconcileChannelDeps): Promise<void> {
+  const { repo, catalog, credentialStatus, logger } = deps;
+  const existing = new Map((await repo.listRows()).map(r => [r.name, r]));
+
+  for (const d of catalog) {
+    const row = existing.get(d.name);
+
+    // Always-on channels: ensure present + enabled, regardless of prior state.
+    if (!d.isToggleable) {
+      if (!row) {
+        await repo.install(d.name, 'reconciliation', false);
+        await repo.enable(d.name, 'reconciliation');
+        logger.info({ channel: d.name }, 'channel registry: enrolled always-on channel as enabled');
+      } else if (!row.enabled) {
+        await repo.enable(d.name, 'reconciliation');
+        logger.warn({ channel: d.name }, 'channel registry: re-enabled always-on channel that was disabled');
+      }
+      continue;
+    }
+
+    // Toggleable channels: respect any existing admin state.
+    if (row) continue;
+
+    const status = await credentialStatus(d);
+    if (status.requiredResolvable) {
+      await repo.install(d.name, 'reconciliation', true);
+      await repo.enable(d.name, 'reconciliation');
+      logger.info({ channel: d.name }, 'channel registry: enrolled channel with resolvable credentials as enabled');
+    } else {
+      logger.info({ channel: d.name }, 'channel registry: channel has no credentials; left uninstalled');
+    }
+  }
+}

--- a/src/registry/channel-reconcile.ts
+++ b/src/registry/channel-reconcile.ts
@@ -3,7 +3,7 @@
 //   - http/cli (non-toggleable) are ALWAYS present and enabled — operator-lockout safeguard.
 //   - toggleable channels with no row whose credentials resolve are installed + enabled, so
 //     existing deployments light up unchanged. Existing admin state is never overwritten.
-import type { Logger } from 'pino';
+import type { Logger } from '../logger.js';
 import type { ChannelDescriptor } from '../channels/catalog.js';
 import type { CredentialStatusFn } from './channel-registry-service.js';
 import type { IChannelRegistryRepo } from './channel-registry-types.js';

--- a/src/registry/channel-registry-repo.ts
+++ b/src/registry/channel-registry-repo.ts
@@ -1,0 +1,89 @@
+// src/registry/channel-registry-repo.ts
+// Postgres-backed channel_registry access. Parameterized queries only.
+import type { DbPool } from '../db/connection.js';
+import type { ChannelRegistryRow, IChannelRegistryRepo } from './channel-registry-types.js';
+
+const COLS = 'name, enabled, is_toggleable, installed_at, installed_by, enabled_at, enabled_by, updated_at';
+
+interface DbChannelRow {
+  name: string;
+  enabled: boolean;
+  is_toggleable: boolean;
+  installed_at: string;
+  installed_by: string;
+  enabled_at: string | null;
+  enabled_by: string | null;
+  updated_at: string;
+}
+
+function mapRow(r: DbChannelRow): ChannelRegistryRow {
+  return {
+    name: r.name,
+    enabled: r.enabled,
+    isToggleable: r.is_toggleable,
+    installedAt: r.installed_at,
+    installedBy: r.installed_by,
+    enabledAt: r.enabled_at,
+    enabledBy: r.enabled_by,
+    updatedAt: r.updated_at,
+  };
+}
+
+export class ChannelRegistryRepo implements IChannelRegistryRepo {
+  constructor(private readonly pool: DbPool) {}
+
+  async listRows(): Promise<ChannelRegistryRow[]> {
+    const { rows } = await this.pool.query<DbChannelRow>(`SELECT ${COLS} FROM channel_registry`);
+    return rows.map(mapRow);
+  }
+
+  async getRow(name: string): Promise<ChannelRegistryRow | null> {
+    const { rows } = await this.pool.query<DbChannelRow>(`SELECT ${COLS} FROM channel_registry WHERE name = $1`, [name]);
+    return rows[0] ? mapRow(rows[0]) : null;
+  }
+
+  async install(name: string, actor: string, isToggleable: boolean): Promise<ChannelRegistryRow> {
+    // Insert a disabled row; if it already exists, leave it untouched (incl. is_toggleable)
+    // and return it. The no-op SET makes ON CONFLICT return the existing row via RETURNING.
+    const { rows } = await this.pool.query<DbChannelRow>(
+      `INSERT INTO channel_registry (name, enabled, is_toggleable, installed_by)
+       VALUES ($1, false, $3, $2)
+       ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+       RETURNING ${COLS}`,
+      [name, actor, isToggleable],
+    );
+    return mapRow(rows[0]!);
+  }
+
+  async enable(name: string, actor: string): Promise<ChannelRegistryRow> {
+    const { rows } = await this.pool.query<DbChannelRow>(
+      `UPDATE channel_registry
+          SET enabled = true, enabled_at = now(), enabled_by = $2, updated_at = now()
+        WHERE name = $1
+        RETURNING ${COLS}`,
+      [name, actor],
+    );
+    if (!rows[0]) throw new Error(`enable: no channel_registry row for '${name}'`);
+    return mapRow(rows[0]);
+  }
+
+  // _actor is required by IChannelRegistryRepo for API symmetry with enable(), but
+  // disable() clears enabled_by rather than recording who disabled — so the SQL binds
+  // only $1 (name). Passing actor as a second param would error: "bind message supplies
+  // 2 parameters, but prepared statement requires 1".
+  async disable(name: string, _actor: string): Promise<ChannelRegistryRow> {
+    const { rows } = await this.pool.query<DbChannelRow>(
+      `UPDATE channel_registry
+          SET enabled = false, enabled_at = NULL, enabled_by = NULL, updated_at = now()
+        WHERE name = $1
+        RETURNING ${COLS}`,
+      [name],
+    );
+    if (!rows[0]) throw new Error(`disable: no channel_registry row for '${name}'`);
+    return mapRow(rows[0]);
+  }
+
+  async uninstall(name: string): Promise<void> {
+    await this.pool.query(`DELETE FROM channel_registry WHERE name = $1`, [name]);
+  }
+}

--- a/src/registry/channel-registry-service.test.ts
+++ b/src/registry/channel-registry-service.test.ts
@@ -1,0 +1,103 @@
+// src/registry/channel-registry-service.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ChannelRegistryService } from './channel-registry-service.js';
+import { ChannelGuardError } from './channel-registry-types.js';
+import type { IChannelRegistryRepo, ChannelRegistryRow } from './channel-registry-types.js';
+import type { ChannelDescriptor } from '../channels/catalog.js';
+import type { ChannelCredentialStatus } from '../channels/credential-resolver.js';
+
+class FakeRepo implements IChannelRegistryRepo {
+  rows = new Map<string, ChannelRegistryRow>();
+  async listRows() { return [...this.rows.values()]; }
+  async getRow(n: string) { return this.rows.get(n) ?? null; }
+  async install(name: string, actor: string, isToggleable: boolean) {
+    const existing = this.rows.get(name);
+    if (existing) return existing;
+    const row: ChannelRegistryRow = { name, enabled: false, isToggleable, installedAt: 't0', installedBy: actor, enabledAt: null, enabledBy: null, updatedAt: 't0' };
+    this.rows.set(name, row); return row;
+  }
+  async enable(name: string, actor: string) {
+    const row = this.rows.get(name); if (!row) throw new Error('no row');
+    const next = { ...row, enabled: true, enabledAt: 't1', enabledBy: actor }; this.rows.set(name, next); return next;
+  }
+  async disable(name: string, _actor: string) {
+    const row = this.rows.get(name); if (!row) throw new Error('no row');
+    const next = { ...row, enabled: false, enabledAt: null, enabledBy: null }; this.rows.set(name, next); return next;
+  }
+  async uninstall(name: string) { this.rows.delete(name); }
+}
+
+const CATALOG: ChannelDescriptor[] = [
+  { name: 'signal', description: 'sig', isToggleable: true,
+    credentialFields: [{ key: 'phone_number', label: 'Phone', secret: false }], requiredSecretKeys: ['phone_number'] },
+  { name: 'http', description: 'http', isToggleable: false, credentialFields: [], requiredSecretKeys: [] },
+];
+
+// Credential status fn: signal resolvable iff `signalReady`, http always resolvable.
+const statusFn = (signalReady: boolean) =>
+  async (d: ChannelDescriptor): Promise<ChannelCredentialStatus> => {
+    if (d.name === 'signal') {
+      return { requiredResolvable: signalReady, fields: [{ key: 'phone_number', label: 'Phone', secret: false, configured: signalReady, source: signalReady ? 'vault' : 'missing' }] };
+    }
+    return { requiredResolvable: true, fields: [] };
+  };
+
+describe('ChannelRegistryService', () => {
+  let repo: FakeRepo;
+  beforeEach(() => { repo = new FakeRepo(); });
+
+  it('list derives state: no row → uninstalled, row+disabled → installed, row+enabled → enabled', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true));
+    let entries = await svc.list();
+    expect(entries.find(e => e.name === 'signal')!.state).toBe('uninstalled');
+    await svc.install('signal', 'a');
+    entries = await svc.list();
+    expect(entries.find(e => e.name === 'signal')!.state).toBe('installed');
+    await svc.enable('signal', 'a');
+    entries = await svc.list();
+    expect(entries.find(e => e.name === 'signal')!.state).toBe('enabled');
+  });
+
+  it('list surfaces isToggleable and credential field status from the catalog + resolver', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(false));
+    const entries = await svc.list();
+    const http = entries.find(e => e.name === 'http')!;
+    expect(http.isToggleable).toBe(false);
+    const signal = entries.find(e => e.name === 'signal')!;
+    expect(signal.requiredResolvable).toBe(false);
+    expect(signal.credentialFields[0]!.source).toBe('missing');
+  });
+
+  it('enable is rejected when required credentials do not resolve', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(false));
+    await svc.install('signal', 'a');
+    await expect(svc.enable('signal', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+  });
+
+  it('enable of a not-installed channel is rejected', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true));
+    await expect(svc.enable('signal', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+  });
+
+  it('install/enable/disable of an unknown channel is rejected', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true));
+    await expect(svc.install('telegram', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+  });
+
+  it('disable and uninstall of a non-toggleable channel are rejected', async () => {
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true));
+    await repo.install('http', 'system', false);
+    await repo.enable('http', 'system');
+    await expect(svc.disable('http', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+    await expect(svc.uninstall('http', 'a')).rejects.toBeInstanceOf(ChannelGuardError);
+  });
+
+  it('uninstall clears the channel vault keys and removes the row', async () => {
+    const deleted: string[] = [];
+    const svc = new ChannelRegistryService(repo, CATALOG, statusFn(true), { delete: async (n: string) => { deleted.push(n); } });
+    await svc.install('signal', 'a');
+    await svc.uninstall('signal', 'a');
+    expect(deleted).toContain('channel.signal.phone_number');
+    expect(await repo.getRow('signal')).toBeNull();
+  });
+});

--- a/src/registry/channel-registry-service.ts
+++ b/src/registry/channel-registry-service.ts
@@ -86,7 +86,9 @@ export class ChannelRegistryService {
   async uninstall(name: string, _actor: string): Promise<void> {
     const d = this.descriptor(name);
     if (!d.isToggleable) throw new ChannelGuardError(`Channel '${name}' cannot be uninstalled.`);
-    // Clear the channel's vault keys (best-effort; delete is a no-op if the key is absent).
+    // Clear the channel's vault keys first; delete is a no-op if the key is absent.
+    // A delete failure surfaces to the caller and aborts before the row is removed,
+    // so the registry row is only removed once the keys are cleared.
     if (this.secrets) {
       for (const field of d.credentialFields) {
         await this.secrets.delete(`channel.${name}.${field.key}`);

--- a/src/registry/channel-registry-service.ts
+++ b/src/registry/channel-registry-service.ts
@@ -1,0 +1,104 @@
+// src/registry/channel-registry-service.ts
+// Drives the channel install/enable lifecycle. Channels are code-defined (CHANNEL_CATALOG),
+// so there is no on-disk discovery and no 'ghost' state. enable() is gated on the channel's
+// required credentials resolving (vault/env/config); disable()/uninstall() are blocked for
+// non-toggleable channels (http, cli).
+import type { ChannelDescriptor } from '../channels/catalog.js';
+import type { ChannelCredentialStatus } from '../channels/credential-resolver.js';
+import {
+  ChannelGuardError,
+  type ChannelRegistryEntry,
+  type IChannelRegistryRepo,
+} from './channel-registry-types.js';
+
+/** Resolves the live credential status for a descriptor (vault/env/config). Injected so the
+ *  service stays decoupled from the vault + config wiring and is trivially fakeable in tests. */
+export type CredentialStatusFn = (descriptor: ChannelDescriptor) => Promise<ChannelCredentialStatus>;
+
+export class ChannelRegistryService {
+  constructor(
+    private readonly repo: IChannelRegistryRepo,
+    private readonly catalog: ChannelDescriptor[],
+    private readonly credentialStatus: CredentialStatusFn,
+    /** Used by uninstall() to clear the channel's vault keys. Optional in tests. */
+    private readonly secrets?: { delete(name: string): Promise<void> },
+  ) {}
+
+  private descriptor(name: string): ChannelDescriptor {
+    const d = this.catalog.find(c => c.name === name);
+    if (!d) throw new ChannelGuardError(`Unknown channel '${name}'.`);
+    return d;
+  }
+
+  async list(): Promise<ChannelRegistryEntry[]> {
+    const rows = await this.repo.listRows();
+    const rowByName = new Map(rows.map(r => [r.name, r]));
+    const entries: ChannelRegistryEntry[] = [];
+
+    for (const d of this.catalog) {
+      const row = rowByName.get(d.name);
+      const status = await this.credentialStatus(d);
+      const state = !row ? 'uninstalled' : row.enabled ? 'enabled' : 'installed';
+      entries.push({
+        name: d.name,
+        description: d.description,
+        state,
+        isToggleable: d.isToggleable,
+        credentialFields: status.fields,
+        requiredResolvable: status.requiredResolvable,
+        installedAt: row?.installedAt ?? null,
+        installedBy: row?.installedBy ?? null,
+        enabledAt: row?.enabledAt ?? null,
+        enabledBy: row?.enabledBy ?? null,
+      });
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    return entries;
+  }
+
+  async install(name: string, actor: string): Promise<ChannelRegistryEntry> {
+    const d = this.descriptor(name);
+    await this.repo.install(name, actor, d.isToggleable);
+    return this.entry(name);
+  }
+
+  async enable(name: string, actor: string): Promise<ChannelRegistryEntry> {
+    const d = this.descriptor(name);
+    const row = await this.repo.getRow(name);
+    if (!row) throw new ChannelGuardError(`Cannot enable '${name}': not installed. Install it first.`);
+    const status = await this.credentialStatus(d);
+    if (!status.requiredResolvable) {
+      throw new ChannelGuardError(`Cannot enable '${name}': required credentials are not configured.`);
+    }
+    await this.repo.enable(name, actor);
+    return this.entry(name);
+  }
+
+  async disable(name: string, actor: string): Promise<ChannelRegistryEntry> {
+    const d = this.descriptor(name);
+    if (!d.isToggleable) throw new ChannelGuardError(`Channel '${name}' cannot be disabled.`);
+    const row = await this.repo.getRow(name);
+    if (!row) throw new ChannelGuardError(`Cannot disable '${name}': no registry row.`);
+    await this.repo.disable(name, actor);
+    return this.entry(name);
+  }
+
+  async uninstall(name: string, _actor: string): Promise<void> {
+    const d = this.descriptor(name);
+    if (!d.isToggleable) throw new ChannelGuardError(`Channel '${name}' cannot be uninstalled.`);
+    // Clear the channel's vault keys (best-effort; delete is a no-op if the key is absent).
+    if (this.secrets) {
+      for (const field of d.credentialFields) {
+        await this.secrets.delete(`channel.${name}.${field.key}`);
+      }
+    }
+    await this.repo.uninstall(name);
+  }
+
+  private async entry(name: string): Promise<ChannelRegistryEntry> {
+    const entries = await this.list();
+    const found = entries.find(e => e.name === name);
+    if (!found) throw new Error(`entry: '${name}' not in catalog after mutation`);
+    return found;
+  }
+}

--- a/src/registry/channel-registry-service.ts
+++ b/src/registry/channel-registry-service.ts
@@ -97,10 +97,25 @@ export class ChannelRegistryService {
     await this.repo.uninstall(name);
   }
 
+  // Build the single entry for a channel after a mutation. Resolves only THIS channel's
+  // row + credential status rather than calling list() — a successful write must not have
+  // its response fail because some unrelated channel's credential resolution errored.
   private async entry(name: string): Promise<ChannelRegistryEntry> {
-    const entries = await this.list();
-    const found = entries.find(e => e.name === name);
-    if (!found) throw new Error(`entry: '${name}' not in catalog after mutation`);
-    return found;
+    const d = this.descriptor(name);
+    const row = await this.repo.getRow(name);
+    if (!row) throw new Error(`entry: '${name}' missing registry row after mutation`);
+    const status = await this.credentialStatus(d);
+    return {
+      name: d.name,
+      description: d.description,
+      state: row.enabled ? 'enabled' : 'installed',
+      isToggleable: d.isToggleable,
+      credentialFields: status.fields,
+      requiredResolvable: status.requiredResolvable,
+      installedAt: row.installedAt,
+      installedBy: row.installedBy,
+      enabledAt: row.enabledAt,
+      enabledBy: row.enabledBy,
+    };
   }
 }

--- a/src/registry/channel-registry-types.ts
+++ b/src/registry/channel-registry-types.ts
@@ -1,0 +1,53 @@
+// src/registry/channel-registry-types.ts
+// Types for the channel registry. Mirrors registry/types.ts but channels are
+// code-defined (CHANNEL_CATALOG), carry is_toggleable, and never reach a 'ghost' state.
+import type { CredentialFieldStatus } from '../channels/credential-resolver.js';
+
+export type ChannelDerivedState = 'uninstalled' | 'installed' | 'enabled';
+
+/** A row in channel_registry, mapped to camelCase. */
+export interface ChannelRegistryRow {
+  name: string;
+  enabled: boolean;
+  isToggleable: boolean;
+  installedAt: string;
+  installedBy: string;
+  enabledAt: string | null;
+  enabledBy: string | null;
+  updatedAt: string;
+}
+
+/** A fully-resolved entry the API returns: catalog × row × credential status → state. */
+export interface ChannelRegistryEntry {
+  name: string;
+  description: string;
+  state: ChannelDerivedState;
+  isToggleable: boolean;
+  credentialFields: CredentialFieldStatus[];
+  requiredResolvable: boolean;
+  installedAt: string | null;
+  installedBy: string | null;
+  enabledAt: string | null;
+  enabledBy: string | null;
+}
+
+/** Thrown for expected guard rejections (unknown channel, not-installed enable,
+ *  disable/uninstall of a non-toggleable channel, missing-credential enable).
+ *  Routes catch this specifically to return HTTP 400. */
+export class ChannelGuardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChannelGuardError';
+  }
+}
+
+/** DB-access contract. Postgres impl is ChannelRegistryRepo; tests use an in-memory fake. */
+export interface IChannelRegistryRepo {
+  listRows(): Promise<ChannelRegistryRow[]>;
+  getRow(name: string): Promise<ChannelRegistryRow | null>;
+  /** Insert enabled=false with the given is_toggleable if absent; return existing row if present. */
+  install(name: string, actor: string, isToggleable: boolean): Promise<ChannelRegistryRow>;
+  enable(name: string, actor: string): Promise<ChannelRegistryRow>;
+  disable(name: string, actor: string): Promise<ChannelRegistryRow>;
+  uninstall(name: string): Promise<void>;
+}

--- a/tests/integration/channel-registry-repo.test.ts
+++ b/tests/integration/channel-registry-repo.test.ts
@@ -1,0 +1,52 @@
+// tests/integration/channel-registry-repo.test.ts
+// Requires Postgres with migration 052 applied. Skips when DATABASE_URL is unset.
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import { ChannelRegistryRepo } from '../../src/registry/channel-registry-repo.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('ChannelRegistryRepo', () => {
+  let pool: pg.Pool;
+  let repo: ChannelRegistryRepo;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM channel_registry LIMIT 0'); // fails loudly if migration 052 not applied
+    repo = new ChannelRegistryRepo(pool);
+  });
+  afterAll(async () => { await pool.end(); });
+  beforeEach(async () => { await pool.query('DELETE FROM channel_registry'); });
+
+  it('install inserts a disabled row carrying is_toggleable', async () => {
+    const row = await repo.install('signal', 'tester', true);
+    expect(row.enabled).toBe(false);
+    expect(row.isToggleable).toBe(true);
+    expect(row.installedBy).toBe('tester');
+    expect(row.enabledAt).toBeNull();
+  });
+
+  it('install is idempotent and preserves is_toggleable of the existing row', async () => {
+    await repo.install('http', 'system', false);
+    const again = await repo.install('http', 'someone', true); // should NOT flip to toggleable
+    expect(again.isToggleable).toBe(false);
+  });
+
+  it('enable then disable toggles enabled + enabled_at', async () => {
+    await repo.install('signal', 'tester', true);
+    const enabled = await repo.enable('signal', 'admin');
+    expect(enabled.enabled).toBe(true);
+    expect(enabled.enabledAt).not.toBeNull();
+    const disabled = await repo.disable('signal', 'admin');
+    expect(disabled.enabled).toBe(false);
+    expect(disabled.enabledAt).toBeNull();
+  });
+
+  it('uninstall removes the row', async () => {
+    await repo.install('signal', 'tester', true);
+    await repo.uninstall('signal');
+    expect(await repo.getRow('signal')).toBeNull();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Adds a database-backed install/enable registry for channels, paralleling the skills/agents registry, with credentials stored in the secrets vault (#542) instead of scattered env vars.

- **`Channel` interface** (`src/channels/channel.ts`) — replaces the duck-typed adapter pattern; all four adapters (email, signal, http, cli) implement `name` / `isToggleable` / `start()` / `stop()`.
- **Channel catalog** (`src/channels/catalog.ts`) — code-defined source of truth for which channels exist and what credentials each needs.
- **`channel_registry` table** (migration `052`) + `ChannelRegistryRepo` / `ChannelRegistryService` / reconcile — install/enable/disable/uninstall lifecycle, mirroring the skill/agent registry plus an `is_toggleable` flag.
- **Vault-first credential resolution** (`src/channels/credential-resolver.ts`) — resolves each credential vault → env → config, so existing deployments keep working untouched; reconcile auto-seeds enabled rows for channels whose credentials already resolve.
- **Startup gating** (`src/index.ts`) — only enabled + resolvable channels construct/start; an enabled channel with missing credentials logs a warning and is skipped (no crash); HTTP and CLI always start and cannot be disabled (operator-lockout safeguard).
- **HTTP routes** (`/api/registry/channels/*`) + a widened vault write guard that accepts catalog-declared `channel.<name>.<key>` credential keys (and only those).
- **Channels console page** — list with state pills + a detail drawer with a credential form, Install/Enable/Disable/Uninstall actions, locked for HTTP/CLI.

Built design-first: see `docs/wip/2026-06-12-channel-registry-design.md` (spec) and `docs/wip/2026-06-12-channel-registry.md` (plan + "Discovered during implementation" notes).

## Out of scope (deliberate)

- **In-app OAuth flow** — no current channel needs one; deferred until a consumer exists.
- **DB-backed channel policy** (`trust` / `unknown_sender` / `threaded`) — that's dispatch-layer security policy, not channel lifecycle. Filed as #962.

## Test Plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm test src/` — 725 passed, 3 skipped (57 files); new unit tests for catalog, resolver, service, reconcile, routes, vault guard
- [x] `ChannelRegistryRepo` integration test against Postgres (migration `052` applied) — passes
- [x] `apps/console` typecheck + build — pass
- [x] Whole-branch code review + silent-failure review — no Critical/High/Medium findings
- [ ] Live boot smoke (reviewer note): not fully exercised in the dev environment (vault lacks a seeded `api_token`, which aborts boot above the channel block); prerequisites confirmed (migration applied, table present). Worth a quick live boot before/after merge.

Closes #543
Follow-up: #962


___

## **CodeAnt-AI Description**
**Add channel management in the console with startup control and credential storage**

### What Changed
- Added a Channels page in the console with a list of channels, status indicators, and a detail drawer for installing, enabling, disabling, and uninstalling channels
- Channel credentials can now be saved through the console into the secrets vault, and enabling a channel is blocked until its required credentials are in place
- HTTP and CLI are shown as always on and cannot be disabled or uninstalled
- Channel startup now follows the registry state at boot, so only enabled channels start while missing credentials cause a warning instead of a crash

### Impact
`✅ Centralized channel setup`
`✅ Fewer startup failures from missing channel credentials`
`✅ Prevented accidental disablement of HTTP and CLI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Channels management page in console with install, enable, disable, and uninstall controls
  * Email and Signal channels now support credential storage and retrieval through the secrets vault with environment variable and configuration fallback
  * Database-backed channel registry tracks installation and enabled state

* **Bug Fixes**
  * Fixed vault scope validation to properly permit channel credential keys
  * Fixed Email channel lifecycle handling on configuration conflicts
  * Improved model output limits for better tool integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->