### PR TITLE
feat: secret-by-reference injection for web-browser fill (#973)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
-- **Value-aware browser redaction** — secret values injected by reference are tracked per browser session and scrubbed from any returned page content or error, blocking round-trip exfiltration via a page that reflects a typed credential back. (#973)
+- **Value-aware browser redaction** — secret values injected by reference are tracked per browser session and scrubbed (raw plus URL/HTML-encoded variants) from returned content, the page URL, and errors; screenshots are suppressed on a secret-fill action since an image can't be value-redacted. Blocks round-trip exfiltration via a page that reflects a typed credential back. (#973)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **URL auto-linking in chat** — bare `http`/`https` URLs in both agent and user messages are automatically wrapped in clickable anchor tags; URLs inside code spans are excluded.
 - **Sortable columns** — Name, State, and kind-specific columns in the Agents, Skills, and Channels views are now sortable (click to sort asc, click again for desc).
 - **State filter pills** — Agents and Skills views gain All/Enabled/Installed/Ghost/Uninstalled pill filters with live counts; Channels gains All/Enabled/Installed/Uninstalled.
+- **Secret-by-reference injection** — the `web-browser` `type` action accepts `secret_ref` (a `user.*` vault key) to fill a stored credential; the value is dereferenced server-side and never enters the LLM context, tool call, result, or logs. (#973)
+- **`secretResolver` capability (skill manifest schema, public API)** — runtime by-reference resolution of dynamic `user.*` secrets; gated to a hard skill allowlist (`web-browser` only) and the `user.*` namespace. (#973)
 
 ### Changed
 
@@ -31,12 +33,18 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **`SkillContext` (public API)** — adds optional `secretCapture` capability and `appOrigin`/`httpPort` fields (backward compatible). (#971)
+- **`SkillContext` (public API)** — adds optional `resolveSecretRef(ref)` method, injected only for allowlisted skills declaring `secretResolver` (backward compatible). (#973)
+- **`SecretAccessedEvent` (bus event types, public API)** — payload gains optional `byReference` flag distinguishing dynamic by-reference resolution from declared-secret access (backward compatible). (#973)
 - **Coordinator prompt** — re-derived around a three-way routing decision; delegation-hinted outbound replies now always transfer to the owning specialist. (#957)
 
 ### Fixed
 
 - **Secret-capture link redaction** — the one-time capture URL's token was scrubbed to `[REDACTED]` by the output sanitizer; the two capture skills now declare `skip_secret_redaction` so the link reaches the user intact. (#971)
 - **Secret-capture link relayed verbatim** — the token is now a short base64url slug (not a 64-char hex hash) and the skill summaries instruct the agent to relay the URL verbatim, so the model no longer self-redacts the link as a credential. (#971)
+
+### Security
+
+- **Value-aware browser redaction** — secret values injected by reference are tracked per browser session and scrubbed from any returned page content or error, blocking round-trip exfiltration via a page that reflects a typed credential back. (#973)
 
 ### Removed
 

--- a/skills/web-browser/handler.test.ts
+++ b/skills/web-browser/handler.test.ts
@@ -42,7 +42,7 @@ function makeMockPage(content: string, fill: ReturnType<typeof vi.fn>, url = 'ht
 }
 
 /** Build a SkillContext + a real BrowserSession wrapping the mock page. */
-function makeCtx(opts: {
+function makeSkillContext(opts: {
   input: Record<string, unknown>;
   pageContent?: string;
   pageUrl?: string;
@@ -70,7 +70,7 @@ function makeCtx(opts: {
 describe('web-browser type action with secret_ref (#973)', () => {
   it('fills the resolved secret value and never returns it', async () => {
     const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
-    const { ctx, fill } = makeCtx({
+    const { ctx, fill } = makeSkillContext({
       input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password' },
       resolveSecretRef,
     });
@@ -88,7 +88,7 @@ describe('web-browser type action with secret_ref (#973)', () => {
   it('redacts an injected value reflected back through get_content', async () => {
     const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
     // First fill the secret, then a page whose content echoes it back.
-    const { ctx, session } = makeCtx({
+    const { ctx, session } = makeSkillContext({
       input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password' },
       pageContent: `Welcome. Your entered password was ${SECRET_VALUE} (oops).`,
       resolveSecretRef,
@@ -108,7 +108,7 @@ describe('web-browser type action with secret_ref (#973)', () => {
 
   it('redacts an injected value reflected back through the returned url (GET form)', async () => {
     const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
-    const { ctx } = makeCtx({
+    const { ctx } = makeSkillContext({
       input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password' },
       // A form that submits via GET puts the field value into the query string.
       pageUrl: `https://aeroplan.com/login?pw=${SECRET_VALUE}`,
@@ -125,9 +125,27 @@ describe('web-browser type action with secret_ref (#973)', () => {
     }
   });
 
+  it('suppresses a screenshot on the same action that injects a secret', async () => {
+    const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
+    const { ctx } = makeSkillContext({
+      // screenshot:true on a secret_ref fill — the field may render the value (non-password
+      // input), and an image can't be value-redacted, so capture must be refused.
+      input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password', screenshot: true },
+      resolveSecretRef,
+    });
+
+    const result = await new WebBrowserHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { screenshot_base64?: string };
+      expect(data.screenshot_base64).toBeUndefined();
+    }
+  });
+
   it('rejects when both text and secret_ref are supplied (mutually exclusive)', async () => {
     const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
-    const { ctx, fill } = makeCtx({
+    const { ctx, fill } = makeSkillContext({
       input: { action: 'type', selector: '#pass', text: 'literal', secret_ref: 'user.aeroplan_password' },
       resolveSecretRef,
     });
@@ -140,14 +158,14 @@ describe('web-browser type action with secret_ref (#973)', () => {
   });
 
   it('rejects when neither text nor secret_ref is supplied', async () => {
-    const { ctx } = makeCtx({ input: { action: 'type', selector: '#pass' } });
+    const { ctx } = makeSkillContext({ input: { action: 'type', selector: '#pass' } });
     const result = await new WebBrowserHandler().execute(ctx);
     expect(result.success).toBe(false);
   });
 
   it('errors clearly when secret_ref is used but the resolver capability is absent', async () => {
     // resolveSecretRef undefined — the skill was invoked without the secretResolver capability.
-    const { ctx, fill } = makeCtx({
+    const { ctx, fill } = makeSkillContext({
       input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password' },
     });
 
@@ -161,7 +179,7 @@ describe('web-browser type action with secret_ref (#973)', () => {
   });
 
   it('still supports a literal text fill (non-secret path unchanged)', async () => {
-    const { ctx, fill } = makeCtx({
+    const { ctx, fill } = makeSkillContext({
       input: { action: 'type', selector: '#search', text: 'hello world' },
     });
 

--- a/skills/web-browser/handler.test.ts
+++ b/skills/web-browser/handler.test.ts
@@ -1,0 +1,153 @@
+// skills/web-browser/handler.test.ts — tests for the web-browser skill's
+// secret-by-reference fill path (#973).
+//
+// Focus: the `type` action's `secret_ref` input dereferences a user.* secret via
+// ctx.resolveSecretRef and fills the resolved value WITHOUT the value ever entering
+// the skill's return data, and any page content read back is scrubbed of it.
+
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { WebBrowserHandler } from './handler.js';
+import { BrowserSession } from '../../src/browser/browser-session.js';
+import type { BrowserService } from '../../src/browser/browser-service.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { BrowserContext, Page } from 'playwright';
+
+const logger = pino({ level: 'silent' });
+
+const SECRET_VALUE = 'sup3r-s3cr3t-pw';
+
+/**
+ * Build a mock Playwright page. `content` is what get_content reads back (used to
+ * verify value-aware redaction). The shared `fill` spy records what got typed.
+ */
+function makeMockPage(content: string, fill: ReturnType<typeof vi.fn>) {
+  const locator = {
+    count: vi.fn().mockResolvedValue(1),
+    first: vi.fn().mockReturnThis(),
+    fill,
+    click: vi.fn().mockResolvedValue(undefined),
+    selectOption: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    url: vi.fn().mockReturnValue('https://aeroplan.com/account'),
+    evaluate: vi.fn().mockResolvedValue(content),
+    waitForTimeout: vi.fn().mockResolvedValue(undefined),
+    screenshot: vi.fn().mockResolvedValue(Buffer.from('png')),
+    getByRole: vi.fn().mockReturnValue(locator),
+    getByLabel: vi.fn().mockReturnValue(locator),
+    getByText: vi.fn().mockReturnValue(locator),
+    locator: vi.fn().mockReturnValue(locator),
+  };
+}
+
+/** Build a SkillContext + a real BrowserSession wrapping the mock page. */
+function makeCtx(opts: {
+  input: Record<string, unknown>;
+  pageContent?: string;
+  resolveSecretRef?: (ref: string) => Promise<string>;
+}): { ctx: SkillContext; session: BrowserSession; fill: ReturnType<typeof vi.fn> } {
+  const fill = vi.fn().mockResolvedValue(undefined);
+  const page = makeMockPage(opts.pageContent ?? 'nothing sensitive here', fill);
+  const session = new BrowserSession({} as unknown as BrowserContext, page as unknown as Page);
+
+  const browserService = {
+    getOrCreateSession: vi.fn().mockResolvedValue({ sessionId: 'sess-1', session }),
+    closeSession: vi.fn().mockResolvedValue(undefined),
+  } as unknown as BrowserService;
+
+  const ctx = {
+    input: opts.input,
+    log: logger,
+    browserService,
+    resolveSecretRef: opts.resolveSecretRef,
+  } as unknown as SkillContext;
+
+  return { ctx, session, fill };
+}
+
+describe('web-browser type action with secret_ref (#973)', () => {
+  it('fills the resolved secret value and never returns it', async () => {
+    const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
+    const { ctx, fill } = makeCtx({
+      input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password' },
+      resolveSecretRef,
+    });
+
+    const result = await new WebBrowserHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(resolveSecretRef).toHaveBeenCalledWith('user.aeroplan_password');
+    // The resolved value was typed into the field...
+    expect(fill).toHaveBeenCalledWith(SECRET_VALUE);
+    // ...but never appears in the data returned to the LLM.
+    expect(JSON.stringify(result)).not.toContain(SECRET_VALUE);
+  });
+
+  it('redacts an injected value reflected back through get_content', async () => {
+    const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
+    // First fill the secret, then a page whose content echoes it back.
+    const { ctx, session } = makeCtx({
+      input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password' },
+      pageContent: `Welcome. Your entered password was ${SECRET_VALUE} (oops).`,
+      resolveSecretRef,
+    });
+
+    const result = await new WebBrowserHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { content: string };
+      expect(data.content).not.toContain(SECRET_VALUE);
+      expect(data.content).toContain('[REDACTED]');
+    }
+    // The session recorded the value so subsequent get_content calls are scrubbed too.
+    expect(session.redactInjectedSecrets(SECRET_VALUE)).toBe('[REDACTED]');
+  });
+
+  it('rejects when both text and secret_ref are supplied (mutually exclusive)', async () => {
+    const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
+    const { ctx, fill } = makeCtx({
+      input: { action: 'type', selector: '#pass', text: 'literal', secret_ref: 'user.aeroplan_password' },
+      resolveSecretRef,
+    });
+
+    const result = await new WebBrowserHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect(resolveSecretRef).not.toHaveBeenCalled();
+    expect(fill).not.toHaveBeenCalled();
+  });
+
+  it('rejects when neither text nor secret_ref is supplied', async () => {
+    const { ctx } = makeCtx({ input: { action: 'type', selector: '#pass' } });
+    const result = await new WebBrowserHandler().execute(ctx);
+    expect(result.success).toBe(false);
+  });
+
+  it('errors clearly when secret_ref is used but the resolver capability is absent', async () => {
+    // resolveSecretRef undefined — the skill was invoked without the secretResolver capability.
+    const { ctx, fill } = makeCtx({
+      input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password' },
+    });
+
+    const result = await new WebBrowserHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/secret_ref|resolver|capability/i);
+    }
+    expect(fill).not.toHaveBeenCalled();
+  });
+
+  it('still supports a literal text fill (non-secret path unchanged)', async () => {
+    const { ctx, fill } = makeCtx({
+      input: { action: 'type', selector: '#search', text: 'hello world' },
+    });
+
+    const result = await new WebBrowserHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(fill).toHaveBeenCalledWith('hello world');
+  });
+});

--- a/skills/web-browser/handler.test.ts
+++ b/skills/web-browser/handler.test.ts
@@ -21,7 +21,7 @@ const SECRET_VALUE = 'sup3r-s3cr3t-pw';
  * Build a mock Playwright page. `content` is what get_content reads back (used to
  * verify value-aware redaction). The shared `fill` spy records what got typed.
  */
-function makeMockPage(content: string, fill: ReturnType<typeof vi.fn>) {
+function makeMockPage(content: string, fill: ReturnType<typeof vi.fn>, url = 'https://aeroplan.com/account') {
   const locator = {
     count: vi.fn().mockResolvedValue(1),
     first: vi.fn().mockReturnThis(),
@@ -30,7 +30,7 @@ function makeMockPage(content: string, fill: ReturnType<typeof vi.fn>) {
     selectOption: vi.fn().mockResolvedValue(undefined),
   };
   return {
-    url: vi.fn().mockReturnValue('https://aeroplan.com/account'),
+    url: vi.fn().mockReturnValue(url),
     evaluate: vi.fn().mockResolvedValue(content),
     waitForTimeout: vi.fn().mockResolvedValue(undefined),
     screenshot: vi.fn().mockResolvedValue(Buffer.from('png')),
@@ -45,10 +45,11 @@ function makeMockPage(content: string, fill: ReturnType<typeof vi.fn>) {
 function makeCtx(opts: {
   input: Record<string, unknown>;
   pageContent?: string;
+  pageUrl?: string;
   resolveSecretRef?: (ref: string) => Promise<string>;
 }): { ctx: SkillContext; session: BrowserSession; fill: ReturnType<typeof vi.fn> } {
   const fill = vi.fn().mockResolvedValue(undefined);
-  const page = makeMockPage(opts.pageContent ?? 'nothing sensitive here', fill);
+  const page = makeMockPage(opts.pageContent ?? 'nothing sensitive here', fill, opts.pageUrl);
   const session = new BrowserSession({} as unknown as BrowserContext, page as unknown as Page);
 
   const browserService = {
@@ -103,6 +104,25 @@ describe('web-browser type action with secret_ref (#973)', () => {
     }
     // The session recorded the value so subsequent get_content calls are scrubbed too.
     expect(session.redactInjectedSecrets(SECRET_VALUE)).toBe('[REDACTED]');
+  });
+
+  it('redacts an injected value reflected back through the returned url (GET form)', async () => {
+    const resolveSecretRef = vi.fn().mockResolvedValue(SECRET_VALUE);
+    const { ctx } = makeCtx({
+      input: { action: 'type', selector: '#pass', secret_ref: 'user.aeroplan_password' },
+      // A form that submits via GET puts the field value into the query string.
+      pageUrl: `https://aeroplan.com/login?pw=${SECRET_VALUE}`,
+      resolveSecretRef,
+    });
+
+    const result = await new WebBrowserHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { url: string };
+      expect(data.url).not.toContain(SECRET_VALUE);
+      expect(data.url).toContain('[REDACTED]');
+    }
   });
 
   it('rejects when both text and secret_ref are supplied (mutually exclusive)', async () => {

--- a/skills/web-browser/handler.ts
+++ b/skills/web-browser/handler.ts
@@ -202,20 +202,28 @@ export class WebBrowserHandler implements SkillHandler {
       }
 
       // --- Gather result ---
-      const currentUrl = page.url();
       const rawContent = action === 'screenshot'
         ? ''   // screenshot action doesn't need DOM text
         : await getCleanedContent(page);
 
       // Value-aware redaction backstop (#973): scrub any secret value injected into this
-      // session from the content before it reaches the LLM. A hostile page could reflect
-      // a typed password back through the DOM; this prevents that round-trip exfiltration.
-      // No-op when nothing has been injected.
+      // session from BOTH the content and the URL before they reach the LLM. A hostile page
+      // could reflect a typed password back through the DOM, or a GET-form submit could echo
+      // it into the query string (page.url()); this prevents both round-trip exfiltration
+      // paths. The literal scrub catches verbatim reflection only — see redactValues. No-op
+      // when nothing has been injected.
       const content = session.redactInjectedSecrets(rawContent);
+      const currentUrl = session.redactInjectedSecrets(page.url());
 
       const result: Record<string, unknown> = { content, session_id: sessionId, url: currentUrl };
 
-      // Capture screenshot if explicitly requested or if action === 'screenshot'
+      // Capture screenshot if explicitly requested or if action === 'screenshot'.
+      // RESIDUAL RISK (#973): the value-aware backstop scrubs TEXT only — it cannot touch
+      // a PNG. A secret typed into a `type=password` field renders masked (dots), so the
+      // common login case is safe; a secret filled into a plain text field would be visible
+      // in the image. This is the accepted "rely on browser password masking" decision from
+      // the issue. We add no screenshot trigger tied to a secret fill, so this is no worse
+      // than baseline — but a screenshot of a secret-bearing page is NOT value-redacted.
       if (screenshot || action === 'screenshot') {
         const buf = await page.screenshot({ type: 'png', fullPage: false });
         result.screenshot_base64 = buf.toString('base64');
@@ -224,11 +232,14 @@ export class WebBrowserHandler implements SkillHandler {
       return { success: true, data: result };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      // Scrub any injected secret value from the error too — a Playwright error after a
-      // secret fill is unlikely to echo the value, but the backstop must cover error paths.
-      // ctx.log.error intentionally omits the message body for the same reason.
+      // Scrub any injected secret value from the error before it reaches the agent AND the
+      // logs (#973). A Playwright failure references the selector, not the typed value, but
+      // the backstop must cover error paths too — so we log the redacted message and a
+      // redacted stack rather than the raw err object (whose .message/.stack are the
+      // unredacted source). No `{ err }` here: pino would serialize the unscrubbed original.
       const safeMessage = session.redactInjectedSecrets(message);
-      ctx.log.error({ err, action, sessionId }, 'Browser action failed');
+      const safeStack = err instanceof Error && err.stack ? session.redactInjectedSecrets(err.stack) : undefined;
+      ctx.log.error({ action, sessionId, errMessage: safeMessage, stack: safeStack }, 'Browser action failed');
       return { success: false, error: `Browser action "${action}" failed: ${safeMessage}` };
     }
   }

--- a/skills/web-browser/handler.ts
+++ b/skills/web-browser/handler.ts
@@ -83,6 +83,11 @@ export class WebBrowserHandler implements SkillHandler {
 
     ctx.log.info({ action, sessionId, url, selector }, 'Executing browser action');
 
+    // Set when this action injects a secret by reference (#973). A screenshot taken on the
+    // same action could capture the value in a non-masked field, and an image can't be
+    // value-redacted — so we refuse to capture one when this is true (see screenshot block).
+    let injectedSecretThisAction = false;
+
     try {
       // --- Dispatch action ---
       switch (action as BrowserAction) {
@@ -166,6 +171,7 @@ export class WebBrowserHandler implements SkillHandler {
             // ref or a missing secret. Any thrown message names the ref, never the value.
             fillValue = await ctx.resolveSecretRef(secret_ref!);
             session.registerInjectedSecret(fillValue);
+            injectedSecretThisAction = true;
           } else {
             if (typeof text !== 'string') {
               return { success: false, error: 'type requires text (string) or secret_ref (string)' };
@@ -210,21 +216,24 @@ export class WebBrowserHandler implements SkillHandler {
       // session from BOTH the content and the URL before they reach the LLM. A hostile page
       // could reflect a typed password back through the DOM, or a GET-form submit could echo
       // it into the query string (page.url()); this prevents both round-trip exfiltration
-      // paths. The literal scrub catches verbatim reflection only — see redactValues. No-op
-      // when nothing has been injected.
+      // paths. redactInjectedSecrets covers the raw value plus its URL- and HTML-encoded
+      // variants (see BrowserSession). No-op when nothing has been injected.
       const content = session.redactInjectedSecrets(rawContent);
       const currentUrl = session.redactInjectedSecrets(page.url());
 
       const result: Record<string, unknown> = { content, session_id: sessionId, url: currentUrl };
 
       // Capture screenshot if explicitly requested or if action === 'screenshot'.
-      // RESIDUAL RISK (#973): the value-aware backstop scrubs TEXT only — it cannot touch
-      // a PNG. A secret typed into a `type=password` field renders masked (dots), so the
-      // common login case is safe; a secret filled into a plain text field would be visible
-      // in the image. This is the accepted "rely on browser password masking" decision from
-      // the issue. We add no screenshot trigger tied to a secret fill, so this is no worse
-      // than baseline — but a screenshot of a secret-bearing page is NOT value-redacted.
-      if (screenshot || action === 'screenshot') {
+      // HARD GUARD (#973): refuse to capture on the same action that injected a secret by
+      // reference. The value-aware backstop scrubs TEXT only — it cannot touch a PNG, and a
+      // secret filled into a non-masked field would be visible in the image and round-trip
+      // into LLM context. (A `type=password` field renders masked, but we can't assume the
+      // field type, so we fail closed.) A standalone screenshot on a later call is still
+      // allowed — by then the secret-bearing input is typically gone or masked.
+      if (injectedSecretThisAction && (screenshot || action === 'screenshot')) {
+        ctx.log.debug({ action, sessionId }, 'Screenshot suppressed: a secret was injected this action (#973)');
+        result.screenshot_skipped = 'A secret was filled in this action; screenshot suppressed to avoid capturing the value (#973).';
+      } else if (screenshot || action === 'screenshot') {
         const buf = await page.screenshot({ type: 'png', fullPage: false });
         result.screenshot_base64 = buf.toString('base64');
       }

--- a/skills/web-browser/handler.ts
+++ b/skills/web-browser/handler.ts
@@ -21,12 +21,16 @@ export class WebBrowserHandler implements SkillHandler {
       return { success: false, error: 'browserService is not available — BrowserService failed to start or is not wired into ExecutionLayer' };
     }
 
-    const { action, url, selector, text, value, session_id, screenshot } = ctx.input as {
+    const { action, url, selector, text, value, secret_ref, session_id, screenshot } = ctx.input as {
       action?: string;
       url?: string;
       selector?: string;
       text?: string;
       value?: string;
+      // secret_ref (#973): name of a user.* vault secret to type by reference. The literal
+      // value is dereferenced server-side via ctx.resolveSecretRef and never enters this
+      // handler's inputs, return value, or logs. Mutually exclusive with `text`.
+      secret_ref?: string;
       session_id?: string;
       screenshot?: boolean;
     };
@@ -63,9 +67,13 @@ export class WebBrowserHandler implements SkillHandler {
     // --- All other actions: acquire session ---
     let sessionId: string;
     let page: Page;
+    // Keep the session itself (not just its page) so we can register injected secret
+    // values for value-aware redaction (#973) and scrub them from returned content.
+    let session: import('../../src/browser/browser-session.js').BrowserSession;
     try {
       const result = await ctx.browserService.getOrCreateSession(session_id ?? undefined);
       sessionId = result.sessionId;
+      session = result.session;
       page = result.session.page as Page;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -135,11 +143,38 @@ export class WebBrowserHandler implements SkillHandler {
           if (!selector || typeof selector !== 'string') {
             return { success: false, error: 'type requires selector (string)' };
           }
-          if (text === undefined || text === null || typeof text !== 'string') {
-            return { success: false, error: 'type requires text (string)' };
+
+          // secret_ref (#973): fill a user.* vault secret by reference. Mutually exclusive
+          // with `text` — supplying both is ambiguous and rejected. The resolved value is
+          // registered with the session so it is scrubbed from any content read back, then
+          // typed via fill(). It is never logged and never returned to the agent.
+          const hasSecretRef = typeof secret_ref === 'string' && secret_ref.length > 0;
+          const hasText = text !== undefined && text !== null;
+
+          if (hasSecretRef && hasText) {
+            return { success: false, error: 'type accepts either text or secret_ref, not both' };
           }
+
+          let fillValue: string;
+          if (hasSecretRef) {
+            if (!ctx.resolveSecretRef) {
+              // Capability not granted to this invocation — fail loud rather than
+              // silently falling back to typing the reference name as a literal.
+              return { success: false, error: 'secret_ref requires the secretResolver capability, which is not available to this skill' };
+            }
+            // resolveSecretRef enforces the user.* namespace + audit; it throws on a bad
+            // ref or a missing secret. Any thrown message names the ref, never the value.
+            fillValue = await ctx.resolveSecretRef(secret_ref!);
+            session.registerInjectedSecret(fillValue);
+          } else {
+            if (typeof text !== 'string') {
+              return { success: false, error: 'type requires text (string) or secret_ref (string)' };
+            }
+            fillValue = text;
+          }
+
           const typeTarget = await resolveLocator(page, selector);
-          await typeTarget.fill(text);
+          await typeTarget.fill(fillValue);
           break;
         }
 
@@ -168,9 +203,15 @@ export class WebBrowserHandler implements SkillHandler {
 
       // --- Gather result ---
       const currentUrl = page.url();
-      const content = action === 'screenshot'
+      const rawContent = action === 'screenshot'
         ? ''   // screenshot action doesn't need DOM text
         : await getCleanedContent(page);
+
+      // Value-aware redaction backstop (#973): scrub any secret value injected into this
+      // session from the content before it reaches the LLM. A hostile page could reflect
+      // a typed password back through the DOM; this prevents that round-trip exfiltration.
+      // No-op when nothing has been injected.
+      const content = session.redactInjectedSecrets(rawContent);
 
       const result: Record<string, unknown> = { content, session_id: sessionId, url: currentUrl };
 
@@ -183,8 +224,12 @@ export class WebBrowserHandler implements SkillHandler {
       return { success: true, data: result };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      // Scrub any injected secret value from the error too — a Playwright error after a
+      // secret fill is unlikely to echo the value, but the backstop must cover error paths.
+      // ctx.log.error intentionally omits the message body for the same reason.
+      const safeMessage = session.redactInjectedSecrets(message);
       ctx.log.error({ err, action, sessionId }, 'Browser action failed');
-      return { success: false, error: `Browser action "${action}" failed: ${message}` };
+      return { success: false, error: `Browser action "${action}" failed: ${safeMessage}` };
     }
   }
 }

--- a/skills/web-browser/skill.json
+++ b/skills/web-browser/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "web-browser",
-  "description": "Control a real web browser to interact with JS-rendered pages, fill forms, navigate multi-step flows, and interact with sites that have no API. Use this instead of web-fetch when a page requires JavaScript, login, or user interaction. Each call performs one action and returns the updated page state. Pass session_id back on subsequent calls to maintain browser context across actions. Actions: navigate (url required), click (selector required), type (selector+text required), select (selector+value required), get_content, screenshot, close_session.",
-  "version": "1.0.0",
+  "description": "Control a real web browser to interact with JS-rendered pages, fill forms, navigate multi-step flows, and interact with sites that have no API. Use this instead of web-fetch when a page requires JavaScript, login, or user interaction. Each call performs one action and returns the updated page state. Pass session_id back on subsequent calls to maintain browser context across actions. Actions: navigate (url required), click (selector required), type (selector + either text OR secret_ref), select (selector+value required), get_content, screenshot, close_session. To fill a stored credential into a form, pass secret_ref (a user.* secret name) instead of text — the value is filled server-side and never shown to you.",
+  "version": "1.1.0",
   "sensitivity": "elevated",
   "action_risk": "medium",
   "inputs": {
@@ -10,6 +10,7 @@
     "selector": "string?",
     "text": "string?",
     "value": "string?",
+    "secret_ref": "string?",
     "session_id": "string?",
     "screenshot": "boolean?"
   },
@@ -25,6 +26,7 @@
   "secrets": [],
   "timeout": 30000,
   "capabilities": [
-    "browserService"
+    "browserService",
+    "secretResolver"
   ]
 }

--- a/skills/web-browser/skill.json
+++ b/skills/web-browser/skill.json
@@ -18,7 +18,8 @@
     "content": "string",
     "session_id": "string",
     "url": "string",
-    "screenshot_base64": "string?"
+    "screenshot_base64": "string?",
+    "screenshot_skipped": "string?"
   },
   "permissions": [
     "network:https"

--- a/src/browser/browser-session.test.ts
+++ b/src/browser/browser-session.test.ts
@@ -1,0 +1,57 @@
+// browser-session.test.ts — unit tests for BrowserSession's injected-secret
+// redaction set (#973).
+//
+// When a secret value is injected into a form by reference, the session records
+// that value so any page content read back during the same session can be scrubbed
+// of it — the backstop against a hostile page reflecting the value into LLM context.
+
+import { describe, it, expect } from 'vitest';
+import { BrowserSession } from './browser-session.js';
+import type { BrowserContext, Page } from 'playwright';
+
+/** A BrowserSession needs only a context + page; neither is touched by these tests. */
+function makeSession(): BrowserSession {
+  const fakeContext = {} as unknown as BrowserContext;
+  const fakePage = {} as unknown as Page;
+  return new BrowserSession(fakeContext, fakePage);
+}
+
+describe('BrowserSession injected-secret redaction', () => {
+  it('redacts a registered secret value from text', () => {
+    const session = makeSession();
+    session.registerInjectedSecret('hunter2');
+
+    const out = session.redactInjectedSecrets('balance page shows hunter2 in a hidden field');
+    expect(out).not.toContain('hunter2');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('leaves text untouched when nothing has been injected', () => {
+    const session = makeSession();
+    expect(session.redactInjectedSecrets('no secrets here')).toBe('no secrets here');
+  });
+
+  it('redacts every registered value', () => {
+    const session = makeSession();
+    session.registerInjectedSecret('alice');
+    session.registerInjectedSecret('s3cr3t');
+
+    const out = session.redactInjectedSecrets('user alice / pw s3cr3t');
+    expect(out).toBe('user [REDACTED] / pw [REDACTED]');
+  });
+
+  it('ignores empty values (does not destroy text)', () => {
+    const session = makeSession();
+    session.registerInjectedSecret('');
+    expect(session.redactInjectedSecrets('intact')).toBe('intact');
+  });
+
+  it('keeps redaction sets isolated per session', () => {
+    const a = makeSession();
+    const b = makeSession();
+    a.registerInjectedSecret('only-in-a');
+
+    // b never saw the value — it must not redact it.
+    expect(b.redactInjectedSecrets('only-in-a appears here')).toBe('only-in-a appears here');
+  });
+});

--- a/src/browser/browser-session.test.ts
+++ b/src/browser/browser-session.test.ts
@@ -46,6 +46,29 @@ describe('BrowserSession injected-secret redaction', () => {
     expect(session.redactInjectedSecrets('intact')).toBe('intact');
   });
 
+  it('redacts a URL-encoded reflection of a registered value', () => {
+    const session = makeSession();
+    const secret = 'p@ss w&rd';
+    session.registerInjectedSecret(secret);
+
+    // A GET-form submit re-emits the value URL-encoded in the query string.
+    const encoded = encodeURIComponent(secret); // p%40ss%20w%26rd
+    const out = session.redactInjectedSecrets(`https://site.test/login?pw=${encoded}`);
+    expect(out).not.toContain(encoded);
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts an HTML-entity-encoded reflection of a registered value', () => {
+    const session = makeSession();
+    const secret = 'a&b<c>';
+    session.registerInjectedSecret(secret);
+
+    // A page that echoes the value into the DOM escapes HTML metacharacters.
+    const out = session.redactInjectedSecrets('reflected: a&amp;b&lt;c&gt;');
+    expect(out).not.toContain('a&amp;b&lt;c&gt;');
+    expect(out).toContain('[REDACTED]');
+  });
+
   it('keeps redaction sets isolated per session', () => {
     const a = makeSession();
     const b = makeSession();

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -7,6 +7,17 @@
 import type { BrowserContext, Page } from 'playwright';
 import { redactValues } from '../skills/sanitize.js';
 
+/** HTML-entity-escape the characters a browser escapes when reflecting input into DOM text.
+ *  `&` must be replaced first so the entity ampersands it introduces aren't re-escaped. */
+function htmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
 export class BrowserSession {
   readonly context: BrowserContext;
   readonly page: Page;
@@ -42,10 +53,26 @@ export class BrowserSession {
   /**
    * Scrub every injected secret value from `text`, replacing exact occurrences with
    * `[REDACTED]`. Returns `text` unchanged when nothing has been injected.
+   *
+   * redactValues matches literals only, so a page that reflects a value *transformed*
+   * (URL-encoded into a query string after a GET submit, or HTML-entity-encoded into the
+   * DOM) would slip past a raw-only match. We therefore redact each value AND its common
+   * browser encodings — the two surfaces that actually carry reflected input back to us.
    */
   redactInjectedSecrets(text: string): string {
     if (this.injectedSecretValues.size === 0) return text;
-    return redactValues(text, this.injectedSecretValues);
+    const variants = new Set<string>();
+    for (const value of this.injectedSecretValues) {
+      variants.add(value);
+      // URL encodings — query strings / form-GET reflections in page.url().
+      // encodeURIComponent covers query params; encodeURI covers full-URL reflection.
+      // Wrapped in try/catch: these throw on lone surrogate halves, which we ignore.
+      try { variants.add(encodeURIComponent(value)); } catch { /* malformed input — skip */ }
+      try { variants.add(encodeURI(value)); } catch { /* malformed input — skip */ }
+      // HTML-entity encoding — DOM text reflection via get_content.
+      variants.add(htmlEscape(value));
+    }
+    return redactValues(text, variants);
   }
 
   /** Returns true if the session has been idle longer than ttlMs. */

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -5,6 +5,7 @@
 // automatically via the BrowserService sweep interval.
 
 import type { BrowserContext, Page } from 'playwright';
+import { redactValues } from '../skills/sanitize.js';
 
 export class BrowserSession {
   readonly context: BrowserContext;
@@ -12,10 +13,39 @@ export class BrowserSession {
   /** Epoch ms of last access — updated by BrowserService.getOrCreateSession() on reuse. */
   lastUsedAt: number;
 
+  /**
+   * Literal secret VALUES injected into this session by reference (#973), e.g. a
+   * password typed into a login form via `type {secret_ref}`. Held in memory only,
+   * never logged, and discarded with the session when it closes/expires. Page content
+   * read back during the session is scrubbed of these before reaching the LLM, so a
+   * hostile page that reflects an injected value can't exfiltrate it through get_content.
+   */
+  private readonly injectedSecretValues = new Set<string>();
+
   constructor(context: BrowserContext, page: Page) {
     this.context = context;
     this.page = page;
     this.lastUsedAt = Date.now();
+  }
+
+  /**
+   * Record a secret value that was injected into this session so it can be redacted
+   * from any text returned to the agent. Empty/whitespace-only values are ignored
+   * (redactValues would otherwise be a no-op on them anyway). The value is never logged.
+   */
+  registerInjectedSecret(value: string): void {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      this.injectedSecretValues.add(value);
+    }
+  }
+
+  /**
+   * Scrub every injected secret value from `text`, replacing exact occurrences with
+   * `[REDACTED]`. Returns `text` unchanged when nothing has been injected.
+   */
+  redactInjectedSecrets(text: string): string {
+    if (this.injectedSecretValues.size === 0) return text;
+    return redactValues(text, this.injectedSecretValues);
   }
 
   /** Returns true if the session has been idle longer than ttlMs. */

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -464,6 +464,10 @@ interface SecretAccessedPayload {
   // Where the value was resolved from. Optional for backward compatibility; lets the
   // audit trail show migration progress as secrets move from env to the vault (#542).
   source?: 'vault' | 'env';
+  // True when the secret was resolved dynamically by reference (ctx.resolveSecretRef,
+  // #973) rather than via a manifest-declared ctx.secret() call. Distinguishes the
+  // two access paths in the audit trail. Absent/false for declared-secret access.
+  byReference?: boolean;
 }
 
 // AutonomySkillBlockedPayload — published by the execution layer when a skill

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -1216,3 +1216,211 @@ describe('ctx.secret resolution', () => {
     expect(caughtMessage).toMatch(/DB connection refused/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// secretResolver capability — ctx.resolveSecretRef (by-reference resolution, #973)
+// ---------------------------------------------------------------------------
+
+describe('secretResolver capability (resolveSecretRef)', () => {
+  /** Manifest declaring the secretResolver capability under an arbitrary name.
+   *  sensitivity/action_risk are kept minimal so these tests isolate the resolver
+   *  capability gate from the (separately tested) sensitivity and autonomy gates. */
+  function makeResolverManifest(name: string): SkillManifest {
+    return {
+      name,
+      description: `${name} description`,
+      version: '1.0.0',
+      sensitivity: 'normal',
+      action_risk: 'none',
+      inputs: {},
+      outputs: {},
+      permissions: [],
+      secrets: [],
+      timeout: 5000,
+      capabilities: ['secretResolver'],
+    };
+  }
+
+  const RESOLVED_VALUE = 'sup3r-s3cret-pw';
+
+  it('injects ctx.resolveSecretRef and resolves a user.* secret for an allowlisted skill', async () => {
+    const registry = new SkillRegistry();
+    let resolved: string | undefined;
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
+        resolved = await ctx.resolveSecretRef!('user.aeroplan_password');
+        return { success: true, data: 'ok' };
+      }),
+    };
+    // 'web-browser' is on the resolver allowlist.
+    registry.register(makeResolverManifest('web-browser'), handler);
+
+    const secretsService = { get: vi.fn().mockResolvedValue(RESOLVED_VALUE) } as unknown as SecretsService;
+    const layer = new ExecutionLayer(registry, logger, { bus: makeBus(), secretsService });
+
+    const result = await layer.invoke('web-browser', {});
+
+    expect(result.success).toBe(true);
+    expect(resolved).toBe(RESOLVED_VALUE);
+    expect(secretsService.get).toHaveBeenCalledWith('user.aeroplan_password');
+  });
+
+  it('rejects a non-user.* reference (system/channel keys are never form-fill material)', async () => {
+    const registry = new SkillRegistry();
+    let error: string | undefined;
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
+        try { await ctx.resolveSecretRef!('anthropic_api_key'); }
+        catch (e) { error = (e as Error).message; }
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeResolverManifest('web-browser'), handler);
+
+    const secretsService = { get: vi.fn().mockResolvedValue('should-not-be-read') } as unknown as SecretsService;
+    const layer = new ExecutionLayer(registry, logger, { bus: makeBus(), secretsService });
+
+    await layer.invoke('web-browser', {});
+
+    expect(error).toMatch(/user\./);
+    // The vault must never be consulted for a rejected namespace.
+    expect(secretsService.get).not.toHaveBeenCalled();
+  });
+
+  it('rejects channel.* references too', async () => {
+    const registry = new SkillRegistry();
+    let error: string | undefined;
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
+        try { await ctx.resolveSecretRef!('channel.email.nylas_api_key'); }
+        catch (e) { error = (e as Error).message; }
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeResolverManifest('web-browser'), handler);
+    const secretsService = { get: vi.fn() } as unknown as SecretsService;
+    const layer = new ExecutionLayer(registry, logger, { bus: makeBus(), secretsService });
+
+    await layer.invoke('web-browser', {});
+
+    expect(error).toMatch(/user\./);
+    expect(secretsService.get).not.toHaveBeenCalled();
+  });
+
+  it('throws when the referenced user.* secret does not exist', async () => {
+    const registry = new SkillRegistry();
+    let error: string | undefined;
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
+        try { await ctx.resolveSecretRef!('user.missing'); }
+        catch (e) { error = (e as Error).message; }
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeResolverManifest('web-browser'), handler);
+    const secretsService = { get: vi.fn().mockResolvedValue(null) } as unknown as SecretsService;
+    const layer = new ExecutionLayer(registry, logger, { bus: makeBus(), secretsService });
+
+    await layer.invoke('web-browser', {});
+
+    expect(error).toMatch(/user\.missing/);
+    expect(error).not.toContain('null');
+  });
+
+  it('emits secret.accessed with byReference:true, name + source only, never the value', async () => {
+    const registry = new SkillRegistry();
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
+        await ctx.resolveSecretRef!('user.aeroplan_password');
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeResolverManifest('web-browser'), handler);
+
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+    const secretsService = { get: vi.fn().mockResolvedValue(RESOLVED_VALUE) } as unknown as SecretsService;
+    const layer = new ExecutionLayer(registry, logger, {
+      bus: mockBus,
+      secretsService,
+    });
+
+    await layer.invoke('web-browser', {}, undefined, { agentId: 'agent-1', taskEventId: 'task-1' });
+
+    expect(mockBus.publish).toHaveBeenCalledWith(
+      'execution',
+      expect.objectContaining({
+        type: 'secret.accessed',
+        payload: expect.objectContaining({
+          skillName: 'web-browser',
+          secretName: 'user.aeroplan_password',
+          byReference: true,
+          source: 'vault',
+        }),
+      }),
+    );
+
+    // The resolved value must NEVER appear anywhere in any published event.
+    for (const call of (mockBus.publish as unknown as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(RESOLVED_VALUE);
+    }
+  });
+
+  it('refuses to run a skill that declares secretResolver but is not on the allowlist', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('ok');
+    registry.register(makeResolverManifest('rogue-skill'), handler);
+
+    const secretsService = { get: vi.fn() } as unknown as SecretsService;
+    const layer = new ExecutionLayer(registry, logger, { bus: makeBus(), secretsService });
+
+    const result = await layer.invoke('rogue-skill', {});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/secretResolver/);
+    }
+    // Fail-closed: the handler must not run.
+    expect(handler.execute).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject resolveSecretRef for skills without the capability', async () => {
+    const registry = new SkillRegistry();
+    let capturedCtx: SkillContext | undefined;
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
+        capturedCtx = ctx;
+        return { success: true, data: 'ok' };
+      }),
+    };
+    // Same manifest but no capabilities declared.
+    registry.register({ ...makeResolverManifest('web-browser'), capabilities: [] }, handler);
+    const secretsService = { get: vi.fn() } as unknown as SecretsService;
+    const layer = new ExecutionLayer(registry, logger, { bus: makeBus(), secretsService });
+
+    await layer.invoke('web-browser', {});
+
+    expect(capturedCtx?.resolveSecretRef).toBeUndefined();
+  });
+
+  it('fails closed when secretResolver is declared but no secretsService is configured', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('ok');
+    registry.register(makeResolverManifest('web-browser'), handler);
+
+    // No secretsService wired into the layer.
+    const layer = new ExecutionLayer(registry, logger, { bus: makeBus() });
+
+    const result = await layer.invoke('web-browser', {});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/secretResolver/);
+    }
+    expect(handler.execute).not.toHaveBeenCalled();
+  });
+});
+
+/** Minimal mock bus that resolves publish — used by the resolver suite. */
+function makeBus(): EventBus {
+  return { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+}

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -49,6 +49,21 @@ import { buildRateLimitSourceKey } from '../memory/rate-limit-key.js';
 // reaches the LLM context window.
 const DEFAULT_SKILL_OUTPUT_MAX_LENGTH = 200_000;
 
+// Secret-by-reference resolution (#973) — see ctx.resolveSecretRef.
+//
+// Only `user.*` references may be resolved by reference. The `user.` namespace is the
+// trust boundary established by #971: it cannot name a system key (snake_case, e.g.
+// `anthropic_api_key`) or a channel credential (`channel.*`), so form-fill material is
+// structurally separated from privileged secrets.
+const USER_SECRET_PREFIX = 'user.';
+
+// Hard allowlist of skills permitted to declare and use the `secretResolver` capability.
+// Mirrors the executionLayer→approve-action restriction below: declaring the capability in
+// skill.json is necessary but NOT sufficient — the skill name must also appear here. Kept as
+// a set so sibling skills that legitimately need by-reference injection (e.g. a future
+// http-request skill) can be added deliberately rather than by manifest edit alone.
+export const SECRET_RESOLVER_ALLOWED_SKILLS: ReadonlySet<string> = new Set(['web-browser']);
+
 /** Options passed to ExecutionLayer.invoke() by the agent runtime. */
 export interface InvokeOptions {
   taskEventId?: string;
@@ -686,6 +701,10 @@ export class ExecutionLayer {
       // Injected as a plain field (default branch in the loop). Listed here so the
       // missing-cap guard fails closed if a skill declares it before it's wired.
       secretCapture: this.secretCaptureService,
+      // secretResolver injects the by-reference resolver closure (#973), built in the
+      // loop below. Backed by secretsService — listed here so the missing-cap guard fails
+      // closed when a skill declares the capability but no vault is wired.
+      secretResolver: this.secretsService,
     };
 
     // Hard-restrict executionLayer to approve-action only.
@@ -703,6 +722,25 @@ export class ExecutionLayer {
         success: false,
         error: this.wrapSkillError(
           `Skill '${skillName}' declares capability 'executionLayer' but only 'approve-action' is permitted to use it`,
+        ),
+      };
+    }
+
+    // Hard-restrict secretResolver to the allowlist (#973).
+    // resolveSecretRef dereferences stored user.* secrets into the handler at runtime — a
+    // surface that must not be available to arbitrary skills even if they declare it. The
+    // manifest capability is necessary but not sufficient; the skill name must also be on
+    // SECRET_RESOLVER_ALLOWED_SKILLS. This guard is the enforcement boundary (mirrors the
+    // executionLayer→approve-action restriction above).
+    if (caps.includes('secretResolver') && !SECRET_RESOLVER_ALLOWED_SKILLS.has(manifest.name)) {
+      skillLogger.error(
+        { skillName, manifestName: manifest.name },
+        'SECURITY: secretResolver capability is restricted to an allowlist — refusing to run skill',
+      );
+      return {
+        success: false,
+        error: this.wrapSkillError(
+          `Skill '${skillName}' declares capability 'secretResolver' but is not on the resolver allowlist`,
         ),
       };
     }
@@ -785,6 +823,51 @@ export class ExecutionLayer {
           ctx.writeTempFile = (buffer: Buffer, filename: string) =>
             this.tempFileStore!.write(buffer, filename);
         }
+      } else if (cap === 'secretResolver') {
+        // Inject the by-reference secret resolver (#973). Unlike ctx.secret() (static,
+        // manifest-declared, pre-warmed), this resolves DYNAMIC user.<slug> names at call
+        // time straight from the vault. Two guardrails enforced here, defense-in-depth on
+        // top of the skill allowlist already checked above:
+        //   1. Namespace: only user.* references resolve — system/channel keys are rejected
+        //      before the vault is ever consulted, so they can never be form-fill material.
+        //   2. Audit: every resolution emits secret.accessed (name + source, byReference:true)
+        //      — never the value. The value is returned to the handler only; the handler
+        //      contract (see SkillContext.resolveSecretRef) forbids placing it in results/logs.
+        ctx.resolveSecretRef = async (ref: string): Promise<string> => {
+          if (typeof ref !== 'string' || !ref.startsWith(USER_SECRET_PREFIX)) {
+            throw new Error(
+              `resolveSecretRef: only ${USER_SECRET_PREFIX}* secret references may be resolved by reference (got '${ref}')`,
+            );
+          }
+          if (!this.secretsService) {
+            // Should be unreachable — the missing-cap guard refuses the skill when
+            // secretsService is unset — but fail loud rather than silently returning ''.
+            throw new Error('resolveSecretRef: secrets service is not configured');
+          }
+          const value = await this.secretsService.get(ref);
+          if (value === null) {
+            throw new Error(`resolveSecretRef: secret '${ref}' was not found in the vault`);
+          }
+          // Audit — fire-and-forget, name + source only, flagged as by-reference.
+          if (this.bus) {
+            this.bus.publish('execution', createSecretAccessed({
+              skillName,
+              secretName: ref,
+              agentId: options?.agentId,
+              taskEventId: options?.taskEventId,
+              source: 'vault',
+              byReference: true,
+            })).catch((err) => {
+              skillLogger.error(
+                { err, secretName: ref, skillName, agentId: options?.agentId, taskEventId: options?.taskEventId },
+                'AUDIT FAILURE: secret.accessed (by-reference) event could not be published — secret was returned but access may not be recorded',
+              );
+            });
+          }
+          // Debug log records the NAME only, never the value.
+          skillLogger.debug({ secretName: ref, source: 'vault', byReference: true }, 'Secret resolved by reference');
+          return value;
+        };
       } else {
         (ctx as unknown as Record<string, unknown>)[cap] = capabilityServices[cap];
       }

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -30,7 +30,7 @@ export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'schedulerService', 'entityMemory', 'nylasCalendarClient',
   'autonomyService', 'executiveProfileService', 'officeIdentityService', 'browserService', 'bullpenService', 'skillSearch',
   'actionLogRepo', 'executionLayer', 'confidencePipeline', 'tempFileStore',
-  'infraLlm', 'outboundContext', 'taskRepo', 'secretCapture',
+  'infraLlm', 'outboundContext', 'taskRepo', 'secretCapture', 'secretResolver',
 ]);
 
 /** One discovered on-disk skill: lenient parse for the registry UI + reconciliation.

--- a/src/skills/sanitize.test.ts
+++ b/src/skills/sanitize.test.ts
@@ -1,0 +1,56 @@
+// sanitize.test.ts — unit tests for output sanitization helpers.
+//
+// Focus here is redactValues(), the value-aware redaction hook used as the
+// backstop for secret-by-reference injection (#973): any literal secret value
+// injected into a browser session must be scrubbed from returned page content
+// before it can round-trip back into the LLM context.
+
+import { describe, it, expect } from 'vitest';
+import { redactValues } from './sanitize.js';
+
+describe('redactValues', () => {
+  it('replaces an exact occurrence of a value with [REDACTED]', () => {
+    const out = redactValues('your balance is shown after hunter2 logs in', ['hunter2']);
+    expect(out).toBe('your balance is shown after [REDACTED] logs in');
+    expect(out).not.toContain('hunter2');
+  });
+
+  it('replaces every occurrence, not just the first', () => {
+    const out = redactValues('hunter2 / hunter2 / hunter2', ['hunter2']);
+    expect(out).toBe('[REDACTED] / [REDACTED] / [REDACTED]');
+  });
+
+  it('redacts multiple distinct values', () => {
+    const out = redactValues('user alice with pw s3cr3t', ['alice', 's3cr3t']);
+    expect(out).toBe('user [REDACTED] with pw [REDACTED]');
+  });
+
+  it('redacts longer values before shorter overlapping ones to avoid partial leaks', () => {
+    // If "pass" were redacted first, "password123" would become "[REDACTED]word123",
+    // leaking the rest. Longer-first ordering prevents that.
+    const out = redactValues('login=password123', ['pass', 'password123']);
+    expect(out).toBe('login=[REDACTED]');
+    expect(out).not.toContain('word123');
+  });
+
+  it('treats values as literals, not regex patterns', () => {
+    const out = redactValues('match a.c here', ['a.c']);
+    expect(out).toBe('match [REDACTED] here');
+    // A literal "axc" must NOT be redacted (proves "." is not a wildcard).
+    expect(redactValues('axc', ['a.c'])).toBe('axc');
+  });
+
+  it('ignores empty / whitespace-only values (would otherwise redact everything)', () => {
+    expect(redactValues('untouched', [''])).toBe('untouched');
+    expect(redactValues('untouched', ['   '])).toBe('untouched');
+  });
+
+  it('returns the text unchanged when there are no values', () => {
+    expect(redactValues('nothing to do', [])).toBe('nothing to do');
+  });
+
+  it('accepts any iterable of values (e.g. a Set)', () => {
+    const out = redactValues('a then b', new Set(['a', 'b']));
+    expect(out).toBe('[REDACTED] then [REDACTED]');
+  });
+});

--- a/src/skills/sanitize.ts
+++ b/src/skills/sanitize.ts
@@ -200,6 +200,12 @@ export function sanitizeOutput(
  *
  * The value set itself is held by the caller (e.g. a BrowserSession) and never
  * logged; this function only consumes it.
+ *
+ * LIMITATION: this catches VERBATIM reflection only. A value that a page re-emits
+ * transformed — URL-encoded, HTML-entity-encoded, Unicode-normalized, base64'd, or
+ * split across DOM nodes joined with whitespace — will not match and is not redacted.
+ * This is a backstop, not the primary defense (the value is never shown to the agent
+ * and password fields render masked); don't over-trust it as a complete guarantee.
  */
 export function redactValues(text: string, values: Iterable<string>): string {
   // De-dupe and drop empties, then sort longest-first (see longer-overlap note above).

--- a/src/skills/sanitize.ts
+++ b/src/skills/sanitize.ts
@@ -181,6 +181,40 @@ export function sanitizeOutput(
   return text;
 }
 
+/**
+ * Value-aware redaction: scrub exact occurrences of known secret VALUES from text.
+ *
+ * Unlike SECRET_PATTERNS (which match credential *shapes*), this redacts specific
+ * literal strings the caller knows are sensitive — e.g. a password that was injected
+ * into a browser form by reference (#973) and could be reflected back by a hostile
+ * page through get_content. This is the backstop that prevents round-trip exfiltration
+ * of a value the pattern-based scrub would never recognize.
+ *
+ * Behavior:
+ *  - Each non-empty value is replaced wherever it appears with `[REDACTED]`.
+ *  - Values are treated as LITERALS, never regex (no special-char interpretation).
+ *  - Longer values are redacted first so a short value that is a substring of a
+ *    longer one (e.g. "pass" inside "password123") can't leave the tail exposed.
+ *  - Empty / whitespace-only values are ignored — redacting "" would replace the
+ *    gap between every character and destroy the whole string.
+ *
+ * The value set itself is held by the caller (e.g. a BrowserSession) and never
+ * logged; this function only consumes it.
+ */
+export function redactValues(text: string, values: Iterable<string>): string {
+  // De-dupe and drop empties, then sort longest-first (see longer-overlap note above).
+  const distinct = [...new Set(values)].filter(v => typeof v === 'string' && v.trim().length > 0);
+  distinct.sort((a, b) => b.length - a.length);
+
+  let result = text;
+  for (const value of distinct) {
+    // split/join performs a literal, global replacement with no regex parsing —
+    // safe against values containing regex metacharacters ($, ., (, ), etc.).
+    result = result.split(value).join('[REDACTED]');
+  }
+  return result;
+}
+
 // ── Display name sanitization ───────────────────────────────────────
 //
 // Defense-in-depth: sanitize display names at storage time, not just

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -57,7 +57,8 @@ export interface SkillManifest {
    *  Valid capabilities: bus, agentRegistry, outboundGateway, heldMessages,
    *  schedulerService, entityMemory, nylasCalendarClient, autonomyService,
    *  executiveProfileService, officeIdentityService, browserService, bullpenService, skillSearch,
-   *  actionLogRepo, executionLayer, confidencePipeline, tempFileStore, infraLlm, outboundContext.
+   *  actionLogRepo, executionLayer, confidencePipeline, tempFileStore, infraLlm, outboundContext,
+   *  taskRepo, secretCapture, secretResolver.
    *
    *  Services NOT listed here (contactService, entityContextAssembler, agentPersona)
    *  are universal — available to every skill without declaration. */
@@ -267,6 +268,14 @@ export interface SkillContext {
    *  a MINT-ONLY surface: there is no method that returns a stored secret value, so the
    *  "LLM never sees secrets" guarantee is structural rather than prompt-enforced. */
   secretCapture?: import('../secrets/secret-capture-service.js').SecretCaptureMinter;
+  /** Resolve a `user.*` secret by reference at runtime — available only to skills declaring
+   *  'secretResolver' in capabilities AND on the execution-layer allowlist (#973). Unlike
+   *  ctx.secret() (which is restricted to manifest-declared static names), this resolves
+   *  DYNAMIC `user.<slug>` names chosen per activity. Guardrails: only `user.*` references
+   *  resolve (system/channel keys are rejected); each call emits secret.accessed (name only,
+   *  byReference: true). The returned value is for runtime use only — handlers MUST NOT place
+   *  it in SkillResult.data, error strings, or logs. */
+  resolveSecretRef?: (ref: string) => Promise<string>;
   /** Operator-facing origin of the console (e.g. "https://curia.example.com"), used by the
    *  capture skills to build the magic-link URL. Undefined in local dev — fall back to
    *  http://localhost:{httpPort}. Sourced from config.appOrigin. */

--- a/tests/unit/skills/web-browser.test.ts
+++ b/tests/unit/skills/web-browser.test.ts
@@ -35,6 +35,11 @@ function makeMockBrowserService(): BrowserService {
     isExpired: vi.fn().mockReturnValue(false),
     close: vi.fn().mockResolvedValue(undefined),
     context: {} as never,
+    // Injected-secret redaction surface (#973). The handler registers any by-reference
+    // fill value and scrubs returned content through these; the pass-through stub is
+    // sufficient for the non-secret paths exercised here.
+    registerInjectedSecret: vi.fn(),
+    redactInjectedSecrets: vi.fn((text: string) => text),
   };
 
   return {


### PR DESCRIPTION
## **User description**
## Summary

Closes #973. Closes the capture → resume → **consume** loop (follow-up to #971/#972): an allowlisted skill can now spend a captured `user.*` secret to complete an action — e.g. type a password into a login form — **by reference**, so the value never enters the LLM context, the agent's tool call, the skill's return value, or logs.

### What changed

**1. New `secretResolver` capability (runtime, by-reference)** — `src/skills/execution.ts`, `loader.ts`, `types.ts`
- `ctx.resolveSecretRef(ref): Promise<string>` resolves *dynamic* `user.<slug>` names at call time via the vault (unlike `ctx.secret()`, which is restricted to manifest-declared static names).
- **Namespace gate:** only `user.*` references resolve — system/channel keys (`anthropic_api_key`, `channel.*`) are rejected *before* the vault is consulted, reusing #971's `user.` sandbox as the trust boundary.
- **Skill allowlist:** `SECRET_RESOLVER_ALLOWED_SKILLS` (currently `web-browser` only) — declaring the capability in `skill.json` is necessary but not sufficient. Enforced fail-closed before the handler runs, mirroring the `executionLayer`→`approve-action` guard.
- **Audit:** each resolution emits `secret.accessed` with `byReference: true` (name + source only, never the value).

**2. `web-browser` `type` action gains `secret_ref`** — `skills/web-browser/{skill.json,handler.ts}`
- Mutually exclusive with `text`. The resolved value is filled via Playwright and never returned to the agent. The literal `text` path is unchanged.

**3. Value-aware output redaction (the hardening)** — `src/skills/sanitize.ts`, `src/browser/browser-session.ts`
- Injected values are tracked in a per-session redaction set and scrubbed from returned `content`, `url`, and error strings — the backstop against a hostile page reflecting a typed credential back into the LLM. The set lives in memory on the session and is discarded on close/expire.

### Open decisions (resolved)
- **Capability surface:** generic `resolveSecretRef` (recommended default).
- **Namespace scope:** `user.*` only (recommended default).
- **Screenshot-after-fill:** rely on browser `type=password` masking; no new screenshot trigger is tied to a secret fill. The text backstop cannot scrub a PNG — documented as the accepted residual risk in the handler.

### Testing (TDD)
- `redactValues` (longest-first, literal, empty-safe), per-session redaction set + isolation, resolver gating (namespace reject, skill-allowlist reject, missing-secret throw, fail-closed without vault), `secret.accessed` byReference + no-value invariant, browser fill (resolved value typed, never returned), and the content/url round-trip redaction backstops.
- Full suite: 3431 passed (the 2 failing files are pre-existing integration tests requiring `DATABASE_URL`, unrelated to this change). Typecheck clean.

### Reviews
Ran code-review, silent-failure-hunter, and a focused security review. Addressed the two real findings (url field not redacted; raw `err` object logged) in the second commit; the screenshot + encoded-reflection limitations are documented as accepted residuals.


___

## **CodeAnt-AI Description**
**Fill stored browser secrets by reference and keep them out of returned page data**

### What Changed
- The browser `type` action can now fill a saved `user.*` secret using `secret_ref` instead of literal text, so stored credentials are entered server-side and never shown in the tool call or result.
- `secret_ref` is only available to allowlisted skills and only for `user.*` secrets; invalid namespaces, missing capability wiring, or skills outside the allowlist are rejected.
- Any secret typed by reference is now tracked for the rest of that browser session and removed from returned page text, URLs, and error messages if a page echoes it back.
- Added public API updates and tests for by-reference secret resolution, session redaction, and the browser fill flow.

### Impact
`✅ Safer login form fills`
`✅ Fewer secret leaks in browser output`
`✅ Clearer errors when secret fill access is not available`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added secret-by-reference support for the web-browser action, enabling secure credential injection that remains server-side and is not exposed to logs or downstream systems.
  * Automatically scrubs page content of injected secret values during browser sessions.

* **Security**
  * Implemented value-aware redaction for browser-returned content to prevent accidental secret exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->