### PR TITLE
feat: wire merge-decline → dedup_exclusion memory (#1027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`DuplicatePairContact`** — added `kgNodeId: string | null` field (populated from the `Contact` object in `DedupService`); enables the skill to check `dedup_exclusion` KG facts without a second DB round-trip. (#1037)
 
 ### Added
-- **`contact-dedup-exclude` skill** — writes permanent `dedup_exclusion` KG facts on both contacts when the CEO explicitly says they are not the same person, closing the anti-nag loop for the dedup sweep. Pinned exclusively to the contacts agent. (#1027)
-- **Contacts agent decline paths** — three explicit "not a duplicate" branches added: duplicate notification, dedup review task, and weekly scan. "Skip this one" remains a temporary defer that does not write an exclusion. (#1027)
-
-### Changed
-- **`writeExclusion` / `hasExclusion`** — extracted from `scripts/dedup-contacts.ts` into `src/contacts/dedup-exclusions.ts`; `contact-find-duplicates` now uses the shared `hasExclusion` instead of its own local copy. The script re-exports them for backward compatibility.
+- **`contact-dedup-exclude`** — new skill + contacts agent decline paths that write permanent `dedup_exclusion` KG facts, preventing explicitly rejected pairs from resurfacing on future sweeps. (#1027)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`DuplicatePairContact`** — added `kgNodeId: string | null` field (populated from the `Contact` object in `DedupService`); enables the skill to check `dedup_exclusion` KG facts without a second DB round-trip. (#1037)
 
 ### Added
+- **`contact-dedup-exclude` skill** — writes permanent `dedup_exclusion` KG facts on both contacts when the CEO explicitly says they are not the same person, closing the anti-nag loop for the dedup sweep. Pinned exclusively to the contacts agent. (#1027)
+- **Contacts agent decline paths** — three explicit "not a duplicate" branches added: duplicate notification, dedup review task, and weekly scan. "Skip this one" remains a temporary defer that does not write an exclusion. (#1027)
+
+### Changed
+- **`writeExclusion` / `hasExclusion`** — extracted from `scripts/dedup-contacts.ts` into `src/contacts/dedup-exclusions.ts` so the sweep and the new skill share one implementation. The script re-exports them for backward compatibility.
+
+### Added
 
 - **Contact `tier` + `kind` model (migration 055)** — ordered capability `tier` and descriptive `kind`, backfilled from legacy fields. (#945)
 - **Contact de-duplication (`dedup:contacts`)** — maintenance sweep that auto-merges structurally-proven duplicates (shared verified identity / same `kg_node_id` / exact normalized name) and files Curia-owned review tasks for fuzzy matches, never auto-merging the principal and never re-surfacing a declined pair. Tunable for controlled rollout via `--dry-run`, `--no-tasks`, `--min-score`/`--max-score` bands, and `--max-tasks`, and shipped in the production image. (#944, #1034)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Contacts agent decline paths** — three explicit "not a duplicate" branches added: duplicate notification, dedup review task, and weekly scan. "Skip this one" remains a temporary defer that does not write an exclusion. (#1027)
 
 ### Changed
-- **`writeExclusion` / `hasExclusion`** — extracted from `scripts/dedup-contacts.ts` into `src/contacts/dedup-exclusions.ts` so the sweep and the new skill share one implementation. The script re-exports them for backward compatibility.
+- **`writeExclusion` / `hasExclusion`** — extracted from `scripts/dedup-contacts.ts` into `src/contacts/dedup-exclusions.ts`; `contact-find-duplicates` now uses the shared `hasExclusion` instead of its own local copy. The script re-exports them for backward compatibility.
 
 ### Added
 

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -1,5 +1,5 @@
 name: contacts
-version: "0.3.0"
+version: "0.4.0"
 role: specialist
 description: >
   Contact domain specialist — briefings, CRUD, deduplication, relationship management,

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -160,7 +160,25 @@ system_prompt: |
      - J. Torres (no role, email jenna@acme.com)
      I'd merge them into Jenna Torres (CFO). Want me to proceed?"
   5. On confirmation: call contact-merge with dry_run: false.
-  6. Never auto-merge without CEO confirmation.
+  6. If the CEO explicitly says they are not the same person ("not a duplicate",
+     "different people", "don't merge them"): call contact-dedup-exclude with both
+     contact IDs. This prevents the pair from being proposed again.
+  7. Never auto-merge without CEO confirmation.
+
+  ### When you have a dedup review task
+  The weekly sweep creates tasks like "Review possible duplicate: Alice / A. Smith"
+  with both contact IDs in the task description. Work through them the same way as
+  duplicate_detected notifications:
+  1. Use contact-lookup to load both contacts in full (IDs are in the task description).
+  2. Apply the primary heuristic above to identify which would be primary.
+  3. Call contact-merge dry_run: true to preview the golden record.
+  4. Present both contacts side-by-side and ask the CEO whether to merge.
+  5. On confirmation: call contact-merge with dry_run: false.
+  6. If the CEO explicitly says they are not the same person ("not a duplicate",
+     "different people", "don't merge them"): call contact-dedup-exclude with both
+     contact IDs. This prevents the pair from resurfacing on future sweeps.
+  7. If the CEO defers or wants to decide later: close the task without calling
+     contact-dedup-exclude. The pair may resurface on a future sweep.
 
   ### Weekly contacts dedup scan
   When the scheduler sends "Run your weekly contacts dedup scan":
@@ -236,6 +254,7 @@ pinned_skills:
   # Lifecycle
   - contact-merge
   - contact-find-duplicates
+  - contact-dedup-exclude
   - contact-grant-permission
   - contact-revoke-permission
   # Knowledge graph

--- a/docs/wip/2026-06-17-dedup-exclusion-wiring.md
+++ b/docs/wip/2026-06-17-dedup-exclusion-wiring.md
@@ -1,0 +1,788 @@
+# Dedup Exclusion Wiring — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the anti-nag loop by wiring `writeExclusion()` into the contacts agent's decline paths, so that an explicit "not a duplicate" from the CEO writes a permanent `dedup_exclusion` KG fact and prevents the pair from resurfacing.
+
+**Architecture:** Extract `writeExclusion`/`hasExclusion` from `scripts/dedup-contacts.ts` into `src/contacts/dedup-exclusions.ts` so both the sweep script and the new agent skill share one implementation. A new `contact-dedup-exclude` skill exposes the exclusion write to the contacts agent. The agent YAML gains three explicit decline branches — duplicate notification, dedup review task, and weekly scan — each calling the skill when the CEO says "not a duplicate". "Skip this one" remains a temporary defer with no write.
+
+**Tech Stack:** TypeScript ESM, Vitest, PostgreSQL via `pg`, KG facts via `EntityMemory.storeFact()`
+
+## Global Constraints
+
+- ESM only: `.js` extensions on all relative imports; `import.meta.dirname` if dirname is needed
+- No `any` — use proper types, generics, or discriminated unions; cast through `unknown` when narrowing `Record<string, unknown>`
+- Array element access (`calls[0]`) is `T | undefined` under strict null checks — use non-null assertion `calls[0]!` when element is guaranteed
+- All skills return `{ success: true, data }` or `{ success: false, error }` — never throw
+- Run `pnpm -C <worktree> run typecheck` before every commit touching `.ts` files
+- Test command: `pnpm -C <worktree> run test`
+- Worktree path: `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/contacts/dedup-exclusions.ts` | Shared `writeExclusion` / `hasExclusion` helpers |
+| Create | `src/contacts/dedup-exclusions.test.ts` | Unit tests for shared helpers (moved from script) |
+| Modify | `scripts/dedup-contacts.ts` | Remove local definitions; import from shared module |
+| Create | `skills/contact-dedup-exclude/skill.json` | Skill manifest |
+| Create | `skills/contact-dedup-exclude/handler.ts` | Skill handler — looks up contacts, calls `writeExclusion` twice |
+| Create | `tests/unit/skills/contact-dedup-exclude.test.ts` | Skill unit tests |
+| Modify | `agents/contacts.yaml` | Add three decline paths; pin `contact-dedup-exclude`; bump version |
+| Modify | `CHANGELOG.md` | Entry under `[Unreleased]` |
+
+---
+
+## Task 1: Extract shared exclusion helpers
+
+**Files:**
+- Create: `src/contacts/dedup-exclusions.ts`
+- Create: `src/contacts/dedup-exclusions.test.ts`
+- Modify: `scripts/dedup-contacts.ts:122–210` (remove local definitions, add import)
+
+**Interfaces:**
+- Produces: `WriteExclusionOptions`, `HasExclusionOptions`, `writeExclusion()`, `hasExclusion()` — consumed by Task 2 (handler) and the sweep script
+
+- [ ] **Step 1: Create the shared module**
+
+Create `src/contacts/dedup-exclusions.ts` with the type definitions and both helpers. This is a direct extraction from `scripts/dedup-contacts.ts` lines 122–210, with one addition: an optional `source` field on `WriteExclusionOptions` (default `'contacts-dedup'`) so the skill can pass `ctx.memoryWriteSource` for correct per-task rate-limit tracking.
+
+```typescript
+// src/contacts/dedup-exclusions.ts
+import type { StoreFactOptions } from '../memory/types.js';
+import type { KgNode } from '../memory/types.js';
+
+export interface WriteExclusionOptions {
+  /** The contact whose KG node will receive the fact. */
+  kgNodeId: string;
+  /** The other contact's ID that this node is excluding. */
+  contactBId: string;
+  storeFact: (options: StoreFactOptions) => Promise<unknown>;
+  /** Source key for the storeFact call. Skills should pass ctx.memoryWriteSource.
+   *  Defaults to 'contacts-dedup' for backward compatibility with the sweep script. */
+  source?: string;
+}
+
+/**
+ * Record a dedup_exclusion KG fact on kgNodeId naming contactBId.
+ *
+ * Uses permanent decay so the exclusion survives the normal decay schedule.
+ * Format: label "dedup_exclusion: <contactBId>", properties.attribute = 'dedup_exclusion',
+ * properties.value = contactBId — matching what hasExclusion() queries for.
+ */
+export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
+  const { contactBId, kgNodeId, storeFact, source = 'contacts-dedup' } = opts;
+  await storeFact({
+    entityNodeId: kgNodeId,
+    label: `dedup_exclusion: ${contactBId}`,
+    properties: { attribute: 'dedup_exclusion', value: contactBId },
+    decayClass: 'permanent',
+    confidence: 1.0,
+    source,
+    sensitivity: 'internal',
+  });
+}
+
+export interface HasExclusionOptions {
+  contactAId: string;
+  contactBId: string;
+  kgNodeIdA: string | null;
+  kgNodeIdB: string | null;
+  getFacts: (kgNodeId: string) => Promise<KgNode[]>;
+}
+
+/**
+ * Check whether either contact has a dedup_exclusion fact naming the other.
+ * Returns true if an exclusion exists in either direction (A→B or B→A).
+ */
+export async function hasExclusion(opts: HasExclusionOptions): Promise<boolean> {
+  const { contactAId, contactBId, kgNodeIdA, kgNodeIdB, getFacts } = opts;
+
+  if (kgNodeIdA === null && kgNodeIdB === null) return false;
+
+  if (kgNodeIdA !== null) {
+    const factsA = await getFacts(kgNodeIdA);
+    for (const fact of factsA) {
+      const props = fact.properties as Record<string, unknown>;
+      if (props.attribute === 'dedup_exclusion' && props.value === contactBId) {
+        return true;
+      }
+    }
+  }
+
+  if (kgNodeIdB !== null) {
+    const factsB = await getFacts(kgNodeIdB);
+    for (const fact of factsB) {
+      const props = fact.properties as Record<string, unknown>;
+      if (props.attribute === 'dedup_exclusion' && props.value === contactAId) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+```
+
+- [ ] **Step 2: Create the test file for the shared module**
+
+Move the `writeExclusion` and `hasExclusion` tests from `scripts/dedup-contacts.test.ts` (lines 657–787) to a new colocated test file. The test structure is identical — the only change is the import path.
+
+```typescript
+// src/contacts/dedup-exclusions.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { writeExclusion, hasExclusion } from './dedup-exclusions.js';
+import type { KgNode } from '../memory/types.js';
+
+// Minimal KgNode shape that satisfies the KgNode type for test fixtures
+function makeFactNode(overrides: { attribute: string; value: string; id?: string }): KgNode {
+  return {
+    id: overrides.id ?? 'fn-1',
+    type: 'fact' as const,
+    label: `dedup_exclusion: ${overrides.value}`,
+    properties: { attribute: overrides.attribute, value: overrides.value },
+    aliases: [],
+    embedding: null,
+    confidence: 1.0,
+    sensitivity: 'internal' as const,
+    decayClass: 'permanent' as const,
+    source: 'contacts-dedup',
+    temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
+  };
+}
+
+describe('writeExclusion', () => {
+  it('calls storeFact with the correct attribute and value for a dedup_exclusion', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({
+      contactBId: 'c2',
+      kgNodeId: 'kg-c1',
+      storeFact: storeFactMock,
+    });
+
+    expect(storeFactMock).toHaveBeenCalledOnce();
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.entityNodeId).toBe('kg-c1');
+    expect((args.properties as Record<string, unknown>).attribute).toBe('dedup_exclusion');
+    expect((args.properties as Record<string, unknown>).value).toBe('c2');
+    expect(args.decayClass).toBe('permanent');
+  });
+
+  it('writes the exclusion label in the expected format', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({ contactBId: 'c2', kgNodeId: 'kg-c1', storeFact: storeFactMock });
+
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.label).toBe('dedup_exclusion: c2');
+  });
+
+  it('defaults source to contacts-dedup when not provided', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({ contactBId: 'c2', kgNodeId: 'kg-c1', storeFact: storeFactMock });
+
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.source).toBe('contacts-dedup');
+  });
+
+  it('uses the provided source when supplied', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({
+      contactBId: 'c2',
+      kgNodeId: 'kg-c1',
+      storeFact: storeFactMock,
+      source: 'agent:contacts/task:t1/channel:cli',
+    });
+
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.source).toBe('agent:contacts/task:t1/channel:cli');
+  });
+});
+
+describe('hasExclusion', () => {
+  it('returns true when the KG node has a dedup_exclusion fact for the other contact', async () => {
+    const getFactsMock = vi.fn().mockResolvedValue([
+      makeFactNode({ attribute: 'dedup_exclusion', value: 'c2' }),
+    ]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when no dedup_exclusion fact exists', async () => {
+    const getFactsMock = vi.fn().mockResolvedValue([]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when neither contact has a kg_node_id', async () => {
+    const getFactsMock = vi.fn().mockResolvedValue([]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: null,
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(false);
+    expect(getFactsMock).not.toHaveBeenCalled();
+  });
+
+  it('checks both sides when both contacts have kg_node_ids', async () => {
+    const getFactsMock = vi.fn().mockImplementation(async (kgNodeId: string) => {
+      if (kgNodeId === 'kg-c2') {
+        return [makeFactNode({ attribute: 'dedup_exclusion', value: 'c1', id: 'fn-2' })];
+      }
+      return [];
+    });
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: 'kg-c2',
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run the new tests to verify they pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring run test src/contacts/dedup-exclusions.test.ts
+```
+
+Expected: all 8 tests pass (6 writeExclusion + hasExclusion, plus 2 new source tests).
+
+- [ ] **Step 4: Update `scripts/dedup-contacts.ts` to import from the shared module**
+
+Remove lines 119–210 (the `WriteExclusionOptions`, `HasExclusionOptions`, `writeExclusion`, and `hasExclusion` definitions). Replace the existing type import block at the top with imports from the shared module:
+
+At the top of `scripts/dedup-contacts.ts`, after the existing imports, add:
+
+```typescript
+import {
+  writeExclusion,
+  hasExclusion,
+} from '../src/contacts/dedup-exclusions.js';
+import type {
+  WriteExclusionOptions,
+  HasExclusionOptions,
+} from '../src/contacts/dedup-exclusions.js';
+```
+
+Then delete lines 119–210 (the local interface and function definitions, starting with `// ---------------------------------------------------------------------------` through the closing `}` of `hasExclusion`).
+
+Also remove the comment on the existing `writeExclusion` call site note (the "NOTE: This function is intentionally NOT called" block is deleted since the function itself is gone). Keep the `storeFact` parameter on `RunDedupOptions` — it's still needed by the sweep for the KG fact cache, just not for exclusion writes.
+
+- [ ] **Step 5: Remove the tests for writeExclusion/hasExclusion from the script test file**
+
+Delete lines 657–787 from `scripts/dedup-contacts.test.ts` (the `describe('writeExclusion')` and `describe('hasExclusion')` blocks and the `// ---------------------------------------------------------------------------` separator above them). They now live in `src/contacts/dedup-exclusions.test.ts`.
+
+- [ ] **Step 6: Run the full test suite and typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring run test
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring run typecheck
+```
+
+Expected: all tests pass, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring add \
+  src/contacts/dedup-exclusions.ts \
+  src/contacts/dedup-exclusions.test.ts \
+  scripts/dedup-contacts.ts \
+  scripts/dedup-contacts.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring commit -m "refactor: extract writeExclusion/hasExclusion to shared src/contacts/dedup-exclusions module"
+```
+
+---
+
+## Task 2: Create `contact-dedup-exclude` skill
+
+**Files:**
+- Create: `skills/contact-dedup-exclude/skill.json`
+- Create: `skills/contact-dedup-exclude/handler.ts`
+- Create: `tests/unit/skills/contact-dedup-exclude.test.ts`
+
+**Interfaces:**
+- Consumes: `writeExclusion`, `WriteExclusionOptions` from `../../src/contacts/dedup-exclusions.js`
+- Consumes: `SkillHandler`, `SkillContext`, `SkillResult` from `../../src/skills/types.js`
+- Consumes: `ctx.contactService.getContact(id)` → `Promise<Contact | undefined>` where `Contact` has `kgNodeId: string | null`
+- Consumes: `ctx.entityMemory.storeFact` (bound) as the `storeFact` callback
+- Consumes: `ctx.memoryWriteSource?: string` — falls back to `'contacts-dedup'`
+- Produces: `{ success: true, data: { contact_a_id, contact_b_id, contact_a_excluded, contact_b_excluded } }` or `{ success: false, error }`
+
+- [ ] **Step 1: Write the failing skill tests**
+
+```typescript
+// tests/unit/skills/contact-dedup-exclude.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { ContactDedupExcludeHandler } from '../../../skills/contact-dedup-exclude/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+const UUID_A = '550e8400-e29b-41d4-a716-446655440000';
+const UUID_B = '550e8400-e29b-41d4-a716-446655440001';
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+describe('ContactDedupExcludeHandler', () => {
+  const handler = new ContactDedupExcludeHandler();
+
+  it('fails when contact_a_id is missing', async () => {
+    const result = await handler.execute(makeCtx({ contact_b_id: UUID_B }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('contact_a_id');
+  });
+
+  it('fails when contact_b_id is missing', async () => {
+    const result = await handler.execute(makeCtx({ contact_a_id: UUID_A }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('contact_b_id');
+  });
+
+  it('fails when contact_a_id is not a valid UUID', async () => {
+    const result = await handler.execute(makeCtx({ contact_a_id: 'not-a-uuid', contact_b_id: UUID_B }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('UUID');
+  });
+
+  it('fails when both IDs are the same', async () => {
+    const result = await handler.execute(makeCtx({ contact_a_id: UUID_A, contact_b_id: UUID_A }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('different');
+  });
+
+  it('fails when contactService is not available', async () => {
+    const result = await handler.execute(makeCtx({ contact_a_id: UUID_A, contact_b_id: UUID_B }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('contactService');
+  });
+
+  it('fails when entityMemory is not available', async () => {
+    const contactService = { getContact: vi.fn() } as unknown as SkillContext['contactService'];
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('entityMemory');
+  });
+
+  it('fails when contact A is not found', async () => {
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) =>
+        id === UUID_B ? { id: UUID_B, kgNodeId: 'kg-b' } : undefined,
+      ),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: vi.fn() } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain(UUID_A);
+  });
+
+  it('fails when contact B is not found', async () => {
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) =>
+        id === UUID_A ? { id: UUID_A, kgNodeId: 'kg-a' } : undefined,
+      ),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: vi.fn() } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain(UUID_B);
+  });
+
+  it('writes exclusion facts on both KG nodes when both contacts have KG nodes', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
+        displayName: id === UUID_A ? 'Alice' : 'Bob',
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: storeFactMock } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contact_a_excluded).toBe(true);
+      expect(result.data.contact_b_excluded).toBe(true);
+    }
+
+    expect(storeFactMock).toHaveBeenCalledTimes(2);
+    // A's node names B
+    const callA = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callA.entityNodeId).toBe('kg-a');
+    expect((callA.properties as Record<string, unknown>).value).toBe(UUID_B);
+    // B's node names A
+    const callB = storeFactMock.mock.calls[1]![0] as Record<string, unknown>;
+    expect(callB.entityNodeId).toBe('kg-b');
+    expect((callB.properties as Record<string, unknown>).value).toBe(UUID_A);
+  });
+
+  it('skips writing on contacts with no KG node', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : null, // B has no KG node
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: storeFactMock } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contact_a_excluded).toBe(true);
+      expect(result.data.contact_b_excluded).toBe(false);
+    }
+    expect(storeFactMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses ctx.memoryWriteSource as the storeFact source', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: storeFactMock } as unknown as SkillContext['entityMemory'];
+
+    await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory, memoryWriteSource: 'agent:contacts/task:t1/channel:cli' },
+    ));
+
+    const call = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(call.source).toBe('agent:contacts/task:t1/channel:cli');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail (handler doesn't exist yet)**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring run test tests/unit/skills/contact-dedup-exclude.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../../../skills/contact-dedup-exclude/handler.js'`
+
+- [ ] **Step 3: Create the skill manifest**
+
+```json
+// skills/contact-dedup-exclude/skill.json
+{
+  "name": "contact-dedup-exclude",
+  "description": "Record a permanent dedup_exclusion KG fact on both contacts, naming each other as not-a-duplicate. Call this when the CEO explicitly confirms two contacts are not the same person. Prevents the pair from being proposed as duplicates again on future sweeps.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "contact_a_id": "string (UUID of the first contact)",
+    "contact_b_id": "string (UUID of the second contact)"
+  },
+  "outputs": {
+    "contact_a_id": "string — echoed back",
+    "contact_b_id": "string — echoed back",
+    "contact_a_excluded": "boolean — true if an exclusion fact was written on contact A's KG node",
+    "contact_b_excluded": "boolean — true if an exclusion fact was written on contact B's KG node"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000,
+  "capabilities": [
+    "entityMemory"
+  ]
+}
+```
+
+- [ ] **Step 4: Create the skill handler**
+
+```typescript
+// skills/contact-dedup-exclude/handler.ts
+import { validate as uuidValidate } from 'uuid';
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { writeExclusion } from '../../src/contacts/dedup-exclusions.js';
+
+export class ContactDedupExcludeHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input = ctx.input as Record<string, unknown>;
+    const contactAId = input['contact_a_id'];
+    const contactBId = input['contact_b_id'];
+
+    if (typeof contactAId !== 'string' || !uuidValidate(contactAId)) {
+      return { success: false, error: 'contact_a_id must be a valid UUID' };
+    }
+    if (typeof contactBId !== 'string' || !uuidValidate(contactBId)) {
+      return { success: false, error: 'contact_b_id must be a valid UUID' };
+    }
+    if (contactAId === contactBId) {
+      return { success: false, error: 'contact_a_id and contact_b_id must be different' };
+    }
+    if (!ctx.contactService) {
+      return { success: false, error: 'contactService not available' };
+    }
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'entityMemory not available' };
+    }
+
+    const [contactA, contactB] = await Promise.all([
+      ctx.contactService.getContact(contactAId),
+      ctx.contactService.getContact(contactBId),
+    ]);
+
+    if (!contactA) {
+      return { success: false, error: `Contact not found: ${contactAId}` };
+    }
+    if (!contactB) {
+      return { success: false, error: `Contact not found: ${contactBId}` };
+    }
+
+    const source = ctx.memoryWriteSource ?? 'contacts-dedup';
+    const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
+    let contactAExcluded = false;
+    let contactBExcluded = false;
+
+    // Write exclusion on A's node naming B
+    if (contactA.kgNodeId !== null) {
+      await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
+      contactAExcluded = true;
+    }
+
+    // Write exclusion on B's node naming A (bidirectional — hasExclusion checks both sides,
+    // but writing both ensures the exclusion is found regardless of which contact's node
+    // is queried first and handles any edge case where one node is later created)
+    if (contactB.kgNodeId !== null) {
+      await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
+      contactBExcluded = true;
+    }
+
+    return {
+      success: true,
+      data: {
+        contact_a_id: contactAId,
+        contact_b_id: contactBId,
+        contact_a_excluded: contactAExcluded,
+        contact_b_excluded: contactBExcluded,
+      },
+    };
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring run test tests/unit/skills/contact-dedup-exclude.test.ts
+```
+
+Expected: all 10 tests pass.
+
+- [ ] **Step 6: Run full suite and typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring run test
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring run typecheck
+```
+
+Expected: all tests pass, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring add \
+  skills/contact-dedup-exclude/skill.json \
+  skills/contact-dedup-exclude/handler.ts \
+  tests/unit/skills/contact-dedup-exclude.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring commit -m "feat: add contact-dedup-exclude skill to write permanent dedup_exclusion KG facts"
+```
+
+---
+
+## Task 3: Update `agents/contacts.yaml`
+
+**Files:**
+- Modify: `agents/contacts.yaml`
+
+Three changes in one edit: (1) add the new dedup task handling section, (2) add decline branch to the duplicate notification section, (3) add explicit rejection branch to weekly scan section. Also pin the new skill and bump the agent version.
+
+- [ ] **Step 1: Read the current contacts.yaml dedup section**
+
+Read `agents/contacts.yaml` lines 140–185 to confirm the current text before editing.
+
+- [ ] **Step 2: Add `contact-dedup-exclude` to `pinned_skills`**
+
+Find the `pinned_skills:` block (around line 218) and add the new skill alongside the other contact skills:
+
+```yaml
+  - contact-dedup-exclude
+```
+
+Add it after `contact-find-duplicates` to keep contact skills grouped.
+
+- [ ] **Step 3: Replace the duplicate notification section**
+
+Find and replace the section from `### When you receive a contact.duplicate_detected notification` through `6. Never auto-merge without CEO confirmation.`
+
+Replace with:
+
+```yaml
+  ### When you receive a contact.duplicate_detected notification
+  A background check found that a newly-created contact may be a duplicate of an
+  existing one. Handle this at the next natural opportunity (not as an interrupt):
+  1. Use contact-lookup to load both contacts in full (IDs are in the notification).
+  2. Identify the primary contact using this heuristic (in priority order):
+     - Most verified channel identities
+     - Has a role assigned
+     - Older created_at (established contact wins)
+  3. Call contact-merge with dry_run: true to get the golden record preview.
+  4. Present both contacts side-by-side, show what will change, and ask the
+     coordinator to confirm with the CEO before merging. Example:
+     "I noticed two contacts that look like the same person:
+     - Jenna Torres (CFO, verified email jenna@acme.com)
+     - J. Torres (no role, email jenna@acme.com)
+     I'd merge them into Jenna Torres (CFO). Want me to proceed?"
+  5. On confirmation: call contact-merge with dry_run: false.
+  6. If the CEO explicitly says they are not the same person ("not a duplicate",
+     "different people", "don't merge them"): call contact-dedup-exclude with both
+     contact IDs. This prevents the pair from being proposed again.
+  7. Never auto-merge without CEO confirmation.
+```
+
+- [ ] **Step 4: Add the new dedup review task section**
+
+Insert a new section immediately after the duplicate notification section (before `### Weekly contacts dedup scan`):
+
+```yaml
+  ### When you have a dedup review task
+  The weekly dedup sweep creates tasks like "Review possible duplicate: Alice / A. Smith"
+  with both contact IDs in the task description. Work through them the same way as
+  duplicate_detected notifications:
+  1. Use contact-lookup to load both contacts in full (IDs are in the task description).
+  2. Apply the primary heuristic above to identify which would be primary.
+  3. Call contact-merge dry_run: true to preview the golden record.
+  4. Present both contacts side-by-side and ask the CEO whether to merge.
+  5. On confirmation: call contact-merge with dry_run: false.
+  6. If the CEO explicitly says they are not the same person ("not a duplicate",
+     "different people", "don't merge them"): call contact-dedup-exclude with both
+     contact IDs. This prevents the pair from resurfacing on future sweeps.
+  7. If the CEO defers or wants to decide later: close the task without calling
+     contact-dedup-exclude. The pair may resurface on a future sweep.
+```
+
+- [ ] **Step 5: Replace the weekly scan section**
+
+Find and replace from `### Weekly contacts dedup scan` through `4. After finishing: summarize what was merged.`
+
+Replace with:
+
+```yaml
+  ### Weekly contacts dedup scan
+  When the scheduler sends "Run your weekly contacts dedup scan":
+  1. Call contact-find-duplicates (default min_confidence: probable).
+  2. If no pairs found: confirm that no duplicates were detected.
+  3. If pairs found: work through them one at a time.
+     - For each pair: use the primary heuristic above, call contact-merge dry_run: true,
+       present the preview, get confirmation, then merge.
+     - If the CEO defers a pair ("skip this one", "not now", "later"): move on without
+       merging or recording anything. The pair will resurface next sweep.
+     - If the CEO explicitly says they are not the same person ("not a duplicate",
+       "different people", "don't merge them"): call contact-dedup-exclude with both
+       contact IDs, then move on. The pair will not resurface.
+     - Continue until all pairs are reviewed or the CEO ends the session.
+  4. After finishing: summarize what was merged and what was permanently excluded.
+```
+
+- [ ] **Step 6: Bump the contacts agent version**
+
+Find `version:` in `agents/contacts.yaml` and bump it by a minor increment (new capability added). If current is `0.X.Y`, change to `0.(X+1).0`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring add agents/contacts.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring commit -m "feat: wire contact-dedup-exclude into contacts agent decline paths"
+```
+
+---
+
+## Task 4: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add entry under `[Unreleased]`**
+
+Open `CHANGELOG.md` and add under the `## [Unreleased]` heading:
+
+```markdown
+### Added
+- **`contact-dedup-exclude` skill** — writes permanent `dedup_exclusion` KG facts on both contacts when the CEO says they are not duplicates, closing the anti-nag loop for the dedup sweep. (#1027)
+- **Dedup exclusion helpers** — `writeExclusion`/`hasExclusion` extracted from `scripts/dedup-contacts.ts` to `src/contacts/dedup-exclusions.ts` for shared use between the sweep and the new skill.
+- **Contacts agent decline paths** — three explicit "not a duplicate" branches added to `agents/contacts.yaml`: duplicate notification, dedup review task, and weekly scan. "Skip" remains a temporary defer. (#1027)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-dedup-exclusion-wiring commit -m "chore: update CHANGELOG for dedup exclusion wiring (#1027)"
+```

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -11,15 +11,12 @@
 //   3. Principal-involving pair → task created (no merge), even if structural
 //   4. Excluded pair → skipped (no merge, no task)
 //   5. Dry-run mode → no writes of any kind (no merges, no tasks)
-//   6. writeExclusion helper → writes the correct KG fact
-//   7. hasExclusion helper → correctly reads exclusion facts
+// writeExclusion/hasExclusion unit tests live in src/contacts/dedup-exclusions.test.ts
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
 import {
   runDedup,
-  writeExclusion,
-  hasExclusion,
   parseNumericFlag,
   type DedupRunOptions,
 } from './dedup-contacts.js';
@@ -647,142 +644,6 @@ describe('runDedup — unit', () => {
     expect(result.taskCount).toBe(2);
     expect(result.skippedAboveMaxScoreCount).toBe(1);   // the 1.0 pair excluded
     expect(result.skippedLowScoreCount).toBe(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// writeExclusion helper tests
-// ---------------------------------------------------------------------------
-
-describe('writeExclusion', () => {
-  it('calls storeFact with the correct attribute and value for a dedup_exclusion', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-
-    await writeExclusion({
-      // contactAId removed from WriteExclusionOptions (F9) — kgNodeId is already A's node
-      contactBId: 'c2',
-      kgNodeId: 'kg-c1',
-      storeFact: storeFactMock,
-    });
-
-    expect(storeFactMock).toHaveBeenCalledOnce();
-    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
-    expect(args.entityNodeId).toBe('kg-c1');
-    expect((args.properties as Record<string, unknown>).attribute).toBe('dedup_exclusion');
-    expect((args.properties as Record<string, unknown>).value).toBe('c2');
-    // Exclusion facts must be permanent so they survive decay
-    expect(args.decayClass).toBe('permanent');
-  });
-
-  it('writes the exclusion label in the expected format', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-
-    await writeExclusion({
-      contactBId: 'c2',
-      kgNodeId: 'kg-c1',
-      storeFact: storeFactMock,
-    });
-
-    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
-    // Label must follow the "field: value" format used by all KG facts
-    expect(args.label).toBe('dedup_exclusion: c2');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// hasExclusion helper tests
-// ---------------------------------------------------------------------------
-
-describe('hasExclusion', () => {
-  it('returns true when the KG node has a dedup_exclusion fact for the other contact', async () => {
-    const exclusionFact = {
-      id: 'fn-1',
-      type: 'fact' as const,
-      label: 'dedup_exclusion: c2',
-      properties: { attribute: 'dedup_exclusion', value: 'c2' },
-      aliases: [],
-      embedding: null,
-      confidence: 1.0,
-      sensitivity: 'internal' as const,
-      decayClass: 'permanent' as const,
-      source: 'contacts-dedup',
-      temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
-    };
-
-    const getFactsMock = vi.fn().mockResolvedValue([exclusionFact]);
-
-    const result = await hasExclusion({
-      contactAId: 'c1',
-      contactBId: 'c2',
-      kgNodeIdA: 'kg-c1',
-      kgNodeIdB: null,
-      getFacts: getFactsMock,
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it('returns false when no dedup_exclusion fact exists', async () => {
-    const getFactsMock = vi.fn().mockResolvedValue([]);
-
-    const result = await hasExclusion({
-      contactAId: 'c1',
-      contactBId: 'c2',
-      kgNodeIdA: 'kg-c1',
-      kgNodeIdB: null,
-      getFacts: getFactsMock,
-    });
-
-    expect(result).toBe(false);
-  });
-
-  it('returns false when neither contact has a kg_node_id', async () => {
-    const getFactsMock = vi.fn().mockResolvedValue([]);
-
-    const result = await hasExclusion({
-      contactAId: 'c1',
-      contactBId: 'c2',
-      kgNodeIdA: null,
-      kgNodeIdB: null,
-      getFacts: getFactsMock,
-    });
-
-    // No KG nodes → no exclusion facts possible
-    expect(result).toBe(false);
-    // Should not even call getFacts since there's nothing to query
-    expect(getFactsMock).not.toHaveBeenCalled();
-  });
-
-  it('checks both sides when both contacts have kg_node_ids', async () => {
-    // Exclusion is on contactB's KG node naming contactA
-    const getFactsMock = vi.fn().mockImplementation(async (kgNodeId: string) => {
-      if (kgNodeId === 'kg-c2') {
-        return [{
-          id: 'fn-1',
-          type: 'fact',
-          label: 'dedup_exclusion: c1',
-          properties: { attribute: 'dedup_exclusion', value: 'c1' },
-          aliases: [],
-          embedding: null,
-          confidence: 1.0,
-          sensitivity: 'internal',
-          decayClass: 'permanent',
-          source: 'contacts-dedup',
-          temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
-        }];
-      }
-      return [];
-    });
-
-    const result = await hasExclusion({
-      contactAId: 'c1',
-      contactBId: 'c2',
-      kgNodeIdA: 'kg-c1',
-      kgNodeIdB: 'kg-c2',
-      getFacts: getFactsMock,
-    });
-
-    expect(result).toBe(true);
   });
 });
 

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -19,7 +19,12 @@ import { createLogger } from '../src/logger.js';
 import { classifyPair, type PairClassification } from '../src/contacts/dedup-classifier.js';
 import type { Contact, ChannelIdentity, ContactKind } from '../src/contacts/types.js';
 import type { KgNode } from '../src/memory/types.js';
-import type { StoreFactOptions } from '../src/memory/types.js';
+import {
+  writeExclusion,
+  hasExclusion,
+  type WriteExclusionOptions,
+  type HasExclusionOptions,
+} from '../src/contacts/dedup-exclusions.js';
 import { ModelRegistry } from '../src/agents/llm/model-registry.js';
 import { EventBus } from '../src/bus/bus.js';
 import { AuditLogger } from '../src/audit/logger.js';
@@ -108,106 +113,14 @@ export interface DedupRunOptions {
     sourceAgentId: string;
     tags: string[];
   }) => Promise<unknown>;
-  // storeFact is intentionally NOT included here: the sweep never writes exclusion facts
-  // itself. The decline→exclusion write is performed by the contacts agent's decline flow
-  // (not yet wired; tracked as a follow-up). Only writeExclusion() has its own storeFact param.
+  // storeFact is NOT included here: the sweep never writes exclusion facts.
+  // Decline→exclusion writes go through the contacts agent calling contact-dedup-exclude.
   /** Calls EntityMemory.getFacts for a KG node — returns fact nodes. */
   getFacts: (kgNodeId: string) => Promise<KgNode[]>;
 }
 
-// ---------------------------------------------------------------------------
-// Exclusion helpers (exported for tests)
-// ---------------------------------------------------------------------------
-
-export interface WriteExclusionOptions {
-  // contactAId is intentionally omitted: the exclusion fact is always written on
-  // kgNodeId (which is A's KG node) and names contactBId as the excluded party.
-  // The caller already knows which node belongs to A — passing A's contact ID into
-  // the helper adds no value and would just be ignored.
-  contactBId: string;
-  /** KG node on which to record the exclusion fact. */
-  kgNodeId: string;
-  storeFact: (options: StoreFactOptions) => Promise<unknown>;
-}
-
-/**
- * Record a dedup_exclusion KG fact on kgNodeId naming contactBId.
- *
- * This is the memory-store path for a "do not suggest again" signal.
- * The fact uses permanent decay so it survives the normal slow/fast decay
- * schedule and is never quietly discarded.
- *
- * Format follows the convention used by backfill-contact-attributes:
- *   label: "dedup_exclusion: <otherContactId>"
- *   properties.attribute = 'dedup_exclusion'
- *   properties.value     = otherContactId
- *
- * NOTE: This function is intentionally NOT called by runDedup() / the sweep.
- * The decline→exclusion write is performed by the contacts agent's decline flow
- * (i.e. when a human reviews a fuzzy recommendation task and declines to merge).
- * That wiring is not yet implemented; tracked as a follow-up. This function is
- * therefore NOT dead code — it is the target of that future call site.
- */
-export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
-  const { contactBId, kgNodeId, storeFact } = opts;
-  await storeFact({
-    entityNodeId: kgNodeId,
-    label: `dedup_exclusion: ${contactBId}`,
-    properties: { attribute: 'dedup_exclusion', value: contactBId },
-    // Permanent decay — exclusion decisions must not quietly expire
-    decayClass: 'permanent',
-    confidence: 1.0,
-    source: 'contacts-dedup',
-    sensitivity: 'internal',
-  });
-}
-
-// ---------------------------------------------------------------------------
-
-export interface HasExclusionOptions {
-  contactAId: string;
-  contactBId: string;
-  kgNodeIdA: string | null;
-  kgNodeIdB: string | null;
-  getFacts: (kgNodeId: string) => Promise<KgNode[]>;
-}
-
-/**
- * Check whether either contact has recorded a dedup_exclusion fact naming the other.
- *
- * Returns true if an exclusion exists in either direction (A→B or B→A).
- * Returns false immediately if neither contact has a kg_node_id (no facts possible).
- */
-export async function hasExclusion(opts: HasExclusionOptions): Promise<boolean> {
-  const { contactAId, contactBId, kgNodeIdA, kgNodeIdB, getFacts } = opts;
-
-  // Short-circuit: no KG nodes means no facts can exist
-  if (kgNodeIdA === null && kgNodeIdB === null) return false;
-
-  // Check A's node for an exclusion naming B
-  if (kgNodeIdA !== null) {
-    const factsA = await getFacts(kgNodeIdA);
-    for (const fact of factsA) {
-      const props = fact.properties as Record<string, unknown>;
-      if (props.attribute === 'dedup_exclusion' && props.value === contactBId) {
-        return true;
-      }
-    }
-  }
-
-  // Check B's node for an exclusion naming A
-  if (kgNodeIdB !== null) {
-    const factsB = await getFacts(kgNodeIdB);
-    for (const fact of factsB) {
-      const props = fact.properties as Record<string, unknown>;
-      if (props.attribute === 'dedup_exclusion' && props.value === contactAId) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
+// Re-export shared helpers so existing test imports from this module keep working.
+export { writeExclusion, hasExclusion, type WriteExclusionOptions, type HasExclusionOptions };
 
 // ---------------------------------------------------------------------------
 // Core sweep logic (exported for tests)

--- a/skills/contact-dedup-exclude/handler.ts
+++ b/skills/contact-dedup-exclude/handler.ts
@@ -25,6 +25,10 @@ export class ContactDedupExcludeHandler implements SkillHandler {
       return { success: false, error: 'entityMemory not available' };
     }
 
+    // Hoisted so both variables are in scope in the catch block for partial-write logging
+    let contactAExcluded = false;
+    let contactBExcluded = false;
+
     try {
       const [contactA, contactB] = await Promise.all([
         ctx.contactService.getContact(contactAId),
@@ -40,13 +44,15 @@ export class ContactDedupExcludeHandler implements SkillHandler {
 
       const source = ctx.memoryWriteSource ?? 'contacts-dedup';
       const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
-      let contactAExcluded = false;
-      let contactBExcluded = false;
 
       // Write on A's node naming B
       if (contactA.kgNodeId !== null) {
         await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
         contactAExcluded = true;
+      } else {
+        // A has no KG node — exclusion written on B only (best-effort); if B's node is
+        // later lost the exclusion may not be checkable. Logged so operators can audit.
+        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact A has no KG node — exclusion written on B only');
       }
 
       // Write on B's node naming A — bidirectional so hasExclusion finds it regardless of
@@ -54,6 +60,8 @@ export class ContactDedupExcludeHandler implements SkillHandler {
       if (contactB.kgNodeId !== null) {
         await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
         contactBExcluded = true;
+      } else {
+        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact B has no KG node — exclusion written on A only');
       }
 
       // If neither contact has a KG node yet, the exclusion cannot be stored anywhere.
@@ -77,7 +85,8 @@ export class ContactDedupExcludeHandler implements SkillHandler {
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, contactAId, contactBId }, 'contact-dedup-exclude: failed to write exclusion facts');
+      // Include partial-write state so operators can tell which write failed
+      ctx.log.error({ err, contactAId, contactBId, contactAExcluded, contactBExcluded }, 'contact-dedup-exclude: failed to write exclusion facts');
       return { success: false, error: `Failed to write dedup exclusion: ${message}` };
     }
   }

--- a/skills/contact-dedup-exclude/handler.ts
+++ b/skills/contact-dedup-exclude/handler.ts
@@ -25,44 +25,60 @@ export class ContactDedupExcludeHandler implements SkillHandler {
       return { success: false, error: 'entityMemory not available' };
     }
 
-    const [contactA, contactB] = await Promise.all([
-      ctx.contactService.getContact(contactAId),
-      ctx.contactService.getContact(contactBId),
-    ]);
+    try {
+      const [contactA, contactB] = await Promise.all([
+        ctx.contactService.getContact(contactAId),
+        ctx.contactService.getContact(contactBId),
+      ]);
 
-    if (!contactA) {
-      return { success: false, error: `Contact not found: ${contactAId}` };
+      if (!contactA) {
+        return { success: false, error: `Contact not found: ${contactAId}` };
+      }
+      if (!contactB) {
+        return { success: false, error: `Contact not found: ${contactBId}` };
+      }
+
+      const source = ctx.memoryWriteSource ?? 'contacts-dedup';
+      const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
+      let contactAExcluded = false;
+      let contactBExcluded = false;
+
+      // Write on A's node naming B
+      if (contactA.kgNodeId !== null) {
+        await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
+        contactAExcluded = true;
+      }
+
+      // Write on B's node naming A — bidirectional so hasExclusion finds it regardless of
+      // which contact's node is checked first
+      if (contactB.kgNodeId !== null) {
+        await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
+        contactBExcluded = true;
+      }
+
+      // If neither contact has a KG node yet, the exclusion cannot be stored anywhere.
+      // Return failure so the agent knows to retry rather than telling the CEO it's done.
+      if (!contactAExcluded && !contactBExcluded) {
+        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: neither contact has a KG node; exclusion could not be written');
+        return {
+          success: false,
+          error: 'Neither contact has a KG node yet — the exclusion cannot be stored. Retry after the contacts have been enriched.',
+        };
+      }
+
+      return {
+        success: true,
+        data: {
+          contact_a_id: contactAId,
+          contact_b_id: contactBId,
+          contact_a_excluded: contactAExcluded,
+          contact_b_excluded: contactBExcluded,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, contactAId, contactBId }, 'contact-dedup-exclude: failed to write exclusion facts');
+      return { success: false, error: `Failed to write dedup exclusion: ${message}` };
     }
-    if (!contactB) {
-      return { success: false, error: `Contact not found: ${contactBId}` };
-    }
-
-    const source = ctx.memoryWriteSource ?? 'contacts-dedup';
-    const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
-    let contactAExcluded = false;
-    let contactBExcluded = false;
-
-    // Write on A's node naming B
-    if (contactA.kgNodeId !== null) {
-      await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
-      contactAExcluded = true;
-    }
-
-    // Write on B's node naming A — bidirectional so hasExclusion finds it regardless of
-    // which contact's node is checked first
-    if (contactB.kgNodeId !== null) {
-      await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
-      contactBExcluded = true;
-    }
-
-    return {
-      success: true,
-      data: {
-        contact_a_id: contactAId,
-        contact_b_id: contactBId,
-        contact_a_excluded: contactAExcluded,
-        contact_b_excluded: contactBExcluded,
-      },
-    };
   }
 }

--- a/skills/contact-dedup-exclude/handler.ts
+++ b/skills/contact-dedup-exclude/handler.ts
@@ -1,0 +1,68 @@
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { writeExclusion } from '../../src/contacts/dedup-exclusions.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class ContactDedupExcludeHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input = ctx.input as Record<string, unknown>;
+    const contactAId = input['contact_a_id'];
+    const contactBId = input['contact_b_id'];
+
+    if (typeof contactAId !== 'string' || !UUID_RE.test(contactAId)) {
+      return { success: false, error: 'contact_a_id must be a valid UUID' };
+    }
+    if (typeof contactBId !== 'string' || !UUID_RE.test(contactBId)) {
+      return { success: false, error: 'contact_b_id must be a valid UUID' };
+    }
+    if (contactAId === contactBId) {
+      return { success: false, error: 'contact_a_id and contact_b_id must be different' };
+    }
+    if (!ctx.contactService) {
+      return { success: false, error: 'contactService not available' };
+    }
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'entityMemory not available' };
+    }
+
+    const [contactA, contactB] = await Promise.all([
+      ctx.contactService.getContact(contactAId),
+      ctx.contactService.getContact(contactBId),
+    ]);
+
+    if (!contactA) {
+      return { success: false, error: `Contact not found: ${contactAId}` };
+    }
+    if (!contactB) {
+      return { success: false, error: `Contact not found: ${contactBId}` };
+    }
+
+    const source = ctx.memoryWriteSource ?? 'contacts-dedup';
+    const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
+    let contactAExcluded = false;
+    let contactBExcluded = false;
+
+    // Write on A's node naming B
+    if (contactA.kgNodeId !== null) {
+      await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
+      contactAExcluded = true;
+    }
+
+    // Write on B's node naming A — bidirectional so hasExclusion finds it regardless of
+    // which contact's node is checked first
+    if (contactB.kgNodeId !== null) {
+      await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
+      contactBExcluded = true;
+    }
+
+    return {
+      success: true,
+      data: {
+        contact_a_id: contactAId,
+        contact_b_id: contactBId,
+        contact_a_excluded: contactAExcluded,
+        contact_b_excluded: contactBExcluded,
+      },
+    };
+  }
+}

--- a/skills/contact-dedup-exclude/handler.ts
+++ b/skills/contact-dedup-exclude/handler.ts
@@ -45,10 +45,19 @@ export class ContactDedupExcludeHandler implements SkillHandler {
       const source = ctx.memoryWriteSource ?? 'contacts-dedup';
       const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
 
-      // Write on A's node naming B
+      // Write on A's node naming B. Each side is independent: if A's write fails (e.g.
+      // KG conflict), we still attempt B — hasExclusion is bidirectional so a single
+      // side is enough to prevent the pair from resurfacing.
       if (contactA.kgNodeId !== null) {
-        await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
-        contactAExcluded = true;
+        try {
+          await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
+          contactAExcluded = true;
+        } catch (writeErrA) {
+          ctx.log.error(
+            { writeErrA, contactAId, contactBId },
+            'contact-dedup-exclude: failed to write exclusion on A — still attempting B',
+          );
+        }
       } else {
         // A has no KG node — exclusion written on B only (best-effort); if B's node is
         // later lost the exclusion may not be checkable. Logged so operators can audit.
@@ -58,19 +67,25 @@ export class ContactDedupExcludeHandler implements SkillHandler {
       // Write on B's node naming A — bidirectional so hasExclusion finds it regardless of
       // which contact's node is checked first
       if (contactB.kgNodeId !== null) {
-        await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
-        contactBExcluded = true;
+        try {
+          await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
+          contactBExcluded = true;
+        } catch (writeErrB) {
+          ctx.log.error(
+            { writeErrB, contactAId, contactBId, contactAExcluded },
+            'contact-dedup-exclude: failed to write exclusion on B',
+          );
+        }
       } else {
         ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact B has no KG node — exclusion written on A only');
       }
 
-      // If neither contact has a KG node yet, the exclusion cannot be stored anywhere.
-      // Return failure so the agent knows to retry rather than telling the CEO it's done.
+      // Both sides failed (no KG nodes, or both writes errored) — nothing was stored.
       if (!contactAExcluded && !contactBExcluded) {
-        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: neither contact has a KG node; exclusion could not be written');
+        ctx.log.warn({ contactAId, contactBId, contactA: !!contactA.kgNodeId, contactB: !!contactB.kgNodeId }, 'contact-dedup-exclude: exclusion could not be written on either contact');
         return {
           success: false,
-          error: 'Neither contact has a KG node yet — the exclusion cannot be stored. Retry after the contacts have been enriched.',
+          error: 'Could not write dedup exclusion on either contact — exclusion not stored. Retry after enrichment or resolve the KG conflict.',
         };
       }
 
@@ -84,10 +99,11 @@ export class ContactDedupExcludeHandler implements SkillHandler {
         },
       };
     } catch (err) {
+      // Outer catch: only contact lookup failures reach here (writeExclusion errors
+      // are handled above with their own per-side try/catch)
       const message = err instanceof Error ? err.message : String(err);
-      // Include partial-write state so operators can tell which write failed
-      ctx.log.error({ err, contactAId, contactBId, contactAExcluded, contactBExcluded }, 'contact-dedup-exclude: failed to write exclusion facts');
-      return { success: false, error: `Failed to write dedup exclusion: ${message}` };
+      ctx.log.error({ err, contactAId, contactBId }, 'contact-dedup-exclude: contact lookup failed');
+      return { success: false, error: `Failed to look up contacts: ${message}` };
     }
   }
 }

--- a/skills/contact-dedup-exclude/skill.json
+++ b/skills/contact-dedup-exclude/skill.json
@@ -1,0 +1,23 @@
+{
+  "name": "contact-dedup-exclude",
+  "description": "Record a permanent dedup_exclusion KG fact on both contacts, preventing the pair from being proposed as duplicates again. Call this when the CEO explicitly says two contacts are not the same person. Pinned exclusively to the contacts agent — not available to other agents.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "contact_a_id": "string (UUID of the first contact)",
+    "contact_b_id": "string (UUID of the second contact)"
+  },
+  "outputs": {
+    "contact_a_id": "string — echoed back",
+    "contact_b_id": "string — echoed back",
+    "contact_a_excluded": "boolean — true if an exclusion fact was written on contact A's KG node",
+    "contact_b_excluded": "boolean — true if an exclusion fact was written on contact B's KG node"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000,
+  "capabilities": [
+    "entityMemory"
+  ]
+}

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -13,6 +13,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { DuplicatePair } from '../../src/contacts/types.js';
 import type { KgNode } from '../../src/memory/types.js';
+import { hasExclusion } from '../../src/contacts/dedup-exclusions.js';
 
 // Default minimum Jaro-Winkler score — chosen empirically as the precision sweet
 // spot on the production contact set (0.95 is very clean, 0.90 starts to pick up
@@ -50,45 +51,6 @@ function extractPairIds(description: string | null | undefined): { aId: string; 
   }
   if (found['A'] && found['B']) return { aId: found['A'], bId: found['B'] };
   return null;
-}
-
-/**
- * Check whether either contact in a pair has a dedup_exclusion KG fact naming
- * the other — bidirectional, same logic as hasExclusion() in dedup-contacts.ts.
- * Short-circuits to false when neither contact has a kgNodeId.
- *
- * Matching is by `properties.attribute === 'dedup_exclusion'` only (per the KG
- * fact schema guidance: never match on `label` for lookups). This assumes that
- * no other part of the system stores facts with this attribute name for an
- * unrelated purpose, which is enforced by convention — the attribute is
- * exclusively written by writeExclusion() in dedup-contacts.ts.
- */
-async function checkExclusion(
-  aId: string,
-  bId: string,
-  kgNodeIdA: string | null,
-  kgNodeIdB: string | null,
-  getFacts: (nodeId: string) => Promise<KgNode[]>,
-): Promise<boolean> {
-  if (kgNodeIdA === null && kgNodeIdB === null) return false;
-
-  if (kgNodeIdA !== null) {
-    const factsA = await getFacts(kgNodeIdA);
-    for (const fact of factsA) {
-      const props = fact.properties as Record<string, unknown>;
-      if (props['attribute'] === 'dedup_exclusion' && props['value'] === bId) return true;
-    }
-  }
-
-  if (kgNodeIdB !== null) {
-    const factsB = await getFacts(kgNodeIdB);
-    for (const fact of factsB) {
-      const props = fact.properties as Record<string, unknown>;
-      if (props['attribute'] === 'dedup_exclusion' && props['value'] === aId) return true;
-    }
-  }
-
-  return false;
 }
 
 export class ContactFindDuplicatesHandler implements SkillHandler {
@@ -211,13 +173,13 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
       }
 
       try {
-        const excluded = await checkExclusion(
-          pair.contactA.id,
-          pair.contactB.id,
-          pair.contactA.kgNodeId,
-          pair.contactB.kgNodeId,
-          cachedGetFacts,
-        );
+        const excluded = await hasExclusion({
+          contactAId: pair.contactA.id,
+          contactBId: pair.contactB.id,
+          kgNodeIdA: pair.contactA.kgNodeId,
+          kgNodeIdB: pair.contactB.kgNodeId,
+          getFacts: cachedGetFacts,
+        });
         if (excluded) {
           skippedExcluded++;
           continue;

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -172,24 +172,38 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
         continue;
       }
 
+      // Exclusion check is isolated from task filing: a transient getFacts failure
+      // should increment failed and skip the pair (same as a task-filing failure),
+      // but logging a distinct message lets operators tell the two apart.
+      let excluded: boolean;
       try {
-        const excluded = await hasExclusion({
+        excluded = await hasExclusion({
           contactAId: pair.contactA.id,
           contactBId: pair.contactB.id,
           kgNodeIdA: pair.contactA.kgNodeId,
           kgNodeIdB: pair.contactB.kgNodeId,
           getFacts: cachedGetFacts,
         });
-        if (excluded) {
-          skippedExcluded++;
-          continue;
-        }
+      } catch (exclusionErr) {
+        failed++;
+        ctx.log.error(
+          { exclusionErr, contactAId: pair.contactA.id, contactBId: pair.contactB.id },
+          'contact-find-duplicates: exclusion check failed — skipping pair, may re-surface next sweep',
+        );
+        continue;
+      }
 
-        if (maxTasks !== undefined && filed >= maxTasks) {
-          capped++;
-          continue;
-        }
+      if (excluded) {
+        skippedExcluded++;
+        continue;
+      }
 
+      if (maxTasks !== undefined && filed >= maxTasks) {
+        capped++;
+        continue;
+      }
+
+      try {
         const description = [
           `Possible duplicate contacts detected by the dedup skill scan.`,
           ``,
@@ -218,14 +232,14 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
           'contact-find-duplicates: filed review task',
         );
         filed++;
-      } catch (pairErr) {
+      } catch (taskErr) {
         // Fail open: log and continue so one pair error doesn't abort the entire scan.
         // The pair is not counted as filed, so the idempotency check will attempt it again
         // on the next weekly run — the risk of re-filing is preferable to losing all progress.
         failed++;
         ctx.log.error(
-          { pairErr, contactAId: pair.contactA.id, contactBId: pair.contactB.id },
-          'contact-find-duplicates: error processing pair — skipping and continuing',
+          { taskErr, contactAId: pair.contactA.id, contactBId: pair.contactB.id },
+          'contact-find-duplicates: error filing task for pair — skipping and continuing',
         );
       }
     }

--- a/src/contacts/dedup-exclusions.test.ts
+++ b/src/contacts/dedup-exclusions.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+import { writeExclusion, hasExclusion } from './dedup-exclusions.js';
+import type { KgNode } from '../memory/types.js';
+
+function makeFactNode(overrides: { attribute: string; value: string; id?: string }): KgNode {
+  return {
+    id: overrides.id ?? 'fn-1',
+    type: 'fact' as const,
+    label: `dedup_exclusion: ${overrides.value}`,
+    properties: { attribute: overrides.attribute, value: overrides.value },
+    aliases: [],
+    sensitivity: 'internal' as const,
+    temporal: {
+      createdAt: new Date(),
+      lastConfirmedAt: new Date(),
+      confidence: 1.0,
+      decayClass: 'permanent' as const,
+      source: 'contacts-dedup',
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// writeExclusion
+// ---------------------------------------------------------------------------
+
+describe('writeExclusion', () => {
+  it('calls storeFact with the correct attribute and value for a dedup_exclusion', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({
+      contactBId: 'c2',
+      kgNodeId: 'kg-c1',
+      storeFact: storeFactMock,
+    });
+
+    expect(storeFactMock).toHaveBeenCalledOnce();
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.entityNodeId).toBe('kg-c1');
+    expect((args.properties as Record<string, unknown>).attribute).toBe('dedup_exclusion');
+    expect((args.properties as Record<string, unknown>).value).toBe('c2');
+    // Exclusion facts must be permanent so they survive decay
+    expect(args.decayClass).toBe('permanent');
+  });
+
+  it('writes the exclusion label in the expected format', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({ contactBId: 'c2', kgNodeId: 'kg-c1', storeFact: storeFactMock });
+
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.label).toBe('dedup_exclusion: c2');
+  });
+
+  it('defaults source to contacts-dedup when not provided', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({ contactBId: 'c2', kgNodeId: 'kg-c1', storeFact: storeFactMock });
+
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.source).toBe('contacts-dedup');
+  });
+
+  it('uses the provided source when supplied', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+
+    await writeExclusion({
+      contactBId: 'c2',
+      kgNodeId: 'kg-c1',
+      storeFact: storeFactMock,
+      source: 'agent:contacts/task:t1/channel:cli',
+    });
+
+    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.source).toBe('agent:contacts/task:t1/channel:cli');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasExclusion
+// ---------------------------------------------------------------------------
+
+describe('hasExclusion', () => {
+  it('returns true when the KG node has a dedup_exclusion fact for the other contact', async () => {
+    const getFactsMock = vi.fn().mockResolvedValue([
+      makeFactNode({ attribute: 'dedup_exclusion', value: 'c2' }),
+    ]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when no dedup_exclusion fact exists', async () => {
+    const getFactsMock = vi.fn().mockResolvedValue([]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when neither contact has a kg_node_id', async () => {
+    const getFactsMock = vi.fn().mockResolvedValue([]);
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: null,
+      kgNodeIdB: null,
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(false);
+    // No KG nodes → no facts possible; should not even attempt to fetch
+    expect(getFactsMock).not.toHaveBeenCalled();
+  });
+
+  it('checks both sides when both contacts have kg_node_ids', async () => {
+    // Exclusion is on B's node naming A
+    const getFactsMock = vi.fn().mockImplementation(async (kgNodeId: string) => {
+      if (kgNodeId === 'kg-c2') {
+        return [makeFactNode({ attribute: 'dedup_exclusion', value: 'c1', id: 'fn-2' })];
+      }
+      return [];
+    });
+
+    const result = await hasExclusion({
+      contactAId: 'c1',
+      contactBId: 'c2',
+      kgNodeIdA: 'kg-c1',
+      kgNodeIdB: 'kg-c2',
+      getFacts: getFactsMock,
+    });
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/contacts/dedup-exclusions.test.ts
+++ b/src/contacts/dedup-exclusions.test.ts
@@ -74,6 +74,22 @@ describe('writeExclusion', () => {
     const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
     expect(args.source).toBe('agent:contacts/task:t1/channel:cli');
   });
+
+  it('throws when storeFact returns stored: false (e.g. conflict with existing exclusion for different pair)', async () => {
+    // This exercises the critical path where EntityMemory contradiction detection fires
+    // because the same attribute ('dedup_exclusion') already exists on the node for a
+    // different pair (different label/value). Without the throw, the handler would
+    // silently treat the non-stored fact as written and return success to the agent.
+    const storeFactMock = vi.fn().mockResolvedValue({
+      stored: false,
+      action: 'conflict',
+      conflict: 'Contradicts existing fact dedup_exclusion: c3 (same attribute, different label, equal confidence)',
+    });
+
+    await expect(
+      writeExclusion({ contactBId: 'c2', kgNodeId: 'kg-c1', storeFact: storeFactMock }),
+    ).rejects.toThrow(/not stored.*action: conflict/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/contacts/dedup-exclusions.ts
+++ b/src/contacts/dedup-exclusions.ts
@@ -39,7 +39,10 @@ export interface WriteExclusionOptions {
  * done in a dedicated issue (see curia#1027 discussion).
  */
 export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
-  const { contactBId, kgNodeId, storeFact, source = 'contacts-dedup' } = opts;
+  const { contactBId: rawContactBId, kgNodeId, storeFact, source = 'contacts-dedup' } = opts;
+  // Normalize to lowercase so writes and reads are always comparable regardless of
+  // input casing (the UUID validator accepts uppercase; the DB always returns lowercase).
+  const contactBId = rawContactBId.toLowerCase();
   const result = await storeFact({
     entityNodeId: kgNodeId,
     label: `dedup_exclusion: ${contactBId}`,
@@ -77,7 +80,9 @@ export interface HasExclusionOptions {
  * should treat the error as "unknown" and skip the pair rather than proceeding.
  */
 export async function hasExclusion(opts: HasExclusionOptions): Promise<boolean> {
-  const { contactAId, contactBId, kgNodeIdA, kgNodeIdB, getFacts } = opts;
+  const { contactAId: rawContactAId, contactBId: rawContactBId, kgNodeIdA, kgNodeIdB, getFacts } = opts;
+  const contactAId = rawContactAId.toLowerCase();
+  const contactBId = rawContactBId.toLowerCase();
 
   // Short-circuit: no KG nodes means no facts can exist
   if (kgNodeIdA === null && kgNodeIdB === null) return false;

--- a/src/contacts/dedup-exclusions.ts
+++ b/src/contacts/dedup-exclusions.ts
@@ -1,12 +1,20 @@
 import type { StoreFactOptions } from '../memory/types.js';
 import type { KgNode } from '../memory/types.js';
 
+// Minimal structural return type for storeFact — matches StoreFactResult in entity-memory.ts
+// without creating a cross-module dependency. action values are the full union from that type.
+export interface StoreFactSummary {
+  stored: boolean;
+  action: 'created' | 'updated' | 'conflict' | 'auto_rejected' | 'auto_resolved' | 'entity_not_found' | 'rate_limited';
+  conflict?: string;
+}
+
 export interface WriteExclusionOptions {
   /** The other contact's ID that this node is excluding. */
   contactBId: string;
   /** The KG node on which to record the exclusion fact (belongs to the other contact, A). */
   kgNodeId: string;
-  storeFact: (options: StoreFactOptions) => Promise<unknown>;
+  storeFact: (options: StoreFactOptions) => Promise<StoreFactSummary>;
   /** Source key for the storeFact call. Skills should pass ctx.memoryWriteSource.
    *  Defaults to 'contacts-dedup' for backward compatibility with the sweep script. */
   source?: string;
@@ -18,10 +26,21 @@ export interface WriteExclusionOptions {
  * Uses permanent decay so the exclusion survives the normal decay schedule.
  * Format: label "dedup_exclusion: <contactBId>", properties.attribute = 'dedup_exclusion',
  * properties.value = contactBId — matching what hasExclusion() queries for.
+ *
+ * Throws if the fact was not stored (action: 'conflict' | 'auto_rejected' | ...).
+ * The 'conflict' case typically fires when a contact already has a dedup_exclusion
+ * for a DIFFERENT pair — EntityMemory's contradiction detection treats same-attribute,
+ * different-label facts at equal confidence as conflicts. Callers should catch and
+ * surface this rather than treating a non-throwing return as a guarantee of persistence.
+ *
+ * @TODO: The underlying fix is to key contradiction detection on (attribute + value)
+ * rather than (attribute + label), so multiple dedup_exclusion facts per node are
+ * permitted. That change touches shared memory-validation semantics and should be
+ * done in a dedicated issue (see curia#1027 discussion).
  */
 export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
   const { contactBId, kgNodeId, storeFact, source = 'contacts-dedup' } = opts;
-  await storeFact({
+  const result = await storeFact({
     entityNodeId: kgNodeId,
     label: `dedup_exclusion: ${contactBId}`,
     properties: { attribute: 'dedup_exclusion', value: contactBId },
@@ -31,6 +50,11 @@ export async function writeExclusion(opts: WriteExclusionOptions): Promise<void>
     source,
     sensitivity: 'internal',
   });
+  if (!result.stored) {
+    throw new Error(
+      `dedup_exclusion fact for ${contactBId} was not stored (action: ${result.action}${result.conflict ? `, reason: ${result.conflict}` : ''})`,
+    );
+  }
 }
 
 export interface HasExclusionOptions {
@@ -38,6 +62,7 @@ export interface HasExclusionOptions {
   contactBId: string;
   kgNodeIdA: string | null;
   kgNodeIdB: string | null;
+  /** getFacts errors propagate to the caller — callers must decide their own failure policy. */
   getFacts: (kgNodeId: string) => Promise<KgNode[]>;
 }
 
@@ -45,6 +70,11 @@ export interface HasExclusionOptions {
  * Check whether either contact has a dedup_exclusion fact naming the other.
  * Returns true if an exclusion exists in either direction (A→B or B→A).
  * Short-circuits immediately when neither contact has a KG node.
+ *
+ * Any error thrown by getFacts propagates to the caller unchanged — this function
+ * has no internal retry or fallback. Callers that treat a getFacts error as "no
+ * exclusion" would silently re-file tasks for previously-rejected pairs; callers
+ * should treat the error as "unknown" and skip the pair rather than proceeding.
  */
 export async function hasExclusion(opts: HasExclusionOptions): Promise<boolean> {
   const { contactAId, contactBId, kgNodeIdA, kgNodeIdB, getFacts } = opts;

--- a/src/contacts/dedup-exclusions.ts
+++ b/src/contacts/dedup-exclusions.ts
@@ -1,0 +1,78 @@
+import type { StoreFactOptions } from '../memory/types.js';
+import type { KgNode } from '../memory/types.js';
+
+export interface WriteExclusionOptions {
+  /** The other contact's ID that this node is excluding. */
+  contactBId: string;
+  /** The KG node on which to record the exclusion fact (belongs to the other contact, A). */
+  kgNodeId: string;
+  storeFact: (options: StoreFactOptions) => Promise<unknown>;
+  /** Source key for the storeFact call. Skills should pass ctx.memoryWriteSource.
+   *  Defaults to 'contacts-dedup' for backward compatibility with the sweep script. */
+  source?: string;
+}
+
+/**
+ * Record a dedup_exclusion KG fact on kgNodeId naming contactBId.
+ *
+ * Uses permanent decay so the exclusion survives the normal decay schedule.
+ * Format: label "dedup_exclusion: <contactBId>", properties.attribute = 'dedup_exclusion',
+ * properties.value = contactBId — matching what hasExclusion() queries for.
+ */
+export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
+  const { contactBId, kgNodeId, storeFact, source = 'contacts-dedup' } = opts;
+  await storeFact({
+    entityNodeId: kgNodeId,
+    label: `dedup_exclusion: ${contactBId}`,
+    properties: { attribute: 'dedup_exclusion', value: contactBId },
+    // Permanent decay — exclusion decisions must not quietly expire
+    decayClass: 'permanent',
+    confidence: 1.0,
+    source,
+    sensitivity: 'internal',
+  });
+}
+
+export interface HasExclusionOptions {
+  contactAId: string;
+  contactBId: string;
+  kgNodeIdA: string | null;
+  kgNodeIdB: string | null;
+  getFacts: (kgNodeId: string) => Promise<KgNode[]>;
+}
+
+/**
+ * Check whether either contact has a dedup_exclusion fact naming the other.
+ * Returns true if an exclusion exists in either direction (A→B or B→A).
+ * Short-circuits immediately when neither contact has a KG node.
+ */
+export async function hasExclusion(opts: HasExclusionOptions): Promise<boolean> {
+  const { contactAId, contactBId, kgNodeIdA, kgNodeIdB, getFacts } = opts;
+
+  // Short-circuit: no KG nodes means no facts can exist
+  if (kgNodeIdA === null && kgNodeIdB === null) return false;
+
+  // Check A's node for an exclusion naming B
+  if (kgNodeIdA !== null) {
+    const factsA = await getFacts(kgNodeIdA);
+    for (const fact of factsA) {
+      const props = fact.properties as Record<string, unknown>;
+      if (props.attribute === 'dedup_exclusion' && props.value === contactBId) {
+        return true;
+      }
+    }
+  }
+
+  // Check B's node for an exclusion naming A
+  if (kgNodeIdB !== null) {
+    const factsB = await getFacts(kgNodeIdB);
+    for (const fact of factsB) {
+      const props = fact.properties as Record<string, unknown>;
+      if (props.attribute === 'dedup_exclusion' && props.value === contactAId) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -151,6 +151,59 @@ describe('ContactDedupExcludeHandler', () => {
     expect(storeFactMock).toHaveBeenCalledTimes(1);
   });
 
+  it('returns failure when getContact throws', async () => {
+    const contactService = {
+      getContact: vi.fn().mockRejectedValue(new Error('DB connection refused')),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: vi.fn() } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('DB connection refused');
+  });
+
+  it('returns failure when storeFact throws', async () => {
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = {
+      storeFact: vi.fn().mockRejectedValue(new Error('KG write failed')),
+    } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('KG write failed');
+  });
+
+  it('returns failure when neither contact has a KG node', async () => {
+    const storeFactMock = vi.fn();
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({ id, kgNodeId: null })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: storeFactMock } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('KG node');
+    // No facts should be written when there's nowhere to attach them
+    expect(storeFactMock).not.toHaveBeenCalled();
+  });
+
   it('uses ctx.memoryWriteSource as the storeFact source', async () => {
     const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
     const contactService = {

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ContactDedupExcludeHandler } from '../../../skills/contact-dedup-exclude/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+const UUID_A = '550e8400-e29b-41d4-a716-446655440000';
+const UUID_B = '550e8400-e29b-41d4-a716-446655440001';
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+describe('ContactDedupExcludeHandler', () => {
+  const handler = new ContactDedupExcludeHandler();
+
+  it('fails when contact_a_id is missing', async () => {
+    const result = await handler.execute(makeCtx({ contact_b_id: UUID_B }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('contact_a_id');
+  });
+
+  it('fails when contact_b_id is missing', async () => {
+    const result = await handler.execute(makeCtx({ contact_a_id: UUID_A }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('contact_b_id');
+  });
+
+  it('fails when contact_a_id is not a valid UUID', async () => {
+    const result = await handler.execute(makeCtx({ contact_a_id: 'not-a-uuid', contact_b_id: UUID_B }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('UUID');
+  });
+
+  it('fails when both IDs are the same', async () => {
+    const result = await handler.execute(makeCtx({ contact_a_id: UUID_A, contact_b_id: UUID_A }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('different');
+  });
+
+  it('fails when contactService is not available', async () => {
+    const result = await handler.execute(makeCtx({ contact_a_id: UUID_A, contact_b_id: UUID_B }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('contactService');
+  });
+
+  it('fails when entityMemory is not available', async () => {
+    const contactService = { getContact: vi.fn() } as unknown as SkillContext['contactService'];
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('entityMemory');
+  });
+
+  it('fails when contact A is not found', async () => {
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) =>
+        id === UUID_B ? { id: UUID_B, kgNodeId: 'kg-b' } : undefined,
+      ),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: vi.fn() } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain(UUID_A);
+  });
+
+  it('fails when contact B is not found', async () => {
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) =>
+        id === UUID_A ? { id: UUID_A, kgNodeId: 'kg-a' } : undefined,
+      ),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: vi.fn() } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain(UUID_B);
+  });
+
+  it('writes exclusion facts on both KG nodes when both contacts have KG nodes', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
+        displayName: id === UUID_A ? 'Alice' : 'Bob',
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: storeFactMock } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contact_a_excluded).toBe(true);
+      expect(result.data.contact_b_excluded).toBe(true);
+    }
+    expect(storeFactMock).toHaveBeenCalledTimes(2);
+
+    // A's node names B
+    const callA = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callA.entityNodeId).toBe('kg-a');
+    expect((callA.properties as Record<string, unknown>).value).toBe(UUID_B);
+
+    // B's node names A
+    const callB = storeFactMock.mock.calls[1]![0] as Record<string, unknown>;
+    expect(callB.entityNodeId).toBe('kg-b');
+    expect((callB.properties as Record<string, unknown>).value).toBe(UUID_A);
+  });
+
+  it('skips writing on a contact with no KG node', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : null, // B has no KG node
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: storeFactMock } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contact_a_excluded).toBe(true);
+      expect(result.data.contact_b_excluded).toBe(false);
+    }
+    // Only one write — B has no KG node to attach a fact to
+    expect(storeFactMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses ctx.memoryWriteSource as the storeFact source', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = { storeFact: storeFactMock } as unknown as SkillContext['entityMemory'];
+
+    await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory, memoryWriteSource: 'agent:contacts/task:t1/channel:cli' },
+    ));
+
+    const call = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(call.source).toBe('agent:contacts/task:t1/channel:cli');
+  });
+});

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -166,7 +166,7 @@ describe('ContactDedupExcludeHandler', () => {
     if (!result.success) expect(result.error).toContain('DB connection refused');
   });
 
-  it('returns failure when storeFact throws', async () => {
+  it('returns failure when storeFact throws on both sides', async () => {
     const contactService = {
       getContact: vi.fn().mockImplementation(async (id: string) => ({
         id,
@@ -182,8 +182,36 @@ describe('ContactDedupExcludeHandler', () => {
       { contactService, entityMemory },
     ));
 
+    // Each write is attempted independently; when both fail the handler returns failure
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('KG write failed');
+    if (!result.success) expect(result.error).toContain('dedup exclusion');
+  });
+
+  it('returns success when only one write succeeds (partial exclusion is valid)', async () => {
+    // hasExclusion is bidirectional, so one side is enough to block re-surfacing
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = {
+      storeFact: vi.fn()
+        // First call (A-side) conflicts; second call (B-side) succeeds
+        .mockResolvedValueOnce({ stored: false, action: 'conflict', conflict: 'existing exclusion' })
+        .mockResolvedValue({ stored: true, action: 'created' }),
+    } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contact_a_excluded).toBe(false);
+      expect(result.data.contact_b_excluded).toBe(true);
+    }
   });
 
   it('returns failure when storeFact returns stored: false (second exclusion silent-drop)', async () => {
@@ -226,7 +254,7 @@ describe('ContactDedupExcludeHandler', () => {
     ));
 
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('KG node');
+    if (!result.success) expect(result.error).toContain('dedup exclusion');
     // No facts should be written when there's nowhere to attach them
     expect(storeFactMock).not.toHaveBeenCalled();
   });

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -186,6 +186,33 @@ describe('ContactDedupExcludeHandler', () => {
     if (!result.success) expect(result.error).toContain('KG write failed');
   });
 
+  it('returns failure when storeFact returns stored: false (second exclusion silent-drop)', async () => {
+    // Validates the critical path where EntityMemory contradiction detection fires for
+    // a contact that already has a dedup_exclusion for a different pair. Before the fix,
+    // writeExclusion ignored the return value and the handler falsely returned success.
+    const contactService = {
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
+      })),
+    } as unknown as SkillContext['contactService'];
+    const entityMemory = {
+      storeFact: vi.fn().mockResolvedValue({
+        stored: false,
+        action: 'conflict',
+        conflict: 'Contradicts existing dedup_exclusion fact for a different pair',
+      }),
+    } as unknown as SkillContext['entityMemory'];
+
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService, entityMemory },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('dedup exclusion');
+  });
+
   it('returns failure when neither contact has a KG node', async () => {
     const storeFactMock = vi.fn();
     const contactService = {


### PR DESCRIPTION
## Summary

- Extracts `writeExclusion` / `hasExclusion` from `scripts/dedup-contacts.ts` into `src/contacts/dedup-exclusions.ts` so the skill and sweep share one implementation
- Adds `contact-dedup-exclude` skill — writes permanent `dedup_exclusion` KG facts on both contacts when the CEO explicitly says two contacts are not the same person; pinned exclusively to the contacts agent, not available to other agents
- Replaces local `checkExclusion()` in `contact-find-duplicates` handler with the shared `hasExclusion()`
- Wires explicit decline paths into the contacts agent: step 6 on both the `duplicate_detected` notification flow and the dedup review task flow; the weekly scan's scan-only flow (from #1037) is preserved unchanged
- "Skip this one" = temporary defer (no exclusion written); only explicit rejection ("not a duplicate", "different people", "don't merge them") triggers the skill call

**Critical fix included:** `writeExclusion` now checks `storeFact`'s return value and throws on `stored: false` — previously, a contact's second exclusion was silently dropped by EntityMemory's contradiction detection (same `attribute`, different `label`, equal confidence), causing previously-rejected pairs to resurface.

Closes #1027

## Test plan

- [ ] `src/contacts/dedup-exclusions.test.ts` — 9 tests including `stored: false` case
- [ ] `tests/unit/skills/contact-dedup-exclude.test.ts` — 16 tests including partial-write, DB error, and `stored: false` (second exclusion silent-drop)
- [ ] `scripts/dedup-contacts.test.ts` — 31 tests, re-exports verified
- [ ] `pnpm run typecheck` clean