### PR TITLE
fix: escape double quotes in auto-linked href attributes (CodeQL #158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 
 - **hono** — bumped override floor from 4.12.18 to 4.12.25, resolving 5 CVEs including CORS credential reflection (CVE-2026-54290, HIGH 7.1), body-limit bypass (CVE-2026-54288), path traversal in serve-static (CVE-2026-54286), Set-Cookie header merging (CVE-2026-54287), and Lambda@Edge header dropping (CVE-2026-54289).
+- **`markdown-to-html`** — `href` attribute now explicitly encodes `"` as `&quot;` in auto-linked URLs, closing CodeQL XSS alert #158.
 
 ## [0.35.0] — 2026-06-16 — "Garak"
 

--- a/src/utils/markdown-to-html.test.ts
+++ b/src/utils/markdown-to-html.test.ts
@@ -53,4 +53,13 @@ describe('markdownToHtml — URL auto-linking', () => {
     expect(result).not.toContain('<a href="javascript:');
     expect(result).not.toContain('<a href="data:');
   });
+
+  it('does not inject content after a double quote into the href attribute', () => {
+    // The URL regex [^\s<>"] stops at " so the href value only contains the URL portion.
+    // This validates the regex boundary; the &quot; encoding in hrefValue (and now also
+    // in escapeHtml) provides defense-in-depth against future regex relaxation.
+    const result = markdownToHtml('Visit https://example.com" onclick="alert(1)');
+    expect(result).toContain('<a href="https://example.com"');
+    expect(result).not.toContain('href="https://example.com" onclick=');
+  });
 });

--- a/src/utils/markdown-to-html.test.ts
+++ b/src/utils/markdown-to-html.test.ts
@@ -56,8 +56,9 @@ describe('markdownToHtml — URL auto-linking', () => {
 
   it('does not inject content after a double quote into the href attribute', () => {
     // The URL regex [^\s<>"] stops at " so the href value only contains the URL portion.
-    // This validates the regex boundary; the &quot; encoding in hrefValue (and now also
-    // in escapeHtml) provides defense-in-depth against future regex relaxation.
+    // This validates the regex boundary; the &quot; encoding in hrefValue provides
+    // defense-in-depth against future regex relaxation (escapeHtml intentionally does
+    // NOT encode " — see the comment on escapeHtml for why).
     const result = markdownToHtml('Visit https://example.com" onclick="alert(1)');
     expect(result).toContain('<a href="https://example.com"');
     expect(result).not.toContain('href="https://example.com" onclick=');

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -98,7 +98,11 @@ function applyInline(text: string): string {
         stripped = stripped.slice(0, -1);
       }
       const suffix = url.slice(stripped.length);
-      return `<a href="${stripped}" target="_blank" rel="noopener noreferrer">${stripped}</a>${suffix}`;
+      // Escape " for the href attribute context; & < > are already escaped by the
+      // earlier escapeHtml call, and the URL regex excludes " from matching, but
+      // we encode it explicitly here for defense in depth (CodeQL alert #158).
+      const hrefValue = stripped.replace(/"/g, '&quot;');
+      return `<a href="${hrefValue}" target="_blank" rel="noopener noreferrer">${stripped}</a>${suffix}`;
     },
   );
 
@@ -108,6 +112,10 @@ function applyInline(text: string): string {
   return out;
 }
 
+// Intentionally does NOT encode " — escapeHtml runs before URL auto-linking, and encoding
+// " to &quot; would cause the URL regex [^\s<>"] to match greedily through what were
+// intended as " boundaries in the raw text. The href attribute is protected separately
+// by the hrefValue.replace(/"/g, '&quot;') call at the point of attribute construction.
 function escapeHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')


### PR DESCRIPTION
## **User description**
## Summary

Fixes CodeQL alert #158 (`js/incomplete-html-attribute-sanitization`) in `src/utils/markdown-to-html.ts`.

The URL auto-linker in `applyInline()` placed a user-controlled URL directly into `href="..."` without encoding `"`. The URL regex `[^\s<>"]` already excludes `"` from matching (so `stripped` provably can't contain `"` at runtime), but CodeQL flags the data flow because the escaping wasn't visible at the attribute construction site.

**Fix:** add `stripped.replace(/"/g, '&quot;')` immediately before building the template literal — defense-in-depth that's local and auditable.

**Why `escapeHtml` was NOT extended to encode `"`:** `escapeHtml` runs before URL auto-linking. If it encoded `"` → `&quot;`, the URL regex would match greedily through what were intended as `"` terminators (since `&quot;` contains no `"`, `<`, `>`, or whitespace). This was caught by a failing test during review. A comment in the function documents this constraint.

## Test plan

- [x] Added test: `does not inject content after a double quote into the href attribute` — validates regex boundary behavior and the `href` attribute closes at the URL
- [x] Test comment documents that `&quot;` encoding is defense-in-depth (not directly exercised since the regex prevents `"` from reaching `stripped`)
- [x] All 3575 unit tests pass (2 pre-existing integration failures require a running Postgres, unrelated)
- [x] Typecheck clean


___

## **CodeAnt-AI Description**
**Close the auto-linked URL quote injection gap**

### What Changed
- Auto-linked URLs now escape double quotes before being placed into the `href` attribute, so a quoted URL can no longer extend the link and add extra HTML attributes.
- Added a test that checks a URL followed by `"` stops at the quote and does not turn the following text into part of the link.
- Updated the changelog to note the security fix.

### Impact
`✅ Fewer XSS injection risks in auto-linked links`
`✅ Safer links from pasted or user-entered URLs`
`✅ Clearer protection against malformed URL markup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
