### PR TITLE
feat: web-console chat ack-and-stream — no more 120s blocking wait (#985)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Coordinator prompt (policy/reference split)** — tool-specific mechanics moved out of the coordinator prompt into the skill manifests the model already sees: config-store namespace conventions, the context_bridge shape, and decay-warning nudge phrasings now live on their respective skills; the `## Reference` region is removed. Drive-upload steps stay condensed in the prompt (their target `create_drive_file` is an MCP tool with no local manifest). (#958)
 - **`config-store` / `email-reply` / `email-send` / `signal-send` / `decay-warnings-list`** — descriptions/input docs expanded to carry the relocated mechanics; behavior unchanged. (#958)
 - **User chat bubble** — user messages now appear with a teal background (`--app-teal`) and white text, visually distinguishing them from agent replies.
+- **Web console chat (ack-and-stream)** — `POST /api/kg/chat/messages` now acks with `202` and the reply streams over SSE instead of blocking on a 120s synchronous wait, so long agent tasks (browser automation, delegation chains, research) complete without a 504. (#985)
 
 - **`secret-capture-request` (skill manifest schema)** — adds an optional `resume_intent` input and persists the minting agent's routing context on the token so the capture can re-enter the right conversation. (#972)
 

--- a/apps/console/src/pages/chat/chat-utils.test.ts
+++ b/apps/console/src/pages/chat/chat-utils.test.ts
@@ -22,12 +22,22 @@ describe('parseSseEvent', () => {
     expect(parseSseEvent(data)).toEqual({ kind: 'reply', text: 'Hi', html: null });
   });
 
-  it('returns a rejected event with friendly text for message.rejected', () => {
-    const data = JSON.stringify({ type: 'message.rejected', reason: 'global_rate_limited' });
-    const result = parseSseEvent(data);
+  it('returns a rejected event with friendly text for both rate-limit reasons', () => {
+    // Both global_rate_limited and sender_rate_limited are real MessageRejectedEvent
+    // reason codes and must get the friendly rate-limit copy.
+    for (const reason of ['global_rate_limited', 'sender_rate_limited']) {
+      const result = parseSseEvent(JSON.stringify({ type: 'message.rejected', reason }));
+      expect(result?.kind).toBe('rejected');
+      if (result?.kind !== 'rejected') throw new Error('expected rejected');
+      expect(result.text).toMatch(/rate limit/i);
+    }
+  });
+
+  it('returns a rejected event naming the reason for non-rate-limit reasons', () => {
+    const result = parseSseEvent(JSON.stringify({ type: 'message.rejected', reason: 'blocked_sender' }));
     expect(result?.kind).toBe('rejected');
     if (result?.kind !== 'rejected') throw new Error('expected rejected');
-    expect(result.text).toMatch(/rate limit/i);
+    expect(result.text).toContain('blocked_sender');
   });
 
   it('returns null for skill.result events (not displayed)', () => {

--- a/apps/console/src/pages/chat/chat-utils.test.ts
+++ b/apps/console/src/pages/chat/chat-utils.test.ts
@@ -1,31 +1,37 @@
 import { describe, it, expect } from 'vitest';
-import { parseSseEvent, makeMessage, formatTimestamp, linkifyText } from './chat-utils.js';
+import { parseSseEvent, makeMessage, formatTimestamp, linkifyText, pickRecoveredReply } from './chat-utils.js';
 
 describe('parseSseEvent', () => {
-  it('returns status text for skill.invoke events', () => {
-    const data = JSON.stringify({
-      type: 'skill.invoke',
-      skill: 'memory.recall',
-      agent: 'coordinator',
-      conversation_id: 'c1',
-      timestamp: '2026-05-29T00:00:00Z',
-    });
-    expect(parseSseEvent(data)).toBe('invoking memory.recall');
+  it('returns a status event for skill.invoke', () => {
+    const data = JSON.stringify({ type: 'skill.invoke', skill: 'memory.recall', conversation_id: 'c1' });
+    expect(parseSseEvent(data)).toEqual({ kind: 'status', text: 'invoking memory.recall' });
   });
 
   it('falls back to "skill" when the skill field is absent', () => {
     const data = JSON.stringify({ type: 'skill.invoke', conversation_id: 'c1' });
-    expect(parseSseEvent(data)).toBe('invoking skill');
+    expect(parseSseEvent(data)).toEqual({ kind: 'status', text: 'invoking skill' });
+  });
+
+  it('returns a reply event with content and html for message events', () => {
+    const data = JSON.stringify({ type: 'message', content: 'Hello', html: '<p>Hello</p>' });
+    expect(parseSseEvent(data)).toEqual({ kind: 'reply', text: 'Hello', html: '<p>Hello</p>' });
+  });
+
+  it('returns a reply event with html: null when html is absent', () => {
+    const data = JSON.stringify({ type: 'message', content: 'Hi' });
+    expect(parseSseEvent(data)).toEqual({ kind: 'reply', text: 'Hi', html: null });
+  });
+
+  it('returns a rejected event with friendly text for message.rejected', () => {
+    const data = JSON.stringify({ type: 'message.rejected', reason: 'global_rate_limited' });
+    const result = parseSseEvent(data);
+    expect(result?.kind).toBe('rejected');
+    if (result?.kind !== 'rejected') throw new Error('expected rejected');
+    expect(result.text).toMatch(/rate limit/i);
   });
 
   it('returns null for skill.result events (not displayed)', () => {
-    const data = JSON.stringify({ type: 'skill.result', skill: 'memory.recall' });
-    expect(parseSseEvent(data)).toBeNull();
-  });
-
-  it('returns null for message events (handled via POST response)', () => {
-    const data = JSON.stringify({ type: 'message', content: 'Hello' });
-    expect(parseSseEvent(data)).toBeNull();
+    expect(parseSseEvent(JSON.stringify({ type: 'skill.result', skill: 'memory.recall' }))).toBeNull();
   });
 
   it('returns null for malformed JSON', () => {
@@ -39,6 +45,32 @@ describe('parseSseEvent', () => {
   it('returns null for non-object JSON', () => {
     expect(parseSseEvent('42')).toBeNull();
     expect(parseSseEvent('"hello"')).toBeNull();
+  });
+});
+
+describe('pickRecoveredReply', () => {
+  const sentAt = new Date('2026-06-15T12:00:00Z').getTime();
+
+  it('returns the most recent assistant reply that landed at or after the send time', () => {
+    const items = [
+      { id: '1', role: 'user' as const, content: 'q', html: null, timestamp: '2026-06-15T11:59:00Z' },
+      { id: '2', role: 'assistant' as const, content: 'old', html: null, timestamp: '2026-06-15T11:59:30Z' },
+      { id: '3', role: 'user' as const, content: 'q2', html: null, timestamp: '2026-06-15T12:00:00Z' },
+      { id: '4', role: 'assistant' as const, content: 'fresh', html: '<p>fresh</p>', timestamp: '2026-06-15T12:03:00Z' },
+    ];
+    expect(pickRecoveredReply(items, sentAt)).toEqual({ text: 'fresh', html: '<p>fresh</p>' });
+  });
+
+  it('returns null when no assistant reply landed after the send time', () => {
+    const items = [
+      { id: '1', role: 'user' as const, content: 'q', html: null, timestamp: '2026-06-15T12:00:00Z' },
+      { id: '2', role: 'assistant' as const, content: 'stale', html: null, timestamp: '2026-06-15T11:00:00Z' },
+    ];
+    expect(pickRecoveredReply(items, sentAt)).toBeNull();
+  });
+
+  it('returns null for an empty history page', () => {
+    expect(pickRecoveredReply([], sentAt)).toBeNull();
   });
 });
 

--- a/apps/console/src/pages/chat/chat-utils.test.ts
+++ b/apps/console/src/pages/chat/chat-utils.test.ts
@@ -59,28 +59,46 @@ describe('parseSseEvent', () => {
 });
 
 describe('pickRecoveredReply', () => {
-  const sentAt = new Date('2026-06-15T12:00:00Z').getTime();
-
-  it('returns the most recent assistant reply that landed at or after the send time', () => {
+  // Timestamps are deliberately out of order vs. position to prove the function
+  // relies on message ORDERING, not wall-clock comparison (clock-skew safe).
+  it('returns the assistant reply that follows the last user message', () => {
     const items = [
       { id: '1', role: 'user' as const, content: 'q', html: null, timestamp: '2026-06-15T11:59:00Z' },
       { id: '2', role: 'assistant' as const, content: 'old', html: null, timestamp: '2026-06-15T11:59:30Z' },
       { id: '3', role: 'user' as const, content: 'q2', html: null, timestamp: '2026-06-15T12:00:00Z' },
       { id: '4', role: 'assistant' as const, content: 'fresh', html: '<p>fresh</p>', timestamp: '2026-06-15T12:03:00Z' },
     ];
-    expect(pickRecoveredReply(items, sentAt)).toEqual({ text: 'fresh', html: '<p>fresh</p>' });
+    expect(pickRecoveredReply(items)).toEqual({ text: 'fresh', html: '<p>fresh</p>' });
   });
 
-  it('returns null when no assistant reply landed after the send time', () => {
+  it('returns the reply even when its server timestamp predates the user turn (clock skew)', () => {
+    // Assistant row stamped BEFORE the user row — would be dropped by a wall-clock
+    // comparison, but ordering correctly identifies it as the reply.
     const items = [
-      { id: '1', role: 'user' as const, content: 'q', html: null, timestamp: '2026-06-15T12:00:00Z' },
-      { id: '2', role: 'assistant' as const, content: 'stale', html: null, timestamp: '2026-06-15T11:00:00Z' },
+      { id: '1', role: 'user' as const, content: 'q', html: null, timestamp: '2026-06-15T12:00:05Z' },
+      { id: '2', role: 'assistant' as const, content: 'reply', html: null, timestamp: '2026-06-15T12:00:00Z' },
     ];
-    expect(pickRecoveredReply(items, sentAt)).toBeNull();
+    expect(pickRecoveredReply(items)).toEqual({ text: 'reply', html: null });
+  });
+
+  it('returns null when the latest turn is unanswered (history ends on a user message)', () => {
+    const items = [
+      { id: '1', role: 'user' as const, content: 'q', html: null, timestamp: '2026-06-15T11:00:00Z' },
+      { id: '2', role: 'assistant' as const, content: 'prior reply', html: null, timestamp: '2026-06-15T11:00:30Z' },
+      { id: '3', role: 'user' as const, content: 'q2', html: null, timestamp: '2026-06-15T12:00:00Z' },
+    ];
+    expect(pickRecoveredReply(items)).toBeNull();
+  });
+
+  it('returns null when there is no user turn', () => {
+    const items = [
+      { id: '1', role: 'assistant' as const, content: 'orphan', html: null, timestamp: '2026-06-15T12:00:00Z' },
+    ];
+    expect(pickRecoveredReply(items)).toBeNull();
   });
 
   it('returns null for an empty history page', () => {
-    expect(pickRecoveredReply([], sentAt)).toBeNull();
+    expect(pickRecoveredReply([])).toBeNull();
   });
 });
 

--- a/apps/console/src/pages/chat/chat-utils.ts
+++ b/apps/console/src/pages/chat/chat-utils.ts
@@ -2,12 +2,18 @@ import type { Message, SseEvent, HistoryMessage } from './types.js';
 
 /**
  * Friendly, user-facing text for a message.rejected reason code.
- * Falls back to a generic message naming the reason for unrecognized codes.
+ *
+ * Reason codes mirror MessageRejectedEvent.reason in src/bus/events.ts:
+ * unknown_sender | provisional_sender | blocked_sender | message_too_large
+ * | global_rate_limited | sender_rate_limited. Both rate-limit variants get the
+ * same friendly copy; everything else falls back to a generic message naming the
+ * reason (the sender-identity reasons can't normally occur on the CEO-only web
+ * channel, so a generic message is acceptable for them).
  */
 function rejectionText(reason: string): string {
   switch (reason) {
     case 'global_rate_limited':
-    case 'rate_limited':
+    case 'sender_rate_limited':
       return 'Rate limit reached. Please wait a moment and try again.';
     case 'message_too_large':
       return 'That message is too large to process.';

--- a/apps/console/src/pages/chat/chat-utils.ts
+++ b/apps/console/src/pages/chat/chat-utils.ts
@@ -1,11 +1,31 @@
-import type { Message } from './types.js';
+import type { Message, SseEvent, HistoryMessage } from './types.js';
 
 /**
- * Parses a raw SSE event data string into a human-readable status label,
- * or returns null for events that should not be displayed in the thread.
- * Only skill.invoke events produce visible status messages.
+ * Friendly, user-facing text for a message.rejected reason code.
+ * Falls back to a generic message naming the reason for unrecognized codes.
  */
-export function parseSseEvent(data: string): string | null {
+function rejectionText(reason: string): string {
+  switch (reason) {
+    case 'global_rate_limited':
+    case 'rate_limited':
+      return 'Rate limit reached. Please wait a moment and try again.';
+    case 'message_too_large':
+      return 'That message is too large to process.';
+    default:
+      return `Message rejected (${reason}).`;
+  }
+}
+
+/**
+ * Parses a raw SSE event data string from GET /api/kg/chat/stream into a
+ * normalized SseEvent, or null for events the chat UI ignores.
+ *
+ * Ack-and-stream (#985): the POST only acks, so the `message` event is now the
+ * source of truth for the agent's final reply (terminal). `message.rejected` is
+ * a terminal error. `skill.invoke` is intermediate progress. Everything else
+ * (skill.result, malformed payloads, unknown types) returns null.
+ */
+export function parseSseEvent(data: string): SseEvent | null {
   let payload: unknown;
   try {
     payload = JSON.parse(data);
@@ -17,9 +37,41 @@ export function parseSseEvent(data: string): string | null {
   }
   if (typeof payload !== 'object' || payload === null) return null;
   const p = payload as Record<string, unknown>;
-  if (p['type'] === 'skill.invoke') {
-    const skill = typeof p['skill'] === 'string' ? p['skill'] : 'skill';
-    return `invoking ${skill}`;
+
+  switch (p['type']) {
+    case 'skill.invoke': {
+      const skill = typeof p['skill'] === 'string' ? p['skill'] : 'skill';
+      return { kind: 'status', text: `invoking ${skill}` };
+    }
+    case 'message': {
+      const text = typeof p['content'] === 'string' ? p['content'] : '';
+      const html = typeof p['html'] === 'string' ? p['html'] : null;
+      return { kind: 'reply', text, html };
+    }
+    case 'message.rejected': {
+      const reason = typeof p['reason'] === 'string' ? p['reason'] : 'unknown';
+      return { kind: 'rejected', text: rejectionText(reason) };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Recovery helper for the client watchdog: given a page of chat history (oldest
+ * first) and the time we sent the current turn, return the most recent assistant
+ * reply that landed at or after the send time — the reply we may have missed if
+ * the SSE message event never arrived. Returns null if there's no such reply.
+ */
+export function pickRecoveredReply(
+  items: HistoryMessage[],
+  sentAtMs: number,
+): { text: string; html: string | null } | null {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const m = items[i]!;
+    if (m.role === 'assistant' && new Date(m.timestamp).getTime() >= sentAtMs) {
+      return { text: m.content, html: m.html };
+    }
   }
   return null;
 }

--- a/apps/console/src/pages/chat/chat-utils.ts
+++ b/apps/console/src/pages/chat/chat-utils.ts
@@ -65,17 +65,31 @@ export function parseSseEvent(data: string): SseEvent | null {
 
 /**
  * Recovery helper for the client watchdog: given a page of chat history (oldest
- * first) and the time we sent the current turn, return the most recent assistant
- * reply that landed at or after the send time — the reply we may have missed if
- * the SSE message event never arrived. Returns null if there's no such reply.
+ * first), return the assistant reply to the most recent user turn — i.e. the most
+ * recent assistant message positioned AFTER the last user message. Returns null
+ * when the latest turn is still unanswered (history ends on a user message) or
+ * there is no user turn yet.
+ *
+ * Uses message ORDERING, not wall-clock timestamps. The previous version compared
+ * a server-written timestamp against a client-side Date.now(), which a skewed
+ * client clock could trip — a valid reply judged "too old" and silently dropped.
+ * The server persists the inbound user turn (runtime addTurn) before producing a
+ * reply, so "an assistant message after the last user message" reliably identifies
+ * the reply to the current turn without depending on either clock. (#985)
  */
 export function pickRecoveredReply(
   items: HistoryMessage[],
-  sentAtMs: number,
 ): { text: string; html: string | null } | null {
+  // Find the most recent user message; its reply (if any) sits after it.
+  let lastUserIdx = -1;
   for (let i = items.length - 1; i >= 0; i--) {
+    if (items[i]!.role === 'user') { lastUserIdx = i; break; }
+  }
+  if (lastUserIdx === -1) return null;
+
+  for (let i = items.length - 1; i > lastUserIdx; i--) {
     const m = items[i]!;
-    if (m.role === 'assistant' && new Date(m.timestamp).getTime() >= sentAtMs) {
+    if (m.role === 'assistant') {
       return { text: m.content, html: m.html };
     }
   }

--- a/apps/console/src/pages/chat/types.ts
+++ b/apps/console/src/pages/chat/types.ts
@@ -7,3 +7,24 @@ export interface Message {
   html?: string;     // Pre-rendered HTML for agent messages (server-side markdown conversion)
   timestamp?: Date;  // Display time; absent for status and error messages
 }
+
+/**
+ * A parsed SSE event from GET /api/kg/chat/stream, normalized for the chat UI.
+ * - status:   intermediate progress (skill invocation) — append as a status line.
+ * - reply:    the agent's final reply for this turn (terminal).
+ * - rejected: the turn was rejected before reaching the agent (terminal error).
+ * parseSseEvent returns null for everything else (skill.result, malformed, etc.).
+ */
+export type SseEvent =
+  | { kind: 'status'; text: string }
+  | { kind: 'reply'; text: string; html: string | null }
+  | { kind: 'rejected'; text: string };
+
+/** A chat history row as returned by GET /api/kg/chat/history. */
+export interface HistoryMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  html: string | null;
+  timestamp: string;
+}

--- a/apps/console/src/pages/chat/useChatSession.ts
+++ b/apps/console/src/pages/chat/useChatSession.ts
@@ -1,8 +1,8 @@
 // apps/console/src/pages/chat/useChatSession.ts
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { apiFetch } from '../../api.js';
-import { makeMessage, parseSseEvent } from './chat-utils.js';
-import type { Message } from './types.js';
+import { makeMessage, parseSseEvent, pickRecoveredReply } from './chat-utils.js';
+import type { Message, HistoryMessage } from './types.js';
 
 // localStorage key for persisting the conversationId across page reloads.
 const CONV_ID_KEY = 'curia:chat:conversationId';
@@ -12,6 +12,19 @@ const KICKOFF_TEXT = 'Just finished setup — say hi!';
 
 const HISTORY_PAGE_SIZE = 25;
 
+// Ack-and-stream (#985): the reply arrives over SSE, not the POST. If no terminal
+// event arrives within this window (rare: a suppressed-duplicate turn or an agent
+// crash), the client fetches /history once to recover a missed reply, then shows a
+// soft notice and unlocks the composer WITHOUT closing the stream — a late reply
+// still renders. Deliberately long so legitimately slow tasks are never cut off.
+const REPLY_WATCHDOG_MS = 5 * 60_000;
+// How long to wait for the SSE connection to open before POSTing anyway. If the
+// stream is degraded the POST still publishes and the watchdog recovers the reply.
+const SSE_OPEN_TIMEOUT_MS = 3_000;
+// Shown when the watchdog fires and /history has no reply yet.
+const STILL_WORKING_TEXT =
+  'Still working on this — it is taking longer than usual. The reply will appear here when it is ready.';
+
 interface ChatSession {
   messages: Message[];
   sending: boolean;
@@ -19,14 +32,6 @@ interface ChatSession {
   loadingHistory: boolean;
   send: (text: string) => Promise<void>;
   loadMore: () => Promise<void>;
-}
-
-interface HistoryMessage {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  html: string | null;
-  timestamp: string;
 }
 
 interface HistoryResponse {
@@ -197,6 +202,12 @@ export function useChatSession(): ChatSession {
     }
     const convId = conversationId.current;
 
+    // Close any stream left open by a prior turn's soft-recovery path before
+    // starting a new one, so we never leak a dangling EventSource.
+    sourceRef.current?.close();
+    sourceRef.current = null;
+
+    const sentAt = Date.now();
     // Optimistic append so the user sees their message immediately.
     setMessages((prev) => [
       ...prev,
@@ -205,30 +216,102 @@ export function useChatSession(): ChatSession {
     isSending.current = true;
     setSending(true);
 
-    // EventSource is created inside try so a synchronous constructor failure
-    // (e.g. CSP block) hits the catch block and resets the sending state.
     let source: EventSource | undefined;
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+
+    // Unlock the composer (and stop the watchdog) without touching the stream —
+    // used by the soft-recovery path so a late reply can still render.
+    const unlock = () => {
+      if (watchdog) { clearTimeout(watchdog); watchdog = undefined; }
+      isSending.current = false;
+      setSending(false);
+    };
+    // Fully finish the turn: unlock and close the stream. Idempotent.
+    const finalize = () => {
+      if (settled) return;
+      settled = true;
+      unlock();
+      source?.close();
+      sourceRef.current = null;
+    };
+
+    // Watchdog recovery: fetch one history page and render a missed reply, else
+    // post a soft notice and unlock (leaving the stream open for a late reply).
+    const runRecovery = async () => {
+      try {
+        const res = await apiFetch(
+          `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}`,
+        );
+        if (res.ok) {
+          const data = (await res.json()) as HistoryResponse;
+          const recovered = pickRecoveredReply(data.messages, sentAt);
+          if (recovered) {
+            setMessages((prev) => [
+              ...prev,
+              makeMessage('agent', recovered.text, { html: recovered.html ?? undefined, timestamp: new Date() }),
+            ]);
+            finalize();
+            return;
+          }
+        } else {
+          console.error('[useChatSession] recovery history fetch non-ok:', res.status);
+        }
+      } catch (err) {
+        console.error('[useChatSession] recovery history fetch failed:', err);
+      }
+      // Nothing to recover yet — soft notice, unlock, keep the stream open.
+      setMessages((prev) => [...prev, makeMessage('status', STILL_WORKING_TEXT)]);
+      unlock();
+    };
+
     try {
-      // Open the SSE stream BEFORE the POST to avoid racing a fast reply.
-      // withCredentials sends the session cookie, matching apiFetch behavior.
+      // Open the SSE stream and wait for it to connect BEFORE the POST, so a fast
+      // reply broadcast can't race past an unregistered stream. withCredentials
+      // sends the session cookie, matching apiFetch behavior.
       source = new EventSource(
         `/api/kg/chat/stream?conversationId=${encodeURIComponent(convId)}`,
         { withCredentials: true },
       );
-      sourceRef.current = source as EventSource;
+      sourceRef.current = source;
+
       source.onmessage = (event: MessageEvent<string>) => {
-        const statusText = parseSseEvent(event.data);
-        if (statusText) {
-          setMessages((prev) => [...prev, makeMessage('status', statusText)]);
+        const parsed = parseSseEvent(event.data);
+        if (!parsed) return;
+        if (parsed.kind === 'status') {
+          setMessages((prev) => [...prev, makeMessage('status', parsed.text)]);
+          return;
         }
+        if (parsed.kind === 'reply') {
+          // Terminal: the agent's final reply for this turn.
+          setMessages((prev) => [
+            ...prev,
+            makeMessage('agent', parsed.text, { html: parsed.html ?? undefined, timestamp: new Date() }),
+          ]);
+          finalize();
+          return;
+        }
+        // parsed.kind === 'rejected' — terminal error.
+        setMessages((prev) => [...prev, makeMessage('error', parsed.text)]);
+        finalize();
       };
+
       source.onerror = (event) => {
-        // SSE failures are non-fatal — the POST response is authoritative.
-        // Close immediately to prevent the browser's automatic reconnection loop.
-        console.error('[useChatSession] SSE stream error:', event);
-        // source is always defined here — onerror can only fire after construction.
-        source!.close();
+        // Non-fatal: EventSource auto-reconnects on transient errors. On a fatal
+        // close (readyState === CLOSED) the reply, if any, is recovered by the
+        // watchdog via /history. We do not finalize here so a reconnect can still
+        // deliver the terminal event.
+        console.error('[useChatSession] SSE stream error (readyState=%d):', source?.readyState, event);
       };
+
+      // Wait for the stream to open, but don't block forever — if it doesn't open
+      // within SSE_OPEN_TIMEOUT_MS, POST anyway and let the watchdog recover.
+      await new Promise<void>((resolve) => {
+        if (!source) { resolve(); return; }
+        if (source.readyState === EventSource.OPEN) { resolve(); return; }
+        const to = setTimeout(resolve, SSE_OPEN_TIMEOUT_MS);
+        source.onopen = () => { clearTimeout(to); resolve(); };
+      });
 
       const res = await apiFetch('/api/kg/chat/messages', {
         method: 'POST',
@@ -246,38 +329,20 @@ export function useChatSession(): ChatSession {
           console.error('[useChatSession] failed to parse error response body:', bodyErr);
         }
         setMessages((prev) => [...prev, makeMessage('error', errMsg)]);
+        finalize();
         return;
       }
 
-      const raw = await res.json() as unknown;
-      if (
-        typeof raw !== 'object' ||
-        raw === null ||
-        typeof (raw as Record<string, unknown>)['reply'] !== 'string'
-      ) {
-        console.error('[useChatSession] unexpected response shape:', raw);
-        setMessages((prev) => [...prev, makeMessage('error', 'Received an unexpected response.')]);
-        return;
-      }
-      // Runtime guard above confirmed `reply` is a string; cast through unknown
-      // per project convention for narrowing from Record<string, unknown>.
-      const data = raw as unknown as { reply: string; html: string | null; conversationId: string };
-      setMessages((prev) => [
-        ...prev,
-        makeMessage('agent', data.reply, {
-          html: data.html ?? undefined,
-          timestamp: new Date(),
-        }),
-      ]);
+      // 202 ack received. The reply arrives over SSE; arm the watchdog in case it
+      // never does (suppressed-duplicate turn or agent crash).
+      watchdog = setTimeout(() => { void runRecovery(); }, REPLY_WATCHDOG_MS);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Network error';
       setMessages((prev) => [...prev, makeMessage('error', msg)]);
-    } finally {
-      isSending.current = false;
-      source?.close();
-      sourceRef.current = null;
-      setSending(false);
+      finalize();
     }
+    // NOTE: no finally that clears sending/closes the stream — the turn is
+    // finished by the SSE terminal event, the watchdog, or an error path above.
   }
 
   return { messages, sending, hasMore, loadingHistory, send, loadMore };

--- a/apps/console/src/pages/chat/useChatSession.ts
+++ b/apps/console/src/pages/chat/useChatSession.ts
@@ -334,8 +334,13 @@ export function useChatSession(): ChatSession {
       }
 
       // 202 ack received. The reply arrives over SSE; arm the watchdog in case it
-      // never does (suppressed-duplicate turn or agent crash).
-      watchdog = setTimeout(() => { void runRecovery(); }, REPLY_WATCHDOG_MS);
+      // never does (suppressed-duplicate turn or agent crash). Guard on !settled:
+      // a fast reply can fire between the onopen gate and the POST resolving, in
+      // which case the turn is already finalized and arming the watchdog would
+      // later append a duplicate of the already-rendered reply via /history.
+      if (!settled) {
+        watchdog = setTimeout(() => { void runRecovery(); }, REPLY_WATCHDOG_MS);
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Network error';
       setMessages((prev) => [...prev, makeMessage('error', msg)]);

--- a/apps/console/src/pages/chat/useChatSession.ts
+++ b/apps/console/src/pages/chat/useChatSession.ts
@@ -224,7 +224,6 @@ export function useChatSession(): ChatSession {
     sourceRef.current = null;
     if (watchdogRef.current) { clearTimeout(watchdogRef.current); watchdogRef.current = null; }
 
-    const sentAt = Date.now();
     // Optimistic append so the user sees their message immediately.
     setMessages((prev) => [
       ...prev,
@@ -273,10 +272,14 @@ export function useChatSession(): ChatSession {
         const res = await apiFetch(
           `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}`,
         );
+        // A terminal SSE event may have settled the turn during the await — bail
+        // before mutating state so we don't append a duplicate or stale notice.
+        if (settled) return;
         if (res.ok) {
           fetchOk = true;
           const data = (await res.json()) as HistoryResponse;
-          const recovered = pickRecoveredReply(data.messages, sentAt);
+          if (settled) return;
+          const recovered = pickRecoveredReply(data.messages);
           if (recovered) {
             setMessages((prev) => [
               ...prev,
@@ -292,6 +295,8 @@ export function useChatSession(): ChatSession {
         console.error('[useChatSession] recovery history fetch failed:', err);
       }
 
+      // Re-check after the try/catch: the turn may have settled while awaiting.
+      if (settled) return;
       if (!fetchOk) {
         // Recovery itself failed — we can't claim progress. Tell the user the
         // status is unknown and finalize (close the dead stream; nothing more is

--- a/apps/console/src/pages/chat/useChatSession.ts
+++ b/apps/console/src/pages/chat/useChatSession.ts
@@ -21,9 +21,17 @@ const REPLY_WATCHDOG_MS = 5 * 60_000;
 // How long to wait for the SSE connection to open before POSTing anyway. If the
 // stream is degraded the POST still publishes and the watchdog recovers the reply.
 const SSE_OPEN_TIMEOUT_MS = 3_000;
-// Shown when the watchdog fires and /history has no reply yet.
+// Shown when recovery ran, the /history fetch succeeded, but no reply has landed
+// yet. Phrased conditionally ("if it arrives") because we genuinely can't tell a
+// slow turn from a dropped one (e.g. an email-skill suppressed-duplicate turn that
+// produces no chat reply at all) — so we don't promise a reply that may never come.
 const STILL_WORKING_TEXT =
-  'Still working on this — it is taking longer than usual. The reply will appear here when it is ready.';
+  'This is taking longer than usual. The reply will appear here if it arrives — you can also resend.';
+// Shown when recovery itself failed (the /history fetch errored or returned non-ok,
+// e.g. an expired session or a server error). We have no basis to claim progress,
+// so we tell the user the status is unknown rather than implying a reply is coming.
+const RECOVERY_FAILED_TEXT =
+  'Could not confirm your message status — the connection may have dropped. You can resend.';
 
 interface ChatSession {
   messages: Message[];
@@ -227,6 +235,10 @@ export function useChatSession(): ChatSession {
 
     let source: EventSource | undefined;
     let settled = false;
+    // Guards runRecovery so it runs at most once per turn — both the watchdog
+    // timeout and a fatal stream close (onerror) can trigger it, and we never
+    // want two recovery passes (which could post two notices).
+    let recoveryStarted = false;
 
     // Unlock the composer (and stop the watchdog) without touching the stream —
     // used by the soft-recovery path so a late reply can still render. The
@@ -245,14 +257,24 @@ export function useChatSession(): ChatSession {
       sourceRef.current = null;
     };
 
-    // Watchdog recovery: fetch one history page and render a missed reply, else
-    // post a soft notice and unlock (leaving the stream open for a late reply).
+    // Recovery: fetch one history page and render a reply the SSE stream may have
+    // missed. Triggered by the watchdog timeout OR a fatal stream close. Three
+    // outcomes, each with honest feedback:
+    //   1. reply found      → render it + finalize.
+    //   2. fetch failed      → "couldn't confirm status, resend" (status unknown).
+    //   3. fetch ok, no reply → soft "taking longer" notice, leave the stream open.
+    // Runs at most once per turn (recoveryStarted guard).
     const runRecovery = async () => {
+      if (recoveryStarted || settled) return;
+      recoveryStarted = true;
+
+      let fetchOk = false;
       try {
         const res = await apiFetch(
           `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}`,
         );
         if (res.ok) {
+          fetchOk = true;
           const data = (await res.json()) as HistoryResponse;
           const recovered = pickRecoveredReply(data.messages, sentAt);
           if (recovered) {
@@ -269,9 +291,19 @@ export function useChatSession(): ChatSession {
       } catch (err) {
         console.error('[useChatSession] recovery history fetch failed:', err);
       }
-      // Nothing to recover yet — soft notice, unlock, keep the stream open so a
-      // late reply still renders. This open stream is closed by one of: a late
-      // SSE reply (onmessage → finalize), the next send() (closes the prior
+
+      if (!fetchOk) {
+        // Recovery itself failed — we can't claim progress. Tell the user the
+        // status is unknown and finalize (close the dead stream; nothing more is
+        // coming through it).
+        setMessages((prev) => [...prev, makeMessage('error', RECOVERY_FAILED_TEXT)]);
+        finalize();
+        return;
+      }
+
+      // Fetch succeeded but no reply yet — soft notice, unlock, keep the stream
+      // open so a late reply still renders. This open stream is closed by one of:
+      // a late SSE reply (onmessage → finalize), the next send() (closes the prior
       // stream up top), or unmount cleanup. That closure contract is non-local.
       setMessages((prev) => [...prev, makeMessage('status', STILL_WORKING_TEXT)]);
       unlock();
@@ -309,11 +341,18 @@ export function useChatSession(): ChatSession {
       };
 
       source.onerror = (event) => {
-        // Non-fatal: EventSource auto-reconnects on transient errors. On a fatal
-        // close (readyState === CLOSED) the reply, if any, is recovered by the
-        // watchdog via /history. We do not finalize here so a reconnect can still
-        // deliver the terminal event.
+        // EventSource auto-reconnects on transient errors (readyState CONNECTING) —
+        // leave those alone so a reconnect can still deliver the terminal event.
+        // But on a FATAL close (readyState CLOSED, e.g. an expired session 401 or a
+        // dropped server) the browser will NOT reconnect: the terminal event can
+        // never arrive over this stream. Don't make the user wait out the full
+        // watchdog — recover immediately so a missed reply (or an honest "status
+        // unknown" notice) surfaces in seconds rather than minutes.
         console.error('[useChatSession] SSE stream error (readyState=%d):', source?.readyState, event);
+        if (source?.readyState === EventSource.CLOSED && !settled) {
+          if (watchdogRef.current) { clearTimeout(watchdogRef.current); watchdogRef.current = null; }
+          void runRecovery();
+        }
       };
 
       // Wait for the stream to open, but don't block forever — if it doesn't open

--- a/apps/console/src/pages/chat/useChatSession.ts
+++ b/apps/console/src/pages/chat/useChatSession.ts
@@ -63,6 +63,10 @@ export function useChatSession(): ChatSession {
   const isLoadingMore = useRef(false);
   // Holds the active EventSource so cleanup can close it on unmount.
   const sourceRef = useRef<EventSource | null>(null);
+  // Holds the in-flight reply watchdog timer so cleanup can clear it on unmount
+  // (otherwise a turn that unmounts mid-flight leaves a up-to-5-minute timer that
+  // later fires a post-unmount /history fetch + setState). See send() below.
+  const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // One conversationId per chat thread — persisted in localStorage.
   // localStorage.getItem can throw SecurityError in restricted browsing contexts
   // (e.g. Safari private mode with strict settings), so we guard the read.
@@ -100,8 +104,12 @@ export function useChatSession(): ChatSession {
   // ISO timestamp of the oldest loaded message — used as the pagination cursor.
   const oldestTimestamp = useRef<string | null>(null);
 
-  // Close any in-flight SSE connection when the component unmounts.
-  useEffect(() => () => { sourceRef.current?.close(); }, []);
+  // Close any in-flight SSE connection and clear the reply watchdog when the
+  // component unmounts, so neither survives to fire after teardown.
+  useEffect(() => () => {
+    sourceRef.current?.close();
+    if (watchdogRef.current) clearTimeout(watchdogRef.current);
+  }, []);
 
   // On mount, if we have a stored conversationId, load the most recent history page.
   useEffect(() => {
@@ -202,10 +210,11 @@ export function useChatSession(): ChatSession {
     }
     const convId = conversationId.current;
 
-    // Close any stream left open by a prior turn's soft-recovery path before
-    // starting a new one, so we never leak a dangling EventSource.
+    // Close any stream left open by a prior turn's soft-recovery path, and clear
+    // any pending watchdog, before starting a new one — never leak either.
     sourceRef.current?.close();
     sourceRef.current = null;
+    if (watchdogRef.current) { clearTimeout(watchdogRef.current); watchdogRef.current = null; }
 
     const sentAt = Date.now();
     // Optimistic append so the user sees their message immediately.
@@ -217,13 +226,13 @@ export function useChatSession(): ChatSession {
     setSending(true);
 
     let source: EventSource | undefined;
-    let watchdog: ReturnType<typeof setTimeout> | undefined;
     let settled = false;
 
     // Unlock the composer (and stop the watchdog) without touching the stream —
-    // used by the soft-recovery path so a late reply can still render.
+    // used by the soft-recovery path so a late reply can still render. The
+    // watchdog lives in a ref so the unmount cleanup can also clear it.
     const unlock = () => {
-      if (watchdog) { clearTimeout(watchdog); watchdog = undefined; }
+      if (watchdogRef.current) { clearTimeout(watchdogRef.current); watchdogRef.current = null; }
       isSending.current = false;
       setSending(false);
     };
@@ -260,7 +269,10 @@ export function useChatSession(): ChatSession {
       } catch (err) {
         console.error('[useChatSession] recovery history fetch failed:', err);
       }
-      // Nothing to recover yet — soft notice, unlock, keep the stream open.
+      // Nothing to recover yet — soft notice, unlock, keep the stream open so a
+      // late reply still renders. This open stream is closed by one of: a late
+      // SSE reply (onmessage → finalize), the next send() (closes the prior
+      // stream up top), or unmount cleanup. That closure contract is non-local.
       setMessages((prev) => [...prev, makeMessage('status', STILL_WORKING_TEXT)]);
       unlock();
     };
@@ -339,7 +351,7 @@ export function useChatSession(): ChatSession {
       // which case the turn is already finalized and arming the watchdog would
       // later append a duplicate of the already-rendered reply via /history.
       if (!settled) {
-        watchdog = setTimeout(() => { void runRecovery(); }, REPLY_WATCHDOG_MS);
+        watchdogRef.current = setTimeout(() => { void runRecovery(); }, REPLY_WATCHDOG_MS);
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Network error';

--- a/docs/wip/2026-06-15-chat-ack-stream-design.md
+++ b/docs/wip/2026-06-15-chat-ack-stream-design.md
@@ -1,0 +1,163 @@
+# Web-console chat: ack-and-stream (remove the synchronous 120s wait)
+
+**Issue:** [#985](https://github.com/josephfung/curia/issues/985)
+**Date:** 2026-06-15
+**Status:** Design approved, ready for implementation plan
+
+## Problem
+
+`POST /api/kg/chat/messages` waits **synchronously** for the entire agent
+response via `waitForResponse(conversationId, CHAT_RESPONSE_TIMEOUT_MS = 120_000)`
+and only returns once the full reply is ready
+([kg.ts:1059-1127](../../src/channels/http/routes/kg.ts#L1059-L1127)). Many normal
+web-console tasks — browser automation, multi-agent delegation chains, research —
+routinely exceed 120s. When they do, the user gets a 504 even though the agent is
+still working and will eventually answer. This is a **common, expected case**, not
+an edge case: the first real-world test of the web-browser + secrets feature hit it
+immediately (a coordinator turn fanning out two delegate sub-agents ran past 120s).
+
+The architecture already has the right plumbing: `GET /api/kg/chat/stream` is an
+SSE endpoint that broadcasts `outbound.message`, `skill.invoke`, `skill.result`,
+and `message.rejected` events with a 30s heartbeat
+([kg.ts:1135+](../../src/channels/http/routes/kg.ts#L1135)). The POST just shouldn't
+block on the full response when the stream can deliver it.
+
+## Chosen approach: Option 1 — ack + stream
+
+POST returns `202 { conversationId }` immediately once the inbound message is
+published. The final reply and intermediate events arrive over the existing SSE
+stream, which becomes the **source of truth** for the final assistant message.
+This removes the synchronous timeout entirely and surfaces progress during long
+tasks.
+
+Two design forks were resolved during brainstorming:
+
+- **POST contract → full async (202-only).** No opt-in synchronous mode. The reply
+  is delivered only over SSE (or recoverable via `/api/kg/chat/history`).
+  Programmatic callers that previously read `reply` from the POST body must consume
+  the stream or the history endpoint. This keeps a single code path and fully
+  removes the 120s timeout path from this route.
+- **HTML rendering → server-side in the SSE event.** The `outbound.message` SSE
+  payload currently carries markdown only; the old POST path rendered HTML via
+  `markdownToHtml`. We add an `html` field to the `message` SSE payload in
+  `event-router.ts` so the frontend keeps rendering server-produced HTML with no
+  new client dependency, consistent with the POST and `/history` paths.
+
+## Current behavior (baseline)
+
+### Backend
+- **POST** registers a waiter *before* publishing, awaits a `WaitResult`
+  discriminated union, and maps outcomes to HTTP status:
+  `ok → 200 { reply, html, conversationId }`, `timeout → 504`,
+  `rejected → 403/429` (via `mapWaitFailureToHttp`), `superseded → 500`.
+- **SSE** (`addSseClient` in
+  [event-router.ts](../../src/channels/http/event-router.ts)) broadcasts, filtered
+  by `conversationId`:
+  - `outbound.message` → `{ type: 'message', conversation_id, content, timestamp }`
+    — **markdown only**, no HTML.
+  - `skill.invoke` → `{ type: 'skill.invoke', agent, skill, conversation_id, timestamp }`
+  - `skill.result` → `{ type: 'skill.result', agent, skill, success, duration_ms, conversation_id, timestamp }`
+  - `message.rejected` → `{ type: 'message.rejected', conversation_id, channel_id, sender_id, reason, timestamp }`
+- **Cardinality:** exactly one `outbound.message` per agent turn, *except* the rare
+  case where a human-facing skill (email-reply/email-send) already fired during the
+  turn — then the outbound is suppressed (`outbound.suppressed_duplicate`) and no
+  `message` event reaches the stream.
+- **Errors:** a failed agent turn still surfaces as an `outbound.message` carrying
+  the error text as content (so it renders like a normal reply). `agent.error` is
+  *not* broadcast to SSE.
+
+### Frontend (`apps/console/src/pages/chat/`)
+- `useChatSession.ts` already opens the `EventSource` **before** the POST, but only
+  renders `skill.invoke` as status lines and treats the **POST response body** as
+  the source of truth for the final reply. The `message` SSE event is ignored
+  (`parseSseEvent` returns `null` for it).
+- `conversationId` is `crypto.randomUUID()` persisted in `localStorage`
+  (`curia:chat:conversationId`).
+
+## Target design
+
+### 1. Backend — `POST /api/kg/chat/messages` (`src/channels/http/routes/kg.ts`)
+
+- Remove `waitForResponse`, the `cancelPending` call, and the entire
+  `WaitResult` / `mapWaitFailureToHttp` post-resolution block from this route.
+- After a successful `bus.publish`, return **`202 { conversationId }`**.
+- Retain: `assertSecret` guard (401), empty-message **400**, **503** when
+  `webAppBootstrapSecret` is undefined, and **500** on a synchronous publish
+  failure.
+- Remove `CHAT_RESPONSE_TIMEOUT_MS` and `mapWaitFailureToHttp` imports **iff** they
+  become unused in this file (they remain in `messages.ts`, which is untouched).
+
+### 2. Backend — SSE `outbound.message` branch (`src/channels/http/event-router.ts`)
+
+- In the `outbound.message` → SSE serialization, add an `html` field rendered via
+  `markdownToHtml(event.payload.content)`, alongside the existing `content`
+  (markdown retained for non-HTML consumers).
+- Wrap the render in try/catch: on failure, emit `html: null` and log a warning
+  (mirrors the existing graceful-fallback pattern in `kg.ts`). A render error must
+  never drop the message event.
+- Additive change: `/api/messages/stream` consumers ignore the new field.
+
+### 3. Frontend — `apps/console/src/pages/chat/`
+
+- **Race fix (`useChatSession.ts`):** gate the POST on the SSE connection being
+  live. Open `EventSource`, await `onopen`, *then* issue the POST. This closes the
+  window where a fast reply is broadcast before the stream is registered
+  server-side — now critical, since the stream is the only delivery path.
+- **`parseSseEvent` (`chat-utils.ts`):** extend to handle:
+  - `message` → return the final agent message (`content` + `html`) as a terminal
+    result.
+  - `message.rejected` → return terminal error text derived from `reason`.
+  - `skill.invoke` → unchanged status line.
+- **`useChatSession.ts` send flow:** the POST response is now just an ack (expect
+  202; non-2xx → error). The **`message` SSE event becomes the source of truth** for
+  the final reply. On a terminal event (`message` or `message.rejected`): render it,
+  clear the `sending` state, close the stream. Long tasks (>120s) keep streaming
+  with **no client-side cliff**.
+- **Hang safety (soft recovery):** the only no-terminal-event cases are the rare
+  suppressed-duplicate turn or an agent crash. After **5 minutes** with no terminal
+  event, the client fetches `/api/kg/chat/history?conversationId=...` once to recover
+  any assistant reply that landed; if one is found, render it and finish. If still
+  nothing, show a soft, non-error "still working — check back" notice and **leave
+  the stream open** (no hard failure that would kill a legitimately long task). The
+  5-minute cap is a named constant for easy tuning.
+
+### 4. Tests
+
+- **`tests/unit/channels/http/kg-chat-routes.test.ts`:** rewrite the POST cases.
+  Assert **202 + `{ conversationId }`**, that `bus.publish` was called, and that
+  `waitForResponse` is **not** called. Keep 401 (no auth), 400 (empty message), 503
+  (no bootstrap secret), and 500 (synchronous publish failure). Drop the
+  504/403/429/500-supersede sync-mapping cases for *this* route.
+- **`tests/unit/channels/http/event-router.test.ts`:** assert the `message` SSE
+  payload now includes a rendered `html` field, and that a `markdownToHtml` failure
+  degrades to `html: null` without dropping the event.
+- **Frontend:** add/adjust coverage for `parseSseEvent` (new `message` /
+  `message.rejected` handling) and the `useChatSession` terminal-event + onopen-gate
+  flow, matching whatever test setup already exists in `apps/console`.
+
+## Acceptance criteria (from #985)
+
+- A web-console chat task that takes >120s completes and shows its result without an
+  error. ✔ (no synchronous timeout; reply delivered over SSE)
+- No single chat turn ties up a server connection for minutes. ✔ (POST returns 202
+  immediately)
+- Intermediate progress (skill invocations / delegate steps) is visible during long
+  tasks. ✔ (`skill.invoke` status lines already render; stream stays open)
+- Fast (<5s) chats still feel synchronous. ✔ (onopen-gated POST + SSE terminal
+  event delivered immediately)
+
+## Out of scope / notes
+
+- **#983 (uncaught-rejection hardening) is independent.** This route no longer
+  registers a waiter, so the supersede-reject path is moot *here*, but `messages.ts`
+  still uses `waitForResponse` and #983 remains its own work.
+- No changes to `messages.ts`, the dispatcher, or the bus event definitions.
+- `outbound.suppressed_duplicate` is *not* added to the SSE broadcast in this change;
+  the soft `/history` recovery covers that case without new bus plumbing.
+
+## Risks
+
+- **Race on fast replies** if the onopen gate is wrong — mitigated by gating the
+  POST on `EventSource.onopen` and the `/history` recovery fallback.
+- **API-contract break** for programmatic POST callers reading `reply` from the body
+  — accepted per the chosen "full async" decision; tests updated accordingly.

--- a/docs/wip/2026-06-15-chat-ack-stream.md
+++ b/docs/wip/2026-06-15-chat-ack-stream.md
@@ -1,0 +1,847 @@
+# Web-console chat ack-and-stream Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `POST /api/kg/chat/messages` from blocking on the agent's full reply; ack immediately with `202`, deliver the reply (and progress) over the existing SSE stream.
+
+**Architecture:** The POST publishes the inbound message and returns `202 { conversationId }`. The `outbound.message` SSE event becomes the source of truth for the final reply and now carries server-rendered `html`. The console opens the SSE stream, waits for it to connect, POSTs, then renders the final reply from the stream's terminal event. A 5-minute client watchdog recovers a missed reply via `/history` and otherwise shows a soft "still working" notice without killing long tasks.
+
+**Tech Stack:** TypeScript (ESM), Fastify, Node SSE, React (Vite), Vitest.
+
+**Design reference:** [docs/wip/2026-06-15-chat-ack-stream-design.md](2026-06-15-chat-ack-stream-design.md) · Issue [#985](https://github.com/josephfung/curia/issues/985)
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream` (branch `feat/chat-ack-stream`). All commands below assume this worktree via `pnpm -C` / `git -C`.
+
+---
+
+## File Structure
+
+- **Modify** `src/channels/http/event-router.ts` — add rendered `html` to the `outbound.message` → SSE payload.
+- **Modify** `tests/unit/channels/http/event-router.test.ts` — add SSE-broadcast coverage (html present + render-failure fallback).
+- **Modify** `src/channels/http/routes/kg.ts` — POST becomes a `202` ack; remove `waitForResponse`/wait-mapping; prune now-unused imports.
+- **Modify** `tests/unit/channels/http/kg-chat-routes.test.ts` — rewrite POST cases for the ack contract.
+- **Modify** `apps/console/src/pages/chat/types.ts` — add `SseEvent` discriminated union and shared `HistoryMessage` type.
+- **Modify** `apps/console/src/pages/chat/chat-utils.ts` — `parseSseEvent` returns `SseEvent | null`; add `pickRecoveredReply`.
+- **Modify** `apps/console/src/pages/chat/chat-utils.test.ts` — rewrite `parseSseEvent` cases; add `pickRecoveredReply` cases.
+- **Modify** `apps/console/src/pages/chat/useChatSession.ts` — ack+stream send flow: onopen-gated POST, terminal-event finish, watchdog recovery.
+- **Modify** `CHANGELOG.md` — one `Changed` bullet.
+
+---
+
+## Task 1: SSE `outbound.message` event carries rendered HTML
+
+**Files:**
+- Modify: `src/channels/http/event-router.ts:160-169`
+- Test: `tests/unit/channels/http/event-router.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this block at the end of `tests/unit/channels/http/event-router.test.ts` (before the final newline; after the existing `describe('EventRouter.waitForResponse', ...)` block). It uses a mock SSE client whose `res.write` captures the serialized frame.
+
+```typescript
+describe('EventRouter SSE — outbound.message html rendering', () => {
+  it('includes server-rendered html alongside markdown content', () => {
+    const { router, emit } = makeRouter();
+    const writes: string[] = [];
+    const res = { write: (chunk: string) => { writes.push(chunk); return true; } };
+    router.addSseClient({ res: res as unknown as ServerResponse, conversationId: 'c1' });
+
+    emit({
+      type: 'outbound.message',
+      timestamp: '2026-06-15T00:00:00.000Z',
+      payload: { channelId: 'web', conversationId: 'c1', content: 'hello **world**' },
+    } as unknown as BusEvent);
+
+    // The SSE frame is `data: <json>\n\n`. Strip the prefix/suffix and parse.
+    const frame = writes.find((w) => w.startsWith('data: '));
+    expect(frame).toBeDefined();
+    const payload = JSON.parse(frame!.slice('data: '.length).trim()) as {
+      type: string; content: string; html: string | null;
+    };
+    expect(payload.type).toBe('message');
+    expect(payload.content).toBe('hello **world**');
+    expect(payload.html).toContain('<strong>world</strong>');
+  });
+
+  it('falls back to html: null when markdown rendering throws', () => {
+    const { router, emit } = makeRouter();
+    const writes: string[] = [];
+    const res = { write: (chunk: string) => { writes.push(chunk); return true; } };
+    router.addSseClient({ res: res as unknown as ServerResponse, conversationId: 'c2' });
+
+    // A non-string content slips past the type system via the cast and makes
+    // markdownToHtml throw; the event must still be delivered with html: null.
+    emit({
+      type: 'outbound.message',
+      timestamp: '2026-06-15T00:00:00.000Z',
+      payload: { channelId: 'web', conversationId: 'c2', content: { not: 'a string' } },
+    } as unknown as BusEvent);
+
+    const frame = writes.find((w) => w.startsWith('data: '));
+    expect(frame).toBeDefined();
+    const payload = JSON.parse(frame!.slice('data: '.length).trim()) as { html: string | null };
+    expect(payload.html).toBeNull();
+  });
+});
+```
+
+Add the `ServerResponse` type import at the top of the test file (after the existing imports):
+
+```typescript
+import type { ServerResponse } from 'node:http';
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream test tests/unit/channels/http/event-router.test.ts`
+Expected: FAIL — the first test fails because `payload.html` is `undefined` (field not emitted yet); the second also fails on `html` being absent.
+
+- [ ] **Step 3: Implement the html field**
+
+In `src/channels/http/event-router.ts`, add the import near the other imports at the top of the file:
+
+```typescript
+import { markdownToHtml } from '../../utils/markdown-to-html.js';
+```
+
+Then replace the `outbound.message` SSE serialization block (currently lines 160-169) with:
+
+```typescript
+      // Stream to all SSE clients (filtered by conversationId if set).
+      // Wrap writes in try/catch so a dead client doesn't abort delivery
+      // to the remaining clients in this dispatch cycle.
+      //
+      // Render markdown→HTML server-side so the SSE consumer (the web console)
+      // gets the same pre-rendered HTML the POST path used to return. Wrapped in
+      // try/catch: a render failure must degrade to html: null, never drop the
+      // message event. (#985)
+      let html: string | null = null;
+      try {
+        html = markdownToHtml(event.payload.content);
+      } catch (renderErr) {
+        this.logger.warn({ err: renderErr, conversationId: convId }, 'markdownToHtml failed for SSE message; sending html: null');
+      }
+      const sseData = JSON.stringify({
+        type: 'message',
+        conversation_id: convId,
+        content: event.payload.content,
+        html,
+        timestamp: event.timestamp,
+      });
+      this.broadcastToSseClients(sseData, convId);
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream test tests/unit/channels/http/event-router.test.ts`
+Expected: PASS (all tests in the file, including the existing `waitForResponse` cases).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream add src/channels/http/event-router.ts tests/unit/channels/http/event-router.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream commit -m "feat: render html in outbound.message SSE payload (#985)"
+```
+
+---
+
+## Task 2: POST `/api/kg/chat/messages` returns a 202 ack
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts` (imports line 10, constant line 36, handler lines 1059-1127)
+- Test: `tests/unit/channels/http/kg-chat-routes.test.ts`
+
+- [ ] **Step 1: Rewrite the POST test cases (failing)**
+
+In `tests/unit/channels/http/kg-chat-routes.test.ts`:
+
+(a) Simplify the mock EventRouter — it no longer needs `waitForResponse`/`cancelPending` for the POST path, but keep them harmless for other call sites. Replace `createMockEventRouter` (lines 37-44) with:
+
+```typescript
+// The ack-and-stream POST no longer calls waitForResponse; it only publishes and
+// returns 202. We keep addSseClient/setupSubscriptions for the stream route wiring.
+function createMockEventRouter(): EventRouter {
+  return {
+    waitForResponse: vi.fn(),
+    cancelPending: vi.fn(),
+    addSseClient: vi.fn().mockReturnValue(() => { /* cleanup noop */ }),
+    setupSubscriptions: vi.fn(),
+  } as unknown as EventRouter;
+}
+```
+
+Update the two call sites that passed an argument (`createMockEventRouter('Hey there!')` at line 109 and `createMockEventRouter('reply')` at line 167) to `createMockEventRouter()`.
+
+The `MessageRejectedError` import (line 16) becomes unused after removing the 403 case below — drop it from the import, leaving `import { type EventRouter } from '../../../../src/channels/http/event-router.js';`.
+
+(b) Replace the happy-path test (lines 107-139) with the ack assertion:
+
+```typescript
+  it('POST /api/kg/chat/messages — 202 ack with valid bootstrap-secret header', async () => {
+    const bus = createMockBus();
+    const eventRouter = createMockEventRouter();
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(knowledgeGraphRoutes, {
+      pool: createPool() as Pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'test-secret',
+      secureCookies: false,
+      bus,
+      eventRouter,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/kg/chat/messages',
+      headers: { 'x-web-bootstrap-secret': 'test-secret' },
+      payload: { message: 'What is on the agenda?', conversationId: 'test-convo-1' },
+    });
+
+    expect(response.statusCode).toBe(202);
+    const body = response.json();
+    expect(body.conversationId).toBe('test-convo-1');
+    // The reply now arrives over SSE, not in the POST body.
+    expect(body.reply).toBeUndefined();
+
+    // The inbound message was published; the handler does NOT block on a reply.
+    expect(bus.publish).toHaveBeenCalledOnce();
+    expect(eventRouter.waitForResponse).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+```
+
+(c) Replace the auto-generates-conversationId test (lines 165-197) body's assertions: change `expect(response.statusCode).toBe(200)` → `toBe(202)`, and replace the final `waitForResponse` assertion with:
+
+```typescript
+    expect(response.statusCode).toBe(202);
+    const body = response.json();
+    expect(typeof body.conversationId).toBe('string');
+    expect(body.conversationId.length).toBeGreaterThan(0);
+    expect(eventRouter.waitForResponse).not.toHaveBeenCalled();
+```
+
+(d) Delete the four wait-mapping tests that no longer apply to this route: the 504 timeout (lines 202-231), the 403 rejected (233-265), the 429 rate-limited (267-301), and the 500 superseded (303-331) cases. Their behavior now lives on the SSE path / is gone with the synchronous wait.
+
+(e) Add a publish-failure test (insert after the empty-message 400 test, around line 163):
+
+```typescript
+  it('POST /api/kg/chat/messages — 500 when publish fails synchronously', async () => {
+    const bus = {
+      publish: vi.fn().mockRejectedValue(new Error('bus down')),
+      subscribe: vi.fn(),
+    } as unknown as EventBus;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(knowledgeGraphRoutes, {
+      pool: createPool() as Pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'test-secret',
+      secureCookies: false,
+      bus,
+      eventRouter: createMockEventRouter(),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/kg/chat/messages',
+      headers: { 'x-web-bootstrap-secret': 'test-secret' },
+      payload: { message: 'hello', conversationId: 'c-fail' },
+    });
+
+    expect(response.statusCode).toBe(500);
+    await app.close();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream test tests/unit/channels/http/kg-chat-routes.test.ts`
+Expected: FAIL — the 202 tests fail because the handler still returns 200 with a `reply` body and still calls `waitForResponse`.
+
+- [ ] **Step 3: Rewrite the POST handler**
+
+In `src/channels/http/routes/kg.ts`, replace the handler body (lines 1059-1127, from `app.post('/api/kg/chat/messages', ...` through its closing `});`) with the ack implementation:
+
+```typescript
+  /**
+   * POST /api/kg/chat/messages — publish a chat message and ack immediately.
+   *
+   * Body: { message: string, conversationId?: string }
+   * Response: 202 { conversationId }
+   *
+   * Ack-and-stream (#985): the handler publishes the inbound message and returns
+   * 202 without waiting for the agent's reply. The final reply and intermediate
+   * progress (skill.invoke / skill.result) arrive over GET /api/kg/chat/stream,
+   * which is the source of truth for the assistant turn. This removes the former
+   * synchronous 120s wait that 504'd on long tasks (browser automation, delegation
+   * chains, research).
+   */
+  app.post('/api/kg/chat/messages', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+
+    const body = request.body as { message?: unknown; conversationId?: unknown };
+    if (typeof body?.message !== 'string' || body.message.trim().length === 0) {
+      return reply.status(400).send({ error: 'Missing required field: message (non-empty string)' });
+    }
+
+    const conversationId =
+      typeof body.conversationId === 'string' && body.conversationId.length > 0
+        ? body.conversationId
+        : `kg-web-${randomUUID()}`;
+
+    try {
+      await bus.publish('channel', createInboundMessage({
+        conversationId,
+        channelId: WEB_CHANNEL_ID,
+        senderId: WEB_SENDER_ID,
+        content: body.message,
+        // Tag with structural channel trust level — session-cookie auth earns medium trust,
+        // same as bearer token auth on the API channel. Required for messageTrustScore computation.
+        metadata: { trustLevel: 'medium' },
+      }));
+    } catch (publishErr) {
+      const message = publishErr instanceof Error ? publishErr.message : String(publishErr);
+      logger.error({ err: publishErr, conversationId }, 'KG chat message publish failed');
+      return reply.status(500).send({ error: message });
+    }
+
+    // Ack: the reply is delivered over the SSE stream, not this response.
+    return reply.status(202).send({ conversationId });
+  });
+```
+
+- [ ] **Step 4: Prune now-unused imports and constant**
+
+In `src/channels/http/routes/kg.ts`:
+- Line 10: change `import { type EventRouter, mapWaitFailureToHttp } from '../event-router.js';` → `import type { EventRouter } from '../event-router.js';` (`mapWaitFailureToHttp` is no longer used in this file).
+- Line 36: delete `const CHAT_RESPONSE_TIMEOUT_MS = 120_000;` (no longer referenced).
+- Leave `markdownToHtml` (line 12) — still used by the `/history` route.
+
+- [ ] **Step 5: Run the tests + typecheck to verify they pass**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream test tests/unit/channels/http/kg-chat-routes.test.ts`
+Expected: PASS.
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream run typecheck`
+Expected: no errors (confirms no dangling references to the removed import/constant).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream add src/channels/http/routes/kg.ts tests/unit/channels/http/kg-chat-routes.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream commit -m "feat: POST /api/kg/chat/messages acks with 202 instead of blocking (#985)"
+```
+
+---
+
+## Task 3: Frontend SSE parsing — `parseSseEvent` returns a discriminated event + recovery helper
+
+**Files:**
+- Modify: `apps/console/src/pages/chat/types.ts`
+- Modify: `apps/console/src/pages/chat/chat-utils.ts`
+- Test: `apps/console/src/pages/chat/chat-utils.test.ts`
+
+- [ ] **Step 1: Add shared types**
+
+In `apps/console/src/pages/chat/types.ts`, append:
+
+```typescript
+/**
+ * A parsed SSE event from GET /api/kg/chat/stream, normalized for the chat UI.
+ * - status:   intermediate progress (skill invocation) — append as a status line.
+ * - reply:    the agent's final reply for this turn (terminal).
+ * - rejected: the turn was rejected before reaching the agent (terminal error).
+ * parseSseEvent returns null for everything else (skill.result, malformed, etc.).
+ */
+export type SseEvent =
+  | { kind: 'status'; text: string }
+  | { kind: 'reply'; text: string; html: string | null }
+  | { kind: 'rejected'; text: string };
+
+/** A chat history row as returned by GET /api/kg/chat/history. */
+export interface HistoryMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  html: string | null;
+  timestamp: string;
+}
+```
+
+- [ ] **Step 2: Rewrite the `parseSseEvent` tests (failing)**
+
+In `apps/console/src/pages/chat/chat-utils.test.ts`, replace the entire `describe('parseSseEvent', ...)` block (lines 4-43) with:
+
+```typescript
+describe('parseSseEvent', () => {
+  it('returns a status event for skill.invoke', () => {
+    const data = JSON.stringify({ type: 'skill.invoke', skill: 'memory.recall', conversation_id: 'c1' });
+    expect(parseSseEvent(data)).toEqual({ kind: 'status', text: 'invoking memory.recall' });
+  });
+
+  it('falls back to "skill" when the skill field is absent', () => {
+    const data = JSON.stringify({ type: 'skill.invoke', conversation_id: 'c1' });
+    expect(parseSseEvent(data)).toEqual({ kind: 'status', text: 'invoking skill' });
+  });
+
+  it('returns a reply event with content and html for message events', () => {
+    const data = JSON.stringify({ type: 'message', content: 'Hello', html: '<p>Hello</p>' });
+    expect(parseSseEvent(data)).toEqual({ kind: 'reply', text: 'Hello', html: '<p>Hello</p>' });
+  });
+
+  it('returns a reply event with html: null when html is absent', () => {
+    const data = JSON.stringify({ type: 'message', content: 'Hi' });
+    expect(parseSseEvent(data)).toEqual({ kind: 'reply', text: 'Hi', html: null });
+  });
+
+  it('returns a rejected event with friendly text for message.rejected', () => {
+    const data = JSON.stringify({ type: 'message.rejected', reason: 'global_rate_limited' });
+    const result = parseSseEvent(data);
+    expect(result?.kind).toBe('rejected');
+    if (result?.kind !== 'rejected') throw new Error('expected rejected');
+    expect(result.text).toMatch(/rate limit/i);
+  });
+
+  it('returns null for skill.result events (not displayed)', () => {
+    expect(parseSseEvent(JSON.stringify({ type: 'skill.result', skill: 'memory.recall' }))).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseSseEvent('not-json')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseSseEvent('')).toBeNull();
+  });
+
+  it('returns null for non-object JSON', () => {
+    expect(parseSseEvent('42')).toBeNull();
+    expect(parseSseEvent('"hello"')).toBeNull();
+  });
+});
+
+describe('pickRecoveredReply', () => {
+  const sentAt = new Date('2026-06-15T12:00:00Z').getTime();
+
+  it('returns the most recent assistant reply that landed at or after the send time', () => {
+    const items = [
+      { id: '1', role: 'user' as const, content: 'q', html: null, timestamp: '2026-06-15T11:59:00Z' },
+      { id: '2', role: 'assistant' as const, content: 'old', html: null, timestamp: '2026-06-15T11:59:30Z' },
+      { id: '3', role: 'user' as const, content: 'q2', html: null, timestamp: '2026-06-15T12:00:00Z' },
+      { id: '4', role: 'assistant' as const, content: 'fresh', html: '<p>fresh</p>', timestamp: '2026-06-15T12:03:00Z' },
+    ];
+    expect(pickRecoveredReply(items, sentAt)).toEqual({ text: 'fresh', html: '<p>fresh</p>' });
+  });
+
+  it('returns null when no assistant reply landed after the send time', () => {
+    const items = [
+      { id: '1', role: 'user' as const, content: 'q', html: null, timestamp: '2026-06-15T12:00:00Z' },
+      { id: '2', role: 'assistant' as const, content: 'stale', html: null, timestamp: '2026-06-15T11:00:00Z' },
+    ];
+    expect(pickRecoveredReply(items, sentAt)).toBeNull();
+  });
+
+  it('returns null for an empty history page', () => {
+    expect(pickRecoveredReply([], sentAt)).toBeNull();
+  });
+});
+```
+
+Update the import on line 2 to include `pickRecoveredReply`:
+
+```typescript
+import { parseSseEvent, makeMessage, formatTimestamp, linkifyText, pickRecoveredReply } from './chat-utils.js';
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream test apps/console/src/pages/chat/chat-utils.test.ts`
+Expected: FAIL — `parseSseEvent` still returns strings/null and `pickRecoveredReply` does not exist.
+
+- [ ] **Step 4: Implement the new `parseSseEvent` and `pickRecoveredReply`**
+
+In `apps/console/src/pages/chat/chat-utils.ts`, update the import on line 1:
+
+```typescript
+import type { Message, SseEvent, HistoryMessage } from './types.js';
+```
+
+Replace the existing `parseSseEvent` function (lines 3-25) with:
+
+```typescript
+/**
+ * Friendly, user-facing text for a message.rejected reason code.
+ * Falls back to a generic message naming the reason for unrecognized codes.
+ */
+function rejectionText(reason: string): string {
+  switch (reason) {
+    case 'global_rate_limited':
+    case 'rate_limited':
+      return 'Rate limit reached. Please wait a moment and try again.';
+    case 'message_too_large':
+      return 'That message is too large to process.';
+    default:
+      return `Message rejected (${reason}).`;
+  }
+}
+
+/**
+ * Parses a raw SSE event data string from GET /api/kg/chat/stream into a
+ * normalized SseEvent, or null for events the chat UI ignores.
+ *
+ * Ack-and-stream (#985): the POST only acks, so the `message` event is now the
+ * source of truth for the agent's final reply (terminal). `message.rejected` is
+ * a terminal error. `skill.invoke` is intermediate progress. Everything else
+ * (skill.result, malformed payloads, unknown types) returns null.
+ */
+export function parseSseEvent(data: string): SseEvent | null {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(data);
+  } catch (parseErr) {
+    // Non-fatal: malformed SSE data is silently ignored.
+    // Log at debug level so it's visible in DevTools when investigating SSE issues.
+    console.debug('[parseSseEvent] failed to parse SSE data:', parseErr);
+    return null;
+  }
+  if (typeof payload !== 'object' || payload === null) return null;
+  const p = payload as Record<string, unknown>;
+
+  switch (p['type']) {
+    case 'skill.invoke': {
+      const skill = typeof p['skill'] === 'string' ? p['skill'] : 'skill';
+      return { kind: 'status', text: `invoking ${skill}` };
+    }
+    case 'message': {
+      const text = typeof p['content'] === 'string' ? p['content'] : '';
+      const html = typeof p['html'] === 'string' ? p['html'] : null;
+      return { kind: 'reply', text, html };
+    }
+    case 'message.rejected': {
+      const reason = typeof p['reason'] === 'string' ? p['reason'] : 'unknown';
+      return { kind: 'rejected', text: rejectionText(reason) };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Recovery helper for the client watchdog: given a page of chat history (oldest
+ * first) and the time we sent the current turn, return the most recent assistant
+ * reply that landed at or after the send time — the reply we may have missed if
+ * the SSE message event never arrived. Returns null if there's no such reply.
+ */
+export function pickRecoveredReply(
+  items: HistoryMessage[],
+  sentAtMs: number,
+): { text: string; html: string | null } | null {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const m = items[i]!;
+    if (m.role === 'assistant' && new Date(m.timestamp).getTime() >= sentAtMs) {
+      return { text: m.content, html: m.html };
+    }
+  }
+  return null;
+}
+```
+
+- [ ] **Step 5: Run the tests + typecheck to verify they pass**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream test apps/console/src/pages/chat/chat-utils.test.ts`
+Expected: PASS.
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream/apps/console run typecheck`
+Expected: errors only in `useChatSession.ts` (it still references the old `parseSseEvent` string contract and the local `HistoryMessage` type) — those are fixed in Task 4. If you see errors elsewhere, fix before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream add apps/console/src/pages/chat/types.ts apps/console/src/pages/chat/chat-utils.ts apps/console/src/pages/chat/chat-utils.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream commit -m "feat: parse terminal SSE events + history recovery helper for chat console (#985)"
+```
+
+---
+
+## Task 4: Frontend `useChatSession` — ack+stream send flow
+
+**Files:**
+- Modify: `apps/console/src/pages/chat/useChatSession.ts`
+
+No unit test is added for the hook itself: `apps/console` runs under the `node` Vitest environment with no React/DOM test harness (no `@testing-library/react`, no jsdom, no `EventSource`/`localStorage` polyfills). The testable logic (SSE parsing, reply recovery) was extracted into `chat-utils` and covered in Task 3. The hook wiring is verified here via typecheck + production build, and manually in Task 5. **Coverage gap to flag in the PR:** the onopen gate, terminal-event finalize, and watchdog timing are not unit-tested; introducing a React test harness for `apps/console` is worth a follow-up issue.
+
+- [ ] **Step 1: Replace the local `HistoryMessage` interface with the shared type**
+
+In `apps/console/src/pages/chat/useChatSession.ts`:
+- Update the import on line 5 to: `import type { Message, HistoryMessage } from './types.js';`
+- Delete the local `interface HistoryMessage { ... }` (lines 24-30). Keep `interface HistoryResponse` (lines 32-35) as-is.
+
+- [ ] **Step 2: Add constants for the watchdog and onopen gate**
+
+In `apps/console/src/pages/chat/useChatSession.ts`, after `const HISTORY_PAGE_SIZE = 25;` (line 13), add:
+
+```typescript
+// Ack-and-stream (#985): the reply arrives over SSE, not the POST. If no terminal
+// event arrives within this window (rare: a suppressed-duplicate turn or an agent
+// crash), the client fetches /history once to recover a missed reply, then shows a
+// soft notice and unlocks the composer WITHOUT closing the stream — a late reply
+// still renders. Deliberately long so legitimately slow tasks are never cut off.
+const REPLY_WATCHDOG_MS = 5 * 60_000;
+// How long to wait for the SSE connection to open before POSTing anyway. If the
+// stream is degraded the POST still publishes and the watchdog recovers the reply.
+const SSE_OPEN_TIMEOUT_MS = 3_000;
+// Shown when the watchdog fires and /history has no reply yet.
+const STILL_WORKING_TEXT =
+  'Still working on this — it is taking longer than usual. The reply will appear here when it is ready.';
+```
+
+- [ ] **Step 3: Rewrite the `send` function**
+
+Replace the entire `send` function (lines 189-281) with the ack+stream flow below. Key changes: open the stream and await `onopen` (bounded by `SSE_OPEN_TIMEOUT_MS`) before POSTing; treat the POST as an ack only; let the SSE terminal event finish the turn; arm a watchdog that recovers via `/history`.
+
+```typescript
+  async function send(text: string): Promise<void> {
+    if (isSending.current || text.trim().length === 0) return;
+
+    if (!conversationId.current) {
+      const newId = crypto.randomUUID();
+      conversationId.current = newId;
+      // Guarded for restricted browsing contexts (e.g. Safari private mode).
+      try { localStorage.setItem(CONV_ID_KEY, newId); } catch { /* best-effort */ }
+    }
+    const convId = conversationId.current;
+
+    // Close any stream left open by a prior turn's soft-recovery path before
+    // starting a new one, so we never leak a dangling EventSource.
+    sourceRef.current?.close();
+    sourceRef.current = null;
+
+    const sentAt = Date.now();
+    // Optimistic append so the user sees their message immediately.
+    setMessages((prev) => [
+      ...prev,
+      makeMessage('user', text, { timestamp: new Date() }),
+    ]);
+    isSending.current = true;
+    setSending(true);
+
+    let source: EventSource | undefined;
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+
+    // Unlock the composer (and stop the watchdog) without touching the stream —
+    // used by the soft-recovery path so a late reply can still render.
+    const unlock = () => {
+      if (watchdog) { clearTimeout(watchdog); watchdog = undefined; }
+      isSending.current = false;
+      setSending(false);
+    };
+    // Fully finish the turn: unlock and close the stream. Idempotent.
+    const finalize = () => {
+      if (settled) return;
+      settled = true;
+      unlock();
+      source?.close();
+      sourceRef.current = null;
+    };
+
+    // Watchdog recovery: fetch one history page and render a missed reply, else
+    // post a soft notice and unlock (leaving the stream open for a late reply).
+    const runRecovery = async () => {
+      try {
+        const res = await apiFetch(
+          `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}`,
+        );
+        if (res.ok) {
+          const data = (await res.json()) as HistoryResponse;
+          const recovered = pickRecoveredReply(data.messages, sentAt);
+          if (recovered) {
+            setMessages((prev) => [
+              ...prev,
+              makeMessage('agent', recovered.text, { html: recovered.html ?? undefined, timestamp: new Date() }),
+            ]);
+            finalize();
+            return;
+          }
+        } else {
+          console.error('[useChatSession] recovery history fetch non-ok:', res.status);
+        }
+      } catch (err) {
+        console.error('[useChatSession] recovery history fetch failed:', err);
+      }
+      // Nothing to recover yet — soft notice, unlock, keep the stream open.
+      setMessages((prev) => [...prev, makeMessage('status', STILL_WORKING_TEXT)]);
+      unlock();
+    };
+
+    try {
+      // Open the SSE stream and wait for it to connect BEFORE the POST, so a fast
+      // reply broadcast can't race past an unregistered stream. withCredentials
+      // sends the session cookie, matching apiFetch behavior.
+      source = new EventSource(
+        `/api/kg/chat/stream?conversationId=${encodeURIComponent(convId)}`,
+        { withCredentials: true },
+      );
+      sourceRef.current = source;
+
+      source.onmessage = (event: MessageEvent<string>) => {
+        const parsed = parseSseEvent(event.data);
+        if (!parsed) return;
+        if (parsed.kind === 'status') {
+          setMessages((prev) => [...prev, makeMessage('status', parsed.text)]);
+          return;
+        }
+        if (parsed.kind === 'reply') {
+          // Terminal: the agent's final reply for this turn.
+          setMessages((prev) => [
+            ...prev,
+            makeMessage('agent', parsed.text, { html: parsed.html ?? undefined, timestamp: new Date() }),
+          ]);
+          finalize();
+          return;
+        }
+        // parsed.kind === 'rejected' — terminal error.
+        setMessages((prev) => [...prev, makeMessage('error', parsed.text)]);
+        finalize();
+      };
+
+      source.onerror = (event) => {
+        // Non-fatal: EventSource auto-reconnects on transient errors. On a fatal
+        // close (readyState === CLOSED) the reply, if any, is recovered by the
+        // watchdog via /history. We do not finalize here so a reconnect can still
+        // deliver the terminal event.
+        console.error('[useChatSession] SSE stream error (readyState=%d):', source?.readyState, event);
+      };
+
+      // Wait for the stream to open, but don't block forever — if it doesn't open
+      // within SSE_OPEN_TIMEOUT_MS, POST anyway and let the watchdog recover.
+      await new Promise<void>((resolve) => {
+        if (!source) { resolve(); return; }
+        if (source.readyState === EventSource.OPEN) { resolve(); return; }
+        const to = setTimeout(resolve, SSE_OPEN_TIMEOUT_MS);
+        source.onopen = () => { clearTimeout(to); resolve(); };
+      });
+
+      const res = await apiFetch('/api/kg/chat/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text, conversationId: convId }),
+      });
+
+      if (!res.ok) {
+        let errMsg = `Error ${res.status}`;
+        try {
+          const errData = await res.json() as { error?: string };
+          if (errData.error) errMsg = errData.error;
+        } catch (bodyErr) {
+          // Non-JSON error body — log for debugging, fall back to HTTP status.
+          console.error('[useChatSession] failed to parse error response body:', bodyErr);
+        }
+        setMessages((prev) => [...prev, makeMessage('error', errMsg)]);
+        finalize();
+        return;
+      }
+
+      // 202 ack received. The reply arrives over SSE; arm the watchdog in case it
+      // never does (suppressed-duplicate turn or agent crash).
+      watchdog = setTimeout(() => { void runRecovery(); }, REPLY_WATCHDOG_MS);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Network error';
+      setMessages((prev) => [...prev, makeMessage('error', msg)]);
+      finalize();
+    }
+    // NOTE: no finally that clears sending/closes the stream — the turn is
+    // finished by the SSE terminal event, the watchdog, or an error path above.
+  }
+```
+
+Update the import on line 4 to include `pickRecoveredReply`:
+
+```typescript
+import { makeMessage, parseSseEvent, pickRecoveredReply } from './chat-utils.js';
+```
+
+- [ ] **Step 4: Typecheck the console app**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream/apps/console run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Build the console app**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream/apps/console run build`
+Expected: build succeeds (Vite emits to `dist/`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream add apps/console/src/pages/chat/useChatSession.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream commit -m "feat: web console chat renders reply from SSE stream, no sync wait (#985)"
+```
+
+---
+
+## Task 5: Full verification + changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the changelog entry**
+
+In `CHANGELOG.md`, under `## [Unreleased]` add a `### Changed` bullet (create the `### Changed` subsection if absent):
+
+```markdown
+- **Web console chat** — `POST /api/kg/chat/messages` now acks with `202` and the reply streams over SSE instead of blocking on a 120s synchronous wait, so long agent tasks (browser automation, delegation chains, research) complete without a 504. (#985)
+```
+
+- [ ] **Step 2: Run the full backend test suite**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream test`
+Expected: PASS (all suites, including the rewritten event-router, kg-chat-routes, and chat-utils tests).
+
+- [ ] **Step 3: Typecheck both packages**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream run typecheck`
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream/apps/console run typecheck`
+Expected: no errors in either.
+
+- [ ] **Step 4: Lint**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream run lint`
+Expected: no new errors.
+
+- [ ] **Step 5: Manual verification (acceptance criteria)**
+
+Per `superpowers:verification-before-completion`, run the app and exercise the chat:
+1. Start the stack (or the console dev server against a running backend) and open the web console chat.
+2. **Fast chat (<5s):** send a short message; confirm the reply appears promptly and the composer re-enables — still feels synchronous.
+3. **Long task (>120s):** send a message that triggers a multi-step/delegation turn; confirm `invoking …` status lines appear during the wait and the final reply renders when ready, with **no 504 / no error**, past the old 120s cliff.
+4. Confirm the Network tab shows the POST returning **202** immediately (not held open for minutes).
+Record what you observed (the actual reply, timing) as evidence before claiming done.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-chat-ack-stream commit -m "docs: changelog for chat ack-and-stream (#985)"
+```
+
+---
+
+## Post-implementation
+
+- Run the pre-PR review subagents (code-reviewer, silent-failure-hunter) per global workflow.
+- Open a PR with `Closes #985` in the Summary. CHANGELOG already updated.
+- **Spotted-in-passing (do not fix here):** the `@TODO` at `event-router.ts:144-148` notes `sseClients` is shared across `/api/messages/stream` and `/api/kg/chat/stream` with no per-endpoint `channelId` filter. Out of scope for #985 — mention in the PR, don't touch.
+
+## Self-review notes (author)
+
+- **Spec coverage:** POST→202 (Task 2), SSE html (Task 1), frontend onopen-gate + terminal render + watchdog recovery (Tasks 3-4), tests (Tasks 1-3), changelog + manual AC check (Task 5). All four acceptance criteria map to Task 5 Step 5.
+- **Type consistency:** `SseEvent` and `HistoryMessage` defined once in `types.ts`, consumed by `chat-utils.ts` and `useChatSession.ts`; `parseSseEvent` returns `SseEvent | null` everywhere; `pickRecoveredReply` signature matches its call site.
+- **Known coverage gap (called out in Task 4):** hook timing/onopen/watchdog not unit-tested — no React harness in `apps/console`; logic extracted to tested pure helpers; follow-up issue suggested.

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -170,7 +170,15 @@ export class EventRouter {
       try {
         html = markdownToHtml(event.payload.content);
       } catch (renderErr) {
-        this.logger.warn({ err: renderErr, conversationId: convId }, 'markdownToHtml failed for SSE message; sending html: null');
+        // Include the content length so the failure is reproducible from the log
+        // (conversationId alone can't recover the offending content once working_memory
+        // rolls). Guard the .length read: content may be a non-string in the throw case.
+        const contentLength =
+          typeof event.payload.content === 'string' ? event.payload.content.length : undefined;
+        this.logger.warn(
+          { err: renderErr, conversationId: convId, contentLength },
+          'markdownToHtml failed for SSE message; sending html: null',
+        );
       }
       const sseData = JSON.stringify({
         type: 'message',

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -13,6 +13,7 @@ import type { EventBus } from '../../bus/bus.js';
 import type { BusEvent } from '../../bus/events.js';
 import type { Logger } from '../../logger.js';
 import type { ServerResponse } from 'node:http';
+import { markdownToHtml } from '../../utils/markdown-to-html.js';
 
 /**
  * Thrown by the event router when the dispatcher rejects a message. Typed
@@ -160,10 +161,22 @@ export class EventRouter {
       // Stream to all SSE clients (filtered by conversationId if set).
       // Wrap writes in try/catch so a dead client doesn't abort delivery
       // to the remaining clients in this dispatch cycle.
+      //
+      // Render markdown→HTML server-side so the SSE consumer (the web console)
+      // gets the same pre-rendered HTML the POST path used to return. Wrapped in
+      // try/catch: a render failure must degrade to html: null, never drop the
+      // message event. (#985)
+      let html: string | null = null;
+      try {
+        html = markdownToHtml(event.payload.content);
+      } catch (renderErr) {
+        this.logger.warn({ err: renderErr, conversationId: convId }, 'markdownToHtml failed for SSE message; sending html: null');
+      }
       const sseData = JSON.stringify({
         type: 'message',
         conversation_id: convId,
         content: event.payload.content,
+        html,
         timestamp: event.timestamp,
       });
       this.broadcastToSseClients(sseData, convId);

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1079,9 +1079,10 @@ export async function knowledgeGraphRoutes(
         metadata: { trustLevel: 'medium' },
       }));
     } catch (publishErr) {
-      const message = publishErr instanceof Error ? publishErr.message : String(publishErr);
+      // Log the real error server-side (full context) but return a fixed,
+      // client-safe message — don't echo internal bus/implementation detail back.
       logger.error({ err: publishErr, conversationId }, 'KG chat message publish failed');
-      return reply.status(500).send({ error: message });
+      return reply.status(500).send({ error: 'Failed to publish chat message.' });
     }
 
     // Ack: the reply is delivered over the SSE stream, not this response.

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -7,7 +7,7 @@ import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import { ContactValidationError } from '../../../contacts/contact-service.js';
 import type { Contact, ContactCanonicalFields, ContactStatus, TrustLevel } from '../../../contacts/types.js';
-import { type EventRouter, mapWaitFailureToHttp } from '../event-router.js';
+import type { EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { markdownToHtml } from '../../../utils/markdown-to-html.js';
 import { stripOutboundContextPreamble } from '../../../dispatch/outbound-context.js';
@@ -30,10 +30,6 @@ export interface KnowledgeGraphRouteOptions {
   // so both can accept the curia_session cookie for authentication.
   sessions: SessionStore;
 }
-
-// How long the chat POST waits for an agent response before timing out.
-// Mirrors RESPONSE_TIMEOUT_MS in src/channels/http/routes/messages.ts — keep in sync.
-const CHAT_RESPONSE_TIMEOUT_MS = 120_000;
 
 // Channel identifier used when the KG web app dispatches messages to the agent layer.
 // The 'web' channel is special-cased in contact-resolver.ts to auto-resolve to the CEO —
@@ -1047,14 +1043,17 @@ export async function knowledgeGraphRoutes(
   // (programmatic flow, e.g. tests and scripts).
 
   /**
-   * POST /api/kg/chat/messages — dispatch a chat message, wait for the agent response.
+   * POST /api/kg/chat/messages — publish a chat message and ack immediately.
    *
    * Body: { message: string, conversationId?: string }
-   * Response: { reply: string, conversationId: string }
+   * Response: 202 { conversationId }
    *
-   * Mirrors the publish/wait pattern in POST /api/messages: register the waiter BEFORE
-   * publishing so a fast response isn't missed, then map publish/timeout/rejection
-   * errors to structured HTTP status codes.
+   * Ack-and-stream (#985): the handler publishes the inbound message and returns
+   * 202 without waiting for the agent's reply. The final reply and intermediate
+   * progress (skill.invoke / skill.result) arrive over GET /api/kg/chat/stream,
+   * which is the source of truth for the assistant turn. This removes the former
+   * synchronous 120s wait that 504'd on long tasks (browser automation, delegation
+   * chains, research).
    */
   app.post('/api/kg/chat/messages', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
@@ -1069,9 +1068,6 @@ export async function knowledgeGraphRoutes(
         ? body.conversationId
         : `kg-web-${randomUUID()}`;
 
-    // Register the waiter BEFORE publishing so we don't race past a fast reply.
-    const responsePromise = eventRouter.waitForResponse(conversationId, CHAT_RESPONSE_TIMEOUT_MS);
-
     try {
       await bus.publish('channel', createInboundMessage({
         conversationId,
@@ -1083,47 +1079,13 @@ export async function knowledgeGraphRoutes(
         metadata: { trustLevel: 'medium' },
       }));
     } catch (publishErr) {
-      // Publish failed synchronously — cancel our pending waiter (still ours, nothing
-      // has had a chance to supersede it yet) and surface a 500.
-      eventRouter.cancelPending(conversationId);
       const message = publishErr instanceof Error ? publishErr.message : String(publishErr);
       logger.error({ err: publishErr, conversationId }, 'KG chat message publish failed');
       return reply.status(500).send({ error: message });
     }
 
-    // waitForResponse never rejects — it resolves with a discriminated WaitResult.
-    // This is the crux of the #983 fix: a timeout/supersede firing after the client
-    // has disconnected can no longer escape as an unhandledRejection.
-    //
-    // The try/catch is belt-and-suspenders: the await itself can't reject, but the
-    // post-resolution work (markdownToHtml, reply.send, the exhaustiveness guard
-    // below) could, and any unexpected throw must route through the route's failure
-    // path as a clean 500 rather than escaping the handler.
-    try {
-      const result = await responsePromise;
-
-      if (result.ok) {
-        // Per-try/catch so a markdownToHtml failure falls back gracefully rather
-        // than turning a successful agent response into a 500.
-        let html: string | null = null;
-        try {
-          html = markdownToHtml(result.content);
-        } catch (convErr) {
-          logger.warn({ err: convErr, conversationId }, 'markdownToHtml failed for chat reply; sending plain text');
-        }
-        return reply.send({ reply: result.content, html, conversationId });
-      }
-
-      // Non-ok outcome — map to the shared HTTP status/message contract.
-      const { status, message } = mapWaitFailureToHttp(result);
-      logger.error({ conversationId, kind: result.kind }, 'KG chat message handling failed');
-      return reply.status(status).send({ error: message });
-    } catch (err) {
-      // Unexpected failure in the post-resolution path — log and return a clean 500
-      // rather than letting it escape the route handler.
-      logger.error({ err, conversationId }, 'KG chat message handling failed unexpectedly');
-      return reply.status(500).send({ error: 'Internal error handling chat message' });
-    }
+    // Ack: the reply is delivered over the SSE stream, not this response.
+    return reply.status(202).send({ conversationId });
   });
 
   /**

--- a/tests/unit/channels/http/event-router.test.ts
+++ b/tests/unit/channels/http/event-router.test.ts
@@ -12,6 +12,7 @@ import { EventRouter, MessageRejectedError } from '../../../../src/channels/http
 import type { EventBus } from '../../../../src/bus/bus.js';
 import type { BusEvent } from '../../../../src/bus/events.js';
 import type { Logger } from '../../../../src/logger.js';
+import type { ServerResponse } from 'node:http';
 
 function createLogger(): Logger {
   return {
@@ -124,5 +125,50 @@ describe('EventRouter.waitForResponse', () => {
     }
 
     expect(captured).toEqual([]);
+  });
+});
+
+describe('EventRouter SSE — outbound.message html rendering', () => {
+  it('includes server-rendered html alongside markdown content', () => {
+    const { router, emit } = makeRouter();
+    const writes: string[] = [];
+    const res = { write: (chunk: string) => { writes.push(chunk); return true; } };
+    router.addSseClient({ res: res as unknown as ServerResponse, conversationId: 'c1' });
+
+    emit({
+      type: 'outbound.message',
+      timestamp: '2026-06-15T00:00:00.000Z',
+      payload: { channelId: 'web', conversationId: 'c1', content: 'hello **world**' },
+    } as unknown as BusEvent);
+
+    // The SSE frame is `data: <json>\n\n`. Strip the prefix/suffix and parse.
+    const frame = writes.find((w) => w.startsWith('data: '));
+    expect(frame).toBeDefined();
+    const payload = JSON.parse(frame!.slice('data: '.length).trim()) as {
+      type: string; content: string; html: string | null;
+    };
+    expect(payload.type).toBe('message');
+    expect(payload.content).toBe('hello **world**');
+    expect(payload.html).toContain('<strong>world</strong>');
+  });
+
+  it('falls back to html: null when markdown rendering throws', () => {
+    const { router, emit } = makeRouter();
+    const writes: string[] = [];
+    const res = { write: (chunk: string) => { writes.push(chunk); return true; } };
+    router.addSseClient({ res: res as unknown as ServerResponse, conversationId: 'c2' });
+
+    // A non-string content slips past the type system via the cast and makes
+    // markdownToHtml throw; the event must still be delivered with html: null.
+    emit({
+      type: 'outbound.message',
+      timestamp: '2026-06-15T00:00:00.000Z',
+      payload: { channelId: 'web', conversationId: 'c2', content: { not: 'a string' } },
+    } as unknown as BusEvent);
+
+    const frame = writes.find((w) => w.startsWith('data: '));
+    expect(frame).toBeDefined();
+    const payload = JSON.parse(frame!.slice('data: '.length).trim()) as { html: string | null };
+    expect(payload.html).toBeNull();
   });
 });

--- a/tests/unit/channels/http/kg-chat-routes.test.ts
+++ b/tests/unit/channels/http/kg-chat-routes.test.ts
@@ -13,7 +13,7 @@ import type { Logger } from '../../../../src/logger.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { knowledgeGraphRoutes } from '../../../../src/channels/http/routes/kg.js';
 import type { EventBus } from '../../../../src/bus/bus.js';
-import { MessageRejectedError, type EventRouter } from '../../../../src/channels/http/event-router.js';
+import { type EventRouter } from '../../../../src/channels/http/event-router.js';
 
 function createLogger(): Logger {
   return {
@@ -31,12 +31,11 @@ function createPool(): Pick<Pool, 'query'> {
   return { query: vi.fn() } as unknown as Pick<Pool, 'query'>;
 }
 
-// Create a mock EventRouter whose waitForResponse resolves immediately with a
-// canned reply so the route handler can complete synchronously in tests.
-// waitForResponse resolves a discriminated WaitResult (never rejects) — see #983.
-function createMockEventRouter(reply = 'Hello from Curia'): EventRouter {
+// The ack-and-stream POST no longer calls waitForResponse; it only publishes and
+// returns 202. We keep addSseClient/setupSubscriptions for the stream route wiring.
+function createMockEventRouter(): EventRouter {
   return {
-    waitForResponse: vi.fn().mockResolvedValue({ ok: true, content: reply }),
+    waitForResponse: vi.fn(),
     cancelPending: vi.fn(),
     addSseClient: vi.fn().mockReturnValue(() => { /* cleanup noop */ }),
     setupSubscriptions: vi.fn(),
@@ -104,9 +103,9 @@ describe('KG chat routes', () => {
 
   // ── Happy path: authenticated via x-web-bootstrap-secret header ───────
 
-  it('POST /api/kg/chat/messages — 200 with valid bootstrap-secret header', async () => {
+  it('POST /api/kg/chat/messages — 202 ack with valid bootstrap-secret header', async () => {
     const bus = createMockBus();
-    const eventRouter = createMockEventRouter('Hey there!');
+    const eventRouter = createMockEventRouter();
 
     const app = Fastify();
     await app.register(cookie);
@@ -126,14 +125,15 @@ describe('KG chat routes', () => {
       payload: { message: 'What is on the agenda?', conversationId: 'test-convo-1' },
     });
 
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(202);
     const body = response.json();
-    expect(body.reply).toBe('Hey there!');
     expect(body.conversationId).toBe('test-convo-1');
+    // The reply now arrives over SSE, not in the POST body.
+    expect(body.reply).toBeUndefined();
 
-    // Verify the bus and eventRouter were called correctly.
+    // The inbound message was published; the handler does NOT block on a reply.
     expect(bus.publish).toHaveBeenCalledOnce();
-    expect(eventRouter.waitForResponse).toHaveBeenCalledWith('test-convo-1', expect.any(Number));
+    expect(eventRouter.waitForResponse).not.toHaveBeenCalled();
 
     await app.close();
   });
@@ -162,9 +162,37 @@ describe('KG chat routes', () => {
     await app.close();
   });
 
+  it('POST /api/kg/chat/messages — 500 when publish fails synchronously', async () => {
+    const bus = {
+      publish: vi.fn().mockRejectedValue(new Error('bus down')),
+      subscribe: vi.fn(),
+    } as unknown as EventBus;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(knowledgeGraphRoutes, {
+      pool: createPool() as Pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'test-secret',
+      secureCookies: false,
+      bus,
+      eventRouter: createMockEventRouter(),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/kg/chat/messages',
+      headers: { 'x-web-bootstrap-secret': 'test-secret' },
+      payload: { message: 'hello', conversationId: 'c-fail' },
+    });
+
+    expect(response.statusCode).toBe(500);
+    await app.close();
+  });
+
   it('POST /api/kg/chat/messages — auto-generates conversationId when omitted', async () => {
     const bus = createMockBus();
-    const eventRouter = createMockEventRouter('reply');
+    const eventRouter = createMockEventRouter();
 
     const app = Fastify();
     await app.register(cookie);
@@ -184,149 +212,12 @@ describe('KG chat routes', () => {
       payload: { message: 'hi' },
     });
 
-    expect(response.statusCode).toBe(200);
-    // A generated conversationId should be returned and match the waiter call.
+    expect(response.statusCode).toBe(202);
     const body = response.json();
     expect(typeof body.conversationId).toBe('string');
     expect(body.conversationId.length).toBeGreaterThan(0);
-    expect(eventRouter.waitForResponse).toHaveBeenCalledWith(body.conversationId, expect.any(Number));
+    expect(eventRouter.waitForResponse).not.toHaveBeenCalled();
 
-    await app.close();
-  });
-
-  // ── WaitResult outcome mapping (#983) ─────────────────────────────────
-  //
-  // waitForResponse resolves a discriminated result rather than rejecting, so the
-  // handler maps each non-ok outcome to a status code without try/catch control flow.
-
-  it('POST /api/kg/chat/messages — 504 when the agent response times out', async () => {
-    const eventRouter = {
-      waitForResponse: vi.fn().mockResolvedValue({ ok: false, kind: 'timeout' }),
-      cancelPending: vi.fn(),
-      addSseClient: vi.fn().mockReturnValue(() => {}),
-      setupSubscriptions: vi.fn(),
-    } as unknown as EventRouter;
-
-    const app = Fastify();
-    await app.register(cookie);
-    await app.register(knowledgeGraphRoutes, {
-      pool: createPool() as Pool,
-      logger: createLogger(),
-      webAppBootstrapSecret: 'test-secret',
-      secureCookies: false,
-      bus: createMockBus(),
-      eventRouter,
-    });
-
-    const response = await app.inject({
-      method: 'POST',
-      url: '/api/kg/chat/messages',
-      headers: { 'x-web-bootstrap-secret': 'test-secret' },
-      payload: { message: 'slow one' },
-    });
-
-    expect(response.statusCode).toBe(504);
-    expect(response.json().error).toMatch(/timeout/i);
-    await app.close();
-  });
-
-  it('POST /api/kg/chat/messages — 403 when the message is rejected by policy', async () => {
-    const eventRouter = {
-      waitForResponse: vi.fn().mockResolvedValue({
-        ok: false,
-        kind: 'rejected',
-        error: new MessageRejectedError('blocked_sender'),
-      }),
-      cancelPending: vi.fn(),
-      addSseClient: vi.fn().mockReturnValue(() => {}),
-      setupSubscriptions: vi.fn(),
-    } as unknown as EventRouter;
-
-    const app = Fastify();
-    await app.register(cookie);
-    await app.register(knowledgeGraphRoutes, {
-      pool: createPool() as Pool,
-      logger: createLogger(),
-      webAppBootstrapSecret: 'test-secret',
-      secureCookies: false,
-      bus: createMockBus(),
-      eventRouter,
-    });
-
-    const response = await app.inject({
-      method: 'POST',
-      url: '/api/kg/chat/messages',
-      headers: { 'x-web-bootstrap-secret': 'test-secret' },
-      payload: { message: 'who are you' },
-    });
-
-    expect(response.statusCode).toBe(403);
-    await app.close();
-  });
-
-  it('POST /api/kg/chat/messages — 429 when the message is rate-limited', async () => {
-    // Rate-limit rejections must surface their own status code (429), matching
-    // /api/messages — not a hardcoded 403. See CodeAnt review on PR #989.
-    const eventRouter = {
-      waitForResponse: vi.fn().mockResolvedValue({
-        ok: false,
-        kind: 'rejected',
-        error: new MessageRejectedError('sender_rate_limited'),
-      }),
-      cancelPending: vi.fn(),
-      addSseClient: vi.fn().mockReturnValue(() => {}),
-      setupSubscriptions: vi.fn(),
-    } as unknown as EventRouter;
-
-    const app = Fastify();
-    await app.register(cookie);
-    await app.register(knowledgeGraphRoutes, {
-      pool: createPool() as Pool,
-      logger: createLogger(),
-      webAppBootstrapSecret: 'test-secret',
-      secureCookies: false,
-      bus: createMockBus(),
-      eventRouter,
-    });
-
-    const response = await app.inject({
-      method: 'POST',
-      url: '/api/kg/chat/messages',
-      headers: { 'x-web-bootstrap-secret': 'test-secret' },
-      payload: { message: 'spam spam spam' },
-    });
-
-    expect(response.statusCode).toBe(429);
-    await app.close();
-  });
-
-  it('POST /api/kg/chat/messages — 500 when the waiter is superseded', async () => {
-    const eventRouter = {
-      waitForResponse: vi.fn().mockResolvedValue({ ok: false, kind: 'superseded' }),
-      cancelPending: vi.fn(),
-      addSseClient: vi.fn().mockReturnValue(() => {}),
-      setupSubscriptions: vi.fn(),
-    } as unknown as EventRouter;
-
-    const app = Fastify();
-    await app.register(cookie);
-    await app.register(knowledgeGraphRoutes, {
-      pool: createPool() as Pool,
-      logger: createLogger(),
-      webAppBootstrapSecret: 'test-secret',
-      secureCookies: false,
-      bus: createMockBus(),
-      eventRouter,
-    });
-
-    const response = await app.inject({
-      method: 'POST',
-      url: '/api/kg/chat/messages',
-      headers: { 'x-web-bootstrap-secret': 'test-secret' },
-      payload: { message: 'newer request won' },
-    });
-
-    expect(response.statusCode).toBe(500);
     await app.close();
   });
 

--- a/tests/unit/channels/http/kg-chat-routes.test.ts
+++ b/tests/unit/channels/http/kg-chat-routes.test.ts
@@ -1,9 +1,9 @@
 // Unit tests for the KG web app chat endpoints:
-//   POST /api/kg/chat/messages — dispatch a message, await agent response
+//   POST /api/kg/chat/messages — publish a message and ack 202 (reply arrives over SSE)
 //   GET  /api/kg/chat/stream  — SSE event stream
 //
-// Focuses on the auth guard and the happy path. The full publish/wait contract
-// is covered by the integration test suite; here we only need to verify that
+// Focuses on the auth guard and the ack contract. The reply delivery is covered
+// by the SSE stream (see event-router tests); here we only need to verify that
 // the routes are wired up correctly and enforce the session/secret auth.
 
 import Fastify from 'fastify';


### PR DESCRIPTION
## **User description**
## Summary

Closes #985.

`POST /api/kg/chat/messages` used to block synchronously for up to `CHAT_RESPONSE_TIMEOUT_MS` (120s) on the full agent reply, then 504 on anything slower — which long web-console tasks (browser automation, multi-agent delegation, research) hit routinely. This switches the route to **ack-and-stream**: the POST publishes the inbound message and returns `202 { conversationId }` immediately, and the reply (plus intermediate progress) is delivered over the existing SSE stream, which is now the source of truth for the assistant turn.

### What changed
- **Backend POST** (`src/channels/http/routes/kg.ts`) — returns `202 { conversationId }` after publishing; the synchronous `waitForResponse` + `WaitResult`→HTTP mapping is removed (unused `mapWaitFailureToHttp` import and `CHAT_RESPONSE_TIMEOUT_MS` pruned). Auth (401), empty-message (400), no-secret (503), and synchronous-publish-failure (500) paths are retained. `messages.ts` is untouched and still uses `waitForResponse`.
- **SSE event** (`src/channels/http/event-router.ts`) — the `outbound.message` frame now carries a server-rendered `html` field (via `markdownToHtml`), additive and harmless to `/api/messages/stream` consumers. A render failure degrades to `html: null` (logged with `contentLength`), never dropping the event.
- **Frontend** (`apps/console/src/pages/chat/`) — `parseSseEvent` now returns a discriminated `SseEvent` (status / reply / rejected); `useChatSession` gates the POST on the SSE connection opening, renders the final reply from the SSE terminal event (no client-side cliff on long tasks), and recovers a missed reply via `/api/kg/chat/history`. Recovery gives honest feedback: a found reply renders; a failed `/history` fetch says "status unknown, resend"; a successful-but-empty fetch shows a soft "taking longer" notice without over-promising. A fatal stream close (e.g. expired session) triggers recovery immediately instead of waiting out the 5-minute watchdog.

### Acceptance criteria
- [x] >120s task completes and shows its result without an error (no synchronous timeout)
- [x] POST returns promptly (202), no connection held for minutes
- [x] Intermediate progress (skill invocations) visible during long tasks
- [x] Fast (<5s) chats still feel synchronous (onopen-gated POST + SSE terminal event)

## Test Plan
- [x] `pnpm test` — 3475 pass (2 pre-existing DB-integration files fail only for lack of `DATABASE_URL`, unrelated to this branch)
- [x] Root + `apps/console` typecheck clean; `apps/console` build succeeds; lint clean (1 pre-existing warning in an untouched file)
- [x] New/rewritten unit tests: `event-router.test.ts` (SSE html + null fallback), `kg-chat-routes.test.ts` (202 ack contract), `chat-utils.test.ts` (`parseSseEvent` discriminated shapes + `pickRecoveredReply`)
- [ ] **Manual e2e (recommend before merge):** run the console against a live backend; confirm a fast chat feels synchronous, a >120s delegation task streams progress and renders its reply with no 504, and the POST returns 202 immediately in the Network tab.

## Notes
- #983 (uncaught-rejection hardening) is independent: this route no longer registers a waiter, but `messages.ts` still uses `waitForResponse`.
- Out of scope (pre-existing `@TODO` at `event-router.ts:144`): the shared `sseClients` Set has no per-endpoint `channelId` filter. Noted, not touched.
- No client telemetry hook exists for the new recovery/missed-event paths; worth a follow-up so the missed-SSE rate is observable in prod.


___

## **CodeAnt-AI Description**
**Make web console chat return immediately and stream replies**

### What Changed
- Chat messages now return a `202` confirmation right away instead of waiting for the full answer, so long tasks keep running without hitting the old 120-second timeout.
- The chat UI now reads the final reply from the live stream, shows progress updates while the agent works, and recovers a missed reply from chat history if the stream drops.
- Streamed replies now include pre-rendered HTML, and render failures fall back to plain text without losing the message.

### Impact
`✅ Fewer 120-second chat timeouts`
`✅ Long-running chat tasks finish without blocking the page`
`✅ Clearer progress during multi-step replies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat messages now return a `202` acknowledgement immediately instead of waiting synchronously, with replies streaming in real-time via Server-Sent Events.
  * Eliminates `504` timeout errors on long-running agent operations.

* **Documentation**
  * Added implementation planning documentation for chat streaming delivery model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->