### PR TITLE
feat: judgment-driven auto-elevation (#951)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Auto-elevation** — contacts are automatically promoted from `tier='unknown'` to `tier='known'` via three signal paths: correspondence (outbound email sent to the contact), domain-validated (first inbound from an org-kind contact), and judgment (confidence score crosses the 0.20 threshold). New `contact.elevated` bus event for the audit trail. Automated and agent contacts are excluded at the database layer. (#951)
 - **Automated sender classification** — `classifyEmailSender()` now detects noreply/mailer-daemon/newsletter patterns and sets `kind='automated'`; new contacts skip the KG org-node path. (#953)
 - **`contact-list` skill `kind` filter** — accepts `kind` to filter by contact kind; default view excludes `automated` and `agent`. (#953)
 

--- a/docs/wip/2026-06-18-judgment-driven-auto-elevation-design.md
+++ b/docs/wip/2026-06-18-judgment-driven-auto-elevation-design.md
@@ -1,0 +1,168 @@
+# Judgment-Driven Auto-Elevation — Design
+
+**Issue:** #951
+**Milestone:** v0.36 — Contacts redesign
+**Depends on:** #945 (unified tier + kind — closed/merged)
+**Date:** 2026-06-18
+
+---
+
+## Context
+
+The contact ledger currently starts every new sender at `tier='unknown'`. Promotion to `tier='known'` has no automated path — it requires a manual confirm step, which contradicts the goal of a self-maintaining entity database. This design adds three automated elevation paths that match how a good EA would manage a contact list: act on signals, don't ask for confirmation.
+
+`known` only unlocks light principal context and availability disclosure. Third-party PII and confidential content always escalate regardless of tier (the bounded profile is the guardrail). This means false positives from generous elevation are low-cost.
+
+Demotion fires only on an explicit negative signal (blocked, marked spam, Joseph says so) — never on inactivity.
+
+`kind='automated'` contacts skip all elevation logic. The tier gate already bypasses them on inbound; auto-elevation should not apply either.
+
+---
+
+## Three Elevation Paths
+
+### Path 1: Correspondence (`unknown → known`)
+
+**Trigger:** `email-reply` or `email-send` skill succeeds (Joseph or Curia sends outbound email to the contact).
+
+**Rationale:** An explicit outbound to someone is the clearest possible signal that the relationship is real.
+
+**Hook:** `Dispatcher.handleSkillResult()` — already parses the `to` field for the reply-lock. After reply-lock logic, resolve each recipient email via `this.contactResolver.resolve('email', address)` (read — already wired) and call `this.contactService.elevateTierToKnown(contactId, 'correspondence')` (write — new field).
+
+**Scope:** Only contacts that already exist in the DB (resolved contactId). Brand-new outbound targets have no contact record yet; they get created and elevated when they reply (path 2 handles org replies; path 3 handles person replies).
+
+**Note on outbound gating:** The tier gate is inbound-only. The outbound gateway only blocks `tier='blocked'` contacts; unknown-tier contacts pass through unconditionally. Elevation is not a prerequisite for sending.
+
+---
+
+### Path 2: Domain-Validated Org (`unknown → known`)
+
+**Trigger:** First (or any) inbound from a contact with `kind='organization'` and `tier='unknown'`.
+
+**Rationale:** Repeated receipt from a resolvable business domain that is never blocked or marked spam is sufficient. No interaction required. DKIM/DMARC alignment is a corroborating bonus, not a gate.
+
+**Hook:** `Dispatcher.handleInboundMessage()` — after contact resolution succeeds and `senderContext.kind === 'organization' && senderContext.tier === 'unknown'`, call `contactService.elevateTierToKnown(contactId, 'domain-validated')`. Fire-and-forget.
+
+---
+
+### Path 3: Judgment (`unknown → known`)
+
+**Trigger:** `contact_confidence` crosses `JUDGMENT_ELEVATION_THRESHOLD` (0.20) after a confidence update.
+
+**Rationale:** A person who has sent a handful of recent emails "seems reasonable" to a good EA — accumulated signals are sufficient without requiring an explicit reply. The 0.20 threshold requires either recent activity (the recency component alone is worth 0.20) or a moderate history of messages.
+
+**Hook:** `Dispatcher.handleInboundMessage()` — after `confidencePipeline.incrementalUpdate()` returns the new confidence value, check: `senderContext.tier === 'unknown' && !isAutomatedKind(senderContext.kind) && newConfidence >= JUDGMENT_ELEVATION_THRESHOLD`. If true, call `contactService.elevateTierToKnown(contactId, 'judgment')`. Fire-and-forget, chained on the confidence update promise.
+
+**Threshold constant:** `JUDGMENT_ELEVATION_THRESHOLD = 0.20`, exported from `src/contacts/confidence-scorer.ts` alongside the existing tunable constants (`SATURATION`, `W_INTERACTION`, etc.).
+
+---
+
+## Components
+
+### 1. `ContactService.elevateTierToKnown(contactId, reason)`
+
+New method on `ContactService` and `ContactServiceBackend`.
+
+**Backend SQL (atomic, TOCTOU-safe):**
+```sql
+UPDATE contacts
+SET tier = 'known', updated_at = now()
+WHERE id = $1
+  AND tier = 'unknown'
+  AND kind NOT IN ('automated', 'agent')
+```
+
+Returns `true` if a row was updated, `false` otherwise (already known/blocked/trusted/principal, or automated). Same pattern as `promoteToConfirmed()`.
+
+**Service method:** Calls the backend, logs provenance with `reason` at `info` level on success, `warn` on DB error. Non-throwing — catches internally and returns `false` on error. The `reason` parameter (`'correspondence' | 'domain-validated' | 'judgment'`) is recorded in the structured log only (not persisted to the DB), consistent with the issue's "audit log only" decision.
+
+**`InMemoryContactBackend`:** Implements the same guard logic in-memory for tests.
+
+### 2. `DispatcherConfig` — new optional field
+
+```typescript
+contactService?: ContactService;
+```
+
+Same injection pattern as `confidencePipeline`. When absent, all three elevation paths are silently skipped.
+
+### 3. `ConfidencePipeline.incrementalUpdate()` — return type change
+
+Changes from `Promise<void>` to `Promise<number>`. Returns `newConfidence` after persisting the update. Allows the dispatcher to chain judgment elevation without a separate DB read. Backward-compatible — existing callers that ignore the return value are unaffected.
+
+### 4. `contact.elevated` bus event
+
+Added to `src/bus/events.ts`:
+
+```typescript
+type: 'contact.elevated';
+payload: {
+  contactId: string;
+  reason: 'correspondence' | 'domain-validated' | 'judgment';
+  parentEventId?: string;
+}
+```
+
+Emitted by `ContactService.elevateTierToKnown()` on success via an optional `onContactElevated` callback added to `ContactServiceOptions` (same callback pattern as `onContactMerged`). The callback is wired in `src/index.ts` to publish the bus event on the `'dispatch'` topic. Provides an audit trail consistent with `contact.resolved`, `contact.merged`, etc.
+
+---
+
+## Data Flow Summary
+
+```
+Inbound email arrives
+  → contact-resolver resolves sender
+  → kind='organization' && tier='unknown'?  → elevateTierToKnown('domain-validated')  [Path 2]
+  → confidence pipeline updates
+  → newConfidence >= 0.20 && tier='unknown' && !automated? → elevateTierToKnown('judgment')  [Path 3]
+
+Outbound email-reply / email-send succeeds
+  → parse `to` recipients
+  → resolve each to contactId
+  → elevateTierToKnown('correspondence') for each resolved contactId  [Path 1]
+```
+
+---
+
+## Error Handling
+
+All elevation calls are fire-and-forget. Failures must never drop an inbound message or block an outbound send.
+
+- `elevateTierToKnown()` catches internally, logs at `warn`, returns `false`
+- Call sites use `.catch(err => this.logger.warn(...))` on the promise chain
+- Transient DB failures: contact stays at `unknown`, elevation retries on the next qualifying event — no manual recovery needed
+
+---
+
+## Testing
+
+### `contact-service.test.ts`
+- `elevateTierToKnown()` from `unknown` → succeeds, returns `true`, tier is `'known'`
+- From `known` → no-op, returns `false`
+- From `blocked` → no-op, returns `false`
+- From `trusted` / `principal` → no-op, returns `false`
+- `kind='automated'` with `tier='unknown'` → no-op, returns `false`
+- `kind='agent'` with `tier='unknown'` → no-op, returns `false`
+- On DB error → returns `false`, does not throw
+
+### `confidence-pipeline.test.ts`
+- `incrementalUpdate()` returns the new confidence value (return-type change)
+
+### `dispatcher.test.ts`
+- Correspondence: mock `email-reply` result with `to` field; assert `elevateTierToKnown('correspondence')` called for resolved contact
+- Correspondence: recipient resolves to `null` (no contact yet) → no elevation call
+- Domain-validated: mock inbound with `kind='organization'`, `tier='unknown'`; assert elevation called
+- Domain-validated: `kind='organization'`, `tier='known'` → no elevation call
+- Judgment: mock confidence update returning 0.22; `tier='unknown'`, `kind='person'`; assert elevation called
+- Judgment: mock confidence update returning 0.18 → no elevation call
+- Judgment: mock confidence update returning 0.22; `kind='automated'` → no elevation call
+- No `contactService` wired → all paths silently skip, no error
+
+---
+
+## What This Does Not Change
+
+- Demotion logic — unchanged. Only explicit negative signals (blocked, spam, Joseph says so) demote a contact.
+- `kind='automated'` routing — unchanged. Automated contacts bypass the tier gate on inbound and are excluded from all elevation paths.
+- Disclosure behavior — provenance (`correspondence` / `domain-validated` / `judgment`) is audit-log only. All `known` contacts get the same runtime treatment regardless of how they were elevated.
+- No DB migration needed — `elevateTierToKnown()` writes to the existing `tier` column (migration 055).

--- a/docs/wip/2026-06-18-judgment-driven-auto-elevation-progress.md
+++ b/docs/wip/2026-06-18-judgment-driven-auto-elevation-progress.md
@@ -1,0 +1,121 @@
+# Judgment-Driven Auto-Elevation — Work-in-Progress
+
+**Issue:** #951
+**Branch:** `feat/auto-elevation-951`
+**Plan:** `docs/wip/2026-06-18-judgment-driven-auto-elevation.md`
+**Design spec:** `docs/wip/2026-06-18-judgment-driven-auto-elevation-design.md`
+**Last updated:** 2026-06-18
+
+---
+
+## Status: 4 of 6 tasks complete
+
+All completed tasks have been reviewed (spec ✅ + quality approved).
+
+| Task | Description | Status | Commits |
+|------|-------------|--------|---------|
+| 1 | `JUDGMENT_ELEVATION_THRESHOLD` constant + `incrementalUpdate()` returns `Promise<number>` | ✅ complete | `d80b6c9a` |
+| 2 | `contact.elevated` bus event (payload, interface, union, factory) | ✅ complete | `9db4de08` |
+| 3 | `ContactService.elevateTierToKnown()` — backend interface, Postgres, InMemory, service class, callback | ✅ complete | `01e0d4bd` |
+| 4 | Dispatcher Paths 2 + 3 — domain-validated org elevation + judgment elevation in `handleInboundMessage()` | ✅ complete | `5476fe4a` |
+| 5 | Dispatcher Path 1 — correspondence elevation in `handleSkillResult()` after `email-reply`/`email-send` | ⏳ pending | — |
+| 6 | Wire `index.ts` + `CHANGELOG.md` | ⏳ pending | — |
+
+---
+
+## What's been built
+
+### Task 1 — Threshold constant + pipeline return type
+
+- `src/contacts/confidence-scorer.ts`: exported `JUDGMENT_ELEVATION_THRESHOLD = 0.20`
+- `src/contacts/confidence-pipeline.ts`: `incrementalUpdate()` now returns `Promise<number>` (was `Promise<void>`). Early-return paths return `0`; principal contacts return `1.0`; normal path returns `newConfidence`.
+- `tests/unit/contacts/confidence-pipeline.test.ts`: added test verifying the return value matches stored `contactConfidence`.
+
+### Task 2 — Bus event
+
+- `src/bus/events.ts`: added `ContactElevatedPayload`, `ContactElevatedEvent`, union member `| ContactElevatedEvent`, and `createContactElevated()` factory — all following existing patterns for `contact.merged` etc.
+
+### Task 3 — ContactService.elevateTierToKnown()
+
+- `src/contacts/types.ts`: `onContactElevated?` added to `ContactServiceOptions`
+- `src/contacts/contact-service.ts`:
+  - `ContactServiceBackend` interface: `elevateTierToKnown()` method added
+  - `PostgresContactBackend`: atomic SQL `WHERE id=$1 AND tier='unknown' AND kind NOT IN ('automated','agent')`
+  - `InMemoryContactBackend`: equivalent in-memory guard logic
+  - `ContactService`: service method that catches internally (non-throwing), logs at info on success / warn on error, fires `onContactElevated` callback only on success
+- 8 unit tests added.
+
+### Task 4 — Dispatcher inbound paths
+
+- `src/dispatch/dispatcher.ts`:
+  - Imports `JUDGMENT_ELEVATION_THRESHOLD`
+  - `DispatcherConfig`: `contactService?` field added
+  - Class: `private contactService?` field, wired in constructor
+  - `handleInboundMessage()`: old 4-line confidence block replaced with new 29-line block:
+    - **Path 2** (domain-validated): fires immediately when `kind='organization' && tier='unknown'`
+    - **Path 3** (judgment): chains after `incrementalUpdate()`, fires when `snapshotTier='unknown' && !isAutomatedKind(snapshotKind) && newConfidence >= 0.20`
+  - Both paths are fire-and-forget with `.catch()` — failures never block message handling
+- 9 dispatcher unit tests added (4 for Path 2, 5 for Path 3).
+
+---
+
+## What's remaining
+
+### Task 5 — Dispatcher Path 1 (correspondence)
+
+Add to `handleSkillResult()` in `dispatcher.ts`, after the existing reply-lock `if (!matched)` debug block:
+
+```typescript
+if (this.contactResolver && this.contactService) {
+  const cr = this.contactResolver;
+  const cs = this.contactService;
+  for (const address of recipients) {
+    cr.resolve('email', address)
+      .then(ctx => {
+        if (ctx.resolved) {
+          return cs.elevateTierToKnown(ctx.contactId, 'correspondence');
+        }
+      })
+      .catch(err => this.logger.warn({ err, address }, 'Correspondence elevation failed (non-fatal)'));
+  }
+}
+```
+
+5 unit tests needed (see plan Task 5, Step 1).
+
+### Task 6 — Wire index.ts + CHANGELOG
+
+Three changes to `src/index.ts`:
+1. Add `createContactElevated` to the `bus/events.ts` import
+2. Add `onContactElevated` callback in the `ContactService.createWithPostgres()` options (publishes `contact.elevated` bus event)
+3. Add `contactService` to the `new Dispatcher({...})` config
+
+CHANGELOG entry:
+```
+- **Auto-elevation** — contacts are automatically promoted from `tier='unknown'` to `tier='known'` via three signal paths: correspondence (outbound email sent to the contact), domain-validated (first inbound from an org-kind contact), and judgment (confidence score crosses the 0.20 threshold). New `contact.elevated` bus event for the audit trail. Automated and agent contacts are excluded at the database layer. (#951)
+```
+
+No new unit tests for Task 6 (wiring is validated by typecheck and the Task 5/3/4 tests).
+
+---
+
+## Resuming on another machine
+
+```bash
+# From the office-of-the-ceo workspace root:
+git -C repos/curia fetch origin
+git worktree add worktrees/curia-auto-elevation-951 feat/auto-elevation-951
+
+# Symlink .env
+MAIN=/path/to/repos/curia WORKTREE=/path/to/worktrees/curia-auto-elevation-951
+ln -sf "$MAIN/.env" "$WORKTREE/.env"
+
+# Install deps
+pnpm -C worktrees/curia-auto-elevation-951 install
+
+# Verify state
+git -C worktrees/curia-auto-elevation-951 log --oneline
+pnpm -C worktrees/curia-auto-elevation-951 run test
+```
+
+Then continue with Task 5 (brief in plan, Step 1 = write failing tests for Path 1 correspondence).

--- a/docs/wip/2026-06-18-judgment-driven-auto-elevation.md
+++ b/docs/wip/2026-06-18-judgment-driven-auto-elevation.md
@@ -1,0 +1,1181 @@
+# Judgment-Driven Auto-Elevation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically promote contacts from `tier='unknown'` to `tier='known'` via three signal paths — correspondence (outbound email sent to contact), domain-validated (first inbound from org-kind contact), and judgment (confidence score crosses 0.20 threshold) — with no manual confirmation required.
+
+**Architecture:** New `JUDGMENT_ELEVATION_THRESHOLD` constant in `confidence-scorer.ts`. `ConfidencePipeline.incrementalUpdate()` return type changes from `Promise<void>` to `Promise<number>` so callers chain judgment elevation without a second DB read. New `ContactService.elevateTierToKnown()` uses atomic SQL (`WHERE tier='unknown' AND kind NOT IN ('automated','agent')`) — same pattern as `promoteToConfirmed()`. `DispatcherConfig` gains optional `contactService` field; `handleInboundMessage()` hooks Paths 2 and 3; `handleSkillResult()` hooks Path 1. New `contact.elevated` bus event (audit trail), published via `onContactElevated` callback wired in `index.ts`.
+
+**Tech Stack:** TypeScript/ESM, Vitest, PostgreSQL 16 (no new migration — writes to existing `tier` column from migration 055)
+
+## Global Constraints
+
+- Worktree: `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951`
+- Run tests with: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test <file>`
+- Run typecheck with: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run typecheck`
+- All elevation calls are fire-and-forget — failures must never block inbound message handling or outbound sends
+- `kind='automated'` and `kind='agent'` contacts are never elevated (enforced at DB level)
+- `JUDGMENT_ELEVATION_THRESHOLD = 0.20` — about one recent inbound message worth of confidence
+- No DB migration needed — `elevateTierToKnown()` writes only to the existing `tier` column
+- No comments on obvious code; add comments only where the WHY is non-obvious
+
+---
+
+## File Structure
+
+**Modified source files:**
+- `src/contacts/confidence-scorer.ts` — add `JUDGMENT_ELEVATION_THRESHOLD` export
+- `src/contacts/confidence-pipeline.ts` — `incrementalUpdate()` return type `Promise<void>` → `Promise<number>`
+- `src/bus/events.ts` — add `contact.elevated` payload, event interface, union member, and factory function
+- `src/contacts/types.ts` — add `onContactElevated?` to `ContactServiceOptions`
+- `src/contacts/contact-service.ts` — add `elevateTierToKnown()` to backend interface, PostgresContactBackend, InMemoryContactBackend, and ContactService
+- `src/dispatch/dispatcher.ts` — add `contactService?` to config and class; add Path 1 in `handleSkillResult()`; add Paths 2 and 3 in `handleInboundMessage()`
+- `src/index.ts` — wire `contactService` into dispatcher config, add `onContactElevated` callback to ContactService options
+- `CHANGELOG.md` — add entry under `## [Unreleased]`
+
+**Modified test files:**
+- `tests/unit/contacts/confidence-pipeline.test.ts` — test that `incrementalUpdate()` returns the new confidence value
+- `tests/unit/contacts/contact-service.test.ts` — test `elevateTierToKnown()` across all tier/kind combinations
+- `tests/unit/dispatch/dispatcher.test.ts` — test Paths 1, 2, and 3
+
+---
+
+## Task 1: Scoring Threshold Constant + Pipeline Return Type
+
+**Files:**
+- Modify: `src/contacts/confidence-scorer.ts` (after line 32 — after `PAIRING_BOOST`)
+- Modify: `src/contacts/confidence-pipeline.ts` (line 40 signature; line 103 add return)
+- Modify: `tests/unit/contacts/confidence-pipeline.test.ts` (add return-value test)
+
+**Interfaces:**
+- Produces: `JUDGMENT_ELEVATION_THRESHOLD` exported from `confidence-scorer.ts` — used by Task 4 (dispatcher import)
+- Produces: `ConfidencePipeline.incrementalUpdate(id, signal): Promise<number>` — used by Task 4 (chain `.then(newConfidence =>`)
+
+- [ ] **Step 1: Write the failing test for the return value**
+
+Add a new `it` block inside the existing `describe('incrementalUpdate — message_seen')` in `tests/unit/contacts/confidence-pipeline.test.ts`:
+
+```typescript
+it('returns the updated confidence value', async () => {
+  const contact = await createTestContact();
+  const result = await pipeline.incrementalUpdate(contact.id, { type: 'message_seen' });
+  // message_seen with recency contribution should be > 0
+  expect(typeof result).toBe('number');
+  expect(result).toBeGreaterThan(0);
+  // Must match the stored contactConfidence
+  const updated = await service.getContact(contact.id);
+  expect(result).toBeCloseTo(updated!.contactConfidence);
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test tests/unit/contacts/confidence-pipeline.test.ts
+```
+
+Expected: TypeScript compile error ("Property 'then' does not exist on type 'void'") or the test fails because `result` is `undefined`.
+
+- [ ] **Step 3: Add `JUDGMENT_ELEVATION_THRESHOLD` to `confidence-scorer.ts`**
+
+After line 32 (`export const PAIRING_BOOST = 0.10;`), add:
+
+```typescript
+/** Minimum contact_confidence to trigger automatic tier elevation from 'unknown' to 'known'. */
+export const JUDGMENT_ELEVATION_THRESHOLD = 0.20;
+```
+
+- [ ] **Step 4: Change `incrementalUpdate()` return type and add return statement**
+
+In `src/contacts/confidence-pipeline.ts`, change line 40:
+
+```typescript
+// Before:
+async incrementalUpdate(contactId: string, signal: ConfidenceSignal): Promise<void> {
+
+// After:
+async incrementalUpdate(contactId: string, signal: ConfidenceSignal): Promise<number> {
+```
+
+Then add `return newConfidence;` after the `updateScoringFields` call (after the closing `});` on line 103, before the method's closing `}`):
+
+```typescript
+    await this.contactService.updateScoringFields(contactId, {
+      inboundMessageCountDelta: inboundDelta,
+      outboundMessageCountDelta: outboundDelta,
+      contactConfidence: newConfidence,
+      lastSeenAt,
+    });
+    return newConfidence;  // ← add this line
+  }
+```
+
+Also update the three early-return paths (non-principal skip and validation fail) to return `0` instead of `undefined`:
+
+```typescript
+  async incrementalUpdate(contactId: string, signal: ConfidenceSignal): Promise<number> {
+    const contact = await this.contactService.getContact(contactId);
+    if (!contact) {
+      this.logger?.debug({ contactId }, 'confidence-pipeline: contact not found — skipping');
+      return 0;  // ← was: return;
+    }
+
+    if (contact.systemRole === 'principal') return 1.0;  // ← was: return;
+
+    const count = ('count' in signal ? signal.count : undefined) ?? 1;
+    if (!Number.isInteger(count) || count < 1) {
+      this.logger?.warn({ contactId, count }, 'confidence-pipeline: non-positive or non-integer count — skipping (likely a caller bug)');
+      return 0;  // ← was: return;
+    }
+    // ... rest of method unchanged, ends with: return newConfidence;
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test tests/unit/contacts/confidence-pipeline.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Run typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 add src/contacts/confidence-scorer.ts src/contacts/confidence-pipeline.ts tests/unit/contacts/confidence-pipeline.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 commit -m "feat: export JUDGMENT_ELEVATION_THRESHOLD; incrementalUpdate returns new confidence"
+```
+
+---
+
+## Task 2: `contact.elevated` Bus Event
+
+**Files:**
+- Modify: `src/bus/events.ts` — 4 additions (payload interface, event interface, union member, factory function)
+
+**Interfaces:**
+- Produces: `ContactElevatedEvent`, `createContactElevated()` — used by Task 6 (index.ts wiring)
+
+No unit tests needed here — the TypeScript compiler catches structural errors, and the event is exercised by the end-to-end wiring in Task 6.
+
+- [ ] **Step 1: Add `ContactElevatedPayload` interface after `ContactMergedPayload` (around line 288)**
+
+```typescript
+// contact.elevated — published when a contact is automatically promoted from 'unknown' to 'known'.
+// Fired by ContactService.elevateTierToKnown() on success via the onContactElevated callback.
+interface ContactElevatedPayload {
+  contactId: string;
+  reason: 'correspondence' | 'domain-validated' | 'judgment';
+}
+```
+
+- [ ] **Step 2: Add `ContactElevatedEvent` interface after `ContactMergedEvent` (around line 692)**
+
+```typescript
+export interface ContactElevatedEvent extends BaseEvent {
+  type: 'contact.elevated';
+  sourceLayer: 'dispatch';
+  payload: ContactElevatedPayload;
+}
+```
+
+- [ ] **Step 3: Add `ContactElevatedEvent` to the `BusEvent` union**
+
+In the `BusEvent` union (around line 961), add after the `ContactMergedEvent` entry:
+
+```typescript
+  | ContactMergedEvent              // Dedup: two contacts have been merged
+  | ContactElevatedEvent            // #951: automatic tier elevation from unknown → known
+```
+
+- [ ] **Step 4: Add `createContactElevated()` factory after `createContactMerged()` (around line 1296)**
+
+```typescript
+export function createContactElevated(
+  payload: ContactElevatedPayload & { parentEventId?: string },
+): ContactElevatedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'contact.elevated',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
+```
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 add src/bus/events.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 commit -m "feat: add contact.elevated bus event (#951)"
+```
+
+---
+
+## Task 3: `ContactService.elevateTierToKnown()`
+
+**Files:**
+- Modify: `src/contacts/types.ts:462` — add `onContactElevated?` to `ContactServiceOptions`
+- Modify: `src/contacts/contact-service.ts` — 6 changes across backend interface, Postgres, InMemory, and service class
+- Modify: `tests/unit/contacts/contact-service.test.ts` — add test block
+
+**Interfaces:**
+- Consumes: `ContactElevatedPayload.reason` type (`'correspondence' | 'domain-validated' | 'judgment'`) from Task 2
+- Produces: `ContactService.elevateTierToKnown(contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment'): Promise<boolean>` — used by Tasks 4 and 5
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe('elevateTierToKnown')` block in `tests/unit/contacts/contact-service.test.ts` (after the existing describe blocks, before the final closing `}`):
+
+```typescript
+describe('elevateTierToKnown', () => {
+  it('promotes an unknown contact to known and returns true', async () => {
+    const contact = await service.createContact({
+      displayName: 'Jane Doe',
+      source: 'email_participant',
+      status: 'provisional',
+    });
+    // provisional → tier='unknown' by default
+    expect(contact.tier).toBe('unknown');
+
+    const result = await service.elevateTierToKnown(contact.id, 'judgment');
+    expect(result).toBe(true);
+
+    const updated = await service.getContact(contact.id);
+    expect(updated!.tier).toBe('known');
+  });
+
+  it('returns false and does not modify a contact already at tier="known"', async () => {
+    const contact = await service.createContact({
+      displayName: 'Jane Doe',
+      source: 'email_participant',
+      status: 'confirmed',
+    });
+    expect(contact.tier).toBe('known');
+
+    const result = await service.elevateTierToKnown(contact.id, 'judgment');
+    expect(result).toBe(false);
+
+    const updated = await service.getContact(contact.id);
+    expect(updated!.tier).toBe('known'); // unchanged
+  });
+
+  it('returns false and does not modify a contact at tier="trusted"', async () => {
+    const contact = await service.createContact({
+      displayName: 'Jane Doe',
+      source: 'email_participant',
+      status: 'confirmed',
+    });
+    await service.setTrustLevel(contact.id, 'high'); // drives tier to 'trusted'
+    const before = await service.getContact(contact.id);
+    expect(before!.tier).toBe('trusted');
+
+    const result = await service.elevateTierToKnown(contact.id, 'judgment');
+    expect(result).toBe(false);
+
+    const updated = await service.getContact(contact.id);
+    expect(updated!.tier).toBe('trusted'); // unchanged
+  });
+
+  it('returns false and does not modify a blocked contact', async () => {
+    const contact = await service.createContact({
+      displayName: 'Jane Doe',
+      source: 'email_participant',
+      status: 'blocked',
+    });
+    expect(contact.tier).toBe('blocked');
+
+    const result = await service.elevateTierToKnown(contact.id, 'correspondence');
+    expect(result).toBe(false);
+
+    const updated = await service.getContact(contact.id);
+    expect(updated!.tier).toBe('blocked'); // unchanged
+  });
+
+  it('returns false for kind="automated" contacts even when tier="unknown"', async () => {
+    const contact = await service.createContact({
+      displayName: 'noreply@example.com',
+      source: 'email_participant',
+      status: 'provisional',
+      kind: 'automated',
+    });
+    expect(contact.tier).toBe('unknown');
+    expect(contact.kind).toBe('automated');
+
+    const result = await service.elevateTierToKnown(contact.id, 'judgment');
+    expect(result).toBe(false);
+
+    const updated = await service.getContact(contact.id);
+    expect(updated!.tier).toBe('unknown'); // unchanged
+  });
+
+  it('returns false for kind="agent" contacts even when tier="unknown"', async () => {
+    const contact = await service.createContact({
+      displayName: 'Specialist Agent',
+      source: 'email_participant',
+      status: 'provisional',
+      kind: 'agent',
+    });
+    const result = await service.elevateTierToKnown(contact.id, 'domain-validated');
+    expect(result).toBe(false);
+  });
+
+  it('fires the onContactElevated callback with contactId and reason', async () => {
+    const onContactElevated = vi.fn();
+    const svc = ContactService.createInMemory(entityMemory, { onContactElevated });
+
+    const contact = await svc.createContact({
+      displayName: 'Callback Test',
+      source: 'email_participant',
+      status: 'provisional',
+    });
+
+    await svc.elevateTierToKnown(contact.id, 'correspondence');
+
+    expect(onContactElevated).toHaveBeenCalledOnce();
+    expect(onContactElevated).toHaveBeenCalledWith(contact.id, 'correspondence');
+  });
+
+  it('does not fire onContactElevated when elevation is a no-op', async () => {
+    const onContactElevated = vi.fn();
+    const svc = ContactService.createInMemory(entityMemory, { onContactElevated });
+
+    const contact = await svc.createContact({
+      displayName: 'Already Known',
+      source: 'email_participant',
+      status: 'confirmed', // already known
+    });
+
+    await svc.elevateTierToKnown(contact.id, 'judgment');
+
+    expect(onContactElevated).not.toHaveBeenCalled();
+  });
+});
+```
+
+You also need to add `vi` to the import at the top of the test file:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test tests/unit/contacts/contact-service.test.ts
+```
+
+Expected: compile error — `elevateTierToKnown` does not exist on `ContactService`.
+
+- [ ] **Step 3: Add `onContactElevated?` to `ContactServiceOptions` in `src/contacts/types.ts`**
+
+After the `onIdentityVerified?` entry (around line 462):
+
+```typescript
+export interface ContactServiceOptions {
+  dedupService?: import('./dedup-service.js').DedupService;
+  onDuplicateDetected?: (
+    newContactId: string,
+    matchContactId: string,
+    confidence: DedupConfidence,
+    reason: string,
+  ) => void;
+  /** Called after a successful non-dry-run merge to notify subscribers (e.g., for audit logging). */
+  onContactMerged?: (primaryId: string, secondaryId: string, mergedAt: Date) => void;
+  /** Called when a verified identity is linked — triggers confidence recompute.
+   *  May return a Promise; rejections are caught by ContactService (non-fatal). */
+  onIdentityVerified?: (contactId: string) => void | Promise<void>;
+  /** Called after a contact's tier is automatically elevated to 'known'.
+   *  Fired with the reason for observability/audit trail. Non-throwing. */
+  onContactElevated?: (contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment') => void;
+}
+```
+
+- [ ] **Step 4: Add `elevateTierToKnown()` to the `ContactServiceBackend` interface**
+
+In `src/contacts/contact-service.ts`, add after `promoteToConfirmed()` in the `ContactServiceBackend` interface (around line 211):
+
+```typescript
+  /**
+   * Atomically elevate a contact's tier from 'unknown' to 'known'.
+   * Guards against automated/agent kinds at DB level.
+   * Returns true if the row was updated, false otherwise (already elevated, wrong tier, or excluded kind).
+   */
+  elevateTierToKnown(contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment'): Promise<boolean>;
+```
+
+- [ ] **Step 5: Add `onContactElevated` private field and wire it in the `ContactService` constructor**
+
+In the `ContactService` class body (around line 281), add after `private onContactMerged?`:
+
+```typescript
+  private onContactElevated?: (contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment') => void;
+```
+
+In the constructor body (around line 297), add after `this.onContactMerged`:
+
+```typescript
+    this.onContactElevated = options?.onContactElevated;
+```
+
+- [ ] **Step 6: Add `elevateTierToKnown()` service method**
+
+In `ContactService`, add after `promoteToConfirmed()` (around line 1012):
+
+```typescript
+  /**
+   * Atomically elevate a contact from tier='unknown' to tier='known'.
+   * No-op for automated/agent kinds (enforced by backend SQL) and contacts already
+   * at known/trusted/principal/blocked. Non-throwing — returns false on error.
+   */
+  async elevateTierToKnown(
+    contactId: string,
+    reason: 'correspondence' | 'domain-validated' | 'judgment',
+  ): Promise<boolean> {
+    try {
+      const elevated = await this.backend.elevateTierToKnown(contactId, reason);
+      if (elevated) {
+        this.logger?.info({ contactId, reason }, 'contacts: tier elevated to known');
+        if (this.onContactElevated) {
+          try {
+            this.onContactElevated(contactId, reason);
+          } catch (callbackErr) {
+            this.logger?.warn({ err: callbackErr }, 'onContactElevated callback threw (non-fatal)');
+          }
+        }
+      }
+      return elevated;
+    } catch (err) {
+      this.logger?.warn({ err, contactId, reason }, 'contacts: elevateTierToKnown failed (non-fatal)');
+      return false;
+    }
+  }
+```
+
+- [ ] **Step 7: Add `elevateTierToKnown()` to `PostgresContactBackend`**
+
+After `promoteToConfirmed()` in `PostgresContactBackend` (around line 1691):
+
+```typescript
+  async elevateTierToKnown(contactId: string, _reason: string): Promise<boolean> {
+    // Atomic conditional: only upgrades tier when it is STILL 'unknown' at write time
+    // AND the contact's kind is not automated or agent.
+    const result = await this.pool.query(
+      `UPDATE contacts
+       SET tier = 'known', updated_at = now()
+       WHERE id = $1
+         AND tier = 'unknown'
+         AND kind NOT IN ('automated', 'agent')`,
+      [contactId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+```
+
+- [ ] **Step 8: Add `elevateTierToKnown()` to `InMemoryContactBackend`**
+
+After `promoteToConfirmed()` in `InMemoryContactBackend` (around line 2173):
+
+```typescript
+  async elevateTierToKnown(contactId: string, _reason: string): Promise<boolean> {
+    const contact = this.contacts.get(contactId);
+    if (!contact || contact.tier !== 'unknown') return false;
+    if (contact.kind === 'automated' || contact.kind === 'agent') return false;
+    this.contacts.set(contactId, { ...contact, tier: 'known', updatedAt: new Date() });
+    return true;
+  }
+```
+
+- [ ] **Step 9: Run tests to confirm they pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test tests/unit/contacts/contact-service.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 10: Run typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 add src/contacts/types.ts src/contacts/contact-service.ts tests/unit/contacts/contact-service.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 commit -m "feat: add ContactService.elevateTierToKnown() for auto-elevation (#951)"
+```
+
+---
+
+## Task 4: Dispatcher Inbound Paths (Path 2 Domain-Validated + Path 3 Judgment)
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts` — 5 changes: import, config field, class field, constructor, `handleInboundMessage()` block
+- Modify: `tests/unit/dispatch/dispatcher.test.ts` — add two describe blocks
+
+**Interfaces:**
+- Consumes: `JUDGMENT_ELEVATION_THRESHOLD` from `confidence-scorer.ts` (Task 1)
+- Consumes: `ConfidencePipeline.incrementalUpdate()` returning `Promise<number>` (Task 1)
+- Consumes: `ContactService.elevateTierToKnown()` (Task 3)
+- Produces: Dispatcher fires Path 2 and Path 3 elevation on inbound messages
+
+- [ ] **Step 1: Write the failing tests**
+
+Add two `describe` blocks near the end of `tests/unit/dispatch/dispatcher.test.ts`. First, add these imports at the top of the file alongside existing imports:
+
+```typescript
+import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
+import type { ContactService } from '../../../src/contacts/contact-service.js';
+import type { ConfidencePipeline } from '../../../src/contacts/confidence-pipeline.js';
+import { createLogger } from '../../../src/logger.js';
+import { EventBus } from '../../../src/bus/bus.js';
+```
+
+(Note: `ContactResolver`, `ContactTier`, `ContactKind` are likely already imported — check and add only what's missing. `createLogger` and `EventBus` are already there.)
+
+Then add the two describe blocks:
+
+```typescript
+describe('Dispatcher auto-elevation — Path 2 domain-validated (#951)', () => {
+  function buildHarness(opts: {
+    tier?: import('../../../src/contacts/types.js').ContactTier;
+    kind?: import('../../../src/contacts/types.js').ContactKind;
+    withContactService?: boolean;
+    confidence?: number;
+  } = {}) {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const elevateFn = vi.fn().mockResolvedValue(true);
+    const contactService = opts.withContactService === false
+      ? undefined
+      : { elevateTierToKnown: elevateFn } as unknown as ContactService;
+
+    const confidencePipeline = {
+      incrementalUpdate: vi.fn().mockResolvedValue(opts.confidence ?? 0.05),
+    } as unknown as ConfidencePipeline;
+
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: true,
+        contactId: 'test-contact-id',
+        displayName: 'Corp Inc',
+        role: null,
+        systemRole: null,
+        status: 'provisional',
+        tier: opts.tier ?? 'unknown',
+        kind: opts.kind ?? 'organization',
+        verified: true,
+        kgNodeId: null,
+        knowledgeSummary: '',
+        authorization: null,
+        contactConfidence: 0.0,
+        trustLevel: null,
+      }),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver,
+      contactService,
+      confidencePipeline,
+    });
+    dispatcher.register();
+
+    return { bus, elevateFn };
+  }
+
+  it('elevates an unknown org-kind sender on inbound', async () => {
+    const { bus, elevateFn } = buildHarness({ tier: 'unknown', kind: 'organization' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'billing@corp.com',
+      content: 'Invoice attached.',
+    }));
+
+    await vi.waitFor(() => expect(elevateFn).toHaveBeenCalledWith('test-contact-id', 'domain-validated'), { timeout: 200 });
+  });
+
+  it('does not elevate when kind is "person"', async () => {
+    const { bus, elevateFn } = buildHarness({ tier: 'unknown', kind: 'person' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    }));
+
+    // Give microtasks time to settle, then assert nothing was called
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'domain-validated');
+  });
+
+  it('does not elevate when org contact is already tier="known"', async () => {
+    const { bus, elevateFn } = buildHarness({ tier: 'known', kind: 'organization' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'billing@corp.com',
+      content: 'Invoice',
+    }));
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'domain-validated');
+  });
+
+  it('silently skips when no contactService configured', async () => {
+    const { bus, elevateFn } = buildHarness({ withContactService: false });
+
+    await expect(bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'billing@corp.com',
+      content: 'Invoice',
+    }))).resolves.not.toThrow();
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('Dispatcher auto-elevation — Path 3 judgment (#951)', () => {
+  function buildHarness(opts: {
+    tier?: import('../../../src/contacts/types.js').ContactTier;
+    kind?: import('../../../src/contacts/types.js').ContactKind;
+    confidence: number;
+    withContactService?: boolean;
+  }) {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const elevateFn = vi.fn().mockResolvedValue(true);
+    const contactService = opts.withContactService === false
+      ? undefined
+      : { elevateTierToKnown: elevateFn } as unknown as ContactService;
+
+    const confidencePipeline = {
+      incrementalUpdate: vi.fn().mockResolvedValue(opts.confidence),
+    } as unknown as ConfidencePipeline;
+
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: true,
+        contactId: 'test-contact-id',
+        displayName: 'Alice',
+        role: null,
+        systemRole: null,
+        status: 'provisional',
+        tier: opts.tier ?? 'unknown',
+        kind: opts.kind ?? 'person',
+        verified: true,
+        kgNodeId: null,
+        knowledgeSummary: '',
+        authorization: null,
+        contactConfidence: 0.0,
+        trustLevel: null,
+      }),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver,
+      contactService,
+      confidencePipeline,
+    });
+    dispatcher.register();
+
+    return { bus, elevateFn };
+  }
+
+  it('elevates when confidence crosses 0.20 threshold', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.22 });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello again',
+    }));
+
+    await vi.waitFor(() => expect(elevateFn).toHaveBeenCalledWith('test-contact-id', 'judgment'), { timeout: 200 });
+  });
+
+  it('does not elevate when confidence is below threshold', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.18 });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    }));
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'judgment');
+  });
+
+  it('does not elevate automated contacts even when confidence >= threshold', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.30, kind: 'automated' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'noreply@example.com',
+      content: 'Your receipt',
+    }));
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'judgment');
+  });
+
+  it('does not elevate when tier is already "known"', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.50, tier: 'known' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    }));
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'judgment');
+  });
+
+  it('silently skips when no contactService configured', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.50, withContactService: false });
+
+    await expect(bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    }))).resolves.not.toThrow();
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test tests/unit/dispatch/dispatcher.test.ts
+```
+
+Expected: compile error — `contactService` is not a property of `DispatcherConfig`.
+
+- [ ] **Step 3: Add import + `contactService` to `DispatcherConfig` in `dispatcher.ts`**
+
+At the top of `src/dispatch/dispatcher.ts`, add after the existing imports:
+
+```typescript
+import { JUDGMENT_ELEVATION_THRESHOLD } from '../contacts/confidence-scorer.js';
+```
+
+In `DispatcherConfig` (around line 71), add after `outboundContextService?`:
+
+```typescript
+  /** Contact service for automatic tier elevation (issue #951).
+   *  When absent, all three elevation paths are silently skipped. */
+  contactService?: import('../contacts/contact-service.js').ContactService;
+```
+
+- [ ] **Step 4: Add `private contactService?` class field and wire in constructor**
+
+In the `Dispatcher` class body (around line 120), add after `_outboundContextService`:
+
+```typescript
+  private contactService?: import('../contacts/contact-service.js').ContactService;
+```
+
+In the constructor (around line 135), add after `this._outboundContextService`:
+
+```typescript
+    this.contactService = config.contactService;
+```
+
+- [ ] **Step 5: Add Paths 2 and 3 in `handleInboundMessage()`**
+
+Replace the existing confidence pipeline fire-and-forget block (around lines 283–287):
+
+```typescript
+// Before (4 lines):
+if (this.confidencePipeline && senderContext.tier !== 'blocked') {
+  const resolvedContactId = senderContext.contactId;
+  this.confidencePipeline.incrementalUpdate(resolvedContactId, { type: 'message_seen' })
+    .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'Confidence pipeline update failed (non-fatal)'));
+}
+```
+
+With:
+
+```typescript
+if (this.confidencePipeline && senderContext.tier !== 'blocked') {
+  const resolvedContactId = senderContext.contactId;
+
+  // Path 2: domain-validated org elevation — fires immediately for org-kind unknown contacts.
+  if (this.contactService && senderContext.kind === 'organization' && senderContext.tier === 'unknown') {
+    const cs = this.contactService;
+    cs.elevateTierToKnown(resolvedContactId, 'domain-validated')
+      .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'domain-validated elevation failed (non-fatal)'));
+  }
+
+  // Path 3: judgment elevation — chains after the confidence update to get the new score.
+  // Capture tier and kind snapshots so the async callback sees pre-message values.
+  const contactService = this.contactService;
+  const snapshotTier = senderContext.tier;
+  const snapshotKind = senderContext.kind;
+  this.confidencePipeline.incrementalUpdate(resolvedContactId, { type: 'message_seen' })
+    .then(newConfidence => {
+      if (
+        contactService &&
+        snapshotTier === 'unknown' &&
+        !isAutomatedKind(snapshotKind) &&
+        newConfidence >= JUDGMENT_ELEVATION_THRESHOLD
+      ) {
+        return contactService.elevateTierToKnown(resolvedContactId, 'judgment');
+      }
+    })
+    .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'Confidence pipeline or judgment elevation failed (non-fatal)'));
+}
+```
+
+- [ ] **Step 6: Run tests to confirm they pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test tests/unit/dispatch/dispatcher.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Run typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 add src/dispatch/dispatcher.ts tests/unit/dispatch/dispatcher.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 commit -m "feat: dispatcher auto-elevation Paths 2 (domain-validated) and 3 (judgment) (#951)"
+```
+
+---
+
+## Task 5: Dispatcher Outbound Path (Path 1 — Correspondence)
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts` — add Path 1 in `handleSkillResult()` (after the existing reply-lock loop)
+- Modify: `tests/unit/dispatch/dispatcher.test.ts` — add describe block for Path 1
+
+**Interfaces:**
+- Consumes: `ContactResolver.resolve()` (already on Dispatcher as private field)
+- Consumes: `ContactService.elevateTierToKnown()` (from Task 3)
+- Consumes: `createSkillResult` from `bus/events.ts` (for test harness)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these imports to the test file if not already present:
+```typescript
+import { createSkillResult, createAgentResponse, type BusEvent } from '../../../src/bus/events.js';
+import type { Logger } from '../../../src/logger.js';
+```
+
+Add a new describe block in `tests/unit/dispatch/dispatcher.test.ts`:
+
+```typescript
+describe('Dispatcher auto-elevation — Path 1 correspondence (#951)', () => {
+  type StubBus = {
+    subscribe: ReturnType<typeof vi.fn>;
+    publish: ReturnType<typeof vi.fn>;
+  };
+
+  function buildHarness(opts: {
+    resolvedContactId?: string | null;
+    withContactService?: boolean;
+  } = {}) {
+    const subscribeHandlers = new Map<string, (event: BusEvent) => void | Promise<void>>();
+    const publishedEvents: BusEvent[] = [];
+
+    const bus = {
+      subscribe: vi.fn((eventType: string, _layer: string, handler: (e: BusEvent) => void | Promise<void>) => {
+        subscribeHandlers.set(eventType, handler);
+      }),
+      publish: vi.fn(async (_layer: string, event: BusEvent) => { publishedEvents.push(event); }),
+    } as unknown as EventBus;
+
+    const logger = {
+      info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+    } as unknown as Logger;
+
+    const elevateFn = vi.fn().mockResolvedValue(true);
+    const contactService = opts.withContactService === false
+      ? undefined
+      : { elevateTierToKnown: elevateFn } as unknown as ContactService;
+
+    const resolvedContactId = opts.resolvedContactId !== undefined ? opts.resolvedContactId : 'contact-abc';
+    const resolveFn = vi.fn().mockResolvedValue(
+      resolvedContactId
+        ? {
+            resolved: true,
+            contactId: resolvedContactId,
+            displayName: 'Test Recipient',
+            role: null, systemRole: null, status: 'provisional',
+            tier: 'unknown', kind: 'person', verified: true,
+            kgNodeId: null, knowledgeSummary: '', authorization: null,
+            contactConfidence: 0.1, trustLevel: null,
+          }
+        : { resolved: false, channel: 'email', senderId: 'unknown@example.com' },
+    );
+    const contactResolver = { resolve: resolveFn } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({ bus, logger, contactResolver, contactService });
+    dispatcher.register();
+
+    return { subscribeHandlers, elevateFn, resolveFn };
+  }
+
+  async function fireSkillResult(
+    subscribeHandlers: Map<string, (event: BusEvent) => void | Promise<void>>,
+    opts: { skillName: string; to: string },
+  ) {
+    const event = createSkillResult({
+      agentId: 'coordinator',
+      conversationId: 'conv-1',
+      skillName: opts.skillName,
+      result: { success: true, data: { message_id: 'msg-1', to: opts.to } },
+      durationMs: 50,
+      parentEventId: 'invoke-1',
+    });
+    const handler = subscribeHandlers.get('skill.result');
+    if (!handler) throw new Error('No skill.result handler registered');
+    await handler(event);
+    // Flush microtasks so fire-and-forget promise chains settle.
+    await new Promise<void>(r => setImmediate(r));
+  }
+
+  it('calls elevateTierToKnown("correspondence") after email-reply to a resolved contact', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness();
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-reply', to: 'recipient@example.com' });
+    expect(elevateFn).toHaveBeenCalledWith('contact-abc', 'correspondence');
+  });
+
+  it('calls elevateTierToKnown("correspondence") after email-send to a resolved contact', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness();
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-send', to: 'someone@example.com' });
+    expect(elevateFn).toHaveBeenCalledWith('contact-abc', 'correspondence');
+  });
+
+  it('calls elevate for each recipient in a comma-separated to field', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness();
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-send', to: 'a@example.com, b@example.com' });
+    // resolve is called for each address
+    expect(elevateFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call elevate when resolver returns no contact', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness({ resolvedContactId: null });
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-reply', to: 'new@example.com' });
+    expect(elevateFn).not.toHaveBeenCalled();
+  });
+
+  it('silently skips when no contactService configured', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness({ withContactService: false });
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-reply', to: 'someone@example.com' });
+    expect(elevateFn).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test tests/unit/dispatch/dispatcher.test.ts
+```
+
+Expected: new tests fail — `elevateFn` is never called.
+
+- [ ] **Step 3: Add Path 1 to `handleSkillResult()`**
+
+In `src/dispatch/dispatcher.ts`, at the end of `handleSkillResult()` after the `if (!matched)` debug block (after line ~755):
+
+```typescript
+    if (!matched) {
+      this.logger.debug(
+        { skillName, conversationId, routingMapSize: this.taskRouting.size },
+        'Dispatcher reply-lock: no routing entry matched skill result — no lock set',
+      );
+    }
+
+    // Path 1: Correspondence elevation — attempt to elevate each outbound recipient
+    // from unknown → known. Fires for all recipients regardless of reply-lock match.
+    // elevateTierToKnown() is a no-op when the contact is already elevated.
+    if (this.contactResolver && this.contactService) {
+      const cr = this.contactResolver;
+      const cs = this.contactService;
+      for (const address of recipients) {
+        cr.resolve('email', address)
+          .then(ctx => {
+            if (ctx.resolved) {
+              return cs.elevateTierToKnown(ctx.contactId, 'correspondence');
+            }
+          })
+          .catch(err => this.logger.warn({ err, address }, 'Correspondence elevation failed (non-fatal)'));
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test tests/unit/dispatch/dispatcher.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 add src/dispatch/dispatcher.ts tests/unit/dispatch/dispatcher.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 commit -m "feat: dispatcher auto-elevation Path 1 (correspondence via email-reply/email-send) (#951)"
+```
+
+---
+
+## Task 6: Wire index.ts + CHANGELOG
+
+**Files:**
+- Modify: `src/index.ts` — add `createContactElevated` import, `onContactElevated` callback in ContactService options, `contactService` in Dispatcher config
+- Modify: `CHANGELOG.md` — add entry under `## [Unreleased]`
+
+**Interfaces:**
+- Consumes: `createContactElevated()` from `bus/events.ts` (Task 2)
+- Consumes: `contactService` in `DispatcherConfig` (Task 4)
+- Consumes: `onContactElevated` in `ContactServiceOptions` (Task 3)
+
+- [ ] **Step 1: Add `createContactElevated` to the import from `bus/events.ts` in `index.ts`**
+
+Find the import line that pulls from `'./bus/events.js'` (it already imports `createContactDuplicateDetected`, `createContactMerged`, etc.) and add `createContactElevated`:
+
+```typescript
+// Before (excerpt):
+import { ..., createContactDuplicateDetected, createContactMerged, ... } from './bus/events.js';
+
+// After: add createContactElevated to the list
+import { ..., createContactDuplicateDetected, createContactMerged, createContactElevated, ... } from './bus/events.js';
+```
+
+- [ ] **Step 2: Add `onContactElevated` callback in the `ContactService.createWithPostgres()` options block**
+
+In `src/index.ts`, inside the `ContactService.createWithPostgres()` call (around line 549), add after `onContactMerged`:
+
+```typescript
+    onContactElevated: (contactId, reason) => {
+      const event = createContactElevated({ contactId, reason });
+      bus.publish('dispatch', event).catch((err: unknown) =>
+        logger.error({ err }, 'Failed to publish contact.elevated — audit trail may be incomplete'),
+      );
+    },
+```
+
+- [ ] **Step 3: Add `contactService` to the `Dispatcher` config block**
+
+In `src/index.ts`, inside the `new Dispatcher({...})` call (around line 1890), add `contactService` alongside `confidencePipeline`:
+
+```typescript
+    confidencePipeline,
+    selfEmail: resolvedEmailAccounts[0]?.selfEmail,
+    outboundContextService,
+    contactService,       // ← add this line
+```
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run test
+```
+
+Expected: all tests PASS (no regressions).
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Add CHANGELOG entry**
+
+In `CHANGELOG.md`, add to the first `### Added` section under `## [Unreleased]`:
+
+```markdown
+- **Auto-elevation** — contacts are automatically promoted from `tier='unknown'` to `tier='known'` via three signal paths: correspondence (outbound email sent to the contact), domain-validated (first inbound from an org-kind contact), and judgment (confidence score crosses the 0.20 threshold). New `contact.elevated` bus event for the audit trail. Automated and agent contacts are excluded at the database layer. (#951)
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 add src/index.ts CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-auto-elevation-951 commit -m "feat: wire contact auto-elevation in bootstrap; add CHANGELOG entry (#951)"
+```
+
+---
+
+## Self-Review Checklist
+
+After completing all tasks, verify coverage against the design spec:
+
+- [ ] **Path 1** (`handleSkillResult` — correspondence): tests and implementation present ✓
+- [ ] **Path 2** (`handleInboundMessage` — domain-validated org): tests and implementation present ✓
+- [ ] **Path 3** (`handleInboundMessage` — judgment threshold): tests and implementation present ✓
+- [ ] **`JUDGMENT_ELEVATION_THRESHOLD`** exported constant: present ✓
+- [ ] **`incrementalUpdate()` returns `Promise<number>`**: change + test present ✓
+- [ ] **`contact.elevated` bus event**: payload, event, union, factory present ✓
+- [ ] **`elevateTierToKnown()`**: backend interface, Postgres backend, InMemory backend, service, callback present ✓
+- [ ] **Wiring in `index.ts`**: `onContactElevated` + `contactService` in dispatcher ✓
+- [ ] **No DB migration**: confirmed — writes only to existing `tier` column ✓
+- [ ] **Automated/agent exclusion**: enforced at DB level in Postgres backend (`AND kind NOT IN ('automated','agent')`) and in-memory backend (explicit guard) ✓
+- [ ] **TOCTOU safety**: `WHERE tier='unknown'` in SQL prevents double-elevation races ✓
+- [ ] **Fire-and-forget safety**: all elevation calls have `.catch()` — failures log at warn level and never throw ✓

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -287,6 +287,13 @@ interface ContactMergedPayload {
   mergedAt: Date;
 }
 
+// contact.elevated — published when a contact is automatically promoted from 'unknown' to 'known'.
+// Fired by ContactService.elevateTierToKnown() on success via the onContactElevated callback.
+interface ContactElevatedPayload {
+  contactId: string;
+  reason: 'correspondence' | 'domain-validated' | 'judgment';
+}
+
 // MessageRejectedPayload — emitted by the dispatch layer when a message is rejected
 // due to an unknown_sender: ignore policy (or a blocked sender). The conversationId
 // is included so the HTTP adapter can immediately resolve the pending response
@@ -691,6 +698,12 @@ export interface ContactMergedEvent extends BaseEvent {
   payload: ContactMergedPayload;
 }
 
+export interface ContactElevatedEvent extends BaseEvent {
+  type: 'contact.elevated';
+  sourceLayer: 'dispatch';
+  payload: ContactElevatedPayload;
+}
+
 export interface MessageRejectedEvent extends BaseEvent {
   type: 'message.rejected';
   sourceLayer: 'dispatch';
@@ -959,6 +972,7 @@ export type BusEvent =
   | ContactUnknownEvent   // Contacts Phase A: sender has no contact record
   | ContactDuplicateDetectedEvent   // Dedup: new contact matches an existing one
   | ContactMergedEvent              // Dedup: two contacts have been merged
+  | ContactElevatedEvent            // #951: automatic tier elevation from unknown → known
   | MessageRejectedEvent  // Unknown sender policy: message rejected, signals HTTP adapter to return 403
   | OutboundBlockedEvent  // Outbound content filter: message blocked before delivery (#38)
   | OutboundDeliveredEvent // Outbound delivery: wire-level send succeeded (#729)
@@ -1295,6 +1309,19 @@ export function createContactMerged(
   };
 }
 
+export function createContactElevated(
+  payload: ContactElevatedPayload & { parentEventId?: string },
+): ContactElevatedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'contact.elevated',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
 
 export function createMessageRejected(
   // parentEventId is required — rejection events must trace back to the inbound event.

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -11,6 +11,8 @@ import type { Layer, EventType } from './events.js';
 //                 system layer gets full access for audit logging and monitoring.
 // Contact Merge: dispatch layer publishes contact.duplicate_detected and contact.merged — these
 //                fire as background side-effects of createContact() when DedupService is wired.
+// #951 (auto-elevation): dispatch layer publishes contact.elevated when a contact's tier is promoted
+//                        from 'unknown' to 'known'; system layer gets full access for audit logging.
 // Bullpen: agent layer publishes agent.discuss; dispatch and system layers subscribe.
 // Checkpoint pipeline: dispatch layer publishes conversation.checkpoint after inactivity;
 //                      system layer's ConversationCheckpointProcessor subscribes to run skills.
@@ -36,10 +38,10 @@ import type { Layer, EventType } from './events.js';
 //          and audit logger subscribe via the system layer.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message', 'channel.poll', 'channel.stalled']),
-  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'autonomy.send_blocked']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'conversation.checkpoint', 'human.decision', 'autonomy.send_blocked']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call', 'context.budget']),
   execution: new Set(['skill.result', 'secret.accessed', 'autonomy.skill_blocked', 'contact.resolved']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
@@ -51,7 +53,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss', 'skill.result']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/contacts/confidence-pipeline.ts
+++ b/src/contacts/confidence-pipeline.ts
@@ -36,21 +36,23 @@ export class ConfidencePipeline {
    *
    * Skips principal contacts (systemRole = 'principal') — their confidence is hardcoded to 1.0
    * in ContactResolver.
+   *
+   * Returns the new confidence value (or 0 if skipped).
    */
-  async incrementalUpdate(contactId: string, signal: ConfidenceSignal): Promise<void> {
+  async incrementalUpdate(contactId: string, signal: ConfidenceSignal): Promise<number> {
     const contact = await this.contactService.getContact(contactId);
     if (!contact) {
       this.logger?.debug({ contactId }, 'confidence-pipeline: contact not found — skipping');
-      return;
+      return 0;
     }
 
     // Skip principal contacts — confidence is hardcoded in ContactResolver
-    if (contact.systemRole === 'principal') return; // Principal confidence is hardcoded in ContactResolver
+    if (contact.systemRole === 'principal') return 1.0; // Principal confidence is hardcoded in ContactResolver
 
     const count = ('count' in signal ? signal.count : undefined) ?? 1;
     if (!Number.isInteger(count) || count < 1) {
       this.logger?.warn({ contactId, count }, 'confidence-pipeline: non-positive or non-integer count — skipping (likely a caller bug)');
-      return;
+      return 0;
     }
 
     // Determine stat deltas based on signal type
@@ -78,7 +80,7 @@ export class ConfidencePipeline {
     const result = await this.contactService.getContactWithIdentities(contactId);
     if (!result) {
       this.logger?.warn({ contactId }, 'confidence-pipeline: getContactWithIdentities returned null after getContact succeeded — possible data inconsistency');
-      return;
+      return 0;
     }
     const { identities } = result;
 
@@ -101,6 +103,7 @@ export class ConfidencePipeline {
       contactConfidence: newConfidence,
       lastSeenAt,
     });
+    return newConfidence;
   }
 
   /**

--- a/src/contacts/confidence-scorer.ts
+++ b/src/contacts/confidence-scorer.ts
@@ -31,6 +31,9 @@ export const MANUAL_BOOST = 0.10;
 /** Max confidence boost from verified identity pairings. Capped at 3 identities. */
 export const PAIRING_BOOST = 0.10;
 
+/** Minimum contact_confidence to trigger automatic tier elevation from 'unknown' to 'known'. */
+export const JUDGMENT_ELEVATION_THRESHOLD = 0.20;
+
 /** Max number of verified identities that contribute to the pairing score. */
 const MAX_PAIRING_IDENTITIES = 3;
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1736,8 +1736,8 @@ class PostgresContactBackend implements ContactServiceBackend {
       `UPDATE contacts
        SET tier = 'known', updated_at = now()
        WHERE id = $1
-         AND tier = 'unknown'
-         AND kind NOT IN ('automated', 'agent')`,
+         AND COALESCE(tier, 'unknown') = 'unknown'
+         AND COALESCE(kind, 'person') NOT IN ('automated', 'agent')`,
       [contactId],
     );
     return (result.rowCount ?? 0) > 0;

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -210,6 +210,13 @@ interface ContactServiceBackend {
    */
   promoteToConfirmed(contactId: string): Promise<boolean>;
 
+  /**
+   * Atomically elevate a contact's tier from 'unknown' to 'known'.
+   * Guards against automated/agent kinds at DB level.
+   * Returns true if the row was updated, false otherwise (already elevated, wrong tier, or excluded kind).
+   */
+  elevateTierToKnown(contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment'): Promise<boolean>;
+
   getAuthOverrides(contactId: string): Promise<Array<{ permission: string; granted: boolean }>>;
   createAuthOverride(override: AuthOverride): Promise<void>;
   revokeAuthOverride(contactId: string, permission: string): Promise<boolean>;
@@ -280,6 +287,7 @@ const AUTO_VERIFIED_SOURCES: ReadonlySet<IdentitySource> = new Set([
 export class ContactService {
   private onContactMerged?: (primaryId: string, secondaryId: string, mergedAt: Date) => void;
   private onIdentityVerified?: (contactId: string) => void;
+  private onContactElevated?: (contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment') => void;
   private dedupService?: DedupService;
   private onDuplicateDetected?: (
     newContactId: string,
@@ -296,6 +304,7 @@ export class ContactService {
   ) {
     this.onContactMerged = options?.onContactMerged;
     this.onIdentityVerified = options?.onIdentityVerified;
+    this.onContactElevated = options?.onContactElevated;
     this.dedupService = options?.dedupService;
     this.onDuplicateDetected = options?.onDuplicateDetected;
   }
@@ -1012,6 +1021,34 @@ export class ContactService {
     return this.backend.promoteToConfirmed(contactId);
   }
 
+  /**
+   * Atomically elevate a contact from tier='unknown' to tier='known'.
+   * No-op for automated/agent kinds (enforced by backend SQL) and contacts already
+   * at known/trusted/principal/blocked. Non-throwing — returns false on error.
+   */
+  async elevateTierToKnown(
+    contactId: string,
+    reason: 'correspondence' | 'domain-validated' | 'judgment',
+  ): Promise<boolean> {
+    try {
+      const elevated = await this.backend.elevateTierToKnown(contactId, reason);
+      if (elevated) {
+        this.logger?.info({ contactId, reason }, 'contacts: tier elevated to known');
+        if (this.onContactElevated) {
+          try {
+            this.onContactElevated(contactId, reason);
+          } catch (callbackErr) {
+            this.logger?.warn({ err: callbackErr }, 'onContactElevated callback threw (non-fatal)');
+          }
+        }
+      }
+      return elevated;
+    } catch (err) {
+      this.logger?.warn({ err, contactId, reason }, 'contacts: elevateTierToKnown failed (non-fatal)');
+      return false;
+    }
+  }
+
   /** Remove a channel identity by its ID. Returns true if found and removed, false if not found. */
   async unlinkIdentity(identityId: string): Promise<boolean> {
     return this.backend.unlinkIdentity(identityId);
@@ -1690,6 +1727,22 @@ class PostgresContactBackend implements ContactServiceBackend {
     return (result.rowCount ?? 0) > 0;
   }
 
+  async elevateTierToKnown(contactId: string, _reason: string): Promise<boolean> {
+    // Atomic conditional: only upgrades tier when it is STILL 'unknown' at write time
+    // AND the contact's kind is not automated or agent.
+    // The reason parameter is accepted for interface compatibility but not written to the
+    // DB here — it is logged at the service layer for the audit trail.
+    const result = await this.pool.query(
+      `UPDATE contacts
+       SET tier = 'known', updated_at = now()
+       WHERE id = $1
+         AND tier = 'unknown'
+         AND kind NOT IN ('automated', 'agent')`,
+      [contactId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
   async setIdentityStatus(identityId: string, status: IdentityStatus): Promise<ChannelIdentity> {
     this.logger.debug({ identityId, status }, 'contacts: updating identity status');
     const result = await this.pool.query<{
@@ -2169,6 +2222,16 @@ class InMemoryContactBackend implements ContactServiceBackend {
     // which by definition have tier='unknown').
     const newTier: ContactTier = contact.tier === 'unknown' ? 'known' : contact.tier;
     this.contacts.set(contactId, { ...contact, status: 'confirmed', tier: newTier, updatedAt: new Date() });
+    return true;
+  }
+
+  async elevateTierToKnown(contactId: string, _reason: string): Promise<boolean> {
+    // JS is single-threaded, so check-and-set is effectively atomic here.
+    // Mirrors the conditional logic of the Postgres implementation.
+    const contact = this.contacts.get(contactId);
+    if (!contact || contact.tier !== 'unknown') return false;
+    if (contact.kind === 'automated' || contact.kind === 'agent') return false;
+    this.contacts.set(contactId, { ...contact, tier: 'known', updatedAt: new Date() });
     return true;
   }
 

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -460,4 +460,7 @@ export interface ContactServiceOptions {
   /** Called when a verified identity is linked — triggers confidence recompute.
    *  May return a Promise; rejections are caught by ContactService (non-fatal). */
   onIdentityVerified?: (contactId: string) => void | Promise<void>;
+  /** Called after a contact's tier is automatically elevated to 'known'.
+   *  Fired with the reason for observability/audit trail. Non-throwing. */
+  onContactElevated?: (contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment') => void;
 }

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -785,6 +785,23 @@ export class Dispatcher {
         'Dispatcher reply-lock: no routing entry matched skill result — no lock set',
       );
     }
+
+    // Path 1: Correspondence elevation — attempt to elevate each outbound recipient
+    // from unknown → known. Fires for all recipients regardless of reply-lock match.
+    // elevateTierToKnown() is a no-op when the contact is already elevated.
+    if (this.contactResolver && this.contactService) {
+      const cr = this.contactResolver;
+      const cs = this.contactService;
+      for (const address of recipients) {
+        cr.resolve('email', address)
+          .then(ctx => {
+            if (ctx.resolved) {
+              return cs.elevateTierToKnown(ctx.contactId, 'correspondence');
+            }
+          })
+          .catch(err => this.logger.warn({ err, address }, 'Correspondence elevation failed (non-fatal)'));
+      }
+    }
   }
 
   private async handleAgentResponse(event: AgentResponseEvent): Promise<void> {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -282,40 +282,47 @@ export class Dispatcher {
               parentEventId: event.id,
             }));
 
-            // Fire-and-forget: update contact confidence for this interaction.
-            // Non-blocking — the trust score for THIS message already used the
-            // stored contactConfidence. This update benefits the NEXT inbound.
-            // Skip blocked contacts — they are being dropped and should not accrue history.
-            // Uses tier for the gate check (issue #945); tier='blocked' == old status='blocked'.
-            if (this.confidencePipeline && senderContext.tier !== 'blocked') {
+            // Auto-elevation paths 2 and 3 — skip blocked contacts entirely.
+            if (senderContext.tier !== 'blocked') {
               const resolvedContactId = senderContext.contactId;
 
-              // Path 2: domain-validated org elevation — fires immediately for org-kind unknown contacts.
-              // Organizations that email us are implicitly domain-validated on first contact; no judgment call needed.
+              // Path 2: domain-validated org elevation — awaited so the unknown-sender gate below
+              // sees the updated tier on the first inbound. Organizations emailing us are implicitly
+              // domain-validated; no confidence score is needed.
               if (this.contactService && senderContext.kind === 'organization' && senderContext.tier === 'unknown') {
                 const cs = this.contactService;
-                cs.elevateTierToKnown(resolvedContactId, 'domain-validated')
-                  .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'domain-validated elevation failed (non-fatal)'));
+                try {
+                  const elevated = await cs.elevateTierToKnown(resolvedContactId, 'domain-validated');
+                  if (elevated) senderContext.tier = 'known';
+                } catch (err) {
+                  this.logger.warn({ err, contactId: resolvedContactId }, 'domain-validated elevation failed (non-fatal)');
+                }
               }
 
-              // Path 3: judgment elevation — chains after the confidence update to get the new score.
-              // Capture tier and kind snapshots so the async callback sees pre-message values;
-              // senderContext may be mutated by the time the promise resolves.
-              const contactService = this.contactService;
-              const snapshotTier = senderContext.tier;
-              const snapshotKind = senderContext.kind;
-              this.confidencePipeline.incrementalUpdate(resolvedContactId, { type: 'message_seen' })
-                .then(newConfidence => {
-                  if (
-                    contactService &&
-                    snapshotTier === 'unknown' &&
-                    !isAutomatedKind(snapshotKind) &&
-                    newConfidence >= JUDGMENT_ELEVATION_THRESHOLD
-                  ) {
-                    return contactService.elevateTierToKnown(resolvedContactId, 'judgment');
+              // Path 3: judgment elevation — fire-and-forget; updates confidence history for the NEXT
+              // inbound. The trust score for THIS message already used the stored contactConfidence.
+              // Capture tier/kind snapshots before the IIFE so it sees pre-message values even if
+              // senderContext is mutated (e.g. by Path 2 above).
+              if (this.confidencePipeline) {
+                const contactService = this.contactService;
+                const snapshotTier = senderContext.tier;
+                const snapshotKind = senderContext.kind;
+                void (async () => {
+                  try {
+                    const newConfidence = await this.confidencePipeline!.incrementalUpdate(resolvedContactId, { type: 'message_seen' });
+                    if (
+                      contactService &&
+                      snapshotTier === 'unknown' &&
+                      !isAutomatedKind(snapshotKind) &&
+                      newConfidence >= JUDGMENT_ELEVATION_THRESHOLD
+                    ) {
+                      await contactService.elevateTierToKnown(resolvedContactId, 'judgment');
+                    }
+                  } catch (err) {
+                    this.logger.warn({ err, contactId: resolvedContactId }, 'Confidence pipeline or judgment elevation failed (non-fatal)');
                   }
-                })
-                .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'Confidence pipeline or judgment elevation failed (non-fatal)'));
+                })();
+              }
             }
 
             // Unknown/blocked contacts gate: applies to tier='unknown' (was: provisional) and
@@ -793,13 +800,16 @@ export class Dispatcher {
       const cr = this.contactResolver;
       const cs = this.contactService;
       for (const address of recipients) {
-        cr.resolve('email', address)
-          .then(ctx => {
+        void (async () => {
+          try {
+            const ctx = await cr.resolve('email', address);
             if (ctx.resolved) {
-              return cs.elevateTierToKnown(ctx.contactId, 'correspondence');
+              await cs.elevateTierToKnown(ctx.contactId, 'correspondence');
             }
-          })
-          .catch(err => this.logger.warn({ err, address }, 'Correspondence elevation failed (non-fatal)'));
+          } catch (err) {
+            this.logger.warn({ err, address }, 'Correspondence elevation failed (non-fatal)');
+          }
+        })();
       }
     }
   }

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -5,6 +5,7 @@ import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy, TaskOriginator } from '../contacts/types.js';
 import { isAutomatedKind } from '../contacts/types.js';
+import { JUDGMENT_ELEVATION_THRESHOLD } from '../contacts/confidence-scorer.js';
 import type { InboundScanner } from './inbound-scanner.js';
 import type { RateLimiter } from './rate-limiter.js';
 import type { DbPool } from '../db/connection.js';
@@ -68,6 +69,9 @@ export interface DispatcherConfig {
   /** Outbound context service — v2 context bridging. When present, replaces
    *  the working-memory-based context memo injection. */
   outboundContextService?: import('./outbound-context.js').OutboundContextService;
+  /** Contact service for automatic tier elevation (issue #951).
+   *  When absent, all elevation paths are silently skipped. */
+  contactService?: import('../contacts/contact-service.js').ContactService;
 }
 
 /**
@@ -118,6 +122,8 @@ export class Dispatcher {
   private selfEmail?: string;
   /** Outbound context service — v2 context bridging (replaces working-memory memo read path). */
   private _outboundContextService?: import('./outbound-context.js').OutboundContextService;
+  /** Contact service for automatic tier elevation (issue #951). */
+  private contactService?: import('../contacts/contact-service.js').ContactService;
 
   constructor(config: DispatcherConfig) {
     this.bus = config.bus;
@@ -133,6 +139,7 @@ export class Dispatcher {
     this.confidencePipeline = config.confidencePipeline;
     this.selfEmail = config.selfEmail;
     this._outboundContextService = config.outboundContextService;
+    this.contactService = config.contactService;
   }
 
   /**
@@ -282,8 +289,33 @@ export class Dispatcher {
             // Uses tier for the gate check (issue #945); tier='blocked' == old status='blocked'.
             if (this.confidencePipeline && senderContext.tier !== 'blocked') {
               const resolvedContactId = senderContext.contactId;
+
+              // Path 2: domain-validated org elevation — fires immediately for org-kind unknown contacts.
+              // Organizations that email us are implicitly domain-validated on first contact; no judgment call needed.
+              if (this.contactService && senderContext.kind === 'organization' && senderContext.tier === 'unknown') {
+                const cs = this.contactService;
+                cs.elevateTierToKnown(resolvedContactId, 'domain-validated')
+                  .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'domain-validated elevation failed (non-fatal)'));
+              }
+
+              // Path 3: judgment elevation — chains after the confidence update to get the new score.
+              // Capture tier and kind snapshots so the async callback sees pre-message values;
+              // senderContext may be mutated by the time the promise resolves.
+              const contactService = this.contactService;
+              const snapshotTier = senderContext.tier;
+              const snapshotKind = senderContext.kind;
               this.confidencePipeline.incrementalUpdate(resolvedContactId, { type: 'message_seen' })
-                .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'Confidence pipeline update failed (non-fatal)'));
+                .then(newConfidence => {
+                  if (
+                    contactService &&
+                    snapshotTier === 'unknown' &&
+                    !isAutomatedKind(snapshotKind) &&
+                    newConfidence >= JUDGMENT_ELEVATION_THRESHOLD
+                  ) {
+                    return contactService.elevateTierToKnown(resolvedContactId, 'judgment');
+                  }
+                })
+                .catch(err => this.logger.warn({ err, contactId: resolvedContactId }, 'Confidence pipeline or judgment elevation failed (non-fatal)'));
             }
 
             // Unknown/blocked contacts gate: applies to tier='unknown' (was: provisional) and

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ import type { ChannelIdentity, Contact } from './contacts/types.js';
 import { ConfidencePipeline } from './contacts/confidence-pipeline.js';
 import { DedupService } from './contacts/dedup-service.js';
 import { ContactResolver } from './contacts/contact-resolver.js';
-import { createContactDuplicateDetected, createContactMerged } from './bus/events.js';
+import { createContactDuplicateDetected, createContactElevated, createContactMerged } from './bus/events.js';
 import { NylasClient } from './channels/email/nylas-client.js';
 import { NylasCalendarClient } from './channels/calendar/nylas-calendar-client.js';
 import { EmailAdapter } from './channels/email/email-adapter.js';
@@ -577,6 +577,12 @@ async function main(): Promise<void> {
       });
       bus.publish('dispatch', event).catch((err: unknown) =>
         logger.error({ err }, 'Failed to publish contact.merged — audit trail may be incomplete'),
+      );
+    },
+    onContactElevated: (contactId, reason) => {
+      const event = createContactElevated({ contactId, reason });
+      bus.publish('dispatch', event).catch((err: unknown) =>
+        logger.error({ err }, 'Failed to publish contact.elevated — audit trail may be incomplete'),
       );
     },
   });
@@ -1899,6 +1905,7 @@ async function main(): Promise<void> {
     trustScorerWeights,
     maxMessageBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
     confidencePipeline,
+    contactService,
     selfEmail: resolvedEmailAccounts[0]?.selfEmail,
     outboundContextService,
   });

--- a/tests/unit/contacts/confidence-pipeline.test.ts
+++ b/tests/unit/contacts/confidence-pipeline.test.ts
@@ -37,6 +37,17 @@ describe('ConfidencePipeline', () => {
       const updated = await service.getContact(contact.id);
       expect(updated!.inboundMessageCount).toBe(15);
     });
+
+    it('returns the updated confidence value', async () => {
+      const contact = await createTestContact();
+      const result = await pipeline.incrementalUpdate(contact.id, { type: 'message_seen' });
+      // message_seen with recency contribution should be > 0
+      expect(typeof result).toBe('number');
+      expect(result).toBeGreaterThan(0);
+      // Must match the stored contactConfidence
+      const updated = await service.getContact(contact.id);
+      expect(result).toBeCloseTo(updated!.contactConfidence);
+    });
   });
 
   describe('incrementalUpdate — message_sent', () => {

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -943,6 +943,7 @@ describe('ContactService', () => {
       expect(result).toBe(true);
 
       const updated = await service.getContact(contact.id);
+      expect(updated).not.toBeNull();
       expect(updated!.tier).toBe('known');
     });
 

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -1,5 +1,5 @@
 // tests/unit/contacts/contact-service.test.ts
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ContactService } from '../../../src/contacts/contact-service.js';
 import type { Contact } from '../../../src/contacts/types.js';
 import { DedupService } from '../../../src/contacts/dedup-service.js';
@@ -926,6 +926,130 @@ describe('ContactService', () => {
       });
       // Normalized to lowercase on write
       expect(updated.primaryEmail).toBe('match@example.com');
+    });
+  });
+
+  describe('elevateTierToKnown', () => {
+    it('promotes an unknown contact to known and returns true', async () => {
+      const contact = await service.createContact({
+        displayName: 'Jane Doe',
+        source: 'email_participant',
+        status: 'provisional',
+      });
+      // provisional → tier='unknown' by default
+      expect(contact.tier).toBe('unknown');
+
+      const result = await service.elevateTierToKnown(contact.id, 'judgment');
+      expect(result).toBe(true);
+
+      const updated = await service.getContact(contact.id);
+      expect(updated!.tier).toBe('known');
+    });
+
+    it('returns false and does not modify a contact already at tier="known"', async () => {
+      const contact = await service.createContact({
+        displayName: 'Jane Doe',
+        source: 'email_participant',
+        status: 'confirmed',
+      });
+      expect(contact.tier).toBe('known');
+
+      const result = await service.elevateTierToKnown(contact.id, 'judgment');
+      expect(result).toBe(false);
+
+      const updated = await service.getContact(contact.id);
+      expect(updated!.tier).toBe('known'); // unchanged
+    });
+
+    it('returns false and does not modify a contact at tier="trusted"', async () => {
+      const contact = await service.createContact({
+        displayName: 'Jane Doe',
+        source: 'email_participant',
+        status: 'confirmed',
+      });
+      await service.setTrustLevel(contact.id, 'high'); // drives tier to 'trusted'
+      const before = await service.getContact(contact.id);
+      expect(before!.tier).toBe('trusted');
+
+      const result = await service.elevateTierToKnown(contact.id, 'judgment');
+      expect(result).toBe(false);
+
+      const updated = await service.getContact(contact.id);
+      expect(updated!.tier).toBe('trusted'); // unchanged
+    });
+
+    it('returns false and does not modify a blocked contact', async () => {
+      const contact = await service.createContact({
+        displayName: 'Jane Doe',
+        source: 'email_participant',
+        status: 'blocked',
+      });
+      expect(contact.tier).toBe('blocked');
+
+      const result = await service.elevateTierToKnown(contact.id, 'correspondence');
+      expect(result).toBe(false);
+
+      const updated = await service.getContact(contact.id);
+      expect(updated!.tier).toBe('blocked'); // unchanged
+    });
+
+    it('returns false for kind="automated" contacts even when tier="unknown"', async () => {
+      const contact = await service.createContact({
+        displayName: 'noreply@example.com',
+        source: 'email_participant',
+        status: 'provisional',
+        kind: 'automated',
+      });
+      expect(contact.tier).toBe('unknown');
+      expect(contact.kind).toBe('automated');
+
+      const result = await service.elevateTierToKnown(contact.id, 'judgment');
+      expect(result).toBe(false);
+
+      const updated = await service.getContact(contact.id);
+      expect(updated!.tier).toBe('unknown'); // unchanged
+    });
+
+    it('returns false for kind="agent" contacts even when tier="unknown"', async () => {
+      const contact = await service.createContact({
+        displayName: 'Specialist Agent',
+        source: 'email_participant',
+        status: 'provisional',
+        kind: 'agent',
+      });
+      const result = await service.elevateTierToKnown(contact.id, 'domain-validated');
+      expect(result).toBe(false);
+    });
+
+    it('fires the onContactElevated callback with contactId and reason', async () => {
+      const onContactElevated = vi.fn();
+      const svc = ContactService.createInMemory(entityMemory, { onContactElevated });
+
+      const contact = await svc.createContact({
+        displayName: 'Callback Test',
+        source: 'email_participant',
+        status: 'provisional',
+      });
+
+      await svc.elevateTierToKnown(contact.id, 'correspondence');
+
+      expect(onContactElevated).toHaveBeenCalledOnce();
+      expect(onContactElevated).toHaveBeenCalledWith(contact.id, 'correspondence');
+    });
+
+    it('does not fire onContactElevated when elevation is a no-op', async () => {
+      const onContactElevated = vi.fn();
+      const svc = ContactService.createInMemory(entityMemory, { onContactElevated });
+
+      const contact = await svc.createContact({
+        displayName: 'Already Known',
+        source: 'email_participant',
+        status: 'confirmed', // already known
+      });
+
+      await svc.elevateTierToKnown(contact.id, 'judgment');
+
+      expect(onContactElevated).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -2,13 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
 import { EventBus } from '../../../src/bus/bus.js';
 import { AgentRuntime } from '../../../src/agents/runtime.js';
-import { createInboundMessage, createAgentError, createAgentTask, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type ContactUnknownEvent } from '../../../src/bus/events.js';
+import { createInboundMessage, createAgentError, createAgentTask, createSkillResult, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type ContactUnknownEvent, type BusEvent } from '../../../src/bus/events.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
 import type { ContactService } from '../../../src/contacts/contact-service.js';
 import type { ConfidencePipeline } from '../../../src/contacts/confidence-pipeline.js';
 import type { InboundSenderContext, ContactStatus, TrustLevel, TaskOriginator, ContactTier, ContactKind } from '../../../src/contacts/types.js';
 import { createLogger } from '../../../src/logger.js';
+import type { Logger } from '../../../src/logger.js';
 
 // Minimal provenance block for all mock LLM responses — satisfies the required field.
 const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model', providerRequestId: 'msg_mock_000' } as const;
@@ -1883,5 +1884,106 @@ describe('Dispatcher — automated sender tier gate bypass (#953)', () => {
     expect(rejected).toHaveLength(0);
     expect(tasks).toHaveLength(1);
     expect(tasks[0]!.payload.senderContext?.kind).toBe('automated');
+  });
+});
+
+describe('Dispatcher auto-elevation — Path 1 correspondence (#951)', () => {
+  type StubBus = {
+    subscribe: ReturnType<typeof vi.fn>;
+    publish: ReturnType<typeof vi.fn>;
+  };
+
+  function buildHarness(opts: {
+    resolvedContactId?: string | null;
+    withContactService?: boolean;
+  } = {}) {
+    const subscribeHandlers = new Map<string, (event: BusEvent) => void | Promise<void>>();
+    const publishedEvents: BusEvent[] = [];
+
+    const bus = {
+      subscribe: vi.fn((eventType: string, _layer: string, handler: (e: BusEvent) => void | Promise<void>) => {
+        subscribeHandlers.set(eventType, handler);
+      }),
+      publish: vi.fn(async (_layer: string, event: BusEvent) => { publishedEvents.push(event); }),
+    } as unknown as EventBus;
+
+    const logger = {
+      info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+    } as unknown as Logger;
+
+    const elevateFn = vi.fn().mockResolvedValue(true);
+    const contactService = opts.withContactService === false
+      ? undefined
+      : { elevateTierToKnown: elevateFn } as unknown as ContactService;
+
+    const resolvedContactId = opts.resolvedContactId !== undefined ? opts.resolvedContactId : 'contact-abc';
+    const resolveFn = vi.fn().mockResolvedValue(
+      resolvedContactId
+        ? {
+            resolved: true,
+            contactId: resolvedContactId,
+            displayName: 'Test Recipient',
+            role: null, systemRole: null, status: 'provisional',
+            tier: 'unknown', kind: 'person', verified: true,
+            kgNodeId: null, knowledgeSummary: '', authorization: null,
+            contactConfidence: 0.1, trustLevel: null,
+          }
+        : { resolved: false, channel: 'email', senderId: 'unknown@example.com' },
+    );
+    const contactResolver = { resolve: resolveFn } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({ bus, logger, contactResolver, contactService });
+    dispatcher.register();
+
+    return { subscribeHandlers, elevateFn, resolveFn };
+  }
+
+  async function fireSkillResult(
+    subscribeHandlers: Map<string, (event: BusEvent) => void | Promise<void>>,
+    opts: { skillName: string; to: string },
+  ) {
+    const event = createSkillResult({
+      agentId: 'coordinator',
+      conversationId: 'conv-1',
+      skillName: opts.skillName,
+      result: { success: true, data: { message_id: 'msg-1', to: opts.to } },
+      durationMs: 50,
+      parentEventId: 'invoke-1',
+    });
+    const handler = subscribeHandlers.get('skill.result');
+    if (!handler) throw new Error('No skill.result handler registered');
+    await handler(event);
+    // Flush microtasks so fire-and-forget promise chains settle.
+    await new Promise<void>(r => setImmediate(r));
+  }
+
+  it('calls elevateTierToKnown("correspondence") after email-reply to a resolved contact', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness();
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-reply', to: 'recipient@example.com' });
+    expect(elevateFn).toHaveBeenCalledWith('contact-abc', 'correspondence');
+  });
+
+  it('calls elevateTierToKnown("correspondence") after email-send to a resolved contact', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness();
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-send', to: 'someone@example.com' });
+    expect(elevateFn).toHaveBeenCalledWith('contact-abc', 'correspondence');
+  });
+
+  it('calls elevate for each recipient in a comma-separated to field', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness();
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-send', to: 'a@example.com, b@example.com' });
+    expect(elevateFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call elevate when resolver returns no contact', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness({ resolvedContactId: null });
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-reply', to: 'new@example.com' });
+    expect(elevateFn).not.toHaveBeenCalled();
+  });
+
+  it('silently skips when no contactService configured', async () => {
+    const { subscribeHandlers, elevateFn } = buildHarness({ withContactService: false });
+    await fireSkillResult(subscribeHandlers, { skillName: 'email-reply', to: 'someone@example.com' });
+    expect(elevateFn).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -5,6 +5,8 @@ import { AgentRuntime } from '../../../src/agents/runtime.js';
 import { createInboundMessage, createAgentError, createAgentTask, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type ContactUnknownEvent } from '../../../src/bus/events.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
+import type { ContactService } from '../../../src/contacts/contact-service.js';
+import type { ConfidencePipeline } from '../../../src/contacts/confidence-pipeline.js';
 import type { InboundSenderContext, ContactStatus, TrustLevel, TaskOriginator, ContactTier, ContactKind } from '../../../src/contacts/types.js';
 import { createLogger } from '../../../src/logger.js';
 
@@ -1573,6 +1575,233 @@ describe('Dispatcher — thread-participants block', () => {
     const content = tasks[0]!.payload.content;
     expect(content).not.toContain('[Thread participants');
     expect(content).toBe('Signal message.');
+  });
+});
+
+describe('Dispatcher auto-elevation — Path 2 domain-validated (#951)', () => {
+  function buildHarness(opts: {
+    tier?: import('../../../src/contacts/types.js').ContactTier;
+    kind?: import('../../../src/contacts/types.js').ContactKind;
+    withContactService?: boolean;
+    confidence?: number;
+  } = {}) {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const elevateFn = vi.fn().mockResolvedValue(true);
+    const contactService = opts.withContactService === false
+      ? undefined
+      : { elevateTierToKnown: elevateFn } as unknown as ContactService;
+
+    const confidencePipeline = {
+      incrementalUpdate: vi.fn().mockResolvedValue(opts.confidence ?? 0.05),
+    } as unknown as ConfidencePipeline;
+
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: true,
+        contactId: 'test-contact-id',
+        displayName: 'Corp Inc',
+        role: null,
+        systemRole: null,
+        status: 'provisional',
+        tier: opts.tier ?? 'unknown',
+        kind: opts.kind ?? 'organization',
+        verified: true,
+        kgNodeId: null,
+        knowledgeSummary: '',
+        authorization: null,
+        contactConfidence: 0.0,
+        trustLevel: null,
+      }),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver,
+      contactService,
+      confidencePipeline,
+    });
+    dispatcher.register();
+
+    return { bus, elevateFn };
+  }
+
+  it('elevates an unknown org-kind sender on inbound', async () => {
+    const { bus, elevateFn } = buildHarness({ tier: 'unknown', kind: 'organization' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'billing@corp.com',
+      content: 'Invoice attached.',
+    }));
+
+    await vi.waitFor(() => expect(elevateFn).toHaveBeenCalledWith('test-contact-id', 'domain-validated'), { timeout: 200 });
+  });
+
+  it('does not elevate when kind is "person"', async () => {
+    const { bus, elevateFn } = buildHarness({ tier: 'unknown', kind: 'person' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    }));
+
+    // Give microtasks time to settle, then assert nothing was called
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'domain-validated');
+  });
+
+  it('does not elevate when org contact is already tier="known"', async () => {
+    const { bus, elevateFn } = buildHarness({ tier: 'known', kind: 'organization' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'billing@corp.com',
+      content: 'Invoice',
+    }));
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'domain-validated');
+  });
+
+  it('silently skips when no contactService configured', async () => {
+    const { bus, elevateFn } = buildHarness({ withContactService: false });
+
+    await expect(bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'billing@corp.com',
+      content: 'Invoice',
+    }))).resolves.not.toThrow();
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('Dispatcher auto-elevation — Path 3 judgment (#951)', () => {
+  function buildHarness(opts: {
+    tier?: import('../../../src/contacts/types.js').ContactTier;
+    kind?: import('../../../src/contacts/types.js').ContactKind;
+    confidence: number;
+    withContactService?: boolean;
+  }) {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const elevateFn = vi.fn().mockResolvedValue(true);
+    const contactService = opts.withContactService === false
+      ? undefined
+      : { elevateTierToKnown: elevateFn } as unknown as ContactService;
+
+    const confidencePipeline = {
+      incrementalUpdate: vi.fn().mockResolvedValue(opts.confidence),
+    } as unknown as ConfidencePipeline;
+
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: true,
+        contactId: 'test-contact-id',
+        displayName: 'Alice',
+        role: null,
+        systemRole: null,
+        status: 'provisional',
+        tier: opts.tier ?? 'unknown',
+        kind: opts.kind ?? 'person',
+        verified: true,
+        kgNodeId: null,
+        knowledgeSummary: '',
+        authorization: null,
+        contactConfidence: 0.0,
+        trustLevel: null,
+      }),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver,
+      contactService,
+      confidencePipeline,
+    });
+    dispatcher.register();
+
+    return { bus, elevateFn };
+  }
+
+  it('elevates when confidence crosses 0.20 threshold', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.22 });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello again',
+    }));
+
+    await vi.waitFor(() => expect(elevateFn).toHaveBeenCalledWith('test-contact-id', 'judgment'), { timeout: 200 });
+  });
+
+  it('does not elevate when confidence is below threshold', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.18 });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    }));
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'judgment');
+  });
+
+  it('does not elevate automated contacts even when confidence >= threshold', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.30, kind: 'automated' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'noreply@example.com',
+      content: 'Your receipt',
+    }));
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'judgment');
+  });
+
+  it('does not elevate when tier is already "known"', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.50, tier: 'known' });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    }));
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'judgment');
+  });
+
+  it('silently skips when no contactService configured', async () => {
+    const { bus, elevateFn } = buildHarness({ confidence: 0.50, withContactService: false });
+
+    await expect(bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    }))).resolves.not.toThrow();
+
+    await new Promise<void>(r => setTimeout(r, 10));
+    expect(elevateFn).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -1652,9 +1652,10 @@ describe('Dispatcher auto-elevation — Path 2 domain-validated (#951)', () => {
       content: 'Hello',
     }));
 
-    // Give microtasks time to settle, then assert nothing was called
-    await new Promise<void>(r => setTimeout(r, 10));
-    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'domain-validated');
+    // Path 2 is awaited; by the time bus.publish resolves, elevation was not attempted.
+    // Flush remaining microtasks (Path 3 fire-and-forget) before asserting.
+    await new Promise<void>(r => setImmediate(r));
+    expect(elevateFn).not.toHaveBeenCalled();
   });
 
   it('does not elevate when org contact is already tier="known"', async () => {
@@ -1667,8 +1668,8 @@ describe('Dispatcher auto-elevation — Path 2 domain-validated (#951)', () => {
       content: 'Invoice',
     }));
 
-    await new Promise<void>(r => setTimeout(r, 10));
-    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'domain-validated');
+    await new Promise<void>(r => setImmediate(r));
+    expect(elevateFn).not.toHaveBeenCalled();
   });
 
   it('silently skips when no contactService configured', async () => {
@@ -1681,7 +1682,7 @@ describe('Dispatcher auto-elevation — Path 2 domain-validated (#951)', () => {
       content: 'Invoice',
     }))).resolves.not.toThrow();
 
-    await new Promise<void>(r => setTimeout(r, 10));
+    await new Promise<void>(r => setImmediate(r));
     expect(elevateFn).not.toHaveBeenCalled();
   });
 });
@@ -1759,8 +1760,8 @@ describe('Dispatcher auto-elevation — Path 3 judgment (#951)', () => {
       content: 'Hello',
     }));
 
-    await new Promise<void>(r => setTimeout(r, 10));
-    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'judgment');
+    await new Promise<void>(r => setImmediate(r));
+    expect(elevateFn).not.toHaveBeenCalled();
   });
 
   it('does not elevate automated contacts even when confidence >= threshold', async () => {
@@ -1773,8 +1774,8 @@ describe('Dispatcher auto-elevation — Path 3 judgment (#951)', () => {
       content: 'Your receipt',
     }));
 
-    await new Promise<void>(r => setTimeout(r, 10));
-    expect(elevateFn).not.toHaveBeenCalledWith(expect.anything(), 'judgment');
+    await new Promise<void>(r => setImmediate(r));
+    expect(elevateFn).not.toHaveBeenCalled();
   });
 
   it('does not elevate when tier is already "known"', async () => {
@@ -1888,11 +1889,6 @@ describe('Dispatcher — automated sender tier gate bypass (#953)', () => {
 });
 
 describe('Dispatcher auto-elevation — Path 1 correspondence (#951)', () => {
-  type StubBus = {
-    subscribe: ReturnType<typeof vi.fn>;
-    publish: ReturnType<typeof vi.fn>;
-  };
-
   function buildHarness(opts: {
     resolvedContactId?: string | null;
     withContactService?: boolean;


### PR DESCRIPTION
## Summary

- Contacts are automatically promoted from `tier='unknown'` to `tier='known'` via three signal paths: **correspondence** (outbound email sent to the contact), **domain-validated** (first inbound from an org-kind contact), and **judgment** (confidence score crosses the 0.20 threshold).
- New `contact.elevated` bus event (with `reason: 'correspondence' | 'domain-validated' | 'judgment'`) provides a full audit trail.
- Automated and agent contacts are excluded at the database layer (`elevateTierToKnown()` checks `kind` before updating).

## Implementation

| Commit | Change |
|--------|--------|
| `d80b6c9` | Export `JUDGMENT_ELEVATION_THRESHOLD`; `incrementalUpdate()` returns `Promise<number>` |
| `9db4de0` | `contact.elevated` bus event type + factory |
| `01e0d4b` | `ContactService.elevateTierToKnown()` |
| `5476fe4` | Dispatcher Paths 2 (domain-validated) + 3 (judgment) in inbound handler |
| `3886fb3` | Dispatcher Path 1 (correspondence) in `handleSkillResult` |
| `53240fd` | Wire `onContactElevated` + `contactService` in bootstrap; CHANGELOG |

## Test plan

- [x] Unit tests for `elevateTierToKnown()` — covers exclusion of automated/agent contacts, idempotent re-elevation, correct tier update
- [x] Unit tests for dispatcher elevation paths (correspondence, domain-validated, judgment threshold)
- [x] `contact.elevated` event shape validated in event factory tests
- [x] Full suite: 3737 tests pass, typecheck clean

Closes #951
