### PR TITLE
fix: clear stale Xvfb lock before startup so web-browser survives crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Stale Xvfb lock recovery** — `BrowserService` now clears an orphaned `/tmp/.X99-lock` + socket left by an unclean exit before spawning Xvfb, guarded on a live X server so an active display is never clobbered; the web-browser skill survives a crash-induced restart. (#982)
 - **Secret-capture link redaction** — the one-time capture URL's token was scrubbed to `[REDACTED]` by the output sanitizer; the two capture skills now declare `skip_secret_redaction` so the link reaches the user intact. (#971)
 - **Secret-capture link relayed verbatim** — the token is now a short base64url slug (not a 64-char hex hash) and the skill summaries instruct the agent to relay the URL verbatim, so the model no longer self-redacts the link as a credential. (#971)
 

--- a/src/browser/browser-service.test.ts
+++ b/src/browser/browser-service.test.ts
@@ -6,7 +6,10 @@
 //   RUN_BROWSER_TESTS=1 pnpm test src/browser/browser-service.test.ts
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { BrowserService } from './browser-service.js';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { BrowserService, clearStaleX11Lock } from './browser-service.js';
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
@@ -144,6 +147,96 @@ describe('BrowserService (unit — mocked browser)', () => {
     await service.stop();
     expect(mockContext.close).toHaveBeenCalledTimes(2);
     expect(mockBrowser.close).toHaveBeenCalledOnce();
+  });
+});
+
+// --- clearStaleX11Lock (stale Xvfb lock cleanup) ---
+
+describe('clearStaleX11Lock', () => {
+  let dir: string;       // fake tmp dir standing in for /tmp
+  let lockPath: string;  // fake /tmp/.X99-lock
+  let socketPath: string; // fake /tmp/.X11-unix/X99
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'xvfb-lock-test-'));
+    mkdirSync(join(dir, '.X11-unix'), { recursive: true });
+    lockPath = join(dir, '.X99-lock');
+    socketPath = join(dir, '.X11-unix', 'X99');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes a stale lock + socket when no live process owns the display', () => {
+    // X servers write the owning PID left-padded to 10 chars with a trailing newline.
+    writeFileSync(lockPath, '      4242\n');
+    writeFileSync(socketPath, '');
+
+    const removed = clearStaleX11Lock({
+      displayNum: 99,
+      tmpDir: dir,
+      // Owning PID is dead — this is the crash-leftover case from the issue.
+      isProcessAlive: () => false,
+      logger,
+    });
+
+    expect(removed).toBe(true);
+    expect(existsSync(lockPath)).toBe(false);
+    expect(existsSync(socketPath)).toBe(false);
+  });
+
+  it('leaves the lock + socket intact when a live X server owns the display', () => {
+    writeFileSync(lockPath, '      4242\n');
+    writeFileSync(socketPath, '');
+
+    const removed = clearStaleX11Lock({
+      displayNum: 99,
+      tmpDir: dir,
+      // A genuinely live owner must never be clobbered.
+      isProcessAlive: () => true,
+      logger,
+    });
+
+    expect(removed).toBe(false);
+    expect(existsSync(lockPath)).toBe(true);
+    expect(existsSync(socketPath)).toBe(true);
+  });
+
+  it('treats an unparseable lock as stale and removes it (liveness check is skipped)', () => {
+    writeFileSync(lockPath, 'not-a-pid\n');
+    const aliveCheck = vi.fn().mockReturnValue(true);
+
+    const removed = clearStaleX11Lock({ displayNum: 99, tmpDir: dir, isProcessAlive: aliveCheck, logger });
+
+    expect(removed).toBe(true);
+    expect(existsSync(lockPath)).toBe(false);
+    // No PID to check, so the liveness probe should never run.
+    expect(aliveCheck).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no lock or socket is present', () => {
+    const removed = clearStaleX11Lock({
+      displayNum: 99,
+      tmpDir: dir,
+      isProcessAlive: () => false,
+      logger,
+    });
+    expect(removed).toBe(false);
+  });
+
+  it('leaves a lockless socket untouched — no PID means ownership cannot be proven', () => {
+    // Socket present but no lock file. Without a recorded PID we can't prove the
+    // display is free, so we must not remove it (could clobber a live server). A
+    // genuinely stale lockless socket is harmless — the X server recreates it.
+    writeFileSync(socketPath, '');
+    const aliveCheck = vi.fn().mockReturnValue(false);
+
+    const removed = clearStaleX11Lock({ displayNum: 99, tmpDir: dir, isProcessAlive: aliveCheck, logger });
+
+    expect(removed).toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+    expect(aliveCheck).not.toHaveBeenCalled();
   });
 });
 

