### PR TITLE
feat: add close_after flag to bullpen reply for atomic thread closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **`task-create`** — optional `target_agent_id` assigns a new task (and its wake-up) to another registered agent, so the coordinator or ceo-inbox can schedule work for a specialist like meeting-debrief. (#880)
-- **`bullpen`** — `reply` accepts `close_after: true` to close a thread atomically with the reply, and `formatBullpenContext()` now nudges agents to use it so concluded threads actually get closed. (#881)
+- **`bullpen`** — `reply` accepts `close_after: true` to close a thread atomically with the reply, `formatBullpenContext()` nudges agents to use it, and the dispatcher skips reply-task fan-out for closed threads so a concluding reply doesn't create dead-end tasks. (#881)
 
 ## [0.34.0] — 2026-06-12 — "Heimdall"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **`task-create`** — optional `target_agent_id` assigns a new task (and its wake-up) to another registered agent, so the coordinator or ceo-inbox can schedule work for a specialist like meeting-debrief. (#880)
+- **`bullpen`** — `reply` accepts `close_after: true` to close a thread atomically with the reply, and `formatBullpenContext()` now nudges agents to use it so concluded threads actually get closed. (#881)
 
 ## [0.34.0] — 2026-06-12 — "Heimdall"
 

--- a/skills/bullpen/handler.test.ts
+++ b/skills/bullpen/handler.test.ts
@@ -87,6 +87,61 @@ describe('BullpenHandler', () => {
     expect((openCtx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 
+  it('reply: close_after=true posts the reply and closes the thread', async () => {
+    const openCtx = makeCtx({
+      action: 'post',
+      topic: 'Close-after test',
+      participants: ['coordinator', 'agent-b'],
+      content: 'Start',
+      mentioned_agent_ids: ['agent-b'],
+    });
+    const openResult = await handler.execute(openCtx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    const replyCtx = makeCtx(
+      { action: 'reply', thread_id: threadId, content: 'Concluding reply', close_after: true },
+      { bullpenService: openCtx.bullpenService, bus: openCtx.bus, agentId: 'agent-b' },
+    );
+    const replyResult = await handler.execute(replyCtx);
+    expect(replyResult.success).toBe(true);
+    const data = (replyResult as { success: true; data: Record<string, unknown> }).data;
+    expect(typeof data.message_id).toBe('string');
+    expect(data.status).toBe('closed');
+
+    // Thread is actually closed: a follow-up reply must now fail.
+    const followUp = makeCtx(
+      { action: 'reply', thread_id: threadId, content: 'Too late' },
+      { bullpenService: openCtx.bullpenService, bus: openCtx.bus, agentId: 'coordinator' },
+    );
+    const followUpResult = await handler.execute(followUp);
+    expect(followUpResult.success).toBe(false);
+    expect((followUpResult as { success: false; error: string }).error).toMatch(/closed/);
+  });
+
+  it('reply: close_after=false (default) leaves the thread open', async () => {
+    const openCtx = makeCtx({
+      action: 'post',
+      topic: 'Stay-open test',
+      participants: ['coordinator', 'agent-b'],
+      content: 'Start',
+      mentioned_agent_ids: ['agent-b'],
+    });
+    const openResult = await handler.execute(openCtx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    const replyCtx = makeCtx(
+      { action: 'reply', thread_id: threadId, content: 'Still going' },
+      { bullpenService: openCtx.bullpenService, bus: openCtx.bus, agentId: 'agent-b' },
+    );
+    const replyResult = await handler.execute(replyCtx);
+    expect(replyResult.success).toBe(true);
+    const data = (replyResult as { success: true; data: Record<string, unknown> }).data;
+    expect(data.status).toBeUndefined();
+
+    const get = await openCtx.bullpenService!.getThread(threadId);
+    expect(get!.thread.status).toBe('open');
+  });
+
   it('get_thread: returns full thread without publishing', async () => {
     const ctx = makeCtx({
       action: 'post',

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -146,7 +146,12 @@ export class BullpenHandler implements SkillHandler {
             ? (rawMentioned as string[]).map(m => m.trim()).filter(m => m.length > 0 && existing.thread.participants.includes(m))
             : [];
 
-          const message = await ctx.bullpenService.postMessage(threadId, ctx.agentId, content, mentionedAgentIds);
+          // close_after lets an agent conclude a thread in the same call as its reply (#881).
+          // The message is persisted first, then the thread is closed atomically — so a
+          // successful postMessage means both happened. Only an explicit `true` closes.
+          const closeAfter = input['close_after'] === true;
+
+          const message = await ctx.bullpenService.postMessage(threadId, ctx.agentId, content, mentionedAgentIds, closeAfter);
 
           // Publish is fire-and-forget — reply is already persisted. Same
           // rationale as `post`: bus.publish dispatches subscribers sequentially,
@@ -171,7 +176,13 @@ export class BullpenHandler implements SkillHandler {
             );
           });
 
-          return { success: true, data: { thread_id: threadId, message_id: message.id } };
+          // Report the close in the result so the agent gets confirmation the thread is done.
+          return {
+            success: true,
+            data: closeAfter
+              ? { thread_id: threadId, message_id: message.id, status: 'closed' }
+              : { thread_id: threadId, message_id: message.id },
+          };
         }
 
         case 'get_thread': {

--- a/skills/bullpen/skill.json
+++ b/skills/bullpen/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "bullpen",
   "description": "Open, reply to, read, or close inter-agent Bullpen discussion threads. Use 'post' to start a new thread addressed to other agents, 'reply' to add a message to an existing thread, 'get_thread' to read the full message history, and 'close' to end a thread when the discussion is complete.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -11,6 +11,7 @@
     "mentioned_agent_ids": "string[]? (agent IDs to at-mention; defaults to all participants when action is 'post')",
     "content": "string? (message body; required when action is 'post' or 'reply')",
     "thread_id": "string? (thread ID; required when action is 'reply', 'get_thread', or 'close')",
+    "close_after": "boolean? (for 'reply' only; default false. When true, the thread is closed atomically after the reply is posted — use it when your reply concludes the discussion)",
     "source_message_id": "string? (dedup key for 'post'; if a thread already exists with this ID the existing thread is returned instead of creating a new one)"
   },
   "outputs": {
@@ -18,7 +19,7 @@
     "message_id": "string: the persisted message ID (post/reply)",
     "deduplicated": "boolean: true when source_message_id matched an existing thread and no new thread was opened (post only)",
     "thread": "object: full thread + messages (get_thread)",
-    "status": "string: 'closed' (close)"
+    "status": "string: 'closed' (returned by 'close', and by 'reply' when close_after was true)"
   },
   "permissions": [],
   "secrets": [],

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -51,6 +51,18 @@ export class BullpenDispatcher {
       return;
     }
 
+    // A reply with close_after: true closes the thread atomically, then still publishes a
+    // normal agent.discuss event for the concluding message. Creating reply-oriented tasks
+    // for a closed thread is a dead end — any reply is rejected with "Cannot post to closed
+    // thread" — so skip dispatch here, mirroring the message-cap guard above. (#881)
+    if (threadRecord.thread.status === 'closed') {
+      this.logger.info(
+        { threadId },
+        'BullpenDispatcher: thread is closed — skipping task creation (concluding reply needs no follow-up)',
+      );
+      return;
+    }
+
     const { topic, participants } = threadRecord.thread;
 
     // Prefer the originator from the discuss event (fast path — already in memory).

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -57,7 +57,9 @@ export interface PendingThreadContext {
 
 interface BullpenBackend {
   openThread(thread: BullpenThread, message: BullpenMessage): Promise<void>;
-  postMessage(threadId: string, message: BullpenMessage): Promise<void>;
+  // closeAfter, when true, marks the thread closed in the same operation that
+  // persists the message — the message is always written first (see #881).
+  postMessage(threadId: string, message: BullpenMessage, closeAfter?: boolean): Promise<void>;
   closeThread(threadId: string): Promise<void>;
   getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null>;
   findThreadBySourceMessageId(sourceMessageId: string): Promise<{ thread: BullpenThread; message: BullpenMessage } | null>;
@@ -96,7 +98,7 @@ class InMemoryBullpenBackend implements BullpenBackend {
     return { thread: { ...thread }, message: { ...msgs[0]! } };
   }
 
-  async postMessage(threadId: string, message: BullpenMessage): Promise<void> {
+  async postMessage(threadId: string, message: BullpenMessage, closeAfter = false): Promise<void> {
     const thread = this.threads.get(threadId);
     if (!thread) throw new Error(`Thread ${threadId} not found`);
     thread.messageCount++;
@@ -104,6 +106,8 @@ class InMemoryBullpenBackend implements BullpenBackend {
     const msgs = this.messages.get(threadId) ?? [];
     msgs.push({ ...message });
     this.messages.set(threadId, msgs);
+    // Close after the message is appended so the reply is never lost (#881).
+    if (closeAfter) thread.status = 'closed';
   }
 
   async closeThread(threadId: string): Promise<void> {
@@ -181,7 +185,7 @@ class PostgresBullpenBackend implements BullpenBackend {
     }
   }
 
-  async postMessage(threadId: string, message: BullpenMessage): Promise<void> {
+  async postMessage(threadId: string, message: BullpenMessage, closeAfter = false): Promise<void> {
     // Atomically insert the message and conditionally increment message_count.
     // The UPDATE uses WHERE status='open' AND message_count<100 so that concurrent
     // close or cap-reaching posts are rejected at the DB level, not just app level.
@@ -193,13 +197,18 @@ class PostgresBullpenBackend implements BullpenBackend {
          VALUES ($1, $2, $3, $4, $5, $6, $7)`,
         [message.id, threadId, message.senderType, message.senderId, JSON.stringify(message.content), message.mentionedAgentIds, message.createdAt],
       );
+      // When closeAfter is set, flip status to 'closed' in the same UPDATE that
+      // records the message — the INSERT above runs first, so the reply is always
+      // persisted, and the close is atomic with it (#881). The WHERE status='open'
+      // guard means we only ever close a thread that was open at write time.
       const updateRes = await client.query<{ message_count: number }>(
         `UPDATE bullpen_threads
          SET message_count = message_count + 1,
-             last_message_at = $1
+             last_message_at = $1,
+             status = CASE WHEN $3 THEN 'closed' ELSE status END
          WHERE id = $2 AND status = 'open' AND message_count < 100
          RETURNING message_count`,
-        [message.createdAt, threadId],
+        [message.createdAt, threadId, closeAfter],
       );
       if (updateRes.rows.length === 0) {
         // Thread is closed or at cap — roll back the message insert.
@@ -413,6 +422,10 @@ export class BullpenService {
     senderAgentId: string,
     content: string,
     mentionedAgentIds: string[],
+    // When true, the thread is closed atomically with this reply (#881). Unlike the
+    // explicit closeThread action, close_after is a soft conclusion signal available
+    // to any replying participant — the participant check below is the only gate.
+    closeAfter = false,
   ): Promise<BullpenMessage> {
     const existing = await this.backend.getThread(threadId);
     if (!existing) throw new Error(`Thread ${threadId} not found`);
@@ -433,7 +446,7 @@ export class BullpenService {
       senderId: senderAgentId, content, mentionedAgentIds,
       createdAt: new Date(),
     };
-    await this.backend.postMessage(threadId, message);
+    await this.backend.postMessage(threadId, message, closeAfter);
     return message;
   }
 
@@ -483,5 +496,10 @@ export function formatBullpenContext(pending: PendingThreadContext[]): string {
       lines.push(`  → Call bullpen get_thread for full history.`);
     }
   }
+  // Thread-closure convention (#881): bullpen threads tend to be left open because
+  // nothing prompts agents to close them. Surfacing this line on every turn that
+  // injects bullpen state gives all agents the convention without per-agent prompt edits.
+  lines.push('');
+  lines.push('When your bullpen reply concludes a thread, pass close_after: true so it is closed atomically. Leave it off (or false) if the discussion is still going.');
   return lines.join('\n');
 }

--- a/tests/integration/bullpen.test.ts
+++ b/tests/integration/bullpen.test.ts
@@ -77,4 +77,18 @@ describeIf('BullpenService integration (Postgres)', () => {
     // Also verify the application-layer guard blocks further posts
     await expect(service.postMessage(thread.id, 'coordinator', 'After close', [])).rejects.toThrow('closed');
   });
+
+  it('postMessage with closeAfter=true persists the reply and closes the thread atomically (#881)', async () => {
+    // Full open → reply with close_after → thread is closed flow.
+    const { thread } = await service.openThread(`${runId} — Close-after test`, 'coordinator', ['coordinator', 'agent-b'], 'Opening', []);
+    const reply = await service.postMessage(thread.id, 'agent-b', 'Concluding reply', [], true);
+
+    const after = await service.getThread(thread.id);
+    // The reply was written first and persisted...
+    expect(after!.thread.status).toBe('closed');
+    expect(after!.thread.messageCount).toBe(2);
+    expect(after!.messages.some(m => m.id === reply.id)).toBe(true);
+    // ...and the thread is now closed, so further posts are rejected.
+    await expect(service.postMessage(thread.id, 'coordinator', 'Too late', [])).rejects.toThrow('closed');
+  });
 });

--- a/tests/integration/bullpen.test.ts
+++ b/tests/integration/bullpen.test.ts
@@ -84,6 +84,7 @@ describeIf('BullpenService integration (Postgres)', () => {
     const reply = await service.postMessage(thread.id, 'agent-b', 'Concluding reply', [], true);
 
     const after = await service.getThread(thread.id);
+    expect(after).not.toBeNull();
     // The reply was written first and persisted...
     expect(after!.thread.status).toBe('closed');
     expect(after!.thread.messageCount).toBe(2);

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -214,4 +214,22 @@ describe('BullpenDispatcher', () => {
       .filter(([_l, e]) => (e as { type: string }).type === 'agent.task');
     expect(tasks).toHaveLength(0);
   });
+
+  it('skips task creation when the thread is closed (e.g. reply with close_after)', async () => {
+    // A close_after reply closes the thread atomically and then publishes the concluding
+    // agent.discuss; the dispatcher must not fan out reply tasks for a closed thread. (#881)
+    const { thread } = await bullpenService.openThread(
+      'Close-after dispatch test', 'coordinator', ['coordinator', 'agent-b'], 'Start', [],
+    );
+    await bullpenService.postMessage(thread.id, 'agent-b', 'Concluding reply', [], true);
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-closed', topic: 'Close-after dispatch test',
+      senderAgentId: 'agent-b', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['coordinator'], content: 'Concluding reply', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task');
+    expect(tasks).toHaveLength(0);
+  });
 });

--- a/tests/unit/memory/bullpen.test.ts
+++ b/tests/unit/memory/bullpen.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { BullpenService } from '../../../src/memory/bullpen.js';
+import { BullpenService, formatBullpenContext } from '../../../src/memory/bullpen.js';
+import type { PendingThreadContext } from '../../../src/memory/bullpen.js';
 
 describe('BullpenService (in-memory)', () => {
   let service: BullpenService;
@@ -67,6 +68,39 @@ describe('BullpenService (in-memory)', () => {
     expect(result?.thread.status).toBe('closed');
   });
 
+  it('postMessage with closeAfter=true posts the reply and closes the thread', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Hello', []);
+    const message = await service.postMessage(thread.id, 'agent-b', 'Concluding reply', [], true);
+    const result = await service.getThread(thread.id);
+    // The reply is written first and persists...
+    expect(result?.thread.messageCount).toBe(2);
+    expect(result?.messages.some(m => m.id === message.id)).toBe(true);
+    // ...and the thread is closed atomically with it.
+    expect(result?.thread.status).toBe('closed');
+  });
+
+  it('postMessage with closeAfter=false (default) leaves the thread open', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Hello', []);
+    await service.postMessage(thread.id, 'agent-b', 'Still talking', []);
+    const result = await service.getThread(thread.id);
+    expect(result?.thread.status).toBe('open');
+  });
+
+  it('postMessage with closeAfter=true allows a non-creator participant to close', async () => {
+    // close_after is a soft conclusion signal available to any replying participant,
+    // unlike the explicit `close` action which is restricted to creator/coordinator.
+    const { thread } = await service.openThread('Test', 'agent-a', ['agent-a', 'agent-b'], 'Hi', []);
+    await service.postMessage(thread.id, 'agent-b', 'Done here', [], true);
+    const result = await service.getThread(thread.id);
+    expect(result?.thread.status).toBe('closed');
+  });
+
+  it('postMessage with closeAfter=true rejects (and does not close) a closed thread', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator'], 'Hi', []);
+    await service.closeThread(thread.id, 'coordinator');
+    await expect(service.postMessage(thread.id, 'coordinator', 'Late', [], true)).rejects.toThrow('closed');
+  });
+
   it('getPendingThreadsForAgent returns only threads where latest sender is not the agent', async () => {
     const { thread } = await service.openThread(
       'Pending test',
@@ -106,5 +140,27 @@ describe('BullpenService (in-memory)', () => {
     expect(pending[0]?.recentMessages).toHaveLength(5);
     // Should be the last 5 messages
     expect(pending[0]?.recentMessages[4]?.content).toBe('Msg 8');
+  });
+});
+
+describe('formatBullpenContext', () => {
+  function makePending(): PendingThreadContext {
+    return {
+      threadId: 'thread-1',
+      topic: 'Q2 planning',
+      totalMessages: 1,
+      recentMessages: [
+        { senderAgentId: 'coordinator', content: 'What do you think?', mentionedAgentIds: [], createdAt: new Date(0) },
+      ],
+    };
+  }
+
+  it('returns empty string when there are no pending threads', () => {
+    expect(formatBullpenContext([])).toBe('');
+  });
+
+  it('includes the close_after convention note when threads are present', () => {
+    const out = formatBullpenContext([makePending()]);
+    expect(out).toContain('close_after');
   });
 });


### PR DESCRIPTION
## Summary

Bullpen threads are rarely closed in practice (prod showed 29 of the last 31 still `open`). The `close` action exists but nothing prompts agents to call it after replying. This adds the missing signal, in shared infrastructure rather than per-agent prompts.

Changes:

1. **`reply` action accepts `close_after?: boolean` (default `false`).** When `true`, the thread is closed atomically with the reply. In the Postgres backend the message INSERT and the status flip run in the same transaction (`UPDATE ... SET status = CASE WHEN $3 THEN 'closed' ELSE status END` in the same `UPDATE` that records the message). The message is always written first; the `WHERE status='open'` guard means we only ever close a thread that was open at write time.

2. **`formatBullpenContext()` gains a one-line convention note** nudging agents to pass `close_after: true` when a reply concludes a thread. This is the centralized function injected into every agent's context, so all agents learn the convention without touching individual prompts.

3. **`BullpenDispatcher` skips reply-task fan-out for closed threads.** A `close_after` reply closes the thread and then still publishes the concluding `agent.discuss`. Added a `thread.status === 'closed'` guard (mirroring the existing `messageCount >= 100` guard) so the dispatcher doesn't create dead-end reply tasks for a thread that can no longer accept replies.

### Design note

Unlike the explicit `close` action (restricted to creator/coordinator), `close_after` is a soft conclusion signal available to **any replying participant** — the participant check in `postMessage` is the only gate. This matches the issue's intent: any agent concluding a thread should be able to close it.

## Acceptance criteria

- [x] `reply` accepts optional `close_after: boolean` (default `false`)
- [x] When `true`, thread is closed atomically after the reply is persisted
- [x] Closing mid-reply never affects the message — it is always written first (INSERT before the close in the same txn; rollback drops both on cap/closed)
- [x] `formatBullpenContext()` includes a one-line close convention note
- [x] Replying to a thread closed via `close_after` behaves identically to any other closed thread (existing guard rejects with "closed")
- [x] Unit tests: `close_after: true` closes, `close_after: false` leaves open, non-creator participant can close, closed-thread reply rejected
- [x] Integration test: full open → reply with `close_after: true` → thread closed (verified against real Postgres)

## Testing

- `pnpm run typecheck` — clean
- Unit + handler + dispatcher tests pass; integration test against local Postgres passes (incl. atomic-close flow and dispatcher closed-thread skip)

Closes #881