### PR TITLE
fix: secret-capture link self-redacted by the model — shorter slug + verbatim-relay instruction (#971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Secret-capture link redaction** — the one-time capture URL's token was scrubbed to `[REDACTED]` by the output sanitizer; the two capture skills now declare `skip_secret_redaction` so the link reaches the user intact. (#971)
+- **Secret-capture link relayed verbatim** — the token is now a short base64url slug (not a 64-char hex hash) and the skill summaries instruct the agent to relay the URL verbatim, so the model no longer self-redacts the link as a credential. (#971)
 
 ### Removed
 

--- a/skills/secret-capture-request/handler.ts
+++ b/skills/secret-capture-request/handler.ts
@@ -67,8 +67,11 @@ export class SecretCaptureRequestHandler implements SkillHandler {
           secret_name: secretName,
           displayTimezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : undefined,
           summary:
-            `Send this one-time link to the user so they can enter the value. It expires in 30 minutes ` +
-            `and works once. The value goes straight to the vault under "${secretName}" — you will not see it.`,
+            `Reply to the user with the capture_url EXACTLY as given, including the full token — ` +
+            `do not redact, mask, shorten, or alter any part of it, and do not replace it with ` +
+            `a placeholder. The link itself is safe to share; it is not a secret. (The secret is ` +
+            `the value the user types into the form, which goes straight to the vault under ` +
+            `"${secretName}" and never reaches you.) Tell them it is one-time and expires in 30 minutes.`,
         },
       };
     } catch (err) {

--- a/skills/secret-capture-request/skill.json
+++ b/skills/secret-capture-request/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "secret-capture-request",
-  "description": "Mint a one-time, single-use, 30-minute link the user can click to enter a NEW personal secret (e.g. a website password). The value is typed by the user into a secure web form and written straight to the vault under a `user.<slug>` key. You never see the value — this skill returns only the link, never the secret. Use when a task needs a secret the vault does not yet have.",
-  "version": "0.1.1",
+  "description": "Mint a one-time, single-use, 30-minute link the user can click to enter a NEW personal secret (e.g. a website password). The value is typed by the user into a secure web form and written straight to the vault under a `user.<slug>` key. You never see the value — this skill returns only the link, never the secret. Relay the returned capture_url to the user verbatim. Use when a task needs a secret the vault does not yet have.",
+  "version": "0.1.2",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/system-secret-capture-request/handler.ts
+++ b/skills/system-secret-capture-request/handler.ts
@@ -69,8 +69,11 @@ export class SystemSecretCaptureRequestHandler implements SkillHandler {
           secret_name: secretName,
           displayTimezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : undefined,
           summary:
-            `Send this one-time link to the user so they can enter the value for "${secretName}". ` +
-            `It expires in 30 minutes and works once. The value goes straight to the vault — you will not see it.`,
+            `Reply to the user with the capture_url EXACTLY as given, including the full token — ` +
+            `do not redact, mask, shorten, or alter any part of it, and do not replace it with ` +
+            `a placeholder. The link itself is safe to share; it is not a secret. (The secret is ` +
+            `the value the user types into the form for "${secretName}", which goes straight to the ` +
+            `vault and never reaches you.) Tell them it is one-time and expires in 30 minutes.`,
         },
       };
     } catch (err) {

--- a/skills/system-secret-capture-request/skill.json
+++ b/skills/system-secret-capture-request/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "system-secret-capture-request",
   "description": "Mint a one-time, single-use, 30-minute link for the user to enter a SYSTEM secret during setup — an API key or channel credential (e.g. the Anthropic API key). The target name must be a secret declared by a skill or a known channel credential key. The value goes straight to the vault; you never see it. Setup-wizard only.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/src/secrets/secret-capture-service.test.ts
+++ b/src/secrets/secret-capture-service.test.ts
@@ -125,8 +125,10 @@ describe('SecretCaptureService minting (via the public name-policy entry points)
     expect(storedHash).toBe(hashToken(rawToken));
     // The raw token must never be a stored parameter.
     expect(insert!.params).not.toContain(rawToken);
-    // 64 hex chars = 32 bytes of entropy.
-    expect(rawToken).toMatch(/^[0-9a-f]{64}$/);
+    // Short base64url slug (~22 chars from 16 bytes) — not a long hex hash, and it matches
+    // none of the secret-scrub regexes (no 32+ hex run, no sk-/AKIA/Bearer).
+    expect(rawToken).toMatch(/^[A-Za-z0-9_-]{20,24}$/);
+    expect(rawToken).not.toMatch(/[a-f0-9]{32,}/);
   });
 
   it('sets a fixed 30-minute expiry (TTL is not caller-controlled)', async () => {
@@ -143,7 +145,7 @@ describe('SecretCaptureService.mintUserSecret / mintSystemSecret', () => {
     const { svc } = makeService();
     const res = await svc.mintUserSecret({ rawName: 'Flight Site Password' });
     expect(res.secretName).toBe('user.flight_site_password');
-    expect(res.rawToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(res.rawToken).toMatch(/^[A-Za-z0-9_-]{20,24}$/);
   });
 
   it('mintSystemSecret accepts an allowed key and rejects an unknown one', async () => {

--- a/src/secrets/secret-capture-service.ts
+++ b/src/secrets/secret-capture-service.ts
@@ -131,9 +131,15 @@ export class SecretCaptureService implements SecretCaptureMinter {
    * by passing an arbitrary secretName. TTL is fixed (not a parameter) for the same reason.
    */
   private async mint(secretName: string, label: string | undefined, valueFormat: CaptureValueFormat): Promise<{ rawToken: string; expiresAt: Date }> {
-    // 256-bit raw token — lives only in the returned URL. We persist its hash, matching the
-    // session-auth pattern, so a DB compromise cannot reconstruct a usable capture link.
-    const rawToken = randomBytes(32).toString('hex');
+    // 128-bit raw token, base64url-encoded → a short (~22 char) mixed-case slug that reads
+    // like an ordinary magic-link id, NOT a 64-char hex hash. Two reasons for this shape:
+    //   1. The relaying LLM was self-redacting the old hex token (it pattern-matched a long
+    //      hex string in a "secret-capture" context as a credential and printed [REDACTED]).
+    //      A short base64url slug doesn't trip that instinct.
+    //   2. It matches none of the secret-scrub regexes (not a 32+ hex run, no sk-/AKIA/Bearer).
+    // 128 bits is still cryptographically unguessable for a single-use, 30-minute, rate-limited
+    // link. The token lives only in the URL; we persist its hash (session-auth pattern).
+    const rawToken = randomBytes(16).toString('base64url');
     const tokenHash = hashToken(rawToken);
     // Compute expires_at from the DB clock (now() + TTL), not the app clock, and read it back.
     // Redemption/metadata also compare against the DB now(), so mint and redeem share one time


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #977, found in continued production testing. The link domain and the execution-layer redaction were both fixed, but the URL still reached the user as `…/secret-capture/[REDACTED]`.

**Root cause (confirmed via the prod audit log):** the token now reaches the LLM intact — `skill.result` carries the full token, working memory has no redaction, and the tool_result is passed verbatim. The **model itself** was self-redacting: it pattern-matched the 64-char hex token in a "secret-capture / password" context as a credential and printed `[REDACTED]`. When asked explicitly for the "unredacted URL", it printed the real token — proving the value was present and the redaction was the model's own behavior, not code.

## Fix

Two changes so the link is relayed by default:

1. **Shorter, non-secret-looking slug.** The token is now `randomBytes(16).toString('base64url')` (~22 mixed-case chars) instead of `randomBytes(32).toString('hex')` (64 hex chars). It reads like an ordinary magic-link id rather than a credential hash, and matches none of the secret-scrub regexes. 128 bits is ample for a single-use, 30-minute, rate-limited link. `hashToken()` hashes whatever string we pass, so **no DB/migration change**.
2. **Verbatim-relay instruction.** Both skill summaries now tell the agent to relay `capture_url` exactly, and decouple "the link is safe to share" from "the value the user types is the secret you never see" — the previous wording blurred the two and primed the redaction.

No prompt carve-out was needed: there's no explicit "redact secrets" instruction in the coordinator/agent prompts (verified by grep) — it was pure model habit triggered by the hex token.

## Files
- `src/secrets/secret-capture-service.ts` — base64url slug (+ test updated for the new format and to assert it matches no hex-secret pattern)
- `skills/{secret-capture-request,system-secret-capture-request}/{handler.ts,skill.json}` — summary rewrite, description note, bump to 0.1.2

## Testing
Full suite green (only the pre-existing `DATABASE_URL`-gated autonomy integration tests fail). Typecheck clean. Will verify end-to-end on the prod instance after merge+deploy (mint a link, confirm the agent relays the full slug with no `[REDACTED]`).


___

## **CodeAnt-AI Description**
**Stop secret-capture links from being self-redacted**

### What Changed
- Secret-capture links now use a short mixed-character token instead of a long hex string, so they are less likely to be treated like a secret and hidden in the reply.
- The capture instructions now tell the agent to send the link exactly as returned, without masking, shortening, or replacing it.
- The secret-capture skill notes and changelog were updated to reflect the new link behavior.

### Impact
`✅ Fewer hidden capture links`
`✅ Clearer secret-entry prompts`
`✅ Lower chance of broken one-time links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
