### PR TITLE
feat: add sweep-local tuning flags to dedup:contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Contact de-duplication sweep (`dedup:contacts`)** — maintenance script that auto-merges structural duplicates (shared channel identity / same `kg_node_id` / exact name), files Curia-owned tasks for fuzzy matches, skips `dedup_exclusion` pairs, and never auto-merges the principal. Supports `--dry-run`. (#944)
 - **`dedup-classifier`** — pure module classifying a contact pair as `structural` or `fuzzy`; name/JW similarity is always fuzzy (never auto-merge). (#944)
 - **`writeExclusion` / `hasExclusion` helpers** — permanent `dedup_exclusion` KG facts so a declined pair is never re-surfaced. (#944)
+- **`dedup:contacts` sweep-local tuning flags** — `--no-tasks` (merge-only), `--min-score <n>` (raise the fuzzy bar for this run), and `--max-tasks <n>` (cap review tasks), so a first sweep over a large un-deduped contact set doesn't flood the queue. Leaves the global `DedupService` threshold untouched. (#944)
 
 ### Changed
 

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -530,6 +530,91 @@ describe('runDedup — unit', () => {
     );
     expect(c1c2WasMerged).toBe(false);
   });
+
+  // -------------------------------------------------------------------------
+  // Sweep-local tuning flags: --no-tasks, --min-score, --max-tasks
+  // -------------------------------------------------------------------------
+
+  it('--no-tasks: applies structural merges but creates no review tasks', async () => {
+    const contacts: Contact[] = [
+      // Structural pair (exact normalized name) → should still merge
+      makeContact({ id: 'c1', displayName: 'Quentin Alvarez' }),
+      makeContact({ id: 'c2', displayName: 'quentin alvarez' }),
+      // Fuzzy pair (similar, dissimilar from the above) → would be a task, suppressed
+      makeContact({ id: 'c3', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c4', displayName: 'Michael Sorenson' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, { ...opts, noTasks: true });
+
+    expect(mergeMock).toHaveBeenCalledOnce();        // structural merge still happens
+    expect(createTaskMock).not.toHaveBeenCalled();   // no tasks created
+    expect(result.mergedCount).toBe(1);
+    expect(result.taskCount).toBe(0);
+    expect(result.suppressedTaskCount).toBe(1);      // the fuzzy pair was suppressed
+  });
+
+  it('--min-score: skips a fuzzy pair scoring below the bar', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }), // fuzzy, scores 0.96
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    // 0.99 sits above this pair's 0.96 score, so it should be skipped.
+    const result = await runDedup(contacts, identityMap, { ...opts, minScore: 0.99 });
+
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.taskCount).toBe(0);
+    expect(result.skippedLowScoreCount).toBe(1);
+  });
+
+  it('--min-score: still creates a task for a fuzzy pair at/above the bar', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }), // fuzzy, scores 0.96
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, { ...opts, minScore: 0.5 });
+
+    expect(createTaskMock).toHaveBeenCalledOnce();
+    expect(result.taskCount).toBe(1);
+    expect(result.skippedLowScoreCount).toBe(0);
+  });
+
+  it('--max-tasks: caps task creation and suppresses the overflow', async () => {
+    // Three mutually-similar names → three fuzzy pairs (c1c2, c1c3, c2c3), none structural.
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }),
+      makeContact({ id: 'c3', displayName: 'Mikhael Sorensen' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, { ...opts, maxTasks: 1 });
+
+    expect(createTaskMock).toHaveBeenCalledTimes(1);  // capped at 1
+    expect(result.taskCount).toBe(1);
+    expect(result.suppressedTaskCount).toBe(2);       // the other two pairs suppressed
+  });
+
+  it('--max-tasks cap is reflected in dry-run counts too', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }),
+      makeContact({ id: 'c3', displayName: 'Mikhael Sorensen' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, { ...opts, dryRun: true, maxTasks: 1 });
+
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.wouldCreateTaskCount).toBe(1);      // dry-run honors the cap
+    expect(result.suppressedTaskCount).toBe(2);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -20,6 +20,7 @@ import {
   runDedup,
   writeExclusion,
   hasExclusion,
+  parseNumericFlag,
   type DedupRunOptions,
 } from './dedup-contacts.js';
 
