### PR TITLE
fix: loosen flaky confidence-pipeline idempotency tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Secret-capture link relayed verbatim** — the token is now a short base64url slug (not a 64-char hex hash) and the skill summaries instruct the agent to relay the URL verbatim, so the model no longer self-redacts the link as a credential. (#971)
 - **Chat waiter no longer crashes the process** — `EventRouter.waitForResponse` now resolves a discriminated result instead of rejecting, so a timeout/supersede firing after the client disconnects can't surface as an `unhandledRejection`; a process-level backstop logs and stays up. (#983)
 - **KG chat rate-limit status** — `POST /api/kg/chat/messages` now returns 429 for rate-limited rejections (was a hardcoded 403), matching `/api/messages`. (#983)
+- **Flaky confidence-pipeline idempotency test** — loosened the `fullRecompute` idempotency assertion from 10 to 9 decimal places; the recency component's `new Date()` jitter (~1.5e-10) exceeded the old 5e-11 tolerance and intermittently failed CI.
 
 ### Security
 

--- a/tests/unit/contacts/confidence-pipeline.test.ts
+++ b/tests/unit/contacts/confidence-pipeline.test.ts
@@ -111,10 +111,11 @@ describe('ConfidencePipeline', () => {
 
       // Use toBeCloseTo rather than toBe: the recency component uses `new Date()` for
       // decay calculation, so two calls milliseconds apart produce values that differ at
-      // floating-point epsilon (e.g. 0.375 vs 0.37499999997). The scores are functionally
-      // identical — the precision (10 decimal places) is far tighter than any meaningful
-      // confidence distinction.
-      expect(second!.contactConfidence).toBeCloseTo(first!.contactConfidence, 10);
+      // floating-point epsilon (e.g. 0.375 vs 0.3749999998). The scores are functionally
+      // identical. We assert to 9 decimal places (tolerance 5e-10); 10 places (5e-11) was
+      // too tight — observed jitter reached ~1.5e-10 and flaked CI. 9 places is still far
+      // tighter than any meaningful confidence distinction.
+      expect(second!.contactConfidence).toBeCloseTo(first!.contactConfidence, 9);
     });
 
     it('does not modify message counts or lastSeenAt', async () => {


### PR DESCRIPTION
## Summary

The `ConfidencePipeline > fullRecompute > is idempotent` test asserted equality to **10 decimal places** (`toBeCloseTo(..., 10)` → tolerance 5e-11). The recency component computes decay from `new Date()`, so two `fullRecompute` calls milliseconds apart produce values that differ at floating-point epsilon. Observed jitter reached ~1.5e-10, exceeding the 5e-11 tolerance and intermittently failing CI (it nearly blocked an unrelated Dependabot PR).

Loosened to **9 decimal places** (tolerance 5e-10) — comfortably above the observed jitter while still far tighter than any meaningful confidence distinction. Comment updated to record the rationale.

## Testing

- `pnpm run typecheck` — clean
- `vitest run tests/unit/contacts/confidence-pipeline.test.ts` — 12/12 pass