### PR TITLE
fix: harden dedup sweep (audit drain, --max-score, log accuracy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Contact de-duplication sweep (`dedup:contacts`)** — maintenance script that auto-merges structural duplicates (shared channel identity / same `kg_node_id` / exact name), files Curia-owned tasks for fuzzy matches, skips `dedup_exclusion` pairs, and never auto-merges the principal. Supports `--dry-run`. (#944)
 - **`dedup-classifier`** — pure module classifying a contact pair as `structural` or `fuzzy`; name/JW similarity is always fuzzy (never auto-merge). (#944)
 - **`writeExclusion` / `hasExclusion` helpers** — permanent `dedup_exclusion` KG facts so a declined pair is never re-surfaced. (#944)
-- **`dedup:contacts` sweep-local tuning flags** — `--no-tasks` (merge-only), `--min-score <n>` (raise the fuzzy bar for this run), and `--max-tasks <n>` (cap review tasks), so a first sweep over a large un-deduped contact set doesn't flood the queue. Leaves the global `DedupService` threshold untouched. (#944)
+- **`dedup:contacts` sweep-local tuning flags** — `--no-tasks` (merge-only), `--min-score <n>` / `--max-score <n>` (run a fuzzy-score band), and `--max-tasks <n>` (cap review tasks), so a sweep over a large un-deduped contact set doesn't flood the queue. `--max-score` enables incremental band runs (a lower-threshold pass that doesn't re-create tasks an earlier run already surfaced). Leaves the global `DedupService` threshold untouched. (#944, #1034)
 
 ### Changed
 
@@ -34,6 +34,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Docker image now ships `scripts/`** — maintenance commands (`dedup:contacts`, `backfill-*`) were absent from the runtime image, so they failed in prod with "file not found"; the Dockerfile now copies `scripts/`.
+- **`dedup:contacts` merge-audit completeness** — `contact.merged` publishes are now drained before the process exits, so every merge persists an `audit_log` row (a prior run lost 1 of 14 to an exit race); a lost publish now fails the run's exit code instead of being silently logged. (#1034)
+- **`dedup:contacts` suppressed-task logging** — the "creating review task" line is logged after the suppression gate, so `--no-tasks` / capped runs no longer print a "creating" line for every pair they suppress. (#1034)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Contact `tier` + `kind` model (migration 055)** — ordered capability `tier` and descriptive `kind`, backfilled from legacy fields. (#945)
-- **Contact de-duplication sweep (`dedup:contacts`)** — maintenance script that auto-merges structural duplicates (shared channel identity / same `kg_node_id` / exact name), files Curia-owned tasks for fuzzy matches, skips `dedup_exclusion` pairs, and never auto-merges the principal. Supports `--dry-run`. (#944)
-- **`dedup-classifier`** — pure module classifying a contact pair as `structural` or `fuzzy`; name/JW similarity is always fuzzy (never auto-merge). (#944)
-- **`writeExclusion` / `hasExclusion` helpers** — permanent `dedup_exclusion` KG facts so a declined pair is never re-surfaced. (#944)
-- **`dedup:contacts` sweep-local tuning flags** — `--no-tasks` (merge-only), `--min-score <n>` / `--max-score <n>` (run a fuzzy-score band), and `--max-tasks <n>` (cap review tasks), so a sweep over a large un-deduped contact set doesn't flood the queue. `--max-score` enables incremental band runs (a lower-threshold pass that doesn't re-create tasks an earlier run already surfaced). Leaves the global `DedupService` threshold untouched. (#944, #1034)
+- **Contact de-duplication (`dedup:contacts`)** — maintenance sweep that auto-merges structurally-proven duplicates (shared verified identity / same `kg_node_id` / exact normalized name) and files Curia-owned review tasks for fuzzy matches, never auto-merging the principal and never re-surfacing a declined pair. Tunable for controlled rollout via `--dry-run`, `--no-tasks`, `--min-score`/`--max-score` bands, and `--max-tasks`, and shipped in the production image. (#944, #1034)
 
 ### Changed
 
@@ -30,12 +27,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Removed
 
 - **`pending-actions-digest` skill** — removed; coordinator composes the daily digest directly from `list-pending-actions` and `task-list`.
-
-### Fixed
-
-- **Docker image now ships `scripts/`** — maintenance commands (`dedup:contacts`, `backfill-*`) were absent from the runtime image, so they failed in prod with "file not found"; the Dockerfile now copies `scripts/`.
-- **`dedup:contacts` merge-audit completeness** — `contact.merged` publishes are now drained before the process exits, so every merge persists an `audit_log` row (a prior run lost 1 of 14 to an exit race); a lost publish now fails the run's exit code instead of being silently logged. (#1034)
-- **`dedup:contacts` suppressed-task logging** — the "creating review task" line is logged after the suppression gate, so `--no-tasks` / capped runs no longer print a "creating" line for every pair they suppress. (#1034)
 
 ### Security
 

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -616,6 +616,38 @@ describe('runDedup — unit', () => {
     expect(result.wouldCreateTaskCount).toBe(1);      // dry-run honors the cap
     expect(result.suppressedTaskCount).toBe(2);
   });
+
+  it('--max-score: skips a fuzzy pair scoring at/above the bar', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }), // fuzzy, scores 0.96
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    // 0.95 sits below this pair's 0.96 score, so --max-score 0.95 excludes it.
+    const result = await runDedup(contacts, identityMap, { ...opts, maxScore: 0.95 });
+
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.taskCount).toBe(0);
+    expect(result.skippedAboveMaxScoreCount).toBe(1);
+  });
+
+  it('--min-score + --max-score: only pairs within [min, max) create tasks', async () => {
+    // Three names → pairs score 0.96, 1.0, 0.96. Band [0.95, 1.0): the two 0.96 pairs are
+    // in-band (tasks); the 1.0 pair is at/above max (skipped).
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Mikael Sorensen' }),
+      makeContact({ id: 'c2', displayName: 'Michael Sorenson' }),
+      makeContact({ id: 'c3', displayName: 'Mikhael Sorensen' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, { ...opts, minScore: 0.95, maxScore: 1.0 });
+
+    expect(result.taskCount).toBe(2);
+    expect(result.skippedAboveMaxScoreCount).toBe(1);   // the 1.0 pair excluded
+    expect(result.skippedLowScoreCount).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -59,6 +59,8 @@ export interface DedupRunResult {
   wouldCreateTaskCount: number;
   /** Number of fuzzy pairs skipped because their score was below the sweep's --min-score. */
   skippedLowScoreCount: number;
+  /** Number of fuzzy pairs skipped because their score was at/above the sweep's --max-score. */
+  skippedAboveMaxScoreCount: number;
   /** Number of would-be review tasks suppressed by --no-tasks or the --max-tasks cap. */
   suppressedTaskCount: number;
   /** Number of errors during merge/task-create operations. */
@@ -75,6 +77,15 @@ export interface DedupRunOptions {
    * this maintenance run. Undefined = accept whatever the classifier returns (≥ 0.7).
    */
   minScore?: number;
+  /**
+   * Sweep-local maximum score for FUZZY matches — pairs scoring AT/ABOVE this are skipped
+   * (counted in skippedAboveMaxScoreCount). Pairs with `minScore ≤ score < maxScore` are
+   * acted on. Used for incremental band runs: a later, lower `--min-score` pass sets
+   * `--max-score` to the previous run's `--min-score` so it doesn't re-create tasks for
+   * pairs the earlier run already surfaced (the sweep is not task-idempotent). Undefined =
+   * no upper bound.
+   */
+  maxScore?: number;
   /**
    * Hard cap on the number of review tasks this sweep creates. Once reached, further
    * would-be tasks are skipped (counted in suppressedTaskCount). Undefined = no cap.
@@ -218,7 +229,7 @@ export async function runDedup(
   identityMap: Map<string, ChannelIdentity[]>,
   opts: DedupRunOptions,
 ): Promise<DedupRunResult> {
-  const { dryRun, mergeContacts, createTask, getFacts, minScore, maxTasks, noTasks } = opts;
+  const { dryRun, mergeContacts, createTask, getFacts, minScore, maxScore, maxTasks, noTasks } = opts;
 
   // Memoize getFacts per KG node for the duration of the sweep. The exclusion check
   // runs inside the O(n²) pair loop, and a contact that appears in many candidate
@@ -243,6 +254,7 @@ export async function runDedup(
     wouldMergeCount: 0,
     wouldCreateTaskCount: 0,
     skippedLowScoreCount: 0,
+    skippedAboveMaxScoreCount: 0,
     suppressedTaskCount: 0,
     errorCount: 0,
   };
@@ -380,36 +392,29 @@ export async function runDedup(
           result.errorCount++;
         }
       } else {
-        // Sweep-local --min-score: drop FUZZY pairs below the bar before any task
-        // accounting. Structural+principal pairs are always surfaced (the principal
-        // guard is about safety, not similarity score). This filters this sweep only —
-        // the global DedupService threshold is untouched.
+        // Sweep-local score band: drop FUZZY pairs outside [minScore, maxScore) before any
+        // task accounting. Structural+principal pairs are always surfaced (the principal
+        // guard is about safety, not similarity score). This filters this sweep only — the
+        // global DedupService threshold is untouched.
+        //   --min-score: skip below the bar (too weak to review this run)
+        //   --max-score: skip at/above the bar — for incremental band runs, so a
+        //     lower-threshold pass doesn't re-create tasks for pairs an earlier, higher-bar
+        //     run already surfaced.
         if (classification.type === 'fuzzy' && minScore !== undefined && classification.score < minScore) {
           result.skippedLowScoreCount++;
           continue;
         }
+        if (classification.type === 'fuzzy' && maxScore !== undefined && classification.score >= maxScore) {
+          result.skippedAboveMaxScoreCount++;
+          continue;
+        }
 
-        // ------------------------------------------------------------------
-        // Fuzzy pair OR structural pair involving the principal → task
-        // ------------------------------------------------------------------
-        // Name/embedding similarity alone is never enough to auto-merge (see design).
-        // Also, any pair touching the principal must go through human review even when
-        // structural proof exists — identity mistakes for the principal are too costly.
-        // principalSkippedCount counts ONLY structural pairs withheld from auto-merge by
-        // the principal guard (see the DedupRunResult contract). A fuzzy pair involving the
-        // principal would never auto-merge anyway — it's an ordinary recommendation task —
-        // so counting it here would inflate the metric and misreport operator-facing results.
+        // principalSkippedCount counts ONLY structural pairs withheld from auto-merge by the
+        // principal guard (see the DedupRunResult contract). It records the MERGE decision,
+        // so it is incremented even if the resulting task is later suppressed. A fuzzy pair
+        // involving the principal would never auto-merge anyway, so it must not inflate this.
         if (classification.type === 'structural' && involvePrincipal) {
           result.principalSkippedCount++;
-          logger.info(
-            { contactAId: a.id, contactBId: b.id, reason: classification.reason },
-            'dedup: principal contact involved — routing structural pair to task instead of auto-merge',
-          );
-        } else {
-          logger.info(
-            { contactAId: a.id, contactBId: b.id, classification },
-            'dedup: fuzzy match — creating recommendation task',
-          );
         }
 
         // --no-tasks (merge-only) or the --max-tasks cap: suppress task creation. Compare
@@ -421,6 +426,16 @@ export async function runDedup(
           result.suppressedTaskCount++;
           continue;
         }
+
+        // Past the suppression gate: a task WILL be created (real) or counted (dry-run).
+        // Log here — NOT before the gate — so a suppressed pair never logs a misleading
+        // "creating ... task" line (a --no-tasks run previously printed one per pair).
+        logger.info(
+          { contactAId: a.id, contactBId: b.id, classification, involvePrincipal },
+          involvePrincipal
+            ? 'dedup: principal pair — creating review task (no auto-merge)'
+            : 'dedup: fuzzy match — creating review task',
+        );
 
         if (dryRun) {
           result.wouldCreateTaskCount++;
@@ -663,13 +678,23 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
   // threshold is never changed. See DedupRunOptions for semantics.
   //   --no-tasks       merge-only: apply structural merges, create no review tasks
   //   --min-score <n>  only create fuzzy tasks at/above this Jaro-Winkler score (0–1)
+  //   --max-score <n>  only create fuzzy tasks BELOW this score (incremental band runs)
   //   --max-tasks <n>  cap the number of review tasks created this run
   const noTasks = process.argv.includes('--no-tasks');
   const minScore = parseNumericFlag(process.argv, '--min-score');
+  const maxScore = parseNumericFlag(process.argv, '--max-score');
   const maxTasks = parseNumericFlag(process.argv, '--max-tasks');
 
   if (minScore !== undefined && (minScore < 0 || minScore > 1)) {
     logger.error({ minScore }, 'dedup-contacts: --min-score must be between 0 and 1');
+    process.exit(1);
+  }
+  if (maxScore !== undefined && (maxScore < 0 || maxScore > 1)) {
+    logger.error({ maxScore }, 'dedup-contacts: --max-score must be between 0 and 1');
+    process.exit(1);
+  }
+  if (minScore !== undefined && maxScore !== undefined && minScore >= maxScore) {
+    logger.error({ minScore, maxScore }, 'dedup-contacts: --min-score must be less than --max-score (empty band otherwise)');
     process.exit(1);
   }
   if (maxTasks !== undefined && (maxTasks < 0 || !Number.isInteger(maxTasks))) {
@@ -685,6 +710,9 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
   }
   if (minScore !== undefined) {
     logger.info({ minScore }, 'dedup-contacts: --min-score active — fuzzy pairs below this score are skipped');
+  }
+  if (maxScore !== undefined) {
+    logger.info({ maxScore }, 'dedup-contacts: --max-score active — fuzzy pairs at/above this score are skipped');
   }
   if (maxTasks !== undefined) {
     logger.info({ maxTasks }, 'dedup-contacts: --max-tasks active — review tasks capped');
@@ -736,17 +764,30 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       const validator = new MemoryValidator(kgStore, embeddingService);
       const entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
 
+      // contact.merged publishes are async (the write-ahead audit hook persists them).
+      // onContactMerged is a SYNC callback, so we can't await inside it — instead we collect
+      // each publish promise and drain them (below) BEFORE pool.end()/exit. Without this, the
+      // last merge's audit insert can lose the race against process.exit and never persist
+      // (observed: 14 merges → 13 audit rows on the first prod run).
+      const pendingMergePublishes: Promise<void>[] = [];
+      let auditPublishFailures = 0;
+
       const dedupService = new DedupService();
       const contactService = ContactService.createWithPostgres(pool, entityMemory, logger, {
         dedupService,
         // Publish contact.merged to the bus so the write-ahead audit hook records it.
-        // TODO: a bus.publish failure here is logged but not reflected in the exit code
-        // or errorCount. This is acceptable for a maintenance script (the merge itself
-        // succeeded, the audit gap is narrow), but revisit if audit-gap detection becomes
-        // a hard requirement.
         onContactMerged: (primaryContactId, secondaryContactId, mergedAt) => {
-          bus.publish('dispatch', createContactMerged({ primaryContactId, secondaryContactId, mergedAt }))
-            .catch((err: unknown) => logger.error({ err }, 'Failed to publish contact.merged — audit trail may be incomplete'));
+          pendingMergePublishes.push(
+            bus.publish('dispatch', createContactMerged({ primaryContactId, secondaryContactId, mergedAt }))
+              .then(() => undefined)
+              .catch((err: unknown) => {
+                auditPublishFailures++;
+                logger.error(
+                  { err, primaryContactId, secondaryContactId },
+                  'Failed to publish contact.merged — audit trail may be incomplete',
+                );
+              }),
+          );
         },
       });
 
@@ -757,6 +798,7 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
         dryRun,
         // Sweep-local tuning (see DedupRunOptions) — passed straight through.
         minScore,
+        maxScore,
         maxTasks,
         noTasks,
 
@@ -778,12 +820,22 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
 
       const result = await runDedup(contacts, identityMap, opts);
 
+      // Drain pending contact.merged audit publishes before closing the pool, so every merge
+      // has a persisted audit_log row (fixes the exit-race that dropped 1 of 14 on the first
+      // prod run). allSettled never rejects; per-publish failures are counted in the .catch
+      // above and folded into the exit code below.
+      if (pendingMergePublishes.length > 0) {
+        logger.info({ pending: pendingMergePublishes.length }, 'dedup-contacts: draining pending audit publishes');
+        await Promise.allSettled(pendingMergePublishes);
+      }
+
       // Summary report
       if (dryRun) {
         logger.info({
           wouldMergeCount: result.wouldMergeCount,
           wouldCreateTaskCount: result.wouldCreateTaskCount,
           skippedLowScoreCount: result.skippedLowScoreCount,
+          skippedAboveMaxScoreCount: result.skippedAboveMaxScoreCount,
           suppressedTaskCount: result.suppressedTaskCount,
           skippedExcludedCount: result.skippedExcludedCount,
           principalSkippedCount: result.principalSkippedCount,
@@ -797,15 +849,19 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
           mergedCount: result.mergedCount,
           taskCount: result.taskCount,
           skippedLowScoreCount: result.skippedLowScoreCount,
+          skippedAboveMaxScoreCount: result.skippedAboveMaxScoreCount,
           suppressedTaskCount: result.suppressedTaskCount,
           skippedExcludedCount: result.skippedExcludedCount,
           principalSkippedCount: result.principalSkippedCount,
+          auditPublishFailures,
           errorCount: result.errorCount,
         }, 'dedup-contacts: sweep complete');
       }
 
       await pool.end();
-      process.exit(result.errorCount > 0 ? 1 : 0);
+      // Non-zero exit on any sweep error OR any lost audit publish, so a partial audit
+      // trail surfaces as a failed run rather than a silent gap.
+      process.exit((result.errorCount > 0 || auditPublishFailures > 0) ? 1 : 0);
     } catch (err) {
       logger.error({ err }, 'dedup-contacts: fatal error');
       await pool.end();


### PR DESCRIPTION
## Summary
Three follow-ups surfaced by the first production `dedup:contacts` sweep. Closes #1034.

1. **Merge-audit completeness.** `contact.merged` publishes were fire-and-forget (`bus.publish().catch()`), so the last one could lose the race against `process.exit` — the first prod run committed **14 merges but persisted only 13 `contact.merged` audit rows**. Now the script collects the publish promises and drains them (`Promise.allSettled`) before `pool.end()`, and a lost publish increments a failure count that flips the exit code (no more silent audit gap).

2. **Re-run safety — `--max-score <n>`.** The sweep isn't task-idempotent, so a second run at a lower `--min-score` would duplicate tasks for higher-score pairs already surfaced. `--max-score` adds an upper bound for incremental **band** runs (`--min-score 0.90 --max-score 0.95`). Validated (0–1, `min < max`); new `skippedAboveMaxScoreCount` in the summary.

3. **Log accuracy.** The per-pair "creating … task" line was logged *before* the suppression gate, so a `--no-tasks` run printed ~2000 "creating" lines while creating zero (alarming in prod). Moved it after the gate.

## Test plan
- [x] +2 unit tests (`--max-score`, `[min,max)` band); 37/37 pass
- [x] typecheck clean
- [ ] CI green

Note: the audit-drain path isn't exercised by a task-only band run (0 merges), but is covered by reasoning + the existing merge tests; it'll be validated on the next sweep that performs merges.