### PR TITLE
docs(release): run security gate and doc-sync before cutting a release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,42 @@ not just "it works."
 
 A release is a deliberate, standalone step — separate from day-to-day PR work. Follow these steps in order.
 
+**Pre-flight — get `main` release-ready (before the numbered steps)**
+
+Both of the steps below happen *before* cutting the release, while there is still room to fix problems on a normal branch. They land as ordinary PRs — each with its own CHANGELOG entry, which then rolls into this release — and never inside the release PR itself, which carries no code changes (step 6).
+
+***A. Sync the documentation***
+
+Bring the docs in line with what actually shipped this batch. Do this first, so the security gate below scans the final pre-release state.
+
+- **`docs/specs/`** — update the architecture specs so they describe the system as it now behaves. New capability shipped → its spec reflects it; behavior changed → the affected spec is corrected.
+- **`docs/wip/`** — prune it. Remove artifacts whose work has shipped and been folded into `docs/specs/` (or is otherwise complete). Leave anything still in progress untouched.
+- **`docs/dev/`** — update the how-to guides (`adding-a-skill`, `adding-an-agent`, `configuration`, `setup`, etc.) wherever this release changed the steps they describe.
+- **curia-docs repo** — the public site (docs.meetcuria.com) lives in the separate `curia-docs` repo. Where this release changed user-facing behavior, update it there via its own PR. This is not part of the Curia release PR.
+
+***B. Pre-release security gate***
+
+Run the on-demand security scans against current `main` and clear them **before** cutting the release. Because the release PR carries no code changes (step 6), the commit you tag will be code-identical to what you scan here — so clearing the gate now means clearing it for the tag, while you can still fix findings on a normal branch instead of being stuck with a merged release commit you cannot tag.
+
+(Trivy fs, Semgrep, and Gitleaks already run on every push/PR; this gate covers the scans that do *not* — the Docker image scan, a fresh CodeQL pass, the repo-level Scorecard, and the OWASP ZAP passive DAST run.)
+
+```bash
+gh workflow run trivy.yml     # on-demand Trivy image scan (base image + OS package CVEs)
+gh workflow run codeql.yml    # fresh CodeQL security-extended pass (takes several minutes)
+gh workflow run scorecard.yml # repo-level supply-chain posture
+gh workflow run dast.yml      # OWASP ZAP passive DAST against the running HTTP API (slow: boots the full app)
+# Wait for each to finish, then review results:
+gh run list --limit 5
+```
+
+Review **GitHub → Security → Code Scanning** for the results of all scanners. **Block the release on any unresolved CRITICAL finding.** A HIGH is a judgment call — fix it or document why it's accepted (e.g. unreachable code path, no fix available) before proceeding.
+
+Don't merge other code PRs between clearing this gate and tagging. If code lands on `main` after the gate clears, re-run it — the release PR adds no code, so the gate is only meaningful if `main` hasn't moved underneath it.
+
+The ZAP DAST scan (`zap-dast` category) is alert-only and review-only for now — until its first run is triaged into the `alertFilter` baseline in `.zap/plan.yaml`, its findings are informational and do not block a release. Once a triaged baseline exists (and `failOnError` flips), treat its unresolved CRITICALs the same as the other scanners.
+
+With docs synced and the security gate clear, cut the release:
+
 **1. Read the unreleased changes**
 
 Open `CHANGELOG.md` and review all entries under `## [Unreleased]`. Read for themes: what capabilities shipped, what was fixed, what changed under the hood.
@@ -296,24 +332,7 @@ Write a haiku thematically aligned with the release — drawn from the changes, 
 - No other code changes — this PR is the release commit only
 - Watch CI; wait for merge before proceeding
 
