### PR TITLE
chore: align on Node 24 LTS, digest-pin Docker base images, close Dependabot gap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,34 @@ updates:
       actions:
         patterns:
           - "*"
+
+  # Docker base images — the root Dockerfile (node:24-slim, digest-pinned).
+  # Without this ecosystem the base image was never tracked and silently drifted
+  # (prod ended up on node 26 Current via curia-deploy#87). Dependabot keeps the
+  # @sha256 digest fresh within the pinned tag.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    ignore:
+      # node 24 is the Active LTS. Do NOT auto-bump the major: the next even
+      # release (26) is Current/unstable until it reaches LTS (~Oct 2026), and
+      # Node.js says production should run only Active/Maintenance LTS. Digest +
+      # minor/patch updates still flow; bump the major by hand when 26 goes LTS.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+
+  # Docker base images — docker/postgres.Dockerfile (pgvector/pgvector:pg16,
+  # digest-pinned). Pin the pg major: a pg16→pg17 jump needs a deliberate DB
+  # upgrade, so block majors and let only digest/minor refreshes land.
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "pgvector/pgvector"
+        update-types: ["version-update:semver-major"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`config-store` / `email-reply` / `email-send` / `signal-send` / `decay-warnings-list`** — descriptions/input docs expanded to carry the relocated mechanics; behavior unchanged. (#958)
 - **User chat bubble** — user messages now appear with a teal background (`--app-teal`) and white text, visually distinguishing them from agent replies.
 - **Web console chat (ack-and-stream)** — `POST /api/kg/chat/messages` now acks with `202` and the reply streams over SSE instead of blocking on a 120s synchronous wait, so long agent tasks (browser automation, delegation chains, research) complete without a 504. (#985)
+- **Node 22 → 24 (Active LTS)** — the `Dockerfile` build + runtime stages move to `node:24-slim`, matching the production image. The `RUN npm install -g npm@11.16.0` line is removed: node 24's bundled npm is unused (corepack/pnpm at build, tsx at runtime) and scans clean, clearing the Scorecard `npmCommand` finding. (#905)
 
 - **`secret-capture-request` (skill manifest schema)** — adds an optional `resume_intent` input and persists the minting agent's routing context on the token so the capture can re-enter the right conversation. (#972)
 
@@ -64,6 +65,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 
 - **Value-aware browser redaction** — secret values injected by reference are tracked per browser session and scrubbed (raw plus URL/HTML-encoded variants) from returned content, the page URL, and errors; screenshots are suppressed on a secret-fill action since an image can't be value-redacted. Blocks round-trip exfiltration via a page that reflects a typed credential back. (#973)
+- **Docker base images digest-pinned** — `Dockerfile` (node:24-slim, both stages) and `docker/postgres.Dockerfile` (pgvector/pgvector:pg16) are now pinned by `@sha256:` digest, clearing the Scorecard Pinned-Dependencies Docker findings. (#905)
+- **`docker` Dependabot ecosystem** — added to `.github/dependabot.yml` (watching `/` and `/docker`) so the base images are tracked; a `semver-major` ignore on `node` keeps it from drifting onto Current/non-LTS releases. (#905)
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
 # Build stage: compile TypeScript and install dependencies
-FROM node:22-slim AS build
+#
+# Base image pinned by digest for a reproducible supply chain (clears the OpenSSF
+# Scorecard Pinned-Dependencies Docker finding). The tag is kept inline (not just
+# in a trailing comment) so Dependabot's docker ecosystem can read the semantic
+# version and apply the "don't chase Current majors" ignore rule in
+# .github/dependabot.yml — a bare `node@sha256:…` pin would otherwise track `latest`.
+# Node 24 "Krypton" is the Active LTS (node 22 is Maintenance, node 26 is Current).
+FROM node:24-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203 AS build
 
 WORKDIR /app
 
-# Enable pnpm via corepack (ships with Node 22)
+# Enable pnpm via corepack (bundled with Node 24)
 RUN corepack enable
 
 # Install dependencies first (layer caching — deps change less often than src).
@@ -23,8 +30,10 @@ RUN pnpm exec tsup src/index.ts --format esm --no-dts
 COPY apps/console/ ./apps/console/
 RUN pnpm --filter @curia/console run build
 
-# Production stage: minimal runtime image
-FROM node:22-slim
+# Production stage: minimal runtime image.
+# Same node:24-slim digest pin as the build stage above (see that comment for the
+# Scorecard / Dependabot rationale). Both stages must stay on the same digest.
+FROM node:24-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
 
 # curl is needed for the HEALTHCHECK command
 # Copy uv/uvx binaries from the official signed image (Astral's recommended
@@ -33,7 +42,7 @@ FROM node:22-slim
 COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
 
 # apt-get upgrade pulls the latest Debian 12 security patches for packages baked
-# into the node:22-slim base layer (e.g. libgnutls30, libgcrypt20). Without it the
+# into the node:24-slim base layer (e.g. libgnutls30, libgcrypt20). Without it the
 # image ships whatever versions were frozen when the base image was built, which
 # Trivy flags as known CVEs even though Debian has already published fixes.
 # Run upgrade before installing curl so curl is installed from the patched lists.
@@ -41,15 +50,6 @@ RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends curl \
  && rm -rf /var/lib/apt/lists/*
-
-# The global npm bundled in the base image carries its own transitive deps that
-# Trivy flags (picomatch, brace-expansion, ip-address). npm is never invoked at
-# runtime here — we use corepack/pnpm at build and tsx to run — but bumping it
-# pulls patched bundled deps (npm 11.16.0 ships picomatch 4.0.4, brace-expansion
-# 5.0.6, ip-address 10.2.0) and clears the findings rather than leaving stale
-# copies in the image. Pinned (not @latest) so rebuilds can't silently regress
-# the cleared CVEs; bump deliberately when a newer npm is needed.
-RUN npm install -g npm@11.16.0
 
 # Create a non-root system user/group for the runtime process.
 # UIDs/GIDs are pinned (not dynamic) so docker-compose tmpfs uid= options

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -2,7 +2,12 @@
 # pgAudit captures INSERT/UPDATE/DELETE/DDL statements at the database level,
 # providing a tamper-independent audit trail alongside Curia's application-level
 # audit_log table. See docs/specs/10-audit-log-hardening.md.
-FROM pgvector/pgvector:pg16
+#
+# Pinned by digest for a reproducible supply chain (clears the OpenSSF Scorecard
+# Pinned-Dependencies Docker finding on this line). Tag kept inline so Dependabot's
+# docker ecosystem (see .github/dependabot.yml) can read the pg16 version and bump
+# the digest within the major. Re-resolve the digest when intentionally moving pg majors.
+FROM pgvector/pgvector:pg16@sha256:00ba258a66dac104fd5171074a0084462a64a1369d8513f3d0a634e2f24d15bc
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-16-pgaudit \


### PR DESCRIPTION
## **User description**
## Summary

Closes #905.

Unifies the curia and curia-deploy images on **Node 24 (Active LTS)**, pins every base image by `@sha256:` digest, and closes the Dependabot coverage gap that let the base image silently drift onto a Current/non-LTS release. This is the **curia-repo half**; the production image lives in curia-deploy and is handled in a sibling PR (josephfung/curia-deploy#124). Both must merge for #905 to be fully resolved.

### Changes (curia repo)

- **`Dockerfile`** — build + runtime stages move from `node:22-slim` to `node:24-slim`, both pinned by `@sha256:` digest (tag kept inline so Dependabot can still read the semantic version). Clears Scorecard `Dockerfile:2` / `Dockerfile:27` Pinned-Dependencies findings.
- **`Dockerfile`** — removed `RUN npm install -g npm@11.16.0`. On node 24, npm is unused (corepack bundled, installs via pnpm, runtime via tsx). Deleted outright rather than upgrade-or-dismiss, clearing the Scorecard `npmCommand` (`Dockerfile:52`) finding. Verified via Trivy that node:24's bundled global npm scans **clean** (0 HIGH/CRITICAL), so the `rm -rf` fallback in the issue was not needed.
- **`docker/postgres.Dockerfile`** — `pgvector/pgvector:pg16` pinned by `@sha256:` digest. Clears Scorecard `postgres.Dockerfile:5`.
- **`.github/dependabot.yml`** — added a `docker` ecosystem watching both `/` (Dockerfile) and `/docker` (postgres.Dockerfile). A `semver-major` ignore on `node` (and `pgvector/pgvector`) keeps the base from auto-bumping onto Current/non-LTS majors; digest + minor/patch updates still flow.
- **`CHANGELOG.md`** — entries under Unreleased (Changed + Security).

### Verification

- `docker build .` succeeds on node 24 (build is now `node v24.16.0`).
- Trivy scan (CI-equivalent `--ignore-unfixed --severity HIGH,CRITICAL`): node:24's bundled npm tree scans clean. Remaining findings (esbuild/ws/form-data) are pre-existing `package.json` app/transitive deps, version-independent and out of scope for this base-image issue.
- Runtime smoke test: the entrypoint boots through tsx → ESM load → `loadConfig()` on node 24 and exits with the expected "DATABASE_URL required" structured error (full `/api/health` needs the prod DB/secrets and is validated at deploy).

### Note (deferred, per issue)

The scanned image (`curia/Dockerfile`) is not the shipped image (`curia-deploy/Dockerfile.curia`); unifying on node 24 makes the repo scan fairly representative. Whether to also scan the production image is a separate decision — noted and deferred, not expanded here.


___

## **CodeAnt-AI Description**
**Move Docker images to Node 24 LTS and pin base images**

### What Changed
- The app Docker image now builds and runs on Node 24 LTS instead of Node 22
- Both Docker base images are pinned to exact digests, so rebuilds use the same trusted image contents
- The unused global npm install was removed from the runtime image
- Docker base images are now tracked by Dependabot, with major version jumps held back for manual review

### Impact
`✅ Reproducible Docker builds`
`✅ Fewer supply-chain drift surprises`
`✅ Clearer base-image update control`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with supply-chain improvements and base image updates.

* **Chores**
  * Upgraded Docker base image to Node.js 24 with digest pinning for reproducible builds.
  * Configured automated monitoring of Docker dependencies with version controls.
  * Removed global npm installation from production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->