### PR TITLE
fix: remove stale corepack pnpm cache to clear CVE-2026-53655

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+
+- **CVE-2026-53655 (pnpm bundled tar)** — deleted corepack's pnpm cache from the production image after install. Node 24's bundled corepack pre-caches pnpm@11.0.8 (which bundles tar@7.5.13) during `corepack enable`, even though the project uses pnpm@11.7.0. pnpm is not used at runtime, so the cache is removed entirely.
+
 ### Added
 
 - **Escalation-line policy judge** — LLM-powered classifier that maps `tier` × disclosure-sensitivity / action-consequence → allow / escalate; policy is deterministic code, LLM does only the natural-language classification; fail-closed by design. (#948)

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,11 @@ RUN pnpm add tsx
 # differential). Upgrading packageManager to pnpm@11.7.0 is not sufficient on
 # its own because the old cached tarball remains on disk and Trivy flags it.
 # pnpm is not used at runtime (CMD calls tsx directly), so the cache is safe to
-# remove entirely.
-RUN rm -rf /root/.cache/node/corepack
+# remove entirely. Both paths are removed: Node 24's corepack writes to
+# /root/.cache/node/corepack (confirmed by the Trivy alert path); the alternate
+# layout /root/.cache/corepack (used by older corepack versions) is removed too
+# so this stays correct across future base-image bumps.
+RUN rm -rf /root/.cache/node/corepack /root/.cache/corepack
 
 # Copy compiled output from build stage
 COPY --from=build /app/dist ./dist
@@ -175,11 +178,12 @@ USER curia
 
 # Invoke tsx directly rather than going through `pnpm exec tsx ...`. The pnpm
 # route triggers corepack at runtime, which in turn looks for a pnpm tarball
-# in /tmp/.cache/corepack (HOME=/tmp for the curia user). That cache is empty
-# at runtime because the build-stage pnpm install ran as root and populated
-# /root/.cache/corepack, and corepack then prompts before downloading. In a
-# non-TTY container the prompt sees EOF and the process exits 1 silently —
-# exactly the failure mode that took two hours to debug in #805.
+# in /tmp/.cache/node/corepack (HOME=/tmp for the curia user). That cache is
+# empty at runtime because the build-stage pnpm install ran as root and
+# populated /root/.cache/node/corepack (then cleaned up — see the rm step
+# above), and corepack then prompts before downloading. In a non-TTY container
+# the prompt sees EOF and the process exits 1 silently — exactly the failure
+# mode that took two hours to debug in #805.
 #
 # tsx is needed because dist/index.js dynamically imports raw .ts skill handlers
 # at runtime via ESM .js→.ts extension resolution. node alone cannot do that.

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,6 @@ RUN corepack enable
 #   - CVE-2026-45149: brace-expansion < 5.0.6 (arbitrary string generation)
 #   - CVE-2026-42338: ip-address < 10.1.1 (XSS via improper HTML escaping)
 # npm@11.17.0 bundles tar@7.5.16, brace-expansion@5.0.6, ip-address@10.2.0.
-# CVE-2026-53655 in pnpm's own bundled tar is addressed separately by upgrading
-# pnpm to 11.7.0 (packageManager field in package.json), which bundles tar@7.5.16.
 # TODO: Dependabot does not track RUN-instruction version pins — bump this
 # manually when npm publishes a patch that addresses new bundled CVEs.
 RUN npm install -g npm@11.17.0
@@ -82,6 +80,16 @@ RUN pnpm install --frozen-lockfile --prod
 # resolving to foo.ts). Node's --experimental-strip-types doesn't handle this;
 # tsx does, and it's already used for dev (pnpm dev).
 RUN pnpm add tsx
+
+# Remove corepack's cached pnpm tarballs. Node 24's bundled corepack pre-caches
+# pnpm@11.0.8 (the version shipped with Node 24) during `corepack enable`, even
+# though this project uses pnpm@11.7.0. pnpm@11.0.8 bundles tar@7.5.13 which is
+# vulnerable to CVE-2026-53655 (PAX size override / tar parser interpretation
+# differential). Upgrading packageManager to pnpm@11.7.0 is not sufficient on
+# its own because the old cached tarball remains on disk and Trivy flags it.
+# pnpm is not used at runtime (CMD calls tsx directly), so the cache is safe to
+# remove entirely.
+RUN rm -rf /root/.cache/node/corepack
 
 # Copy compiled output from build stage
 COPY --from=build /app/dist ./dist


### PR DESCRIPTION
## Summary

- Node 24's bundled corepack pre-caches `pnpm@11.0.8` during `corepack enable`, even though the project uses `pnpm@11.7.0` (the `packageManager` field). `pnpm@11.0.8` bundles `tar@7.5.13`, which is vulnerable to CVE-2026-53655 (PAX extended header `size=` override causes tar parser interpretation differential / file smuggling, CWE-436).
- Upgrading `packageManager` to `pnpm@11.7.0` is necessary but not sufficient: the old `pnpm@11.0.8` tarball remains cached at `/root/.cache/node/corepack/v1/pnpm/11.0.8/` and Trivy still flags it (code-scanning alert #169).
- `pnpm` is never used at runtime — `CMD` calls `tsx` directly. The entire corepack cache is safe to remove after all `pnpm install`/`pnpm add` steps complete. Both the current layout (`/root/.cache/node/corepack`) and the older layout (`/root/.cache/corepack`) are removed to stay correct across future base-image bumps.
- Also corrects a stale comment in the `CMD` block that described the corepack cache path without the `node/` segment.

Closes #169 (code-scanning).

## Test plan

- [ ] Trivy image scan (`gh workflow run trivy.yml`) shows CVE-2026-53655 cleared after merge
- [ ] CI passes (no Dockerfile syntax errors, image builds successfully)
- [ ] Verify `pnpm` is still functional during the build stages (the `rm` only runs after the last `pnpm add tsx`)