-**7. After merge: pre-release security gate**
-
-Once the release PR is merged, `main` is the exact commit you are about to tag. Run the on-demand security scans against it and review the results **before** tagging. (Trivy fs, Semgrep, and Gitleaks already ran on the release PR; the gate below covers the scans that do *not* run on a normal push — the Docker image scan, a fresh CodeQL pass, and the repo-level Scorecard.)
-
-```bash
-gh workflow run trivy.yml     # on-demand Trivy image scan (base image + OS package CVEs)
-gh workflow run codeql.yml    # fresh CodeQL security-extended pass (takes several minutes)
-gh workflow run scorecard.yml # repo-level supply-chain posture
-gh workflow run dast.yml      # OWASP ZAP passive DAST against the running HTTP API (slow: boots the full app)
-# Wait for each to finish, then review results:
-gh run list --limit 5
-```
-
-Review **GitHub → Security → Code Scanning** for the results of all scanners. **Block the release on any unresolved CRITICAL finding.** A HIGH is a judgment call — fix it or document why it's accepted (e.g. unreachable code path, no fix available) before proceeding.
-
-The ZAP DAST scan (`zap-dast` category) is alert-only and review-only for now — until its first run is triaged into the `alertFilter` baseline in `.zap/plan.yaml`, its findings are informational and do not block a release. Once a triaged baseline exists (and `failOnError` flips), treat its unresolved CRITICALs the same as the other scanners.
-
-**8. Tag and publish**
+**7. Tag and publish**
 
 Confirm the merge landed, then tag `origin/main` directly (do not rely on local branch state — the release worktree is on `chore/release-X.Y.Z`, not `main`):
 
@@ -344,9 +363,9 @@ EOF
 )"
 ```
 
-Tagging stays `git tag -a` (annotated, **unsigned**) — releases are signed at the artifact layer (step 9), not the tag.
+Tagging stays `git tag -a` (annotated, **unsigned**) — releases are signed at the artifact layer (step 8), not the tag.
 
-**9. Verify release artifacts (SBOM + signatures)**
+**8. Verify release artifacts (SBOM + signatures)**
 
 Publishing the release triggers `release.yml`, which generates an SPDX SBOM and a source tarball, signs both with cosign (keyless, via GitHub OIDC), and attaches all four files to the release. This step is **not optional and not silent** — the workflow fails loudly if anything is missing or a signature fails to verify (this is the fix for v0.34.0, which shipped with no SBOM because the old auto-attach skipped silently).
 


### PR DESCRIPTION
## **User description**
## What

Restructures the **Preparing a release** runbook in `CLAUDE.md` so two things happen as **pre-flight steps** (on a normal branch, before the release is cut) rather than after the release PR merges:

- **A. Sync the documentation** — update `docs/specs/`, shipped-only prune of `docs/wip/`, update `docs/dev/` how-to guides, and sync the separate **curia-docs** repo via its own PR.
- **B. Pre-release security gate** — run the on-demand scans (Trivy image, CodeQL, Scorecard, ZAP DAST) against `main`, block on unresolved CRITICAL.

The old **post-merge** security gate (former step 7) is removed. Tag/Verify renumber to steps 7/8, and the artifact-layer cross-reference is updated to `(step 8)`.

## Why

Previously the security gate ran *after* the release PR merged, so a CRITICAL finding left you with a merged release commit on `main` that you couldn't tag, and no clean branch to fix it on. Because the release PR carries **no code changes** (step 6), the code on `main` before cutting is identical to what gets tagged — so scanning pre-flight covers the exact tagged commit while there's still room to fix findings on a normal branch.

A guard line keeps the safety the post-merge gate used to provide: don't merge other code PRs between clearing the gate and tagging; if code lands on `main` afterward, re-run the gate.

The doc-sync step ensures specs/guides/public docs reflect what actually shipped, and that stale WIP artifacts are pruned, before the version is stamped.

## Notes

- Doc updates land as their own PRs *before* the release PR (so their CHANGELOG entries roll into the release); they are never part of the release PR, which stays code-change-free.
- Documentation-only change to the runbook. No code, tests, or behavior affected.


___

## **CodeAnt-AI Description**
Move release checks and doc updates before cutting a release

### What Changed
- Added a pre-flight step to update shipped docs, remove completed WIP docs, and sync public-facing documentation before the release is cut
- Moved the release security checks to run on current `main` before tagging, so release blockers are found while changes are still easy to fix
- Kept the release PR itself free of code changes, renumbered the release steps, and updated the artifact verification reference

### Impact
`✅ Fewer release-day blockers`
`✅ Clearer release documentation`
`✅ Safer release tagging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
