### PR TITLE
fix: use mkdtempSync for unpredictable temp dir in loader test (CodeQL #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+
+- **Insecure temp directory in loader test** — replaced predictable hardcoded temp path with `fs.mkdtempSync()` to eliminate CWE-377 (insecure temporary file creation) CodeQL alert #159.
+
 ### Fixed
 
 - **`contact-find-duplicates` scheduled scan** — skill now files bounded review tasks (instead of returning a raw list) and is idempotent across runs; default threshold raised to 0.93 to cut false positives; `max_tasks` cap prevents queue flooding; weekly contacts dedup scan updated to scan-only mode. (#1037)

--- a/tests/unit/skills/loader.test.ts
+++ b/tests/unit/skills/loader.test.ts
@@ -40,7 +40,9 @@ describe('loadSkillsFromDirectory', () => {
   // (raw JSON.parse, no Ajv), so a malformed manifest can't leak a non-array/non-string
   // shape into the registry gate or vault scope guard.
   describe('install.requires_secrets normalization', () => {
-    const tmpDir = path.join(os.tmpdir(), 'curia-loader-requires-secrets-test');
+    // mkdtempSync creates a directory with a random suffix, avoiding the
+    // predictable path that triggers CWE-377 (insecure temp file creation).
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-loader-requires-secrets-'));
 
     function writeSkill(name: string, install: unknown): void {
       const dir = path.join(tmpDir, name);


### PR DESCRIPTION
## Summary

- **`loader.test.ts`** — replaced predictable hardcoded temp directory (`curia-loader-requires-secrets-test`) with `fs.mkdtempSync()`, which appends a random suffix and creates the directory atomically. Resolves CodeQL code scanning alert #159 (CWE-377: insecure temporary file creation).

No behaviour change in tests — all 8 tests in `loader.test.ts` continue to pass. The `afterAll` cleanup and `writeSkill` helper are unaffected.

## Test plan

- [x] `vitest run tests/unit/skills/loader.test.ts` — 8/8 tests pass
- [x] CodeQL alert https://github.com/josephfung/curia/security/code-scanning/159 should be resolved on next scan