### PR TITLE
chore(ci): sign release artifacts + make release SBOM reliable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,19 +92,39 @@ jobs:
           path: .
           upload-artifact: false
 
-      - name: Verify SBOM was written
+      - name: Verify SBOM was written and non-trivial
         run: |
           if [ ! -s sbom.spdx.json ]; then
             echo "::error::sbom.spdx.json is missing or empty after generation" >&2
             exit 1
           fi
+          # SPDX always emits a root document-describes package; require real
+          # entries beyond it. A syft run that scanned nothing (wrong path,
+          # unexpected layout) emits a valid-but-empty SBOM that the size check
+          # alone would wave through — same "green run, worthless artifact" trap
+          # this workflow exists to close.
+          PKGS=$(jq '.packages | length' sbom.spdx.json)
+          if [ "$PKGS" -lt 2 ]; then
+            echo "::error::SBOM contains $PKGS package(s) — generation likely scanned nothing" >&2
+            exit 1
+          fi
 
       # Reproducible source tarball for the tag. HEAD is the checked-out tag.
+      # git archive stamps every entry with the commit timestamp (fixed per tag)
+      # and `gzip -n` drops the gzip header's name+mtime, so re-running this
+      # workflow for the same tag (the documented backfill/recovery path) yields
+      # byte-identical output — a --clobber re-upload doesn't change what was
+      # signed, and a previously-pinned digest still matches.
       - name: Build source tarball
         run: |
-          git archive --format=tar.gz --prefix="curia-${TAG}/" HEAD -o "curia-${TAG}.tar.gz"
+          git archive --format=tar --prefix="curia-${TAG}/" HEAD | gzip -n > "curia-${TAG}.tar.gz"
           if [ ! -s "curia-${TAG}.tar.gz" ]; then
             echo "::error::source tarball curia-${TAG}.tar.gz is missing or empty" >&2
+            exit 1
+          fi
+          ENTRIES=$(tar -tzf "curia-${TAG}.tar.gz" | wc -l)
+          if [ "$ENTRIES" -lt 2 ]; then
+            echo "::error::source tarball has $ENTRIES entries — archive looks degenerate" >&2
             exit 1
           fi
 
@@ -125,16 +145,23 @@ jobs:
             "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore" \
             --clobber
 
-      # Final gate: re-read the release from GitHub and re-verify the signatures
-      # against the GitHub Actions OIDC issuer. This is what makes a green run
-      # trustworthy — it proves the assets are present AND the signatures verify,
-      # rather than trusting that the upload step "probably" worked.
+      # Final gate: re-download the assets FROM the release and verify the
+      # signatures against the downloaded bytes — NOT the local build outputs.
+      # This is what makes a green run trustworthy: it proves the release
+      # actually carries the artifacts AND that the uploaded content (not merely
+      # a same-named file) verifies, so a consumer downloading this release will
+      # succeed too. Verifying the local copies would only re-confirm what we
+      # just signed and would miss a truncated/corrupt upload.
       - name: Verify attached + signed
         run: |
-          ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          rm -rf verify && mkdir verify
+          # We attach exactly 4 assets, well within one API page; `gh release
+          # download` with no --pattern pulls them all. (If a release ever grows
+          # past one page of assets, switch to per-name --pattern fetches.)
+          gh release download "$TAG" --dir verify --clobber
           for f in sbom.spdx.json sbom.spdx.json.sigstore "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore"; do
-            if ! printf '%s\n' "$ASSETS" | grep -Fxq "$f"; then
-              echo "::error::expected release asset '$f' is not attached to $TAG" >&2
+            if [ ! -s "verify/$f" ]; then
+              echo "::error::expected release asset '$f' is missing from $TAG" >&2
               exit 1
             fi
           done
@@ -143,12 +170,12 @@ jobs:
           # default branch for workflow_dispatch backfills), so it is left open.
           IDENTITY_REGEXP="^https://github.com/${GH_REPO}/.github/workflows/release.yml@"
           cosign verify-blob \
-            --bundle sbom.spdx.json.sigstore \
+            --bundle verify/sbom.spdx.json.sigstore \
             --certificate-identity-regexp "$IDENTITY_REGEXP" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            sbom.spdx.json
