### PR TITLE
fix: fail Gate C closed when an external originator has no resolved tier (#1059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **Gate C fail-closed for unstamped external tiers** — an external originator with no resolved tier now escalates a consequential action instead of bypassing the tier gate; emits a `warn` so the case is observable. (#1059)
 - **CVE-2026-53655 (pnpm bundled tar)** — removed corepack's unused pnpm cache from the production image to eliminate a bundled tar CVE.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
-- **Gate C fail-closed for unstamped external tiers** — an external originator with no resolved tier now escalates a consequential action instead of bypassing the tier gate; emits a `warn` so the case is observable. (#1059)
-- **Dispatcher stamps an `unknown`-tier originator for unresolved inbound senders** — defence in depth so Gate C enforces tier policy even when the channel layer's first-contact creation was skipped, rather than trusting the channel layer to always pre-create the contact. (#1059)
+- **Gate C fail-closed for unstamped external tiers** — an external originator with no resolved tier now escalates instead of bypassing the gate. (#1059)
+- **Dispatcher stamps an `unknown`-tier originator for unresolved inbound senders** — defence in depth so Gate C still enforces tier policy if the channel layer skipped contact creation. (#1059)
 - **CVE-2026-53655 (pnpm bundled tar)** — removed corepack's unused pnpm cache from the production image to eliminate a bundled tar CVE.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 
 - **Gate C fail-closed for unstamped external tiers** — an external originator with no resolved tier now escalates a consequential action instead of bypassing the tier gate; emits a `warn` so the case is observable. (#1059)
+- **Dispatcher stamps an `unknown`-tier originator for unresolved inbound senders** — defence in depth so Gate C enforces tier policy even when the channel layer's first-contact creation was skipped, rather than trusting the channel layer to always pre-create the contact. (#1059)
 - **CVE-2026-53655 (pnpm bundled tar)** — removed corepack's unused pnpm cache from the production image to eliminate a bundled tar CVE.
 
 ### Added

--- a/src/contacts/principal.test.ts
+++ b/src/contacts/principal.test.ts
@@ -28,7 +28,7 @@ describe('getInitiatingTier', () => {
   });
 });
 
-describe('isExternalOriginatorMissingTier (#1059 fail-open detector)', () => {
+describe('isExternalOriginatorMissingTier (#1059 fail-closed trigger)', () => {
   it('is true only when an external originator has no resolved tier', () => {
     expect(isExternalOriginatorMissingTier(meta({ ...baseExternal }))).toBe(true); // tier absent
     expect(isExternalOriginatorMissingTier(meta({ ...baseExternal, tier: null }))).toBe(true);

--- a/src/contacts/principal.ts
+++ b/src/contacts/principal.ts
@@ -69,10 +69,12 @@ export function makeSystemOriginator(): TaskOriginator {
 /**
  * Extract the initiating contact's tier for the execution-layer action gate (issue #950).
  *
- * Returns null (fail-open) when:
- *  - There is no task metadata or no originator
- *  - The originator is system- or agent-originated (no external contact involved)
- *  - The originator predates #950 and carries no tier field
+ * Returns null when:
+ *  - There is no task metadata or no originator — structurally not externally initiated → skip
+ *  - The originator is system- or agent-originated (no external contact involved) → skip
+ *  - The originator is external but carries no tier field (pre-#950 in flight or a stamping
+ *    defect). This null must NOT be read as "skip": the caller pairs it with
+ *    isExternalOriginatorMissingTier() to fail closed instead (#1059).
  *
  * Returns the tier for external-contact-originated tasks. The caller should apply
  * applyActionPolicy() from escalation-policy.ts using the returned tier.
@@ -91,12 +93,12 @@ export function getInitiatingTier(
 
 /**
  * True when a task was initiated by an EXTERNAL contact (not system- or agent-originated)
- * that carries no resolved tier — the Gate C fail-open case tracked in #1059.
+ * that carries no resolved tier — the Gate C fail-closed trigger tracked in #1059.
  *
  * getInitiatingTier() collapses three cases into null (system, agent, and external-with-no-tier);
- * this predicate isolates the third so the execution layer can surface it for observability
- * while the fail-closed remediation (#1059) is pending. It only identifies the case — it does
- * not decide allow/escalate, and the gate's behavior is unchanged.
+ * this predicate isolates the third so the execution layer can fail it closed (escalate) rather
+ * than skip the gate. A totally absent originator returns false here — that case is structurally
+ * internal (e.g. the checkpoint processor) and is intentionally skipped, not escalated.
  */
 export function isExternalOriginatorMissingTier(
   metadata: Record<string, unknown> | undefined,

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -659,13 +659,25 @@ export class Dispatcher {
       }
     }
 
-    // Stamp TaskOriginator on every task — not just principal-originated ones.
-    // The originator tracks who started this task chain. For inbound messages,
-    // that's the sender. For self-initiated tasks (scheduler, proactive), the
-    // caller sets originator before invoking createAgentTask.
-    // SECURITY: originator is the ONLY source of systemRole for downstream
-    // authorization. Channel-supplied originator is stripped in mergeTaskMetadata.
-    const originator: TaskOriginator | undefined = senderContext?.resolved
+    // Stamp TaskOriginator on every inbound task — not just principal-originated ones.
+    // The originator tracks who started this task chain. For inbound messages, that's the
+    // sender. For self-initiated tasks (scheduler, proactive), the caller sets originator
+    // before invoking createAgentTask.
+    //
+    // SECURITY: originator is the ONLY source of systemRole for downstream authorization.
+    // Channel-supplied originator is stripped in mergeTaskMetadata.
+    //
+    // Defence in depth (#1059): inbound messages are external by definition. When the sender
+    // could not be resolved to a contact — the channel adapter's first-contact creation was
+    // skipped (rate caps, a creation failure, a malformed From) or no resolver is wired — we
+    // still stamp an originator with tier='unknown'. The Dispatch layer must not assume the
+    // Channel layer always pre-creates the contact: a missing originator would make the
+    // execution layer's Gate C fail-open (skip) on a consequential action, whereas tier='unknown'
+    // routes it through normal tier enforcement (which escalates third-party-facing sends). No
+    // contact UUID exists, so the raw channel sender id is the contactId sentinel — consistent
+    // with the existing non-UUID originator.contactId values ('system', 'primary-user'); the
+    // skill layer already guards UUID-typed lookups against non-UUID caller ids.
+    const originator: TaskOriginator = senderContext?.resolved
       ? {
           contactId: senderContext.contactId,
           systemRole: senderContext.systemRole ?? null,
@@ -673,12 +685,18 @@ export class Dispatcher {
           initiatedAt: new Date().toISOString(),
           tier: senderContext.tier,
         }
-      : undefined;
-    const originatorMeta = originator ? { originator } : undefined;
-    if (!originator) {
+      : {
+          contactId: payload.senderId,
+          systemRole: null,
+          channel: payload.channelId,
+          initiatedAt: new Date().toISOString(),
+          tier: 'unknown',
+        };
+    const originatorMeta = { originator };
+    if (!senderContext?.resolved) {
       this.logger.warn(
         { channelId: payload.channelId, senderId: payload.senderId },
-        'Dispatcher: dispatching task without TaskOriginator — sender was unresolved; isPrincipalOriginated will return false for this task',
+        'Dispatcher: inbound sender unresolved — stamped unknown-tier originator so Gate C enforces tier policy (#1059); isPrincipalOriginated remains false',
       );
     }
 

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -933,13 +933,39 @@ describe('autonomy gates', () => {
       expect(handler.execute).toHaveBeenCalledOnce();
     });
 
-    it('fails open (allows) when no tier is set on the originator', async () => {
+    it('fails closed (escalates) when an external originator has no resolved tier (#1059)', async () => {
+      // An EXTERNAL contact (systemRole not system/agent) whose tier was never stamped —
+      // a pre-#950 task in flight during a deploy or a dispatcher stamping defect. Gate C
+      // cannot establish the tier it needs, so a consequential action must NOT auto-execute:
+      // it fails closed (escalates) instead of bypassing tier enforcement entirely.
       const { registry, layer } = makeLayerWithScore100();
-      const handler = makeHandler('ok');
+      const handler = makeHandler('should not run');
       registry.register(makeRiskyManifest('email-reply', 'medium'), handler);
 
-      // Originator without tier field (pre-#950 or agent-originated)
       const result = await layer.invoke('email-reply', {}, undefined, {
+        taskMetadata: {
+          originator: {
+            contactId: 'contact-xyz',
+            systemRole: null,
+            channel: 'email',
+            initiatedAt: new Date().toISOString(),
+            // no tier
+          },
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(handler.execute).not.toHaveBeenCalled();
+    });
+
+    it('still allows a none-risk skill from an external originator with no resolved tier (#1059)', async () => {
+      // The fail-closed path is gated on a consequential action. A read-only (none) skill
+      // has no external effect, so a missing tier never escalates it.
+      const { registry, layer } = makeLayerWithScore100();
+      const handler = makeHandler('ok');
+      registry.register(makeRiskyManifest('search-docs', 'none'), handler);
+
+      const result = await layer.invoke('search-docs', {}, undefined, {
         taskMetadata: {
           originator: {
             contactId: 'contact-xyz',
@@ -955,7 +981,41 @@ describe('autonomy gates', () => {
       expect(handler.execute).toHaveBeenCalledOnce();
     });
 
-    it('fails open (allows) when there is no originator in task metadata', async () => {
+    it('emits a warn with skill name and action_risk on the fail-closed path (#1059)', async () => {
+      // The unstamped-tier external task must be observable, not silent.
+      const warn = vi.fn();
+      const spyLogger = {
+        ...logger,
+        child: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+      } as unknown as typeof logger;
+      const registry = new SkillRegistry();
+      const layer = new ExecutionLayer(registry, spyLogger, { autonomyService: makeAutonomyService(100) });
+      registry.register(makeRiskyManifest('email-send', 'medium'), makeHandler('should not run'));
+
+      await layer.invoke('email-send', {}, undefined, {
+        taskMetadata: {
+          originator: {
+            contactId: 'contact-xyz',
+            systemRole: null,
+            channel: 'email',
+            initiatedAt: new Date().toISOString(),
+            // no tier
+          },
+        },
+      });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({ skillName: 'email-send', actionRisk: 'medium' }),
+        expect.stringContaining('failing closed'),
+      );
+    });
+
+    it('skips Gate C when there is no originator in task metadata (structurally internal, #1059)', async () => {
+      // A task with NO originator never came through the dispatcher's external-task path —
+      // e.g. the checkpoint processor invoking extract-facts directly. There is no external
+      // contact to gate, so Gate C is skipped. Failing closed here would break legitimate
+      // system-internal invocations (low/medium-risk KG writes) with zero security benefit,
+      // because an absent originator structurally rules out an external initiator.
       const { registry, layer } = makeLayerWithScore100();
       const handler = makeHandler('ok');
       registry.register(makeRiskyManifest('email-reply', 'medium'), handler);

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -742,11 +742,18 @@ export class ExecutionLayer {
             // established, so the action must NOT auto-execute: escalate rather than bypassing
             // tier enforcement entirely (which would defeat the escalation judge wired in #1057).
             // The warn keeps the unstamped-tier task observable instead of silently escalating.
+            // originatorContactId is hoisted out as a flat field (in addition to the full
+            // originator object) so operators can aggregate this warn by contact when sizing
+            // how often the unstamped-tier gap is hit.
+            const failedOriginator = options?.taskMetadata?.['originator'] as
+              | { contactId?: string }
+              | undefined;
             skillLogger.warn(
               {
                 skillName,
                 actionRisk: manifest.action_risk,
                 originator: options?.taskMetadata?.['originator'],
+                originatorContactId: failedOriginator?.contactId,
                 agentId: options?.agentId,
                 taskEventId: options?.taskEventId,
               },

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -708,8 +708,11 @@ export class ExecutionLayer {
 
           // Gate C: Contact-tier gate — consequential actions from lower-tier contacts
           // escalate instead of auto-executing, even when the autonomy score permits them.
-          // Principal bypass is already handled above. Fail-open when the initiating tier
-          // is unavailable (system/agent tasks, pre-#950 stored originators).
+          // Principal bypass is already handled above. System/agent tasks and tasks with no
+          // originator at all skip the gate (structurally not externally initiated — e.g. the
+          // checkpoint processor invoking extract-facts with no task metadata). An EXTERNAL
+          // originator that carries no resolved tier instead FAILS CLOSED (#1059) — see the
+          // else-if below — because we cannot establish the tier the gate needs.
           const initiatingTier = getInitiatingTier(options?.taskMetadata);
           if (initiatingTier !== null && manifest.action_risk !== 'none') {
             const actionClass = mapActionRiskToConsequenceClass(manifest.action_risk);
@@ -733,10 +736,12 @@ export class ExecutionLayer {
             manifest.action_risk !== 'none' &&
             isExternalOriginatorMissingTier(options?.taskMetadata)
           ) {
-            // Fail-open observability (#1059): an external contact drove a consequential action
-            // but carries no resolved tier, so Gate C is skipped. Behavior is unchanged — the
-            // action is still allowed — but this warn makes the silent skip visible until #1059
-            // fails it closed. Operators can grep this to size how often the gap is hit in prod.
+            // Fail-closed (#1059): an external contact (systemRole not system/agent) drove a
+            // consequential action but carries no resolved tier — a pre-#950 task in flight
+            // during a deploy or a dispatcher stamping defect. The tier Gate C needs cannot be
+            // established, so the action must NOT auto-execute: escalate rather than bypassing
+            // tier enforcement entirely (which would defeat the escalation judge wired in #1057).
+            // The warn keeps the unstamped-tier task observable instead of silently escalating.
             skillLogger.warn(
               {
                 skillName,
@@ -745,8 +750,17 @@ export class ExecutionLayer {
                 agentId: options?.agentId,
                 taskEventId: options?.taskEventId,
               },
-              'autonomy gate: Gate C skipped — external originator has no resolved tier (fail-open, see #1059)',
+              'autonomy gate: skill blocked — external originator has no resolved tier, failing closed (Gate C, see #1059)',
             );
+            // No tier to feed buildTierGateError — pass an explicit sentinel label so the
+            // escalation message and approval request read sensibly (tier 'unresolved').
+            const gateCError = await this.buildTierGateError(
+              skillName, input, 'unresolved', manifest.action_risk, currentScore, options, skillLogger,
+            );
+            return {
+              success: false,
+              error: this.wrapSkillError(gateCError),
+            };
           }
         }
       } else {

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -1424,6 +1424,44 @@ describe('originator metadata stamping', () => {
     expect(originator!.contactId).not.toBe('forged-id');
   });
 
+  it('stamps an unknown-tier originator for an unresolved inbound sender (#1059 defense-in-depth)', async () => {
+    // The Dispatch layer must not assume the Channel layer always pre-creates the contact.
+    // When the sender is unresolved (the adapter's first-contact creation was skipped — rate
+    // caps, a creation failure, or a malformed From), the dispatcher still stamps an originator
+    // with tier='unknown' so the execution layer's Gate C enforces tier policy on consequential
+    // actions instead of fail-open skipping a missing originator. Inbound is external by definition.
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const resolver = makeResolverWithNoContact();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: resolver,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow', threaded: true } },
+    });
+    dispatcher.register();
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => { tasks.push(e as AgentTaskEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-unresolved-originator',
+      channelId: 'email',
+      senderId: 'stranger@example.com',
+      content: 'Please book a meeting on the CEO calendar',
+    }));
+
+    expect(tasks).toHaveLength(1);
+    const originator = tasks[0]!.payload.metadata?.originator as TaskOriginator | undefined;
+    expect(originator).toBeDefined();
+    expect(originator!.tier).toBe('unknown');
+    expect(originator!.systemRole).toBeNull();
+    // No contact UUID exists for an unresolved sender — the channel sender id is the sentinel.
+    expect(originator!.contactId).toBe('stranger@example.com');
+    expect(originator!.channel).toBe('email');
+  });
+
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1059.

Gate C (the contact-tier enforcement gate in `src/skills/execution.ts`) previously **failed open** whenever `getInitiatingTier()` returned `null`. That `null` collapses three distinct cases — and one of them is an **external** contact whose `tier` was never stamped (a pre-#950 task in flight during a deploy, or a dispatcher stamping defect). For that case, a consequential action (`email-send`, `signal-send`, …) auto-executed with **no tier gate at all**, defeating the escalation judge wired in #1057.

This change distinguishes *structurally-not-external* from *external-with-missing-tier*:

- `systemRole === 'system' | 'agent'` → **skip** (unchanged, safe — no external contact).
- Task with **no originator at all** → **skip** (structurally internal; see decision note below).
- **External** originator (`systemRole` not system/agent) with `tier == null` and `action_risk !== 'none'` → **fail closed**: escalate via the existing tier-gate error path (creates an approval request when wired) and the handler does not run.
- `action_risk === 'none'` → still allowed (no external effect to gate).

The fail-closed path emits a structured `warn` (`skillName`, `actionRisk`, `originatorContactId`, full `originator`, `agentId`, `taskEventId`) so an unstamped-tier external task is observable rather than silent.

## "No originator" decision (documented per the issue's AC)

A task with no originator continues to **skip** Gate C. The only `invoke` callers are the agent runtime (always threads task metadata) and the checkpoint processor, which invokes `extract-facts`/`extract-relationships` (`low` risk) with **no** metadata. Failing closed on no-originator would block legitimate internal KG writes with zero security benefit. "Metadata present but no originator" is also not reliably external — the bullpen dispatcher creates internal inter-agent tasks that omit the originator — so an absent originator is treated as structurally internal at this layer.

## Residual fail-open (pre-existing, out of scope, follow-up filed)

Pre-PR review surfaced that the dispatcher only stamps an originator when `senderContext.resolved` is true, so a **truly unresolved external sender** dispatches a task with metadata but no originator and reaches Gate C as "no originator" → skipped. This is pre-existing and can only be fixed **upstream at the dispatcher** (Gate C can't tell an unresolved sender from an internal bullpen task). Tracked separately.

## Rollout

#1057 only just started deploying and is not yet in production, so there's no live incidence data to query (per the issue's measurement step). The path is reachable only by transient pre-#950 in-flight tasks (drain after deploy) or a stamping defect (which we want surfaced, not tolerated), so a direct flip is correct; a warn-only staging window would only delay closing a known hole.

## Testing

- `pnpm run typecheck` — clean.
- `src/skills/execution.test.ts` + `src/contacts/principal.test.ts` — 86 pass. Inverted the external-missing-tier fail-open test to assert fail-closed; added none-risk-allowed, warn-emission, and no-originator-skip tests; retained explicit system/agent skip tests.
- Full unit suite passes (one DB-integration test mislocated under `tests/unit/` requires `DATABASE_URL` and is unrelated — flagged below).

## Notes / tech debt spotted (not touched)

- `tests/unit/autonomy/autonomy-service-pagination.test.ts` requires a live `DATABASE_URL` despite living under `tests/unit/` — it's effectively an integration test and fails without Postgres. Worth relocating to `tests/integration/`.
---

## Update: dispatcher defence-in-depth folded in

A deeper trace (prompted by review) surfaced that the *everyday* brand-new-sender case is already handled — the channel adapter pre-creates the sender's contact with `tier='unknown'` ([email-adapter.ts:434-440](src/channels/email/email-adapter.ts#L434-L440)) before dispatch, so Gate C escalates correctly. But the Dispatch layer should not *assume* the Channel layer always does this: contact creation is skipped when the adapter's rate caps are hit, creation fails, or the From is malformed. In those degraded cases the sender reached dispatch unresolved → no originator → Gate C skipped.

So the dispatcher now **always stamps an originator** for inbound messages ([dispatcher.ts:668](src/dispatch/dispatcher.ts#L668)): resolved → real tier; unresolved → `{ contactId: senderId, systemRole: null, tier: 'unknown' }`. An `unknown`-tier originator flows through Gate C's *normal* path (which escalates consequential third-party actions), so the gap closes even when the channel layer didn't pre-create the contact. This also makes "no originator at all ⇒ structurally internal" finally airtight.

Reviewed for blast radius (always-present originator + non-UUID `ctx.caller.contactId`): the elevated-skill gate still blocks unresolved senders (`systemRole: null`), and every consumer of a non-UUID caller id is guarded (`UUID_RE` checks; the entity-context assembler catches Postgres `22P02`; audit columns are `TEXT`). No regressions.

New test: `tests/unit/dispatch/dispatcher.test.ts` — "stamps an unknown-tier originator for an unresolved inbound sender". Full unit suite green.