@@ -750,6 +751,65 @@ describe('hasExclusion', () => {
     });
 
     expect(result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseNumericFlag — CLI numeric flag parsing
+// ---------------------------------------------------------------------------
+
+describe('parseNumericFlag', () => {
+  it('returns undefined when the flag is absent', () => {
+    expect(parseNumericFlag(['node', 'script', '--dry-run'], '--min-score')).toBeUndefined();
+  });
+
+  it('parses --flag value form', () => {
+    expect(parseNumericFlag(['node', 'script', '--max-tasks', '50'], '--max-tasks')).toBe(50);
+  });
+
+  it('parses --flag=value form', () => {
+    expect(parseNumericFlag(['node', 'script', '--min-score=0.88'], '--min-score')).toBe(0.88);
+  });
+
+  it('accepts an explicit zero (--flag=0)', () => {
+    expect(parseNumericFlag(['node', 'script', '--max-tasks=0'], '--max-tasks')).toBe(0);
+  });
+
+  it('exits on an empty value (--flag=) rather than silently coercing to 0', () => {
+    // process.exit is stubbed to throw so we can assert the loud-fail path. Without the
+    // empty-value guard, Number('') === 0 would be returned silently.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    try {
+      expect(() => parseNumericFlag(['node', 'script', '--max-tasks='], '--max-tasks')).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('exits on a whitespace-only value', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    try {
+      expect(() => parseNumericFlag(['node', 'script', '--min-score', '   '], '--min-score')).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('exits on a non-numeric value', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    try {
+      expect(() => parseNumericFlag(['node', 'script', '--min-score=high'], '--min-score')).toThrow('process.exit');
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 });
 

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -624,7 +624,7 @@ async function loadContactsAndIdentities(pool: pg.Pool): Promise<{
  * the flag is present but its value is missing or not a finite number — better to
  * fail loudly than to silently ignore an operator's tuning intent on a prod sweep.
  */
-function parseNumericFlag(argv: string[], flag: string): number | undefined {
+export function parseNumericFlag(argv: string[], flag: string): number | undefined {
   const eq = argv.find(a => a.startsWith(`${flag}=`));
   let raw: string | undefined;
   if (eq) {
@@ -634,7 +634,11 @@ function parseNumericFlag(argv: string[], flag: string): number | undefined {
     if (idx === -1) return undefined;
     raw = argv[idx + 1];
   }
-  const n = raw === undefined ? NaN : Number(raw);
+  // Empty / whitespace-only values (e.g. `--min-score=` or `--max-tasks= `) must fail
+  // loudly, NOT be silently coerced to 0 — Number('') and Number('  ') are both 0, which
+  // is finite, so without this guard a missing operator value would pass as a real 0
+  // setting (e.g. `--max-tasks=` would behave like --no-tasks).
+  const n = (raw === undefined || raw.trim() === '') ? NaN : Number(raw);
   if (!Number.isFinite(n)) {
     logger.error({ flag, raw }, `dedup-contacts: ${flag} requires a numeric value`);
     process.exit(1);

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -57,6 +57,10 @@ export interface DedupRunResult {
   wouldMergeCount: number;
   /** Number of pairs that would have had tasks created (dry-run report). */
   wouldCreateTaskCount: number;
+  /** Number of fuzzy pairs skipped because their score was below the sweep's --min-score. */
+  skippedLowScoreCount: number;
+  /** Number of would-be review tasks suppressed by --no-tasks or the --max-tasks cap. */
+  suppressedTaskCount: number;
   /** Number of errors during merge/task-create operations. */
   errorCount: number;
 }
@@ -64,6 +68,23 @@ export interface DedupRunResult {
 /** Dependency-injected callbacks used by runDedup() — allows unit testing without a DB. */
 export interface DedupRunOptions {
   dryRun: boolean;
+  /**
+   * Sweep-local minimum score for FUZZY matches (0–1). Fuzzy pairs scoring below this
+   * are skipped (counted in skippedLowScoreCount). Does NOT affect structural matches and
+   * does NOT change the global DedupService THRESHOLD_PROBABLE — it only raises the bar for
+   * this maintenance run. Undefined = accept whatever the classifier returns (≥ 0.7).
+   */
+  minScore?: number;
+  /**
+   * Hard cap on the number of review tasks this sweep creates. Once reached, further
+   * would-be tasks are skipped (counted in suppressedTaskCount). Undefined = no cap.
+   */
+  maxTasks?: number;
+  /**
+   * Merge-only mode: apply structural auto-merges but create NO review tasks (every
+   * would-be task is counted in suppressedTaskCount). Equivalent to maxTasks = 0.
+   */
+  noTasks?: boolean;
   /** Calls ContactService.mergeContacts (or equivalent). Returns a MergeResult. */
   mergeContacts: (primaryId: string, secondaryId: string) => Promise<unknown>;
   /** Calls TaskRepo.createTask (or equivalent). */
@@ -197,7 +218,7 @@ export async function runDedup(
   identityMap: Map<string, ChannelIdentity[]>,
   opts: DedupRunOptions,
 ): Promise<DedupRunResult> {
-  const { dryRun, mergeContacts, createTask, getFacts } = opts;
+  const { dryRun, mergeContacts, createTask, getFacts, minScore, maxTasks, noTasks } = opts;
 
   // Memoize getFacts per KG node for the duration of the sweep. The exclusion check
   // runs inside the O(n²) pair loop, and a contact that appears in many candidate
@@ -221,6 +242,8 @@ export async function runDedup(
     principalSkippedCount: 0,
     wouldMergeCount: 0,
     wouldCreateTaskCount: 0,
+    skippedLowScoreCount: 0,
+    suppressedTaskCount: 0,
     errorCount: 0,
   };
 
@@ -357,6 +380,15 @@ export async function runDedup(
           result.errorCount++;
         }
       } else {
+        // Sweep-local --min-score: drop FUZZY pairs below the bar before any task
+        // accounting. Structural+principal pairs are always surfaced (the principal
+        // guard is about safety, not similarity score). This filters this sweep only —
+        // the global DedupService threshold is untouched.
+        if (classification.type === 'fuzzy' && minScore !== undefined && classification.score < minScore) {
+          result.skippedLowScoreCount++;
+          continue;
+        }
+
         // ------------------------------------------------------------------
         // Fuzzy pair OR structural pair involving the principal → task
         // ------------------------------------------------------------------
@@ -378,6 +410,16 @@ export async function runDedup(
             { contactAId: a.id, contactBId: b.id, classification },
             'dedup: fuzzy match — creating recommendation task',
           );
+        }
+
+        // --no-tasks (merge-only) or the --max-tasks cap: suppress task creation. Compare
+        // against tasks already acted on (real run: taskCount; dry-run: wouldCreateTaskCount)
+        // so the cap behaves identically in both modes and the dry-run preview reflects
+        // exactly what a real run with the same flags would create.
+        const tasksActedOn = dryRun ? result.wouldCreateTaskCount : result.taskCount;
+        if (noTasks || (maxTasks !== undefined && tasksActedOn >= maxTasks)) {
+          result.suppressedTaskCount++;
+          continue;
         }
 
         if (dryRun) {
@@ -573,6 +615,34 @@ async function loadContactsAndIdentities(pool: pg.Pool): Promise<{
 }
 
 // ---------------------------------------------------------------------------
+// CLI argument helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a numeric CLI flag supporting both `--flag value` and `--flag=value`.
+ * Returns undefined if the flag is absent. Exits the process with a clear error if
+ * the flag is present but its value is missing or not a finite number — better to
+ * fail loudly than to silently ignore an operator's tuning intent on a prod sweep.
+ */
+function parseNumericFlag(argv: string[], flag: string): number | undefined {
+  const eq = argv.find(a => a.startsWith(`${flag}=`));
+  let raw: string | undefined;
+  if (eq) {
+    raw = eq.slice(flag.length + 1);
+  } else {
+    const idx = argv.indexOf(flag);
+    if (idx === -1) return undefined;
+    raw = argv[idx + 1];
+  }
+  const n = raw === undefined ? NaN : Number(raw);
+  if (!Number.isFinite(n)) {
+    logger.error({ flag, raw }, `dedup-contacts: ${flag} requires a numeric value`);
+    process.exit(1);
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
 // CLI entry point
 // ---------------------------------------------------------------------------
 
@@ -585,8 +655,35 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
 
   const dryRun = process.argv.includes('--dry-run');
 
+  // Sweep-local tuning flags — these tune THIS run only; the global DedupService
+  // threshold is never changed. See DedupRunOptions for semantics.
+  //   --no-tasks       merge-only: apply structural merges, create no review tasks
+  //   --min-score <n>  only create fuzzy tasks at/above this Jaro-Winkler score (0–1)
+  //   --max-tasks <n>  cap the number of review tasks created this run
+  const noTasks = process.argv.includes('--no-tasks');
+  const minScore = parseNumericFlag(process.argv, '--min-score');
+  const maxTasks = parseNumericFlag(process.argv, '--max-tasks');
+
+  if (minScore !== undefined && (minScore < 0 || minScore > 1)) {
+    logger.error({ minScore }, 'dedup-contacts: --min-score must be between 0 and 1');
+    process.exit(1);
+  }
+  if (maxTasks !== undefined && (maxTasks < 0 || !Number.isInteger(maxTasks))) {
+    logger.error({ maxTasks }, 'dedup-contacts: --max-tasks must be a non-negative integer');
+    process.exit(1);
+  }
+
   if (dryRun) {
     logger.info('dedup-contacts: running in DRY-RUN mode — no writes will be made');
+  }
+  if (noTasks) {
+    logger.info('dedup-contacts: --no-tasks — merge-only; no review tasks will be created');
+  }
+  if (minScore !== undefined) {
+    logger.info({ minScore }, 'dedup-contacts: --min-score active — fuzzy pairs below this score are skipped');
+  }
+  if (maxTasks !== undefined) {
+    logger.info({ maxTasks }, 'dedup-contacts: --max-tasks active — review tasks capped');
   }
 
   const pool = new Pool({ connectionString: databaseUrl });
@@ -654,6 +751,10 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       // Build injected callbacks — all delegate to real services, no hand-rolled SQL
       const opts: DedupRunOptions = {
         dryRun,
+        // Sweep-local tuning (see DedupRunOptions) — passed straight through.
+        minScore,
+        maxTasks,
+        noTasks,
 
         // ContactService.mergeContacts handles: identity dedup (resolves the unique-email
         // constraint violation the old UPDATE would have caused), kg_node_id repointing,
@@ -678,6 +779,8 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
         logger.info({
           wouldMergeCount: result.wouldMergeCount,
           wouldCreateTaskCount: result.wouldCreateTaskCount,
+          skippedLowScoreCount: result.skippedLowScoreCount,
+          suppressedTaskCount: result.suppressedTaskCount,
           skippedExcludedCount: result.skippedExcludedCount,
           principalSkippedCount: result.principalSkippedCount,
           // F5: Include errorCount in the dry-run summary — otherwise an operator
@@ -689,6 +792,8 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
         logger.info({
           mergedCount: result.mergedCount,
           taskCount: result.taskCount,
+          skippedLowScoreCount: result.skippedLowScoreCount,
+          suppressedTaskCount: result.suppressedTaskCount,
           skippedExcludedCount: result.skippedExcludedCount,
           principalSkippedCount: result.principalSkippedCount,
           errorCount: result.errorCount,


### PR DESCRIPTION
## **User description**
## Summary

The first production dry-run (378 contacts) surfaced **14 structural auto-merges** (safe) but **2009 fuzzy review tasks** — almost all clustered at Jaro-Winkler 0.70–0.78, which is noise for short names. A real run would flood the contacts queue with 2000+ tasks.

This adds three **sweep-local** tuning flags so the maintenance run can be tuned **without** changing the global `DedupService` `THRESHOLD_PROBABLE` (which also drives the live entity-resolution suggestion path — we don't want that blast radius for a one-off sweep):

- `--no-tasks` — merge-only: apply structural merges, create no review tasks
- `--min-score <n>` — only create fuzzy tasks at/above this score (0–1); structural matches are unaffected
- `--max-tasks <n>` — cap the number of review tasks created this run

New result counters `skippedLowScoreCount` + `suppressedTaskCount` make the filtering/capping visible in the summary (no silent caps). The `--max-tasks` cap is honored identically in dry-run and real runs, so the preview reflects exactly what a real run with the same flags would do.

## Operational plan this unblocks
1. `--no-tasks` → apply the 14 structural merges, zero tasks.
2. `--dry-run --min-score 0.88` → find a reviewable fuzzy count.
3. `--min-score <tuned> [--max-tasks N]` → create that reviewable set.

## Test plan
- [x] 6 new unit tests (each flag, plus dry-run cap parity); 28/28 pass
- [x] typecheck clean
- [ ] CI green


___

## **CodeAnt-AI Description**
**Add sweep-local controls for contact dedup runs**

### What Changed
- Added a merge-only mode that applies structural merges but creates no review tasks.
- Added a minimum score setting to skip fuzzy matches below a chosen bar for that run.
- Added a task cap so large sweeps stop creating review tasks after the limit is reached.
- The run summary now shows how many fuzzy pairs were skipped for low score and how many tasks were suppressed.
- Added coverage for the new flags, including the dry-run behavior of the task cap.

### Impact
`✅ Fewer review queue floods`
`✅ Shorter dedup sweeps`
`✅ Clearer sweep summaries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
