### PR TITLE
feat: contact de-duplication via entity resolution (#944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Contact `tier` + `kind` model (migration 055)** — ordered capability `tier` and descriptive `kind`, backfilled from legacy fields. (#945)
+- **Contact de-duplication sweep (`dedup:contacts`)** — maintenance script that auto-merges structural duplicates (shared channel identity / same `kg_node_id` / exact name), files Curia-owned tasks for fuzzy matches, skips `dedup_exclusion` pairs, and never auto-merges the principal. Supports `--dry-run`. (#944)
+- **`dedup-classifier`** — pure module classifying a contact pair as `structural` or `fuzzy`; name/JW similarity is always fuzzy (never auto-merge). (#944)
+- **`writeExclusion` / `hasExclusion` helpers** — permanent `dedup_exclusion` KG facts so a declined pair is never re-surfaced. (#944)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "redteam": "promptfoo redteam run --config tests/redteam/promptfooconfig.yaml --env-file .env",
     "redteam:report": "promptfoo view",
     "backfill:contact-attributes": "tsx --env-file=.env scripts/backfill-contact-attributes.ts",
+    "dedup:contacts": "tsx --env-file=.env scripts/dedup-contacts.ts",
     "seed-vault": "tsx --env-file=.env scripts/seed-vault.ts"
   },
   "license": "MIT",

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -1,0 +1,587 @@
+// scripts/dedup-contacts.test.ts
+//
+// Tests for the contact deduplication maintenance script.
+//
+// Unit tests run without a database (mock pool). Integration tests are
+// guarded by `describeIf(DATABASE_URL)` and require a real Postgres connection.
+//
+// Behaviors under test:
+//   1. Structural pair → auto-merges (ContactService.mergeContacts called)
+//   2. Fuzzy pair → task created (no merge)
+//   3. Principal-involving pair → task created (no merge), even if structural
+//   4. Excluded pair → skipped (no merge, no task)
+//   5. Dry-run mode → no writes of any kind (no merges, no tasks)
+//   6. writeExclusion helper → writes the correct KG fact
+//   7. hasExclusion helper → correctly reads exclusion facts
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type pg from 'pg';
+import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
+import {
+  runDedup,
+  writeExclusion,
+  hasExclusion,
+  type DedupRunOptions,
+} from './dedup-contacts.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContact(
+  overrides: Partial<Contact> & { id: string; displayName: string },
+): Contact {
+  return {
+    kgNodeId: null,
+    role: null,
+    systemRole: null,
+    status: 'confirmed',
+    contactConfidence: 0.8,
+    trustLevel: null,
+    lastSeenAt: null,
+    inboundMessageCount: 0,
+    outboundMessageCount: 0,
+    notes: null,
+    preferredName: null,
+    title: null,
+    organization: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    timezone: null,
+    locale: null,
+    location: null,
+    pronouns: null,
+    linkedinUrl: null,
+    bio: null,
+    birthday: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+function makeIdentity(
+  contactId: string,
+  channel: string,
+  channelIdentifier: string,
+): ChannelIdentity {
+  return {
+    id: `${contactId}-${channel}`,
+    contactId,
+    channel,
+    channelIdentifier,
+    label: null,
+    verified: true,
+    verifiedAt: new Date('2026-01-01'),
+    status: 'active',
+    source: 'email_participant',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeMockPool(contacts: Contact[], identityMap: Map<string, ChannelIdentity[]>) {
+  return {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      if (typeof sql === 'string' && sql.includes('FROM contacts')) {
+        return { rows: contacts.map(c => ({
+          id: c.id,
+          display_name: c.displayName,
+          kg_node_id: c.kgNodeId,
+          system_role: c.systemRole,
+          status: c.status,
+          role: c.role,
+          contact_confidence: String(c.contactConfidence),
+          trust_level: c.trustLevel,
+          last_seen_at: c.lastSeenAt,
+          inbound_message_count: String(c.inboundMessageCount),
+          outbound_message_count: String(c.outboundMessageCount),
+          notes: c.notes,
+          created_at: c.createdAt,
+          updated_at: c.updatedAt,
+          preferred_name: c.preferredName,
+          title: c.title,
+          organization: c.organization,
+          primary_email: c.primaryEmail,
+          primary_phone: c.primaryPhone,
+          timezone: c.timezone,
+          locale: c.locale,
+          location: c.location,
+          pronouns: c.pronouns,
+          linkedin_url: c.linkedinUrl,
+          bio: c.bio,
+          birthday: c.birthday,
+        })) };
+      }
+      if (typeof sql === 'string' && sql.includes('FROM contact_channel_identities')) {
+        const contactId = params?.[0] as string;
+        return { rows: (identityMap.get(contactId) ?? []).map(i => ({
+          id: i.id,
+          contact_id: i.contactId,
+          channel: i.channel,
+          channel_identifier: i.channelIdentifier,
+          label: i.label,
+          verified: i.verified,
+          verified_at: i.verifiedAt,
+          status: i.status,
+          source: i.source,
+          created_at: i.createdAt,
+          updated_at: i.updatedAt,
+        })) };
+      }
+      // Default: return empty rows for INSERT/UPDATE
+      return { rows: [] };
+    }),
+  } as unknown as pg.Pool;
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (mock dependencies, no DB)
+// ---------------------------------------------------------------------------
+
+describe('runDedup — unit', () => {
+  let mergeMock: ReturnType<typeof vi.fn>;
+  let createTaskMock: ReturnType<typeof vi.fn>;
+  let storeFactMock: ReturnType<typeof vi.fn>;
+  let getFactsMock: ReturnType<typeof vi.fn>;
+  let opts: DedupRunOptions;
+
+  beforeEach(() => {
+    mergeMock = vi.fn().mockResolvedValue({
+      primaryContactId: 'c1',
+      secondaryContactId: 'c2',
+      goldenRecord: {},
+      dryRun: false,
+      mergedAt: new Date(),
+    });
+    createTaskMock = vi.fn().mockResolvedValue({ id: 'task-1', title: 'test' });
+    storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created', nodeId: 'fn-1' });
+    getFactsMock = vi.fn().mockResolvedValue([]);
+
+    opts = {
+      dryRun: false,
+      mergeContacts: mergeMock,
+      createTask: createTaskMock,
+      storeFact: storeFactMock,
+      getFacts: getFactsMock,
+    };
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 1: structural pair → auto-merge
+  // -------------------------------------------------------------------------
+
+  it('auto-merges structural pairs (shared channel identity)', async () => {
+    // Two contacts sharing the same email — structural proof
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Alice Smith' }),
+      makeContact({ id: 'c2', displayName: 'A. Smith' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>([
+      ['c1', [makeIdentity('c1', 'email', 'alice@example.com')]],
+      ['c2', [makeIdentity('c2', 'email', 'alice@example.com')]],
+    ]);
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(mergeMock).toHaveBeenCalledOnce();
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.mergedCount).toBe(1);
+    expect(result.taskCount).toBe(0);
+  });
+
+  it('auto-merges structural pairs (same kg_node_id)', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Bob Jones', kgNodeId: 'kg-xyz' }),
+      makeContact({ id: 'c2', displayName: 'Bobby Jones', kgNodeId: 'kg-xyz' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(mergeMock).toHaveBeenCalledOnce();
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.mergedCount).toBe(1);
+  });
+
+  it('auto-merges structural pairs (exact normalized name match)', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Carol White' }),
+      makeContact({ id: 'c2', displayName: 'carol white' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(mergeMock).toHaveBeenCalledOnce();
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.mergedCount).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: fuzzy pair → task (no merge)
+  // -------------------------------------------------------------------------
+
+  it('creates a task for fuzzy pairs and does NOT merge them', async () => {
+    // Similar but not identical names, no shared identities.
+    // Must be names that share no exact normalized variant — otherwise classifyPair
+    // returns 'structural' (exact initial variant match).
+    //
+    // "Mikael Sorensen" variants: ["mikael sorensen", "sorensen mikael", "m sorensen"]
+    // "Michael Sorenson" variants: ["michael sorenson", "sorenson michael", "m sorenson"]
+    // No shared exact variant ("m sorensen" ≠ "m sorenson", etc.).
+    // JW("mikael sorensen", "michael sorenson") is high (~0.88) → above 0.7 threshold.
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    // Should create a task, not merge
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(createTaskMock).toHaveBeenCalledOnce();
+    expect(result.mergedCount).toBe(0);
+    expect(result.taskCount).toBe(1);
+
+    // Task description must include both contact IDs for the contacts agent to act on
+    const taskArgs = createTaskMock.mock.calls[0]![0] as Record<string, unknown>;
+    const description = taskArgs.description as string;
+    expect(description).toContain('c1');
+    expect(description).toContain('c2');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: principal-involving pair → task (no merge), even if structural
+  // -------------------------------------------------------------------------
+
+  it('creates a task for a structural pair involving the principal (no auto-merge)', async () => {
+    // Principal contact with a structural match — must never auto-merge
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Diana Prince', systemRole: 'principal' }),
+      makeContact({ id: 'c2', displayName: 'Diana Prince' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>([
+      ['c1', [makeIdentity('c1', 'email', 'diana@example.com')]],
+      ['c2', [makeIdentity('c2', 'email', 'diana@example.com')]],
+    ]);
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    // Must NOT auto-merge even though it's structural proof
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(createTaskMock).toHaveBeenCalledOnce();
+    expect(result.mergedCount).toBe(0);
+    expect(result.taskCount).toBe(1);
+    expect(result.principalSkippedCount).toBe(1);
+  });
+
+  it('creates a task when the principal is contactB (the secondary)', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Eve Principal' }),
+      makeContact({ id: 'c2', displayName: 'Eve Principal', systemRole: 'principal' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    // Exact name match is structural, but principal is involved → task
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(result.principalSkippedCount).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: excluded pair → skipped
+  // -------------------------------------------------------------------------
+
+  it('skips pairs that have a dedup_exclusion fact', async () => {
+    // getFactsMock returns an exclusion fact for c1's KG node naming c2
+    getFactsMock.mockImplementation(async (kgNodeId: string) => {
+      if (kgNodeId === 'kg-c1') {
+        return [{
+          id: 'fn-excl',
+          type: 'fact',
+          label: 'dedup_exclusion: c2',
+          properties: { attribute: 'dedup_exclusion', value: 'c2' },
+          aliases: [],
+          embedding: null,
+          confidence: 1.0,
+          sensitivity: 'internal',
+          decayClass: 'permanent',
+          source: 'contacts-dedup',
+          temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
+        }];
+      }
+      return [];
+    });
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Frank Lee', kgNodeId: 'kg-c1' }),
+      makeContact({ id: 'c2', displayName: 'frank lee' }), // exact normalized match
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.skippedExcludedCount).toBe(1);
+  });
+
+  it('skips pairs where exclusion is recorded on contactB side', async () => {
+    getFactsMock.mockImplementation(async (kgNodeId: string) => {
+      if (kgNodeId === 'kg-c2') {
+        return [{
+          id: 'fn-excl',
+          type: 'fact',
+          label: 'dedup_exclusion: c1',
+          properties: { attribute: 'dedup_exclusion', value: 'c1' },
+          aliases: [],
+          embedding: null,
+          confidence: 1.0,
+          sensitivity: 'internal',
+          decayClass: 'permanent',
+          source: 'contacts-dedup',
+          temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
+        }];
+      }
+      return [];
+    });
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Grace Park' }),
+      makeContact({ id: 'c2', displayName: 'grace park', kgNodeId: 'kg-c2' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(result.skippedExcludedCount).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5: dry-run mode → no writes
+  // -------------------------------------------------------------------------
+
+  it('in dry-run mode, makes no merges and no task creation writes', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Harry Scott' }),
+      makeContact({ id: 'c2', displayName: 'harry scott' }), // structural exact match
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const dryRunOpts: DedupRunOptions = { ...opts, dryRun: true };
+    const result = await runDedup(contacts, identityMap, dryRunOpts);
+
+    // No writes
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(storeFactMock).not.toHaveBeenCalled();
+
+    // But report counts are accurate (reflecting what WOULD have been done)
+    expect(result.wouldMergeCount).toBeGreaterThan(0);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it('in dry-run mode, fuzzy pairs are reported but not acted on', async () => {
+    // "Mikael Sorensen" / "Michael Sorenson" — fuzzy pair (no shared exact variants, high JW).
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const dryRunOpts: DedupRunOptions = { ...opts, dryRun: true };
+    const result = await runDedup(contacts, identityMap, dryRunOpts);
+
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.dryRun).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Additional: transient merge failure does not abort the whole run
+  // -------------------------------------------------------------------------
+
+  it('continues after a merge failure and reports the error count', async () => {
+    mergeMock.mockRejectedValue(new Error('DB error'));
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Jake Park' }),
+      makeContact({ id: 'c2', displayName: 'jake park' }), // structural
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(result.errorCount).toBe(1);
+    expect(result.mergedCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeExclusion helper tests
+// ---------------------------------------------------------------------------
+
+describe('writeExclusion', () => {
+  it('calls storeFact with the correct attribute and value for a dedup_exclusion', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeId: 'kg-c1',
+      storeFact: storeFactMock,
+    });
+
+    expect(storeFactMock).toHaveBeenCalledOnce();
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.entityNodeId).toBe('kg-c1');
+    expect((args.properties as Record<string, unknown>).attribute).toBe('dedup_exclusion');
+    expect((args.properties as Record<string, unknown>).value).toBe('c2');
+    // Exclusion facts must be permanent so they survive decay
+    expect(args.decayClass).toBe('permanent');
+  });
+
+  it('writes the exclusion label in the expected format', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeId: 'kg-c1',
+      storeFact: storeFactMock,
+    });
+
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    // Label must follow the "field: value" format used by all KG facts
+    expect(args.label).toBe('dedup_exclusion: c2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasExclusion helper tests
+// ---------------------------------------------------------------------------
+
+describe('hasExclusion', () => {
+  it('returns true when the KG node has a dedup_exclusion fact for the other contact', async () => {
+    const exclusionFact = {
+      id: 'fn-1',
+      type: 'fact' as const,
+      label: 'dedup_exclusion: c2',
+      properties: { attribute: 'dedup_exclusion', value: 'c2' },
+      aliases: [],
+      embedding: null,
+      confidence: 1.0,
+      sensitivity: 'internal' as const,
+      decayClass: 'permanent' as const,
+      source: 'contacts-dedup',
+      temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
+    };
+
+    const getFactsMock = vi.fn().mockResolvedValue([exclusionFact]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when no dedup_exclusion fact exists', async () => {
+    const getFactsMock = vi.fn().mockResolvedValue([]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when neither contact has a kg_node_id', async () => {
+    const getFactsMock = vi.fn().mockResolvedValue([]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: null,
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    // No KG nodes → no exclusion facts possible
+    expect(result).toBe(false);
+    // Should not even call getFacts since there's nothing to query
+    expect(getFactsMock).not.toHaveBeenCalled();
+  });
+
+  it('checks both sides when both contacts have kg_node_ids', async () => {
+    // Exclusion is on contactB's KG node naming contactA
+    const getFactsMock = vi.fn().mockImplementation(async (kgNodeId: string) => {
+      if (kgNodeId === 'kg-c2') {
+        return [{
+          id: 'fn-1',
+          type: 'fact',
+          label: 'dedup_exclusion: c1',
+          properties: { attribute: 'dedup_exclusion', value: 'c1' },
+          aliases: [],
+          embedding: null,
+          confidence: 1.0,
+          sensitivity: 'internal',
+          decayClass: 'permanent',
+          source: 'contacts-dedup',
+          temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
+        }];
+      }
+      return [];
+    });
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: 'kg-c2',
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — guarded by DATABASE_URL
+// ---------------------------------------------------------------------------
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('runDedup — integration', () => {
+  // Integration tests exercising the full script against a real DB.
+  // Uses explicit DELETE cleanup in afterAll per project convention.
+  //
+  // NOTE: These are intentionally minimal — they verify the script can
+  // load and run against real tables. The full behavioral coverage is in the
+  // unit tests above. See src/contacts/dedup-classifier.test.ts for classifier
+  // coverage and tests/integration/contacts.test.ts for ContactService coverage.
+
+  it('placeholder: DATABASE_URL-gated integration tests', () => {
+    // Integration-level test scaffolding. Full integration test expansion
+    // is deferred — the unit coverage above validates all behavioral paths.
+    // TODO: Add integration tests that create real contacts, run the sweep,
+    //       and verify DB state (merge applied, task created, exclusion respected).
+    expect(true).toBe(true);
+  });
+});

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -15,7 +15,6 @@
 //   7. hasExclusion helper → correctly reads exclusion facts
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type pg from 'pg';
 import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
 import {
   runDedup,
@@ -81,72 +80,12 @@ function makeIdentity(
 }
 
 // ---------------------------------------------------------------------------
-// Mock factories
-// ---------------------------------------------------------------------------
-
-function makeMockPool(contacts: Contact[], identityMap: Map<string, ChannelIdentity[]>) {
-  return {
-    query: vi.fn(async (sql: string, params?: unknown[]) => {
-      if (typeof sql === 'string' && sql.includes('FROM contacts')) {
-        return { rows: contacts.map(c => ({
-          id: c.id,
-          display_name: c.displayName,
-          kg_node_id: c.kgNodeId,
-          system_role: c.systemRole,
-          status: c.status,
-          role: c.role,
-          contact_confidence: String(c.contactConfidence),
-          trust_level: c.trustLevel,
-          last_seen_at: c.lastSeenAt,
-          inbound_message_count: String(c.inboundMessageCount),
-          outbound_message_count: String(c.outboundMessageCount),
-          notes: c.notes,
-          created_at: c.createdAt,
-          updated_at: c.updatedAt,
-          preferred_name: c.preferredName,
-          title: c.title,
-          organization: c.organization,
-          primary_email: c.primaryEmail,
-          primary_phone: c.primaryPhone,
-          timezone: c.timezone,
-          locale: c.locale,
-          location: c.location,
-          pronouns: c.pronouns,
-          linkedin_url: c.linkedinUrl,
-          bio: c.bio,
-          birthday: c.birthday,
-        })) };
-      }
-      if (typeof sql === 'string' && sql.includes('FROM contact_channel_identities')) {
-        const contactId = params?.[0] as string;
-        return { rows: (identityMap.get(contactId) ?? []).map(i => ({
-          id: i.id,
-          contact_id: i.contactId,
-          channel: i.channel,
-          channel_identifier: i.channelIdentifier,
-          label: i.label,
-          verified: i.verified,
-          verified_at: i.verifiedAt,
-          status: i.status,
-          source: i.source,
-          created_at: i.createdAt,
-          updated_at: i.updatedAt,
-        })) };
-      }
-      // Default: return empty rows for INSERT/UPDATE
-      return { rows: [] };
-    }),
-  } as unknown as pg.Pool;
-}
-
-// ---------------------------------------------------------------------------
 // Unit tests (mock dependencies, no DB)
 // ---------------------------------------------------------------------------
 
 describe('runDedup — unit', () => {
   let mergeMock: ReturnType<typeof vi.fn>;
   let createTaskMock: ReturnType<typeof vi.fn>;
-  let storeFactMock: ReturnType<typeof vi.fn>;
   let getFactsMock: ReturnType<typeof vi.fn>;
   let opts: DedupRunOptions;
 
@@ -159,14 +98,13 @@ describe('runDedup — unit', () => {
       mergedAt: new Date(),
     });
     createTaskMock = vi.fn().mockResolvedValue({ id: 'task-1', title: 'test' });
-    storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created', nodeId: 'fn-1' });
     getFactsMock = vi.fn().mockResolvedValue([]);
 
     opts = {
       dryRun: false,
       mergeContacts: mergeMock,
       createTask: createTaskMock,
-      storeFact: storeFactMock,
+      // storeFact is not part of DedupRunOptions (F6)
       getFacts: getFactsMock,
     };
   });
@@ -379,13 +317,37 @@ describe('runDedup — unit', () => {
     const dryRunOpts: DedupRunOptions = { ...opts, dryRun: true };
     const result = await runDedup(contacts, identityMap, dryRunOpts);
 
-    // No writes
+    // No writes (storeFact is no longer part of DedupRunOptions — F6)
     expect(mergeMock).not.toHaveBeenCalled();
     expect(createTaskMock).not.toHaveBeenCalled();
-    expect(storeFactMock).not.toHaveBeenCalled();
 
     // But report counts are accurate (reflecting what WOULD have been done)
     expect(result.wouldMergeCount).toBeGreaterThan(0);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it('in dry-run mode, result includes errorCount so the caller can surface it in the summary log', async () => {
+    // F5: The DedupRunResult always has errorCount; the CLI summary must include it.
+    // We verify here that errorCount is present on the result (the CLI log inclusion
+    // is verified by reading the dedup-contacts.ts source — it's a documentation check
+    // rather than a runtime assertion).
+    //
+    // Trigger an error by making getFacts throw on the only structural pair.
+    getFactsMock.mockRejectedValue(new Error('DB error'));
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Dry Run Test', kgNodeId: 'kg-c1' }),
+      makeContact({ id: 'c2', displayName: 'dry run test', kgNodeId: 'kg-c2' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const dryRunOpts: DedupRunOptions = { ...opts, dryRun: true };
+    const result = await runDedup(contacts, identityMap, dryRunOpts);
+
+    // The error must be recorded even in dry-run mode
+    expect(result.errorCount).toBe(1);
+    // No merge or task creation (it was an error, not a successful classification)
+    expect(result.wouldMergeCount).toBe(0);
     expect(result.dryRun).toBe(true);
   });
 
@@ -422,6 +384,89 @@ describe('runDedup — unit', () => {
     expect(result.errorCount).toBe(1);
     expect(result.mergedCount).toBe(0);
   });
+
+  // -------------------------------------------------------------------------
+  // F2: merged-away contacts must be skipped in subsequent pairs
+  // -------------------------------------------------------------------------
+
+  it('skips a pair where one contact was already merged away by a prior pair', async () => {
+    // c1≡c2 (structural — shared email identity).
+    // c2≡c3 (structural — shared email identity).
+    // c1 and c3 do NOT share an identity and have different names, so (c1,c3) is NOT structural.
+    //
+    // Loop order: (c1,c2) merges first, c2 added to mergedAwayIds.
+    // Then (c1,c3) is checked — not structural (different names, no shared identity) → skipped (null).
+    // Then (c2,c3) is checked — c2 is in mergedAwayIds → skipped (no merge, no task).
+    // So mergeContacts is called exactly once (for c1/c2) and not again for the dead c2.
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Lena Kovacs Alpha' }),
+      makeContact({ id: 'c2', displayName: 'Lena Kovacs' }),
+      makeContact({ id: 'c3', displayName: 'Lena Kovacs Beta' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>([
+      // c1 and c2 share an email → structural pair
+      ['c1', [makeIdentity('c1', 'email', 'lena@example.com')]],
+      ['c2', [
+        makeIdentity('c2', 'email', 'lena@example.com'), // shared with c1
+        makeIdentity('c2', 'email', 'lena@other.com'),   // shared with c3
+      ]],
+      // c2 and c3 share a second email → structural pair
+      ['c3', [makeIdentity('c3', 'email', 'lena@other.com')]],
+    ]);
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    // Only the first structural pair (c1, c2) should be merged.
+    // The (c2, c3) pair must be skipped because c2 was merged away.
+    expect(mergeMock).toHaveBeenCalledTimes(1);
+    // errorCount must be 0 — the skipped pair is not an error
+    expect(result.errorCount).toBe(0);
+    expect(result.mergedCount).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // F4: errors during exclusion check / classify must fail closed
+  // -------------------------------------------------------------------------
+
+  it('skips pair and increments errorCount when getFacts throws, and continues to the next pair', async () => {
+    // c1 and c2 share an exact name — would normally be structural.
+    // But getFacts throws a DB error when checking exclusions for c1/c2.
+    // F4: must fail closed (no merge, no task), increment errorCount, and continue.
+    // c3 and c4 also share an exact name — should still be processed (no error on that pair).
+    getFactsMock.mockImplementation(async (kgNodeId: string) => {
+      // c1 has a kg_node_id; trigger the error only on that node
+      if (kgNodeId === 'kg-c1') {
+        throw new Error('DB connection error');
+      }
+      return [];
+    });
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Marco Polo', kgNodeId: 'kg-c1' }),
+      makeContact({ id: 'c2', displayName: 'marco polo' }), // structural — exact name; getFacts throws
+      makeContact({ id: 'c3', displayName: 'Anna Pavlova' }),
+      makeContact({ id: 'c4', displayName: 'anna pavlova' }), // structural — exact name; no error
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    // The c1/c2 pair errored — must not have merged and must have incremented errorCount
+    // The c3/c4 pair had no error — must have merged
+    expect(result.errorCount).toBe(1);
+    // At least the c3/c4 pair merged (the sweep continued after c1/c2 error)
+    expect(result.mergedCount).toBeGreaterThanOrEqual(1);
+
+    // Verify the c1/c2 pair specifically: mergeContacts must never have been called
+    // with c1 or c2 as arguments (fail closed — no merge on the errored pair)
+    const mergeCallArgs = mergeMock.mock.calls.map((call) => [call[0] as string, call[1] as string]);
+    const c1c2WasMerged = mergeCallArgs.some(
+      ([primary, secondary]) =>
+        (primary === 'c1' || primary === 'c2') &&
+        (secondary === 'c1' || secondary === 'c2'),
+    );
+    expect(c1c2WasMerged).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -433,7 +478,7 @@ describe('writeExclusion', () => {
     const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
 
     await writeExclusion({
-      contactAId: 'c1',
+      // contactAId removed from WriteExclusionOptions (F9) — kgNodeId is already A's node
       contactBId: 'c2',
       kgNodeId: 'kg-c1',
       storeFact: storeFactMock,
@@ -452,7 +497,6 @@ describe('writeExclusion', () => {
     const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
 
     await writeExclusion({
-      contactAId: 'c1',
       contactBId: 'c2',
       kgNodeId: 'kg-c1',
       storeFact: storeFactMock,
@@ -577,11 +621,6 @@ describeIf('runDedup — integration', () => {
   // unit tests above. See src/contacts/dedup-classifier.test.ts for classifier
   // coverage and tests/integration/contacts.test.ts for ContactService coverage.
 
-  it('placeholder: DATABASE_URL-gated integration tests', () => {
-    // Integration-level test scaffolding. Full integration test expansion
-    // is deferred — the unit coverage above validates all behavioral paths.
-    // TODO: Add integration tests that create real contacts, run the sweep,
-    //       and verify DB state (merge applied, task created, exclusion respected).
-    expect(true).toBe(true);
-  });
+  // TODO: Add integration tests that create real contacts, run the sweep,
+  //       and verify DB state (merge applied, task created, exclusion respected).
 });

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -389,15 +389,12 @@ describe('runDedup — unit', () => {
   // F2: merged-away contacts must be skipped in subsequent pairs
   // -------------------------------------------------------------------------
 
-  it('skips a pair where one contact was already merged away by a prior pair', async () => {
-    // c1≡c2 (structural — shared email identity).
-    // c2≡c3 (structural — shared email identity).
-    // c1 and c3 do NOT share an identity and have different names, so (c1,c3) is NOT structural.
-    //
-    // Loop order: (c1,c2) merges first, c2 added to mergedAwayIds.
-    // Then (c1,c3) is checked — not structural (different names, no shared identity) → skipped (null).
-    // Then (c2,c3) is checked — c2 is in mergedAwayIds → skipped (no merge, no task).
-    // So mergeContacts is called exactly once (for c1/c2) and not again for the dead c2.
+  it('merges transitively after a prior merge and skips the merged-away contact (M4 + F2)', async () => {
+    // c1≡c2 (shared email A) and c2≡c3 (shared email B); c2 bridges all three as one entity.
+    // Loop: (c1,c2) merges → c2 is merged away AND c1 absorbs c2's identities, incl. email B (M4).
+    // Then (c1,c3) now shares email B → transitive structural merge.
+    // (c2,c3) is skipped because c2 is merged away (F2).
+    // Net: all three collapse into c1 via two merges — (c1,c2) then (c1,c3).
     const contacts: Contact[] = [
       makeContact({ id: 'c1', displayName: 'Lena Kovacs Alpha' }),
       makeContact({ id: 'c2', displayName: 'Lena Kovacs' }),
@@ -416,12 +413,41 @@ describe('runDedup — unit', () => {
 
     const result = await runDedup(contacts, identityMap, opts);
 
-    // Only the first structural pair (c1, c2) should be merged.
-    // The (c2, c3) pair must be skipped because c2 was merged away.
-    expect(mergeMock).toHaveBeenCalledTimes(1);
-    // errorCount must be 0 — the skipped pair is not an error
+    // Two merges: (c1,c2) then the transitive (c1,c3). (c2,c3) is skipped because c2 is
+    // merged away, so c2 is never used as a merge argument again.
+    expect(mergeMock).toHaveBeenCalledTimes(2);
+    expect(mergeMock).toHaveBeenNthCalledWith(1, 'c1', 'c2');
+    expect(mergeMock).toHaveBeenNthCalledWith(2, 'c1', 'c3');
     expect(result.errorCount).toBe(0);
-    expect(result.mergedCount).toBe(1);
+    expect(result.mergedCount).toBe(2);
+  });
+
+  it('dry-run marks would-be-merged contacts away so counts are not inflated (M3)', async () => {
+    // c1≡c2 (shared email A), c2≡c3 (shared email B); names are dissimilar so the only
+    // matches are the structural identity ones. In dry-run nothing is written and
+    // identities are not reattached, so (c1,c3) is not transitive here — but (c2,c3)
+    // must still be skipped because c2 is marked merged-away. Without M3 it would be
+    // double-counted as a second would-merge.
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Alpha One' }),
+      makeContact({ id: 'c2', displayName: 'Beta Two' }),
+      makeContact({ id: 'c3', displayName: 'Gamma Three' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>([
+      ['c1', [makeIdentity('c1', 'email', 'one@example.com')]],
+      ['c2', [
+        makeIdentity('c2', 'email', 'one@example.com'),
+        makeIdentity('c2', 'email', 'two@example.com'),
+      ]],
+      ['c3', [makeIdentity('c3', 'email', 'two@example.com')]],
+    ]);
+
+    const result = await runDedup(contacts, identityMap, { ...opts, dryRun: true });
+
+    // Only (c1,c2) counted; (c2,c3) skipped because c2 is marked merged-away. No real merges.
+    expect(result.wouldMergeCount).toBe(1);
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(result.mergedCount).toBe(0);
   });
 
   // -------------------------------------------------------------------------

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -631,22 +631,6 @@ describe('hasExclusion', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Integration tests — guarded by DATABASE_URL
-// ---------------------------------------------------------------------------
-
-const DATABASE_URL = process.env['DATABASE_URL'];
-const describeIf = DATABASE_URL ? describe : describe.skip;
-
-describeIf('runDedup — integration', () => {
-  // Integration tests exercising the full script against a real DB.
-  // Uses explicit DELETE cleanup in afterAll per project convention.
-  //
-  // NOTE: These are intentionally minimal — they verify the script can
-  // load and run against real tables. The full behavioral coverage is in the
-  // unit tests above. See src/contacts/dedup-classifier.test.ts for classifier
-  // coverage and tests/integration/contacts.test.ts for ContactService coverage.
-
-  // TODO: Add integration tests that create real contacts, run the sweep,
-  //       and verify DB state (merge applied, task created, exclusion respected).
-});
+// Full-script integration coverage against a real Postgres (create contacts,
+// run the real merge path, assert DB state + audit row) lives in
+// tests/integration/dedup-contacts-merge.test.ts.

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -160,6 +160,23 @@ describe('runDedup — unit', () => {
     expect(result.mergedCount).toBe(1);
   });
 
+  it('picks the contact WITH a kg_node_id as the survivor, regardless of ID order', async () => {
+    // c1 < c2 lexicographically, but only c2 has a KG link. mergeContacts() keeps the
+    // primary and would orphan c2's KG node if c1 were chosen — so c2 must be the primary.
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Otto Becker' }),
+      makeContact({ id: 'c2', displayName: 'otto becker', kgNodeId: 'kg-c2' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(mergeMock).toHaveBeenCalledOnce();
+    // Survivor (primary) is c2 (the KG-bearing side); c1 is the secondary that gets deleted.
+    expect(mergeMock).toHaveBeenCalledWith('c2', 'c1');
+    expect(result.mergedCount).toBe(1);
+  });
+
   // -------------------------------------------------------------------------
   // Test 2: fuzzy pair → task (no merge)
   // -------------------------------------------------------------------------
@@ -231,6 +248,26 @@ describe('runDedup — unit', () => {
     // Exact name match is structural, but principal is involved → task
     expect(mergeMock).not.toHaveBeenCalled();
     expect(result.principalSkippedCount).toBe(1);
+  });
+
+  it('does NOT count a FUZZY principal pair toward principalSkippedCount', async () => {
+    // Similar-but-not-identical names (fuzzy, not structural) where one side is the principal.
+    // A fuzzy pair never auto-merges anyway, so it is an ordinary recommendation task and
+    // must NOT inflate principalSkippedCount (which counts only structural pairs withheld
+    // from auto-merge by the principal guard).
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen', systemRole: 'principal' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    // Fuzzy → a task is created, no merge, and the principal counter stays at 0.
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(createTaskMock).toHaveBeenCalledOnce();
+    expect(result.taskCount).toBe(1);
+    expect(result.principalSkippedCount).toBe(0);
   });
 
   // -------------------------------------------------------------------------

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -1,0 +1,668 @@
+// scripts/dedup-contacts.ts
+//
+// Contact de-duplication maintenance sweep.
+//
+// Implements GitHub issue #944: Contact de-duplication via entity resolution.
+//
+// Merge strategy:
+//   - Structural pair (shared channel identity / same kg_node_id / exact name) → auto-merge
+//     UNLESS either contact is the principal (system_role='principal') → task instead.
+//   - Fuzzy pair (name/JW similarity) → Curia-owned task (never auto-merge).
+//   - Excluded pair (dedup_exclusion KG fact) → skip entirely.
+//
+// Dry-run mode (--dry-run flag): reports what would happen without writing anything.
+//
+// Run: pnpm run dedup:contacts [--dry-run]
+
+import pg from 'pg';
+import pino from 'pino';
+import { classifyPair } from '../src/contacts/dedup-classifier.js';
+import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
+import type { KgNode } from '../src/memory/types.js';
+import type { StoreFactOptions } from '../src/memory/types.js';
+
+const logger = pino({ name: 'dedup-contacts' });
+
+const { Pool } = pg;
+
+// ---------------------------------------------------------------------------
+// Public types (exported for tests)
+// ---------------------------------------------------------------------------
+
+export interface DedupRunResult {
+  dryRun: boolean;
+  /** Number of pairs successfully auto-merged (0 in dry-run). */
+  mergedCount: number;
+  /** Number of fuzzy pairs that had tasks created (0 in dry-run). */
+  taskCount: number;
+  /** Number of pairs skipped due to dedup_exclusion facts. */
+  skippedExcludedCount: number;
+  /** Number of structural pairs involving the principal (routed to task instead of merge). */
+  principalSkippedCount: number;
+  /** Number of pairs that would have been merged (dry-run report). */
+  wouldMergeCount: number;
+  /** Number of pairs that would have had tasks created (dry-run report). */
+  wouldCreateTaskCount: number;
+  /** Number of errors during merge/task-create operations. */
+  errorCount: number;
+}
+
+/** Dependency-injected callbacks used by runDedup() — allows unit testing without a DB. */
+export interface DedupRunOptions {
+  dryRun: boolean;
+  /** Calls ContactService.mergeContacts (or equivalent). Returns a MergeResult. */
+  mergeContacts: (primaryId: string, secondaryId: string) => Promise<unknown>;
+  /** Calls TaskRepo.createTask (or equivalent). */
+  createTask: (params: {
+    agentId: string;
+    title: string;
+    description: string;
+    owner: 'curia';
+    source: 'agent';
+    sourceAgentId: string;
+    tags: string[];
+  }) => Promise<unknown>;
+  /** Calls EntityMemory.storeFact (or equivalent). */
+  storeFact: (options: StoreFactOptions) => Promise<unknown>;
+  /** Calls EntityMemory.getFacts for a KG node — returns fact nodes. */
+  getFacts: (kgNodeId: string) => Promise<KgNode[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Exclusion helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+export interface WriteExclusionOptions {
+  contactAId: string;
+  contactBId: string;
+  /** KG node on which to record the exclusion fact. */
+  kgNodeId: string;
+  storeFact: (options: StoreFactOptions) => Promise<unknown>;
+}
+
+/**
+ * Record a dedup_exclusion KG fact on kgNodeId naming contactBId.
+ *
+ * This is the memory-store path for a "do not suggest again" signal.
+ * The fact uses permanent decay so it survives the normal slow/fast decay
+ * schedule and is never quietly discarded.
+ *
+ * Format follows the convention used by backfill-contact-attributes:
+ *   label: "dedup_exclusion: <otherContactId>"
+ *   properties.attribute = 'dedup_exclusion'
+ *   properties.value     = otherContactId
+ */
+export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
+  const { contactAId: _contactAId, contactBId, kgNodeId, storeFact } = opts;
+  await storeFact({
+    entityNodeId: kgNodeId,
+    label: `dedup_exclusion: ${contactBId}`,
+    properties: { attribute: 'dedup_exclusion', value: contactBId },
+    // Permanent decay — exclusion decisions must not quietly expire
+    decayClass: 'permanent',
+    confidence: 1.0,
+    source: 'contacts-dedup',
+    sensitivity: 'internal',
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+export interface HasExclusionOptions {
+  contactAId: string;
+  contactBId: string;
+  kgNodeIdA: string | null;
+  kgNodeIdB: string | null;
+  getFacts: (kgNodeId: string) => Promise<KgNode[]>;
+}
+
+/**
+ * Check whether either contact has recorded a dedup_exclusion fact naming the other.
+ *
+ * Returns true if an exclusion exists in either direction (A→B or B→A).
+ * Returns false immediately if neither contact has a kg_node_id (no facts possible).
+ */
+export async function hasExclusion(opts: HasExclusionOptions): Promise<boolean> {
+  const { contactAId, contactBId, kgNodeIdA, kgNodeIdB, getFacts } = opts;
+
+  // Short-circuit: no KG nodes means no facts can exist
+  if (kgNodeIdA === null && kgNodeIdB === null) return false;
+
+  // Check A's node for an exclusion naming B
+  if (kgNodeIdA !== null) {
+    const factsA = await getFacts(kgNodeIdA);
+    for (const fact of factsA) {
+      const props = fact.properties as Record<string, unknown>;
+      if (props.attribute === 'dedup_exclusion' && props.value === contactBId) {
+        return true;
+      }
+    }
+  }
+
+  // Check B's node for an exclusion naming A
+  if (kgNodeIdB !== null) {
+    const factsB = await getFacts(kgNodeIdB);
+    for (const fact of factsB) {
+      const props = fact.properties as Record<string, unknown>;
+      if (props.attribute === 'dedup_exclusion' && props.value === contactAId) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Core sweep logic (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the deduplication sweep over the supplied contacts.
+ *
+ * This function contains all the decision logic (structural vs fuzzy, principal
+ * guard, exclusion check, dry-run) and is injected with callbacks so it can be
+ * unit-tested without a real database.
+ *
+ * @param contacts - all active contacts to sweep
+ * @param identityMap - channel identities keyed by contactId
+ * @param opts - injected dependencies + dryRun flag
+ */
+export async function runDedup(
+  contacts: Contact[],
+  identityMap: Map<string, ChannelIdentity[]>,
+  opts: DedupRunOptions,
+): Promise<DedupRunResult> {
+  const { dryRun, mergeContacts, createTask, storeFact, getFacts } = opts;
+
+  const result: DedupRunResult = {
+    dryRun,
+    mergedCount: 0,
+    taskCount: 0,
+    skippedExcludedCount: 0,
+    principalSkippedCount: 0,
+    wouldMergeCount: 0,
+    wouldCreateTaskCount: 0,
+    errorCount: 0,
+  };
+
+  if (contacts.length < 2) return result;
+
+  // Track pairs we've already handled to avoid double-processing (A,B) and (B,A).
+  const processedPairs = new Set<string>();
+
+  // We need a canonical ordering for pair keys
+  function pairKey(aId: string, bId: string): string {
+    return aId < bId ? `${aId}:${bId}` : `${bId}:${aId}`;
+  }
+
+  for (let i = 0; i < contacts.length; i++) {
+    for (let j = i + 1; j < contacts.length; j++) {
+      const a = contacts[i]!;
+      const b = contacts[j]!;
+
+      const key = pairKey(a.id, b.id);
+      if (processedPairs.has(key)) continue;
+      processedPairs.add(key);
+
+      const aIdentities = identityMap.get(a.id) ?? [];
+      const bIdentities = identityMap.get(b.id) ?? [];
+
+      // Classify the pair: structural, fuzzy, or null (below threshold)
+      const classification = classifyPair(a, aIdentities, b, bIdentities);
+      if (classification === null) continue;
+
+      // ------------------------------------------------------------------
+      // Check for a prior dedup_exclusion in either direction
+      // ------------------------------------------------------------------
+      // We check regardless of classification type — exclusions apply to all matches.
+      const excluded = await hasExclusion({
+        contactAId: a.id,
+        contactBId: b.id,
+        kgNodeIdA: a.kgNodeId,
+        kgNodeIdB: b.kgNodeId,
+        getFacts,
+      });
+      if (excluded) {
+        logger.debug({ contactAId: a.id, contactBId: b.id }, 'dedup: skipped — dedup_exclusion fact present');
+        result.skippedExcludedCount++;
+        continue;
+      }
+
+      // ------------------------------------------------------------------
+      // Principal guard: never auto-merge a pair involving the principal
+      // ------------------------------------------------------------------
+      const involvePrincipal = a.systemRole === 'principal' || b.systemRole === 'principal';
+
+      if (classification.type === 'structural' && !involvePrincipal) {
+        // ------------------------------------------------------------------
+        // Structural pair — auto-merge
+        // ------------------------------------------------------------------
+        // Choose the primary: prefer the contact with the lower string ID (arbitrary
+        // but stable tiebreaker). In practice the contacts specialist may have a smarter
+        // selection policy, but for the maintenance script determinism is more important
+        // than optimal selection.
+        const [primaryId, secondaryId] = a.id < b.id ? [a.id, b.id] : [b.id, a.id];
+
+        logger.info(
+          { primaryId, secondaryId, reason: classification.reason },
+          'dedup: structural proof — auto-merging',
+        );
+
+        if (dryRun) {
+          result.wouldMergeCount++;
+          continue;
+        }
+
+        try {
+          await mergeContacts(primaryId!, secondaryId!);
+          result.mergedCount++;
+          logger.info({ primaryId, secondaryId }, 'dedup: merge complete');
+        } catch (err) {
+          logger.error({ err, primaryId, secondaryId }, 'dedup: merge failed — continuing');
+          result.errorCount++;
+        }
+      } else {
+        // ------------------------------------------------------------------
+        // Fuzzy pair OR structural pair involving the principal → task
+        // ------------------------------------------------------------------
+        // Name/embedding similarity alone is never enough to auto-merge (see design).
+        // Also, any pair touching the principal must go through human review even when
+        // structural proof exists — identity mistakes for the principal are too costly.
+        if (involvePrincipal) {
+          result.principalSkippedCount++;
+          logger.info(
+            { contactAId: a.id, contactBId: b.id, reason: classification.reason },
+            'dedup: principal contact involved — routing to task instead of auto-merge',
+          );
+        } else {
+          logger.info(
+            { contactAId: a.id, contactBId: b.id, classification },
+            'dedup: fuzzy match — creating recommendation task',
+          );
+        }
+
+        if (dryRun) {
+          result.wouldCreateTaskCount++;
+          continue;
+        }
+
+        try {
+          // The task description must include both contact IDs so the contacts specialist
+          // can fetch them and decide how to proceed. Use structured JSON-like format
+          // so the agent can reliably parse the IDs.
+          const description = [
+            `Possible duplicate contacts detected by the dedup maintenance sweep.`,
+            ``,
+            `Contact A ID: ${a.id}  (${a.displayName})`,
+            `Contact B ID: ${b.id}  (${b.displayName})`,
+            ``,
+            `Match type: ${classification.type}`,
+            `Reason: ${classification.reason}`,
+            classification.type === 'fuzzy' ? `Score: ${classification.score.toFixed(3)}` : '',
+            ``,
+            involvePrincipal
+              ? `NOTE: One of these contacts is the principal — this pair was intentionally withheld from auto-merge and requires manual verification.`
+              : `Please verify these are the same person, then either merge them or mark them as not duplicates (which will prevent future re-surfacing).`,
+          ].filter(line => line !== undefined).join('\n');
+
+          await createTask({
+            agentId: 'contacts',
+            title: `Review possible duplicate: ${a.displayName} / ${b.displayName}`,
+            description,
+            owner: 'curia',
+            source: 'agent',
+            sourceAgentId: 'contacts',
+            tags: ['dedup', 'contacts'],
+          });
+          result.taskCount++;
+        } catch (err) {
+          logger.error({ err, contactAId: a.id, contactBId: b.id }, 'dedup: task creation failed — continuing');
+          result.errorCount++;
+        }
+      }
+    }
+  }
+
+  logger.info(result, 'dedup: sweep complete');
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// DB data loading helpers
+// ---------------------------------------------------------------------------
+
+type ContactRow = {
+  id: string;
+  kg_node_id: string | null;
+  display_name: string;
+  role: string | null;
+  system_role: string | null;
+  status: string;
+  contact_confidence: string;
+  trust_level: string | null;
+  last_seen_at: Date | null;
+  inbound_message_count: string;
+  outbound_message_count: string;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+  preferred_name: string | null;
+  title: string | null;
+  organization: string | null;
+  primary_email: string | null;
+  primary_phone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedin_url: string | null;
+  bio: string | null;
+  birthday: string | null;
+};
+
+type IdentityRow = {
+  id: string;
+  contact_id: string;
+  channel: string;
+  channel_identifier: string;
+  label: string | null;
+  verified: boolean;
+  verified_at: Date | null;
+  status: string;
+  source: string;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function rowToContact(row: ContactRow): Contact {
+  return {
+    id: row.id,
+    kgNodeId: row.kg_node_id,
+    displayName: row.display_name,
+    role: row.role,
+    systemRole: (row.system_role === 'principal' || row.system_role === 'agent' || row.system_role === 'system')
+      ? row.system_role
+      : null,
+    status: row.status as Contact['status'],
+    contactConfidence: Number(row.contact_confidence),
+    trustLevel: row.trust_level as Contact['trustLevel'],
+    lastSeenAt: row.last_seen_at,
+    inboundMessageCount: Number(row.inbound_message_count),
+    outboundMessageCount: Number(row.outbound_message_count),
+    notes: row.notes,
+    preferredName: row.preferred_name,
+    title: row.title,
+    organization: row.organization,
+    primaryEmail: row.primary_email,
+    primaryPhone: row.primary_phone,
+    timezone: row.timezone,
+    locale: row.locale,
+    location: row.location,
+    pronouns: row.pronouns,
+    linkedinUrl: row.linkedin_url,
+    bio: row.bio,
+    birthday: row.birthday,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToIdentity(row: IdentityRow): ChannelIdentity {
+  return {
+    id: row.id,
+    contactId: row.contact_id,
+    channel: row.channel,
+    channelIdentifier: row.channel_identifier,
+    label: row.label,
+    verified: row.verified,
+    verifiedAt: row.verified_at,
+    status: row.status as ChannelIdentity['status'],
+    source: row.source as ChannelIdentity['source'],
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function loadContactsAndIdentities(pool: pg.Pool): Promise<{
+  contacts: Contact[];
+  identityMap: Map<string, ChannelIdentity[]>;
+}> {
+  // Load only 'confirmed' and 'provisional' contacts — skip 'blocked'.
+  // Blocked contacts should not be merged; they are deliberately excluded.
+  const contactsResult = await pool.query<ContactRow>(
+    `SELECT id, kg_node_id, display_name, role, system_role, status, contact_confidence,
+            trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes,
+            created_at, updated_at, preferred_name, title, organization, primary_email,
+            primary_phone, timezone, locale, location, pronouns, linkedin_url, bio, birthday
+     FROM contacts
+     WHERE status IN ('confirmed', 'provisional')
+     ORDER BY created_at ASC`,
+  );
+  const contacts = contactsResult.rows.map(rowToContact);
+
+  // Load all identities for the fetched contacts in one query.
+  // The contact IDs are parameterized via ANY($1) to avoid string interpolation.
+  const contactIds = contacts.map(c => c.id);
+  const identityMap = new Map<string, ChannelIdentity[]>();
+
+  if (contactIds.length === 0) return { contacts, identityMap };
+
+  const identitiesResult = await pool.query<IdentityRow>(
+    `SELECT id, contact_id, channel, channel_identifier, label, verified, verified_at,
+            status, source, created_at, updated_at
+     FROM contact_channel_identities
+     WHERE contact_id = ANY($1)
+       AND status = 'active'`,
+    [contactIds],
+  );
+
+  for (const row of identitiesResult.rows) {
+    const identity = rowToIdentity(row);
+    const existing = identityMap.get(identity.contactId);
+    if (existing) {
+      existing.push(identity);
+    } else {
+      identityMap.set(identity.contactId, [identity]);
+    }
+  }
+
+  return { contacts, identityMap };
+}
+
+// ---------------------------------------------------------------------------
+// KG fact helpers for use with the real pool
+// ---------------------------------------------------------------------------
+
+async function getFactsFromDb(pool: pg.Pool, kgNodeId: string): Promise<KgNode[]> {
+  // Replicates the query used in EntityMemory.getFacts().
+  // Returns all fact nodes reachable via a 'relates_to' edge from the given node.
+  const result = await pool.query<{
+    id: string;
+    type: string;
+    label: string;
+    properties: Record<string, unknown>;
+    embedding: number[] | null;
+    confidence: string;
+    decay_class: string;
+    source: string;
+    sensitivity: string;
+    aliases: string[];
+    created_at: Date;
+    last_confirmed_at: Date;
+  }>(
+    `SELECT n.id, n.type, n.label, n.properties, n.embedding, n.confidence,
+            n.decay_class, n.source, n.sensitivity, n.aliases,
+            n.created_at, n.last_confirmed_at
+     FROM kg_nodes n
+     JOIN kg_edges e ON (
+       (e.source_node_id = $1 AND e.target_node_id = n.id)
+       OR (e.target_node_id = $1 AND e.source_node_id = n.id)
+     )
+     WHERE e.type = 'relates_to'
+       AND e.archived_at IS NULL
+       AND n.type = 'fact'
+       AND n.archived_at IS NULL`,
+    [kgNodeId],
+  );
+
+  return result.rows.map(row => ({
+    id: row.id,
+    type: row.type as KgNode['type'],
+    label: row.label,
+    properties: row.properties,
+    embedding: row.embedding ?? undefined,
+    confidence: Number(row.confidence),
+    decayClass: row.decay_class as KgNode['decayClass'],
+    source: row.source,
+    sensitivity: row.sensitivity as KgNode['sensitivity'],
+    aliases: row.aliases,
+    temporal: {
+      createdAt: row.created_at,
+      lastConfirmedAt: row.last_confirmed_at,
+    },
+  }));
+}
+
+async function storeFactInDb(pool: pg.Pool, options: StoreFactOptions): Promise<void> {
+  // Write a KG fact via direct SQL (no EntityMemory available in the script context
+  // because EntityMemory requires EmbeddingService and MemoryValidator).
+  //
+  // This is intentionally minimal: we only need to write exclusion facts, which have
+  // a known schema (attribute/value properties, permanent decay). If a full EntityMemory
+  // is needed in future the script can be wired with real DI.
+  //
+  // The label "dedup_exclusion: <id>" is short, ascii-only — no embedding needed.
+  // We insert with embedding = NULL (allowed; the vector column is nullable).
+  await pool.query(
+    `INSERT INTO kg_nodes (
+       type, label, properties, confidence, decay_class, source, sensitivity,
+       aliases, created_at, last_confirmed_at
+     ) VALUES (
+       'fact', $1, $2, $3, $4, $5, $6, '{}', NOW(), NOW()
+     )`,
+    [
+      options.label,
+      JSON.stringify(options.properties ?? {}),
+      options.confidence ?? 0.7,
+      options.decayClass ?? 'permanent',
+      options.source,
+      options.sensitivity ?? 'internal',
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const databaseUrl = process.env['DATABASE_URL'];
+  if (!databaseUrl) {
+    logger.error('dedup-contacts: DATABASE_URL is not set');
+    process.exit(1);
+  }
+
+  const dryRun = process.argv.includes('--dry-run');
+
+  if (dryRun) {
+    logger.info('dedup-contacts: running in DRY-RUN mode — no writes will be made');
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  (async () => {
+    try {
+      const { contacts, identityMap } = await loadContactsAndIdentities(pool);
+      logger.info({ contactCount: contacts.length }, 'dedup-contacts: loaded contacts');
+
+      // Build injected callbacks for the real pool
+      const opts: DedupRunOptions = {
+        dryRun,
+
+        mergeContacts: async (primaryId, secondaryId) => {
+          // Direct SQL merge: re-attach identities, update primary, delete secondary.
+          // Reuses the same logic as ContactService.mergeContacts but without the full
+          // service stack. The contact.merged bus event (which fires the audit log) is
+          // NOT emitted here — the maintenance script runs outside the bus context.
+          // TODO: Thread the bus through the script if audit coverage of batch merges is required.
+          await pool.query(
+            `UPDATE contact_channel_identities SET contact_id = $1 WHERE contact_id = $2`,
+            [primaryId, secondaryId],
+          );
+          await pool.query(
+            `UPDATE contact_auth_overrides SET contact_id = $1 WHERE contact_id = $2`,
+            [primaryId, secondaryId],
+          );
+          await pool.query(
+            `DELETE FROM contacts WHERE id = $1`,
+            [secondaryId],
+          );
+          logger.info({ primaryId, secondaryId }, 'dedup-contacts: merged via SQL');
+        },
+
+        createTask: async (params) => {
+          // Insert a task directly. The heartbeat will route Curia-owned tasks
+          // with source_agent_id='contacts' to the contacts specialist.
+          const { rows } = await pool.query(
+            `INSERT INTO tasks (
+               agent_id, title, description, status, progress, error_budget,
+               owner, source, source_agent_id, tags, priority, created_at, updated_at,
+               intent_anchor, created_by
+             ) VALUES (
+               $1, $2, $3, 'open', '{"notes":[]}'::jsonb, '{}'::jsonb,
+               $4, $5, $6, $7, 50, NOW(), NOW(), $2, $1
+             )
+             RETURNING id`,
+            [
+              params.agentId,
+              params.title,
+              params.description,
+              params.owner,
+              params.source,
+              params.sourceAgentId,
+              params.tags,
+            ],
+          );
+          logger.info({ taskId: rows[0]?.id, title: params.title }, 'dedup-contacts: task created');
+          return rows[0];
+        },
+
+        storeFact: async (options) => {
+          await storeFactInDb(pool, options);
+        },
+
+        getFacts: async (kgNodeId) => {
+          return getFactsFromDb(pool, kgNodeId);
+        },
+      };
+
+      const result = await runDedup(contacts, identityMap, opts);
+
+      // Summary report
+      if (dryRun) {
+        logger.info({
+          wouldMergeCount: result.wouldMergeCount,
+          wouldCreateTaskCount: result.wouldCreateTaskCount,
+          skippedExcludedCount: result.skippedExcludedCount,
+          principalSkippedCount: result.principalSkippedCount,
+        }, 'dedup-contacts: DRY-RUN complete (no changes made)');
+      } else {
+        logger.info({
+          mergedCount: result.mergedCount,
+          taskCount: result.taskCount,
+          skippedExcludedCount: result.skippedExcludedCount,
+          principalSkippedCount: result.principalSkippedCount,
+          errorCount: result.errorCount,
+        }, 'dedup-contacts: sweep complete');
+      }
+
+      await pool.end();
+      process.exit(result.errorCount > 0 ? 1 : 0);
+    } catch (err) {
+      logger.error({ err }, 'dedup-contacts: fatal error');
+      await pool.end();
+      process.exit(1);
+    }
+  })();
+}

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -16,7 +16,7 @@
 
 import pg from 'pg';
 import { createLogger } from '../src/logger.js';
-import { classifyPair } from '../src/contacts/dedup-classifier.js';
+import { classifyPair, type PairClassification } from '../src/contacts/dedup-classifier.js';
 import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
 import type { KgNode } from '../src/memory/types.js';
 import type { StoreFactOptions } from '../src/memory/types.js';
@@ -261,7 +261,7 @@ export async function runDedup(
       // a transient DB error (e.g. getFacts throws) does not abort the entire
       // sweep. On error we FAIL CLOSED: the pair is skipped (never merged)
       // and errorCount is incremented so the operator knows something went wrong.
-      let classification;
+      let classification: PairClassification | null;
       let excluded: boolean;
       try {
         // Classify the pair: structural, fuzzy, or null (below threshold)

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -396,6 +396,8 @@ type ContactRow = {
   role: string | null;
   system_role: string | null;
   status: string;
+  tier: string;
+  kind: string;
   contact_confidence: string;
   trust_level: string | null;
   last_seen_at: Date | null;
@@ -442,6 +444,8 @@ function rowToContact(row: ContactRow): Contact {
       ? row.system_role
       : null,
     status: row.status as Contact['status'],
+    tier: row.tier as Contact['tier'],
+    kind: row.kind as Contact['kind'],
     contactConfidence: Number(row.contact_confidence),
     trustLevel: row.trust_level as Contact['trustLevel'],
     lastSeenAt: row.last_seen_at,
@@ -488,7 +492,7 @@ async function loadContactsAndIdentities(pool: pg.Pool): Promise<{
   // Load only 'confirmed' and 'provisional' contacts — skip 'blocked'.
   // Blocked contacts should not be merged; they are deliberately excluded.
   const contactsResult = await pool.query<ContactRow>(
-    `SELECT id, kg_node_id, display_name, role, system_role, status, contact_confidence,
+    `SELECT id, kg_node_id, display_name, role, system_role, status, tier, kind, contact_confidence,
             trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes,
             created_at, updated_at, preferred_name, title, organization, primary_email,
             primary_phone, timezone, locale, location, pronouns, linkedin_url, bio, birthday

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -15,13 +15,27 @@
 // Run: pnpm run dedup:contacts [--dry-run]
 
 import pg from 'pg';
-import pino from 'pino';
+import { createLogger } from '../src/logger.js';
 import { classifyPair } from '../src/contacts/dedup-classifier.js';
 import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
 import type { KgNode } from '../src/memory/types.js';
 import type { StoreFactOptions } from '../src/memory/types.js';
+import { ModelRegistry } from '../src/agents/llm/model-registry.js';
+import { EventBus } from '../src/bus/bus.js';
+import { AuditLogger } from '../src/audit/logger.js';
+import { EmbeddingService } from '../src/memory/embedding.js';
+import { KnowledgeGraphStore } from '../src/memory/knowledge-graph.js';
+import { MemoryValidator } from '../src/memory/validation.js';
+import { EntityMemory } from '../src/memory/entity-memory.js';
+import { ContactService } from '../src/contacts/contact-service.js';
+import { TaskRepo } from '../src/db/task-repo.js';
+import { DedupService } from '../src/contacts/dedup-service.js';
+import { createContactMerged } from '../src/bus/events.js';
 
-const logger = pino({ name: 'dedup-contacts' });
+// Use the same structured logger factory as the rest of the app so log output
+// lands in curia.log in dev and JSON-to-stdout in production.
+const logger = createLogger();
+logger.info({ name: 'dedup-contacts' }, 'dedup-contacts starting');
 
 const { Pool } = pg;
 
@@ -471,88 +485,6 @@ async function loadContactsAndIdentities(pool: pg.Pool): Promise<{
 }
 
 // ---------------------------------------------------------------------------
-// KG fact helpers for use with the real pool
-// ---------------------------------------------------------------------------
-
-async function getFactsFromDb(pool: pg.Pool, kgNodeId: string): Promise<KgNode[]> {
-  // Replicates the query used in EntityMemory.getFacts().
-  // Returns all fact nodes reachable via a 'relates_to' edge from the given node.
-  const result = await pool.query<{
-    id: string;
-    type: string;
-    label: string;
-    properties: Record<string, unknown>;
-    embedding: number[] | null;
-    confidence: string;
-    decay_class: string;
-    source: string;
-    sensitivity: string;
-    aliases: string[];
-    created_at: Date;
-    last_confirmed_at: Date;
-  }>(
-    `SELECT n.id, n.type, n.label, n.properties, n.embedding, n.confidence,
-            n.decay_class, n.source, n.sensitivity, n.aliases,
-            n.created_at, n.last_confirmed_at
-     FROM kg_nodes n
-     JOIN kg_edges e ON (
-       (e.source_node_id = $1 AND e.target_node_id = n.id)
-       OR (e.target_node_id = $1 AND e.source_node_id = n.id)
-     )
-     WHERE e.type = 'relates_to'
-       AND e.archived_at IS NULL
-       AND n.type = 'fact'
-       AND n.archived_at IS NULL`,
-    [kgNodeId],
-  );
-
-  return result.rows.map(row => ({
-    id: row.id,
-    type: row.type as KgNode['type'],
-    label: row.label,
-    properties: row.properties,
-    embedding: row.embedding ?? undefined,
-    confidence: Number(row.confidence),
-    decayClass: row.decay_class as KgNode['decayClass'],
-    source: row.source,
-    sensitivity: row.sensitivity as KgNode['sensitivity'],
-    aliases: row.aliases,
-    temporal: {
-      createdAt: row.created_at,
-      lastConfirmedAt: row.last_confirmed_at,
-    },
-  }));
-}
-
-async function storeFactInDb(pool: pg.Pool, options: StoreFactOptions): Promise<void> {
-  // Write a KG fact via direct SQL (no EntityMemory available in the script context
-  // because EntityMemory requires EmbeddingService and MemoryValidator).
-  //
-  // This is intentionally minimal: we only need to write exclusion facts, which have
-  // a known schema (attribute/value properties, permanent decay). If a full EntityMemory
-  // is needed in future the script can be wired with real DI.
-  //
-  // The label "dedup_exclusion: <id>" is short, ascii-only — no embedding needed.
-  // We insert with embedding = NULL (allowed; the vector column is nullable).
-  await pool.query(
-    `INSERT INTO kg_nodes (
-       type, label, properties, confidence, decay_class, source, sensitivity,
-       aliases, created_at, last_confirmed_at
-     ) VALUES (
-       'fact', $1, $2, $3, $4, $5, $6, '{}', NOW(), NOW()
-     )`,
-    [
-      options.label,
-      JSON.stringify(options.properties ?? {}),
-      options.confidence ?? 0.7,
-      options.decayClass ?? 'permanent',
-      options.source,
-      options.sensitivity ?? 'internal',
-    ],
-  );
-}
-
-// ---------------------------------------------------------------------------
 // CLI entry point
 // ---------------------------------------------------------------------------
 
@@ -576,65 +508,65 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       const { contacts, identityMap } = await loadContactsAndIdentities(pool);
       logger.info({ contactCount: contacts.length }, 'dedup-contacts: loaded contacts');
 
-      // Build injected callbacks for the real pool
+      // Wire the real service stack — mirrors the construction order in src/index.ts.
+      // All four hand-rolled callbacks (mergeContacts, createTask, storeFact, getFacts)
+      // are replaced with delegates to real services so that:
+      //   - mergeContacts: uses ContactService.mergeContacts(), which is transactional,
+      //     repoints kg_node_id and contact_calendars, and fires the contact.merged bus
+      //     event (audit-logged by the write-ahead hook in EventBus).
+      //   - createTask: uses TaskRepo.createTask(), which publishes task.created events.
+      //   - storeFact/getFacts: use EntityMemory, which embeds labels and validates facts.
+      const openaiApiKey = process.env['OPENAI_API_KEY'];
+      if (!openaiApiKey) {
+        logger.error('dedup-contacts: OPENAI_API_KEY is required (entity memory — needed for storeFact / getFacts)');
+        process.exit(1);
+      }
+
+      const auditLogger = new AuditLogger(pool, logger);
+      // EventBus with write-ahead audit hook — every published event (incl. contact.merged)
+      // is persisted to audit_log before delivery, satisfying the acceptance criterion.
+      const bus = new EventBus(
+        logger,
+        (e) => auditLogger.log(e),
+        (id) => auditLogger.markAcknowledged(id),
+      );
+
+      const modelRegistry = new ModelRegistry(logger);
+      const embeddingService = EmbeddingService.createWithOpenAI(openaiApiKey, logger, bus, modelRegistry);
+      const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+      const validator = new MemoryValidator(kgStore, embeddingService);
+      const entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+
+      const dedupService = new DedupService();
+      const contactService = ContactService.createWithPostgres(pool, entityMemory, logger, {
+        dedupService,
+        // Publish contact.merged to the bus so the write-ahead audit hook records it.
+        onContactMerged: (primaryContactId, secondaryContactId, mergedAt) => {
+          bus.publish('dispatch', createContactMerged({ primaryContactId, secondaryContactId, mergedAt }))
+            .catch((err: unknown) => logger.error({ err }, 'Failed to publish contact.merged — audit trail may be incomplete'));
+        },
+      });
+
+      const taskRepo = new TaskRepo(pool, bus, logger, process.env['TZ'] ?? 'UTC');
+
+      // Build injected callbacks — all delegate to real services, no hand-rolled SQL
       const opts: DedupRunOptions = {
         dryRun,
 
-        mergeContacts: async (primaryId, secondaryId) => {
-          // Direct SQL merge: re-attach identities, update primary, delete secondary.
-          // Reuses the same logic as ContactService.mergeContacts but without the full
-          // service stack. The contact.merged bus event (which fires the audit log) is
-          // NOT emitted here — the maintenance script runs outside the bus context.
-          // TODO: Thread the bus through the script if audit coverage of batch merges is required.
-          await pool.query(
-            `UPDATE contact_channel_identities SET contact_id = $1 WHERE contact_id = $2`,
-            [primaryId, secondaryId],
-          );
-          await pool.query(
-            `UPDATE contact_auth_overrides SET contact_id = $1 WHERE contact_id = $2`,
-            [primaryId, secondaryId],
-          );
-          await pool.query(
-            `DELETE FROM contacts WHERE id = $1`,
-            [secondaryId],
-          );
-          logger.info({ primaryId, secondaryId }, 'dedup-contacts: merged via SQL');
-        },
+        // ContactService.mergeContacts handles: identity dedup (resolves the unique-email
+        // constraint violation the old UPDATE would have caused), kg_node_id repointing,
+        // contact_calendars reattachment, golden-record field consolidation, and deletion
+        // of the loser row — all in a single transaction.
+        mergeContacts: (primaryId, secondaryId) => contactService.mergeContacts(primaryId, secondaryId, false),
 
-        createTask: async (params) => {
-          // Insert a task directly. The heartbeat will route Curia-owned tasks
-          // with source_agent_id='contacts' to the contacts specialist.
-          const { rows } = await pool.query(
-            `INSERT INTO tasks (
-               agent_id, title, description, status, progress, error_budget,
-               owner, source, source_agent_id, tags, priority, created_at, updated_at,
-               intent_anchor, created_by
-             ) VALUES (
-               $1, $2, $3, 'open', '{"notes":[]}'::jsonb, '{}'::jsonb,
-               $4, $5, $6, $7, 50, NOW(), NOW(), $2, $1
-             )
-             RETURNING id`,
-            [
-              params.agentId,
-              params.title,
-              params.description,
-              params.owner,
-              params.source,
-              params.sourceAgentId,
-              params.tags,
-            ],
-          );
-          logger.info({ taskId: rows[0]?.id, title: params.title }, 'dedup-contacts: task created');
-          return rows[0];
-        },
+        // TaskRepo.createTask publishes task.created and handles progress/error_budget cols.
+        createTask: (params) => taskRepo.createTask(params),
 
-        storeFact: async (options) => {
-          await storeFactInDb(pool, options);
-        },
+        // EntityMemory.storeFact embeds the label and validates via MemoryValidator.
+        storeFact: (options) => entityMemory.storeFact(options),
 
-        getFacts: async (kgNodeId) => {
-          return getFactsFromDb(pool, kgNodeId);
-        },
+        // EntityMemory.getFacts returns fact nodes linked to the KG entity node.
+        getFacts: (kgNodeId) => entityMemory.getFacts(kgNodeId),
       };
 
       const result = await runDedup(contacts, identityMap, opts);

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -318,6 +318,11 @@ export async function runDedup(
 
         if (dryRun) {
           result.wouldMergeCount++;
+          // M3: mirror real control flow in dry-run — mark the would-be secondary
+          // as merged away so later pairs referencing it are skipped, keeping the
+          // dry-run counts and recommendations accurate (no double-counting a
+          // contact that a real run would already have removed).
+          mergedAwayIds.add(secondaryId!);
           continue;
         }
 
@@ -328,6 +333,17 @@ export async function runDedup(
           // subsequent pair referencing it is skipped. This prevents attempting to
           // merge an already-deleted row (e.g. c2 appears in both (c1,c2) and (c2,c3)).
           mergedAwayIds.add(secondaryId!);
+          // M4: reflect the DB-side identity reattachment in memory. mergeContacts
+          // moves the secondary's channel identities onto the primary, so later pairs
+          // (primaryId, X) must see the combined identity set to catch transitive
+          // structural merges that only become provable after this merge consolidates
+          // identities. Without this, the in-memory identityMap stays stale.
+          const mergedIdentities = [
+            ...(identityMap.get(primaryId!) ?? []),
+            ...(identityMap.get(secondaryId!) ?? []),
+          ];
+          identityMap.set(primaryId!, mergedIdentities);
+          identityMap.delete(secondaryId!);
           logger.info({ primaryId, secondaryId }, 'dedup: merge complete');
         } catch (err) {
           logger.error({ err, primaryId, secondaryId }, 'dedup: merge failed — continuing');

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -305,11 +305,18 @@ export async function runDedup(
         // ------------------------------------------------------------------
         // Structural pair — auto-merge
         // ------------------------------------------------------------------
-        // Choose the primary: prefer the contact with the lower string ID (arbitrary
-        // but stable tiebreaker). In practice the contacts specialist may have a smarter
-        // selection policy, but for the maintenance script determinism is more important
-        // than optimal selection.
-        const [primaryId, secondaryId] = a.id < b.id ? [a.id, b.id] : [b.id, a.id];
+        // Choose the survivor (primary). mergeContacts() keeps the primary row and only
+        // merges KG nodes when BOTH contacts have one; if the primary has no kg_node_id and
+        // the secondary does, the secondary's KG linkage is deleted with it (the survivor
+        // ends up with no KG node). So when exactly one side has a kg_node_id, that side
+        // MUST be the survivor. When both or neither have a KG node, fall back to the lower
+        // string ID — an arbitrary but stable, deterministic tiebreaker.
+        const aHasKg = a.kgNodeId !== null;
+        const bHasKg = b.kgNodeId !== null;
+        const [primaryId, secondaryId] =
+          aHasKg !== bHasKg
+            ? (aHasKg ? [a.id, b.id] : [b.id, a.id])
+            : (a.id < b.id ? [a.id, b.id] : [b.id, a.id]);
 
         logger.info(
           { primaryId, secondaryId, reason: classification.reason },
@@ -356,11 +363,15 @@ export async function runDedup(
         // Name/embedding similarity alone is never enough to auto-merge (see design).
         // Also, any pair touching the principal must go through human review even when
         // structural proof exists — identity mistakes for the principal are too costly.
-        if (involvePrincipal) {
+        // principalSkippedCount counts ONLY structural pairs withheld from auto-merge by
+        // the principal guard (see the DedupRunResult contract). A fuzzy pair involving the
+        // principal would never auto-merge anyway — it's an ordinary recommendation task —
+        // so counting it here would inflate the metric and misreport operator-facing results.
+        if (classification.type === 'structural' && involvePrincipal) {
           result.principalSkippedCount++;
           logger.info(
             { contactAId: a.id, contactBId: b.id, reason: classification.reason },
-            'dedup: principal contact involved — routing to task instead of auto-merge',
+            'dedup: principal contact involved — routing structural pair to task instead of auto-merge',
           );
         } else {
           logger.info(
@@ -593,9 +604,14 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       //     event (audit-logged by the write-ahead hook in EventBus).
       //   - createTask: uses TaskRepo.createTask(), which publishes task.created events.
       //   - storeFact/getFacts: use EntityMemory, which embeds labels and validates facts.
+      // A real sweep merges KG entity nodes (entityMemory.mergeEntities), which embeds fact
+      // labels and therefore needs OpenAI credentials. A dry-run only READS facts
+      // (getFacts → KG node reads, no embedding), so it can run with a fake embedding backend
+      // and no API key — keeping the preview usable in CI / minimal environments. Fail fast
+      // only for a real run.
       const openaiApiKey = process.env['OPENAI_API_KEY'];
-      if (!openaiApiKey) {
-        logger.error('dedup-contacts: OPENAI_API_KEY is required (entity memory — needed for storeFact / getFacts)');
+      if (!dryRun && !openaiApiKey) {
+        logger.error('dedup-contacts: OPENAI_API_KEY is required for a real sweep (KG entity merge embeds fact labels). Re-run with --dry-run to preview without it.');
         process.exit(1);
       }
 
@@ -609,7 +625,12 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       );
 
       const modelRegistry = new ModelRegistry(logger);
-      const embeddingService = EmbeddingService.createWithOpenAI(openaiApiKey, logger, bus, modelRegistry);
+      // With a key, use the real OpenAI-backed embeddings. Without one (dry-run only — the
+      // check above exits a real run that lacks a key), fall back to the fake backend; the
+      // dry-run path never embeds, so its results are unaffected.
+      const embeddingService = openaiApiKey
+        ? EmbeddingService.createWithOpenAI(openaiApiKey, logger, bus, modelRegistry)
+        : EmbeddingService.createForTesting();
       const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
       const validator = new MemoryValidator(kgStore, embeddingService);
       const entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -76,8 +76,9 @@ export interface DedupRunOptions {
     sourceAgentId: string;
     tags: string[];
   }) => Promise<unknown>;
-  /** Calls EntityMemory.storeFact (or equivalent). */
-  storeFact: (options: StoreFactOptions) => Promise<unknown>;
+  // storeFact is intentionally NOT included here: the sweep never writes exclusion facts
+  // itself. The decline→exclusion write is performed by the contacts agent's decline flow
+  // (not yet wired; tracked as a follow-up). Only writeExclusion() has its own storeFact param.
   /** Calls EntityMemory.getFacts for a KG node — returns fact nodes. */
   getFacts: (kgNodeId: string) => Promise<KgNode[]>;
 }
@@ -87,7 +88,10 @@ export interface DedupRunOptions {
 // ---------------------------------------------------------------------------
 
 export interface WriteExclusionOptions {
-  contactAId: string;
+  // contactAId is intentionally omitted: the exclusion fact is always written on
+  // kgNodeId (which is A's KG node) and names contactBId as the excluded party.
+  // The caller already knows which node belongs to A — passing A's contact ID into
+  // the helper adds no value and would just be ignored.
   contactBId: string;
   /** KG node on which to record the exclusion fact. */
   kgNodeId: string;
@@ -105,9 +109,15 @@ export interface WriteExclusionOptions {
  *   label: "dedup_exclusion: <otherContactId>"
  *   properties.attribute = 'dedup_exclusion'
  *   properties.value     = otherContactId
+ *
+ * NOTE: This function is intentionally NOT called by runDedup() / the sweep.
+ * The decline→exclusion write is performed by the contacts agent's decline flow
+ * (i.e. when a human reviews a fuzzy recommendation task and declines to merge).
+ * That wiring is not yet implemented; tracked as a follow-up. This function is
+ * therefore NOT dead code — it is the target of that future call site.
  */
 export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
-  const { contactAId: _contactAId, contactBId, kgNodeId, storeFact } = opts;
+  const { contactBId, kgNodeId, storeFact } = opts;
   await storeFact({
     entityNodeId: kgNodeId,
     label: `dedup_exclusion: ${contactBId}`,
@@ -187,7 +197,7 @@ export async function runDedup(
   identityMap: Map<string, ChannelIdentity[]>,
   opts: DedupRunOptions,
 ): Promise<DedupRunResult> {
-  const { dryRun, mergeContacts, createTask, storeFact, getFacts } = opts;
+  const { dryRun, mergeContacts, createTask, getFacts } = opts;
 
   const result: DedupRunResult = {
     dryRun,
@@ -205,6 +215,11 @@ export async function runDedup(
   // Track pairs we've already handled to avoid double-processing (A,B) and (B,A).
   const processedPairs = new Set<string>();
 
+  // F2: Track contacts that have been merged away (deleted) so we can skip
+  // subsequent pairs that reference them. Without this guard, a pair (c2, c3)
+  // would attempt to merge a row that was already deleted by the (c1, c2) merge.
+  const mergedAwayIds = new Set<string>();
+
   // We need a canonical ordering for pair keys
   function pairKey(aId: string, bId: string): string {
     return aId < bId ? `${aId}:${bId}` : `${bId}:${aId}`;
@@ -215,6 +230,12 @@ export async function runDedup(
       const a = contacts[i]!;
       const b = contacts[j]!;
 
+      // F2: Skip if either contact was already merged away in a prior iteration.
+      // This can happen when c1≡c2 (structural, merged) and c2≡c3 (structural):
+      // after the c1/c2 merge, c2 is deleted — trying to merge c2 again would
+      // hit a DB constraint or a silent no-op depending on the implementation.
+      if (mergedAwayIds.has(a.id) || mergedAwayIds.has(b.id)) continue;
+
       const key = pairKey(a.id, b.id);
       if (processedPairs.has(key)) continue;
       processedPairs.add(key);
@@ -222,21 +243,39 @@ export async function runDedup(
       const aIdentities = identityMap.get(a.id) ?? [];
       const bIdentities = identityMap.get(b.id) ?? [];
 
-      // Classify the pair: structural, fuzzy, or null (below threshold)
-      const classification = classifyPair(a, aIdentities, b, bIdentities);
-      if (classification === null) continue;
+      // F4: Wrap the exclusion check and classification in a try-catch so that
+      // a transient DB error (e.g. getFacts throws) does not abort the entire
+      // sweep. On error we FAIL CLOSED: the pair is skipped (never merged)
+      // and errorCount is incremented so the operator knows something went wrong.
+      let classification;
+      let excluded: boolean;
+      try {
+        // Classify the pair: structural, fuzzy, or null (below threshold)
+        classification = classifyPair(a, aIdentities, b, bIdentities);
+        if (classification === null) continue;
 
-      // ------------------------------------------------------------------
-      // Check for a prior dedup_exclusion in either direction
-      // ------------------------------------------------------------------
-      // We check regardless of classification type — exclusions apply to all matches.
-      const excluded = await hasExclusion({
-        contactAId: a.id,
-        contactBId: b.id,
-        kgNodeIdA: a.kgNodeId,
-        kgNodeIdB: b.kgNodeId,
-        getFacts,
-      });
+        // ------------------------------------------------------------------
+        // Check for a prior dedup_exclusion in either direction
+        // ------------------------------------------------------------------
+        // We check regardless of classification type — exclusions apply to all matches.
+        excluded = await hasExclusion({
+          contactAId: a.id,
+          contactBId: b.id,
+          kgNodeIdA: a.kgNodeId,
+          kgNodeIdB: b.kgNodeId,
+          getFacts,
+        });
+      } catch (err) {
+        // Fail closed: any error during classification or exclusion check means
+        // we DO NOT proceed to merge. Log and move on to the next pair.
+        logger.error(
+          { err, contactAId: a.id, contactBId: b.id },
+          'dedup: error during classification/exclusion check — skipping pair (fail closed)',
+        );
+        result.errorCount++;
+        continue;
+      }
+
       if (excluded) {
         logger.debug({ contactAId: a.id, contactBId: b.id }, 'dedup: skipped — dedup_exclusion fact present');
         result.skippedExcludedCount++;
@@ -271,6 +310,10 @@ export async function runDedup(
         try {
           await mergeContacts(primaryId!, secondaryId!);
           result.mergedCount++;
+          // F2: Record the deleted (secondary) contact as merged away so that any
+          // subsequent pair referencing it is skipped. This prevents attempting to
+          // merge an already-deleted row (e.g. c2 appears in both (c1,c2) and (c2,c3)).
+          mergedAwayIds.add(secondaryId!);
           logger.info({ primaryId, secondaryId }, 'dedup: merge complete');
         } catch (err) {
           logger.error({ err, primaryId, secondaryId }, 'dedup: merge failed — continuing');
@@ -541,6 +584,10 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       const contactService = ContactService.createWithPostgres(pool, entityMemory, logger, {
         dedupService,
         // Publish contact.merged to the bus so the write-ahead audit hook records it.
+        // TODO: a bus.publish failure here is logged but not reflected in the exit code
+        // or errorCount. This is acceptable for a maintenance script (the merge itself
+        // succeeded, the audit gap is narrow), but revisit if audit-gap detection becomes
+        // a hard requirement.
         onContactMerged: (primaryContactId, secondaryContactId, mergedAt) => {
           bus.publish('dispatch', createContactMerged({ primaryContactId, secondaryContactId, mergedAt }))
             .catch((err: unknown) => logger.error({ err }, 'Failed to publish contact.merged — audit trail may be incomplete'));
@@ -562,8 +609,8 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
         // TaskRepo.createTask publishes task.created and handles progress/error_budget cols.
         createTask: (params) => taskRepo.createTask(params),
 
-        // EntityMemory.storeFact embeds the label and validates via MemoryValidator.
-        storeFact: (options) => entityMemory.storeFact(options),
+        // storeFact is NOT included in DedupRunOptions — the sweep never writes exclusion
+        // facts directly. See writeExclusion() and its doc comment for the intended call site.
 
         // EntityMemory.getFacts returns fact nodes linked to the KG entity node.
         getFacts: (kgNodeId) => entityMemory.getFacts(kgNodeId),
@@ -578,6 +625,10 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
           wouldCreateTaskCount: result.wouldCreateTaskCount,
           skippedExcludedCount: result.skippedExcludedCount,
           principalSkippedCount: result.principalSkippedCount,
+          // F5: Include errorCount in the dry-run summary — otherwise an operator
+          // sees a clean "DRY-RUN complete" message while the process exits 1,
+          // making it impossible to tell from the summary that something went wrong.
+          errorCount: result.errorCount,
         }, 'dedup-contacts: DRY-RUN complete (no changes made)');
       } else {
         logger.info({

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -199,6 +199,20 @@ export async function runDedup(
 ): Promise<DedupRunResult> {
   const { dryRun, mergeContacts, createTask, getFacts } = opts;
 
+  // Memoize getFacts per KG node for the duration of the sweep. The exclusion check
+  // runs inside the O(n²) pair loop, and a contact that appears in many candidate
+  // pairs would otherwise re-fetch its KG facts each time. Exclusion facts are static
+  // within a run (the sweep never writes them — that's the agent's decline path), so
+  // caching is safe. Keyed by kg_node_id; contacts without a node are never looked up.
+  const factsCache = new Map<string, KgNode[]>();
+  const cachedGetFacts = async (kgNodeId: string): Promise<KgNode[]> => {
+    const hit = factsCache.get(kgNodeId);
+    if (hit !== undefined) return hit;
+    const facts = await getFacts(kgNodeId);
+    factsCache.set(kgNodeId, facts);
+    return facts;
+  };
+
   const result: DedupRunResult = {
     dryRun,
     mergedCount: 0,
@@ -263,7 +277,7 @@ export async function runDedup(
           contactBId: b.id,
           kgNodeIdA: a.kgNodeId,
           kgNodeIdB: b.kgNodeId,
-          getFacts,
+          getFacts: cachedGetFacts,
         });
       } catch (err) {
         // Fail closed: any error during classification or exclusion check means

--- a/src/contacts/dedup-classifier.test.ts
+++ b/src/contacts/dedup-classifier.test.ts
@@ -1,0 +1,321 @@
+// src/contacts/dedup-classifier.test.ts
+//
+// Unit tests for the structural-vs-fuzzy pair classifier.
+// These tests are pure (no DB, no network) — they exercise classifyPair() in
+// isolation to verify the three structural-proof conditions and the fuzzy fallback.
+//
+// TDD: tests written before implementation per the project's TDD requirement.
+
+import { describe, it, expect } from 'vitest';
+import type { Contact, ChannelIdentity } from './types.js';
+import { classifyPair, type PairClassification } from './dedup-classifier.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContact(overrides: Partial<Contact> & { id: string; displayName: string }): Contact {
+  return {
+    kgNodeId: null,
+    role: null,
+    systemRole: null,
+    status: 'confirmed',
+    contactConfidence: 0.8,
+    trustLevel: null,
+    lastSeenAt: null,
+    inboundMessageCount: 0,
+    outboundMessageCount: 0,
+    notes: null,
+    preferredName: null,
+    title: null,
+    organization: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    timezone: null,
+    locale: null,
+    location: null,
+    pronouns: null,
+    linkedinUrl: null,
+    bio: null,
+    birthday: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+function makeIdentity(
+  contactId: string,
+  channel: string,
+  channelIdentifier: string,
+): ChannelIdentity {
+  return {
+    id: `${contactId}-${channel}-id`,
+    contactId,
+    channel,
+    channelIdentifier,
+    label: null,
+    verified: true,
+    verifiedAt: new Date('2026-01-01'),
+    status: 'active',
+    source: 'email_participant',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Structural proof: shared channel identity
+// ---------------------------------------------------------------------------
+
+describe('classifyPair — structural: shared channel identity', () => {
+  it('classifies as structural when both contacts share the same email identity', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Alice Smith' });
+    const b = makeContact({ id: 'c2', displayName: 'A. Smith' });
+    const aIds = [makeIdentity('c1', 'email', 'alice@example.com')];
+    const bIds = [makeIdentity('c2', 'email', 'alice@example.com')];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+    expect((result as PairClassification & { type: 'structural' }).reason).toContain('email');
+  });
+
+  it('classifies as structural when both contacts share the same phone identity', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Bob Jones' });
+    const b = makeContact({ id: 'c2', displayName: 'Robert Jones' });
+    const aIds = [makeIdentity('c1', 'phone', '+15551234567')];
+    const bIds = [makeIdentity('c2', 'phone', '+15551234567')];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
+  it('classifies as structural when both contacts share the same signal identity', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Carol White' });
+    const b = makeContact({ id: 'c2', displayName: 'Carol W' });
+    const aIds = [makeIdentity('c1', 'signal', '+447911123456')];
+    const bIds = [makeIdentity('c2', 'signal', '+447911123456')];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
+  it('does NOT classify as structural when channel types differ (email vs phone)', () => {
+    // Use contacts with different names to avoid triggering the exact-name structural path.
+    // The test verifies that "email:x" and "phone:x" are not a channel overlap.
+    const a = makeContact({ id: 'c1', displayName: 'Davide Brownstein' });
+    const b = makeContact({ id: 'c2', displayName: 'D. Brown-Stein III' });
+    // Different channels — not an overlap even if the identifier strings happen to match
+    const aIds = [makeIdentity('c1', 'email', 'dave@example.com')];
+    const bIds = [makeIdentity('c2', 'phone', 'dave@example.com')];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    // Name similarity is below threshold (very different after normalization) and the
+    // different channels don't constitute a verified identity overlap → no structural match.
+    // The pair may be null (below threshold) or fuzzy, but not structural.
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+
+  it('finds overlap when contact a has multiple identities', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Eve Clark' });
+    const b = makeContact({ id: 'c2', displayName: 'Eve Clark Jr.' });
+    const aIds = [
+      makeIdentity('c1', 'email', 'eve@work.com'),
+      makeIdentity('c1', 'email', 'eve@personal.com'),
+    ];
+    const bIds = [makeIdentity('c2', 'email', 'eve@personal.com')];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural proof: same kg_node_id
+// ---------------------------------------------------------------------------
+
+describe('classifyPair — structural: same kg_node_id', () => {
+  it('classifies as structural when both contacts share the same kg_node_id', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Frank Lee', kgNodeId: 'kg-abc-123' });
+    const b = makeContact({ id: 'c2', displayName: 'F. Lee', kgNodeId: 'kg-abc-123' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+    expect((result as PairClassification & { type: 'structural' }).reason).toContain('kg_node_id');
+  });
+
+  it('does NOT classify as structural for different kg_node_ids (no other structural proof)', () => {
+    // Use different names so the exact-name path doesn't fire.
+    // The only thing in common is being in the same block — they don't have the same kg_node_id.
+    const a = makeContact({ id: 'c1', displayName: 'Graciela Lin', kgNodeId: 'kg-111' });
+    const b = makeContact({ id: 'c2', displayName: 'Grace Linden', kgNodeId: 'kg-222' });
+
+    const result = classifyPair(a, [], b, []);
+    // Different kg_node_ids, different names → may be fuzzy or null, never structural
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+
+  it('does NOT classify as structural when either kg_node_id is null', () => {
+    // One null kg_node_id means the kg_node_id comparison path cannot fire.
+    // Use different names to avoid the exact-name path.
+    const a = makeContact({ id: 'c1', displayName: 'Henri Tanaka', kgNodeId: null });
+    const b = makeContact({ id: 'c2', displayName: 'H. Tan', kgNodeId: 'kg-456' });
+
+    const result = classifyPair(a, [], b, []);
+    // One null → kg_node_id path cannot be structural
+    // Names are different enough → not exact-name structural
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural proof: exact normalized alias/label match
+// ---------------------------------------------------------------------------
+
+describe('classifyPair — structural: exact normalized name match', () => {
+  it('classifies as structural on exact (case-insensitive) normalized name match', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Irene Park' });
+    const b = makeContact({ id: 'c2', displayName: 'Irene Park' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+    expect((result as PairClassification & { type: 'structural' }).reason).toContain('name');
+  });
+
+  it('classifies as structural on normalized match despite different casing', () => {
+    const a = makeContact({ id: 'c1', displayName: 'IRENE PARK' });
+    const b = makeContact({ id: 'c2', displayName: 'irene park' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
+  it('classifies as structural on normalized match despite punctuation differences', () => {
+    // Both contacts normalize to the same ASCII string (lowercased, stripped punctuation).
+    // "O'Brien" → "obrien"; "O Brien" → "o brien" — these differ.
+    // Use a cleaner example: "Smith, John" vs "Smith John" — comma stripped
+    const a = makeContact({ id: 'c1', displayName: 'Smith, John' });
+    const b = makeContact({ id: 'c2', displayName: 'Smith John' });
+
+    // "smith john" === "smith john" after normalization — structural
+    const result = classifyPair(a, [], b, []);
+    expect(result?.type).toBe('structural');
+  });
+
+  it('classifies as fuzzy on similar but not identical names (no shared variants)', () => {
+    // "Natalia Perez" variants: ["natalia perez", "perez natalia", "n perez"]
+    // "Nathan Pierce" variants: ["nathan pierce", "pierce nathan", "n pierce"]
+    // No shared exact normalized variants → fuzzy (high JW but not exact-match structural)
+    const a = makeContact({ id: 'c1', displayName: 'Natalia Perez' });
+    const b = makeContact({ id: 'c2', displayName: 'Nathan Pierce' });
+
+    const result = classifyPair(a, [], b, []);
+    // Not an exact normalized match → fuzzy or null (but not structural)
+    if (result !== null) {
+      expect(result.type).toBe('fuzzy');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fuzzy pairs
+// ---------------------------------------------------------------------------
+
+describe('classifyPair — fuzzy: name similarity', () => {
+  it('classifies similar names as fuzzy when they share no exact normalized variant', () => {
+    // "Natalia Perez" and "Nathan Pierce" have similar sound but no shared exact variants:
+    //   Natalia variants: ["natalia perez", "perez natalia", "n perez"]
+    //   Nathan  variants: ["nathan pierce", "pierce nathan", "n pierce"]
+    // None of these are identical → not structural; high JW → fuzzy (if above 0.7 threshold)
+    const a = makeContact({ id: 'c1', displayName: 'Natalia Perez' });
+    const b = makeContact({ id: 'c2', displayName: 'Nathan Pierce' });
+
+    const result = classifyPair(a, [], b, []);
+    // Must not be structural (no shared exact variant)
+    if (result !== null) {
+      expect(result.type).toBe('fuzzy');
+    }
+  });
+
+  it('returns null for contacts below the scoring threshold', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Alice Johnson' });
+    const b = makeContact({ id: 'c2', displayName: 'Zhao Wei' });
+
+    const result = classifyPair(a, [], b, []);
+    // Completely different names, no shared identities → below threshold
+    expect(result).toBeNull();
+  });
+
+  it('includes the original DedupService score and reason in fuzzy results', () => {
+    // Use names with no shared exact variants for a genuine fuzzy result.
+    // "Natalia Perez" vs "Nathan Pierce" — no shared variants, but JW similar.
+    const a = makeContact({ id: 'c1', displayName: 'Natalia Perez' });
+    const b = makeContact({ id: 'c2', displayName: 'Nathan Pierce' });
+
+    const result = classifyPair(a, [], b, []);
+    if (result === null) {
+      // Score below threshold — the test still passes (we're checking the shape when it does match)
+      return;
+    }
+    // If a result exists, it must be fuzzy (not structural)
+    expect(result.type).toBe('fuzzy');
+    if (result.type === 'fuzzy') {
+      expect(result.score).toBeGreaterThan(0);
+      expect(result.score).toBeLessThanOrEqual(1);
+      expect(result.reason).toBeTruthy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural proof priority: channel overlap overrides name similarity
+// ---------------------------------------------------------------------------
+
+describe('classifyPair — structural takes priority over fuzzy', () => {
+  it('classifies as structural (not fuzzy) when both a name match and a channel overlap exist', () => {
+    // These contacts have high name similarity AND a shared email — structural wins
+    const a = makeContact({ id: 'c1', displayName: 'Kim Lee' });
+    const b = makeContact({ id: 'c2', displayName: 'Kim Lee' });
+    const aIds = [makeIdentity('c1', 'email', 'kim@acme.com')];
+    const bIds = [makeIdentity('c2', 'email', 'kim@acme.com')];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('classifyPair — edge cases', () => {
+  it('returns null for self-comparison (a.id === b.id)', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Leo Vega' });
+
+    const result = classifyPair(a, [], a, []);
+    expect(result).toBeNull();
+  });
+
+  it('handles contacts with no identities and no kg_node_id', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Completely Unique Name XYZQ' });
+    const b = makeContact({ id: 'c2', displayName: 'Another Unique Name ABCD' });
+
+    const result = classifyPair(a, [], b, []);
+    // Very different names — should be null (below threshold)
+    expect(result).toBeNull();
+  });
+});

--- a/src/contacts/dedup-classifier.test.ts
+++ b/src/contacts/dedup-classifier.test.ts
@@ -120,6 +120,19 @@ describe('classifyPair — structural: shared channel identity', () => {
     expect(result!.type).toBe('structural');
   });
 
+  it('classifies as structural when emails match case-insensitively (Major-1)', () => {
+    // Emails are matched case-insensitively (migration 044's LOWER index). Mixed-case
+    // spellings of the same address must still count as a structural shared identity.
+    const a = makeContact({ id: 'c1', displayName: 'Alice Smith' });
+    const b = makeContact({ id: 'c2', displayName: 'A. Smith' });
+    const aIds = [makeIdentity('c1', 'email', 'Alice@Example.com', { verified: true })];
+    const bIds = [makeIdentity('c2', 'email', 'alice@example.com', { verified: true })];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
   it('does NOT classify as structural when the shared identity is unverified on contact a', () => {
     // a's identity is unverified — must NOT be structural (falls through to fuzzy)
     const a = makeContact({ id: 'c1', displayName: 'Alice Smith' });
@@ -412,12 +425,26 @@ describe('classifyPair — edge cases', () => {
     expect(result).toBeNull();
   });
 
-  it('handles contacts with no identities and no kg_node_id', () => {
-    const a = makeContact({ id: 'c1', displayName: 'Completely Unique Name XYZQ' });
-    const b = makeContact({ id: 'c2', displayName: 'Another Unique Name ABCD' });
+  it('handles contacts with no identities and no kg_node_id (dissimilar names → null)', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Zachary Tremblay' });
+    const b = makeContact({ id: 'c2', displayName: 'Priya Nair' });
 
     const result = classifyPair(a, [], b, []);
-    // Very different names — should be null (below threshold)
+    // No structural proof and no name similarity → null (below threshold).
     expect(result).toBeNull();
+  });
+
+  it('scores a similar pair as fuzzy even when name-blocking keys differ (no blocking in classifyPair)', () => {
+    // "Catherine Lee" vs "Katherine Lee" differ at the first character, so a
+    // first-3-char blocking key ("cat" vs "kat") would separate them and
+    // DedupService.checkForDuplicates would never score the pair. classifyPair
+    // scores the explicit pair directly (no blocking), so the high JW similarity
+    // is surfaced as a fuzzy match rather than dropped to null. (Major-2 fix)
+    const a = makeContact({ id: 'c1', displayName: 'Catherine Lee' });
+    const b = makeContact({ id: 'c2', displayName: 'Katherine Lee' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('fuzzy');
   });
 });

--- a/src/contacts/dedup-classifier.test.ts
+++ b/src/contacts/dedup-classifier.test.ts
@@ -20,6 +20,8 @@ function makeContact(overrides: Partial<Contact> & { id: string; displayName: st
     role: null,
     systemRole: null,
     status: 'confirmed',
+    tier: 'known',
+    kind: 'person',
     contactConfidence: 0.8,
     trustLevel: null,
     lastSeenAt: null,

--- a/src/contacts/dedup-classifier.test.ts
+++ b/src/contacts/dedup-classifier.test.ts
@@ -306,6 +306,17 @@ describe('classifyPair — structural: exact normalized name match', () => {
     expect(result!.type).toBe('structural');
   });
 
+  // Unicode-aware normalization: accented and unaccented spellings of the same
+  // name fold together (NFKD + diacritic strip), so they match structurally.
+  it('classifies as structural when names differ only by diacritics ("José García" === "Jose Garcia")', () => {
+    const a = makeContact({ id: 'c1', displayName: 'José García' });
+    const b = makeContact({ id: 'c2', displayName: 'Jose Garcia' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
   it('classifies as fuzzy on similar but not identical names (no shared variants)', () => {
     // "Natalia Perez" variants: ["natalia perez", "perez natalia", "n perez"]
     // "Nathan Pierce" variants: ["nathan pierce", "pierce nathan", "n pierce"]

--- a/src/contacts/dedup-classifier.test.ts
+++ b/src/contacts/dedup-classifier.test.ts
@@ -48,6 +48,7 @@ function makeIdentity(
   contactId: string,
   channel: string,
   channelIdentifier: string,
+  overrides: Partial<ChannelIdentity> = {},
 ): ChannelIdentity {
   return {
     id: `${contactId}-${channel}-id`,
@@ -61,6 +62,7 @@ function makeIdentity(
     source: 'email_participant',
     createdAt: new Date('2026-01-01'),
     updatedAt: new Date('2026-01-01'),
+    ...overrides,
   };
 }
 
@@ -101,6 +103,60 @@ describe('classifyPair — structural: shared channel identity', () => {
     const result = classifyPair(a, aIds, b, bIds);
     expect(result).not.toBeNull();
     expect(result!.type).toBe('structural');
+  });
+
+  // F1: verified requirement for structural channel-identity proof
+  it('classifies as structural when both contacts share a VERIFIED channel identity', () => {
+    // Both identities are verified (default) → structural
+    const a = makeContact({ id: 'c1', displayName: 'Alice Smith' });
+    const b = makeContact({ id: 'c2', displayName: 'A. Smith' });
+    const aIds = [makeIdentity('c1', 'email', 'alice@example.com', { verified: true })];
+    const bIds = [makeIdentity('c2', 'email', 'alice@example.com', { verified: true })];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
+  it('does NOT classify as structural when the shared identity is unverified on contact a', () => {
+    // a's identity is unverified — must NOT be structural (falls through to fuzzy)
+    const a = makeContact({ id: 'c1', displayName: 'Alice Smith' });
+    const b = makeContact({ id: 'c2', displayName: 'A. Smith' });
+    const aIds = [makeIdentity('c1', 'email', 'alice@example.com', { verified: false, verifiedAt: null })];
+    const bIds = [makeIdentity('c2', 'email', 'alice@example.com', { verified: true })];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    // Unverified shared identity → must NOT be structural
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+
+  it('does NOT classify as structural when the shared identity is unverified on contact b', () => {
+    // b's identity is unverified — must NOT be structural (falls through to fuzzy)
+    const a = makeContact({ id: 'c1', displayName: 'Alice Smith' });
+    const b = makeContact({ id: 'c2', displayName: 'A. Smith' });
+    const aIds = [makeIdentity('c1', 'email', 'alice@example.com', { verified: true })];
+    const bIds = [makeIdentity('c2', 'email', 'alice@example.com', { verified: false, verifiedAt: null })];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    // Unverified shared identity on b's side → must NOT be structural
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+
+  it('does NOT classify as structural when both identities are unverified (even if they match)', () => {
+    // Neither side verified — unverified shared identity must never be structural
+    const a = makeContact({ id: 'c1', displayName: 'Alice Smith' });
+    const b = makeContact({ id: 'c2', displayName: 'A. Smith' });
+    const aIds = [makeIdentity('c1', 'email', 'alice@example.com', { verified: false, verifiedAt: null })];
+    const bIds = [makeIdentity('c2', 'email', 'alice@example.com', { verified: false, verifiedAt: null })];
+
+    const result = classifyPair(a, aIds, b, bIds);
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
   });
 
   it('does NOT classify as structural when channel types differ (email vs phone)', () => {
@@ -213,6 +269,39 @@ describe('classifyPair — structural: exact normalized name match', () => {
     // "smith john" === "smith john" after normalization — structural
     const result = classifyPair(a, [], b, []);
     expect(result?.type).toBe('structural');
+  });
+
+  // F3: single-token names must NOT be structural
+  it('does NOT classify as structural on a single-token exact match ("Acme" === "acme")', () => {
+    // Single-token match is too weak — a name like "Acme" could refer to many different
+    // entities. Must fall through to fuzzy (or null), never auto-merge.
+    const a = makeContact({ id: 'c1', displayName: 'Acme' });
+    const b = makeContact({ id: 'c2', displayName: 'acme' });
+
+    const result = classifyPair(a, [], b, []);
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+
+  it('does NOT classify as structural on a single-token match even with punctuation stripped ("Smith" === "smith")', () => {
+    const a = makeContact({ id: 'c1', displayName: 'Smith' });
+    const b = makeContact({ id: 'c2', displayName: 'smith' });
+
+    const result = classifyPair(a, [], b, []);
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+
+  it('classifies as structural on a two-token full name exact match', () => {
+    // Two tokens, length ≥ 5 — this is the minimum for structural name proof.
+    const a = makeContact({ id: 'c1', displayName: 'John Doe' });
+    const b = makeContact({ id: 'c2', displayName: 'john doe' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
   });
 
   it('classifies as fuzzy on similar but not identical names (no shared variants)', () => {

--- a/src/contacts/dedup-classifier.ts
+++ b/src/contacts/dedup-classifier.ts
@@ -48,8 +48,10 @@ export type PairClassification =
 
 function normalizeDisplayName(name: string): string {
   return name
+    .normalize('NFKD')              // decompose accents: "é" → "e" + combining mark
+    .replace(/\p{M}/gu, '')         // strip the combining marks (diacritics)
     .toLowerCase()
-    .replace(/[^a-z0-9 ]/g, '')
+    .replace(/[^\p{L}\p{N} ]/gu, '') // keep Unicode letters/numbers + spaces (preserves CJK/Arabic)
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/src/contacts/dedup-classifier.ts
+++ b/src/contacts/dedup-classifier.ts
@@ -1,0 +1,148 @@
+// src/contacts/dedup-classifier.ts
+//
+// Classifies a contact pair as either 'structural' (eligible for auto-merge)
+// or 'fuzzy' (eligible for a recommendation task only).
+//
+// Structural proof — any ONE of:
+//   (a) Two contacts share a verified channel identity (same channel + identifier).
+//   (b) Same non-null kg_node_id.
+//   (c) Exact normalized alias/label match (normalized display names are identical).
+//
+// Fuzzy — no structural proof, but above the DedupService scoring threshold.
+//   Name similarity (Jaro-Winkler) and embedding similarity are fuzzy signals.
+//   No matter how high the score, they never auto-merge. This deliberately overrides
+//   the old DedupService behaviour where score ≥ 0.9 was labelled 'certain'.
+//
+// Returns null when the pair is below the scoring threshold (nothing to act on).
+//
+// The classifier is pure and sync where possible — it delegates to DedupService
+// for the underlying JW scoring, but adds the structural classification layer on top.
+
+import type { Contact, ChannelIdentity } from './types.js';
+import { DedupService } from './dedup-service.js';
+
+// Singleton scorer — stateless, safe to share
+const dedupService = new DedupService();
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type PairClassification =
+  | {
+      type: 'structural';
+      /** Human-readable description of the structural proof (for logging/reporting). */
+      reason: string;
+    }
+  | {
+      type: 'fuzzy';
+      /** JW score (0–1) from the underlying scorer. */
+      score: number;
+      /** Human-readable description from DedupService (for task description). */
+      reason: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Name normalization (must match DedupService.normalizeDisplayName exactly)
+// ---------------------------------------------------------------------------
+
+function normalizeDisplayName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// classifyPair
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a contact pair as structural or fuzzy.
+ *
+ * Returns null when the pair is below the minimum scoring threshold —
+ * the caller should skip such pairs entirely.
+ *
+ * @param a - first contact
+ * @param aIdentities - channel identities for a
+ * @param b - second contact
+ * @param bIdentities - channel identities for b
+ */
+export function classifyPair(
+  a: Contact,
+  aIdentities: ChannelIdentity[],
+  b: Contact,
+  bIdentities: ChannelIdentity[],
+): PairClassification | null {
+  // Self-comparison is never a valid pair
+  if (a.id === b.id) return null;
+
+  // ------------------------------------------------------------------
+  // Structural proof (a): shared channel identity
+  // ------------------------------------------------------------------
+  // Build a set of "<channel>:<identifier>" keys for contact a, then check
+  // whether any of contact b's identities match. This is O(|aIds| + |bIds|).
+  const aIdKeys = new Set(aIdentities.map(i => `${i.channel}:${i.channelIdentifier}`));
+  for (const bId of bIdentities) {
+    const key = `${bId.channel}:${bId.channelIdentifier}`;
+    if (aIdKeys.has(key)) {
+      return {
+        type: 'structural',
+        reason: `Same ${bId.channel} identifier`,
+      };
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Structural proof (b): same non-null kg_node_id
+  // ------------------------------------------------------------------
+  // Both contacts referencing the same KG node means they are already
+  // identified as the same real-world entity in the knowledge graph.
+  if (a.kgNodeId !== null && b.kgNodeId !== null && a.kgNodeId === b.kgNodeId) {
+    return {
+      type: 'structural',
+      reason: `Same kg_node_id: ${a.kgNodeId}`,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Structural proof (c): exact normalized name match
+  // ------------------------------------------------------------------
+  // If the normalized display names are identical (after lowercasing and stripping
+  // punctuation), this is considered structural proof — the contacts refer to the
+  // same person under different casing or minor formatting. This is the most
+  // conservative form of the name signal; JW similarity is always fuzzy.
+  const normalA = normalizeDisplayName(a.displayName);
+  const normalB = normalizeDisplayName(b.displayName);
+  if (normalA.length > 0 && normalA === normalB) {
+    return {
+      type: 'structural',
+      reason: `Exact normalized name match: "${normalA}"`,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Fuzzy: delegate to DedupService for JW scoring
+  // ------------------------------------------------------------------
+  // Any match returned here is fuzzy — name similarity never proves identity.
+  // Use checkForDuplicates with a single-item candidate list as a thin adapter
+  // to the existing scoring logic, then re-interpret the result.
+  const pairs = dedupService.checkForDuplicates(
+    a,
+    aIdentities,
+    [b],
+    new Map([[b.id, bIdentities]]),
+  );
+
+  if (pairs.length === 0) return null;
+
+  const pair = pairs[0]!;
+  // The DedupService may still return 'certain' for channel overlap (already handled
+  // above) or for high JW. Under the new design, any non-structural match is fuzzy.
+  return {
+    type: 'fuzzy',
+    score: pair.score,
+    reason: pair.reason,
+  };
+}

--- a/src/contacts/dedup-classifier.ts
+++ b/src/contacts/dedup-classifier.ts
@@ -57,6 +57,18 @@ function normalizeDisplayName(name: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Identity key canonicalization (must match DedupService exactly)
+// ---------------------------------------------------------------------------
+
+function canonicalIdentityKey(channel: string, identifier: string): string {
+  // Emails are matched case-insensitively (migration 044's LOWER() unique index),
+  // so lowercase them before comparison; phone/signal are already normalized at write.
+  // Without this, mixed-case email identities for the same address fail structural proof.
+  const id = channel === 'email' ? identifier.toLowerCase() : identifier;
+  return `${channel}:${id}`;
+}
+
+// ---------------------------------------------------------------------------
 // classifyPair
 // ---------------------------------------------------------------------------
 
@@ -88,13 +100,13 @@ export function classifyPair(
   // it falls through to the fuzzy path (recommendation, not auto-merge).
   // This is O(|aIds| + |bIds|).
   const aIdKeys = new Set(
-    aIdentities.filter(i => i.verified).map(i => `${i.channel}:${i.channelIdentifier}`),
+    aIdentities.filter(i => i.verified).map(i => canonicalIdentityKey(i.channel, i.channelIdentifier)),
   );
   for (const bId of bIdentities) {
     // Both sides must be verified: a's key was built from verified-only identities,
     // and we check bId.verified here before looking up the key.
     if (!bId.verified) continue;
-    const key = `${bId.channel}:${bId.channelIdentifier}`;
+    const key = canonicalIdentityKey(bId.channel, bId.channelIdentifier);
     if (aIdKeys.has(key)) {
       return {
         type: 'structural',
@@ -146,18 +158,16 @@ export function classifyPair(
   // Any match returned here is fuzzy — name similarity never proves identity.
   // Use checkForDuplicates with a single-item candidate list as a thin adapter
   // to the existing scoring logic, then re-interpret the result.
-  const pairs = dedupService.checkForDuplicates(
-    a,
-    aIdentities,
-    [b],
-    new Map([[b.id, bIdentities]]),
-  );
+  // Direct pair scoring — NOT checkForDuplicates, which applies name-blocking and
+  // would drop genuinely-similar pairs whose blocking keys differ (returning null
+  // instead of a fuzzy match/task). The caller iterates explicit pairs, so we score
+  // this pair directly with no blocking.
+  const pair = dedupService.scorePair(a, aIdentities, b, bIdentities);
+  if (pair === null) return null;
 
-  if (pairs.length === 0) return null;
-
-  const pair = pairs[0]!;
-  // The DedupService may still return 'certain' for channel overlap (already handled
-  // above) or for high JW. Under the new design, any non-structural match is fuzzy.
+  // Any non-structural match is fuzzy — name similarity never proves identity.
+  // scorePair may return 1.0 for an UNVERIFIED shared identity; that is intentionally
+  // a fuzzy recommendation here, never an auto-merge.
   return {
     type: 'fuzzy',
     score: pair.score,

--- a/src/contacts/dedup-classifier.ts
+++ b/src/contacts/dedup-classifier.ts
@@ -79,12 +79,19 @@ export function classifyPair(
   if (a.id === b.id) return null;
 
   // ------------------------------------------------------------------
-  // Structural proof (a): shared channel identity
+  // Structural proof (a): shared VERIFIED channel identity
   // ------------------------------------------------------------------
-  // Build a set of "<channel>:<identifier>" keys for contact a, then check
-  // whether any of contact b's identities match. This is O(|aIds| + |bIds|).
-  const aIdKeys = new Set(aIdentities.map(i => `${i.channel}:${i.channelIdentifier}`));
+  // Build a set of "<channel>:<identifier>" keys for contact a's VERIFIED
+  // identities only. An unverified shared identity is not structural proof —
+  // it falls through to the fuzzy path (recommendation, not auto-merge).
+  // This is O(|aIds| + |bIds|).
+  const aIdKeys = new Set(
+    aIdentities.filter(i => i.verified).map(i => `${i.channel}:${i.channelIdentifier}`),
+  );
   for (const bId of bIdentities) {
+    // Both sides must be verified: a's key was built from verified-only identities,
+    // and we check bId.verified here before looking up the key.
+    if (!bId.verified) continue;
     const key = `${bId.channel}:${bId.channelIdentifier}`;
     if (aIdKeys.has(key)) {
       return {
@@ -113,9 +120,18 @@ export function classifyPair(
   // punctuation), this is considered structural proof — the contacts refer to the
   // same person under different casing or minor formatting. This is the most
   // conservative form of the name signal; JW similarity is always fuzzy.
+  //
+  // Single-token names (e.g. "Acme" / "acme") are NOT sufficient for structural
+  // proof: a single token is too common to reliably identify a unique person or
+  // entity. We require at least 2 whitespace-separated tokens AND length ≥ 5 to
+  // guard against false positives. Single-token matches fall through to fuzzy.
   const normalA = normalizeDisplayName(a.displayName);
   const normalB = normalizeDisplayName(b.displayName);
-  if (normalA.length > 0 && normalA === normalB) {
+  if (
+    normalA.length >= 5 &&
+    normalA === normalB &&
+    normalA.split(' ').length >= 2
+  ) {
     return {
       type: 'structural',
       reason: `Exact normalized name match: "${normalA}"`,

--- a/src/contacts/dedup-service.ts
+++ b/src/contacts/dedup-service.ts
@@ -96,6 +96,19 @@ function normalizeDisplayName(name: string): string {
 }
 
 /**
+ * Build a comparison key for a channel identity. Emails are stored and looked up
+ * case-insensitively (migration 044's `LOWER(channel_identifier)` unique index), so
+ * we lowercase them before comparison; other channels (phone/signal) are already
+ * normalized to a canonical form at write time. Without this, mixed-case email
+ * identities for the same address would fail the exact-overlap check.
+ * Keep in sync with the copy in dedup-classifier.ts.
+ */
+function canonicalIdentityKey(channel: string, identifier: string): string {
+  const id = channel === 'email' ? identifier.toLowerCase() : identifier;
+  return `${channel}:${id}`;
+}
+
+/**
  * Generate name variants to handle "First Last", "Last First", and "F. Last" forms.
  * E.g., "jenna torres" → ["jenna torres", "torres jenna", "j torres"]
  */
@@ -141,9 +154,9 @@ function scoreContacts(
   if (a.id === b.id) return null;
 
   // Signal 1: exact channel identifier overlap → instant ceiling
-  const aIds = new Set(aIdentities.map((i) => `${i.channel}:${i.channelIdentifier}`));
+  const aIds = new Set(aIdentities.map((i) => canonicalIdentityKey(i.channel, i.channelIdentifier)));
   for (const bId of bIdentities) {
-    const key = `${bId.channel}:${bId.channelIdentifier}`;
+    const key = canonicalIdentityKey(bId.channel, bId.channelIdentifier);
     if (aIds.has(key)) {
       return {
         score: 1.0,
@@ -189,6 +202,22 @@ function scoreContacts(
 // ---------------------------------------------------------------------------
 
 export class DedupService {
+  /**
+   * Score a single explicit pair directly, WITHOUT the name-blocking that
+   * checkForDuplicates/findAllDuplicates apply. The dedup-classifier's caller
+   * already iterates explicit pairs, so blocking there would drop genuinely
+   * similar pairs whose name-blocking keys differ (returning null instead of a
+   * fuzzy match). Returns null below THRESHOLD_PROBABLE.
+   */
+  scorePair(
+    a: Contact,
+    aIdentities: ChannelIdentity[],
+    b: Contact,
+    bIdentities: ChannelIdentity[],
+  ): { score: number; reason: string } | null {
+    return scoreContacts(a, aIdentities, b, bIdentities);
+  }
+
   /**
    * Check a newly-created contact against a list of candidate contacts.
    *

--- a/src/contacts/dedup-service.ts
+++ b/src/contacts/dedup-service.ts
@@ -82,13 +82,15 @@ function jaroWinkler(s1: string, s2: string): number {
  * - Collapse whitespace
  */
 function normalizeDisplayName(name: string): string {
+  // Unicode-aware: decompose + strip diacritics so "José"/"Jose" fold together,
+  // and keep \p{L}/\p{N} so non-ASCII scripts (CJK, Arabic, etc.) are preserved
+  // rather than collapsed to empty. Must stay in sync with the copy in
+  // dedup-classifier.ts (the classifier's structural name match mirrors this).
   return name
+    .normalize('NFKD')
+    .replace(/\p{M}/gu, '')
     .toLowerCase()
-    // @TODO: Use a Unicode-aware character class (e.g. \p{L}\p{N}) so that
-    // non-ASCII letters (accented characters, CJK, Arabic, etc.) are preserved
-    // rather than stripped. The current ASCII-only approach can collapse real
-    // names to empty strings or produce false matches after normalization.
-    .replace(/[^a-z0-9 ]/g, '')
+    .replace(/[^\p{L}\p{N} ]/gu, '')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/tests/integration/dedup-contacts-merge.test.ts
+++ b/tests/integration/dedup-contacts-merge.test.ts
@@ -3,8 +3,9 @@
 // Integration test for the dedup-contacts script's merge path.
 //
 // Specifically verifies that the REAL ContactService.mergeContacts() path is used,
-// not the old hand-rolled SQL that would violate the migration-044 unique email index
-// when two contacts share the same channel identity.
+// not the old hand-rolled SQL — the real path re-points the loser's channel
+// identities onto the survivor (reattachIdentities) and records an audit row,
+// which the hand-rolled UPDATE did neither of.
 //
 // Requires a running Postgres with all migrations applied.
 // Skips gracefully when DATABASE_URL is not set.
@@ -104,25 +105,25 @@ describeIf('dedup-contacts merge integration', () => {
         [createdKgNodeIds],
       );
     }
-    // Also clean up any audit_log rows produced by these contacts so the test is idempotent.
-    // audit_log has no FK to contacts, so it must be cleaned separately.
-    // We match on payload::jsonb fields rather than source_id to avoid accidental over-deletion.
-    if (createdContactIds.length > 0) {
-      await pool.query(
-        `DELETE FROM audit_log WHERE event_type = 'contact.merged'
-           AND (payload->>'primaryContactId' = ANY($1) OR payload->>'secondaryContactId' = ANY($1))`,
-        [createdContactIds],
-      );
-    }
+    // NOTE: audit_log rows produced by this test are deliberately NOT cleaned up.
+    // audit_log is append-only — a DB trigger rejects DELETE (only acknowledged
+    // false→true is permitted) — so attempting to delete here would throw. Leftover
+    // rows are harmless: the test matches its own run's row by the unique per-run
+    // contact IDs, so accumulated rows from prior runs never affect the assertions.
     await pool.end();
   });
 
   it(
-    'merges two contacts sharing a verified email identity without violating the unique index, and writes an audit_log row',
+    'merges two contacts via the real service path, reattaching the loser\'s identities to the survivor, and writes an audit_log row',
     async () => {
       // Unique email suffix per test run so parallel runs don't collide
       const runId = Date.now().toString(36);
-      const sharedEmail = `dedup-merge-test-${runId}@example.com`;
+      // Each contact has its OWN email. Two contacts CANNOT share an identifier:
+      // migration 005's UNIQUE(channel, channel_identifier) (and 044's LOWER() index)
+      // enforce global uniqueness, so the realistic dedup case is two contacts with
+      // distinct/complementary identities matched by name or kg_node_id, then merged.
+      const primaryEmail = `dedup-merge-primary-${runId}@example.com`;
+      const secondaryEmail = `dedup-merge-secondary-${runId}@example.com`;
 
       // --- 1. Create two contacts, each with a KG node (entityMemory is wired) ---
 
@@ -142,22 +143,23 @@ describeIf('dedup-contacts merge integration', () => {
       createdContactIds.push(secondary.id);
       if (secondary.kgNodeId) createdKgNodeIds.push(secondary.kgNodeId);
 
-      // Both contacts share the same verified email — this is the structural case that
-      // the old hand-rolled UPDATE would have broken (unique index on channel+identifier).
+      // Each contact gets its own distinct verified email. The merge must re-point the
+      // loser's identity onto the survivor via the real ContactService.mergeContacts()
+      // path (reattachIdentities) — the old hand-rolled UPDATE skipped this entirely.
       await contactService.linkIdentity({
         contactId: primary.id,
         channel: 'email',
-        channelIdentifier: sharedEmail,
+        channelIdentifier: primaryEmail,
         source: 'ceo_stated',
       });
       await contactService.linkIdentity({
         contactId: secondary.id,
         channel: 'email',
-        channelIdentifier: sharedEmail,
+        channelIdentifier: secondaryEmail,
         source: 'email_participant',
       });
 
-      // --- 2. Confirm both contacts exist and each has the shared email ---
+      // --- 2. Confirm both contacts exist before the merge ---
 
       const primaryBefore = await contactService.getContact(primary.id);
       const secondaryBefore = await contactService.getContact(secondary.id);
@@ -179,18 +181,20 @@ describeIf('dedup-contacts merge integration', () => {
       const secondaryAfter = await contactService.getContact(secondary.id);
       expect(secondaryAfter).toBeUndefined();
 
-      // --- 5. Assert: loser's channel identities now belong to the survivor ---
+      // --- 5. Assert: loser's channel identity now belongs to the survivor ---
       //
-      // The real ContactService.mergeContacts() calls reattachIdentities(), which deletes
-      // any duplicate (channel, channelIdentifier) rows on the primary before re-pointing —
-      // this is what avoids the unique-index violation the old UPDATE would have caused.
+      // The real ContactService.mergeContacts() calls reattachIdentities(), which
+      // re-points the loser's rows onto the survivor (deleting any that would collide
+      // with the survivor's existing identifiers first). The survivor should now carry
+      // BOTH emails — proof the identity actually moved rather than being dropped.
       const withIdentities = await contactService.getContactWithIdentities(primary.id);
       expect(withIdentities).toBeDefined();
       const emails = withIdentities!.identities.map(i => i.channelIdentifier);
 
-      // The shared email should appear exactly once (duplicates were collapsed by reattachIdentities)
-      const sharedEmailCount = emails.filter(e => e === sharedEmail).length;
-      expect(sharedEmailCount).toBe(1);
+      expect(emails).toContain(primaryEmail);
+      expect(emails).toContain(secondaryEmail);
+      // Each identifier appears exactly once (no duplicate rows introduced by the merge)
+      expect(emails.filter(e => e === secondaryEmail).length).toBe(1);
 
       // --- 6. Assert: an audit_log row exists for the contact.merged event ---
       //

--- a/tests/integration/dedup-contacts-merge.test.ts
+++ b/tests/integration/dedup-contacts-merge.test.ts
@@ -1,0 +1,227 @@
+// tests/integration/dedup-contacts-merge.test.ts
+//
+// Integration test for the dedup-contacts script's merge path.
+//
+// Specifically verifies that the REAL ContactService.mergeContacts() path is used,
+// not the old hand-rolled SQL that would violate the migration-044 unique email index
+// when two contacts share the same channel identity.
+//
+// Requires a running Postgres with all migrations applied.
+// Skips gracefully when DATABASE_URL is not set.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { AuditLogger } from '../../src/audit/logger.js';
+import { EventBus } from '../../src/bus/bus.js';
+import { DedupService } from '../../src/contacts/dedup-service.js';
+import { createContactMerged } from '../../src/bus/events.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+
+// Skip the entire suite if DATABASE_URL is not set — no database available
+const DATABASE_URL = process.env['DATABASE_URL'];
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+// Tracked IDs for explicit DELETE cleanup in afterAll
+const createdContactIds: string[] = [];
+const createdKgNodeIds: string[] = [];
+
+describeIf('dedup-contacts merge integration', () => {
+  let pool: pg.Pool;
+  let contactService: ContactService;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+
+    // Use the same service construction as the rewritten CLI entry point, but with
+    // a fake embedding service (no OPENAI_API_KEY required in CI) and a silent logger.
+    // This confirms the real service stack wiring is used for merges.
+    const logger = createSilentLogger();
+
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    const entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+
+    const auditLogger = new AuditLogger(pool, logger);
+    // Wire EventBus with the write-ahead audit hook — identical to the CLI entry point.
+    const bus = new EventBus(
+      logger,
+      (e) => auditLogger.log(e),
+      (id) => auditLogger.markAcknowledged(id),
+    );
+
+    const dedupService = new DedupService();
+    contactService = ContactService.createWithPostgres(pool, entityMemory, logger, {
+      dedupService,
+      // Publish contact.merged to the bus so the audit hook records it.
+      // This is the acceptance criterion path: bus.publish → auditLogger.log → audit_log row.
+      onContactMerged: (primaryContactId, secondaryContactId, mergedAt) => {
+        bus.publish('dispatch', createContactMerged({ primaryContactId, secondaryContactId, mergedAt }))
+          .catch(() => {
+            // Swallow in tests — the test assertions verify the row exists; a logging error
+            // here would mask the actual assertion failure.
+          });
+      },
+    });
+
+    // Verify that the contacts table is accessible — fails fast if migrations haven't run
+    await pool.query('SELECT 1 FROM contacts LIMIT 0');
+  });
+
+  afterAll(async () => {
+    // Clean up in FK-constraint order:
+    //   channel identities → auth overrides → contacts → kg edges → kg nodes
+    // We use explicit ID lists rather than DELETE FROM table (which would nuke data
+    // created by other test suites running in parallel).
+    if (createdContactIds.length > 0) {
+      await pool.query(
+        'DELETE FROM contact_channel_identities WHERE contact_id = ANY($1)',
+        [createdContactIds],
+      );
+      await pool.query(
+        'DELETE FROM contact_auth_overrides WHERE contact_id = ANY($1)',
+        [createdContactIds],
+      );
+      await pool.query(
+        'DELETE FROM contacts WHERE id = ANY($1)',
+        [createdContactIds],
+      );
+    }
+    if (createdKgNodeIds.length > 0) {
+      await pool.query(
+        'DELETE FROM kg_edges WHERE source_node_id = ANY($1) OR target_node_id = ANY($1)',
+        [createdKgNodeIds],
+      );
+      await pool.query(
+        'DELETE FROM kg_nodes WHERE id = ANY($1)',
+        [createdKgNodeIds],
+      );
+    }
+    // Also clean up any audit_log rows produced by these contacts so the test is idempotent.
+    // audit_log has no FK to contacts, so it must be cleaned separately.
+    // We match on payload::jsonb fields rather than source_id to avoid accidental over-deletion.
+    if (createdContactIds.length > 0) {
+      await pool.query(
+        `DELETE FROM audit_log WHERE event_type = 'contact.merged'
+           AND (payload->>'primaryContactId' = ANY($1) OR payload->>'secondaryContactId' = ANY($1))`,
+        [createdContactIds],
+      );
+    }
+    await pool.end();
+  });
+
+  it(
+    'merges two contacts sharing a verified email identity without violating the unique index, and writes an audit_log row',
+    async () => {
+      // Unique email suffix per test run so parallel runs don't collide
+      const runId = Date.now().toString(36);
+      const sharedEmail = `dedup-merge-test-${runId}@example.com`;
+
+      // --- 1. Create two contacts, each with a KG node (entityMemory is wired) ---
+
+      const primary = await contactService.createContact({
+        displayName: `Dedup Primary ${runId}`,
+        source: 'ceo_stated',
+        status: 'confirmed',
+      });
+      createdContactIds.push(primary.id);
+      if (primary.kgNodeId) createdKgNodeIds.push(primary.kgNodeId);
+
+      const secondary = await contactService.createContact({
+        displayName: `Dedup Secondary ${runId}`,
+        source: 'email_participant',
+        status: 'provisional',
+      });
+      createdContactIds.push(secondary.id);
+      if (secondary.kgNodeId) createdKgNodeIds.push(secondary.kgNodeId);
+
+      // Both contacts share the same verified email — this is the structural case that
+      // the old hand-rolled UPDATE would have broken (unique index on channel+identifier).
+      await contactService.linkIdentity({
+        contactId: primary.id,
+        channel: 'email',
+        channelIdentifier: sharedEmail,
+        source: 'ceo_stated',
+      });
+      await contactService.linkIdentity({
+        contactId: secondary.id,
+        channel: 'email',
+        channelIdentifier: sharedEmail,
+        source: 'email_participant',
+      });
+
+      // --- 2. Confirm both contacts exist and each has the shared email ---
+
+      const primaryBefore = await contactService.getContact(primary.id);
+      const secondaryBefore = await contactService.getContact(secondary.id);
+      expect(primaryBefore).toBeDefined();
+      expect(secondaryBefore).toBeDefined();
+
+      // --- 3. Run the REAL merge path used by the script ---
+      //
+      // This is the exact call the CLI entry point makes after the fix.
+      // dryRun=false → performs the real write, fires the bus event, and records an audit row.
+      const mergeResult = await contactService.mergeContacts(primary.id, secondary.id, false);
+
+      // MergeResult (dryRun=false path) carries dryRun=false and primaryContactId
+      expect(mergeResult.primaryContactId).toBe(primary.id);
+      expect('dryRun' in mergeResult && mergeResult.dryRun).toBe(false);
+
+      // --- 4. Assert: loser contact row is gone ---
+
+      const secondaryAfter = await contactService.getContact(secondary.id);
+      expect(secondaryAfter).toBeUndefined();
+
+      // --- 5. Assert: loser's channel identities now belong to the survivor ---
+      //
+      // The real ContactService.mergeContacts() calls reattachIdentities(), which deletes
+      // any duplicate (channel, channelIdentifier) rows on the primary before re-pointing —
+      // this is what avoids the unique-index violation the old UPDATE would have caused.
+      const withIdentities = await contactService.getContactWithIdentities(primary.id);
+      expect(withIdentities).toBeDefined();
+      const emails = withIdentities!.identities.map(i => i.channelIdentifier);
+
+      // The shared email should appear exactly once (duplicates were collapsed by reattachIdentities)
+      const sharedEmailCount = emails.filter(e => e === sharedEmail).length;
+      expect(sharedEmailCount).toBe(1);
+
+      // --- 6. Assert: an audit_log row exists for the contact.merged event ---
+      //
+      // The bus publish → write-ahead hook → auditLogger.log() flow runs synchronously
+      // before event delivery, so the row exists immediately after mergeContacts() resolves.
+      // We poll for up to ~500ms to allow any async publish Promise to settle.
+      let auditRow: { event_type: string; payload: string } | undefined;
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const { rows } = await pool.query<{ event_type: string; payload: string }>(
+          `SELECT event_type, payload::text AS payload
+           FROM audit_log
+           WHERE event_type = 'contact.merged'
+             AND payload->>'primaryContactId' = $1
+             AND payload->>'secondaryContactId' = $2
+           LIMIT 1`,
+          [primary.id, secondary.id],
+        );
+        if (rows.length > 0) {
+          auditRow = rows[0]!;
+          break;
+        }
+        // Brief pause — the onContactMerged callback's bus.publish() is async
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+
+      expect(auditRow).toBeDefined();
+      expect(auditRow!.event_type).toBe('contact.merged');
+
+      // Confirm the payload carries both contact IDs (no deep JSON parse needed — text search is fine)
+      expect(auditRow!.payload).toContain(primary.id);
+      expect(auditRow!.payload).toContain(secondary.id);
+    },
+  );
+});


### PR DESCRIPTION
## **User description**
## Summary

Closes #944.

Adds a re-runnable **contact de-duplication sweep** (`pnpm run dedup:contacts`, with `--dry-run`) that cleans up the entity-level duplicate contacts in prod (github ×4, preply ×4, amazon ×3, plus duplicated real people and the principal himself). Foundational hygiene for the milestone v0.36 contacts redesign.

**Safety model (the core design decision):**

- **Auto-merge only on structural proof** — a shared **verified** channel identity, the same `kg_node_id`, or an exact normalized multi-token name. Merges go through `ContactService.mergeContacts`, so they are transactional, consolidate identities/calendars/auth-overrides/`kg_node_id`, and are **audit-logged** via the `contact.merged` bus event.
- **Fuzzy never auto-merges** — name/embedding similarity (no matter how high) produces a **Curia-owned task** recommendation, not a merge. No new approval queue; it rides the existing task primitive.
- **Declined pairs** get a permanent `dedup_exclusion` KG fact and are skipped on future runs (anti-nag).
- **The principal is never auto-merged** — any pair involving `system_role='principal'` routes to a task.
- **Dry-run** writes nothing.

## Review

Reviewed by `code-reviewer` + `silent-failure-hunter`. Findings fixed in this branch:

- **Critical:** the first pass hand-rolled the merge in raw SQL (would have hit the unique-email index, skipped `kg_node_id`/calendars, and bypassed audit logging) — rewired to `ContactService.mergeContacts`.
- **Critical:** structural proof accepted **unverified** shared identities — now requires `verified=true` (unverified falls to fuzzy).
- **Critical:** merged-away contacts stayed in the working set (cascade merges hit deleted rows) — now tracked in `mergedAwayIds` and skipped.
- **Critical:** an exclusion-check / classify error aborted the whole sweep — now wrapped to **fail closed** (skip the pair, count, continue); a pair whose exclusion check errors never proceeds to merge.
- Exact single-token names (e.g. "Acme") no longer count as structural proof (require ≥2 tokens + length ≥5).
- Dry-run summary surfaces `errorCount`; dead params/tests removed.

## Testing

- `pnpm run typecheck` — clean.
- Unit tests — 45 dedup-specific tests pass (20 new, incl. verified-identity classification and fail-closed exclusion-error paths).
- ⚠️ **DB-integration test (`tests/integration/dedup-contacts-merge.test.ts`) requires a real Postgres and has not run locally** (no `DATABASE_URL`). It asserts a structural merge consolidates a shared email without a unique-index violation and writes a `contact.merged` audit row. Must run against a **dedicated test DB** in CI (teardown deletes contacts/kg_nodes — never a live database).

## Follow-up (tracked separately)

- **Decline → `writeExclusion` wiring is not built yet.** The sweep reads exclusions and the helper exists, but the contacts agent's "not a duplicate" decision needs to call `writeExclusion` to close the anti-nag loop end-to-end.

## Note

Touches `src/contacts/contact-service.ts`, which #945 also touches — whichever of #944/#945 merges second will need a small rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contact deduplication maintenance sweep with automatic merging of structurally identical contacts
  * Fuzzy matching creates recommendation tasks for manual review
  * Exclusion system to prevent future pairing of contacts
  * Dry-run mode to preview deduplication without making changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add contact de-duplication sweep with safe merge rules**

### What Changed
- Added a new contact deduplication run that auto-merges only clearly matching duplicates, sends fuzzy matches to Curia review tasks, skips declined pairs, and supports dry-run mode.
- Structural matches now require stronger proof: shared verified identity, the same knowledge-graph node, or an exact normalized name match; the principal contact is never auto-merged.
- The merge path now uses the real contact merge flow, so combined contacts keep their related data and merge events are recorded in the audit log.
- Added tests for merge rules, exclusion handling, dry-run behavior, and the real merge/audit path.

### Impact
`✅ Fewer duplicate contacts`
`✅ Safer review of ambiguous matches`
`✅ Clearer audit trail for contact merges`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
