### PR TITLE
fix: contact-find-duplicates files bounded tasks, adds idempotency (#1037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`contact-find-duplicates` scheduled scan** — skill now files bounded review tasks (instead of returning a raw list) and is idempotent across runs; default threshold raised to 0.93 to cut false positives; `max_tasks` cap prevents queue flooding; weekly contacts dedup scan updated to scan-only mode. (#1037)
+
+### Changed
+
+- **`DuplicatePairContact`** — added `kgNodeId: string | null` field (populated from the `Contact` object in `DedupService`); enables the skill to check `dedup_exclusion` KG facts without a second DB round-trip. (#1037)
+
 ### Added
 
 - **Contact `tier` + `kind` model (migration 055)** — ordered capability `tier` and descriptive `kind`, backfilled from legacy fields. (#945)

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -1,5 +1,5 @@
 name: contacts
-version: "0.2.0"
+version: "0.3.0"
 role: specialist
 description: >
   Contact domain specialist — briefings, CRUD, deduplication, relationship management,
@@ -164,14 +164,18 @@ system_prompt: |
 
   ### Weekly contacts dedup scan
   When the scheduler sends "Run your weekly contacts dedup scan":
-  1. Call contact-find-duplicates (default min_confidence: probable).
-  2. If no pairs found: confirm that no duplicates were detected.
-  3. If pairs found: work through them one at a time.
-     - For each pair: use the primary heuristic above, call contact-merge dry_run: true,
-       present the preview, get confirmation, then merge.
-     - If the CEO defers a pair ("skip this one"), move on without merging.
-     - Continue until all pairs are reviewed or the CEO ends the session.
-  4. After finishing: summarize what was merged.
+  1. Call contact-find-duplicates (default min_score: 0.93, max_tasks: 20).
+     The skill scans all contacts, files review tasks for new qualifying pairs,
+     and returns a summary — it does NOT return the raw pair list.
+  2. Report the summary counts from the skill result:
+     - filed: new tasks filed this run
+     - skipped_existing: pairs already in the review queue (idempotent skip)
+     - skipped_excluded: pairs with a dedup_exclusion fact (do-not-resurface skip)
+     - capped: pairs not filed because max_tasks was reached
+     - total_scanned: qualifying pairs above the score threshold
+  3. Call scheduler-report with the job_id and the summary as the report text.
+  4. Do NOT attempt to work through or merge pairs in this scan turn — merging
+     happens as the contacts task queue is drained in subsequent turns.
 
   ### Primary contact heuristic (for merge decisions)
   Apply in order — first rule that produces a clear winner decides:
@@ -253,8 +257,8 @@ pinned_skills:
 
 schedule:
   - cron: "0 9 * * 1"   # Mondays at 9 AM
-    task: "Run your weekly contacts dedup scan — find probable and certain duplicate contact pairs, present them to the CEO for review one pair at a time, and merge confirmed pairs."
-    expectedDurationSeconds: 900
+    task: "Run your weekly contacts dedup scan. Call contact-find-duplicates (min_score: 0.93, max_tasks: 20) to file review tasks for new duplicate pairs, then report the summary counts via scheduler-report."
+    expectedDurationSeconds: 60
 
   - cron: "0 8 * * *"   # Daily at 8 AM
     task: >

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -172,7 +172,9 @@ system_prompt: |
      - skipped_existing: pairs already in the review queue (idempotent skip)
      - skipped_excluded: pairs with a dedup_exclusion fact (do-not-resurface skip)
      - capped: pairs not filed because max_tasks was reached
+     - failed: pairs that errored during KG lookup or task creation
      - total_scanned: qualifying pairs above the score threshold
+     If failed > 0, note that those pairs will be retried on the next run.
   3. Call scheduler-report with the job_id and the summary as the report text.
   4. Do NOT attempt to work through or merge pairs in this scan turn — merging
      happens as the contacts task queue is drained in subsequent turns.

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -1,58 +1,250 @@
 // handler.ts — contact-find-duplicates skill
 //
-// Scans all contacts for probable duplicate pairs using the DedupService
-// (wired into ContactService at bootstrap). Returns a ranked list for the
-// Coordinator to present to the CEO for review and merge confirmation.
+// Scans all contacts for duplicate pairs above a numeric score threshold,
+// files Curia-owned review tasks for qualifying pairs, and returns a summary.
+// This is the scheduled-scan entry point: it files tasks (rather than returning
+// a raw list) so a single run never floods the agent context or causes a timeout.
+//
+// Idempotency: pairs that already have an open 'dedup' task, or that have a
+// dedup_exclusion KG fact in either direction, are skipped and counted in the
+// summary. This makes repeated weekly runs safe to run without accumulating
+// duplicate tasks.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { DuplicatePair } from '../../src/contacts/types.js';
+import type { KgNode } from '../../src/memory/types.js';
 
-const VALID_CONFIDENCES = new Set(['certain', 'probable']);
+// Default minimum Jaro-Winkler score — chosen empirically as the precision sweet
+// spot on the production contact set (0.95 is very clean, 0.90 starts to pick up
+// same-surname false positives, 0.7 is the DedupService base floor). See #1037.
+const DEFAULT_MIN_SCORE = 0.93;
+
+// Statuses that constitute an "open" task for idempotency purposes.
+const OPEN_STATUSES = ['open', 'in_progress', 'waiting', 'blocked'];
+
+// Upper bound on how many open dedup tasks we load for the idempotency check.
+// With a per-run max_tasks cap, the realistic ceiling is much lower — but 1000
+// ensures we never silently miss existing tasks and re-file them.
+const EXISTING_TASK_FETCH_LIMIT = 1000;
+
+// Regex to extract contact IDs from task descriptions filed by this skill or
+// by the dedup-contacts maintenance script, both of which use the same format:
+//   "Contact A ID: <uuid>  (Display Name)"
+//   "Contact B ID: <uuid>  (Display Name)"
+const CONTACT_ID_LINE_RE = /Contact ([AB]) ID: ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gi;
+
+/** Canonical (order-independent) key for a contact pair. */
+function pairKey(aId: string, bId: string): string {
+  return aId < bId ? `${aId}:${bId}` : `${bId}:${aId}`;
+}
+
+/** Extract contact A and B IDs from a dedup task description. Returns null if not found. */
+function extractPairIds(description: string | null | undefined): { aId: string; bId: string } | null {
+  if (!description) return null;
+  const found: Record<string, string> = {};
+  for (const match of description.matchAll(CONTACT_ID_LINE_RE)) {
+    found[match[1]!.toUpperCase()] = match[2]!;
+  }
+  if (found['A'] && found['B']) return { aId: found['A'], bId: found['B'] };
+  return null;
+}
+
+/**
+ * Check whether either contact in a pair has a dedup_exclusion KG fact naming
+ * the other — bidirectional, same logic as hasExclusion() in dedup-contacts.ts.
+ * Short-circuits to false when neither contact has a kgNodeId.
+ *
+ * Matching is by `properties.attribute === 'dedup_exclusion'` only (per the KG
+ * fact schema guidance: never match on `label` for lookups). This assumes that
+ * no other part of the system stores facts with this attribute name for an
+ * unrelated purpose, which is enforced by convention — the attribute is
+ * exclusively written by writeExclusion() in dedup-contacts.ts.
+ */
+async function checkExclusion(
+  aId: string,
+  bId: string,
+  kgNodeIdA: string | null,
+  kgNodeIdB: string | null,
+  getFacts: (nodeId: string) => Promise<KgNode[]>,
+): Promise<boolean> {
+  if (kgNodeIdA === null && kgNodeIdB === null) return false;
+
+  if (kgNodeIdA !== null) {
+    const factsA = await getFacts(kgNodeIdA);
+    for (const fact of factsA) {
+      const props = fact.properties as Record<string, unknown>;
+      if (props['attribute'] === 'dedup_exclusion' && props['value'] === bId) return true;
+    }
+  }
+
+  if (kgNodeIdB !== null) {
+    const factsB = await getFacts(kgNodeIdB);
+    for (const fact of factsB) {
+      const props = fact.properties as Record<string, unknown>;
+      if (props['attribute'] === 'dedup_exclusion' && props['value'] === aId) return true;
+    }
+  }
+
+  return false;
+}
 
 export class ContactFindDuplicatesHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { min_confidence } = ctx.input as { min_confidence?: string };
+    const { min_score: rawMinScore, max_tasks: rawMaxTasks } = ctx.input as {
+      min_score?: unknown;
+      max_tasks?: unknown;
+    };
 
-    if (min_confidence !== undefined && !VALID_CONFIDENCES.has(min_confidence)) {
-      return {
-        success: false,
-        error: `Invalid min_confidence: "${min_confidence}". Must be "certain" or "probable".`,
-      };
+    const minScore = rawMinScore !== undefined ? Number(rawMinScore) : DEFAULT_MIN_SCORE;
+    const maxTasks = rawMaxTasks !== undefined ? Number(rawMaxTasks) : undefined;
+
+    if (!Number.isFinite(minScore) || minScore < 0 || minScore > 1) {
+      return { success: false, error: `Invalid min_score "${rawMinScore}": must be a number between 0 and 1.` };
+    }
+    if (maxTasks !== undefined && (!Number.isFinite(maxTasks) || maxTasks < 0 || !Number.isInteger(maxTasks))) {
+      return { success: false, error: `Invalid max_tasks "${rawMaxTasks}": must be a non-negative integer.` };
     }
 
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-find-duplicates: contactService not available — this is a universal service, check ExecutionLayer configuration.',
+        error: 'contact-find-duplicates: contactService not available — check ExecutionLayer configuration.',
+      };
+    }
+    if (!ctx.taskRepo) {
+      return {
+        success: false,
+        error: 'contact-find-duplicates: taskRepo not available — declare "taskRepo" in capabilities.',
+      };
+    }
+    if (!ctx.entityMemory) {
+      return {
+        success: false,
+        error: 'contact-find-duplicates: entityMemory not available — declare "entityMemory" in capabilities.',
       };
     }
 
-    ctx.log.info({ minConfidence: min_confidence ?? 'probable' }, 'Scanning for duplicate contacts');
+    ctx.log.info({ minScore, maxTasks }, 'contact-find-duplicates: starting scan');
 
     try {
-      const pairs = await ctx.contactService.findDuplicates(
-        (min_confidence as 'certain' | 'probable' | undefined) ?? 'probable',
+      // Fetch all pairs at the base floor (0.7) then filter to the requested threshold.
+      // This avoids changing the ContactService/DedupService interface for a per-call
+      // numeric threshold, while keeping the hot path (DB + identity load) a single pass.
+      const allPairs = await ctx.contactService.findDuplicates('probable');
+      const pairs = allPairs.filter((p: DuplicatePair) => p.score >= minScore);
+
+      ctx.log.info(
+        { basePairs: allPairs.length, qualifyingPairs: pairs.length, minScore },
+        'contact-find-duplicates: threshold filtering complete',
+      );
+
+      // Load all open dedup tasks for the idempotency check. The limit is high
+      // enough to capture any realistic backlog; pairs already in the queue are
+      // silently skipped so repeated runs don't accumulate duplicate tasks.
+      const existingTasks = await ctx.taskRepo.listTasks({
+        statuses: OPEN_STATUSES,
+        tag: 'dedup',
+        limit: EXISTING_TASK_FETCH_LIMIT,
+      });
+      const existingPairKeys = new Set<string>();
+      for (const task of existingTasks) {
+        const ids = extractPairIds(task.description ?? null);
+        if (ids) {
+          existingPairKeys.add(pairKey(ids.aId, ids.bId));
+        } else {
+          // A dedup-tagged task whose description doesn't contain the expected
+          // "Contact A/B ID: <uuid>" lines is invisible to the idempotency check —
+          // the pair will be re-filed if it comes up again. Log so operators can
+          // investigate (e.g. manually-created tasks, old format, truncated description).
+          ctx.log.warn({ taskId: task.id }, 'contact-find-duplicates: dedup task has no parseable contact IDs — excluded from idempotency check');
+        }
+      }
+
+      // Memoize KG fact lookups for the duration of the run — a contact that appears
+      // in multiple pairs would otherwise re-fetch its facts each time. Exclusion
+      // facts are permanent and not written by this skill, so caching is safe.
+      const factsCache = new Map<string, KgNode[]>();
+      const cachedGetFacts = async (nodeId: string): Promise<KgNode[]> => {
+        const cached = factsCache.get(nodeId);
+        if (cached !== undefined) return cached;
+        const facts = await ctx.entityMemory!.getFacts(nodeId);
+        factsCache.set(nodeId, facts);
+        return facts;
+      };
+
+      let filed = 0;
+      let skippedExisting = 0;
+      let skippedExcluded = 0;
+      let capped = 0;
+
+      for (const pair of pairs) {
+        const key = pairKey(pair.contactA.id, pair.contactB.id);
+
+        if (existingPairKeys.has(key)) {
+          skippedExisting++;
+          continue;
+        }
+
+        const excluded = await checkExclusion(
+          pair.contactA.id,
+          pair.contactB.id,
+          pair.contactA.kgNodeId,
+          pair.contactB.kgNodeId,
+          cachedGetFacts,
+        );
+        if (excluded) {
+          skippedExcluded++;
+          continue;
+        }
+
+        if (maxTasks !== undefined && filed >= maxTasks) {
+          capped++;
+          continue;
+        }
+
+        const description = [
+          `Possible duplicate contacts detected by the dedup skill scan.`,
+          ``,
+          `Contact A ID: ${pair.contactA.id}  (${pair.contactA.displayName})`,
+          `Contact B ID: ${pair.contactB.id}  (${pair.contactB.displayName})`,
+          ``,
+          `Match type: fuzzy`,
+          `Reason: ${pair.reason}`,
+          `Score: ${pair.score.toFixed(3)}`,
+          ``,
+          `Please verify these are the same person, then either merge them or mark them as not duplicates (which will prevent future re-surfacing).`,
+        ].join('\n');
+
+        await ctx.taskRepo.createTask({
+          agentId: 'contacts',
+          title: `Review possible duplicate: ${pair.contactA.displayName} / ${pair.contactB.displayName}`,
+          description,
+          owner: 'curia',
+          source: 'agent',
+          sourceAgentId: 'contacts',
+          tags: ['dedup', 'contacts'],
+        });
+
+        ctx.log.debug(
+          { contactAId: pair.contactA.id, contactBId: pair.contactB.id, score: pair.score },
+          'contact-find-duplicates: filed review task',
+        );
+        filed++;
+      }
+
+      ctx.log.info(
+        { filed, skippedExisting, skippedExcluded, capped, totalScanned: pairs.length },
+        'contact-find-duplicates: scan complete',
       );
 
       return {
         success: true,
         data: {
-          pairs: pairs.map((p: DuplicatePair) => ({
-            contact_a: {
-              contact_id: p.contactA.id,
-              display_name: p.contactA.displayName,
-              role: p.contactA.role,
-            },
-            contact_b: {
-              contact_id: p.contactB.id,
-              display_name: p.contactB.displayName,
-              role: p.contactB.role,
-            },
-            score: Math.round(p.score * 100) / 100,
-            confidence: p.confidence,
-            reason: p.reason,
-          })),
-          count: pairs.length,
+          filed,
+          skipped_existing: skippedExisting,
+          skipped_excluded: skippedExcluded,
+          capped,
+          total_scanned: pairs.length,
         },
       };
     } catch (err) {

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -23,8 +23,11 @@ const DEFAULT_MIN_SCORE = 0.93;
 const OPEN_STATUSES = ['open', 'in_progress', 'waiting', 'blocked'];
 
 // Upper bound on how many open dedup tasks we load for the idempotency check.
-// With a per-run max_tasks cap, the realistic ceiling is much lower — but 1000
-// ensures we never silently miss existing tasks and re-file them.
+// With max_tasks=20 and a weekly cadence, reaching 1000 open dedup tasks would
+// require ~50 weeks with zero task resolution — well outside normal operation.
+// listTasks has no offset support, so true pagination isn't possible without a
+// schema change; document this as an accepted ceiling. If it ever becomes an
+// issue, adding offset to ListTasksFilters and paginating here is the right fix.
 const EXISTING_TASK_FETCH_LIMIT = 1000;
 
 // Regex to extract contact IDs from task descriptions filed by this skill or

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -124,14 +124,21 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
       };
     }
 
+    // Capture as local variables so closures below don't need non-null assertions.
+    const taskRepo = ctx.taskRepo;
+    const entityMemory = ctx.entityMemory;
+
     ctx.log.info({ minScore, maxTasks }, 'contact-find-duplicates: starting scan');
 
+    // -- Setup phase: failures here abort the scan entirely before any writes --
+    let pairs: DuplicatePair[];
+    let existingPairKeys: Set<string>;
     try {
       // Fetch all pairs at the base floor (0.7) then filter to the requested threshold.
       // This avoids changing the ContactService/DedupService interface for a per-call
       // numeric threshold, while keeping the hot path (DB + identity load) a single pass.
       const allPairs = await ctx.contactService.findDuplicates('probable');
-      const pairs = allPairs.filter((p: DuplicatePair) => p.score >= minScore);
+      pairs = allPairs.filter((p: DuplicatePair) => p.score >= minScore);
 
       ctx.log.info(
         { basePairs: allPairs.length, qualifyingPairs: pairs.length, minScore },
@@ -141,50 +148,66 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
       // Load all open dedup tasks for the idempotency check. The limit is high
       // enough to capture any realistic backlog; pairs already in the queue are
       // silently skipped so repeated runs don't accumulate duplicate tasks.
-      const existingTasks = await ctx.taskRepo.listTasks({
+      const existingTasks = await taskRepo.listTasks({
         statuses: OPEN_STATUSES,
         tag: 'dedup',
         limit: EXISTING_TASK_FETCH_LIMIT,
       });
-      const existingPairKeys = new Set<string>();
+
+      existingPairKeys = new Set<string>();
+      let unparseable = 0;
       for (const task of existingTasks) {
         const ids = extractPairIds(task.description ?? null);
         if (ids) {
           existingPairKeys.add(pairKey(ids.aId, ids.bId));
         } else {
-          // A dedup-tagged task whose description doesn't contain the expected
-          // "Contact A/B ID: <uuid>" lines is invisible to the idempotency check —
-          // the pair will be re-filed if it comes up again. Log so operators can
-          // investigate (e.g. manually-created tasks, old format, truncated description).
-          ctx.log.warn({ taskId: task.id }, 'contact-find-duplicates: dedup task has no parseable contact IDs — excluded from idempotency check');
+          unparseable++;
         }
       }
+      if (unparseable > 0) {
+        // Dedup-tagged tasks without parseable contact IDs (manually created, old format,
+        // or truncated description) are invisible to the idempotency check — those pairs
+        // may be re-filed. Operators can fix by adding "Contact A/B ID: <uuid>" lines
+        // to the description, or removing the 'dedup' tag to suppress this warning.
+        ctx.log.warn(
+          { count: unparseable },
+          'contact-find-duplicates: some dedup-tagged tasks have no parseable contact IDs — those pairs may be re-filed',
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'contact-find-duplicates: setup phase failed (findDuplicates or listTasks)');
+      return { success: false, error: `Failed to scan for duplicates: ${message}` };
+    }
 
-      // Memoize KG fact lookups for the duration of the run — a contact that appears
-      // in multiple pairs would otherwise re-fetch its facts each time. Exclusion
-      // facts are permanent and not written by this skill, so caching is safe.
-      const factsCache = new Map<string, KgNode[]>();
-      const cachedGetFacts = async (nodeId: string): Promise<KgNode[]> => {
-        const cached = factsCache.get(nodeId);
-        if (cached !== undefined) return cached;
-        const facts = await ctx.entityMemory!.getFacts(nodeId);
-        factsCache.set(nodeId, facts);
-        return facts;
-      };
+    // Memoize KG fact lookups for the duration of the run — a contact that appears
+    // in multiple pairs would otherwise re-fetch its facts each time. Exclusion
+    // facts are permanent and not written by this skill, so caching is safe.
+    const factsCache = new Map<string, KgNode[]>();
+    const cachedGetFacts = async (nodeId: string): Promise<KgNode[]> => {
+      const cached = factsCache.get(nodeId);
+      if (cached !== undefined) return cached;
+      const facts = await entityMemory.getFacts(nodeId);
+      factsCache.set(nodeId, facts);
+      return facts;
+    };
 
-      let filed = 0;
-      let skippedExisting = 0;
-      let skippedExcluded = 0;
-      let capped = 0;
+    let filed = 0;
+    let skippedExisting = 0;
+    let skippedExcluded = 0;
+    let capped = 0;
+    let failed = 0;
 
-      for (const pair of pairs) {
-        const key = pairKey(pair.contactA.id, pair.contactB.id);
+    // -- Per-pair processing: errors are isolated so one failing pair doesn't abort the scan --
+    for (const pair of pairs) {
+      const key = pairKey(pair.contactA.id, pair.contactB.id);
 
-        if (existingPairKeys.has(key)) {
-          skippedExisting++;
-          continue;
-        }
+      if (existingPairKeys.has(key)) {
+        skippedExisting++;
+        continue;
+      }
 
+      try {
         const excluded = await checkExclusion(
           pair.contactA.id,
           pair.contactB.id,
@@ -215,7 +238,7 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
           `Please verify these are the same person, then either merge them or mark them as not duplicates (which will prevent future re-surfacing).`,
         ].join('\n');
 
-        await ctx.taskRepo.createTask({
+        await taskRepo.createTask({
           agentId: 'contacts',
           title: `Review possible duplicate: ${pair.contactA.displayName} / ${pair.contactB.displayName}`,
           description,
@@ -230,27 +253,33 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
           'contact-find-duplicates: filed review task',
         );
         filed++;
+      } catch (pairErr) {
+        // Fail open: log and continue so one pair error doesn't abort the entire scan.
+        // The pair is not counted as filed, so the idempotency check will attempt it again
+        // on the next weekly run — the risk of re-filing is preferable to losing all progress.
+        failed++;
+        ctx.log.error(
+          { pairErr, contactAId: pair.contactA.id, contactBId: pair.contactB.id },
+          'contact-find-duplicates: error processing pair — skipping and continuing',
+        );
       }
-
-      ctx.log.info(
-        { filed, skippedExisting, skippedExcluded, capped, totalScanned: pairs.length },
-        'contact-find-duplicates: scan complete',
-      );
-
-      return {
-        success: true,
-        data: {
-          filed,
-          skipped_existing: skippedExisting,
-          skipped_excluded: skippedExcluded,
-          capped,
-          total_scanned: pairs.length,
-        },
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'contact-find-duplicates failed');
-      return { success: false, error: `Failed to scan for duplicates: ${message}` };
     }
+
+    ctx.log.info(
+      { filed, skippedExisting, skippedExcluded, capped, failed, totalScanned: pairs.length },
+      'contact-find-duplicates: scan complete',
+    );
+
+    return {
+      success: true,
+      data: {
+        filed,
+        skipped_existing: skippedExisting,
+        skipped_excluded: skippedExcluded,
+        capped,
+        failed,
+        total_scanned: pairs.length,
+      },
+    };
   }
 }

--- a/skills/contact-find-duplicates/skill.json
+++ b/skills/contact-find-duplicates/skill.json
@@ -13,6 +13,7 @@
     "skipped_existing": "number",
     "skipped_excluded": "number",
     "capped": "number",
+    "failed": "number",
     "total_scanned": "number"
   },
   "capabilities": ["taskRepo", "entityMemory"],

--- a/skills/contact-find-duplicates/skill.json
+++ b/skills/contact-find-duplicates/skill.json
@@ -1,17 +1,22 @@
 {
   "name": "contact-find-duplicates",
-  "description": "Scan all contacts for probable duplicate pairs. Returns a ranked list of contacts that likely refer to the same person. Use before or during a contacts dedup review session with the CEO.",
-  "version": "1.0.0",
+  "description": "Scan all contacts for duplicate pairs above a score threshold, file Curia-owned review tasks for new pairs, and return a summary. Idempotent: pairs that already have an open 'dedup' task or a dedup_exclusion KG fact are skipped. Use this for the weekly scheduled scan — it files tasks rather than returning a raw list, so it never floods the agent context.",
+  "version": "2.0.0",
   "sensitivity": "normal",
-  "action_risk": "none",
+  "action_risk": "low",
   "inputs": {
-    "min_confidence": "string?"
+    "min_score": "number?",
+    "max_tasks": "number?"
   },
   "outputs": {
-    "pairs": "array",
-    "count": "number"
+    "filed": "number",
+    "skipped_existing": "number",
+    "skipped_excluded": "number",
+    "capped": "number",
+    "total_scanned": "number"
   },
+  "capabilities": ["taskRepo", "entityMemory"],
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 60000
 }

--- a/src/contacts/dedup-service.ts
+++ b/src/contacts/dedup-service.ts
@@ -246,8 +246,8 @@ export class DedupService {
         if (newIdKeys.has(key)) {
           alreadyMatched.add(candidate.id);
           pairs.push({
-            contactA: { id: newContact.id, displayName: newContact.displayName, role: newContact.role, identities: newIdentities },
-            contactB: { id: candidate.id, displayName: candidate.displayName, role: candidate.role, identities: candidateIds },
+            contactA: { id: newContact.id, kgNodeId: newContact.kgNodeId, displayName: newContact.displayName, role: newContact.role, identities: newIdentities },
+            contactB: { id: candidate.id, kgNodeId: candidate.kgNodeId, displayName: candidate.displayName, role: candidate.role, identities: candidateIds },
             score: 1.0,
             confidence: 'certain',
             reason: `Same ${cId.channel} identifier`,
@@ -288,8 +288,8 @@ export class DedupService {
       if (!result) continue;
       const confidence: DedupConfidence = result.score >= THRESHOLD_CERTAIN ? 'certain' : 'probable';
       pairs.push({
-        contactA: { id: newContact.id, displayName: newContact.displayName, role: newContact.role, identities: newIdentities },
-        contactB: { id: candidate.id, displayName: candidate.displayName, role: candidate.role, identities: existingIdentitiesMap.get(candidate.id) ?? [] },
+        contactA: { id: newContact.id, kgNodeId: newContact.kgNodeId, displayName: newContact.displayName, role: newContact.role, identities: newIdentities },
+        contactB: { id: candidate.id, kgNodeId: candidate.kgNodeId, displayName: candidate.displayName, role: candidate.role, identities: existingIdentitiesMap.get(candidate.id) ?? [] },
         score: result.score,
         confidence,
         reason: result.reason,
@@ -350,8 +350,8 @@ export class DedupService {
           const a = contacts.find((x) => x.id === aId)!;
           const b = contacts.find((x) => x.id === bId)!;
           pairs.push({
-            contactA: { id: a.id, displayName: a.displayName, role: a.role, identities: identitiesMap.get(a.id) ?? [] },
-            contactB: { id: b.id, displayName: b.displayName, role: b.role, identities: identitiesMap.get(b.id) ?? [] },
+            contactA: { id: a.id, kgNodeId: a.kgNodeId, displayName: a.displayName, role: a.role, identities: identitiesMap.get(a.id) ?? [] },
+            contactB: { id: b.id, kgNodeId: b.kgNodeId, displayName: b.displayName, role: b.role, identities: identitiesMap.get(b.id) ?? [] },
             score: 1.0,
             confidence: 'certain',
             reason: `Same ${channelName} identifier`,
@@ -390,8 +390,8 @@ export class DedupService {
           if (minConfidence === 'certain' && confidence !== 'certain') continue;
 
           pairs.push({
-            contactA: { id: a.id, displayName: a.displayName, role: a.role, identities: identitiesMap.get(a.id) ?? [] },
-            contactB: { id: b.id, displayName: b.displayName, role: b.role, identities: identitiesMap.get(b.id) ?? [] },
+            contactA: { id: a.id, kgNodeId: a.kgNodeId, displayName: a.displayName, role: a.role, identities: identitiesMap.get(a.id) ?? [] },
+            contactB: { id: b.id, kgNodeId: b.kgNodeId, displayName: b.displayName, role: b.role, identities: identitiesMap.get(b.id) ?? [] },
             score: result.score,
             confidence,
             reason: result.reason,

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -413,6 +413,7 @@ export type DedupConfidence = 'certain' | 'probable';
 
 export interface DuplicatePairContact {
   id: string;
+  kgNodeId: string | null;
   displayName: string;
   role: string | null;
   identities: ChannelIdentity[];

--- a/tests/unit/skills/contact-find-duplicates.test.ts
+++ b/tests/unit/skills/contact-find-duplicates.test.ts
@@ -39,7 +39,7 @@ function makeTaskRow(aId: string, bId: string, aName = 'A', bName = 'B'): Partia
   };
 }
 
-function makeCtx(
+function makeContext(
   input: Record<string, unknown>,
   overrides: {
     contactService?: { findDuplicates: () => Promise<DuplicatePair[]> };
@@ -78,14 +78,14 @@ describe('ContactFindDuplicatesHandler', () => {
   // ---------------------------------------------------------------------------
 
   it('returns failure when contactService is not available', async () => {
-    const result = await handler.execute(makeCtx({}));
+    const result = await handler.execute(makeContext({}));
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('contactService');
   });
 
   it('returns failure when taskRepo is not available', async () => {
     const contactService = { findDuplicates: async () => [] };
-    const result = await handler.execute(makeCtx({}, { contactService }));
+    const result = await handler.execute(makeContext({}, { contactService }));
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('taskRepo');
   });
@@ -93,7 +93,7 @@ describe('ContactFindDuplicatesHandler', () => {
   it('returns failure when entityMemory is not available', async () => {
     const contactService = { findDuplicates: async () => [] };
     const taskRepo = { listTasks: async () => [], createTask: async () => ({}) };
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('entityMemory');
   });
@@ -105,7 +105,7 @@ describe('ContactFindDuplicatesHandler', () => {
   it('rejects min_score outside [0, 1]', async () => {
     const contactService = { findDuplicates: async () => [] };
     const result = await handler.execute(
-      makeCtx({ min_score: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never, entityMemory: noFactsEntityMemory }),
+      makeContext({ min_score: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never, entityMemory: noFactsEntityMemory }),
     );
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('min_score');
@@ -114,7 +114,7 @@ describe('ContactFindDuplicatesHandler', () => {
   it('rejects non-integer max_tasks', async () => {
     const contactService = { findDuplicates: async () => [] };
     const result = await handler.execute(
-      makeCtx({ max_tasks: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never, entityMemory: noFactsEntityMemory }),
+      makeContext({ max_tasks: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never, entityMemory: noFactsEntityMemory }),
     );
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('max_tasks');
@@ -132,7 +132,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -151,7 +151,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -171,7 +171,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeCtx({ min_score: 0.7 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({ min_score: 0.7 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -196,7 +196,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeCtx({ max_tasks: 1 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({ max_tasks: 1 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -215,7 +215,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeCtx({ max_tasks: 0 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({ max_tasks: 0 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -241,7 +241,7 @@ describe('ContactFindDuplicatesHandler', () => {
       createTask,
     };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -264,7 +264,7 @@ describe('ContactFindDuplicatesHandler', () => {
       createTask,
     };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -294,7 +294,7 @@ describe('ContactFindDuplicatesHandler', () => {
       },
     };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -321,7 +321,7 @@ describe('ContactFindDuplicatesHandler', () => {
       },
     };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -341,7 +341,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const getFacts = vi.fn().mockResolvedValue([]);
     const entityMemory = { getFacts };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
 
     expect(result.success).toBe(true);
     // getFacts should never be called because both kgNodeIds are null
@@ -368,7 +368,7 @@ describe('ContactFindDuplicatesHandler', () => {
       createTask,
     };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -394,7 +394,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn();
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -419,7 +419,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const malformedTask = { id: 'manual-task', description: 'Manually filed dedup task — no IDs', tags: ['dedup'] };
     const taskRepo = { listTasks: async () => [malformedTask], createTask };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     // Should not crash, and should still file the task since the malformed entry
     // is not recognized as an existing task for this pair
@@ -449,7 +449,7 @@ describe('ContactFindDuplicatesHandler', () => {
     });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     // Scan reports success (partial), not failure
     expect(result.success).toBe(true);
@@ -473,7 +473,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(createTask).toHaveBeenCalledOnce();
     const callArg = createTask.mock.calls[0]![0] as { description: string };

--- a/tests/unit/skills/contact-find-duplicates.test.ts
+++ b/tests/unit/skills/contact-find-duplicates.test.ts
@@ -377,12 +377,14 @@ describe('ContactFindDuplicatesHandler', () => {
         skipped_existing: number;
         skipped_excluded: number;
         capped: number;
+        failed: number;
         total_scanned: number;
       };
       expect(data.filed).toBe(1);
       expect(data.skipped_existing).toBe(1);
       expect(data.skipped_excluded).toBe(0);
       expect(data.capped).toBe(0);
+      expect(data.failed).toBe(0);
       expect(data.total_scanned).toBe(2);
     }
   });
@@ -427,6 +429,36 @@ describe('ContactFindDuplicatesHandler', () => {
       expect(data.filed).toBe(1);
       expect(data.skipped_existing).toBe(0);
     }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-pair error isolation
+  // ---------------------------------------------------------------------------
+
+  it('continues scan and increments failed count when createTask throws for one pair', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.96),   // createTask fails
+      makePair(UUID_A, 'Alice', null, UUID_C, 'Carol', null, 0.95), // succeeds
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    let callCount = 0;
+    const createTask = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error('DB pool exhausted');
+      return { id: 'task-1' };
+    });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    // Scan reports success (partial), not failure
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; failed: number };
+      expect(data.filed).toBe(1);  // second pair succeeded
+      expect(data.failed).toBe(1); // first pair failed
+    }
+    expect(createTask).toHaveBeenCalledTimes(2);
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/skills/contact-find-duplicates.test.ts
+++ b/tests/unit/skills/contact-find-duplicates.test.ts
@@ -1,24 +1,81 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ContactFindDuplicatesHandler } from '../../../skills/contact-find-duplicates/handler.js';
 import type { SkillContext } from '../../../src/skills/types.js';
+import type { DuplicatePair } from '../../../src/contacts/types.js';
+import type { TaskRow } from '../../../src/db/queries/tasks.js';
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
 
+// UUID-shaped IDs for description-parsing tests
+const UUID_A = '11111111-1111-1111-1111-111111111111';
+const UUID_B = '22222222-2222-2222-2222-222222222222';
+const UUID_C = '33333333-3333-3333-3333-333333333333';
+
+function makePair(
+  aId: string, aName: string, aKgNodeId: string | null,
+  bId: string, bName: string, bKgNodeId: string | null,
+  score: number,
+): DuplicatePair {
+  return {
+    contactA: { id: aId, kgNodeId: aKgNodeId, displayName: aName, role: null, identities: [] },
+    contactB: { id: bId, kgNodeId: bKgNodeId, displayName: bName, role: null, identities: [] },
+    score,
+    confidence: score >= 0.9 ? 'certain' : 'probable',
+    reason: `Similar name (${score.toFixed(2)})`,
+  };
+}
+
+function makeTaskRow(aId: string, bId: string, aName = 'A', bName = 'B'): Partial<TaskRow> {
+  return {
+    id: `task-${aId}-${bId}`,
+    description: [
+      `Possible duplicate contacts detected by the dedup skill scan.`,
+      ``,
+      `Contact A ID: ${aId}  (${aName})`,
+      `Contact B ID: ${bId}  (${bName})`,
+    ].join('\n'),
+    tags: ['dedup', 'contacts'],
+  };
+}
+
 function makeCtx(
   input: Record<string, unknown>,
-  contactServiceOverride?: Partial<{ findDuplicates: (minConfidence?: string) => Promise<unknown[]> }>,
+  overrides: {
+    contactService?: { findDuplicates: () => Promise<DuplicatePair[]> };
+    taskRepo?: {
+      listTasks: () => Promise<Partial<TaskRow>[]>;
+      createTask: (p: unknown) => Promise<Partial<TaskRow>>;
+    };
+    entityMemory?: { getFacts: (nodeId: string) => Promise<unknown[]> };
+  } = {},
 ): SkillContext {
   return {
     input,
     secret: () => { throw new Error('no secrets'); },
     log: logger,
-    contactService: contactServiceOverride as never,
+    contactService: overrides.contactService as never,
+    taskRepo: overrides.taskRepo as never,
+    entityMemory: overrides.entityMemory as never,
   };
 }
 
+// Default stubs used in most tests
+const emptyTaskRepo = {
+  listTasks: async () => [],
+  createTask: async () => ({ id: 'task-1' }),
+};
+
+const noFactsEntityMemory = {
+  getFacts: async () => [],
+};
+
 describe('ContactFindDuplicatesHandler', () => {
   const handler = new ContactFindDuplicatesHandler();
+
+  // ---------------------------------------------------------------------------
+  // Service availability guards
+  // ---------------------------------------------------------------------------
 
   it('returns failure when contactService is not available', async () => {
     const result = await handler.execute(makeCtx({}));
@@ -26,67 +83,370 @@ describe('ContactFindDuplicatesHandler', () => {
     if (!result.success) expect(result.error).toContain('contactService');
   });
 
-  it('returns empty list when no duplicates exist', async () => {
+  it('returns failure when taskRepo is not available', async () => {
     const contactService = { findDuplicates: async () => [] };
-    const result = await handler.execute(makeCtx({}, contactService));
+    const result = await handler.execute(makeCtx({}, { contactService }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('taskRepo');
+  });
+
+  it('returns failure when entityMemory is not available', async () => {
+    const contactService = { findDuplicates: async () => [] };
+    const taskRepo = { listTasks: async () => [], createTask: async () => ({}) };
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('entityMemory');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Input validation
+  // ---------------------------------------------------------------------------
+
+  it('rejects min_score outside [0, 1]', async () => {
+    const contactService = { findDuplicates: async () => [] };
+    const result = await handler.execute(
+      makeCtx({ min_score: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never, entityMemory: noFactsEntityMemory }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('min_score');
+  });
+
+  it('rejects non-integer max_tasks', async () => {
+    const contactService = { findDuplicates: async () => [] };
+    const result = await handler.execute(
+      makeCtx({ max_tasks: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never, entityMemory: noFactsEntityMemory }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('max_tasks');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Numeric threshold filtering
+  // ---------------------------------------------------------------------------
+
+  it('filters out pairs below min_score using the default (0.93)', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Alice Smith', null, 0.92),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { pairs: unknown[]; count: number };
-      expect(data.pairs).toHaveLength(0);
-      expect(data.count).toBe(0);
+      const data = result.data as { filed: number; total_scanned: number };
+      expect(data.total_scanned).toBe(0);  // 0.92 < 0.93 default
+      expect(data.filed).toBe(0);
+      expect(createTask).not.toHaveBeenCalled();
     }
   });
 
-  it('passes min_confidence to findDuplicates', async () => {
-    let calledWith: string | undefined;
-    const contactService = {
-      findDuplicates: async (minConfidence?: string) => {
-        calledWith = minConfidence;
+  it('files a task for a pair at or above min_score', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Alice Smith', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; total_scanned: number };
+      expect(data.total_scanned).toBe(1);
+      expect(data.filed).toBe(1);
+      expect(createTask).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('respects a custom min_score of 0.7', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Alice Smith', null, 0.75),
+      makePair(UUID_A, 'Alice', null, UUID_C, 'Alicia', null, 0.65),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeCtx({ min_score: 0.7 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; total_scanned: number };
+      // 0.75 passes, 0.65 is filtered by DedupService before we even see it
+      // (but here our mock returns both — we filter to ≥ 0.7, so 0.75 passes, 0.65 doesn't)
+      expect(data.total_scanned).toBe(1);  // 0.75 >= 0.7
+      expect(data.filed).toBe(1);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // max_tasks cap
+  // ---------------------------------------------------------------------------
+
+  it('caps task filing at max_tasks and counts capped pairs', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Alice B', null, 0.95),
+      makePair(UUID_A, 'Alice', null, UUID_C, 'Alice C', null, 0.94),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeCtx({ max_tasks: 1 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; capped: number };
+      expect(data.filed).toBe(1);
+      expect(data.capped).toBe(1);
+      expect(createTask).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('files nothing and counts all as capped when max_tasks is 0', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeCtx({ max_tasks: 0 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; capped: number };
+      expect(data.filed).toBe(0);
+      expect(data.capped).toBe(1);
+      expect(createTask).not.toHaveBeenCalled();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Idempotency: existing open task
+  // ---------------------------------------------------------------------------
+
+  it('skips pairs that already have an open dedup task', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = {
+      listTasks: async () => [makeTaskRow(UUID_A, UUID_B)],
+      createTask,
+    };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; skipped_existing: number };
+      expect(data.filed).toBe(0);
+      expect(data.skipped_existing).toBe(1);
+      expect(createTask).not.toHaveBeenCalled();
+    }
+  });
+
+  it('handles existing task with reversed pair order (B, A) the same as (A, B)', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    // Existing task has B as Contact A and A as Contact B
+    const taskRepo = {
+      listTasks: async () => [makeTaskRow(UUID_B, UUID_A)],
+      createTask,
+    };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; skipped_existing: number };
+      expect(data.skipped_existing).toBe(1);
+      expect(createTask).not.toHaveBeenCalled();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Idempotency: dedup_exclusion KG fact
+  // ---------------------------------------------------------------------------
+
+  it('skips pairs that have a dedup_exclusion fact on contact A naming contact B', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', 'kg-node-a', UUID_B, 'Bob', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+    const entityMemory = {
+      getFacts: async (nodeId: string) => {
+        if (nodeId === 'kg-node-a') {
+          return [{ properties: { attribute: 'dedup_exclusion', value: UUID_B } }];
+        }
         return [];
       },
     };
-    await handler.execute(makeCtx({ min_confidence: 'certain' }, contactService));
-    expect(calledWith).toBe('certain');
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; skipped_excluded: number };
+      expect(data.filed).toBe(0);
+      expect(data.skipped_excluded).toBe(1);
+      expect(createTask).not.toHaveBeenCalled();
+    }
   });
 
-  it('rejects invalid min_confidence value', async () => {
+  it('skips pairs that have a dedup_exclusion fact on contact B naming contact A', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', 'kg-node-b', 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+    const entityMemory = {
+      getFacts: async (nodeId: string) => {
+        if (nodeId === 'kg-node-b') {
+          return [{ properties: { attribute: 'dedup_exclusion', value: UUID_A } }];
+        }
+        return [];
+      },
+    };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; skipped_excluded: number };
+      expect(data.skipped_excluded).toBe(1);
+      expect(createTask).not.toHaveBeenCalled();
+    }
+  });
+
+  it('does not skip pairs when neither contact has a kgNodeId', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+    const getFacts = vi.fn().mockResolvedValue([]);
+    const entityMemory = { getFacts };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
+
+    expect(result.success).toBe(true);
+    // getFacts should never be called because both kgNodeIds are null
+    expect(getFacts).not.toHaveBeenCalled();
+    if (result.success) {
+      const data = result.data as { filed: number };
+      expect(data.filed).toBe(1);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Summary counts
+  // ---------------------------------------------------------------------------
+
+  it('returns correct summary with mixed outcomes', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.96),   // filed
+      makePair(UUID_A, 'Alice', null, UUID_C, 'Carol', null, 0.95), // skipped (existing task)
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = {
+      listTasks: async () => [makeTaskRow(UUID_A, UUID_C)],
+      createTask,
+    };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        filed: number;
+        skipped_existing: number;
+        skipped_excluded: number;
+        capped: number;
+        total_scanned: number;
+      };
+      expect(data.filed).toBe(1);
+      expect(data.skipped_existing).toBe(1);
+      expect(data.skipped_excluded).toBe(0);
+      expect(data.capped).toBe(0);
+      expect(data.total_scanned).toBe(2);
+    }
+  });
+
+  it('returns zero counts when no pairs exist above threshold', async () => {
     const contactService = { findDuplicates: async () => [] };
-    const result = await handler.execute(makeCtx({ min_confidence: 'unknown_value' }, contactService));
-    expect(result.success).toBe(false);
-  });
+    const createTask = vi.fn();
+    const taskRepo = { listTasks: async () => [], createTask };
 
-  it('returns formatted duplicate pairs', async () => {
-    const fakePair = {
-      contactA: { id: 'aaa', displayName: 'Alice', role: 'CFO', identities: [] },
-      contactB: { id: 'bbb', displayName: 'Alice Smith', role: null, identities: [] },
-      score: 0.95,
-      confidence: 'certain',
-      reason: 'Similar name (0.95)',
-    };
-    const contactService = { findDuplicates: async () => [fakePair] };
-    const result = await handler.execute(makeCtx({}, contactService));
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { pairs: Array<{ contact_a: { contact_id: string } }>; count: number };
-      expect(data.count).toBe(1);
-      expect(data.pairs[0].contact_a.contact_id).toBe('aaa');
+      const data = result.data as { filed: number; total_scanned: number };
+      expect(data.filed).toBe(0);
+      expect(data.total_scanned).toBe(0);
+      expect(createTask).not.toHaveBeenCalled();
     }
   });
 
-  it('rounds score to 2 decimal places', async () => {
-    const fakePair = {
-      contactA: { id: 'aaa', displayName: 'Alice', role: null, identities: [] },
-      contactB: { id: 'bbb', displayName: 'Bob', role: null, identities: [] },
-      score: 0.94567,
-      confidence: 'probable',
-      reason: 'Name similarity',
-    };
-    const contactService = { findDuplicates: async () => [fakePair] };
-    const result = await handler.execute(makeCtx({}, contactService));
+  // ---------------------------------------------------------------------------
+  // Idempotency: malformed existing task description (graceful degradation)
+  // ---------------------------------------------------------------------------
+
+  it('does not crash when a dedup-tagged task has no parseable contact IDs, and still files for unmatched pairs', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    // Existing task with a non-UUID-format description — should be silently ignored
+    const malformedTask = { id: 'manual-task', description: 'Manually filed dedup task — no IDs', tags: ['dedup'] };
+    const taskRepo = { listTasks: async () => [malformedTask], createTask };
+
+    const result = await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    // Should not crash, and should still file the task since the malformed entry
+    // is not recognized as an existing task for this pair
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { pairs: Array<{ score: number }> };
-      expect(data.pairs[0].score).toBe(0.95);
+      const data = result.data as { filed: number; skipped_existing: number };
+      expect(data.filed).toBe(1);
+      expect(data.skipped_existing).toBe(0);
     }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Task description format (for idempotency key parsing on subsequent runs)
+  // ---------------------------------------------------------------------------
+
+  it('writes task description with parseable Contact A/B ID lines', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    await handler.execute(makeCtx({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(createTask).toHaveBeenCalledOnce();
+    const callArg = createTask.mock.calls[0]![0] as { description: string };
+    expect(callArg.description).toContain(`Contact A ID: ${UUID_A}`);
+    expect(callArg.description).toContain(`Contact B ID: ${UUID_B}`);
+    expect(callArg.description).toContain('Score:');
   });
 });


### PR DESCRIPTION
## Summary

Closes #1037

The scheduled weekly contacts dedup scan (`contacts.yaml`, Mondays 9 AM) was timing out in production because `contact-find-duplicates` returned all ~1,900 pairs at the 0.7 base threshold, causing the contacts agent to loop until timeout.

- **Numeric threshold** — replaces the `'certain'`/`'probable'` enum with a numeric `min_score` (default 0.93); pairs below the threshold are discarded before task filing
- **Task filing** — skill now files Curia-owned `dedup` review tasks instead of returning a raw pair list; a `max_tasks` cap (optional) prevents queue flooding in a single run
- **Idempotency** — before filing, skips any pair that (a) already has an open `dedup` task, or (b) has a `dedup_exclusion` KG fact in either direction; repeated weekly runs are safe
- **Per-pair error isolation** — individual `createTask`/`getFacts` errors are caught and counted in a `failed` field; one broken pair does not abort the entire scan
- **`DuplicatePairContact.kgNodeId`** — added to the type and populated in `DedupService` so the skill can query KG exclusion facts without a second DB round-trip
- **`contacts.yaml`** — weekly scan updated from "present pairs to CEO one at a time" to "scan → file tasks → report summary"; expected duration reduced from 900s to 60s

## Test plan

- [x] 20 unit tests covering: numeric threshold filtering, `max_tasks` cap, idempotency (existing-task skip + exclusion skip), summary counts, per-pair error isolation, malformed task description graceful degradation, task description format
- [x] All 170 contacts unit tests pass (no regression in `DedupService` or `ContactService`)
- [x] All 37 `dedup-contacts.ts` script tests pass
- [x] Typecheck clean