### PR TITLE
chore: relocate coordinator tool-mechanics into skill manifests (#958)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Coordinator prompt (policy/reference split)** — tool-specific mechanics moved out of the coordinator prompt into the skill manifests the model already sees: config-store namespace conventions, the context_bridge shape, and decay-warning nudge phrasings now live on their respective skills; the `## Reference` region is removed. Drive-upload steps stay condensed in the prompt (their target `create_drive_file` is an MCP tool with no local manifest). (#958)
+- **`config-store` / `email-reply` / `email-send` / `signal-send` / `decay-warnings-list`** — descriptions/input docs expanded to carry the relocated mechanics; behavior unchanged. (#958)
 - **User chat bubble** — user messages now appear with a teal background (`--app-teal`) and white text, visually distinguishing them from agent replies.
 
 - **Secret capture** — agents mint a one-time link to a web form so a user can add a new vault secret mid-conversation; the value never touches the LLM. Skills `secret-capture-request` and `system-secret-capture-request`. (#971)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.8.0"
+version: "0.8.1"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -163,8 +163,8 @@ system_prompt: |
 
   When you call signal-send, email-send, or email-reply and you know which specialist
   should handle any reply, pass the `context_bridge` parameter to add a delegation hint
-  (see the context_bridge shape in Reference). This is optional — every outbound message
-  is automatically tracked — but the hint helps you route replies faster.
+  (the parameter shape and an example are documented on those skills). This is optional —
+  every outbound message is automatically tracked — but the hint helps you route replies faster.
 
   ### Self-contained vs reply-shaped
   If no [ACTIVE OUTBOUND CONTEXT] section is present, apply this two-part test:
@@ -203,8 +203,11 @@ system_prompt: |
   specialist with the specific request and present the result in your own voice.
   The ceo-inbox specialist owns both reply drafts and cold-compose drafts for
   the CEO's personal Gmail — do not call `email-draft-save` on the CEO's behalf.
-  Cold-compose requests need actual email addresses, not display names — see the
-  cold-compose address resolution rule in Reference before delegating.
+  Cold-compose requests need actual email addresses, not display names: before
+  delegating a cold-compose, resolve every recipient name to an email address using
+  the `<resolved_entities>` block in your context. If a recipient's email is not in
+  `<resolved_entities>`, ask the CEO for the full address — do not pass bare display
+  names like "Alice" to the ceo-inbox specialist.
   "Your inbox" or "Curia's inbox" refers to your own email account — use your
   own email skills for those.
 
@@ -311,8 +314,8 @@ system_prompt: |
   When the CEO says to remember company info, meeting links, travel preferences, or
   loyalty program details — store them immediately via config-store. On tasks that
   depend on these (booking travel, scheduling meetings, drafting company docs) —
-  retrieve the relevant namespace first. The available namespaces and their exact
-  store/retrieve syntax are in Reference.
+  retrieve the relevant namespace first. The available namespaces and their key
+  conventions are documented on the config-store tool itself.
 
   **No delete action** — config-store does not support removing individual entries.
   To change a value, store again under the same key (the new value overwrites the
@@ -379,8 +382,12 @@ system_prompt: |
   compose an email." Use the contact IDs from the <resolved_entities> block for
   addressing. Only ask the CEO for contact details as a last resort.
 
-  The mechanics for selecting which mailbox a tool acts on (the `account` param
-  rules, including the CEO-inbox exception) are in Reference.
+  **Which mailbox a tool acts on:** the `account` param on email-list, email-get,
+  email-draft-save, and email-archive selects the mailbox. Default to your own — omit
+  the param or pass your own account. Never read, draft, or archive the CEO's mailbox
+  directly; route anything about the CEO's email to the ceo-inbox specialist (see CEO
+  inbox requests). For a CC'd email (`[OWNER CC —]` context), reply with `email-reply`,
+  which uses your account automatically.
 
   ### Google Workspace
   You have access to Google Drive, Docs, and Sheets through your workspace skills.
@@ -403,10 +410,16 @@ system_prompt: |
   down — tell the CEO it appears to be temporarily unavailable.
 
   **Uploading attachments to Drive:** When you download an email attachment, you can
-  upload it to Google Drive with `create_drive_file`. The exact step-by-step (which
-  fields to pass, the temp-file timing constraints, and failure handling) is in
-  Reference. To attach a Drive file to an email, use drive-download-file (not
-  get_drive_file_content — text only, not binary-safe).
+  upload it to Google Drive with `create_drive_file`: pass `fileUrl` set to the download
+  result's `temp_file_url` (a `file://` URL), `file_name` from the original filename,
+  `mime_type` from the content_type, and optionally `folder_id`. Do NOT pass the base64
+  bytes as `content` — that writes a corrupted file; always use `fileUrl` for binary
+  uploads. Temp files live only a few minutes: if `temp_file_url` is missing, or the
+  upload fails with a file-not-found error on it (the temp file expired), tell the CEO
+  the attachment could not be saved and ask them to re-send the email — do NOT retry
+  without a fresh download. On other failures (quota, auth, permissions), report the
+  error and do NOT claim success. To attach a Drive file to an email, use
+  drive-download-file (not get_drive_file_content — text only, not binary-safe).
 
   ### Reaching the principal
   The CEO's verified contact details are in the **"Principal Contact Details"** block
@@ -415,6 +428,20 @@ system_prompt: |
   hardcode the CEO's contact details — the injected block is the authoritative source.
   For other contacts (third parties, external people), use `entity-context` with the
   contact ID to discover their verified addresses.
+
+  ### Account identity for tool calls
+  Your concrete email address and phone number are in the **"Your Contact Details"**
+  block injected into this prompt. Use those values when any tool requires an email
+  address, phone number, account identifier, or similar "acting as" parameter
+  (e.g. user_email, account_id, phone).
+
+  Default to your own accounts — never the CEO's. Only use the CEO's details if a
+  tool call explicitly fails with an authorization or not-found error AND the CEO
+  has directed you to act on their behalf. Never assume — default to yourself.
+  This applies to all third-party integrations: Google Workspace, calendar services,
+  file storage, messaging, or any other tool that takes an account parameter. (The
+  email skills' `account` param is the one exception — see "Which mailbox a tool acts
+  on" under Email.)
 
   ### Data protection
   Never bulk-export sensitive data without explicit confirmation.
@@ -447,7 +474,8 @@ system_prompt: |
   confidential/restricted, or well-connected to many other facts. They get a 7-day
   hold-back window during which the CEO can confirm (keep) or dismiss (archive now).
   (When to raise a decay warning with the CEO is governed by "What I Proactively
-  Surface"; the exact nudge phrasings are in Reference.)
+  Surface"; the exact nudge phrasings, keyed by the warning's reason, are documented
+  on the decay-warnings-list tool.)
 
   - Call decay-warnings-list to see if any nodes are flagged for re-confirmation
     (and use it directly if the CEO asks to see all pending warnings — "show me
@@ -515,125 +543,6 @@ system_prompt: |
   be [request nature from preview]. Want me to identify them?"). If totalLength exceeds
   the preview length the message was truncated — qualify your description ("appears to be
   asking for..." rather than stating definitively).
-
-  ## Reference
-
-  This region holds tool-specific mechanics referenced by the operating sections above.
-
-  ### config-store namespaces
-  `config-store` data survives restarts and is not subject to KG decay. Namespaces:
-
-  **`company`** — company overview information (legal name, registered address,
-  officers, board members, etc.):
-  - Store: `config-store { action: "store", namespace: "company", key: "<field>", value: "<value>" }`
-  - Retrieve all: `config-store { action: "retrieve", namespace: "company" }`
-  - Use descriptive key names (e.g. `legal_name`, `registered_address`, `ceo_name`).
-
-  **`meeting_links`** — personal meeting links (Zoom, Teams, Google Meet, etc.):
-  - Store: `config-store { action: "store", namespace: "meeting_links", key: "<person> <platform> link", value: "<url>" }`
-  - Retrieve all: `config-store { action: "retrieve", namespace: "meeting_links" }`
-  - Key format: `"{person_name} {platform} link"` (e.g. `"joseph zoom link"`).
-  - Single lookup: `config-store { action: "retrieve", namespace: "meeting_links", key: "joseph zoom link" }`
-
-  **`travel_preferences`** — the CEO's travel preferences (airline, seat class,
-  hotel chain, dietary restrictions, etc.):
-  - Store: `config-store { action: "store", namespace: "travel_preferences", key: "<field>", value: "<value>" }`
-  - Retrieve all: `config-store { action: "retrieve", namespace: "travel_preferences" }`
-  - Use descriptive key names (e.g. `preferred_airline`, `seat_preference`, `hotel_chain`).
-
-  **`loyalty_programs`** — loyalty program memberships (frequent flyer numbers,
-  hotel rewards, etc.):
-  - Store: `config-store { action: "store", namespace: "loyalty_programs", key: "<program_name>", value: "<json>" }`
-  - Retrieve all: `config-store { action: "retrieve", namespace: "loyalty_programs" }`
-  - Value is a JSON string with the program details:
-    `'{"member_number":"ABC123","tier":"Super Elite","notes":"..."}'`
-  - Example: `key: "Aeroplan"`, `value: '{"member_number":"ABC123","tier":"Super Elite"}'`
-
-  ### Account identity for tool calls
-  Your concrete email address and phone number are in the **"Your Contact Details"**
-  block injected into this prompt. Use those values when any tool requires an email
-  address, phone number, account identifier, or similar "acting as" parameter
-  (e.g. user_email, account_id, phone).
-
-  Default to your own accounts — never the CEO's. Only use the CEO's details if a
-  tool call explicitly fails with an authorization or not-found error AND the CEO
-  has directed you to act on their behalf. Never assume — default to yourself.
-
-  This applies to all third-party integrations: Google Workspace, calendar
-  services, file storage, messaging, or any other tool that takes an account
-  parameter.
-
-  **Exception — email skills (`email-list`, `email-get`, `email-draft-save`,
-  `email-archive`):**
-  The `account` param on these skills selects which mailbox to operate on.
-  The "default to yourself" rule does NOT apply to email-skill account selection.
-  Use these rules IN ORDER:
-
-  0. **CC'd email (`[OWNER CC —]` context):** The email came to YOUR inbox —
-     reply using `email-reply` (no account selection needed; it uses your
-     account automatically).
-  1. **CEO's inbox** — any request to read, draft, archive, or otherwise
-     act on the CEO's email: delegate to the ceo-inbox specialist per the
-     CEO inbox requests section above. Do not use email-list/email-get/
-     email-draft-save/email-archive with the CEO's account directly.
-  2. If operating on your own inbox (Curia's messages, Curia's drafts),
-     use your own account or omit the param.
-
-  When in doubt about whose mailbox to target, ask the CEO.
-
-  ### CEO inbox cold-compose address resolution
-  `ceo-inbox-draft-compose` requires actual email addresses, not display names.
-  Before delegating a cold-compose request, resolve all recipient names to email
-  addresses using the `<resolved_entities>` block in your context. If a recipient's
-  email is not in `<resolved_entities>`, ask the CEO to provide the full email
-  address — do not pass bare names like "Alice" to the ceo-inbox specialist.
-
-  ### Uploading attachments to Drive
-  When you download an email attachment (via email-download-attachment or when the
-  ceo-inbox specialist hands off an attachment), the result may include a
-  `temp_file_url` field — a `file://` URL pointing to the raw bytes on disk. To upload
-  the file to Google Drive, call create_drive_file with:
-  - `fileUrl`: the `temp_file_url` value (e.g. `file:///run/curia-tempfiles/...`)
-  - `file_name`: the original `filename` from the download result
-  - `mime_type`: the `content_type` from the download result
-  - `folder_id`: the target Drive folder (or omit for root)
-
-  Do NOT pass `content_base64` as the `content` parameter — that produces a
-  corrupted file containing raw base64 text instead of binary data. Always use
-  `fileUrl` for binary file uploads.
-
-  If `temp_file_url` is missing or undefined, the temp file store was
-  unavailable. Do NOT attempt to upload — inform the CEO the attachment could
-  not be saved to Drive and suggest they download and upload it manually.
-
-  **Timing:** Temp files have a limited lifespan (a few minutes). If
-  create_drive_file fails with a file-not-found error on the `temp_file_url`,
-  the temp file has expired. Tell the CEO the upload window expired and ask
-  them to re-send or forward the email so the attachment can be re-downloaded.
-  Do NOT retry the upload without a fresh download — the temp file cannot be
-  regenerated from the coordinator.
-
-  If create_drive_file fails for other reasons (quota, auth, permissions),
-  tell the CEO the upload failed and include the error. Do NOT claim success.
-
-  ### context_bridge shape
-  When you call signal-send, email-send, or email-reply and you know which
-  specialist should handle any reply, pass the context_bridge parameter:
-
-    context_bridge: {"agent_id": "coordinator", "delegation_hint": "calendar-specialist", "expected_reply": "confirmation or reschedule request"}
-
-  This is optional — every outbound message is automatically tracked. But passing
-  context_bridge adds delegation hints that help you route replies faster without
-  needing to re-derive context.
-
-  ### Decay-warning nudge phrasings
-  Phrase the decay-warning nudge using the reason field:
-  - high_sensitivity: "I have [label] on file but it's going stale — it's marked
-    confidential. Is it still accurate?"
-  - high_connectivity: "I have [label] on file but it's going stale — it's connected
-    to [edgeCount] other facts in my notes. Is it still accurate?"
-  - both: "I have [label] on file but it's going stale — it's confidential and
-    well-connected. Is it still accurate?"
 pinned_skills:
   - web-fetch
   - web-browser

--- a/docs/wip/2026-06-14-coordinator-policy-reference-split.md
+++ b/docs/wip/2026-06-14-coordinator-policy-reference-split.md
@@ -1,0 +1,68 @@
+# Coordinator prompt: policy / reference split (#958)
+
+Follow-up to #957. #957 parked tool-specific mechanics in a bottom **`## Reference`**
+region of `agents/coordinator.yaml`. This change relocates those mechanics out of the
+prompt — into the relevant **local** skill manifests where the model already sees the
+text — so the coordinator prompt is pure operating policy and the Reference region is
+removed.
+
+## Constraint discovered during design
+
+- Skill `description` and `inputs` text **is** surfaced verbatim to the model as the tool
+  schema (`src/skills/registry.ts` `toToolDefinitions` → `anthropic.ts`). So moving prose
+  into a local manifest keeps it visible. Confirmed end-to-end.
+- **MCP tools have no local description override** (`src/skills/mcp-loader.ts:308` takes the
+  server's description as-is). `create_drive_file` is an MCP tool (`google-workspace`
+  server) — its Drive-upload how-to **cannot** move into a manifest.
+
+## Decisions (confirmed with Joseph)
+
+1. **Drive-upload mechanics** → keep a **condensed** version in the prompt's Google
+   Workspace policy section (target tool is MCP-only; no manifest can hold it). The
+   `## Reference` heading is still removed.
+2. **Account-identity general rule** and **cold-compose address resolution** are operating
+   *policy*, not per-tool how-to → relocate them out of Reference into their policy sections
+   (account-identity → a small `### Account identity` subsection under "What I Do Directly";
+   cold-compose → the existing "CEO inbox requests" section). They stay in the prompt.
+
+## Reference subsection → destination map
+
+| Reference subsection | Destination |
+|---|---|
+| config-store namespaces (company, meeting_links, travel_preferences, loyalty_programs) | `config-store` skill.json `description` |
+| context_bridge shape (example JSON) | `email-reply` / `email-send` / `signal-send` `context_bridge` input description |
+| Decay-warning nudge phrasings (by `reason`) | `decay-warnings-list` skill.json `description` |
+| Account identity — general "default to yourself" | prompt: new `### Account identity` policy subsection |
+| Account identity — email-skill account param exception | prompt: already covered by the email `account` input descriptions + CEO-inbox-delegate rule in the "CEO inbox requests" section; inline a one-line default in the Email section |
+| CEO-inbox cold-compose address resolution | prompt: "CEO inbox requests" section (inline) |
+| Uploading attachments to Drive | prompt: condensed into Google Workspace section (MCP target — decision 1) |
+
+After all moves, delete the `## Reference` heading and fix the in-prompt pointers that
+said "… are in Reference".
+
+## Blast radius
+
+- `config-store` is pinned by **coordinator, ceo-inbox, meeting-debrief**. Adding the
+  namespace catalog to its description is additive/informational for the other two; they
+  only use namespaces relevant to their work. Spot-check their behavior is unaffected.
+- `email-draft-save` is pinned by coordinator + meeting-debrief; we are **not** changing its
+  description (only adding context_bridge examples to email-reply/email-send/signal-send,
+  which are coordinator-only).
+- All other edited skills are coordinator-only.
+
+## Versioning (patch — description/prompt clarification, behavior-preserving)
+
+- `config-store` 1.0.0 → 1.0.1
+- `email-reply` 1.3.0 → 1.3.1
+- `email-send` 1.2.0 → 1.2.1
+- `signal-send` 1.1.0 → 1.1.1
+- `decay-warnings-list` 1.0.0 → 1.0.1
+- `coordinator.yaml` 0.8.0 → 0.8.1
+
+## Validation
+
+- `pnpm run typecheck`
+- Startup validator test (loads every manifest — catches malformed JSON / schema breaks)
+- config-store / email / decay / signal handler tests
+- Grep the coordinator prompt: no "in Reference" pointers remain; no `## Reference` heading.
+- CHANGELOG `[Unreleased]` updated.

--- a/skills/config-store/skill.json
+++ b/skills/config-store/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "config-store",
-  "description": "Store or retrieve agent configuration in the knowledge graph. Use 'store' to save a key-value pair under a namespace (e.g. namespace='writing_config', key='writing_guide_url'). Use 'retrieve' to read one key or all keys in a namespace. Use 'list_namespaces' to see which namespaces have been written to. Values are permanent — use this for deploy-agnostic config the CEO provides once via chat.",
-  "version": "1.0.0",
+  "description": "Store or retrieve agent configuration in the knowledge graph. Use 'store' to save a key-value pair under a namespace (e.g. namespace='writing_config', key='writing_guide_url'). Use 'retrieve' to read one key or all keys in a namespace. Use 'list_namespaces' to see which namespaces have been written to. Values are permanent — use this for deploy-agnostic config the CEO provides once via chat. Common namespaces and their key conventions: `company` (company overview — descriptive keys like legal_name, registered_address, ceo_name); `meeting_links` (personal meeting links — key format \"{person_name} {platform} link\", value is the URL); `travel_preferences` (CEO travel prefs — descriptive keys like preferred_airline, seat_preference, hotel_chain); `loyalty_programs` (memberships — key is the program name, e.g. \"Aeroplan\", value is a JSON string like '{\"member_number\":\"ABC123\",\"tier\":\"Super Elite\"}'). No delete action: to change a value, store again under the same key to overwrite it.",
+  "version": "1.0.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/decay-warnings-list/skill.json
+++ b/skills/decay-warnings-list/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "decay-warnings-list",
-  "description": "List knowledge graph nodes flagged for CEO re-confirmation before archival. Returns nodeId, label, nodeType, sensitivity, edgeCount, reason (high_sensitivity/high_connectivity/both), daysRemaining, and warnedAt per warning. Sorted oldest-first.",
-  "version": "1.0.0",
+  "description": "List knowledge graph nodes flagged for CEO re-confirmation before archival. Returns nodeId, label, nodeType, sensitivity, edgeCount, reason (high_sensitivity/high_connectivity/both), daysRemaining, and warnedAt per warning. Sorted oldest-first. When nudging the CEO, phrase by reason: high_sensitivity → \"I have [label] on file but it's going stale — it's marked confidential. Is it still accurate?\"; high_connectivity → \"I have [label] on file but it's going stale — it's connected to [edgeCount] other facts in my notes. Is it still accurate?\"; both → \"I have [label] on file but it's going stale — it's confidential and well-connected. Is it still accurate?\". State the time pressure using daysRemaining.",
+  "version": "1.0.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/skills/email-reply/skill.json
+++ b/skills/email-reply/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "email-reply",
   "description": "Reply to an existing email thread. By default, replies to all participants (reply-all). Pass cc as empty string to reply to sender only, or as a comma-separated list to explicitly set recipients. Provide the Nylas message ID to reply to and the reply body.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
@@ -9,7 +9,7 @@
     "body": "string",
     "cc": "string? (comma-separated — omit for reply-all default, empty string to reply to sender only)",
     "attachments": "object[]? (file attachments — array of {file_url: string, filename: string, content_type: string}. file_url must be a file:// URL from email-download-attachment or similar. Max 10 attachments, 20 MB total.)",
-    "context_bridge": "string? (JSON — optional context bridge registration: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?})"
+    "context_bridge": "string? (JSON — optional context bridge registration that adds a delegation hint so the agent can route any reply faster; every outbound is auto-tracked even without it. Shape: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?}. Example: {\"agent_id\":\"coordinator\",\"delegation_hint\":\"calendar-specialist\",\"expected_reply\":\"confirmation or reschedule request\"})"
   },
   "outputs": {
     "message_id": "string",

--- a/skills/email-send/skill.json
+++ b/skills/email-send/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "email-send",
   "description": "Send a new email. Provide comma-separated recipient email addresses, subject, and body. Emails are sent from the agent's configured email address.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
@@ -11,7 +11,7 @@
     "body": "string",
     "reply_to_message_id": "string? (Nylas message ID — when set, the original message is quoted below the reply and the send is threaded)",
     "attachments": "object[]? (file attachments — array of {file_url: string, filename: string, content_type: string}. file_url must be a file:// URL from email-download-attachment or similar. Max 10 attachments, 20 MB total.)",
-    "context_bridge": "string? (JSON — optional context bridge registration: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?})"
+    "context_bridge": "string? (JSON — optional context bridge registration that adds a delegation hint so the agent can route any reply faster; every outbound is auto-tracked even without it. Shape: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?}. Example: {\"agent_id\":\"coordinator\",\"delegation_hint\":\"calendar-specialist\",\"expected_reply\":\"confirmation or reschedule request\"})"
   },
   "outputs": {
     "message_id": "string",

--- a/skills/signal-send/skill.json
+++ b/skills/signal-send/skill.json
@@ -1,14 +1,14 @@
 {
   "name": "signal-send",
   "description": "Send a Signal message to a person (by their E.164 phone number) or a group (by group ID). For 1:1 sends, use the contact's verified Signal phone number from contact-lookup — display names are not trusted for Signal identity. For group sends, all group members must be verified contacts; unverified groups are refused with a list of which members need verification.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
     "recipient": "string?",
     "group_id": "string?",
     "message": "string",
-    "context_bridge": "string? (JSON — optional context bridge registration: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?})"
+    "context_bridge": "string? (JSON — optional context bridge registration that adds a delegation hint so the agent can route any reply faster; every outbound is auto-tracked even without it. Shape: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?}. Example: {\"agent_id\":\"coordinator\",\"delegation_hint\":\"calendar-specialist\",\"expected_reply\":\"confirmation or reschedule request\"})"
   },
   "outputs": {
     "delivered_to": "string",


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #957 (decision-spine restructure). That change parked tool-specific mechanics in a bottom `## Reference` region of the coordinator prompt; this change relocates those mechanics **out of the prompt and into the skill manifests the model already sees** (skill `description` / `inputs` text is passed verbatim as the tool schema), so the coordinator prompt is pure operating policy and the `## Reference` region is removed.

Closes #958.

## Relocated into manifests
- **config-store namespace conventions** (`company`, `meeting_links`, `travel_preferences`, `loyalty_programs`) → `config-store` `description`. The `"joseph zoom link"` example was genericized to `"{person_name} {platform} link"` (no deployment-specific names in manifests).
- **context_bridge shape + example** → `email-reply` / `email-send` / `signal-send` `context_bridge` input descriptions.
- **decay-warning nudge phrasings** (keyed by `reason`) → `decay-warnings-list` `description`.

## Kept in the prompt (not per-tool how-to, or no manifest can hold them)
- **Account-identity "default to yourself" rule** — operating policy, moved out of Reference into a `### Account identity for tool calls` subsection under *What I Do Directly*.
- **Cold-compose address resolution** — coordinator delegation policy, inlined into *CEO inbox requests*.
- **Drive-upload steps** — condensed into the *Google Workspace* section. Its target `create_drive_file` is an **MCP tool** (workspace-mcp server) with no local `skill.json` and no description-override mechanism, so it cannot live in a manifest. (Confirmed with the issue author.)

The `## Reference` heading is removed entirely (coordinator prompt: net −143 lines).

## Behavior preservation
- Every deleted Reference subsection maps to a destination; nothing dropped (cross-checked, incl. the `[OWNER CC —]` → `email-reply` rule).
- Manifest edits are additive prose only — no schema or handler changes.
- **Blast radius:** `config-store` is also pinned by ceo-inbox + meeting-debrief; the added namespace catalog is hedged as "Common namespaces" and is purely informational for them (each uses its own namespace). All other edited skills are coordinator-only.

## Versioning
Patch bumps (description/prompt clarification, behavior-preserving): `config-store` 1.0.1, `email-reply` 1.3.1, `email-send` 1.2.1, `signal-send` 1.1.1, `decay-warnings-list` 1.0.1, `coordinator.yaml` 0.8.1.

## Validation
- `pnpm run typecheck` — clean
- Startup manifest validator + skill-loader + agent-loader tests — 173 passing
- Edited skills' handler tests — 87 passing
- No `## Reference` heading or "in Reference" pointers remain; all five manifests parse.
- CHANGELOG `[Unreleased]` updated.

## Out of scope
Model/taxonomy restructure (done in #957).


___

## **CodeAnt-AI Description**
**Move coordinator guidance into the skills that use it**

### What Changed
- Tool-specific guidance was removed from the coordinator prompt’s `## Reference` section and moved into the related skill descriptions, so the model sees the same instructions where it makes the tool call.
- Email sending and replying now include a clearer `context_bridge` example and explain when to use it to help route follow-up replies.
- Config storage now lists the common namespaces and how to name keys for company details, meeting links, travel preferences, and loyalty programs.
- Decay warning messages now include the exact wording to use for each warning reason.
- The coordinator prompt now spells out which account to use by default, how to handle CEO inbox requests, how to resolve cold-compose recipients, and how to upload email attachments to Drive without corrupting files.
- The `## Reference` section has been removed from the coordinator prompt.

### Impact
`✅ Fewer wrong-tool instructions`
`✅ Clearer email reply routing`
`✅ Fewer broken Drive uploads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced outbound messaging routing with clearer delegation hint guidance
  * Refined email composition rules for recipient address resolution and mailbox handling
  * Expanded Drive file upload instructions with improved binary-safe handling
  * Clarified account identity defaults across tool operations

* **Documentation**
  * Updated skill documentation for config storage, email tools, decay warnings, and messaging features
  * Consolidated tool-specific mechanics with improved clarity on parameters and behaviour

<!-- end of auto-generated comment: release notes by coderabbit.ai -->