### PR TITLE
feat: agent-initiated secret capture via one-time vault link (#971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Secret capture** — agents mint a one-time link to a web form so a user can add a new vault secret mid-conversation; the value never touches the LLM. Skills `secret-capture-request` and `system-secret-capture-request`. (#971)
 - **`task-create`** — optional `target_agent_id` assigns a new task (and its wake-up) to another registered agent, so the coordinator or ceo-inbox can schedule work for a specialist like meeting-debrief. (#880)
 - **`bullpen`** — `reply` accepts `close_after: true` to close a thread atomically with the reply, `formatBullpenContext()` nudges agents to use it, and the dispatcher skips reply-task fan-out for closed threads so a concluding reply doesn't create dead-end tasks. (#881)
 
 ### Changed
 
+- **`SkillContext` (public API)** — adds optional `secretCapture` capability and `appOrigin`/`httpPort` fields (backward compatible). (#971)
 - **Coordinator prompt** — re-derived around a three-way routing decision; delegation-hinted outbound replies now always transfer to the owning specialist. (#957)
 
 ### Removed

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.7.0"
+version: "0.8.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -705,6 +705,7 @@ pinned_skills:
   - approval-expiry-sweep
   - pending-actions-digest
   - scheduler-report
+  - secret-capture-request
 allow_discovery: true
 enable_task_management: true
 error_budget:

--- a/agents/setup-wizard.yaml
+++ b/agents/setup-wizard.yaml
@@ -1,4 +1,5 @@
 name: setup-wizard
+version: "0.1.0"
 role: specialist
 description: >
   First-conversation specialist and setup guide. Invoke when the principal
@@ -70,5 +71,6 @@ pinned_skills:
   - skill-registry
   - memory-store
   - executive-profile-update
+  - system-secret-capture-request
 allow_discovery: false
 inject_specialists: false

--- a/agents/setup-wizard.yaml
+++ b/agents/setup-wizard.yaml
@@ -49,12 +49,18 @@ system_prompt: |
   a plain-language summary grouped by category (email, calendar, research,
   scheduling, memory). Keep it to ~5 bullets.
 
-  ## Integration setup (v1)
+  ## Integration setup
 
-  When asked about setting up Nylas, Twilio, Signal, OpenAI key, or similar:
-  - Return the specific env var names needed and a one-line description of each.
-  - Add: "After setting these, restart Curia and I'll be ready to use them."
-  - Add: "An in-app setup flow for this is coming in v2."
+  When asked about setting up Nylas, Twilio, Signal, an API key, or similar:
+  - For each secret needed (API key, channel credential), call
+    system-secret-capture-request with the exact vault key name (e.g.
+    "anthropic_api_key", "channel.email.nylas_api_key") and a short label. Return
+    the one-time link it produces and tell the principal to click it to enter the
+    value securely. The value goes straight to the vault — you never see it.
+  - One link per secret. The links are single-use and expire in 30 minutes.
+  - Only fall back to naming raw env vars for non-secret config or a key the tool
+    rejects (not a declared skill secret or known channel credential). In that case,
+    add: "After setting these, restart Curia and I'll be ready to use them."
 
   ## Rules
 

--- a/apps/console/src/pages/SecretCapturePage.tsx
+++ b/apps/console/src/pages/SecretCapturePage.tsx
@@ -1,0 +1,125 @@
+// SecretCapturePage.tsx — public, unauthenticated form for one-time secret capture (#971).
+//
+// Reachable WITHOUT a session: it lives under rootRoute (not the authed layout), and the
+// backend routes are exempt from bearer auth. The single-use token in the URL is the only
+// credential. The value the user types is POSTed straight to the vault server-side; it is
+// never echoed back, stored client-side, or sent anywhere but the capture endpoint.
+
+import { useState, useEffect, type FormEvent } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { CuriaWordmark } from '../components/Icons';
+import { apiFetch } from '../api';
+import {
+  classifyMetadataResponse,
+  validateSubmitValue,
+  type CaptureView,
+  type CaptureMetadataBody,
+} from './secret-capture-utils';
+
+export default function SecretCapturePage() {
+  const { token } = useParams({ from: '/secret-capture/$token' });
+  const [view, setView] = useState<CaptureView>({ kind: 'loading' });
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Load form metadata on mount. We never request the vault key — only the label + format.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch(`/api/secret-capture/${token}`);
+        let body: CaptureMetadataBody | null = null;
+        if (res.headers.get('content-type')?.includes('application/json')) {
+          body = (await res.json()) as CaptureMetadataBody;
+        }
+        if (!cancelled) setView(classifyMetadataResponse(res.status, body));
+      } catch {
+        if (!cancelled) setView({ kind: 'error' });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [token]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (view.kind !== 'form') return;
+    setError(null);
+
+    const check = validateSubmitValue(value, view.valueFormat);
+    if (!check.ok) {
+      setError(check.error);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await apiFetch(`/api/secret-capture/${token}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value }),
+      });
+      if (res.ok) {
+        setValue(''); // drop the value from memory as soon as it's accepted
+        setView({ kind: 'success' });
+        return;
+      }
+      if (res.status === 410) { setView({ kind: 'gone' }); return; }
+      if (res.status === 404) { setView({ kind: 'notfound' }); return; }
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      setError(data.error ?? 'Could not save the value. Please try again.');
+    } catch {
+      setError('Network error. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="login-root">
+      <div className="login-card">
+        <div className="login-wordmark" aria-label="Curia">
+          <CuriaWordmark />
+        </div>
+        {renderBody()}
+      </div>
+    </div>
+  );
+
+  function renderBody() {
+    switch (view.kind) {
+      case 'loading':
+        return <p>Loading…</p>;
+      case 'gone':
+        return <p>This link has expired or has already been used. Ask Curia for a new one.</p>;
+      case 'notfound':
+        return <p>This link is not valid. Ask Curia for a new one.</p>;
+      case 'error':
+        return <p className="login-error">Something went wrong loading this form. Please try again later.</p>;
+      case 'success':
+        return <p>Saved. You can close this window.</p>;
+      case 'form':
+        return (
+          <form onSubmit={handleSubmit} className="login-form">
+            <label htmlFor="capture-value">
+              Enter value for: <strong>{view.label ?? 'the requested secret'}</strong>
+            </label>
+            <textarea
+              id="capture-value"
+              aria-label="Secret value"
+              placeholder={view.valueFormat === 'json' ? '{ "key": "value" }' : 'Paste or type the value'}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              rows={view.valueFormat === 'json' ? 6 : 3}
+              autoFocus
+              required
+            />
+            {error && <p className="login-error">{error}</p>}
+            <button type="submit" className="btn btn-primary" disabled={submitting}>
+              {submitting ? 'Saving…' : 'Save securely'}
+            </button>
+          </form>
+        );
+    }
+  }
+}

--- a/apps/console/src/pages/SecretCapturePage.tsx
+++ b/apps/console/src/pages/SecretCapturePage.tsx
@@ -5,7 +5,7 @@
 // credential. The value the user types is POSTed straight to the vault server-side; it is
 // never echoed back, stored client-side, or sent anywhere but the capture endpoint.
 
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, useEffect, useRef, type FormEvent } from 'react';
 import { useParams } from '@tanstack/react-router';
 import { CuriaWordmark } from '../components/Icons';
 import { apiFetch } from '../api';
@@ -22,12 +22,17 @@ export default function SecretCapturePage() {
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // Always holds the token currently shown. A submit captures the token it started with and
+  // compares against this ref before applying its result, so a late response from a previous
+  // token (after the user navigated to a different capture link) can't clobber the new page.
+  const activeToken = useRef(token);
 
   // Load form metadata on mount AND whenever the token changes. We reset to a clean loading
   // state and clear any previously typed value first, so the old form (with an old secret and
   // old token binding) can never be submitted against a newly navigated-to token.
   useEffect(() => {
     let cancelled = false;
+    activeToken.current = token;
     setView({ kind: 'loading' });
     setValue('');
     setError(null);
@@ -59,13 +64,17 @@ export default function SecretCapturePage() {
       return;
     }
 
+    const submittedToken = token;
     setSubmitting(true);
     try {
-      const res = await apiFetch(`/api/secret-capture/${token}`, {
+      const res = await apiFetch(`/api/secret-capture/${submittedToken}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ value }),
       });
+      // If the user navigated to a different capture link while this POST was in flight, drop
+      // the stale result rather than overwriting the now-active token's page.
+      if (activeToken.current !== submittedToken) return;
       if (res.ok) {
         setValue(''); // drop the value from memory as soon as it's accepted
         setView({ kind: 'success' });
@@ -83,9 +92,10 @@ export default function SecretCapturePage() {
       }
       setError(data.error ?? 'Could not save the value. Please try again.');
     } catch {
-      setError('Network error. Please try again.');
+      if (activeToken.current === submittedToken) setError('Network error. Please try again.');
     } finally {
-      setSubmitting(false);
+      // Only clear the spinner if we're still on the token this submit started for.
+      if (activeToken.current === submittedToken) setSubmitting(false);
     }
   }
 

--- a/apps/console/src/pages/SecretCapturePage.tsx
+++ b/apps/console/src/pages/SecretCapturePage.tsx
@@ -23,9 +23,14 @@ export default function SecretCapturePage() {
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  // Load form metadata on mount. We never request the vault key — only the label + format.
+  // Load form metadata on mount AND whenever the token changes. We reset to a clean loading
+  // state and clear any previously typed value first, so the old form (with an old secret and
+  // old token binding) can never be submitted against a newly navigated-to token.
   useEffect(() => {
     let cancelled = false;
+    setView({ kind: 'loading' });
+    setValue('');
+    setError(null);
     (async () => {
       try {
         const res = await apiFetch(`/api/secret-capture/${token}`);
@@ -43,7 +48,9 @@ export default function SecretCapturePage() {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    if (view.kind !== 'form') return;
+    // Guard against a double-submit race: a second in-flight POST could otherwise land a 410
+    // (token already consumed by the first) and flip the UI away from the success state.
+    if (submitting || view.kind !== 'form') return;
     setError(null);
 
     const check = validateSubmitValue(value, view.valueFormat);
@@ -64,8 +71,10 @@ export default function SecretCapturePage() {
         setView({ kind: 'success' });
         return;
       }
-      if (res.status === 410) { setView({ kind: 'gone' }); return; }
-      if (res.status === 404) { setView({ kind: 'notfound' }); return; }
+      // Terminal failures: the link is no longer usable, so drop the entered secret from
+      // component state rather than leaving it sitting in memory behind a dead form.
+      if (res.status === 410) { setValue(''); setView({ kind: 'gone' }); return; }
+      if (res.status === 404) { setValue(''); setView({ kind: 'notfound' }); return; }
       const data = (await res.json().catch(() => ({}))) as { error?: string };
       setError(data.error ?? 'Could not save the value. Please try again.');
     } catch {

--- a/apps/console/src/pages/SecretCapturePage.tsx
+++ b/apps/console/src/pages/SecretCapturePage.tsx
@@ -75,7 +75,12 @@ export default function SecretCapturePage() {
       // component state rather than leaving it sitting in memory behind a dead form.
       if (res.status === 410) { setValue(''); setView({ kind: 'gone' }); return; }
       if (res.status === 404) { setValue(''); setView({ kind: 'notfound' }); return; }
-      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      // Parse the error body only when it's actually JSON, with an explicit fall-through to
+      // the generic message — mirrors WizardPage's extractError() convention (no console).
+      let data: { error?: string } = {};
+      if (res.headers.get('content-type')?.includes('application/json')) {
+        try { data = (await res.json()) as { error?: string }; } catch { /* fall through to fallback */ }
+      }
       setError(data.error ?? 'Could not save the value. Please try again.');
     } catch {
       setError('Network error. Please try again.');

--- a/apps/console/src/pages/secret-capture-utils.test.ts
+++ b/apps/console/src/pages/secret-capture-utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { classifyMetadataResponse, validateSubmitValue } from './secret-capture-utils.js';
+
+describe('classifyMetadataResponse', () => {
+  it('renders the form for a valid (200) token', () => {
+    expect(classifyMetadataResponse(200, { label: 'Flight password', value_format: 'string' })).toEqual({
+      kind: 'form',
+      label: 'Flight password',
+      valueFormat: 'string',
+    });
+  });
+
+  it('defaults an unknown value_format to string', () => {
+    const view = classifyMetadataResponse(200, { label: null });
+    expect(view).toMatchObject({ kind: 'form', valueFormat: 'string' });
+  });
+
+  it('carries through a json value_format', () => {
+    expect(classifyMetadataResponse(200, { label: 'creds', value_format: 'json' })).toMatchObject({
+      kind: 'form',
+      valueFormat: 'json',
+    });
+  });
+
+  it('shows an expired/used message for 410', () => {
+    expect(classifyMetadataResponse(410, null)).toEqual({ kind: 'gone' });
+  });
+
+  it('shows a not-found message for 404', () => {
+    expect(classifyMetadataResponse(404, null)).toEqual({ kind: 'notfound' });
+  });
+
+  it('falls back to a generic error for 5xx', () => {
+    expect(classifyMetadataResponse(500, null)).toEqual({ kind: 'error' });
+  });
+});
+
+describe('validateSubmitValue', () => {
+  it('rejects an empty value', () => {
+    expect(validateSubmitValue('', 'string')).toMatchObject({ ok: false });
+  });
+
+  it('accepts any non-empty string for a string link', () => {
+    expect(validateSubmitValue('hunter2', 'string')).toEqual({ ok: true });
+  });
+
+  it('rejects malformed JSON for a json link', () => {
+    expect(validateSubmitValue('not json', 'json')).toMatchObject({ ok: false });
+  });
+
+  it('accepts well-formed JSON for a json link', () => {
+    expect(validateSubmitValue('{"a":1}', 'json')).toEqual({ ok: true });
+  });
+});

--- a/apps/console/src/pages/secret-capture-utils.ts
+++ b/apps/console/src/pages/secret-capture-utils.ts
@@ -1,0 +1,47 @@
+// secret-capture-utils.ts — pure view/validation logic for the public SecretCapturePage.
+//
+// Extracted from the component so it can be unit-tested under the project's node test env
+// (the console has no jsdom render harness; logic lives in *-utils.ts, mirroring wizard-utils).
+
+export type CaptureValueFormat = 'string' | 'json';
+
+/** Metadata returned by GET /api/secret-capture/:token for a live token. */
+export interface CaptureMetadataBody {
+  label?: string | null;
+  value_format?: string;
+}
+
+/** The form's top-level view state, derived from the metadata fetch. */
+export type CaptureView =
+  | { kind: 'loading' }
+  | { kind: 'form'; label: string | null; valueFormat: CaptureValueFormat }
+  | { kind: 'gone' }       // 410 — expired or already used
+  | { kind: 'notfound' }   // 404 — never valid
+  | { kind: 'error' }      // network / 5xx
+  | { kind: 'success' };   // value submitted
+
+/** Map a metadata-fetch result to a view state. 200 → form, 410 → gone, 404 → notfound,
+ *  anything else → a generic error (so a 5xx doesn't masquerade as a usable form). */
+export function classifyMetadataResponse(status: number, body: CaptureMetadataBody | null): CaptureView {
+  if (status === 200 && body) {
+    const valueFormat: CaptureValueFormat = body.value_format === 'json' ? 'json' : 'string';
+    return { kind: 'form', label: body.label ?? null, valueFormat };
+  }
+  if (status === 410) return { kind: 'gone' };
+  if (status === 404) return { kind: 'notfound' };
+  return { kind: 'error' };
+}
+
+/** Client-side guard before POST: non-empty, and valid JSON when the link expects JSON.
+ *  The server re-validates — this is purely for fast, friendly feedback. */
+export function validateSubmitValue(value: string, valueFormat: CaptureValueFormat): { ok: true } | { ok: false; error: string } {
+  if (value.length === 0) return { ok: false, error: 'Please enter a value.' };
+  if (valueFormat === 'json') {
+    try {
+      JSON.parse(value);
+    } catch {
+      return { ok: false, error: 'This must be valid JSON.' };
+    }
+  }
+  return { ok: true };
+}

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -27,6 +27,7 @@ const ChannelsPage = lazy(() =>
   import('./pages/ChannelSettings').then(m => ({ default: m.ChannelsPage })),
 );
 const WizardPage = lazy(() => import('./pages/WizardPage'));
+const SecretCapturePage = lazy(() => import('./pages/SecretCapturePage'));
 const ContactsPage = lazy(() => import('./pages/ContactsPage'));
 const JobsPage = lazy(() => import('./pages/JobsPage'));
 const TasksPage = lazy(() => import('./pages/TasksPage'));
@@ -133,6 +134,14 @@ const loginRoute = createRoute({
   component: LoginPage,
 });
 
+// Public secret-capture form (#971). Child of rootRoute — NOT authedRoute — so it renders
+// without a session: the single-use token in the path is the only credential.
+const secretCaptureRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/secret-capture/$token',
+  component: SecretCapturePage,
+});
+
 const contactsRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: '/contacts',
@@ -194,6 +203,7 @@ const routeTree = rootRoute.addChildren([
     settingsRoute.addChildren([autonomyRoute, workspaceRoute, skillsSettingsRedirect, agentsSettingsRedirect]),
   ]),
   loginRoute,
+  secretCaptureRoute,
 ]);
 
 export const router = createRouter({ routeTree });

--- a/docs/wip/2026-06-13-secret-capture.md
+++ b/docs/wip/2026-06-13-secret-capture.md
@@ -1,0 +1,64 @@
+# Agent-initiated secret capture (one-time link to the vault) — #971
+
+## Goal
+Let Curia help a user add a **new** secret to the vault mid-conversation by minting a
+one-time, single-use, 30-minute tokenized link to a public web form. The value is entered
+by the user and written straight to the encrypted vault server-side. The secret value never
+passes through the LLM, the chat transcript, the agent context, or logs.
+
+The "LLM never sees secrets" guarantee is **structural** — the skills have no code path that
+returns a value.
+
+## Components (build order, TDD)
+
+### 1. Migration `053_create_secret_capture_tokens.sql`
+Token-metadata-only store (no secret material). Schema per issue: `token_hash` PK (SHA-256 of
+raw URL token), `secret_name`, `label`, `value_format` (`string|json`), `expires_at`,
+`consumed_at`, `created_at`. Index on `expires_at`.
+
+### 2. Core service `src/secrets/secret-capture-service.ts`
+- Pure name-policy functions (exported, unit-tested):
+  - `resolveUserSecretName(input)` → slugify to `user.<a-z0-9_>+`; reject empty/over-long.
+  - `resolveSystemSecretName(input, allowedNames)` → must be in the allowlist, else throw.
+- `SecretCaptureService` (implements `SecretCaptureMinter` for skills):
+  - `mint({ secretName, label, valueFormat, ttlMinutes })` → `{ rawToken, expiresAt }`
+    (low-level; secretName already validated). `randomBytes(32).hex`, store `hashToken(raw)`.
+  - `mintUserSecret({ rawName, ... })` / `mintSystemSecret({ rawName, ... })` → resolve name + mint.
+  - `getMetadata(rawToken)` → `{ label, valueFormat } | 'expired' | 'not_found'` (never the key).
+  - `redeem(rawToken, value)` → `'ok' | 'expired' | 'not_found' | 'invalid_json'`.
+    Atomic single-use claim via `UPDATE ... WHERE consumed_at IS NULL AND expires_at > now()`.
+    JSON validated **before** claim (so invalid input doesn't burn the token). On vault-write
+    failure: clear `consumed_at` (retry-able) and rethrow → route 500.
+- Reuses `hashToken()` from `session-auth.ts` and `SecretsService.set/setJSON`.
+- `CHANNEL_CREDENTIAL_KEYS` exported from `vault.ts` and reused for the system allowlist.
+
+### 3. HTTP routes `src/channels/http/routes/secret-capture.ts`
+Unauthenticated except for the token (the token is the capability). Rate limit 10 / 15 min / IP.
+- `GET /api/secret-capture/:token` → `{ label, value_format }` | 410 | 404.
+- `POST /api/secret-capture/:token` `{ value }` → `redeem` → `{ ok: true }` | 410 | 404 | 400.
+- Registered in `http-adapter.ts` **outside** the bearer-auth guard (add `/api/secret-capture`
+  to the `onRequest` exemption list) and before the console wildcard.
+
+### 4. Skill capability wiring
+- Add `secretCapture` to `VALID_CAPABILITIES` (loader.ts) and `SkillContext` (types.ts).
+- Inject `this.secretCaptureService` + `appOrigin` / `httpPort` into `SkillContext` (execution.ts).
+- `ExecutionLayer`: `appOrigin`/`httpPort` via constructor; `secretCaptureService` via a setter
+  (it is constructed after `registryService`, which executionLayer precedes in bootstrap).
+
+### 5. Skills
+- `secret-capture-request` — any caller; `mintUserSecret`; name auto-prefixed `user.<slug>`.
+  `sensitivity: normal`, `action_risk: low`.
+- `system-secret-capture-request` — `allowed_callers: ["setup-wizard"]`; `mintSystemSecret`;
+  literal declared/channel key. `sensitivity: normal`, `action_risk: none`.
+- Handlers build `${origin}/secret-capture/${rawToken}` (origin = `ctx.appOrigin` or dev
+  `http://localhost:${ctx.httpPort}`). Neither declares `requires_secrets`; neither can read a value.
+
+### 6. Frontend `apps/console/src/pages/SecretCapturePage.tsx` + public route `/secret-capture/$token`
+Child of `rootRoute` (no auth gate). GET metadata on mount; render value field (textarea; JSON
+validated client-side when `value_format==='json'`); POST; success/expired states.
+
+## Test matrix
+Service (mint hashes, redeem atomic/single-use, expiry, vault-fail clears consumed_at, JSON);
+name policy (user slug+prefix, rejects protected; system accepts declared/channel, rejects unknown);
+routes (GET metadata/410/404, POST writes+consumes, rate limit); skills (URL from origin,
+system blocked for non-setup-wizard, output shape); frontend (form for valid token, expired for 410).

--- a/skills/secret-capture-request/handler.test.ts
+++ b/skills/secret-capture-request/handler.test.ts
@@ -37,7 +37,7 @@ function makeCtx(input: Record<string, unknown>, overrides: Partial<SkillContext
 describe('SecretCaptureRequestHandler', () => {
   it('mints a user secret and builds the URL from appOrigin', async () => {
     const minter = fakeMinter();
-    const ctx = makeCtx({ secret_name: 'my flight password' }, { secretCapture: minter });
+    const ctx = makeCtx({ secret_name: 'my flight password' }, { secretCapture: minter, timezone: 'America/Toronto' });
     const result = await new SecretCaptureRequestHandler().execute(ctx);
 
     expect(result.success).toBe(true);
@@ -45,6 +45,9 @@ describe('SecretCaptureRequestHandler', () => {
     expect(data.capture_url).toBe('https://curia.example.com/secret-capture/abc123');
     expect(data.secret_name).toBe('user.flight');
     expect(minter.userCalls).toEqual([{ rawName: 'my flight password', label: 'my flight password', valueFormat: 'string' }]);
+    // Timestamp-metadata contract: the field is `displayTimezone` (camelCase), not snake_case.
+    expect(typeof data.displayTimezone).toBe('string');
+    expect(data).not.toHaveProperty('display_timezone');
   });
 
   it('falls back to localhost:{httpPort} when appOrigin is unset', async () => {

--- a/skills/secret-capture-request/handler.test.ts
+++ b/skills/secret-capture-request/handler.test.ts
@@ -1,0 +1,89 @@
+// handler.test.ts — secret-capture-request skill.
+
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { SecretCaptureRequestHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { SecretCaptureMinter, MintResult } from '../../src/secrets/secret-capture-service.js';
+
+function fakeMinter(over: Partial<MintResult> = {}): SecretCaptureMinter & { userCalls: unknown[]; systemCalls: unknown[] } {
+  const userCalls: unknown[] = [];
+  const systemCalls: unknown[] = [];
+  return {
+    userCalls,
+    systemCalls,
+    async mintUserSecret(args) {
+      userCalls.push(args);
+      return { rawToken: 'abc123', secretName: 'user.flight', expiresAt: new Date(Date.now() + 30 * 60_000), ...over };
+    },
+    async mintSystemSecret(args) {
+      systemCalls.push(args);
+      return { rawToken: 'abc123', secretName: 'anthropic_api_key', expiresAt: new Date(), ...over };
+    },
+  };
+}
+
+function makeCtx(input: Record<string, unknown>, overrides: Partial<SkillContext> = {}): SkillContext {
+  return {
+    input,
+    secret: () => 'unused',
+    log: pino({ level: 'silent' }),
+    secretCapture: fakeMinter(),
+    appOrigin: 'https://curia.example.com',
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+describe('SecretCaptureRequestHandler', () => {
+  it('mints a user secret and builds the URL from appOrigin', async () => {
+    const minter = fakeMinter();
+    const ctx = makeCtx({ secret_name: 'my flight password' }, { secretCapture: minter });
+    const result = await new SecretCaptureRequestHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.capture_url).toBe('https://curia.example.com/secret-capture/abc123');
+    expect(data.secret_name).toBe('user.flight');
+    expect(minter.userCalls).toEqual([{ rawName: 'my flight password', label: 'my flight password', valueFormat: 'string' }]);
+  });
+
+  it('falls back to localhost:{httpPort} when appOrigin is unset', async () => {
+    const ctx = makeCtx({ secret_name: 'x' }, { appOrigin: undefined, httpPort: 4521 });
+    const result = await new SecretCaptureRequestHandler().execute(ctx);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.capture_url).toBe('http://localhost:4521/secret-capture/abc123');
+  });
+
+  it('never returns the submitted value (mint surface has no read path)', async () => {
+    const ctx = makeCtx({ secret_name: 'x' });
+    const result = await new SecretCaptureRequestHandler().execute(ctx);
+    // The output carries only the link + metadata, never a value field.
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(Object.keys(data)).not.toContain('value');
+  });
+
+  it('rejects a missing secret_name', async () => {
+    const ctx = makeCtx({});
+    const result = await new SecretCaptureRequestHandler().execute(ctx);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid value_format', async () => {
+    const ctx = makeCtx({ secret_name: 'x', value_format: 'xml' });
+    const result = await new SecretCaptureRequestHandler().execute(ctx);
+    expect(result.success).toBe(false);
+  });
+
+  it('errors when the secretCapture capability is missing', async () => {
+    const ctx = makeCtx({ secret_name: 'x' }, { secretCapture: undefined });
+    const result = await new SecretCaptureRequestHandler().execute(ctx);
+    expect(result.success).toBe(false);
+  });
+
+  it('passes value_format through to the minter', async () => {
+    const minter = fakeMinter();
+    const ctx = makeCtx({ secret_name: 'creds', value_format: 'json' }, { secretCapture: minter });
+    await new SecretCaptureRequestHandler().execute(ctx);
+    expect(minter.userCalls).toEqual([{ rawName: 'creds', label: 'creds', valueFormat: 'json' }]);
+  });
+});

--- a/skills/secret-capture-request/handler.test.ts
+++ b/skills/secret-capture-request/handler.test.ts
@@ -57,6 +57,13 @@ describe('SecretCaptureRequestHandler', () => {
     expect(data.capture_url).toBe('http://localhost:4521/secret-capture/abc123');
   });
 
+  it('trims a trailing slash on appOrigin so the URL has no double slash', async () => {
+    const ctx = makeCtx({ secret_name: 'x' }, { appOrigin: 'https://curia.example.com/' });
+    const result = await new SecretCaptureRequestHandler().execute(ctx);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.capture_url).toBe('https://curia.example.com/secret-capture/abc123');
+  });
+
   it('never returns the submitted value (mint surface has no read path)', async () => {
     const ctx = makeCtx({ secret_name: 'x' });
     const result = await new SecretCaptureRequestHandler().execute(ctx);

--- a/skills/secret-capture-request/handler.ts
+++ b/skills/secret-capture-request/handler.ts
@@ -12,7 +12,9 @@ import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 /** Build the operator-facing magic-link URL. Prod uses ctx.appOrigin; dev falls back to the
  *  local SPA origin (Fastify serves the built console on httpPort). */
 function buildCaptureUrl(ctx: SkillContext, rawToken: string): string {
-  const origin = ctx.appOrigin ?? `http://localhost:${ctx.httpPort ?? 3000}`;
+  // Trim any trailing slash so a configured appOrigin like "https://host/" doesn't yield a
+  // "//secret-capture/..." path that breaks SPA route matching.
+  const origin = (ctx.appOrigin ?? `http://localhost:${ctx.httpPort ?? 3000}`).replace(/\/+$/, '');
   return `${origin}/secret-capture/${rawToken}`;
 }
 

--- a/skills/secret-capture-request/handler.ts
+++ b/skills/secret-capture-request/handler.ts
@@ -1,0 +1,77 @@
+// handler.ts — secret-capture-request skill (#971).
+//
+// Mints a one-time tokenized link the user clicks to enter a NEW personal secret. The name
+// is auto-namespaced to `user.<slug>` by the minter, so this skill structurally cannot target
+// a system/channel/protected key. The skill returns ONLY the link — it has no code path that
+// reads a value, which is the structural form of the "LLM never sees secrets" guarantee.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { CaptureValueFormat } from '../../src/secrets/secret-capture-service.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+
+/** Build the operator-facing magic-link URL. Prod uses ctx.appOrigin; dev falls back to the
+ *  local SPA origin (Fastify serves the built console on httpPort). */
+function buildCaptureUrl(ctx: SkillContext, rawToken: string): string {
+  const origin = ctx.appOrigin ?? `http://localhost:${ctx.httpPort ?? 3000}`;
+  return `${origin}/secret-capture/${rawToken}`;
+}
+
+/** Validate the optional value_format input, defaulting to 'string'. */
+function parseValueFormat(input: unknown): CaptureValueFormat {
+  if (input === undefined || input === null) return 'string';
+  if (input === 'string' || input === 'json') return input;
+  throw new Error(`value_format must be 'string' or 'json', got '${String(input)}'.`);
+}
+
+export class SecretCaptureRequestHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.secretCapture) {
+      return { success: false, error: 'secret-capture-request requires the secretCapture capability in context.' };
+    }
+
+    const { secret_name, label, value_format } = ctx.input as {
+      secret_name?: unknown;
+      label?: unknown;
+      value_format?: unknown;
+    };
+
+    if (typeof secret_name !== 'string' || secret_name.trim().length === 0) {
+      return { success: false, error: 'secret_name is required and must be a non-empty string.' };
+    }
+    const labelStr = typeof label === 'string' && label.trim() ? label.trim() : secret_name.trim();
+
+    let valueFormat: CaptureValueFormat;
+    try {
+      valueFormat = parseValueFormat(value_format);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    try {
+      const { rawToken, secretName, expiresAt } = await ctx.secretCapture.mintUserSecret({
+        rawName: secret_name,
+        label: labelStr,
+        valueFormat,
+      });
+      const captureUrl = buildCaptureUrl(ctx, rawToken);
+      const expiresLocal = toLocalIso(Math.floor(expiresAt.getTime() / 1000), ctx.timezone);
+
+      return {
+        success: true,
+        data: {
+          capture_url: captureUrl,
+          expires_at: expiresLocal,
+          secret_name: secretName,
+          display_timezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : undefined,
+          summary:
+            `Send this one-time link to the user so they can enter the value. It expires in 30 minutes ` +
+            `and works once. The value goes straight to the vault under "${secretName}" — you will not see it.`,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'secret-capture-request failed');
+      return { success: false, error: message };
+    }
+  }
+}

--- a/skills/secret-capture-request/handler.ts
+++ b/skills/secret-capture-request/handler.ts
@@ -44,6 +44,7 @@ export class SecretCaptureRequestHandler implements SkillHandler {
     try {
       valueFormat = parseValueFormat(value_format);
     } catch (err) {
+      ctx.log.warn({ err, value_format }, 'secret-capture-request: invalid value_format');
       return { success: false, error: err instanceof Error ? err.message : String(err) };
     }
 
@@ -62,7 +63,7 @@ export class SecretCaptureRequestHandler implements SkillHandler {
           capture_url: captureUrl,
           expires_at: expiresLocal,
           secret_name: secretName,
-          display_timezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : undefined,
+          displayTimezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : undefined,
           summary:
             `Send this one-time link to the user so they can enter the value. It expires in 30 minutes ` +
             `and works once. The value goes straight to the vault under "${secretName}" — you will not see it.`,

--- a/skills/secret-capture-request/skill.json
+++ b/skills/secret-capture-request/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "secret-capture-request",
+  "description": "Mint a one-time, single-use, 30-minute link the user can click to enter a NEW personal secret (e.g. a website password). The value is typed by the user into a secure web form and written straight to the vault under a `user.<slug>` key. You never see the value — this skill returns only the link, never the secret. Use when a task needs a secret the vault does not yet have.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "secret_name": "string (human description of the secret, e.g. 'my flight site password'; auto-namespaced to user.<slug>)",
+    "label": "string? (text shown to the user on the form; defaults to the secret_name)",
+    "value_format": "string? ('string' (default) or 'json')"
+  },
+  "outputs": {
+    "capture_url": "string (the one-time link to send the user)",
+    "expires_at": "string (local ISO timestamp when the link expires)",
+    "secret_name": "string (the resolved user.<slug> vault key the value will be stored under)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["secretCapture"]
+}

--- a/skills/system-secret-capture-request/handler.test.ts
+++ b/skills/system-secret-capture-request/handler.test.ts
@@ -1,0 +1,82 @@
+// handler.test.ts — system-secret-capture-request skill.
+//
+// allowed_callers enforcement (setup-wizard only) is the execution layer's job and is covered
+// generically in src/skills/execution.test.ts; the manifest declaration is what wires it. These
+// tests cover the handler's own behavior: it mints via the SYSTEM name policy and surfaces a
+// rejected (non-declared/non-channel) name as an error.
+
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { SystemSecretCaptureRequestHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { SecretCaptureMinter, MintResult } from '../../src/secrets/secret-capture-service.js';
+
+function fakeMinter(opts: { reject?: boolean; result?: Partial<MintResult> } = {}): SecretCaptureMinter & { systemCalls: unknown[] } {
+  const systemCalls: unknown[] = [];
+  return {
+    systemCalls,
+    async mintUserSecret() {
+      throw new Error('user policy must not be used by the system skill');
+    },
+    async mintSystemSecret(args) {
+      systemCalls.push(args);
+      if (opts.reject) throw new Error("'made_up' is not a declared skill secret nor a known channel credential key");
+      return { rawToken: 'tok', secretName: 'anthropic_api_key', expiresAt: new Date(Date.now() + 30 * 60_000), ...opts.result };
+    },
+  };
+}
+
+function makeCtx(input: Record<string, unknown>, minter: SecretCaptureMinter | undefined = fakeMinter()): SkillContext {
+  return {
+    input,
+    secret: () => 'unused',
+    log: pino({ level: 'silent' }),
+    secretCapture: minter,
+    appOrigin: 'https://curia.example.com',
+  } as unknown as SkillContext;
+}
+
+describe('SystemSecretCaptureRequestHandler', () => {
+  it('mints via the system name policy and returns the link', async () => {
+    const minter = fakeMinter();
+    const ctx = makeCtx({ secret_name: 'anthropic_api_key' }, minter);
+    const result = await new SystemSecretCaptureRequestHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.capture_url).toBe('https://curia.example.com/secret-capture/tok');
+    expect(data.secret_name).toBe('anthropic_api_key');
+    expect(minter.systemCalls).toEqual([{ rawName: 'anthropic_api_key', label: 'anthropic_api_key', valueFormat: 'string' }]);
+  });
+
+  it('uses mintSystemSecret, never mintUserSecret', async () => {
+    // The fake's mintUserSecret throws — a passing test proves the system path was taken.
+    const ctx = makeCtx({ secret_name: 'anthropic_api_key' });
+    const result = await new SystemSecretCaptureRequestHandler().execute(ctx);
+    expect(result.success).toBe(true);
+  });
+
+  it('surfaces a rejected (unknown) name as a skill error', async () => {
+    const ctx = makeCtx({ secret_name: 'made_up' }, fakeMinter({ reject: true }));
+    const result = await new SystemSecretCaptureRequestHandler().execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/not a declared/);
+  });
+
+  it('rejects a missing secret_name', async () => {
+    const ctx = makeCtx({});
+    const result = await new SystemSecretCaptureRequestHandler().execute(ctx);
+    expect(result.success).toBe(false);
+  });
+
+  it('errors when the secretCapture capability is missing', async () => {
+    const ctx = {
+      input: { secret_name: 'anthropic_api_key' },
+      secret: () => 'unused',
+      log: pino({ level: 'silent' }),
+      secretCapture: undefined,
+    } as unknown as SkillContext;
+    const result = await new SystemSecretCaptureRequestHandler().execute(ctx);
+    expect(result.success).toBe(false);
+  });
+});

--- a/skills/system-secret-capture-request/handler.test.ts
+++ b/skills/system-secret-capture-request/handler.test.ts
@@ -69,6 +69,26 @@ describe('SystemSecretCaptureRequestHandler', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects an invalid value_format', async () => {
+    const ctx = makeCtx({ secret_name: 'anthropic_api_key', value_format: 'xml' });
+    const result = await new SystemSecretCaptureRequestHandler().execute(ctx);
+    expect(result.success).toBe(false);
+  });
+
+  it('falls back to localhost:{httpPort} when appOrigin is unset', async () => {
+    const ctx = {
+      input: { secret_name: 'anthropic_api_key' },
+      secret: () => 'unused',
+      log: pino({ level: 'silent' }),
+      secretCapture: fakeMinter({ result: { rawToken: 'tok' } }),
+      appOrigin: undefined,
+      httpPort: 4521,
+    } as unknown as SkillContext;
+    const result = await new SystemSecretCaptureRequestHandler().execute(ctx);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.capture_url).toBe('http://localhost:4521/secret-capture/tok');
+  });
+
   it('errors when the secretCapture capability is missing', async () => {
     const ctx = {
       input: { secret_name: 'anthropic_api_key' },

--- a/skills/system-secret-capture-request/handler.ts
+++ b/skills/system-secret-capture-request/handler.ts
@@ -1,0 +1,81 @@
+// handler.ts — system-secret-capture-request skill (#971).
+//
+// Sibling of secret-capture-request, differing only in name policy and access control:
+//   - Name policy: the target must be a DECLARED skill secret or a known channel credential
+//     key (the same allowlist the vault PUT route enforces), used verbatim as the vault key.
+//   - Access: allowed_callers ["setup-wizard"] — runnable only during onboarding, which is
+//     principal-originated. The execution layer enforces this; it is not a prompt convention.
+// Like its sibling, it returns ONLY the link and has no code path that reads a value.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { CaptureValueFormat } from '../../src/secrets/secret-capture-service.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+
+/** Build the operator-facing magic-link URL. Prod uses ctx.appOrigin; dev falls back to the
+ *  local SPA origin (Fastify serves the built console on httpPort). */
+function buildCaptureUrl(ctx: SkillContext, rawToken: string): string {
+  const origin = ctx.appOrigin ?? `http://localhost:${ctx.httpPort ?? 3000}`;
+  return `${origin}/secret-capture/${rawToken}`;
+}
+
+/** Validate the optional value_format input, defaulting to 'string'. */
+function parseValueFormat(input: unknown): CaptureValueFormat {
+  if (input === undefined || input === null) return 'string';
+  if (input === 'string' || input === 'json') return input;
+  throw new Error(`value_format must be 'string' or 'json', got '${String(input)}'.`);
+}
+
+export class SystemSecretCaptureRequestHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.secretCapture) {
+      return { success: false, error: 'system-secret-capture-request requires the secretCapture capability in context.' };
+    }
+
+    const { secret_name, label, value_format } = ctx.input as {
+      secret_name?: unknown;
+      label?: unknown;
+      value_format?: unknown;
+    };
+
+    if (typeof secret_name !== 'string' || secret_name.trim().length === 0) {
+      return { success: false, error: 'secret_name is required and must be a non-empty string.' };
+    }
+    const labelStr = typeof label === 'string' && label.trim() ? label.trim() : secret_name.trim();
+
+    let valueFormat: CaptureValueFormat;
+    try {
+      valueFormat = parseValueFormat(value_format);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    try {
+      const { rawToken, secretName, expiresAt } = await ctx.secretCapture.mintSystemSecret({
+        rawName: secret_name,
+        label: labelStr,
+        valueFormat,
+      });
+      const captureUrl = buildCaptureUrl(ctx, rawToken);
+      const expiresLocal = toLocalIso(Math.floor(expiresAt.getTime() / 1000), ctx.timezone);
+
+      return {
+        success: true,
+        data: {
+          capture_url: captureUrl,
+          expires_at: expiresLocal,
+          secret_name: secretName,
+          display_timezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : undefined,
+          summary:
+            `Send this one-time link to the user so they can enter the value for "${secretName}". ` +
+            `It expires in 30 minutes and works once. The value goes straight to the vault — you will not see it.`,
+        },
+      };
+    } catch (err) {
+      // A rejected name (not a declared/channel key) lands here — surface it so the agent can
+      // correct the target rather than silently failing.
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'system-secret-capture-request failed');
+      return { success: false, error: message };
+    }
+  }
+}

--- a/skills/system-secret-capture-request/handler.ts
+++ b/skills/system-secret-capture-request/handler.ts
@@ -46,6 +46,7 @@ export class SystemSecretCaptureRequestHandler implements SkillHandler {
     try {
       valueFormat = parseValueFormat(value_format);
     } catch (err) {
+      ctx.log.warn({ err, value_format }, 'system-secret-capture-request: invalid value_format');
       return { success: false, error: err instanceof Error ? err.message : String(err) };
     }
 
@@ -64,7 +65,7 @@ export class SystemSecretCaptureRequestHandler implements SkillHandler {
           capture_url: captureUrl,
           expires_at: expiresLocal,
           secret_name: secretName,
-          display_timezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : undefined,
+          displayTimezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : undefined,
           summary:
             `Send this one-time link to the user so they can enter the value for "${secretName}". ` +
             `It expires in 30 minutes and works once. The value goes straight to the vault — you will not see it.`,

--- a/skills/system-secret-capture-request/handler.ts
+++ b/skills/system-secret-capture-request/handler.ts
@@ -14,7 +14,9 @@ import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 /** Build the operator-facing magic-link URL. Prod uses ctx.appOrigin; dev falls back to the
  *  local SPA origin (Fastify serves the built console on httpPort). */
 function buildCaptureUrl(ctx: SkillContext, rawToken: string): string {
-  const origin = ctx.appOrigin ?? `http://localhost:${ctx.httpPort ?? 3000}`;
+  // Trim any trailing slash so a configured appOrigin like "https://host/" doesn't yield a
+  // "//secret-capture/..." path that breaks SPA route matching.
+  const origin = (ctx.appOrigin ?? `http://localhost:${ctx.httpPort ?? 3000}`).replace(/\/+$/, '');
   return `${origin}/secret-capture/${rawToken}`;
 }
 

--- a/skills/system-secret-capture-request/skill.json
+++ b/skills/system-secret-capture-request/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "system-secret-capture-request",
+  "description": "Mint a one-time, single-use, 30-minute link for the user to enter a SYSTEM secret during setup — an API key or channel credential (e.g. the Anthropic API key). The target name must be a secret declared by a skill or a known channel credential key. The value goes straight to the vault; you never see it. Setup-wizard only.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "secret_name": "string (the EXACT vault key to capture, e.g. 'anthropic_api_key' or 'channel.email.nylas_api_key')",
+    "label": "string? (text shown to the user on the form; defaults to the secret_name)",
+    "value_format": "string? ('string' (default) or 'json')"
+  },
+  "outputs": {
+    "capture_url": "string (the one-time link to send the user)",
+    "expires_at": "string (local ISO timestamp when the link expires)",
+    "secret_name": "string (the vault key the value will be stored under)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["secretCapture"],
+  "allowed_callers": ["setup-wizard"]
+}

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -241,6 +241,16 @@ export class HttpAdapter implements Channel {
           logger.error({ err }, 'Session prune DELETE failed — Postgres session storage may be unavailable');
         })
         .finally(() => { isPruning = false; });
+      // Prune expired secret-capture tokens on the same tick (#971). These rows hold only a
+      // hash + metadata (no secret value), but expired tokens accumulate unbounded without a
+      // sweep. Best-effort and independent of the session prune's in-flight guard — a slow
+      // delete here only delays this table's cleanup, never the session one.
+      if (this.config.secretCaptureService) {
+        pool.query('DELETE FROM secret_capture_tokens WHERE expires_at < NOW()')
+          .catch((err: unknown) => {
+            logger.error({ err }, 'Secret-capture token prune DELETE failed');
+          });
+      }
     }, 60_000);
     pruneInterval.unref();
 

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -38,6 +38,7 @@ import { autonomyRoutes } from './routes/autonomy.js';
 import { registryRoutes } from './routes/registry.js';
 import { channelRegistryRoutes } from './routes/channel-registry.js';
 import { vaultRoutes } from './routes/vault.js';
+import { secretCaptureRoutes } from './routes/secret-capture.js';
 import { setupRoutes } from './routes/setup.js';
 import type { OfficeIdentityService } from '../../identity/service.js';
 import type { ExecutiveProfileService } from '../../executive/service.js';
@@ -69,6 +70,9 @@ export interface HttpAdapterConfig {
   /** Backs the /api/vault/* routes (secrets status + skill-secret entry). Mounted only
    *  alongside registryService, which scopes which secret names may be written. */
   secretsService?: import('../../secrets/secrets-service.js').SecretsService;
+  /** Backs the public /api/secret-capture/* routes (one-time tokenized secret capture, #971).
+   *  Token-authed, so mounted independently of the bootstrap secret. */
+  secretCaptureService?: import('../../secrets/secret-capture-service.js').SecretCaptureService;
   /**
    * True when the process booted without a principal contact and is running in
    * setup-required mode (email + Signal adapters are skipped until restart).
@@ -174,6 +178,9 @@ export class HttpAdapter implements Channel {
         routeUrl.startsWith('/api/autonomy') ||
         routeUrl.startsWith('/api/registry') ||
         routeUrl.startsWith('/api/vault') ||
+        // Secret-capture routes are token-authed (the single-use token in the URL is the
+        // capability), so they bypass bearer auth and self-authorize via the token (#971).
+        routeUrl.startsWith('/api/secret-capture') ||
         routeUrl.startsWith('/api/setup')
       ) return;
 
@@ -364,6 +371,16 @@ export class HttpAdapter implements Channel {
         eventRouter: this.eventRouter,
         contactService: this.config.contactService,
         sessions,
+      });
+    }
+
+    // Secret-capture routes (#971) — public, token-authed form for agent-initiated secret
+    // capture. Independent of the bootstrap secret: the single-use token IS the credential,
+    // and the routes are exempted from bearer auth in the onRequest hook above. Registered
+    // before the console wildcard so /api/secret-capture/* resolves to the API, not the SPA.
+    if (this.config.secretCaptureService) {
+      await this.app.register(secretCaptureRoutes, {
+        secretCaptureService: this.config.secretCaptureService,
       });
     }
 

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -243,8 +243,10 @@ export class HttpAdapter implements Channel {
         .finally(() => { isPruning = false; });
       // Prune expired secret-capture tokens on the same tick (#971). These rows hold only a
       // hash + metadata (no secret value), but expired tokens accumulate unbounded without a
-      // sweep. Best-effort and independent of the session prune's in-flight guard — a slow
-      // delete here only delays this table's cleanup, never the session one.
+      // sweep. Best-effort: it shares the session prune's `isPruning` early-return above (so a
+      // long-running session DELETE also defers this sweep a tick), but it doesn't touch
+      // `isPruning` itself, so a slow delete here never blocks the session prune. A delayed
+      // sweep of this low-volume, value-free table is harmless.
       if (this.config.secretCaptureService) {
         pool.query('DELETE FROM secret_capture_tokens WHERE expires_at < NOW()')
           .catch((err: unknown) => {

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -229,11 +229,29 @@ export class HttpAdapter implements Channel {
     // interval tick would launch a second concurrent DELETE against the same pool, eventually
     // exhausting connections. Skip the DB prune for this tick if one is already running.
     let isPruning = false;
+    // Separate in-flight guard for the secret-capture token sweep (#971). Without it, a
+    // DELETE that stalls (e.g. on a table lock) would let every 60s tick enqueue another
+    // query against the same pool, piling up work and exhausting connections — the same
+    // overlap the sessions guard prevents for its own DELETE.
+    let isPruningCaptureTokens = false;
     const pruneInterval = setInterval(() => {
       const now = Date.now();
       for (const [tokenHash, expiresAt] of sessions) {
         if (now > expiresAt) sessions.delete(tokenHash);
       }
+
+      // Prune expired secret-capture tokens. These rows hold only a hash + metadata (no secret
+      // value), but expired tokens accumulate unbounded without a sweep. Guarded independently
+      // of the session prune so neither can block or skip the other.
+      if (this.config.secretCaptureService && !isPruningCaptureTokens) {
+        isPruningCaptureTokens = true;
+        pool.query('DELETE FROM secret_capture_tokens WHERE expires_at < NOW()')
+          .catch((err: unknown) => {
+            logger.error({ err }, 'Secret-capture token prune DELETE failed');
+          })
+          .finally(() => { isPruningCaptureTokens = false; });
+      }
+
       if (isPruning) return;
       isPruning = true;
       pool.query('DELETE FROM sessions WHERE expires_at < NOW()')
@@ -241,18 +259,6 @@ export class HttpAdapter implements Channel {
           logger.error({ err }, 'Session prune DELETE failed — Postgres session storage may be unavailable');
         })
         .finally(() => { isPruning = false; });
-      // Prune expired secret-capture tokens on the same tick (#971). These rows hold only a
-      // hash + metadata (no secret value), but expired tokens accumulate unbounded without a
-      // sweep. Best-effort: it shares the session prune's `isPruning` early-return above (so a
-      // long-running session DELETE also defers this sweep a tick), but it doesn't touch
-      // `isPruning` itself, so a slow delete here never blocks the session prune. A delayed
-      // sweep of this low-volume, value-free table is harmless.
-      if (this.config.secretCaptureService) {
-        pool.query('DELETE FROM secret_capture_tokens WHERE expires_at < NOW()')
-          .catch((err: unknown) => {
-            logger.error({ err }, 'Secret-capture token prune DELETE failed');
-          });
-      }
     }, 60_000);
     pruneInterval.unref();
 
@@ -393,6 +399,7 @@ export class HttpAdapter implements Channel {
     if (this.config.secretCaptureService) {
       await this.app.register(secretCaptureRoutes, {
         secretCaptureService: this.config.secretCaptureService,
+        logger,
       });
     }
 

--- a/src/channels/http/routes/secret-capture.test.ts
+++ b/src/channels/http/routes/secret-capture.test.ts
@@ -1,0 +1,139 @@
+// secret-capture.test.ts — exercises the public secret-capture HTTP routes against a fake
+// service. These routes are token-only (no bootstrap secret / session), so there is no auth
+// header to set — the token in the URL is the sole credential.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import rateLimit from '@fastify/rate-limit';
+import { secretCaptureRoutes, type SecretCapturePort } from './secret-capture.js';
+import type { CaptureMetadata, RedeemResult } from '../../../secrets/secret-capture-service.js';
+
+/** A scripted fake: returns the configured metadata/redeem outcome and records redeem calls. */
+function fakeService(opts: {
+  metadata?: CaptureMetadata;
+  redeem?: RedeemResult | (() => Promise<RedeemResult>);
+}): SecretCapturePort & { redeemCalls: Array<{ token: string; value: string }> } {
+  const redeemCalls: Array<{ token: string; value: string }> = [];
+  return {
+    redeemCalls,
+    async getMetadata() {
+      return opts.metadata ?? 'not_found';
+    },
+    async redeem(token: string, value: string) {
+      redeemCalls.push({ token, value });
+      if (typeof opts.redeem === 'function') return opts.redeem();
+      return opts.redeem ?? 'ok';
+    },
+  };
+}
+
+async function build(service: SecretCapturePort, withRateLimit = false): Promise<FastifyInstance> {
+  const app = Fastify();
+  if (withRateLimit) await app.register(rateLimit, { max: 1000, timeWindow: '1 minute' });
+  await app.register(secretCaptureRoutes, { secretCaptureService: service });
+  return app;
+}
+
+describe('secret-capture routes', () => {
+  let app: FastifyInstance;
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  describe('GET /api/secret-capture/:token', () => {
+    it('returns label + value_format for a live token', async () => {
+      app = await build(fakeService({ metadata: { label: 'Flight password', valueFormat: 'string' } }));
+      const res = await app.inject({ method: 'GET', url: '/api/secret-capture/abc' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ label: 'Flight password', value_format: 'string' });
+    });
+
+    it('returns 410 for an expired/consumed token', async () => {
+      app = await build(fakeService({ metadata: 'expired' }));
+      const res = await app.inject({ method: 'GET', url: '/api/secret-capture/abc' });
+      expect(res.statusCode).toBe(410);
+    });
+
+    it('returns 404 for an unknown token', async () => {
+      app = await build(fakeService({ metadata: 'not_found' }));
+      const res = await app.inject({ method: 'GET', url: '/api/secret-capture/abc' });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('never includes the vault key in the response', async () => {
+      app = await build(fakeService({ metadata: { label: 'x', valueFormat: 'string' } }));
+      const res = await app.inject({ method: 'GET', url: '/api/secret-capture/abc' });
+      expect(res.body).not.toContain('secret_name');
+      expect(res.body).not.toContain('user.');
+    });
+  });
+
+  describe('POST /api/secret-capture/:token', () => {
+    it('redeems a value and returns { ok: true }', async () => {
+      const svc = fakeService({ redeem: 'ok' });
+      app = await build(svc);
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'hunter2' } });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true });
+      expect(svc.redeemCalls).toEqual([{ token: 'tok', value: 'hunter2' }]);
+    });
+
+    it('rejects a missing/empty value with 400 (and never calls redeem)', async () => {
+      const svc = fakeService({ redeem: 'ok' });
+      app = await build(svc);
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: '' } });
+      expect(res.statusCode).toBe(400);
+      expect(svc.redeemCalls).toHaveLength(0);
+    });
+
+    it('rejects an oversized value with 400', async () => {
+      app = await build(fakeService({ redeem: 'ok' }));
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'x'.repeat(9000) } });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('maps expired → 410', async () => {
+      app = await build(fakeService({ redeem: 'expired' }));
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
+      expect(res.statusCode).toBe(410);
+    });
+
+    it('maps not_found → 404', async () => {
+      app = await build(fakeService({ redeem: 'not_found' }));
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('maps invalid_json → 400', async () => {
+      app = await build(fakeService({ redeem: 'invalid_json' }));
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'not json' } });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('maps a vault-write throw → 500', async () => {
+      app = await build(fakeService({ redeem: () => Promise.reject(new Error('vault down')) }));
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
+      expect(res.statusCode).toBe(500);
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('enforces a per-route cap when @fastify/rate-limit is registered', async () => {
+      // Register the route with a real (tiny) limit to prove the config is wired.
+      const app2 = Fastify();
+      await app2.register(rateLimit, { global: false });
+      await app2.register(secretCaptureRoutes, { secretCaptureService: fakeService({ metadata: 'not_found' }) });
+      try {
+        let last = 0;
+        // The route declares max 10 / 15 min. The 11th request in the window should 429.
+        for (let i = 0; i < 12; i++) {
+          const r = await app2.inject({ method: 'GET', url: '/api/secret-capture/abc' });
+          last = r.statusCode;
+        }
+        expect(last).toBe(429);
+      } finally {
+        await app2.close();
+      }
+    });
+  });
+});

--- a/src/channels/http/routes/secret-capture.test.ts
+++ b/src/channels/http/routes/secret-capture.test.ts
@@ -7,6 +7,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 import { secretCaptureRoutes, type SecretCapturePort } from './secret-capture.js';
 import type { CaptureMetadata, RedeemResult } from '../../../secrets/secret-capture-service.js';
+import { createSilentLogger } from '../../../logger.js';
 
 /** A scripted fake: returns the configured metadata/redeem outcome and records redeem calls. */
 function fakeService(opts: {
@@ -30,7 +31,7 @@ function fakeService(opts: {
 async function build(service: SecretCapturePort, withRateLimit = false): Promise<FastifyInstance> {
   const app = Fastify();
   if (withRateLimit) await app.register(rateLimit, { max: 1000, timeWindow: '1 minute' });
-  await app.register(secretCaptureRoutes, { secretCaptureService: service });
+  await app.register(secretCaptureRoutes, { secretCaptureService: service, logger: createSilentLogger() });
   return app;
 }
 
@@ -122,7 +123,7 @@ describe('secret-capture routes', () => {
       // Register the route with a real (tiny) limit to prove the config is wired.
       const app2 = Fastify();
       await app2.register(rateLimit, { global: false });
-      await app2.register(secretCaptureRoutes, { secretCaptureService: fakeService({ metadata: 'not_found' }) });
+      await app2.register(secretCaptureRoutes, { secretCaptureService: fakeService({ metadata: 'not_found' }), logger: createSilentLogger() });
       try {
         let last = 0;
         // The route declares max 10 / 15 min. The 11th request in the window should 429.

--- a/src/channels/http/routes/secret-capture.ts
+++ b/src/channels/http/routes/secret-capture.ts
@@ -1,0 +1,96 @@
+// secret-capture.ts — public HTTP routes for the one-time secret-capture form (#971).
+//
+// UNAUTHENTICATED except for the token: the single-use, 30-minute token in the URL IS the
+// capability. These routes are registered OUTSIDE the bearer-auth guard (see http-adapter's
+// onRequest exemption list) and self-authorize purely by redeeming the token. There is no
+// read path — the form can only WRITE a value into the vault, never reveal one.
+//
+//   GET  /api/secret-capture/:token  — form metadata { label, value_format } | 410 | 404
+//   POST /api/secret-capture/:token  — submit { value } → write to vault | 410 | 404 | 400
+//
+// 410 Gone (not 404) for expired/consumed tokens deliberately does not distinguish "never
+// existed" from "already used" beyond what the user needs: a 404 means the token was never
+// valid, a 410 means it was valid but is now spent. Neither reveals whether the target vault
+// key already exists.
+
+import type { FastifyInstance } from 'fastify';
+import type { CaptureMetadata, RedeemResult } from '../../../secrets/secret-capture-service.js';
+
+/** The narrow service surface these routes need: read metadata, redeem a value. No mint. */
+export interface SecretCapturePort {
+  getMetadata(rawToken: string): Promise<CaptureMetadata>;
+  redeem(rawToken: string, value: string): Promise<RedeemResult>;
+}
+
+export interface SecretCaptureRouteOptions {
+  secretCaptureService: SecretCapturePort;
+}
+
+/** Generous ceiling for a captured value (API keys, passwords, small JSON credential sets).
+ *  Matches the vault PUT route's cap so neither surface accepts an oversized blob. */
+const MAX_CAPTURE_VALUE_LENGTH = 8192;
+
+export async function secretCaptureRoutes(
+  app: FastifyInstance,
+  options: SecretCaptureRouteOptions,
+): Promise<void> {
+  const { secretCaptureService } = options;
+
+  // Tight per-route rate limit — the token is unauthenticated, so cap brute-force/abuse
+  // per IP the same way POST /auth does. No-op if @fastify/rate-limit isn't registered.
+  const CAPTURE_RATE = { config: { rateLimit: { max: 10, timeWindow: '15 minutes' } } };
+
+  // -- GET metadata for the form --
+  app.get('/api/secret-capture/:token', CAPTURE_RATE, async (request, reply) => {
+    const { token } = request.params as { token: string };
+    try {
+      const meta = await secretCaptureService.getMetadata(token);
+      if (meta === 'not_found') {
+        return reply.status(404).send({ error: 'This capture link is not valid.' });
+      }
+      if (meta === 'expired') {
+        return reply.status(410).send({ error: 'This capture link has expired or already been used.' });
+      }
+      return reply.send({ label: meta.label, value_format: meta.valueFormat });
+    } catch (err) {
+      // Never log the token — only that the lookup failed.
+      request.log.error({ err }, 'GET /api/secret-capture failed');
+      return reply.status(500).send({ error: 'Failed to load the capture form. Check server logs.' });
+    }
+  });
+
+  // -- POST the submitted value --
+  app.post('/api/secret-capture/:token', CAPTURE_RATE, async (request, reply) => {
+    const { token } = request.params as { token: string };
+    const body = request.body as { value?: unknown } | undefined;
+    const value = body?.value;
+
+    // Value must be a non-empty string within the size cap. Validated here so the service
+    // only ever sees a sane value (and so an empty submission can't consume the token).
+    if (typeof value !== 'string' || value.length === 0) {
+      return reply.status(400).send({ error: 'Body must include a non-empty string "value".' });
+    }
+    if (value.length > MAX_CAPTURE_VALUE_LENGTH) {
+      return reply.status(400).send({ error: `Value exceeds ${MAX_CAPTURE_VALUE_LENGTH} characters.` });
+    }
+
+    try {
+      const result = await secretCaptureService.redeem(token, value);
+      switch (result) {
+        case 'ok':
+          return reply.send({ ok: true });
+        case 'not_found':
+          return reply.status(404).send({ error: 'This capture link is not valid.' });
+        case 'expired':
+          return reply.status(410).send({ error: 'This capture link has expired or already been used.' });
+        case 'invalid_json':
+          return reply.status(400).send({ error: 'Value must be valid JSON for this link.' });
+      }
+    } catch (err) {
+      // A vault-write failure rolls the token back to unconsumed inside redeem() — the user
+      // can retry. Never log the submitted value, only the failure.
+      request.log.error({ err }, 'POST /api/secret-capture redeem failed');
+      return reply.status(500).send({ error: 'Failed to save the value. Check server logs.' });
+    }
+  });
+}

--- a/src/channels/http/routes/secret-capture.ts
+++ b/src/channels/http/routes/secret-capture.ts
@@ -53,9 +53,10 @@ export async function secretCaptureRoutes(
       }
       return reply.send({ label: meta.label, value_format: meta.valueFormat });
     } catch (err) {
-      // Never log the token — only that the lookup failed.
+      // Never log the token — only that the lookup failed. The error body is end-user-facing
+      // (an anonymous form visitor), so it stays generic and actionable to them, not an operator.
       request.log.error({ err }, 'GET /api/secret-capture failed');
-      return reply.status(500).send({ error: 'Failed to load the capture form. Check server logs.' });
+      return reply.status(500).send({ error: 'Something went wrong loading this form. Please try the link again.' });
     }
   });
 
@@ -88,9 +89,9 @@ export async function secretCaptureRoutes(
       }
     } catch (err) {
       // A vault-write failure rolls the token back to unconsumed inside redeem() — the user
-      // can retry. Never log the submitted value, only the failure.
+      // can retry. Never log the submitted value, only the failure. End-user-facing copy.
       request.log.error({ err }, 'POST /api/secret-capture redeem failed');
-      return reply.status(500).send({ error: 'Failed to save the value. Check server logs.' });
+      return reply.status(500).send({ error: 'Something went wrong saving the value. Please try again.' });
     }
   });
 }

--- a/src/channels/http/routes/secret-capture.ts
+++ b/src/channels/http/routes/secret-capture.ts
@@ -14,6 +14,7 @@
 // key already exists.
 
 import type { FastifyInstance } from 'fastify';
+import type { Logger } from '../../../logger.js';
 import type { CaptureMetadata, RedeemResult } from '../../../secrets/secret-capture-service.js';
 
 /** The narrow service surface these routes need: read metadata, redeem a value. No mint. */
@@ -24,6 +25,10 @@ export interface SecretCapturePort {
 
 export interface SecretCaptureRouteOptions {
   secretCaptureService: SecretCapturePort;
+  /** The real pino logger. The Fastify instance is created with `logger: false`, so
+   *  `request.log` is a no-op — we log through this injected logger instead so failures on
+   *  these security-sensitive endpoints are actually recorded. */
+  logger: Logger;
 }
 
 /** Generous ceiling for a captured value (API keys, passwords, small JSON credential sets).
@@ -34,7 +39,7 @@ export async function secretCaptureRoutes(
   app: FastifyInstance,
   options: SecretCaptureRouteOptions,
 ): Promise<void> {
-  const { secretCaptureService } = options;
+  const { secretCaptureService, logger } = options;
 
   // Tight per-route rate limit — the token is unauthenticated, so cap brute-force/abuse
   // per IP the same way POST /auth does. No-op if @fastify/rate-limit isn't registered.
@@ -55,7 +60,7 @@ export async function secretCaptureRoutes(
     } catch (err) {
       // Never log the token — only that the lookup failed. The error body is end-user-facing
       // (an anonymous form visitor), so it stays generic and actionable to them, not an operator.
-      request.log.error({ err }, 'GET /api/secret-capture failed');
+      logger.error({ err }, 'GET /api/secret-capture failed');
       return reply.status(500).send({ error: 'Something went wrong loading this form. Please try the link again.' });
     }
   });
@@ -90,7 +95,7 @@ export async function secretCaptureRoutes(
     } catch (err) {
       // A vault-write failure rolls the token back to unconsumed inside redeem() — the user
       // can retry. Never log the submitted value, only the failure. End-user-facing copy.
-      request.log.error({ err }, 'POST /api/secret-capture redeem failed');
+      logger.error({ err }, 'POST /api/secret-capture redeem failed');
       return reply.status(500).send({ error: 'Something went wrong saving the value. Please try again.' });
     }
   });

--- a/src/channels/http/routes/vault.ts
+++ b/src/channels/http/routes/vault.ts
@@ -19,13 +19,22 @@ import { CHANNEL_CATALOG } from '../../catalog.js';
 // (channel, field) pairs the catalog declares are writable here. This mirrors the
 // skill-declared-secret scope guard: the channel console can configure known credentials,
 // but no arbitrary `channel.*` name may be written (e.g. `channel.email.bogus` is rejected).
-// Exported so the secret-capture system-name allowlist (#971) reuses the exact same set of
-// writable channel credential keys, rather than re-deriving it from the catalog independently.
-export const CHANNEL_CREDENTIAL_KEYS: ReadonlySet<string> = new Set(
+// Private backing set — never exported directly. A `ReadonlySet` type annotation only guards
+// at compile time; exporting the live object would let any importer `.add()` to the exact set
+// these routes (and the #971 system-capture allowlist) trust. Consumers get a fresh copy via
+// channelCredentialKeys() instead, so the writable allow-list can't be widened at runtime.
+const CHANNEL_CREDENTIAL_KEYS: ReadonlySet<string> = new Set(
   CHANNEL_CATALOG.flatMap(descriptor =>
     descriptor.credentialFields.map(field => `channel.${descriptor.name}.${field.key}`),
   ),
 );
+
+/** A fresh copy of the writable channel-credential key set, derived once from the catalog.
+ *  Returns a new Set each call so callers can spread/iterate it without being able to mutate
+ *  the canonical backing set. Reused by the secret-capture system-name allowlist (#971). */
+export function channelCredentialKeys(): ReadonlySet<string> {
+  return new Set(CHANNEL_CREDENTIAL_KEYS);
+}
 
 /** True iff `name` is a valid channel credential key declared by the catalog. */
 function isChannelCredentialKey(name: string): boolean {

--- a/src/channels/http/routes/vault.ts
+++ b/src/channels/http/routes/vault.ts
@@ -19,7 +19,9 @@ import { CHANNEL_CATALOG } from '../../catalog.js';
 // (channel, field) pairs the catalog declares are writable here. This mirrors the
 // skill-declared-secret scope guard: the channel console can configure known credentials,
 // but no arbitrary `channel.*` name may be written (e.g. `channel.email.bogus` is rejected).
-const CHANNEL_CREDENTIAL_KEYS: ReadonlySet<string> = new Set(
+// Exported so the secret-capture system-name allowlist (#971) reuses the exact same set of
+// writable channel credential keys, rather than re-deriving it from the catalog independently.
+export const CHANNEL_CREDENTIAL_KEYS: ReadonlySet<string> = new Set(
   CHANNEL_CATALOG.flatMap(descriptor =>
     descriptor.credentialFields.map(field => `channel.${descriptor.name}.${field.key}`),
   ),

--- a/src/db/migrations/053_create_secret_capture_tokens.sql
+++ b/src/db/migrations/053_create_secret_capture_tokens.sql
@@ -1,0 +1,23 @@
+-- Up Migration
+-- One-time, single-use, time-boxed tokens that back agent-initiated secret capture (#971).
+-- Holds NO secret material — only token metadata. The raw URL token exists only in the
+-- magic link; we persist its SHA-256 hash (token_hash) so a DB read can never reconstruct
+-- the capability. The secret VALUE never lands here at all — on redemption it is written
+-- straight into the encrypted `secrets` vault and the token row is simply marked consumed.
+
+CREATE TABLE secret_capture_tokens (
+  token_hash   TEXT PRIMARY KEY,          -- SHA-256 of the raw URL token (raw token only ever in the URL)
+  secret_name  TEXT NOT NULL,             -- resolved vault key, fixed & validated at mint time
+  label        TEXT,                      -- human-friendly text shown on the form
+  value_format TEXT NOT NULL DEFAULT 'string' CHECK (value_format IN ('string', 'json')),
+  expires_at   TIMESTAMPTZ NOT NULL,
+  consumed_at  TIMESTAMPTZ,               -- set on first successful submission (single-use)
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Supports the periodic prune of expired tokens (same pattern as sessions).
+CREATE INDEX idx_sct_expires ON secret_capture_tokens (expires_at);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS secret_capture_tokens;

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,8 @@ import { OfficeIdentityService } from './identity/service.js';
 import { ExecutiveProfileService } from './executive/service.js';
 import { loadEncryptionKey } from './secrets/crypto.js';
 import { SecretsService } from './secrets/secrets-service.js';
+import { SecretCaptureService } from './secrets/secret-capture-service.js';
+import { CHANNEL_CREDENTIAL_KEYS } from './channels/http/routes/vault.js';
 import { applyVaultSecrets } from './secrets/apply-vault-secrets.js';
 import { SensitivityClassifier } from './memory/sensitivity.js';
 import { DreamEngine } from './memory/dream-engine.js';
@@ -1506,7 +1508,7 @@ async function main(): Promise<void> {
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
   // infraLlmService provides constrained LLM access (classify/extract) with telemetry.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, secretsService, executiveProfileService, officeIdentityService, browserService, bullpenService, approvalTrigger, actionLogRepo, taskRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, secretsService, executiveProfileService, officeIdentityService, browserService, bullpenService, approvalTrigger, actionLogRepo, taskRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs, appOrigin: config.appOrigin, httpPort: config.httpPort });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete
@@ -1559,6 +1561,19 @@ async function main(): Promise<void> {
     // install.requires_secrets can't go live until those keys exist in the vault.
     secretsService,
   );
+
+  // Secret-capture service (#971) — mints one-time tokens for agent-initiated secret
+  // capture and redeems submitted values into the vault. Shared by the public HTTP routes
+  // and the two capture skills. The system-name allowlist is a live thunk: declared skill
+  // secrets ∪ channel credential keys, reusing RegistryService's exact logic + the vault
+  // route's CHANNEL_CREDENTIAL_KEYS so there's a single source of truth for writable names.
+  const secretCaptureService = new SecretCaptureService(pool, secretsService, {
+    getAllowedSystemNames: () =>
+      new Set([...registryService.declaredSecretNames(), ...CHANNEL_CREDENTIAL_KEYS]),
+  });
+  // Injected after construction because the ExecutionLayer is created before registryService
+  // (which the allowlist thunk depends on). Mirrors setAgentContactId's post-hoc injection.
+  executionLayer.setSecretCaptureService(secretCaptureService);
 
   // Agents with enable_task_management: true — read by the BacklogHeartbeat to
   // know which source_agent_ids it may wake (and as the fallback target list).
@@ -1906,6 +1921,7 @@ async function main(): Promise<void> {
     registryService,
     channelRegistryService,
     secretsService,
+    secretCaptureService,
     setupRequiredAtBoot,
     bootStartedAt,
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ import { ExecutiveProfileService } from './executive/service.js';
 import { loadEncryptionKey } from './secrets/crypto.js';
 import { SecretsService } from './secrets/secrets-service.js';
 import { SecretCaptureService } from './secrets/secret-capture-service.js';
-import { CHANNEL_CREDENTIAL_KEYS } from './channels/http/routes/vault.js';
+import { channelCredentialKeys } from './channels/http/routes/vault.js';
 import { applyVaultSecrets } from './secrets/apply-vault-secrets.js';
 import { SensitivityClassifier } from './memory/sensitivity.js';
 import { DreamEngine } from './memory/dream-engine.js';
@@ -1569,7 +1569,7 @@ async function main(): Promise<void> {
   // route's CHANNEL_CREDENTIAL_KEYS so there's a single source of truth for writable names.
   const secretCaptureService = new SecretCaptureService(pool, secretsService, {
     getAllowedSystemNames: () =>
-      new Set([...registryService.declaredSecretNames(), ...CHANNEL_CREDENTIAL_KEYS]),
+      new Set([...registryService.declaredSecretNames(), ...channelCredentialKeys()]),
     logger,
   });
   // Injected after construction because the ExecutionLayer is created before registryService

--- a/src/index.ts
+++ b/src/index.ts
@@ -1570,6 +1570,7 @@ async function main(): Promise<void> {
   const secretCaptureService = new SecretCaptureService(pool, secretsService, {
     getAllowedSystemNames: () =>
       new Set([...registryService.declaredSecretNames(), ...CHANNEL_CREDENTIAL_KEYS]),
+    logger,
   });
   // Injected after construction because the ExecutionLayer is created before registryService
   // (which the allowlist thunk depends on). Mirrors setAgentContactId's post-hoc injection.

--- a/src/secrets/secret-capture-service.test.ts
+++ b/src/secrets/secret-capture-service.test.ts
@@ -10,6 +10,7 @@ import {
   type CaptureSecretsPort,
 } from './secret-capture-service.js';
 import { hashToken } from '../channels/http/session-auth.js';
+import type { Logger } from '../logger.js';
 
 /** A mock pool whose response is computed per-query from a handler, so a test can
  *  branch on the SQL (peek vs claim vs clear) and simulate races/empty results. */
@@ -256,5 +257,30 @@ describe('SecretCaptureService.redeem', () => {
     await expect(svc.redeem('deadbeef', 'hunter2')).rejects.toThrow('vault write failed');
     const clear = queries.find(q => q.sql.includes('SET consumed_at = NULL'));
     expect(clear).toBeDefined();
+    // The rollback must only un-consume a still-live token (never resurrect a dead row).
+    expect(clear!.sql).toContain('expires_at > now()');
+  });
+
+  it('propagates the ORIGINAL vault error (not the rollback error) when the rollback also fails', async () => {
+    // Simulate the correlated-DB-outage case: the vault write fails AND the rollback UPDATE
+    // rejects. The user must see the real vault error, and the token-stranded event is logged.
+    const errors: unknown[] = [];
+    const { pool } = makePool((sql) => {
+      if (sql.includes('SELECT')) {
+        return { rows: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null }] };
+      }
+      if (sql.includes('consumed_at = now()')) return { rows: [{ secret_name: 'user.flight', value_format: 'string' }] };
+      throw new Error('rollback UPDATE failed (db down)');
+    });
+    const secrets = makeSecretsPort();
+    secrets.failNextWrite();
+    const logger = { error: (obj: unknown) => { errors.push(obj); } } as unknown as Logger;
+    const svc = new SecretCaptureService(pool, secrets, {
+      getAllowedSystemNames: () => SYSTEM_ALLOWED,
+      logger,
+    });
+    await expect(svc.redeem('deadbeef', 'hunter2')).rejects.toThrow('vault write failed');
+    // The stranded-token event was logged for an operator.
+    expect(errors).toHaveLength(1);
   });
 });

--- a/src/secrets/secret-capture-service.test.ts
+++ b/src/secrets/secret-capture-service.test.ts
@@ -55,8 +55,13 @@ function makeSecretsPort(): CaptureSecretsPort & {
 
 const SYSTEM_ALLOWED = new Set(['anthropic_api_key', 'channel.email.nylas_api_key']);
 
+// Default handler: the mint INSERT now uses RETURNING expires_at (DB-clock TTL), so echo a
+// row back for it; everything else returns no rows unless a test overrides the handler.
 function makeService(
-  poolHandler: (sql: string, params: unknown[]) => { rows: Record<string, unknown>[]; rowCount?: number } = () => ({ rows: [] }),
+  poolHandler: (sql: string, params: unknown[]) => { rows: Record<string, unknown>[]; rowCount?: number } =
+    (sql) => sql.includes('INSERT INTO secret_capture_tokens')
+      ? { rows: [{ expires_at: new Date(Date.now() + 30 * 60_000) }] }
+      : { rows: [] },
 ) {
   const { pool, queries } = makePool(poolHandler);
   const secrets = makeSecretsPort();

--- a/src/secrets/secret-capture-service.test.ts
+++ b/src/secrets/secret-capture-service.test.ts
@@ -1,0 +1,260 @@
+// secret-capture-service.test.ts — unit tests for the secret-capture token service.
+// All DB interaction is intercepted via a mock pool; no real Postgres required.
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Pool, QueryResult } from 'pg';
+import {
+  SecretCaptureService,
+  resolveUserSecretName,
+  resolveSystemSecretName,
+  type CaptureSecretsPort,
+} from './secret-capture-service.js';
+import { hashToken } from '../channels/http/session-auth.js';
+
+/** A mock pool whose response is computed per-query from a handler, so a test can
+ *  branch on the SQL (peek vs claim vs clear) and simulate races/empty results. */
+function makePool(
+  handler: (sql: string, params: unknown[]) => { rows: Record<string, unknown>[]; rowCount?: number },
+): { pool: Pool; queries: Array<{ sql: string; params: unknown[] }> } {
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  const pool = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const p = params ?? [];
+      queries.push({ sql, params: p });
+      const { rows, rowCount } = handler(sql, p);
+      return { rows, rowCount: rowCount ?? rows.length } as unknown as QueryResult;
+    }),
+  } as unknown as Pool;
+  return { pool, queries };
+}
+
+/** A fake vault port that records writes so tests can assert what was stored. */
+function makeSecretsPort(): CaptureSecretsPort & {
+  setCalls: Array<{ name: string; value: string }>;
+  setJSONCalls: Array<{ name: string; obj: unknown }>;
+  failNextWrite: () => void;
+} {
+  const setCalls: Array<{ name: string; value: string }> = [];
+  const setJSONCalls: Array<{ name: string; obj: unknown }> = [];
+  let fail = false;
+  return {
+    setCalls,
+    setJSONCalls,
+    failNextWrite() { fail = true; },
+    async set(name: string, value: string) {
+      if (fail) { fail = false; throw new Error('vault write failed'); }
+      setCalls.push({ name, value });
+    },
+    async setJSON(name: string, obj: unknown) {
+      if (fail) { fail = false; throw new Error('vault write failed'); }
+      setJSONCalls.push({ name, obj });
+    },
+  };
+}
+
+const SYSTEM_ALLOWED = new Set(['anthropic_api_key', 'channel.email.nylas_api_key']);
+
+function makeService(
+  poolHandler: (sql: string, params: unknown[]) => { rows: Record<string, unknown>[]; rowCount?: number } = () => ({ rows: [] }),
+) {
+  const { pool, queries } = makePool(poolHandler);
+  const secrets = makeSecretsPort();
+  const svc = new SecretCaptureService(pool, secrets, {
+    getAllowedSystemNames: () => SYSTEM_ALLOWED,
+  });
+  return { svc, secrets, queries };
+}
+
+describe('resolveUserSecretName', () => {
+  it('slugifies and prefixes with user.', () => {
+    expect(resolveUserSecretName('My Flight Site Password')).toBe('user.my_flight_site_password');
+  });
+
+  it('collapses non-alphanumeric runs and trims edge underscores', () => {
+    expect(resolveUserSecretName('  Foo--Bar!! ')).toBe('user.foo_bar');
+  });
+
+  it('rejects empty / whitespace input', () => {
+    expect(() => resolveUserSecretName('   ')).toThrow();
+  });
+
+  it('rejects input with no usable alphanumeric characters', () => {
+    expect(() => resolveUserSecretName('!!!')).toThrow();
+  });
+
+  it('rejects over-long input', () => {
+    expect(() => resolveUserSecretName('x'.repeat(200))).toThrow();
+  });
+
+  it('structurally cannot produce a protected system or channel name', () => {
+    // A user trying to overwrite a system key still lands inside the user. namespace.
+    expect(resolveUserSecretName('anthropic_api_key')).toBe('user.anthropic_api_key');
+    expect(resolveUserSecretName('channel.email.nylas_api_key')).toBe('user.channel_email_nylas_api_key');
+  });
+});
+
+describe('resolveSystemSecretName', () => {
+  it('accepts a declared / channel credential key verbatim', () => {
+    expect(resolveSystemSecretName('anthropic_api_key', SYSTEM_ALLOWED)).toBe('anthropic_api_key');
+    expect(resolveSystemSecretName('channel.email.nylas_api_key', SYSTEM_ALLOWED)).toBe('channel.email.nylas_api_key');
+  });
+
+  it('rejects a name not in the allowlist', () => {
+    expect(() => resolveSystemSecretName('made_up_key', SYSTEM_ALLOWED)).toThrow();
+  });
+
+  it('rejects empty input', () => {
+    expect(() => resolveSystemSecretName('  ', SYSTEM_ALLOWED)).toThrow();
+  });
+});
+
+describe('SecretCaptureService.mint', () => {
+  it('stores the SHA-256 hash, never the raw token', async () => {
+    const { svc, queries } = makeService();
+    const { rawToken } = await svc.mint({ secretName: 'user.x', valueFormat: 'string', ttlMinutes: 30 });
+
+    const insert = queries.find(q => q.sql.includes('INSERT INTO secret_capture_tokens'));
+    expect(insert).toBeDefined();
+    const storedHash = insert!.params[0];
+    expect(storedHash).toBe(hashToken(rawToken));
+    // The raw token must never be a stored parameter.
+    expect(insert!.params).not.toContain(rawToken);
+    // 64 hex chars = 32 bytes of entropy.
+    expect(rawToken).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('sets expiry ttlMinutes in the future', async () => {
+    const { svc } = makeService();
+    const before = Date.now();
+    const { expiresAt } = await svc.mint({ secretName: 'user.x', valueFormat: 'string', ttlMinutes: 30 });
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 29 * 60_000);
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(Date.now() + 31 * 60_000);
+  });
+});
+
+describe('SecretCaptureService.mintUserSecret / mintSystemSecret', () => {
+  it('mintUserSecret namespaces the resolved key under user.', async () => {
+    const { svc } = makeService();
+    const res = await svc.mintUserSecret({ rawName: 'Flight Site Password' });
+    expect(res.secretName).toBe('user.flight_site_password');
+    expect(res.rawToken).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('mintSystemSecret accepts an allowed key and rejects an unknown one', async () => {
+    const { svc } = makeService();
+    const ok = await svc.mintSystemSecret({ rawName: 'anthropic_api_key' });
+    expect(ok.secretName).toBe('anthropic_api_key');
+    await expect(svc.mintSystemSecret({ rawName: 'not_a_real_key' })).rejects.toThrow();
+  });
+});
+
+describe('SecretCaptureService.getMetadata', () => {
+  it('returns not_found for an unknown token', async () => {
+    const { svc } = makeService(() => ({ rows: [] }));
+    expect(await svc.getMetadata('deadbeef')).toBe('not_found');
+  });
+
+  it('returns expired for a consumed token', async () => {
+    const { svc } = makeService(() => ({
+      rows: [{ label: 'x', value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: new Date() }],
+    }));
+    expect(await svc.getMetadata('deadbeef')).toBe('expired');
+  });
+
+  it('returns expired for a past token', async () => {
+    const { svc } = makeService(() => ({
+      rows: [{ label: 'x', value_format: 'string', expires_at: new Date(Date.now() - 60_000), consumed_at: null }],
+    }));
+    expect(await svc.getMetadata('deadbeef')).toBe('expired');
+  });
+
+  it('returns label + valueFormat for a live token, never the vault key', async () => {
+    const { svc } = makeService(() => ({
+      rows: [{ label: 'Flight password', value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null, secret_name: 'user.secret' }],
+    }));
+    const meta = await svc.getMetadata('deadbeef');
+    expect(meta).toEqual({ label: 'Flight password', valueFormat: 'string' });
+    expect(JSON.stringify(meta)).not.toContain('user.secret');
+  });
+});
+
+describe('SecretCaptureService.redeem', () => {
+  // The service issues: (1) a peek SELECT, (2) an atomic claim UPDATE, (3) optional clear UPDATE.
+  function router(opts: {
+    peek?: Record<string, unknown>[];
+    claim?: Record<string, unknown>[];
+  }) {
+    return (sql: string) => {
+      if (sql.includes('SELECT') && sql.includes('secret_capture_tokens')) return { rows: opts.peek ?? [] };
+      if (sql.includes('consumed_at = now()')) return { rows: opts.claim ?? [] };
+      // clear consumed_at on vault failure (consumed_at = NULL)
+      return { rows: [] };
+    };
+  }
+
+  it('returns not_found for an unknown token', async () => {
+    const { svc } = makeService(router({ peek: [] }));
+    expect(await svc.redeem('deadbeef', 'val')).toBe('not_found');
+  });
+
+  it('returns expired for a consumed token', async () => {
+    const { svc } = makeService(router({
+      peek: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: new Date() }],
+    }));
+    expect(await svc.redeem('deadbeef', 'val')).toBe('expired');
+  });
+
+  it('writes a string value into the vault and consumes the token', async () => {
+    const { svc, secrets, queries } = makeService(router({
+      peek: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      claim: [{ secret_name: 'user.flight', value_format: 'string' }],
+    }));
+    const result = await svc.redeem('deadbeef', 'hunter2');
+    expect(result).toBe('ok');
+    expect(secrets.setCalls).toEqual([{ name: 'user.flight', value: 'hunter2' }]);
+    // The atomic claim guards consumed_at IS NULL AND expires_at > now() — single use.
+    const claim = queries.find(q => q.sql.includes('SET consumed_at = now()'));
+    expect(claim!.sql).toContain('consumed_at IS NULL');
+    expect(claim!.sql).toContain('expires_at > now()');
+  });
+
+  it('writes JSON via setJSON when value_format is json', async () => {
+    const { svc, secrets } = makeService(router({
+      peek: [{ value_format: 'json', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      claim: [{ secret_name: 'user.creds', value_format: 'json' }],
+    }));
+    const result = await svc.redeem('deadbeef', '{"a":1}');
+    expect(result).toBe('ok');
+    expect(secrets.setJSONCalls).toEqual([{ name: 'user.creds', obj: { a: 1 } }]);
+  });
+
+  it('rejects invalid JSON without burning the token', async () => {
+    const { svc, secrets, queries } = makeService(router({
+      peek: [{ value_format: 'json', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+    }));
+    const result = await svc.redeem('deadbeef', 'not json');
+    expect(result).toBe('invalid_json');
+    expect(secrets.setJSONCalls).toHaveLength(0);
+    // No claim UPDATE should have fired — the token is still usable for a retry.
+    expect(queries.find(q => q.sql.includes('SET consumed_at = now()'))).toBeUndefined();
+  });
+
+  it('treats a lost claim race as expired (single-use)', async () => {
+    const { svc } = makeService(router({
+      peek: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      claim: [], // someone else consumed it between peek and claim
+    }));
+    expect(await svc.redeem('deadbeef', 'val')).toBe('expired');
+  });
+
+  it('clears consumed_at and rethrows when the vault write fails', async () => {
+    const { svc, secrets, queries } = makeService(router({
+      peek: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      claim: [{ secret_name: 'user.flight', value_format: 'string' }],
+    }));
+    secrets.failNextWrite();
+    await expect(svc.redeem('deadbeef', 'hunter2')).rejects.toThrow('vault write failed');
+    const clear = queries.find(q => q.sql.includes('SET consumed_at = NULL'));
+    expect(clear).toBeDefined();
+  });
+});

--- a/src/secrets/secret-capture-service.test.ts
+++ b/src/secrets/secret-capture-service.test.ts
@@ -109,10 +109,10 @@ describe('resolveSystemSecretName', () => {
   });
 });
 
-describe('SecretCaptureService.mint', () => {
+describe('SecretCaptureService minting (via the public name-policy entry points)', () => {
   it('stores the SHA-256 hash, never the raw token', async () => {
     const { svc, queries } = makeService();
-    const { rawToken } = await svc.mint({ secretName: 'user.x', valueFormat: 'string', ttlMinutes: 30 });
+    const { rawToken } = await svc.mintUserSecret({ rawName: 'x' });
 
     const insert = queries.find(q => q.sql.includes('INSERT INTO secret_capture_tokens'));
     expect(insert).toBeDefined();
@@ -124,10 +124,10 @@ describe('SecretCaptureService.mint', () => {
     expect(rawToken).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it('sets expiry ttlMinutes in the future', async () => {
+  it('sets a fixed 30-minute expiry (TTL is not caller-controlled)', async () => {
     const { svc } = makeService();
     const before = Date.now();
-    const { expiresAt } = await svc.mint({ secretName: 'user.x', valueFormat: 'string', ttlMinutes: 30 });
+    const { expiresAt } = await svc.mintUserSecret({ rawName: 'x' });
     expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 29 * 60_000);
     expect(expiresAt.getTime()).toBeLessThanOrEqual(Date.now() + 31 * 60_000);
   });
@@ -155,23 +155,16 @@ describe('SecretCaptureService.getMetadata', () => {
     expect(await svc.getMetadata('deadbeef')).toBe('not_found');
   });
 
-  it('returns expired for a consumed token', async () => {
+  it('returns expired for a spent token (consumed or past — computed in SQL)', async () => {
     const { svc } = makeService(() => ({
-      rows: [{ label: 'x', value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: new Date() }],
-    }));
-    expect(await svc.getMetadata('deadbeef')).toBe('expired');
-  });
-
-  it('returns expired for a past token', async () => {
-    const { svc } = makeService(() => ({
-      rows: [{ label: 'x', value_format: 'string', expires_at: new Date(Date.now() - 60_000), consumed_at: null }],
+      rows: [{ label: 'x', value_format: 'string', spent: true }],
     }));
     expect(await svc.getMetadata('deadbeef')).toBe('expired');
   });
 
   it('returns label + valueFormat for a live token, never the vault key', async () => {
     const { svc } = makeService(() => ({
-      rows: [{ label: 'Flight password', value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null, secret_name: 'user.secret' }],
+      rows: [{ label: 'Flight password', value_format: 'string', spent: false, secret_name: 'user.secret' }],
     }));
     const meta = await svc.getMetadata('deadbeef');
     expect(meta).toEqual({ label: 'Flight password', valueFormat: 'string' });
@@ -200,14 +193,14 @@ describe('SecretCaptureService.redeem', () => {
 
   it('returns expired for a consumed token', async () => {
     const { svc } = makeService(router({
-      peek: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: new Date() }],
+      peek: [{ value_format: 'string', spent: true }],
     }));
     expect(await svc.redeem('deadbeef', 'val')).toBe('expired');
   });
 
   it('writes a string value into the vault and consumes the token', async () => {
     const { svc, secrets, queries } = makeService(router({
-      peek: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      peek: [{ value_format: 'string', spent: false }],
       claim: [{ secret_name: 'user.flight', value_format: 'string' }],
     }));
     const result = await svc.redeem('deadbeef', 'hunter2');
@@ -221,7 +214,7 @@ describe('SecretCaptureService.redeem', () => {
 
   it('writes JSON via setJSON when value_format is json', async () => {
     const { svc, secrets } = makeService(router({
-      peek: [{ value_format: 'json', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      peek: [{ value_format: 'json', spent: false }],
       claim: [{ secret_name: 'user.creds', value_format: 'json' }],
     }));
     const result = await svc.redeem('deadbeef', '{"a":1}');
@@ -231,7 +224,7 @@ describe('SecretCaptureService.redeem', () => {
 
   it('rejects invalid JSON without burning the token', async () => {
     const { svc, secrets, queries } = makeService(router({
-      peek: [{ value_format: 'json', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      peek: [{ value_format: 'json', spent: false }],
     }));
     const result = await svc.redeem('deadbeef', 'not json');
     expect(result).toBe('invalid_json');
@@ -242,7 +235,7 @@ describe('SecretCaptureService.redeem', () => {
 
   it('treats a lost claim race as expired (single-use)', async () => {
     const { svc } = makeService(router({
-      peek: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      peek: [{ value_format: 'string', spent: false }],
       claim: [], // someone else consumed it between peek and claim
     }));
     expect(await svc.redeem('deadbeef', 'val')).toBe('expired');
@@ -250,7 +243,7 @@ describe('SecretCaptureService.redeem', () => {
 
   it('clears consumed_at and rethrows when the vault write fails', async () => {
     const { svc, secrets, queries } = makeService(router({
-      peek: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null }],
+      peek: [{ value_format: 'string', spent: false }],
       claim: [{ secret_name: 'user.flight', value_format: 'string' }],
     }));
     secrets.failNextWrite();
@@ -267,7 +260,7 @@ describe('SecretCaptureService.redeem', () => {
     const errors: unknown[] = [];
     const { pool } = makePool((sql) => {
       if (sql.includes('SELECT')) {
-        return { rows: [{ value_format: 'string', expires_at: new Date(Date.now() + 60_000), consumed_at: null }] };
+        return { rows: [{ value_format: 'string', spent: false }] };
       }
       if (sql.includes('consumed_at = now()')) return { rows: [{ secret_name: 'user.flight', value_format: 'string' }] };
       throw new Error('rollback UPDATE failed (db down)');

--- a/src/secrets/secret-capture-service.ts
+++ b/src/secrets/secret-capture-service.ts
@@ -87,7 +87,9 @@ export interface MintNameArgs {
   rawName: string;
   label?: string;
   valueFormat?: CaptureValueFormat;
-  ttlMinutes?: number;
+  // NOTE: TTL is intentionally NOT caller-controlled. The lifetime is a fixed security
+  // property of the feature (single-use + 30 min, per #971), so callers cannot mint links
+  // that are already dead, absurdly long-lived, or NaN. See DEFAULT_CAPTURE_TTL_MINUTES.
 }
 
 export interface MintResult {
@@ -122,63 +124,55 @@ export class SecretCaptureService implements SecretCaptureMinter {
     private readonly options: SecretCaptureServiceOptions,
   ) {}
 
-  /** Low-level mint: secretName is assumed already resolved & validated by the caller. */
-  async mint(args: {
-    secretName: string;
-    label?: string;
-    valueFormat: CaptureValueFormat;
-    ttlMinutes: number;
-  }): Promise<{ rawToken: string; expiresAt: Date }> {
+  /**
+   * Low-level mint — PRIVATE on purpose. The only public entry points are mintUserSecret /
+   * mintSystemSecret, which each run a name policy first. Keeping this private means no holder
+   * of a SecretCaptureService can bypass the `user.` namespace sandbox or the system allowlist
+   * by passing an arbitrary secretName. TTL is fixed (not a parameter) for the same reason.
+   */
+  private async mint(secretName: string, label: string | undefined, valueFormat: CaptureValueFormat): Promise<{ rawToken: string; expiresAt: Date }> {
     // 256-bit raw token — lives only in the returned URL. We persist its hash, matching the
     // session-auth pattern, so a DB compromise cannot reconstruct a usable capture link.
     const rawToken = randomBytes(32).toString('hex');
     const tokenHash = hashToken(rawToken);
-    const expiresAt = new Date(Date.now() + args.ttlMinutes * 60_000);
+    const expiresAt = new Date(Date.now() + DEFAULT_CAPTURE_TTL_MINUTES * 60_000);
     await this.pool.query(
       `INSERT INTO secret_capture_tokens (token_hash, secret_name, label, value_format, expires_at)
        VALUES ($1, $2, $3, $4, $5)`,
-      [tokenHash, args.secretName, args.label ?? null, args.valueFormat, expiresAt],
+      [tokenHash, secretName, label ?? null, valueFormat, expiresAt],
     );
     return { rawToken, expiresAt };
   }
 
   async mintUserSecret(args: MintNameArgs): Promise<MintResult> {
     const secretName = resolveUserSecretName(args.rawName);
-    const { rawToken, expiresAt } = await this.mint({
-      secretName,
-      label: args.label,
-      valueFormat: args.valueFormat ?? 'string',
-      ttlMinutes: args.ttlMinutes ?? DEFAULT_CAPTURE_TTL_MINUTES,
-    });
+    const { rawToken, expiresAt } = await this.mint(secretName, args.label, args.valueFormat ?? 'string');
     return { rawToken, secretName, expiresAt };
   }
 
   async mintSystemSecret(args: MintNameArgs): Promise<MintResult> {
     const secretName = resolveSystemSecretName(args.rawName, this.options.getAllowedSystemNames());
-    const { rawToken, expiresAt } = await this.mint({
-      secretName,
-      label: args.label,
-      valueFormat: args.valueFormat ?? 'string',
-      ttlMinutes: args.ttlMinutes ?? DEFAULT_CAPTURE_TTL_MINUTES,
-    });
+    const { rawToken, expiresAt } = await this.mint(secretName, args.label, args.valueFormat ?? 'string');
     return { rawToken, secretName, expiresAt };
   }
 
-  /** Metadata for the public GET endpoint. Never returns the vault key (secret_name). */
+  /** Metadata for the public GET endpoint. Never returns the vault key (secret_name).
+   *  `spent` is computed in SQL with the DB clock (`now()`), the same time source the atomic
+   *  claim uses — so metadata and redemption never disagree about validity under clock skew. */
   async getMetadata(rawToken: string): Promise<CaptureMetadata> {
     const res = await this.pool.query<{
       label: string | null;
       value_format: CaptureValueFormat;
-      expires_at: Date;
-      consumed_at: Date | null;
+      spent: boolean;
     }>(
-      `SELECT label, value_format, expires_at, consumed_at
+      `SELECT label, value_format,
+              (consumed_at IS NOT NULL OR expires_at <= now()) AS spent
          FROM secret_capture_tokens WHERE token_hash = $1`,
       [hashToken(rawToken)],
     );
     const row = res.rows[0];
     if (!row) return 'not_found';
-    if (this.isSpent(row.consumed_at, row.expires_at)) return 'expired';
+    if (row.spent) return 'expired';
     return { label: row.label, valueFormat: row.value_format };
   }
 
@@ -193,18 +187,20 @@ export class SecretCaptureService implements SecretCaptureMinter {
     const tokenHash = hashToken(rawToken);
 
     // Peek to distinguish not_found / expired / invalid_json before mutating anything.
+    // `spent` uses the DB clock (`now()`) — the same source as the atomic claim below — so the
+    // pre-check and the claim agree on validity regardless of app/DB clock skew.
     const peek = await this.pool.query<{
       value_format: CaptureValueFormat;
-      expires_at: Date;
-      consumed_at: Date | null;
+      spent: boolean;
     }>(
-      `SELECT value_format, expires_at, consumed_at
+      `SELECT value_format,
+              (consumed_at IS NOT NULL OR expires_at <= now()) AS spent
          FROM secret_capture_tokens WHERE token_hash = $1`,
       [tokenHash],
     );
     const row = peek.rows[0];
     if (!row) return 'not_found';
-    if (this.isSpent(row.consumed_at, row.expires_at)) return 'expired';
+    if (row.spent) return 'expired';
 
     let parsed: unknown;
     if (row.value_format === 'json') {
@@ -259,10 +255,5 @@ export class SecretCaptureService implements SecretCaptureMinter {
       throw err; // always the original vault-write error, never the rollback error
     }
     return 'ok';
-  }
-
-  /** A token is spent if it has been consumed or its expiry has passed. */
-  private isSpent(consumedAt: Date | null, expiresAt: Date): boolean {
-    return consumedAt !== null || new Date(expiresAt).getTime() <= Date.now();
   }
 }

--- a/src/secrets/secret-capture-service.ts
+++ b/src/secrets/secret-capture-service.ts
@@ -1,0 +1,248 @@
+// secret-capture-service.ts — mint & redeem one-time tokens for agent-initiated
+// secret capture (#971).
+//
+// The structural guarantee: this service is the ONLY path a capture link takes, and it
+// has no method that returns a stored secret VALUE. Agents mint a token (which only ever
+// yields a URL), the user submits the value to the public form, and redeem() writes it
+// straight into the encrypted vault. The token store holds metadata only — never the value.
+//
+// Two name policies live here as pure functions so the two sibling skills can share one
+// service and differ only in WHICH policy they apply:
+//   - resolveUserSecretName   — slugifies to `user.<slug>`; an unprivileged agent literally
+//                               cannot name a system/channel key (no dot-free or `channel.`
+//                               output is possible), so it is sandboxed by construction.
+//   - resolveSystemSecretName — must be a declared skill secret or channel credential key
+//                               (the same allowlist the vault PUT route enforces).
+
+import type { DbPool } from '../db/connection.js';
+import { hashToken } from '../channels/http/session-auth.js';
+import { randomBytes } from 'node:crypto';
+
+export type CaptureValueFormat = 'string' | 'json';
+
+/** Default link lifetime — short by design (single-use + 30 min, per #971). */
+export const DEFAULT_CAPTURE_TTL_MINUTES = 30;
+
+/** Upper bound on the raw user-supplied name before slugification. */
+const MAX_SECRET_NAME_INPUT = 128;
+
+/**
+ * Slugify an arbitrary user description into a `user.<a-z0-9_>+` vault key.
+ *
+ * The `user.` namespace is the sandbox: the dot-separated prefix cannot be produced by
+ * snake_case system keys (e.g. `anthropic_api_key`) or `channel.*` credential keys, so a
+ * general-purpose capture can never overwrite a privileged secret — even if the agent
+ * passes the literal name of one (it just becomes `user.anthropic_api_key`).
+ */
+export function resolveUserSecretName(input: string): string {
+  if (typeof input !== 'string') throw new Error('secret_name must be a string');
+  const trimmed = input.trim();
+  if (trimmed.length === 0) throw new Error('secret_name must not be empty');
+  if (trimmed.length > MAX_SECRET_NAME_INPUT) {
+    throw new Error(`secret_name exceeds ${MAX_SECRET_NAME_INPUT} characters`);
+  }
+  // Lowercase, collapse every non-alphanumeric run to a single underscore, trim edge underscores.
+  const slug = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  if (slug.length === 0) {
+    throw new Error(`secret_name '${input}' has no usable alphanumeric characters`);
+  }
+  return `user.${slug}`;
+}
+
+/**
+ * Validate a system secret name against the live allowlist (declared skill secrets ∪ known
+ * channel credential keys). The literal name is used as the vault key — system secrets are
+ * fixed identifiers, not free text, so we never slugify here.
+ */
+export function resolveSystemSecretName(input: string, allowedNames: ReadonlySet<string>): string {
+  if (typeof input !== 'string') throw new Error('secret_name must be a string');
+  const name = input.trim();
+  if (name.length === 0) throw new Error('secret_name must not be empty');
+  if (!allowedNames.has(name)) {
+    throw new Error(
+      `'${name}' is not a secret declared by any skill (install.requires_secrets) ` +
+      `nor a known channel credential key. Only those names may be captured by ` +
+      `system-secret-capture-request.`,
+    );
+  }
+  return name;
+}
+
+/** The narrow slice of SecretsService that redeem() needs — write a value, never read one. */
+export interface CaptureSecretsPort {
+  set(name: string, value: string): Promise<void>;
+  setJSON(name: string, obj: unknown): Promise<void>;
+}
+
+/** The mint-only surface injected into skills as the `secretCapture` capability.
+ *  Deliberately excludes redeem/getMetadata so a skill can create a link but never read a value. */
+export interface SecretCaptureMinter {
+  mintUserSecret(args: MintNameArgs): Promise<MintResult>;
+  mintSystemSecret(args: MintNameArgs): Promise<MintResult>;
+}
+
+export interface MintNameArgs {
+  /** Raw, unresolved name from the skill input. Resolution depends on the policy. */
+  rawName: string;
+  label?: string;
+  valueFormat?: CaptureValueFormat;
+  ttlMinutes?: number;
+}
+
+export interface MintResult {
+  rawToken: string;
+  /** The fully resolved vault key the value will be written to. */
+  secretName: string;
+  expiresAt: Date;
+}
+
+export interface SecretCaptureServiceOptions {
+  /** Returns the live allowlist for system captures (declared secrets ∪ channel keys).
+   *  A thunk (not a static set) so it reflects the registry state at mint time. */
+  getAllowedSystemNames: () => ReadonlySet<string>;
+}
+
+/** Outcome of a redeem attempt. Vault-write failures are not in this union — they rethrow
+ *  (after clearing consumed_at) so the route surfaces a 500 and the user can retry. */
+export type RedeemResult = 'ok' | 'expired' | 'not_found' | 'invalid_json';
+
+export type CaptureMetadata =
+  | { label: string | null; valueFormat: CaptureValueFormat }
+  | 'expired'
+  | 'not_found';
+
+export class SecretCaptureService implements SecretCaptureMinter {
+  constructor(
+    private readonly pool: DbPool,
+    private readonly secrets: CaptureSecretsPort,
+    private readonly options: SecretCaptureServiceOptions,
+  ) {}
+
+  /** Low-level mint: secretName is assumed already resolved & validated by the caller. */
+  async mint(args: {
+    secretName: string;
+    label?: string;
+    valueFormat: CaptureValueFormat;
+    ttlMinutes: number;
+  }): Promise<{ rawToken: string; expiresAt: Date }> {
+    // 256-bit raw token — lives only in the returned URL. We persist its hash, matching the
+    // session-auth pattern, so a DB compromise cannot reconstruct a usable capture link.
+    const rawToken = randomBytes(32).toString('hex');
+    const tokenHash = hashToken(rawToken);
+    const expiresAt = new Date(Date.now() + args.ttlMinutes * 60_000);
+    await this.pool.query(
+      `INSERT INTO secret_capture_tokens (token_hash, secret_name, label, value_format, expires_at)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [tokenHash, args.secretName, args.label ?? null, args.valueFormat, expiresAt],
+    );
+    return { rawToken, expiresAt };
+  }
+
+  async mintUserSecret(args: MintNameArgs): Promise<MintResult> {
+    const secretName = resolveUserSecretName(args.rawName);
+    const { rawToken, expiresAt } = await this.mint({
+      secretName,
+      label: args.label,
+      valueFormat: args.valueFormat ?? 'string',
+      ttlMinutes: args.ttlMinutes ?? DEFAULT_CAPTURE_TTL_MINUTES,
+    });
+    return { rawToken, secretName, expiresAt };
+  }
+
+  async mintSystemSecret(args: MintNameArgs): Promise<MintResult> {
+    const secretName = resolveSystemSecretName(args.rawName, this.options.getAllowedSystemNames());
+    const { rawToken, expiresAt } = await this.mint({
+      secretName,
+      label: args.label,
+      valueFormat: args.valueFormat ?? 'string',
+      ttlMinutes: args.ttlMinutes ?? DEFAULT_CAPTURE_TTL_MINUTES,
+    });
+    return { rawToken, secretName, expiresAt };
+  }
+
+  /** Metadata for the public GET endpoint. Never returns the vault key (secret_name). */
+  async getMetadata(rawToken: string): Promise<CaptureMetadata> {
+    const res = await this.pool.query<{
+      label: string | null;
+      value_format: CaptureValueFormat;
+      expires_at: Date;
+      consumed_at: Date | null;
+    }>(
+      `SELECT label, value_format, expires_at, consumed_at
+         FROM secret_capture_tokens WHERE token_hash = $1`,
+      [hashToken(rawToken)],
+    );
+    const row = res.rows[0];
+    if (!row) return 'not_found';
+    if (this.isSpent(row.consumed_at, row.expires_at)) return 'expired';
+    return { label: row.label, valueFormat: row.value_format };
+  }
+
+  /**
+   * Atomically claim and redeem a capture token, writing the value into the vault.
+   *
+   * JSON is validated BEFORE the atomic claim so a malformed submission does not burn the
+   * single-use token (the user can fix and resubmit). The claim's WHERE clause re-checks
+   * single-use/expiry atomically, so concurrent submissions cannot both win.
+   */
+  async redeem(rawToken: string, value: string): Promise<RedeemResult> {
+    const tokenHash = hashToken(rawToken);
+
+    // Peek to distinguish not_found / expired / invalid_json before mutating anything.
+    const peek = await this.pool.query<{
+      value_format: CaptureValueFormat;
+      expires_at: Date;
+      consumed_at: Date | null;
+    }>(
+      `SELECT value_format, expires_at, consumed_at
+         FROM secret_capture_tokens WHERE token_hash = $1`,
+      [tokenHash],
+    );
+    const row = peek.rows[0];
+    if (!row) return 'not_found';
+    if (this.isSpent(row.consumed_at, row.expires_at)) return 'expired';
+
+    let parsed: unknown;
+    if (row.value_format === 'json') {
+      try {
+        parsed = JSON.parse(value);
+      } catch {
+        return 'invalid_json';
+      }
+    }
+
+    // Atomic single-use claim. RETURNING is empty if another request already consumed it
+    // or it expired in the gap since the peek — both map to 'expired'.
+    const claim = await this.pool.query<{ secret_name: string; value_format: CaptureValueFormat }>(
+      `UPDATE secret_capture_tokens
+          SET consumed_at = now()
+        WHERE token_hash = $1 AND consumed_at IS NULL AND expires_at > now()
+        RETURNING secret_name, value_format`,
+      [tokenHash],
+    );
+    const claimed = claim.rows[0];
+    if (!claimed) return 'expired';
+
+    try {
+      if (claimed.value_format === 'json') {
+        await this.secrets.setJSON(claimed.secret_name, parsed);
+      } else {
+        await this.secrets.set(claimed.secret_name, value);
+      }
+    } catch (err) {
+      // Roll the token back to unconsumed so the user can retry the submission. The value
+      // is never logged — only the failure propagates.
+      await this.pool.query(
+        `UPDATE secret_capture_tokens SET consumed_at = NULL WHERE token_hash = $1`,
+        [tokenHash],
+      );
+      throw err;
+    }
+    return 'ok';
+  }
+
+  /** A token is spent if it has been consumed or its expiry has passed. */
+  private isSpent(consumedAt: Date | null, expiresAt: Date): boolean {
+    return consumedAt !== null || new Date(expiresAt).getTime() <= Date.now();
+  }
+}

--- a/src/secrets/secret-capture-service.ts
+++ b/src/secrets/secret-capture-service.ts
@@ -135,13 +135,16 @@ export class SecretCaptureService implements SecretCaptureMinter {
     // session-auth pattern, so a DB compromise cannot reconstruct a usable capture link.
     const rawToken = randomBytes(32).toString('hex');
     const tokenHash = hashToken(rawToken);
-    const expiresAt = new Date(Date.now() + DEFAULT_CAPTURE_TTL_MINUTES * 60_000);
-    await this.pool.query(
+    // Compute expires_at from the DB clock (now() + TTL), not the app clock, and read it back.
+    // Redemption/metadata also compare against the DB now(), so mint and redeem share one time
+    // source — app/DB clock skew can never make a link expire early or linger past its TTL.
+    const result = await this.pool.query<{ expires_at: Date }>(
       `INSERT INTO secret_capture_tokens (token_hash, secret_name, label, value_format, expires_at)
-       VALUES ($1, $2, $3, $4, $5)`,
-      [tokenHash, secretName, label ?? null, valueFormat, expiresAt],
+       VALUES ($1, $2, $3, $4, now() + make_interval(mins => $5))
+       RETURNING expires_at`,
+      [tokenHash, secretName, label ?? null, valueFormat, DEFAULT_CAPTURE_TTL_MINUTES],
     );
-    return { rawToken, expiresAt };
+    return { rawToken, expiresAt: result.rows[0]!.expires_at };
   }
 
   async mintUserSecret(args: MintNameArgs): Promise<MintResult> {

--- a/src/secrets/secret-capture-service.ts
+++ b/src/secrets/secret-capture-service.ts
@@ -15,6 +15,7 @@
 //                               (the same allowlist the vault PUT route enforces).
 
 import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
 import { hashToken } from '../channels/http/session-auth.js';
 import { randomBytes } from 'node:crypto';
 
@@ -100,6 +101,9 @@ export interface SecretCaptureServiceOptions {
   /** Returns the live allowlist for system captures (declared secrets ∪ channel keys).
    *  A thunk (not a static set) so it reflects the registry state at mint time. */
   getAllowedSystemNames: () => ReadonlySet<string>;
+  /** Logger for the one operator-actionable failure mode: a token stranded consumed-but-unsaved
+   *  when the post-vault-failure rollback itself fails. Optional so tests can omit it. */
+  logger?: Logger;
 }
 
 /** Outcome of a redeem attempt. Vault-write failures are not in this union — they rethrow
@@ -213,6 +217,10 @@ export class SecretCaptureService implements SecretCaptureMinter {
 
     // Atomic single-use claim. RETURNING is empty if another request already consumed it
     // or it expired in the gap since the peek — both map to 'expired'.
+    //
+    // We consume the token BEFORE writing to the vault (not after) so a crash between the two
+    // can never leave a redeemable token whose value was already stored. The failure direction
+    // is "capability lost, retry needed" rather than "single-use token still reusable".
     const claim = await this.pool.query<{ secret_name: string; value_format: CaptureValueFormat }>(
       `UPDATE secret_capture_tokens
           SET consumed_at = now()
@@ -230,13 +238,25 @@ export class SecretCaptureService implements SecretCaptureMinter {
         await this.secrets.set(claimed.secret_name, value);
       }
     } catch (err) {
-      // Roll the token back to unconsumed so the user can retry the submission. The value
-      // is never logged — only the failure propagates.
-      await this.pool.query(
-        `UPDATE secret_capture_tokens SET consumed_at = NULL WHERE token_hash = $1`,
-        [tokenHash],
-      );
-      throw err;
+      // Roll the token back to unconsumed so the user can retry — but only if it is still live
+      // (the `expires_at > now()` guard avoids resurrecting consumed_at on an already-dead row).
+      // The rollback is wrapped so that if IT fails (e.g. the same DB outage that failed the
+      // vault write), the ORIGINAL vault error still propagates and we log the stranded token
+      // for an operator. The value is never logged — only the failure.
+      try {
+        await this.pool.query(
+          `UPDATE secret_capture_tokens SET consumed_at = NULL
+            WHERE token_hash = $1 AND expires_at > now()`,
+          [tokenHash],
+        );
+      } catch (rollbackErr) {
+        this.options.logger?.error(
+          { err: rollbackErr },
+          'secret-capture: failed to roll back consumed_at after a vault-write error — ' +
+          'token is stranded consumed-but-unsaved; the user cannot retry and must be re-issued a link',
+        );
+      }
+      throw err; // always the original vault-write error, never the rollback error
     }
     return 'ok';
   }

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -103,6 +103,13 @@ export class ExecutionLayer {
   private skillOutputMaxLength: number;
   /** Configurable fallback timeout for the delegate skill when no timeout_ms is supplied. */
   private defaultDelegateTimeoutMs?: number;
+  /** Secret-capture minter — injected post-construction via setSecretCaptureService()
+   *  because it depends on registryService, which is built after the ExecutionLayer (#971). */
+  private secretCaptureService?: import('../secrets/secret-capture-service.js').SecretCaptureMinter;
+  /** Operator-facing console origin + local HTTP port — used by the capture skills to build
+   *  the magic-link URL (appOrigin in prod, http://localhost:{httpPort} in dev). */
+  private appOrigin?: string;
+  private httpPort?: number;
 
   constructor(registry: SkillRegistry, logger: Logger, options?: {
     bus?: EventBus;
@@ -133,6 +140,8 @@ export class ExecutionLayer {
     selfEmail?: string;
     skillOutputMaxLength?: number;
     defaultDelegateTimeoutMs?: number;
+    appOrigin?: string;
+    httpPort?: number;
   }) {
     this.registry = registry;
     this.logger = logger;
@@ -164,6 +173,17 @@ export class ExecutionLayer {
     this.selfEmail = options?.selfEmail;
     this.skillOutputMaxLength = options?.skillOutputMaxLength ?? DEFAULT_SKILL_OUTPUT_MAX_LENGTH;
     this.defaultDelegateTimeoutMs = options?.defaultDelegateTimeoutMs;
+    this.appOrigin = options?.appOrigin;
+    this.httpPort = options?.httpPort;
+  }
+
+  /**
+   * Inject the secret-capture minter after construction.
+   * Called from index.ts once registryService (which the system-name allowlist depends on)
+   * is available. Mirrors setAgentContactId's post-bootstrap injection pattern (#971).
+   */
+  setSecretCaptureService(svc: import('../secrets/secret-capture-service.js').SecretCaptureMinter): void {
+    this.secretCaptureService = svc;
   }
 
   /**
@@ -615,6 +635,10 @@ export class ExecutionLayer {
       selfEmail: this.selfEmail,
       // Configurable fallback timeout for the delegate skill (sourced from config.delegate.defaultTimeoutMs).
       defaultDelegateTimeoutMs: this.defaultDelegateTimeoutMs,
+      // Console origin + local port so the capture skills can build the magic-link URL
+      // (appOrigin in prod, http://localhost:{httpPort} in dev). Harmless for other skills.
+      appOrigin: this.appOrigin,
+      httpPort: this.httpPort,
     };
 
     // Capability-gated service injection.
@@ -658,6 +682,10 @@ export class ExecutionLayer {
       // instance is created per-invocation (pre-scoped with conversationId) in the injection loop.
       // Listed here so the missing-cap guard knows it's configured when outboundContextService is set.
       outboundContext: this.outboundContextService,
+      // secretCapture is the mint-only minter for agent-initiated secret capture (#971).
+      // Injected as a plain field (default branch in the loop). Listed here so the
+      // missing-cap guard fails closed if a skill declares it before it's wired.
+      secretCapture: this.secretCaptureService,
     };
 
     // Hard-restrict executionLayer to approve-action only.

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -30,7 +30,7 @@ export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'schedulerService', 'entityMemory', 'nylasCalendarClient',
   'autonomyService', 'executiveProfileService', 'officeIdentityService', 'browserService', 'bullpenService', 'skillSearch',
   'actionLogRepo', 'executionLayer', 'confidencePipeline', 'tempFileStore',
-  'infraLlm', 'outboundContext', 'taskRepo',
+  'infraLlm', 'outboundContext', 'taskRepo', 'secretCapture',
 ]);
 
 /** One discovered on-disk skill: lenient parse for the registry UI + reconciliation.

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -255,6 +255,18 @@ export interface SkillContext {
   /** Configurable fallback timeout for specialist delegations when no timeout_ms is supplied.
    *  Sourced from config.delegate.defaultTimeoutMs. Relevant to the delegate skill only. */
   defaultDelegateTimeoutMs?: number;
+  /** Secret-capture minter — available to skills declaring 'secretCapture' in capabilities.
+   *  Mints one-time tokenized links for agent-initiated secret capture (#971). Deliberately
+   *  a MINT-ONLY surface: there is no method that returns a stored secret value, so the
+   *  "LLM never sees secrets" guarantee is structural rather than prompt-enforced. */
+  secretCapture?: import('../secrets/secret-capture-service.js').SecretCaptureMinter;
+  /** Operator-facing origin of the console (e.g. "https://curia.example.com"), used by the
+   *  capture skills to build the magic-link URL. Undefined in local dev — fall back to
+   *  http://localhost:{httpPort}. Sourced from config.appOrigin. */
+  appOrigin?: string;
+  /** Local HTTP port the SPA is served on, used as the dev fallback origin when appOrigin
+   *  is unset. Sourced from config.httpPort. */
+  httpPort?: number;
 }
 
 /**


### PR DESCRIPTION
## **User description**
## Summary

Closes #971. Lets Curia help a user add a **new** secret to the vault mid-conversation by minting a one-time, single-use, 30-minute tokenized link to a public web form. The value is entered by the user and written straight to the encrypted vault server-side. **The secret value never passes through the LLM, the chat transcript, the agent context, or logs** — the capture skills have no code path that returns a value, so the guarantee is structural, not prompt-enforced.

This is the **Capture** part of a three-issue set (#972 Resume and #973 Consume close the loop; both out of scope here).

## What's included

- **Migration `053_create_secret_capture_tokens.sql`** — token metadata only (SHA-256 hash at rest, no secret value).
- **`SecretCaptureService`** (`src/secrets/secret-capture-service.ts`) — mint/redeem with an atomic single-use claim (`UPDATE ... WHERE consumed_at IS NULL AND expires_at > now() RETURNING`), JSON validated before the claim so a bad submission doesn't burn the token, and a hardened rollback on vault-write failure. Two name policies live here as pure functions: `resolveUserSecretName` (slugify → `user.<slug>`) and `resolveSystemSecretName` (must be a declared skill secret or channel credential key — same allowlist as the vault PUT route).
- **Public HTTP routes** (`src/channels/http/routes/secret-capture.ts`) — `GET`/`POST /api/secret-capture/:token`, token-as-credential (registered outside the bearer-auth guard), rate-limited 10 / 15 min per IP.
- **`secretCapture` skill capability** + `appOrigin`/`httpPort` injected into `SkillContext` (additive, backward-compatible public API change).
- **Two skills:** `secret-capture-request` (any caller, `user.<slug>`, pinned to coordinator) and `system-secret-capture-request` (`allowed_callers: ["setup-wizard"]`, declared/channel keys, pinned to setup-wizard).
- **Public console page** `apps/console/src/pages/SecretCapturePage.tsx` + `/secret-capture/$token` route (renders without a session).
- **Prune** of expired tokens on the existing session-prune tick.

## Structural guarantees (verified by a dedicated security review)

- Raw 256-bit token exists only in the URL; only its SHA-256 hash is persisted. Never logged.
- Single-use + 30-min TTL enforced by the atomic claim — no double-redeem, no TOCTOU window.
- Token store holds **no** secret value; `getMetadata` never returns the vault key.
- `secret-capture-request` is structurally sandboxed to `user.*` — an unprivileged agent cannot target `anthropic_api_key`, `channel.*`, etc.
- `system-secret-capture-request` is restricted to the setup-wizard caller and validated against the same allowlist as `PUT /api/vault/secrets/:name`.

## Testing

- TDD throughout: service (mint hashes/atomic single-use/expiry/vault-fail rollback/JSON), name policy, routes (metadata/410/404/rate-limit), both skills (URL build, name policy, access control), and the frontend view/validation logic.
- Full suite green except 2 pre-existing `DATABASE_URL`-gated autonomy integration tests (unrelated). Both `typecheck`s clean.

## Review

Ran code-review, silent-failure-hunter, and a focused security review. All 7 security guarantees confirmed to hold; the one robustness finding (rollback could swallow the original error / strand a token under a correlated DB outage) was fixed — the rollback is now wrapped, logger-injected, and `expires_at`-guarded, with a test for the rollback-also-fails path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-time secret capture links so users can securely enter secrets without exposing them in chat.
  * Added support for assigning tasks to another agent and for closing reply threads atomically.
  * Added a public secret-capture page in the console for entering values from a shared link.

* **Bug Fixes**
  * Improved handling for expired, missing, and invalid secret-capture links.
  * Added validation to prevent empty, oversized, or malformed secret submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add public one-time links for users to enter secrets securely**

### What Changed
- Added a public secret-capture page where a user can open a one-time link, enter a new secret, and save it without signing in
- Added two request paths: one for personal secrets saved under a `user.<slug>` name, and one for approved setup secrets using exact vault keys
- The form now shows clearer states for valid, expired, invalid, and failed links, and validates JSON links before submission
- Secret links now expire after 30 minutes, can be used once, and are cleaned up after expiry
- Setup flow can now generate secret-capture links for required API keys and channel credentials instead of only listing env vars
- Fixed a failure case where a save error could leave the link in a bad state; the original error is now shown and expired links are handled cleanly

### Impact
`✅ Shorter setup for API keys`
`✅ Fewer secret-handling mistakes`
`✅ Clearer expired-link messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
