### PR TITLE
fix(http): set X-Content-Type-Options: nosniff on all API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **`X-Content-Type-Options: nosniff` on all HTTP responses** — a baseline header hook on the Fastify API blocks MIME-sniffing on every response (incl. 401s and static assets), clearing the ZAP DAST finding for rule 10021. (#568)
 - **Value-aware browser redaction** — secret values injected by reference are tracked per browser session and scrubbed (raw plus URL/HTML-encoded variants) from returned content, the page URL, and errors; screenshots are suppressed on a secret-fill action since an image can't be value-redacted. Blocks round-trip exfiltration via a page that reflects a typed credential back. (#973)
 - **Docker base images digest-pinned** — `Dockerfile` (node:24-slim, both stages) and `docker/postgres.Dockerfile` (pgvector/pgvector:pg16) are now pinned by `@sha256:` digest, clearing the Scorecard Pinned-Dependencies Docker findings. (#905)
 - **`docker` Dependabot ecosystem** — added to `.github/dependabot.yml` (watching `/` and `/docker`) so the base images are tracked; a `semver-major` ignore on `node` keeps it from drifting onto Current/non-LTS releases. (#905)

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -24,6 +24,7 @@ import type { Logger } from '../../logger.js';
 import type { Pool } from 'pg';
 import type { AgentRegistry } from '../../agents/agent-registry.js';
 import { validateBearerToken } from './auth.js';
+import { registerSecurityHeaders } from './security-headers.js';
 import { EventRouter } from './event-router.js';
 import type { SchedulerService } from '../../scheduler/scheduler-service.js';
 import { healthRoutes } from './routes/health.js';
@@ -140,6 +141,11 @@ export class HttpAdapter implements Channel {
       origin: appOrigin ?? false,
       credentials: true, // needed so the browser sends the session cookie cross-origin
     });
+
+    // Baseline security headers (X-Content-Type-Options: nosniff) on every response.
+    // Registered BEFORE the auth hook so the header lands even on 401-short-circuited
+    // responses — Fastify stops running later onRequest hooks once one sends a reply.
+    registerSecurityHeaders(this.app);
 
     // Auth hook — runs before every request
     this.app.addHook('onRequest', async (request, reply) => {

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -143,8 +143,9 @@ export class HttpAdapter implements Channel {
     });
 
     // Baseline security headers (X-Content-Type-Options: nosniff) on every response.
-    // Registered BEFORE the auth hook so the header lands even on 401-short-circuited
-    // responses — Fastify stops running later onRequest hooks once one sends a reply.
+    // Implemented as an onSend hook, so it covers replies short-circuited by the cors /
+    // rate-limit plugins above (preflight OPTIONS, 429) and the auth 401 below alike —
+    // hook registration order does not affect onSend coverage.
     registerSecurityHeaders(this.app);
 
     // Auth hook — runs before every request

--- a/src/channels/http/security-headers.test.ts
+++ b/src/channels/http/security-headers.test.ts
@@ -1,0 +1,51 @@
+// security-headers.test.ts — verifies the baseline security response headers are set
+// on every HTTP response, including non-2xx ones. Mirrors the bare-Fastify + inject
+// harness used by the route tests.
+import { describe, it, expect, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { registerSecurityHeaders } from './security-headers.js';
+
+let app: FastifyInstance | undefined;
+
+afterEach(async () => {
+  await app?.close();
+  app = undefined;
+});
+
+async function build(): Promise<FastifyInstance> {
+  const instance = Fastify();
+  // Register headers BEFORE routes/other hooks so the header is set even when a later
+  // onRequest hook short-circuits the response (e.g. an auth 401).
+  registerSecurityHeaders(instance);
+  instance.get('/ok', async () => ({ ok: true }));
+  // A hook that 401s before the handler — proves the header lands on short-circuited
+  // responses (the case that matters for the API's auth gate).
+  instance.get('/blocked', {
+    onRequest: async (_req, reply) => reply.status(401).send({ error: 'no' }),
+  }, async () => ({ never: true }));
+  await instance.ready();
+  return instance;
+}
+
+describe('registerSecurityHeaders', () => {
+  it('sets X-Content-Type-Options: nosniff on a 200 response', async () => {
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/ok' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets the header on a 404 response', async () => {
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/does-not-exist' });
+    expect(res.statusCode).toBe(404);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets the header on a response short-circuited by a later onRequest hook (401)', async () => {
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/blocked' });
+    expect(res.statusCode).toBe(401);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+});

--- a/src/channels/http/security-headers.test.ts
+++ b/src/channels/http/security-headers.test.ts
@@ -3,6 +3,8 @@
 // harness used by the route tests.
 import { describe, it, expect, afterEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
+import cors from '@fastify/cors';
+import rateLimit from '@fastify/rate-limit';
 import { registerSecurityHeaders } from './security-headers.js';
 
 let app: FastifyInstance | undefined;
@@ -41,6 +43,25 @@ async function build(): Promise<FastifyInstance> {
   return instance;
 }
 
+// Mirrors http-adapter.ts: register cors + rate-limit FIRST, then the security headers.
+// Both plugins terminate requests in their own onRequest hooks (preflight OPTIONS, 429),
+// so this proves the onSend-based header survives a plugin short-circuit that a later
+// onRequest hook would miss.
+async function buildWithPlugins(): Promise<FastifyInstance> {
+  const instance = Fastify();
+  try {
+    await instance.register(rateLimit, { max: 1, timeWindow: '1 minute' });
+    await instance.register(cors, { origin: 'https://example.com', credentials: true });
+    registerSecurityHeaders(instance);
+    instance.get('/ok', async () => ({ ok: true }));
+    await instance.ready();
+  } catch (err) {
+    await instance.close().catch(() => {});
+    throw new Error(`test Fastify instance failed to start: ${(err as Error).message}`, { cause: err });
+  }
+  return instance;
+}
+
 describe('registerSecurityHeaders', () => {
   it('sets X-Content-Type-Options: nosniff on a 200 response', async () => {
     app = await build();
@@ -60,6 +81,28 @@ describe('registerSecurityHeaders', () => {
     app = await build();
     const res = await app.inject({ method: 'GET', url: '/blocked' });
     expect(res.statusCode).toBe(401);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets the header on a 429 short-circuited by @fastify/rate-limit', async () => {
+    app = await buildWithPlugins();
+    const first = await app.inject({ method: 'GET', url: '/ok' });
+    expect(first.statusCode).toBe(200);
+    expect(first.headers['x-content-type-options']).toBe('nosniff');
+    const second = await app.inject({ method: 'GET', url: '/ok' });
+    expect(second.statusCode).toBe(429);
+    expect(second.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets the header on a CORS preflight (OPTIONS) handled by @fastify/cors', async () => {
+    app = await buildWithPlugins();
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/ok',
+      headers: { origin: 'https://example.com', 'access-control-request-method': 'GET' },
+    });
+    // @fastify/cors replies to the preflight directly (204 No Content).
+    expect([200, 204]).toContain(res.statusCode);
     expect(res.headers['x-content-type-options']).toBe('nosniff');
   });
 });

--- a/src/channels/http/security-headers.test.ts
+++ b/src/channels/http/security-headers.test.ts
@@ -8,8 +8,15 @@ import { registerSecurityHeaders } from './security-headers.js';
 let app: FastifyInstance | undefined;
 
 afterEach(async () => {
-  await app?.close();
-  app = undefined;
+  try {
+    await app?.close();
+  } catch (err) {
+    // Surface a teardown failure in the test report rather than letting it become an
+    // unhandled rejection between tests.
+    throw new Error(`test teardown: app.close() failed: ${(err as Error).message}`, { cause: err });
+  } finally {
+    app = undefined;
+  }
 });
 
 async function build(): Promise<FastifyInstance> {
@@ -23,7 +30,14 @@ async function build(): Promise<FastifyInstance> {
   instance.get('/blocked', {
     onRequest: async (_req, reply) => reply.status(401).send({ error: 'no' }),
   }, async () => ({ never: true }));
-  await instance.ready();
+  try {
+    await instance.ready();
+  } catch (err) {
+    // Close the half-initialized instance before propagating so a failed ready() never
+    // leaks an open server, and normalize the error with context.
+    await instance.close().catch(() => {});
+    throw new Error(`test Fastify instance failed to start: ${(err as Error).message}`, { cause: err });
+  }
   return instance;
 }
 

--- a/src/channels/http/security-headers.ts
+++ b/src/channels/http/security-headers.ts
@@ -1,0 +1,20 @@
+// security-headers.ts — baseline security response headers for the HTTP API.
+import type { FastifyInstance } from 'fastify';
+
+/**
+ * Set baseline security headers on every HTTP response.
+ *
+ * Register this BEFORE the auth hook so the header is applied even on responses that a
+ * later onRequest hook short-circuits (Fastify stops running subsequent hooks once one
+ * sends a reply, so a header set by an earlier hook is the only one that survives a 401).
+ *
+ * Currently sets `X-Content-Type-Options: nosniff`, which tells browsers not to
+ * MIME-sniff a response away from its declared Content-Type. It's cheap and correct even
+ * for a pure JSON API (it also covers the static console assets), and it clears the ZAP
+ * DAST baseline finding for rule 10021 (X-Content-Type-Options Header Missing). See #568.
+ */
+export function registerSecurityHeaders(app: FastifyInstance): void {
+  app.addHook('onRequest', async (_request, reply) => {
+    reply.header('X-Content-Type-Options', 'nosniff');
+  });
+}

--- a/src/channels/http/security-headers.ts
+++ b/src/channels/http/security-headers.ts
@@ -4,9 +4,13 @@ import type { FastifyInstance } from 'fastify';
 /**
  * Set baseline security headers on every HTTP response.
  *
- * Register this BEFORE the auth hook so the header is applied even on responses that a
- * later onRequest hook short-circuits (Fastify stops running subsequent hooks once one
- * sends a reply, so a header set by an earlier hook is the only one that survives a 401).
+ * Uses an `onSend` hook, not `onRequest`. `onSend` runs for *every* reply that is sent —
+ * including ones short-circuited by an earlier plugin's `onRequest` hook, which a later
+ * `onRequest` hook would miss. That matters because `@fastify/cors` (preflight OPTIONS
+ * responses) and `@fastify/rate-limit` (429 rejections) terminate the request in their
+ * own `onRequest` hooks before any hook we register afterwards runs. `onSend` fires
+ * before headers are flushed, so `reply.header()` still applies; the payload is returned
+ * unchanged.
  *
  * Currently sets `X-Content-Type-Options: nosniff`, which tells browsers not to
  * MIME-sniff a response away from its declared Content-Type. It's cheap and correct even
@@ -14,7 +18,8 @@ import type { FastifyInstance } from 'fastify';
  * DAST baseline finding for rule 10021 (X-Content-Type-Options Header Missing). See #568.
  */
 export function registerSecurityHeaders(app: FastifyInstance): void {
-  app.addHook('onRequest', async (_request, reply) => {
+  app.addHook('onSend', async (_request, reply, payload) => {
     reply.header('X-Content-Type-Options', 'nosniff');
+    return payload;
   });
 }


### PR DESCRIPTION
## **User description**
## Summary

The first triaged ZAP DAST run flagged one finding — rule **10021 "X-Content-Type-Options Header Missing"** on the HTTP API. This adds the header rather than suppressing the alert: `nosniff` is correct hardening even for a JSON API (and covers the static console assets too).

- **`src/channels/http/security-headers.ts`** — new `registerSecurityHeaders(app)` helper that sets `X-Content-Type-Options: nosniff` via an `onRequest` hook.
- **`http-adapter.ts`** — calls it **before** the auth hook, so the header also lands on `401`-short-circuited responses (Fastify stops running later `onRequest` hooks once one sends a reply).

## Testing

New `security-headers.test.ts` (bare Fastify + `inject`, mirroring the route tests): asserts the header is present on a 200, a 404, and a response short-circuited by a later `onRequest` 401. Factored into its own module because `HttpAdapter.start()` is heavy to exercise directly.

- `vitest run src/channels/http tests/unit/channels/http` → 12 files / 89 tests pass
- `pnpm run typecheck` clean, lint clean

## Follow-up

Once merged, the next DAST run should report **0 findings** for `zap-dast`. The `.zap/plan.yaml` `alertFilter` block stays as the documented mechanism for any future known-safe alerts.

Closes #568.


___

## **CodeAnt-AI Description**
Add `X-Content-Type-Options: nosniff` to every HTTP response

### What Changed
- Every API response now includes `X-Content-Type-Options: nosniff`, including 200s, 404s, and 401 responses
- The header is applied early enough to also cover responses stopped by authentication
- Added coverage to confirm the header is present on successful, missing-route, and blocked requests

### Impact
`✅ Fewer MIME-sniffing risks`
`✅ Consistent security headers on error responses`
`✅ Cleared the missing-header DAST finding`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
