### PR TITLE
feat: OWASP ZAP baseline DAST scan for the HTTP API (#568)

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -1,0 +1,154 @@
+name: DAST — OWASP ZAP Baseline
+
+# Dynamic application security testing. Boots the Curia HTTP API in CI and runs an
+# OWASP ZAP passive (baseline) scan against the unauthenticated surface, then publishes
+# SARIF to the Security tab and an HTML report as an artifact.
+#
+# Release-prep only: this is NOT run per-PR. Booting Curia + Postgres and running ZAP
+# adds several minutes of overhead with low incremental value over the SAST jobs
+# (CodeQL, Semgrep, Trivy), so it runs weekly and on manual dispatch. The scan is
+# alert-only — `failOnError: false` in the AF plan means findings never fail the job
+# until a stable baseline is established (see issue #568).
+on:
+  # No inputs: this job always boots a fresh Curia instance in CI and scans it.
+  # Scanning an arbitrary external URL is intentionally unsupported here — all the
+  # Postgres/migrate/seed/boot steps exist to stand up that local target.
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 09:00 UTC — staggered after the Wednesday SAST jobs
+    # (CodeQL 06:00, Semgrep 07:00, Trivy 08:00). Release-prep cadence.
+    - cron: '0 9 * * 1'
+
+# Least privilege: the workflow token defaults to read-only. The scan job grants
+# `security-events: write` at the job level for the SARIF upload (Scorecard
+# TokenPermissionsID).
+permissions:
+  contents: read
+
+jobs:
+  zap-baseline:
+    name: ZAP Baseline Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required for the SARIF upload to the Security tab
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: curia_test
+          POSTGRES_USER: curia
+          POSTGRES_PASSWORD: curia_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U curia"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://curia:curia_test@localhost:5432/curia_test
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Rebuild esbuild
+        run: pnpm rebuild esbuild
+
+      # The vault is encrypted with this key, and the server decrypts with it at boot,
+      # so the seed step and the server step MUST share one value. Generate it once and
+      # export to $GITHUB_ENV. CI-only, ephemeral DB — there is nothing real to protect.
+      - name: Generate vault encryption key
+        run: echo "SECRET_ENCRYPTION_KEY=$(openssl rand -base64 32)" >> "$GITHUB_ENV"
+
+      - name: Run database migrations
+        run: pnpm tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql
+
+      # Curia resolves its required secrets (api_token, anthropic_api_key,
+      # web_app_bootstrap_secret) from the encrypted vault, NOT from env — there is no
+      # env fallback (src/secrets/apply-vault-secrets.ts). So we must seed the vault
+      # after migrations (the `secrets` table) and before the server boots, with
+      # placeholder values: ZAP exercises the HTTP surface, not live LLM behavior.
+      # Invoke tsx directly rather than `pnpm run seed-vault` to bypass that script's
+      # hardcoded `--env-file=.env` (there is no .env in CI).
+      - name: Seed the secrets vault with CI placeholders
+        run: pnpm tsx scripts/seed-vault.ts
+        env:
+          API_TOKEN: ci-dast-token-not-a-real-secret
+          ANTHROPIC_API_KEY: sk-ant-ci-dast-placeholder
+          WEB_APP_BOOTSTRAP_SECRET: ci-dast-bootstrap-not-a-real-secret
+
+      # Start the HTTP API in the background. It binds 0.0.0.0:3000, so the ZAP
+      # container can reach it via the Docker bridge gateway (172.17.0.1) later.
+      - name: Start Curia HTTP API
+        run: pnpm tsx src/index.ts > curia-server.log 2>&1 &
+        env:
+          HTTP_PORT: "3000"
+          LOG_LEVEL: info
+
+      # Poll the unauthenticated health endpoint until the server is up. Fail loudly
+      # (and dump the log) if it never comes up, rather than letting the ZAP step hang
+      # until its own timeout on a server that silently failed to boot.
+      - name: Wait for the server to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3000/api/health > /dev/null; then
+              echo "Curia HTTP API is up after $((i * 2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Curia HTTP API did not become ready within 120s"
+          echo "----- curia-server.log -----"
+          cat curia-server.log || true
+          exit 1
+
+      # ZAP Automation Framework (first-party, SHA-pinned). The plan drives a passive
+      # baseline scan and emits both SARIF and HTML into /zap/wrk/ (the workspace).
+      # The plan's failOnError is false, so this step never fails the job on findings.
+      - name: Run ZAP Automation Framework scan
+        uses: zaproxy/action-af@d186d5d9536d0f1380e5eaa58168432fefc8ed6d # v0.3.0
+        with:
+          plan: '.zap/plan.yaml'
+
+      # List what ZAP actually wrote (the reportFile naming has historically been
+      # surprising), so a failed upload is easy to diagnose from the run log.
+      - name: List ZAP reports
+        if: always()
+        run: ls -la dast.* || true
+
+      - name: Upload ZAP reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: zap-baseline-report
+          path: |
+            dast.html
+            dast.sarif.json
+          if-no-files-found: warn
+
+      - name: Upload SARIF to the Security tab
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        if: always()
+        with:
+          sarif_file: dast.sarif.json
+          category: zap-dast
+
+      # Surface the server log on failure for debugging a boot/scan problem.
+      - name: Dump server log on failure
+        if: failure()
+        run: cat curia-server.log || true

--- a/.zap/plan.yaml
+++ b/.zap/plan.yaml
@@ -1,9 +1,15 @@
 # ZAP Automation Framework plan for the Curia DAST baseline scan (issue #568).
 # Driven by .github/workflows/dast.yml via the zaproxy/action-af GitHub Action.
 #
-# This is a PASSIVE baseline scan: spider the unauthenticated surface, let the passive
-# scanner finish, then emit SARIF (for the Security tab) and HTML (for the CI artifact).
-# No active attack scan — that is intentionally out of scope for the baseline.
+# This is a PASSIVE baseline scan: request the HTTP API surface, let the passive scanner
+# finish, then emit SARIF (for the Security tab) and HTML (for the CI artifact). No active
+# attack scan — that is intentionally out of scope for the baseline.
+#
+# Scope is restricted to `/api/*`. The root path `/` is served by the console SPA, which
+# in CI (no `apps/console/dist` build) returns a 503 "Console not built" placeholder with
+# no crawlable links — so a root-seeded spider would achieve near-zero coverage of the
+# actual target. This plan instead scopes to the API and drives it with an explicit
+# `requestor` job (below), since a JSON API has no link graph for a spider to follow.
 env:
   contexts:
     - name: curia
@@ -12,9 +18,10 @@ env:
         # `localhost`. The Curia HTTP API binds 0.0.0.0:3000 (see http-adapter.ts),
         # which is reachable from inside the container via the Docker bridge gateway.
         # On Linux GitHub runners that gateway is 172.17.0.1.
-        - http://172.17.0.1:3000
+        - http://172.17.0.1:3000/api/health
       includePaths:
-        - http://172.17.0.1:3000.*
+        # Scope to the HTTP API only — the console SPA at `/` is out of scope (see above).
+        - http://172.17.0.1:3000/api.*
   parameters:
     # Alert-only: never exit non-zero on findings. We keep the baseline non-blocking
     # until a stable, triaged baseline exists (issue #568). Revisit once findings are
@@ -31,11 +38,39 @@ jobs:
       maxAlertsPerRule: 10
       scanOnlyInScope: true
 
-  # Crawl the unauthenticated surface to discover endpoints for the passive scanner.
+  # Explicitly request the HTTP API surface so the passive scanner inspects each
+  # response (headers, cookies, error bodies, info disclosure). A JSON API exposes no
+  # link graph for a spider to follow, so we drive coverage with a fixed request list
+  # rather than relying on crawling. These are the bearer-auth-exempt GET endpoints
+  # (see the onRequest hook in http-adapter.ts); session-protected ones return 401/403,
+  # which is itself useful baseline coverage. Streaming/SSE and `:param` routes are
+  # omitted (a spider/requestor would hang on a stream, and param routes need values).
+  - type: requestor
+    requests:
+      - url: http://172.17.0.1:3000/api/health
+      - url: http://172.17.0.1:3000/api/setup/status
+      - url: http://172.17.0.1:3000/api/autonomy
+      - url: http://172.17.0.1:3000/api/autonomy/history
+      - url: http://172.17.0.1:3000/api/identity
+      - url: http://172.17.0.1:3000/api/identity/history
+      - url: http://172.17.0.1:3000/api/executive
+      - url: http://172.17.0.1:3000/api/executive/history
+      - url: http://172.17.0.1:3000/api/jobs
+      - url: http://172.17.0.1:3000/api/registry/agents
+      - url: http://172.17.0.1:3000/api/registry/skills
+      - url: http://172.17.0.1:3000/api/registry/channels
+      - url: http://172.17.0.1:3000/api/vault/status
+      - url: http://172.17.0.1:3000/api/kg/contacts
+      - url: http://172.17.0.1:3000/api/kg/graph
+      - url: http://172.17.0.1:3000/api/kg/nodes
+      - url: http://172.17.0.1:3000/api/kg/tasks
+
+  # Best-effort crawl within /api to pick up anything unexpectedly linked. Short by
+  # design — a JSON API yields little to follow, but it's cheap and catches surprises.
   - type: spider
     parameters:
       context: curia
-      maxDuration: 3 # minutes — the API surface is small; keep CI time bounded
+      maxDuration: 1 # minute — scoped to /api, which has no real link graph
       maxChildren: 0 # 0 = unlimited within the duration cap
 
   # Wait for the passive scanner to drain its queue before reporting.

--- a/.zap/plan.yaml
+++ b/.zap/plan.yaml
@@ -1,0 +1,90 @@
+# ZAP Automation Framework plan for the Curia DAST baseline scan (issue #568).
+# Driven by .github/workflows/dast.yml via the zaproxy/action-af GitHub Action.
+#
+# This is a PASSIVE baseline scan: spider the unauthenticated surface, let the passive
+# scanner finish, then emit SARIF (for the Security tab) and HTML (for the CI artifact).
+# No active attack scan — that is intentionally out of scope for the baseline.
+env:
+  contexts:
+    - name: curia
+      urls:
+        # ZAP runs in its own Docker container, so it cannot reach the host's
+        # `localhost`. The Curia HTTP API binds 0.0.0.0:3000 (see http-adapter.ts),
+        # which is reachable from inside the container via the Docker bridge gateway.
+        # On Linux GitHub runners that gateway is 172.17.0.1.
+        - http://172.17.0.1:3000
+      includePaths:
+        - http://172.17.0.1:3000.*
+  parameters:
+    # Alert-only: never exit non-zero on findings. We keep the baseline non-blocking
+    # until a stable, triaged baseline exists (issue #568). Revisit once findings are
+    # triaged and false positives are filtered.
+    failOnError: false
+    failOnWarning: false
+    progressToStdout: true
+
+jobs:
+  # Configure the passive scanner before any traffic is generated.
+  - type: passiveScan-config
+    parameters:
+      enableTags: false
+      maxAlertsPerRule: 10
+      scanOnlyInScope: true
+
+  # Crawl the unauthenticated surface to discover endpoints for the passive scanner.
+  - type: spider
+    parameters:
+      context: curia
+      maxDuration: 3 # minutes — the API surface is small; keep CI time bounded
+      maxChildren: 0 # 0 = unlimited within the duration cap
+
+  # Wait for the passive scanner to drain its queue before reporting.
+  - type: passiveScan-wait
+    parameters:
+      maxDuration: 3 # minutes
+
+  # --- Suppressions for known-safe Curia API behavior --------------------------------
+  # The AF equivalent of action-baseline's `.zap/rules.tsv` is an `alertFilter` job.
+  # It is intentionally NOT included yet: ZAP rejects an alertFilter job with an empty
+  # `alertFilters` list ("nofilters" error), and we should not guess at suppressions
+  # before seeing what the first run actually raises against a pure JSON API.
+  #
+  # To suppress an alert after triaging the first run, uncomment and adapt this block
+  # (place it before the report jobs). `newRisk` must be one of: 'False Positive',
+  # 'Info', 'Low', 'Medium', 'High'. Use 'False Positive' to drop an alert entirely.
+  # Every entry must carry a comment justifying why the alert is safe to suppress.
+  #
+  #   - type: alertFilter
+  #     parameters:
+  #       deleteGlobalAlerts: false
+  #     alertFilters:
+  #       - ruleId: 10020          # Anti-clickjacking (X-Frame-Options) header missing
+  #         newRisk: 'False Positive'  # irrelevant for a pure JSON API with no HTML UI
+  #       - ruleId: 10038          # Content-Security-Policy header missing
+  #         newRisk: 'False Positive'  # CSP protects HTML documents; this API serves JSON
+  # ------------------------------------------------------------------------------------
+
+  # SARIF report → consumed by github/codeql-action/upload-sarif for the Security tab.
+  # /zap/wrk/ maps to the GitHub workspace, so this lands at repo-root dast.sarif.json.
+  #
+  # Filename note: the sarif-json template's native extension is `.json`, and ZAP
+  # appends that extension unless reportFile already ends in it. We name the file
+  # `dast.sarif.json` (ends in `.json`, so no double-append) — and `.sarif.json` is one
+  # of the two extensions github/codeql-action/upload-sarif accepts (the other is
+  # `.sarif`). A bare `.json` would be rejected by that action.
+  - type: report
+    parameters:
+      template: sarif-json
+      reportDir: /zap/wrk/
+      reportFile: dast.sarif.json
+      reportTitle: Curia DAST — ZAP Baseline
+      reportDescription: Passive baseline scan of the Curia HTTP API.
+
+  # Human-readable HTML report → uploaded as a CI artifact.
+  - type: report
+    parameters:
+      template: traditional-html
+      reportDir: /zap/wrk/
+      reportFile: dast.html
+      reportTitle: Curia DAST — ZAP Baseline
+      reportDescription: Passive baseline scan of the Curia HTTP API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`web-browser` per-frame SSRF gating** — now that content extraction and locator resolution reach into iframes, child frames pointing at private/internal hosts (IPv4 loopback/RFC1918/link-local, IPv6 link-local + unique-local `fc00::/7` + IPv4-mapped forms, cloud-metadata) or `file:` are skipped, so a malicious page can't exfiltrate internal resources through an embedded frame the navigate guard never saw.
 - **Signed release artifacts** — each published release now attaches an SPDX SBOM and a source tarball, each signed with cosign keyless (Sigstore + GitHub OIDC, no long-lived keys) via the new `release.yml`. Satisfies the OpenSSF Scorecard Signed-Releases check; verify with `cosign verify-blob`.
 - **Reliable release SBOMs** — release SBOM generation/attachment moved out of `sbom.yml` (which skipped silently and shipped v0.34.0 with no SBOM) into `release.yml`, where a failed generate/attach/verify fails the run loudly. `sbom.yml` is now push-to-main only.
+- **DAST baseline scan (`dast.yml`)** — weekly + manual OWASP ZAP passive scan of the running HTTP API via the ZAP Automation Framework; publishes SARIF to the Security tab and an HTML artifact. Alert-only for now. (#568)
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,11 +304,14 @@ Once the release PR is merged, `main` is the exact commit you are about to tag. 
 gh workflow run trivy.yml     # on-demand Trivy image scan (base image + OS package CVEs)
 gh workflow run codeql.yml    # fresh CodeQL security-extended pass (takes several minutes)
 gh workflow run scorecard.yml # repo-level supply-chain posture
+gh workflow run dast.yml      # OWASP ZAP passive DAST against the running HTTP API (slow: boots the full app)
 # Wait for each to finish, then review results:
 gh run list --limit 5
 ```
 
 Review **GitHub → Security → Code Scanning** for the results of all scanners. **Block the release on any unresolved CRITICAL finding.** A HIGH is a judgment call — fix it or document why it's accepted (e.g. unreachable code path, no fix available) before proceeding.
+
+The ZAP DAST scan (`zap-dast` category) is alert-only and review-only for now — until its first run is triaged into the `alertFilter` baseline in `.zap/plan.yaml`, its findings are informational and do not block a release. Once a triaged baseline exists (and `failOnError` flips), treat its unresolved CRITICALs the same as the other scanners.
 
 **8. Tag and publish**
 

--- a/docs/wip/2026-06-16-dast-zap-design.md
+++ b/docs/wip/2026-06-16-dast-zap-design.md
@@ -1,0 +1,122 @@
+# DAST — OWASP ZAP baseline scan (issue #568)
+
+**Date:** 2026-06-16
+**Status:** Approved (design)
+**Issue:** #568 — security: add OWASP ZAP baseline DAST scan for the Fastify HTTP API
+
+## Goal
+
+Add a release-prep DAST scan that boots Curia's HTTP API in CI, runs an OWASP ZAP
+passive (baseline) scan against the unauthenticated surface, and publishes results
+both to the GitHub Security tab (SARIF) and as a downloadable HTML artifact. The
+scan is **alert-only** initially — it never fails the job on findings — and runs on
+a weekly schedule plus manual dispatch, not on every PR.
+
+## Why ZAP Automation Framework instead of `action-baseline`
+
+The issue's recipe uses `zaproxy/action-baseline`, but that action **cannot emit
+SARIF natively**, and the acceptance criteria require SARIF in the Security tab.
+The two ways to get SARIF are:
+
+1. `action-baseline` + a third-party converter (`SvanBoxel/zaproxy-to-ghas`) — adds
+   an unpinned third-party action that handles security results, which cuts against
+   this repo's supply-chain posture (all actions SHA-pinned, Scorecard, least-privilege).
+2. `zaproxy/action-af` (ZAP Automation Framework) with a `sarif-json` report template —
+   first-party, SHA-pinnable, generates SARIF (and HTML) natively inside ZAP.
+
+We chose **option 2**. The cost is one extra artifact: an Automation Framework plan
+YAML. The benefit is no third-party security action and a cleaner SARIF path.
+
+## Corrections to the issue's CI recipe
+
+The issue's startup snippet is materially wrong about how Curia boots. Verified
+against the actual code:
+
+- **Secrets are vault-only.** `applyVaultSecrets()` (src/secrets/apply-vault-secrets.ts)
+  resolves `api_token`, `anthropic_api_key`, `web_app_bootstrap_secret` (all required,
+  fail-closed) from an encrypted Postgres vault. There is **no env fallback** — setting
+  `ANTHROPIC_API_KEY` / `BEARER_TOKEN` env vars on the server process does nothing.
+  CI must seed the vault after migrations via `scripts/seed-vault.ts`.
+- **Port var is `HTTP_PORT`**, not `HTTP_API_PORT` (src/config.ts, default 3000).
+- **`SECRET_ENCRYPTION_KEY` is required** at boot — base64 of 32 random bytes
+  (src/secrets/crypto.ts). The seed script and the server must share the same key.
+- The bearer token lives in the vault as `api_token`, seeded from the `API_TOKEN`
+  env var read by `seed-vault.ts`.
+
+## Components
+
+### 1. `.github/workflows/dast.yml`
+
+- **Triggers:** `workflow_dispatch` (optional `target_url` input, default the local
+  test server) + `schedule` weekly Monday 09:00 UTC (staggered after the Wed SAST jobs).
+- **Permissions:** top-level `contents: read`; the job adds `security-events: write`
+  for the SARIF upload. No `issues: write` — we publish SARIF, not ZAP-created issues.
+- **Postgres service:** `pgvector/pgvector:pg16`, same creds as `ci.yml`.
+- **Boot sequence** (mirrors `ci.yml` where it overlaps):
+  1. checkout / pnpm / Node 22 / `pnpm install --frozen-lockfile --ignore-scripts` /
+     `pnpm rebuild esbuild`
+  2. Generate `SECRET_ENCRYPTION_KEY` (`openssl rand -base64 32`) into `$GITHUB_ENV`
+  3. Run migrations (same command as `ci.yml`)
+  4. Seed the vault: `pnpm tsx scripts/seed-vault.ts` with `API_TOKEN`,
+     `ANTHROPIC_API_KEY`, `WEB_APP_BOOTSTRAP_SECRET` set to CI placeholders. (Invoke
+     `tsx` directly, not `pnpm run seed-vault`, to bypass its hardcoded `--env-file=.env`.)
+  5. Start the server in the background: `pnpm tsx src/index.ts &` with `DATABASE_URL`,
+     `HTTP_PORT=3000`, `SECRET_ENCRYPTION_KEY`.
+  6. Poll `http://localhost:3000/api/health` until ready, with a hard fail if it never
+     comes up (so a silent boot failure fails the job loudly instead of hanging until
+     the ZAP step times out). On failure, dump the server log.
+- **Scan:** `zaproxy/action-af` (SHA-pinned) with `plan: .zap/plan.yaml`.
+- **Publish:** `actions/upload-artifact` for `dast.html` + `dast.sarif.json`;
+  `github/codeql-action/upload-sarif` with `category: zap-dast`, `if: always()`.
+
+### 2. `.zap/plan.yaml` — ZAP Automation Framework plan
+
+- `env.contexts[0].urls`: `http://172.17.0.1:3000` — the ZAP container reaches the
+  host-bound server (the API listens on `0.0.0.0:3000`, see http-adapter.ts:413) via the
+  Docker bridge gateway. `localhost` inside the ZAP container would not reach the host.
+- `env.parameters.failOnError: false` — alert-only.
+- Jobs: `passiveScan-config` → `spider` → `passiveScan-wait` → `report`
+  (`sarif-json` → `/zap/wrk/dast.sarif.json`) → `report` (`traditional-html` →
+  `/zap/wrk/dast.html`). `/zap/wrk/` maps to the workspace.
+- **Report filenames:** the `sarif-json` template's native extension is `.json` and
+  ZAP appends it unless the name already ends in it, so we name the SARIF file
+  `dast.sarif.json` — both to avoid a double extension and because `.sarif.json` is one
+  of the two extensions `upload-sarif` accepts (a bare `.json` is rejected).
+
+### 3. Suppressions
+
+AF uses an `alertFilter` job, not the `.zap/rules.tsv` file the issue mentions (that
+is an `action-baseline` concept). We do **not** ship an active filter job initially:
+ZAP rejects an `alertFilter` job whose `alertFilters` list is empty, and we should not
+guess at suppressions before seeing the first run. The plan instead carries a
+documented, schema-correct, commented-out example block (ruleId + `newRisk: 'False
+Positive'`, e.g. for `X-Frame-Options`/CSP header alerts that are irrelevant for a pure
+JSON API) to be activated and tuned after the first run's findings are triaged. Each
+real suppression must carry an inline justification comment.
+
+## Networking note
+
+ZAP runs in its own Docker container, so the scan target must be reachable from inside
+that container. On Linux GitHub runners the Docker bridge gateway is `172.17.0.1`, and
+the server binds `0.0.0.0`, so `http://172.17.0.1:3000` reaches it. This is the single
+most failure-prone detail; the health-check poll uses `localhost` (host side) while the
+ZAP plan uses the gateway IP (container side).
+
+## Out of scope
+
+- Authenticated scanning (the issue defers this; baseline covers the unauthenticated
+  surface only).
+- Failing CI on findings (`failOnError` stays false until a stable baseline exists).
+- Triage of the first run's findings happens after the workflow is merged and dispatched
+  once — follow-up issues for any FAIL-level alerts, per the issue's acceptance criteria.
+
+## Acceptance criteria (from #568)
+
+- [x] `dast.yml` present, triggerable manually and on weekly schedule
+- [x] ZAP starts and scans the running Curia HTTP API (`/api/health` reachable)
+- [x] Documented suppressions for known-safe API behavior (via a documented, commented
+  `alertFilter` example, ready to activate after first-run triage)
+- [x] ZAP report uploaded as CI artifact (HTML + SARIF)
+- [x] SARIF results flow to the GitHub Security tab (`upload-sarif`)
+- [ ] Initial findings triaged — done after the first dispatched run (post-merge)
+- [x] `failOnError: false` initially (alert-only)

--- a/docs/wip/2026-06-16-dast-zap-design.md
+++ b/docs/wip/2026-06-16-dast-zap-design.md
@@ -72,12 +72,20 @@ against the actual code:
 
 ### 2. `.zap/plan.yaml` — ZAP Automation Framework plan
 
-- `env.contexts[0].urls`: `http://172.17.0.1:3000` — the ZAP container reaches the
-  host-bound server (the API listens on `0.0.0.0:3000`, see http-adapter.ts:413) via the
-  Docker bridge gateway. `localhost` inside the ZAP container would not reach the host.
+- `env.contexts[0].urls`: `http://172.17.0.1:3000/api/health` — the ZAP container reaches
+  the host-bound server (the API listens on `0.0.0.0:3000`, see http-adapter.ts:413) via
+  the Docker bridge gateway. `localhost` inside the ZAP container would not reach the host.
+- **Scope is restricted to `/api/*`** (`includePaths: …/api.*`). The root `/` is served by
+  the console SPA, which in CI (no `apps/console/dist` build) returns a 503 "Console not
+  built" placeholder with no crawlable links — so a root-seeded spider would achieve
+  near-zero coverage. Since the issue targets the *HTTP API*, we scope to `/api` and drive
+  coverage with an explicit `requestor` job rather than crawling. (Resolves the CodeAnt
+  review finding about root-503 / near-zero crawl coverage.)
 - `env.parameters.failOnError: false` — alert-only.
-- Jobs: `passiveScan-config` → `spider` → `passiveScan-wait` → `report`
-  (`sarif-json` → `/zap/wrk/dast.sarif.json`) → `report` (`traditional-html` →
+- Jobs: `passiveScan-config` → `requestor` (explicit GETs to the bearer-auth-exempt API
+  endpoints, so the passive scanner inspects each response; a JSON API has no link graph
+  to spider) → `spider` (short, scoped to `/api`, best-effort) → `passiveScan-wait` →
+  `report` (`sarif-json` → `/zap/wrk/dast.sarif.json`) → `report` (`traditional-html` →
   `/zap/wrk/dast.html`). `/zap/wrk/` maps to the workspace.
 - **Report filenames:** the `sarif-json` template's native extension is `.json` and
   ZAP appends it unless the name already ends in it, so we name the SARIF file
@@ -99,7 +107,7 @@ real suppression must carry an inline justification comment.
 
 ZAP runs in its own Docker container, so the scan target must be reachable from inside
 that container. On Linux GitHub runners the Docker bridge gateway is `172.17.0.1`, and
-the server binds `0.0.0.0`, so `http://172.17.0.1:3000` reaches it. This is the single
+the server binds `0.0.0.0`, so `http://172.17.0.1:3000/...` reaches it. This is the single
 most failure-prone detail; the health-check poll uses `localhost` (host side) while the
 ZAP plan uses the gateway IP (container side).
 

--- a/docs/wip/2026-06-16-dast-zap-design.md
+++ b/docs/wip/2026-06-16-dast-zap-design.md
@@ -47,8 +47,9 @@ against the actual code:
 
 ### 1. `.github/workflows/dast.yml`
 
-- **Triggers:** `workflow_dispatch` (optional `target_url` input, default the local
-  test server) + `schedule` weekly Monday 09:00 UTC (staggered after the Wed SAST jobs).
+- **Triggers:** `workflow_dispatch` (no inputs — the job always boots and scans a fresh
+  local instance; an arbitrary-URL input would be dead config) + `schedule` weekly
+  Monday 09:00 UTC (staggered after the Wed SAST jobs).
 - **Permissions:** top-level `contents: read`; the job adds `security-events: write`
   for the SARIF upload. No `issues: write` — we publish SARIF, not ZAP-created issues.
 - **Postgres service:** `pgvector/pgvector:pg16`, same creds as `ci.yml`.


### PR DESCRIPTION
## **User description**
## Summary

Adds a release-prep DAST scan that boots the Curia HTTP API in CI and runs an OWASP ZAP passive baseline scan against the unauthenticated surface, publishing SARIF to the Security tab and an HTML report as a CI artifact. Alert-only for now (never fails the job on findings) until a stable, triaged baseline exists.

Closes #568.

- **`.github/workflows/dast.yml`** — weekly (Mon 09:00 UTC, staggered after the Wed SAST jobs) + `workflow_dispatch`. Not run per-PR. Boots Curia (Postgres service → migrations → vault seed → background server → `/api/health` poll), runs the scan, uploads SARIF (`category: zap-dast`) + HTML.
- **`.zap/plan.yaml`** — ZAP Automation Framework plan: `spider` → `passiveScan-wait` → SARIF + HTML reports, `failOnError: false`. Targets `http://172.17.0.1:3000` (Docker bridge gateway → the host-bound server). Carries a documented, commented-out `alertFilter` suppression block to activate after first-run triage.
- CHANGELOG `Security` entry + design doc in `docs/wip/`.

## Why ZAP Automation Framework instead of `action-baseline`

The issue's recipe used `zaproxy/action-baseline`, which **cannot emit SARIF natively**. The two ways to get SARIF are a third-party converter or the first-party Automation Framework. We use `zaproxy/action-af` with the `sarif-json` report template so SARIF is generated first-party and SHA-pinnable — no third-party security action, matching the repo's supply-chain posture.

## Corrections to the issue's CI recipe (verified against the code)

- **Secrets are vault-only** (`src/secrets/apply-vault-secrets.ts`) — no env fallback. Setting `ANTHROPIC_API_KEY`/`BEARER_TOKEN` on the server process does nothing. CI generates a `SECRET_ENCRYPTION_KEY`, runs migrations, then **seeds the vault** (`scripts/seed-vault.ts`, invoked directly to bypass its hardcoded `--env-file=.env`) with placeholders before boot.
- Port var is **`HTTP_PORT`** (default 3000), not `HTTP_API_PORT`.
- `SECRET_ENCRYPTION_KEY` (base64 32 bytes) is required at boot and shared between the seed step and server step via `$GITHUB_ENV`.

## Networking note

ZAP runs in its own Docker container, so the scan target must be reachable from inside it. The health poll uses host-side `localhost:3000`; the ZAP plan uses the Docker bridge gateway `172.17.0.1:3000`. The server binds `0.0.0.0:3000`, reachable both ways.

## Testing

- Both YAML files validated as parseable; ZAP report filenames and the `alertFilter` schema verified against the ZAP extensions source; all action SHAs verified against upstream tags.
- The real proof is a `workflow_dispatch` run once merged — that's where we confirm the in-CI boot completes within the 120s poll, ZAP reaches the host, SARIF lands in the Security tab, and we triage the first findings into the `alertFilter` block.

## Acceptance criteria (#568)

- [x] `dast.yml` present, triggerable manually + weekly schedule
- [x] ZAP scans the running HTTP API (`/api/health` reachable, auth-exempt)
- [x] Documented suppressions (`alertFilter` example, ready to activate post-triage)
- [x] ZAP report uploaded as CI artifact (HTML + SARIF)
- [x] SARIF flows to the Security tab (`upload-sarif`)
- [ ] Initial findings triaged — after the first dispatched run (post-merge)
- [x] `failOnError: false` initially (alert-only)


___

## **CodeAnt-AI Description**
**Add a weekly OWASP ZAP baseline scan for the HTTP API**

### What Changed
- Added a new CI workflow that starts the Curia HTTP API, runs an OWASP ZAP baseline scan, and publishes the results to the GitHub Security tab and as an HTML artifact
- The scan runs on a weekly schedule and can also be started manually; it does not run on every pull request
- The scan is alert-only for now, so findings are reported without failing the job
- Added a short design note and changelog entry describing the scan and its release-prep scope

### Impact
`✅ Security findings appear in the GitHub Security tab`
`✅ Weekly API security checks without blocking releases`
`✅ Downloadable HTML scan reports for triage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
