### PR TITLE
fix: sanitize object skill output structurally to prevent JSON corruption (#986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Execution-layer output sanitization** — object-returning skills whose string values contain HTML (e.g. email bodies) no longer produce corrupted JSON. `sanitizeObjectOutput` walks the result structure and sanitizes string leaves directly; JSON structural characters are never exposed to the HTML stripper. Fixes the `ceo-inbox-search` retry loop incident. (#986)
 - **Stale Xvfb lock recovery** — `BrowserService` now clears an orphaned `/tmp/.X99-lock` + socket left by an unclean exit before spawning Xvfb, guarded on a live X server so an active display is never clobbered; the web-browser skill survives a crash-induced restart. (#982)
 - **Secret-capture link redaction** — the one-time capture URL's token was scrubbed to `[REDACTED]` by the output sanitizer; the two capture skills now declare `skip_secret_redaction` so the link reaches the user intact. (#971)
 - **Secret-capture link relayed verbatim** — the token is now a short base64url slug (not a 64-char hex hash) and the skill summaries instruct the agent to relay the URL verbatim, so the model no longer self-redacts the link as a credential. (#971)

--- a/docs/wip/2026-06-15-issue-986-sanitize-object-output-design.md
+++ b/docs/wip/2026-06-15-issue-986-sanitize-object-output-design.md
@@ -1,0 +1,173 @@
+# Design: Execution-layer structural output sanitization (issue #986)
+
+**Date:** 2026-06-15
+**Issue:** [#986](https://github.com/josephfung/curia/issues/986)
+**Status:** Approved, pending implementation
+
+---
+
+## Problem
+
+`ExecutionLayer.invoke` sanitizes object-returning skill results with a
+stringify→mutate→reparse round-trip:
+
+```
+JSON.stringify(result.data)       // object → flat string
+sanitizeOutput(raw, { maxLength }) // HTML stripper mutates the string
+JSON.parse(sanitized)             // throws when structural chars were removed
+```
+
+`sanitizeOutput` runs an HTML parser over the *entire serialized JSON document*.
+When a string value inside the document contains an HTML tag
+(`<style>`, `<script>`, `<div>`, etc.), the parser strips the tag — along with
+any structural JSON characters that happen to be inside it (quotes, braces).
+The resulting string is no longer valid JSON. On parse failure, the execution
+layer returned the corrupted string as `{ success: true, data: corruptedString }`,
+which agents could not use, triggering retry loops.
+
+Observed in prod (2026-06-15): `ceo-inbox-search` returns Nylas message objects
+whose `body` field is HTML. The sanitizer mangled the serialized JSON →
+`SyntaxError: Unterminated string in JSON at position 2756`. The `ceo-inbox`
+agent received corrupted output, could not parse it, and re-ran the skill 8+
+times before the 120s request window closed.
+
+---
+
+## Root cause
+
+`sanitizeOutput` is a *string-level* transform. It has no awareness of JSON
+structure. Applying it to a serialized JSON document is safe only if every
+string value in that document contains no HTML markup — a guarantee that cannot
+be made for email bodies or any other user-generated rich text.
+
+---
+
+## Fix
+
+Sanitize *structurally*: walk the object, apply `sanitizeOutput` to each string
+leaf value, and return the sanitized object. JSON keys and structural characters
+are never exposed to the HTML stripper or secret redactor.
+
+---
+
+## Architecture
+
+### New function: `sanitizeObjectOutput` in `src/skills/sanitize.ts`
+
+```ts
+export function sanitizeObjectOutput(
+  data: unknown,
+  options: Omit<SanitizeOptions, 'isError'> = {},
+): unknown
+```
+
+**Walker behaviour by node type:**
+
+| Node type | Action |
+|---|---|
+| `string` | Call `sanitizeOutput(leaf, options)` — tag-strip, redact, truncate per-value |
+| `Array` | Map each element through the walker recursively |
+| Plain `object` | Map each value through the walker; keys are not sanitized |
+| `number` / `boolean` / `null` / `undefined` | Returned as-is |
+
+`isError` is excluded from the options type — wrapping a structured object in
+`<tool_error>` tags is not meaningful. The execution layer's error path is
+handled separately as a string.
+
+**Truncation:** `maxLength` from `SanitizeOptions` is applied *per string leaf
+value*. Each individual string is independently capped. This is simpler and less
+error-prone than a shared budget, and matches the existing per-string behaviour
+of `sanitizeOutput`.
+
+**Reuse:** The walker calls the existing `sanitizeOutput` for each leaf, which
+already handles tag-stripping, secret redaction, `skipSecretRedaction`, and
+`extraRedactPatterns` in the correct order. No logic is duplicated.
+
+### Changes to `src/skills/execution.ts`
+
+The object-result branch (lines 977–990) is replaced:
+
+**Before (broken):**
+```ts
+const raw = JSON.stringify(result.data);
+const sanitized = sanitizeOutput(raw, { maxLength, skipSecretRedaction });
+try {
+  return { success: true, data: JSON.parse(sanitized) };
+} catch (parseErr) {
+  skillLogger.warn(...);
+  return { success: true, data: sanitized }; // returns corrupted string
+}
+```
+
+**After (fixed):**
+```ts
+const sanitizedData = sanitizeObjectOutput(result.data, {
+  maxLength: this.skillOutputMaxLength,
+  skipSecretRedaction,
+});
+return { success: true, data: sanitizedData };
+```
+
+The `try/catch` parse-failure branch is removed entirely. Any unexpected throw
+from `sanitizeObjectOutput` (e.g., circular reference in skill output) is caught
+by the outer `try/catch` already wrapping `invoke`, which returns
+`{ success: false, error: ... }` — correct behavior that stops agent retries.
+
+---
+
+## Security properties preserved
+
+- Dangerous HTML/XML tags (`<script>`, `<style>`, `<system>`, etc.) are still
+  stripped from all string values.
+- Secrets matching `SECRET_PATTERNS` are still redacted from all string values.
+- `skipSecretRedaction` and `extraRedactPatterns` are forwarded to the leaf
+  sanitizer unchanged.
+- `maxLength` truncation still applies, per string leaf value.
+- Tag-stripping still uses `sanitize-html` (library parser, not regex), so
+  ReDoS and bad-tag-filter protections are inherited.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/skills/sanitize.ts` | Add `sanitizeObjectOutput` export |
+| `src/skills/execution.ts` | Replace stringify→sanitize→parse branch with `sanitizeObjectOutput` call |
+| `tests/unit/skills/sanitize.test.ts` | Add `sanitizeObjectOutput` test suite |
+| `tests/unit/skills/execution.test.ts` | Add object-result sanitization tests |
+
+---
+
+## Test plan
+
+### `sanitizeObjectOutput` unit tests
+
+- Passes plain objects with no HTML or secrets through unchanged
+- Strips dangerous HTML tags from string leaf values; object structure preserved
+- Redacts secrets from string leaf values
+- Preserves non-string leaf values (numbers, booleans, null, arrays, nested objects)
+- `maxLength` truncates each string leaf independently; adjacent short values unaffected
+- `skipSecretRedaction` forwarded correctly to leaf sanitizer
+- **Regression (from AC):** `{ messages: [{ body: '<style>x{}</style><div>"quoted"</div>' }] }`
+  → valid object; `body` is a string with dangerous content removed; JSON structure intact
+
+### `ExecutionLayer` integration tests
+
+- Object-returning skill whose values contain HTML returns `{ success: true, data: <object> }`
+  where `data` is a valid object (not a string)
+- Dangerous tags are stripped from string values inside the returned object
+- Existing string-returning skill tests pass unchanged
+
+---
+
+## Acceptance criteria (from issue)
+
+- [ ] An object-returning skill whose values contain HTML / `<…>` / secret-shaped content
+      sanitizes to a valid object, not a mangled string
+- [ ] Dangerous tags inside string values are stripped; secrets are redacted
+- [ ] `ceo-inbox-search` over messages with HTML bodies returns parseable structured data
+- [ ] Regression test passes: `{ messages: [{ body: '<style>x{}</style><div>"quoted"</div>' }] }`
+      round-trips to a valid object with the dangerous tag removed
+- [ ] If the execution layer encounters an unexpected error during sanitization,
+      it returns `{ success: false }` — not corrupted data as `success: true`

--- a/docs/wip/2026-06-15-issue-986-sanitize-object.md
+++ b/docs/wip/2026-06-15-issue-986-sanitize-object.md
@@ -1,0 +1,432 @@
+# Issue #986: Execution-layer structural output sanitization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `ExecutionLayer.invoke` so that object-returning skills whose string values contain HTML are sanitized without corrupting the JSON structure.
+
+**Architecture:** Add a new `sanitizeObjectOutput` function to `src/skills/sanitize.ts` that recursively walks an unknown value and applies the existing `sanitizeOutput` to each string leaf. Replace the broken stringify→sanitize→parse branch in `execution.ts` with a single call to `sanitizeObjectOutput`. JSON keys and structural characters never pass through the HTML stripper.
+
+**Tech Stack:** TypeScript (ESM), Vitest, `sanitize-html` (already a dependency via `sanitizeOutput`)
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object`
+**Branch:** `fix/986-sanitize-object`
+
+---
+
+### Task 1: Write failing tests for `sanitizeObjectOutput`
+
+**Files:**
+- Modify: `tests/unit/skills/sanitize.test.ts`
+
+- [ ] **Step 1: Add the import for `sanitizeObjectOutput`**
+
+Open `tests/unit/skills/sanitize.test.ts`. Change the import at the top from:
+
+```ts
+import {
+  sanitizeOutput,
+  sanitizeDisplayName,
+  DISPLAY_NAME_MAX_LENGTH,
+} from '../../../src/skills/sanitize.js';
+```
+
+to:
+
+```ts
+import {
+  sanitizeOutput,
+  sanitizeDisplayName,
+  sanitizeObjectOutput,
+  DISPLAY_NAME_MAX_LENGTH,
+} from '../../../src/skills/sanitize.js';
+```
+
+- [ ] **Step 2: Add the test suite at the end of the file**
+
+Append this block after the last `describe` block:
+
+```ts
+describe('sanitizeObjectOutput', () => {
+  it('passes a plain object with no HTML or secrets through unchanged', () => {
+    const input = { count: 3, label: 'hello world', active: true, nothing: null };
+    const result = sanitizeObjectOutput(input);
+    expect(result).toEqual(input);
+  });
+
+  it('strips dangerous HTML tags from string leaf values', () => {
+    const input = { body: '<style>x{}</style><div>"quoted"</div>' };
+    const result = sanitizeObjectOutput(input) as { body: string };
+    // Dangerous tag and its content removed
+    expect(result.body).not.toContain('<style>');
+    expect(result.body).not.toContain('x{}');
+    // Safe content preserved
+    expect(result.body).toContain('"quoted"');
+    // Result is still a plain object, not a string
+    expect(typeof result).toBe('object');
+    expect(typeof result.body).toBe('string');
+  });
+
+  it('preserves JSON structure: keys, nesting, arrays, non-string values', () => {
+    const input = {
+      messages: [
+        { id: 1, body: 'hello <b>world</b>', read: false },
+        { id: 2, body: 'clean text', read: true },
+      ],
+      count: 2,
+    };
+    const result = sanitizeObjectOutput(input) as typeof input;
+    expect(result.count).toBe(2);
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]!.id).toBe(1);
+    expect(result.messages[0]!.read).toBe(false);
+    expect(result.messages[1]!.id).toBe(2);
+    expect(result.messages[1]!.read).toBe(true);
+    // HTML stripped from body values
+    expect(result.messages[0]!.body).not.toContain('<b>');
+    expect(result.messages[0]!.body).toContain('world');
+    expect(result.messages[1]!.body).toBe('clean text');
+  });
+
+  it('redacts secrets from string leaf values', () => {
+    const input = { token: 'sk-ant-api03-abcdefghijk1234567890', label: 'keep this' };
+    const result = sanitizeObjectOutput(input) as { token: string; label: string };
+    expect(result.token).not.toContain('sk-ant-api03-abcdefghijk1234567890');
+    expect(result.token).toContain('[REDACTED]');
+    expect(result.label).toBe('keep this');
+  });
+
+  it('applies maxLength truncation per string leaf independently', () => {
+    const suffix = '[truncated — output exceeded limit]';
+    const long = 'x'.repeat(200);
+    const short = 'hello';
+    const input = { a: long, b: short };
+    const result = sanitizeObjectOutput(input, { maxLength: 100 }) as { a: string; b: string };
+    // Long value truncated
+    expect(result.a).toContain(suffix);
+    expect(result.a.length).toBeLessThanOrEqual(100 + suffix.length);
+    // Short value unaffected — per-value truncation, not shared budget
+    expect(result.b).toBe('hello');
+  });
+
+  it('forwards skipSecretRedaction to leaf sanitization', () => {
+    const token = 'a'.repeat(64); // 64-char hex token
+    const input = { link: `https://host/capture/${token}` };
+    // With skipSecretRedaction: token survives
+    const kept = sanitizeObjectOutput(input, { skipSecretRedaction: true }) as { link: string };
+    expect(kept.link).toContain(token);
+    // Without it: token is redacted
+    const redacted = sanitizeObjectOutput(input) as { link: string };
+    expect(redacted.link).toContain('[REDACTED]');
+    expect(redacted.link).not.toContain(token);
+  });
+
+  // Regression test from issue #986 acceptance criteria
+  it('regression: object with HTML-body message round-trips to valid object with dangerous tags removed', () => {
+    const input = { messages: [{ body: '<style>x{}</style><div>"quoted"</div>' }] };
+    const result = sanitizeObjectOutput(input) as { messages: Array<{ body: string }> };
+    // Still a structured object
+    expect(typeof result).toBe('object');
+    expect(Array.isArray(result.messages)).toBe(true);
+    expect(typeof result.messages[0]!.body).toBe('string');
+    // Dangerous content removed
+    expect(result.messages[0]!.body).not.toContain('<style>');
+    expect(result.messages[0]!.body).not.toContain('x{}');
+    // Safe content preserved
+    expect(result.messages[0]!.body).toContain('"quoted"');
+  });
+
+  it('passes through number, boolean, null, and undefined leaf values unchanged', () => {
+    const input = { n: 42, b: false, nil: null };
+    const result = sanitizeObjectOutput(input);
+    expect(result).toEqual({ n: 42, b: false, nil: null });
+  });
+
+  it('handles arrays at the top level', () => {
+    const input = [{ body: '<script>evil()</script>hello' }, { body: 'clean' }];
+    const result = sanitizeObjectOutput(input) as Array<{ body: string }>;
+    expect(Array.isArray(result)).toBe(true);
+    expect(result[0]!.body).not.toContain('evil');
+    expect(result[0]!.body).toContain('hello');
+    expect(result[1]!.body).toBe('clean');
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests — confirm they fail**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object run test tests/unit/skills/sanitize.test.ts
+```
+
+Expected: tests in the `sanitizeObjectOutput` suite **FAIL** with something like
+`SyntaxError: The requested module ... does not provide an export named 'sanitizeObjectOutput'`
+or import resolution error. The existing `sanitizeOutput` and `sanitizeDisplayName` tests must still **PASS**.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object add tests/unit/skills/sanitize.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object commit -m "test: add failing tests for sanitizeObjectOutput (#986)"
+```
+
+---
+
+### Task 2: Implement `sanitizeObjectOutput` in `sanitize.ts`
+
+**Files:**
+- Modify: `src/skills/sanitize.ts`
+
+- [ ] **Step 1: Add the function at the end of `src/skills/sanitize.ts`**
+
+Append after the `sanitizeDisplayName` function (after line 306):
+
+```ts
+/**
+ * Sanitize an object-type skill result by recursively walking its structure
+ * and applying sanitizeOutput to each string leaf value.
+ *
+ * JSON structural characters (keys, braces, brackets, colons) are never
+ * passed to the HTML stripper or secret redactor, so they cannot be corrupted.
+ * This is the correct approach for sanitizing object-returning skill output —
+ * the alternative (stringify → sanitize → parse) corrupts JSON when string values
+ * contain HTML, because the sanitizer strips tag characters that happen to be
+ * structural JSON characters inside string values.
+ *
+ * Truncation is applied per string leaf (each string is independently capped at
+ * maxLength). isError is excluded — wrapping a structured object in <tool_error>
+ * is not meaningful; the execution layer's error path handles that as a string.
+ */
+export function sanitizeObjectOutput(
+  data: unknown,
+  options: Omit<SanitizeOptions, 'isError'> = {},
+): unknown {
+  function walk(node: unknown): unknown {
+    if (typeof node === 'string') {
+      return sanitizeOutput(node, options);
+    }
+    if (Array.isArray(node)) {
+      return node.map(walk);
+    }
+    if (node !== null && typeof node === 'object') {
+      const result: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        result[key] = walk(value);
+      }
+      return result;
+    }
+    // Numbers, booleans, null, undefined — pass through unchanged.
+    return node;
+  }
+  return walk(data);
+}
+```
+
+- [ ] **Step 2: Run the sanitize tests — confirm they all pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object run test tests/unit/skills/sanitize.test.ts
+```
+
+Expected: all tests **PASS**, including the new `sanitizeObjectOutput` suite.
+
+- [ ] **Step 3: Run the typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object add src/skills/sanitize.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object commit -m "feat: add sanitizeObjectOutput for structural object sanitization (#986)"
+```
+
+---
+
+### Task 3: Write failing tests for execution layer object sanitization
+
+**Files:**
+- Modify: `tests/unit/skills/execution.test.ts`
+
+- [ ] **Step 1: Append new tests to `tests/unit/skills/execution.test.ts`**
+
+Open the file. Find the closing `});` of the top-level `describe('ExecutionLayer', ...)` block and insert these tests before it:
+
+```ts
+  it('object-returning skill with HTML body values returns valid object (not corrupted string)', async () => {
+    const handler: SkillHandler = {
+      execute: async () => ({
+        success: true,
+        data: { messages: [{ body: '<style>x{}</style><div>"quoted"</div>' }] },
+      }),
+    };
+    registry.register(makeManifest(), handler);
+
+    const result = await execution.invoke('test-skill', {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Must be a plain object, never a corrupted string
+      expect(typeof result.data).toBe('object');
+      const data = result.data as { messages: Array<{ body: string }> };
+      expect(Array.isArray(data.messages)).toBe(true);
+      expect(typeof data.messages[0]!.body).toBe('string');
+      // Dangerous content stripped
+      expect(data.messages[0]!.body).not.toContain('<style>');
+      expect(data.messages[0]!.body).not.toContain('x{}');
+      // Safe content preserved
+      expect(data.messages[0]!.body).toContain('"quoted"');
+    }
+  });
+
+  it('object-returning skill with clean values returns data unchanged', async () => {
+    const handler: SkillHandler = {
+      execute: async () => ({
+        success: true,
+        data: { count: 5, label: 'results', items: ['a', 'b'] },
+      }),
+    };
+    registry.register(makeManifest(), handler);
+
+    const result = await execution.invoke('test-skill', {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { count: number; label: string; items: string[] };
+      expect(data.count).toBe(5);
+      expect(data.label).toBe('results');
+      expect(data.items).toEqual(['a', 'b']);
+    }
+  });
+```
+
+- [ ] **Step 2: Run the execution tests — confirm the new tests fail**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object run test tests/unit/skills/execution.test.ts
+```
+
+Expected: the two new tests **FAIL** (execution layer still uses the broken stringify→parse path). All existing tests must still **PASS**.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object add tests/unit/skills/execution.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object commit -m "test: add failing execution-layer tests for object output sanitization (#986)"
+```
+
+---
+
+### Task 4: Fix the execution layer
+
+**Files:**
+- Modify: `src/skills/execution.ts`
+
+- [ ] **Step 1: Add `sanitizeObjectOutput` to the import**
+
+Find line 24 in `src/skills/execution.ts`:
+
+```ts
+import { sanitizeOutput } from './sanitize.js';
+```
+
+Change it to:
+
+```ts
+import { sanitizeOutput, sanitizeObjectOutput } from './sanitize.js';
+```
+
+- [ ] **Step 2: Replace the broken object-sanitization branch**
+
+Find this block (around lines 977–990):
+
+```ts
+      } else if (result.success && result.data !== null && result.data !== undefined) {
+        const raw = JSON.stringify(result.data);
+        const sanitized = sanitizeOutput(raw, { maxLength: this.skillOutputMaxLength, skipSecretRedaction });
+        if (raw.length > this.skillOutputMaxLength) {
+          skillLogger.warn({ skillName, outputLength: raw.length }, 'Skill output truncated to configured limit');
+        }
+        try {
+          return { success: true, data: JSON.parse(sanitized) };
+        } catch (parseErr) {
+          // Sanitization truncated the JSON mid-structure — return as string rather
+          // than silently dropping the truncation marker.
+          skillLogger.warn({ err: parseErr, skillName }, 'Sanitized output is not valid JSON, returning as string');
+          return { success: true, data: sanitized };
+        }
+      }
+```
+
+Replace it with:
+
+```ts
+      } else if (result.success && result.data !== null && result.data !== undefined) {
+        // Sanitize structurally: walk the object and apply tag-stripping + secret
+        // redaction to each string leaf. JSON structure is never exposed to the HTML
+        // stripper, so it cannot be corrupted. No stringify→parse round-trip needed.
+        // Any unexpected throw is caught by the outer try/catch and returned as
+        // { success: false } — correct behavior that stops agent retry loops.
+        const sanitizedData = sanitizeObjectOutput(result.data, {
+          maxLength: this.skillOutputMaxLength,
+          skipSecretRedaction,
+        });
+        return { success: true, data: sanitizedData };
+      }
+```
+
+- [ ] **Step 3: Run the execution tests — confirm all pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object run test tests/unit/skills/execution.test.ts
+```
+
+Expected: all tests **PASS**, including the two new ones.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object run test
+```
+
+Expected: all tests **PASS**.
+
+- [ ] **Step 5: Run the typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object add src/skills/execution.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object commit -m "fix: sanitize object skill output structurally to prevent JSON corruption (#986)"
+```
+
+---
+
+### Task 5: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add entry under `## [Unreleased]`**
+
+Open `CHANGELOG.md`. Under `## [Unreleased]`, add to the `Fixed` section (create it if not present):
+
+```markdown
+### Fixed
+
+- **Execution-layer output sanitization** — object-returning skills whose string values contain HTML (e.g. email bodies) no longer produce corrupted JSON. `sanitizeObjectOutput` walks the result structure and sanitizes string leaves directly; JSON structural characters are never exposed to the HTML stripper. Fixes the `ceo-inbox-search` retry loop incident. (#986)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-fix-986-sanitize-object commit -m "chore: changelog entry for issue #986 sanitize fix"
+```

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -984,6 +984,13 @@ export class ExecutionLayer {
           maxLength: this.skillOutputMaxLength,
           skipSecretRedaction,
         });
+        // Rough post-sanitize size check for observability: if the sanitized object
+        // would serialize larger than the limit, at least one leaf was truncated.
+        // This is a warn-only signal — sanitizeObjectOutput already capped each leaf.
+        const sanitizedSize = JSON.stringify(sanitizedData).length;
+        if (sanitizedSize > this.skillOutputMaxLength) {
+          skillLogger.warn({ skillName, outputLength: sanitizedSize }, 'Skill output truncated to configured limit');
+        }
         return { success: true, data: sanitizedData };
       }
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -21,7 +21,7 @@ import type { SkillResult, SkillContext, CallerContext, AgentPersona, ToolDefini
 import { normalizeTimestamp } from '../time/timestamp.js';
 import { isPrincipalOriginated } from '../contacts/principal.js';
 import type { SkillRegistry } from './registry.js';
-import { sanitizeOutput } from './sanitize.js';
+import { sanitizeOutput, sanitizeObjectOutput } from './sanitize.js';
 import { createSecretAccessed, createAutonomySkillBlocked } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { EventBus } from '../bus/bus.js';
@@ -975,19 +975,16 @@ export class ExecutionLayer {
         }
         return { success: true, data: sanitized };
       } else if (result.success && result.data !== null && result.data !== undefined) {
-        const raw = JSON.stringify(result.data);
-        const sanitized = sanitizeOutput(raw, { maxLength: this.skillOutputMaxLength, skipSecretRedaction });
-        if (raw.length > this.skillOutputMaxLength) {
-          skillLogger.warn({ skillName, outputLength: raw.length }, 'Skill output truncated to configured limit');
-        }
-        try {
-          return { success: true, data: JSON.parse(sanitized) };
-        } catch (parseErr) {
-          // Sanitization truncated the JSON mid-structure — return as string rather
-          // than silently dropping the truncation marker.
-          skillLogger.warn({ err: parseErr, skillName }, 'Sanitized output is not valid JSON, returning as string');
-          return { success: true, data: sanitized };
-        }
+        // Sanitize structurally: walk the object and apply tag-stripping + secret
+        // redaction to each string leaf. JSON structure is never exposed to the HTML
+        // stripper, so it cannot be corrupted. No stringify→parse round-trip needed.
+        // Any unexpected throw is caught by the outer try/catch and returned as
+        // { success: false } — correct behavior that stops agent retry loops.
+        const sanitizedData = sanitizeObjectOutput(result.data, {
+          maxLength: this.skillOutputMaxLength,
+          skipSecretRedaction,
+        });
+        return { success: true, data: sanitizedData };
       }
 
       // Handler returned { success: false, error } directly (did not throw).

--- a/src/skills/sanitize.ts
+++ b/src/skills/sanitize.ts
@@ -319,6 +319,10 @@ export function sanitizeDisplayName(
  * Truncation is applied per string leaf (each string is independently capped at
  * maxLength). isError is excluded — wrapping a structured object in <tool_error>
  * is not meaningful; the execution layer's error path handles that as a string.
+ *
+ * Non-plain objects (Date, Map, class instances) are walked via Object.entries,
+ * which returns [] for internal-slot types; they will emerge as {}. Skill results
+ * are expected to be JSON-serializable, so this is accepted.
  */
 export function sanitizeObjectOutput(
   data: unknown,

--- a/src/skills/sanitize.ts
+++ b/src/skills/sanitize.ts
@@ -304,3 +304,42 @@ export function sanitizeDisplayName(
   const safeFallback = applyDisplayNamePipeline(fallback);
   return safeFallback.length > 0 ? safeFallback : 'Unknown';
 }
+
+/**
+ * Sanitize an object-type skill result by recursively walking its structure
+ * and applying sanitizeOutput to each string leaf value.
+ *
+ * JSON structural characters (keys, braces, brackets, colons) are never
+ * passed to the HTML stripper or secret redactor, so they cannot be corrupted.
+ * This is the correct approach for sanitizing object-returning skill output —
+ * the alternative (stringify → sanitize → parse) corrupts JSON when string values
+ * contain HTML, because the sanitizer strips tag characters that happen to be
+ * structural JSON characters inside string values.
+ *
+ * Truncation is applied per string leaf (each string is independently capped at
+ * maxLength). isError is excluded — wrapping a structured object in <tool_error>
+ * is not meaningful; the execution layer's error path handles that as a string.
+ */
+export function sanitizeObjectOutput(
+  data: unknown,
+  options: Omit<SanitizeOptions, 'isError'> = {},
+): unknown {
+  function walk(node: unknown): unknown {
+    if (typeof node === 'string') {
+      return sanitizeOutput(node, options);
+    }
+    if (Array.isArray(node)) {
+      return node.map(walk);
+    }
+    if (node !== null && typeof node === 'object') {
+      const result: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        result[key] = walk(value);
+      }
+      return result;
+    }
+    // Numbers, booleans, null, undefined — pass through unchanged.
+    return node;
+  }
+  return walk(data);
+}

--- a/src/skills/sanitize.ts
+++ b/src/skills/sanitize.ts
@@ -338,7 +338,13 @@ export function sanitizeObjectOutput(
     if (node !== null && typeof node === 'object') {
       const result: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
-        result[key] = walk(value);
+        // Sanitize keys too: strip injection tags and redact secrets, matching the
+        // old stringify→sanitize behaviour. No maxLength — a truncated key changes semantics.
+        const sanitizedKey = sanitizeOutput(key, {
+          skipSecretRedaction: options.skipSecretRedaction,
+          extraRedactPatterns: options.extraRedactPatterns,
+        });
+        result[sanitizedKey] = walk(value);
       }
       return result;
     }

--- a/tests/unit/skills/execution.test.ts
+++ b/tests/unit/skills/execution.test.ts
@@ -718,7 +718,7 @@ describe('ExecutionLayer', () => {
     const handler: SkillHandler = {
       execute: async () => ({
         success: true,
-        data: { messages: [{ body: '<style>x{}</style><div>"quoted"</div>' }] },
+        data: { messages: [{ body: '<style>.x{}</style> Reply &quot;yes&quot; to confirm' }] },
       }),
     };
     registry.register(makeManifest(), handler);
@@ -733,9 +733,11 @@ describe('ExecutionLayer', () => {
       expect(typeof data.messages[0]!.body).toBe('string');
       // Dangerous content stripped
       expect(data.messages[0]!.body).not.toContain('<style>');
-      expect(data.messages[0]!.body).not.toContain('x{}');
-      // Safe content preserved
-      expect(data.messages[0]!.body).toContain('"quoted"');
+      expect(data.messages[0]!.body).not.toContain('.x{}');
+      // HTML entity decoded, not left as &quot; literal
+      expect(data.messages[0]!.body).not.toContain('&quot;');
+      // Safe text preserved
+      expect(data.messages[0]!.body).toContain('yes');
     }
   });
 

--- a/tests/unit/skills/execution.test.ts
+++ b/tests/unit/skills/execution.test.ts
@@ -713,4 +713,48 @@ describe('ExecutionLayer', () => {
       }
     });
   });
+
+  it('object-returning skill with HTML body values returns valid object (not corrupted string)', async () => {
+    const handler: SkillHandler = {
+      execute: async () => ({
+        success: true,
+        data: { messages: [{ body: '<style>x{}</style><div>"quoted"</div>' }] },
+      }),
+    };
+    registry.register(makeManifest(), handler);
+
+    const result = await execution.invoke('test-skill', {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Must be a plain object, never a corrupted string
+      expect(typeof result.data).toBe('object');
+      const data = result.data as { messages: Array<{ body: string }> };
+      expect(Array.isArray(data.messages)).toBe(true);
+      expect(typeof data.messages[0]!.body).toBe('string');
+      // Dangerous content stripped
+      expect(data.messages[0]!.body).not.toContain('<style>');
+      expect(data.messages[0]!.body).not.toContain('x{}');
+      // Safe content preserved
+      expect(data.messages[0]!.body).toContain('"quoted"');
+    }
+  });
+
+  it('object-returning skill with clean values returns data unchanged', async () => {
+    const handler: SkillHandler = {
+      execute: async () => ({
+        success: true,
+        data: { count: 5, label: 'results', items: ['a', 'b'] },
+      }),
+    };
+    registry.register(makeManifest(), handler);
+
+    const result = await execution.invoke('test-skill', {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { count: number; label: string; items: string[] };
+      expect(data.count).toBe(5);
+      expect(data.label).toBe('results');
+      expect(data.items).toEqual(['a', 'b']);
+    }
+  });
 });

--- a/tests/unit/skills/execution.test.ts
+++ b/tests/unit/skills/execution.test.ts
@@ -730,6 +730,7 @@ describe('ExecutionLayer', () => {
       expect(typeof result.data).toBe('object');
       const data = result.data as { messages: Array<{ body: string }> };
       expect(Array.isArray(data.messages)).toBe(true);
+      expect(data.messages).toHaveLength(1);
       expect(typeof data.messages[0]!.body).toBe('string');
       // Dangerous content stripped
       expect(data.messages[0]!.body).not.toContain('<style>');

--- a/tests/unit/skills/sanitize.test.ts
+++ b/tests/unit/skills/sanitize.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   sanitizeOutput,
   sanitizeDisplayName,
+  sanitizeObjectOutput,
   DISPLAY_NAME_MAX_LENGTH,
 } from '../../../src/skills/sanitize.js';
 
@@ -312,5 +313,110 @@ describe('sanitizeDisplayName', () => {
     const start = Date.now();
     sanitizeDisplayName(input);
     expect(Date.now() - start).toBeLessThan(500);
+  });
+});
+
+describe('sanitizeObjectOutput', () => {
+  it('passes a plain object with no HTML or secrets through unchanged', () => {
+    const input = { count: 3, label: 'hello world', active: true, nothing: null };
+    const result = sanitizeObjectOutput(input);
+    expect(result).toEqual(input);
+  });
+
+  it('strips dangerous HTML tags from string leaf values', () => {
+    const input = { body: '<style>x{}</style><div>"quoted"</div>' };
+    const result = sanitizeObjectOutput(input) as { body: string };
+    // Dangerous tag and its content removed
+    expect(result.body).not.toContain('<style>');
+    expect(result.body).not.toContain('x{}');
+    // Safe content preserved
+    expect(result.body).toContain('"quoted"');
+    // Result is still a plain object, not a string
+    expect(typeof result).toBe('object');
+    expect(typeof result.body).toBe('string');
+  });
+
+  it('preserves JSON structure: keys, nesting, arrays, non-string values', () => {
+    const input = {
+      messages: [
+        { id: 1, body: 'hello <b>world</b>', read: false },
+        { id: 2, body: 'clean text', read: true },
+      ],
+      count: 2,
+    };
+    const result = sanitizeObjectOutput(input) as typeof input;
+    expect(result.count).toBe(2);
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]!.id).toBe(1);
+    expect(result.messages[0]!.read).toBe(false);
+    expect(result.messages[1]!.id).toBe(2);
+    expect(result.messages[1]!.read).toBe(true);
+    // HTML stripped from body values
+    expect(result.messages[0]!.body).not.toContain('<b>');
+    expect(result.messages[0]!.body).toContain('world');
+    expect(result.messages[1]!.body).toBe('clean text');
+  });
+
+  it('redacts secrets from string leaf values', () => {
+    const input = { token: 'sk-ant-api03-abcdefghijk1234567890', label: 'keep this' };
+    const result = sanitizeObjectOutput(input) as { token: string; label: string };
+    expect(result.token).not.toContain('sk-ant-api03-abcdefghijk1234567890');
+    expect(result.token).toContain('[REDACTED]');
+    expect(result.label).toBe('keep this');
+  });
+
+  it('applies maxLength truncation per string leaf independently', () => {
+    const suffix = '[truncated — output exceeded limit]';
+    const long = 'x'.repeat(200);
+    const short = 'hello';
+    const input = { a: long, b: short };
+    const result = sanitizeObjectOutput(input, { maxLength: 100 }) as { a: string; b: string };
+    // Long value truncated
+    expect(result.a).toContain(suffix);
+    expect(result.a.length).toBeLessThanOrEqual(100 + suffix.length);
+    // Short value unaffected — per-value truncation, not shared budget
+    expect(result.b).toBe('hello');
+  });
+
+  it('forwards skipSecretRedaction to leaf sanitization', () => {
+    const token = 'a'.repeat(64); // 64-char hex token
+    const input = { link: `https://host/capture/${token}` };
+    // With skipSecretRedaction: token survives
+    const kept = sanitizeObjectOutput(input, { skipSecretRedaction: true }) as { link: string };
+    expect(kept.link).toContain(token);
+    // Without it: token is redacted
+    const redacted = sanitizeObjectOutput(input) as { link: string };
+    expect(redacted.link).toContain('[REDACTED]');
+    expect(redacted.link).not.toContain(token);
+  });
+
+  // Regression test from issue #986 acceptance criteria
+  it('regression: object with HTML-body message round-trips to valid object with dangerous tags removed', () => {
+    const input = { messages: [{ body: '<style>x{}</style><div>"quoted"</div>' }] };
+    const result = sanitizeObjectOutput(input) as { messages: Array<{ body: string }> };
+    // Still a structured object
+    expect(typeof result).toBe('object');
+    expect(Array.isArray(result.messages)).toBe(true);
+    expect(typeof result.messages[0]!.body).toBe('string');
+    // Dangerous content removed
+    expect(result.messages[0]!.body).not.toContain('<style>');
+    expect(result.messages[0]!.body).not.toContain('x{}');
+    // Safe content preserved
+    expect(result.messages[0]!.body).toContain('"quoted"');
+  });
+
+  it('passes through number, boolean, null, and undefined leaf values unchanged', () => {
+    const input = { n: 42, b: false, nil: null };
+    const result = sanitizeObjectOutput(input);
+    expect(result).toEqual({ n: 42, b: false, nil: null });
+  });
+
+  it('handles arrays at the top level', () => {
+    const input = [{ body: '<script>evil()</script>hello' }, { body: 'clean' }];
+    const result = sanitizeObjectOutput(input) as Array<{ body: string }>;
+    expect(Array.isArray(result)).toBe(true);
+    expect(result[0]!.body).not.toContain('evil');
+    expect(result[0]!.body).toContain('hello');
+    expect(result[1]!.body).toBe('clean');
   });
 });

