### PR TITLE
fix: copy scripts/ into the runtime Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Tier-based capability gating** — dispatcher, outbound gateway, and Signal trust now gate via `meetsMinimumTier()`; legacy `status`/`trust_level` deprecated (removal in #955). (#945)
 
+### Fixed
+
+- **Docker image now ships `scripts/`** — maintenance commands (`dedup:contacts`, `backfill-*`) were absent from the runtime image, so they failed in prod with "file not found"; the Dockerfile now copies `scripts/`.
+
 ### Security
 
 - **hono** — bumped override floor from 4.12.18 to 4.12.25, resolving 5 CVEs including CORS credential reflection (CVE-2026-54290, HIGH 7.1), body-limit bypass (CVE-2026-54288), path traversal in serve-static (CVE-2026-54286), Set-Cookie header merging (CVE-2026-54287), and Lambda@Edge header dropping (CVE-2026-54289).

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,14 @@ COPY config/ ./config/
 # computed from src/index.ts (../schemas), which resolves to /app/schemas here.
 COPY schemas/ ./schemas/
 COPY src/ ./src/
+# Maintenance scripts (e.g. dedup-contacts, backfill-*) are run as one-off commands
+# in the running container via `tsx scripts/<name>.ts`. They import from src/ (copied
+# above) and rely on tsx + prod node_modules, both present at runtime. Without this
+# COPY the scripts simply aren't in the image, so the commands fail with "file not
+# found" — copy the whole dir so new maintenance scripts are available without a
+# Dockerfile edit each time. (The handful of *.test.ts files here are inert: vitest
+# isn't installed in the prod image, so they can't run; they just ride along.)
+COPY scripts/ ./scripts/
 
 # node_modules were installed as root above, so we chown the entire /app tree
 # to the non-root user before dropping privileges. /usr/local/bin/uv,


### PR DESCRIPTION
## **User description**
## Summary

Maintenance commands (`dedup:contacts`, `backfill-*`) are run as one-off `tsx scripts/<name>.ts` invocations in the running container. The runtime stage of the Dockerfile copied `dist/`, `agents/`, `skills/`, `config/`, `schemas/`, and `src/` — but **not `scripts/`** — so those commands failed in prod with "file not found". This blocks running the new contact de-duplication sweep (#944) in production.

Copy the whole `scripts/` directory (placed right after `COPY src/ ./src/`, before the recursive `chown`) so:
- new maintenance scripts are available without a Dockerfile edit each time (this has bitten us before), and
- the scripts' `../src/...` imports resolve to `/app/src` (already present), with `tsx` + prod `node_modules` both available at runtime.

## Notes
- The handful of `*.test.ts` files in `scripts/` ride along (~34KB); they're inert in prod since vitest isn't installed.
- No secret material is shipped — the secret-mgmt tooling (`rotate-secret-key.ts`, `seed-vault.ts`, `gdrive-auth.py`) reads all credentials from runtime env, and `.env`/keys are dockerignored.
- **Operational:** run these in prod via direct `tsx scripts/<name>.ts` (with env vars passed inline), **not** `pnpm run <script>` — the package.json wrappers use `--env-file=.env`, which is absent from the prod image.

## Test plan
- [ ] CI green
- [ ] Post-deploy: `docker exec curia-curia-1 ./node_modules/.bin/tsx scripts/dedup-contacts.ts --dry-run` runs (no "file not found")


___

## **CodeAnt-AI Description**
**Include maintenance scripts in the runtime Docker image**

### What Changed
- The runtime image now includes the full `scripts/` directory, so maintenance commands like `dedup-contacts` and `backfill-*` can run in production instead of failing with “file not found”
- New maintenance scripts will be available automatically without needing another Dockerfile update
- The copied scripts continue to work with the app source and runtime Node tools already present in the image

### Impact
`✅ Fewer production script failures`
`✅ Reliable contact cleanup runs`
`✅ Easier rollout of new maintenance jobs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
