### PR TITLE
fix(dast): normalize ZAP SARIF URIs so Code Scanning accepts the upload

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -141,6 +141,20 @@ jobs:
             dast.sarif.json
           if-no-files-found: warn
 
+      # GitHub Code Scanning is source-oriented and rejects SARIF whose result location
+      # URIs use a non-file scheme ("SARIF URI scheme http did not match the checkout URI
+      # scheme file"). ZAP, being a DAST tool, emits http(s) URLs. Rewrite them to
+      # repo-relative paths (original URL preserved in the report) so the upload is
+      # accepted. Runs only if ZAP produced the file.
+      - name: Normalize SARIF location URIs for Code Scanning
+        if: always()
+        run: |
+          if [ -f dast.sarif.json ]; then
+            node .zap/normalize-sarif.mjs dast.sarif.json
+          else
+            echo "::warning::dast.sarif.json not found — skipping normalization"
+          fi
+
       - name: Upload SARIF to the Security tab
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         if: always()

--- a/.zap/normalize-sarif.mjs
+++ b/.zap/normalize-sarif.mjs
@@ -25,12 +25,21 @@ if (!file) {
 const sarif = JSON.parse(readFileSync(file, 'utf8'));
 let rewritten = 0;
 
-// Strip scheme+host from an absolute http(s) URL, returning a repo-relative path.
-// A bare site root (no path) maps to `index` so the URI is non-empty and valid.
+// Reduce an absolute http(s) URL to a repo-relative path: the URL's pathname only,
+// with the leading slash stripped. Query string and fragment are intentionally dropped
+// — Code Scanning expects a file-like path, not URL components. A bare site root (empty
+// pathname) maps to `index` so the URI is non-empty and valid. Non-http(s) or already
+// relative URIs return null (left untouched).
 function toRelative(uri) {
-  const m = /^https?:\/\/[^/]+\/?(.*)$/.exec(uri);
-  if (!m) return null; // already relative or non-http — leave as-is
-  return m[1] === '' ? 'index' : m[1];
+  let parsed;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return null; // not an absolute URL (already relative, or non-URL) — leave as-is
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  const path = parsed.pathname.replace(/^\/+/, '');
+  return path === '' ? 'index' : path;
 }
 
 function fixLocation(loc) {
@@ -38,8 +47,12 @@ function fixLocation(loc) {
   if (!al || typeof al.uri !== 'string') return;
   const relative = toRelative(al.uri);
   if (relative === null) return;
-  // Preserve the original URL for the human-readable report.
-  if (al.description === undefined) al.description = { text: al.uri };
+  // Always preserve the full original URL (incl. query/fragment dropped from the path)
+  // in the description, appending to any description ZAP already wrote rather than
+  // overwriting or skipping it.
+  const note = `ZAP scanned URL: ${al.uri}`;
+  const existing = typeof al.description?.text === 'string' ? al.description.text.trim() : '';
+  al.description = { text: existing ? `${existing} — ${note}` : note };
   al.uri = relative;
   rewritten++;
 }

--- a/.zap/normalize-sarif.mjs
+++ b/.zap/normalize-sarif.mjs
@@ -1,0 +1,55 @@
+// Normalize ZAP SARIF location URIs for GitHub Code Scanning.
+//
+// ZAP is a DAST tool: its findings point at web URLs, so each result's
+// physicalLocation.artifactLocation.uri is an absolute http(s) URL (e.g.
+// http://172.17.0.1:3000/api/health). GitHub Code Scanning is source-oriented and
+// rejects SARIF whose location URIs use a scheme that doesn't match the checkout
+// (file://), failing the upload with:
+//   "SARIF URI scheme \"http\" did not match the checkout URI scheme \"file\""
+//
+// We rewrite each absolute http(s) location URI to a repo-relative path (the URL's
+// path, e.g. `api/health`), which Code Scanning accepts. The full original URL is
+// preserved in artifactLocation.description so no information is lost in the report.
+// helpUri / taxonomy / rule URLs are left untouched — only result *locations* matter
+// to the checkout-scheme validation.
+//
+// Usage: node .zap/normalize-sarif.mjs <sarif-file>   (rewrites the file in place)
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: node normalize-sarif.mjs <sarif-file>');
+  process.exit(1);
+}
+
+const sarif = JSON.parse(readFileSync(file, 'utf8'));
+let rewritten = 0;
+
+// Strip scheme+host from an absolute http(s) URL, returning a repo-relative path.
+// A bare site root (no path) maps to `index` so the URI is non-empty and valid.
+function toRelative(uri) {
+  const m = /^https?:\/\/[^/]+\/?(.*)$/.exec(uri);
+  if (!m) return null; // already relative or non-http — leave as-is
+  return m[1] === '' ? 'index' : m[1];
+}
+
+function fixLocation(loc) {
+  const al = loc?.physicalLocation?.artifactLocation;
+  if (!al || typeof al.uri !== 'string') return;
+  const relative = toRelative(al.uri);
+  if (relative === null) return;
+  // Preserve the original URL for the human-readable report.
+  if (al.description === undefined) al.description = { text: al.uri };
+  al.uri = relative;
+  rewritten++;
+}
+
+for (const run of sarif.runs ?? []) {
+  for (const res of run.results ?? []) {
+    for (const loc of res.locations ?? []) fixLocation(loc);
+    for (const loc of res.relatedLocations ?? []) fixLocation(loc);
+  }
+}
+
+writeFileSync(file, JSON.stringify(sarif, null, 2));
+console.log(`normalized ${rewritten} location URI(s) in ${file}`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **DAST SARIF reaches the Security tab** — ZAP emits `http://` location URIs, which GitHub Code Scanning rejected (scheme mismatch vs the `file://` checkout); `dast.yml` now normalizes them to repo-relative paths via `.zap/normalize-sarif.mjs` before upload. (#568)
 - **Drafts reachable in the CEO inbox (find → read → edit)** — `ceo-inbox-list`/`ceo-inbox-search` now query Nylas's `/drafts` resource for the DRAFTS folder instead of `/messages` (which never contains drafts), so existing drafts are listed and searchable by subject/recipient; `ceo-inbox-read` accepts a `draft_id` to return a draft's full body before editing. Results key on `drafts` to distinguish a genuine "none" from the old silent-zero, and the inbox watermark is never applied to drafts. (#1000)
 - **Execution-layer output sanitization** — object-returning skills whose string values contain HTML (e.g. email bodies) no longer produce corrupted JSON. `sanitizeObjectOutput` walks the result structure and sanitizes string leaves directly; JSON structural characters are never exposed to the HTML stripper. Fixes the `ceo-inbox-search` retry loop incident. (#986)
 - **Stale Xvfb lock recovery** — `BrowserService` now clears an orphaned `/tmp/.X99-lock` + socket left by an unclean exit before spawning Xvfb, guarded on a live X server so an active display is never clobbered; the web-browser skill survives a crash-induced restart. (#982)


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #568. The first dispatched DAST run ([run 27632129753](https://github.com/josephfung/curia/actions/runs/27632129753)) proved the hard parts work — Curia booted in CI, the server came up, ZAP scanned the `/api` surface, and the HTML + SARIF reports uploaded as an artifact. The **only** failure was the Security-tab upload:

> `SARIF URI scheme "http" did not match the checkout URI scheme "file"`

ZAP is a DAST tool, so its result locations are absolute `http(s)` URLs (e.g. `http://172.17.0.1:3000/api/health`). GitHub Code Scanning is source-oriented and rejects SARIF whose location URIs aren't repo-relative `file` paths.

## Fix

- Add **`.zap/normalize-sarif.mjs`** — rewrites each result location's `artifactLocation.uri` from an absolute `http(s)` URL to a repo-relative path (`api/health`), preserving the original URL in `artifactLocation.description` so nothing is lost in the report. Leaves `helpUri`/taxonomy/rule URLs untouched (only result *locations* matter to the checkout-scheme validation).
- **`dast.yml`** — run the normalizer (guarded on the file existing) between report generation and `upload-sarif`.

## Testing

Verified against the **actual SARIF** produced by the failed run: 1 location rewritten (`http://172.17.0.1:3000/api/health` → `api/health`, original stashed in `description`), zero absolute `http` URIs remain in any result location. Workflow YAML validated.

The end-to-end proof is the next dispatched run landing `zap-dast` results in the Security tab — I'll dispatch it once this merges.

## Note on findings

That first run surfaced one alert: rule **10021 "X-Content-Type-Options Header Missing"** (level: note) on `/api/health`. Low-risk on a JSON API; it's a candidate for either a one-line `nosniff` header fix or an `alertFilter` suppression once the baseline is established. Tracking separately, not in this PR.

Refs #568.


___

## **CodeAnt-AI Description**
**Make ZAP security scans upload to GitHub Code Scanning**

### What Changed
- ZAP scan results now convert web URLs into repo-relative paths before upload, so GitHub accepts the SARIF file
- The original URL is kept in the report for context
- If no SARIF file is present, the upload step skips the rewrite instead of failing

### Impact
`✅ DAST results reach the Security tab`
`✅ Fewer SARIF upload failures`
`✅ Clearer scan reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