+            verify/sbom.spdx.json
           cosign verify-blob \
-            --bundle "curia-${TAG}.tar.gz.sigstore" \
+            --bundle "verify/curia-${TAG}.tar.gz.sigstore" \
             --certificate-identity-regexp "$IDENTITY_REGEXP" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            "curia-${TAG}.tar.gz"
+            "verify/curia-${TAG}.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,154 @@
+name: Release Artifacts
+
+# Builds, signs, and attaches release artifacts on every published release:
+#   - sbom.spdx.json            (SPDX SBOM for the release commit)
+#   - curia-<tag>.tar.gz        (reproducible source tarball)
+#   - *.sigstore                (cosign keyless signature bundle per artifact)
+#
+# Signing is keyless via Sigstore + the GitHub OIDC token (id-token: write) —
+# no long-lived keys to manage. Verifiable with `cosign verify-blob` against the
+# GitHub Actions OIDC issuer.
+#
+# Unlike the old release-gated SBOM job (which ran green while silently skipping
+# the attach — that is how v0.34.0 shipped with no SBOM), every step here is
+# fatal: a failed generate, sign, upload, or verify turns the run red. The final
+# job re-reads the release assets and re-verifies the signatures, so "green" can
+# only mean the artifacts are actually present and valid on the release.
+#
+# workflow_dispatch with a `tag` input allows (re)building artifacts for an
+# existing release — used to backfill v0.34.0 and to recover from any failed run.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build + sign artifacts for (e.g. v0.34.0)"
+        required: true
+        type: string
+
+# Least privilege at the workflow level; jobs opt into the scopes they need.
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  # Resolve the target tag from either trigger and validate its format BEFORE it
+  # is used anywhere (checkout ref, git archive, gh upload). The strict regex is
+  # the injection guard: the tag is the only externally-influenced value, and a
+  # workflow_dispatch input is operator-supplied free text.
+  resolve:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Resolve and validate tag
+        id: resolve
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          TAG="${INPUT_TAG:-$EVENT_TAG}"
+          # Tags follow vMAJOR.MINOR.PATCH with an optional pre-release suffix.
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$'; then
+            echo "::error::Invalid or missing release tag: '$TAG'" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Build, sign, attach
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # gh release upload attaches assets to the release
+      id-token: write   # cosign keyless signing via GitHub OIDC
+    env:
+      TAG: ${{ needs.resolve.outputs.tag }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      # Checkout the release tag. The ref is the format-validated tag from the
+      # resolve job, so it is safe to interpolate here. fetch-depth: 0 gives
+      # git archive the full object it needs to build the tarball.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Generate the SBOM for the release commit. Fatal on failure — a release
+      # without an SBOM is not an acceptable outcome.
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+          path: .
+          upload-artifact: false
+
+      - name: Verify SBOM was written
+        run: |
+          if [ ! -s sbom.spdx.json ]; then
+            echo "::error::sbom.spdx.json is missing or empty after generation" >&2
+            exit 1
+          fi
+
+      # Reproducible source tarball for the tag. HEAD is the checked-out tag.
+      - name: Build source tarball
+        run: |
+          git archive --format=tar.gz --prefix="curia-${TAG}/" HEAD -o "curia-${TAG}.tar.gz"
+          if [ ! -s "curia-${TAG}.tar.gz" ]; then
+            echo "::error::source tarball curia-${TAG}.tar.gz is missing or empty" >&2
+            exit 1
+          fi
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless sign each artifact, producing a self-contained Sigstore bundle
+      # (signature + cert + transparency-log entry) per file.
+      - name: Sign artifacts
+        run: |
+          cosign sign-blob --yes --bundle sbom.spdx.json.sigstore sbom.spdx.json
+          cosign sign-blob --yes --bundle "curia-${TAG}.tar.gz.sigstore" "curia-${TAG}.tar.gz"
+
+      - name: Attach artifacts to release
+        run: |
+          gh release upload "$TAG" \
+            sbom.spdx.json sbom.spdx.json.sigstore \
+            "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore" \
+            --clobber
+
+      # Final gate: re-read the release from GitHub and re-verify the signatures
+      # against the GitHub Actions OIDC issuer. This is what makes a green run
+      # trustworthy — it proves the assets are present AND the signatures verify,
+      # rather than trusting that the upload step "probably" worked.
+      - name: Verify attached + signed
+        run: |
+          ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          for f in sbom.spdx.json sbom.spdx.json.sigstore "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore"; do
+            if ! printf '%s\n' "$ASSETS" | grep -Fxq "$f"; then
+              echo "::error::expected release asset '$f' is not attached to $TAG" >&2
+              exit 1
+            fi
+          done
+          # Identity is pinned to this workflow in this repo; issuer is pinned to
+          # GitHub's OIDC. The ref after @ varies (tag for release events, the
+          # default branch for workflow_dispatch backfills), so it is left open.
+          IDENTITY_REGEXP="^https://github.com/${GH_REPO}/.github/workflows/release.yml@"
+          cosign verify-blob \
+            --bundle sbom.spdx.json.sigstore \
+            --certificate-identity-regexp "$IDENTITY_REGEXP" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            sbom.spdx.json
+          cosign verify-blob \
+            --bundle "curia-${TAG}.tar.gz.sigstore" \
+            --certificate-identity-regexp "$IDENTITY_REGEXP" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "curia-${TAG}.tar.gz"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,15 +1,16 @@
 name: SBOM
 
+# Generates an SPDX SBOM artifact on every push to main, for supply-chain
+# visibility on in-development builds. Release SBOMs (generated, signed, and
+# attached to the GitHub release) are handled by release.yml — keeping the two
+# concerns separate avoids the silent skip that dropped v0.34.0's SBOM, where a
+# release-gated attach job ran green but attached nothing.
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
 
-# Least privilege: default the workflow token to read-only. Generation never
-# needs write; only the release-attachment job does, and it runs solely on
-# release events — so the write scope is isolated there instead of being held
-# by every push-triggered run (Scorecard TokenPermissionsID).
+# Least privilege: generation never needs write access, so the workflow token
+# stays read-only (Scorecard TokenPermissionsID).
 permissions:
   contents: read
 
@@ -22,10 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Surface the generation step's outcome so the release job can skip cleanly
-    # when generation failed (continue-on-error swallows the failure here).
-    outputs:
-      sbom_outcome: ${{ steps.sbom.outcome }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -33,7 +30,8 @@ jobs:
 
       - name: Generate SPDX SBOM
         id: sbom
-        # Non-fatal: SBOM generation must never block CI or a release.
+        # Non-fatal: an SBOM artifact on a main push must never block CI.
+        # (Release SBOMs are not optional — see release.yml, which fails loudly.)
         continue-on-error: true
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
@@ -43,39 +41,3 @@ jobs:
           artifact-name: sbom-${{ github.sha }}.spdx.json
           upload-artifact: true
           upload-artifact-retention: 90
-
-  attach-release:
-    name: Attach SBOM to release
-    runs-on: ubuntu-latest
-    needs: generate
-    # Only on a published release, and only if generation actually succeeded.
-    # This is the sole path that needs write access to the repo.
-    if: github.event_name == 'release' && needs.generate.outputs.sbom_outcome == 'success'
-    permissions:
-      contents: write  # gh release upload attaches an asset to the release
-      actions: read    # download-artifact: not required for same-run, but explicit on this CI-untested path
-    steps:
-      - name: Download SBOM artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: sbom-${{ github.sha }}.spdx.json
-          path: ./sbom-download
-
-      - name: Attach SBOM to release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}  # gh needs repo context (no checkout in this job)
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          # anchore/sbom-action stores the file inside the artifact under the
-          # artifact name (sbom-<sha>.spdx.json), not the output-file name, so
-          # resolve it dynamically rather than assuming a fixed path. Fail loudly
-          # if it's missing instead of attaching nothing to the release.
-          FILE=$(find ./sbom-download -name '*.spdx.json' | head -n1)
-          if [ -z "$FILE" ]; then
-            echo "::error::SBOM artifact downloaded but no .spdx.json file found inside it" >&2
-            exit 1
-          fi
-          # Copy to a stable name so the release asset is always `sbom.spdx.json`.
-          cp "$FILE" sbom.spdx.json
-          gh release upload "$RELEASE_TAG" sbom.spdx.json --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Docker base images digest-pinned** — `Dockerfile` (node:24-slim, both stages) and `docker/postgres.Dockerfile` (pgvector/pgvector:pg16) are now pinned by `@sha256:` digest, clearing the Scorecard Pinned-Dependencies Docker findings. (#905)
 - **`docker` Dependabot ecosystem** — added to `.github/dependabot.yml` (watching `/` and `/docker`) so the base images are tracked; a `semver-major` ignore on `node` keeps it from drifting onto Current/non-LTS releases. (#905)
 - **`web-browser` per-frame SSRF gating** — now that content extraction and locator resolution reach into iframes, child frames pointing at private/internal hosts (IPv4 loopback/RFC1918/link-local, IPv6 link-local + unique-local `fc00::/7` + IPv4-mapped forms, cloud-metadata) or `file:` are skipped, so a malicious page can't exfiltrate internal resources through an embedded frame the navigate guard never saw.
+- **Signed release artifacts** — each published release now attaches an SPDX SBOM and a source tarball, each signed with cosign keyless (Sigstore + GitHub OIDC, no long-lived keys) via the new `release.yml`. Satisfies the OpenSSF Scorecard Signed-Releases check; verify with `cosign verify-blob`.
+- **Reliable release SBOMs** — release SBOM generation/attachment moved out of `sbom.yml` (which skipped silently and shipped v0.34.0 with no SBOM) into `release.yml`, where a failed generate/attach/verify fails the run loudly. `sbom.yml` is now push-to-main only.
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,9 +296,23 @@ Write a haiku thematically aligned with the release — drawn from the changes, 
 - No other code changes — this PR is the release commit only
 - Watch CI; wait for merge before proceeding
 
-**7. After merge: tag and publish**
+**7. After merge: pre-release security gate**
 
-Once the release PR is merged, first confirm the merge landed, then tag `origin/main` directly (do not rely on local branch state — the release worktree is on `chore/release-X.Y.Z`, not `main`):
+Once the release PR is merged, `main` is the exact commit you are about to tag. Run the on-demand security scans against it and review the results **before** tagging. (Trivy fs, Semgrep, and Gitleaks already ran on the release PR; the gate below covers the scans that do *not* run on a normal push — the Docker image scan, a fresh CodeQL pass, and the repo-level Scorecard.)
+
+```bash
+gh workflow run trivy.yml     # on-demand Trivy image scan (base image + OS package CVEs)
+gh workflow run codeql.yml    # fresh CodeQL security-extended pass (takes several minutes)
+gh workflow run scorecard.yml # repo-level supply-chain posture
+# Wait for each to finish, then review results:
+gh run list --limit 5
+```
+
+Review **GitHub → Security → Code Scanning** for the results of all scanners. **Block the release on any unresolved CRITICAL finding.** A HIGH is a judgment call — fix it or document why it's accepted (e.g. unreachable code path, no fix available) before proceeding.
+
+**8. Tag and publish**
+
+Confirm the merge landed, then tag `origin/main` directly (do not rely on local branch state — the release worktree is on `chore/release-X.Y.Z`, not `main`):
 
 ```bash
 # Confirm the merge landed — grep must return a result before proceeding
@@ -325,6 +339,35 @@ gh release create vX.Y.Z \
 [haiku here]
 EOF
 )"
+```
+
+Tagging stays `git tag -a` (annotated, **unsigned**) — releases are signed at the artifact layer (step 9), not the tag.
+
+**9. Verify release artifacts (SBOM + signatures)**
+
+Publishing the release triggers `release.yml`, which generates an SPDX SBOM and a source tarball, signs both with cosign (keyless, via GitHub OIDC), and attaches all four files to the release. This step is **not optional and not silent** — the workflow fails loudly if anything is missing or a signature fails to verify (this is the fix for v0.34.0, which shipped with no SBOM because the old auto-attach skipped silently).
+
+Confirm the workflow succeeded and the four assets are present:
+
+```bash
+gh run list --workflow=release.yml --limit 1   # must be green
+gh release view vX.Y.Z --json assets --jq '.assets[].name'
+# expect: sbom.spdx.json, sbom.spdx.json.sigstore, curia-vX.Y.Z.tar.gz, curia-vX.Y.Z.tar.gz.sigstore
+```
+
+If the run failed or assets are missing, re-run it (do **not** consider the release done until they are present):
+
+```bash
+gh workflow run release.yml -f tag=vX.Y.Z
+```
+
+Anyone can verify a downloaded artifact against the GitHub Actions OIDC issuer:
+
+```bash
+cosign verify-blob --bundle sbom.spdx.json.sigstore \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/<owner>/curia/.github/workflows/release.yml@' \
+  sbom.spdx.json
 ```
 
 ## Scope Discipline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,11 @@ gh workflow run release.yml -f tag=vX.Y.Z
 Anyone can verify a downloaded artifact against the GitHub Actions OIDC issuer:
 
 ```bash
+# The signer identity is release.yml in this repo. The ref after @ is the tag
+# (refs/tags/vX.Y.Z) for a normally-published release, or refs/heads/main for a
+# release whose artifacts were built via the workflow_dispatch backfill path
+# (e.g. v0.34.0). The regexp below matches both; tighten the @ suffix if you
+# know which path produced a given release.
 cosign verify-blob --bundle sbom.spdx.json.sigstore \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github.com/<owner>/curia/.github/workflows/release.yml@' \


### PR DESCRIPTION
## **User description**
## Summary

Hardens the release pipeline across three axes: a pre-release **security-scan gate**, **reliable SBOM** attachment, and **signed release artifacts**. Motivated by v0.34.0 shipping with no SBOM — its SBOM run reported green in 21s because the generate job succeeded while the release-gated attach job silently **skipped**.

### What changed

- **`release.yml` (new)** — on each published release (and via `workflow_dispatch` with a `tag` input for backfill/recovery): generate an SPDX SBOM, build a reproducible `git archive` source tarball, sign both with **cosign keyless** (Sigstore + GitHub OIDC, `id-token: write`, no long-lived keys), attach all four files, then **re-download from the release and re-verify the signatures** before going green. Every step is fatal — no `continue-on-error`, no skip-gated attach.
- **`sbom.yml`** — reduced to push-to-main only. The release trigger + the silently-skipping `attach-release` job are removed; release SBOMs now live in `release.yml`.
- **`CLAUDE.md` ("Preparing a release")** — adds a pre-release security gate (dispatch Trivy image + CodeQL + Scorecard, review the Security tab, block on unresolved CRITICAL) and a post-publish artifact-verification step.
- **`CHANGELOG.md`** — Security entries.

### Why no signed tags / image signing

Curia publishes no container image to a registry (deploy builds on the VPS), so the signable release artifacts are the SBOM + source tarball. Signing is at the asset layer; tagging stays `git tag -a` (annotated, unsigned). This satisfies the OpenSSF Scorecard **Signed-Releases** check the security memo already tracks.

### Verification

- `actionlint` (incl. bundled shellcheck) passes clean on both workflows.
- End-to-end test after merge: `gh workflow run release.yml -f tag=v0.34.0` backfills the missing v0.34.0 SBOM + signatures and exercises the full path.

### Review

Passed three pre-PR review agents (code-reviewer, silent-failure-hunter, security). Security review found no CRITICAL/HIGH/MEDIUM issues. Substantive findings (verify downloaded bytes not local files; reproducible tarball; reject empty-but-valid SBOM) are addressed in the second commit.

> Note: the security-memo scan-table update lives in the office-of-the-ceo workspace (outside this repo) and is not part of this PR.


___

## **CodeAnt-AI Description**
**Sign and reliably attach release artifacts**

### What Changed
- Published releases now include two signed files: the SBOM and a source tarball
- Release artifact checks now fail if the SBOM is missing, empty, or too small to be useful
- The source tarball is built in a repeatable way so the same release tag produces the same file when rebuilt
- Release SBOM handling was removed from the main push workflow to prevent silent skips from leaving releases without an SBOM
- The release runbook now includes a pre-release security scan gate and a post-publish verification step

### Impact
`✅ Fewer releases shipped without an SBOM`
`✅ Safer release downloads with signed artifacts`
`✅ Easier release recovery for missing or failed artifacts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