--- a/src/browser/browser-service.test.ts
+++ b/src/browser/browser-service.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { BrowserService, clearStaleX11Lock } from './browser-service.js';
+import { BrowserService, clearStaleX11Lock, isXServerBinary } from './browser-service.js';
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
@@ -237,6 +237,27 @@ describe('clearStaleX11Lock', () => {
     expect(removed).toBe(false);
     expect(existsSync(socketPath)).toBe(true);
     expect(aliveCheck).not.toHaveBeenCalled();
+  });
+});
+
+// --- isXServerBinary (X server detection for the liveness guard) ---
+
+describe('isXServerBinary', () => {
+  it('recognizes all common X server flavours, not just Xvfb/Xorg', () => {
+    for (const binary of ['X', 'Xvfb', 'Xorg', 'Xwayland', 'Xephyr', 'Xvnc', 'Xnest']) {
+      expect(isXServerBinary(binary)).toBe(true);
+    }
+  });
+
+  it('recognizes an unlisted server following the X<name> convention', () => {
+    expect(isXServerBinary('Xfoo')).toBe(true);
+  });
+
+  it('rejects non-X-server binaries that merely start with x or mention X', () => {
+    // These would be false positives under the old substring match.
+    for (const binary of ['node', 'bash', 'xterm', 'Xfce4-session', 'chrome']) {
+      expect(isXServerBinary(binary)).toBe(false);
+    }
   });
 });
 

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -25,6 +25,7 @@
 import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { chromium, type Browser } from 'playwright';
 import { PlaywrightBlocker } from '@ghostery/adblocker-playwright';
 import type { Logger } from '../logger.js';
@@ -293,6 +294,13 @@ export class BrowserService {
       return;
     }
 
