### PR TITLE
fix: stop chat waiter rejection from crashing the process (#983)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Secret-capture link redaction** — the one-time capture URL's token was scrubbed to `[REDACTED]` by the output sanitizer; the two capture skills now declare `skip_secret_redaction` so the link reaches the user intact. (#971)
 - **Secret-capture link relayed verbatim** — the token is now a short base64url slug (not a 64-char hex hash) and the skill summaries instruct the agent to relay the URL verbatim, so the model no longer self-redacts the link as a credential. (#971)
 - **Chat waiter no longer crashes the process** — `EventRouter.waitForResponse` now resolves a discriminated result instead of rejecting, so a timeout/supersede firing after the client disconnects can't surface as an `unhandledRejection`; a process-level backstop logs and stays up. (#983)
+- **KG chat rate-limit status** — `POST /api/kg/chat/messages` now returns 429 for rate-limited rejections (was a hardcoded 403), matching `/api/messages`. (#983)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Stale Xvfb lock recovery** — `BrowserService` now clears an orphaned `/tmp/.X99-lock` + socket left by an unclean exit before spawning Xvfb, guarded on a live X server so an active display is never clobbered; the web-browser skill survives a crash-induced restart. (#982)
 - **Secret-capture link redaction** — the one-time capture URL's token was scrubbed to `[REDACTED]` by the output sanitizer; the two capture skills now declare `skip_secret_redaction` so the link reaches the user intact. (#971)
 - **Secret-capture link relayed verbatim** — the token is now a short base64url slug (not a 64-char hex hash) and the skill summaries instruct the agent to relay the URL verbatim, so the model no longer self-redacts the link as a credential. (#971)
+- **Chat waiter no longer crashes the process** — `EventRouter.waitForResponse` now resolves a discriminated result instead of rejecting, so a timeout/supersede firing after the client disconnects can't surface as an `unhandledRejection`; a process-level backstop logs and stays up. (#983)
 
 ### Security
 

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -72,6 +72,34 @@ export type WaitResult =
 export const WAIT_TIMEOUT_MESSAGE = 'Response timeout — the agent did not respond in time';
 export const WAIT_SUPERSEDED_MESSAGE = 'Superseded by a newer request for the same conversation_id';
 
+/**
+ * Map a non-ok {@link WaitResult} to its HTTP status code and client-facing
+ * message. Shared by the /api/messages and /api/kg/chat/messages handlers so the
+ * status contract can't drift between them — it already did once (rate-limit
+ * rejections returned 403 instead of 429 on the KG route). The `never` guard
+ * forces any new WaitResult variant to be handled here at compile time.
+ *
+ * Mapping: too-large → 413, rate-limited → 429, other policy rejection → 403,
+ * timeout → 504, supersede → 500.
+ */
+export function mapWaitFailureToHttp(result: Extract<WaitResult, { ok: false }>): { status: number; message: string } {
+  switch (result.kind) {
+    case 'rejected':
+      return {
+        status: result.error.reason === 'message_too_large' ? 413 : result.error.statusCode,
+        message: result.error.message,
+      };
+    case 'timeout':
+      return { status: 504, message: WAIT_TIMEOUT_MESSAGE };
+    case 'superseded':
+      return { status: 500, message: WAIT_SUPERSEDED_MESSAGE };
+    default: {
+      const _exhaustive: never = result;
+      throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}
+
 export interface PendingResponse {
   /** Settle the waiter's promise. Resolving (never rejecting) is what keeps a
    *  late timeout/supersede from leaking as an unhandledRejection — see WaitResult. */

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -44,9 +44,38 @@ export class MessageRejectedError extends Error {
   }
 }
 
+/**
+ * Discriminated result of a publish/wait cycle. `waitForResponse` ALWAYS resolves
+ * with one of these — it never rejects.
+ *
+ * Why never reject: the timeout and supersede outcomes are fired by a timer / a
+ * later request, potentially long after the route handler stopped awaiting (the
+ * client disconnected, or a newer POST replaced the pending entry). A rejection
+ * with no attached handler becomes an `unhandledRejection` and, under Node's
+ * default policy, crashes the entire multi-agent process — taking every channel
+ * and agent down with it. A *resolved* promise can never be an unhandled
+ * rejection, so resolving with a discriminated result makes that crash
+ * structurally impossible regardless of who is (or isn't) awaiting. See #983.
+ */
+export type WaitResult =
+  | { ok: true; content: string }
+  | { ok: false; kind: 'timeout' }
+  | { ok: false; kind: 'superseded' }
+  | { ok: false; kind: 'rejected'; error: MessageRejectedError };
+
+/**
+ * Canonical client-facing messages for the non-error WaitResult outcomes.
+ * Defined here (next to WaitResult) so both the /api/messages and /api/kg/chat
+ * handlers map a given `kind` to identical wording — they used to be free-floating
+ * strings on the Error objects and risked drifting apart once moved to the routes.
+ */
+export const WAIT_TIMEOUT_MESSAGE = 'Response timeout — the agent did not respond in time';
+export const WAIT_SUPERSEDED_MESSAGE = 'Superseded by a newer request for the same conversation_id';
+
 export interface PendingResponse {
-  resolve: (content: string) => void;
-  reject: (error: Error) => void;
+  /** Settle the waiter's promise. Resolving (never rejecting) is what keeps a
+   *  late timeout/supersede from leaking as an unhandledRejection — see WaitResult. */
+  settle: (result: WaitResult) => void;
   timeout: NodeJS.Timeout;
 }
 
@@ -97,7 +126,7 @@ export class EventRouter {
       if (pending) {
         clearTimeout(pending.timeout);
         this.pendingResponses.delete(convId);
-        pending.resolve(event.payload.content);
+        pending.settle({ ok: true, content: event.payload.content });
       }
 
       // Stream to all SSE clients (filtered by conversationId if set).
@@ -175,7 +204,7 @@ export class EventRouter {
         if (pending) {
           clearTimeout(pending.timeout);
           this.pendingResponses.delete(convId);
-          pending.reject(new MessageRejectedError(event.payload.reason));
+          pending.settle({ ok: false, kind: 'rejected', error: new MessageRejectedError(event.payload.reason) });
         }
       }
 
@@ -215,27 +244,34 @@ export class EventRouter {
   }
 
   /**
-   * Register a pending POST response. Returns a promise that resolves with the response content.
-   * If a request is already pending for this conversationId, rejects it first to avoid
-   * orphaned promises and leaked timeouts.
+   * Register a pending POST response. Returns a promise that ALWAYS resolves with
+   * a discriminated {@link WaitResult} — it never rejects (see WaitResult for why).
+   *
+   * If a request is already pending for this conversationId, it is settled with
+   * `{ ok: false, kind: 'superseded' }` first to avoid orphaned promises and
+   * leaked timeouts. This can happen if two POSTs race with the same ID.
    */
-  waitForResponse(conversationId: string, timeoutMs: number): Promise<string> {
-    // Reject any existing pending request for this conversationId to prevent
-    // orphaned promises. This can happen if two POSTs race with the same ID.
+  waitForResponse(conversationId: string, timeoutMs: number): Promise<WaitResult> {
+    // Supersede any existing pending request for this conversationId. Settling
+    // (not rejecting) means the old route handler — which may no longer be
+    // awaiting — gets a clean result rather than a floating rejection.
     const existing = this.pendingResponses.get(conversationId);
     if (existing) {
       clearTimeout(existing.timeout);
       this.pendingResponses.delete(conversationId);
-      existing.reject(new Error('Superseded by a newer request for the same conversation_id'));
+      existing.settle({ ok: false, kind: 'superseded' });
     }
 
-    return new Promise<string>((resolve, reject) => {
+    return new Promise<WaitResult>((resolve) => {
       const timeout = setTimeout(() => {
         this.pendingResponses.delete(conversationId);
-        reject(new Error('Response timeout — the agent did not respond in time'));
+        // resolve, never reject: the awaiter may be gone (client disconnected) and
+        // an unhandled rejection here would crash the whole process. See #983.
+        resolve({ ok: false, kind: 'timeout' });
       }, timeoutMs);
 
-      this.pendingResponses.set(conversationId, { resolve, reject, timeout });
+      // `resolve` is the promise's resolve — settling delivers the WaitResult.
+      this.pendingResponses.set(conversationId, { settle: resolve, timeout });
     });
   }
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1094,45 +1094,59 @@ export async function knowledgeGraphRoutes(
     // waitForResponse never rejects — it resolves with a discriminated WaitResult.
     // This is the crux of the #983 fix: a timeout/supersede firing after the client
     // has disconnected can no longer escape as an unhandledRejection.
-    const result = await responsePromise;
+    //
+    // The try/catch is belt-and-suspenders: the await itself can't reject, but the
+    // post-resolution work (markdownToHtml, reply.send, the exhaustiveness guard
+    // below) could, and any unexpected throw must route through the route's failure
+    // path as a clean 500 rather than escaping the handler.
+    try {
+      const result = await responsePromise;
 
-    if (result.ok) {
-      // Per-try/catch so a markdownToHtml failure falls back gracefully rather
-      // than turning a successful agent response into a 500.
-      let html: string | null = null;
-      try {
-        html = markdownToHtml(result.content);
-      } catch (convErr) {
-        logger.warn({ err: convErr, conversationId }, 'markdownToHtml failed for chat reply; sending plain text');
+      if (result.ok) {
+        // Per-try/catch so a markdownToHtml failure falls back gracefully rather
+        // than turning a successful agent response into a 500.
+        let html: string | null = null;
+        try {
+          html = markdownToHtml(result.content);
+        } catch (convErr) {
+          logger.warn({ err: convErr, conversationId }, 'markdownToHtml failed for chat reply; sending plain text');
+        }
+        return reply.send({ reply: result.content, html, conversationId });
       }
-      return reply.send({ reply: result.content, html, conversationId });
-    }
 
-    // Non-ok outcome. Preserves prior status mapping: too-large → 413, any other
-    // policy rejection → 403, timeout → 504, supersede → 500.
-    let status: number;
-    let message: string;
-    switch (result.kind) {
-      case 'rejected':
-        status = result.error.reason === 'message_too_large' ? 413 : 403;
-        message = result.error.message;
-        break;
-      case 'timeout':
-        status = 504;
-        message = WAIT_TIMEOUT_MESSAGE;
-        break;
-      case 'superseded':
-        status = 500;
-        message = WAIT_SUPERSEDED_MESSAGE;
-        break;
-      default: {
-        // Exhaustiveness guard — a new WaitResult variant must be handled here.
-        const _exhaustive: never = result;
-        throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
+      // Non-ok outcome. Preserves prior status mapping: too-large → 413, timeout →
+      // 504, supersede → 500. Rate-limit rejections now use the error's own status
+      // code (429) instead of a hardcoded 403, matching /api/messages.
+      let status: number;
+      let message: string;
+      switch (result.kind) {
+        case 'rejected':
+          status = result.error.reason === 'message_too_large' ? 413 : result.error.statusCode;
+          message = result.error.message;
+          break;
+        case 'timeout':
+          status = 504;
+          message = WAIT_TIMEOUT_MESSAGE;
+          break;
+        case 'superseded':
+          status = 500;
+          message = WAIT_SUPERSEDED_MESSAGE;
+          break;
+        default: {
+          // Exhaustiveness guard — a new WaitResult variant must be handled above.
+          // Throwing routes it through the catch below as a normalized 500.
+          const _exhaustive: never = result;
+          throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
+        }
       }
+      logger.error({ conversationId, kind: result.kind }, 'KG chat message handling failed');
+      return reply.status(status).send({ error: message });
+    } catch (err) {
+      // Unexpected failure in the post-resolution path — log and return a clean 500
+      // rather than letting it escape the route handler.
+      logger.error({ err, conversationId }, 'KG chat message handling failed unexpectedly');
+      return reply.status(500).send({ error: 'Internal error handling chat message' });
     }
-    logger.error({ conversationId, kind: result.kind }, 'KG chat message handling failed');
-    return reply.status(status).send({ error: message });
   });
 
   /**

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -7,7 +7,7 @@ import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import { ContactValidationError } from '../../../contacts/contact-service.js';
 import type { Contact, ContactCanonicalFields, ContactStatus, TrustLevel } from '../../../contacts/types.js';
-import { type EventRouter, WAIT_TIMEOUT_MESSAGE, WAIT_SUPERSEDED_MESSAGE } from '../event-router.js';
+import { type EventRouter, mapWaitFailureToHttp } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { markdownToHtml } from '../../../utils/markdown-to-html.js';
 import { stripOutboundContextPreamble } from '../../../dispatch/outbound-context.js';
@@ -1114,31 +1114,8 @@ export async function knowledgeGraphRoutes(
         return reply.send({ reply: result.content, html, conversationId });
       }
 
-      // Non-ok outcome. Preserves prior status mapping: too-large → 413, timeout →
-      // 504, supersede → 500. Rate-limit rejections now use the error's own status
-      // code (429) instead of a hardcoded 403, matching /api/messages.
-      let status: number;
-      let message: string;
-      switch (result.kind) {
-        case 'rejected':
-          status = result.error.reason === 'message_too_large' ? 413 : result.error.statusCode;
-          message = result.error.message;
-          break;
-        case 'timeout':
-          status = 504;
-          message = WAIT_TIMEOUT_MESSAGE;
-          break;
-        case 'superseded':
-          status = 500;
-          message = WAIT_SUPERSEDED_MESSAGE;
-          break;
-        default: {
-          // Exhaustiveness guard — a new WaitResult variant must be handled above.
-          // Throwing routes it through the catch below as a normalized 500.
-          const _exhaustive: never = result;
-          throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
-        }
-      }
+      // Non-ok outcome — map to the shared HTTP status/message contract.
+      const { status, message } = mapWaitFailureToHttp(result);
       logger.error({ conversationId, kind: result.kind }, 'KG chat message handling failed');
       return reply.status(status).send({ error: message });
     } catch (err) {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -7,7 +7,7 @@ import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import { ContactValidationError } from '../../../contacts/contact-service.js';
 import type { Contact, ContactCanonicalFields, ContactStatus, TrustLevel } from '../../../contacts/types.js';
-import { MessageRejectedError, type EventRouter } from '../event-router.js';
+import { type EventRouter, WAIT_TIMEOUT_MESSAGE, WAIT_SUPERSEDED_MESSAGE } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { markdownToHtml } from '../../../utils/markdown-to-html.js';
 import { stripOutboundContextPreamble } from '../../../dispatch/outbound-context.js';
@@ -1091,29 +1091,48 @@ export async function knowledgeGraphRoutes(
       return reply.status(500).send({ error: message });
     }
 
-    try {
-      const content = await responsePromise;
+    // waitForResponse never rejects — it resolves with a discriminated WaitResult.
+    // This is the crux of the #983 fix: a timeout/supersede firing after the client
+    // has disconnected can no longer escape as an unhandledRejection.
+    const result = await responsePromise;
+
+    if (result.ok) {
       // Per-try/catch so a markdownToHtml failure falls back gracefully rather
       // than turning a successful agent response into a 500.
       let html: string | null = null;
       try {
-        html = markdownToHtml(content);
+        html = markdownToHtml(result.content);
       } catch (convErr) {
         logger.warn({ err: convErr, conversationId }, 'markdownToHtml failed for chat reply; sending plain text');
       }
-      return reply.send({ reply: content, html, conversationId });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error({ err, conversationId }, 'KG chat message handling failed');
-      // instanceof + reason check for rejection — string matching would silently break if the
-      // error wording changes. Timeout still falls back to substring because the event
-      // router doesn't expose a dedicated TimeoutError class.
-      const isRejected = err instanceof MessageRejectedError;
-      const isTooLarge = isRejected && err.reason === 'message_too_large';
-      const isTimeout = message.includes('timeout') || message.includes('Timeout');
-      const status = isTooLarge ? 413 : isRejected ? 403 : isTimeout ? 504 : 500;
-      return reply.status(status).send({ error: message });
+      return reply.send({ reply: result.content, html, conversationId });
     }
+
+    // Non-ok outcome. Preserves prior status mapping: too-large → 413, any other
+    // policy rejection → 403, timeout → 504, supersede → 500.
+    let status: number;
+    let message: string;
+    switch (result.kind) {
+      case 'rejected':
+        status = result.error.reason === 'message_too_large' ? 413 : 403;
+        message = result.error.message;
+        break;
+      case 'timeout':
+        status = 504;
+        message = WAIT_TIMEOUT_MESSAGE;
+        break;
+      case 'superseded':
+        status = 500;
+        message = WAIT_SUPERSEDED_MESSAGE;
+        break;
+      default: {
+        // Exhaustiveness guard — a new WaitResult variant must be handled here.
+        const _exhaustive: never = result;
+        throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
+      }
+    }
+    logger.error({ conversationId, kind: result.kind }, 'KG chat message handling failed');
+    return reply.status(status).send({ error: message });
   });
 
   /**

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -80,44 +80,57 @@ export async function messageRoutes(
     // disconnected can't escape as an unhandledRejection and crash the process (#983).
     // The pending entry may have been superseded by a concurrent request with the
     // same conversation_id; in that case our promise resolves with kind 'superseded'.
-    const result = await responsePromise;
+    //
+    // The try/catch is belt-and-suspenders: the await itself can't reject, but the
+    // post-resolution work (reply.send, the exhaustiveness guard below) could, and
+    // any unexpected throw must route through the route's failure path as a clean
+    // 500 rather than escaping the handler.
+    try {
+      const result = await responsePromise;
 
-    if (result.ok) {
-      // TODO: agent_id is hardcoded — OutboundMessagePayload doesn't carry agentId.
-      // Once we add agentId to the outbound event, extract it here for accuracy
-      // in multi-agent delegation scenarios.
-      return reply.send({
-        conversation_id: conversationId,
-        content: result.content,
-        agent_id: 'coordinator',
-      });
-    }
-
-    // Non-ok outcome. Preserves prior status mapping: too-large → 413, rate-limited
-    // → 429, other policy rejections → 403, timeout → 504, supersede → 500.
-    let status: number;
-    let message: string;
-    switch (result.kind) {
-      case 'rejected':
-        status = result.error.reason === 'message_too_large' ? 413 : result.error.statusCode;
-        message = result.error.message;
-        break;
-      case 'timeout':
-        status = 504;
-        message = WAIT_TIMEOUT_MESSAGE;
-        break;
-      case 'superseded':
-        status = 500;
-        message = WAIT_SUPERSEDED_MESSAGE;
-        break;
-      default: {
-        // Exhaustiveness guard — a new WaitResult variant must be handled here.
-        const _exhaustive: never = result;
-        throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
+      if (result.ok) {
+        // TODO: agent_id is hardcoded — OutboundMessagePayload doesn't carry agentId.
+        // Once we add agentId to the outbound event, extract it here for accuracy
+        // in multi-agent delegation scenarios.
+        return reply.send({
+          conversation_id: conversationId,
+          content: result.content,
+          agent_id: 'coordinator',
+        });
       }
+
+      // Non-ok outcome. Preserves prior status mapping: too-large → 413, rate-limited
+      // → 429, other policy rejections → 403, timeout → 504, supersede → 500.
+      let status: number;
+      let message: string;
+      switch (result.kind) {
+        case 'rejected':
+          status = result.error.reason === 'message_too_large' ? 413 : result.error.statusCode;
+          message = result.error.message;
+          break;
+        case 'timeout':
+          status = 504;
+          message = WAIT_TIMEOUT_MESSAGE;
+          break;
+        case 'superseded':
+          status = 500;
+          message = WAIT_SUPERSEDED_MESSAGE;
+          break;
+        default: {
+          // Exhaustiveness guard — a new WaitResult variant must be handled above.
+          // Throwing routes it through the catch below as a normalized 500.
+          const _exhaustive: never = result;
+          throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
+        }
+      }
+      logger.error({ conversationId, kind: result.kind }, 'HTTP message handling failed');
+      return reply.status(status).send({ error: message });
+    } catch (err) {
+      // Unexpected failure in the post-resolution path — log and return a clean 500
+      // rather than letting it escape the route handler.
+      logger.error({ err, conversationId }, 'HTTP message handling failed unexpectedly');
+      return reply.status(500).send({ error: 'Internal error handling message' });
     }
-    logger.error({ conversationId, kind: result.kind }, 'HTTP message handling failed');
-    return reply.status(status).send({ error: message });
   });
 
   /**

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -13,7 +13,7 @@ import type { EventBus } from '../../../bus/bus.js';
 import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { EventRouter } from '../event-router.js';
-import { WAIT_TIMEOUT_MESSAGE, WAIT_SUPERSEDED_MESSAGE } from '../event-router.js';
+import { mapWaitFailureToHttp } from '../event-router.js';
 
 export interface MessageRouteOptions {
   bus: EventBus;
@@ -99,30 +99,8 @@ export async function messageRoutes(
         });
       }
 
-      // Non-ok outcome. Preserves prior status mapping: too-large → 413, rate-limited
-      // → 429, other policy rejections → 403, timeout → 504, supersede → 500.
-      let status: number;
-      let message: string;
-      switch (result.kind) {
-        case 'rejected':
-          status = result.error.reason === 'message_too_large' ? 413 : result.error.statusCode;
-          message = result.error.message;
-          break;
-        case 'timeout':
-          status = 504;
-          message = WAIT_TIMEOUT_MESSAGE;
-          break;
-        case 'superseded':
-          status = 500;
-          message = WAIT_SUPERSEDED_MESSAGE;
-          break;
-        default: {
-          // Exhaustiveness guard — a new WaitResult variant must be handled above.
-          // Throwing routes it through the catch below as a normalized 500.
-          const _exhaustive: never = result;
-          throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
-        }
-      }
+      // Non-ok outcome — map to the shared HTTP status/message contract.
+      const { status, message } = mapWaitFailureToHttp(result);
       logger.error({ conversationId, kind: result.kind }, 'HTTP message handling failed');
       return reply.status(status).send({ error: message });
     } catch (err) {

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -13,7 +13,7 @@ import type { EventBus } from '../../../bus/bus.js';
 import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { EventRouter } from '../event-router.js';
-import { MessageRejectedError } from '../event-router.js';
+import { WAIT_TIMEOUT_MESSAGE, WAIT_SUPERSEDED_MESSAGE } from '../event-router.js';
 
 export interface MessageRouteOptions {
   bus: EventBus;
@@ -75,34 +75,49 @@ export async function messageRoutes(
       return reply.status(500).send({ error: message });
     }
 
-    // Wait for the agent response. At this point the pending entry may have been
-    // superseded by a concurrent request with the same conversation_id — in that
-    // case our promise already rejected with "Superseded". We must NOT call
-    // cancelPending here because the entry now belongs to the newer request.
-    try {
-      const content = await responsePromise;
+    // Wait for the agent response. waitForResponse never rejects — it resolves with
+    // a discriminated WaitResult, so a timeout/supersede firing after the client has
+    // disconnected can't escape as an unhandledRejection and crash the process (#983).
+    // The pending entry may have been superseded by a concurrent request with the
+    // same conversation_id; in that case our promise resolves with kind 'superseded'.
+    const result = await responsePromise;
 
+    if (result.ok) {
       // TODO: agent_id is hardcoded — OutboundMessagePayload doesn't carry agentId.
       // Once we add agentId to the outbound event, extract it here for accuracy
       // in multi-agent delegation scenarios.
       return reply.send({
         conversation_id: conversationId,
-        content,
+        content: result.content,
         agent_id: 'coordinator',
       });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error({ err, conversationId }, 'HTTP message handling failed');
-
-      // Distinguish oversized (413), rate-limited (429), other rejections (403),
-      // timeout (504), and internal errors (500). Use instanceof + err.statusCode
-      // rather than string matching so wording changes can't silently break status codes.
-      const isRejected = err instanceof MessageRejectedError;
-      const isTooLarge = isRejected && err.reason === 'message_too_large';
-      const isTimeout = message.includes('timeout') || message.includes('Timeout');
-      const status = isTooLarge ? 413 : isRejected ? err.statusCode : isTimeout ? 504 : 500;
-      return reply.status(status).send({ error: message });
     }
+
+    // Non-ok outcome. Preserves prior status mapping: too-large → 413, rate-limited
+    // → 429, other policy rejections → 403, timeout → 504, supersede → 500.
+    let status: number;
+    let message: string;
+    switch (result.kind) {
+      case 'rejected':
+        status = result.error.reason === 'message_too_large' ? 413 : result.error.statusCode;
+        message = result.error.message;
+        break;
+      case 'timeout':
+        status = 504;
+        message = WAIT_TIMEOUT_MESSAGE;
+        break;
+      case 'superseded':
+        status = 500;
+        message = WAIT_SUPERSEDED_MESSAGE;
+        break;
+      default: {
+        // Exhaustiveness guard — a new WaitResult variant must be handled here.
+        const _exhaustive: never = result;
+        throw new Error(`Unhandled WaitResult: ${JSON.stringify(_exhaustive)}`);
+      }
+    }
+    logger.error({ conversationId, kind: result.kind }, 'HTTP message handling failed');
+    return reply.status(status).send({ error: message });
   });
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,26 @@ async function main(): Promise<void> {
   const logger = createLogger(config.logLevel);
   logger.info('Curia starting...');
 
+  // Defense in depth for #983: keep a single stray unhandled rejection from
+  // taking the whole multi-agent process down. Node's default policy on an
+  // unhandledRejection is to terminate, so a rejected promise that loses its
+  // awaiter (e.g. a route waiter whose client disconnected) would crash every
+  // channel and agent at once. The primary fix is to never leak such rejections
+  // in the first place (EventRouter.waitForResponse resolves rather than
+  // rejects); this handler is the backstop. We log loudly at fatal and stay up
+  // rather than exit — the structured log surfaces the offending promise so a
+  // genuine bug is still loud in dev and CI.
+  process.on('unhandledRejection', (reason, promise) => {
+    // Normalize non-Error rejection values so the log always carries a stack. Capture
+    // the originating promise too — when `reason` isn't an Error it's often the only
+    // pointer back to the offending call site.
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    logger.fatal(
+      { err, promise: String(promise), source: 'unhandledRejection' },
+      'Unhandled promise rejection — process kept alive (see #983)',
+    );
+  });
+
   // Surface the `.env.example` placeholder case so it's obvious in logs why
   // CEO_PRIMARY_EMAIL appears to be ignored. loadConfig() normalized the value
   // to undefined silently because the logger doesn't exist yet at that point;

--- a/tests/unit/channels/http/event-router.test.ts
+++ b/tests/unit/channels/http/event-router.test.ts
@@ -1,0 +1,128 @@
+// Unit tests for EventRouter.waitForResponse — the publish/wait primitive behind
+// POST /api/messages and POST /api/kg/chat/messages.
+//
+// Regression coverage for #983: a chat POST whose client disconnects or is
+// superseded before the agent responds must NOT produce an unhandledRejection
+// (which previously crashed the entire multi-agent process). The contract is now
+// "waitForResponse never rejects — it always resolves with a discriminated
+// WaitResult", which makes an unhandled rejection structurally impossible.
+
+import { describe, it, expect, vi } from 'vitest';
+import { EventRouter, MessageRejectedError } from '../../../../src/channels/http/event-router.js';
+import type { EventBus } from '../../../../src/bus/bus.js';
+import type { BusEvent } from '../../../../src/bus/events.js';
+import type { Logger } from '../../../../src/logger.js';
+
+function createLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+}
+
+// A fake bus that captures the EventRouter's subscribers so a test can emit
+// events directly into them without standing up the real EventBus.
+function createBus(): { bus: EventBus; emit: (event: BusEvent) => void } {
+  const handlers = new Map<string, (event: BusEvent) => void>();
+  const bus = {
+    subscribe: (type: string, _layer: string, handler: (event: BusEvent) => void) => {
+      handlers.set(type, handler);
+    },
+  } as unknown as EventBus;
+  return { bus, emit: (event: BusEvent) => handlers.get(event.type)?.(event) };
+}
+
+function makeRouter(): { router: EventRouter; emit: (event: BusEvent) => void } {
+  const { bus, emit } = createBus();
+  const router = new EventRouter(createLogger());
+  router.setupSubscriptions(bus);
+  return { router, emit };
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('EventRouter.waitForResponse', () => {
+  it('resolves { ok: true, content } when an outbound.message arrives', async () => {
+    const { router, emit } = makeRouter();
+    const promise = router.waitForResponse('c1', 1000);
+
+    emit({
+      type: 'outbound.message',
+      timestamp: '2026-06-15T00:00:00.000Z',
+      payload: { channelId: 'web', conversationId: 'c1', content: 'hi there' },
+    } as unknown as BusEvent);
+
+    await expect(promise).resolves.toEqual({ ok: true, content: 'hi there' });
+  });
+
+  it('resolves { ok: false, kind: "timeout" } when no response arrives in time', async () => {
+    const { router } = makeRouter();
+    await expect(router.waitForResponse('c2', 10)).resolves.toEqual({ ok: false, kind: 'timeout' });
+  });
+
+  it('resolves the first waiter with { ok: false, kind: "superseded" } when a second waiter takes the slot', async () => {
+    const { router, emit } = makeRouter();
+    const first = router.waitForResponse('c3', 1000);
+    const second = router.waitForResponse('c3', 1000);
+
+    await expect(first).resolves.toEqual({ ok: false, kind: 'superseded' });
+
+    // Settle the second waiter so its timer doesn't dangle past the test.
+    emit({
+      type: 'outbound.message',
+      timestamp: '2026-06-15T00:00:00.000Z',
+      payload: { channelId: 'web', conversationId: 'c3', content: 'done' },
+    } as unknown as BusEvent);
+    await expect(second).resolves.toEqual({ ok: true, content: 'done' });
+  });
+
+  it('resolves { ok: false, kind: "rejected", error } when the message is rejected by policy', async () => {
+    const { router, emit } = makeRouter();
+    const promise = router.waitForResponse('c4', 1000);
+
+    emit({
+      type: 'message.rejected',
+      timestamp: '2026-06-15T00:00:00.000Z',
+      payload: { channelId: 'web', conversationId: 'c4', senderId: 'x', reason: 'blocked_sender' },
+    } as unknown as BusEvent);
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected a non-ok result');
+    expect(result.kind).toBe('rejected');
+    if (result.kind !== 'rejected') throw new Error('expected a rejected result');
+    expect(result.error).toBeInstanceOf(MessageRejectedError);
+    expect(result.error.reason).toBe('blocked_sender');
+  });
+
+  // The core regression for #983: when nothing is awaiting the promise (client
+  // disconnected / superseded), neither the timeout timer nor the supersede path
+  // may surface as an unhandledRejection on the process.
+  it('never triggers process unhandledRejection on the timeout or supersede paths', async () => {
+    const { router } = makeRouter();
+    const captured: unknown[] = [];
+    const listener = (reason: unknown) => captured.push(reason);
+    process.on('unhandledRejection', listener);
+
+    try {
+      // Timeout path with no consumer awaiting the promise.
+      void router.waitForResponse('orphan-timeout', 10);
+
+      // Supersede path: the first waiter is rejected-internally with no consumer;
+      // the second resolves via its own short timeout so no timer dangles.
+      void router.waitForResponse('orphan-supersede', 30);
+      void router.waitForResponse('orphan-supersede', 30);
+
+      // Give both the timers and any unhandledRejection microtasks room to fire.
+      await delay(80);
+    } finally {
+      process.off('unhandledRejection', listener);
+    }
+
+    expect(captured).toEqual([]);
+  });
+});

--- a/tests/unit/channels/http/kg-chat-routes.test.ts
+++ b/tests/unit/channels/http/kg-chat-routes.test.ts
@@ -13,7 +13,7 @@ import type { Logger } from '../../../../src/logger.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { knowledgeGraphRoutes } from '../../../../src/channels/http/routes/kg.js';
 import type { EventBus } from '../../../../src/bus/bus.js';
-import type { EventRouter } from '../../../../src/channels/http/event-router.js';
+import { MessageRejectedError, type EventRouter } from '../../../../src/channels/http/event-router.js';
 
 function createLogger(): Logger {
   return {
@@ -31,11 +31,12 @@ function createPool(): Pick<Pool, 'query'> {
   return { query: vi.fn() } as unknown as Pick<Pool, 'query'>;
 }
 
-// Create a mock EventRouter whose waitForResponse resolves immediately with
-// a canned reply so the route handler can complete synchronously in tests.
+// Create a mock EventRouter whose waitForResponse resolves immediately with a
+// canned reply so the route handler can complete synchronously in tests.
+// waitForResponse resolves a discriminated WaitResult (never rejects) — see #983.
 function createMockEventRouter(reply = 'Hello from Curia'): EventRouter {
   return {
-    waitForResponse: vi.fn().mockResolvedValue(reply),
+    waitForResponse: vi.fn().mockResolvedValue({ ok: true, content: reply }),
     cancelPending: vi.fn(),
     addSseClient: vi.fn().mockReturnValue(() => { /* cleanup noop */ }),
     setupSubscriptions: vi.fn(),
@@ -190,6 +191,76 @@ describe('KG chat routes', () => {
     expect(body.conversationId.length).toBeGreaterThan(0);
     expect(eventRouter.waitForResponse).toHaveBeenCalledWith(body.conversationId, expect.any(Number));
 
+    await app.close();
+  });
+
+  // ── WaitResult outcome mapping (#983) ─────────────────────────────────
+  //
+  // waitForResponse resolves a discriminated result rather than rejecting, so the
+  // handler maps each non-ok outcome to a status code without try/catch control flow.
+
+  it('POST /api/kg/chat/messages — 504 when the agent response times out', async () => {
+    const eventRouter = {
+      waitForResponse: vi.fn().mockResolvedValue({ ok: false, kind: 'timeout' }),
+      cancelPending: vi.fn(),
+      addSseClient: vi.fn().mockReturnValue(() => {}),
+      setupSubscriptions: vi.fn(),
+    } as unknown as EventRouter;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(knowledgeGraphRoutes, {
+      pool: createPool() as Pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'test-secret',
+      secureCookies: false,
+      bus: createMockBus(),
+      eventRouter,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/kg/chat/messages',
+      headers: { 'x-web-bootstrap-secret': 'test-secret' },
+      payload: { message: 'slow one' },
+    });
+
+    expect(response.statusCode).toBe(504);
+    expect(response.json().error).toMatch(/timeout/i);
+    await app.close();
+  });
+
+  it('POST /api/kg/chat/messages — 403 when the message is rejected by policy', async () => {
+    const eventRouter = {
+      waitForResponse: vi.fn().mockResolvedValue({
+        ok: false,
+        kind: 'rejected',
+        error: new MessageRejectedError('blocked_sender'),
+      }),
+      cancelPending: vi.fn(),
+      addSseClient: vi.fn().mockReturnValue(() => {}),
+      setupSubscriptions: vi.fn(),
+    } as unknown as EventRouter;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(knowledgeGraphRoutes, {
+      pool: createPool() as Pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'test-secret',
+      secureCookies: false,
+      bus: createMockBus(),
+      eventRouter,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/kg/chat/messages',
+      headers: { 'x-web-bootstrap-secret': 'test-secret' },
+      payload: { message: 'who are you' },
+    });
+
+    expect(response.statusCode).toBe(403);
     await app.close();
   });
 

--- a/tests/unit/channels/http/kg-chat-routes.test.ts
+++ b/tests/unit/channels/http/kg-chat-routes.test.ts
@@ -264,6 +264,42 @@ describe('KG chat routes', () => {
     await app.close();
   });
 
+  it('POST /api/kg/chat/messages — 429 when the message is rate-limited', async () => {
+    // Rate-limit rejections must surface their own status code (429), matching
+    // /api/messages — not a hardcoded 403. See CodeAnt review on PR #989.
+    const eventRouter = {
+      waitForResponse: vi.fn().mockResolvedValue({
+        ok: false,
+        kind: 'rejected',
+        error: new MessageRejectedError('sender_rate_limited'),
+      }),
+      cancelPending: vi.fn(),
+      addSseClient: vi.fn().mockReturnValue(() => {}),
+      setupSubscriptions: vi.fn(),
+    } as unknown as EventRouter;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(knowledgeGraphRoutes, {
+      pool: createPool() as Pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'test-secret',
+      secureCookies: false,
+      bus: createMockBus(),
+      eventRouter,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/kg/chat/messages',
+      headers: { 'x-web-bootstrap-secret': 'test-secret' },
+      payload: { message: 'spam spam spam' },
+    });
+
+    expect(response.statusCode).toBe(429);
+    await app.close();
+  });
+
   // ── 503 when the secret is not configured ─────────────────────────────
 
   it('POST /api/kg/chat/messages — 503 when webAppBootstrapSecret is undefined', async () => {

--- a/tests/unit/channels/http/kg-chat-routes.test.ts
+++ b/tests/unit/channels/http/kg-chat-routes.test.ts
@@ -300,6 +300,36 @@ describe('KG chat routes', () => {
     await app.close();
   });
 
+  it('POST /api/kg/chat/messages — 500 when the waiter is superseded', async () => {
+    const eventRouter = {
+      waitForResponse: vi.fn().mockResolvedValue({ ok: false, kind: 'superseded' }),
+      cancelPending: vi.fn(),
+      addSseClient: vi.fn().mockReturnValue(() => {}),
+      setupSubscriptions: vi.fn(),
+    } as unknown as EventRouter;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(knowledgeGraphRoutes, {
+      pool: createPool() as Pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'test-secret',
+      secureCookies: false,
+      bus: createMockBus(),
+      eventRouter,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/kg/chat/messages',
+      headers: { 'x-web-bootstrap-secret': 'test-secret' },
+      payload: { message: 'newer request won' },
+    });
+
+    expect(response.statusCode).toBe(500);
+    await app.close();
+  });
+
   // ── 503 when the secret is not configured ─────────────────────────────
 
   it('POST /api/kg/chat/messages — 503 when webAppBootstrapSecret is undefined', async () => {


### PR DESCRIPTION
## **User description**
## Summary

Fixes #983. A chat POST whose client disconnected (or was superseded by a newer POST with the same `conversation_id`) before the agent replied could crash the **entire** multi-agent process.

`EventRouter.waitForResponse` stored a promise's `reject` and fired it later from a 120s timer or the supersede path. Once the route handler was no longer awaiting that promise, the rejection had no handler → `unhandledRejection` → Node's default policy terminates the process, taking every channel and agent down and forcing a container restart. A routine "long chat + navigate away" was enough to trigger it.

`Closes #983`

## The fix

**Primary — make the leak structurally impossible.** `waitForResponse` now ALWAYS resolves a discriminated `WaitResult` and never rejects:

```ts
type WaitResult =
  | { ok: true; content: string }
  | { ok: false; kind: 'timeout' }
  | { ok: false; kind: 'superseded' }
  | { ok: false; kind: 'rejected'; error: MessageRejectedError };
```

A *resolved* promise can never become an unhandled rejection, no matter who is (or isn't) awaiting. Both call sites (`/api/messages` and `/api/kg/chat/messages`) interpret the result with an exhaustive `switch` (with a `never` guard), preserving the prior HTTP status mapping exactly:

| Outcome | Status |
|---|---|
| success | 200 |
| `message_too_large` | 413 |
| rate-limited (`/api/messages`) | 429 |
| other policy rejection | 403 |
| timeout | 504 |
| superseded | 500 |

This also removes the fragile `message.includes('timeout')` substring check that previously decided the 504 — wording drift can no longer silently downgrade it. The two canonical timeout/supersede strings are now exported once from `event-router.ts` so the two handlers can't drift.

**Defense in depth.** A process-level `unhandledRejection` backstop in `index.ts` logs at `fatal` (with the offending promise) and keeps the process alive rather than exiting, so any *future* stray rejection from an unrelated path can't take down all channels at once.

## Acceptance criteria

- ✅ Timeout at 120s with the client still connected → **504** (preserved).
- ✅ Client disconnect / supersede before the agent responds → no `unhandledRejection`, no crash.
- ✅ New `event-router.test.ts` attaches a real `process.on('unhandledRejection')` listener and asserts it is **never** invoked across the timeout and supersede paths.
- ✅ Global `unhandledRejection` handler added: logs structured error + stays up.

## Notes / deviations

- **Audit entry for the backstop:** the acceptance criterion's "log + audit entry" was scoped down to structured `fatal` logging only. A DB audit entry requires a `BusEvent`, and no event type fits a process-level unhandled rejection — adding one (plus its permissions-map entry) is out of scope for this fix, and the primary change already makes the documented leak impossible.
- **"Stay alive" policy** (raised in review): keeping the process up on an unrelated future rejection trades a loud crash+restart for a fatal log line. This matches the issue's explicit request ("does not exit the process"). Confirm the deploy's log pipeline alerts on `fatal`; a metric/health-degradation hook would be a reasonable follow-up.
- **Pre-existing, untouched:** if `bus.publish` throws *and* a concurrent supersede races in the same tick, the publish-catch `cancelPending(convId)` can clear the newer request's timer. With this change the worst case is a hung request (no longer a crash); fixing it cleanly needs identity-scoped cancellation. Flagging, not fixing (scope).

## Testing

- `pnpm run typecheck` — clean
- `pnpm run lint` — clean (one pre-existing unrelated warning)
- New `tests/unit/channels/http/event-router.test.ts` (5 tests) + route-level 504/403 tests in `kg-chat-routes.test.ts`
- `tests/unit` + `src` unit suites: 2701 passed (the one failure is a DB-gated integration test needing `DATABASE_URL`, unrelated)


___

## **CodeAnt-AI Description**
**Stop chat requests from crashing the process when a reply times out or is replaced**

### What Changed
- Chat waits now always end with a normal result instead of a rejected promise, so a late timeout or superseded request no longer takes the whole process down
- Both chat endpoints now handle success, timeout, superseded, and policy rejection outcomes with the same user-facing status codes and messages
- If a promise is still rejected unexpectedly, the process logs it and stays running instead of exiting

### Impact
`✅ Fewer chat-driven process restarts`
`✅ Fewer lost conversations after client disconnects`
`✅ Clearer timeout and rejection responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat waiter crash that could interrupt conversations.
  * KG chat endpoint now returns HTTP 429 for rate-limited requests (previously 403), aligning with standard API practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->