### PR TITLE
feat: console UX quality-of-life improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **URL auto-linking in chat** — bare `http`/`https` URLs in both agent and user messages are automatically wrapped in clickable anchor tags; URLs inside code spans are excluded.
+- **Sortable columns** — Name, State, and kind-specific columns in the Agents, Skills, and Channels views are now sortable (click to sort asc, click again for desc).
+- **State filter pills** — Agents and Skills views gain All/Enabled/Installed/Ghost/Uninstalled pill filters with live counts; Channels gains All/Enabled/Installed/Uninstalled.
+
+### Changed
+
+- **User chat bubble** — user messages now appear with a teal background (`--app-teal`) and white text, visually distinguishing them from agent replies.
+
 - **Secret capture** — agents mint a one-time link to a web form so a user can add a new vault secret mid-conversation; the value never touches the LLM. Skills `secret-capture-request` and `system-secret-capture-request`. (#971)
 - **`skip_secret_redaction` (skill manifest schema, public API)** — opt a skill's output out of only the broad generic-hex secret scrub (structured credential patterns stay active); gated at startup to skills declaring `secretCapture`. For capability tokens (e.g. capture links) that must reach the LLM. (#971)
 - **`task-create`** — optional `target_agent_id` assigns a new task (and its wake-up) to another registered agent, so the coordinator or ceo-inbox can schedule work for a specialist like meeting-debrief. (#880)

--- a/apps/console/src/pages/ChannelSettings.tsx
+++ b/apps/console/src/pages/ChannelSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { Topbar } from '../components/Topbar.js';
@@ -312,8 +312,20 @@ function ChannelDrawer({ entry, onClose, onChanged }: {
 //
 // Mirrors the RegistrySettings (Skills/Agents) layout: its own sidebar + topbar, a
 // records table of channels with state pills, and a detail drawer with a credential
-// form + lifecycle actions. The catalog is small (four channels), so there is no
-// search or pagination.
+// form + lifecycle actions.
+
+type ChannelSortKey = 'name' | 'state' | 'description';
+
+// Defined at module level so it's not recreated on every render.
+// Non-toggleable channels (http, cli) are always on — treat as 'enabled' for sort/filter.
+function channelSortValue(e: ChannelEntry, key: ChannelSortKey): string {
+  switch (key) {
+    case 'name':        return e.name;
+    case 'state':       return e.isToggleable ? e.state : 'enabled';
+    case 'description': return e.description;
+    default:            return '';
+  }
+}
 
 export function ChannelsPage() {
   const [theme, setTheme] = useTheme();
@@ -322,6 +334,8 @@ export function ChannelsPage() {
   const [entries, setEntries] = useState<ChannelEntry[]>([]);
   const [selected, setSelected] = useState<ChannelEntry | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [sort, setSort] = useState<{ key: ChannelSortKey; dir: 'asc' | 'desc' }>({ key: 'name', dir: 'asc' });
+  const [stateFilter, setStateFilter] = useState<'all' | ChannelState>('all');
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
@@ -347,6 +361,40 @@ export function ChannelsPage() {
 
   useEffect(() => { void load(); }, [load]);
 
+  const counts = useMemo(() => ({
+    all:         entries.length,
+    // Non-toggleable channels count as enabled (they are always on)
+    enabled:     entries.filter(e => e.state === 'enabled' || !e.isToggleable).length,
+    installed:   entries.filter(e => e.isToggleable && e.state === 'installed').length,
+    uninstalled: entries.filter(e => e.isToggleable && e.state === 'uninstalled').length,
+  }), [entries]);
+
+  const filtered = useMemo(() => {
+    let rows = entries;
+    if (stateFilter !== 'all') {
+      if (stateFilter === 'enabled') {
+        rows = rows.filter(e => e.state === 'enabled' || !e.isToggleable);
+      } else {
+        rows = rows.filter(e => e.isToggleable && e.state === stateFilter);
+      }
+    }
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      const av = channelSortValue(a, sort.key);
+      const bv = channelSortValue(b, sort.key);
+      if (av < bv) return -1 * dir;
+      if (av > bv) return  1 * dir;
+      return 0;
+    });
+  }, [entries, stateFilter, sort]);
+
+  function toggleSort(key: ChannelSortKey) {
+    setSort(s => s.key === key
+      ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
+      : { key, dir: 'asc' });
+  }
+  const sortArrow = (key: ChannelSortKey) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
+
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
@@ -364,58 +412,92 @@ export function ChannelsPage() {
           {loadError ? (
             <div style={{ padding: 32, color: 'var(--app-destructive)', fontSize: 13 }}>{loadError}</div>
           ) : (
-            <div className="records-layout">
-              <div className="records-main">
-                <div className="records-table-wrap">
-                  <table className="records-table">
-                    <thead>
-                      <tr>
-                        <th>Name</th>
-                        <th>State</th>
-                        <th>Description</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {entries.map(e => (
-                        <tr
-                          key={e.name}
-                          className={selected?.name === e.name ? 'active' : undefined}
-                          onClick={() => setSelected(e)}
-                          style={{ cursor: 'pointer' }}
-                        >
-                          <td>{e.name}</td>
-                          <td>
-                            {/* Non-toggleable channels (http, cli) are always on. */}
-                            {e.isToggleable ? (
-                              <span className={`status-pill ${STATE_PILL[e.state]}`}>{STATE_LABEL[e.state]}</span>
-                            ) : (
-                              <span className="status-pill confirmed">Always on</span>
-                            )}
-                          </td>
-                          <td>{e.description}</td>
-                        </tr>
-                      ))}
-                      {entries.length === 0 && (
-                        <tr>
-                          <td colSpan={3} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
-                            No channels.
-                          </td>
-                        </tr>
-                      )}
-                    </tbody>
-                  </table>
+            <>
+              <div className="records-toolbar">
+                <div className="records-toolbar-left">
+                  {(['all', 'enabled', 'installed', 'uninstalled'] as const).map(v => (
+                    <button
+                      key={v}
+                      className={`records-filter-chip${stateFilter === v ? ' active' : ''}`}
+                      onClick={() => setStateFilter(v)}
+                    >
+                      {v === 'all' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+                        {counts[v as keyof typeof counts]}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <div className="records-toolbar-right">
+                  <span className="topbar-meta">{filtered.length} of {entries.length}</span>
                 </div>
               </div>
 
-              {selected && (
-                <ChannelDrawer
-                  key={selected.name}
-                  entry={selected}
-                  onClose={() => setSelected(null)}
-                  onChanged={() => { void load(); }}
-                />
-              )}
-            </div>
+              <div className="records-layout">
+                <div className="records-main">
+                  <div className="records-table-wrap">
+                    <table className="records-table">
+                      <thead>
+                        <tr>
+                          <th className="sortable" aria-sort={sort.key === 'name' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('name')}>
+                              Name <span className="sort-arrow">{sortArrow('name')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={sort.key === 'state' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('state')}>
+                              State <span className="sort-arrow">{sortArrow('state')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={sort.key === 'description' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('description')}>
+                              Description <span className="sort-arrow">{sortArrow('description')}</span>
+                            </button>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {filtered.map(e => (
+                          <tr
+                            key={e.name}
+                            className={selected?.name === e.name ? 'active' : undefined}
+                            onClick={() => setSelected(e)}
+                            style={{ cursor: 'pointer' }}
+                          >
+                            <td>{e.name}</td>
+                            <td>
+                              {/* Non-toggleable channels (http, cli) are always on. */}
+                              {e.isToggleable ? (
+                                <span className={`status-pill ${STATE_PILL[e.state]}`}>{STATE_LABEL[e.state]}</span>
+                              ) : (
+                                <span className="status-pill confirmed">Always on</span>
+                              )}
+                            </td>
+                            <td>{e.description}</td>
+                          </tr>
+                        ))}
+                        {filtered.length === 0 && (
+                          <tr>
+                            <td colSpan={3} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                              No channels.
+                            </td>
+                          </tr>
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+
+                {selected && (
+                  <ChannelDrawer
+                    key={selected.name}
+                    entry={selected}
+                    onClose={() => setSelected(null)}
+                    onChanged={() => { void load(); }}
+                  />
+                )}
+              </div>
+            </>
           )}
         </main>
       </div>

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -420,6 +420,25 @@ function Pagination({ total, page, pageSize, totalPages, onPage, onPageSize }: P
   );
 }
 
+// ── Sort types and helpers ────────────────────────────────────────────────────
+
+// Sort key covers columns from both kinds; kind-specific ones only appear
+// in the table when the relevant kind is active.
+type SortKey = 'name' | 'state' | 'version' | 'modelTier' | 'memoryScopes' | 'actionRisk' | 'sensitivity';
+
+function getSortValue(entry: RegistryEntry, key: SortKey): string {
+  switch (key) {
+    case 'name':         return entry.name;
+    case 'state':        return entry.state;
+    case 'version':      return entry.metadata?.version ?? '';
+    case 'modelTier':    return entry.metadata?.modelTier ?? '';
+    case 'memoryScopes': return entry.metadata?.memoryScopes?.join(', ') ?? '';
+    case 'actionRisk':   return entry.metadata?.actionRisk != null ? String(entry.metadata.actionRisk) : '';
+    case 'sensitivity':  return entry.metadata?.sensitivity ?? '';
+    default:             return '';
+  }
+}
+
 // ── Standalone registry page (Skills / Agents) ───────────────────────────────
 //
 // Mirrors the Contacts/Tasks layout: its own sidebar + topbar (with search), a
@@ -438,6 +457,8 @@ function RegistryPage({ kind }: { kind: 'skill' | 'agent' }) {
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'name', dir: 'asc' });
+  const [stateFilter, setStateFilter] = useState<'all' | DerivedState>('all');
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
@@ -463,14 +484,41 @@ function RegistryPage({ kind }: { kind: 'skill' | 'agent' }) {
 
   useEffect(() => { void load(); }, [load]);
 
-  // Search filters on name + description; pagination is applied to the result.
+  // Count entries by state for the filter pill badges.
+  const counts = useMemo(() => ({
+    all:         entries.length,
+    uninstalled: entries.filter(e => e.state === 'uninstalled').length,
+    installed:   entries.filter(e => e.state === 'installed').length,
+    enabled:     entries.filter(e => e.state === 'enabled').length,
+    ghost:       entries.filter(e => e.state === 'ghost').length,
+  }), [entries]);
+
+  // State filter, search filter, and sort — all in one pass.
   const filtered = useMemo(() => {
-    if (!search) return entries;
-    const q = search.toLowerCase();
-    return entries.filter(e =>
-      (e.name + ' ' + (e.metadata?.description ?? '')).toLowerCase().includes(q),
-    );
-  }, [entries, search]);
+    let rows = entries;
+    if (stateFilter !== 'all') rows = rows.filter(e => e.state === stateFilter);
+    if (search) {
+      const q = search.toLowerCase();
+      rows = rows.filter(e =>
+        (e.name + ' ' + (e.metadata?.description ?? '')).toLowerCase().includes(q),
+      );
+    }
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      const av = getSortValue(a, sort.key);
+      const bv = getSortValue(b, sort.key);
+      if (av < bv) return -1 * dir;
+      if (av > bv) return  1 * dir;
+      return 0;
+    });
+  }, [entries, stateFilter, search, sort]);
+
+  function toggleSort(key: SortKey) {
+    setSort(s => s.key === key
+      ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
+      : { key, dir: 'asc' });
+  }
+  const sortArrow = (key: SortKey) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const safePage = Math.min(page, totalPages);
@@ -514,26 +562,74 @@ function RegistryPage({ kind }: { kind: 'skill' | 'agent' }) {
                 />
               </div>
 
+              <div className="records-toolbar">
+                <div className="records-toolbar-left">
+                  {(['all', 'enabled', 'installed', 'ghost', 'uninstalled'] as const).map(v => (
+                    <button
+                      key={v}
+                      className={`records-filter-chip${stateFilter === v ? ' active' : ''}`}
+                      onClick={() => { setStateFilter(v); setPage(1); }}
+                    >
+                      {v === 'all' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+                        {counts[v as keyof typeof counts]}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <div className="records-toolbar-right">
+                  <span className="topbar-meta">{filtered.length} of {entries.length}</span>
+                </div>
+              </div>
+
               <div className="records-layout">
                 <div className="records-main">
                   <div className="records-table-wrap">
                     <table className="records-table">
                       <thead>
                         <tr>
-                          <th>Name</th>
-                          <th>State</th>
+                          <th className="sortable" aria-sort={sort.key === 'name' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('name')}>
+                              Name <span className="sort-arrow">{sortArrow('name')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={sort.key === 'state' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('state')}>
+                              State <span className="sort-arrow">{sortArrow('state')}</span>
+                            </button>
+                          </th>
                           {kind === 'agent' ? (
                             <>
-                              <th>Model tier</th>
-                              <th>Memory scopes</th>
+                              <th className="sortable" aria-sort={sort.key === 'modelTier' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                                <button className="sort-btn" onClick={() => toggleSort('modelTier')}>
+                                  Model tier <span className="sort-arrow">{sortArrow('modelTier')}</span>
+                                </button>
+                              </th>
+                              <th className="sortable" aria-sort={sort.key === 'memoryScopes' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                                <button className="sort-btn" onClick={() => toggleSort('memoryScopes')}>
+                                  Memory scopes <span className="sort-arrow">{sortArrow('memoryScopes')}</span>
+                                </button>
+                              </th>
                             </>
                           ) : (
                             <>
-                              <th>Action risk</th>
-                              <th>Sensitivity</th>
+                              <th className="sortable" aria-sort={sort.key === 'actionRisk' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                                <button className="sort-btn" onClick={() => toggleSort('actionRisk')}>
+                                  Action risk <span className="sort-arrow">{sortArrow('actionRisk')}</span>
+                                </button>
+                              </th>
+                              <th className="sortable" aria-sort={sort.key === 'sensitivity' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                                <button className="sort-btn" onClick={() => toggleSort('sensitivity')}>
+                                  Sensitivity <span className="sort-arrow">{sortArrow('sensitivity')}</span>
+                                </button>
+                              </th>
                             </>
                           )}
-                          <th>Version</th>
+                          <th className="sortable" aria-sort={sort.key === 'version' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('version')}>
+                              Version <span className="sort-arrow">{sortArrow('version')}</span>
+                            </button>
+                          </th>
                         </tr>
                       </thead>
                       <tbody>

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -426,6 +426,15 @@ function Pagination({ total, page, pageSize, totalPages, onPage, onPageSize }: P
 // in the table when the relevant kind is active.
 type SortKey = 'name' | 'state' | 'version' | 'modelTier' | 'memoryScopes' | 'actionRisk' | 'sensitivity';
 
+function actionRiskToSortKey(v: string | number | null | undefined): string {
+  // Normalize to a zero-padded 3-digit number string so lexicographic sort = numeric sort.
+  // String labels map to their spec-defined minimum autonomy scores.
+  if (v == null) return '000';
+  if (typeof v === 'number') return String(v).padStart(3, '0');
+  const labels: Record<string, number> = { none: 0, low: 60, medium: 70, high: 80, critical: 90 };
+  return String(labels[v] ?? 0).padStart(3, '0');
+}
+
 function getSortValue(entry: RegistryEntry, key: SortKey): string {
   switch (key) {
     case 'name':         return entry.name;
@@ -433,7 +442,7 @@ function getSortValue(entry: RegistryEntry, key: SortKey): string {
     case 'version':      return entry.metadata?.version ?? '';
     case 'modelTier':    return entry.metadata?.modelTier ?? '';
     case 'memoryScopes': return entry.metadata?.memoryScopes?.join(', ') ?? '';
-    case 'actionRisk':   return entry.metadata?.actionRisk != null ? String(entry.metadata.actionRisk) : '';
+    case 'actionRisk':   return actionRiskToSortKey(entry.metadata?.actionRisk);
     case 'sensitivity':  return entry.metadata?.sensitivity ?? '';
     default:             return '';
   }

--- a/apps/console/src/pages/chat/ChatThread.tsx
+++ b/apps/console/src/pages/chat/ChatThread.tsx
@@ -1,6 +1,6 @@
 // apps/console/src/pages/chat/ChatThread.tsx
 import { useEffect, useRef } from 'react';
-import { formatTimestamp } from './chat-utils.js';
+import { formatTimestamp, linkifyText } from './chat-utils.js';
 import type { Message } from './types.js';
 
 interface ChatThreadProps {
@@ -108,7 +108,9 @@ export function ChatThread({ messages, hasMore, loadingHistory, loadMore }: Chat
                 // No raw user input ever reaches dangerouslySetInnerHTML.
                 <span dangerouslySetInnerHTML={{ __html: msg.html }} />
               ) : (
-                msg.text
+                // Safe: linkifyText() escapes all HTML entities before adding anchor tags,
+                // so user-supplied text cannot inject markup. Only http/https URLs are linked.
+                <span dangerouslySetInnerHTML={{ __html: linkifyText(msg.text) }} />
               )}
             </div>
             {msg.timestamp && (

--- a/apps/console/src/pages/chat/chat-utils.test.ts
+++ b/apps/console/src/pages/chat/chat-utils.test.ts
@@ -128,4 +128,10 @@ describe('linkifyText', () => {
     const result = linkifyText('javascript:alert(1)');
     expect(result).not.toContain('<a href="javascript:');
   });
+
+  it('strips trailing punctuation from linked URLs', () => {
+    const result = linkifyText('Visit https://example.com. for more');
+    expect(result).toContain('<a href="https://example.com"');
+    expect(result).not.toContain('<a href="https://example.com."');
+  });
 });

--- a/apps/console/src/pages/chat/chat-utils.test.ts
+++ b/apps/console/src/pages/chat/chat-utils.test.ts
@@ -134,4 +134,9 @@ describe('linkifyText', () => {
     expect(result).toContain('<a href="https://example.com"');
     expect(result).not.toContain('<a href="https://example.com."');
   });
+
+  it('preserves balanced parentheses inside URLs', () => {
+    const result = linkifyText('See https://en.wikipedia.org/wiki/Function_(mathematics) here');
+    expect(result).toContain('<a href="https://en.wikipedia.org/wiki/Function_(mathematics)"');
+  });
 });

--- a/apps/console/src/pages/chat/chat-utils.test.ts
+++ b/apps/console/src/pages/chat/chat-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseSseEvent, makeMessage, formatTimestamp } from './chat-utils.js';
+import { parseSseEvent, makeMessage, formatTimestamp, linkifyText } from './chat-utils.js';
 
 describe('parseSseEvent', () => {
   it('returns status text for skill.invoke events', () => {
@@ -84,5 +84,48 @@ describe('formatTimestamp', () => {
     expect(result).not.toMatch(/^Today · /);
     // Should contain a middle dot
     expect(result).toContain(' · ');
+  });
+});
+
+describe('linkifyText', () => {
+  it('wraps a bare https URL in an anchor tag', () => {
+    const result = linkifyText('Visit https://example.com please');
+    expect(result).toContain('<a href="https://example.com"');
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noopener noreferrer"');
+    expect(result).toContain('Visit ');
+    expect(result).toContain(' please');
+  });
+
+  it('wraps a bare http URL', () => {
+    const result = linkifyText('http://example.com');
+    expect(result).toContain('<a href="http://example.com"');
+  });
+
+  it('escapes HTML before linking so user text cannot inject markup', () => {
+    const result = linkifyText('<script>alert(1)</script>');
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;');
+  });
+
+  it('passes through plain text unchanged (modulo entity escaping)', () => {
+    const result = linkifyText('Hello world');
+    expect(result).toBe('Hello world');
+  });
+
+  it('handles text with no URLs', () => {
+    const result = linkifyText('No links here.');
+    expect(result).toBe('No links here.');
+  });
+
+  it('handles multiple URLs in one message', () => {
+    const result = linkifyText('See https://a.com and https://b.com');
+    expect(result).toContain('<a href="https://a.com"');
+    expect(result).toContain('<a href="https://b.com"');
+  });
+
+  it('does not linkify javascript: URIs', () => {
+    const result = linkifyText('javascript:alert(1)');
+    expect(result).not.toContain('<a href="javascript:');
   });
 });

--- a/apps/console/src/pages/chat/chat-utils.ts
+++ b/apps/console/src/pages/chat/chat-utils.ts
@@ -50,3 +50,23 @@ export function formatTimestamp(ts: Date): string {
   const date = ts.toLocaleDateString([], { month: 'short', day: 'numeric' });
   return `${date} · ${time}`;
 }
+
+/**
+ * Escapes HTML in user-supplied text and wraps bare http/https URLs in anchor tags.
+ * The result is safe to pass to dangerouslySetInnerHTML: HTML escaping runs first,
+ * so no user text can inject markup. The URL regex only matches http/https, blocking
+ * javascript: and other non-http schemes.
+ */
+export function linkifyText(text: string): string {
+  // Escape HTML entities first so user text cannot inject markup.
+  const escaped = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  // Wrap bare URLs. The exclusion set [^\s<>"] stops at whitespace and the HTML
+  // characters that would break the surrounding attribute or tag context.
+  return escaped.replace(
+    /https?:\/\/[^\s<>"]+/g,
+    url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
+  );
+}

--- a/apps/console/src/pages/chat/chat-utils.ts
+++ b/apps/console/src/pages/chat/chat-utils.ts
@@ -68,8 +68,21 @@ export function linkifyText(text: string): string {
   return escaped.replace(
     /https?:\/\/[^\s<>"]+/g,
     url => {
-      // Strip trailing sentence punctuation that is almost certainly not part of the URL.
-      const stripped = url.replace(/[.,;:!?)'"\]]+$/, '');
+      // Strip trailing sentence punctuation. Balanced bracket pairs (e.g.
+      // Wikipedia /wiki/Function_(mathematics)) are only stripped when unmatched.
+      let stripped = url.replace(/[.,;:!?'"`]+$/, '');
+      while (stripped.endsWith(')')) {
+        const opens = (stripped.match(/\(/g) ?? []).length;
+        const closes = (stripped.match(/\)/g) ?? []).length;
+        if (closes <= opens) break;
+        stripped = stripped.slice(0, -1);
+      }
+      while (stripped.endsWith(']')) {
+        const opens = (stripped.match(/\[/g) ?? []).length;
+        const closes = (stripped.match(/\]/g) ?? []).length;
+        if (closes <= opens) break;
+        stripped = stripped.slice(0, -1);
+      }
       const suffix = url.slice(stripped.length);
       return `<a href="${stripped}" target="_blank" rel="noopener noreferrer">${stripped}</a>${suffix}`;
     },

--- a/apps/console/src/pages/chat/chat-utils.ts
+++ b/apps/console/src/pages/chat/chat-utils.ts
@@ -67,6 +67,11 @@ export function linkifyText(text: string): string {
   // characters that would break the surrounding attribute or tag context.
   return escaped.replace(
     /https?:\/\/[^\s<>"]+/g,
-    url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
+    url => {
+      // Strip trailing sentence punctuation that is almost certainly not part of the URL.
+      const stripped = url.replace(/[.,;:!?)'"\]]+$/, '');
+      const suffix = url.slice(stripped.length);
+      return `<a href="${stripped}" target="_blank" rel="noopener noreferrer">${stripped}</a>${suffix}`;
+    },
   );
 }

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1273,6 +1273,12 @@ table.records-table tbody tr.active td { background: transparent; }
   text-decoration: underline;
 }
 
+/* In dark mode --app-teal is #478189 (4.41:1 against white — just below AA).
+   Override to light-mode teal (#1A6B5E, 6.4:1) so the bubble stays AA-compliant. */
+[data-theme="dark"] .msg-bubble.user {
+  background: #1A6B5E;
+}
+
 .msg-bubble.agent {
   background: var(--app-card);
   border: 1px solid var(--app-border);

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1268,6 +1268,11 @@ table.records-table tbody tr.active td { background: transparent; }
   border-radius: 12px 12px 2px 12px;
 }
 
+.msg-bubble.user a {
+  color: #fff;
+  text-decoration: underline;
+}
+
 .msg-bubble.agent {
   background: var(--app-card);
   border: 1px solid var(--app-border);

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1263,7 +1263,8 @@ table.records-table tbody tr.active td { background: transparent; }
 }
 
 .msg-bubble.user {
-  background: var(--app-card-elev);
+  background: var(--app-teal);
+  color: #fff;
   border-radius: 12px 12px 2px 12px;
 }
 

--- a/docs/wip/2026-06-14-console-ux-qol-design.md
+++ b/docs/wip/2026-06-14-console-ux-qol-design.md
@@ -1,0 +1,127 @@
+# Console UX QoL — Design
+
+**Date:** 2026-06-14
+**Scope:** Four small UI improvements to the web console: chat bubble colour, URL hyperlinking in chat, sortable columns, and state pill filters.
+
+---
+
+## 1. User Chat Bubble Colour
+
+**File:** `apps/console/src/styles/app.css`
+
+`.msg-bubble.user` currently uses `--app-card-elev` (a neutral elevated surface). Change to `--app-teal` with white text so user messages are visually distinct from agent messages.
+
+```css
+.msg-bubble.user {
+  background: var(--app-teal);
+  color: #fff;
+  border-radius: 12px 12px 2px 12px;
+}
+```
+
+Dark-mode `--app-teal` is `#478189`. White on `#478189` clears WCAG AA (4.5:1 for small text). Light-mode `--app-teal` is `#1A6B5E`, which also passes.
+
+---
+
+## 2. URL Auto-Hyperlinking in Chat
+
+### 2a. Agent messages — server-side (`src/utils/markdown-to-html.ts`)
+
+Add URL detection to `applyInline()`, after code-span restoration. The existing `escapeHtml()` runs at the top of `applyInline()`, so by the time URL matching runs the text is already safe: `&`, `<`, `>` are entities, so no injection path exists through the URL.
+
+Pattern: match `https?://[^\s<>"]+` after inline-formatting passes. Wrap in `<a href="..." target="_blank" rel="noopener noreferrer">...</a>`.
+
+**Scope:** only `src/utils/markdown-to-html.ts` (chat path). The email copy at `src/channels/email/markdown-to-html.ts` is untouched.
+
+### 2b. User messages — client-side (`apps/console/src/pages/chat/ChatThread.tsx`)
+
+User bubbles currently render `msg.text` as a plain text node, so no URL is ever clickable. Add a `linkifyText(text: string): string` helper that:
+
+1. Escapes HTML entities (same four replacements as server-side `escapeHtml`: `&`, `<`, `>`)
+2. Detects `https?://[^\s<>"]+` with a regex
+3. Wraps each match in `<a href="..." target="_blank" rel="noopener noreferrer">...</a>`
+
+The helper is pure (no I/O) and lives at the top of `ChatThread.tsx`. User bubbles switch from `{msg.text}` to `dangerouslySetInnerHTML={{ __html: linkifyText(msg.text) }}`. This is safe: step 1 ensures no raw HTML from the user ever reaches the DOM.
+
+URLs in user messages preserve surrounding whitespace because `.msg-bubble` already has `white-space: pre-wrap`.
+
+---
+
+## 3. Sortable Columns — Agents & Skills (`RegistrySettings.tsx`)
+
+`ContactsPage` already implements the full sort pattern; this mirrors it exactly.
+
+**State added to `RegistryPage`:**
+```ts
+type SortKey = 'name' | 'state' | 'version' | 'actionRisk' | 'sensitivity' | 'modelTier' | 'memoryScopes';
+const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'name', dir: 'asc' });
+```
+
+**`filtered` useMemo** — extends existing search filter to also sort. String comparison on the resolved display value for each key.
+
+**Table headers** — each `<th>` gains `className="sortable"` and `aria-sort`. Inside, a `<button className="sort-btn">` with a `<span className="sort-arrow">` (↑/↓/empty). Same CSS classes ContactsPage already uses — no new CSS needed.
+
+Sortable columns:
+- **Both kinds:** Name, State, Version
+- **Skills only:** Action risk, Sensitivity
+- **Agents only:** Model tier, Memory scopes
+
+Default sort: Name ascending.
+
+---
+
+## 4. Sortable Columns — Channels (`ChannelSettings.tsx`)
+
+Same pattern. Sortable columns: Name, State, Description. Default sort: Name ascending.
+
+Since Channels has no search/pagination today, this change also adds the `useMemo` pattern for sorting (sort applied to the full `entries` array; output replaces `entries.map(...)` in the table body).
+
+---
+
+## 5. State Pill Filters — Agents & Skills (`RegistrySettings.tsx`)
+
+Mirror `ContactsPage`'s `records-toolbar` pattern.
+
+**State added:**
+```ts
+const [stateFilter, setStateFilter] = useState<'all' | DerivedState>('all');
+```
+
+**`counts` useMemo:**
+```ts
+const counts = useMemo(() => ({
+  all:         entries.length,
+  uninstalled: entries.filter(e => e.state === 'uninstalled').length,
+  installed:   entries.filter(e => e.state === 'installed').length,
+  enabled:     entries.filter(e => e.state === 'enabled').length,
+  ghost:       entries.filter(e => e.state === 'ghost').length,
+}), [entries]);
+```
+
+**Filter integration:** `stateFilter` applied in `filtered` useMemo before search, resets `page` to 1 on change.
+
+**Toolbar markup:** `<div className="records-toolbar">` with `records-filter-chip` buttons, count badges — identical HTML structure to ContactsPage. No new CSS.
+
+Filter labels: All, Enabled, Installed, Ghost, Uninstalled.
+
+---
+
+## 6. State Pill Filters — Channels (`ChannelSettings.tsx`)
+
+Same pattern. States: All, Enabled, Installed, Uninstalled. (No "ghost" state for channels.)
+
+Since Channels currently has no filtered/pagination useMemo, this change introduces one to support filter + sort together.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `apps/console/src/styles/app.css` | User bubble colour |
+| `apps/console/src/pages/chat/ChatThread.tsx` | `linkifyText` helper + user bubble `dangerouslySetInnerHTML` |
+| `src/utils/markdown-to-html.ts` | URL auto-link in `applyInline()` |
+| `apps/console/src/pages/RegistrySettings.tsx` | Sort state + sortable headers + state filter toolbar |
+| `apps/console/src/pages/ChannelSettings.tsx` | Sort state + sortable headers + state filter toolbar |
+
+No new dependencies. No database changes. No API changes. No new CSS classes (all classes already exist in `app.css` from the ContactsPage implementation).

--- a/docs/wip/2026-06-14-console-ux-qol.md
+++ b/docs/wip/2026-06-14-console-ux-qol.md
@@ -1,0 +1,762 @@
+# Console UX QoL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Four targeted UI improvements to the web console: distinct user-message bubble colour, URL auto-hyperlinking in chat, sortable columns in Agents/Skills/Channels views, and state pill filters in those same views.
+
+**Architecture:** All changes are pure UI — no API, database, or CSS-class additions. The sort/filter pattern is lifted directly from `ContactsPage`, which already implements the full `records-toolbar` + `sort-btn` stack. URL linking is handled in two places: server-side inside `applyInline()` (agent messages, where markdown is already processed) and client-side via a new `linkifyText()` helper (user messages, which render as plain text today).
+
+**Tech Stack:** React 19, TypeScript (strict), Vitest, CSS custom properties (`--app-teal`), `dangerouslySetInnerHTML` (safe: HTML is escaped before any markup is added).
+
+---
+
+## Prerequisite: Install dependencies in the worktree
+
+The worktree does not share `node_modules` with the main checkout.
+
+- [ ] **Install dependencies**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol install
+```
+
+Expected: pnpm links from global cache. Should complete in seconds.
+
+---
+
+## Task 1: User bubble colour
+
+**Files:**
+- Modify: `apps/console/src/styles/app.css`
+
+No unit test needed — pure CSS change.
+
+- [ ] **Step 1: Change `.msg-bubble.user` in `app.css`**
+
+Find the existing rule (around line 1265):
+```css
+.msg-bubble.user {
+  background: var(--app-card-elev);
+  border-radius: 12px 12px 2px 12px;
+}
+```
+
+Replace with:
+```css
+.msg-bubble.user {
+  background: var(--app-teal);
+  color: #fff;
+  border-radius: 12px 12px 2px 12px;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol add apps/console/src/styles/app.css
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol commit -m "feat: teal background + white text for user chat bubbles"
+```
+
+---
+
+## Task 2: URL auto-linking in agent messages
+
+**Files:**
+- Create: `src/utils/markdown-to-html.test.ts`
+- Modify: `src/utils/markdown-to-html.ts`
+
+Agent messages are rendered via `markdownToHtml()`. The `applyInline()` helper already HTML-escapes all text before processing, so URL detection runs on safe, already-escaped text. URLs are added **after** bold/italic processing but **before** code-span restoration so that URLs inside code spans (`\`https://...\``) are not linkified.
+
+- [ ] **Step 1: Create the failing test**
+
+Create `src/utils/markdown-to-html.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { markdownToHtml } from './markdown-to-html.js';
+
+describe('markdownToHtml — URL auto-linking', () => {
+  it('wraps a bare https URL in an anchor tag', () => {
+    const result = markdownToHtml('Visit https://example.com for more.');
+    expect(result).toContain('<a href="https://example.com"');
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+
+  it('wraps a bare http URL in an anchor tag', () => {
+    const result = markdownToHtml('See http://example.com');
+    expect(result).toContain('<a href="http://example.com"');
+  });
+
+  it('does not linkify URLs inside inline code spans', () => {
+    const result = markdownToHtml('Run `https://example.com`');
+    // URL is inside <code>, not inside an <a>
+    expect(result).toContain('<code>https://example.com</code>');
+    expect(result).not.toContain('<a href="https://example.com"');
+  });
+
+  it('linkifies a URL that contains query parameters', () => {
+    const result = markdownToHtml('Go to https://example.com?a=1&b=2 now');
+    // & is escaped to &amp; before URL detection runs
+    expect(result).toContain('<a href="https://example.com?a=1&amp;b=2"');
+  });
+
+  it('linkifies URLs inside bold text', () => {
+    const result = markdownToHtml('See **https://example.com**');
+    expect(result).toContain('<a href="https://example.com"');
+  });
+
+  it('does not break non-URL text', () => {
+    const result = markdownToHtml('Hello world');
+    expect(result).toBe('<p>Hello world</p>');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol test src/utils/markdown-to-html.test.ts
+```
+
+Expected: FAIL — the URL tests fail because `applyInline()` does not yet link URLs.
+
+- [ ] **Step 3: Add URL linking to `applyInline()` in `src/utils/markdown-to-html.ts`**
+
+Find `applyInline()` (around line 58). Add the URL-linking step after the italic replacements but **before** the code-span restoration:
+
+```typescript
+function applyInline(text: string): string {
+  let out = escapeHtml(text);
+
+  // Replace code spans with stable placeholders before bold/italic processing so
+  // that content like `**inside code**` is not transformed by the bold regex.
+  // \x00 is safe here: escapeHtml doesn't produce it and LLM text won't contain it.
+  const codePlaceholders: string[] = [];
+  out = out.replace(/`([^`]+)`/g, (_, inner: string) => {
+    codePlaceholders.push(`<code>${inner}</code>`);
+    return `\x00CODE${codePlaceholders.length - 1}\x00`;
+  });
+
+  // Bold: **text** or __text__
+  out = out.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  out = out.replace(/__(.+?)__/g, '<strong>$1</strong>');
+
+  // Italic: *text*
+  out = out.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '<em>$1</em>');
+  // Italic: _text_ (word-boundary anchored to avoid matching underscores in identifiers)
+  out = out.replace(/(?<!_)\b_(?!_)(.+?)(?<!_)_\b(?!_)/g, '<em>$1</em>');
+
+  // Auto-link bare URLs. Runs after bold/italic so formatting inside URLs is preserved,
+  // and before code-span restoration so URLs inside code spans are not linkified
+  // (they exist only as \x00CODE...\x00 placeholders at this point).
+  out = out.replace(
+    /https?:\/\/[^\s<>"]+/g,
+    url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
+  );
+
+  // Restore code spans
+  out = out.replace(/\x00CODE(\d+)\x00/g, (_, i: string) => codePlaceholders[parseInt(i, 10)]!);
+
+  return out;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol test src/utils/markdown-to-html.test.ts
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Run the full test suite to check for regressions**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol add src/utils/markdown-to-html.ts src/utils/markdown-to-html.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol commit -m "feat: auto-link URLs in agent chat messages"
+```
+
+---
+
+## Task 3: URL auto-linking in user messages
+
+**Files:**
+- Modify: `apps/console/src/pages/chat/chat-utils.ts`
+- Modify: `apps/console/src/pages/chat/chat-utils.test.ts`
+- Modify: `apps/console/src/pages/chat/ChatThread.tsx`
+
+User messages render as plain text today. We add a `linkifyText()` helper that HTML-escapes the text first, then wraps bare URLs in `<a>` tags. The chat bubble then uses `dangerouslySetInnerHTML` with this output. This is safe: escaping runs before any markup is added, so no user-supplied text can inject HTML.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/console/src/pages/chat/chat-utils.test.ts`, after the existing `describe` blocks:
+
+```typescript
+describe('linkifyText', () => {
+  it('wraps a bare https URL in an anchor tag', () => {
+    // Import linkifyText at the top of the test file (add to the import line)
+    const result = linkifyText('Visit https://example.com please');
+    expect(result).toContain('<a href="https://example.com"');
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noopener noreferrer"');
+    expect(result).toContain('Visit ');
+    expect(result).toContain(' please');
+  });
+
+  it('wraps a bare http URL', () => {
+    const result = linkifyText('http://example.com');
+    expect(result).toContain('<a href="http://example.com"');
+  });
+
+  it('escapes HTML before linking so user text cannot inject markup', () => {
+    const result = linkifyText('<script>alert(1)</script>');
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;');
+  });
+
+  it('passes through plain text unchanged (modulo entity escaping)', () => {
+    const result = linkifyText('Hello world');
+    expect(result).toBe('Hello world');
+  });
+
+  it('handles text with no URLs', () => {
+    const result = linkifyText('No links here.');
+    expect(result).toBe('No links here.');
+  });
+
+  it('handles multiple URLs in one message', () => {
+    const result = linkifyText('See https://a.com and https://b.com');
+    expect(result).toContain('<a href="https://a.com"');
+    expect(result).toContain('<a href="https://b.com"');
+  });
+
+  it('does not linkify javascript: URIs', () => {
+    const result = linkifyText('javascript:alert(1)');
+    expect(result).not.toContain('<a href="javascript:');
+  });
+});
+```
+
+Also update the import line at the top of the file to include `linkifyText`:
+```typescript
+import { parseSseEvent, makeMessage, formatTimestamp, linkifyText } from './chat-utils.js';
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol test apps/console/src/pages/chat/chat-utils.test.ts
+```
+
+Expected: FAIL — `linkifyText` is not exported from `chat-utils.ts`.
+
+- [ ] **Step 3: Add `linkifyText` to `chat-utils.ts`**
+
+Add after the `formatTimestamp` export at the end of `apps/console/src/pages/chat/chat-utils.ts`:
+
+```typescript
+/**
+ * Escapes HTML in user-supplied text and wraps bare http/https URLs in anchor tags.
+ * The result is safe to pass to dangerouslySetInnerHTML: HTML escaping runs first,
+ * so no user text can inject markup. The URL regex only matches http/https, blocking
+ * javascript: and other non-http schemes.
+ */
+export function linkifyText(text: string): string {
+  // Escape HTML entities first so user text cannot inject markup.
+  const escaped = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  // Wrap bare URLs. The exclusion set [^\s<>"] stops at whitespace and the HTML
+  // characters that would break the surrounding attribute or tag context. The &
+  // character is allowed so that escaped query strings (e.g. &amp;) are included.
+  return escaped.replace(
+    /https?:\/\/[^\s<>"]+/g,
+    url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol test apps/console/src/pages/chat/chat-utils.test.ts
+```
+
+Expected: all `linkifyText` tests PASS.
+
+- [ ] **Step 5: Update `ChatThread.tsx` to use `linkifyText` for user bubbles**
+
+In `apps/console/src/pages/chat/ChatThread.tsx`, add `linkifyText` to the import:
+```typescript
+import { formatTimestamp, linkifyText } from './chat-utils.js';
+```
+
+Then find the user-bubble render branch (around line 101–113). The current render is:
+```tsx
+<div key={msg.id} className={`msg-group ${msg.kind}`}>
+  <div className={`msg-bubble ${msg.kind}`}>
+    {msg.html ? (
+      <span dangerouslySetInnerHTML={{ __html: msg.html }} />
+    ) : (
+      msg.text
+    )}
+  </div>
+  {msg.timestamp && (
+    <div className="msg-time">{formatTimestamp(msg.timestamp)}</div>
+  )}
+</div>
+```
+
+Replace with (user messages now always use `dangerouslySetInnerHTML` via `linkifyText`; agent messages use `msg.html` if present, otherwise fall back to `linkifyText` as well for safety):
+```tsx
+<div key={msg.id} className={`msg-group ${msg.kind}`}>
+  <div className={`msg-bubble ${msg.kind}`}>
+    {msg.html ? (
+      // Safe: html is produced server-side by markdownToHtml(), which
+      // runs escapeHtml() BEFORE inserting any markup.
+      <span dangerouslySetInnerHTML={{ __html: msg.html }} />
+    ) : (
+      // Safe: linkifyText() escapes all HTML entities before adding anchor tags,
+      // so user-supplied text cannot inject markup. Only http/https URLs are linked.
+      <span dangerouslySetInnerHTML={{ __html: linkifyText(msg.text) }} />
+    )}
+  </div>
+  {msg.timestamp && (
+    <div className="msg-time">{formatTimestamp(msg.timestamp)}</div>
+  )}
+</div>
+```
+
+- [ ] **Step 6: Typecheck the console**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol --filter @curia/console run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Run the full test suite**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol add apps/console/src/pages/chat/chat-utils.ts apps/console/src/pages/chat/chat-utils.test.ts apps/console/src/pages/chat/ChatThread.tsx
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol commit -m "feat: auto-link URLs in user chat messages"
+```
+
+---
+
+## Task 4: Sortable columns + state filters in `RegistrySettings.tsx`
+
+**Files:**
+- Modify: `apps/console/src/pages/RegistrySettings.tsx`
+
+No unit tests for React component logic (no testing library in console). Relies on typecheck and visual verification. The sort/filter pattern mirrors `ContactsPage` exactly — same CSS classes (`sort-btn`, `sort-arrow`, `sortable`, `records-toolbar`, `records-filter-chip`), same state shape.
+
+- [ ] **Step 1: Add sort and filter state + counts useMemo**
+
+Add the `SortKey` type at module level, just above `function RegistryPage(...)` (around line 430):
+
+```typescript
+// Sort key covers columns from both kinds; kind-specific ones only appear
+// in the table when the relevant kind is active.
+type SortKey = 'name' | 'state' | 'version' | 'modelTier' | 'memoryScopes' | 'actionRisk' | 'sensitivity';
+```
+
+Then inside `RegistryPage`, after the existing `useState` declarations, add two new state hooks:
+
+```typescript
+const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'name', dir: 'asc' });
+const [stateFilter, setStateFilter] = useState<'all' | DerivedState>('all');
+```
+
+Add a `counts` useMemo after the existing `load` callback (before the `filtered` useMemo):
+
+```typescript
+const counts = useMemo(() => ({
+  all:         entries.length,
+  uninstalled: entries.filter(e => e.state === 'uninstalled').length,
+  installed:   entries.filter(e => e.state === 'installed').length,
+  enabled:     entries.filter(e => e.state === 'enabled').length,
+  ghost:       entries.filter(e => e.state === 'ghost').length,
+}), [entries]);
+```
+
+- [ ] **Step 2: Add a `getSortValue` helper and extend `filtered` useMemo**
+
+Add a `getSortValue` helper immediately before `RegistryPage` (above the component, as a module-level function):
+
+```typescript
+function getSortValue(entry: RegistryEntry, key: SortKey): string {
+  switch (key) {
+    case 'name':        return entry.name;
+    case 'state':       return entry.state;
+    case 'version':     return entry.metadata?.version ?? '';
+    case 'modelTier':   return entry.metadata?.modelTier ?? '';
+    case 'memoryScopes': return entry.metadata?.memoryScopes?.join(', ') ?? '';
+    case 'actionRisk':  return entry.metadata?.actionRisk != null ? String(entry.metadata.actionRisk) : '';
+    case 'sensitivity': return entry.metadata?.sensitivity ?? '';
+    default:            return '';
+  }
+}
+```
+
+Replace the existing `filtered` useMemo (which only filters by search) with:
+
+```typescript
+const filtered = useMemo(() => {
+  let rows = entries;
+  if (stateFilter !== 'all') rows = rows.filter(e => e.state === stateFilter);
+  if (search) {
+    const q = search.toLowerCase();
+    rows = rows.filter(e =>
+      (e.name + ' ' + (e.metadata?.description ?? '')).toLowerCase().includes(q),
+    );
+  }
+  const dir = sort.dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const av = getSortValue(a, sort.key);
+    const bv = getSortValue(b, sort.key);
+    if (av < bv) return -1 * dir;
+    if (av > bv) return  1 * dir;
+    return 0;
+  });
+}, [entries, stateFilter, search, sort]);
+```
+
+Add a `toggleSort` helper and `sortArrow` after the `filtered` useMemo (inside the component, since they close over `sort` state):
+
+```typescript
+function toggleSort(key: SortKey) {
+  setSort(s => s.key === key
+    ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
+    : { key, dir: 'asc' });
+}
+const sortArrow = (key: SortKey) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
+```
+
+- [ ] **Step 3: Add the state filter toolbar to the JSX**
+
+In the JSX, after the mobile search `<div className="contacts-mobile-search">` block and before `<div className="records-layout">`, insert:
+
+```tsx
+<div className="records-toolbar">
+  <div className="records-toolbar-left">
+    {(['all', 'enabled', 'installed', 'ghost', 'uninstalled'] as const).map(v => (
+      <button
+        key={v}
+        className={`records-filter-chip${stateFilter === v ? ' active' : ''}`}
+        onClick={() => { setStateFilter(v); setPage(1); }}
+      >
+        {v === 'all' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+        <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+          {counts[v]}
+        </span>
+      </button>
+    ))}
+  </div>
+  <div className="records-toolbar-right">
+    <span className="topbar-meta">{filtered.length} of {entries.length}</span>
+  </div>
+</div>
+```
+
+- [ ] **Step 4: Replace table headers with sortable buttons**
+
+Find the `<thead>` block in the table and replace it:
+
+```tsx
+<thead>
+  <tr>
+    <th className="sortable" aria-sort={sort.key === 'name' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+      <button className="sort-btn" onClick={() => toggleSort('name')}>
+        Name <span className="sort-arrow">{sortArrow('name')}</span>
+      </button>
+    </th>
+    <th className="sortable" aria-sort={sort.key === 'state' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+      <button className="sort-btn" onClick={() => toggleSort('state')}>
+        State <span className="sort-arrow">{sortArrow('state')}</span>
+      </button>
+    </th>
+    {kind === 'agent' ? (
+      <>
+        <th className="sortable" aria-sort={sort.key === 'modelTier' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+          <button className="sort-btn" onClick={() => toggleSort('modelTier')}>
+            Model tier <span className="sort-arrow">{sortArrow('modelTier')}</span>
+          </button>
+        </th>
+        <th className="sortable" aria-sort={sort.key === 'memoryScopes' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+          <button className="sort-btn" onClick={() => toggleSort('memoryScopes')}>
+            Memory scopes <span className="sort-arrow">{sortArrow('memoryScopes')}</span>
+          </button>
+        </th>
+      </>
+    ) : (
+      <>
+        <th className="sortable" aria-sort={sort.key === 'actionRisk' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+          <button className="sort-btn" onClick={() => toggleSort('actionRisk')}>
+            Action risk <span className="sort-arrow">{sortArrow('actionRisk')}</span>
+          </button>
+        </th>
+        <th className="sortable" aria-sort={sort.key === 'sensitivity' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+          <button className="sort-btn" onClick={() => toggleSort('sensitivity')}>
+            Sensitivity <span className="sort-arrow">{sortArrow('sensitivity')}</span>
+          </button>
+        </th>
+      </>
+    )}
+    <th className="sortable" aria-sort={sort.key === 'version' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+      <button className="sort-btn" onClick={() => toggleSort('version')}>
+        Version <span className="sort-arrow">{sortArrow('version')}</span>
+      </button>
+    </th>
+  </tr>
+</thead>
+```
+
+- [ ] **Step 5: Typecheck the console**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol --filter @curia/console run typecheck
+```
+
+Expected: no errors. If TypeScript complains about `counts[v]` indexing (because `v` is `'all' | DerivedState` but `counts` keys include `'all'`), cast: `counts[v as keyof typeof counts]`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol add apps/console/src/pages/RegistrySettings.tsx
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol commit -m "feat: sortable columns and state filter pills in Agents/Skills views"
+```
+
+---
+
+## Task 5: Sortable columns + state filters in `ChannelSettings.tsx`
+
+**Files:**
+- Modify: `apps/console/src/pages/ChannelSettings.tsx`
+
+Same pattern as Task 4. Channels has no existing `filtered` useMemo or search state; this adds both to support sort + filter. Non-toggleable channels (http, cli) display "Always on" and are treated as `enabled` for filtering and sort comparison purposes.
+
+- [ ] **Step 1: Add sort + filter state**
+
+In `ChannelsPage` (around line 318), after the existing state declarations:
+
+```typescript
+type ChannelSortKey = 'name' | 'state' | 'description';
+
+export function ChannelsPage() {
+  // ... existing state ...
+  const [sort, setSort] = useState<{ key: ChannelSortKey; dir: 'asc' | 'desc' }>({ key: 'name', dir: 'asc' });
+  const [stateFilter, setStateFilter] = useState<'all' | ChannelState>('all');
+```
+
+- [ ] **Step 2: Add counts useMemo + filtered useMemo**
+
+After the `load` callback, add:
+
+```typescript
+const counts = useMemo(() => ({
+  all:         entries.length,
+  enabled:     entries.filter(e => e.state === 'enabled' || !e.isToggleable).length,
+  installed:   entries.filter(e => e.isToggleable && e.state === 'installed').length,
+  uninstalled: entries.filter(e => e.isToggleable && e.state === 'uninstalled').length,
+}), [entries]);
+
+// For sorting, treat non-toggleable channels (http, cli) as 'enabled' since they
+// are always on and display "Always on" rather than a lifecycle state.
+function channelSortValue(e: ChannelEntry, key: ChannelSortKey): string {
+  switch (key) {
+    case 'name':        return e.name;
+    case 'state':       return e.isToggleable ? e.state : 'enabled';
+    case 'description': return e.description;
+    default:            return '';
+  }
+}
+
+const filtered = useMemo(() => {
+  let rows = entries;
+  if (stateFilter !== 'all') {
+    if (stateFilter === 'enabled') {
+      rows = rows.filter(e => e.state === 'enabled' || !e.isToggleable);
+    } else {
+      rows = rows.filter(e => e.isToggleable && e.state === stateFilter);
+    }
+  }
+  const dir = sort.dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const av = channelSortValue(a, sort.key);
+    const bv = channelSortValue(b, sort.key);
+    if (av < bv) return -1 * dir;
+    if (av > bv) return  1 * dir;
+    return 0;
+  });
+}, [entries, stateFilter, sort]);
+
+function toggleSort(key: ChannelSortKey) {
+  setSort(s => s.key === key
+    ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
+    : { key, dir: 'asc' });
+}
+const sortArrow = (key: ChannelSortKey) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
+```
+
+Note: `channelSortValue` is a pure helper with no dependency on component state — define it as a `const` arrow function just above `ChannelsPage` (module level) so it doesn't get recreated on every render.
+
+- [ ] **Step 3: Add the state filter toolbar + sortable headers to the JSX**
+
+In the JSX return, find the `<div className="records-layout">` and add the toolbar above it. Also replace `entries.map(...)` in the table body with `filtered.map(...)`, and replace the plain `<th>` headers with sortable buttons.
+
+The full updated JSX block (replace everything from `{loadError ? (` to the closing `)}` of the `main` section):
+
+```tsx
+{loadError ? (
+  <div style={{ padding: 32, color: 'var(--app-destructive)', fontSize: 13 }}>{loadError}</div>
+) : (
+  <>
+    <div className="records-toolbar">
+      <div className="records-toolbar-left">
+        {(['all', 'enabled', 'installed', 'uninstalled'] as const).map(v => (
+          <button
+            key={v}
+            className={`records-filter-chip${stateFilter === v ? ' active' : ''}`}
+            onClick={() => setStateFilter(v)}
+          >
+            {v === 'all' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+            <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+              {counts[v]}
+            </span>
+          </button>
+        ))}
+      </div>
+      <div className="records-toolbar-right">
+        <span className="topbar-meta">{filtered.length} of {entries.length}</span>
+      </div>
+    </div>
+
+    <div className="records-layout">
+      <div className="records-main">
+        <div className="records-table-wrap">
+          <table className="records-table">
+            <thead>
+              <tr>
+                <th className="sortable" aria-sort={sort.key === 'name' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                  <button className="sort-btn" onClick={() => toggleSort('name')}>
+                    Name <span className="sort-arrow">{sortArrow('name')}</span>
+                  </button>
+                </th>
+                <th className="sortable" aria-sort={sort.key === 'state' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                  <button className="sort-btn" onClick={() => toggleSort('state')}>
+                    State <span className="sort-arrow">{sortArrow('state')}</span>
+                  </button>
+                </th>
+                <th className="sortable" aria-sort={sort.key === 'description' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                  <button className="sort-btn" onClick={() => toggleSort('description')}>
+                    Description <span className="sort-arrow">{sortArrow('description')}</span>
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map(e => (
+                <tr
+                  key={e.name}
+                  className={selected?.name === e.name ? 'active' : undefined}
+                  onClick={() => setSelected(e)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <td>{e.name}</td>
+                  <td>
+                    {/* Non-toggleable channels (http, cli) are always on. */}
+                    {e.isToggleable ? (
+                      <span className={`status-pill ${STATE_PILL[e.state]}`}>{STATE_LABEL[e.state]}</span>
+                    ) : (
+                      <span className="status-pill confirmed">Always on</span>
+                    )}
+                  </td>
+                  <td>{e.description}</td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={3} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                    No channels.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {selected && (
+        <ChannelDrawer
+          key={selected.name}
+          entry={selected}
+          onClose={() => setSelected(null)}
+          onChanged={() => { void load(); }}
+        />
+      )}
+    </div>
+  </>
+)}
+```
+
+- [ ] **Step 4: Typecheck the console**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol --filter @curia/console run typecheck
+```
+
+Expected: no errors. If TypeScript complains about `counts[v]` where `v` is `'all' | ChannelState`, note that `ChannelState` is `'uninstalled' | 'installed' | 'enabled'` — all of which are keys of `counts`. If needed, cast: `counts[v as keyof typeof counts]`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol add apps/console/src/pages/ChannelSettings.tsx
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol commit -m "feat: sortable columns and state filter pills in Channels view"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run the root typecheck (covers all src/ TypeScript)**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run the console typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-ux-qol --filter @curia/console run typecheck
+```
+
+Expected: no errors.

--- a/src/utils/markdown-to-html.test.ts
+++ b/src/utils/markdown-to-html.test.ts
@@ -42,4 +42,15 @@ describe('markdownToHtml — URL auto-linking', () => {
     expect(result).toContain('<a href="https://example.com"');
     expect(result).not.toContain('<a href="https://example.com."');
   });
+
+  it('preserves balanced parentheses inside URLs', () => {
+    const result = markdownToHtml('See https://en.wikipedia.org/wiki/Function_(mathematics) here');
+    expect(result).toContain('<a href="https://en.wikipedia.org/wiki/Function_(mathematics)"');
+  });
+
+  it('does not linkify javascript: or data: URIs', () => {
+    const result = markdownToHtml('Try javascript:alert(1) or data:text/html,x');
+    expect(result).not.toContain('<a href="javascript:');
+    expect(result).not.toContain('<a href="data:');
+  });
 });

--- a/src/utils/markdown-to-html.test.ts
+++ b/src/utils/markdown-to-html.test.ts
@@ -36,4 +36,10 @@ describe('markdownToHtml — URL auto-linking', () => {
     const result = markdownToHtml('Hello world');
     expect(result).toBe('<p>Hello world</p>');
   });
+
+  it('strips trailing punctuation from linked URLs', () => {
+    const result = markdownToHtml('Visit https://example.com. for more');
+    expect(result).toContain('<a href="https://example.com"');
+    expect(result).not.toContain('<a href="https://example.com."');
+  });
 });

--- a/src/utils/markdown-to-html.test.ts
+++ b/src/utils/markdown-to-html.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { markdownToHtml } from './markdown-to-html.js';
+
+describe('markdownToHtml — URL auto-linking', () => {
+  it('wraps a bare https URL in an anchor tag', () => {
+    const result = markdownToHtml('Visit https://example.com for more.');
+    expect(result).toContain('<a href="https://example.com"');
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+
+  it('wraps a bare http URL in an anchor tag', () => {
+    const result = markdownToHtml('See http://example.com');
+    expect(result).toContain('<a href="http://example.com"');
+  });
+
+  it('does not linkify URLs inside inline code spans', () => {
+    const result = markdownToHtml('Run `https://example.com`');
+    // URL is inside <code>, not inside an <a>
+    expect(result).toContain('<code>https://example.com</code>');
+    expect(result).not.toContain('<a href="https://example.com"');
+  });
+
+  it('linkifies a URL that contains query parameters', () => {
+    const result = markdownToHtml('Go to https://example.com?a=1&b=2 now');
+    // & is escaped to &amp; before URL detection runs
+    expect(result).toContain('<a href="https://example.com?a=1&amp;b=2"');
+  });
+
+  it('linkifies URLs inside bold text', () => {
+    const result = markdownToHtml('See **https://example.com**');
+    expect(result).toContain('<a href="https://example.com"');
+  });
+
+  it('does not break non-URL text', () => {
+    const result = markdownToHtml('Hello world');
+    expect(result).toBe('<p>Hello world</p>');
+  });
+});

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -81,7 +81,12 @@ function applyInline(text: string): string {
   // (they exist only as \x00CODE...\x00 placeholders at this point).
   out = out.replace(
     /https?:\/\/[^\s<>"]+/g,
-    url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
+    url => {
+      // Strip trailing sentence punctuation that is almost certainly not part of the URL.
+      const stripped = url.replace(/[.,;:!?)'"\]]+$/, '');
+      const suffix = url.slice(stripped.length);
+      return `<a href="${stripped}" target="_blank" rel="noopener noreferrer">${stripped}</a>${suffix}`;
+    },
   );
 
   // Restore code spans

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -76,6 +76,14 @@ function applyInline(text: string): string {
   // Italic: _text_ (word-boundary anchored to avoid matching underscores in identifiers)
   out = out.replace(/(?<!_)\b_(?!_)(.+?)(?<!_)_\b(?!_)/g, '<em>$1</em>');
 
+  // Auto-link bare URLs. Runs after bold/italic so formatting inside URLs is preserved,
+  // and before code-span restoration so URLs inside code spans are not linkified
+  // (they exist only as \x00CODE...\x00 placeholders at this point).
+  out = out.replace(
+    /https?:\/\/[^\s<>"]+/g,
+    url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
+  );
+
   // Restore code spans
   out = out.replace(/\x00CODE(\d+)\x00/g, (_, i: string) => codePlaceholders[parseInt(i, 10)]!);
 

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -82,8 +82,21 @@ function applyInline(text: string): string {
   out = out.replace(
     /https?:\/\/[^\s<>"]+/g,
     url => {
-      // Strip trailing sentence punctuation that is almost certainly not part of the URL.
-      const stripped = url.replace(/[.,;:!?)'"\]]+$/, '');
+      // Strip trailing sentence punctuation. Balanced bracket pairs (e.g.
+      // Wikipedia /wiki/Function_(mathematics)) are only stripped when unmatched.
+      let stripped = url.replace(/[.,;:!?'"`]+$/, '');
+      while (stripped.endsWith(')')) {
+        const opens = (stripped.match(/\(/g) ?? []).length;
+        const closes = (stripped.match(/\)/g) ?? []).length;
+        if (closes <= opens) break;
+        stripped = stripped.slice(0, -1);
+      }
+      while (stripped.endsWith(']')) {
+        const opens = (stripped.match(/\[/g) ?? []).length;
+        const closes = (stripped.match(/\]/g) ?? []).length;
+        if (closes <= opens) break;
+        stripped = stripped.slice(0, -1);
+      }
       const suffix = url.slice(stripped.length);
       return `<a href="${stripped}" target="_blank" rel="noopener noreferrer">${stripped}</a>${suffix}`;
     },


### PR DESCRIPTION
## **User description**
## Summary

- **User chat bubble colour** — user messages now show a teal background (`--app-teal`) and white text, making them visually distinct from agent replies
- **URL auto-linking in chat** — bare `http`/`https` URLs in both agent messages (via `markdownToHtml`) and user messages (via `linkifyText`) become clickable links; URLs inside code spans are left as-is; trailing sentence punctuation is stripped from the href
- **Sortable columns** — Name, State, and kind-specific columns in the Agents, Skills, and Channels views are now sortable (click to toggle asc/desc); mirrors the existing ContactsPage pattern
- **State filter pills** — Agents/Skills gain All/Enabled/Installed/Ghost/Uninstalled pills; Channels gains All/Enabled/Installed/Uninstalled; all with live counts

## Implementation notes

- No new CSS classes, no new dependencies, no API or DB changes
- `linkifyText` HTML-escapes first, then wraps URLs — safe for `dangerouslySetInnerHTML`
- `actionRisk` sort normalises string labels and numeric values to the same zero-padded scale (`none`→`000`, `low`→`060`, etc.)
- Non-toggleable channels (http, cli) are treated as `enabled` in filter and sort

## Test plan

- [ ] Run tests: `pnpm test` — 3390 pass, 2 pre-existing DB pool failures unrelated to this change
- [ ] Typecheck: `pnpm --filter @curia/console run typecheck` — clean
- [ ] Chat: send a message with a URL — user bubble is teal, URL is clickable, trailing period is not in the href
- [ ] Chat: agent response with a URL — link appears in agent bubble
- [ ] Chat: user bubble link text is white (matching bubble text colour)
- [ ] Agents/Skills: click column headers — rows sort asc/desc; arrow indicator updates
- [ ] Agents/Skills: click state pills — table filters; count badge updates
- [ ] Channels: same sort and filter checks


___

## **CodeAnt-AI Description**
**Improve chat links and add sorting and filters in the console**

### What Changed
- User chat messages now use a teal bubble with white text, and URLs in both user and agent chat messages become clickable links.
- Chat links open in a new tab, ignore URLs inside code spans, and drop trailing punctuation from the link target.
- Agents, Skills, and Channels tables now let users sort columns and filter rows by state with live counts.
- Non-toggleable channels are treated as always on in filters and sorting, so their status matches what users see.
- Added tests that cover URL linking, HTML escaping, punctuation handling, and code-span behavior.

### Impact
`✅ Clearer chat messages`
`✅ Faster finding agents, skills, and channels`
`✅ Fewer broken or unsafe chat links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * URLs in chat messages are now automatically clickable and open in new tabs
  * Sortable columns added to Agents, Skills, and Channels tables for easier organization
  * Live-count filter pills now available for Agents and Skills
  * Enhanced filtering capabilities for Channels

* **Style**
  * User chat messages now display with a teal background and white text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->