### PR TITLE
feat: target_agent_id for cross-agent wake scheduling (task-create)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **`task-create`** — optional `target_agent_id` assigns a new task (and its wake-up) to another registered agent, so the coordinator or ceo-inbox can schedule work for a specialist like meeting-debrief. (#880)
+
 ## [0.34.0] — 2026-06-12 — "Heimdall"
 
 > **Heimdall** *(Norse myth; Marvel's Thor, 2011, Kenneth Branagh)* — the unsleeping sentry of the Bifröst, who sees and hears across the nine realms and lets no one cross the gate unbidden. v0.34 gives Curia the same watch at every threshold: a registry decides which skills, agents, and channels may load; a secrets vault holds the keys, so nothing enables until its credentials are present; and a second-stage judge guards what crosses outward. Nothing runs, or leaves, without passing the gate.

--- a/skills/task-create/handler.test.ts
+++ b/skills/task-create/handler.test.ts
@@ -4,8 +4,17 @@ import { TaskCreateHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 import type { TaskRepo } from '../../src/db/task-repo.js';
 import type { TaskRow } from '../../src/db/queries/tasks.js';
+import type { AgentRegistry } from '../../src/agents/agent-registry.js';
 
 const silentLog = pino({ level: 'silent' });
+
+// Minimal AgentRegistry stub — task-create only calls has() to validate a
+// cross-agent target exists before redirecting the wake to it.
+function makeRegistry(knownAgents: string[] = []): AgentRegistry {
+  return {
+    has: vi.fn((name: string) => knownAgents.includes(name)),
+  } as unknown as AgentRegistry;
+}
 
 function makeCtx(overrides: Partial<SkillContext> = {}): SkillContext {
   return {
@@ -224,6 +233,121 @@ describe('TaskCreateHandler', () => {
     const data = (result as { success: true; data: { displayTimezone: string } }).data;
     expect(typeof data.displayTimezone).toBe('string');
     expect(data.displayTimezone).not.toBe('');
+  });
+
+  // ── Cross-agent targeting (target_agent_id) ───────────────────────────────
+
+  it('self-routes ownership to the calling agent when target_agent_id is omitted', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Self-owned task' },
+      taskRepo,
+      agentId: 'meeting-debrief',
+    });
+
+    await new TaskCreateHandler().execute(ctx);
+
+    const calls = (taskRepo.createTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toMatchObject({
+      agentId: 'meeting-debrief',
+      sourceAgentId: 'meeting-debrief',
+      createdBy: 'meeting-debrief',
+    });
+  });
+
+  it('routes ownership and the wake to a valid cross-agent target', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: {
+        title: 'Debrief: Acme sync',
+        target_agent_id: 'meeting-debrief',
+        wake_at: '2026-06-10T17:00:00.000Z',
+      },
+      taskRepo,
+      agentId: 'coordinator',
+      agentRegistry: makeRegistry(['coordinator', 'meeting-debrief', 'ceo-inbox']),
+    });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const calls = (taskRepo.createTask as ReturnType<typeof vi.fn>).mock.calls;
+    // The target owns the task (agent_id + source_agent_id) so re-wakes scheduled
+    // by the target via task-update route back to it; created_by records the
+    // actual creator for audit.
+    expect(calls[0]![0]).toMatchObject({
+      agentId: 'meeting-debrief',
+      sourceAgentId: 'meeting-debrief',
+      createdBy: 'coordinator',
+    });
+  });
+
+  it('treats target_agent_id equal to the caller as self-routing (no registry needed)', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Self target', target_agent_id: 'meeting-debrief' },
+      taskRepo,
+      agentId: 'meeting-debrief',
+      // No agentRegistry provided — self-targeting must not require it.
+    });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const calls = (taskRepo.createTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toMatchObject({
+      agentId: 'meeting-debrief',
+      sourceAgentId: 'meeting-debrief',
+      createdBy: 'meeting-debrief',
+    });
+  });
+
+  it('rejects a target_agent_id that is not a registered agent', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Bad target', target_agent_id: 'ghost-agent' },
+      taskRepo,
+      agentId: 'coordinator',
+      agentRegistry: makeRegistry(['coordinator', 'meeting-debrief']),
+    });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/target_agent_id/);
+    expect(taskRepo.createTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string target_agent_id', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Task', target_agent_id: 123 as unknown as string },
+      taskRepo,
+      agentId: 'coordinator',
+      agentRegistry: makeRegistry(['coordinator']),
+    });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/target_agent_id/);
+    expect(taskRepo.createTask).not.toHaveBeenCalled();
+  });
+
+  it('errors when target_agent_id is set but the agent registry is unavailable', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({
+      input: { title: 'Task', target_agent_id: 'meeting-debrief' },
+      taskRepo,
+      agentId: 'coordinator',
+      // agentRegistry intentionally omitted.
+    });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/agentRegistry|registry/);
+    expect(taskRepo.createTask).not.toHaveBeenCalled();
   });
 
   // ── Error propagation ─────────────────────────────────────────────────────

