### PR TITLE
feat: harden browser sessions against bot detection (#987)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`secretResolver` capability (skill manifest schema, public API)** — runtime by-reference resolution of dynamic `user.*` secrets; gated to a hard skill allowlist (`web-browser` only) and the `user.*` namespace. (#973)
 - **Agent resume after secret capture** — filling a capture link now publishes a `secret.captured` event (name/routing only, never the value) and a thin subscriber re-enters the originating agent so it can continue what it was blocked on. (#972)
 - **`secret.captured` bus event (public API)** — emitted by the capture endpoint on a successful redeem, carrying secret name/label + routing metadata and never the value. (#972)
+- **Browser incognito sessions** — `incognito:true` on `web-browser` runs in a throwaway isolated context, keeping Curia's own logins out of the principal's profile. (#987)
+- **Persistent browser profile** — the browser now uses a persistent context on a mounted volume, so logins/cookies survive restarts. (#987)
 
 ### Changed
 
@@ -43,6 +45,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`SkillContext` (public API)** — adds optional `resolveSecretRef(ref)` method, injected only for allowlisted skills declaring `secretResolver` (backward compatible). (#973)
 - **`SecretAccessedEvent` (bus event types, public API)** — payload gains optional `byReference` flag distinguishing dynamic by-reference resolution from declared-secret access (backward compatible). (#973)
 - **Coordinator prompt** — re-derived around a three-way routing decision; delegation-hinted outbound replies now always transfer to the owning specialist. (#957)
+- **`web-browser` ad blocking is now opt-in** (`block_ads:true`) and off by default, so login/auth/form-fill flows no longer trip "privacy extension" bot detection. (#987)
+- **Browser fingerprint hardened** — real Chrome channel where available, current UA via `playwright-extra` + stealth, plus context locale/timezone/colorScheme. (#987)
 
 ### Fixed
 
@@ -53,6 +57,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Chat waiter no longer crashes the process** — `EventRouter.waitForResponse` now resolves a discriminated result instead of rejecting, so a timeout/supersede firing after the client disconnects can't surface as an `unhandledRejection`; a process-level backstop logs and stays up. (#983)
 - **KG chat rate-limit status** — `POST /api/kg/chat/messages` now returns 429 for rate-limited rejections (was a hardcoded 403), matching `/api/messages`. (#983)
 - **Flaky confidence-pipeline idempotency test** — loosened the `fullRecompute` idempotency assertion from 10 to 9 decimal places; the recency component's `new Date()` jitter (~1.5e-10) exceeded the old 5e-11 tolerance and intermittently failed CI.
+- **Browser YAML config now takes effect** — `browser.*` settings were read through a dead cast and silently ignored. (#987, #204)
 
 ### Security
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -62,6 +62,14 @@ browser:
   sessionTtlMs: 600000   # 10 minutes
   # How often the session sweep runs to close expired sessions (ms).
   sweepIntervalMs: 120000  # 2 minutes
+  # Persistent profile directory. Empty → ${HOME}/.curia/browser-profile.
+  # Mount this on a volume in production so logins survive restarts.
+  profileDir: ""
+  # Browser channel: "chrome" for real Chrome (must be installed in the image),
+  # empty for the bundled Playwright Chromium.
+  channel: ""
+  # Context locale (BCP 47).
+  locale: "en-US"
 
 agents:
   coordinator:

--- a/docs/wip/2026-06-15-browser-stealth-design.md
+++ b/docs/wip/2026-06-15-browser-stealth-design.md
@@ -35,6 +35,7 @@ still resist automation from the server IP; that is an accepted limitation.
 | Blocklist fetch | **Lazy, first-use** | No wasted startup download now that blocking is off by default. |
 | Deploy changes | **Drafted alongside** (separate curia-deploy PR) | `channel: 'chrome'` and cross-restart persistence need a real-Chrome image + a mounted profile volume. Code degrades gracefully without them. |
 | User agent | **Stop overriding it** | Real Chrome channel + stealth's UA-override evasion sends the genuine, current UA — "never goes stale" by construction; sidesteps the chicken-and-egg of reading `browser.version()` before context creation. |
+| Identity scope | **Persistent profile = the principal's identity; `incognito` escape hatch** | A true second persistent identity (Curia-as-itself) is YAGNI today (Curia's own services go through APIs, not the browser). But add a cheap opt-in ephemeral session now so Curia's own / one-off logins don't pollute the principal's cookie jar. |
 
 ## Architecture change: persistent context replaces Browser + per-session contexts
 
@@ -85,6 +86,35 @@ The current `browserFactory: () => Promise<Browser>` injection becomes
 Default implementation launches the stealth-wrapped persistent context; tests
 inject a mock context exposing `newPage`, `close`, `browser()`.
 
+### Identity scope & incognito sessions
+
+The persistent profile represents **the principal's browsing identity**. Curia's
+own browser logins, and any deliberately-throwaway login, must not pollute it.
+
+- `getOrCreateSession(sessionId, { incognito })` (default `incognito: false`):
+  - **Persistent (default):** `this.context.newPage()` — shares the principal's
+    profile (cookies/storage/history). `BrowserSession.close()` closes only the
+    **page**.
+  - **Incognito:** `this.context.browser()!.newContext({ ...fingerprint })` then
+    `.newPage()` — a fresh, isolated context that never touches the profile and
+    does not survive restart. The session **owns** this context, so
+    `BrowserSession.close()` closes the **context** (which closes its page).
+- `launchPersistentContext(...).browser()` returns a real `Browser`, so ephemeral
+  contexts spin up off the same warm process — no second launch, no profile lock
+  conflict.
+- `BrowserSession` gains an optional `ownedContext` reference: set for incognito
+  sessions (close the context), null for persistent sessions (close the page).
+  This is the single switch that distinguishes the two lifecycles; sweep / TTL /
+  the session map are otherwise identical.
+- Fingerprint hardening (locale, timezoneId, colorScheme, viewport, no UA
+  override) applies to both kinds; stealth is browser-level (`chromium.use`) so
+  it covers ephemeral contexts automatically.
+- **Single-identity assumption (documented in code):** there is exactly one
+  persistent identity. If Curia ever needs its *own* persistent browser identity
+  on a service the principal also uses, that is a future extension (per-identity
+  profile dirs + multiple persistent contexts) — not built now. Incognito covers
+  the one-off case until then.
+
 ## Ad blocker → opt-in, off by default
 
 - New skill input `block_ads` (boolean, default `false`).
@@ -97,6 +127,20 @@ inject a mock context exposing `newPage`, `close`, `browser()`.
   browsing — never for login / authenticated / form-fill flows.
 
 **First validation step when implementing:** blocker off, re-test x.com renders.
+
+## Skill inputs (web-browser)
+
+Two new optional inputs, both default `false`, both only meaningful on the call
+that *creates* a session (ignored when reusing an existing `session_id`, since a
+page's profile/incognito nature is fixed at creation):
+
+- `block_ads` — attach the ad blocker to this session (off by default).
+- `incognito` — create the session in an ephemeral, isolated context instead of
+  the principal's persistent profile. For Curia's own logins or throwaway flows.
+
+The skill description guides the LLM: default (persistent) for the principal's
+own accounts; `incognito: true` only when logging in as Curia itself or when a
+clean, non-persisted session is explicitly wanted.
 
 ## Fingerprint hardening
 
@@ -165,7 +209,9 @@ Drafted alongside this work:
   sessions-as-pages. New cases:
   - `block_ads` gating — blocker attaches only when `true`; lazy fetch happens
     once and is cached.
-  - `session.close()` closes the page, not the shared context.
+  - persistent `session.close()` closes the page, not the shared context.
+  - incognito session uses a fresh `newContext` and its `close()` closes that
+    owned context; it is isolated from the persistent profile.
   - disconnect → relaunch re-attaches the handler and clears sessions.
 - **Integration (`RUN_BROWSER_TESTS=1`, temp profile dir):**
   - persistence across restart: set a cookie / localStorage value, `stop()`,
@@ -183,6 +229,7 @@ Drafted alongside this work:
 | UA matches current real Chrome, not hardcoded | `channel: 'chrome'` + stealth UA-override, no override, version logged |
 | locale + timezoneId + viewport + stealth active | context options + `chromium.use(stealth())` |
 | Persistent profile retains cookies across restarts | `launchPersistentContext(profileDir)` on a volume |
+| Curia-vs-principal identity collision | `incognito` opt-in (ephemeral isolated context); single-identity assumption documented |
 | OpenTable + form fill reach/submit | manual re-test checklist |
 
 ## Risks & notes
@@ -193,9 +240,16 @@ Drafted alongside this work:
 - **Stealth plugin is puppeteer-oriented** (compat shims via playwright-extra)
   and lightly maintained. Acceptable for now; revisit if it breaks on a
   Playwright upgrade.
-- **Lost isolation** is deliberate. If a future need for per-principal isolation
-  arises (multi-principal), it would mean per-principal profile dirs + multiple
-  browser processes — out of scope here.
+- **Lost isolation** between persistent sessions is deliberate (they share the
+  principal's profile). When isolation *is* wanted, `incognito: true` provides it
+  per session. A second *persistent* identity (multi-principal, or Curia-as-itself
+  on a shared service) would mean per-identity profile dirs + multiple persistent
+  contexts — out of scope here.
+- **`incognito` mis-routing:** the LLM could set it wrong (incognito for the
+  principal → lost persistence; persistent for a self-login → polluted profile).
+  Blast radius is mild (no credential leak — secrets are per-call via
+  `secret_ref`); default is persistent (the main use case) and the skill
+  description steers the choice.
 - **Profile corruption** (e.g. unclean shutdown) could wedge the browser. Launch
   failure already triggers graceful degradation (web-browser skill unavailable);
   a corrupt-profile recovery (wipe + relaunch) can be a follow-up if observed.

--- a/docs/wip/2026-06-15-browser-stealth-design.md
+++ b/docs/wip/2026-06-15-browser-stealth-design.md
@@ -1,0 +1,201 @@
+# Harden browser sessions against bot detection — design
+
+**Issue:** #987
+**Date:** 2026-06-15
+**Status:** Approved (brainstorming)
+
+## Goal
+
+Authorized, user-initiated automation (the principal asking Curia to log into
+*their own* accounts or make *their own* reservations) is being blocked by
+anti-bot systems. Confirmed failures: x.com login, OpenTable reservation, an
+online personality test (form fill).
+
+The browser already runs headed (`headless: false` + Xvfb) with
+`--disable-blink-features=AutomationControlled`, which strips
+`navigator.webdriver`. Headedness is **not** the gap. The blockers are:
+
+1. The ad blocker injecting cosmetic filters / request interception that sites
+   fingerprint as a privacy extension (x.com explicitly refuses).
+2. A stale, generic fingerprint (hardcoded `Chrome/122` UA, bundled Chromium,
+   no locale/timezone/colorScheme, residual CDP automation signals).
+3. No persistent profile — every session is a brand-new incognito context, so
+   every visit looks like a first-time visitor and re-triggers login / 2FA.
+
+Out of scope (per issue): proxy / residential-IP work. Some strict sites may
+still resist automation from the server IP; that is an accepted limitation.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Persistence model | **Persistent context** (`launchPersistentContext`), single shared profile | Curia is single-principal per instance, so per-principal ≡ shared. Most realistic "returning user" fingerprint; matches the issue's explicit ask. |
+| Stealth layer | **`playwright-extra` + `puppeteer-extra-plugin-stealth`** | Broadest out-of-the-box evasion coverage for residual CDP/automation signals. |
+| Ad blocking | **Opt-in** via `block_ads` input, default `false` | Off by default for login/auth/form-fill; normal browsing can still enable it. Handler can't auto-classify flow type (LLM drives navigation), so opt-in is the clean mechanism. |
+| Blocklist fetch | **Lazy, first-use** | No wasted startup download now that blocking is off by default. |
+| Deploy changes | **Drafted alongside** (separate curia-deploy PR) | `channel: 'chrome'` and cross-restart persistence need a real-Chrome image + a mounted profile volume. Code degrades gracefully without them. |
+| User agent | **Stop overriding it** | Real Chrome channel + stealth's UA-override evasion sends the genuine, current UA — "never goes stale" by construction; sidesteps the chicken-and-egg of reading `browser.version()` before context creation. |
+
+## Architecture change: persistent context replaces Browser + per-session contexts
+
+### Before
+
+```
+chromium.launch()  →  one warm Browser (kept across sessions)
+  └─ browser.newContext()  →  isolated context per session (cookies wiped each time)
+       └─ context.newPage()  →  one page
+BrowserSession.close()  →  context.close()
+stop()  →  close each session, then browser.close()
+```
+
+### After
+
+```
+chromium.use(stealth())
+chromium.launchPersistentContext(profileDir, {...})  →  one persistent context = the warm browser
+  └─ context.newPage()  →  one page PER SESSION (shared cookies/localStorage/history)
+BrowserSession.close()  →  page.close()        // NOT context.close()
+stop()  →  close each page, then context.close()
+```
+
+Key consequences:
+
+- **A session is now a `Page`, not a `BrowserContext`.** `BrowserSession` keeps a
+  reference to the shared context (for the API surface) but `close()` closes only
+  its `page`. The injected-secret redaction stays per-session (per-page) and is
+  unaffected.
+- **Isolation between sessions is intentionally dropped.** Sessions share cookies
+  and storage — that is the persistence. This is correct for a single principal
+  and is documented in the file header (the old "separate cookies/storage per
+  session" comment is replaced).
+- **Crash/disconnect recovery** re-attaches to the persistent context's underlying
+  browser via `context.browser()?.on('disconnected')`. On disconnect: clear the
+  page map and relaunch the persistent context, then re-attach the handler (same
+  recover-more-than-once pattern as today).
+- **TTL sweep** closes idle pages, not contexts. `getOrCreateSession` /
+  `closeSession` / `sweep` semantics are otherwise unchanged — they operate on the
+  `Map<SessionId, BrowserSession>` exactly as before.
+- **Single profile, single owner.** A profile dir can be opened by only one
+  process. Fine for one instance; tests use temp dirs.
+
+### Factory abstraction (testability)
+
+The current `browserFactory: () => Promise<Browser>` injection becomes
+`contextFactory: () => Promise<BrowserContext>` returning a persistent context.
+Default implementation launches the stealth-wrapped persistent context; tests
+inject a mock context exposing `newPage`, `close`, `browser()`.
+
+## Ad blocker → opt-in, off by default
+
+- New skill input `block_ads` (boolean, default `false`).
+- `enableBlockingInPage(page)` runs only when `block_ads: true`.
+- Blocklist is fetched lazily on first opt-in and cached:
+  `this.blocker ??= await (this.blockerPromise ??= PlaywrightBlocker.fromPrebuiltAdsAndTracking(fetch))`.
+  Fetch failure logs a warning and proceeds without blocking (current behavior).
+- The eager startup fetch in `start()` is removed.
+- Skill description updated so the LLM enables `block_ads` only for plain content
+  browsing — never for login / authenticated / form-fill flows.
+
+**First validation step when implementing:** blocker off, re-test x.com renders.
+
+## Fingerprint hardening
+
+Applied at `launchPersistentContext` time:
+
+- `channel: 'chrome'` when `browser.channel` config is set and Chrome is present;
+  graceful fallback to bundled Chromium otherwise (catch launch error, retry
+  without `channel`, log a warning).
+- No `userAgent` override (see decision above). Log `context.browser()?.version()`
+  after launch for observability.
+- `locale` (default `'en-US'`, config `browser.locale`).
+- `timezoneId` from `config.timezone` (already wired through to the service).
+- `colorScheme: 'light'`.
+- `viewport: { width: 1280, height: 720 }` (matches the Xvfb screen size).
+- Launch args unchanged (`--disable-blink-features=AutomationControlled`,
+  `--no-sandbox`, `--disable-dev-shm-usage`).
+- Stealth: `chromium.use(stealth())` before launch.
+
+## Persistent profile
+
+- New config `browser.profileDir` (default `${HOME}/.curia/browser-profile`).
+- In prod this directory must live on a mounted volume so cookies/session survive
+  container restarts (curia-deploy follow-up — see below).
+- Single shared profile dir for the instance.
+
+## Config & wiring
+
+`config/default.yaml` gains a `browser` section (the cast in `index.ts` is
+replaced by a typed read):
+
+```yaml
+browser:
+  sessionTtlMs: 600000
+  sweepIntervalMs: 120000
+  profileDir: ""        # empty → default ${HOME}/.curia/browser-profile
+  channel: ""           # empty → bundled Chromium; "chrome" → real Chrome
+  locale: "en-US"
+```
+
+`BrowserService` constructor gains `profileDir`, `channel`, `locale`, `timezone`.
+`index.ts` passes `timezone: config.timezone` and the new browser config through.
+
+## Dependencies
+
+Add to `package.json`:
+
+- `playwright-extra`
+- `puppeteer-extra-plugin-stealth`
+
+Run `pnpm install`, commit lockfile. If pnpm flags new build scripts, set the
+`allowBuilds` entry explicitly to `true`/`false` (never placeholder text) per
+repo convention.
+
+## Deploy changes (curia-deploy — separate PR)
+
+Drafted alongside this work:
+
+- Install `google-chrome-stable` in the image (so `channel: 'chrome'` resolves).
+- Mount a persistent volume at the configured `browser.profileDir`.
+- Set `browser.channel: chrome` and `browser.profileDir` in the deployment config.
+
+## Test plan
+
+- **Unit (mocked):** rework mocks to the persistent-context shape. Keep all
+  existing behaviors green (create / reuse / expire / sweep / stop) with
+  sessions-as-pages. New cases:
+  - `block_ads` gating — blocker attaches only when `true`; lazy fetch happens
+    once and is cached.
+  - `session.close()` closes the page, not the shared context.
+  - disconnect → relaunch re-attaches the handler and clears sessions.
+- **Integration (`RUN_BROWSER_TESTS=1`, temp profile dir):**
+  - persistence across restart: set a cookie / localStorage value, `stop()`,
+    `start()` against the same profile dir, assert it survived.
+  - existing navigate / content / close flows still pass.
+- **Manual re-test (PR checklist):** x.com login renders + accepts creds (no
+  "privacy related extensions" error); OpenTable reservation reaches + submits;
+  personality-test form fill reaches + submits.
+
+## Acceptance criteria mapping
+
+| Criterion | Covered by |
+|---|---|
+| Ad blocking off by default, opt-out per session; x.com renders | `block_ads` opt-in (default false), lazy blocklist |
+| UA matches current real Chrome, not hardcoded | `channel: 'chrome'` + stealth UA-override, no override, version logged |
+| locale + timezoneId + viewport + stealth active | context options + `chromium.use(stealth())` |
+| Persistent profile retains cookies across restarts | `launchPersistentContext(profileDir)` on a volume |
+| OpenTable + form fill reach/submit | manual re-test checklist |
+
+## Risks & notes
+
+- **Single-profile concurrency:** all sessions are tabs in one browser. The
+  current model is already single-browser, so no regression; concurrency stays
+  bounded by one process.
+- **Stealth plugin is puppeteer-oriented** (compat shims via playwright-extra)
+  and lightly maintained. Acceptable for now; revisit if it breaks on a
+  Playwright upgrade.
+- **Lost isolation** is deliberate. If a future need for per-principal isolation
+  arises (multi-principal), it would mean per-principal profile dirs + multiple
+  browser processes — out of scope here.
+- **Profile corruption** (e.g. unclean shutdown) could wedge the browser. Launch
+  failure already triggers graceful degradation (web-browser skill unavailable);
+  a corrupt-profile recovery (wipe + relaunch) can be a follow-up if observed.

--- a/docs/wip/2026-06-15-browser-stealth.md
+++ b/docs/wip/2026-06-15-browser-stealth.md
@@ -1,0 +1,1127 @@
+# Browser Bot-Detection Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop anti-bot systems from blocking authorized, user-initiated browser automation by removing the ad-blocker fingerprint, modernizing the browser fingerprint, and adding a persistent profile (with an incognito escape hatch).
+
+**Architecture:** Replace the "one warm `Browser` + isolated context per session" model with a single `launchPersistentContext` (the principal's profile); sessions become pages in that shared context. An opt-in `incognito` flag spins up an ephemeral isolated context off the same browser for Curia's own / throwaway logins. Ad blocking becomes opt-in (off by default, lazy blocklist). Fingerprint is hardened via `playwright-extra` + stealth plugin, real Chrome channel, and context locale/timezone/colorScheme/viewport.
+
+**Tech Stack:** TypeScript (ESM), Playwright, `playwright-extra`, `puppeteer-extra-plugin-stealth`, `@ghostery/adblocker-playwright`, Vitest, Docker (curia-deploy).
+
+**Design doc:** `docs/wip/2026-06-15-browser-stealth-design.md`
+
+**Worktrees:**
+- Part A (curia): `worktrees/curia-browser-stealth` (branch `feat/browser-stealth`) — already created.
+- Part B (curia-deploy): create a separate worktree at execution time, e.g. `worktrees/curia-deploy-browser-chrome` (branch `feat/browser-chrome-profile`), its own PR.
+
+---
+
+## Part A — curia
+
+### Task 1: Add stealth dependencies
+
+**Files:**
+- Modify: `package.json` (root)
+- Modify: `pnpm-lock.yaml`
+
+- [ ] **Step 1: Add the dependencies**
+
+Run (from the worktree root):
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add playwright-extra puppeteer-extra-plugin-stealth
+```
+
+Expected: both added to `dependencies` in `package.json`, `pnpm-lock.yaml` updated.
+
+- [ ] **Step 2: Verify install + no workspace corruption**
+
+Run:
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth status -s pnpm-workspace.yaml
+```
+
+Expected: NO changes to `pnpm-workspace.yaml` (if it changed, `git checkout -- pnpm-workspace.yaml` and re-run with `pnpm -C`). If pnpm prints a build-script approval warning for a new package, leave `pnpm-workspace.yaml`'s `allowBuilds` alone unless a genuinely new entry appears — then set it explicitly to `true`/`false`, never placeholder text.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add package.json pnpm-lock.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "chore: add playwright-extra + stealth plugin (#987)"
+```
+
+---
+
+### Task 2: Config typing for new browser fields
+
+**Files:**
+- Modify: `src/config.ts` (the `YamlConfig.browser` block, ~lines 134-137)
+- Modify: `config/default.yaml` (the `browser:` block, ~lines 60-64)
+
+No behavior to unit-test here (pure type + YAML additions read by the generic loader); verification is `typecheck` in Task 9.
+
+- [ ] **Step 1: Extend the `browser` interface**
+
+In `src/config.ts`, replace the `browser?:` block:
+
+```ts
+  browser?: {
+    sessionTtlMs?: number;
+    sweepIntervalMs?: number;
+    /**
+     * Persistent browser profile directory. Empty/absent → ${HOME}/.curia/browser-profile.
+     * Must be on a mounted volume in production so cookies/session survive restarts.
+     */
+    profileDir?: string;
+    /** Browser channel, e.g. "chrome" for real Chrome. Empty/absent → bundled Chromium. */
+    channel?: string;
+    /** Context locale (BCP 47). Default "en-US". */
+    locale?: string;
+  };
+```
+
+- [ ] **Step 2: Add the new keys to default.yaml**
+
+In `config/default.yaml`, replace the `browser:` block:
+
+```yaml
+browser:
+  # How long a browser session stays alive after its last action (ms).
+  sessionTtlMs: 600000   # 10 minutes
+  # How often the session sweep runs to close expired sessions (ms).
+  sweepIntervalMs: 120000  # 2 minutes
+  # Persistent profile directory. Empty → ${HOME}/.curia/browser-profile.
+  # Mount this on a volume in production so logins survive restarts.
+  profileDir: ""
+  # Browser channel: "chrome" for real Chrome (must be installed in the image),
+  # empty for the bundled Playwright Chromium.
+  channel: ""
+  # Context locale (BCP 47).
+  locale: "en-US"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add src/config.ts config/default.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "feat: add browser profileDir/channel/locale config (#987)"
+```
+
+---
+
+### Task 3: BrowserSession — owned-context lifecycle
+
+**Files:**
+- Modify: `src/browser/browser-session.ts`
+- Test: `src/browser/browser-session.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/browser/browser-session.test.ts` (inside the file, after the existing `describe` block). First add a mock helper near the top (below the existing `makeSession`):
+
+```ts
+import { vi } from 'vitest';
+
+/** A session backed by vi.fn() page/context so close() behavior can be asserted. */
+function makeClosableSession(opts: { incognito: boolean }) {
+  const page = { close: vi.fn().mockResolvedValue(undefined) } as unknown as Page;
+  const ownedContext = { close: vi.fn().mockResolvedValue(undefined) } as unknown as BrowserContext;
+  const sharedContext = { close: vi.fn().mockResolvedValue(undefined) } as unknown as BrowserContext;
+  const session = opts.incognito
+    ? new BrowserSession(ownedContext, page, ownedContext)
+    : new BrowserSession(sharedContext, page, null);
+  return { session, page, ownedContext, sharedContext };
+}
+
+describe('BrowserSession close lifecycle', () => {
+  it('persistent session closes only its page, not the shared context', async () => {
+    const { session, page, sharedContext } = makeClosableSession({ incognito: false });
+    await session.close();
+    expect((page as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
+    expect((sharedContext as unknown as { close: ReturnType<typeof vi.fn> }).close).not.toHaveBeenCalled();
+  });
+
+  it('incognito session closes its owned context (which closes the page)', async () => {
+    const { session, page, ownedContext } = makeClosableSession({ incognito: true });
+    await session.close();
+    expect((ownedContext as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
+    // We do NOT also call page.close() — context.close() tears the page down.
+    expect((page as unknown as { close: ReturnType<typeof vi.fn> }).close).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/browser/browser-session.test.ts | tail -30`
+Expected: FAIL — the new `close lifecycle` tests fail because `close()` currently calls `this.context.close()` unconditionally and the constructor ignores a third arg.
+
+- [ ] **Step 3: Implement owned-context lifecycle**
+
+In `src/browser/browser-session.ts`, add the field, constructor param, and new `close()`:
+
+```ts
+  /**
+   * For INCOGNITO sessions: the ephemeral BrowserContext this session OWNS and must
+   * tear down on close. Null for PERSISTENT sessions, whose page lives in the shared
+   * persistent profile context — closing that context would kill the whole browser, so
+   * a persistent session closes only its page instead. This single switch distinguishes
+   * the two session lifecycles (see #987 design).
+   */
+  private readonly ownedContext: BrowserContext | null;
+```
+
+Update the constructor:
+
+```ts
+  constructor(context: BrowserContext, page: Page, ownedContext: BrowserContext | null = null) {
+    this.context = context;
+    this.page = page;
+    this.ownedContext = ownedContext;
+    this.lastUsedAt = Date.now();
+  }
+```
+
+Replace `close()`:
+
+```ts
+  /**
+   * Release this session's browser resources.
+   * - Incognito: close the owned ephemeral context (also closes its page).
+   * - Persistent: close only the page; the shared profile context stays alive for
+   *   other sessions and to keep the profile warm.
+   */
+  async close(): Promise<void> {
+    if (this.ownedContext) {
+      await this.ownedContext.close();
+    } else {
+      await this.page.close();
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/browser/browser-session.test.ts | tail -30`
+Expected: PASS (all existing redaction tests + the two new lifecycle tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add src/browser/browser-session.ts src/browser/browser-session.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "feat: BrowserSession owned-context close lifecycle (#987)"
+```
+
+---
+
+### Task 4: BrowserService — persistent context refactor
+
+This is the core change: drop `chromium.launch()` + per-session `newContext()`, launch a single stealth-wrapped persistent context, and make sessions pages within it. Incognito and lazy-blocker land in Tasks 5 and 6.
+
+**Files:**
+- Modify: `src/browser/browser-service.ts`
+- Test: `src/browser/browser-service.test.ts`
+
+- [ ] **Step 1: Rework the test mocks**
+
+Replace the `--- Mock Playwright objects ---` section (the three `makeMock*` factories) in `src/browser/browser-service.test.ts` with:
+
+```ts
+function makeMockPage() {
+  return {
+    on: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    goto: vi.fn().mockResolvedValue(null),
+    evaluate: vi.fn().mockResolvedValue('page content'),
+    screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
+    url: vi.fn().mockReturnValue('https://example.com'),
+  };
+}
+
+function makeMockBrowser() {
+  return {
+    isConnected: vi.fn().mockReturnValue(true),
+    on: vi.fn(),
+    version: vi.fn().mockReturnValue('123.0.0.0'),
+    // Set per-test for incognito cases (Task 5).
+    newContext: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// The persistent context is the warm "browser" in the new model. browser() returns
+// the underlying Browser so the service can spin up incognito contexts off it.
+function makeMockContext(page: ReturnType<typeof makeMockPage>, browser: ReturnType<typeof makeMockBrowser>) {
+  return {
+    newPage: vi.fn().mockResolvedValue(page),
+    close: vi.fn().mockResolvedValue(undefined),
+    browser: vi.fn().mockReturnValue(browser),
+    on: vi.fn(),
+  };
+}
+```
+
+Update the unit-suite `beforeEach` wiring (the `mockPage/mockContext/mockBrowser` block and the `new BrowserService` call):
+
+```ts
+  let mockPage: ReturnType<typeof makeMockPage>;
+  let mockBrowser: ReturnType<typeof makeMockBrowser>;
+  let mockContext: ReturnType<typeof makeMockContext>;
+```
+
+```ts
+    mockPage = makeMockPage();
+    mockBrowser = makeMockBrowser();
+    mockContext = makeMockContext(mockPage, mockBrowser);
+
+    service = new BrowserService({
+      logger,
+      sessionTtlMs: 1000,
+      sweepIntervalMs: 60000,
+      // Inject a fake persistent context so no real Playwright process is needed.
+      contextFactory: async () => mockContext as never,
+    });
+    await service.start();
+```
+
+- [ ] **Step 2: Update existing unit assertions to the page model**
+
+In `src/browser/browser-service.test.ts`, change the existing behavior assertions:
+
+- "creates a new session when no session_id is provided":
+  `expect(mockContext.newPage).toHaveBeenCalledOnce();` (was `mockBrowser.newContext`).
+- "reuses an existing session": `expect(mockContext.newPage).toHaveBeenCalledOnce();`.
+- "creates a fresh session when the provided session_id has expired":
+  `expect(mockContext.newPage).toHaveBeenCalledTimes(2);` and replace the
+  `expect(mockContext.close)...` line with `expect(mockPage.close).toHaveBeenCalledOnce();`.
+- "closeSession() closes the context and removes the session" → rename intent to page:
+  replace `expect(mockContext.close).toHaveBeenCalledOnce();` with
+  `expect(mockPage.close).toHaveBeenCalledOnce();`.
+- "sweep removes expired sessions": replace `expect(mockContext.close)...` with
+  `expect(mockPage.close).toHaveBeenCalledOnce();`.
+- "stop() closes all sessions and the browser": replace the two assertions with
+  `expect(mockPage.close).toHaveBeenCalledTimes(2);` and
+  `expect(mockContext.close).toHaveBeenCalledOnce();`.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run src/browser/browser-service.test.ts | tail -40`
+Expected: FAIL — `contextFactory` is not a recognized option and the service still references `this.browser`.
+
+- [ ] **Step 4: Rewrite BrowserService for the persistent-context model**
+
+In `src/browser/browser-service.ts`:
+
+Replace the imports block (top of file) — drop `chromium` from `'playwright'`, add playwright-extra, stealth, os/path, and the `BrowserContext` type:
+
+```ts
+import { randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { chromium as stealthChromium } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import type { Browser, BrowserContext, BrowserContextOptions } from 'playwright';
+import { PlaywrightBlocker } from '@ghostery/adblocker-playwright';
+import type { Logger } from '../logger.js';
+import { BrowserSession } from './browser-session.js';
+import type { SessionId } from './types.js';
+
+// Register the stealth plugin once at module load. It patches the residual automation
+// signals (navigator.plugins, window.chrome, WebGL vendor/renderer, permissions.query,
+// and the User-Agent) that --disable-blink-features=AutomationControlled alone leaves
+// exposed. It applies at the browser level, so it covers both the persistent context and
+// any incognito context spun off the same browser.
+stealthChromium.use(StealthPlugin());
+```
+
+Replace the `BrowserServiceOptions` interface:
+
+```ts
+interface BrowserServiceOptions {
+  logger: Logger;
+  /** Session idle TTL in ms. Default: 600_000 (10 minutes). */
+  sessionTtlMs?: number;
+  /** How often to sweep expired sessions in ms. Default: 120_000 (2 minutes). */
+  sweepIntervalMs?: number;
+  /** Persistent profile directory. Empty/absent → ${HOME}/.curia/browser-profile. */
+  profileDir?: string;
+  /** Browser channel, e.g. 'chrome' for real Chrome. Absent → bundled Chromium. */
+  channel?: string;
+  /** Context locale (BCP 47). Default 'en-US'. */
+  locale?: string;
+  /** IANA timezone for the context, aligned to the principal. */
+  timezone?: string;
+  /**
+   * Optional factory to create the persistent BrowserContext.
+   * Defaults to launchPersistentContext(...). Override in tests to inject a mock.
+   */
+  contextFactory?: () => Promise<BrowserContext>;
+}
+```
+
+Replace the class fields block (the `private logger ... private xvfbProcess` group and the constructor) with:
+
+```ts
+  private logger: Logger;
+  private sessionTtlMs: number;
+  private sweepIntervalMs: number;
+  private profileDir: string;
+  private channel: string | undefined;
+  private locale: string;
+  private timezone: string | undefined;
+  private contextFactory: () => Promise<BrowserContext>;
+
+  // The persistent context IS the warm browser in this model. Sessions are pages within
+  // it (shared cookies/storage = "returning user"); incognito sessions get their own
+  // ephemeral context spun off context.browser() (see getOrCreateSession).
+  private context: BrowserContext | null = null;
+  // Ad blocker is loaded lazily on first opt-in (block_ads:true) and cached. Off by
+  // default so login/auth/form-fill flows carry no privacy-extension signal.
+  private blocker: PlaywrightBlocker | null = null;
+  private blockerPromise: Promise<PlaywrightBlocker> | null = null;
+  private sessions: Map<SessionId, BrowserSession> = new Map();
+  private sweepTimer: NodeJS.Timeout | null = null;
+  private xvfbProcess: ChildProcess | null = null;
+
+  constructor(options: BrowserServiceOptions) {
+    this.logger = options.logger.child({ service: 'BrowserService' });
+    this.sessionTtlMs = options.sessionTtlMs ?? 600_000;
+    this.sweepIntervalMs = options.sweepIntervalMs ?? 120_000;
+    this.profileDir = options.profileDir && options.profileDir.length > 0
+      ? options.profileDir
+      : join(homedir(), '.curia', 'browser-profile');
+    this.channel = options.channel && options.channel.length > 0 ? options.channel : undefined;
+    this.locale = options.locale && options.locale.length > 0 ? options.locale : 'en-US';
+    this.timezone = options.timezone;
+    this.contextFactory = options.contextFactory ?? (() => this.launchPersistentContext());
+  }
+```
+
+Replace `start()`:
+
+```ts
+  async start(): Promise<void> {
+    if (this.context !== null) {
+      throw new Error('BrowserService.start() called while already running — call stop() first');
+    }
+
+    await this.maybeStartXvfb();
+    this.context = await this.contextFactory();
+
+    // Restart the browser automatically on disconnect (e.g., OOM kill).
+    this.attachDisconnectedHandler(this.context);
+
+    this.sweepTimer = setInterval(() => void this.sweep(), this.sweepIntervalMs);
+    this.sweepTimer.unref();
+
+    this.logger.info({ sessionTtlMs: this.sessionTtlMs }, 'BrowserService started');
+  }
+```
+
+Replace `attachDisconnectedHandler(...)`:
+
+```ts
+  /**
+   * Attach the 'disconnected' crash-recovery listener to the persistent context's
+   * underlying browser. On disconnect we clear sessions and relaunch the persistent
+   * context, then re-attach so a second crash is also recovered.
+   */
+  private attachDisconnectedHandler(context: BrowserContext): void {
+    const browser = context.browser();
+    if (!browser) {
+      this.logger.warn('Persistent context has no associated browser — crash recovery disabled');
+      return;
+    }
+    browser.on('disconnected', () => {
+      this.logger.error('Playwright browser disconnected — clearing sessions and restarting');
+      this.sessions.clear();
+      void this.contextFactory().then(ctx => {
+        this.context = ctx;
+        this.attachDisconnectedHandler(ctx);
+      }).catch(err => {
+        this.logger.error({ err }, 'Browser restart failed');
+      });
+    });
+  }
+```
+
+Replace `stop()` (the body that closes sessions/browser/xvfb) — change the browser close to context close:
+
+```ts
+  async stop(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+
+    for (const [sessionId, session] of this.sessions.entries()) {
+      try {
+        await session.close();
+      } catch (err) {
+        this.logger.error({ err, sessionId }, 'Error closing session during shutdown');
+      }
+    }
+    this.sessions.clear();
+
+    if (this.context) {
+      try {
+        await this.context.close();
+      } catch (err) {
+        this.logger.error({ err }, 'Error closing browser context during shutdown');
+      }
+      this.context = null;
+    }
+
+    if (this.xvfbProcess) {
+      this.xvfbProcess.kill();
+      this.xvfbProcess = null;
+    }
+
+    this.logger.info('BrowserService stopped');
+  }
+```
+
+Replace `getOrCreateSession(...)` (persistent-only for now; incognito/blockAds params added but incognito branch and blocker added in Tasks 5/6 — include the full version here so the file is consistent):
+
+```ts
+  async getOrCreateSession(
+    sessionId: SessionId | undefined,
+    opts: { incognito?: boolean; blockAds?: boolean } = {},
+  ): Promise<{ sessionId: SessionId; session: BrowserSession }> {
+    const browser = this.context?.browser();
+    if (!this.context || !browser || !browser.isConnected()) {
+      throw new Error('BrowserService: browser is not running. Call start() first.');
+    }
+
+    if (sessionId) {
+      const existing = this.sessions.get(sessionId);
+      if (existing && !existing.isExpired(this.sessionTtlMs)) {
+        existing.lastUsedAt = Date.now();
+        return { sessionId, session: existing };
+      }
+      if (existing) {
+        this.logger.debug({ sessionId }, 'Session expired — closing and creating fresh session');
+        await existing.close().catch(err => this.logger.error({ err, sessionId }, 'Error closing expired session'));
+        this.sessions.delete(sessionId);
+      }
+    }
+
+    // Incognito → fresh isolated context off the same browser, never touching the
+    // principal's persistent profile. Persistent (default) → a page in the shared profile.
+    let ownedContext: BrowserContext | null = null;
+    let page;
+    try {
+      if (opts.incognito) {
+        ownedContext = await browser.newContext(this.buildContextOptions());
+        page = await ownedContext.newPage();
+      } else {
+        page = await this.context.newPage();
+      }
+      if (opts.blockAds) {
+        const blocker = await this.getBlocker();
+        if (blocker) {
+          try {
+            await blocker.enableBlockingInPage(page);
+          } catch (err) {
+            this.logger.warn({ err }, 'Ad blocker failed to attach to page — continuing without ad blocking for this session');
+          }
+        }
+      }
+    } catch (err) {
+      // Clean up a half-created session to prevent a leak (it's not yet in the map).
+      if (ownedContext) {
+        await ownedContext.close().catch(closeErr => {
+          this.logger.error({ err: closeErr }, 'Failed to close incognito context during cleanup — possible resource leak');
+        });
+      } else if (page) {
+        await page.close().catch(() => {});
+      }
+      throw err;
+    }
+
+    const newSessionId = randomUUID();
+    const session = new BrowserSession(ownedContext ?? this.context, page, ownedContext);
+
+    page.on('crash', () => {
+      this.logger.error({ sessionId: newSessionId }, 'Page crashed — removing session');
+      void session.close().catch(() => {});
+      this.sessions.delete(newSessionId);
+    });
+
+    this.sessions.set(newSessionId, session);
+    this.logger.debug(
+      { sessionId: newSessionId, incognito: opts.incognito === true, blockAds: opts.blockAds === true },
+      'New browser session created',
+    );
+
+    return { sessionId: newSessionId, session };
+  }
+```
+
+Add the private helpers (`buildContextOptions`, `getBlocker`, `launchPersistentContext`, `logChannel`) in the `--- Private helpers ---` section, REPLACING the old `launchChromium()`:
+
+```ts
+  /**
+   * Fingerprint/context options shared by the persistent context and any incognito
+   * context. We deliberately DO NOT set userAgent — with the real Chrome channel and the
+   * stealth plugin's UA-override evasion the genuine current UA is sent, so it can never
+   * go stale (the old hardcoded Chrome/122 was a bot tell). timezoneId is set only when a
+   * timezone is configured, aligning the context with the principal.
+   */
+  private buildContextOptions(): BrowserContextOptions {
+    return {
+      viewport: { width: 1280, height: 720 },
+      locale: this.locale,
+      colorScheme: 'light',
+      ...(this.timezone ? { timezoneId: this.timezone } : {}),
+    };
+  }
+
+  /**
+   * Lazily fetch the Ghostery blocklist on first opt-in (block_ads:true) and cache it.
+   * Off by default, so most sessions never pay this cost. A fetch failure logs and returns
+   * null (blocking is best-effort) and clears the cached promise so a later opt-in retries.
+   */
+  private async getBlocker(): Promise<PlaywrightBlocker | null> {
+    if (this.blocker) return this.blocker;
+    try {
+      this.blockerPromise ??= PlaywrightBlocker.fromPrebuiltAdsAndTracking(fetch);
+      this.blocker = await this.blockerPromise;
+      this.logger.info('Ad blocker initialized (first opt-in)');
+      return this.blocker;
+    } catch (err) {
+      this.logger.warn({ err }, 'Ad blocker failed to initialize — continuing without ad blocking');
+      this.blockerPromise = null;
+      return null;
+    }
+  }
+
+  /**
+   * Launch the single persistent browser context (the principal's profile). Tries the
+   * configured channel (e.g. real Chrome) first and falls back to bundled Chromium if it
+   * isn't installed, so the skill degrades instead of failing to boot. Cast through unknown:
+   * playwright-extra returns a playwright-core BrowserContext, structurally identical to the
+   * 'playwright' BrowserContext we type against.
+   */
+  private async launchPersistentContext(): Promise<BrowserContext> {
+    const baseOptions = {
+      headless: false,
+      args: [
+        '--disable-blink-features=AutomationControlled', // removes navigator.webdriver flag
+        '--no-sandbox',                                   // required in container environments
+        '--disable-dev-shm-usage',                        // prevents /dev/shm OOM in Docker
+      ],
+      ...this.buildContextOptions(),
+    };
+
+    try {
+      const context = await stealthChromium.launchPersistentContext(
+        this.profileDir,
+        this.channel ? { ...baseOptions, channel: this.channel } : baseOptions,
+      ) as unknown as BrowserContext;
+      this.logChannel(context, this.channel);
+      return context;
+    } catch (err) {
+      if (!this.channel) throw err; // no channel to fall back from — a genuine launch failure
+      this.logger.warn({ err, channel: this.channel }, 'Failed to launch with channel — falling back to bundled Chromium');
+      const context = await stealthChromium.launchPersistentContext(
+        this.profileDir,
+        baseOptions,
+      ) as unknown as BrowserContext;
+      this.logChannel(context, undefined);
+      return context;
+    }
+  }
+
+  /** Log the resolved channel + real browser version for observability (UA traceability). */
+  private logChannel(context: BrowserContext, channel: string | undefined): void {
+    const version = context.browser()?.version();
+    this.logger.info({ channel: channel ?? 'chromium', version, profileDir: this.profileDir }, 'Persistent browser context launched');
+  }
+```
+
+Also update the file-header comment block: the line "Each session gets its own isolated BrowserContext (separate cookies/storage)" should be replaced with a note that sessions are pages in one shared persistent profile context (returning-user state) and incognito sessions get an isolated ephemeral context. Keep the SCALABILITY @TODO block.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/browser/browser-service.test.ts | tail -40`
+Expected: PASS for the unit suite (the `clearStaleX11Lock` / `isXServerBinary` suites are untouched). Integration suite stays skipped (no `RUN_BROWSER_TESTS`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add src/browser/browser-service.ts src/browser/browser-service.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "feat: persistent-context browser model with fingerprint hardening (#987)"
+```
+
+---
+
+### Task 5: Incognito session test coverage
+
+The incognito branch was implemented in Task 4; this task locks it with tests.
+
+**Files:**
+- Test: `src/browser/browser-service.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the `describe('BrowserService (unit — mocked browser)', ...)` block:
+
+```ts
+  it('incognito session uses a fresh isolated context, not the persistent profile', async () => {
+    const incognitoPage = makeMockPage();
+    const incognitoContext = {
+      newPage: vi.fn().mockResolvedValue(incognitoPage),
+      close: vi.fn().mockResolvedValue(undefined),
+      browser: vi.fn().mockReturnValue(mockBrowser),
+      on: vi.fn(),
+    };
+    mockBrowser.newContext.mockResolvedValue(incognitoContext as never);
+
+    const { sessionId } = await service.getOrCreateSession(undefined, { incognito: true });
+
+    // Came from a fresh context off the browser, NOT the persistent profile.
+    expect(mockBrowser.newContext).toHaveBeenCalledOnce();
+    expect(mockContext.newPage).not.toHaveBeenCalled();
+
+    // Closing the session tears down the OWNED context (isolation), not just a page.
+    await service.closeSession(sessionId);
+    expect(incognitoContext.close).toHaveBeenCalledOnce();
+  });
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `npx vitest run src/browser/browser-service.test.ts -t incognito | tail -20`
+Expected: PASS (implementation already exists from Task 4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add src/browser/browser-service.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "test: incognito session isolation (#987)"
+```
+
+---
+
+### Task 6: Opt-in ad blocker test coverage
+
+The blocker is now opt-in + lazy (implemented in Task 4). This task adds tests and the adblocker module mock.
+
+**Files:**
+- Test: `src/browser/browser-service.test.ts`
+
+- [ ] **Step 1: Add the hoisted adblocker mock**
+
+Near the top of `src/browser/browser-service.test.ts` (after the imports), add:
+
+```ts
+// Mock the Ghostery blocker so no real blocklist is fetched in unit tests. A stable
+// fakeBlocker lets us assert enableBlockingInPage call counts; fromPrebuilt lets us
+// assert the lazy fetch happened (or didn't).
+const { fakeBlocker, fromPrebuilt } = vi.hoisted(() => {
+  const fb = { enableBlockingInPage: vi.fn().mockResolvedValue(undefined) };
+  return { fakeBlocker: fb, fromPrebuilt: vi.fn().mockResolvedValue(fb) };
+});
+vi.mock('@ghostery/adblocker-playwright', () => ({
+  PlaywrightBlocker: { fromPrebuiltAdsAndTracking: fromPrebuilt },
+}));
+```
+
+In the unit suite `beforeEach`, after `await service.start();`, clear the spies so each test starts clean:
+
+```ts
+    fromPrebuilt.mockClear();
+    fakeBlocker.enableBlockingInPage.mockClear();
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add inside the unit `describe` block:
+
+```ts
+  it('does not fetch or attach the blocker by default (off for login/form flows)', async () => {
+    await service.getOrCreateSession(undefined);
+    expect(fromPrebuilt).not.toHaveBeenCalled();
+    expect(fakeBlocker.enableBlockingInPage).not.toHaveBeenCalled();
+  });
+
+  it('attaches the blocker only when block_ads is true, fetching the list lazily once', async () => {
+    await service.getOrCreateSession(undefined, { blockAds: true });
+    await service.getOrCreateSession(undefined, { blockAds: true });
+    // Blocklist fetched once and cached across opt-ins.
+    expect(fromPrebuilt).toHaveBeenCalledOnce();
+    // Attached per opt-in session.
+    expect(fakeBlocker.enableBlockingInPage).toHaveBeenCalledTimes(2);
+  });
+```
+
+- [ ] **Step 3: Run to verify they pass**
+
+Run: `npx vitest run src/browser/browser-service.test.ts -t "blocker" | tail -20`
+Expected: PASS (implementation from Task 4).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add src/browser/browser-service.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "test: opt-in lazy ad blocker (#987)"
+```
+
+---
+
+### Task 7: Wire config into index.ts
+
+Fixes the long-standing dead cast (#204) and passes the new fields + timezone.
+
+**Files:**
+- Modify: `src/index.ts` (~lines 762-770)
+
+No new behavior test (covered by typecheck + startup); the browser config path has no unit harness.
+
+- [ ] **Step 1: Replace the dead cast with typed config**
+
+In `src/index.ts`, replace the `const browserConfig = (config as unknown as ...)` line and the `new BrowserService({...})` call with:
+
+```ts
+    const browserConfig = yamlConfig.browser;
+    browserService = new BrowserService({
+      logger,
+      sessionTtlMs: browserConfig?.sessionTtlMs ?? 600_000,
+      sweepIntervalMs: browserConfig?.sweepIntervalMs ?? 120_000,
+      profileDir: browserConfig?.profileDir,
+      channel: browserConfig?.channel,
+      locale: browserConfig?.locale,
+      // Align the browser timezone with the principal's configured timezone.
+      timezone: config.timezone,
+    });
+```
+
+(Delete the now-obsolete TODO(#192)/#204 comment block above it.)
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth run typecheck | tail -20`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add src/index.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "feat: wire browser profileDir/channel/locale/timezone config (#987, fixes #204)"
+```
+
+---
+
+### Task 8: web-browser skill — block_ads + incognito inputs
+
+**Files:**
+- Modify: `skills/web-browser/handler.ts`
+- Modify: `skills/web-browser/skill.json`
+- Test: `skills/web-browser/handler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Inspect `skills/web-browser/handler.test.ts` for the existing mock-context shape (it stubs `ctx.browserService.getOrCreateSession`). Add a test asserting the handler forwards the two flags. Use the existing test's harness/helpers; the assertion is:
+
+```ts
+  it('forwards block_ads and incognito to getOrCreateSession', async () => {
+    const getOrCreateSession = vi.fn().mockResolvedValue({
+      sessionId: 'sess-1',
+      session: { page: makeFakePage(), registerInjectedSecret: vi.fn(), redactInjectedSecrets: (s: string) => s },
+    });
+    const ctx = makeCtx({ browserService: { getOrCreateSession, closeSession: vi.fn() } }, {
+      action: 'navigate', url: 'https://example.com', block_ads: true, incognito: true,
+    });
+
+    await new WebBrowserHandler().execute(ctx);
+
+    expect(getOrCreateSession).toHaveBeenCalledWith(undefined, { incognito: true, blockAds: true });
+  });
+```
+
+(Adapt `makeCtx` / `makeFakePage` to the existing helpers in that test file. If the file builds `ctx` inline, mirror that style — the key assertion is the `getOrCreateSession` call args.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run skills/web-browser/handler.test.ts -t "forwards block_ads" | tail -20`
+Expected: FAIL — handler calls `getOrCreateSession(session_id ?? undefined)` with no options object.
+
+- [ ] **Step 3: Implement flag parsing + forwarding**
+
+In `skills/web-browser/handler.ts`, add `block_ads` and `incognito` to the destructured input and its type:
+
+```ts
+    const { action, url, selector, text, value, secret_ref, session_id, screenshot, block_ads, incognito } = ctx.input as {
+      action?: string;
+      url?: string;
+      selector?: string;
+      text?: string;
+      value?: string;
+      secret_ref?: string;
+      session_id?: string;
+      screenshot?: boolean;
+      // block_ads (#987): opt in to ad/tracker blocking. Off by default — login,
+      // authenticated, and form-fill flows must not carry a privacy-extension signal.
+      block_ads?: boolean;
+      // incognito (#987): run this session in a fresh, isolated context instead of the
+      // principal's persistent profile. For Curia's own logins or throwaway flows.
+      incognito?: boolean;
+    };
+```
+
+Update the `getOrCreateSession` call in the session-acquisition block:
+
+```ts
+      const result = await ctx.browserService.getOrCreateSession(session_id ?? undefined, {
+        incognito: incognito === true,
+        blockAds: block_ads === true,
+      });
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run skills/web-browser/handler.test.ts | tail -30`
+Expected: PASS (new test + all existing).
+
+- [ ] **Step 5: Update skill.json**
+
+In `skills/web-browser/skill.json`:
+- Bump `"version"` from `"1.1.0"` to `"1.2.0"` (new inputs/capability → minor).
+- Add to `inputs`: `"block_ads": "boolean?"` and `"incognito": "boolean?"`.
+- Update `description` — append before the final period:
+
+> ` Set block_ads:true ONLY for plain content browsing — never for login, authenticated, or form-fill flows (sites flag the ad blocker as a privacy extension). Set incognito:true to run in a throwaway, isolated session (e.g. logging in as Curia itself) instead of the principal's persistent profile; omit it for the principal's own accounts so sessions persist.`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add skills/web-browser/handler.ts skills/web-browser/handler.test.ts skills/web-browser/skill.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "feat: block_ads + incognito inputs on web-browser skill (#987)"
+```
+
+---
+
+### Task 9: CHANGELOG + verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add CHANGELOG entries**
+
+Under `## [Unreleased]`, add (create the section headers if absent):
+
+```markdown
+### Added
+- **Browser incognito sessions** — `incognito:true` on `web-browser` runs in a throwaway isolated context, keeping Curia's own logins out of the principal's profile. (#987)
+- **Persistent browser profile** — the browser now uses a persistent context on a mounted volume, so logins/cookies survive restarts. (#987)
+
+### Changed
+- **`web-browser` ad blocking is now opt-in** (`block_ads:true`) and off by default, so login/auth/form-fill flows no longer trip "privacy extension" bot detection (e.g. x.com). (#987)
+- **Browser fingerprint hardened** — real Chrome channel where available, current (non-stale) UA via `playwright-extra` + stealth, plus context locale/timezone/colorScheme. (#987)
+
+### Fixed
+- **Browser YAML config now takes effect** — `browser.*` settings were read through a dead cast and silently ignored. (#987, #204)
+```
+
+- [ ] **Step 2: Full typecheck + test suite**
+
+Run:
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth run typecheck | tail -20
+```
+
+Expected: no errors.
+
+```bash
+npx vitest run src/browser/ skills/web-browser/ | tail -40
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Optional real-browser smoke (if Chromium available locally)**
+
+Run: `RUN_BROWSER_TESTS=1 npx vitest run src/browser/browser-service.test.ts | tail -30`
+Expected: the integration suite passes (creates a persistent context in a temp profile, navigates example.com). If it fails only due to a missing local display/browser, note it and rely on CI.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "docs: changelog for browser hardening (#987)"
+```
+
+---
+
+### Task 10: Persistence integration test (gated)
+
+**Files:**
+- Test: `src/browser/browser-service.test.ts` (integration block)
+
+- [ ] **Step 1: Add a restart-persistence integration test**
+
+Inside the `describe.skipIf(!runBrowserTests)('BrowserService (integration — real Chromium)', ...)` block, add a test that uses a fixed temp profile dir across two service instances:
+
+```ts
+  it('persists cookies across a service restart (persistent profile)', async () => {
+    const profileDir = mkdtempSync(join(tmpdir(), 'curia-profile-'));
+    try {
+      const s1 = new BrowserService({ logger, sessionTtlMs: 30000, sweepIntervalMs: 60000, profileDir });
+      await s1.start();
+      const { session } = await s1.getOrCreateSession(undefined);
+      await session.page.goto('https://example.com');
+      await session.page.evaluate(() => { document.cookie = 'curia_test=1; path=/'; });
+      await s1.stop();
+
+      const s2 = new BrowserService({ logger, sessionTtlMs: 30000, sweepIntervalMs: 60000, profileDir });
+      await s2.start();
+      const { session: session2 } = await s2.getOrCreateSession(undefined);
+      await session2.page.goto('https://example.com');
+      const cookie = await session2.page.evaluate(() => document.cookie);
+      expect(cookie).toContain('curia_test=1');
+      await s2.stop();
+    } finally {
+      rmSync(profileDir, { recursive: true, force: true });
+    }
+  });
+```
+
+(`mkdtempSync`, `tmpdir`, `join`, `rmSync` are already imported at the top of the test file.)
+
+- [ ] **Step 2: Run it (gated)**
+
+Run: `RUN_BROWSER_TESTS=1 npx vitest run src/browser/browser-service.test.ts -t "persists cookies" | tail -30`
+Expected: PASS (a returning visit to example.com still has the cookie set before restart). If no local browser/display, document that this runs in CI / manual verification.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth add src/browser/browser-service.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-browser-stealth commit -m "test: persistent-profile survives restart (#987)"
+```
+
+---
+
+## Part B — curia-deploy (separate worktree + PR)
+
+> Execute in a fresh curia-deploy worktree (e.g. `worktrees/curia-deploy-browser-chrome`, branch `feat/browser-chrome-profile`). Pull main first; symlink any gitignored files; `pnpm -C` for installs. Separate PR.
+
+### Task B1: Install real Chrome in the image
+
+**Files:**
+- Modify: `deploy/compose/Dockerfile.curia` (~lines 100-101)
+
+- [ ] **Step 1: Add the Chrome channel install**
+
+After the existing `playwright install --with-deps chromium` block, add a line so the real Chrome channel resolves for `channel: 'chrome'`:
+
+```dockerfile
+# Install real Google Chrome (the "chrome" channel) for fingerprint hardening (#987).
+# --with-deps on the chromium install above already pulled the shared system libs, so
+# this just lays down Google Chrome stable. Sites fingerprint bundled Chromium; real
+# Chrome presents a genuine, current UA + feature set.
+RUN pnpm exec playwright install chrome
+```
+
+- [ ] **Step 2: Build the image locally to confirm Chrome installs**
+
+Run a build (from the build context root that holds `curia/` and `curia-deploy/`):
+
+```bash
+docker build -f curia-deploy/deploy/compose/Dockerfile.curia -t curia-test .
+```
+
+Expected: build succeeds; `playwright install chrome` completes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C <curia-deploy-worktree> add deploy/compose/Dockerfile.curia
+git -C <curia-deploy-worktree> commit -m "feat: install real Chrome channel for browser hardening (curia#987)"
+```
+
+### Task B2: Persistent profile volume
+
+**Files:**
+- Modify: `deploy/compose/Dockerfile.curia` (pre-create the dir, near the google_workspace_mcp block ~line 167)
+- Modify: `deploy/compose/compose.production.yaml` (volumes + the named volume declaration)
+
+- [ ] **Step 1: Pre-create + chown the profile dir in the Dockerfile**
+
+After the `mkdir -p /home/curia/.google_workspace_mcp` block, add:
+
+```dockerfile
+# Pre-create the persistent browser profile dir (#987) owned by curia. The web-browser
+# skill's BrowserService launches a persistent context here so cookies/sessions survive
+# restarts. Path is $HOME/.curia/browser-profile; HOME=/home/curia (set below). On a fresh
+# named volume Docker copy-up seeds this curia ownership so first-run writes succeed.
+RUN mkdir -p /home/curia/.curia/browser-profile \
+ && chown -R curia:curia /home/curia/.curia
+```
+
+- [ ] **Step 2: Mount a named volume at the profile path**
+
+In `compose.production.yaml`, under the curia service `volumes:` (alongside `google-workspace-tokens`), add:
+
+```yaml
+      # Persistent browser profile (#987) — cookies/localStorage/history for the
+      # web-browser skill, so logins survive restarts. Path matches HOME=/home/curia
+      # and browser.profileDir's default (${HOME}/.curia/browser-profile).
+      - curia-browser-profile:/home/curia/.curia/browser-profile
+```
+
+And under the top-level `volumes:` block, declare it:
+
+```yaml
+  # Persistent browser profile for the web-browser skill (#987).
+  curia-browser-profile:
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C <curia-deploy-worktree> add deploy/compose/Dockerfile.curia deploy/compose/compose.production.yaml
+git -C <curia-deploy-worktree> commit -m "feat: persistent browser-profile volume (curia#987)"
+```
+
+### Task B3: Enable the Chrome channel in deploy config
+
+**Files:**
+- Modify: the instance config layer (`config/local.yaml` provided at deploy time, or the equivalent curia-deploy config mechanism — confirm during the worktree setup)
+
+- [ ] **Step 1: Set the channel**
+
+Add to the deploy-time `local.yaml` (merged over `config/default.yaml`):
+
+```yaml
+browser:
+  channel: chrome
+  # profileDir left as default → ${HOME}/.curia/browser-profile (matches the volume mount).
+```
+
+- [ ] **Step 2: Commit** (in whatever file the instance owns; if it's a gitignored secret-layer file, document the change in the deploy runbook instead).
+
+---
+
+## Manual re-test checklist (post-deploy, in the PR description)
+
+Per the issue's acceptance criteria — verify by hand after deploy:
+
+- [ ] x.com login page **renders and accepts credentials** with `block_ads` off (no "privacy related extensions" error).
+- [ ] OpenTable reservation flow reaches and submits its form.
+- [ ] A personality-test form fill reaches and submits.
+- [ ] Log into a site once, `docker restart` the curia container, revisit — still authenticated (persistent profile works).
+- [ ] An `incognito:true` session does NOT see cookies set in a prior persistent session.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** ad-blocker opt-in (T4/T6/T8), fingerprint UA/channel/locale/tz/colorScheme/viewport (T4), stealth (T1/T4), persistent profile (T4/T10/B2), incognito identity scope (T3/T4/T5/T8), deploy chrome+volume (B1/B2/B3), config wiring + #204 fix (T2/T7). All design sections map to a task.
+- **Type consistency:** `getOrCreateSession(sessionId, { incognito?, blockAds? })`, `BrowserSession(context, page, ownedContext?)`, `buildContextOptions(): BrowserContextOptions`, `getBlocker()`, `launchPersistentContext()` are used consistently across tasks and the handler.
+- **Known cast:** `launchPersistentContext(...) as unknown as BrowserContext` bridges playwright-extra (playwright-core) and the `'playwright'` types; commented at the call site.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "pgvector": "^0.3.0",
     "pino": "^10.3.1",
     "playwright": "^1.60.0",
+    "playwright-extra": "^4.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "sanitize-html": "^2.17.5"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,12 @@ importers:
       playwright:
         specifier: ^1.60.0
         version: 1.60.0
+      playwright-extra:
+        specifier: ^4.3.6
+        version: 4.3.6(playwright-core@1.60.0)(playwright@1.60.0)
+      puppeteer-extra-plugin-stealth:
+        specifier: ^2.11.2
+        version: 2.11.2(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0))
       sanitize-html:
         specifier: ^2.17.5
         version: 2.17.5
@@ -2394,6 +2400,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  arr-union@3.1.0:
+    resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
+    engines: {node: '>=0.10.0'}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -2473,6 +2483,9 @@ packages:
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
@@ -2580,6 +2593,10 @@ packages:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
+  clone-deep@0.2.4:
+    resolution: {integrity: sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==}
+    engines: {node: '>=0.10.0'}
+
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
@@ -2636,6 +2653,9 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@10.0.3:
     resolution: {integrity: sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==}
@@ -3307,6 +3327,18 @@ packages:
       debug:
         optional: true
 
+  for-in@0.1.8:
+    resolution: {integrity: sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==}
+    engines: {node: '>=0.10.0'}
+
+  for-in@1.0.2:
+    resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
+    engines: {node: '>=0.10.0'}
+
+  for-own@0.1.5:
+    resolution: {integrity: sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==}
+    engines: {node: '>=0.10.0'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -3341,6 +3373,13 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -3418,6 +3457,10 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
     engines: {node: '>=10.0'}
@@ -3457,6 +3500,9 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   gtoken@8.0.0:
     resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
@@ -3562,6 +3608,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -3588,6 +3638,10 @@ packages:
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3612,6 +3666,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
 
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -3642,6 +3700,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -3717,6 +3779,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
@@ -3740,6 +3805,14 @@ packages:
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
+  kind-of@2.0.1:
+    resolution: {integrity: sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==}
+    engines: {node: '>=0.10.0'}
+
+  kind-of@3.2.2:
+    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
+    engines: {node: '>=0.10.0'}
+
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
@@ -3756,6 +3829,14 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lazy-cache@0.2.7:
+    resolution: {integrity: sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==}
+    engines: {node: '>=0.10.0'}
+
+  lazy-cache@1.0.4:
+    resolution: {integrity: sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==}
+    engines: {node: '>=0.10.0'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3945,6 +4026,10 @@ packages:
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
 
+  merge-deep@3.0.3:
+    resolution: {integrity: sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==}
+    engines: {node: '>=0.10.0'}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -3978,6 +4063,9 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3988,6 +4076,10 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mixin-object@2.0.1:
+    resolution: {integrity: sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==}
+    engines: {node: '>=0.10.0'}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -4334,6 +4426,10 @@ packages:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -4558,6 +4654,54 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  puppeteer-extra-plugin-stealth@2.11.2:
+    resolution: {integrity: sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      playwright-extra: '*'
+      puppeteer-extra: '*'
+    peerDependenciesMeta:
+      playwright-extra:
+        optional: true
+      puppeteer-extra:
+        optional: true
+
+  puppeteer-extra-plugin-user-data-dir@2.4.1:
+    resolution: {integrity: sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      playwright-extra: '*'
+      puppeteer-extra: '*'
+    peerDependenciesMeta:
+      playwright-extra:
+        optional: true
+      puppeteer-extra:
+        optional: true
+
+  puppeteer-extra-plugin-user-preferences@2.4.1:
+    resolution: {integrity: sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      playwright-extra: '*'
+      puppeteer-extra: '*'
+    peerDependenciesMeta:
+      playwright-extra:
+        optional: true
+      puppeteer-extra:
+        optional: true
+
+  puppeteer-extra-plugin@3.2.3:
+    resolution: {integrity: sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==}
+    engines: {node: '>=9.11.2'}
+    peerDependencies:
+      playwright-extra: '*'
+      puppeteer-extra: '*'
+    peerDependenciesMeta:
+      playwright-extra:
+        optional: true
+      puppeteer-extra:
+        optional: true
+
   python-shell@5.0.0:
     resolution: {integrity: sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w==}
     engines: {node: '>=0.10'}
@@ -4658,6 +4802,11 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
@@ -4760,6 +4909,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shallow-clone@0.1.2:
+    resolution: {integrity: sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==}
+    engines: {node: '>=0.10.0'}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -5114,6 +5267,10 @@ packages:
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -7376,7 +7533,6 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
-    optional: true
 
   '@types/deep-eql@4.0.2': {}
 
@@ -7392,8 +7548,7 @@ snapshots:
 
   '@types/luxon@3.7.1': {}
 
-  '@types/ms@2.1.0':
-    optional: true
+  '@types/ms@2.1.0': {}
 
   '@types/node@18.19.80':
     dependencies:
@@ -7681,6 +7836,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  arr-union@3.1.0: {}
+
   asap@2.0.6: {}
 
   asn1@0.2.6:
@@ -7770,6 +7927,11 @@ snapshots:
 
   bowser@2.14.1:
     optional: true
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@2.1.1:
     dependencies:
@@ -7889,6 +8051,14 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  clone-deep@0.2.4:
+    dependencies:
+      for-own: 0.1.5
+      is-plain-object: 2.0.4
+      kind-of: 3.2.2
+      lazy-cache: 1.0.4
+      shallow-clone: 0.1.2
+
   cluster-key-slot@1.1.2:
     optional: true
 
@@ -7943,6 +8113,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  concat-map@0.0.1: {}
 
   concurrently@10.0.3:
     dependencies:
@@ -8628,6 +8800,14 @@ snapshots:
       debug: 4.3.4
     optional: true
 
+  for-in@0.1.8: {}
+
+  for-in@1.0.2: {}
+
+  for-own@0.1.5:
+    dependencies:
+      for-in: 1.0.2
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8664,6 +8844,14 @@ snapshots:
   fraction.js@5.3.4: {}
 
   fresh@2.0.0: {}
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
     optional: true
@@ -8777,6 +8965,15 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   global-agent@3.0.0:
     dependencies:
       boolean: 3.2.0
@@ -8861,6 +9058,8 @@ snapshots:
       - supports-color
 
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
 
   gtoken@8.0.0:
     dependencies:
@@ -9000,6 +9199,11 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
 
   ip-address@10.2.0: {}
@@ -9008,14 +9212,15 @@ snapshots:
 
   ipaddr.js@2.4.0: {}
 
-  is-buffer@1.1.6:
-    optional: true
+  is-buffer@1.1.6: {}
 
   is-docker@3.0.0:
     optional: true
 
   is-electron@2.2.2:
     optional: true
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -9033,6 +9238,10 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
 
   is-plain-object@5.0.0: {}
 
@@ -9052,6 +9261,8 @@ snapshots:
   isbot@5.1.41: {}
 
   isexe@2.0.0: {}
+
+  isobject@3.0.1: {}
 
   isstream@0.1.2:
     optional: true
@@ -9123,6 +9334,12 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsonwebtoken@9.0.3:
     dependencies:
       jws: 4.0.1
@@ -9164,6 +9381,14 @@ snapshots:
     dependencies:
       '@keyv/serialize': 1.1.1
 
+  kind-of@2.0.1:
+    dependencies:
+      is-buffer: 1.1.6
+
+  kind-of@3.2.2:
+    dependencies:
+      is-buffer: 1.1.6
+
   kuler@2.0.0: {}
 
   langfuse-core@3.38.20:
@@ -9181,6 +9406,10 @@ snapshots:
       dayjs: 1.11.21
 
   layout-base@2.0.1: {}
+
+  lazy-cache@0.2.7: {}
+
+  lazy-cache@1.0.4: {}
 
   levn@0.4.1:
     dependencies:
@@ -9359,6 +9588,12 @@ snapshots:
   memory-pager@1.5.0:
     optional: true
 
+  merge-deep@3.0.3:
+    dependencies:
+      arr-union: 3.1.0
+      clone-deep: 0.2.4
+      kind-of: 3.2.2
+
   merge-descriptors@2.0.0: {}
 
   mime-db@1.52.0: {}
@@ -9381,6 +9616,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.1
@@ -9388,6 +9627,11 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
+
+  mixin-object@2.0.1:
+    dependencies:
+      for-in: 0.1.8
+      is-extendable: 0.1.1
 
   mlly@1.8.2:
     dependencies:
@@ -9758,6 +10002,8 @@ snapshots:
 
   path-expression-matcher@1.5.0: {}
 
+  path-is-absolute@1.0.1: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -9893,7 +10139,6 @@ snapshots:
       playwright-core: 1.60.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   playwright@1.60.0:
     dependencies:
@@ -10166,6 +10411,48 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0)):
+    dependencies:
+      debug: 4.4.3
+      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0))
+      puppeteer-extra-plugin-user-preferences: 2.4.1(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0))
+    optionalDependencies:
+      playwright-extra: 4.3.6(playwright-core@1.60.0)(playwright@1.60.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  puppeteer-extra-plugin-user-data-dir@2.4.1(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0)):
+    dependencies:
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0))
+      rimraf: 3.0.2
+    optionalDependencies:
+      playwright-extra: 4.3.6(playwright-core@1.60.0)(playwright@1.60.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  puppeteer-extra-plugin-user-preferences@2.4.1(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0)):
+    dependencies:
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0))
+      puppeteer-extra-plugin-user-data-dir: 2.4.1(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0))
+    optionalDependencies:
+      playwright-extra: 4.3.6(playwright-core@1.60.0)(playwright@1.60.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  puppeteer-extra-plugin@3.2.3(playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0)):
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      merge-deep: 3.0.3
+    optionalDependencies:
+      playwright-extra: 4.3.6(playwright-core@1.60.0)(playwright@1.60.0)
+    transitivePeerDependencies:
+      - supports-color
+
   python-shell@5.0.0: {}
 
   qs@6.15.2:
@@ -10254,6 +10541,10 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
 
   rimraf@5.0.10:
     dependencies:
@@ -10419,6 +10710,13 @@ snapshots:
   set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
+
+  shallow-clone@0.1.2:
+    dependencies:
+      is-extendable: 0.1.1
+      kind-of: 2.0.1
+      lazy-cache: 0.2.7
+      mixin-object: 2.0.1
 
   sharp@0.34.5:
     dependencies:
@@ -10826,6 +11124,8 @@ snapshots:
 
   universalify@0.2.0:
     optional: true
+
+  universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
 

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -44,7 +44,10 @@
       "additionalProperties": false,
       "properties": {
         "sessionTtlMs": { "type": "integer", "minimum": 1 },
-        "sweepIntervalMs": { "type": "integer", "minimum": 1 }
+        "sweepIntervalMs": { "type": "integer", "minimum": 1 },
+        "profileDir": { "type": "string" },
+        "channel": { "type": "string" },
+        "locale": { "type": "string" }
       }
     },
     "agents": {

--- a/skills/web-browser/handler.test.ts
+++ b/skills/web-browser/handler.test.ts
@@ -189,3 +189,38 @@ describe('web-browser type action with secret_ref (#973)', () => {
     expect(fill).toHaveBeenCalledWith('hello world');
   });
 });
+
+describe('web-browser block_ads + incognito inputs (#987)', () => {
+  it('forwards block_ads and incognito to getOrCreateSession', async () => {
+    // Build a mock page that satisfies the navigate action path:
+    // - page.goto() — called during navigate
+    // - page.url() — called when building the result
+    // - page.evaluate() — called by getCleanedContent
+    // We reuse makeMockPage (which has url+evaluate) and add goto to the result.
+    const fill = vi.fn().mockResolvedValue(undefined);
+    const mockPage = {
+      ...makeMockPage('Example Domain', fill, 'https://example.com/'),
+      goto: vi.fn().mockResolvedValue(undefined),
+    };
+    const session = new BrowserSession({} as unknown as BrowserContext, mockPage as unknown as Page);
+
+    // Track the getOrCreateSession spy directly so we can assert its call args.
+    const getOrCreateSession = vi.fn().mockResolvedValue({ sessionId: 'sess-stealth', session });
+    const browserService = {
+      getOrCreateSession,
+      closeSession: vi.fn().mockResolvedValue(undefined),
+    } as unknown as BrowserService;
+
+    const ctx = {
+      input: { action: 'navigate', url: 'https://example.com', block_ads: true, incognito: true },
+      log: logger,
+      browserService,
+    } as unknown as SkillContext;
+
+    await new WebBrowserHandler().execute(ctx);
+
+    // The handler must forward both flags as the second arg to getOrCreateSession.
+    // session_id was not supplied, so first arg must be undefined.
+    expect(getOrCreateSession).toHaveBeenCalledWith(undefined, { incognito: true, blockAds: true });
+  });
+});

--- a/skills/web-browser/handler.ts
+++ b/skills/web-browser/handler.ts
@@ -21,7 +21,7 @@ export class WebBrowserHandler implements SkillHandler {
       return { success: false, error: 'browserService is not available — BrowserService failed to start or is not wired into ExecutionLayer' };
     }
 
-    const { action, url, selector, text, value, secret_ref, session_id, screenshot } = ctx.input as {
+    const { action, url, selector, text, value, secret_ref, session_id, screenshot, block_ads, incognito } = ctx.input as {
       action?: string;
       url?: string;
       selector?: string;
@@ -33,6 +33,12 @@ export class WebBrowserHandler implements SkillHandler {
       secret_ref?: string;
       session_id?: string;
       screenshot?: boolean;
+      // block_ads (#987): opt in to ad/tracker blocking. Off by default — login,
+      // authenticated, and form-fill flows must not carry a privacy-extension signal.
+      block_ads?: boolean;
+      // incognito (#987): run this session in a fresh, isolated context instead of the
+      // principal's persistent profile. For Curia's own logins or throwaway flows.
+      incognito?: boolean;
     };
 
     if (!action || typeof action !== 'string') {
@@ -71,7 +77,10 @@ export class WebBrowserHandler implements SkillHandler {
     // values for value-aware redaction (#973) and scrub them from returned content.
     let session: import('../../src/browser/browser-session.js').BrowserSession;
     try {
-      const result = await ctx.browserService.getOrCreateSession(session_id ?? undefined);
+      const result = await ctx.browserService.getOrCreateSession(session_id ?? undefined, {
+        incognito: incognito === true,
+        blockAds: block_ads === true,
+      });
       sessionId = result.sessionId;
       session = result.session;
       page = result.session.page as Page;

--- a/skills/web-browser/skill.json
+++ b/skills/web-browser/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "web-browser",
-  "description": "Control a real web browser to interact with JS-rendered pages, fill forms, navigate multi-step flows, and interact with sites that have no API. Use this instead of web-fetch when a page requires JavaScript, login, or user interaction. Each call performs one action and returns the updated page state. Pass session_id back on subsequent calls to maintain browser context across actions. Actions: navigate (url required), click (selector required), type (selector + either text OR secret_ref), select (selector+value required), get_content, screenshot, close_session. To fill a stored credential into a form, pass secret_ref (a user.* secret name) instead of text — the value is filled server-side and never shown to you.",
-  "version": "1.1.0",
+  "description": "Control a real web browser to interact with JS-rendered pages, fill forms, navigate multi-step flows, and interact with sites that have no API. Use this instead of web-fetch when a page requires JavaScript, login, or user interaction. Each call performs one action and returns the updated page state. Pass session_id back on subsequent calls to maintain browser context across actions. Actions: navigate (url required), click (selector required), type (selector + either text OR secret_ref), select (selector+value required), get_content, screenshot, close_session. To fill a stored credential into a form, pass secret_ref (a user.* secret name) instead of text — the value is filled server-side and never shown to you. Set block_ads:true ONLY for plain content browsing — never for login, authenticated, or form-fill flows (sites flag the ad blocker as a privacy extension). Set incognito:true to run in a throwaway, isolated session (e.g. logging in as Curia itself) instead of the principal's persistent profile; omit it for the principal's own accounts so sessions persist.",
+  "version": "1.2.0",
   "sensitivity": "elevated",
   "action_risk": "medium",
   "inputs": {
@@ -12,7 +12,9 @@
     "value": "string?",
     "secret_ref": "string?",
     "session_id": "string?",
-    "screenshot": "boolean?"
+    "screenshot": "boolean?",
+    "block_ads": "boolean?",
+    "incognito": "boolean?"
   },
   "outputs": {
     "content": "string",

--- a/src/browser/browser-service.test.ts
+++ b/src/browser/browser-service.test.ts
@@ -14,39 +14,50 @@ import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
 
+// Mock the Ghostery blocker so no real blocklist is fetched in unit tests.
+// fakeBlocker is exposed for the blocker-specific assertions Task 6 adds (it will
+// reference fakeBlocker.enableBlockingInPage); the void below keeps it from tripping
+// noUnusedLocals until then.
+const { fakeBlocker, fromPrebuilt } = vi.hoisted(() => {
+  const fb = { enableBlockingInPage: vi.fn().mockResolvedValue(undefined) };
+  return { fakeBlocker: fb, fromPrebuilt: vi.fn().mockResolvedValue(fb) };
+});
+void fakeBlocker;
+vi.mock('@ghostery/adblocker-playwright', () => ({
+  PlaywrightBlocker: { fromPrebuiltAdsAndTracking: fromPrebuilt },
+}));
+
 // --- Mock Playwright objects ---
 
 function makeMockPage() {
   return {
     on: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
     goto: vi.fn().mockResolvedValue(null),
-    click: vi.fn().mockResolvedValue(null),
-    fill: vi.fn().mockResolvedValue(null),
-    selectOption: vi.fn().mockResolvedValue(null),
     evaluate: vi.fn().mockResolvedValue('page content'),
     screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
     url: vi.fn().mockReturnValue('https://example.com'),
-    getByText: vi.fn().mockReturnValue({ click: vi.fn().mockResolvedValue(null) }),
-    getByRole: vi.fn().mockReturnValue({ click: vi.fn().mockResolvedValue(null), fill: vi.fn().mockResolvedValue(null) }),
-    getByLabel: vi.fn().mockReturnValue({ click: vi.fn().mockResolvedValue(null), fill: vi.fn().mockResolvedValue(null) }),
-    locator: vi.fn().mockReturnValue({ click: vi.fn().mockResolvedValue(null), fill: vi.fn().mockResolvedValue(null), selectOption: vi.fn().mockResolvedValue(null) }),
   };
 }
 
-function makeMockContext(page: ReturnType<typeof makeMockPage>) {
+function makeMockBrowser() {
+  return {
+    isConnected: vi.fn().mockReturnValue(true),
+    on: vi.fn(),
+    version: vi.fn().mockReturnValue('123.0.0.0'),
+    // Set per-test for incognito cases (Task 5).
+    newContext: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// The persistent context is the warm "browser" in the new model. browser() returns
+// the underlying Browser so the service can spin up incognito contexts off it.
+function makeMockContext(page: ReturnType<typeof makeMockPage>, browser: ReturnType<typeof makeMockBrowser>) {
   return {
     newPage: vi.fn().mockResolvedValue(page),
     close: vi.fn().mockResolvedValue(undefined),
-    route: vi.fn().mockResolvedValue(undefined),
-    on: vi.fn(),
-  };
-}
-
-function makeMockBrowser(context: ReturnType<typeof makeMockContext>) {
-  return {
-    newContext: vi.fn().mockResolvedValue(context),
-    isConnected: vi.fn().mockReturnValue(true),
-    close: vi.fn().mockResolvedValue(undefined),
+    browser: vi.fn().mockReturnValue(browser),
     on: vi.fn(),
   };
 }
@@ -56,8 +67,8 @@ function makeMockBrowser(context: ReturnType<typeof makeMockContext>) {
 describe('BrowserService (unit — mocked browser)', () => {
   let service: BrowserService;
   let mockPage: ReturnType<typeof makeMockPage>;
-  let mockContext: ReturnType<typeof makeMockContext>;
   let mockBrowser: ReturnType<typeof makeMockBrowser>;
+  let mockContext: ReturnType<typeof makeMockContext>;
 
   // Isolate unit tests from the host display environment.
   // BrowserService.start() calls maybeStartXvfb() which spawns Xvfb on Linux
@@ -72,15 +83,15 @@ describe('BrowserService (unit — mocked browser)', () => {
     process.env.DISPLAY = savedDisplay ?? ':99';
 
     mockPage = makeMockPage();
-    mockContext = makeMockContext(mockPage);
-    mockBrowser = makeMockBrowser(mockContext);
+    mockBrowser = makeMockBrowser();
+    mockContext = makeMockContext(mockPage, mockBrowser);
 
     service = new BrowserService({
       logger,
       sessionTtlMs: 1000,
       sweepIntervalMs: 60000,
-      // Inject fake browser so no real Playwright process is needed
-      browserFactory: async () => mockBrowser as never,
+      // Inject a fake persistent context so no real Playwright process is needed.
+      contextFactory: async () => mockContext as never,
     });
     await service.start();
   });
@@ -98,15 +109,15 @@ describe('BrowserService (unit — mocked browser)', () => {
     const result = await service.getOrCreateSession(undefined);
     expect(result.sessionId).toBeTruthy();
     expect(typeof result.sessionId).toBe('string');
-    expect(mockBrowser.newContext).toHaveBeenCalledOnce();
+    expect(mockContext.newPage).toHaveBeenCalledOnce();
   });
 
   it('reuses an existing session when a valid session_id is provided', async () => {
     const first = await service.getOrCreateSession(undefined);
     const second = await service.getOrCreateSession(first.sessionId);
     expect(second.sessionId).toBe(first.sessionId);
-    // newContext called only once — second call reused existing session
-    expect(mockBrowser.newContext).toHaveBeenCalledOnce();
+    // newPage called only once — second call reused existing session
+    expect(mockContext.newPage).toHaveBeenCalledOnce();
   });
 
   it('creates a fresh session when the provided session_id has expired', async () => {
@@ -118,14 +129,14 @@ describe('BrowserService (unit — mocked browser)', () => {
 
     const second = await service.getOrCreateSession(first.sessionId);
     expect(second.sessionId).not.toBe(first.sessionId);
-    expect(mockBrowser.newContext).toHaveBeenCalledTimes(2);
-    expect(mockContext.close).toHaveBeenCalledOnce();
+    expect(mockContext.newPage).toHaveBeenCalledTimes(2);
+    expect(mockPage.close).toHaveBeenCalledOnce();
   });
 
   it('closeSession() closes the context and removes the session', async () => {
     const { sessionId } = await service.getOrCreateSession(undefined);
     await service.closeSession(sessionId);
-    expect(mockContext.close).toHaveBeenCalledOnce();
+    expect(mockPage.close).toHaveBeenCalledOnce();
     expect(service.getSession(sessionId)).toBeUndefined();
   });
 
@@ -138,15 +149,15 @@ describe('BrowserService (unit — mocked browser)', () => {
 
     await service.sweep();
     expect(service.getSession(sessionId)).toBeUndefined();
-    expect(mockContext.close).toHaveBeenCalledOnce();
+    expect(mockPage.close).toHaveBeenCalledOnce();
   });
 
   it('stop() closes all sessions and the browser', async () => {
     await service.getOrCreateSession(undefined);
     await service.getOrCreateSession(undefined); // two sessions
     await service.stop();
-    expect(mockContext.close).toHaveBeenCalledTimes(2);
-    expect(mockBrowser.close).toHaveBeenCalledOnce();
+    expect(mockPage.close).toHaveBeenCalledTimes(2);
+    expect(mockContext.close).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/browser/browser-service.test.ts
+++ b/src/browser/browser-service.test.ts
@@ -198,6 +198,37 @@ describe('BrowserService (unit — mocked browser)', () => {
     // Attached per opt-in session.
     expect(fakeBlocker.enableBlockingInPage).toHaveBeenCalledTimes(2);
   });
+
+  it('reports channel fallback inactive by default', () => {
+    expect(service.isChannelFallbackActive()).toBe(false);
+  });
+
+  it('does not restart the browser when a disconnect fires after stop()', async () => {
+    // Dedicated instance with a counting factory so we can assert no relaunch happens.
+    const page = makeMockPage();
+    const browser = makeMockBrowser();
+    const ctx = makeMockContext(page, browser);
+    const factory = vi.fn().mockResolvedValue(ctx);
+    const svc = new BrowserService({
+      logger,
+      sessionTtlMs: 1000,
+      sweepIntervalMs: 60000,
+      contextFactory: factory as never,
+    });
+    await svc.start();
+    expect(factory).toHaveBeenCalledOnce();
+
+    // Grab the 'disconnected' handler the service registered on the browser.
+    const onCall = browser.on.mock.calls.find(c => c[0] === 'disconnected');
+    expect(onCall).toBeDefined();
+    const disconnectHandler = onCall![1] as () => void;
+
+    await svc.stop();        // running -> false
+    disconnectHandler();     // simulate a late/teardown 'disconnected' after shutdown
+
+    // No crash-recovery relaunch: the factory is still called exactly once.
+    expect(factory).toHaveBeenCalledOnce();
+  });
 });
 
 // --- clearStaleX11Lock (stale Xvfb lock cleanup) ---
@@ -388,9 +419,12 @@ describe.skipIf(!runBrowserTests)('BrowserService (integration — real Chromium
   // beforeEach/afterEach service, and cleans up in finally regardless of outcome.
   it('persists cookies across a service restart (persistent profile)', async () => {
     const profileDir = mkdtempSync(join(tmpdir(), 'curia-profile-'));
+    // Both services are declared in the outer scope so finally can always stop them —
+    // a throw between s1.start() and s1.stop() must not leak a live browser/Xvfb process.
+    let s1: BrowserService | null = null;
     let s2: BrowserService | null = null;
     try {
-      const s1 = new BrowserService({ logger, sessionTtlMs: 30000, sweepIntervalMs: 60000, profileDir });
+      s1 = new BrowserService({ logger, sessionTtlMs: 30000, sweepIntervalMs: 60000, profileDir });
       await s1.start();
       const { session } = await s1.getOrCreateSession(undefined);
       await session.page.goto('https://example.com');
@@ -405,6 +439,7 @@ describe.skipIf(!runBrowserTests)('BrowserService (integration — real Chromium
         (globalThis as unknown as Win).document!.cookie = 'curia_test=1; path=/; max-age=3600';
       });
       await s1.stop();
+      s1 = null;
 
       // After context.close(), Playwright kills the browser process, but the OS may
       // take a moment to release the profile's SingletonLock. Retry s2.start() with
@@ -434,7 +469,9 @@ describe.skipIf(!runBrowserTests)('BrowserService (integration — real Chromium
       await s2.stop();
       s2 = null;
     } finally {
-      // Best-effort stop of s2 if the test threw after start() but before stop()
+      // Best-effort stop of either service if the test threw before its own stop() ran,
+      // so a failure mid-test can't leak a live browser/Xvfb process into later tests.
+      await s1?.stop().catch(() => { /* already stopped or never started */ });
       await s2?.stop().catch(() => { /* already stopped or never started */ });
       rmSync(profileDir, { recursive: true, force: true });
     }

--- a/src/browser/browser-service.test.ts
+++ b/src/browser/browser-service.test.ts
@@ -379,4 +379,65 @@ describe.skipIf(!runBrowserTests)('BrowserService (integration — real Chromium
     await service.closeSession(sessionId);
     expect(service.getSession(sessionId)).toBeUndefined();
   });
+
+  // Task 10: persistent profile survives a service restart
+  //
+  // Spins up two independent BrowserService instances sharing the SAME profileDir
+  // to prove that cookies written by the first survive into the second.
+  // Uses a local profileDir so these services never share state with the outer
+  // beforeEach/afterEach service, and cleans up in finally regardless of outcome.
+  it('persists cookies across a service restart (persistent profile)', async () => {
+    const profileDir = mkdtempSync(join(tmpdir(), 'curia-profile-'));
+    let s2: BrowserService | null = null;
+    try {
+      const s1 = new BrowserService({ logger, sessionTtlMs: 30000, sweepIntervalMs: 60000, profileDir });
+      await s1.start();
+      const { session } = await s1.getOrCreateSession(undefined);
+      await session.page.goto('https://example.com');
+      // Set a PERSISTENT cookie (max-age=3600 so it is written to the Cookies DB on
+      // disk, not just held in the browser's in-memory session-cookie store).
+      // Session cookies (no max-age/expires) are never flushed to disk and therefore
+      // cannot survive a browser restart. Must use globalThis cast because "dom" is
+      // not in this project's server tsconfig lib (mirrors the pattern from the
+      // full-flow integration test above).
+      await session.page.evaluate((): void => {
+        type Win = { document?: { cookie: string } };
+        (globalThis as unknown as Win).document!.cookie = 'curia_test=1; path=/; max-age=3600';
+      });
+      await s1.stop();
+
+      // After context.close(), Playwright kills the browser process, but the OS may
+      // take a moment to release the profile's SingletonLock. Retry s2.start() with
+      // exponential back-off for up to 5 seconds before giving up.
+      s2 = new BrowserService({ logger, sessionTtlMs: 30000, sweepIntervalMs: 60000, profileDir });
+      let lastErr: unknown;
+      for (let attempt = 0; attempt < 6; attempt++) {
+        try {
+          await s2.start();
+          lastErr = undefined;
+          break;
+        } catch (err) {
+          lastErr = err;
+          const delayMs = 200 * Math.pow(2, attempt); // 200, 400, 800, 1600, 3200ms
+          await new Promise<void>(resolve => setTimeout(resolve, delayMs));
+        }
+      }
+      if (lastErr !== undefined) throw lastErr;
+
+      const { session: session2 } = await s2.getOrCreateSession(undefined);
+      await session2.page.goto('https://example.com');
+      const cookie = await session2.page.evaluate((): string => {
+        type Win = { document?: { cookie: string } };
+        return (globalThis as unknown as Win).document?.cookie ?? '';
+      });
+      expect(cookie).toContain('curia_test=1');
+      await s2.stop();
+      s2 = null;
+    } finally {
+      // Best-effort stop of s2 if the test threw after start() but before stop()
+      await s2?.stop().catch(() => { /* already stopped or never started */ });
+      rmSync(profileDir, { recursive: true, force: true });
+    }
+  // Two full browser launches + navigations + stop/restart needs well over the 5s default.
+  }, 60_000);
 });

--- a/src/browser/browser-service.test.ts
+++ b/src/browser/browser-service.test.ts
@@ -15,14 +15,12 @@ import pino from 'pino';
 const logger = pino({ level: 'silent' });
 
 // Mock the Ghostery blocker so no real blocklist is fetched in unit tests.
-// fakeBlocker is exposed for the blocker-specific assertions Task 6 adds (it will
-// reference fakeBlocker.enableBlockingInPage); the void below keeps it from tripping
-// noUnusedLocals until then.
+// fakeBlocker is exposed for the blocker-specific assertions in Task 6
+// (see "does not fetch" and "attaches the blocker" tests below).
 const { fakeBlocker, fromPrebuilt } = vi.hoisted(() => {
   const fb = { enableBlockingInPage: vi.fn().mockResolvedValue(undefined) };
   return { fakeBlocker: fb, fromPrebuilt: vi.fn().mockResolvedValue(fb) };
 });
-void fakeBlocker;
 vi.mock('@ghostery/adblocker-playwright', () => ({
   PlaywrightBlocker: { fromPrebuiltAdsAndTracking: fromPrebuilt },
 }));
@@ -94,6 +92,9 @@ describe('BrowserService (unit — mocked browser)', () => {
       contextFactory: async () => mockContext as never,
     });
     await service.start();
+    // Reset blocker spies between tests so Task 6 assertions are per-test, not cumulative.
+    fromPrebuilt.mockClear();
+    fakeBlocker.enableBlockingInPage.mockClear();
   });
 
   afterEach(async () => {
@@ -158,6 +159,44 @@ describe('BrowserService (unit — mocked browser)', () => {
     await service.stop();
     expect(mockPage.close).toHaveBeenCalledTimes(2);
     expect(mockContext.close).toHaveBeenCalledOnce();
+  });
+
+  // Task 5: incognito session isolation
+  it('incognito session uses a fresh isolated context, not the persistent profile', async () => {
+    const incognitoPage = makeMockPage();
+    const incognitoContext = {
+      newPage: vi.fn().mockResolvedValue(incognitoPage),
+      close: vi.fn().mockResolvedValue(undefined),
+      browser: vi.fn().mockReturnValue(mockBrowser),
+      on: vi.fn(),
+    };
+    mockBrowser.newContext.mockResolvedValue(incognitoContext as never);
+
+    const { sessionId } = await service.getOrCreateSession(undefined, { incognito: true });
+
+    // Came from a fresh context off the browser, NOT the persistent profile.
+    expect(mockBrowser.newContext).toHaveBeenCalledOnce();
+    expect(mockContext.newPage).not.toHaveBeenCalled();
+
+    // Closing the session tears down the OWNED context (isolation), not just a page.
+    await service.closeSession(sessionId);
+    expect(incognitoContext.close).toHaveBeenCalledOnce();
+  });
+
+  // Task 6: opt-in lazy ad blocker
+  it('does not fetch or attach the blocker by default (off for login/form flows)', async () => {
+    await service.getOrCreateSession(undefined);
+    expect(fromPrebuilt).not.toHaveBeenCalled();
+    expect(fakeBlocker.enableBlockingInPage).not.toHaveBeenCalled();
+  });
+
+  it('attaches the blocker only when block_ads is true, fetching the list lazily once', async () => {
+    await service.getOrCreateSession(undefined, { blockAds: true });
+    await service.getOrCreateSession(undefined, { blockAds: true });
+    // Blocklist fetched once and cached across opt-ins.
+    expect(fromPrebuilt).toHaveBeenCalledOnce();
+    // Attached per opt-in session.
+    expect(fakeBlocker.enableBlockingInPage).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -83,6 +83,9 @@ export class BrowserService {
   private context: BrowserContext | null = null;
   // Ad blocker is loaded lazily on first opt-in (block_ads:true) and cached. Off by
   // default so login/auth/form-fill flows carry no privacy-extension signal.
+  // These fields intentionally survive stop()/restart() — the blocklist is process-global
+  // data independent of the browser process, so it is reused rather than refetched on
+  // each browser restart.
   private blocker: PlaywrightBlocker | null = null;
   private blockerPromise: Promise<PlaywrightBlocker> | null = null;
   private sessions: Map<SessionId, BrowserSession> = new Map();
@@ -103,7 +106,7 @@ export class BrowserService {
   }
 
   /**
-   * Start the browser service: spawn Xvfb if needed, launch Chromium, start sweep timer.
+   * Start the browser service: spawn Xvfb if needed, launch the persistent browser context, start sweep timer.
    * Must be called before any session operations.
    */
   async start(): Promise<void> {
@@ -114,7 +117,7 @@ export class BrowserService {
     await this.maybeStartXvfb();
     this.context = await this.contextFactory();
 
-    // Restart the browser automatically on disconnect (e.g., OOM kill).
+    // Restart the persistent context automatically on disconnect (e.g., OOM kill).
     this.attachDisconnectedHandler(this.context);
 
     this.sweepTimer = setInterval(() => void this.sweep(), this.sweepIntervalMs);
@@ -136,7 +139,15 @@ export class BrowserService {
     }
     browser.on('disconnected', () => {
       this.logger.error('Playwright browser disconnected — clearing sessions and restarting');
+      // Best-effort close of any live sessions before dropping them from the map. On a
+      // genuine crash/OOM kill the pages are already gone and these close() calls no-op;
+      // but if 'disconnected' fires while the process is still alive (explicit close,
+      // transport drop), this prevents leaking the underlying pages/contexts.
+      const orphaned = [...this.sessions.values()];
       this.sessions.clear();
+      for (const session of orphaned) {
+        void session.close().catch(() => { /* browser likely gone — nothing to clean */ });
+      }
       void this.contextFactory().then(ctx => {
         this.context = ctx;
         this.attachDisconnectedHandler(ctx);

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -81,9 +81,12 @@ export class BrowserService {
   // it (shared cookies/storage = "returning user"); incognito sessions get their own
   // ephemeral context spun off context.browser() (see getOrCreateSession).
   private context: BrowserContext | null = null;
-  // Set to true by stop() before closing the context so the 'disconnected' handler
-  // knows the disconnect is intentional and must NOT trigger a crash-recovery restart.
-  private stopping = false;
+  // Lifecycle flag: true between a successful start() and the start of stop(). The
+  // 'disconnected' crash-recovery handler consults it (a) to skip restarting when the
+  // disconnect is our own intentional context.close() during stop(), and (b) at the
+  // moment an async relaunch resolves — so a relaunch already in flight when stop() runs
+  // discards its fresh context instead of reviving a browser after shutdown.
+  private running = false;
   // True once a configured browser channel (e.g. 'chrome') failed to launch and we fell
   // back to bundled Chromium — a degraded fingerprint posture. Exposed via
   // isChannelFallbackActive() so health checks can surface the divergence (see #987).
@@ -122,7 +125,20 @@ export class BrowserService {
     }
 
     await this.maybeStartXvfb();
-    this.context = await this.contextFactory();
+    try {
+      this.context = await this.contextFactory();
+    } catch (err) {
+      // Roll back the Xvfb display we just spawned — otherwise a context-launch failure
+      // leaves a stray X server around that breaks later restarts (the stale-:99-lock bug
+      // we already guard against on the next start). stop() also kills it, but start()
+      // must clean up after itself for callers that don't call stop() on failure.
+      if (this.xvfbProcess) {
+        this.logger.error({ err }, 'Persistent context launch failed — killing the Xvfb display started for it');
+        this.xvfbProcess.kill();
+        this.xvfbProcess = null;
+      }
+      throw err;
+    }
 
     // Restart the persistent context automatically on disconnect (e.g., OOM kill).
     this.attachDisconnectedHandler(this.context);
@@ -130,6 +146,9 @@ export class BrowserService {
     this.sweepTimer = setInterval(() => void this.sweep(), this.sweepIntervalMs);
     this.sweepTimer.unref();
 
+    // Mark running only after a fully successful start, so the disconnect handler never
+    // tries to recover a service that never finished starting.
+    this.running = true;
     this.logger.info({ sessionTtlMs: this.sessionTtlMs }, 'BrowserService started');
   }
 
@@ -145,11 +164,12 @@ export class BrowserService {
       return;
     }
     browser.on('disconnected', () => {
-      // Intentional shutdown via stop() — do not restart. stop() sets this.stopping
-      // before calling context.close() so we can distinguish a deliberate close from
-      // an unexpected crash/OOM disconnect.
-      if (this.stopping) {
-        this.logger.debug('Browser disconnected during stop() — skipping crash-recovery restart');
+      // Intentional shutdown — do not restart. stop() flips `running` to false before
+      // closing the context, so a disconnect fired by our own teardown (or one that
+      // arrives after stop() already finished) is distinguished from an unexpected
+      // crash/OOM disconnect.
+      if (!this.running) {
+        this.logger.debug('Browser disconnected while not running (intentional stop) — skipping crash-recovery restart');
         return;
       }
       this.logger.error('Playwright browser disconnected — clearing sessions and restarting');
@@ -160,9 +180,20 @@ export class BrowserService {
       const orphaned = [...this.sessions.values()];
       this.sessions.clear();
       for (const session of orphaned) {
-        void session.close().catch(() => { /* browser likely gone — nothing to clean */ });
+        void session.close().catch(err =>
+          this.logger.debug({ err }, 'Failed to close orphaned session during disconnect cleanup (browser likely already gone)'),
+        );
       }
       void this.contextFactory().then(ctx => {
+        // stop() may have run while the relaunch was in flight. Reviving the browser now
+        // would leak a live context past shutdown, so discard the fresh one instead.
+        if (!this.running) {
+          this.logger.debug('Relaunch resolved after shutdown — discarding the recovered context');
+          void ctx.close().catch(err =>
+            this.logger.warn({ err }, 'Failed to close recovered context discarded after shutdown'),
+          );
+          return;
+        }
         this.context = ctx;
         this.attachDisconnectedHandler(ctx);
       }).catch(err => {
@@ -175,6 +206,11 @@ export class BrowserService {
    * Stop the browser service: close all sessions, close the browser, kill Xvfb.
    */
   async stop(): Promise<void> {
+    // Flip running=false up front: it tells the 'disconnected' handler that the imminent
+    // context.close() is intentional (skip crash-recovery), AND it makes any relaunch
+    // already in flight discard its fresh context when it resolves (no revival after stop).
+    this.running = false;
+
     if (this.sweepTimer) {
       clearInterval(this.sweepTimer);
       this.sweepTimer = null;
@@ -191,18 +227,11 @@ export class BrowserService {
     this.sessions.clear();
 
     if (this.context) {
-      // Signal the 'disconnected' handler that this disconnect is intentional so it
-      // does not trigger crash-recovery (which would try to relaunch the browser while
-      // we're tearing down, potentially racing with a restart that reuses the profile).
-      this.stopping = true;
       try {
         await this.context.close();
       } catch (err) {
         this.logger.error({ err }, 'Error closing browser context during shutdown');
       } finally {
-        // Reset stopping so the instance can be reused after stop() (e.g. in tests)
-        // and a future unexpected disconnect still triggers recovery.
-        this.stopping = false;
         this.context = null;
       }
     }
@@ -277,7 +306,9 @@ export class BrowserService {
           this.logger.error({ err: closeErr }, 'Failed to close incognito context during cleanup — possible resource leak');
         });
       } else if (page) {
-        await page.close().catch(() => {});
+        await page.close().catch(closeErr =>
+          this.logger.debug({ err: closeErr }, 'Failed to close page during session-creation cleanup'),
+        );
       }
       throw err;
     }
@@ -403,6 +434,11 @@ export class BrowserService {
       ],
       ...this.buildContextOptions(),
     };
+
+    // Reset before each attempt so the flag reflects the CURRENT launch, not a stale
+    // historical fallback — otherwise a later successful relaunch (crash recovery, or a
+    // start() after stop()) would still report a degraded channel forever.
+    this.channelFallbackActive = false;
 
     try {
       const context = await stealthChromium.launchPersistentContext(

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -1,7 +1,10 @@
 // src/browser/browser-service.ts — manages a warm Playwright browser and session map.
 //
-// A single Chromium browser process is launched at startup and kept warm.
-// Each session gets its own isolated BrowserContext (separate cookies/storage).
+// A single PERSISTENT browser context is launched at startup (the principal's profile)
+// and kept warm. Sessions are PAGES within that one shared context, so they share
+// cookies/storage/cache — the site sees a "returning user", not a fresh anonymous
+// browser each time. An opt-in incognito session instead gets its own isolated ephemeral
+// context spun off the same browser (never touching the persistent profile).
 // Sessions expire after sessionTtlMs of inactivity and are swept on an interval.
 //
 // SCALABILITY @TODO: This implementation runs a single Playwright browser in-process.
@@ -26,11 +29,22 @@ import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
-import { chromium, type Browser } from 'playwright';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { chromium as stealthChromium } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import type { BrowserContext, BrowserContextOptions } from 'playwright';
 import { PlaywrightBlocker } from '@ghostery/adblocker-playwright';
 import type { Logger } from '../logger.js';
 import { BrowserSession } from './browser-session.js';
 import type { SessionId } from './types.js';
+
+// Register the stealth plugin once at module load. It patches the residual automation
+// signals (navigator.plugins, window.chrome, WebGL vendor/renderer, permissions.query,
+// and the User-Agent) that --disable-blink-features=AutomationControlled alone leaves
+// exposed. It applies at the browser level, so it covers both the persistent context and
+// any incognito context spun off the same browser.
+stealthChromium.use(StealthPlugin());
 
 interface BrowserServiceOptions {
   logger: Logger;
@@ -38,21 +52,39 @@ interface BrowserServiceOptions {
   sessionTtlMs?: number;
   /** How often to sweep expired sessions in ms. Default: 120_000 (2 minutes). */
   sweepIntervalMs?: number;
+  /** Persistent profile directory. Empty/absent → ${HOME}/.curia/browser-profile. */
+  profileDir?: string;
+  /** Browser channel, e.g. 'chrome' for real Chrome. Absent → bundled Chromium. */
+  channel?: string;
+  /** Context locale (BCP 47). Default 'en-US'. */
+  locale?: string;
+  /** IANA timezone for the context, aligned to the principal. */
+  timezone?: string;
   /**
-   * Optional factory to create the Browser instance.
-   * Defaults to chromium.launch(...). Override in tests to inject a mock.
+   * Optional factory to create the persistent BrowserContext.
+   * Defaults to launchPersistentContext(...). Override in tests to inject a mock.
    */
-  browserFactory?: () => Promise<Browser>;
+  contextFactory?: () => Promise<BrowserContext>;
 }
 
 export class BrowserService {
   private logger: Logger;
   private sessionTtlMs: number;
   private sweepIntervalMs: number;
-  private browserFactory: () => Promise<Browser>;
+  private profileDir: string;
+  private channel: string | undefined;
+  private locale: string;
+  private timezone: string | undefined;
+  private contextFactory: () => Promise<BrowserContext>;
 
-  private browser: Browser | null = null;
+  // The persistent context IS the warm browser in this model. Sessions are pages within
+  // it (shared cookies/storage = "returning user"); incognito sessions get their own
+  // ephemeral context spun off context.browser() (see getOrCreateSession).
+  private context: BrowserContext | null = null;
+  // Ad blocker is loaded lazily on first opt-in (block_ads:true) and cached. Off by
+  // default so login/auth/form-fill flows carry no privacy-extension signal.
   private blocker: PlaywrightBlocker | null = null;
+  private blockerPromise: Promise<PlaywrightBlocker> | null = null;
   private sessions: Map<SessionId, BrowserSession> = new Map();
   private sweepTimer: NodeJS.Timeout | null = null;
   private xvfbProcess: ChildProcess | null = null;
@@ -61,7 +93,13 @@ export class BrowserService {
     this.logger = options.logger.child({ service: 'BrowserService' });
     this.sessionTtlMs = options.sessionTtlMs ?? 600_000;
     this.sweepIntervalMs = options.sweepIntervalMs ?? 120_000;
-    this.browserFactory = options.browserFactory ?? (() => this.launchChromium());
+    this.profileDir = options.profileDir && options.profileDir.length > 0
+      ? options.profileDir
+      : join(homedir(), '.curia', 'browser-profile');
+    this.channel = options.channel && options.channel.length > 0 ? options.channel : undefined;
+    this.locale = options.locale && options.locale.length > 0 ? options.locale : 'en-US';
+    this.timezone = options.timezone;
+    this.contextFactory = options.contextFactory ?? (() => this.launchPersistentContext());
   }
 
   /**
@@ -69,49 +107,39 @@ export class BrowserService {
    * Must be called before any session operations.
    */
   async start(): Promise<void> {
-    if (this.browser !== null) {
+    if (this.context !== null) {
       throw new Error('BrowserService.start() called while already running — call stop() first');
     }
 
     await this.maybeStartXvfb();
-    this.browser = await this.browserFactory();
+    this.context = await this.contextFactory();
 
-    // Restart browser automatically on disconnect (e.g., OOM kill)
-    this.attachDisconnectedHandler(this.browser);
-
-    // Initialize ad blocker in the background — don't block startup on a network download.
-    // Sessions created before initialization completes will run without ad blocking,
-    // which is acceptable for correctness. The blocker will be applied to all contexts
-    // created after it finishes.
-    PlaywrightBlocker.fromPrebuiltAdsAndTracking(fetch).then(blocker => {
-      this.blocker = blocker;
-      this.logger.info('Ad blocker initialized');
-    }).catch((err: unknown) => {
-      this.logger.warn({ err }, 'Ad blocker failed to initialize — continuing without ad blocking');
-    });
+    // Restart the browser automatically on disconnect (e.g., OOM kill).
+    this.attachDisconnectedHandler(this.context);
 
     this.sweepTimer = setInterval(() => void this.sweep(), this.sweepIntervalMs);
-    // Don't let the sweep timer prevent graceful shutdown
     this.sweepTimer.unref();
 
     this.logger.info({ sessionTtlMs: this.sessionTtlMs }, 'BrowserService started');
   }
 
   /**
-   * Attach the 'disconnected' crash-recovery listener to a browser instance.
-   * Called on the initial browser and on every restarted browser so that
-   * crash recovery continues working after the first restart.
+   * Attach the 'disconnected' crash-recovery listener to the persistent context's
+   * underlying browser. On disconnect we clear sessions and relaunch the persistent
+   * context, then re-attach so a second crash is also recovered.
    */
-  private attachDisconnectedHandler(browser: import('playwright').Browser): void {
+  private attachDisconnectedHandler(context: BrowserContext): void {
+    const browser = context.browser();
+    if (!browser) {
+      this.logger.warn('Persistent context has no associated browser — crash recovery disabled');
+      return;
+    }
     browser.on('disconnected', () => {
       this.logger.error('Playwright browser disconnected — clearing sessions and restarting');
       this.sessions.clear();
-      // Non-blocking restart — if it fails, subsequent skill calls return errors
-      void this.browserFactory().then(b => {
-        this.browser = b;
-        // Reattach the handler on the new browser instance so that a second
-        // crash is also recovered. Without this, recovery only works once.
-        this.attachDisconnectedHandler(b);
+      void this.contextFactory().then(ctx => {
+        this.context = ctx;
+        this.attachDisconnectedHandler(ctx);
       }).catch(err => {
         this.logger.error({ err }, 'Browser restart failed');
       });
@@ -137,13 +165,13 @@ export class BrowserService {
     }
     this.sessions.clear();
 
-    if (this.browser) {
+    if (this.context) {
       try {
-        await this.browser.close();
+        await this.context.close();
       } catch (err) {
-        this.logger.error({ err }, 'Error closing browser during shutdown');
+        this.logger.error({ err }, 'Error closing browser context during shutdown');
       }
-      this.browser = null;
+      this.context = null;
     }
 
     if (this.xvfbProcess) {
@@ -159,58 +187,70 @@ export class BrowserService {
    *
    * - No sessionId → always creates a fresh session.
    * - Valid, non-expired sessionId → refreshes TTL and returns existing session.
-   * - Expired sessionId → closes old context, creates a fresh session with a new ID.
+   * - Expired sessionId → closes the old session, creates a fresh session with a new ID.
+   *
+   * opts.incognito → isolated ephemeral context off the same browser (no persistent
+   * profile). opts.blockAds → attach the (lazily-fetched) Ghostery ad blocker to the page.
    *
    * Returns the session and its (possibly new) sessionId.
    */
-  async getOrCreateSession(sessionId: SessionId | undefined): Promise<{ sessionId: SessionId; session: BrowserSession }> {
-    if (!this.browser || !this.browser.isConnected()) {
+  async getOrCreateSession(
+    sessionId: SessionId | undefined,
+    opts: { incognito?: boolean; blockAds?: boolean } = {},
+  ): Promise<{ sessionId: SessionId; session: BrowserSession }> {
+    const browser = this.context?.browser();
+    if (!this.context || !browser || !browser.isConnected()) {
       throw new Error('BrowserService: browser is not running. Call start() first.');
     }
 
     if (sessionId) {
       const existing = this.sessions.get(sessionId);
       if (existing && !existing.isExpired(this.sessionTtlMs)) {
-        // Refresh TTL and return
         existing.lastUsedAt = Date.now();
         return { sessionId, session: existing };
       }
-      // Session expired or not found — close it if it exists and create a fresh one
       if (existing) {
-        this.logger.debug({ sessionId }, 'Session expired — closing and creating fresh context');
+        this.logger.debug({ sessionId }, 'Session expired — closing and creating fresh session');
         await existing.close().catch(err => this.logger.error({ err, sessionId }, 'Error closing expired session'));
         this.sessions.delete(sessionId);
       }
     }
 
-    // Create new isolated context + page
-    const context = await this.browser.newContext({
-      viewport: { width: 1280, height: 720 },
-      userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
-    });
-
+    // Incognito → fresh isolated context off the same browser, never touching the
+    // principal's persistent profile. Persistent (default) → a page in the shared profile.
+    let ownedContext: BrowserContext | null = null;
     let page;
     try {
-      // Apply ad blocker to this context if initialized
-      page = await context.newPage();
-      if (this.blocker) {
-        try {
-          await this.blocker.enableBlockingInPage(page);
-        } catch (err) {
-          this.logger.warn({ err }, 'Ad blocker failed to attach to page — continuing without ad blocking for this session');
+      if (opts.incognito) {
+        ownedContext = await browser.newContext(this.buildContextOptions());
+        page = await ownedContext.newPage();
+      } else {
+        page = await this.context.newPage();
+      }
+      if (opts.blockAds) {
+        const blocker = await this.getBlocker();
+        if (blocker) {
+          try {
+            await blocker.enableBlockingInPage(page);
+          } catch (err) {
+            this.logger.warn({ err }, 'Ad blocker failed to attach to page — continuing without ad blocking for this session');
+          }
         }
       }
     } catch (err) {
-      // If page creation fails, close the context to prevent a resource leak.
-      // Without this, the BrowserContext would never be closed since it's not
-      // yet in this.sessions and stop() only closes sessions in the map.
-      await context.close().catch(closeErr => {
-        this.logger.error({ err: closeErr }, 'Failed to close context during page creation cleanup — possible resource leak');
-      });
+      // Clean up a half-created session to prevent a leak (it's not yet in the map).
+      if (ownedContext) {
+        await ownedContext.close().catch(closeErr => {
+          this.logger.error({ err: closeErr }, 'Failed to close incognito context during cleanup — possible resource leak');
+        });
+      } else if (page) {
+        await page.close().catch(() => {});
+      }
       throw err;
     }
+
     const newSessionId = randomUUID();
-    const session = new BrowserSession(context, page);
+    const session = new BrowserSession(ownedContext ?? this.context, page, ownedContext);
 
     // Crash safety: if the page crashes, invalidate the session so the next
     // skill call starts fresh rather than retrying on a broken page.
@@ -221,7 +261,10 @@ export class BrowserService {
     });
 
     this.sessions.set(newSessionId, session);
-    this.logger.debug({ sessionId: newSessionId }, 'New browser session created');
+    this.logger.debug(
+      { sessionId: newSessionId, incognito: opts.incognito === true, blockAds: opts.blockAds === true },
+      'New browser session created',
+    );
 
     return { sessionId: newSessionId, session };
   }
@@ -266,19 +309,82 @@ export class BrowserService {
 
   // --- Private helpers ---
 
-  private async launchChromium(): Promise<Browser> {
-    return chromium.launch({
-      // headless: false + Xvfb = full browser on a virtual display.
-      // This avoids Cloudflare fingerprinting that targets headless mode's
-      // missing APIs and renderer differences. On macOS dev machines, no Xvfb
-      // is needed — the real display is used directly.
+  /**
+   * Fingerprint/context options shared by the persistent context and any incognito
+   * context. We deliberately DO NOT set userAgent — with the real Chrome channel and the
+   * stealth plugin's UA-override evasion the genuine current UA is sent, so it can never
+   * go stale (the old hardcoded Chrome/122 was a bot tell). timezoneId is set only when a
+   * timezone is configured, aligning the context with the principal.
+   */
+  private buildContextOptions(): BrowserContextOptions {
+    return {
+      viewport: { width: 1280, height: 720 },
+      locale: this.locale,
+      colorScheme: 'light',
+      ...(this.timezone ? { timezoneId: this.timezone } : {}),
+    };
+  }
+
+  /**
+   * Lazily fetch the Ghostery blocklist on first opt-in (block_ads:true) and cache it.
+   * Off by default, so most sessions never pay this cost. A fetch failure logs and returns
+   * null (blocking is best-effort) and clears the cached promise so a later opt-in retries.
+   */
+  private async getBlocker(): Promise<PlaywrightBlocker | null> {
+    if (this.blocker) return this.blocker;
+    try {
+      this.blockerPromise ??= PlaywrightBlocker.fromPrebuiltAdsAndTracking(fetch);
+      this.blocker = await this.blockerPromise;
+      this.logger.info('Ad blocker initialized (first opt-in)');
+      return this.blocker;
+    } catch (err) {
+      this.logger.warn({ err }, 'Ad blocker failed to initialize — continuing without ad blocking');
+      this.blockerPromise = null;
+      return null;
+    }
+  }
+
+  /**
+   * Launch the single persistent browser context (the principal's profile). Tries the
+   * configured channel (e.g. real Chrome) first and falls back to bundled Chromium if it
+   * isn't installed, so the skill degrades instead of failing to boot. Cast through unknown:
+   * playwright-extra returns a playwright-core BrowserContext, structurally identical to the
+   * 'playwright' BrowserContext we type against.
+   */
+  private async launchPersistentContext(): Promise<BrowserContext> {
+    const baseOptions = {
       headless: false,
       args: [
         '--disable-blink-features=AutomationControlled', // removes navigator.webdriver flag
         '--no-sandbox',                                   // required in container environments
         '--disable-dev-shm-usage',                        // prevents /dev/shm OOM in Docker
       ],
-    });
+      ...this.buildContextOptions(),
+    };
+
+    try {
+      const context = await stealthChromium.launchPersistentContext(
+        this.profileDir,
+        this.channel ? { ...baseOptions, channel: this.channel } : baseOptions,
+      ) as unknown as BrowserContext;
+      this.logChannel(context, this.channel);
+      return context;
+    } catch (err) {
+      if (!this.channel) throw err; // no channel to fall back from — a genuine launch failure
+      this.logger.warn({ err, channel: this.channel }, 'Failed to launch with channel — falling back to bundled Chromium');
+      const context = await stealthChromium.launchPersistentContext(
+        this.profileDir,
+        baseOptions,
+      ) as unknown as BrowserContext;
+      this.logChannel(context, undefined);
+      return context;
+    }
+  }
+
+  /** Log the resolved channel + real browser version for observability (UA traceability). */
+  private logChannel(context: BrowserContext, channel: string | undefined): void {
+    const version = context.browser()?.version();
+    this.logger.info({ channel: channel ?? 'chromium', version, profileDir: this.profileDir }, 'Persistent browser context launched');
   }
 
   /**

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -84,6 +84,10 @@ export class BrowserService {
   // Set to true by stop() before closing the context so the 'disconnected' handler
   // knows the disconnect is intentional and must NOT trigger a crash-recovery restart.
   private stopping = false;
+  // True once a configured browser channel (e.g. 'chrome') failed to launch and we fell
+  // back to bundled Chromium — a degraded fingerprint posture. Exposed via
+  // isChannelFallbackActive() so health checks can surface the divergence (see #987).
+  private channelFallbackActive = false;
   // Ad blocker is loaded lazily on first opt-in (block_ads:true) and cached. Off by
   // default so login/auth/form-fill flows carry no privacy-extension signal.
   // These fields intentionally survive stop()/restart() — the blocklist is process-global
@@ -336,6 +340,15 @@ export class BrowserService {
     return this.sessions.get(sessionId);
   }
 
+  /**
+   * True if a configured browser channel failed to launch and the service degraded to
+   * bundled Chromium (a weaker fingerprint than configured). Lets health checks surface
+   * the configured-vs-actual divergence rather than leaving it buried in a log line (#987).
+   */
+  isChannelFallbackActive(): boolean {
+    return this.channelFallbackActive;
+  }
+
   // --- Private helpers ---
 
   /**
@@ -400,7 +413,17 @@ export class BrowserService {
       return context;
     } catch (err) {
       if (!this.channel) throw err; // no channel to fall back from — a genuine launch failure
-      this.logger.warn({ err, channel: this.channel }, 'Failed to launch with channel — falling back to bundled Chromium');
+      // Configured-vs-actual divergence: the operator asked for a real browser channel
+      // (the whole point of the fingerprint hardening) and we couldn't honour it — almost
+      // always a missing browser in the image. Degrade to bundled Chromium so the skill
+      // still works, but log at ERROR (not warn): production is now running a materially
+      // weaker fingerprint than configured, and that must be loud/alertable, not buried.
+      // `channelFallbackActive` exposes the degraded posture for health checks/greppability.
+      this.channelFallbackActive = true;
+      this.logger.error(
+        { err, requestedChannel: this.channel },
+        'Browser channel launch failed — DEGRADED to bundled Chromium (weaker fingerprint than configured); is the channel installed in the image?',
+      );
       const context = await stealthChromium.launchPersistentContext(
         this.profileDir,
         baseOptions,

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -81,6 +81,9 @@ export class BrowserService {
   // it (shared cookies/storage = "returning user"); incognito sessions get their own
   // ephemeral context spun off context.browser() (see getOrCreateSession).
   private context: BrowserContext | null = null;
+  // Set to true by stop() before closing the context so the 'disconnected' handler
+  // knows the disconnect is intentional and must NOT trigger a crash-recovery restart.
+  private stopping = false;
   // Ad blocker is loaded lazily on first opt-in (block_ads:true) and cached. Off by
   // default so login/auth/form-fill flows carry no privacy-extension signal.
   // These fields intentionally survive stop()/restart() — the blocklist is process-global
@@ -138,6 +141,13 @@ export class BrowserService {
       return;
     }
     browser.on('disconnected', () => {
+      // Intentional shutdown via stop() — do not restart. stop() sets this.stopping
+      // before calling context.close() so we can distinguish a deliberate close from
+      // an unexpected crash/OOM disconnect.
+      if (this.stopping) {
+        this.logger.debug('Browser disconnected during stop() — skipping crash-recovery restart');
+        return;
+      }
       this.logger.error('Playwright browser disconnected — clearing sessions and restarting');
       // Best-effort close of any live sessions before dropping them from the map. On a
       // genuine crash/OOM kill the pages are already gone and these close() calls no-op;
@@ -177,12 +187,20 @@ export class BrowserService {
     this.sessions.clear();
 
     if (this.context) {
+      // Signal the 'disconnected' handler that this disconnect is intentional so it
+      // does not trigger crash-recovery (which would try to relaunch the browser while
+      // we're tearing down, potentially racing with a restart that reuses the profile).
+      this.stopping = true;
       try {
         await this.context.close();
       } catch (err) {
         this.logger.error({ err }, 'Error closing browser context during shutdown');
+      } finally {
+        // Reset stopping so the instance can be reused after stop() (e.g. in tests)
+        // and a future unexpected disconnect still triggers recovery.
+        this.stopping = false;
+        this.context = null;
       }
-      this.context = null;
     }
 
     if (this.xvfbProcess) {

--- a/src/browser/browser-session.test.ts
+++ b/src/browser/browser-session.test.ts
@@ -5,7 +5,7 @@
 // that value so any page content read back during the same session can be scrubbed
 // of it — the backstop against a hostile page reflecting the value into LLM context.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { BrowserSession } from './browser-session.js';
 import type { BrowserContext, Page } from 'playwright';
 
@@ -15,6 +15,34 @@ function makeSession(): BrowserSession {
   const fakePage = {} as unknown as Page;
   return new BrowserSession(fakeContext, fakePage);
 }
+
+/** A session backed by vi.fn() page/context so close() behavior can be asserted. */
+function makeClosableSession(opts: { incognito: boolean }) {
+  const page = { close: vi.fn().mockResolvedValue(undefined) } as unknown as Page;
+  const ownedContext = { close: vi.fn().mockResolvedValue(undefined) } as unknown as BrowserContext;
+  const sharedContext = { close: vi.fn().mockResolvedValue(undefined) } as unknown as BrowserContext;
+  const session = opts.incognito
+    ? new BrowserSession(ownedContext, page, ownedContext)
+    : new BrowserSession(sharedContext, page, null);
+  return { session, page, ownedContext, sharedContext };
+}
+
+describe('BrowserSession close lifecycle', () => {
+  it('persistent session closes only its page, not the shared context', async () => {
+    const { session, page, sharedContext } = makeClosableSession({ incognito: false });
+    await session.close();
+    expect((page as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
+    expect((sharedContext as unknown as { close: ReturnType<typeof vi.fn> }).close).not.toHaveBeenCalled();
+  });
+
+  it('incognito session closes its owned context (which closes the page)', async () => {
+    const { session, page, ownedContext } = makeClosableSession({ incognito: true });
+    await session.close();
+    expect((ownedContext as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
+    // We do NOT also call page.close() — context.close() tears the page down.
+    expect((page as unknown as { close: ReturnType<typeof vi.fn> }).close).not.toHaveBeenCalled();
+  });
+});
 
 describe('BrowserSession injected-secret redaction', () => {
   it('redacts a registered secret value from text', () => {

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -33,9 +33,19 @@ export class BrowserSession {
    */
   private readonly injectedSecretValues = new Set<string>();
 
-  constructor(context: BrowserContext, page: Page) {
+  /**
+   * For INCOGNITO sessions: the ephemeral BrowserContext this session OWNS and must
+   * tear down on close. Null for PERSISTENT sessions, whose page lives in the shared
+   * persistent profile context — closing that context would kill the whole browser, so
+   * a persistent session closes only its page instead. This single switch distinguishes
+   * the two session lifecycles (see #987 design).
+   */
+  private readonly ownedContext: BrowserContext | null;
+
+  constructor(context: BrowserContext, page: Page, ownedContext: BrowserContext | null = null) {
     this.context = context;
     this.page = page;
+    this.ownedContext = ownedContext;
     this.lastUsedAt = Date.now();
   }
 
@@ -80,8 +90,17 @@ export class BrowserSession {
     return Date.now() - this.lastUsedAt > ttlMs;
   }
 
-  /** Close the underlying browser context, releasing all associated resources. */
+  /**
+   * Release this session's browser resources.
+   * - Incognito: close the owned ephemeral context (also closes its page).
+   * - Persistent: close only the page; the shared profile context stays alive for
+   *   other sessions and to keep the profile warm.
+   */
   async close(): Promise<void> {
-    await this.context.close();
+    if (this.ownedContext) {
+      await this.ownedContext.close();
+    } else {
+      await this.page.close();
+    }
   }
 }

--- a/src/config.browser.test.ts
+++ b/src/config.browser.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { loadYamlConfig } from './config.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+function writeTempConfig(content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-config-'));
+  fs.writeFileSync(path.join(dir, 'default.yaml'), content);
+  return dir;
+}
+
+// The browser block can be overridden via config/local.yaml, which is deep-merged but not
+// schema-validated — so loadYamlConfig() rejects malformed values explicitly. A bad
+// sweepIntervalMs (0/-1) would otherwise reach BrowserService and schedule runaway sweeps.
+describe('loadYamlConfig: browser block validation', () => {
+  it('accepts a valid browser block', () => {
+    const dir = writeTempConfig(
+      `browser:\n  sessionTtlMs: 600000\n  sweepIntervalMs: 120000\n  profileDir: "/data/profile"\n  channel: chrome\n  locale: en-US\n`,
+    );
+    const config = loadYamlConfig(dir);
+    expect(config.browser?.channel).toBe('chrome');
+    expect(config.browser?.sweepIntervalMs).toBe(120000);
+  });
+
+  it('rejects sweepIntervalMs: 0', () => {
+    const dir = writeTempConfig(`browser:\n  sweepIntervalMs: 0\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('browser.sweepIntervalMs');
+  });
+
+  it('rejects a negative sessionTtlMs', () => {
+    const dir = writeTempConfig(`browser:\n  sessionTtlMs: -1\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('browser.sessionTtlMs');
+  });
+
+  it('rejects a non-integer sweepIntervalMs', () => {
+    const dir = writeTempConfig(`browser:\n  sweepIntervalMs: 1.5\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('browser.sweepIntervalMs');
+  });
+
+  it('rejects a non-string channel', () => {
+    const dir = writeTempConfig(`browser:\n  channel: 123\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('browser.channel');
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -134,6 +134,15 @@ export interface YamlConfig {
   browser?: {
     sessionTtlMs?: number;
     sweepIntervalMs?: number;
+    /**
+     * Persistent browser profile directory. Empty/absent → ${HOME}/.curia/browser-profile.
+     * Must be on a mounted volume in production so cookies/session survive restarts.
+     */
+    profileDir?: string;
+    /** Browser channel, e.g. "chrome" for real Chrome. Empty/absent → bundled Chromium. */
+    channel?: string;
+    /** Context locale (BCP 47). Default "en-US". */
+    locale?: string;
   };
   agents?: {
     coordinator?: { config_path?: string };

--- a/src/config.ts
+++ b/src/config.ts
@@ -487,6 +487,25 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     throw new Error(`skillOutput.maxLength must be a positive integer, got: ${maxLength}`);
   }
 
+  // Validate the browser block. config/local.yaml is deep-merged above but not
+  // schema-validated, so a bad override (e.g. sweepIntervalMs: 0 or -1) would otherwise
+  // reach BrowserService and schedule near-continuous sweeps. Reject malformed values here.
+  const browser = config.browser;
+  if (browser !== undefined) {
+    const { sessionTtlMs, sweepIntervalMs, profileDir, channel, locale } = browser;
+    if (sessionTtlMs !== undefined && (!Number.isInteger(sessionTtlMs) || sessionTtlMs <= 0)) {
+      throw new Error(`browser.sessionTtlMs must be a positive integer, got: ${sessionTtlMs}`);
+    }
+    if (sweepIntervalMs !== undefined && (!Number.isInteger(sweepIntervalMs) || sweepIntervalMs <= 0)) {
+      throw new Error(`browser.sweepIntervalMs must be a positive integer, got: ${sweepIntervalMs}`);
+    }
+    for (const [key, value] of [['profileDir', profileDir], ['channel', channel], ['locale', locale]] as const) {
+      if (value !== undefined && typeof value !== 'string') {
+        throw new Error(`browser.${key} must be a string, got: ${typeof value}`);
+      }
+    }
+  }
+
   const checkpointDebounceMs = config.dispatch?.conversationCheckpointDebounceMs;
   if (checkpointDebounceMs !== undefined && (!Number.isInteger(checkpointDebounceMs) || checkpointDebounceMs <= 0)) {
     throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -759,14 +759,16 @@ async function main(): Promise<void> {
   // but web-browser skill invocations will fail at the ctx.browserService check.
   let browserService: BrowserService | undefined;
   try {
-    // TODO(#192): browserConfig should come from yamlConfig.browser, not this cast.
-    // The cast always resolves to undefined, so these values are always the hardcoded
-    // defaults and the YAML settings have no effect. Fix tracked in issue #204.
-    const browserConfig = (config as unknown as { browser?: { sessionTtlMs?: number; sweepIntervalMs?: number } }).browser;
+    const browserConfig = yamlConfig.browser;
     browserService = new BrowserService({
       logger,
       sessionTtlMs: browserConfig?.sessionTtlMs ?? 600_000,
       sweepIntervalMs: browserConfig?.sweepIntervalMs ?? 120_000,
+      profileDir: browserConfig?.profileDir,
+      channel: browserConfig?.channel,
+      locale: browserConfig?.locale,
+      // Align the browser timezone with the principal's configured timezone.
+      timezone: config.timezone,
     });
     await browserService.start();
     logger.info('Browser service started');

--- a/tests/unit/skills/web-browser.test.ts
+++ b/tests/unit/skills/web-browser.test.ts
@@ -137,18 +137,18 @@ describe('WebBrowserHandler', () => {
       expect(data.url).toBe(FAKE_URL);
       expect(typeof data.content).toBe('string');
     }
-    expect(mockBrowserService.getOrCreateSession).toHaveBeenCalledWith(undefined);
+    expect(mockBrowserService.getOrCreateSession).toHaveBeenCalledWith(undefined, { incognito: false, blockAds: false });
   });
 
   it('navigate: passes existing session_id to getOrCreateSession', async () => {
     await handler.execute(makeCtx({ action: 'navigate', url: FAKE_URL, session_id: FAKE_SESSION_ID }, mockBrowserService));
-    expect(mockBrowserService.getOrCreateSession).toHaveBeenCalledWith(FAKE_SESSION_ID);
+    expect(mockBrowserService.getOrCreateSession).toHaveBeenCalledWith(FAKE_SESSION_ID, { incognito: false, blockAds: false });
   });
 
   it('click: calls getOrCreateSession with session_id', async () => {
     const result = await handler.execute(makeCtx({ action: 'click', selector: 'Sign up button', session_id: FAKE_SESSION_ID }, mockBrowserService));
     expect(result.success).toBe(true);
-    expect(mockBrowserService.getOrCreateSession).toHaveBeenCalledWith(FAKE_SESSION_ID);
+    expect(mockBrowserService.getOrCreateSession).toHaveBeenCalledWith(FAKE_SESSION_ID, { incognito: false, blockAds: false });
   });
 
   it('type: succeeds with selector and text', async () => {


### PR DESCRIPTION
## **User description**
## Summary

Closes #987.

Authorized, user-initiated browser automation (the principal asking Curia to log into *their own* accounts / make *their own* reservations) was being blocked by anti-bot systems (x.com login, OpenTable, a personality-test form fill). The browser already ran headed + `--disable-blink-features=AutomationControlled`, so headedness wasn't the gap. This PR removes the three real blockers: the ad-blocker fingerprint, a stale/generic fingerprint, and the lack of a persistent profile.

### What changed
- **Persistent context model.** Replaces "one warm `Browser` + isolated context per session" with a single `launchPersistentContext` (the principal's persistent profile). Sessions are now pages in that shared context, so authenticated state looks like a returning user and survives restarts.
- **Incognito escape hatch** (`incognito: true`). A throwaway, isolated context off the same browser for Curia's own / one-off logins, so they don't pollute the principal's profile. `BrowserSession.ownedContext` is the single switch: persistent → close the page; incognito → close the context.
- **Ad blocking is now opt-in** (`block_ads: true`, off by default, blocklist fetched lazily). The Ghostery blocker injection was what x.com fingerprinted as a "privacy related extension" — so it's off for login/auth/form-fill by default.
- **Fingerprint hardening.** `playwright-extra` + `puppeteer-extra-plugin-stealth`; real Chrome `channel` with graceful fallback to bundled Chromium; context `locale`/`timezoneId`/`colorScheme`/viewport. The hardcoded stale `Chrome/122` UA override is **removed** — the real channel + stealth supply a current UA that can't go stale.
- **Config wiring** for `browser.profileDir`/`channel`/`locale` + the principal's timezone. This also fixes **#204**: `browser.*` settings were read through a dead cast and silently ignored.

### Notable robustness fixes found in review
- The persistent context's `context.close()` during intentional `stop()` fires the browser's `disconnected` event; a `stopping` flag prevents that from triggering a crash-recovery restart that would race the next instance for the profile lock. (This latent bug also existed in the old `browser.close()` path — mocks just never fired the event.)
- A configured `channel: 'chrome'` that fails to launch now degrades to bundled Chromium **loudly** (error log + `isChannelFallbackActive()` flag) rather than silently weakening the fingerprint.

### Deploy dependency
Requires curia-deploy PR (real Chrome in the image + a persistent-profile volume + `browser.channel: chrome`). **Merge this PR first**, then deploy curia-deploy — without this PR's config schema, the deploy's `browser:` config block would fail startup validation.

## Testing
- `pnpm run typecheck` clean; full unit suite green (pre-existing autonomy DB tests aside, which need `DATABASE_URL`).
- **39/39 browser + skill tests pass, including the real-Chromium integration suite** (`RUN_BROWSER_TESTS=1`): navigate, content extraction, and **persistence-across-restart** (set a cookie, restart the service against the same profile dir, confirm it survives).
- Reviewed by spec-compliance, code-quality, and silent-failure passes; findings addressed.

## Out of scope
Proxy / residential-IP work (per the issue — accepted limitation; strict sites may still resist from the server IP).

## Manual acceptance checklist (post-deploy — the real gate)
- [ ] x.com login page renders and accepts credentials with `block_ads` off (no "privacy related extensions" error).
- [ ] OpenTable reservation flow reaches and submits its form.
- [ ] A personality-test form fill reaches and submits.
- [ ] Log in once, `docker restart` the curia container, revisit — still authenticated (persistent profile).
- [ ] An `incognito: true` session does not see cookies set in a prior persistent session.

## Follow-up (not in this PR)
- A failed browser **restart** (after a crash) currently leaves the service down until process restart, with a generic "call start() first" error. Worth a bounded-retry + clearer degraded-state message later (noted by the silent-failure review).


___

## **CodeAnt-AI Description**
**Use a persistent browser profile by default, with optional incognito sessions and opt-in ad blocking**

### What Changed
- Browser sessions now keep the principal’s logged-in state across actions and restarts instead of starting from a fresh isolated context each time
- Added an `incognito` option for throwaway sessions that should not affect the saved profile
- Added an optional `block_ads` setting that turns ad blocking on only when requested, so login and form flows are less likely to be flagged
- Browser settings such as profile directory, channel, locale, and timezone are now read from config and take effect
- The browser skill now accepts `block_ads` and `incognito` inputs, and its guidance tells users when to use each one

### Impact
`✅ Persistent logins across browser restarts`
`✅ Fewer login blocks on sites that flag ad blockers`
`✅ Safer throwaway sessions for Curia-owned logins`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added incognito mode for creating isolated throwaway browser sessions
  * Introduced opt-in ad blocking capability for web browsing
  * Enhanced browser fingerprinting using Chrome channel support and stealth techniques

* **Bug Fixes**
  * Fixed browser configuration settings not being properly applied

* **Chores**
  * Added stealth-related dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->