### PR TITLE
feat: secret.captured event + agent resume after secret capture (#972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **State filter pills** — Agents and Skills views gain All/Enabled/Installed/Ghost/Uninstalled pill filters with live counts; Channels gains All/Enabled/Installed/Uninstalled.
 - **Secret-by-reference injection** — the `web-browser` `type` action accepts `secret_ref` (a `user.*` vault key) to fill a stored credential; the value is dereferenced server-side and never enters the LLM context, tool call, result, or logs. (#973)
 - **`secretResolver` capability (skill manifest schema, public API)** — runtime by-reference resolution of dynamic `user.*` secrets; gated to a hard skill allowlist (`web-browser` only) and the `user.*` namespace. (#973)
+- **Agent resume after secret capture** — filling a capture link now publishes a `secret.captured` event (name/routing only, never the value) and a thin subscriber re-enters the originating agent so it can continue what it was blocked on. (#972)
+- **`secret.captured` bus event (public API)** — emitted by the capture endpoint on a successful redeem, carrying secret name/label + routing metadata and never the value. (#972)
 
 ### Changed
 
 - **Coordinator prompt (policy/reference split)** — tool-specific mechanics moved out of the coordinator prompt into the skill manifests the model already sees: config-store namespace conventions, the context_bridge shape, and decay-warning nudge phrasings now live on their respective skills; the `## Reference` region is removed. Drive-upload steps stay condensed in the prompt (their target `create_drive_file` is an MCP tool with no local manifest). (#958)
 - **`config-store` / `email-reply` / `email-send` / `signal-send` / `decay-warnings-list`** — descriptions/input docs expanded to carry the relocated mechanics; behavior unchanged. (#958)
 - **User chat bubble** — user messages now appear with a teal background (`--app-teal`) and white text, visually distinguishing them from agent replies.
+
+- **`secret-capture-request` (skill manifest schema)** — adds an optional `resume_intent` input and persists the minting agent's routing context on the token so the capture can re-enter the right conversation. (#972)
 
 - **Secret capture** — agents mint a one-time link to a web form so a user can add a new vault secret mid-conversation; the value never touches the LLM. Skills `secret-capture-request` and `system-secret-capture-request`. (#971)
 - **`skip_secret_redaction` (skill manifest schema, public API)** — opt a skill's output out of only the broad generic-hex secret scrub (structured credential patterns stay active); gated at startup to skills declaring `secretCapture`. For capability tokens (e.g. capture links) that must reach the LLM. (#971)

--- a/docs/wip/2026-06-14-secret-captured-resume.md
+++ b/docs/wip/2026-06-14-secret-captured-resume.md
@@ -1,0 +1,75 @@
+# secret.captured event + agent resume after secret capture (#972)
+
+Follow-up to #971. Today secret capture is fire-and-forget: an agent mints a link, the
+user fills it, and nothing tells the agent. This adds a `secret.captured` event and a thin
+**resume** path that re-enters the originating agent when a capture arrives, so it can
+continue what it was blocked on.
+
+The secret **value** never flows through the LLM, the event, or the resume task — only
+secret names/labels and routing metadata do. The agent reads actual values via
+`ctx.secret()` / `ctx.resolveSecretRef()` only when it performs the action (#973).
+
+## Design
+
+No group/coordination layer. Each capture link is independent. When a capture arrives the
+agent is re-entered and reasons about completeness from its own conversation history — it
+asked for "username and password," now sees "username captured," so it knows it still waits
+on the password. No DB bookkeeping duplicates that; the LLM already has the context.
+
+State is parked on the token row; the agent is re-entered by publishing a synthetic
+`agent.task` (mirrors the scheduler), not by holding a live process.
+
+## Changes
+
+### 1. Migration `054_add_secret_capture_routing.sql`
+Add nullable routing columns to `secret_capture_tokens` (no new table):
+`conversation_id TEXT`, `channel_id TEXT`, `agent_id TEXT`, `task_event_id TEXT`,
+`originator JSONB`, `resume_intent TEXT`. All nullable → backward compatible with #971 rows.
+
+### 2. Mint persists routing context (`secret-capture-service.ts`)
+`MintNameArgs` gains an optional `origin` object (conversationId, channelId, agentId,
+taskEventId, originator, resumeIntent). `mint()` writes these columns. The
+`secret-capture-request` skill builds `origin` from `SkillContext`
+(`conversationId`, `agentId`, `channelId`, `taskEventId`, `taskMetadata.originator`) and a
+`resume_intent` derived from the optional skill input (defaults to the label).
+
+### 3. `redeem()` returns routing context
+`redeem()` returns a discriminated `RedeemOutcome`:
+`{ status: 'ok'; captured: CapturedContext } | { status: 'expired' | 'not_found' | 'invalid_json' }`.
+The atomic claim's `RETURNING` is widened to include the routing columns. Still idempotent
+on `consumed_at` → one capture yields exactly one `captured`, a replay yields `expired` with
+no captured context (so no event).
+
+### 4. `secret.captured` event (`bus/events.ts`, `bus/permissions.ts`)
+New `SecretCapturedEvent` (`sourceLayer: 'system'`) + `createSecretCaptured()` factory.
+Payload: `{ secretName, label, conversationId?, agentId?, channelId?, taskEventId?,
+resumeIntent?, originator? }` — **never the value**. Add `secret.captured` to the system
+layer's publish and subscribe allowlists.
+
+### 5. Publish on redeem (`routes/secret-capture.ts`, `http-adapter.ts`)
+The capture POST route gets a `bus` and, on `status === 'ok'`, publishes `secret.captured`
+(layer `'system'`) carrying only the captured routing context. `http-adapter` passes `bus`.
+
+### 6. Resume subscriber (`src/secrets/secret-capture-resume-subscriber.ts`)
+Subscribes to `secret.captured`. Per event it does one thing: re-enter the originating agent
+by publishing a synthetic `agent.task` to the event's `agentId`/`conversationId`/`channelId`
+with `parentEventId = taskEventId`, `originator` preserved, `senderId = originator.contactId`,
+and content stating what arrived + the `resumeIntent`. In-memory dedup by event id so a
+duplicate delivery never double-dispatches. If essential routing (agentId/conversationId/
+channelId) is absent (e.g. a pre-migration token), it logs and skips — no dispatch.
+
+### 7. Wire subscriber at startup (`index.ts`)
+Instantiate the subscriber with `bus` + `logger` and `start()` it alongside the bus/scheduler.
+
+## Tests (TDD)
+- **Event/redeem:** `redeem()` returns captured routing on ok; a replayed (consumed) redeem
+  returns `expired` with no captured context. Captured context carries no value.
+- **Mint:** routing context is persisted on the token from the origin args.
+- **Resume subscriber:** a `secret.captured` event injects an `agent.task` to the originating
+  agent/conversation with `parentEventId` threaded and `resumeIntent` in the content;
+  duplicate delivery does not double-dispatch; missing routing → no dispatch.
+- **Privacy:** no secret value appears in any published event or injected task payload.
+
+## Out of scope
+Capture groups / multi-secret coordination; the consumer skill (#973, merged); bespoke
+expiry sweeps (owned by #971's token lifecycle).

--- a/skills/secret-capture-request/handler.test.ts
+++ b/skills/secret-capture-request/handler.test.ts
@@ -44,7 +44,9 @@ describe('SecretCaptureRequestHandler', () => {
     const data = (result as { success: true; data: Record<string, unknown> }).data;
     expect(data.capture_url).toBe('https://curia.example.com/secret-capture/abc123');
     expect(data.secret_name).toBe('user.flight');
-    expect(minter.userCalls).toEqual([{ rawName: 'my flight password', label: 'my flight password', valueFormat: 'string' }]);
+    // origin is always present (#972); with no routing on ctx its fields are undefined and
+    // resumeIntent falls back to the label. toEqual ignores undefined-valued properties.
+    expect(minter.userCalls).toEqual([{ rawName: 'my flight password', label: 'my flight password', valueFormat: 'string', origin: { resumeIntent: 'my flight password' } }]);
     // Timestamp-metadata contract: the field is `displayTimezone` (camelCase), not snake_case.
     expect(typeof data.displayTimezone).toBe('string');
     expect(data).not.toHaveProperty('display_timezone');
@@ -94,6 +96,36 @@ describe('SecretCaptureRequestHandler', () => {
     const minter = fakeMinter();
     const ctx = makeCtx({ secret_name: 'creds', value_format: 'json' }, { secretCapture: minter });
     await new SecretCaptureRequestHandler().execute(ctx);
-    expect(minter.userCalls).toEqual([{ rawName: 'creds', label: 'creds', valueFormat: 'json' }]);
+    expect(minter.userCalls).toEqual([{ rawName: 'creds', label: 'creds', valueFormat: 'json', origin: { resumeIntent: 'creds' } }]);
+  });
+
+  it('captures origin routing context from ctx for resume (#972)', async () => {
+    const minter = fakeMinter();
+    const originator = { contactId: 'ceo', systemRole: 'principal', channel: 'email', initiatedAt: 't' };
+    const ctx = makeCtx(
+      { secret_name: 'Aeroplan password', resume_intent: 'check the Aeroplan balance' },
+      {
+        secretCapture: minter,
+        conversationId: 'conv-1',
+        channelId: 'email',
+        agentId: 'coordinator',
+        taskEventId: 'task-evt-9',
+        taskMetadata: { originator },
+      },
+    );
+    await new SecretCaptureRequestHandler().execute(ctx);
+    expect(minter.userCalls).toEqual([{
+      rawName: 'Aeroplan password',
+      label: 'Aeroplan password',
+      valueFormat: 'string',
+      origin: {
+        conversationId: 'conv-1',
+        channelId: 'email',
+        agentId: 'coordinator',
+        taskEventId: 'task-evt-9',
+        originator,
+        resumeIntent: 'check the Aeroplan balance',
+      },
+    }]);
   });
 });

--- a/skills/secret-capture-request/handler.ts
+++ b/skills/secret-capture-request/handler.ts
@@ -31,10 +31,11 @@ export class SecretCaptureRequestHandler implements SkillHandler {
       return { success: false, error: 'secret-capture-request requires the secretCapture capability in context.' };
     }
 
-    const { secret_name, label, value_format } = ctx.input as {
+    const { secret_name, label, value_format, resume_intent } = ctx.input as {
       secret_name?: unknown;
       label?: unknown;
       value_format?: unknown;
+      resume_intent?: unknown;
     };
 
     if (typeof secret_name !== 'string' || secret_name.trim().length === 0) {
@@ -50,11 +51,29 @@ export class SecretCaptureRequestHandler implements SkillHandler {
       return { success: false, error: err instanceof Error ? err.message : String(err) };
     }
 
+    // Capture the origin routing context (#972) so that when the user fills the link, the
+    // capture endpoint can re-enter THIS agent in THIS conversation to continue. Holds no
+    // secret material — only routing + the agent's own description of what it's doing. The
+    // originator is forwarded opaquely from the task metadata so the resumed task is attributed
+    // to whoever started the chain. resume_intent falls back to the label when not supplied.
+    const resumeIntent = typeof resume_intent === 'string' && resume_intent.trim()
+      ? resume_intent.trim()
+      : labelStr;
+    const originator = ctx.taskMetadata?.originator as Record<string, unknown> | undefined;
+
     try {
       const { rawToken, secretName, expiresAt } = await ctx.secretCapture.mintUserSecret({
         rawName: secret_name,
         label: labelStr,
         valueFormat,
+        origin: {
+          conversationId: ctx.conversationId,
+          channelId: ctx.channelId,
+          agentId: ctx.agentId,
+          taskEventId: ctx.taskEventId,
+          originator,
+          resumeIntent,
+        },
       });
       const captureUrl = buildCaptureUrl(ctx, rawToken);
       const expiresLocal = toLocalIso(Math.floor(expiresAt.getTime() / 1000), ctx.timezone);

--- a/skills/secret-capture-request/skill.json
+++ b/skills/secret-capture-request/skill.json
@@ -1,13 +1,14 @@
 {
   "name": "secret-capture-request",
-  "description": "Mint a one-time, single-use, 30-minute link the user can click to enter a NEW personal secret (e.g. a website password). The value is typed by the user into a secure web form and written straight to the vault under a `user.<slug>` key. You never see the value — this skill returns only the link, never the secret. Relay the returned capture_url to the user verbatim. Use when a task needs a secret the vault does not yet have.",
-  "version": "0.1.2",
+  "description": "Mint a one-time, single-use, 30-minute link the user can click to enter a NEW personal secret (e.g. a website password). The value is typed by the user into a secure web form and written straight to the vault under a `user.<slug>` key. You never see the value — this skill returns only the link, never the secret. Relay the returned capture_url to the user verbatim. When the user fills the link, you are automatically brought back into this conversation to continue. Use when a task needs a secret the vault does not yet have.",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
     "secret_name": "string (human description of the secret, e.g. 'my flight site password'; auto-namespaced to user.<slug>)",
     "label": "string? (text shown to the user on the form; defaults to the secret_name)",
-    "value_format": "string? ('string' (default) or 'json')"
+    "value_format": "string? ('string' (default) or 'json')",
+    "resume_intent": "string? (a short description of what you are trying to do, e.g. 'check the user's Aeroplan balance'; surfaced back to you when the secret is captured so you can continue)"
   },
   "outputs": {
     "capture_url": "string (the one-time link to send the user)",

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -470,6 +470,24 @@ interface SecretAccessedPayload {
   byReference?: boolean;
 }
 
+// SecretCapturedPayload — emitted when a user submits a value to a one-time capture link and
+// it is redeemed into the vault (#972). Carries the secret NAME/label and the routing context
+// needed to re-enter the originating agent — NEVER the value. The resume subscriber turns this
+// into a synthetic agent.task so the blocked agent can continue. originator is round-tripped
+// opaquely (it is the TaskOriginator JSONB stored on the token at mint time).
+interface SecretCapturedPayload {
+  secretName: string;     // the resolved vault key (e.g. 'user.aeroplan_password') — never the value
+  label: string | null;   // human-friendly label shown on the form
+  // Routing context captured at mint time from SkillContext. All optional: a token minted
+  // outside an agent context (or before #972) has no routable origin and is simply not resumed.
+  conversationId?: string;
+  agentId?: string;
+  channelId?: string;
+  taskEventId?: string;   // originating agent.task event id — threaded as parentEventId on resume
+  resumeIntent?: string;  // NL description of what the agent was trying to do
+  originator?: Record<string, unknown>;  // TaskOriginator that started the chain (preserved on resume)
+}
+
 // AutonomySkillBlockedPayload — published by the execution layer when a skill
 // invocation is blocked because the live autonomy score is below the skill's
 // action_risk threshold. Advisory-only — the agent receives a { success: false }
@@ -824,6 +842,16 @@ export interface SecretAccessedEvent extends BaseEvent {
   payload: SecretAccessedPayload;
 }
 
+// SecretCapturedEvent — published by the capture endpoint (trusted system infra) when a
+// one-time link is redeemed (#972). sourceLayer 'system' because the capture endpoint
+// self-authorizes via the token and writes to the vault, like the scheduler emitting its
+// own events. parentEventId traces to the originating agent.task. Never carries the value.
+export interface SecretCapturedEvent extends BaseEvent {
+  type: 'secret.captured';
+  sourceLayer: 'system';
+  payload: SecretCapturedPayload;
+}
+
 // AutonomySkillBlockedEvent — execution layer blocked a skill invocation
 // due to insufficient autonomy score.
 export interface AutonomySkillBlockedEvent extends BaseEvent {
@@ -964,6 +992,7 @@ export type BusEvent =
   | ContextBudgetEvent        // #24: context budget utilization per LLM call
   | HumanDecisionEvent       // Spec 10: human-in-the-loop decision record (approve/deny/etc.)
   | SecretAccessedEvent      // Spec 06: secrets isolation audit trail (name only, never value)
+  | SecretCapturedEvent      // #972: one-time capture link redeemed (name/routing only, never value)
   | AutonomySkillBlockedEvent  // Autonomy Phase 2: skill blocked by action_risk gate
   | AutonomySendBlockedEvent   // Autonomy Phase 2: outbound send blocked by score < 70 gate
   | EmbeddingCallEvent         // #654: embedding API call cost telemetry
@@ -1461,6 +1490,20 @@ export function createSecretAccessed(
     timestamp: new Date(),
     type: 'secret.accessed',
     sourceLayer: 'execution',
+    payload,
+    parentEventId,
+  };
+}
+
+export function createSecretCaptured(
+  payload: SecretCapturedPayload,
+  parentEventId?: string,
+): SecretCapturedEvent {
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'secret.captured',
+    sourceLayer: 'system',
     payload,
     parentEventId,
   };

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -31,12 +31,15 @@ import type { Layer, EventType } from './events.js';
 // #847 (dispatcher reply-lock): dispatch layer publishes outbound.suppressed_duplicate when
 //          a human-facing reply skill already fired during the same task; dispatch layer
 //          subscribes to skill.result to detect the reply and set the reply-lock flag.
+// #972 (secret-capture resume): system layer publishes secret.captured when a one-time capture
+//          link is redeemed (carries name/routing only, never the value); the resume subscriber
+//          and audit logger subscribe via the system layer.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message', 'channel.poll', 'channel.stalled']),
   dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'autonomy.send_blocked']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call', 'context.budget']),
   execution: new Set(['skill.result', 'secret.accessed', 'autonomy.skill_blocked', 'contact.resolved']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
@@ -48,7 +51,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss', 'skill.result']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -400,6 +400,8 @@ export class HttpAdapter implements Channel {
       await this.app.register(secretCaptureRoutes, {
         secretCaptureService: this.config.secretCaptureService,
         logger,
+        // Pass the bus so a successful redeem publishes secret.captured for agent resume (#972).
+        bus,
       });
     }
 

--- a/src/channels/http/routes/secret-capture.test.ts
+++ b/src/channels/http/routes/secret-capture.test.ts
@@ -12,7 +12,7 @@ import type { BusEvent, Layer } from '../../../bus/events.js';
 import { createSilentLogger } from '../../../logger.js';
 
 /** A scripted fake: returns the configured metadata/redeem outcome and records redeem calls. */
-function fakeService(opts: {
+function makeFakeService(opts: {
   metadata?: CaptureMetadata;
   redeem?: RedeemOutcome | (() => Promise<RedeemOutcome>);
 }): SecretCapturePort & { redeemCalls: Array<{ token: string; value: string }> } {
@@ -31,7 +31,7 @@ function fakeService(opts: {
 }
 
 /** A spy bus that records publishes — enough surface for the route, which only calls publish(). */
-function fakeBus(): EventBus & { published: Array<{ layer: Layer; event: BusEvent }> } {
+function makeFakeBus(): EventBus & { published: Array<{ layer: Layer; event: BusEvent }> } {
   const published: Array<{ layer: Layer; event: BusEvent }> = [];
   return {
     published,
@@ -59,26 +59,26 @@ describe('secret-capture routes', () => {
 
   describe('GET /api/secret-capture/:token', () => {
     it('returns label + value_format for a live token', async () => {
-      app = await build(fakeService({ metadata: { label: 'Flight password', valueFormat: 'string' } }));
+      app = await build(makeFakeService({ metadata: { label: 'Flight password', valueFormat: 'string' } }));
       const res = await app.inject({ method: 'GET', url: '/api/secret-capture/abc' });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ label: 'Flight password', value_format: 'string' });
     });
 
     it('returns 410 for an expired/consumed token', async () => {
-      app = await build(fakeService({ metadata: 'expired' }));
+      app = await build(makeFakeService({ metadata: 'expired' }));
       const res = await app.inject({ method: 'GET', url: '/api/secret-capture/abc' });
       expect(res.statusCode).toBe(410);
     });
 
     it('returns 404 for an unknown token', async () => {
-      app = await build(fakeService({ metadata: 'not_found' }));
+      app = await build(makeFakeService({ metadata: 'not_found' }));
       const res = await app.inject({ method: 'GET', url: '/api/secret-capture/abc' });
       expect(res.statusCode).toBe(404);
     });
 
     it('never includes the vault key in the response', async () => {
-      app = await build(fakeService({ metadata: { label: 'x', valueFormat: 'string' } }));
+      app = await build(makeFakeService({ metadata: { label: 'x', valueFormat: 'string' } }));
       const res = await app.inject({ method: 'GET', url: '/api/secret-capture/abc' });
       expect(res.body).not.toContain('secret_name');
       expect(res.body).not.toContain('user.');
@@ -87,7 +87,7 @@ describe('secret-capture routes', () => {
 
   describe('POST /api/secret-capture/:token', () => {
     it('redeems a value and returns { ok: true }', async () => {
-      const svc = fakeService({ redeem: { status: 'ok', captured: { secretName: 'user.x', label: null } } });
+      const svc = makeFakeService({ redeem: { status: 'ok', captured: { secretName: 'user.x', label: null } } });
       app = await build(svc);
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'hunter2' } });
       expect(res.statusCode).toBe(200);
@@ -96,7 +96,7 @@ describe('secret-capture routes', () => {
     });
 
     it('publishes secret.captured (name/routing only, never the value) on a successful redeem', async () => {
-      const svc = fakeService({
+      const svc = makeFakeService({
         redeem: {
           status: 'ok',
           captured: {
@@ -111,7 +111,7 @@ describe('secret-capture routes', () => {
           },
         },
       });
-      const bus = fakeBus();
+      const bus = makeFakeBus();
       app = await build(svc, { bus });
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'hunter2' } });
       expect(res.statusCode).toBe(200);
@@ -135,15 +135,15 @@ describe('secret-capture routes', () => {
     });
 
     it('does NOT publish when redeem is not ok (no event for expired/not_found/invalid_json)', async () => {
-      const bus = fakeBus();
-      app = await build(fakeService({ redeem: { status: 'expired' } }), { bus });
+      const bus = makeFakeBus();
+      app = await build(makeFakeService({ redeem: { status: 'expired' } }), { bus });
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
       expect(res.statusCode).toBe(410);
       expect(bus.published).toHaveLength(0);
     });
 
     it('still returns 200 when the secret.captured publish throws (value already saved)', async () => {
-      const svc = fakeService({ redeem: { status: 'ok', captured: { secretName: 'user.x', label: null } } });
+      const svc = makeFakeService({ redeem: { status: 'ok', captured: { secretName: 'user.x', label: null } } });
       const bus = { async publish() { throw new Error('bus down'); } } as unknown as EventBus;
       app = await build(svc, { bus });
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
@@ -153,7 +153,7 @@ describe('secret-capture routes', () => {
     });
 
     it('rejects a missing/empty value with 400 (and never calls redeem)', async () => {
-      const svc = fakeService({});
+      const svc = makeFakeService({});
       app = await build(svc);
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: '' } });
       expect(res.statusCode).toBe(400);
@@ -161,31 +161,31 @@ describe('secret-capture routes', () => {
     });
 
     it('rejects an oversized value with 400', async () => {
-      app = await build(fakeService({}));
+      app = await build(makeFakeService({}));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'x'.repeat(9000) } });
       expect(res.statusCode).toBe(400);
     });
 
     it('maps expired → 410', async () => {
-      app = await build(fakeService({ redeem: { status: 'expired' } }));
+      app = await build(makeFakeService({ redeem: { status: 'expired' } }));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
       expect(res.statusCode).toBe(410);
     });
 
     it('maps not_found → 404', async () => {
-      app = await build(fakeService({ redeem: { status: 'not_found' } }));
+      app = await build(makeFakeService({ redeem: { status: 'not_found' } }));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
       expect(res.statusCode).toBe(404);
     });
 
     it('maps invalid_json → 400', async () => {
-      app = await build(fakeService({ redeem: { status: 'invalid_json' } }));
+      app = await build(makeFakeService({ redeem: { status: 'invalid_json' } }));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'not json' } });
       expect(res.statusCode).toBe(400);
     });
 
     it('maps a vault-write throw → 500', async () => {
-      app = await build(fakeService({ redeem: () => Promise.reject(new Error('vault down')) }));
+      app = await build(makeFakeService({ redeem: () => Promise.reject(new Error('vault down')) }));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
       expect(res.statusCode).toBe(500);
     });
@@ -196,7 +196,7 @@ describe('secret-capture routes', () => {
       // Register the route with a real (tiny) limit to prove the config is wired.
       const app2 = Fastify();
       await app2.register(rateLimit, { global: false });
-      await app2.register(secretCaptureRoutes, { secretCaptureService: fakeService({ metadata: 'not_found' }), logger: createSilentLogger() });
+      await app2.register(secretCaptureRoutes, { secretCaptureService: makeFakeService({ metadata: 'not_found' }), logger: createSilentLogger() });
       try {
         let last = 0;
         // The route declares max 10 / 15 min. The 11th request in the window should 429.

--- a/src/channels/http/routes/secret-capture.test.ts
+++ b/src/channels/http/routes/secret-capture.test.ts
@@ -6,13 +6,15 @@ import { describe, it, expect, afterEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 import { secretCaptureRoutes, type SecretCapturePort } from './secret-capture.js';
-import type { CaptureMetadata, RedeemResult } from '../../../secrets/secret-capture-service.js';
+import type { CaptureMetadata, RedeemOutcome } from '../../../secrets/secret-capture-service.js';
+import type { EventBus } from '../../../bus/bus.js';
+import type { BusEvent, Layer } from '../../../bus/events.js';
 import { createSilentLogger } from '../../../logger.js';
 
 /** A scripted fake: returns the configured metadata/redeem outcome and records redeem calls. */
 function fakeService(opts: {
   metadata?: CaptureMetadata;
-  redeem?: RedeemResult | (() => Promise<RedeemResult>);
+  redeem?: RedeemOutcome | (() => Promise<RedeemOutcome>);
 }): SecretCapturePort & { redeemCalls: Array<{ token: string; value: string }> } {
   const redeemCalls: Array<{ token: string; value: string }> = [];
   return {
@@ -23,15 +25,29 @@ function fakeService(opts: {
     async redeem(token: string, value: string) {
       redeemCalls.push({ token, value });
       if (typeof opts.redeem === 'function') return opts.redeem();
-      return opts.redeem ?? 'ok';
+      return opts.redeem ?? { status: 'ok', captured: { secretName: 'user.x', label: null } };
     },
   };
 }
 
-async function build(service: SecretCapturePort, withRateLimit = false): Promise<FastifyInstance> {
+/** A spy bus that records publishes — enough surface for the route, which only calls publish(). */
+function fakeBus(): EventBus & { published: Array<{ layer: Layer; event: BusEvent }> } {
+  const published: Array<{ layer: Layer; event: BusEvent }> = [];
+  return {
+    published,
+    async publish(layer: Layer, event: BusEvent) {
+      published.push({ layer, event });
+    },
+  } as unknown as EventBus & { published: Array<{ layer: Layer; event: BusEvent }> };
+}
+
+async function build(
+  service: SecretCapturePort,
+  opts: { withRateLimit?: boolean; bus?: EventBus } = {},
+): Promise<FastifyInstance> {
   const app = Fastify();
-  if (withRateLimit) await app.register(rateLimit, { max: 1000, timeWindow: '1 minute' });
-  await app.register(secretCaptureRoutes, { secretCaptureService: service, logger: createSilentLogger() });
+  if (opts.withRateLimit) await app.register(rateLimit, { max: 1000, timeWindow: '1 minute' });
+  await app.register(secretCaptureRoutes, { secretCaptureService: service, logger: createSilentLogger(), bus: opts.bus });
   return app;
 }
 
@@ -71,7 +87,7 @@ describe('secret-capture routes', () => {
 
   describe('POST /api/secret-capture/:token', () => {
     it('redeems a value and returns { ok: true }', async () => {
-      const svc = fakeService({ redeem: 'ok' });
+      const svc = fakeService({ redeem: { status: 'ok', captured: { secretName: 'user.x', label: null } } });
       app = await build(svc);
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'hunter2' } });
       expect(res.statusCode).toBe(200);
@@ -79,8 +95,65 @@ describe('secret-capture routes', () => {
       expect(svc.redeemCalls).toEqual([{ token: 'tok', value: 'hunter2' }]);
     });
 
+    it('publishes secret.captured (name/routing only, never the value) on a successful redeem', async () => {
+      const svc = fakeService({
+        redeem: {
+          status: 'ok',
+          captured: {
+            secretName: 'user.aeroplan_password',
+            label: 'Aeroplan password',
+            conversationId: 'conv-1',
+            agentId: 'coordinator',
+            channelId: 'email',
+            taskEventId: 'task-evt-9',
+            resumeIntent: 'check the Aeroplan balance',
+            originator: { contactId: 'ceo', systemRole: 'principal', channel: 'email', initiatedAt: 't' },
+          },
+        },
+      });
+      const bus = fakeBus();
+      app = await build(svc, { bus });
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'hunter2' } });
+      expect(res.statusCode).toBe(200);
+
+      expect(bus.published).toHaveLength(1);
+      const { layer, event } = bus.published[0]!;
+      expect(layer).toBe('system');
+      expect(event.type).toBe('secret.captured');
+      expect(event.parentEventId).toBe('task-evt-9');  // threads back to the originating agent.task
+      expect(event.payload).toMatchObject({
+        secretName: 'user.aeroplan_password',
+        label: 'Aeroplan password',
+        conversationId: 'conv-1',
+        agentId: 'coordinator',
+        channelId: 'email',
+        taskEventId: 'task-evt-9',
+        resumeIntent: 'check the Aeroplan balance',
+      });
+      // Privacy invariant: the submitted value must never appear in the published event.
+      expect(JSON.stringify(event)).not.toContain('hunter2');
+    });
+
+    it('does NOT publish when redeem is not ok (no event for expired/not_found/invalid_json)', async () => {
+      const bus = fakeBus();
+      app = await build(fakeService({ redeem: { status: 'expired' } }), { bus });
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
+      expect(res.statusCode).toBe(410);
+      expect(bus.published).toHaveLength(0);
+    });
+
+    it('still returns 200 when the secret.captured publish throws (value already saved)', async () => {
+      const svc = fakeService({ redeem: { status: 'ok', captured: { secretName: 'user.x', label: null } } });
+      const bus = { async publish() { throw new Error('bus down'); } } as unknown as EventBus;
+      app = await build(svc, { bus });
+      const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
+      // The capture succeeded; a failed resume-publish must not fail the user's submission.
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true });
+    });
+
     it('rejects a missing/empty value with 400 (and never calls redeem)', async () => {
-      const svc = fakeService({ redeem: 'ok' });
+      const svc = fakeService({});
       app = await build(svc);
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: '' } });
       expect(res.statusCode).toBe(400);
@@ -88,25 +161,25 @@ describe('secret-capture routes', () => {
     });
 
     it('rejects an oversized value with 400', async () => {
-      app = await build(fakeService({ redeem: 'ok' }));
+      app = await build(fakeService({}));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'x'.repeat(9000) } });
       expect(res.statusCode).toBe(400);
     });
 
     it('maps expired → 410', async () => {
-      app = await build(fakeService({ redeem: 'expired' }));
+      app = await build(fakeService({ redeem: { status: 'expired' } }));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
       expect(res.statusCode).toBe(410);
     });
 
     it('maps not_found → 404', async () => {
-      app = await build(fakeService({ redeem: 'not_found' }));
+      app = await build(fakeService({ redeem: { status: 'not_found' } }));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'v' } });
       expect(res.statusCode).toBe(404);
     });
 
     it('maps invalid_json → 400', async () => {
-      app = await build(fakeService({ redeem: 'invalid_json' }));
+      app = await build(fakeService({ redeem: { status: 'invalid_json' } }));
       const res = await app.inject({ method: 'POST', url: '/api/secret-capture/tok', payload: { value: 'not json' } });
       expect(res.statusCode).toBe(400);
     });

--- a/src/channels/http/routes/secret-capture.ts
+++ b/src/channels/http/routes/secret-capture.ts
@@ -91,28 +91,31 @@ export async function secretCaptureRoutes(
       switch (result.status) {
         case 'ok':
           // The value is now in the vault. Publish secret.captured (name/routing only, NEVER the
-          // value) so the resume subscriber can re-enter the originating agent (#972). This is
-          // best-effort: the user's submission already succeeded, so a publish failure must not
-          // turn into a 500 — it only means the agent isn't auto-resumed. We log it and still 200.
+          // value) so the resume subscriber can re-enter the originating agent (#972).
+          //
+          // Fire-and-forget on purpose: this side effect is NOT awaited. Bus delivery is
+          // synchronous-and-awaited internally, and the resume subscriber re-enters the agent —
+          // which can run a full LLM turn. Awaiting here would block the user's POST for the
+          // entire downstream resume even though their value is already saved. We detach it and
+          // attach a .catch so a publish failure is logged (not swallowed) without delaying or
+          // failing the request — at worst the agent simply isn't auto-resumed.
           if (bus) {
-            try {
-              const c = result.captured;
-              await bus.publish('system', createSecretCaptured(
-                {
-                  secretName: c.secretName,
-                  label: c.label,
-                  conversationId: c.conversationId,
-                  agentId: c.agentId,
-                  channelId: c.channelId,
-                  taskEventId: c.taskEventId,
-                  resumeIntent: c.resumeIntent,
-                  originator: c.originator,
-                },
-                c.taskEventId,  // parentEventId traces back to the originating agent.task
-              ));
-            } catch (pubErr) {
+            const c = result.captured;
+            void bus.publish('system', createSecretCaptured(
+              {
+                secretName: c.secretName,
+                label: c.label,
+                conversationId: c.conversationId,
+                agentId: c.agentId,
+                channelId: c.channelId,
+                taskEventId: c.taskEventId,
+                resumeIntent: c.resumeIntent,
+                originator: c.originator,
+              },
+              c.taskEventId,  // parentEventId traces back to the originating agent.task
+            )).catch((pubErr: unknown) => {
               logger.error({ err: pubErr }, 'secret-capture: failed to publish secret.captured (value saved; agent not auto-resumed)');
-            }
+            });
           }
           return reply.send({ ok: true });
         case 'not_found':

--- a/src/channels/http/routes/secret-capture.ts
+++ b/src/channels/http/routes/secret-capture.ts
@@ -15,12 +15,14 @@
 
 import type { FastifyInstance } from 'fastify';
 import type { Logger } from '../../../logger.js';
-import type { CaptureMetadata, RedeemResult } from '../../../secrets/secret-capture-service.js';
+import type { CaptureMetadata, RedeemOutcome } from '../../../secrets/secret-capture-service.js';
+import type { EventBus } from '../../../bus/bus.js';
+import { createSecretCaptured } from '../../../bus/events.js';
 
 /** The narrow service surface these routes need: read metadata, redeem a value. No mint. */
 export interface SecretCapturePort {
   getMetadata(rawToken: string): Promise<CaptureMetadata>;
-  redeem(rawToken: string, value: string): Promise<RedeemResult>;
+  redeem(rawToken: string, value: string): Promise<RedeemOutcome>;
 }
 
 export interface SecretCaptureRouteOptions {
@@ -29,6 +31,10 @@ export interface SecretCaptureRouteOptions {
    *  `request.log` is a no-op — we log through this injected logger instead so failures on
    *  these security-sensitive endpoints are actually recorded. */
   logger: Logger;
+  /** Event bus — on a successful redeem the route publishes `secret.captured` (#972) so the
+   *  resume subscriber can re-enter the originating agent. Optional: if absent (e.g. a test
+   *  harness or a deployment without resume wired), redemption still works, just no resume. */
+  bus?: EventBus;
 }
 
 /** Generous ceiling for a captured value (API keys, passwords, small JSON credential sets).
@@ -39,7 +45,7 @@ export async function secretCaptureRoutes(
   app: FastifyInstance,
   options: SecretCaptureRouteOptions,
 ): Promise<void> {
-  const { secretCaptureService, logger } = options;
+  const { secretCaptureService, logger, bus } = options;
 
   // Tight per-route rate limit — the token is unauthenticated, so cap brute-force/abuse
   // per IP the same way POST /auth does. No-op if @fastify/rate-limit isn't registered.
@@ -82,8 +88,32 @@ export async function secretCaptureRoutes(
 
     try {
       const result = await secretCaptureService.redeem(token, value);
-      switch (result) {
+      switch (result.status) {
         case 'ok':
+          // The value is now in the vault. Publish secret.captured (name/routing only, NEVER the
+          // value) so the resume subscriber can re-enter the originating agent (#972). This is
+          // best-effort: the user's submission already succeeded, so a publish failure must not
+          // turn into a 500 — it only means the agent isn't auto-resumed. We log it and still 200.
+          if (bus) {
+            try {
+              const c = result.captured;
+              await bus.publish('system', createSecretCaptured(
+                {
+                  secretName: c.secretName,
+                  label: c.label,
+                  conversationId: c.conversationId,
+                  agentId: c.agentId,
+                  channelId: c.channelId,
+                  taskEventId: c.taskEventId,
+                  resumeIntent: c.resumeIntent,
+                  originator: c.originator,
+                },
+                c.taskEventId,  // parentEventId traces back to the originating agent.task
+              ));
+            } catch (pubErr) {
+              logger.error({ err: pubErr }, 'secret-capture: failed to publish secret.captured (value saved; agent not auto-resumed)');
+            }
+          }
           return reply.send({ ok: true });
         case 'not_found':
           return reply.status(404).send({ error: 'This capture link is not valid.' });

--- a/src/db/migrations/054_add_secret_capture_routing.sql
+++ b/src/db/migrations/054_add_secret_capture_routing.sql
@@ -1,0 +1,31 @@
+-- Up Migration
+-- Routing context for agent resume after secret capture (#972), follow-up to #971.
+--
+-- When an agent mints a capture link it is blocked waiting on the user. These columns record
+-- WHERE to route the resume once the value arrives: the originating conversation/agent/channel,
+-- the agent.task event id to thread parentEventId from, who started the chain (originator), and
+-- an optional natural-language description of what to resume. On redemption the capture endpoint
+-- reads these back and publishes a `secret.captured` event; a thin subscriber re-enters the agent.
+--
+-- Still NO secret material here — only routing metadata. The value never lands on this row.
+-- All columns are nullable so #971 tokens minted before this migration (and any capture minted
+-- outside an agent context) remain valid; the resume subscriber simply skips a row with no
+-- routable context.
+
+ALTER TABLE secret_capture_tokens
+  ADD COLUMN conversation_id TEXT,
+  ADD COLUMN channel_id      TEXT,
+  ADD COLUMN agent_id        TEXT,
+  ADD COLUMN task_event_id   TEXT,        -- originating agent.task event id (parentEventId source)
+  ADD COLUMN originator      JSONB,       -- TaskOriginator who started the chain (round-tripped only)
+  ADD COLUMN resume_intent   TEXT;        -- NL description of what to resume (e.g. the original ask)
+
+-- Down Migration
+
+ALTER TABLE secret_capture_tokens
+  DROP COLUMN conversation_id,
+  DROP COLUMN channel_id,
+  DROP COLUMN agent_id,
+  DROP COLUMN task_event_id,
+  DROP COLUMN originator,
+  DROP COLUMN resume_intent;

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -163,6 +163,30 @@ export class Dispatcher {
     }
   }
 
+  /**
+   * Register channel routing for an agent.task that did NOT originate from handleInbound.
+   *
+   * Normal tasks get a routing entry inside handleInbound (keyed by task event id) so
+   * handleAgentResponse can turn the agent's reply into an outbound.message. A task published
+   * directly to the bus by trusted infra — the secret-capture resume path (#972) — never passes
+   * through handleInbound, so without this its response would find no routing and be dropped as
+   * "no routing info" (the same path bullpen tasks take), never reaching the user.
+   *
+   * accountId is optional: when absent the email adapter falls back to the default account.
+   */
+  registerExternalTaskRouting(
+    taskEventId: string,
+    routing: { channelId: string; conversationId: string; senderId: string; accountId?: string },
+  ): void {
+    this.taskRouting.set(taskEventId, {
+      channelId: routing.channelId,
+      conversationId: routing.conversationId,
+      senderId: routing.senderId,
+      accountId: routing.accountId,
+      humanReplySent: false,
+    });
+  }
+
   /** Clear all pending checkpoint timers. Call during graceful shutdown. */
   close(): void {
     for (const timer of this.checkpointTimers.values()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1577,12 +1577,6 @@ async function main(): Promise<void> {
   // (which the allowlist thunk depends on). Mirrors setAgentContactId's post-hoc injection.
   executionLayer.setSecretCaptureService(secretCaptureService);
 
-  // Resume-after-capture subscriber (#972) — listens for secret.captured (published by the
-  // capture endpoint on a successful redeem) and re-enters the originating agent with a
-  // synthetic agent.task so it can continue what it was blocked on. Pure router, no DB state.
-  const secretCaptureResumeSubscriber = new SecretCaptureResumeSubscriber(bus, logger);
-  secretCaptureResumeSubscriber.start();
-
   // Agents with enable_task_management: true — read by the BacklogHeartbeat to
   // know which source_agent_ids it may wake (and as the fallback target list).
   const taskManagementAgents = new Set<string>();
@@ -1894,6 +1888,18 @@ async function main(): Promise<void> {
     outboundContextService,
   });
   dispatcher.register();
+
+  // Resume-after-capture subscriber (#972) — listens for secret.captured (published by the
+  // capture endpoint on a successful redeem) and re-enters the originating agent with a synthetic
+  // agent.task so it can continue what it was blocked on. Wired AFTER the dispatcher so it can
+  // seed routing for the synthetic task via registerExternalTaskRouting — without that the agent's
+  // resumed reply would find no routing entry and never reach the user.
+  const secretCaptureResumeSubscriber = new SecretCaptureResumeSubscriber(
+    bus,
+    logger,
+    (taskEventId, routing) => dispatcher.registerExternalTaskRouting(taskEventId, routing),
+  );
+  secretCaptureResumeSubscriber.start();
 
   // Conversation checkpoint processor — System Layer subscriber that runs background
   // memory skills (extract-relationships, etc.) at end of each conversation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ import { ExecutiveProfileService } from './executive/service.js';
 import { loadEncryptionKey } from './secrets/crypto.js';
 import { SecretsService } from './secrets/secrets-service.js';
 import { SecretCaptureService } from './secrets/secret-capture-service.js';
+import { SecretCaptureResumeSubscriber } from './secrets/secret-capture-resume-subscriber.js';
 import { channelCredentialKeys } from './channels/http/routes/vault.js';
 import { applyVaultSecrets } from './secrets/apply-vault-secrets.js';
 import { SensitivityClassifier } from './memory/sensitivity.js';
@@ -1575,6 +1576,12 @@ async function main(): Promise<void> {
   // Injected after construction because the ExecutionLayer is created before registryService
   // (which the allowlist thunk depends on). Mirrors setAgentContactId's post-hoc injection.
   executionLayer.setSecretCaptureService(secretCaptureService);
+
+  // Resume-after-capture subscriber (#972) — listens for secret.captured (published by the
+  // capture endpoint on a successful redeem) and re-enters the originating agent with a
+  // synthetic agent.task so it can continue what it was blocked on. Pure router, no DB state.
+  const secretCaptureResumeSubscriber = new SecretCaptureResumeSubscriber(bus, logger);
+  secretCaptureResumeSubscriber.start();
 
   // Agents with enable_task_management: true — read by the BacklogHeartbeat to
   // know which source_agent_ids it may wake (and as the fallback target list).

--- a/src/secrets/secret-capture-resume-subscriber.test.ts
+++ b/src/secrets/secret-capture-resume-subscriber.test.ts
@@ -116,6 +116,15 @@ describe('SecretCaptureResumeSubscriber', () => {
     expect(routingCalls).toHaveLength(0);
   });
 
+  it('skips (no dispatch) when minted on a non-user-facing channel (delegated specialist)', async () => {
+    const { published, emit, routingCalls } = makeSubscriber();
+    // A delegated specialist runs on channelId 'internal' with a throwaway conversation — a resume
+    // there could never reach the user, so it must be skipped rather than dead-ended silently.
+    await emit(makeCapturedEvent({ channelId: 'internal', conversationId: 'delegate-abc', agentId: 'some-specialist' }));
+    expect(published).toHaveLength(0);
+    expect(routingCalls).toHaveLength(0);
+  });
+
   it('falls back to a generic sender when no originator is present', async () => {
     const { published, emit } = makeSubscriber();
     await emit(createSecretCaptured({

--- a/src/secrets/secret-capture-resume-subscriber.test.ts
+++ b/src/secrets/secret-capture-resume-subscriber.test.ts
@@ -1,0 +1,124 @@
+// secret-capture-resume-subscriber.test.ts — unit tests for the #972 resume subscriber.
+// No DB, no real bus: a fake bus records subscriptions/publishes and lets a test emit events.
+
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { SecretCaptureResumeSubscriber } from './secret-capture-resume-subscriber.js';
+import type { EventBus } from '../bus/bus.js';
+import type { BusEvent, Layer, EventType, AgentTaskEvent } from '../bus/events.js';
+import { createSecretCaptured } from '../bus/events.js';
+
+function fakeBus() {
+  const handlers = new Map<EventType, Array<(e: BusEvent) => unknown>>();
+  const published: Array<{ layer: Layer; event: BusEvent }> = [];
+  const bus = {
+    subscribe(type: EventType, _layer: Layer, handler: (e: BusEvent) => unknown) {
+      const list = handlers.get(type) ?? [];
+      list.push(handler);
+      handlers.set(type, list);
+    },
+    async publish(layer: Layer, event: BusEvent) {
+      published.push({ layer, event });
+    },
+  } as unknown as EventBus;
+  async function emit(event: BusEvent) {
+    for (const h of handlers.get(event.type) ?? []) await h(event);
+  }
+  return { bus, published, emit };
+}
+
+const ORIGINATOR = { contactId: 'ceo', systemRole: 'principal', channel: 'email', initiatedAt: 't' };
+
+function fullEvent() {
+  return createSecretCaptured(
+    {
+      secretName: 'user.aeroplan_password',
+      label: 'Aeroplan password',
+      conversationId: 'conv-1',
+      agentId: 'coordinator',
+      channelId: 'email',
+      taskEventId: 'task-evt-9',
+      resumeIntent: 'check the Aeroplan balance',
+      originator: ORIGINATOR,
+    },
+    'task-evt-9',
+  );
+}
+
+function makeSubscriber() {
+  const { bus, published, emit } = fakeBus();
+  const sub = new SecretCaptureResumeSubscriber(bus, pino({ level: 'silent' }));
+  sub.start();
+  return { published, emit };
+}
+
+describe('SecretCaptureResumeSubscriber', () => {
+  it('re-enters the originating agent via a synthetic agent.task with parentEventId threaded', async () => {
+    const { published, emit } = makeSubscriber();
+    await emit(fullEvent());
+
+    expect(published).toHaveLength(1);
+    const { layer, event } = published[0]!;
+    expect(layer).toBe('system');
+    expect(event.type).toBe('agent.task');
+    const task = event as AgentTaskEvent;
+    expect(task.payload.agentId).toBe('coordinator');
+    expect(task.payload.conversationId).toBe('conv-1');
+    expect(task.payload.channelId).toBe('email');
+    // senderId attributes the resumed turn to whoever started the chain (the originator).
+    expect(task.payload.senderId).toBe('ceo');
+    // parentEventId threads back to the originating agent.task for causal tracing.
+    expect(task.parentEventId).toBe('task-evt-9');
+    // originator is preserved so authorization/identity gates still resolve on the resumed task.
+    expect(task.payload.metadata).toEqual({ originator: ORIGINATOR });
+    // The content tells the agent what arrived + the original intent so it can reason about
+    // completeness from its own conversation history.
+    expect(task.payload.content).toContain('Aeroplan password');
+    expect(task.payload.content).toContain('check the Aeroplan balance');
+  });
+
+  it('does not double-dispatch on duplicate event delivery', async () => {
+    const { published, emit } = makeSubscriber();
+    const event = fullEvent();
+    await emit(event);
+    await emit(event); // same event id delivered twice
+    expect(published).toHaveLength(1);
+  });
+
+  it('skips (no dispatch) when essential routing is missing', async () => {
+    const { published, emit } = makeSubscriber();
+    // A token minted outside an agent context has no agentId — nothing to route a resume to.
+    await emit(createSecretCaptured({
+      secretName: 'user.x',
+      label: 'X',
+      conversationId: 'conv-1',
+      channelId: 'email',
+      // agentId intentionally absent
+    }));
+    expect(published).toHaveLength(0);
+  });
+
+  it('falls back to a generic sender when no originator is present', async () => {
+    const { published, emit } = makeSubscriber();
+    await emit(createSecretCaptured({
+      secretName: 'user.x',
+      label: 'X',
+      conversationId: 'conv-1',
+      agentId: 'coordinator',
+      channelId: 'email',
+    }));
+    expect(published).toHaveLength(1);
+    const task = published[0]!.event as AgentTaskEvent;
+    expect(typeof task.payload.senderId).toBe('string');
+    expect(task.payload.senderId.length).toBeGreaterThan(0);
+    expect(task.payload.metadata).toBeUndefined();
+  });
+
+  it('never leaks a secret value (the event carries none; content is name/intent only)', async () => {
+    const { published, emit } = makeSubscriber();
+    await emit(fullEvent());
+    // Sanity: the payload only ever references the vault key/label/intent — there is no value
+    // anywhere in the chain to leak, and the content is built from names only.
+    expect(JSON.stringify(published[0]!.event)).not.toContain('hunter2');
+  });
+});

--- a/src/secrets/secret-capture-resume-subscriber.test.ts
+++ b/src/secrets/secret-capture-resume-subscriber.test.ts
@@ -3,12 +3,12 @@
 
 import { describe, it, expect } from 'vitest';
 import pino from 'pino';
-import { SecretCaptureResumeSubscriber } from './secret-capture-resume-subscriber.js';
+import { SecretCaptureResumeSubscriber, type ResumeRoutingRegistrar } from './secret-capture-resume-subscriber.js';
 import type { EventBus } from '../bus/bus.js';
 import type { BusEvent, Layer, EventType, AgentTaskEvent } from '../bus/events.js';
 import { createSecretCaptured } from '../bus/events.js';
 
-function fakeBus() {
+function makeFakeBus(opts: { publishThrows?: boolean } = {}) {
   const handlers = new Map<EventType, Array<(e: BusEvent) => unknown>>();
   const published: Array<{ layer: Layer; event: BusEvent }> = [];
   const bus = {
@@ -18,6 +18,7 @@ function fakeBus() {
       handlers.set(type, list);
     },
     async publish(layer: Layer, event: BusEvent) {
+      if (opts.publishThrows) throw new Error('bus down');
       published.push({ layer, event });
     },
   } as unknown as EventBus;
@@ -29,7 +30,7 @@ function fakeBus() {
 
 const ORIGINATOR = { contactId: 'ceo', systemRole: 'principal', channel: 'email', initiatedAt: 't' };
 
-function fullEvent() {
+function makeCapturedEvent(overrides: Partial<Parameters<typeof createSecretCaptured>[0]> = {}) {
   return createSecretCaptured(
     {
       secretName: 'user.aeroplan_password',
@@ -40,22 +41,26 @@ function fullEvent() {
       taskEventId: 'task-evt-9',
       resumeIntent: 'check the Aeroplan balance',
       originator: ORIGINATOR,
+      ...overrides,
     },
     'task-evt-9',
   );
 }
 
-function makeSubscriber() {
-  const { bus, published, emit } = fakeBus();
-  const sub = new SecretCaptureResumeSubscriber(bus, pino({ level: 'silent' }));
+function makeSubscriber(opts: { publishThrows?: boolean } = {}) {
+  const { bus, published, emit } = makeFakeBus(opts);
+  // Spy registrar so tests can assert routing is seeded for the resume task.
+  const routingCalls: Array<{ taskEventId: string; routing: Parameters<ResumeRoutingRegistrar>[1] }> = [];
+  const registerRouting: ResumeRoutingRegistrar = (taskEventId, routing) => { routingCalls.push({ taskEventId, routing }); };
+  const sub = new SecretCaptureResumeSubscriber(bus, pino({ level: 'silent' }), registerRouting);
   sub.start();
-  return { published, emit };
+  return { published, emit, routingCalls };
 }
 
 describe('SecretCaptureResumeSubscriber', () => {
   it('re-enters the originating agent via a synthetic agent.task with parentEventId threaded', async () => {
     const { published, emit } = makeSubscriber();
-    await emit(fullEvent());
+    await emit(makeCapturedEvent());
 
     expect(published).toHaveLength(1);
     const { layer, event } = published[0]!;
@@ -77,16 +82,28 @@ describe('SecretCaptureResumeSubscriber', () => {
     expect(task.payload.content).toContain('check the Aeroplan balance');
   });
 
+  it('seeds dispatcher routing for the resume task BEFORE publishing it (#972)', async () => {
+    const { published, emit, routingCalls } = makeSubscriber();
+    await emit(makeCapturedEvent());
+
+    // Routing must be registered for the same task id that is published, with the origin channel,
+    // so the dispatcher delivers the agent's reply back to the user instead of dropping it.
+    expect(routingCalls).toHaveLength(1);
+    const publishedTaskId = (published[0]!.event as AgentTaskEvent).id;
+    expect(routingCalls[0]!.taskEventId).toBe(publishedTaskId);
+    expect(routingCalls[0]!.routing).toEqual({ channelId: 'email', conversationId: 'conv-1', senderId: 'ceo' });
+  });
+
   it('does not double-dispatch on duplicate event delivery', async () => {
     const { published, emit } = makeSubscriber();
-    const event = fullEvent();
+    const event = makeCapturedEvent();
     await emit(event);
     await emit(event); // same event id delivered twice
     expect(published).toHaveLength(1);
   });
 
   it('skips (no dispatch) when essential routing is missing', async () => {
-    const { published, emit } = makeSubscriber();
+    const { published, emit, routingCalls } = makeSubscriber();
     // A token minted outside an agent context has no agentId — nothing to route a resume to.
     await emit(createSecretCaptured({
       secretName: 'user.x',
@@ -96,6 +113,7 @@ describe('SecretCaptureResumeSubscriber', () => {
       // agentId intentionally absent
     }));
     expect(published).toHaveLength(0);
+    expect(routingCalls).toHaveLength(0);
   });
 
   it('falls back to a generic sender when no originator is present', async () => {
@@ -114,9 +132,30 @@ describe('SecretCaptureResumeSubscriber', () => {
     expect(task.payload.metadata).toBeUndefined();
   });
 
+  it('falls back to a generic sender when originator.contactId is malformed (not a string)', async () => {
+    const { published, emit } = makeSubscriber();
+    // A malformed persisted originator (contactId is a number) must not yield a non-string senderId.
+    await emit(makeCapturedEvent({
+      originator: { contactId: 123 as unknown as string, systemRole: 'principal', channel: 'email', initiatedAt: 't' },
+    }));
+    expect(published).toHaveLength(1);
+    const task = published[0]!.event as AgentTaskEvent;
+    expect(task.payload.senderId).toBe('secret-capture');
+  });
+
+  it('rolls back the dedup marker and propagates when publish fails', async () => {
+    const { emit } = makeSubscriber({ publishThrows: true });
+    const event = makeCapturedEvent();
+    // The failure must propagate (catch policy: log + propagate), not be swallowed.
+    await expect(emit(event)).rejects.toThrow('bus down');
+    // After rollback a retry is allowed: a second delivery is attempted again (and throws again),
+    // proving the dedup marker was cleared rather than left blocking the retry.
+    await expect(emit(event)).rejects.toThrow('bus down');
+  });
+
   it('never leaks a secret value (the event carries none; content is name/intent only)', async () => {
     const { published, emit } = makeSubscriber();
-    await emit(fullEvent());
+    await emit(makeCapturedEvent());
     // Sanity: the payload only ever references the vault key/label/intent — there is no value
     // anywhere in the chain to leak, and the content is built from names only.
     expect(JSON.stringify(published[0]!.event)).not.toContain('hunter2');

--- a/src/secrets/secret-capture-resume-subscriber.ts
+++ b/src/secrets/secret-capture-resume-subscriber.ts
@@ -20,19 +20,38 @@ import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
 import type { BusEvent, SecretCapturedEvent } from '../bus/events.js';
 import { createAgentTask } from '../bus/events.js';
-import type { TaskOriginator } from '../contacts/types.js';
+
+/**
+ * Seeds channel routing for the synthetic resume task so the agent's response is delivered back
+ * to the originating channel. Without it, the dispatcher's handleAgentResponse finds no routing
+ * for the task id and drops the reply (the same path bullpen tasks take). In production this is
+ * `Dispatcher.registerExternalTaskRouting`; tests inject a spy.
+ */
+export type ResumeRoutingRegistrar = (
+  taskEventId: string,
+  routing: { channelId: string; conversationId: string; senderId: string; accountId?: string },
+) => void;
+
+/** Cap on the dedup set so a long-running process can't grow it without bound (one entry per
+ *  capture otherwise lives for the process lifetime). Generous — duplicates are rare — and FIFO
+ *  eviction of the oldest id is safe because the source (redeem) is idempotent, so an evicted id
+ *  re-arriving would at worst re-enter the agent once, which it tolerates (re-checks its history). */
+const MAX_DISPATCHED_IDS = 10_000;
 
 export class SecretCaptureResumeSubscriber {
   // In-memory guard against double-dispatch on duplicate event delivery. The redeem is already
   // idempotent on consumed_at (one capture → one event), so this only defends against the bus
   // delivering the same event id twice. A process restart clears it, which is fine: a re-emitted
   // event after a restart re-entering the agent once more is harmless (the agent re-checks its
-  // own history), and the set never needs to outlive the process.
+  // own history). Bounded to MAX_DISPATCHED_IDS with FIFO eviction so it never leaks.
   private readonly dispatched = new Set<string>();
 
   constructor(
     private readonly bus: EventBus,
     private readonly logger: Logger,
+    /** Optional: when provided, routing is registered before publish so the resumed response
+     *  reaches the user. Absent in tests that only assert the published task. */
+    private readonly registerRouting?: ResumeRoutingRegistrar,
   ) {}
 
   /** Subscribe to secret.captured. Call once at startup, alongside the bus/scheduler wiring. */
@@ -66,7 +85,7 @@ export class SecretCaptureResumeSubscriber {
 
     // Mark dispatched BEFORE publishing so a synchronous re-delivery during publish can't slip
     // through (mirrors the scheduler tracking its pending job before publish()).
-    this.dispatched.add(event.id);
+    this.markDispatched(event.id);
 
     const displayName = label ?? secretName;
     const intentLine = resumeIntent ? ` Original request: ${resumeIntent}.` : '';
@@ -75,29 +94,50 @@ export class SecretCaptureResumeSubscriber {
       `If you now have everything you need to continue, proceed. Otherwise, tell the user what ` +
       `is still outstanding (check your conversation history for any other secrets you asked for).`;
 
-    // Attribute the resumed turn to whoever started the chain, and preserve the originator so
-    // principal-identity / authorization gates resolve the same way they did on the original task.
-    const origin = originator as TaskOriginator | undefined;
-    const senderId = origin?.contactId ?? 'secret-capture';
+    // Attribute the resumed turn to whoever started the chain. originator is round-tripped from
+    // JSONB (typed Record<string, unknown>), so validate contactId is actually a string before
+    // using it as senderId — a malformed persisted value must not produce a non-string senderId.
+    // The originator object is still preserved verbatim on metadata so authorization gates resolve
+    // exactly as they did on the original task.
+    const contactId = originator?.['contactId'];
+    const senderId = typeof contactId === 'string' && contactId.length > 0 ? contactId : 'secret-capture';
+
+    // Build the task first so we know its id, then seed dispatcher routing BEFORE publishing —
+    // otherwise the agent's response could arrive before routing exists, or find none and be
+    // dropped (the dispatcher only auto-routes tasks that came through handleInbound).
+    const task = createAgentTask({
+      agentId,
+      conversationId,
+      channelId,
+      senderId,
+      content,
+      metadata: originator ? { originator } : undefined,
+      // Thread back to the originating agent.task when known so the causal chain is intact;
+      // fall back to this event's id otherwise (agent.task requires a parentEventId).
+      parentEventId: taskEventId ?? event.id,
+    });
 
     try {
-      await this.bus.publish('system', createAgentTask({
-        agentId,
-        conversationId,
-        channelId,
-        senderId,
-        content,
-        metadata: originator ? { originator } : undefined,
-        // Thread back to the originating agent.task when known so the causal chain is intact;
-        // fall back to this event's id otherwise (agent.task requires a parentEventId).
-        parentEventId: taskEventId ?? event.id,
-      }));
+      this.registerRouting?.(task.id, { channelId, conversationId, senderId });
+      await this.bus.publish('system', task);
       this.logger.info({ eventId: event.id, agentId, conversationId, secretName }, 'Resumed agent after secret capture');
     } catch (err) {
       // Roll back the dedup marker so a retry (e.g. operator replay) can re-attempt the resume,
-      // and surface the failure — a swallowed error here would silently strand the agent.
+      // log it, then propagate per the catch policy (the bus isolates subscriber errors, so this
+      // does not punish the publisher — it just ensures the failure is never silently swallowed).
       this.dispatched.delete(event.id);
       this.logger.error({ err, eventId: event.id, agentId, conversationId }, 'Failed to dispatch resume agent.task after secret capture');
+      throw err;
     }
+  }
+
+  /** Record an event id as handled, evicting the oldest when the bounded set is full. */
+  private markDispatched(eventId: string): void {
+    if (this.dispatched.size >= MAX_DISPATCHED_IDS) {
+      // Sets preserve insertion order, so the first key is the oldest — FIFO eviction.
+      const oldest = this.dispatched.values().next().value;
+      if (oldest !== undefined) this.dispatched.delete(oldest);
+    }
+    this.dispatched.add(eventId);
   }
 }

--- a/src/secrets/secret-capture-resume-subscriber.ts
+++ b/src/secrets/secret-capture-resume-subscriber.ts
@@ -42,9 +42,12 @@ export class SecretCaptureResumeSubscriber {
   }
 
   private async handle(event: SecretCapturedEvent): Promise<void> {
-    // Duplicate-delivery guard: one capture must re-enter the agent exactly once.
+    // Duplicate-delivery guard: one capture must re-enter the agent exactly once. A duplicate of
+    // the same event id is genuinely unexpected (redeem is idempotent on consumed_at, so the
+    // source emits exactly one event per capture) — so log at info: a steady stream of these
+    // would point at a bus re-delivery bug worth noticing, not routine noise.
     if (this.dispatched.has(event.id)) {
-      this.logger.debug({ eventId: event.id }, 'secret.captured already handled — skipping duplicate');
+      this.logger.info({ eventId: event.id }, 'secret.captured already handled — skipping duplicate');
       return;
     }
 

--- a/src/secrets/secret-capture-resume-subscriber.ts
+++ b/src/secrets/secret-capture-resume-subscriber.ts
@@ -38,6 +38,20 @@ export type ResumeRoutingRegistrar = (
  *  re-arriving would at worst re-enter the agent once, which it tolerates (re-checks its history). */
 const MAX_DISPATCHED_IDS = 10_000;
 
+/**
+ * Internal channels that carry no path back to a human. Resume only works when the link was
+ * minted by an agent running on a real user-facing channel — today that's the coordinator,
+ * which the dispatcher runs directly in the user's conversation. Anything minted by a *delegated*
+ * specialist runs on 'internal' (see the delegate skill, which stamps channelId 'internal' and a
+ * throwaway delegate-<uuid> conversation), so a resume there would publish an outbound.message no
+ * adapter delivers and no user is watching — AND the coordinator's delegate-await that would relay
+ * it has already returned. We skip those with a loud log rather than dead-ending silently.
+ *
+ * Cleanly resuming a delegated specialist is a separate feature: it needs the coordinator to
+ * re-delegate via the delegate skill's resume_token, not a direct re-entry. Tracked as follow-up.
+ */
+const NON_DELIVERABLE_CHANNELS = new Set(['internal', 'bullpen', 'scheduler']);
+
 export class SecretCaptureResumeSubscriber {
   // In-memory guard against double-dispatch on duplicate event delivery. The redeem is already
   // idempotent on consumed_at (one capture → one event), so this only defends against the bus
@@ -79,6 +93,20 @@ export class SecretCaptureResumeSubscriber {
       this.logger.info(
         { eventId: event.id, secretName, hasAgentId: !!agentId, hasConversationId: !!conversationId, hasChannelId: !!channelId },
         'secret.captured has no routable origin — not resuming an agent',
+      );
+      return;
+    }
+
+    // Deliverability guard: a link minted by a delegated specialist runs on an internal channel
+    // (channelId 'internal'/'bullpen'/'scheduler') with a throwaway conversation. Re-entering there
+    // would produce a reply no user can see and bypass the coordinator relay. Skip with a loud log
+    // rather than dead-ending silently. Today only the coordinator mints user-secret links (on a
+    // real channel), so this is a forward guard against a future skill-pinning footgun. Proper
+    // specialist resume needs the coordinator to re-delegate (delegate resume_token) — out of scope.
+    if (NON_DELIVERABLE_CHANNELS.has(channelId)) {
+      this.logger.warn(
+        { eventId: event.id, secretName, agentId, channelId },
+        'secret.captured minted by an agent on a non-user-facing channel — cannot deliver a resume there; skipping (specialist resume requires coordinator re-delegation)',
       );
       return;
     }

--- a/src/secrets/secret-capture-resume-subscriber.ts
+++ b/src/secrets/secret-capture-resume-subscriber.ts
@@ -1,0 +1,100 @@
+// secret-capture-resume-subscriber.ts — agent resume after secret capture (#972).
+//
+// Today secret capture is fire-and-forget: the agent mints a link, the user fills it, and
+// nothing tells the agent. This thin subscriber closes that loop. It listens for the
+// `secret.captured` event (published by the capture endpoint on a successful redeem) and does
+// exactly one thing: re-enter the originating agent by publishing a synthetic `agent.task`
+// back into the same conversation. The agent then reasons — from its OWN conversation history —
+// about whether it now has everything it asked for, and either proceeds (e.g. via the #973
+// consumer skill) or tells the user what's still outstanding.
+//
+// Deliberately NOT here: any group/coordination state, captured-vs-pending bookkeeping, or
+// completion logic. The LLM already has that context; duplicating it in a DB table would be
+// redundant and brittle. This service is a pure router: event in → agent.task out.
+//
+// The secret VALUE never reaches this code. The event carries only the secret name/label and
+// routing metadata (consistent with #971's structural guarantee), so neither the resume task
+// nor its content can contain a value.
+
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+import type { BusEvent, SecretCapturedEvent } from '../bus/events.js';
+import { createAgentTask } from '../bus/events.js';
+import type { TaskOriginator } from '../contacts/types.js';
+
+export class SecretCaptureResumeSubscriber {
+  // In-memory guard against double-dispatch on duplicate event delivery. The redeem is already
+  // idempotent on consumed_at (one capture → one event), so this only defends against the bus
+  // delivering the same event id twice. A process restart clears it, which is fine: a re-emitted
+  // event after a restart re-entering the agent once more is harmless (the agent re-checks its
+  // own history), and the set never needs to outlive the process.
+  private readonly dispatched = new Set<string>();
+
+  constructor(
+    private readonly bus: EventBus,
+    private readonly logger: Logger,
+  ) {}
+
+  /** Subscribe to secret.captured. Call once at startup, alongside the bus/scheduler wiring. */
+  start(): void {
+    this.bus.subscribe('secret.captured', 'system', (event: BusEvent) => this.handle(event as SecretCapturedEvent));
+    this.logger.info('SecretCaptureResumeSubscriber started — listening for secret.captured');
+  }
+
+  private async handle(event: SecretCapturedEvent): Promise<void> {
+    // Duplicate-delivery guard: one capture must re-enter the agent exactly once.
+    if (this.dispatched.has(event.id)) {
+      this.logger.debug({ eventId: event.id }, 'secret.captured already handled — skipping duplicate');
+      return;
+    }
+
+    const { secretName, label, conversationId, agentId, channelId, taskEventId, resumeIntent, originator } = event.payload;
+
+    // Essential routing must be present to re-enter an agent. A token minted outside an agent
+    // context (or before #972's migration) has no origin — there is nothing to resume, so we
+    // skip cleanly rather than fabricate a destination.
+    if (!agentId || !conversationId || !channelId) {
+      this.logger.info(
+        { eventId: event.id, secretName, hasAgentId: !!agentId, hasConversationId: !!conversationId, hasChannelId: !!channelId },
+        'secret.captured has no routable origin — not resuming an agent',
+      );
+      return;
+    }
+
+    // Mark dispatched BEFORE publishing so a synchronous re-delivery during publish can't slip
+    // through (mirrors the scheduler tracking its pending job before publish()).
+    this.dispatched.add(event.id);
+
+    const displayName = label ?? secretName;
+    const intentLine = resumeIntent ? ` Original request: ${resumeIntent}.` : '';
+    const content =
+      `The secret '${displayName}' was just captured and saved to the vault.${intentLine} ` +
+      `If you now have everything you need to continue, proceed. Otherwise, tell the user what ` +
+      `is still outstanding (check your conversation history for any other secrets you asked for).`;
+
+    // Attribute the resumed turn to whoever started the chain, and preserve the originator so
+    // principal-identity / authorization gates resolve the same way they did on the original task.
+    const origin = originator as TaskOriginator | undefined;
+    const senderId = origin?.contactId ?? 'secret-capture';
+
+    try {
+      await this.bus.publish('system', createAgentTask({
+        agentId,
+        conversationId,
+        channelId,
+        senderId,
+        content,
+        metadata: originator ? { originator } : undefined,
+        // Thread back to the originating agent.task when known so the causal chain is intact;
+        // fall back to this event's id otherwise (agent.task requires a parentEventId).
+        parentEventId: taskEventId ?? event.id,
+      }));
+      this.logger.info({ eventId: event.id, agentId, conversationId, secretName }, 'Resumed agent after secret capture');
+    } catch (err) {
+      // Roll back the dedup marker so a retry (e.g. operator replay) can re-attempt the resume,
+      // and surface the failure — a swallowed error here would silently strand the agent.
+      this.dispatched.delete(event.id);
+      this.logger.error({ err, eventId: event.id, agentId, conversationId }, 'Failed to dispatch resume agent.task after secret capture');
+    }
+  }
+}

--- a/src/secrets/secret-capture-service.test.ts
+++ b/src/secrets/secret-capture-service.test.ts
@@ -138,6 +138,42 @@ describe('SecretCaptureService minting (via the public name-policy entry points)
     expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 29 * 60_000);
     expect(expiresAt.getTime()).toBeLessThanOrEqual(Date.now() + 31 * 60_000);
   });
+
+  it('persists the origin routing context on the token at mint time (#972)', async () => {
+    const { svc, queries } = makeService();
+    const originator = { contactId: 'ceo', systemRole: 'principal', channel: 'email', initiatedAt: 't' };
+    await svc.mintUserSecret({
+      rawName: 'Aeroplan password',
+      label: 'Aeroplan password',
+      origin: {
+        conversationId: 'conv-1',
+        channelId: 'email',
+        agentId: 'coordinator',
+        taskEventId: 'task-evt-9',
+        originator,
+        resumeIntent: 'check my Aeroplan balance',
+      },
+    });
+    const insert = queries.find(q => q.sql.includes('INSERT INTO secret_capture_tokens'));
+    expect(insert).toBeDefined();
+    // The INSERT must name the routing columns and carry their values as parameters.
+    expect(insert!.sql).toContain('conversation_id');
+    expect(insert!.sql).toContain('resume_intent');
+    expect(insert!.params).toContain('conv-1');
+    expect(insert!.params).toContain('email');
+    expect(insert!.params).toContain('coordinator');
+    expect(insert!.params).toContain('task-evt-9');
+    expect(insert!.params).toContain('check my Aeroplan balance');
+    expect(insert!.params).toContainEqual(originator);
+  });
+
+  it('mints with NULL routing when no origin is supplied (backward compatible with #971)', async () => {
+    const { svc, queries } = makeService();
+    await svc.mintUserSecret({ rawName: 'x' });
+    const insert = queries.find(q => q.sql.includes('INSERT INTO secret_capture_tokens'));
+    // The four routing params after the fixed columns + TTL should all be null when no origin.
+    expect(insert!.params.filter(p => p === null).length).toBeGreaterThanOrEqual(5);
+  });
 });
 
 describe('SecretCaptureService.mintUserSecret / mintSystemSecret', () => {
@@ -195,23 +231,23 @@ describe('SecretCaptureService.redeem', () => {
 
   it('returns not_found for an unknown token', async () => {
     const { svc } = makeService(router({ peek: [] }));
-    expect(await svc.redeem('deadbeef', 'val')).toBe('not_found');
+    expect(await svc.redeem('deadbeef', 'val')).toEqual({ status: 'not_found' });
   });
 
   it('returns expired for a consumed token', async () => {
     const { svc } = makeService(router({
       peek: [{ value_format: 'string', spent: true }],
     }));
-    expect(await svc.redeem('deadbeef', 'val')).toBe('expired');
+    expect(await svc.redeem('deadbeef', 'val')).toEqual({ status: 'expired' });
   });
 
   it('writes a string value into the vault and consumes the token', async () => {
     const { svc, secrets, queries } = makeService(router({
       peek: [{ value_format: 'string', spent: false }],
-      claim: [{ secret_name: 'user.flight', value_format: 'string' }],
+      claim: [{ secret_name: 'user.flight', value_format: 'string', label: 'Flight password' }],
     }));
     const result = await svc.redeem('deadbeef', 'hunter2');
-    expect(result).toBe('ok');
+    expect(result.status).toBe('ok');
     expect(secrets.setCalls).toEqual([{ name: 'user.flight', value: 'hunter2' }]);
     // The atomic claim guards consumed_at IS NULL AND expires_at > now() — single use.
     const claim = queries.find(q => q.sql.includes('SET consumed_at = now()'));
@@ -219,13 +255,46 @@ describe('SecretCaptureService.redeem', () => {
     expect(claim!.sql).toContain('expires_at > now()');
   });
 
+  it('returns the captured routing context on ok — never the value (#972)', async () => {
+    const { svc } = makeService(router({
+      peek: [{ value_format: 'string', spent: false }],
+      claim: [{
+        secret_name: 'user.aeroplan_password',
+        value_format: 'string',
+        label: 'Aeroplan password',
+        conversation_id: 'conv-1',
+        channel_id: 'email',
+        agent_id: 'coordinator',
+        task_event_id: 'task-evt-9',
+        originator: { contactId: 'ceo', systemRole: 'principal', channel: 'email', initiatedAt: 't' },
+        resume_intent: 'check my Aeroplan balance',
+      }],
+    }));
+    const result = await svc.redeem('deadbeef', 'hunter2');
+    expect(result).toEqual({
+      status: 'ok',
+      captured: {
+        secretName: 'user.aeroplan_password',
+        label: 'Aeroplan password',
+        conversationId: 'conv-1',
+        channelId: 'email',
+        agentId: 'coordinator',
+        taskEventId: 'task-evt-9',
+        originator: { contactId: 'ceo', systemRole: 'principal', channel: 'email', initiatedAt: 't' },
+        resumeIntent: 'check my Aeroplan balance',
+      },
+    });
+    // Privacy invariant: the submitted value must not appear anywhere in the captured context.
+    expect(JSON.stringify(result)).not.toContain('hunter2');
+  });
+
   it('writes JSON via setJSON when value_format is json', async () => {
     const { svc, secrets } = makeService(router({
       peek: [{ value_format: 'json', spent: false }],
-      claim: [{ secret_name: 'user.creds', value_format: 'json' }],
+      claim: [{ secret_name: 'user.creds', value_format: 'json', label: null }],
     }));
     const result = await svc.redeem('deadbeef', '{"a":1}');
-    expect(result).toBe('ok');
+    expect(result.status).toBe('ok');
     expect(secrets.setJSONCalls).toEqual([{ name: 'user.creds', obj: { a: 1 } }]);
   });
 
@@ -234,18 +303,20 @@ describe('SecretCaptureService.redeem', () => {
       peek: [{ value_format: 'json', spent: false }],
     }));
     const result = await svc.redeem('deadbeef', 'not json');
-    expect(result).toBe('invalid_json');
+    expect(result).toEqual({ status: 'invalid_json' });
     expect(secrets.setJSONCalls).toHaveLength(0);
     // No claim UPDATE should have fired — the token is still usable for a retry.
     expect(queries.find(q => q.sql.includes('SET consumed_at = now()'))).toBeUndefined();
   });
 
-  it('treats a lost claim race as expired (single-use)', async () => {
+  it('treats a lost claim race as expired (single-use) — replay yields no captured context', async () => {
     const { svc } = makeService(router({
       peek: [{ value_format: 'string', spent: false }],
       claim: [], // someone else consumed it between peek and claim
     }));
-    expect(await svc.redeem('deadbeef', 'val')).toBe('expired');
+    // A replayed (already-consumed) redeem returns expired with no captured context, so the
+    // route publishes nothing — exactly one secret.captured event per real capture (#972).
+    expect(await svc.redeem('deadbeef', 'val')).toEqual({ status: 'expired' });
   });
 
   it('clears consumed_at and rethrows when the vault write fails', async () => {

--- a/src/secrets/secret-capture-service.ts
+++ b/src/secrets/secret-capture-service.ts
@@ -278,7 +278,10 @@ export class SecretCaptureService implements SecretCaptureMinter {
     if (row.value_format === 'json') {
       try {
         parsed = JSON.parse(value);
-      } catch {
+      } catch (err) {
+        // Log (never the value) so a malformed submission is traceable, then surface invalid_json.
+        // The token is NOT burned — the user can fix and resubmit.
+        this.options.logger?.warn({ err }, 'secret-capture: invalid JSON payload during redeem — token left unspent for retry');
         return { status: 'invalid_json' };
       }
     }

--- a/src/secrets/secret-capture-service.ts
+++ b/src/secrets/secret-capture-service.ts
@@ -82,11 +82,33 @@ export interface SecretCaptureMinter {
   mintSystemSecret(args: MintNameArgs): Promise<MintResult>;
 }
 
+/**
+ * Origin routing context captured at mint time (#972). Persisted on the token row alongside
+ * the metadata so that when the value is redeemed the capture endpoint can publish a
+ * `secret.captured` event with enough context to re-enter the originating agent. Holds NO
+ * secret material — only conversation/agent/channel routing and the original ask. Every field
+ * is optional: a token minted outside an agent context simply has no routable origin and is
+ * never resumed.
+ */
+export interface CaptureOrigin {
+  conversationId?: string;
+  channelId?: string;
+  agentId?: string;
+  /** The originating agent.task event id — threaded as parentEventId on the resume task. */
+  taskEventId?: string;
+  /** The TaskOriginator that started the chain. Round-tripped opaquely (stored as JSONB). */
+  originator?: Record<string, unknown>;
+  /** Natural-language description of what to resume, e.g. the original user ask. */
+  resumeIntent?: string;
+}
+
 export interface MintNameArgs {
   /** Raw, unresolved name from the skill input. Resolution depends on the policy. */
   rawName: string;
   label?: string;
   valueFormat?: CaptureValueFormat;
+  /** Origin routing context (#972), persisted so redeem can re-enter the agent. Optional. */
+  origin?: CaptureOrigin;
   // NOTE: TTL is intentionally NOT caller-controlled. The lifetime is a fixed security
   // property of the feature (single-use + 30 min, per #971), so callers cannot mint links
   // that are already dead, absurdly long-lived, or NaN. See DEFAULT_CAPTURE_TTL_MINUTES.
@@ -108,9 +130,36 @@ export interface SecretCaptureServiceOptions {
   logger?: Logger;
 }
 
-/** Outcome of a redeem attempt. Vault-write failures are not in this union — they rethrow
+/** Status of a redeem attempt. Vault-write failures are not in this union — they rethrow
  *  (after clearing consumed_at) so the route surfaces a 500 and the user can retry. */
-export type RedeemResult = 'ok' | 'expired' | 'not_found' | 'invalid_json';
+export type RedeemStatus = 'ok' | 'expired' | 'not_found' | 'invalid_json';
+
+/**
+ * Routing context returned on a successful redeem (#972). Carries the secret NAME/label and
+ * the origin captured at mint time — NEVER the value — so the capture endpoint can publish a
+ * `secret.captured` event without re-reading the DB. Mirrors CaptureOrigin plus the resolved
+ * secret name/label.
+ */
+export interface CapturedContext {
+  secretName: string;
+  label: string | null;
+  conversationId?: string;
+  channelId?: string;
+  agentId?: string;
+  taskEventId?: string;
+  originator?: Record<string, unknown>;
+  resumeIntent?: string;
+}
+
+/**
+ * Outcome of a redeem attempt. On 'ok' it carries the captured routing context; every other
+ * status carries nothing. Only a real (winning) claim returns 'ok' with context, so a replayed
+ * redeem of an already-consumed token returns 'expired' and the route publishes no event —
+ * exactly one secret.captured per capture.
+ */
+export type RedeemOutcome =
+  | { status: 'ok'; captured: CapturedContext }
+  | { status: 'expired' | 'not_found' | 'invalid_json' };
 
 export type CaptureMetadata =
   | { label: string | null; valueFormat: CaptureValueFormat }
@@ -130,7 +179,7 @@ export class SecretCaptureService implements SecretCaptureMinter {
    * of a SecretCaptureService can bypass the `user.` namespace sandbox or the system allowlist
    * by passing an arbitrary secretName. TTL is fixed (not a parameter) for the same reason.
    */
-  private async mint(secretName: string, label: string | undefined, valueFormat: CaptureValueFormat): Promise<{ rawToken: string; expiresAt: Date }> {
+  private async mint(secretName: string, label: string | undefined, valueFormat: CaptureValueFormat, origin?: CaptureOrigin): Promise<{ rawToken: string; expiresAt: Date }> {
     // 128-bit raw token, base64url-encoded → a short (~22 char) mixed-case slug that reads
     // like an ordinary magic-link id, NOT a 64-char hex hash. Two reasons for this shape:
     //   1. The relaying LLM was self-redacting the old hex token (it pattern-matched a long
@@ -144,24 +193,38 @@ export class SecretCaptureService implements SecretCaptureMinter {
     // Compute expires_at from the DB clock (now() + TTL), not the app clock, and read it back.
     // Redemption/metadata also compare against the DB now(), so mint and redeem share one time
     // source — app/DB clock skew can never make a link expire early or linger past its TTL.
+    // The routing columns (#972) are nullable and round-tripped only — they hold no secret
+    // material. originator is passed as an object so node-postgres serializes it to the JSONB
+    // column; the rest are plain text. A mint with no origin writes NULLs (backward compatible
+    // with #971), and such a token is simply never resumed.
     const result = await this.pool.query<{ expires_at: Date }>(
-      `INSERT INTO secret_capture_tokens (token_hash, secret_name, label, value_format, expires_at)
-       VALUES ($1, $2, $3, $4, now() + make_interval(mins => $5))
+      `INSERT INTO secret_capture_tokens
+         (token_hash, secret_name, label, value_format, expires_at,
+          conversation_id, channel_id, agent_id, task_event_id, originator, resume_intent)
+       VALUES ($1, $2, $3, $4, now() + make_interval(mins => $5), $6, $7, $8, $9, $10, $11)
        RETURNING expires_at`,
-      [tokenHash, secretName, label ?? null, valueFormat, DEFAULT_CAPTURE_TTL_MINUTES],
+      [
+        tokenHash, secretName, label ?? null, valueFormat, DEFAULT_CAPTURE_TTL_MINUTES,
+        origin?.conversationId ?? null,
+        origin?.channelId ?? null,
+        origin?.agentId ?? null,
+        origin?.taskEventId ?? null,
+        origin?.originator ?? null,
+        origin?.resumeIntent ?? null,
+      ],
     );
     return { rawToken, expiresAt: result.rows[0]!.expires_at };
   }
 
   async mintUserSecret(args: MintNameArgs): Promise<MintResult> {
     const secretName = resolveUserSecretName(args.rawName);
-    const { rawToken, expiresAt } = await this.mint(secretName, args.label, args.valueFormat ?? 'string');
+    const { rawToken, expiresAt } = await this.mint(secretName, args.label, args.valueFormat ?? 'string', args.origin);
     return { rawToken, secretName, expiresAt };
   }
 
   async mintSystemSecret(args: MintNameArgs): Promise<MintResult> {
     const secretName = resolveSystemSecretName(args.rawName, this.options.getAllowedSystemNames());
-    const { rawToken, expiresAt } = await this.mint(secretName, args.label, args.valueFormat ?? 'string');
+    const { rawToken, expiresAt } = await this.mint(secretName, args.label, args.valueFormat ?? 'string', args.origin);
     return { rawToken, secretName, expiresAt };
   }
 
@@ -192,7 +255,7 @@ export class SecretCaptureService implements SecretCaptureMinter {
    * single-use token (the user can fix and resubmit). The claim's WHERE clause re-checks
    * single-use/expiry atomically, so concurrent submissions cannot both win.
    */
-  async redeem(rawToken: string, value: string): Promise<RedeemResult> {
+  async redeem(rawToken: string, value: string): Promise<RedeemOutcome> {
     const tokenHash = hashToken(rawToken);
 
     // Peek to distinguish not_found / expired / invalid_json before mutating anything.
@@ -208,15 +271,15 @@ export class SecretCaptureService implements SecretCaptureMinter {
       [tokenHash],
     );
     const row = peek.rows[0];
-    if (!row) return 'not_found';
-    if (row.spent) return 'expired';
+    if (!row) return { status: 'not_found' };
+    if (row.spent) return { status: 'expired' };
 
     let parsed: unknown;
     if (row.value_format === 'json') {
       try {
         parsed = JSON.parse(value);
       } catch {
-        return 'invalid_json';
+        return { status: 'invalid_json' };
       }
     }
 
@@ -226,15 +289,31 @@ export class SecretCaptureService implements SecretCaptureMinter {
     // We consume the token BEFORE writing to the vault (not after) so a crash between the two
     // can never leave a redeemable token whose value was already stored. The failure direction
     // is "capability lost, retry needed" rather than "single-use token still reusable".
-    const claim = await this.pool.query<{ secret_name: string; value_format: CaptureValueFormat }>(
+    //
+    // RETURNING also pulls the routing columns (#972) so the caller can publish secret.captured
+    // without a second read. Only the winning claim returns a row, so a replayed redeem of an
+    // already-consumed token falls through to 'expired' and yields no captured context — the
+    // route then publishes nothing, giving exactly one event per real capture.
+    const claim = await this.pool.query<{
+      secret_name: string;
+      value_format: CaptureValueFormat;
+      label: string | null;
+      conversation_id: string | null;
+      channel_id: string | null;
+      agent_id: string | null;
+      task_event_id: string | null;
+      originator: Record<string, unknown> | null;
+      resume_intent: string | null;
+    }>(
       `UPDATE secret_capture_tokens
           SET consumed_at = now()
         WHERE token_hash = $1 AND consumed_at IS NULL AND expires_at > now()
-        RETURNING secret_name, value_format`,
+        RETURNING secret_name, value_format, label,
+                  conversation_id, channel_id, agent_id, task_event_id, originator, resume_intent`,
       [tokenHash],
     );
     const claimed = claim.rows[0];
-    if (!claimed) return 'expired';
+    if (!claimed) return { status: 'expired' };
 
     try {
       if (claimed.value_format === 'json') {
@@ -263,6 +342,20 @@ export class SecretCaptureService implements SecretCaptureMinter {
       }
       throw err; // always the original vault-write error, never the rollback error
     }
-    return 'ok';
+    // Return the routing context (NEVER the value) so the caller can publish secret.captured.
+    // Normalize SQL NULLs to undefined so the event payload omits absent fields cleanly.
+    return {
+      status: 'ok',
+      captured: {
+        secretName: claimed.secret_name,
+        label: claimed.label,
+        conversationId: claimed.conversation_id ?? undefined,
+        channelId: claimed.channel_id ?? undefined,
+        agentId: claimed.agent_id ?? undefined,
+        taskEventId: claimed.task_event_id ?? undefined,
+        originator: claimed.originator ?? undefined,
+        resumeIntent: claimed.resume_intent ?? undefined,
+      },
+    };
   }
 }

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
 import { EventBus } from '../../../src/bus/bus.js';
 import { AgentRuntime } from '../../../src/agents/runtime.js';
-import { createInboundMessage, createAgentError, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type MessageHeldEvent, type ContactUnknownEvent } from '../../../src/bus/events.js';
+import { createInboundMessage, createAgentError, createAgentTask, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type MessageHeldEvent, type ContactUnknownEvent } from '../../../src/bus/events.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
 import type { ContactService } from '../../../src/contacts/contact-service.js';
@@ -109,6 +109,63 @@ describe('Dispatcher', () => {
     expect(outbound).toHaveLength(1);
     expect(outbound[0]?.payload.content).toBe('Response from Coordinator');
     expect(outbound[0]?.payload.channelId).toBe('cli');
+  });
+});
+
+// #972: a synthetic agent.task (e.g. the secret-capture resume path) never passes through
+// handleInbound, so it needs registerExternalTaskRouting to seed routing — otherwise the
+// agent's response finds no routing entry and is dropped, never reaching the user.
+describe('Dispatcher.registerExternalTaskRouting (#972 resume path)', () => {
+  function buildHarness() {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const outbound: OutboundMessageEvent[] = [];
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Resumed response',
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+    const coordinator = new AgentRuntime({ agentId: 'coordinator', systemPrompt: 'x', provider: mockProvider, bus, logger });
+    coordinator.register();
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+    bus.subscribe('outbound.message', 'channel', (event) => { outbound.push(event as OutboundMessageEvent); });
+    return { bus, dispatcher, outbound };
+  }
+
+  it('delivers the resumed agent response to the originating channel/conversation', async () => {
+    const { bus, dispatcher, outbound } = buildHarness();
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'ceo',
+      content: 'A secret was captured — continue.',
+      parentEventId: 'task-evt-9',
+    });
+    // Seed routing BEFORE publishing the synthetic task (mirrors the resume subscriber).
+    dispatcher.registerExternalTaskRouting(task.id, { channelId: 'email', conversationId: 'conv-1', senderId: 'ceo' });
+    await bus.publish('system', task);
+
+    expect(outbound).toHaveLength(1);
+    expect(outbound[0]!.payload.conversationId).toBe('conv-1');
+    expect(outbound[0]!.payload.channelId).toBe('email');
+    expect(outbound[0]!.payload.content).toBe('Resumed response');
+  });
+
+  it('drops the response when no routing was registered (proves the entry is required)', async () => {
+    const { bus, outbound } = buildHarness();
+    const task = createAgentTask({
+      agentId: 'coordinator', conversationId: 'conv-1', channelId: 'email',
+      senderId: 'ceo', content: 'no routing', parentEventId: 'task-evt-9',
+    });
+    // Intentionally skip registerExternalTaskRouting.
+    await bus.publish('system', task);
+    expect(outbound).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #972. Follow-up to #971 (capture) and #973 (consume), both merged.

Today secret capture is fire-and-forget: an agent mints a one-time link, the user fills it, and nothing tells the agent. This adds a `secret.captured` event and a thin **resume** path that re-enters the originating agent when a capture arrives, so it can continue what it was blocked on.

```
User:  please log into my Aeroplan account and check my balance
Curia: happy to. I'll need your username and password — two secure links: <l1> <l2>
[user fills link 1] → Curia: got your username, still waiting on the password.
[user fills link 2] → Curia: got the password. checking your balance...
```

The secret **value** never flows through the LLM, the event, the resume task, the subscriber, or any log — only secret names/labels and routing metadata do (preserves #971's structural guarantee). The agent reasons about completeness from its own conversation history; there is no group/coordination state.

## What changed

- **Migration 054** — adds nullable routing columns to `secret_capture_tokens` (`conversation_id`, `channel_id`, `agent_id`, `task_event_id`, `originator` JSONB, `resume_intent`). No new table; backward compatible with #971 tokens.
- **Mint** persists the origin from `SkillContext`; **`redeem()`** now returns a `RedeemOutcome` carrying the captured routing context on `ok` (a replayed/already-consumed redeem returns `expired` with no context → exactly one event per capture).
- **`secret.captured` event** + `createSecretCaptured()` factory; `secret.captured` added to the **system** layer's publish/subscribe allowlists.
- **Capture POST route** publishes `secret.captured` on a successful redeem (best-effort: the value is already saved, so a publish failure logs and still returns 200).
- **`SecretCaptureResumeSubscriber`** — a pure router: `secret.captured` in → synthetic `agent.task` out, threading `parentEventId`, preserving `originator`, attributing the turn to the chain's originator. In-memory dedup so duplicate delivery never double-dispatches; skips cleanly when a token has no routable origin.
- **`secret-capture-request`** skill gains an optional `resume_intent` input and captures origin at mint time (version `0.1.2` → `0.2.0`).

## Testing (TDD)

- Event/redeem: `redeem()` returns captured routing on ok; a replayed redeem returns `expired` with no context; captured context carries no value.
- Mint: routing context is persisted on the token; absent origin writes NULLs.
- Route: publishes `secret.captured` (name/routing only) on ok; publishes nothing on non-ok; still 200 if the publish throws.
- Resume subscriber: dispatches an `agent.task` with `parentEventId` threaded + `resumeIntent` in content; no double-dispatch on duplicate delivery; no dispatch when routing is missing.
- Privacy: asserts no value appears in any published event or injected task payload.

Full suite: typecheck clean, 3447 passing (2 failures are pre-existing `DATABASE_URL`-gated autonomy integration tests, unrelated). Reviewed by code-reviewer, silent-failure-hunter, and a security review — no high-priority findings; the no-value invariant and originator non-forgeability were verified end-to-end.

## Out of scope

Capture groups / multi-secret coordination; the consumer skill (#973, merged); bespoke expiry sweeps (owned by #971's token lifecycle); resume for `system-secret-capture-request` (onboarding-only, left untouched).


___

## **CodeAnt-AI Description**
**Resume the original conversation after a secret capture link is filled**

### What Changed
- Filling a secret-capture link now sends a `secret.captured` event and automatically brings the originating agent back into the same conversation so it can continue the task.
- The capture flow now carries only routing details and the secret name/label, not the secret value; if the resume publish fails, the user’s submission still succeeds.
- Capture links can now include a short “resume intent” so the agent is reminded what it was working on when the secret arrives.

### Impact
`✅ Shorter waits after secret entry`
`✅ Fewer stalled conversations`
`✅ Clearer continuation after credential capture`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conversations automatically resume after users complete secret capture links
  * Added optional `resume_intent` input to customise resume behaviour in capture flows
  * Secret capture now supports secure agent-to-agent coordination with routing metadata (no secret values exposed)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->