--- a/skills/task-create/handler.ts
+++ b/skills/task-create/handler.ts
@@ -2,6 +2,22 @@
 //
 // Creates a new task row. Auto-fills agent_id and source_agent_id from the caller context.
 // When wake_at is provided, creates a linked one-shot scheduled_jobs row atomically.
+//
+// Cross-agent scheduling (target_agent_id) — DECISION (issue #880):
+// By default a task is owned by, and its wake fires back to, the creating agent
+// (self-routing). When `target_agent_id` is supplied, the task is instead OWNED by
+// the target: tasks.agent_id and tasks.source_agent_id both become the target, and
+// because the linked scheduled_jobs row inherits agent_id from the task (see
+// TaskRepo.createTask), the wake fires to the target. `created_by` still records the
+// real creator for audit. Owning the task — not merely redirecting the first wake —
+// is what makes re-wakes correct: when the target later reschedules via task-update,
+// that path routes off source_agent_id, which now points at the target.
+//
+// Gating: OPEN model. Any agent may target any *registered* agent. The only gate is
+// existence — the target must be a known agent, otherwise the wake would fire to a
+// dead agent_id that no runtime consumes. A stricter per-agent allowlist
+// (`schedulable_by` in agent YAML) was considered and deliberately deferred; revisit
+// if a compromised-agent threat model warrants restricting who can schedule into whom.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
@@ -29,6 +45,7 @@ export class TaskCreateHandler implements SkillHandler {
       waiting_on_text?: string;
       intent_anchor?: string;
       source?: string;
+      target_agent_id?: string;
     };
 
     if (!input.title || typeof input.title !== 'string' || !input.title.trim()) {
@@ -66,6 +83,43 @@ export class TaskCreateHandler implements SkillHandler {
     const derivedSource = (input.source as 'ceo' | 'agent' | 'scheduler' | 'coordinator' | undefined)
       ?? (ctx.agentId === 'coordinator' ? 'coordinator' : 'agent');
 
+    // Resolve the OWNING agent for this task (see the cross-agent scheduling note at
+    // the top of this file). Defaults to the creator; `target_agent_id` redirects
+    // ownership — and therefore the wake — to another registered agent.
+    const creatorAgentId = ctx.agentId ?? 'system';
+    let owningAgentId = creatorAgentId;
+    if (input.target_agent_id !== undefined) {
+      if (typeof input.target_agent_id !== 'string' || !input.target_agent_id.trim()) {
+        return { success: false, error: 'target_agent_id must be a non-empty string' };
+      }
+      const target = input.target_agent_id.trim();
+      // Self-targeting is just self-routing — always allowed, no registry needed.
+      if (target !== creatorAgentId) {
+        if (!ctx.agentRegistry) {
+          return {
+            success: false,
+            error: 'task-create: agentRegistry not available — cannot validate target_agent_id. '
+              + 'Check that the skill manifest declares the agentRegistry capability.',
+          };
+        }
+        if (!ctx.agentRegistry.has(target)) {
+          return {
+            success: false,
+            error: `target_agent_id '${target}' is not a registered agent — `
+              + 'a wake scheduled to an unknown agent would never fire.',
+          };
+        }
+        owningAgentId = target;
+        // Cross-agent authority operation — one agent scheduling work onto
+        // another agent's queue. Log it explicitly so an unexpected wake on the
+        // target can be traced to its creator without DB archaeology.
+        ctx.log.info(
+          { creatorAgentId, owningAgentId, title: input.title },
+          'task-create: redirecting task ownership to target agent',
+        );
+      }
+    }
+
     let dueAt: Date | undefined;
     if (input.due_at) {
       if (!ISO_DATETIME_RE.test(input.due_at)) {
@@ -87,11 +141,16 @@ export class TaskCreateHandler implements SkillHandler {
       }
     }
 
-    ctx.log.info({ title: input.title, owner: input.owner ?? 'curia' }, 'Creating task');
+    ctx.log.info(
+      { title: input.title, owner: input.owner ?? 'curia', owningAgentId, creatorAgentId },
+      'Creating task',
+    );
 
     try {
       const task = await ctx.taskRepo.createTask({
-        agentId: ctx.agentId ?? 'system',
+        // owningAgentId == creatorAgentId for the default (self-routing) case;
+        // a valid target_agent_id redirects ownership (and the linked wake) to it.
+        agentId: owningAgentId,
         title: input.title.trim(),
         description: input.description,
         owner: (input.owner as 'curia' | 'ceo' | 'external') ?? 'curia',
@@ -105,8 +164,10 @@ export class TaskCreateHandler implements SkillHandler {
         waitingOnText: input.waiting_on_text,
         intentAnchor: input.intent_anchor,
         source: derivedSource,
-        sourceAgentId: ctx.agentId ?? undefined,
-        createdBy: ctx.agentId ?? 'system',
+        // source_agent_id tracks the owning specialist (drives re-wake routing in
+        // TaskRepo.updateTask); created_by always records the actual creator.
+        sourceAgentId: owningAgentId,
+        createdBy: creatorAgentId,
       });
 
       const tz = ctx.timezone;

--- a/skills/task-create/skill.json
+++ b/skills/task-create/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "task-create",
-  "description": "Create a new task in the backlog. Provide a title and optionally description, owner (curia/ceo/external), priority (0-100), due date, tags, parent task, blocked-by task, waiting-on contact, and an intent anchor. When wake_at is set, schedules a one-shot wake-up for this task at that time.",
-  "version": "0.1.0",
+  "description": "Create a new task in the backlog. Provide a title and optionally description, owner (curia/ceo/external), priority (0-100), due date, tags, parent task, blocked-by task, waiting-on contact, and an intent anchor. When wake_at is set, schedules a one-shot wake-up for this task at that time. Set target_agent_id to assign the task (and its wake-up) to another agent — e.g. the coordinator scheduling a debrief task for the meeting-debrief specialist.",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -17,7 +17,8 @@
     "waiting_on_contact_id": "string?",
     "waiting_on_text": "string?",
     "intent_anchor": "string?",
-    "source": "string?"
+    "source": "string?",
+    "target_agent_id": "string?"
   },
   "outputs": {
     "task_id": "string",
@@ -33,5 +34,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 30000,
-  "capabilities": ["taskRepo"]
+  "capabilities": ["taskRepo", "agentRegistry"]
 }


### PR DESCRIPTION
## **User description**
## Summary

Adds an optional `target_agent_id` field to the `task-create` skill so an agent can create a task whose wake-up fires to a *different* agent. Motivating case (from #880): the coordinator or `ceo-inbox` scheduling a debrief task on behalf of the `meeting-debrief` specialist when the CEO books a meeting mid-day.

Closes #880

## Design decisions (confirmed with the user)

**Task ownership — "target owns the task".** When `target_agent_id` is supplied, both `tasks.agent_id` and `tasks.source_agent_id` are set to the target; `created_by` records the actual creator for audit. Owning the task (not merely redirecting the first wake) is what keeps re-wakes correct: `TaskRepo.updateTask` routes re-wakes off `source_agent_id ?? agent_id ?? caller`, so a reminder/expiry wake the target later schedules still fires to the target. No `task-repo` change was needed — the linked `scheduled_jobs` row already inherits `agent_id` from the task.

**Gating — "open".** Any agent may target any *registered* agent. The only gate is existence: the target must be a known agent in the `AgentRegistry`, otherwise the wake would fire to a dead `agent_id` that no runtime consumes. A stricter per-agent allowlist (`schedulable_by` in agent YAML) was considered and deliberately deferred; the decision is documented in a comment at the top of the handler. (This supersedes the issue's allowlist-related acceptance criteria, per the design choice.)

## Changes

- `skills/task-create/handler.ts` — resolve the owning agent; validate `target_agent_id` (non-empty string, must be a registered agent, requires the `agentRegistry` capability); self-targeting short-circuits without needing the registry. Logs the cross-agent redirect explicitly.
- `skills/task-create/skill.json` — new `target_agent_id` input, `agentRegistry` capability, version 0.1.0 → 0.2.0.
- `skills/task-create/handler.test.ts` — covers self-routing, valid cross-agent target, self-target without registry, unknown target rejected, non-string rejected, missing-registry rejected.
- `CHANGELOG.md` — Added entry under `[Unreleased]`.

## Verification

- `vitest run skills/task-create/handler.test.ts` — 20 passed
- `pnpm run typecheck` — clean
- Reviewed by code-reviewer and silent-failure-hunter subagents; the one finding (log the cross-agent redirect for observability) was addressed.

## Acceptance criteria

- [x] `task-create` accepts optional `target_agent_id`.
- [x] When provided, the `scheduled_jobs` row has `agent_id = target_agent_id`; wake fires to the target with the standard payload.
- [x] When omitted, behavior is unchanged (self-routing).
- [x] Gating mechanism defined + enforced (open model: target must be a registered agent) and documented in a decision comment.
- [x] Returns `{ success: false, error }` when `target_agent_id` is invalid (non-string, empty, or unknown agent) / registry unavailable.
- [x] Unit tests cover self-routing, valid cross-agent target, invalid target.
- [ ] ~Agent YAML declares `schedulable_by`~ — N/A under the open-gating decision.


___

## **CodeAnt-AI Description**
**Let tasks be assigned to another registered agent**

### What Changed
- `task-create` can now send a new task and its wake-up to a different registered agent instead of always keeping it with the creator
- The task still records who created it for audit, while ownership is set to the target agent so later re-wakes follow the same agent
- Requests with an unknown target, a missing registry, or an invalid target value are rejected before the task is created
- The task-create help text and version were updated to describe the new cross-agent scheduling option
- Tests now cover default self-routing, valid cross-agent routing, self-targeting, and error cases

### Impact
`✅ Cross-agent task scheduling`
`✅ Fewer misrouted wake-ups`
`✅ Clearer audit trail for delegated work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task creation now supports an optional `target_agent_id` parameter for assigning newly created tasks and wake-up events to other registered agents. The feature maintains accurate ownership tracking and creator attribution, ensuring tasks are properly routed to the target agent while the original creator's information is preserved in task records. Version incremented to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->