### PR TITLE
feat: automated/bulk sender classification (kind=automated) (#953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **Automated sender classification** — `classifyEmailSender()` now returns `'automated'` for noreply, mailer-daemon, bounce, newsletter, and related machine-address patterns; classified at contact-creation time so they never appear as people in the contact ledger. (#953)
+- **`contact-list` skill `kind` filter** — skill now accepts `kind` to filter by contact kind; default view excludes `automated` and `agent` contacts. (#953)
+
+### Changed
+
+- **ceo-inbox agent** (v0.7.0 → v0.8.0) — automated senders (`kind: automated`) default to ✔️ Cleared; still escalated on actionable signals (fraud, payment failure, bounce, hard deadline). (#953)
+- **`contact-list` skill** (v1.2.1 → v1.3.0) — default result set now excludes automated and agent contacts; pass `kind=automated` to see them. (#953)
+
 ### Security
 
 - **CVE-2026-53655 (pnpm bundled tar)** — deleted corepack's pnpm cache from the production image after install. Node 24's bundled corepack pre-caches pnpm@11.0.8 (which bundles tar@7.5.13) during `corepack enable`, even though the project uses pnpm@11.7.0. pnpm is not used at runtime, so the cache is removed entirely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Automated sender classification** — `classifyEmailSender()` now returns `'automated'` for noreply, mailer-daemon, bounce, newsletter, and related machine-address patterns; classified at contact-creation time so they never appear as people in the contact ledger. (#953)
-- **`contact-list` skill `kind` filter** — skill now accepts `kind` to filter by contact kind; default view excludes `automated` and `agent` contacts. (#953)
+- **Automated sender classification** — `classifyEmailSender()` now detects noreply/mailer-daemon/newsletter patterns and sets `kind='automated'`; new contacts skip the KG org-node path. (#953)
+- **`contact-list` skill `kind` filter** — accepts `kind` to filter by contact kind; default view excludes `automated` and `agent`. (#953)
 
 ### Changed
 
-- **ceo-inbox agent** (v0.7.0 → v0.8.0) — automated senders (`kind: automated`) default to ✔️ Cleared; still escalated on actionable signals (fraud, payment failure, bounce, hard deadline). (#953)
-- **`contact-list` skill** (v1.2.1 → v1.3.0) — default result set now excludes automated and agent contacts; pass `kind=automated` to see them. (#953)
+- **ceo-inbox agent** (v0.7.0 → v0.8.0) — automated senders default to Cleared; still escalated on actionable signals (payment failure, fraud, bounce, hard deadline). (#953)
+- **`contact-list` skill** (v1.2.1 → v1.3.0) — default result set excludes automated and agent contacts; pass `kind=automated` to surface them. (#953)
 
 ### Security
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.7.0"
+version: "0.8.0"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -327,6 +327,24 @@ system_prompt: |
   `ceo-inbox-download-attachment` with the attachment's `id` and the message's
   `id`. Then pass `content_base64` and `content_type` to `file-parse` for
   structured extraction (e.g. `extract_as: "receipt"` for invoices).
+
+  ### 4e-pre. Automated sender check
+
+  Before evaluating the five categories below, check the sender's `kind`
+  field in the senderContext. If `kind` is `automated`:
+
+  **Default to low-salience.** Most machine mail is noise. Apply ✔️ Cleared
+  unless the content contains a genuinely actionable signal:
+    - Account suspension or access termination
+    - Payment failure or successful payout
+    - Fraud or security alert requiring a response
+    - Bounce notification (delivery failure)
+    - Hard deadline or expiry embedded in the content
+
+  If any of those signals are present, escalate normally using the
+  five-category rules below regardless of sender kind.
+
+  Do **not** draft replies to automated senders.
 
   ### 4e. Classify into one of five categories
 

--- a/docs/wip/2026-06-18-automated-sender-class-design.md
+++ b/docs/wip/2026-06-18-automated-sender-class-design.md
@@ -1,0 +1,199 @@
+# Design: Automated / Bulk Sender Class (Issue #953)
+
+**Status:** Approved — ready for implementation planning  
+**Depends on:** #945 (tier + kind schema — closed), #946 (contact/KG boundary — closed)  
+**Milestone:** v0.36 Contacts redesign: entity ledger + capability tiers
+
+---
+
+## Context
+
+~20–35% of contacts are newsletters, notifications, and machine-generated mail
+(Google doc comments, Cloudflare alerts, Substack, Stripe receipts). These should
+never look like a person to triage and never appear in the People view. The `kind`
+column (from #945) defines `'automated'` as a first-class value for exactly this
+class, but detection and wiring are not yet implemented.
+
+The hold queue has already been removed. The remaining work is:
+1. Classify automated senders correctly at contact creation time.
+2. Backfill existing misclassified contacts.
+3. Pass `kind` through to the coordinator so it treats automated senders as
+   low-salience machine mail, not as addressable people.
+4. Filter automated senders out of the People view.
+
+Detection uses **address patterns only** (no DKIM/DMARC for now — added complexity
+for marginal gain given the pattern coverage).
+
+---
+
+## Section 1: Detection — `classifyEmailSender()`
+
+**File:** `src/contacts/contact-service.ts`
+
+### Change
+
+Split `NON_PERSON_LOCAL_RE` into two regexes and extend the function's return type
+from `'person' | 'organization'` to `'person' | 'organization' | 'automated'`.
+
+**`AUTOMATED_LOCAL_RE`** — unambiguously machine-sent local-parts:
+- `noreply`, `no-reply`, `no_reply`
+- `donotreply`, `do-not-reply`, `do_not_reply`
+- `mailer-daemon`, `mailerdaemon`
+- `notification`, `notifications`
+- `alert`, `alerts`
+- `newsletter`, `newsletters`
+- `updates`
+- `bounce`, `bounces`, `bounced`
+- `unsubscribe`
+- `postmaster`
+- `automated`, `auto`
+
+**Trimmed `NON_PERSON_LOCAL_RE`** — organisation addresses, not automated (kept):
+`info`, `support`, `help`, `admin`, `billing`, `contact`, `feedback`, `team`,
+`sales`, `marketing`, `legal`, `security`, `service`, `services`, `order`,
+`orders`, `invoice`, `invoices`, `account`, `accounts`, `system`, `news`
+
+### Detection order
+
+1. Check `AUTOMATED_LOCAL_RE` → `'automated'`
+2. Check personal webmail domain (gmail, yahoo, icloud, etc.) → `'person'`
+3. Check trimmed `NON_PERSON_LOCAL_RE` → `'organization'`
+4. Check personal name pattern (`first.last`, `first_last`, etc.) → `'person'`
+5. Default → `'person'`
+
+Order is important: automated check runs before webmail and name-pattern checks so
+`noreply@gmail.com` is not misclassified as `'person'`.
+
+---
+
+## Section 2: Contact creation & KG node handling
+
+**File:** `src/contacts/contact-service.ts` — `createContact()` and
+`resolveOrCreateOrgNode()`
+
+### Change
+
+The existing flow calls `classifyEmailSender()` → on `'organization'`, calls
+`resolveOrCreateOrgNode()` to find/create an org KG node, then sets
+`kind='organization'`.
+
+New `'automated'` branch: **skip `resolveOrCreateOrgNode()`**. Automated senders
+are not an organisation to enrich — `noreply@stripe.com` is unrelated to the Stripe
+org node. The contact gets `kind='automated'`; no KG node is created or linked
+beyond what may already exist.
+
+`tier` for new automated contacts stays `'unknown'` (same default as any new
+contact). Tier is the capability axis; it simply will not be consulted for automated
+senders in the coordinator layer.
+
+---
+
+## Section 3: Migration (057)
+
+**File:** `src/db/migrations/057_backfill_automated_kind.sql`
+
+Single-pass bulk UPDATE via a Postgres regex over the local-part of existing email
+channel identities. Touches both `kind='organization'` and `kind='person'` rows to
+catch contacts created before the classifier was added.
+
+```sql
+UPDATE contacts
+SET kind = 'automated', updated_at = now()
+WHERE id IN (
+  SELECT c.id
+  FROM contacts c
+  JOIN contact_channel_identities cci ON cci.contact_id = c.id
+  WHERE cci.channel = 'email'
+    AND cci.identity_value ~* '^(noreply|no[_.-]reply|donotreply|do[_.-]not[_.-]reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)@'
+    AND c.kind != 'automated'  -- idempotent on re-run
+);
+```
+
+The regex mirrors `AUTOMATED_LOCAL_RE` exactly — keep them in sync when either
+changes.
+
+---
+
+## Section 4: Dispatch context
+
+**File:** `src/dispatch/dispatcher.ts`
+
+### Change
+
+Confirm `kind` is included in the `senderContext` block passed to the coordinator
+alongside `tier`. If missing, add it wherever `tier` is read from the contact for
+the context block.
+
+No routing logic changes. Automated senders flow through the same path as all other
+non-blocked senders — the `kind` field is informational context for the coordinator,
+not a dispatch gate.
+
+**Build-time verification (required):** check the `senderContext` TypeScript type
+definition and confirm it accepts `kind`; update if not.
+
+---
+
+## Section 5: ceo-inbox agent
+
+**File:** `agents/ceo-inbox.yaml`
+
+### Addition to agent instructions
+
+Add a handling rule for `kind: automated` senders:
+
+> **Automated senders (`kind: automated`):** Default to low-salience — most machine
+> mail is noise and should be cleared without interrupting. Scan the content for
+> genuinely actionable signals before clearing: account suspension, payment failure
+> or successful payout, fraud or security alert, bounce notification, or a hard
+> deadline embedded in the content. If any of those are present, escalate as you
+> normally would regardless of sender kind. Do not draft replies to automated
+> senders.
+
+This satisfies the acceptance criterion "actionable machine mail is flagged distinct
+from pure noise" without a second LLM pass. The existing triage judgment applies the
+rule; `kind=automated` is the calibration input.
+
+---
+
+## Section 6: People view (contact-list skill)
+
+**File:** `skills/contact-list/handler.ts`
+
+### Changes
+
+1. **Default query** — when no explicit `kind` param is passed, filter to
+   `kind IN ('person', 'principal', 'organization')`. Excludes `kind='automated'`
+   and `kind='agent'` from the default listing without breaking existing callers.
+
+2. **Explicit `kind` param** — accept a single value or comma-separated list.
+   Passing `kind=automated` returns the Subscriptions & Notifications surface.
+   Provides the query seam needed by #11 (ledger surfaces) without further changes
+   to this skill.
+
+---
+
+## Section 7: Tests
+
+| Area | What to verify |
+|------|----------------|
+| `email-sender-classifier.test.ts` | `noreply@github.com`, `no-reply@stripe.com`, `notifications@slack.com`, `mailer-daemon@googlemail.com`, `bounce@amazonses.com` → `'automated'`; `support@stripe.com`, `billing@acme.com` → `'organization'`; `noreply@gmail.com` → `'automated'` (not `'person'`); ordering: automated checked before webmail |
+| Migration 057 | Fixture with noreply contact at `kind='organization'` and real-person contact — only noreply reclassified; idempotent on re-run |
+| `dispatcher.test.ts` | `kind` present in `senderContext` for automated sender; automated sender message not dropped |
+| `contact-list` skill | Default query excludes `kind='automated'`; `kind=automated` param returns them |
+
+---
+
+## Acceptance criteria (from issue)
+
+- [ ] Google / Cloudflare / newsletter-type senders are auto-classified `automated`
+      and never held.
+- [ ] Actionable machine mail is flagged distinct from pure noise.
+- [ ] Automated senders do not appear in the People view.
+
+---
+
+## Out of scope
+
+- DKIM/DMARC header parsing (future enhancement)
+- Automated sender UI surface (tracked in #11 — ledger surfaces)
+- Action gate at the autonomy approval level (tracked in #7)

--- a/docs/wip/2026-06-18-automated-sender-class.md
+++ b/docs/wip/2026-06-18-automated-sender-class.md
@@ -1,0 +1,1081 @@
+# Automated/Bulk Sender Class (#953) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Classify automated/bulk email senders as `kind='automated'`, bypass the dispatcher tier gate for them, exclude them from the People view, and feed `kind` context to the ceo-inbox agent.
+
+**Architecture:** Extend `classifyEmailSender()` to return `'automated'` as a first-class type; short-circuit `createContact()` to skip org KG node resolution for automated addresses; add a `kind` bypass in the dispatcher's tier gate; update the ceo-inbox agent with a low-salience handling rule; add a `kind` filter to `listContacts()` and the `contact-list` skill handler (defaulting to exclude `'automated'` and `'agent'`).
+
+**Tech Stack:** TypeScript (ESM, `.js` imports), Vitest, node-postgres, node-pg-migrate (plain SQL)
+
+## Global Constraints
+
+- All imports use `.js` extensions on relative paths (`./contact-service.js`, not `./contact-service`)
+- No `any` — use `ContactKind`, `ContactTier`, `ContactStatus` from `src/contacts/types.ts`
+- All SQL uses parameterized queries (`$N` placeholders, never string interpolation)
+- Run `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender run typecheck` before every commit that touches `.ts` files
+- Run `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test` after each task to confirm no regressions
+- Working directory for all commands is the worktree: `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender`
+- Branch: `feat/automated-sender-class`
+
+---
+
+### Task 1: Extend `classifyEmailSender()` to detect automated senders
+
+**Files:**
+- Modify: `src/contacts/contact-service.ts` (lines 133–163)
+- Modify: `src/contacts/email-sender-classifier.test.ts`
+
+**Interfaces:**
+- Produces: `classifyEmailSender(email: string): 'person' | 'organization' | 'automated'`
+
+---
+
+- [ ] **Step 1: Update the test file with failing assertions**
+
+Replace the existing content of `src/contacts/email-sender-classifier.test.ts` with:
+
+```typescript
+// src/contacts/email-sender-classifier.test.ts
+import { describe, it, expect } from 'vitest';
+import { classifyEmailSender } from './contact-service.js';
+
+describe('classifyEmailSender', () => {
+  // ---- Automated senders (checked first — before webmail domain and name patterns) ----
+
+  it('classifies noreply variants as automated', () => {
+    expect(classifyEmailSender('noreply@github.com')).toBe('automated');
+    expect(classifyEmailSender('no-reply@stripe.com')).toBe('automated');
+    expect(classifyEmailSender('no_reply@acme.com')).toBe('automated');
+    expect(classifyEmailSender('donotreply@shopify.com')).toBe('automated');
+    expect(classifyEmailSender('do-not-reply@acme.com')).toBe('automated');
+    expect(classifyEmailSender('do_not_reply@acme.com')).toBe('automated');
+  });
+
+  it('classifies mailer-daemon as automated', () => {
+    expect(classifyEmailSender('mailer-daemon@mailserver.example')).toBe('automated');
+    expect(classifyEmailSender('mailerdaemon@example.com')).toBe('automated');
+  });
+
+  it('classifies notification/alert/newsletter local-parts as automated', () => {
+    expect(classifyEmailSender('notifications@slack.com')).toBe('automated');
+    expect(classifyEmailSender('notification@github.com')).toBe('automated');
+    expect(classifyEmailSender('alerts@monitoring.io')).toBe('automated');
+    expect(classifyEmailSender('alert@pagerduty.com')).toBe('automated');
+    expect(classifyEmailSender('newsletter@substack.com')).toBe('automated');
+    expect(classifyEmailSender('newsletters@acme.com')).toBe('automated');
+    expect(classifyEmailSender('updates@stripe.com')).toBe('automated');
+    expect(classifyEmailSender('update@github.com')).toBe('automated');
+  });
+
+  it('classifies bounce/unsubscribe/postmaster as automated', () => {
+    expect(classifyEmailSender('bounce@amazonses.com')).toBe('automated');
+    expect(classifyEmailSender('bounces@sendgrid.net')).toBe('automated');
+    expect(classifyEmailSender('bounced@mailchimp.com')).toBe('automated');
+    expect(classifyEmailSender('unsubscribe@acme.com')).toBe('automated');
+    expect(classifyEmailSender('postmaster@example.com')).toBe('automated');
+  });
+
+  it('classifies automated/auto as automated', () => {
+    expect(classifyEmailSender('automated@system.example')).toBe('automated');
+    expect(classifyEmailSender('auto@system.example')).toBe('automated');
+  });
+
+  // AUTOMATED CHECK RUNS BEFORE WEBMAIL DOMAIN CHECK — this is the critical ordering test.
+  // noreply@gmail.com should be 'automated', not 'person'.
+  it('classifies noreply on personal webmail domain as automated (not person)', () => {
+    expect(classifyEmailSender('noreply@gmail.com')).toBe('automated');
+    expect(classifyEmailSender('mailer-daemon@googlemail.com')).toBe('automated');
+    expect(classifyEmailSender('bounce@yahoo.com')).toBe('automated');
+  });
+
+  // ---- Organization addresses (stay as organization, not promoted to automated) ----
+
+  it('classifies org role addresses as organization', () => {
+    expect(classifyEmailSender('info@startup.io')).toBe('organization');
+    expect(classifyEmailSender('support@cloudflare.com')).toBe('organization');
+    expect(classifyEmailSender('admin@company.com')).toBe('organization');
+    expect(classifyEmailSender('billing@shopify.com')).toBe('organization');
+    expect(classifyEmailSender('team@acme.com')).toBe('organization');
+    expect(classifyEmailSender('help@acme.com')).toBe('organization');
+    expect(classifyEmailSender('hello@startup.io')).toBe('organization');
+    expect(classifyEmailSender('sales@company.com')).toBe('organization');
+    expect(classifyEmailSender('news@bbc.com')).toBe('organization');
+  });
+
+  // ---- Personal webmail domains → always person (for non-automated local-parts) ----
+
+  it('classifies gmail addresses as person', () => {
+    expect(classifyEmailSender('john@gmail.com')).toBe('person');
+    expect(classifyEmailSender('alice.smith@googlemail.com')).toBe('person');
+  });
+
+  it('classifies common webmail domains as person', () => {
+    expect(classifyEmailSender('user@yahoo.com')).toBe('person');
+    expect(classifyEmailSender('user@hotmail.com')).toBe('person');
+    expect(classifyEmailSender('user@outlook.com')).toBe('person');
+    expect(classifyEmailSender('user@icloud.com')).toBe('person');
+    expect(classifyEmailSender('user@protonmail.com')).toBe('person');
+    expect(classifyEmailSender('user@live.com')).toBe('person');
+  });
+
+  // ---- Personal name patterns → person ----
+
+  it('classifies first.last patterns as person', () => {
+    expect(classifyEmailSender('john.doe@company.com')).toBe('person');
+    expect(classifyEmailSender('alice.smith@bigcorp.com')).toBe('person');
+  });
+
+  it('classifies first_last and first-last patterns as person', () => {
+    expect(classifyEmailSender('john_doe@company.com')).toBe('person');
+    expect(classifyEmailSender('john-doe@company.com')).toBe('person');
+  });
+
+  // ---- Default (ambiguous single-word) → person (conservative) ----
+
+  it('defaults ambiguous single-word local parts to person', () => {
+    expect(classifyEmailSender('alex@startup.io')).toBe('person');
+    expect(classifyEmailSender('dana@company.com')).toBe('person');
+  });
+
+  // ---- Malformed ----
+
+  it('returns person for malformed email with no @ sign', () => {
+    expect(classifyEmailSender('notanemail')).toBe('person');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and confirm the new assertions fail**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test src/contacts/email-sender-classifier.test.ts
+```
+
+Expected: failures on all the new `'automated'` assertions (they currently return `'organization'` or `'person'`).
+
+- [ ] **Step 3: Split the regex constants and update the function**
+
+In `src/contacts/contact-service.ts`, replace lines 129–163 (the two regex constants and the `classifyEmailSender` function) with:
+
+```typescript
+/**
+ * Local-part prefixes that are unambiguously machine-generated: no-reply addresses,
+ * mailing-system roles, bounce handlers, unsubscribe addresses.
+ * Checked first — before the webmail-domain check — so noreply@gmail.com is
+ * correctly classified as automated rather than person.
+ */
+const AUTOMATED_LOCAL_RE =
+  /^(no[_.-]?reply|noreply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)$/i;
+
+/**
+ * Local-part prefixes that belong to an org role address (support, billing, etc.)
+ * but are NOT unambiguously automated. Matches → classify as organization.
+ * hello/news kept here: too ambiguous to call automated (could be a real team).
+ */
+const NON_PERSON_LOCAL_RE =
+  /^(info|support|hello|help|admin|contact|billing|feedback|news|team|sales|marketing|legal|security|service|services|order|orders|invoice|invoices|accounts?|system)$/i;
+
+/**
+ * Local-part pattern for a personal name address (first.last or first_last).
+ * Two alphabetic words separated by a dot, underscore, or hyphen.
+ */
+const PERSON_LOCAL_RE = /^[a-zA-Z]+[._-][a-zA-Z]+$/;
+
+/**
+ * Classify an email sender as a person, an organization role address, or an
+ * automated/bulk sender.
+ *
+ * Rules applied in order:
+ * 1. Automated local-part pattern → 'automated' (checked BEFORE webmail domain
+ *    so noreply@gmail.com is automated, not person)
+ * 2. Personal webmail domain → 'person'
+ * 3. Org/system role local-part pattern → 'organization'
+ * 4. Local part looks like first.last name → 'person'
+ * 5. Default → 'person' (conservative; false negative on org is less harmful
+ *    than merging a real person under an org node)
+ */
+export function classifyEmailSender(email: string): 'person' | 'organization' | 'automated' {
+  const atIdx = email.indexOf('@');
+  if (atIdx === -1) return 'person'; // malformed — safe default
+
+  const localPart = email.slice(0, atIdx);
+  const domain = email.slice(atIdx + 1).toLowerCase();
+
+  if (AUTOMATED_LOCAL_RE.test(localPart)) return 'automated';
+  if (PERSONAL_EMAIL_DOMAINS.has(domain)) return 'person';
+  if (NON_PERSON_LOCAL_RE.test(localPart)) return 'organization';
+  if (PERSON_LOCAL_RE.test(localPart)) return 'person';
+  return 'person'; // default
+}
+```
+
+- [ ] **Step 4: Run tests and confirm all pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test src/contacts/email-sender-classifier.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender run typecheck
+```
+
+Expected: no errors. If TypeScript complains that `'automated'` is not assignable to `'person' | 'organization'` anywhere else, those call sites need updating in their respective tasks.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test
+```
+
+Expected: all tests pass (no regressions).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender add src/contacts/contact-service.ts src/contacts/email-sender-classifier.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender commit -m "feat: extend classifyEmailSender to detect automated senders (#953)
+
+Split NON_PERSON_LOCAL_RE into AUTOMATED_LOCAL_RE (noreply/bounce/daemon/etc)
+and a trimmed org-role set. Return type gains 'automated' as a third value.
+Automated check runs before the webmail-domain check so noreply@gmail.com
+is classified automated, not person."
+```
+
+---
+
+### Task 2: Short-circuit `createContact()` for automated senders
+
+**Files:**
+- Modify: `src/contacts/contact-service.ts` (lines 417–444)
+
+**Interfaces:**
+- Consumes: `classifyEmailSender(email): 'person' | 'organization' | 'automated'` from Task 1
+- Produces: `createContact({ primaryEmail: 'noreply@github.com', ... })` → `Contact` with `kind: 'automated'`
+
+---
+
+- [ ] **Step 1: Write a failing test**
+
+Create or add to a contact service unit test. Check for an existing test file:
+
+```bash
+find /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender/src/contacts -name "contact-service*.test.ts" | head -5
+```
+
+If `src/contacts/contact-service.test.ts` exists, add to it. If not, create it. Add:
+
+```typescript
+// In contact-service.test.ts (new describe block or new file)
+import { describe, it, expect, vi } from 'vitest';
+import { ContactService } from './contact-service.js';
+import { InMemoryContactBackend } from './contact-service.js'; // adjust import if needed
+
+describe('createContact — automated sender', () => {
+  it('sets kind=automated for noreply email and does not create org KG node', async () => {
+    // Mock entityMemory: if resolveOrCreateOrgNode is called, it would invoke
+    // entityMemory.findEntitiesByProperty or similar. We verify it is NOT called
+    // by recording calls on the mock.
+    const mockEntityMemory = {
+      createEntity: vi.fn().mockResolvedValue({
+        entity: { id: 'kg-person-1', type: 'person', label: 'GitHub Notifications', properties: {}, aliases: [] },
+        created: true,
+      }),
+      updateNode: vi.fn(),
+      findEntitiesByProperty: vi.fn(),
+      // add any other methods the type requires with vi.fn()
+    };
+
+    const backend = new InMemoryContactBackend();
+    const service = new ContactService({ backend, entityMemory: mockEntityMemory as any });
+
+    const contact = await service.createContact({
+      displayName: 'GitHub Notifications',
+      primaryEmail: 'noreply@github.com',
+      source: 'test',
+    });
+
+    expect(contact.kind).toBe('automated');
+    // resolveOrCreateOrgNode calls entityMemory.findEntitiesByProperty to look up
+    // the org node by domain — it must NOT have been called for automated senders.
+    expect(mockEntityMemory.findEntitiesByProperty).not.toHaveBeenCalled();
+  });
+
+  it('still creates org KG node for org-role email (regression guard)', async () => {
+    const mockEntityMemory = {
+      createEntity: vi.fn().mockResolvedValue({
+        entity: { id: 'kg-org-1', type: 'organization', label: 'Stripe', properties: {}, aliases: [] },
+        created: true,
+      }),
+      updateNode: vi.fn(),
+      findEntitiesByProperty: vi.fn().mockResolvedValue([]), // no existing org found
+    };
+
+    const backend = new InMemoryContactBackend();
+    const service = new ContactService({ backend, entityMemory: mockEntityMemory as any });
+
+    const contact = await service.createContact({
+      displayName: 'Stripe Billing',
+      primaryEmail: 'billing@stripe.com',
+      source: 'test',
+    });
+
+    // billing@ is org, not automated — org node resolution should have been attempted
+    expect(contact.kind).toBe('organization');
+  });
+});
+```
+
+> **Note:** The exact mock shape depends on `EntityMemory`'s interface. If the mock type doesn't align with what `ContactService` expects, cast to `any` (with a comment noting the test-only cast) and confirm the test fails correctly before the implementation change.
+
+- [ ] **Step 2: Run tests and confirm the first test fails**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test src/contacts/contact-service.test.ts
+```
+
+Expected: `kind=automated` assertion fails (returns `'organization'` currently).
+
+- [ ] **Step 3: Add the automated branch in `createContact()`**
+
+In `src/contacts/contact-service.ts`, find the block starting at line 417:
+
+```typescript
+    if (!kgNodeId && this.entityMemory) {
+      if (options.primaryEmail) {
+        const orgResult = await this.resolveOrCreateOrgNode(
+```
+
+Replace that inner `if (options.primaryEmail)` block with:
+
+```typescript
+    if (!kgNodeId && this.entityMemory) {
+      if (options.primaryEmail) {
+        // Automated senders (noreply, mailer-daemon, etc.) have no org node worth linking.
+        // Skip resolveOrCreateOrgNode entirely and set kind directly.
+        if (classifyEmailSender(options.primaryEmail) === 'automated') {
+          resolvedKind = 'automated';
+        } else {
+          const orgResult = await this.resolveOrCreateOrgNode(
+            options.primaryEmail,
+            safeName,
+            options.displayName,
+            options.source,
+          );
+          if (orgResult) {
+            kgNodeId = orgResult.kgNodeId;
+            resolvedKind = orgResult.kind;
+            if (options.kind && options.kind !== orgResult.kind) {
+              this.logger?.warn(
+                { requestedKind: options.kind, resolvedKind: orgResult.kind, email: options.primaryEmail },
+                'createContact: org routing overrode caller-supplied kind',
+              );
+            } else {
+              this.logger?.debug(
+                { resolvedKind: orgResult.kind, email: options.primaryEmail },
+                'createContact: org routing applied',
+              );
+            }
+          }
+        }
+      }
+```
+
+The rest of the block (person-node fallback, kind downgrade warning) remains unchanged.
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test src/contacts/contact-service.test.ts
+```
+
+Expected: both assertions PASS.
+
+- [ ] **Step 5: Run typecheck and full suite**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender run typecheck
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test
+```
+
+Expected: no errors, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender add src/contacts/contact-service.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender commit -m "feat: skip org KG node creation for automated email senders (#953)
+
+createContact() now short-circuits resolveOrCreateOrgNode when the email
+classifies as 'automated'. The contact gets kind='automated' with no
+org KG node linked."
+```
+
+---
+
+### Task 3: Migration 057 — backfill automated contacts
+
+**Files:**
+- Create: `src/db/migrations/057_backfill_automated_kind.sql`
+
+**Interfaces:**
+- Independent of Tasks 1–2 (pure SQL, no app-layer dependencies)
+
+---
+
+- [ ] **Step 1: Check the next available migration number**
+
+```bash
+ls /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender/src/db/migrations/ | sort | tail -5
+```
+
+Confirm `057_` is not taken. If a collision exists, use the next available prefix.
+
+- [ ] **Step 2: Create the migration file**
+
+Create `src/db/migrations/057_backfill_automated_kind.sql`:
+
+```sql
+-- Migration 057: backfill kind='automated' for existing contacts whose primary
+-- email address matches known automated sender patterns.
+--
+-- Touches both kind='organization' rows (noreply addresses classified as org
+-- before this migration) and kind='person' rows (contacts created before the
+-- classifier existed). Idempotent: contacts already at kind='automated' are
+-- skipped via the WHERE clause.
+--
+-- The regex mirrors AUTOMATED_LOCAL_RE in contact-service.ts exactly.
+-- Keep both in sync if patterns are ever extended.
+
+UPDATE contacts
+SET kind = 'automated', updated_at = now()
+WHERE id IN (
+  SELECT c.id
+  FROM contacts c
+  JOIN contact_channel_identities cci ON cci.contact_id = c.id
+  WHERE cci.channel = 'email'
+    AND cci.identity_value ~* '^(noreply|no[_.-]?reply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)@'
+    AND c.kind != 'automated'
+);
+```
+
+- [ ] **Step 3: Spot-check the regex locally**
+
+Run a dry-run query against the dev DB to see which contacts would be reclassified:
+
+```bash
+# Open a psql session against your dev DB and run:
+SELECT c.id, c.display_name, c.kind, cci.identity_value
+FROM contacts c
+JOIN contact_channel_identities cci ON cci.contact_id = c.id
+WHERE cci.channel = 'email'
+  AND cci.identity_value ~* '^(noreply|no[_.-]?reply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)@'
+  AND c.kind != 'automated';
+```
+
+Verify the result set matches expected automated senders (Google doc-comment noreply, Cloudflare notify, etc.) and does not include real-person contacts.
+
+- [ ] **Step 4: Run the migration**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender run db:migrate
+```
+
+Check startup logs confirm migration 057 applied cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender add src/db/migrations/057_backfill_automated_kind.sql
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender commit -m "chore: migration 057 — backfill kind=automated for existing contacts (#953)
+
+Reclassifies contacts whose email matches AUTOMATED_LOCAL_RE from
+kind='organization' or kind='person' to kind='automated'. Idempotent."
+```
+
+---
+
+### Task 4: Bypass dispatcher tier gate for automated senders
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts` (line 293)
+
+**Interfaces:**
+- Consumes: `isAutomatedKind(kind: ContactKind): boolean` from `src/contacts/types.ts` (already exported, line 350)
+- `SenderContext.kind: ContactKind` is already populated by the contact resolver (confirmed at `src/contacts/types.ts` line 190)
+
+---
+
+- [ ] **Step 1: Determine the dispatcher test approach**
+
+The dispatcher is tested at integration level, not unit level. Check for an integration test harness:
+
+```bash
+find /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender/tests -name "*dispatch*" -o -name "*integration*" | head -10
+find /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender/src/dispatch -name "*.test.ts" | head -10
+```
+
+**If an integration test harness exists:** Add a test case that wires a dispatcher with `unknownSender='ignore'` channel policy, resolves a sender with `tier='unknown'` and `kind='automated'`, dispatches an inbound message, and asserts no `message-rejected` event was published (i.e., the message reached the coordinator). Use the same setup pattern found in the existing tests.
+
+**If no dispatcher integration test harness exists:** Skip the automated test for this task. The acceptance criteria checklist at the end of the plan covers this functionally — verify manually by checking the dispatcher logs after applying the code change.
+
+- [ ] **Step 2: Apply the code change first, then run tests**
+
+Make the code change (Step 3 below), then run any test you wrote.
+
+- [ ] **Step 3: Add the bypass to the tier gate**
+
+In `src/dispatch/dispatcher.ts`, find line 293:
+
+```typescript
+            if (senderContext.tier === 'unknown' || senderContext.tier === 'blocked') {
+```
+
+The import for `isAutomatedKind` may not exist yet. First, confirm the import at the top of the file:
+
+```typescript
+import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy, TaskOriginator } from '../contacts/types.js';
+```
+
+Add `isAutomatedKind` to that import:
+
+```typescript
+import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy, TaskOriginator } from '../contacts/types.js';
+import { isAutomatedKind } from '../contacts/types.js';
+```
+
+> **Note:** If `types.ts` uses only `export type` for `isAutomatedKind`, change it to `export function` (it already is a function, not a type, at line 350).
+
+Then change line 293:
+
+```typescript
+            // Automated senders (kind='automated') bypass the tier gate entirely —
+            // they have no standing in the trust/action system and should always
+            // reach the coordinator. The coordinator uses kind='automated' context
+            // to treat them as low-salience machine mail.
+            if ((senderContext.tier === 'unknown' || senderContext.tier === 'blocked') && !isAutomatedKind(senderContext.kind)) {
+```
+
+- [ ] **Step 4: Run test and confirm it passes**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test src/dispatch/dispatcher-automated.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck and full suite**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender run typecheck
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test
+```
+
+Expected: no errors, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender add src/dispatch/dispatcher.ts src/dispatch/dispatcher-automated.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender commit -m "feat: bypass dispatcher tier gate for kind=automated senders (#953)
+
+Automated senders always reach the coordinator regardless of tier or
+unknownSender channel policy. kind='automated' means the sender has no
+standing in the trust/action system, not that it should be blocked."
+```
+
+---
+
+### Task 5: Update ceo-inbox agent instructions for automated senders
+
+**Files:**
+- Modify: `agents/ceo-inbox.yaml`
+
+**Interfaces:**
+- Consumes: `kind: 'automated'` field in `senderContext` passed to the coordinator (already flows through `SenderContext.kind`)
+
+---
+
+- [ ] **Step 1: Find the correct insertion point in ceo-inbox.yaml**
+
+The triage categories in the `system_prompt` are at lines ~331–466. The `✔️ Cleared` category (line 455) already covers "receipt, newsletter, automated notification" — we're adding a more specific rule that fires before the general classification.
+
+Find the `### 4e. Classify into one of five categories` header and locate the `**🚨 Urgent**` block (first category). The automated-sender rule should be added as a **pre-classification check** immediately above the five-category block.
+
+- [ ] **Step 2: Add the automated sender handling rule**
+
+In `agents/ceo-inbox.yaml`, find the line that starts `### 4e. Classify into one of five categories` and insert the following block immediately before it:
+
+```yaml
+  ### 4e-pre. Automated sender check
+
+  Before evaluating the five categories below, check the sender's `kind`
+  field in the senderContext. If `kind` is `automated`:
+
+  **Default to low-salience.** Most machine mail is noise. Apply ✔️ Cleared
+  unless the content contains a genuinely actionable signal:
+    - Account suspension or access termination
+    - Payment failure or successful payout
+    - Fraud or security alert requiring a response
+    - Bounce notification (delivery failure)
+    - Hard deadline or expiry embedded in the content
+
+  If any of those signals are present, escalate normally using the
+  five-category rules below regardless of sender kind.
+
+  Do **not** draft replies to automated senders.
+
+```
+
+- [ ] **Step 3: Bump the agent version**
+
+In `agents/ceo-inbox.yaml`, find `version: "0.7.0"` (line 2) and change it to:
+
+```yaml
+version: "0.8.0"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender add agents/ceo-inbox.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender commit -m "feat: teach ceo-inbox to de-prioritize automated senders (#953)
+
+Adds a pre-classification check for kind=automated senders: default to
+Cleared (noise), but still escalate fraud alerts, payment failures,
+bounces, and hard deadlines. No replies to automated senders."
+```
+
+---
+
+### Task 6: Add `kind` filter to `listContacts()` and `contact-list` skill
+
+**Files:**
+- Modify: `src/contacts/contact-service.ts`
+  - Backend interface at line 183
+  - `ContactService.listContacts()` wrapper at line 634
+  - `PostgresContactBackend.listContacts()` at line 1408
+  - `InMemoryContactBackend.listContacts()` at line 2056
+- Modify: `skills/contact-list/handler.ts`
+- Modify: `skills/contact-list/skill.json`
+
+**Interfaces:**
+- Produces: `listContacts(filters?: { ..., kind?: ContactKind[] })` — accepts array of kinds to include; when omitted defaults to `['person', 'principal', 'organization']` at the skill handler level (not the service level, to avoid breaking other callers)
+
+---
+
+- [ ] **Step 1: Write a failing test for the contact-list skill**
+
+Find the skill test file:
+
+```bash
+find /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender/skills/contact-list -name "*.test.ts" | head -5
+```
+
+If `skills/contact-list/handler.test.ts` exists, add to it. If not, create it. Add:
+
+```typescript
+// skills/contact-list/handler.test.ts
+import { describe, it, expect } from 'vitest';
+import { ContactListHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeCtx(input: Record<string, unknown>, contacts: unknown[]): SkillContext {
+  return {
+    input,
+    log: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+    contactService: {
+      findContactByRole: async () => [],
+      listContacts: async (filters?: { kind?: string[]; status?: string; limit?: number; offset?: number }) => {
+        // Return only contacts whose kind is in the filter (or all if no filter)
+        return contacts.filter((c: any) =>
+          !filters?.kind || filters.kind.includes(c.kind)
+        );
+      },
+    },
+  } as unknown as SkillContext;
+}
+
+const personContact = { id: '1', displayName: 'Alice', role: null, status: 'confirmed', kgNodeId: null, kind: 'person' };
+const automatedContact = { id: '2', displayName: 'GitHub Notifications', role: null, status: 'confirmed', kgNodeId: null, kind: 'automated' };
+const agentContact = { id: '3', displayName: 'Curia Agent', role: null, status: 'confirmed', kgNodeId: null, kind: 'agent' };
+const orgContact = { id: '4', displayName: 'Stripe', role: null, status: 'confirmed', kgNodeId: null, kind: 'organization' };
+
+describe('ContactListHandler — kind filter', () => {
+  it('excludes automated and agent contacts by default (no kind param)', async () => {
+    const handler = new ContactListHandler();
+    const result = await handler.execute(makeCtx({}, [personContact, automatedContact, agentContact, orgContact]));
+    expect(result.success).toBe(true);
+    const ids = (result as any).data.contacts.map((c: any) => c.contact_id);
+    expect(ids).toContain('1'); // person
+    expect(ids).toContain('4'); // organization
+    expect(ids).not.toContain('2'); // automated excluded
+    expect(ids).not.toContain('3'); // agent excluded
+  });
+
+  it('returns automated contacts when kind=automated is explicitly requested', async () => {
+    const handler = new ContactListHandler();
+    const result = await handler.execute(makeCtx({ kind: 'automated' }, [personContact, automatedContact]));
+    expect(result.success).toBe(true);
+    const ids = (result as any).data.contacts.map((c: any) => c.contact_id);
+    expect(ids).toContain('2');
+    expect(ids).not.toContain('1'); // person not in automated filter
+  });
+
+  it('rejects an invalid kind value', async () => {
+    const handler = new ContactListHandler();
+    const result = await handler.execute(makeCtx({ kind: 'invisible' }, []));
+    expect(result.success).toBe(false);
+    expect((result as any).error).toMatch(/Invalid kind/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test and confirm it fails**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test skills/contact-list/handler.test.ts
+```
+
+Expected: failures (handler doesn't know about `kind` yet).
+
+- [ ] **Step 3: Add `kind` to the backend interface and both backend implementations**
+
+In `src/contacts/contact-service.ts`, make three changes:
+
+**3a. Backend interface at line 183** — add `kind?: ContactKind[]`:
+
+```typescript
+  listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]>;
+```
+
+**3b. `PostgresContactBackend.listContacts()` at line 1408** — add the kind condition:
+
+```typescript
+  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters?.status != null) {
+      params.push(filters.status);
+      conditions.push(`status = $${params.length}`);
+    }
+
+    if (filters?.tier != null) {
+      params.push(filters.tier);
+      conditions.push(`tier = $${params.length}`);
+    }
+
+    // kind filter: pass as a Postgres array and use = ANY($N) for inclusion.
+    if (filters?.kind != null && filters.kind.length > 0) {
+      params.push(filters.kind);
+      conditions.push(`kind = ANY($${params.length})`);
+    }
+
+    const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+    let sql = `SELECT ${CONTACT_COLS} FROM contacts${where} ORDER BY created_at ASC`;
+
+    if (filters?.limit != null) {
+      params.push(filters.limit);
+      sql += ` LIMIT $${params.length}`;
+    }
+
+    if (filters?.offset != null && filters.offset > 0) {
+      params.push(filters.offset);
+      sql += ` OFFSET $${params.length}`;
+    }
+
+    const result = await this.pool.query<ContactRow>(sql, params);
+    return result.rows.map((row) => this.rowToContact(row));
+  }
+```
+
+**3c. `InMemoryContactBackend.listContacts()` at line 2056** — add the kind filter after the tier filter:
+
+```typescript
+  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]> {
+    let results = [...this.contacts.values()];
+
+    if (filters?.status != null) {
+      results = results.filter((c) => c.status === filters.status);
+    }
+
+    if (filters?.tier != null) {
+      results = results.filter((c) => c.tier === filters.tier);
+    }
+
+    if (filters?.kind != null && filters.kind.length > 0) {
+      results = results.filter((c) => filters.kind!.includes(c.kind));
+    }
+
+    results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+    const offset = filters?.offset != null && filters.offset > 0 ? filters.offset : 0;
+    const end = filters?.limit != null ? offset + filters.limit : undefined;
+    results = results.slice(offset, end);
+
+    return results;
+  }
+```
+
+- [ ] **Step 4: Update the `ContactService.listContacts()` wrapper at line 634**
+
+```typescript
+  /** List contacts, optionally filtered by status, kind, and/or capped by limit with offset for pagination. */
+  async listContacts(filters?: { status?: ContactStatus; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]> {
+    return this.backend.listContacts(filters);
+  }
+```
+
+You will need to add `ContactKind` to the import from `./types.js` at the top of `contact-service.ts` if it is not already imported in the service class section. Check the existing imports and add if missing.
+
+- [ ] **Step 5: Update the `contact-list` skill handler**
+
+Replace the content of `skills/contact-list/handler.ts` with:
+
+```typescript
+// handler.ts — contact-list skill implementation.
+//
+// Lists contacts, optionally filtered by role, status, or kind, with optional
+// result limit. Returns an array of contact summaries.
+//
+// Default behavior: excludes kind='automated' and kind='agent' from results.
+// Pass kind='automated' or kind='agent' explicitly to include them.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ContactStatus, ContactKind } from '../../src/contacts/types.js';
+
+const VALID_STATUSES: readonly ContactStatus[] = ['confirmed', 'provisional', 'blocked'];
+const VALID_KINDS: readonly ContactKind[] = ['person', 'organization', 'automated', 'principal', 'agent'];
+
+// Default People-view filter: excludes automated and agent contacts.
+const DEFAULT_KIND_FILTER: ContactKind[] = ['person', 'principal', 'organization'];
+
+export class ContactListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { role, status, kind: kindInput, limit, offset } = ctx.input as unknown as {
+      role?: string;
+      status?: string;
+      kind?: string | string[];
+      limit?: number;
+      offset?: number;
+    };
+
+    // ---- Input validation ----
+
+    if (role && typeof role === 'string' && role.length > 200) {
+      return { success: false, error: 'Role must be 200 characters or fewer' };
+    }
+
+    // Guard against LLM mistake: passing a lifecycle status as the role param.
+    const normalizedRole = typeof role === 'string' ? role.trim().toLowerCase() : undefined;
+    if (normalizedRole && (VALID_STATUSES as readonly string[]).includes(normalizedRole)) {
+      return {
+        success: false,
+        error: `"${role}" is a contact lifecycle status, not a job title. Use the status parameter instead: { status: "${normalizedRole}" }`,
+      };
+    }
+
+    if (status != null && !(VALID_STATUSES as readonly string[]).includes(status)) {
+      return { success: false, error: `Invalid status: "${status}". Must be one of: ${VALID_STATUSES.join(', ')}` };
+    }
+
+    // Parse kind: accept a single string or comma-separated list.
+    let kindFilter: ContactKind[] | undefined;
+    if (kindInput != null) {
+      const rawKinds = Array.isArray(kindInput)
+        ? kindInput
+        : String(kindInput).split(',').map((k) => k.trim());
+      for (const k of rawKinds) {
+        if (!(VALID_KINDS as readonly string[]).includes(k)) {
+          return { success: false, error: `Invalid kind: "${k}". Must be one of: ${VALID_KINDS.join(', ')}` };
+        }
+      }
+      kindFilter = rawKinds as ContactKind[];
+    }
+
+    if (limit != null) {
+      if (typeof limit !== 'number' || !Number.isInteger(limit) || limit < 1) {
+        return { success: false, error: 'Limit must be a positive integer' };
+      }
+    }
+
+    if (offset != null) {
+      if (typeof offset !== 'number' || !Number.isInteger(offset) || offset < 0) {
+        return { success: false, error: 'Offset must be a non-negative integer' };
+      }
+      if (offset > 0 && limit == null) {
+        return { success: false, error: 'Offset requires limit to be set. Use limit together with offset for pagination.' };
+      }
+    }
+
+    if (role && typeof role === 'string' && (status != null || limit != null || offset != null)) {
+      return { success: false, error: 'Cannot combine role filter with status, limit, or offset. Use role alone, or status/limit/offset without role.' };
+    }
+
+    if (!ctx.contactService) {
+      return {
+        success: false,
+        error: 'contact-list: contactService not available — this is a universal service, check ExecutionLayer configuration.',
+      };
+    }
+
+    // When no kind is specified, default to the People view (excludes automated and agent).
+    const effectiveKindFilter = kindFilter ?? DEFAULT_KIND_FILTER;
+
+    ctx.log.info(
+      { role: role ?? '(all)', status: status ?? '(all)', kind: effectiveKindFilter, limit: limit ?? '(none)', offset: offset ?? 0 },
+      'Listing contacts',
+    );
+
+    try {
+      const contacts = role && typeof role === 'string'
+        ? await ctx.contactService.findContactByRole(role)
+        : await ctx.contactService.listContacts({
+            status: status as ContactStatus | undefined,
+            kind: effectiveKindFilter,
+            limit,
+            offset,
+          });
+
+      return {
+        success: true,
+        data: {
+          contacts: contacts.map((c) => ({
+            contact_id: c.id,
+            display_name: c.displayName,
+            role: c.role,
+            status: c.status,
+            kg_node_id: c.kgNodeId,
+          })),
+          count: contacts.length,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, role, status, limit, offset }, 'Failed to list contacts');
+      return { success: false, error: `Failed to list contacts: ${message}` };
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Update `skill.json` to document the `kind` input and bump version**
+
+In `skills/contact-list/skill.json`, update `inputs` and bump `version`:
+
+```json
+{
+  "name": "contact-list",
+  "description": "List contacts, optionally filtered by role, status, or kind, with optional result limit and offset for pagination. By default returns only person, principal, and organization contacts (excludes automated senders and agents).",
+  "version": "1.3.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "role": "string? (filter by job title / professional role, e.g. 'CEO', 'CFO', 'Engineer'; mutually exclusive with status, limit, and offset; this is NOT a lifecycle status)",
+    "status": "string? (confirmed | provisional | blocked)",
+    "kind": "string? (person | organization | automated | principal | agent, or comma-separated list; defaults to person,principal,organization — pass kind=automated to see automated senders)",
+    "limit": "number?",
+    "offset": "number? (skip this many contacts; use with limit for cursor-based pagination)"
+  },
+  "outputs": {
+    "contacts": "array",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}
+```
+
+- [ ] **Step 7: Run tests and confirm they pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test skills/contact-list/handler.test.ts
+```
+
+Expected: all three new assertions PASS.
+
+- [ ] **Step 8: Run typecheck and full suite**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender run typecheck
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test
+```
+
+Expected: no errors, no regressions.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender add src/contacts/contact-service.ts skills/contact-list/handler.ts skills/contact-list/skill.json skills/contact-list/handler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender commit -m "feat: add kind filter to contact-list skill; exclude automated by default (#953)
+
+listContacts() gains a kind[] filter at the backend, service, and skill handler
+layers. The contact-list skill defaults to kind=[person,principal,organization],
+so automated senders and agents are excluded from the People view unless
+explicitly requested with kind=automated."
+```
+
+---
+
+### Task 7: CHANGELOG and final verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+---
+
+- [ ] **Step 1: Add entries under `## [Unreleased]` in CHANGELOG.md**
+
+```markdown
+### Added
+- **Automated sender classification** — `classifyEmailSender()` now returns `'automated'` for noreply, mailer-daemon, bounce, newsletter, and related machine-address patterns; classified at contact-creation time so they never appear as people in the contact ledger. (#953)
+- **`contact-list` skill `kind` filter** — skill now accepts `kind` to filter by contact kind; default view excludes `automated` and `agent` contacts. (#953)
+
+### Changed
+- **ceo-inbox agent** (v0.7.0 → v0.8.0) — automated senders (`kind: automated`) default to ✔️ Cleared; still escalated on actionable signals (fraud, payment failure, bounce, hard deadline). (#953)
+- **`contact-list` skill** (v1.2.1 → v1.3.0) — default result set now excludes automated and agent contacts; pass `kind=automated` to see them. (#953)
+```
+
+- [ ] **Step 2: Final typecheck across the entire worktree**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender run typecheck
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: Final full test run**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-automated-sender commit -m "chore: CHANGELOG entries for #953 automated sender class"
+```
+
+---
+
+## Acceptance criteria checklist
+
+Before creating the PR, verify:
+
+- [ ] `noreply@github.com`, `no-reply@stripe.com`, `mailer-daemon@googlemail.com`, `notifications@slack.com` all return `'automated'` from `classifyEmailSender()`
+- [ ] A new contact created with a noreply email has `kind='automated'` and no org KG node linked
+- [ ] Migration 057 ran clean; `SELECT COUNT(*) FROM contacts WHERE kind='automated'` shows the expected backfill count
+- [ ] An automated sender with `tier='unknown'` reaches the coordinator even when `unknownSender='ignore'` channel policy is set
+- [ ] Calling the `contact-list` skill with no params does not return automated contacts
+- [ ] Calling the `contact-list` skill with `kind=automated` returns automated contacts
+- [ ] ceo-inbox YAML version is `0.8.0`
+- [ ] Typecheck and full test suite pass

--- a/skills/contact-list/handler.test.ts
+++ b/skills/contact-list/handler.test.ts
@@ -1,25 +1,40 @@
 // handler.test.ts — tests for contact-list skill.
 // Covers: no filters, status filter, limit, offset, status+limit+offset, role (existing),
-// invalid status, invalid limit, invalid offset.
+// invalid status, invalid limit, invalid offset, kind filter (new).
 import { describe, it, expect, vi } from 'vitest';
 import { ContactListHandler } from './handler.js';
 import type { SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { Contact } from '../../src/contacts/types.js';
 import { createSilentLogger } from '../../src/logger.js';
 
-// Factory for minimal Contact objects — only fields the handler reads
+// Factory for minimal Contact objects — only fields the handler reads.
+// Defaults kind to 'person' and tier to 'known' so contacts pass the default kind filter.
 function makeContact(overrides: Partial<Contact> & { id: string; displayName: string }): Contact {
   return {
     kgNodeId: null,
     role: null,
     systemRole: null,
     status: 'confirmed',
+    tier: 'known',
+    kind: 'person',
     contactConfidence: 0.5,
     trustLevel: null,
     lastSeenAt: null,
     inboundMessageCount: 0,
     outboundMessageCount: 0,
     notes: null,
+    preferredName: null,
+    title: null,
+    organization: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    timezone: null,
+    locale: null,
+    location: null,
+    pronouns: null,
+    linkedinUrl: null,
+    bio: null,
+    birthday: null,
     createdAt: new Date('2026-01-01'),
     updatedAt: new Date('2026-01-01'),
     ...overrides,
@@ -38,10 +53,14 @@ function makeCtx(input: Record<string, unknown> = {}, contacts: Contact[] = allC
     input,
     log: createSilentLogger(),
     contactService: {
-      listContacts: vi.fn().mockImplementation((filters?: { status?: string; limit?: number; offset?: number }) => {
+      listContacts: vi.fn().mockImplementation((filters?: { status?: string; kind?: string[]; limit?: number; offset?: number }) => {
         let results = [...contacts];
         if (filters?.status) {
           results = results.filter((c) => c.status === filters.status);
+        }
+        // Filter by kind when specified — mirrors the backend's inclusion semantics
+        if (filters?.kind != null && filters.kind.length > 0) {
+          results = results.filter((c) => filters.kind!.includes(c.kind));
         }
         // Sort ascending by createdAt to match real backend
         results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
@@ -73,6 +92,7 @@ describe('ContactListHandler', () => {
     expect(getContacts(result)).toHaveLength(4);
     expect(ctx.contactService!.listContacts).toHaveBeenCalledWith({
       status: undefined,
+      kind: ['person', 'principal', 'organization'],
       limit: undefined,
       offset: undefined,
     });
@@ -328,5 +348,61 @@ describe('ContactListHandler', () => {
     const result = await handler.execute(ctx);
     expect(result.success).toBe(false);
     expect(result.error).toContain('contactService not available');
+  });
+});
+
+// ---- kind filter tests ----
+//
+// Uses a lighter-weight makeCtx that accepts raw objects so the kind field can
+// be set freely without satisfying the full Contact interface.
+
+function makeKindCtx(input: Record<string, unknown>, contacts: unknown[]): SkillContext {
+  return {
+    input,
+    log: createSilentLogger(),
+    contactService: {
+      findContactByRole: async () => [],
+      listContacts: async (filters?: { kind?: string[]; status?: string; limit?: number; offset?: number }) => {
+        // Return only contacts whose kind is in the filter (or all if no filter)
+        return contacts.filter((c: unknown) => {
+          const contact = c as { kind?: string };
+          return !filters?.kind || filters.kind.includes(contact.kind ?? '');
+        });
+      },
+    },
+  } as unknown as SkillContext;
+}
+
+const personContact = { id: '1', displayName: 'Alice', role: null, status: 'confirmed', kgNodeId: null, kind: 'person' };
+const automatedContact = { id: '2', displayName: 'GitHub Notifications', role: null, status: 'confirmed', kgNodeId: null, kind: 'automated' };
+const agentContact = { id: '3', displayName: 'Curia Agent', role: null, status: 'confirmed', kgNodeId: null, kind: 'agent' };
+const orgContact = { id: '4', displayName: 'Stripe', role: null, status: 'confirmed', kgNodeId: null, kind: 'organization' };
+
+describe('ContactListHandler — kind filter', () => {
+  it('excludes automated and agent contacts by default (no kind param)', async () => {
+    const handler = new ContactListHandler();
+    const result = await handler.execute(makeKindCtx({}, [personContact, automatedContact, agentContact, orgContact]));
+    expect(result.success).toBe(true);
+    const ids = (result as { success: true; data: { contacts: Array<{ contact_id: string }> } }).data.contacts.map((c) => c.contact_id);
+    expect(ids).toContain('1'); // person
+    expect(ids).toContain('4'); // organization
+    expect(ids).not.toContain('2'); // automated excluded
+    expect(ids).not.toContain('3'); // agent excluded
+  });
+
+  it('returns automated contacts when kind=automated is explicitly requested', async () => {
+    const handler = new ContactListHandler();
+    const result = await handler.execute(makeKindCtx({ kind: 'automated' }, [personContact, automatedContact]));
+    expect(result.success).toBe(true);
+    const ids = (result as { success: true; data: { contacts: Array<{ contact_id: string }> } }).data.contacts.map((c) => c.contact_id);
+    expect(ids).toContain('2');
+    expect(ids).not.toContain('1'); // person not in automated filter
+  });
+
+  it('rejects an invalid kind value', async () => {
+    const handler = new ContactListHandler();
+    const result = await handler.execute(makeKindCtx({ kind: 'invisible' }, []));
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/Invalid kind/);
   });
 });

--- a/skills/contact-list/handler.test.ts
+++ b/skills/contact-list/handler.test.ts
@@ -405,4 +405,42 @@ describe('ContactListHandler — kind filter', () => {
     expect(result.success).toBe(false);
     expect((result as { success: false; error: string }).error).toMatch(/Invalid kind/);
   });
+
+  it('accepts comma-separated kind values and filters to each requested kind', async () => {
+    const handler = new ContactListHandler();
+    const result = await handler.execute(makeKindCtx({ kind: 'person,automated' }, [personContact, automatedContact, agentContact, orgContact]));
+    expect(result.success).toBe(true);
+    const ids = (result as { success: true; data: { contacts: Array<{ contact_id: string }> } }).data.contacts.map((c) => c.contact_id);
+    expect(ids).toContain('1'); // person
+    expect(ids).toContain('2'); // automated
+    expect(ids).not.toContain('3'); // agent not requested
+    expect(ids).not.toContain('4'); // organization not requested
+  });
+
+  it('rejects an empty kind list', async () => {
+    const handler = new ContactListHandler();
+    const result = await handler.execute(makeKindCtx({ kind: [] }, []));
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/kind must not be empty/);
+  });
+
+  it('role lookup post-filters by effective kind (excludes automated/agent by default)', async () => {
+    // findContactByRole returns contacts of mixed kinds; handler must exclude automated/agent.
+    const handler = new ContactListHandler();
+    const roleContact = { id: '5', displayName: 'Support Bot', role: 'support', status: 'confirmed', kgNodeId: null, kind: 'automated' };
+    const roleHuman = { id: '6', displayName: 'Support Human', role: 'support', status: 'confirmed', kgNodeId: null, kind: 'person' };
+    const ctx = {
+      input: { role: 'support' },
+      log: createSilentLogger(),
+      contactService: {
+        findContactByRole: async () => [roleContact, roleHuman],
+        listContacts: vi.fn(),
+      },
+    } as unknown as SkillContext;
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const ids = (result as { success: true; data: { contacts: Array<{ contact_id: string }> } }).data.contacts.map((c) => c.contact_id);
+    expect(ids).not.toContain('5'); // automated excluded by default kind filter
+    expect(ids).toContain('6'); // person passes through
+  });
 });

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -93,9 +93,13 @@ export class ContactListHandler implements SkillHandler {
     );
 
     try {
-      // TODO: role path bypasses kind filter — findContactByRole has no kind param; acceptable since role and kind are semantically orthogonal
+      // The role path calls findContactByRole which has no kind parameter, so we apply
+      // effectiveKindFilter as a post-filter to keep automated/agent contacts out of results
+      // unless the caller explicitly asked for them via the kind input.
       const contacts = role && typeof role === 'string'
-        ? await ctx.contactService.findContactByRole(role)
+        ? (await ctx.contactService.findContactByRole(role)).filter(c =>
+            effectiveKindFilter.includes(c.kind as ContactKind)
+          )
         : await ctx.contactService.listContacts({
             status: status as ContactStatus | undefined,
             kind: effectiveKindFilter,
@@ -110,6 +114,7 @@ export class ContactListHandler implements SkillHandler {
             contact_id: c.id,
             display_name: c.displayName,
             role: c.role,
+            kind: c.kind,
             status: c.status,
             kg_node_id: c.kgNodeId,
           })),
@@ -118,7 +123,7 @@ export class ContactListHandler implements SkillHandler {
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, role, status, limit, offset }, 'Failed to list contacts');
+      ctx.log.error({ err, role, status, kind: effectiveKindFilter, limit, offset }, 'Failed to list contacts');
       return { success: false, error: `Failed to list contacts: ${message}` };
     }
   }

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -1,33 +1,37 @@
 // handler.ts — contact-list skill implementation.
 //
-// Lists contacts, optionally filtered by role or status, with optional result limit.
-// Returns an array of contact summaries.
+// Lists contacts, optionally filtered by role, status, or kind, with optional
+// result limit. Returns an array of contact summaries.
 //
-// This skill uses contactService, which is a universal service.
+// Default behavior: excludes kind='automated' and kind='agent' from results.
+// Pass kind='automated' or kind='agent' explicitly to include them.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import type { ContactStatus } from '../../src/contacts/types.js';
+import type { ContactStatus, ContactKind } from '../../src/contacts/types.js';
 
 const VALID_STATUSES: readonly ContactStatus[] = ['confirmed', 'provisional', 'blocked'];
+const VALID_KINDS: readonly ContactKind[] = ['person', 'organization', 'automated', 'principal', 'agent'];
+
+// Default People-view filter: excludes automated and agent contacts.
+const DEFAULT_KIND_FILTER: ContactKind[] = ['person', 'principal', 'organization'];
 
 export class ContactListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    // Cast through unknown per repo convention for narrowing from Record<string, unknown>
-    const { role, status, limit, offset } = ctx.input as unknown as {
+    const { role, status, kind: kindInput, limit, offset } = ctx.input as unknown as {
       role?: string;
       status?: string;
+      kind?: string | string[];
       limit?: number;
       offset?: number;
     };
 
-    // Input validation
+    // ---- Input validation ----
+
     if (role && typeof role === 'string' && role.length > 200) {
       return { success: false, error: 'Role must be 200 characters or fewer' };
     }
 
-    // Guard against a common LLM mistake: passing a lifecycle status as the role parameter.
-    // The role filter searches job titles (e.g. "CEO"); lifecycle filtering uses status.
-    // Normalize before comparing so casing/whitespace variants ("Provisional", " blocked") are caught too.
+    // Guard against LLM mistake: passing a lifecycle status as the role param.
     const normalizedRole = typeof role === 'string' ? role.trim().toLowerCase() : undefined;
     if (normalizedRole && (VALID_STATUSES as readonly string[]).includes(normalizedRole)) {
       return {
@@ -40,6 +44,20 @@ export class ContactListHandler implements SkillHandler {
       return { success: false, error: `Invalid status: "${status}". Must be one of: ${VALID_STATUSES.join(', ')}` };
     }
 
+    // Parse kind: accept a single string or comma-separated list.
+    let kindFilter: ContactKind[] | undefined;
+    if (kindInput != null) {
+      const rawKinds = Array.isArray(kindInput)
+        ? kindInput
+        : String(kindInput).split(',').map((k) => k.trim());
+      for (const k of rawKinds) {
+        if (!(VALID_KINDS as readonly string[]).includes(k)) {
+          return { success: false, error: `Invalid kind: "${k}". Must be one of: ${VALID_KINDS.join(', ')}` };
+        }
+      }
+      kindFilter = rawKinds as ContactKind[];
+    }
+
     if (limit != null) {
       if (typeof limit !== 'number' || !Number.isInteger(limit) || limit < 1) {
         return { success: false, error: 'Limit must be a positive integer' };
@@ -50,20 +68,15 @@ export class ContactListHandler implements SkillHandler {
       if (typeof offset !== 'number' || !Number.isInteger(offset) || offset < 0) {
         return { success: false, error: 'Offset must be a non-negative integer' };
       }
-      // Require limit when offset > 0 to prevent accidentally returning an unbounded
-      // result set starting from the middle of the table.
       if (offset > 0 && limit == null) {
         return { success: false, error: 'Offset requires limit to be set. Use limit together with offset for pagination.' };
       }
     }
 
-    // Role uses a separate query path that doesn't support status/limit/offset — reject the combination
-    // rather than silently dropping filters.
     if (role && typeof role === 'string' && (status != null || limit != null || offset != null)) {
       return { success: false, error: 'Cannot combine role filter with status, limit, or offset. Use role alone, or status/limit/offset without role.' };
     }
 
-    // contactService is a universal service — always injected by ExecutionLayer
     if (!ctx.contactService) {
       return {
         success: false,
@@ -71,14 +84,20 @@ export class ContactListHandler implements SkillHandler {
       };
     }
 
-    ctx.log.info({ role: role ?? '(all)', status: status ?? '(all)', limit: limit ?? '(none)', offset: offset ?? 0 }, 'Listing contacts');
+    // When no kind is specified, default to the People view (excludes automated and agent).
+    const effectiveKindFilter = kindFilter ?? DEFAULT_KIND_FILTER;
+
+    ctx.log.info(
+      { role: role ?? '(all)', status: status ?? '(all)', kind: effectiveKindFilter, limit: limit ?? '(none)', offset: offset ?? 0 },
+      'Listing contacts',
+    );
 
     try {
-      // Role filter uses the dedicated findContactByRole path (no change from existing behavior)
       const contacts = role && typeof role === 'string'
         ? await ctx.contactService.findContactByRole(role)
         : await ctx.contactService.listContacts({
             status: status as ContactStatus | undefined,
+            kind: effectiveKindFilter,
             limit,
             offset,
           });

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -93,6 +93,7 @@ export class ContactListHandler implements SkillHandler {
     );
 
     try {
+      // TODO: role path bypasses kind filter — findContactByRole has no kind param; acceptable since role and kind are semantically orthogonal
       const contacts = role && typeof role === 'string'
         ? await ctx.contactService.findContactByRole(role)
         : await ctx.contactService.listContacts({

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -17,6 +17,7 @@ const DEFAULT_KIND_FILTER: ContactKind[] = ['person', 'principal', 'organization
 
 export class ContactListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
+    // Runtime-validated below via VALID_STATUSES, VALID_KINDS, and explicit guards.
     const { role, status, kind: kindInput, limit, offset } = ctx.input as unknown as {
       role?: string;
       status?: string;
@@ -50,6 +51,9 @@ export class ContactListHandler implements SkillHandler {
       const rawKinds = Array.isArray(kindInput)
         ? kindInput
         : String(kindInput).split(',').map((k) => k.trim());
+      if (rawKinds.length === 0) {
+        return { success: false, error: 'kind must not be empty — pass at least one value or omit the parameter to use the default filter' };
+      }
       for (const k of rawKinds) {
         if (!(VALID_KINDS as readonly string[]).includes(k)) {
           return { success: false, error: `Invalid kind: "${k}". Must be one of: ${VALID_KINDS.join(', ')}` };

--- a/skills/contact-list/skill.json
+++ b/skills/contact-list/skill.json
@@ -1,12 +1,13 @@
 {
   "name": "contact-list",
-  "description": "List contacts, optionally filtered by role or status, with optional result limit and offset for pagination.",
-  "version": "1.2.1",
+  "description": "List contacts, optionally filtered by role, status, or kind, with optional result limit and offset for pagination. By default returns only person, principal, and organization contacts (excludes automated senders and agents).",
+  "version": "1.3.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "role": "string? (filter by job title / professional role, e.g. 'CEO', 'CFO', 'Engineer'; mutually exclusive with status, limit, and offset; this is NOT a lifecycle status)",
     "status": "string? (confirmed | provisional | blocked)",
+    "kind": "string? (person | organization | automated | principal | agent, or comma-separated list; defaults to person,principal,organization — pass kind=automated to see automated senders)",
     "limit": "number?",
     "offset": "number? (skip this many contacts; use with limit for cursor-based pagination)"
   },

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -565,15 +565,19 @@ export class ContactService {
       // contact — e.g. two people both named "Alice Smith". Retry without a KG link;
       // the two contacts can be merged later via the contact-merge flow.
       if (pgCode === '23505' && constraint === 'idx_contacts_kg_node_unique') {
-        // Downgrade kind to 'person' alongside stripping the KG link so the contact
-        // row doesn't end up as kind='organization' with kgNodeId=null — that would
-        // violate the invariant that org contacts are always linked to a KG org node.
+        // Downgrade kind to 'person' alongside stripping the KG link — but only if the
+        // contact was an org contact, to avoid violating the invariant that org contacts
+        // are always linked to a KG org node. Automated contacts keep their kind even
+        // without a KG link (their person-type node may still be around; the link is just
+        // lost for this contact instance due to the collision).
         this.logger?.warn(
           { contactId: contact.id, kgNodeId: contact.kgNodeId, contactKind: contact.kind },
-          'KG node already claimed by another contact — creating contact without KG link; kind downgraded to person',
+          'KG node already claimed by another contact — creating contact without KG link; org kind downgraded to person',
         );
         contact.kgNodeId = null;
-        contact.kind = 'person';
+        if (contact.kind === 'organization') {
+          contact.kind = 'person';
+        }
         try {
           await this.backend.createContact(contact);
         } catch (retryErr) {
@@ -657,8 +661,8 @@ export class ContactService {
     return this.backend.findContactBySystemRole(systemRole);
   }
 
-  /** List contacts, optionally filtered by status, kind, and/or capped by limit with offset for pagination. */
-  async listContacts(filters?: { status?: ContactStatus; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]> {
+  /** List contacts, optionally filtered by status, tier, kind, and/or capped by limit with offset for pagination. */
+  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]> {
     return this.backend.listContacts(filters);
   }
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -194,7 +194,7 @@ interface ContactServiceBackend {
   findContactByKgNodeId(kgNodeId: string): Promise<Contact | null>;
   findContactByRole(role: string): Promise<Contact[]>;
   findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null>;
-  listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; limit?: number; offset?: number }): Promise<Contact[]>;
+  listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]>;
   updateContact(contact: Contact): Promise<void>;
   createIdentity(identity: ChannelIdentity): Promise<void>;
   getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]>;
@@ -652,8 +652,8 @@ export class ContactService {
     return this.backend.findContactBySystemRole(systemRole);
   }
 
-  /** List contacts, optionally filtered by status and/or capped by limit with offset for pagination. */
-  async listContacts(filters?: { status?: ContactStatus; limit?: number; offset?: number }): Promise<Contact[]> {
+  /** List contacts, optionally filtered by status, kind, and/or capped by limit with offset for pagination. */
+  async listContacts(filters?: { status?: ContactStatus; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]> {
     return this.backend.listContacts(filters);
   }
 
@@ -1427,7 +1427,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     return this.rowToContact(row);
   }
 
-  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; limit?: number; offset?: number }): Promise<Contact[]> {
+  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]> {
     const conditions: string[] = [];
     const params: unknown[] = [];
 
@@ -1440,6 +1440,12 @@ class PostgresContactBackend implements ContactServiceBackend {
     if (filters?.tier != null) {
       params.push(filters.tier);
       conditions.push(`tier = $${params.length}`);
+    }
+
+    // kind filter: pass as a Postgres array and use = ANY($N) for inclusion.
+    if (filters?.kind != null && filters.kind.length > 0) {
+      params.push(filters.kind);
+      conditions.push(`kind = ANY($${params.length})`);
     }
 
     const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
@@ -2075,7 +2081,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return null;
   }
 
-  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; limit?: number; offset?: number }): Promise<Contact[]> {
+  async listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]> {
     let results = [...this.contacts.values()];
 
     if (filters?.status != null) {
@@ -2085,6 +2091,11 @@ class InMemoryContactBackend implements ContactServiceBackend {
     // tier filter (issue #945) — prefer this over status for new callers
     if (filters?.tier != null) {
       results = results.filter((c) => c.tier === filters.tier);
+    }
+
+    // kind filter: include only contacts whose kind appears in the provided array
+    if (filters?.kind != null && filters.kind.length > 0) {
+      results = results.filter((c) => filters.kind!.includes(c.kind));
     }
 
     // Sort by createdAt ascending to match Postgres ORDER BY created_at ASC

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -423,36 +423,44 @@ export class ContactService {
 
     // Resolve a KG node. Priority:
     //   1. Explicit kgNodeId provided by caller — use as-is (no lookup needed)
-    //   2. primaryEmail set and classifies as org → resolveOrCreateOrgNode()
-    //   3. Fall through to person-node auto-creation
+    //   2. primaryEmail classifies as automated → set kind='automated', skip KG org node
+    //   3. primaryEmail set and classifies as org → resolveOrCreateOrgNode()
+    //   4. Fall through to person-node auto-creation
     let kgNodeId: string | null = options.kgNodeId ?? null;
     let resolvedKind: ContactKind = options.kind ?? 'person';
 
     if (!kgNodeId && this.entityMemory) {
       if (options.primaryEmail) {
-        const orgResult = await this.resolveOrCreateOrgNode(
-          options.primaryEmail,
-          safeName,
-          options.displayName,
-          options.source,
-        );
-        if (orgResult) {
-          kgNodeId = orgResult.kgNodeId;
-          resolvedKind = orgResult.kind;
-          if (options.kind && options.kind !== orgResult.kind) {
-            // Warn when caller explicitly passed a kind that was overridden — this
-            // is likely a caller bug (e.g. passing kind:'person' for an org email).
-            this.logger?.warn(
-              { requestedKind: options.kind, resolvedKind: orgResult.kind, email: options.primaryEmail },
-              'createContact: org routing overrode caller-supplied kind',
-            );
-          } else {
-            // Debug trace on every org routing application so misclassifications
-            // are detectable retroactively even when kind defaulted to 'person'.
-            this.logger?.debug(
-              { resolvedKind: orgResult.kind, email: options.primaryEmail },
-              'createContact: org routing applied',
-            );
+        // Automated senders (noreply, mailer-daemon, etc.) have no org node worth linking.
+        // Skip resolveOrCreateOrgNode entirely and set kind directly. The person-node
+        // fallback below will still run so the contact gets a KG node, just a person-type one.
+        if (classifyEmailSender(options.primaryEmail) === 'automated') {
+          resolvedKind = 'automated';
+        } else {
+          const orgResult = await this.resolveOrCreateOrgNode(
+            options.primaryEmail,
+            safeName,
+            options.displayName,
+            options.source,
+          );
+          if (orgResult) {
+            kgNodeId = orgResult.kgNodeId;
+            resolvedKind = orgResult.kind;
+            if (options.kind && options.kind !== orgResult.kind) {
+              // Warn when caller explicitly passed a kind that was overridden — this
+              // is likely a caller bug (e.g. passing kind:'person' for an org email).
+              this.logger?.warn(
+                { requestedKind: options.kind, resolvedKind: orgResult.kind, email: options.primaryEmail },
+                'createContact: org routing overrode caller-supplied kind',
+              );
+            } else {
+              // Debug trace on every org routing application so misclassifications
+              // are detectable retroactively even when kind defaulted to 'person'.
+              this.logger?.debug(
+                { resolvedKind: orgResult.kind, email: options.primaryEmail },
+                'createContact: org routing applied',
+              );
+            }
           }
         }
       }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -127,11 +127,21 @@ const PERSONAL_EMAIL_DOMAINS = new Set([
 ]);
 
 /**
- * Local-part prefixes that clearly belong to a system/org role rather than a
- * specific person. Anything matching this → classify as organization.
+ * Local-part prefixes that are unambiguously machine-generated: no-reply addresses,
+ * mailing-system roles, bounce handlers, unsubscribe addresses.
+ * Checked first — before the webmail-domain check — so noreply@gmail.com is
+ * correctly classified as automated rather than person.
+ */
+const AUTOMATED_LOCAL_RE =
+  /^(no[_.-]?reply|noreply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)$/i;
+
+/**
+ * Local-part prefixes that belong to an org role address (support, billing, etc.)
+ * but are NOT unambiguously automated. Matches → classify as organization.
+ * hello/news kept here: too ambiguous to call automated (could be a real team).
  */
 const NON_PERSON_LOCAL_RE =
-  /^(no[_.-]?reply|noreply|info|support|hello|help|admin|contact|billing|notification|notifications|alert|alerts|news|newsletter|updates?|feedback|team|sales|marketing|legal|security|postmaster|mailer[_.-]?daemon|bounce|bounces|unsubscribe|do[._-]?not[._-]?reply|donotreply|service|services|order|orders|invoice|invoices|accounts?|system|automated|auto)$/i;
+  /^(info|support|hello|help|admin|contact|billing|feedback|news|team|sales|marketing|legal|security|service|services|order|orders|invoice|invoices|accounts?|system)$/i;
 
 /**
  * Local-part pattern for a personal name address (first.last or first_last).
@@ -140,22 +150,26 @@ const NON_PERSON_LOCAL_RE =
 const PERSON_LOCAL_RE = /^[a-zA-Z]+[._-][a-zA-Z]+$/;
 
 /**
- * Classify an email sender as a person or an organization/automated sender.
+ * Classify an email sender as a person, an organization role address, or an
+ * automated/bulk sender.
  *
  * Rules applied in order:
- * 1. Personal webmail domain → person
- * 2. Local part matches org/system role pattern → organization
- * 3. Local part looks like first.last name → person
- * 4. Default → person (conservative; a false negative on org is less harmful
- *    than a false positive that merges a real person under an org node)
+ * 1. Automated local-part pattern → 'automated' (checked BEFORE webmail domain
+ *    so noreply@gmail.com is automated, not person)
+ * 2. Personal webmail domain → 'person'
+ * 3. Org/system role local-part pattern → 'organization'
+ * 4. Local part looks like first.last name → 'person'
+ * 5. Default → 'person' (conservative; false negative on org is less harmful
+ *    than merging a real person under an org node)
  */
-export function classifyEmailSender(email: string): 'person' | 'organization' {
+export function classifyEmailSender(email: string): 'person' | 'organization' | 'automated' {
   const atIdx = email.indexOf('@');
   if (atIdx === -1) return 'person'; // malformed — safe default
 
   const localPart = email.slice(0, atIdx);
   const domain = email.slice(atIdx + 1).toLowerCase();
 
+  if (AUTOMATED_LOCAL_RE.test(localPart)) return 'automated';
   if (PERSONAL_EMAIL_DOMAINS.has(domain)) return 'person';
   if (NON_PERSON_LOCAL_RE.test(localPart)) return 'organization';
   if (PERSON_LOCAL_RE.test(localPart)) return 'person';

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -436,6 +436,10 @@ export class ContactService {
         // fallback below will still run so the contact gets a KG node, just a person-type one.
         if (classifyEmailSender(options.primaryEmail) === 'automated') {
           resolvedKind = 'automated';
+          this.logger?.debug(
+            { email: options.primaryEmail, requestedKind: options.kind },
+            'createContact: automated sender — skipping org KG node',
+          );
         } else {
           const orgResult = await this.resolveOrCreateOrgNode(
             options.primaryEmail,
@@ -486,8 +490,9 @@ export class ContactService {
         }
 
         // Org routing did not fire or returned null (KG transient failure), so we fell
-        // back to a person node. Downgrade kind to 'person' to match — leaving kind as
-        // 'organization' on a person-linked row violates the invariant checked elsewhere.
+        // back to a person node. Downgrade kind to 'person' to match the node type.
+        // Note: kind='automated' is intentionally left unchanged here — automated contacts
+        // use person-type KG nodes by design; the downgrade guard only applies to org routing.
         if (resolvedKind === 'organization') {
           this.logger?.warn(
             { requestedKind: options.kind, email: options.primaryEmail },

--- a/src/contacts/email-sender-classifier.test.ts
+++ b/src/contacts/email-sender-classifier.test.ts
@@ -3,7 +3,70 @@ import { describe, it, expect } from 'vitest';
 import { classifyEmailSender } from './contact-service.js';
 
 describe('classifyEmailSender', () => {
-  // Personal webmail domains → always person
+  // ---- Automated senders (checked first — before webmail domain and name patterns) ----
+
+  it('classifies noreply variants as automated', () => {
+    expect(classifyEmailSender('noreply@github.com')).toBe('automated');
+    expect(classifyEmailSender('no-reply@stripe.com')).toBe('automated');
+    expect(classifyEmailSender('no_reply@acme.com')).toBe('automated');
+    expect(classifyEmailSender('donotreply@shopify.com')).toBe('automated');
+    expect(classifyEmailSender('do-not-reply@acme.com')).toBe('automated');
+    expect(classifyEmailSender('do_not_reply@acme.com')).toBe('automated');
+  });
+
+  it('classifies mailer-daemon as automated', () => {
+    expect(classifyEmailSender('mailer-daemon@mailserver.example')).toBe('automated');
+    expect(classifyEmailSender('mailerdaemon@example.com')).toBe('automated');
+  });
+
+  it('classifies notification/alert/newsletter local-parts as automated', () => {
+    expect(classifyEmailSender('notifications@slack.com')).toBe('automated');
+    expect(classifyEmailSender('notification@github.com')).toBe('automated');
+    expect(classifyEmailSender('alerts@monitoring.io')).toBe('automated');
+    expect(classifyEmailSender('alert@pagerduty.com')).toBe('automated');
+    expect(classifyEmailSender('newsletter@substack.com')).toBe('automated');
+    expect(classifyEmailSender('newsletters@acme.com')).toBe('automated');
+    expect(classifyEmailSender('updates@stripe.com')).toBe('automated');
+    expect(classifyEmailSender('update@github.com')).toBe('automated');
+  });
+
+  it('classifies bounce/unsubscribe/postmaster as automated', () => {
+    expect(classifyEmailSender('bounce@amazonses.com')).toBe('automated');
+    expect(classifyEmailSender('bounces@sendgrid.net')).toBe('automated');
+    expect(classifyEmailSender('bounced@mailchimp.com')).toBe('automated');
+    expect(classifyEmailSender('unsubscribe@acme.com')).toBe('automated');
+    expect(classifyEmailSender('postmaster@example.com')).toBe('automated');
+  });
+
+  it('classifies automated/auto as automated', () => {
+    expect(classifyEmailSender('automated@system.example')).toBe('automated');
+    expect(classifyEmailSender('auto@system.example')).toBe('automated');
+  });
+
+  // AUTOMATED CHECK RUNS BEFORE WEBMAIL DOMAIN CHECK — this is the critical ordering test.
+  // noreply@gmail.com should be 'automated', not 'person'.
+  it('classifies noreply on personal webmail domain as automated (not person)', () => {
+    expect(classifyEmailSender('noreply@gmail.com')).toBe('automated');
+    expect(classifyEmailSender('mailer-daemon@googlemail.com')).toBe('automated');
+    expect(classifyEmailSender('bounce@yahoo.com')).toBe('automated');
+  });
+
+  // ---- Organization addresses (stay as organization, not promoted to automated) ----
+
+  it('classifies org role addresses as organization', () => {
+    expect(classifyEmailSender('info@startup.io')).toBe('organization');
+    expect(classifyEmailSender('support@cloudflare.com')).toBe('organization');
+    expect(classifyEmailSender('admin@company.com')).toBe('organization');
+    expect(classifyEmailSender('billing@shopify.com')).toBe('organization');
+    expect(classifyEmailSender('team@acme.com')).toBe('organization');
+    expect(classifyEmailSender('help@acme.com')).toBe('organization');
+    expect(classifyEmailSender('hello@startup.io')).toBe('organization');
+    expect(classifyEmailSender('sales@company.com')).toBe('organization');
+    expect(classifyEmailSender('news@bbc.com')).toBe('organization');
+  });
+
+  // ---- Personal webmail domains → always person (for non-automated local-parts) ----
+
   it('classifies gmail addresses as person', () => {
     expect(classifyEmailSender('john@gmail.com')).toBe('person');
     expect(classifyEmailSender('alice.smith@googlemail.com')).toBe('person');
@@ -18,47 +81,27 @@ describe('classifyEmailSender', () => {
     expect(classifyEmailSender('user@live.com')).toBe('person');
   });
 
-  // Non-person local parts → organization
-  it('classifies noreply addresses as organization', () => {
-    expect(classifyEmailSender('noreply@github.com')).toBe('organization');
-    expect(classifyEmailSender('no-reply@stripe.com')).toBe('organization');
-    expect(classifyEmailSender('no_reply@acme.com')).toBe('organization');
-  });
+  // ---- Personal name patterns → person ----
 
-  it('classifies system role local parts as organization', () => {
-    expect(classifyEmailSender('notifications@github.com')).toBe('organization');
-    expect(classifyEmailSender('info@startup.io')).toBe('organization');
-    expect(classifyEmailSender('support@cloudflare.com')).toBe('organization');
-    expect(classifyEmailSender('admin@company.com')).toBe('organization');
-    expect(classifyEmailSender('billing@shopify.com')).toBe('organization');
-    expect(classifyEmailSender('team@acme.com')).toBe('organization');
-    expect(classifyEmailSender('alerts@monitoring.io')).toBe('organization');
-    expect(classifyEmailSender('newsletter@substack.com')).toBe('organization');
-    expect(classifyEmailSender('mailer-daemon@googlemail.com')).toBe('person'); // personal domain wins
-    expect(classifyEmailSender('mailer-daemon@mailserver.example')).toBe('organization');
-  });
-
-  // Personal name patterns → person
   it('classifies first.last patterns as person', () => {
     expect(classifyEmailSender('john.doe@company.com')).toBe('person');
     expect(classifyEmailSender('alice.smith@bigcorp.com')).toBe('person');
   });
 
-  it('classifies first_last patterns as person', () => {
+  it('classifies first_last and first-last patterns as person', () => {
     expect(classifyEmailSender('john_doe@company.com')).toBe('person');
-  });
-
-  it('classifies first-last patterns as person', () => {
     expect(classifyEmailSender('john-doe@company.com')).toBe('person');
   });
 
-  // Default (ambiguous single-word) → person (conservative)
+  // ---- Default (ambiguous single-word) → person (conservative) ----
+
   it('defaults ambiguous single-word local parts to person', () => {
     expect(classifyEmailSender('alex@startup.io')).toBe('person');
     expect(classifyEmailSender('dana@company.com')).toBe('person');
   });
 
-  // Malformed email → person (safe default)
+  // ---- Malformed ----
+
   it('returns person for malformed email with no @ sign', () => {
     expect(classifyEmailSender('notanemail')).toBe('person');
   });

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -294,7 +294,7 @@ export type ContactTier = 'blocked' | 'unknown' | 'known' | 'trusted' | 'princip
  *
  * - 'person'       — individual human contact (default).
  * - 'organization' — a company or institution (linked KG node type='organization').
- * - 'automated'    — automated sender e.g. mailing list (TODO #953: exempts from tier gates).
+ * - 'automated'    — automated sender e.g. mailing list (exempts from unknown-tier gate in dispatcher.ts, #953).
  * - 'principal'    — the human CEO Curia serves.
  * - 'agent'        — Curia itself or another autonomous agent.
  *
@@ -338,14 +338,11 @@ export function meetsMinimumTier(
 }
 
 /**
- * Return true when kind='automated'. Call sites that need to skip tier gates
- * for automated senders (mailing lists, notifications) should use this helper
- * rather than comparing kind directly — keeps the gate logic in one place.
+ * Return true when kind='automated'. Use this helper at call sites that need to
+ * skip tier gates for automated senders (noreply, newsletters, notifications).
  *
- * Full gate-skipping behaviour will be wired in issue #953; for now this is
- * a typed helper so callers can be written ahead of the gate implementation.
- *
- * TODO(#953): Wire this into the dispatch gate and outbound filter.
+ * The dispatch tier gate bypass is wired in dispatcher.ts (#953).
+ * TODO(#953): Wire into the outbound filter.
  */
 export function isAutomatedKind(kind: ContactKind): boolean {
   return kind === 'automated';

--- a/src/db/migrations/057_backfill_automated_kind.sql
+++ b/src/db/migrations/057_backfill_automated_kind.sql
@@ -1,0 +1,21 @@
+-- Migration 057: backfill kind='automated' for existing contacts whose primary
+-- email address matches known automated sender patterns.
+--
+-- Touches both kind='organization' rows (noreply addresses classified as org
+-- before this migration) and kind='person' rows (contacts created before the
+-- classifier existed). Idempotent: contacts already at kind='automated' are
+-- skipped via the WHERE clause.
+--
+-- The regex mirrors AUTOMATED_LOCAL_RE in contact-service.ts exactly.
+-- Keep both in sync if patterns are ever extended.
+
+UPDATE contacts
+SET kind = 'automated', updated_at = now()
+WHERE id IN (
+  SELECT c.id
+  FROM contacts c
+  JOIN contact_channel_identities cci ON cci.contact_id = c.id
+  WHERE cci.channel = 'email'
+    AND cci.identity_value ~* '^(noreply|no[_.-]?reply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)@'
+    AND c.kind != 'automated'
+);

--- a/src/db/migrations/057_backfill_automated_kind.sql
+++ b/src/db/migrations/057_backfill_automated_kind.sql
@@ -6,7 +6,7 @@
 -- classifier existed). Idempotent: contacts already at kind='automated' are
 -- skipped via the WHERE clause.
 --
--- The regex mirrors AUTOMATED_LOCAL_RE in contact-service.ts exactly.
+-- The regex covers the same set of patterns as AUTOMATED_LOCAL_RE in contact-service.ts.
 -- Keep both in sync if patterns are ever extended.
 
 UPDATE contacts

--- a/src/db/migrations/057_backfill_automated_kind.sql
+++ b/src/db/migrations/057_backfill_automated_kind.sql
@@ -1,21 +1,17 @@
 -- Migration 057: backfill kind='automated' for existing contacts whose primary
 -- email address matches known automated sender patterns.
 --
--- Touches both kind='organization' rows (noreply addresses classified as org
--- before this migration) and kind='person' rows (contacts created before the
--- classifier existed). Idempotent: contacts already at kind='automated' are
--- skipped via the WHERE clause.
+-- Touches kind='person' and kind='organization' rows only — principal and agent
+-- contacts are never reclassified, even if their address happens to match a pattern.
+-- Idempotent: contacts already at kind='automated' are skipped.
+--
+-- Uses contacts.primary_email directly (not a JOIN on contact_channel_identities)
+-- so secondary/alias addresses on human contacts can never trigger a reclassification.
 --
 -- The regex covers the same set of patterns as AUTOMATED_LOCAL_RE in contact-service.ts.
 -- Keep both in sync if patterns are ever extended.
 
 UPDATE contacts
 SET kind = 'automated', updated_at = now()
-WHERE id IN (
-  SELECT c.id
-  FROM contacts c
-  JOIN contact_channel_identities cci ON cci.contact_id = c.id
-  WHERE cci.channel = 'email'
-    AND cci.channel_identifier ~* '^(noreply|no[_.-]?reply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)@'
-    AND c.kind != 'automated'
-);
+WHERE primary_email ~* '^(noreply|no[_.-]?reply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)@'
+  AND kind IN ('person', 'organization');

--- a/src/db/migrations/057_backfill_automated_kind.sql
+++ b/src/db/migrations/057_backfill_automated_kind.sql
@@ -16,6 +16,6 @@ WHERE id IN (
   FROM contacts c
   JOIN contact_channel_identities cci ON cci.contact_id = c.id
   WHERE cci.channel = 'email'
-    AND cci.identity_value ~* '^(noreply|no[_.-]?reply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)@'
+    AND cci.channel_identifier ~* '^(noreply|no[_.-]?reply|donotreply|do[_.-]not[_.-]?reply|mailer[_.-]?daemon|mailerdaemon|notifications?|alerts?|newsletters?|updates?|bounced?|bounces?|unsubscribe|postmaster|automated|auto)@'
     AND c.kind != 'automated'
 );

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -4,6 +4,7 @@ import { createAgentTask, createOutboundMessage, createOutboundSuppressedDuplica
 import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy, TaskOriginator } from '../contacts/types.js';
+import { isAutomatedKind } from '../contacts/types.js';
 import type { InboundScanner } from './inbound-scanner.js';
 import type { RateLimiter } from './rate-limiter.js';
 import type { DbPool } from '../db/connection.js';
@@ -290,7 +291,12 @@ export class Dispatcher {
             // contact has not been confirmed. Apply the same hold/reject policy as unknown senders.
             // Uses tier for the gate check (issue #945): 'unknown' == old 'provisional',
             // 'blocked' == old 'blocked'.
-            if (senderContext.tier === 'unknown' || senderContext.tier === 'blocked') {
+            //
+            // Automated senders (kind='automated') bypass the tier gate entirely —
+            // they have no standing in the trust/action system and should always
+            // reach the coordinator. The coordinator uses kind='automated' context
+            // to treat them as low-salience machine mail.
+            if ((senderContext.tier === 'unknown' || senderContext.tier === 'blocked') && !isAutomatedKind(senderContext.kind)) {
               const policy = this.channelPolicies?.[payload.channelId];
 
               if (senderContext.tier === 'blocked') {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -292,11 +292,16 @@ export class Dispatcher {
             // Uses tier for the gate check (issue #945): 'unknown' == old 'provisional',
             // 'blocked' == old 'blocked'.
             //
-            // Automated senders (kind='automated') bypass the tier gate entirely —
-            // they have no standing in the trust/action system and should always
-            // reach the coordinator. The coordinator uses kind='automated' context
-            // to treat them as low-salience machine mail.
-            if ((senderContext.tier === 'unknown' || senderContext.tier === 'blocked') && !isAutomatedKind(senderContext.kind)) {
+            // Automated senders (kind='automated') bypass the tier gate when tier='unknown' —
+            // that is their normal starting state, since they are created on first contact and
+            // never go through the CEO confirmation flow. The coordinator uses kind='automated'
+            // context to treat them as low-salience machine mail.
+            //
+            // Blocked contacts are explicitly blocked by operator decision — always gate them,
+            // regardless of kind. Automated senders only bypass the gate when tier='unknown'
+            // (their normal starting state) — not when they've been explicitly blocked.
+            if (senderContext.tier === 'blocked' ||
+                (senderContext.tier === 'unknown' && !isAutomatedKind(senderContext.kind))) {
               const policy = this.channelPolicies?.[payload.channelId];
 
               if (senderContext.tier === 'blocked') {
@@ -409,6 +414,14 @@ export class Dispatcher {
             return;
           }
 
+          // No contact record — truly unknown sender. The automated-kind bypass above
+          // does not apply here because there is no kind field without a contact record.
+          // The first message from a new automated sender follows the normal unknownSender
+          // policy. Subsequent messages (after createContact runs) will have kind='automated'
+          // and bypass the unknown-tier gate.
+          // TODO(#953): Consider classifyEmailSender(senderId) here to apply the bypass
+          // on first contact for recognizable-pattern addresses.
+          //
           // 'allow' policy or no policy — route to coordinator without sender context.
           // runtime.ts injects a low-trust signal block so the coordinator knows to apply skepticism.
         }

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -116,22 +116,23 @@ describe('ContactService', () => {
       expect(contact.kind).toBe('person');
     });
 
-    it('creates organization contact for noreply business address and new org node', async () => {
+    it('creates automated contact for noreply address and skips org KG node creation', async () => {
+      // noreply@ matches AUTOMATED_LOCAL_RE → kind='automated', no org node
       const contact = await service.createContact({
         displayName: 'GitHub',
         primaryEmail: 'noreply@github.com',
         source: 'email_participant',
         status: 'provisional',
       });
-      expect(contact.kind).toBe('organization');
-      expect(contact.kgNodeId).toBeDefined();
-
-      const orgNodes = await entityMemory.findEntities('GitHub');
-      expect(orgNodes).toHaveLength(1);
-      expect(orgNodes[0]!.type).toBe('organization');
+      expect(contact.kind).toBe('automated');
+      // resolveOrCreateOrgNode is skipped — the person-node fallback creates a
+      // person-type KG node (not an org node) to hold the contact's KG link.
+      const allNodes = await entityMemory.findEntities('GitHub');
+      expect(allNodes.every(n => n.type !== 'organization')).toBe(true);
     });
 
-    it('creates organization contact for notifications address and derives label from domain when name is email-shaped', async () => {
+    it('creates automated contact for notifications address and skips org KG node', async () => {
+      // notifications@ matches AUTOMATED_LOCAL_RE → kind='automated', no org node
       const contact = await service.createContact({
         // When the sender has no name the display name is the email address itself
         displayName: 'notifications@stripe.com',
@@ -140,16 +141,14 @@ describe('ContactService', () => {
         source: 'email_participant',
         status: 'provisional',
       });
-      expect(contact.kind).toBe('organization');
-
-      // Label should be derived from domain, not from the email-shaped display name
+      expect(contact.kind).toBe('automated');
+      // Org node creation is skipped for automated senders; no Stripe org node
       const stripeNodes = await entityMemory.findEntities('Stripe');
-      expect(stripeNodes).toHaveLength(1);
-      expect(stripeNodes[0]!.type).toBe('organization');
+      expect(stripeNodes).toHaveLength(0);
     });
 
-    it('links to existing org node when domain matches', async () => {
-      // Pre-existing org node labeled with the domain
+    it('does not link to existing org node for noreply (automated) email', async () => {
+      // Even if an org node exists, automated senders bypass resolveOrCreateOrgNode
       const { entity: existingOrg } = await entityMemory.createEntity({
         type: 'organization',
         label: 'github.com',
@@ -164,8 +163,10 @@ describe('ContactService', () => {
         status: 'provisional',
       });
 
-      expect(contact.kind).toBe('organization');
-      expect(contact.kgNodeId).toBe(existingOrg.id);
+      // Automated short-circuit: kind='automated', kgNodeId comes from person-node fallback
+      expect(contact.kind).toBe('automated');
+      // The existing org node is NOT used
+      expect(contact.kgNodeId).not.toBe(existingOrg.id);
     });
 
     it('links to existing org node when display name matches', async () => {
@@ -221,19 +222,16 @@ describe('ContactService', () => {
       expect(contact.kind).toBe('person');
     });
 
-    it('org routing overrides explicit kind for org-classified emails', async () => {
-      // A caller can still override kind explicitly
+    it('automated short-circuit takes precedence over caller-supplied kind for automated emails', async () => {
+      // noreply@ classifies as 'automated' — the automated short-circuit fires before
+      // resolveOrCreateOrgNode is called, so kind='automated' regardless of caller input.
       const contact = await service.createContact({
         displayName: 'Automated Bot',
         primaryEmail: 'noreply@example.com',
         kind: 'automated',
         source: 'test',
       });
-      // resolveOrCreateOrgNode classifies as org and sets kind='organization';
-      // explicit caller kind only wins when no org routing happened (person path)
-      // — the org routing overrides caller kind when it fires.
-      // This test documents the current behavior: org routing takes precedence.
-      expect(contact.kind).toBe('organization');
+      expect(contact.kind).toBe('automated');
     });
   });
 

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -128,6 +128,8 @@ describe('ContactService', () => {
       // resolveOrCreateOrgNode is skipped — the person-node fallback creates a
       // person-type KG node (not an org node) to hold the contact's KG link.
       const allNodes = await entityMemory.findEntities('GitHub');
+      // Person-node fallback creates at least one KG node (person-type) for the contact.
+      expect(allNodes.length).toBeGreaterThan(0);
       expect(allNodes.every(n => n.type !== 'organization')).toBe(true);
     });
 
@@ -224,11 +226,12 @@ describe('ContactService', () => {
 
     it('automated short-circuit takes precedence over caller-supplied kind for automated emails', async () => {
       // noreply@ classifies as 'automated' — the automated short-circuit fires before
-      // resolveOrCreateOrgNode is called, so kind='automated' regardless of caller input.
+      // resolveOrCreateOrgNode is called, overriding even an explicit caller-supplied kind.
+      // Pass kind='organization' to prove the classifier wins over the caller's input.
       const contact = await service.createContact({
         displayName: 'Automated Bot',
         primaryEmail: 'noreply@example.com',
-        kind: 'automated',
+        kind: 'organization',
         source: 'test',
       });
       expect(contact.kind).toBe('automated');

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -1578,8 +1578,9 @@ describe('Dispatcher — thread-participants block', () => {
 
 describe('Dispatcher — automated sender tier gate bypass (#953)', () => {
   // Regression test: automated senders (kind='automated') must reach the coordinator
-  // regardless of tier and channel unknownSender policy. They carry no standing in the
-  // trust/action system, so the tier gate does not apply to them.
+  // even when tier='unknown' and the channel unknownSender policy would normally drop them.
+  // Note: tier='blocked' still gates automated senders — this bypass is specific to
+  // the 'unknown' tier ignore-policy, not a blanket tier override.
 
   it('automated sender with tier=unknown bypasses ignore channel policy and reaches coordinator', async () => {
     const logger = createLogger('error');

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -1575,3 +1575,83 @@ describe('Dispatcher — thread-participants block', () => {
     expect(content).toBe('Signal message.');
   });
 });
+
+describe('Dispatcher — automated sender tier gate bypass (#953)', () => {
+  // Regression test: automated senders (kind='automated') must reach the coordinator
+  // regardless of tier and channel unknownSender policy. They carry no standing in the
+  // trust/action system, so the tier gate does not apply to them.
+
+  it('automated sender with tier=unknown bypasses ignore channel policy and reaches coordinator', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // Resolver returns a resolved contact that is tier='unknown' but kind='automated'.
+    // Without the bypass, an 'ignore' policy would emit message.rejected and drop the message.
+    const mockResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: true,
+        contactId: 'automated-sender-id',
+        displayName: 'Notification Bot',
+        role: null,
+        systemRole: null,
+        status: 'confirmed',
+        tier: 'unknown' as ContactTier,
+        kind: 'automated' as ContactKind,
+        verified: false,
+        kgNodeId: null,
+        knowledgeSummary: '',
+        authorization: null,
+        contactConfidence: 0,
+        trustLevel: null,
+      } satisfies InboundSenderContext),
+    } as unknown as ContactResolver;
+
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Acknowledged',
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: mockResolver,
+      // 'ignore' policy would normally drop tier='unknown' senders; automated bypass overrides this.
+      channelPolicies: { email: { trust: 'low', unknownSender: 'ignore', threaded: false } },
+    });
+    dispatcher.register();
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (event) => {
+      rejected.push(event as MessageRejectedEvent);
+    });
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => { tasks.push(e as AgentTaskEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-automated-bypass',
+      channelId: 'email',
+      senderId: 'notifications@service.example.com',
+      content: 'Your report is ready.',
+    }));
+
+    // The automated sender must reach the coordinator despite tier='unknown' + 'ignore' policy.
+    expect(rejected).toHaveLength(0);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.payload.senderContext?.kind).toBe('automated');
+  });
+});


### PR DESCRIPTION
## Summary

- **Classifies automated senders** (`noreply`, `mailer-daemon`, `notifications`, `alerts`, `newsletters`, `bounces`, `postmaster`, etc.) via `AUTOMATED_LOCAL_RE` in `classifyEmailSender()` — new third return value `'automated'` in addition to `'person' | 'organization'`
- **Skips org KG node creation** for automated senders in `createContact()` — `noreply@stripe.com` is unrelated to the Stripe org node
- **Backfills existing contacts** via migration 057 — single-pass Postgres regex UPDATE over `contact_channel_identities.channel_identifier`
- **Bypasses dispatcher tier gate** only for `tier='unknown'` automated senders — `tier='blocked'` still gates regardless of kind (explicit operator decision)
- **Updates ceo-inbox agent** (v0.7.0 → v0.8.0) — automated senders default to Cleared; still escalated on fraud, payment failure, bounce, hard deadline
- **Adds `kind` filter to `contact-list` skill** (v1.2.1 → v1.3.0) — default view excludes `automated` and `agent`; pass `kind=automated` to see them; role-path post-filtered through the same kind filter; `kind` included in returned contact objects

## Closes

Closes #953

## Test plan

- [ ] `pnpm -C <worktree> test -- --run src/contacts/email-sender-classifier.test.ts` — 13 classifier tests covering noreply variants, mailer-daemon, notifications, bounce, and the critical ordering test (`noreply@gmail.com` → `'automated'` not `'person'`)
- [ ] `pnpm -C <worktree> test -- --run src/dispatch/dispatcher.test.ts` — dispatcher gate behavior for automated senders
- [ ] `pnpm -C <worktree> test -- --run src/contacts/contact-service.test.ts` — createContact automated short-circuit
- [ ] Verify migration 057 runs cleanly against a dev Postgres instance and is idempotent on re-run
- [ ] Verify contact-list skill default query excludes automated contacts; `kind=automated` param returns them
- [ ] Verify `tier='blocked'` contacts (automated or otherwise) are still gated by the dispatcher