### PR TITLE
feat: dedup single-token exact-name structural merge for org/automated contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Contact `tier` + `kind` model (migration 055)** — ordered capability `tier` and descriptive `kind`, backfilled from legacy fields. (#945)
 - **Contact de-duplication (`dedup:contacts`)** — maintenance sweep that auto-merges structurally-proven duplicates (shared verified identity / same `kg_node_id` / exact normalized name) and files Curia-owned review tasks for fuzzy matches, never auto-merging the principal and never re-surfacing a declined pair. Tunable for controlled rollout via `--dry-run`, `--no-tasks`, `--min-score`/`--max-score` bands, and `--max-tasks`, and shipped in the production image. (#944, #1034)
+- **Dedup: single-token org/automated name match is now structural** — exact normalized single-token names (e.g. "GitHub", "Amazon.ca") auto-merge when both contacts are `organization` or `automated`; the ≥2-token guard is unchanged for `person` and mixed-kind pairs. (#1035)
 
 ### Changed
 

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -17,7 +17,7 @@
 import pg from 'pg';
 import { createLogger } from '../src/logger.js';
 import { classifyPair, type PairClassification } from '../src/contacts/dedup-classifier.js';
-import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
+import type { Contact, ChannelIdentity, ContactKind } from '../src/contacts/types.js';
 import type { KgNode } from '../src/memory/types.js';
 import type { StoreFactOptions } from '../src/memory/types.js';
 import { ModelRegistry } from '../src/agents/llm/model-registry.js';
@@ -495,7 +495,7 @@ type ContactRow = {
   system_role: string | null;
   status: string;
   tier: string;
-  kind: string;
+  kind: string | null;
   contact_confidence: string;
   trust_level: string | null;
   last_seen_at: Date | null;
@@ -532,6 +532,20 @@ type IdentityRow = {
   updated_at: Date;
 };
 
+const VALID_CONTACT_KINDS: ContactKind[] = ['person', 'organization', 'automated', 'principal', 'agent'];
+
+// Validates the raw DB kind value against the known enum. Defaults to 'person' with a
+// warning log for null or unrecognized values (e.g. pre-backfill rows), consistent with
+// the validation in ContactService.rowToContact. Without this, unvalidated null/legacy
+// kind values silently skip the org single-token structural exemption in the classifier.
+function parseContactKind(contactId: string, raw: string | null): ContactKind {
+  if (raw !== null && (VALID_CONTACT_KINDS as string[]).includes(raw)) {
+    return raw as ContactKind;
+  }
+  logger.warn({ contactId, rawKind: raw }, 'dedup-contacts: unrecognized kind value — defaulting to person; check kind backfill for this contact');
+  return 'person';
+}
+
 function rowToContact(row: ContactRow): Contact {
   return {
     id: row.id,
@@ -543,7 +557,7 @@ function rowToContact(row: ContactRow): Contact {
       : null,
     status: row.status as Contact['status'],
     tier: row.tier as Contact['tier'],
-    kind: row.kind as Contact['kind'],
+    kind: parseContactKind(row.id, row.kind),
     contactConfidence: Number(row.contact_confidence),
     trustLevel: row.trust_level as Contact['trustLevel'],
     lastSeenAt: row.last_seen_at,

--- a/src/contacts/dedup-classifier.test.ts
+++ b/src/contacts/dedup-classifier.test.ts
@@ -396,6 +396,67 @@ describe('classifyPair — fuzzy: name similarity', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Structural proof: single-token exact match for organization / automated kind
+// ---------------------------------------------------------------------------
+// For people, a single-token exact match is too ambiguous for auto-merge.
+// For organizations and automated senders, a byte-identical brand/sender name
+// is a much stronger signal (issue #1035).
+
+describe('classifyPair — structural: single-token org/automated name match', () => {
+  it('classifies as structural on single-token exact match when both contacts are organization', () => {
+    // "GitHub" === "github" after normalization — strong signal for orgs
+    const a = makeContact({ id: 'c1', displayName: 'GitHub', kind: 'organization' });
+    const b = makeContact({ id: 'c2', displayName: 'github', kind: 'organization' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
+  it('classifies as structural on single-token exact match when both contacts are automated', () => {
+    // Automated senders (mailing lists, notifications) with identical single-token names
+    const a = makeContact({ id: 'c1', displayName: 'Preply', kind: 'automated' });
+    const b = makeContact({ id: 'c2', displayName: 'preply', kind: 'automated' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
+  it('classifies as structural on single-token exact match for org + automated (mixed org kinds)', () => {
+    // One organization, one automated — both are in the org/automated set
+    const a = makeContact({ id: 'c1', displayName: 'Amazon.ca', kind: 'organization' });
+    const b = makeContact({ id: 'c2', displayName: 'Amazon.ca', kind: 'automated' });
+
+    const result = classifyPair(a, [], b, []);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('structural');
+  });
+
+  it('does NOT classify as structural on single-token exact match when both are person', () => {
+    // Person/person single-token match must remain fuzzy — unchanged behavior
+    const a = makeContact({ id: 'c1', displayName: 'Acme', kind: 'person' });
+    const b = makeContact({ id: 'c2', displayName: 'acme', kind: 'person' });
+
+    const result = classifyPair(a, [], b, []);
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+
+  it('does NOT classify as structural on single-token exact match for org + person (mixed kind)', () => {
+    // Mixed org/person pair must NOT get the single-token exemption
+    const a = makeContact({ id: 'c1', displayName: 'Communitech', kind: 'organization' });
+    const b = makeContact({ id: 'c2', displayName: 'Communitech', kind: 'person' });
+
+    const result = classifyPair(a, [], b, []);
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Structural proof priority: channel overlap overrides name similarity
 // ---------------------------------------------------------------------------
 

--- a/src/contacts/dedup-classifier.test.ts
+++ b/src/contacts/dedup-classifier.test.ts
@@ -454,6 +454,28 @@ describe('classifyPair — structural: single-token org/automated name match', (
       expect(result.type).not.toBe('structural');
     }
   });
+
+  it('does NOT classify as structural on single-token exact match for kind=principal', () => {
+    // principal contacts are handled by the dedup principal guard, not the org exemption
+    const a = makeContact({ id: 'c1', displayName: 'Curia', kind: 'principal' });
+    const b = makeContact({ id: 'c2', displayName: 'curia', kind: 'principal' });
+
+    const result = classifyPair(a, [], b, []);
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
+
+  it('does NOT classify as structural on single-token exact match for kind=agent', () => {
+    // agent contacts (e.g. Curia itself) do not benefit from the org single-token exemption
+    const a = makeContact({ id: 'c1', displayName: 'Curia', kind: 'agent' });
+    const b = makeContact({ id: 'c2', displayName: 'curia', kind: 'agent' });
+
+    const result = classifyPair(a, [], b, []);
+    if (result !== null) {
+      expect(result.type).not.toBe('structural');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/contacts/dedup-classifier.ts
+++ b/src/contacts/dedup-classifier.ts
@@ -147,15 +147,19 @@ export function classifyPair(
   const normalA = normalizeDisplayName(a.displayName);
   const normalB = normalizeDisplayName(b.displayName);
   if (normalA.length >= 5 && normalA === normalB) {
+    // 'principal' and 'agent' kinds are intentionally excluded: the principal
+    // is never auto-merged by the dedup rules, and agent contacts (Curia itself)
+    // don't benefit from single-token name merging.
     const bothOrgKinds =
       (a.kind === 'organization' || a.kind === 'automated') &&
       (b.kind === 'organization' || b.kind === 'automated');
     const hasMultipleTokens = normalA.split(' ').length >= 2;
     if (bothOrgKinds || hasMultipleTokens) {
-      return {
-        type: 'structural',
-        reason: `Exact normalized name match: "${normalA}"`,
-      };
+      // Include path in reason to distinguish org single-token from multi-token in audit logs.
+      const reason = bothOrgKinds && !hasMultipleTokens
+        ? `Exact normalized name match (single-token org/automated): "${normalA}"`
+        : `Exact normalized name match: "${normalA}"`;
+      return { type: 'structural', reason };
     }
   }
 

--- a/src/contacts/dedup-classifier.ts
+++ b/src/contacts/dedup-classifier.ts
@@ -132,24 +132,31 @@ export function classifyPair(
   // ------------------------------------------------------------------
   // If the normalized display names are identical (after lowercasing and stripping
   // punctuation), this is considered structural proof — the contacts refer to the
-  // same person under different casing or minor formatting. This is the most
+  // same entity under different casing or minor formatting. This is the most
   // conservative form of the name signal; JW similarity is always fuzzy.
   //
-  // Single-token names (e.g. "Acme" / "acme") are NOT sufficient for structural
-  // proof: a single token is too common to reliably identify a unique person or
-  // entity. We require at least 2 whitespace-separated tokens AND length ≥ 5 to
-  // guard against false positives. Single-token matches fall through to fuzzy.
+  // For person contacts, single-token names (e.g. "Smith") are NOT sufficient:
+  // a single first name or last name is too ambiguous. We require at least 2
+  // whitespace-separated tokens AND length ≥ 5 to guard against false positives.
+  //
+  // For organization and automated contacts, an exact single-token name is a
+  // much stronger signal — a brand or sender name is far less ambiguous than a
+  // personal first name. When both contacts are organization/automated, structural
+  // proof is granted on a single-token exact match (still requiring length ≥ 5 to
+  // exclude very short abbreviations). See issue #1035.
   const normalA = normalizeDisplayName(a.displayName);
   const normalB = normalizeDisplayName(b.displayName);
-  if (
-    normalA.length >= 5 &&
-    normalA === normalB &&
-    normalA.split(' ').length >= 2
-  ) {
-    return {
-      type: 'structural',
-      reason: `Exact normalized name match: "${normalA}"`,
-    };
+  if (normalA.length >= 5 && normalA === normalB) {
+    const bothOrgKinds =
+      (a.kind === 'organization' || a.kind === 'automated') &&
+      (b.kind === 'organization' || b.kind === 'automated');
+    const hasMultipleTokens = normalA.split(' ').length >= 2;
+    if (bothOrgKinds || hasMultipleTokens) {
+      return {
+        type: 'structural',
+        reason: `Exact normalized name match: "${normalA}"`,
+      };
+    }
   }
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `dedup-classifier`: exact normalized single-token name match is now classified `structural` (eligible for auto-merge) when both contacts are `kind='organization'` or `kind='automated'`. The >=2-token guard is unchanged for `person` and mixed-kind pairs.
- Reason string now distinguishes the single-token org path from multi-token in audit logs (e.g. `"Exact normalized name match (single-token org/automated): \"github\""`).
- Tests cover all five `ContactKind` values (`person`, `organization`, `automated`, `principal`, `agent`) for the single-token case.

Resolves the 22-of-29 manual review backlog from the first production sweep (Amazon.ca, GitHub, Preply, THEMUSEUM, Communitech).

Closes #1035

## Notes from silent-failure review

Two items found by review that are out of scope for this PR but worth tracking:

- **Pre-migration null `kind`**: contacts with `kind=null` (pre-backfill rows) silently fall back to `'person'` in `ContactService.rowToContact`, bypassing the new org exemption. The classifier has no logger, so there's no diagnostic at that layer. Consider logging the contact display name in the null-kind fallback path in `contact-service.ts` to make this traceable.

- **Script `rowToContact` kind cast**: `scripts/dedup-contacts.ts` does an unchecked `row.kind as Contact['kind']` cast with no null guard — inconsistent with `ContactService`'s validated parse. Recommend aligning it to the defensive pattern in `contact-service.ts`.

## Test plan

- [x] `classifyPair` unit tests: 35 pass, 0 fail
- [x] TypeScript typecheck: clean
- [x] All other unit tests: 3632 pass (2 pre-existing integration test failures require a DB connection — unrelated)
- [x] Code review + silent failure review: no blockers; two out-of-scope observations noted above