### PR TITLE
chore: release v0.35.0 — "Garak"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+## [0.35.0] — 2026-06-16 — "Garak"
+
+> **Elim Garak** *(Star Trek: Deep Space Nine, 1993, Rick Berman & Michael Piller)* — the "plain, simple tailor" who is anything but: an exiled Cardassian spy whose entire craft is discretion, disguise, and never revealing more than the moment demands. This release teaches Curia the same trade — secrets now pass through it to where they are needed without ever being shown to the agent doing the work, and the browser learned to wear a convincing disguise.
+
 ### Added
 
 - **URL auto-linking in chat** — bare `http`/`https` URLs in both agent and user messages are automatically wrapped in clickable anchor tags; URLs inside code spans are excluded.
@@ -35,16 +39,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Web console chat (ack-and-stream)** — `POST /api/kg/chat/messages` now acks with `202` and the reply streams over SSE instead of blocking on a 120s synchronous wait, so long agent tasks (browser automation, delegation chains, research) complete without a 504. (#985)
 - **Node 22 → 24 (Active LTS)** — the `Dockerfile` build + runtime stages move to `node:24-slim`, matching the production image. The `RUN npm install -g npm@11.16.0` line is removed: node 24's bundled npm is unused (corepack/pnpm at build, tsx at runtime) and scans clean, clearing the Scorecard `npmCommand` finding. (#905)
 - **`web-browser` iframe awareness & adaptive waits** — `get_content` and selector resolution now reach into child frames (so embedded booking/date widgets are visible and clickable); `navigate` waits for network idle and fails fast with a clear "hand off" message on edge blocks ("Access Denied").
-
 - **`secret-capture-request` (skill manifest schema)** — adds an optional `resume_intent` input and persists the minting agent's routing context on the token so the capture can re-enter the right conversation. (#972)
-
 - **Secret capture** — agents mint a one-time link to a web form so a user can add a new vault secret mid-conversation; the value never touches the LLM. Skills `secret-capture-request` and `system-secret-capture-request`. (#971)
 - **`skip_secret_redaction` (skill manifest schema, public API)** — opt a skill's output out of only the broad generic-hex secret scrub (structured credential patterns stay active); gated at startup to skills declaring `secretCapture`. For capability tokens (e.g. capture links) that must reach the LLM. (#971)
 - **`task-create`** — optional `target_agent_id` assigns a new task (and its wake-up) to another registered agent, so the coordinator or ceo-inbox can schedule work for a specialist like meeting-debrief. (#880)
 - **`bullpen`** — `reply` accepts `close_after: true` to close a thread atomically with the reply, `formatBullpenContext()` nudges agents to use it, and the dispatcher skips reply-task fan-out for closed threads so a concluding reply doesn't create dead-end tasks. (#881)
-
-### Changed
-
 - **`SkillContext` (public API)** — adds optional `secretCapture` capability and `appOrigin`/`httpPort` fields (backward compatible). (#971)
 - **`SkillContext` (public API)** — adds optional `resolveSecretRef(ref)` method, injected only for allowlisted skills declaring `secretResolver` (backward compatible). (#973)
 - **`SecretAccessedEvent` (bus event types, public API)** — payload gains optional `byReference` flag distinguishing dynamic by-reference resolution from declared-secret access (backward compatible). (#973)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Cross-cutting: Audit Logger, Memory Engine, Scheduler.
 
 ### TypeScript
 - ESM only (`"type": "module"`, `.js` extensions on all relative imports)
-- Node 22+, use `import.meta.dirname` instead of `__dirname`
+- Node 24+, use `import.meta.dirname` instead of `__dirname`
 - No `any` — use proper types, generics, or discriminated unions
 - All event types defined as discriminated unions in `src/bus/events.ts`
 - All errors normalized to `AgentError` type (see `docs/specs/05-error-recovery.md`)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.35.0-blueviolet" alt="Version: 0.35.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
-  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />
+  <img src="https://img.shields.io/badge/node-%3E%3D24-brightgreen" alt="Node >= 24" />
   <img src="https://img.shields.io/badge/typescript-ESM-blue" alt="TypeScript ESM" />
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/josephfung/curia"><img src="https://api.securityscorecards.dev/projects/github.com/josephfung/curia/badge" alt="OpenSSF Scorecard" /></a>
   <a href="https://www.bestpractices.dev/projects/13136"><img src="https://www.bestpractices.dev/projects/13136/badge" alt="OpenSSF Best Practices" /></a>
@@ -96,7 +96,7 @@ Skills come in two flavours (local handlers and MCP servers) behind a single int
 
 ## Quickstart
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/), Node >= 22, pnpm, and an [Anthropic API key](https://console.anthropic.com).
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/), Node >= 24, pnpm, and an [Anthropic API key](https://console.anthropic.com).
 
 ```bash
 git clone https://github.com/josephfung/curia.git

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.34.0-blueviolet" alt="Version: 0.34.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.35.0-blueviolet" alt="Version: 0.35.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "packageManager": "pnpm@11.0.8",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@11.0.8",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "scripts": {
     "setup": "bash scripts/setup.sh",


### PR DESCRIPTION
## **User description**
> **Elim Garak** *(Star Trek: Deep Space Nine, 1993, Rick Berman & Michael Piller)* — the "plain, simple tailor" who is anything but: an exiled Cardassian spy whose entire craft is discretion, disguise, and never revealing more than the moment demands. This release teaches Curia the same trade — secrets now pass through it to where they are needed without ever being shown to the agent doing the work, and the browser learned to wear a convincing disguise.

Release commit only: CHANGELOG restructured into the 0.35.0 section, `package.json` → 0.35.0, README version badge bumped. No code changes.

**Pre-flight (already merged / cleared):**
- Docs sync — #1019 (specs + dev guides + WIP prune), curia-docs #21 (public site).
- Security gate re-run against this exact `main`: **0 CRITICAL**. The 5 dependency HIGHs (ws/form-data/esbuild) were cleared by #1020; remaining 4 HIGH are accepted (3 Scorecard repo-posture signals + 1 test-fixture temp-file finding).

## Headline
- **Secret capture + secret-by-reference** — agents mint one-time vault links and fill stored credentials into the browser; the value never enters the LLM context, tool call, result, or logs, and the blocked agent resumes automatically once a secret lands. (#971, #972, #973)
- **Browser learned to blend in** — stealth fingerprint, persistent profile, incognito, iframe awareness + per-frame SSRF gating, adaptive waits, opt-in ad-block, and stale-lock recovery. (#987, #982)
- **Console no longer blocks** — chat acks `202` and streams over SSE; sortable columns, filter pills, auto-linked URLs. (#985)
- **Coordinator re-derived** around a three-way routing decision; tool mechanics relocated into skill manifests. (#957, #958)
- **Supply chain** — signed releases + reliable SBOMs, OWASP ZAP DAST baseline, digest-pinned images, dependency CVE pins.

---

> the key changes hands
> no one in the room ever
> reads what it unlocks
