### PR TITLE
feat: unified contact tier + kind; collapse status and trust_level (#945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **Contact `tier` + `kind` columns (migration 055)** — unified ordered trust `tier` (`blocked`<`unknown`<`known`<`trusted`<`principal`) plus descriptive `kind` (`person`/`organization`/`automated`/`principal`/`agent`), backfilled from legacy `status`/`trust_level`/`system_role`. (#945)
+
+### Changed
+
+- **Contact capability gating now keys on `tier`** — `meetsMinimumTier()` replaces `meetsMinimumTrust()` at behavioral gates (dispatcher, outbound gateway, Signal trust); legacy `status`/`trust_level` are kept but deprecated (removal tracked in #955). The disclosure gate stays on `trust_level` pending #949. (#945)
+
 ### Security
 
 - **hono** — bumped override floor from 4.12.18 to 4.12.25, resolving 5 CVEs including CORS credential reflection (CVE-2026-54290, HIGH 7.1), body-limit bypass (CVE-2026-54288), path traversal in serve-static (CVE-2026-54286), Set-Cookie header merging (CVE-2026-54287), and Lambda@Edge header dropping (CVE-2026-54289).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Contact `tier` + `kind` columns (migration 055)** — unified ordered trust `tier` (`blocked`<`unknown`<`known`<`trusted`<`principal`) plus descriptive `kind` (`person`/`organization`/`automated`/`principal`/`agent`), backfilled from legacy `status`/`trust_level`/`system_role`. (#945)
+- **Contact `tier` + `kind` model (migration 055)** — ordered capability `tier` and descriptive `kind`, backfilled from legacy fields. (#945)
 
 ### Changed
 
-- **Contact capability gating now keys on `tier`** — `meetsMinimumTier()` replaces `meetsMinimumTrust()` at behavioral gates (dispatcher, outbound gateway, Signal trust); legacy `status`/`trust_level` are kept but deprecated (removal tracked in #955). The disclosure gate stays on `trust_level` pending #949. (#945)
+- **Tier-based capability gating** — dispatcher, outbound gateway, and Signal trust now gate via `meetsMinimumTier()`; legacy `status`/`trust_level` deprecated (removal in #955). (#945)
 
 ### Security
 

--- a/skills/signal-send/handler.test.ts
+++ b/skills/signal-send/handler.test.ts
@@ -21,7 +21,7 @@ function makeCtx(overrides: {
   } as unknown as OutboundGateway;
 
   const contactService = {
-    resolveByChannelIdentity: vi.fn().mockResolvedValue({ contactId: 'c1', status: 'confirmed' }),
+    resolveByChannelIdentity: vi.fn().mockResolvedValue({ contactId: 'c1', status: 'confirmed', tier: 'known' }),
     ...overrides.contactService,
   } as unknown as ContactService;
 
@@ -117,7 +117,7 @@ describe('SignalSendHandler', () => {
       getSignalGroupMembers: vi.fn().mockResolvedValue(['+14155551234']),
     };
     const contactService = {
-      resolveByChannelIdentity: vi.fn().mockResolvedValue({ contactId: 'c1', status: 'confirmed' }),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({ contactId: 'c1', status: 'confirmed', tier: 'known' }),
     };
     const ctx = makeCtx({ input: { group_id: 'grpABC==', message: 'team update' }, gateway, contactService });
 
@@ -159,7 +159,7 @@ describe('SignalSendHandler', () => {
       getSignalGroupMembers: vi.fn().mockResolvedValue(['+14155551234']),
     };
     const contactService = {
-      resolveByChannelIdentity: vi.fn().mockResolvedValue({ contactId: 'c1', status: 'blocked' }),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({ contactId: 'c1', status: 'blocked', tier: 'blocked' }),
     };
     const ctx = makeCtx({ input: { group_id: 'grpABC==', message: 'hi' }, gateway, contactService });
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -729,8 +729,12 @@ export async function knowledgeGraphRoutes(
       kgNodeId: c.kgNodeId,
       displayName: c.displayName,
       role: c.role,
+      // Legacy columns — kept until #955 drops them.
       status: c.status,
       trustLevel: c.trustLevel,
+      // New capability axis (issue #945).
+      tier: c.tier,
+      kind: c.kind,
       systemRole: c.systemRole,
       notes: c.notes,
       createdAt: c.createdAt.toISOString(),

--- a/src/channels/signal/group-trust.ts
+++ b/src/channels/signal/group-trust.ts
@@ -34,9 +34,11 @@ export interface GroupTrustResult {
  * Check the trust level of a set of Signal group member phone numbers.
  *
  * Each phone is resolved against the contact system:
- *   - null contact or status 'provisional' → unknownMember
- *   - status 'blocked'                     → blockedMember
- *   - status 'confirmed' (any non-provisional, non-blocked status) → trusted
+ *   - null contact or tier='unknown'  → unknownMember
+ *   - tier='blocked'                  → blockedMember
+ *   - tier='known'/'trusted'/'principal' → trusted
+ *
+ * Uses contact.tier (issue #945) rather than contact.status for the gate check.
  *
  * @param memberPhones - E.164 numbers of group members (own account already excluded)
  * @param contactService - ContactService for resolving phone numbers to contacts
@@ -50,12 +52,12 @@ export async function checkGroupMemberTrust(
 
   for (const phone of memberPhones) {
     const contact = await contactService.resolveByChannelIdentity('signal', phone);
-    if (!contact || contact.status === 'provisional') {
+    if (!contact || contact.tier === 'unknown') {
       unknownMembers.push(phone);
-    } else if (contact.status === 'blocked') {
+    } else if (contact.tier === 'blocked') {
       blockedMembers.push(phone);
     }
-    // confirmed / any other non-provisional, non-blocked status → trusted
+    // known / trusted / principal → trusted member
   }
 
   return {

--- a/src/channels/signal/group-trust.ts
+++ b/src/channels/signal/group-trust.ts
@@ -20,6 +20,7 @@
 //   - signal-send handler (outbound): gates whether a proactive group send proceeds
 
 import type { ContactService } from '../../contacts/contact-service.js';
+import { meetsMinimumTier } from '../../contacts/types.js';
 
 export interface GroupTrustResult {
   /** True iff all members are verified (non-provisional, non-blocked) contacts. */
@@ -52,12 +53,18 @@ export async function checkGroupMemberTrust(
 
   for (const phone of memberPhones) {
     const contact = await contactService.resolveByChannelIdentity('signal', phone);
-    if (!contact || contact.tier === 'unknown') {
+    if (!contact) {
       unknownMembers.push(phone);
     } else if (contact.tier === 'blocked') {
       blockedMembers.push(phone);
+    } else if (!meetsMinimumTier(contact.tier, 'known')) {
+      // Fail-safe: anything not provably known/trusted/principal (i.e. 'unknown'
+      // or any below-'known' value) is treated as unknown rather than trusted.
+      // A positive allowlist via meetsMinimumTier() avoids the prior denylist
+      // (tier !== 'unknown' && !== 'blocked'), which trusted any unexpected value.
+      unknownMembers.push(phone);
     }
-    // known / trusted / principal → trusted member
+    // meetsMinimumTier(tier, 'known') → trusted member
   }
 
   return {

--- a/src/channels/signal/signal-adapter.ts
+++ b/src/channels/signal/signal-adapter.ts
@@ -14,6 +14,7 @@
 import type { EventBus } from '../../bus/bus.js';
 import type { Logger } from '../../logger.js';
 import type { ContactService } from '../../contacts/contact-service.js';
+import { meetsMinimumTier } from '../../contacts/types.js';
 import type { OutboundGateway } from '../../skills/outbound-gateway.js';
 import type { OutboundMessageEvent } from '../../bus/events.js';
 import type { SignalEnvelope } from './types.js';
@@ -154,10 +155,12 @@ export class SignalAdapter implements Channel {
       const existing = await this.config.contactService.resolveByChannelIdentity('signal', senderId);
 
       if (existing) {
-        // Known sender: tier >= 'known' (i.e. not unknown/blocked) counts as "known"
-        // for read-receipt purposes. The dispatcher enforces hold/block policy.
-        // Uses tier for the check (issue #945); replaces status != 'provisional' && != 'blocked'.
-        isKnownSender = existing.tier !== 'unknown' && existing.tier !== 'blocked';
+        // Known sender: tier >= 'known' counts as "known" for read-receipt purposes.
+        // The dispatcher enforces hold/block policy. Uses a positive allowlist via
+        // meetsMinimumTier() (issue #945) so an unexpected tier value fails safe to
+        // "not known" rather than the prior denylist (!== 'unknown' && !== 'blocked'),
+        // which would have treated any unrecognized value as known.
+        isKnownSender = meetsMinimumTier(existing.tier, 'known');
       } else {
         // New sender — auto-create a provisional contact.
         // signal_participant is auto-verified (per contact-service.ts) so the phone

--- a/src/channels/signal/signal-adapter.ts
+++ b/src/channels/signal/signal-adapter.ts
@@ -154,9 +154,10 @@ export class SignalAdapter implements Channel {
       const existing = await this.config.contactService.resolveByChannelIdentity('signal', senderId);
 
       if (existing) {
-        // Known sender: not provisional and not blocked counts as "known"
+        // Known sender: tier >= 'known' (i.e. not unknown/blocked) counts as "known"
         // for read-receipt purposes. The dispatcher enforces hold/block policy.
-        isKnownSender = existing.status !== 'provisional' && existing.status !== 'blocked';
+        // Uses tier for the check (issue #945); replaces status != 'provisional' && != 'blocked'.
+        isKnownSender = existing.tier !== 'unknown' && existing.tier !== 'blocked';
       } else {
         // New sender — auto-create a provisional contact.
         // signal_participant is auto-verified (per contact-service.ts) so the phone

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -38,23 +38,37 @@ export interface CeoContactBootstrapResult {
  * migration-055 column defaults ('unknown'/'person') — or any older downgraded value —
  * self-heals instead of persisting reduced capability for the run. (#945)
  */
-export async function repairPrincipalMetadata(contactId: string, pool: DbPool): Promise<void> {
-  await pool.query(
-    `UPDATE contacts
-       SET role = 'ceo',
-           trust_level = 'ceo',
-           system_role = 'principal',
-           tier = 'principal',
-           kind = 'principal',
-           updated_at = now()
-     WHERE id = $1
-       AND (role IS DISTINCT FROM 'ceo'
-         OR trust_level IS DISTINCT FROM 'ceo'
-         OR system_role IS DISTINCT FROM 'principal'
-         OR tier IS DISTINCT FROM 'principal'
-         OR kind IS DISTINCT FROM 'principal')`,
-    [contactId],
-  );
+export async function repairPrincipalMetadata(contactId: string, pool: DbPool, logger: Logger): Promise<void> {
+  try {
+    await pool.query(
+      `UPDATE contacts
+         SET role = 'ceo',
+             trust_level = 'ceo',
+             system_role = 'principal',
+             tier = 'principal',
+             kind = 'principal',
+             updated_at = now()
+       WHERE id = $1
+         AND (role IS DISTINCT FROM 'ceo'
+           OR trust_level IS DISTINCT FROM 'ceo'
+           OR system_role IS DISTINCT FROM 'principal'
+           OR tier IS DISTINCT FROM 'principal'
+           OR kind IS DISTINCT FROM 'principal')`,
+      [contactId],
+    );
+  } catch (err) {
+    // Log with context, then propagate. A failure to apply the canonical principal
+    // capability metadata means the CEO's trust gates (e.g. PII-redaction bypass)
+    // may not apply, so every caller treats this as fatal rather than silently
+    // continuing with a possibly-downgraded principal. Centralizing the log+rethrow
+    // here keeps all four call sites (bootstrap main + race winners + ensure-principal)
+    // consistent. Uses a plain Error (consistent with this module's existing throws).
+    logger.error(
+      { err, contactId },
+      'repairPrincipalMetadata: failed to repair principal capability metadata (role/trust_level/system_role/tier/kind) — principal trust gates may not apply until resolved',
+    );
+    throw err;
+  }
 }
 
 /**
@@ -104,15 +118,8 @@ export async function bootstrapCeoContact(
     // filter's trust check. Setting role keeps metadata consistent even if the contact was
     // initially auto-created without a role.
     // tier='principal' and kind='principal' are the new equivalents (issue #945).
-    try {
-      await repairPrincipalMetadata(contact_id, pool);
-    } catch (err) {
-      logger.error(
-        { err, contactId: contact_id },
-        'ceo-bootstrap: failed to set trust_level=ceo/tier=principal on CEO contact — PII redaction bypass will not apply until this is resolved',
-      );
-      throw err;
-    }
+    // repairPrincipalMetadata logs with context and rethrows on failure (see its body).
+    await repairPrincipalMetadata(contact_id, pool, logger);
 
     // Backfill KG node if missing. This handles existing deployments where the contact
     // was created without a KG node (pre-#380 fix). Uses the contact's existing display_name
@@ -234,7 +241,7 @@ export async function bootstrapCeoContact(
         }
         // Self-heal: the winner may be an older writer that left tier/kind at
         // migration defaults. Repair before returning (mirrors the main path).
-        await repairPrincipalMetadata(winnerContactId, pool);
+        await repairPrincipalMetadata(winnerContactId, pool, logger);
         logger.info({ contactId: winnerContactId, kgNodeId: winnerKgNodeId, email: ceoPrimaryEmail }, 'ceo-bootstrap: concurrent startup race resolved — existing CEO contact used');
         return { contactId: winnerContactId, kgNodeId: winnerKgNodeId, alreadyExisted: true };
       }

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -30,6 +30,34 @@ export interface CeoContactBootstrapResult {
 }
 
 /**
+ * Repair a principal/CEO contact's capability metadata to the canonical values.
+ *
+ * Idempotent — the WHERE guard makes it a no-op when the row is already correct.
+ * Called on EVERY path that returns an existing principal row (initial bootstrap,
+ * the 23505 race winner in both this module and ensure-principal), so a row left at
+ * migration-055 column defaults ('unknown'/'person') — or any older downgraded value —
+ * self-heals instead of persisting reduced capability for the run. (#945)
+ */
+export async function repairPrincipalMetadata(contactId: string, pool: DbPool): Promise<void> {
+  await pool.query(
+    `UPDATE contacts
+       SET role = 'ceo',
+           trust_level = 'ceo',
+           system_role = 'principal',
+           tier = 'principal',
+           kind = 'principal',
+           updated_at = now()
+     WHERE id = $1
+       AND (role IS DISTINCT FROM 'ceo'
+         OR trust_level IS DISTINCT FROM 'ceo'
+         OR system_role IS DISTINCT FROM 'principal'
+         OR tier IS DISTINCT FROM 'principal'
+         OR kind IS DISTINCT FROM 'principal')`,
+    [contactId],
+  );
+}
+
+/**
  * Ensure the CEO's primary email contact exists, is confirmed + verified, and has a
  * linked KG person node.
  *
@@ -77,22 +105,7 @@ export async function bootstrapCeoContact(
     // initially auto-created without a role.
     // tier='principal' and kind='principal' are the new equivalents (issue #945).
     try {
-      await pool.query(
-        `UPDATE contacts
-         SET role = 'ceo',
-             trust_level = 'ceo',
-             system_role = 'principal',
-             tier = 'principal',
-             kind = 'principal',
-             updated_at = now()
-         WHERE id = $1
-           AND (role IS DISTINCT FROM 'ceo'
-             OR trust_level IS DISTINCT FROM 'ceo'
-             OR system_role IS DISTINCT FROM 'principal'
-             OR tier IS DISTINCT FROM 'principal'
-             OR kind IS DISTINCT FROM 'principal')`,
-        [contact_id],
-      );
+      await repairPrincipalMetadata(contact_id, pool);
     } catch (err) {
       logger.error(
         { err, contactId: contact_id },
@@ -219,6 +232,9 @@ export async function bootstrapCeoContact(
             );
           }
         }
+        // Self-heal: the winner may be an older writer that left tier/kind at
+        // migration defaults. Repair before returning (mirrors the main path).
+        await repairPrincipalMetadata(winnerContactId, pool);
         logger.info({ contactId: winnerContactId, kgNodeId: winnerKgNodeId, email: ceoPrimaryEmail }, 'ceo-bootstrap: concurrent startup race resolved — existing CEO contact used');
         return { contactId: winnerContactId, kgNodeId: winnerKgNodeId, alreadyExisted: true };
       }

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -68,27 +68,35 @@ export async function bootstrapCeoContact(
     const { contact_id, contact_status, identity_verified, display_name: existingName } = existing.rows[0];
     let { kg_node_id } = existing.rows[0];
 
-    // Always ensure role = 'ceo' and trust_level = 'ceo' on the CEO contact regardless
-    // of which path brought us here. This is idempotent — the UPDATE is a no-op when both
-    // are already correct. Without trust_level = 'ceo', a second CEO email address linked
-    // to the same contact would not match the single CEO_PRIMARY_EMAIL config string and
-    // would fail the outbound filter's trust check. Setting role keeps metadata consistent
-    // even if the contact was initially auto-created without a role.
+    // Always ensure role = 'ceo', trust_level = 'ceo', tier = 'principal', and
+    // kind = 'principal' on the CEO contact regardless of which path brought us here.
+    // This is idempotent — the UPDATE is a no-op when all values are already correct.
+    // Without trust_level = 'ceo', a second CEO email address linked to the same contact
+    // would not match the single CEO_PRIMARY_EMAIL config string and would fail the outbound
+    // filter's trust check. Setting role keeps metadata consistent even if the contact was
+    // initially auto-created without a role.
+    // tier='principal' and kind='principal' are the new equivalents (issue #945).
     try {
       await pool.query(
         `UPDATE contacts
          SET role = 'ceo',
              trust_level = 'ceo',
              system_role = 'principal',
+             tier = 'principal',
+             kind = 'principal',
              updated_at = now()
          WHERE id = $1
-           AND (role IS DISTINCT FROM 'ceo' OR trust_level IS DISTINCT FROM 'ceo' OR system_role IS DISTINCT FROM 'principal')`,
+           AND (role IS DISTINCT FROM 'ceo'
+             OR trust_level IS DISTINCT FROM 'ceo'
+             OR system_role IS DISTINCT FROM 'principal'
+             OR tier IS DISTINCT FROM 'principal'
+             OR kind IS DISTINCT FROM 'principal')`,
         [contact_id],
       );
     } catch (err) {
       logger.error(
         { err, contactId: contact_id },
-        'ceo-bootstrap: failed to set trust_level=ceo on CEO contact — PII redaction bypass will not apply until this is resolved',
+        'ceo-bootstrap: failed to set trust_level=ceo/tier=principal on CEO contact — PII redaction bypass will not apply until this is resolved',
       );
       throw err;
     }
@@ -149,9 +157,10 @@ export async function bootstrapCeoContact(
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
+    // tier='principal' and kind='principal' added in migration 055 (issue #945).
     await client.query(
-      `INSERT INTO contacts (id, kg_node_id, display_name, role, status, trust_level, system_role, created_at, updated_at)
-       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'ceo', 'principal', now(), now())`,
+      `INSERT INTO contacts (id, kg_node_id, display_name, role, status, trust_level, system_role, tier, kind, created_at, updated_at)
+       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'ceo', 'principal', 'principal', 'principal', now(), now())`,
       [contactId, kgNodeId, displayName],
     );
     await client.query(

--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -45,6 +45,16 @@ export class ContactResolver {
       try {
         const principal = await this.contactService.findContactBySystemRole('principal');
         if (principal) {
+          // Warn if migration-055 backfill missed this principal row — kind should
+          // always be 'principal' for a system_role='principal' contact. The ?? fallback
+          // can't catch this because the kind column is NOT NULL (backfill leaves 'person',
+          // not NULL). Making it unconditional here is both authoritative and observable.
+          if (principal.kind !== 'principal') {
+            this.logger.warn(
+              { contactId: principal.id, kind: principal.kind },
+              'contact-resolver: principal contact has kind != "principal" — migration-055 backfill may have missed this row',
+            );
+          }
           return {
             resolved: true,
             contactId: principal.id,
@@ -58,10 +68,11 @@ export class ContactResolver {
             authorization: null,
             contactConfidence: 1.0,   // principal always gets max confidence
             trustLevel: null,
-            // Principal always gets the highest tier; kind comes from the stored row
-            // (should be 'principal' after migration 055 backfill).
+            // Principal always gets the highest tier and is always kind='principal'.
+            // Set unconditionally — the stored row value is authoritative only for the
+            // warning check above; we never surface a non-principal kind for the CEO.
             tier: 'principal' as ContactTier,
-            kind: (principal.kind ?? 'principal') as ContactKind,
+            kind: 'principal' as ContactKind,
           };
         }
         // DB call succeeded but no principal contact row exists yet (fresh install before seeding).

--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -10,7 +10,7 @@ import type { ContactService } from './contact-service.js';
 import type { AuthorizationService } from './authorization.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import type { Logger } from '../logger.js';
-import type { AuthorizationResult, InboundSenderContext } from './types.js';
+import type { AuthorizationResult, ContactTier, ContactKind, InboundSenderContext } from './types.js';
 
 /**
  * Resolves inbound message senders to known contacts.
@@ -58,6 +58,10 @@ export class ContactResolver {
             authorization: null,
             contactConfidence: 1.0,   // principal always gets max confidence
             trustLevel: null,
+            // Principal always gets the highest tier; kind comes from the stored row
+            // (should be 'principal' after migration 055 backfill).
+            tier: 'principal' as ContactTier,
+            kind: (principal.kind ?? 'principal') as ContactKind,
           };
         }
         // DB call succeeded but no principal contact row exists yet (fresh install before seeding).
@@ -94,6 +98,8 @@ export class ContactResolver {
         authorization: null,
         contactConfidence: 1.0,   // principal always gets max confidence
         trustLevel: null,
+        tier: 'principal' as ContactTier,
+        kind: 'principal' as ContactKind,
       };
     }
 
@@ -166,6 +172,8 @@ export class ContactResolver {
       authorization,
       contactConfidence: resolved.contactConfidence,
       trustLevel: resolved.trustLevel,
+      tier: resolved.tier,
+      kind: resolved.kind,
     };
   }
 }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -547,7 +547,14 @@ export class ContactService {
     // derivation; a concurrent block landed after our getContact read above would be overwritten by
     // the updateContact write below, leaving a blocked contact with tier='trusted'. Needs a
     // conditional UPDATE or SELECT FOR UPDATE if concurrent same-contact writes become real.
-    const newTier = deriveTierFromTrustLevelUpdate(trustLevel, contact.status);
+    // Never demote the principal via a trust-level change: trust_level is a per-contact
+    // override, but the principal's capability is structural (system_role). Clearing or
+    // lowering trust_level (null/low/medium) must not drop the principal below 'principal'.
+    // (CodeAnt review — deriveTierFromTrustLevelUpdate would otherwise fall back to the
+    // status-derived 'known' for a confirmed principal.)
+    const newTier = contact.systemRole === 'principal'
+      ? 'principal'
+      : deriveTierFromTrustLevelUpdate(trustLevel, contact.status);
 
     const updated: Contact = {
       ...contact,

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -14,12 +14,14 @@ import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import { sanitizeDisplayName } from '../skills/sanitize.js';
-import { TRUST_RANK, IdentityNotFoundError } from './types.js';
+import { TRUST_RANK, TIER_RANK, IdentityNotFoundError } from './types.js';
 import type {
   AuthOverride,
   Contact,
   ContactCanonicalFields,
   ContactStatus,
+  ContactTier,
+  ContactKind,
   ChannelIdentity,
   ContactServiceOptions,
   CreateContactOptions,
@@ -46,6 +48,65 @@ export class ContactValidationError extends Error {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Tier derivation helpers (issue #945)
+// ---------------------------------------------------------------------------
+// These are internal helpers used by ContactService methods that write to the
+// `tier` column. Exported for testing but not intended for external callers.
+
+/**
+ * Derive an initial tier for a freshly created contact from its status.
+ * New contacts never start as 'trusted' or 'principal' — those require
+ * explicit setTrustLevel() or bootstrap calls after creation.
+ */
+export function deriveInitialTier(status: ContactStatus): ContactTier {
+  if (status === 'blocked')     return 'blocked';
+  if (status === 'provisional') return 'unknown';
+  // 'confirmed' (the default)
+  return 'known';
+}
+
+/**
+ * Derive the new tier when setStatus() is called, preserving any elevated tier
+ * that was previously granted (trusted/principal).
+ *
+ * Rules:
+ * - 'blocked' always overrides — a blocked contact loses any previous tier.
+ * - 'provisional' → 'unknown' (unless already 'principal', which shouldn't happen
+ *   in practice — principal contacts are never set back to provisional).
+ * - 'confirmed' → preserve 'trusted'/'principal' if already set; otherwise 'known'.
+ */
+export function deriveTierFromStatusUpdate(
+  newStatus: ContactStatus,
+  existingTier: ContactTier,
+): ContactTier {
+  if (newStatus === 'blocked')     return 'blocked';
+  if (newStatus === 'provisional') return 'unknown';
+  // confirmed: preserve elevated tiers
+  if (existingTier === 'trusted' || existingTier === 'principal') return existingTier;
+  return 'known';
+}
+
+/**
+ * Derive the new tier when setTrustLevel() is called.
+ *
+ * trust_level maps to tier as follows:
+ *   'ceo'    → 'principal'
+ *   'high'   → 'trusted'
+ *   'medium' → status-derived (same as known/unknown/blocked from status)
+ *   'low'    → status-derived (same fallback)
+ *   null     → status-derived (revert to status-based tier)
+ */
+export function deriveTierFromTrustLevelUpdate(
+  trustLevel: TrustLevel | null,
+  status: ContactStatus,
+): ContactTier {
+  if (trustLevel === 'ceo')  return 'principal';
+  if (trustLevel === 'high') return 'trusted';
+  // medium, low, or null — fall back to the status-derived tier
+  return deriveInitialTier(status);
+}
+
 // -- Backend interface --
 
 interface ContactServiceBackend {
@@ -55,7 +116,7 @@ interface ContactServiceBackend {
   findContactByKgNodeId(kgNodeId: string): Promise<Contact | null>;
   findContactByRole(role: string): Promise<Contact[]>;
   findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null>;
-  listContacts(filters?: { status?: ContactStatus; limit?: number; offset?: number }): Promise<Contact[]>;
+  listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; limit?: number; offset?: number }): Promise<Contact[]>;
   updateContact(contact: Contact): Promise<void>;
   createIdentity(identity: ChannelIdentity): Promise<void>;
   getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]>;
@@ -227,6 +288,22 @@ export class ContactService {
       }
     }
 
+    const contactStatus: ContactStatus = options.status ?? 'confirmed';
+
+    // Derive tier for new contacts. If `tier` is explicitly provided, use it directly.
+    // Otherwise, derive from the legacy `status` field:
+    //   blocked   → tier='blocked'
+    //   provisional → tier='unknown'
+    //   confirmed  → tier='known'
+    //
+    // Note: new contacts always start with null trustLevel, so we never derive
+    // 'trusted' or 'principal' here — those are set via setTrustLevel / bootstrap
+    // after the contact exists.
+    const contactTier: ContactTier = options.tier ?? deriveInitialTier(contactStatus);
+
+    // Derive kind for new contacts. Default to 'person' unless overridden.
+    const contactKind: ContactKind = options.kind ?? 'person';
+
     const contact: Contact = {
       id: randomUUID(),
       kgNodeId,
@@ -235,7 +312,9 @@ export class ContactService {
       // system_role is set only by bootstrap via direct SQL or updateContact; new contacts
       // created through the normal flow always start with null and get assigned explicitly.
       systemRole: null,
-      status: options.status ?? 'confirmed',
+      status: contactStatus,
+      tier: contactTier,
+      kind: contactKind,
       // Trust scoring fields default to zero/null on creation; updated by the scoring pipeline
       contactConfidence: 0,
       trustLevel: null,
@@ -460,9 +539,15 @@ export class ContactService {
       throw new Error(`Contact not found: ${contactId}`);
     }
 
+    // Derive new tier from the trust level change, keeping existing tier context.
+    // trust_level='ceo' → principal, 'high' → trusted, 'medium'/'low' → fall back to status-derived tier.
+    // trust_level=null → revert to status-derived tier.
+    const newTier = deriveTierFromTrustLevelUpdate(trustLevel, contact.status);
+
     const updated: Contact = {
       ...contact,
       trustLevel,
+      tier: newTier,
       updatedAt: new Date(),
     };
 
@@ -571,16 +656,29 @@ export class ContactService {
     return { contact, identities };
   }
 
-  /** Update a contact's status (confirmed, provisional, blocked). */
+  /** Update a contact's status (confirmed, provisional, blocked).
+   *
+   * Also updates `tier` to keep the two in sync. The tier derivation preserves any
+   * 'trusted' or 'principal' tier that was previously set (via setTrustLevel or
+   * bootstrap) — those are not downgraded by a status-only change. Specifically:
+   *   - status='blocked'     → tier='blocked'   (always overrides)
+   *   - status='provisional' → tier='unknown'   (unless already trusted/principal)
+   *   - status='confirmed'   → tier stays if already 'trusted'/'principal', else 'known'
+   */
   async setStatus(contactId: string, status: ContactStatus): Promise<Contact> {
     const contact = await this.backend.getContact(contactId);
     if (!contact) {
       throw new Error(`Contact not found: ${contactId}`);
     }
 
+    // Derive the new tier from status while preserving elevated tiers.
+    // blocked always wins. For confirmed, preserve trusted/principal already granted.
+    const newTier = deriveTierFromStatusUpdate(status, contact.tier);
+
     const updated: Contact = {
       ...contact,
       status,
+      tier: newTier,
       updatedAt: new Date(),
     };
 
@@ -817,13 +915,16 @@ export class ContactService {
       await this.backend.reattachIdentities(secondaryId, primaryId);
       await this.backend.reattachAuthOverrides(secondaryId, primaryId);
 
-      // Write the golden record fields onto the primary contact
+      // Write the golden record fields onto the primary contact.
+      // Also re-derive tier from the merged status to keep them in sync.
       const updatedPrimary: Contact = {
         ...primary,
         displayName: goldenRecord.displayName,
         role: goldenRecord.role,
         notes: goldenRecord.notes,
         status: goldenRecord.status,
+        // Re-derive tier from merged status, preserving any elevated tier on the primary.
+        tier: deriveTierFromStatusUpdate(goldenRecord.status, primary.tier),
         updatedAt: new Date(),
       };
       await this.backend.updateContact(updatedPrimary);
@@ -914,7 +1015,9 @@ export class ContactService {
     const noteParts = [primary.notes, secondary.notes].filter(Boolean);
     const notes = noteParts.length > 0 ? noteParts.join('\n---\n') : null;
 
-    // Most-restrictive status wins: blocked > provisional > confirmed
+    // Most-restrictive status wins: blocked > provisional > confirmed.
+    // We keep this logic on the legacy status field for the MergeGoldenRecord interface.
+    // TODO(#955): Migrate MergeGoldenRecord to use tier instead of status once legacy columns drop.
     const STATUS_RANK: Record<ContactStatus, number> = { blocked: 3, provisional: 2, confirmed: 1 };
     const status: ContactStatus =
       STATUS_RANK[primary.status] >= STATUS_RANK[secondary.status]
@@ -945,20 +1048,24 @@ export class ContactService {
   }
 }
 
-// -- Postgres-specific row shape (all 26 columns) --
+// -- Postgres-specific row shape (all 28 columns as of migration 055) --
 // Shared across all queries that return a full Contact record.
-// The 12 canonical fields (added in migration 048) are always
-// null-safe — they default to null when the column was added after
-// the row was first written.
+// The 12 canonical fields (added in migration 048) and the 2 tier/kind fields
+// (added in migration 055) are all null-safe — they default to sensible values
+// when the column was added after the row was first written.
 type ContactRow = {
   id: string;
   kg_node_id: string | null;
   display_name: string;
   role: string | null;
   system_role: string | null;
+  // Legacy columns (kept until #955 drops them)
   status: string;
-  contact_confidence: string;
   trust_level: string | null;
+  // New capability axis (migration 055)
+  tier: string;
+  kind: string;
+  contact_confidence: string;
   last_seen_at: Date | null;
   inbound_message_count: string;
   outbound_message_count: string;
@@ -981,9 +1088,11 @@ type ContactRow = {
 };
 
 // Column list for all SELECT queries that return a full Contact row.
+// tier and kind added in migration 055.
 const CONTACT_COLS =
-  'id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, ' +
-  'last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at, ' +
+  'id, kg_node_id, display_name, role, system_role, status, trust_level, tier, kind, ' +
+  'contact_confidence, last_seen_at, inbound_message_count, outbound_message_count, notes, ' +
+  'created_at, updated_at, ' +
   'preferred_name, title, organization, primary_email, primary_phone, timezone, locale, location, ' +
   'pronouns, linkedin_url, bio, birthday';
 
@@ -1001,16 +1110,17 @@ class PostgresContactBackend implements ContactServiceBackend {
 
   async createContact(contact: Contact): Promise<void> {
     this.logger.debug({ contactId: contact.id }, 'contacts: creating contact');
+    // tier and kind added in migration 055
     await this.pool.query(
       `INSERT INTO contacts (
-         id, kg_node_id, display_name, role, system_role, status, notes, created_at, updated_at,
+         id, kg_node_id, display_name, role, system_role, status, tier, kind, notes, created_at, updated_at,
          preferred_name, title, organization, primary_email, primary_phone, timezone, locale,
          location, pronouns, linkedin_url, bio, birthday
-       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
-                 $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                 $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)`,
       [
         contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole,
-        contact.status, contact.notes, contact.createdAt, contact.updatedAt,
+        contact.status, contact.tier, contact.kind, contact.notes, contact.createdAt, contact.updatedAt,
         contact.preferredName, contact.title, contact.organization, contact.primaryEmail,
         contact.primaryPhone, contact.timezone, contact.locale, contact.location,
         contact.pronouns, contact.linkedinUrl, contact.bio, contact.birthday,
@@ -1071,13 +1181,19 @@ class PostgresContactBackend implements ContactServiceBackend {
     return this.rowToContact(row);
   }
 
-  async listContacts(filters?: { status?: ContactStatus; limit?: number; offset?: number }): Promise<Contact[]> {
+  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; limit?: number; offset?: number }): Promise<Contact[]> {
     const conditions: string[] = [];
     const params: unknown[] = [];
 
     if (filters?.status != null) {
       params.push(filters.status);
       conditions.push(`status = $${params.length}`);
+    }
+
+    // tier filter (issue #945) — prefer this over status for new callers.
+    if (filters?.tier != null) {
+      params.push(filters.tier);
+      conditions.push(`tier = $${params.length}`);
     }
 
     const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
@@ -1104,18 +1220,19 @@ class PostgresContactBackend implements ContactServiceBackend {
     this.logger.debug({ contactId: contact.id }, 'contacts: updating contact');
     // trust_level is included because ContactService.setTrustLevel writes through this path.
     // system_role is included so bootstrap and any future setter can persist it through the standard update path.
+    // tier and kind (migration 055) are included so setStatus/setTrustLevel keep them in sync.
     // contact_confidence and last_seen_at remain scoring-owned and are not updated here.
     await this.pool.query(
       `UPDATE contacts SET
          kg_node_id = $2, display_name = $3, role = $4, system_role = $5, status = $6,
-         notes = $7, trust_level = $8, updated_at = $9,
-         preferred_name = $10, title = $11, organization = $12, primary_email = $13,
-         primary_phone = $14, timezone = $15, locale = $16, location = $17,
-         pronouns = $18, linkedin_url = $19, bio = $20, birthday = $21
+         notes = $7, trust_level = $8, tier = $9, kind = $10, updated_at = $11,
+         preferred_name = $12, title = $13, organization = $14, primary_email = $15,
+         primary_phone = $16, timezone = $17, locale = $18, location = $19,
+         pronouns = $20, linkedin_url = $21, bio = $22, birthday = $23
        WHERE id = $1`,
       [
         contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole,
-        contact.status, contact.notes, contact.trustLevel, contact.updatedAt,
+        contact.status, contact.notes, contact.trustLevel, contact.tier, contact.kind, contact.updatedAt,
         contact.preferredName, contact.title, contact.organization, contact.primaryEmail,
         contact.primaryPhone, contact.timezone, contact.locale, contact.location,
         contact.pronouns, contact.linkedinUrl, contact.bio, contact.birthday,
@@ -1214,13 +1331,15 @@ class PostgresContactBackend implements ContactServiceBackend {
       role: string | null;
       system_role: string | null;
       status: string;
+      trust_level: string | null;
+      tier: string;
+      kind: string;
       kg_node_id: string | null;
       verified: boolean;
       contact_confidence: string;  // NUMERIC returned as string by node-pg
-      trust_level: string | null;
     }>(
-      `SELECT c.id, c.display_name, c.role, c.system_role, c.status, c.kg_node_id, cci.verified,
-              c.contact_confidence, c.trust_level
+      `SELECT c.id, c.display_name, c.role, c.system_role, c.status, c.trust_level,
+              c.tier, c.kind, c.kg_node_id, cci.verified, c.contact_confidence
        FROM contact_channel_identities cci
        JOIN contacts c ON c.id = cci.contact_id
        WHERE cci.channel = $1
@@ -1255,6 +1374,14 @@ class PostgresContactBackend implements ContactServiceBackend {
       trustLevel: (Object.keys(TRUST_RANK) as TrustLevel[]).includes(row.trust_level as TrustLevel)
         ? row.trust_level as TrustLevel
         : null,
+      // Validate tier against the allowed enum — guard against corrupt DB values.
+      // Default to 'unknown' (safe/conservative) if the DB value is not a known tier.
+      tier: (Object.keys(TIER_RANK) as ContactTier[]).includes(row.tier as ContactTier)
+        ? row.tier as ContactTier
+        : 'unknown',
+      kind: (['person', 'organization', 'automated', 'principal', 'agent'] as ContactKind[]).includes(row.kind as ContactKind)
+        ? row.kind as ContactKind
+        : 'person',
     };
   }
 
@@ -1268,8 +1395,17 @@ class PostgresContactBackend implements ContactServiceBackend {
     // Atomic conditional update — only flips to confirmed when status is STILL
     // 'provisional' at DB write time. Guards against concurrent blocks between
     // the caller's last getContact check and this write (TOCTOU mitigation).
+    //
+    // Also upgrades tier from 'unknown' → 'known'. Provisional contacts always
+    // have tier='unknown' (enforced by the create path), so CASE WHEN tier='unknown'
+    // is a safety guard for any row that might have a non-default tier despite being
+    // provisional (shouldn't happen, but defensive). 'trusted'/'principal' are preserved.
     const result = await this.pool.query(
-      `UPDATE contacts SET status = 'confirmed', updated_at = now() WHERE id = $1 AND status = 'provisional'`,
+      `UPDATE contacts
+       SET status = 'confirmed',
+           tier   = CASE WHEN tier = 'unknown' THEN 'known' ELSE tier END,
+           updated_at = now()
+       WHERE id = $1 AND status = 'provisional'`,
       [contactId],
     );
     return (result.rowCount ?? 0) > 0;
@@ -1481,7 +1617,19 @@ class PostgresContactBackend implements ContactServiceBackend {
       systemRole: (row.system_role === 'principal' || row.system_role === 'agent' || row.system_role === 'system')
         ? row.system_role
         : null,
+      // Legacy columns (kept until #955 drops them)
       status: row.status as ContactStatus,
+      trustLevel: (Object.keys(TRUST_RANK) as TrustLevel[]).includes(row.trust_level as TrustLevel)
+        ? row.trust_level as TrustLevel
+        : null,
+      // New capability axis (migration 055). Guard against corrupt DB values — default to
+      // 'unknown' (safe/conservative) and 'person' respectively.
+      tier: (Object.keys(TIER_RANK) as ContactTier[]).includes(row.tier as ContactTier)
+        ? row.tier as ContactTier
+        : 'unknown',
+      kind: (['person', 'organization', 'automated', 'principal', 'agent'] as ContactKind[]).includes(row.kind as ContactKind)
+        ? row.kind as ContactKind
+        : 'person',
       // PostgreSQL returns NUMERIC as a string via node-pg.
       // Guard against NaN — if migration 020 hasn't run, the column is absent and
       // parseFloat(undefined) = NaN, which would silently corrupt trust score computation.
@@ -1489,9 +1637,6 @@ class PostgresContactBackend implements ContactServiceBackend {
         const v = parseFloat(row.contact_confidence);
         return isFinite(v) ? v : 0.0;
       })(),
-      trustLevel: (Object.keys(TRUST_RANK) as TrustLevel[]).includes(row.trust_level as TrustLevel)
-        ? row.trust_level as TrustLevel
-        : null,
       lastSeenAt: row.last_seen_at,
       inboundMessageCount: parseInt(row.inbound_message_count, 10) || 0,
       outboundMessageCount: parseInt(row.outbound_message_count, 10) || 0,
@@ -1647,11 +1792,16 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return null;
   }
 
-  async listContacts(filters?: { status?: ContactStatus; limit?: number; offset?: number }): Promise<Contact[]> {
+  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; limit?: number; offset?: number }): Promise<Contact[]> {
     let results = [...this.contacts.values()];
 
     if (filters?.status != null) {
       results = results.filter((c) => c.status === filters.status);
+    }
+
+    // tier filter (issue #945) — prefer this over status for new callers
+    if (filters?.tier != null) {
+      results = results.filter((c) => c.tier === filters.tier);
     }
 
     // Sort by createdAt ascending to match Postgres ORDER BY created_at ASC
@@ -1710,7 +1860,12 @@ class InMemoryContactBackend implements ContactServiceBackend {
     // The same conditional-update semantics as the Postgres implementation apply.
     const contact = this.contacts.get(contactId);
     if (!contact || contact.status !== 'provisional') return false;
-    this.contacts.set(contactId, { ...contact, status: 'confirmed', updatedAt: new Date() });
+    // When promoting from provisional → confirmed, only upgrade tier to 'known' if
+    // it was 'unknown'. Don't downgrade 'trusted'/'principal' (in-memory backend
+    // matches Postgres behaviour: promoteToConfirmed only fires on provisional rows,
+    // which by definition have tier='unknown').
+    const newTier: ContactTier = contact.tier === 'unknown' ? 'known' : contact.tier;
+    this.contacts.set(contactId, { ...contact, status: 'confirmed', tier: newTier, updatedAt: new Date() });
     return true;
   }
 
@@ -1764,10 +1919,12 @@ class InMemoryContactBackend implements ContactServiceBackend {
             role: contact.role,
             systemRole: contact.systemRole,
             status: contact.status,
+            trustLevel: contact.trustLevel ?? null,
+            tier: contact.tier,
+            kind: contact.kind,
             kgNodeId: contact.kgNodeId,
             verified: identity.verified,
             contactConfidence: contact.contactConfidence ?? 0,
-            trustLevel: contact.trustLevel ?? null,
           };
         }
       }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -542,6 +542,11 @@ export class ContactService {
     // Derive new tier from the trust level change, keeping existing tier context.
     // trust_level='ceo' → principal, 'high' → trusted, 'medium'/'low' → fall back to status-derived tier.
     // trust_level=null → revert to status-derived tier.
+    //
+    // TODO(#945-followup): TOCTOU — concurrent setStatus('blocked') can be clobbered by this tier
+    // derivation; a concurrent block landed after our getContact read above would be overwritten by
+    // the updateContact write below, leaving a blocked contact with tier='trusted'. Needs a
+    // conditional UPDATE or SELECT FOR UPDATE if concurrent same-contact writes become real.
     const newTier = deriveTierFromTrustLevelUpdate(trustLevel, contact.status);
 
     const updated: Contact = {
@@ -917,14 +922,23 @@ export class ContactService {
 
       // Write the golden record fields onto the primary contact.
       // Also re-derive tier from the merged status to keep them in sync.
+      //
+      // Survivorship takes the MORE CAPABLE of the two tiers, then re-derives via
+      // deriveTierFromStatusUpdate so a blocked golden record always wins.
+      // Rationale: tier represents a CEO grant (e.g. the CEO explicitly trusted a
+      // secondary contact). Merging should never silently downgrade that grant —
+      // losing a 'trusted' tier because the primary happened to be 'known' is
+      // incorrect, especially since #944's dedup calls mergeContacts.
+      const mergedExistingTier = TIER_RANK[primary.tier] >= TIER_RANK[secondary.tier]
+        ? primary.tier
+        : secondary.tier;
       const updatedPrimary: Contact = {
         ...primary,
         displayName: goldenRecord.displayName,
         role: goldenRecord.role,
         notes: goldenRecord.notes,
         status: goldenRecord.status,
-        // Re-derive tier from merged status, preserving any elevated tier on the primary.
-        tier: deriveTierFromStatusUpdate(goldenRecord.status, primary.tier),
+        tier: deriveTierFromStatusUpdate(goldenRecord.status, mergedExistingTier),
         updatedAt: new Date(),
       };
       await this.backend.updateContact(updatedPrimary);
@@ -1374,14 +1388,32 @@ class PostgresContactBackend implements ContactServiceBackend {
       trustLevel: (Object.keys(TRUST_RANK) as TrustLevel[]).includes(row.trust_level as TrustLevel)
         ? row.trust_level as TrustLevel
         : null,
-      // Validate tier against the allowed enum — guard against corrupt DB values.
-      // Default to 'unknown' (safe/conservative) if the DB value is not a known tier.
-      tier: (Object.keys(TIER_RANK) as ContactTier[]).includes(row.tier as ContactTier)
-        ? row.tier as ContactTier
-        : 'unknown',
-      kind: (['person', 'organization', 'automated', 'principal', 'agent'] as ContactKind[]).includes(row.kind as ContactKind)
-        ? row.kind as ContactKind
-        : 'person',
+      // Validate tier against the allowed enum — fail-closed on corrupt DB values.
+      // null/undefined (column absent pre-migration) → 'unknown' (benign, conservative).
+      // A PRESENT but unrecognized value is a data integrity problem: log at ERROR and
+      // return 'blocked' so a corrupted 'blocked' row cannot be un-blocked by bad data.
+      tier: (() => {
+        if (row.tier == null) return 'unknown' as ContactTier;
+        if ((Object.keys(TIER_RANK) as ContactTier[]).includes(row.tier as ContactTier)) {
+          return row.tier as ContactTier;
+        }
+        this.logger.error(
+          { contactId: row.id, rawTier: row.tier },
+          'contacts: unrecognized tier value in DB — failing closed to blocked',
+        );
+        return 'blocked' as ContactTier;
+      })(),
+      kind: (() => {
+        if (row.kind == null) return 'person' as ContactKind;
+        if ((['person', 'organization', 'automated', 'principal', 'agent'] as ContactKind[]).includes(row.kind as ContactKind)) {
+          return row.kind as ContactKind;
+        }
+        this.logger.error(
+          { contactId: row.id, rawKind: row.kind },
+          'contacts: unrecognized kind value in DB',
+        );
+        return 'person' as ContactKind;
+      })(),
     };
   }
 
@@ -1622,14 +1654,33 @@ class PostgresContactBackend implements ContactServiceBackend {
       trustLevel: (Object.keys(TRUST_RANK) as TrustLevel[]).includes(row.trust_level as TrustLevel)
         ? row.trust_level as TrustLevel
         : null,
-      // New capability axis (migration 055). Guard against corrupt DB values — default to
-      // 'unknown' (safe/conservative) and 'person' respectively.
-      tier: (Object.keys(TIER_RANK) as ContactTier[]).includes(row.tier as ContactTier)
-        ? row.tier as ContactTier
-        : 'unknown',
-      kind: (['person', 'organization', 'automated', 'principal', 'agent'] as ContactKind[]).includes(row.kind as ContactKind)
-        ? row.kind as ContactKind
-        : 'person',
+      // New capability axis (migration 055). Fail-closed on corrupt DB values:
+      // null/undefined (column absent pre-migration) → safe default.
+      // A PRESENT but unrecognized tier is a data integrity problem — log at ERROR
+      // and return 'blocked' so a corrupted 'blocked' row cannot be un-blocked by
+      // bad data. For kind (not a security gate), log at ERROR but keep 'person'.
+      tier: (() => {
+        if (row.tier == null) return 'unknown' as ContactTier;
+        if ((Object.keys(TIER_RANK) as ContactTier[]).includes(row.tier as ContactTier)) {
+          return row.tier as ContactTier;
+        }
+        this.logger.error(
+          { contactId: row.id, rawTier: row.tier },
+          'contacts: unrecognized tier value in DB — failing closed to blocked',
+        );
+        return 'blocked' as ContactTier;
+      })(),
+      kind: (() => {
+        if (row.kind == null) return 'person' as ContactKind;
+        if ((['person', 'organization', 'automated', 'principal', 'agent'] as ContactKind[]).includes(row.kind as ContactKind)) {
+          return row.kind as ContactKind;
+        }
+        this.logger.error(
+          { contactId: row.id, rawKind: row.kind },
+          'contacts: unrecognized kind value in DB',
+        );
+        return 'person' as ContactKind;
+      })(),
       // PostgreSQL returns NUMERIC as a string via node-pg.
       // Guard against NaN — if migration 020 hasn't run, the column is absent and
       // parseFloat(undefined) = NaN, which would silently corrupt trust score computation.

--- a/src/contacts/ensure-principal.ts
+++ b/src/contacts/ensure-principal.ts
@@ -21,7 +21,7 @@
 import { randomUUID } from 'crypto';
 import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
-import { insertKgPersonNode, createAndLinkKgNode } from './ceo-bootstrap.js';
+import { insertKgPersonNode, createAndLinkKgNode, repairPrincipalMetadata } from './ceo-bootstrap.js';
 
 export interface EnsurePrincipalOptions {
   /** Display name for the principal contact. Used only when creating; existing principals keep their stored name. */
@@ -71,6 +71,9 @@ export async function ensurePrincipalContact(
         'ensure-principal: backfilled KG person node for existing principal',
       );
     }
+    // Self-heal capability metadata: an existing principal row may have been left at
+    // migration-055 defaults ('unknown'/'person') by an older path; repair before returning.
+    await repairPrincipalMetadata(row.id, pool);
     return { contactId: row.id, kgNodeId, alreadyExisted: true };
   }
 
@@ -139,6 +142,8 @@ export async function ensurePrincipalContact(
             [kgNodeId],
           );
         }
+        // Self-heal: the race winner may be an older writer; repair tier/kind etc.
+        await repairPrincipalMetadata(winnerRow.id, pool);
         logger.info(
           { contactId: winnerRow.id, kgNodeId: winnerKgNodeId },
           'ensure-principal: concurrent race resolved — existing principal used',

--- a/src/contacts/ensure-principal.ts
+++ b/src/contacts/ensure-principal.ts
@@ -82,10 +82,14 @@ export async function ensurePrincipalContact(
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
+    // Include tier and kind explicitly so the principal is never left at the
+    // migration-055 column defaults ('unknown'/'person'). The ceo-bootstrap
+    // corrective UPDATE cannot fire on this path (no channel identity yet), so
+    // the correct values must be present from the moment the row is inserted.
     await client.query(
       `INSERT INTO contacts
-         (id, kg_node_id, display_name, role, status, trust_level, system_role, created_at, updated_at)
-       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'ceo', 'principal', now(), now())`,
+         (id, kg_node_id, display_name, role, status, trust_level, system_role, tier, kind, created_at, updated_at)
+       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'ceo', 'principal', 'principal', 'principal', now(), now())`,
       [contactId, kgNodeId, displayName],
     );
     await client.query('COMMIT');

--- a/src/contacts/ensure-principal.ts
+++ b/src/contacts/ensure-principal.ts
@@ -73,7 +73,7 @@ export async function ensurePrincipalContact(
     }
     // Self-heal capability metadata: an existing principal row may have been left at
     // migration-055 defaults ('unknown'/'person') by an older path; repair before returning.
-    await repairPrincipalMetadata(row.id, pool);
+    await repairPrincipalMetadata(row.id, pool, logger);
     return { contactId: row.id, kgNodeId, alreadyExisted: true };
   }
 
@@ -143,7 +143,7 @@ export async function ensurePrincipalContact(
           );
         }
         // Self-heal: the race winner may be an older writer; repair tier/kind etc.
-        await repairPrincipalMetadata(winnerRow.id, pool);
+        await repairPrincipalMetadata(winnerRow.id, pool, logger);
         logger.info(
           { contactId: winnerRow.id, kgNodeId: winnerKgNodeId },
           'ensure-principal: concurrent race resolved — existing principal used',

--- a/src/contacts/types.test.ts
+++ b/src/contacts/types.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { meetsMinimumTrust } from './types.js';
+import { meetsMinimumTrust, meetsMinimumTier, TIER_RANK } from './types.js';
 
-describe('meetsMinimumTrust', () => {
+describe('meetsMinimumTrust (legacy helper — kept for backward compat)', () => {
   it('returns false for null trust level', () => {
     expect(meetsMinimumTrust(null, 'low')).toBe(false);
   });
@@ -30,5 +30,80 @@ describe('meetsMinimumTrust', () => {
   it('low meets only low', () => {
     expect(meetsMinimumTrust('low', 'medium')).toBe(false);
     expect(meetsMinimumTrust('low', 'low')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// New tier system (issue #945)
+// ---------------------------------------------------------------------------
+
+describe('TIER_RANK ordering', () => {
+  it('enforces blocked < unknown < known < trusted < principal', () => {
+    expect(TIER_RANK['blocked']).toBeLessThan(TIER_RANK['unknown']);
+    expect(TIER_RANK['unknown']).toBeLessThan(TIER_RANK['known']);
+    expect(TIER_RANK['known']).toBeLessThan(TIER_RANK['trusted']);
+    expect(TIER_RANK['trusted']).toBeLessThan(TIER_RANK['principal']);
+  });
+
+  it('covers all five tiers', () => {
+    const tiers = Object.keys(TIER_RANK);
+    expect(tiers).toContain('blocked');
+    expect(tiers).toContain('unknown');
+    expect(tiers).toContain('known');
+    expect(tiers).toContain('trusted');
+    expect(tiers).toContain('principal');
+  });
+});
+
+describe('meetsMinimumTier', () => {
+  it('principal meets all tiers', () => {
+    expect(meetsMinimumTier('principal', 'principal')).toBe(true);
+    expect(meetsMinimumTier('principal', 'trusted')).toBe(true);
+    expect(meetsMinimumTier('principal', 'known')).toBe(true);
+    expect(meetsMinimumTier('principal', 'unknown')).toBe(true);
+    expect(meetsMinimumTier('principal', 'blocked')).toBe(true);
+  });
+
+  it('trusted meets trusted and below but not principal', () => {
+    expect(meetsMinimumTier('trusted', 'principal')).toBe(false);
+    expect(meetsMinimumTier('trusted', 'trusted')).toBe(true);
+    expect(meetsMinimumTier('trusted', 'known')).toBe(true);
+    expect(meetsMinimumTier('trusted', 'unknown')).toBe(true);
+    expect(meetsMinimumTier('trusted', 'blocked')).toBe(true);
+  });
+
+  it('known meets known and below but not trusted or principal', () => {
+    expect(meetsMinimumTier('known', 'principal')).toBe(false);
+    expect(meetsMinimumTier('known', 'trusted')).toBe(false);
+    expect(meetsMinimumTier('known', 'known')).toBe(true);
+    expect(meetsMinimumTier('known', 'unknown')).toBe(true);
+    expect(meetsMinimumTier('known', 'blocked')).toBe(true);
+  });
+
+  it('unknown meets unknown and blocked only', () => {
+    expect(meetsMinimumTier('unknown', 'principal')).toBe(false);
+    expect(meetsMinimumTier('unknown', 'trusted')).toBe(false);
+    expect(meetsMinimumTier('unknown', 'known')).toBe(false);
+    expect(meetsMinimumTier('unknown', 'unknown')).toBe(true);
+    expect(meetsMinimumTier('unknown', 'blocked')).toBe(true);
+  });
+
+  it('blocked meets only blocked', () => {
+    expect(meetsMinimumTier('blocked', 'principal')).toBe(false);
+    expect(meetsMinimumTier('blocked', 'trusted')).toBe(false);
+    expect(meetsMinimumTier('blocked', 'known')).toBe(false);
+    expect(meetsMinimumTier('blocked', 'unknown')).toBe(false);
+    expect(meetsMinimumTier('blocked', 'blocked')).toBe(true);
+  });
+
+  it('is consistent with TIER_RANK ordering for all pairs', () => {
+    // The helper must be strictly equivalent to rank comparison for every combo.
+    const tiers = ['blocked', 'unknown', 'known', 'trusted', 'principal'] as const;
+    for (const actual of tiers) {
+      for (const required of tiers) {
+        const expected = TIER_RANK[actual] >= TIER_RANK[required];
+        expect(meetsMinimumTier(actual, required)).toBe(expected);
+      }
+    }
   });
 });

--- a/src/contacts/types.test.ts
+++ b/src/contacts/types.test.ts
@@ -106,4 +106,25 @@ describe('meetsMinimumTier', () => {
       }
     }
   });
+
+  it('throws on an unrecognized actual tier value', () => {
+    // A silent wrong answer at a trust comparison is worse than an early throw.
+    // The TypeScript type system prevents this at compile time, but runtime data
+    // from the DB or deserialisation can produce invalid values.
+    expect(() => meetsMinimumTier('superadmin' as never, 'known')).toThrow(
+      /unrecognized tier value/,
+    );
+  });
+
+  it('throws on an unrecognized required tier value', () => {
+    expect(() => meetsMinimumTier('known', 'superadmin' as never)).toThrow(
+      /unrecognized tier value/,
+    );
+  });
+
+  it('throws when both tier values are unrecognized', () => {
+    expect(() => meetsMinimumTier('foo' as never, 'bar' as never)).toThrow(
+      /unrecognized tier value/,
+    );
+  });
 });

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -6,10 +6,16 @@ export interface Contact {
   displayName: string;
   role: string | null;
   systemRole: SystemRole | null;
+  // Legacy columns (deprecated, kept until #955 drops them). New code reads `tier`.
   status: ContactStatus;
+  trustLevel: TrustLevel | null;
+  // New capability axis (issue #945). `tier` is the single ordered capability axis
+  // that replaces the status/trust_level read path. `kind` is a descriptive facet.
+  // Added in migration 055.
+  tier: ContactTier;
+  kind: ContactKind;
   // Trust scoring fields (migration 020)
   contactConfidence: number;         // 0.0–1.0; accumulated over time
-  trustLevel: TrustLevel | null;     // nullable per-contact override
   lastSeenAt: Date | null;
   // Message count fields (migration 034) — scoring-owned
   inboundMessageCount: number;
@@ -108,7 +114,13 @@ export interface CreateContactOptions {
    */
   fallbackDisplayName?: string;
   role?: string;
+  // `status` is the legacy field; callers may still set it. When `tier` is also provided,
+  // `tier` takes precedence. When only `status` is set, tier is derived from it.
   status?: ContactStatus;
+  // `tier` is the new capability axis from issue #945. Preferred over `status` for new callers.
+  tier?: ContactTier;
+  // `kind` is the descriptive facet from issue #945.
+  kind?: ContactKind;
   notes?: string;
   /** If provided, links to this existing KG node. Otherwise auto-creates one. */
   kgNodeId?: string;
@@ -145,11 +157,15 @@ export interface ResolvedSender {
   displayName: string;
   role: string | null;
   systemRole: SystemRole | null;
+  // Legacy columns — kept until #955 drops them. New code reads `tier`.
   status: ContactStatus;
+  trustLevel: TrustLevel | null;  // per-contact override, or null
+  // New capability axis (issue #945). Canonical read path going forward.
+  tier: ContactTier;
+  kind: ContactKind;
   kgNodeId: string | null;
   verified: boolean;
   contactConfidence: number;      // 0.0–1.0
-  trustLevel: TrustLevel | null;  // per-contact override, or null
 }
 
 /** Enriched context about a sender, assembled for the coordinator's prompt */
@@ -159,6 +175,7 @@ export interface SenderContext {
   displayName: string;
   role: string | null;
   systemRole: SystemRole | null;
+  // Legacy columns — kept until #955 drops them. New code reads `tier`.
   status: ContactStatus;
   verified: boolean;
   kgNodeId: string | null;
@@ -168,6 +185,9 @@ export interface SenderContext {
   // Trust scoring inputs — available when contact was found in DB. Not propagated to bus events.
   contactConfidence: number;      // 0.0–1.0
   trustLevel: TrustLevel | null;  // per-contact override, or null
+  // New capability axis (issue #945). Canonical read path going forward.
+  tier: ContactTier;
+  kind: ContactKind;
 }
 
 export interface UnknownSenderContext {
@@ -223,6 +243,7 @@ export type SystemRole = 'principal' | 'agent' | 'system';
 // Ordinal ranking for trust level comparison. Higher rank = more trusted.
 // Used by meetsMinimumTrust() so callers don't need to enumerate every level.
 // Exported so authorization.ts and other consumers share the same single source of truth.
+// TODO(#955): Remove TRUST_RANK once all callers have migrated to TIER_RANK + ContactTier.
 export const TRUST_RANK: Record<TrustLevel, number> = {
   low: 0,
   medium: 1,
@@ -233,6 +254,12 @@ export const TRUST_RANK: Record<TrustLevel, number> = {
 /**
  * Check whether an actual trust level meets or exceeds a required minimum.
  * Returns false for null (unknown contacts default to untrusted).
+ *
+ * @deprecated Prefer meetsMinimumTier() against contact.tier. This function
+ *   operates on the legacy trust_level column. Kept alive until #955 completes
+ *   the column drop — existing call sites in authorization.ts and pii-redactor.ts
+ *   still need it for channel-level TrustLevel comparisons (channel trust is
+ *   config-driven and not mapped to tier).
  */
 export function meetsMinimumTrust(
   actual: TrustLevel | null,
@@ -240,6 +267,77 @@ export function meetsMinimumTrust(
 ): boolean {
   if (actual === null) return false;
   return TRUST_RANK[actual] >= TRUST_RANK[required];
+}
+
+// ---------------------------------------------------------------------------
+// New tier + kind system (issue #945)
+// ---------------------------------------------------------------------------
+
+/**
+ * Unified capability axis replacing the old `status` / `trust_level` split.
+ * Ordered ascending: blocked < unknown < known < trusted < principal.
+ *
+ * - 'blocked'   — CEO explicitly rejected this contact; messages are dropped.
+ * - 'unknown'   — contact exists but has not been confirmed (was: 'provisional' / trust_level='low').
+ * - 'known'     — CEO-confirmed, no special trust grant (was: 'confirmed' + no trust_level).
+ * - 'trusted'   — CEO granted elevated trust (was: trust_level='high').
+ * - 'principal' — the human CEO Curia serves (was: system_role='principal' / trust_level='ceo').
+ *
+ * Added in migration 055. See docs/wip/ for the contacts redesign design memo.
+ */
+export type ContactTier = 'blocked' | 'unknown' | 'known' | 'trusted' | 'principal';
+
+/**
+ * Descriptive facet for a contact row — what kind of entity it represents.
+ * Gates nothing directly in this issue; 'automated' will opt a row out of tier
+ * gates in issue #953.
+ *
+ * - 'person'       — individual human contact (default).
+ * - 'organization' — a company or institution (linked KG node type='organization').
+ * - 'automated'    — automated sender e.g. mailing list (TODO #953: exempts from tier gates).
+ * - 'principal'    — the human CEO Curia serves.
+ * - 'agent'        — Curia itself or another autonomous agent.
+ *
+ * Added in migration 055.
+ */
+export type ContactKind = 'person' | 'organization' | 'automated' | 'principal' | 'agent';
+
+// Ordinal ranking for tier comparison. Higher rank = more capability.
+// Used by meetsMinimumTier() so call sites never need to enumerate specific tiers.
+export const TIER_RANK: Record<ContactTier, number> = {
+  blocked:   0,
+  unknown:   1,
+  known:     2,
+  trusted:   3,
+  principal: 4,
+};
+
+/**
+ * Check whether an actual contact tier meets or exceeds a required minimum.
+ *
+ * This is the canonical helper for tier comparisons. ALL call sites must use this
+ * function — never compare specific tier values directly. This ensures a single
+ * source of truth for the ordering and makes future reorderings safe.
+ */
+export function meetsMinimumTier(
+  actual: ContactTier,
+  required: ContactTier,
+): boolean {
+  return TIER_RANK[actual] >= TIER_RANK[required];
+}
+
+/**
+ * Return true when kind='automated'. Call sites that need to skip tier gates
+ * for automated senders (mailing lists, notifications) should use this helper
+ * rather than comparing kind directly — keeps the gate logic in one place.
+ *
+ * Full gate-skipping behaviour will be wired in issue #953; for now this is
+ * a typed helper so callers can be written ahead of the gate implementation.
+ *
+ * TODO(#953): Wire this into the dispatch gate and outbound filter.
+ */
+export function isAutomatedKind(kind: ContactKind): boolean {
+  return kind === 'automated';
 }
 
 export interface AuthorizationResult {
@@ -251,6 +349,7 @@ export interface AuthorizationResult {
   channelTrust: TrustLevel;
   /** Permissions blocked by insufficient channel trust (allowed by role but channel too low) */
   trustBlocked: string[];
+  // TODO(#955): Replace contactStatus with contactTier once all callers have migrated.
   contactStatus: ContactStatus;
 }
 

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -318,12 +318,23 @@ export const TIER_RANK: Record<ContactTier, number> = {
  * This is the canonical helper for tier comparisons. ALL call sites must use this
  * function — never compare specific tier values directly. This ensures a single
  * source of truth for the ordering and makes future reorderings safe.
+ *
+ * Throws if either argument is not a recognized tier value. Matches the convention
+ * in authorization.ts (which throws on unknown trustLevel) — a silent wrong answer
+ * at a trust comparison is worse than an early crash.
  */
 export function meetsMinimumTier(
   actual: ContactTier,
   required: ContactTier,
 ): boolean {
-  return TIER_RANK[actual] >= TIER_RANK[required];
+  const actualRank = TIER_RANK[actual];
+  const requiredRank = TIER_RANK[required];
+  if (actualRank === undefined || requiredRank === undefined) {
+    throw new Error(
+      `meetsMinimumTier: unrecognized tier value(s) — actual='${actual}', required='${required}'`,
+    );
+  }
+  return actualRank >= requiredRank;
 }
 
 /**

--- a/src/db/migrations/055_add_contact_tier_kind.sql
+++ b/src/db/migrations/055_add_contact_tier_kind.sql
@@ -1,0 +1,87 @@
+-- Up Migration
+--
+-- Issue #945: Add unified `tier` + `kind` columns to the contacts table.
+--
+-- DEPRECATION NOTE: The legacy `status` and `trust_level` columns are kept in place
+-- intentionally — they are NOT dropped in this migration (that happens in #955).
+-- New code reads `tier`; legacy code and any parallel branches still reading `status`
+-- are unaffected. Dual-writing both old and new columns keeps the change reversible.
+--
+-- Tier ordering (ascending trust):
+--   blocked < unknown < known < trusted < principal
+--
+-- Mapping from legacy columns:
+--   trust_level='ceo'  / system_role='principal'  → tier='principal'
+--   trust_level='high'                             → tier='trusted'
+--   trust_level='medium' OR status='confirmed'     → tier='known'
+--   trust_level='low'  OR status='provisional'     → tier='unknown'
+--   status='blocked'                               → tier='blocked'
+--
+-- Kind values:
+--   'principal'    — the human CEO that Curia serves (matches system_role='principal')
+--   'agent'        — Curia itself or another autonomous agent (matches system_role='agent')
+--   'organization' — a company or institution (linked KG node type='organization')
+--   'person'       — individual human contact (default for all others)
+--   'automated'    — automated sender (e.g. mailing list); opts out of tier gates in #953
+
+-- Add the tier column with CHECK constraint and a sensible default.
+-- Existing rows will be 'unknown' until the backfill UPDATE below runs.
+ALTER TABLE contacts ADD COLUMN tier TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE contacts ADD CONSTRAINT contacts_tier_check
+  CHECK (tier IN ('blocked', 'unknown', 'known', 'trusted', 'principal'));
+
+-- Add the kind column with CHECK constraint.
+-- Existing rows will be 'person' until the backfill UPDATE below runs.
+ALTER TABLE contacts ADD COLUMN kind TEXT NOT NULL DEFAULT 'person';
+ALTER TABLE contacts ADD CONSTRAINT contacts_kind_check
+  CHECK (kind IN ('person', 'organization', 'automated', 'principal', 'agent'));
+
+-- Index for filtering/sorting by tier — most dispatch-time queries filter on tier.
+-- Exclude 'unknown' (the high-cardinality default) to keep the index small and useful
+-- for the cases that matter: confirming who is trusted/principal/known/blocked.
+CREATE INDEX idx_contacts_tier ON contacts (tier) WHERE tier != 'unknown';
+
+-- Backfill tier from legacy columns.
+--
+-- Priority rules (checked in order, most specific first):
+-- 1. system_role='principal' → tier='principal'  (structural authority, trumps trust_level)
+-- 2. status='blocked'         → tier='blocked'
+-- 3. trust_level='ceo'        → tier='principal'  (deprecated ceo trust level)
+-- 4. trust_level='high'       → tier='trusted'
+-- 5. trust_level='medium'     → tier='known'
+-- 6. status='confirmed'       → tier='known'      (CEO approved but no explicit trust level)
+-- 7. trust_level='low'        → tier='unknown'
+-- 8. status='provisional'     → tier='unknown'    (unconfirmed, system-created)
+-- (default 'unknown' already set above — no final ELSE branch needed)
+UPDATE contacts
+SET tier = CASE
+  WHEN system_role = 'principal'   THEN 'principal'
+  WHEN status      = 'blocked'     THEN 'blocked'
+  WHEN trust_level = 'ceo'         THEN 'principal'
+  WHEN trust_level = 'high'        THEN 'trusted'
+  WHEN trust_level = 'medium'      THEN 'known'
+  WHEN status      = 'confirmed'   THEN 'known'
+  WHEN trust_level = 'low'         THEN 'unknown'
+  ELSE                                  'unknown'
+END;
+
+-- Backfill kind from system_role and linked KG node type.
+--
+-- Priority rules:
+-- 1. system_role='principal' → kind='principal'
+-- 2. system_role='agent'     → kind='agent'
+-- 3. linked KG node type='organization' → kind='organization'
+-- 4. all others              → kind='person'   (default already set above)
+UPDATE contacts c
+SET kind = CASE
+  WHEN c.system_role = 'principal'  THEN 'principal'
+  WHEN c.system_role = 'agent'      THEN 'agent'
+  WHEN EXISTS (
+    SELECT 1 FROM kg_nodes k
+    WHERE k.id = c.kg_node_id AND k.type = 'organization'
+  )                                 THEN 'organization'
+  ELSE                                   'person'
+END
+WHERE c.system_role IS NOT NULL
+   OR c.kg_node_id IS NOT NULL;
+-- (contacts with NULL system_role and NULL kg_node_id keep kind='person', the default)

--- a/src/db/migrations/055_add_contact_tier_kind.sql
+++ b/src/db/migrations/055_add_contact_tier_kind.sql
@@ -46,17 +46,22 @@ CREATE INDEX idx_contacts_tier ON contacts (tier) WHERE tier != 'unknown';
 -- Priority rules (checked in order, most specific first):
 -- 1. system_role='principal' → tier='principal'  (structural authority, trumps trust_level)
 -- 2. status='blocked'         → tier='blocked'
--- 3. trust_level='ceo'        → tier='principal'  (deprecated ceo trust level)
--- 4. trust_level='high'       → tier='trusted'
--- 5. trust_level='medium'     → tier='known'
--- 6. status='confirmed'       → tier='known'      (CEO approved but no explicit trust level)
--- 7. trust_level='low'        → tier='unknown'
--- 8. status='provisional'     → tier='unknown'    (unconfirmed, system-created)
+-- 3. status='provisional'     → tier='unknown'   (BEFORE trust_level branches — the old
+--                                                  authorization.ts gate refused to authorize
+--                                                  ANY provisional contact, so an elevated
+--                                                  trust_level on a provisional row must not
+--                                                  inflate the tier to 'known' or 'trusted')
+-- 4. trust_level='ceo'        → tier='principal'  (deprecated ceo trust level)
+-- 5. trust_level='high'       → tier='trusted'
+-- 6. trust_level='medium'     → tier='known'
+-- 7. status='confirmed'       → tier='known'      (CEO approved but no explicit trust level)
+-- 8. trust_level='low'        → tier='unknown'
 -- (default 'unknown' already set above — no final ELSE branch needed)
 UPDATE contacts
 SET tier = CASE
   WHEN system_role = 'principal'   THEN 'principal'
   WHEN status      = 'blocked'     THEN 'blocked'
+  WHEN status      = 'provisional' THEN 'unknown'
   WHEN trust_level = 'ceo'         THEN 'principal'
   WHEN trust_level = 'high'        THEN 'trusted'
   WHEN trust_level = 'medium'      THEN 'known'

--- a/src/db/migrations/055_add_contact_tier_kind.sql
+++ b/src/db/migrations/055_add_contact_tier_kind.sql
@@ -85,3 +85,13 @@ END
 WHERE c.system_role IS NOT NULL
    OR c.kg_node_id IS NOT NULL;
 -- (contacts with NULL system_role and NULL kg_node_id keep kind='person', the default)
+
+-- Down Migration
+--
+-- Reverses the schema additions only. The legacy `status`/`trust_level` columns
+-- were never touched by the Up migration, so they need no restoration here.
+-- Dropping the columns automatically drops their CHECK constraints and the
+-- partial index, but we drop the index explicitly first for clarity.
+DROP INDEX IF EXISTS idx_contacts_tier;
+ALTER TABLE contacts DROP COLUMN IF EXISTS tier;
+ALTER TABLE contacts DROP COLUMN IF EXISTS kind;

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -6,6 +6,7 @@ import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { ContactService } from '../contacts/contact-service.js';
 import type { HeldMessageService } from '../contacts/held-messages.js';
 import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy, TaskOriginator } from '../contacts/types.js';
+import { meetsMinimumTier } from '../contacts/types.js';
 import type { InboundScanner } from './inbound-scanner.js';
 import type { RateLimiter } from './rate-limiter.js';
 import type { DbPool } from '../db/connection.js';
@@ -311,19 +312,22 @@ export class Dispatcher {
             // Non-blocking — the trust score for THIS message already used the
             // stored contactConfidence. This update benefits the NEXT inbound.
             // Skip blocked contacts — they are being dropped and should not accrue history.
-            if (this.confidencePipeline && senderContext.status !== 'blocked') {
+            // Uses tier for the gate check (issue #945); tier='blocked' == old status='blocked'.
+            if (this.confidencePipeline && senderContext.tier !== 'blocked') {
               const resolvedContactId = senderContext.contactId;
               this.confidencePipeline.incrementalUpdate(resolvedContactId, { type: 'message_seen' })
                 .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'Confidence pipeline update failed (non-fatal)'));
             }
 
-            // Provisional contacts are treated like unknown senders for policy purposes.
-            // They have a contact record (so the resolver finds them), but the CEO hasn't
-            // confirmed them yet. Apply the same hold/reject policy as unknown senders.
-            if (senderContext.status === 'provisional' || senderContext.status === 'blocked') {
+            // Unknown/blocked contacts gate: applies to tier='unknown' (was: provisional) and
+            // tier='blocked'. These have a contact record (so the resolver finds them), but the
+            // contact has not been confirmed. Apply the same hold/reject policy as unknown senders.
+            // Uses tier for the gate check (issue #945): 'unknown' == old 'provisional',
+            // 'blocked' == old 'blocked'.
+            if (senderContext.tier === 'unknown' || senderContext.tier === 'blocked') {
               const policy = this.channelPolicies?.[payload.channelId];
 
-              if (senderContext.status === 'blocked') {
+              if (senderContext.tier === 'blocked') {
                 this.logger.info(
                   { channel: payload.channelId, senderId: payload.senderId, contactId: senderContext.contactId },
                   'Blocked sender — dropping message',
@@ -688,14 +692,14 @@ export class Dispatcher {
       // senders on 'allow' channels. Unknown senders on 'hold_and_notify' and 'ignore' channels
       // already returned early above, so there is no risk of double-holding here.
       //
-      // Confirmed contacts are exempt: a contact with status='confirmed' has passed explicit CEO
-      // approval and should route unconditionally regardless of contact_confidence. The floor is
-      // designed for unknown or provisional senders, not explicitly approved contacts. Provisional
-      // contacts still go through the floor check.
+      // Contacts with tier >= 'known' are exempt: a known/trusted/principal contact has been
+      // confirmed by the CEO and should route unconditionally regardless of contact_confidence.
+      // The floor is designed for unknown (provisional) senders, not confirmed contacts.
+      // Uses meetsMinimumTier() for the exemption check (issue #945).
       const policy = this.channelPolicies[payload.channelId];
       if (
         !threadTrusted &&
-        !(senderContext?.resolved && senderContext.status === 'confirmed') &&
+        !(senderContext?.resolved && meetsMinimumTier(senderContext.tier, 'known')) &&
         messageTrustScore < this.trustScoreFloor &&
         policy?.unknownSender !== 'ignore' &&
         this.heldMessages

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -80,10 +80,13 @@ export async function bootstrapAgentIdentity(
     // DEFAULT_OFFICE_IDENTITY seed) even after the operator changes it. The KG
     // node label clause above already does the same thing for the same reason.
     const contactResult = await pool.query<{ id: string }>(
-      `INSERT INTO contacts (kg_node_id, display_name, role, status, system_role, created_at, updated_at)
-       VALUES ($1, $2, 'agent', 'confirmed', 'agent', now(), now())
+      // tier/kind (migration 055) must be set explicitly: the column defaults
+      // ('unknown'/'person') would mis-classify the agent identity. 'known'/'agent'
+      // matches what migration 055's backfill derives for a confirmed system_role='agent' row.
+      `INSERT INTO contacts (kg_node_id, display_name, role, status, system_role, tier, kind, created_at, updated_at)
+       VALUES ($1, $2, 'agent', 'confirmed', 'agent', 'known', 'agent', now(), now())
        ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL
-       DO UPDATE SET display_name = EXCLUDED.display_name, role = 'agent', system_role = 'agent', updated_at = now()
+       DO UPDATE SET display_name = EXCLUDED.display_name, role = 'agent', system_role = 'agent', kind = 'agent', updated_at = now()
        RETURNING id`,
       [kgNodeId, displayName],
     );

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -86,7 +86,7 @@ export async function bootstrapAgentIdentity(
       `INSERT INTO contacts (kg_node_id, display_name, role, status, system_role, tier, kind, created_at, updated_at)
        VALUES ($1, $2, 'agent', 'confirmed', 'agent', 'known', 'agent', now(), now())
        ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL
-       DO UPDATE SET display_name = EXCLUDED.display_name, role = 'agent', system_role = 'agent', kind = 'agent', updated_at = now()
+       DO UPDATE SET display_name = EXCLUDED.display_name, role = 'agent', system_role = 'agent', tier = 'known', kind = 'agent', updated_at = now()
        RETURNING id`,
       [kgNodeId, displayName],
     );

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -548,7 +548,8 @@ export class OutboundGateway {
     try {
       const contact = await this.contactService.resolveByChannelIdentity(request.channel, recipientId);
       if (contact !== null) {
-        if (contact.status === 'blocked') {
+        // Use tier for the blocked check (issue #945); tier='blocked' == old status='blocked'.
+        if (contact.tier === 'blocked') {
           this.log.warn(
             { channel: request.channel, recipientId: redactId(recipientId), contactId: contact.contactId },
             'outbound-gateway: send blocked — recipient is blocked',
@@ -1085,11 +1086,12 @@ export class OutboundGateway {
       return;
     }
 
-    if (contact.status === 'blocked') {
+    if (contact.tier === 'blocked') {
       // Anomalous: the send proceeded despite the contact being blocked. This indicates
       // either a race (contact was blocked between the initial check and the send) or
       // a DB error on the earlier blocked-contact check that caused fail-open.
       // Log at error so this is visible in alerting — a message reached a blocked recipient.
+      // Uses tier for the gate check (issue #945); tier='blocked' == old status='blocked'.
       this.log.error(
         { channel, recipientId: redactId(recipientId), contactId: contact.contactId },
         'outbound-gateway: sent message to blocked contact — blocked-contact check may have been bypassed due to DB error',
@@ -1097,12 +1099,16 @@ export class OutboundGateway {
       return;
     }
 
-    if (contact.status === 'provisional') {
+    if (contact.tier === 'unknown') {
+      // tier='unknown' == old status='provisional'. The outbound send implicitly confirms
+      // this contact — we know the CEO's system is reaching out to them, so they're trusted
+      // enough to receive replies. Promote to 'known' tier (confirmed status).
+      // Uses tier for the gate check (issue #945).
       try {
         await this.contactService.setStatus(contact.contactId, 'confirmed');
         this.log.info(
           { channel, recipientId: redactId(recipientId), contactId: contact.contactId },
-          'outbound-gateway: promoted provisional contact to confirmed after outbound send',
+          'outbound-gateway: promoted unknown-tier contact to known after outbound send',
         );
       } catch (err) {
         this.log.warn(
@@ -1217,7 +1223,8 @@ export class OutboundGateway {
     // ------------------------------------------------------------------
     try {
       const contact = await this.contactService.resolveByChannelIdentity('email', recipientId);
-      if (contact !== null && contact.status === 'blocked') {
+      // Uses tier for the blocked check (issue #945); tier='blocked' == old status='blocked'.
+      if (contact !== null && contact.tier === 'blocked') {
         this.log.warn(
           { channel: 'email', recipientId: redactId(recipientId), contactId: contact.contactId },
           'outbound-gateway: draft blocked — recipient is blocked',
@@ -1326,7 +1333,8 @@ export class OutboundGateway {
     try {
       const contact = await this.contactService.resolveByChannelIdentity('email', recipientEmail);
       if (contact !== null) {
-        if (contact.status === 'blocked') {
+        // Uses tier for the blocked check (issue #945); tier='blocked' == old status='blocked'.
+        if (contact.tier === 'blocked') {
           this.log.warn(
             { draftId, recipientId: redactId(recipientEmail), contactId: contact.contactId },
             'outbound-gateway: draft send blocked — recipient is blocked',

--- a/tests/unit/channels/signal/group-trust.test.ts
+++ b/tests/unit/channels/signal/group-trust.test.ts
@@ -1,18 +1,37 @@
 import { describe, it, expect, vi } from 'vitest';
 import { checkGroupMemberTrust } from '../../../../src/channels/signal/group-trust.js';
 import type { ContactService } from '../../../../src/contacts/contact-service.js';
+import type { ContactTier } from '../../../../src/contacts/types.js';
+
+// Map legacy status values to their equivalent tier for test fixtures.
+// group-trust.ts now reads `tier` rather than `status` (issue #945).
+function statusToTier(status: 'confirmed' | 'provisional' | 'blocked'): ContactTier {
+  if (status === 'blocked')     return 'blocked';
+  if (status === 'provisional') return 'unknown';
+  return 'known'; // confirmed
+}
 
 /**
  * Build a ContactService mock that returns the provided contact record
  * for the given phone numbers, and null for any other identifier.
+ *
+ * Accepts `status` for readability, but also sets `tier` to keep mock objects
+ * consistent with the post-#945 ResolvedSender shape.
  */
 function makeContactService(
   responses: Record<string, { contactId: string; status: 'confirmed' | 'provisional' | 'blocked' } | null>,
 ): ContactService {
   return {
     resolveByChannelIdentity: vi.fn().mockImplementation(
-      (_channel: string, identifier: string) =>
-        Promise.resolve(responses[identifier] ?? null),
+      (_channel: string, identifier: string) => {
+        const entry = responses[identifier] ?? null;
+        if (!entry) return Promise.resolve(null);
+        return Promise.resolve({
+          ...entry,
+          // Populate `tier` derived from `status` so group-trust.ts's tier gate works.
+          tier: statusToTier(entry.status),
+        });
+      },
     ),
   } as unknown as ContactService;
 }

--- a/tests/unit/channels/signal/signal-adapter.test.ts
+++ b/tests/unit/channels/signal/signal-adapter.test.ts
@@ -7,7 +7,7 @@ import type { OutboundGateway } from '../../../../src/skills/outbound-gateway.js
 import type { ContactService } from '../../../../src/contacts/contact-service.js';
 import type { SignalEnvelope } from '../../../../src/channels/signal/types.js';
 import type { OutboundMessageEvent } from '../../../../src/bus/events.js';
-import type { ContactTier } from '../../../../src/contacts/types.js';
+import type { ContactTier, ContactStatus } from '../../../../src/contacts/types.js';
 import { createLogger } from '../../../../src/logger.js';
 import pino from 'pino';
 
@@ -61,13 +61,13 @@ function makeMockGateway() {
  * Map legacy status string to the equivalent ContactTier (issue #945).
  * signal-adapter.ts now reads `tier` rather than `status` for the isKnownSender check.
  */
-function statusToTier(status: string): ContactTier {
+function statusToTier(status: ContactStatus): ContactTier {
   if (status === 'blocked')     return 'blocked';
   if (status === 'provisional') return 'unknown';
   return 'known'; // confirmed
 }
 
-function makeMockContactService(resolved: { contactId: string; status: string } | null = null) {
+function makeMockContactService(resolved: { contactId: string; status: ContactStatus } | null = null) {
   // Populate `tier` derived from `status` so signal-adapter's tier gate works correctly.
   const resolvedWithTier = resolved ? { ...resolved, tier: statusToTier(resolved.status) } : null;
   return {

--- a/tests/unit/channels/signal/signal-adapter.test.ts
+++ b/tests/unit/channels/signal/signal-adapter.test.ts
@@ -7,6 +7,7 @@ import type { OutboundGateway } from '../../../../src/skills/outbound-gateway.js
 import type { ContactService } from '../../../../src/contacts/contact-service.js';
 import type { SignalEnvelope } from '../../../../src/channels/signal/types.js';
 import type { OutboundMessageEvent } from '../../../../src/bus/events.js';
+import type { ContactTier } from '../../../../src/contacts/types.js';
 import { createLogger } from '../../../../src/logger.js';
 import pino from 'pino';
 
@@ -56,9 +57,21 @@ function makeMockGateway() {
   } as unknown as OutboundGateway;
 }
 
+/**
+ * Map legacy status string to the equivalent ContactTier (issue #945).
+ * signal-adapter.ts now reads `tier` rather than `status` for the isKnownSender check.
+ */
+function statusToTier(status: string): ContactTier {
+  if (status === 'blocked')     return 'blocked';
+  if (status === 'provisional') return 'unknown';
+  return 'known'; // confirmed
+}
+
 function makeMockContactService(resolved: { contactId: string; status: string } | null = null) {
+  // Populate `tier` derived from `status` so signal-adapter's tier gate works correctly.
+  const resolvedWithTier = resolved ? { ...resolved, tier: statusToTier(resolved.status) } : null;
   return {
-    resolveByChannelIdentity: vi.fn().mockResolvedValue(resolved),
+    resolveByChannelIdentity: vi.fn().mockResolvedValue(resolvedWithTier),
     createContact: vi.fn().mockResolvedValue({ id: 'new-contact-id' }),
     linkIdentity: vi.fn().mockResolvedValue(undefined),
   } as unknown as ContactService;
@@ -413,7 +426,7 @@ describe('SignalAdapter', () => {
       ]);
       // contactService resolves the member as confirmed (trusted)
       (contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(
-        { contactId: 'c1', status: 'confirmed' },
+        { contactId: 'c1', status: 'confirmed', tier: 'known' as ContactTier },
       );
 
       rpcClient.simulateMessage(makeGroupEnvelope(GROUP_ID));
@@ -455,7 +468,7 @@ describe('SignalAdapter', () => {
         { id: GROUP_ID, name: 'G', members: [{ number: '+14155551234' }], pendingMembers: [], isMember: true },
       ]);
       (contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(
-        { contactId: 'c1', status: 'blocked' },
+        { contactId: 'c1', status: 'blocked', tier: 'blocked' as ContactTier },
       );
 
       rpcClient.simulateMessage(makeGroupEnvelope(GROUP_ID));

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -7,7 +7,7 @@ import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
 import type { ContactService } from '../../../src/contacts/contact-service.js';
 import type { DbPool } from '../../../src/db/connection.js';
-import type { InboundSenderContext, ContactStatus, TrustLevel, TaskOriginator } from '../../../src/contacts/types.js';
+import type { InboundSenderContext, ContactStatus, TrustLevel, TaskOriginator, ContactTier, ContactKind } from '../../../src/contacts/types.js';
 import { HeldMessageService } from '../../../src/contacts/held-messages.js';
 import { createLogger } from '../../../src/logger.js';
 
@@ -17,10 +17,21 @@ const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model
 // -- Test helpers --
 
 /**
+ * Derive the canonical tier from a legacy ContactStatus value for test fixtures.
+ * Mirrors the backfill logic in migration 055. Used to keep mock objects consistent
+ * with the post-#945 SenderContext shape without requiring a real DB.
+ */
+function statusToTier(status: ContactStatus): ContactTier {
+  if (status === 'blocked')     return 'blocked';
+  if (status === 'provisional') return 'unknown';
+  return 'known'; // confirmed
+}
+
+/**
  * Creates a mock ContactResolver that returns a resolved contact with the given trust inputs.
  * Used to exercise trust scoring paths without a real database.
  */
-function makeResolverWithContact(opts: { contactConfidence: number; trustLevel: TrustLevel | null; status: ContactStatus }): ContactResolver {
+function makeResolverWithContact(opts: { contactConfidence: number; trustLevel: TrustLevel | null; status: ContactStatus; tier?: ContactTier; kind?: ContactKind }): ContactResolver {
   return {
     resolve: async (_channel, _senderId) => ({
       resolved: true,
@@ -29,6 +40,9 @@ function makeResolverWithContact(opts: { contactConfidence: number; trustLevel: 
       role: null,
       systemRole: null,
       status: opts.status,
+      // Derive tier from status unless an explicit override is provided (issue #945).
+      tier: opts.tier ?? statusToTier(opts.status),
+      kind: opts.kind ?? 'person',
       verified: true,
       kgNodeId: null,
       knowledgeSummary: '',
@@ -221,11 +235,16 @@ describe('Dispatcher unknown_sender: ignore policy', () => {
         contactId: 'blocked-contact-id',
         displayName: 'Bad Actor',
         role: null,
+        systemRole: null,
         status: 'blocked',
+        tier: 'blocked' as ContactTier,
+        kind: 'person' as ContactKind,
         verified: false,
         kgNodeId: null,
         knowledgeSummary: '',
         authorization: null,
+        contactConfidence: 0,
+        trustLevel: null,
       } satisfies InboundSenderContext),
     } as unknown as ContactResolver;
 
@@ -857,11 +876,16 @@ describe('Dispatcher — rate limiting', () => {
         contactId: 'blocked-id',
         displayName: 'Bad Actor',
         role: null,
+        systemRole: null,
         status: 'blocked',
+        tier: 'blocked' as ContactTier,
+        kind: 'person' as ContactKind,
         verified: false,
         kgNodeId: null,
         knowledgeSummary: '',
         authorization: null,
+        contactConfidence: 0,
+        trustLevel: null,
       } satisfies InboundSenderContext),
     } as unknown as ContactResolver;
 
@@ -1537,6 +1561,8 @@ describe('originator metadata stamping', () => {
         role: 'ceo',
         systemRole: 'principal' as const,
         status: 'confirmed' as ContactStatus,
+        tier: 'principal' as ContactTier,
+        kind: 'principal' as ContactKind,
         verified: true,
         kgNodeId: null,
         knowledgeSummary: '',
@@ -1585,6 +1611,8 @@ describe('originator metadata stamping', () => {
         role: 'vendor',
         systemRole: null,
         status: 'confirmed' as ContactStatus,
+        tier: 'known' as ContactTier,
+        kind: 'person' as ContactKind,
         verified: true,
         kgNodeId: null,
         knowledgeSummary: '',
@@ -1634,6 +1662,8 @@ describe('originator metadata stamping', () => {
         role: 'vendor',
         systemRole: null,
         status: 'confirmed' as ContactStatus,
+        tier: 'known' as ContactTier,
+        kind: 'person' as ContactKind,
         verified: true,
         kgNodeId: null,
         knowledgeSummary: '',

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -102,6 +102,8 @@ describe('OutboundGateway', () => {
       displayName: 'Blocked Person',
       role: null,
       status: 'blocked',
+      tier: 'blocked',       // issue #945
+      kind: 'person',
       kgNodeId: null,
       verified: true,
     });
@@ -131,6 +133,8 @@ describe('OutboundGateway', () => {
       displayName: 'Confirmed Person',
       role: null,
       status: 'confirmed',
+      tier: 'known',         // issue #945
+      kind: 'person',
       kgNodeId: null,
       verified: true,
     });
@@ -291,6 +295,8 @@ describe('OutboundGateway', () => {
       displayName: 'Rita Recipient',
       role: null,
       status: 'confirmed',
+      tier: 'known',         // issue #945
+      kind: 'person',
       kgNodeId: null,
       verified: true,
       trustLevel: 'medium',
@@ -600,6 +606,8 @@ describe('OutboundGateway', () => {
         displayName: "CEO's EA",
         role: null,
         status: 'confirmed',
+        tier: 'trusted',     // trust_level='high' → tier='trusted' (issue #945)
+        kind: 'person',
         kgNodeId: null,
         verified: true,
         trustLevel: 'high',
@@ -811,6 +819,8 @@ describe('OutboundGateway.createEmailDraft', () => {
         resolveByChannelIdentity: vi.fn().mockResolvedValue({
           contactId: 'contact-blocked',
           status: 'blocked',
+          tier: 'blocked',   // issue #945
+          kind: 'person',
           trustLevel: null,
         }),
       },
@@ -1117,10 +1127,10 @@ describe('OutboundGateway contact promotion on successful send', () => {
 
     const contactService = {
       resolveByChannelIdentity: vi.fn()
-        // First call: blocked-contact check (returns provisional)
-        .mockResolvedValueOnce({ contactId: 'contact-donna', status: 'provisional', trustLevel: null })
-        // Second call: promotion lookup (returns provisional again)
-        .mockResolvedValueOnce({ contactId: 'contact-donna', status: 'provisional', trustLevel: null }),
+        // First call: blocked-contact check (returns provisional/unknown)
+        .mockResolvedValueOnce({ contactId: 'contact-donna', status: 'provisional', tier: 'unknown', kind: 'person', trustLevel: null })
+        // Second call: promotion lookup (returns provisional/unknown again)
+        .mockResolvedValueOnce({ contactId: 'contact-donna', status: 'provisional', tier: 'unknown', kind: 'person', trustLevel: null }),
       setStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ContactService;
 
@@ -1175,6 +1185,8 @@ describe('OutboundGateway contact promotion on successful send', () => {
       resolveByChannelIdentity: vi.fn().mockResolvedValue({
         contactId: 'contact-confirmed',
         status: 'confirmed',
+        tier: 'known',       // issue #945
+        kind: 'person',
         trustLevel: null,
       }),
       setStatus: vi.fn(),
@@ -1198,6 +1210,8 @@ describe('OutboundGateway contact promotion on successful send', () => {
       resolveByChannelIdentity: vi.fn().mockResolvedValue({
         contactId: 'contact-donna',
         status: 'confirmed',
+        tier: 'known',       // issue #945
+        kind: 'person',
         trustLevel: null,
       }),
     } as unknown as ContactService;
@@ -1542,6 +1556,8 @@ describe('PII redaction pipeline step', () => {
       contactId: 'contact-ceo',
       displayName: 'CEO',
       status: 'confirmed',
+      tier: 'principal',   // trust_level='ceo' → tier='principal' (issue #945)
+      kind: 'principal',
       trustLevel: 'ceo',
     });
 
@@ -1663,6 +1679,8 @@ describe('OutboundGateway.sendEmailDraft', () => {
         resolveByChannelIdentity: vi.fn().mockResolvedValue({
           contactId: 'contact-blocked',
           status: 'blocked',
+          tier: 'blocked',   // issue #945
+          kind: 'person',
           trustLevel: null,
         }),
       },
@@ -1790,6 +1808,8 @@ describe('OutboundGateway.sendEmailDraft', () => {
         displayName: 'Draft Recipient',
         role: null,
         status: 'confirmed',
+        tier: 'known',
+        kind: 'person',
         kgNodeId: null,
         verified: true,
         trustLevel: 'medium',
@@ -1866,6 +1886,8 @@ describe('humanApproved option on send()', () => {
       displayName: 'Blocked Person',
       role: null,
       status: 'blocked',
+      tier: 'blocked',
+      kind: 'person',
       kgNodeId: null,
       verified: true,
     });
@@ -2324,6 +2346,8 @@ describe('isSystemNotification option on send()', () => {
       displayName: 'Blocked',
       role: null,
       status: 'blocked',
+      tier: 'blocked',
+      kind: 'person',
       kgNodeId: null,
       verified: true,
     });
@@ -2398,6 +2422,8 @@ describe('outbound.delivered on Signal send', () => {
       displayName: 'Phone Friend',
       role: null,
       status: 'confirmed',
+      tier: 'known',
+      kind: 'person',
       kgNodeId: null,
       verified: true,
       trustLevel: 'medium',


### PR DESCRIPTION
## **User description**
## Summary

Closes #945.

Introduces the unified contact **`tier`** + **`kind`** model that the rest of milestone v0.36 builds on, collapsing the two overlapping legacy axes (`status`: confirmed/provisional/blocked, and `trust_level`: ceo/high/medium/low — set on only 8/317 prod rows) into a single ordered capability tier plus a descriptive facet.

- **`tier`** — single ordered axis that gates capability: `blocked` < `unknown` < `known` < `trusted` < `principal`.
- **`kind`** — descriptive facet: `person` / `organization` / `automated` / `principal` / `agent` (gates nothing yet; `automated` will opt out of gates in #953).
- **Migration 055** adds both columns (CHECK-constrained) and backfills from `status`/`trust_level`/`system_role`, preserving each contact's prior effective capability.
- All behavioral gates now read `tier` via the `meetsMinimumTier()` helper (dispatcher inbound gate, outbound gateway, Signal trust). Call sites never enumerate specific tiers.

**Deprecate, don't drop:** `status` and `trust_level` columns are intentionally kept and still populated. Final removal is tracked for #955. This keeps the change reversible and avoids breaking parallel work (e.g. #944, which still reads `status`).

## Deliberately out of scope (deferred)

- **Disclosure gate** (`pii-redactor`, `outbound-filter`, `trust-scorer`) stays on `trust_level` — migrated to `tier` in **#949**.
- **Action-gate authorization** (`authorization.ts`) stays on `status` — migrated in **#950**.

## Review

Reviewed by `code-reviewer` + `silent-failure-hunter`. Findings fixed in this branch:

- **Critical:** principal `INSERT` in `ensure-principal.ts` omitted `tier`/`kind` (would mis-tier the principal as `unknown` on the onboarding path) — now sets `principal`/`principal`.
- **Critical:** corrupt/unrecognized `tier` DB value silently fell back to permissive `unknown` — now **fails closed to `blocked`** with an error log (null/absent still maps to `unknown`).
- Merge survivorship now takes `max(primary.tier, secondary.tier)` (was dropping a secondary's `trusted` grant).
- Migration backfill prioritizes `provisional → unknown` above `trust_level` (was inflating anomalous rows).
- `meetsMinimumTier()` throws on unrecognized input (was silently returning `false`), matching the existing `authorization.ts` convention.
- Principal `kind` resolution is now authoritative + warns on a backfill miss.
- Added a down-migration to 055.

## Testing

- `pnpm run typecheck` — clean.
- Unit tests — 3585 pass (incl. new `meetsMinimumTier` throw-on-invalid tests).
- ⚠️ **DB-integration tests require a real Postgres and have not run locally** (no `DATABASE_URL`). They must run against a **dedicated test DB** in CI — the suites `DELETE FROM contacts/kg_nodes` in teardown, so they must never touch a live database. The migration backfill and tier-read behavior are proven by unit tests + review, pending the CI integration run.

## Follow-ups (tracked separately)

- `setTrustLevel` TOCTOU vs concurrent `setStatus('blocked')` — documented with a TODO; revisit if concurrent same-contact writes become real.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a refined contact trust model with unified tier levels (blocked, unknown, known, trusted, principal) and contact kind classifications, providing more granular capability-based access control.

* **Chores**
  * Updated trust-based decision logic throughout the platform to use the new tier system for contact gating and authorization.
  * Migrated existing contact data to populate tier and kind fields; legacy fields remain available for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add contact tiers and use them for trust checks**

### What Changed
- Introduced a new contact `tier` and `kind` model, with `tier` becoming the main way the app decides whether a contact is blocked, known, trusted, or the principal
- Updated inbound and outbound behavior to use `tier` for message gating, blocked-recipient checks, Signal group trust, and confirmed-contact exemptions
- Principal and agent contacts now keep the correct tier/kind values during bootstrap, onboarding, and race recovery instead of falling back to default values
- Contacts returned through the API now include the new `tier` and `kind` fields, and filtering can use `tier` directly
- Invalid stored tier values now fail closed instead of being treated as trusted, and Signal group trust now treats unrecognized tiers as unknown

### Impact
`✅ Fewer messages routed from unconfirmed contacts`
`✅ Clearer blocked-recipient enforcement`
`✅ Safer handling of corrupted contact data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