--- a/tests/unit/skills/sanitize.test.ts
+++ b/tests/unit/skills/sanitize.test.ts
@@ -373,7 +373,7 @@ describe('sanitizeObjectOutput', () => {
     const result = sanitizeObjectOutput(input, { maxLength: 100 }) as { a: string; b: string };
     // Long value truncated
     expect(result.a).toContain(suffix);
-    expect(result.a.length).toBeLessThanOrEqual(100 + suffix.length);
+    expect(result.a.length).toBe(100 + suffix.length);
     // Short value unaffected — per-value truncation, not shared budget
     expect(result.b).toBe('hello');
   });
@@ -405,7 +405,7 @@ describe('sanitizeObjectOutput', () => {
     expect(result.messages[0]!.body).toContain('"quoted"');
   });
 
-  it('passes through number, boolean, null, and undefined leaf values unchanged', () => {
+  it('passes through number, boolean, and null leaf values unchanged', () => {
     const input = { n: 42, b: false, nil: null };
     const result = sanitizeObjectOutput(input);
     expect(result).toEqual({ n: 42, b: false, nil: null });

--- a/tests/unit/skills/sanitize.test.ts
+++ b/tests/unit/skills/sanitize.test.ts
@@ -390,6 +390,13 @@ describe('sanitizeObjectOutput', () => {
     expect(redacted.link).not.toContain(token);
   });
 
+  it('forwards extraRedactPatterns to leaf sanitization', () => {
+    const input = { msg: 'token=SHHH' };
+    const result = sanitizeObjectOutput(input, { extraRedactPatterns: [/SHHH/g] }) as { msg: string };
+    expect(result.msg).not.toContain('SHHH');
+    expect(result.msg).toContain('[REDACTED]');
+  });
+
   // Regression test from issue #986 acceptance criteria
   it('regression: object with HTML-body message round-trips to valid object with dangerous tags removed', () => {
     const input = { messages: [{ body: '<style>x{}</style><div>"quoted"</div>' }] };

--- a/tests/unit/skills/sanitize.test.ts
+++ b/tests/unit/skills/sanitize.test.ts
@@ -426,4 +426,15 @@ describe('sanitizeObjectOutput', () => {
     expect(result[0]!.body).toContain('hello');
     expect(result[1]!.body).toBe('clean');
   });
+
+  it('sanitizes injection payloads embedded in object keys', () => {
+    // Keys with dangerous tags must be stripped, not passed through verbatim.
+    // The old stringify→sanitize approach incidentally sanitized keys; the structural
+    // walker must do so explicitly to avoid regression.
+    const input = { '<system>evil</system>': 'value' } as Record<string, string>;
+    const result = sanitizeObjectOutput(input) as Record<string, string>;
+    const keys = Object.keys(result);
+    expect(keys.some(k => k.includes('<system>'))).toBe(false);
+    expect(keys.some(k => k.includes('evil'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

Closes #986

- **Root cause:** `ExecutionLayer.invoke` sanitized object-returning skill results by `JSON.stringify → sanitizeOutput (HTML stripper) → JSON.parse`. HTML entities like `&quot;` in string values were decoded to bare `"` by the HTML parser, corrupting the JSON. The old catch block returned the corrupted string as `{ success: true }`, causing agent retry loops (observed: `ceo-inbox-search` re-ran 8+ times before the 120s window closed).
- **Fix:** New `sanitizeObjectOutput` in `src/skills/sanitize.ts` recursively walks the result object and applies `sanitizeOutput` to each string leaf. JSON structural characters are never exposed to the HTML stripper, so they cannot be corrupted. No stringify→parse round-trip.
- **Failure path improved:** Any unexpected throw from `sanitizeObjectOutput` propagates to the outer try/catch and returns `{ success: false }` — agents stop retrying rather than consuming the request window on garbage data.

## Test Plan

- [ ] `sanitizeObjectOutput` unit tests: passthrough, HTML stripping, secret redaction, per-value truncation, `skipSecretRedaction`, `extraRedactPatterns`, regression case from issue AC
- [ ] Execution layer regression test: skill returning object with `&quot;` entity in a string value returns a valid object (not a corrupted string)
- [ ] Full test suite: 275 unit tests pass; 2 pre-existing integration test failures require `DATABASE_URL` and are unrelated to this change
- [ ] Typecheck: clean


___

## **CodeAnt-AI Description**
**Sanitize object output without breaking JSON**

### What Changed
- Skills that return objects are now sanitized by walking the object directly, so HTML in string values no longer turns the result into corrupted data.
- String values inside returned objects still have unsafe tags removed and secrets redacted, while numbers, booleans, nulls, arrays, and nested objects keep their structure.
- Added tests for object sanitization in both the sanitizer and execution layer, including the HTML-body regression case.
- Added a changelog entry for the fix.

### Impact
`✅ Fewer broken skill responses`
`✅ Clearer email and message output`
`✅ Fewer agent retry loops`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