+    // Clear a stale :99 lock left by a previous unclean exit (crash, OOM, hard
+    // restart). stop() removes Xvfb on graceful shutdown, but cannot run on a hard
+    // crash — and the lock/socket survive in the container's writable layer across
+    // a `docker restart`, so cleanup-before-start is the only robust place to handle
+    // it. Guarded on a live X server so a genuinely active display is never clobbered.
+    clearStaleX11Lock({ displayNum: 99, logger: this.logger });
+
     this.logger.info('Spawning Xvfb virtual display on :99');
     this.xvfbProcess = spawn('Xvfb', [':99', '-screen', '0', '1280x720x24'], {
       stdio: 'ignore',
@@ -334,5 +342,106 @@ export class BrowserService {
       setTimeout(() => { cleanup(); resolve(); }, 500);
     });
     this.logger.info('Xvfb started on DISPLAY=:99');
+  }
+}
+
+interface ClearStaleX11LockOptions {
+  /** X display number (e.g. 99 for `:99`). */
+  displayNum: number;
+  logger: Logger;
+  /** Base tmp directory holding the lock + socket. Defaults to '/tmp'. Overridable for tests. */
+  tmpDir?: string;
+  /**
+   * Liveness probe for the PID recorded in the lock file. Defaults to a real
+   * check that the process is both alive AND an X server (to survive PID reuse).
+   * Overridable for tests.
+   */
+  isProcessAlive?: (pid: number) => boolean;
+}
+
+/**
+ * Remove a stale X11 lock file (`/tmp/.X<n>-lock`) and socket (`/tmp/.X11-unix/X<n>`)
+ * left behind by a previous unclean exit, but only when no live X server owns the
+ * display. Returns true if any stale file was removed.
+ *
+ * The whole check is gated on the lock file, because that is the authoritative signal
+ * of display ownership: an X server always creates `/tmp/.X<n>-lock` (recording its
+ * PID, left-padded to 10 chars) when it claims a display. We read that PID and probe
+ * liveness — if the owner is a genuinely live X server we leave everything untouched
+ * so an active display is never clobbered. If the PID is dead, missing, or unparseable,
+ * the lock is an orphan from a crash and we remove it together with its socket.
+ *
+ * We deliberately do NOT remove a socket when no lock file is present: with no recorded
+ * PID we can't prove the display is free, so removing it could clobber a live server
+ * (guard on a live process, not file presence). A genuinely orphaned lockless socket is
+ * harmless — the X server unlinks and recreates a stale socket itself on startup.
+ */
+export function clearStaleX11Lock(opts: ClearStaleX11LockOptions): boolean {
+  const { displayNum, logger, tmpDir = '/tmp', isProcessAlive = isLiveXServer } = opts;
+  const lockPath = `${tmpDir}/.X${displayNum}-lock`;
+  const socketPath = `${tmpDir}/.X11-unix/X${displayNum}`;
+
+  // No lock file → the X server considers `:${displayNum}` free. Nothing to clean,
+  // and without a recorded PID we have no safe basis to remove the socket.
+  if (!existsSync(lockPath)) return false;
+
+  // A lock file with a live X-server owner means the display is genuinely in use —
+  // bail out without touching anything.
+  const pid = readLockPid(lockPath);
+  if (pid !== null && isProcessAlive(pid)) {
+    logger.warn({ display: `:${displayNum}`, pid }, 'Xvfb lock owned by a live X server — leaving it alone');
+    return false;
+  }
+
+  // No live owner — remove the orphaned lock and socket from the prior unclean exit.
+  let removed = false;
+  for (const path of [lockPath, socketPath]) {
+    if (!existsSync(path)) continue;
+    try {
+      rmSync(path, { force: true });
+      removed = true;
+    } catch (err) {
+      logger.error({ err, path }, 'Failed to remove stale Xvfb file — Xvfb may fail to claim the display');
+    }
+  }
+  if (removed) {
+    logger.warn({ display: `:${displayNum}` }, 'Removed stale Xvfb lock/socket left by a previous unclean exit');
+  }
+  return removed;
+}
+
+/** Read the owning PID from an X11 lock file. Returns null if absent or unparseable. */
+function readLockPid(lockPath: string): number | null {
+  try {
+    // Format: PID left-padded to 10 chars plus a trailing newline. parseInt skips leading space.
+    const pid = Number.parseInt(readFileSync(lockPath, 'utf8').trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    // Unreadable lock file — treat as no valid owner so the caller removes it.
+    return null;
+  }
+}
+
+/**
+ * Default liveness probe: true only if `pid` is alive AND looks like an X server.
+ * The X-server check (via /proc/<pid>/cmdline) guards against PID reuse, where the
+ * recorded PID has been recycled by some unrelated process. If liveness is confirmed
+ * but the command line can't be read, we conservatively assume the display is owned
+ * (better to skip cleanup than risk clobbering a live server).
+ */
+function isLiveXServer(pid: number): boolean {
+  try {
+    // Signal 0 performs no signal delivery — it only probes for the process's existence.
+    process.kill(pid, 0);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false; // no such process
+    // EPERM: the process exists but we can't signal it — still alive, fall through.
+  }
+  try {
+    const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf8');
+    return cmdline.includes('Xvfb') || cmdline.includes('Xorg');
+  } catch {
+    // Couldn't inspect the command line; the process is alive, so assume it owns the display.
+    return true;
   }
 }

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -377,7 +377,9 @@ interface ClearStaleX11LockOptions {
  * harmless — the X server unlinks and recreates a stale socket itself on startup.
  */
 export function clearStaleX11Lock(opts: ClearStaleX11LockOptions): boolean {
-  const { displayNum, logger, tmpDir = '/tmp', isProcessAlive = isLiveXServer } = opts;
+  const { displayNum, logger, tmpDir = '/tmp' } = opts;
+  // Default probe needs the logger so it can surface (not swallow) /proc read failures.
+  const isProcessAlive = opts.isProcessAlive ?? ((pid: number) => isLiveXServer(pid, logger));
   const lockPath = `${tmpDir}/.X${displayNum}-lock`;
   const socketPath = `${tmpDir}/.X11-unix/X${displayNum}`;
 
@@ -387,7 +389,7 @@ export function clearStaleX11Lock(opts: ClearStaleX11LockOptions): boolean {
 
   // A lock file with a live X-server owner means the display is genuinely in use —
   // bail out without touching anything.
-  const pid = readLockPid(lockPath);
+  const pid = readLockPid(lockPath, logger);
   if (pid !== null && isProcessAlive(pid)) {
     logger.warn({ display: `:${displayNum}`, pid }, 'Xvfb lock owned by a live X server — leaving it alone');
     return false;
@@ -411,15 +413,34 @@ export function clearStaleX11Lock(opts: ClearStaleX11LockOptions): boolean {
 }
 
 /** Read the owning PID from an X11 lock file. Returns null if absent or unparseable. */
-function readLockPid(lockPath: string): number | null {
+function readLockPid(lockPath: string, logger: Logger): number | null {
   try {
     // Format: PID left-padded to 10 chars plus a trailing newline. parseInt skips leading space.
     const pid = Number.parseInt(readFileSync(lockPath, 'utf8').trim(), 10);
     return Number.isInteger(pid) && pid > 0 ? pid : null;
-  } catch {
-    // Unreadable lock file — treat as no valid owner so the caller removes it.
+  } catch (err) {
+    // Log rather than swallow, but deliberately do NOT propagate: this cleanup exists to
+    // keep BrowserService startup resilient, so an unreadable lock must degrade (treat as
+    // no valid owner → caller attempts removal) rather than throw and disable the skill.
+    logger.warn({ err, lockPath }, 'Could not read X11 lock PID — treating lock as having no live owner');
     return null;
   }
+}
+
+// X server binaries follow the convention of an executable named `X` or `X<name>`
+// (Xvfb, Xorg, Xwayland, Xephyr, Xvnc, …). We match the basename of argv[0] against
+// known names plus that convention, rather than substring-matching the whole command
+// line, so any live X server flavour is recognised (not just Xvfb/Xorg) and an
+// unrelated process that merely mentions "Xorg" in an argument is not misclassified.
+const X_SERVER_BINARIES = new Set(['X', 'Xvfb', 'Xorg', 'Xwayland', 'Xephyr', 'Xvnc', 'Xnest']);
+
+/**
+ * True if `binary` (an executable basename) is an X server: a known server name, or
+ * the `X<name>` convention (capital X + lowercase initial, alphanumeric, no separators —
+ * so `Xfoo` matches but `Xfce4-session`, `xterm`, and `node` do not).
+ */
+export function isXServerBinary(binary: string): boolean {
+  return X_SERVER_BINARIES.has(binary) || /^X[a-z][A-Za-z0-9]*$/.test(binary);
 }
 
 /**
@@ -429,7 +450,7 @@ function readLockPid(lockPath: string): number | null {
  * but the command line can't be read, we conservatively assume the display is owned
  * (better to skip cleanup than risk clobbering a live server).
  */
-function isLiveXServer(pid: number): boolean {
+function isLiveXServer(pid: number, logger: Logger): boolean {
   try {
     // Signal 0 performs no signal delivery — it only probes for the process's existence.
     process.kill(pid, 0);
@@ -438,10 +459,16 @@ function isLiveXServer(pid: number): boolean {
     // EPERM: the process exists but we can't signal it — still alive, fall through.
   }
   try {
-    const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf8');
-    return cmdline.includes('Xvfb') || cmdline.includes('Xorg');
-  } catch {
-    // Couldn't inspect the command line; the process is alive, so assume it owns the display.
+    // cmdline is NUL-separated; argv[0] is the executable path. Compare its basename
+    // against the X-server naming convention so all server flavours are recognised.
+    const argv0 = readFileSync(`/proc/${pid}/cmdline`, 'utf8').split('\0')[0] ?? '';
+    const binary = argv0.slice(argv0.lastIndexOf('/') + 1);
+    return isXServerBinary(binary);
+  } catch (err) {
+    // Couldn't inspect the command line; the process is alive, so conservatively assume
+    // it owns the display (never clobber a live server). Logged, not swallowed; not
+    // propagated, since that would defeat the resilient-startup purpose of this check.
+    logger.warn({ err, pid }, 'Could not inspect lock-owner cmdline — assuming the live process owns the display');
     return true;
   }
 }


### PR DESCRIPTION
## **User description**
## Summary

Fixes the silent disappearance of the web-browser skill after an unclean exit. `Closes #982`.

When the process exits without running `BrowserService.stop()` (crash, OOM, hard restart), the Xvfb lock `/tmp/.X99-lock` and socket `/tmp/.X11-unix/X99` survive in the container's writable layer — and outlive a `docker restart`. On the next start, `maybeStartXvfb()` spawns `Xvfb :99`, which immediately exits with code 1 because `:99` looks taken. The app stays healthy (`/api/health` → 200), so the failure is silent: the web-browser skill just vanishes until someone manually clears the lock.

## Fix

`maybeStartXvfb()` now calls a new `clearStaleX11Lock()` **before** spawning Xvfb:

- Gated on the lock file, which is the authoritative ownership signal — an X server always creates `/tmp/.X<n>-lock` recording its PID when it claims a display.
- Reads the owning PID and probes liveness. A **genuinely live X server is never clobbered** (guard on a live process, not file presence). The default probe also confirms the PID is actually an X server via `/proc/<pid>/cmdline`, guarding against PID reuse.
- If the PID is dead, missing, or unparseable, the lock + socket are orphans from a crash and are removed, so Xvfb claims `:99` cleanly.
- A **lockless socket is deliberately left untouched** — with no recorded PID we can't prove the display is free, and a genuinely stale lockless socket is harmless (the X server recreates it on startup). This closes a clobber-risk edge case raised in review.

## Acceptance criteria

- [x] After an unclean exit leaving `/tmp/.X99-lock` + the `:99` socket, the next `BrowserService` start claims the display and succeeds with no manual intervention.
- [x] The web-browser skill is available after a crash-induced restart.
- [x] A genuinely live X server on `:99` is not killed or clobbered (guarded on a live process, not file presence).
- [x] Test covers the "stale lock present, no owning process" case (plus live-owner, unparseable-lock, no-files, and lockless-socket cases).

## Testing

- `clearStaleX11Lock` unit-tested against a temp dir with an injectable liveness probe: stale lock removed, live owner preserved, unparseable lock removed, no-op when absent, lockless socket preserved.
- `pnpm run typecheck` and `pnpm run lint` clean (one pre-existing unrelated warning in `src/pii/scrubber.ts`).

The deploy-side tmpfs mitigation noted in the issue is left as optional defense-in-depth for `curia-deploy`; the fix belongs in the application as it also covers non-container environments.


___

## **CodeAnt-AI Description**
**Keep the web browser available after a crash restart**

### What Changed
- Clears an orphaned Xvfb lock and socket before starting the browser, so the display can be claimed again after an unclean exit
- Leaves a live display alone, avoiding disruption when Xvfb is already running
- Keeps a lockless socket in place when ownership cannot be proven
- Adds coverage for stale locks, live displays, unparseable lock files, and lockless sockets

### Impact
`✅ Fewer web-browser outages after crashes`
`✅ Less manual cleanup after restart`
`✅ Safer display recovery on Linux`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for the web-browser skill after crash-induced restarts by clearing orphaned X11 lock and socket files before starting the browser service, ensuring proper restart without interference from previous session artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->