### PR TITLE
fix: upgrade pnpm 11.0.8 → 11.7.0 to clear CVE-2026-53655

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 
 - **Insecure temp directory in loader test** — replaced predictable hardcoded temp path with `fs.mkdtempSync()` to eliminate CWE-377 (insecure temporary file creation) CodeQL alert #159.
+- **pnpm 11.0.8 → 11.7.0** — clears CVE-2026-53655 (node-tar PAX size override / interpretation differential) in pnpm's own bundled tar; pnpm 11.7.0 ships tar@7.5.16.
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,8 @@ RUN corepack enable
 #   - CVE-2026-45149: brace-expansion < 5.0.6 (arbitrary string generation)
 #   - CVE-2026-42338: ip-address < 10.1.1 (XSS via improper HTML escaping)
 # npm@11.17.0 bundles tar@7.5.16, brace-expansion@5.0.6, ip-address@10.2.0.
-# This does not affect pnpm or the app's own node_modules.
+# CVE-2026-53655 in pnpm's own bundled tar is addressed separately by upgrading
+# pnpm to 11.7.0 (packageManager field in package.json), which bundles tar@7.5.16.
 # TODO: Dependabot does not track RUN-instruction version pins — bump this
 # manually when npm publishes a patch that addresses new bundled CVEs.
 RUN npm install -g npm@11.17.0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.35.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
-  "packageManager": "pnpm@11.0.8",
+  "packageManager": "pnpm@11.7.0",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
## Summary

- Upgrades `packageManager` from `pnpm@11.0.8` to `pnpm@11.7.0`
- pnpm 11.0.8 bundles tar@7.5.13 (vulnerable to CVE-2026-53655); pnpm 11.7.0 bundles tar@7.5.16 (fixed)
- Updates Dockerfile comment to note both vectors (npm bundled tar + pnpm bundled tar) are now cleared

**CVE-2026-53655** — node-tar PAX size override / interpretation differential (MEDIUM). A crafted archive can cause node-tar's stream cursor to desync from other tar implementations, hiding archive members from security scanners. Fixed in tar@7.5.16.

The Trivy Docker image scan flagged this at: `root/.cache/node/corepack/v1/pnpm/11.0.8/dist/node_modules/tar/package.json` (code scanning alert #169).

The existing `npm install -g npm@11.17.0` in the Dockerfile already cleared this CVE for npm's bundled tar. This PR closes the pnpm side.

**Verification:** `pnpm install` was run locally with pnpm v11.7.0 and confirmed the lockfile is up to date (`lockfileVersion: '9.0'` is shared across pnpm 9/10/11 — no format bump in this range).

## Test plan

- [ ] CI passes (pnpm 11.7.0 validates frozen lockfile without errors)
- [ ] Trivy Docker image scan no longer flags CVE-2026-53655 at the pnpm corepack path after this merges and the image rebuilds