### PR TITLE
feat: migrate Contacts UI and PATCH API to native tier/kind editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Console Contacts: tier/kind editing** — the admin Contacts page now edits `tier` and `kind` directly; Status and Trust-level controls are removed. List view filters, sorts, and displays by tier + kind facet. (#1055)
+- **PATCH/POST `/api/kg/contacts` accept `tier` and `kind`** — validated against the migration-055 enums with structural guards rejecting `tier='principal'` and `kind ∈ {principal, agent}`. Principal contacts cannot be demoted via the API. (#1055)
+- **Atomic PATCH mutations** — all non-legacy mutations in `PATCH /api/kg/contacts/:id` now run in a single DB transaction; partial failures roll back cleanly. (#1055)
+
 - **Auto-elevation** — contacts auto-promote from `unknown` to `known` via correspondence, domain, and judgment signals. (#951)
 - **Action gate: contact-tier enforcement (Gate C)** — consequential actions from lower-tier contacts escalate unless the initiating tier permits them. (#950)
 - **`tier` on `TaskOriginator`** — dispatcher stamps the initiating contact's tier for Gate C enforcement. (#950)

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -153,11 +153,9 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
     setSaving(true);
     setError(null);
     try {
-      const body = {
+      const body: Record<string, unknown> = {
         displayName: displayName.trim(),
         role: role.trim() || null,
-        tier,
-        kind,
         notes: notes.trim() || null,
         kgNodeId: kgNodeId.trim() || null,
         // Canonical fields
@@ -174,6 +172,15 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
         bio: bio.trim() || null,
         birthday: birthday.trim() || null,
       };
+      // Tier is user-settable for all contacts except the principal (whose tier is structural).
+      // Kind is user-settable only for non-system contacts; principal and agent contacts have
+      // structural kinds ('principal' and 'agent') that the API rejects as invalid values.
+      if (creating || contact?.systemRole !== 'principal') {
+        body.tier = tier;
+      }
+      if (creating || (contact?.systemRole !== 'principal' && contact?.systemRole !== 'agent')) {
+        body.kind = kind;
+      }
 
       let res: Response;
       if (creating) {

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -7,19 +7,28 @@ import { useTheme } from '../hooks/useTheme.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type ContactStatus = 'confirmed' | 'provisional' | 'blocked';
-type TrustLevel = 'ceo' | 'high' | 'medium' | 'low' | null;
+type ContactTier = 'blocked' | 'unknown' | 'known' | 'trusted' | 'principal';
+type ContactKind = 'person' | 'organization' | 'automated' | 'principal' | 'agent';
 type SystemRole = 'principal' | 'agent' | 'system' | null;
+
+// Numeric rank for tier-aware sorting (ascending capability).
+const TIER_ORDER: Record<ContactTier, number> = {
+  blocked: 0, unknown: 1, known: 2, trusted: 3, principal: 4,
+};
 
 interface Contact {
   id: string;
   kgNodeId: string | null;
   displayName: string;
   role: string | null;
-  status: ContactStatus;
-  notes: string | null;
-  trustLevel: TrustLevel;
+  // Legacy columns — kept until #955 drops them.
+  status: string;
+  trustLevel: string | null;
+  // Capability axis (migration 055).
+  tier: ContactTier;
+  kind: ContactKind;
   systemRole: SystemRole;
+  notes: string | null;
   createdAt: string;
   updatedAt: string;
   // Canonical fields (migration 048)
@@ -116,8 +125,8 @@ interface DrawerProps {
 function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: DrawerProps) {
   const [displayName, setDisplayName] = useState(contact?.displayName ?? '');
   const [role, setRole] = useState(contact?.role ?? '');
-  const [status, setStatus] = useState<ContactStatus>(contact?.status ?? 'provisional');
-  const [trustLevel, setTrustLevel] = useState<TrustLevel>(contact?.trustLevel ?? null);
+  const [tier, setTier] = useState<ContactTier>(contact?.tier ?? 'unknown');
+  const [kind, setKind] = useState<ContactKind>(contact?.kind ?? 'person');
   const [kgNodeId, setKgNodeId] = useState(contact?.kgNodeId ?? '');
   const [notes, setNotes] = useState(contact?.notes ?? '');
   const [preferredName, setPreferredName] = useState(contact?.preferredName ?? '');
@@ -147,8 +156,8 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
       const body = {
         displayName: displayName.trim(),
         role: role.trim() || null,
-        status,
-        trustLevel: trustLevel ?? null,
+        tier,
+        kind,
         notes: notes.trim() || null,
         kgNodeId: kgNodeId.trim() || null,
         // Canonical fields
@@ -315,21 +324,35 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
           <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>System</p>
           <div className="form-grid">
             <div className="form-field">
-              <label htmlFor="cf-status">Status</label>
-              <select id="cf-status" value={status} onChange={e => setStatus(e.target.value as ContactStatus)}>
-                <option value="confirmed">Confirmed</option>
-                <option value="provisional">Provisional</option>
+              <label htmlFor="cf-tier">Tier</label>
+              <select
+                id="cf-tier"
+                value={tier}
+                onChange={e => setTier(e.target.value as ContactTier)}
+                disabled={contact?.systemRole === 'principal'}
+                title={contact?.systemRole === 'principal' ? 'The principal contact\'s tier is fixed' : undefined}
+              >
                 <option value="blocked">Blocked</option>
+                <option value="unknown">Unknown</option>
+                <option value="known">Known</option>
+                <option value="trusted">Trusted</option>
+                {contact?.systemRole === 'principal' && <option value="principal">Principal</option>}
               </select>
             </div>
             <div className="form-field">
-              <label htmlFor="cf-trust">Trust level</label>
-              <select id="cf-trust" value={trustLevel ?? ''} onChange={e => setTrustLevel((e.target.value || null) as TrustLevel)}>
-                <option value="">None</option>
-                <option value="ceo">CEO</option>
-                <option value="high">High</option>
-                <option value="medium">Medium</option>
-                <option value="low">Low</option>
+              <label htmlFor="cf-kind">Kind</label>
+              <select
+                id="cf-kind"
+                value={kind}
+                onChange={e => setKind(e.target.value as ContactKind)}
+                disabled={contact?.systemRole === 'principal' || contact?.systemRole === 'agent'}
+                title={contact?.systemRole ? 'System contacts\' kind is fixed' : undefined}
+              >
+                <option value="person">Person</option>
+                <option value="organization">Organization</option>
+                <option value="automated">Automated</option>
+                {contact?.systemRole === 'principal' && <option value="principal">Principal</option>}
+                {contact?.systemRole === 'agent' && <option value="agent">Agent</option>}
               </select>
             </div>
           </div>
@@ -374,8 +397,9 @@ export default function ContactsPage() {
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<'all' | ContactStatus>('confirmed');
-  const [sort, setSort] = useState<{ key: keyof Contact; dir: 'asc' | 'desc' }>({ key: 'updatedAt', dir: 'desc' });
+  const [tierFilter, setTierFilter] = useState<'all' | ContactTier>('all');
+  const [kindFilter, setKindFilter] = useState<'all' | ContactKind>('all');
+  const [sort, setSort] = useState<{ key: keyof Contact; dir: 'asc' | 'desc' }>({ key: 'tier', dir: 'desc' });
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [editing, setEditing] = useState<Contact | null>(null);
@@ -400,15 +424,22 @@ export default function ContactsPage() {
   useEffect(() => { void load(); }, [load]);
 
   const counts = useMemo(() => ({
-    all:         contacts.length,
-    confirmed:   contacts.filter(c => c.status === 'confirmed').length,
-    provisional: contacts.filter(c => c.status === 'provisional').length,
-    blocked:     contacts.filter(c => c.status === 'blocked').length,
+    allTiers:     contacts.length,
+    blocked:      contacts.filter(c => c.tier === 'blocked').length,
+    unknown:      contacts.filter(c => c.tier === 'unknown').length,
+    known:        contacts.filter(c => c.tier === 'known').length,
+    trusted:      contacts.filter(c => c.tier === 'trusted').length,
+    principal:    contacts.filter(c => c.tier === 'principal').length,
+    allKinds:     contacts.length,
+    person:       contacts.filter(c => c.kind === 'person').length,
+    organization: contacts.filter(c => c.kind === 'organization').length,
+    automated:    contacts.filter(c => c.kind === 'automated').length,
   }), [contacts]);
 
   const filtered = useMemo(() => {
     let rows = contacts;
-    if (statusFilter !== 'all') rows = rows.filter(c => c.status === statusFilter);
+    if (tierFilter !== 'all') rows = rows.filter(c => c.tier === tierFilter);
+    if (kindFilter !== 'all') rows = rows.filter(c => c.kind === kindFilter);
     if (search) {
       const q = search.toLowerCase();
       rows = rows.filter(c =>
@@ -417,6 +448,9 @@ export default function ContactsPage() {
     }
     const dir = sort.dir === 'asc' ? 1 : -1;
     rows = [...rows].sort((a, b) => {
+      if (sort.key === 'tier') {
+        return ((TIER_ORDER[a.tier] ?? 0) - (TIER_ORDER[b.tier] ?? 0)) * dir;
+      }
       const av = (a[sort.key] ?? '') as string;
       const bv = (b[sort.key] ?? '') as string;
       if (av < bv) return -1 * dir;
@@ -424,7 +458,7 @@ export default function ContactsPage() {
       return 0;
     });
     return rows;
-  }, [contacts, statusFilter, search, sort]);
+  }, [contacts, tierFilter, kindFilter, search, sort]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const safePage = Math.min(page, totalPages);
@@ -445,8 +479,8 @@ export default function ContactsPage() {
         next[idx] = contact;
         return next;
       }
-      // New contact: switch filter so it's immediately visible.
-      setStatusFilter(contact.status);
+      // New contact: switch tier filter so it's immediately visible.
+      setTierFilter(contact.tier);
       return [...prev, contact];
     });
     setEditing(contact);
@@ -502,15 +536,28 @@ export default function ContactsPage() {
 
               <div className="records-toolbar">
                 <div className="records-toolbar-left">
-                  {(['all', 'confirmed', 'provisional', 'blocked'] as const).map(v => (
+                  {([['all', 'All', counts.allTiers], ['blocked', 'Blocked', counts.blocked], ['unknown', 'Unknown', counts.unknown], ['known', 'Known', counts.known], ['trusted', 'Trusted', counts.trusted]] as const).map(([v, label, count]) => (
                     <button
                       key={v}
-                      className={`records-filter-chip${statusFilter === v ? ' active' : ''}`}
-                      onClick={() => { setStatusFilter(v); setPage(1); }}
+                      className={`records-filter-chip${tierFilter === v ? ' active' : ''}`}
+                      onClick={() => { setTierFilter(v); setPage(1); }}
                     >
-                      {v === 'all' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+                      {label}
                       <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
-                        {counts[v]}
+                        {count}
+                      </span>
+                    </button>
+                  ))}
+                  <span style={{ borderLeft: '1px solid var(--app-border)', margin: '0 4px', height: 16, display: 'inline-block', verticalAlign: 'middle' }} />
+                  {([['all', 'All kinds', counts.allKinds], ['person', 'Person', counts.person], ['organization', 'Org', counts.organization], ['automated', 'Auto', counts.automated]] as const).map(([v, label, count]) => (
+                    <button
+                      key={v}
+                      className={`records-filter-chip${kindFilter === v ? ' active' : ''}`}
+                      onClick={() => { setKindFilter(v); setPage(1); }}
+                    >
+                      {label}
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+                        {count}
                       </span>
                     </button>
                   ))}
@@ -541,11 +588,12 @@ export default function ContactsPage() {
                               Org <span className="sort-arrow">{sortArrow('organization')}</span>
                             </button>
                           </th>
-                          <th className="sortable" aria-sort={sort.key === 'status' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-                            <button className="sort-btn" onClick={() => toggleSort('status')}>
-                              Status <span className="sort-arrow">{sortArrow('status')}</span>
+                          <th className="sortable" aria-sort={sort.key === 'tier' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('tier')}>
+                              Tier <span className="sort-arrow">{sortArrow('tier')}</span>
                             </button>
                           </th>
+                          <th>Kind</th>
                           <th className="sortable col-updated" aria-sort={sort.key === 'updatedAt' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
                             <button className="sort-btn" onClick={() => toggleSort('updatedAt')}>
                               Updated <span className="sort-arrow">{sortArrow('updatedAt')}</span>
@@ -575,7 +623,8 @@ export default function ContactsPage() {
                             </td>
                             <td>{c.title ?? ''}</td>
                             <td>{c.organization ?? ''}</td>
-                            <td><span className={`status-pill ${c.status}`}>{c.status}</span></td>
+                            <td><span className={`status-pill tier-${c.tier}`}>{c.tier}</span></td>
+                            <td style={{ fontSize: 12, color: 'var(--app-fg-muted)' }}>{c.kind}</td>
                             <td className="cell-mono col-updated">{formatDate(c.updatedAt)}</td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>
@@ -594,7 +643,7 @@ export default function ContactsPage() {
                         ))}
                         {pageRows.length === 0 && (
                           <tr>
-                            <td colSpan={6} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                            <td colSpan={7} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
                               No contacts match.
                             </td>
                           </tr>

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -899,20 +899,24 @@ export async function knowledgeGraphRoutes(
     if (typeof body.trustLevel === 'string') {
       await contactService.setTrustLevel(created.id, body.trustLevel as TrustLevel);
     }
-    // Apply tier/kind overrides if provided — these take precedence over status/trustLevel-derived values.
-    if (typeof body.tier === 'string') {
-      await contactService.setTier(created.id, body.tier as ContactTier);
-    }
-    if (typeof body.kind === 'string') {
-      await contactService.setKind(created.id, body.kind as ContactKind);
-    }
 
-    const freshCreated = await contactService.getContact(created.id);
+    // Read back after create + trustLevel so the post-derivation tier is the base
+    // for any tier/kind override below.
+    let freshCreated = await contactService.getContact(created.id);
     if (!freshCreated) {
       // Should never happen — contact was just created — but guard rather than return stale data.
       logger.error({ contactId: created.id }, 'POST /api/kg/contacts: contact not found after creation');
       return reply.status(500).send({ error: 'Contact created but could not be retrieved.' });
     }
+
+    // Apply tier/kind overrides atomically — one write prevents partial state if either fails.
+    if (typeof body.tier === 'string' || typeof body.kind === 'string') {
+      let enriched: Contact = { ...freshCreated, updatedAt: new Date() };
+      if (typeof body.tier === 'string') enriched = { ...enriched, tier: body.tier as ContactTier };
+      if (typeof body.kind === 'string') enriched = { ...enriched, kind: body.kind as ContactKind };
+      freshCreated = await contactService.saveContact(enriched);
+    }
+
     return reply.status(201).send({
       contact: serializeContact(freshCreated),
     });
@@ -993,11 +997,28 @@ export async function knowledgeGraphRoutes(
       }
     }
 
-    // Build the complete updated contact in memory from the pre-validation snapshot.
-    // All per-field setters read the contact non-transactionally, so calling them in
-    // sequence causes each write to clobber earlier changes with stale data. Assembling
-    // the full pending object here and writing once avoids that race.
-    let pending: Contact = { ...contact, updatedAt: new Date() };
+    // Legacy setStatus / setTrustLevel are not transaction-aware (retired in #955).
+    // Run them first: they carry tier-derivation side-effects (setStatus → newTier,
+    // setTrustLevel → newTier) that must be captured before building `pending`.
+    if (typeof body.status === 'string') {
+      await contactService.setStatus(id, body.status as ContactStatus);
+    }
+    if ('trustLevel' in body) {
+      await contactService.setTrustLevel(id, (body.trustLevel as TrustLevel | null));
+    }
+
+    // Re-read after legacy mutations if any ran so that tier/status/trustLevel
+    // derivations from setStatus / setTrustLevel are reflected in the pending base.
+    // Without this, saveContact would overwrite the legacy-mutation writes with
+    // stale values from the pre-mutation `contact` snapshot.
+    const base: Contact = (typeof body.status === 'string' || 'trustLevel' in body)
+      ? ((await contactService.getContact(id)) ?? contact)
+      : contact;
+
+    // Build the complete updated contact in memory. All field changes are merged
+    // here so the transaction only needs one write — avoids non-transactional stale
+    // reads that occur when individual per-field setters each load the contact.
+    let pending: Contact = { ...base, updatedAt: new Date() };
 
     if (typeof body.displayName === 'string' && body.displayName.trim().length > 0) {
       pending = { ...pending, displayName: body.displayName.trim() };
@@ -1032,15 +1053,6 @@ export async function knowledgeGraphRoutes(
         definedFields.primaryEmail = definedFields.primaryEmail.toLowerCase();
       }
       pending = { ...pending, ...definedFields };
-    }
-
-    // Legacy setStatus / setTrustLevel are not transaction-aware (retired in #955).
-    // Run them before the transaction so a legacy-field failure is surfaced cleanly.
-    if (typeof body.status === 'string') {
-      await contactService.setStatus(id, body.status as ContactStatus);
-    }
-    if ('trustLevel' in body) {
-      await contactService.setTrustLevel(id, (body.trustLevel as TrustLevel | null));
     }
 
     // All remaining mutations are wrapped in a single DB transaction for atomicity.

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -960,8 +960,8 @@ export async function knowledgeGraphRoutes(
       if (typeof body.kind !== 'string' || !validContactKinds.includes(body.kind as ContactKind)) {
         return reply.status(400).send({ error: `Invalid kind. Must be one of: ${validContactKinds.join(', ')}.` });
       }
-      if (contact.systemRole === 'principal') {
-        return reply.status(400).send({ error: 'The principal contact\'s kind cannot be changed via the API.' });
+      if (contact.systemRole === 'principal' || contact.systemRole === 'agent') {
+        return reply.status(400).send({ error: 'The kind of a system contact (principal or agent) cannot be changed via the API.' });
       }
     }
     // Trim once; collapse whitespace-only strings to null so they don't reach the DB as invalid UUIDs.
@@ -993,6 +993,47 @@ export async function knowledgeGraphRoutes(
       }
     }
 
+    // Build the complete updated contact in memory from the pre-validation snapshot.
+    // All per-field setters read the contact non-transactionally, so calling them in
+    // sequence causes each write to clobber earlier changes with stale data. Assembling
+    // the full pending object here and writing once avoids that race.
+    let pending: Contact = { ...contact, updatedAt: new Date() };
+
+    if (typeof body.displayName === 'string' && body.displayName.trim().length > 0) {
+      pending = { ...pending, displayName: body.displayName.trim() };
+    }
+    if (typeof body.role === 'string') {
+      pending = { ...pending, role: body.role };
+    } else if (body.role === null) {
+      pending = { ...pending, role: null };
+    }
+    if (typeof body.tier === 'string') {
+      pending = { ...pending, tier: body.tier as ContactTier };
+    }
+    if (typeof body.kind === 'string') {
+      pending = { ...pending, kind: body.kind as ContactKind };
+    }
+    if (body.notes !== undefined) {
+      pending = { ...pending, notes: typeof body.notes === 'string' ? body.notes : null };
+    }
+    if (normalizedKgNodeId !== undefined) {
+      pending = { ...pending, kgNodeId: normalizedKgNodeId };
+    }
+    const CANONICAL_KEYS: Array<keyof typeof canonicalFields> = [
+      'preferredName', 'title', 'organization', 'primaryEmail', 'primaryPhone',
+      'timezone', 'locale', 'location', 'pronouns', 'linkedinUrl', 'bio', 'birthday',
+    ];
+    const hasCanonicalFields = CANONICAL_KEYS.some(k => k in (body as Record<string, unknown>));
+    if (hasCanonicalFields) {
+      const definedFields = Object.fromEntries(
+        Object.entries(canonicalFields).filter(([, value]) => value !== undefined),
+      ) as ContactCanonicalFields;
+      if (definedFields.primaryEmail != null) {
+        definedFields.primaryEmail = definedFields.primaryEmail.toLowerCase();
+      }
+      pending = { ...pending, ...definedFields };
+    }
+
     // Legacy setStatus / setTrustLevel are not transaction-aware (retired in #955).
     // Run them before the transaction so a legacy-field failure is surfaced cleanly.
     if (typeof body.status === 'string') {
@@ -1003,60 +1044,11 @@ export async function knowledgeGraphRoutes(
     }
 
     // All remaining mutations are wrapped in a single DB transaction for atomicity.
+    // saveContact applies display-name sanitization and writes all fields in one UPDATE.
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
-
-      if (typeof body.displayName === 'string' && body.displayName.trim().length > 0) {
-        await contactService.updateDisplayName(id, body.displayName, client);
-      }
-      if (typeof body.role === 'string') {
-        await contactService.setRole(id, body.role, client);
-      } else if (body.role === null) {
-        // Explicit null means "clear the role field" — setRole doesn't accept null so go direct.
-        await client.query(`UPDATE contacts SET role = NULL, updated_at = $2 WHERE id = $1`, [
-          id,
-          new Date().toISOString(),
-        ]);
-      }
-      if (typeof body.tier === 'string') {
-        await contactService.setTier(id, body.tier as ContactTier, client);
-      }
-      if (typeof body.kind === 'string') {
-        await contactService.setKind(id, body.kind as ContactKind, client);
-      }
-
-      // Notes and kgNodeId are updated directly by preserving the rest of the contact.
-      // This route exists only for the web UI and does not expose generic backend mutation.
-      if (typeof body.notes === 'string' || typeof body.kgNodeId === 'string' || body.notes === null || body.kgNodeId === null) {
-        const refreshed = await contactService.getContact(id);
-        if (!refreshed) {
-          await client.query('ROLLBACK');
-          return reply.status(404).send({ error: 'Contact not found.' });
-        }
-        await client.query(
-          `UPDATE contacts
-           SET notes = $2, kg_node_id = $3, updated_at = $4
-           WHERE id = $1`,
-          [
-            id,
-            typeof body.notes === 'string' ? body.notes : body.notes === null ? null : refreshed.notes,
-            normalizedKgNodeId !== undefined ? normalizedKgNodeId : refreshed.kgNodeId,
-            new Date().toISOString(),
-          ],
-        );
-      }
-
-      // Apply canonical fields if any were included in the request body.
-      const CANONICAL_KEYS: Array<keyof typeof canonicalFields> = [
-        'preferredName', 'title', 'organization', 'primaryEmail', 'primaryPhone',
-        'timezone', 'locale', 'location', 'pronouns', 'linkedinUrl', 'bio', 'birthday',
-      ];
-      const hasCanonicalFields = CANONICAL_KEYS.some(k => k in (body as Record<string, unknown>));
-      if (hasCanonicalFields) {
-        await contactService.updateContactFields(id, canonicalFields, client);
-      }
-
+      await contactService.saveContact(pending, client);
       await client.query('COMMIT');
     } catch (err) {
       await client.query('ROLLBACK');

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -6,7 +6,7 @@ import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import { ContactValidationError } from '../../../contacts/contact-service.js';
-import type { Contact, ContactCanonicalFields, ContactStatus, TrustLevel } from '../../../contacts/types.js';
+import type { Contact, ContactCanonicalFields, ContactKind, ContactStatus, ContactTier, TrustLevel } from '../../../contacts/types.js';
 import type { EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { markdownToHtml } from '../../../utils/markdown-to-html.js';
@@ -274,6 +274,9 @@ export async function knowledgeGraphRoutes(
   });
 
   const validContactStatuses: ContactStatus[] = ['confirmed', 'provisional', 'blocked'];
+  // tier/kind selectable via the API — 'principal' and kind∈{principal,agent} are structural-only.
+  const validContactTiers: ContactTier[] = ['blocked', 'unknown', 'known', 'trusted'];
+  const validContactKinds: ContactKind[] = ['person', 'organization', 'automated'];
   const validTaskStatuses = [
     // Legacy values used by the scheduler before task skills shipped
     'active', 'pending', 'paused', 'completed', 'failed',
@@ -842,6 +845,8 @@ export async function knowledgeGraphRoutes(
       role?: unknown;
       status?: unknown;
       trustLevel?: unknown;
+      tier?: unknown;
+      kind?: unknown;
       notes?: unknown;
       kgNodeId?: unknown;
     };
@@ -857,6 +862,14 @@ export async function knowledgeGraphRoutes(
     if (body.trustLevel !== undefined && body.trustLevel !== null &&
         (typeof body.trustLevel !== 'string' || !validTrustLevelsCreate.includes(body.trustLevel))) {
       return reply.status(400).send({ error: 'Invalid trustLevel.' });
+    }
+    if (body.tier !== undefined &&
+        (typeof body.tier !== 'string' || !validContactTiers.includes(body.tier as ContactTier))) {
+      return reply.status(400).send({ error: `Invalid tier. Must be one of: ${validContactTiers.join(', ')}.` });
+    }
+    if (body.kind !== undefined &&
+        (typeof body.kind !== 'string' || !validContactKinds.includes(body.kind as ContactKind))) {
+      return reply.status(400).send({ error: `Invalid kind. Must be one of: ${validContactKinds.join(', ')}.` });
     }
 
     const kgNodeId =
@@ -886,6 +899,13 @@ export async function knowledgeGraphRoutes(
     if (typeof body.trustLevel === 'string') {
       await contactService.setTrustLevel(created.id, body.trustLevel as TrustLevel);
     }
+    // Apply tier/kind overrides if provided — these take precedence over status/trustLevel-derived values.
+    if (typeof body.tier === 'string') {
+      await contactService.setTier(created.id, body.tier as ContactTier);
+    }
+    if (typeof body.kind === 'string') {
+      await contactService.setKind(created.id, body.kind as ContactKind);
+    }
 
     const freshCreated = await contactService.getContact(created.id);
     if (!freshCreated) {
@@ -906,6 +926,8 @@ export async function knowledgeGraphRoutes(
       role?: unknown;
       status?: unknown;
       trustLevel?: unknown;
+      tier?: unknown;
+      kind?: unknown;
       notes?: unknown;
       kgNodeId?: unknown;
     };
@@ -922,6 +944,25 @@ export async function knowledgeGraphRoutes(
     if ('trustLevel' in body && body.trustLevel !== null &&
         (typeof body.trustLevel !== 'string' || !validTrustLevels.includes(body.trustLevel))) {
       return reply.status(400).send({ error: 'Invalid trustLevel.' });
+    }
+    // Validate tier — rejects 'principal' (structural, derived from system_role).
+    if ('tier' in body) {
+      if (typeof body.tier !== 'string' || !validContactTiers.includes(body.tier as ContactTier)) {
+        return reply.status(400).send({ error: `Invalid tier. Must be one of: ${validContactTiers.join(', ')}.` });
+      }
+      // Principal contacts cannot be demoted or re-typed via the API.
+      if (contact.systemRole === 'principal') {
+        return reply.status(400).send({ error: 'The principal contact\'s tier cannot be changed via the API.' });
+      }
+    }
+    // Validate kind — rejects 'principal' and 'agent' (structural).
+    if ('kind' in body) {
+      if (typeof body.kind !== 'string' || !validContactKinds.includes(body.kind as ContactKind)) {
+        return reply.status(400).send({ error: `Invalid kind. Must be one of: ${validContactKinds.join(', ')}.` });
+      }
+      if (contact.systemRole === 'principal') {
+        return reply.status(400).send({ error: 'The principal contact\'s kind cannot be changed via the API.' });
+      }
     }
     // Trim once; collapse whitespace-only strings to null so they don't reach the DB as invalid UUIDs.
     const normalizedKgNodeId: string | null | undefined =
@@ -952,24 +993,37 @@ export async function knowledgeGraphRoutes(
       }
     }
 
+    // Legacy setStatus / setTrustLevel are not transaction-aware (retired in #955).
+    // Run them before the transaction so a legacy-field failure is surfaced cleanly.
+    if (typeof body.status === 'string') {
+      await contactService.setStatus(id, body.status as ContactStatus);
+    }
+    if ('trustLevel' in body) {
+      await contactService.setTrustLevel(id, (body.trustLevel as TrustLevel | null));
+    }
+
+    // All remaining mutations are wrapped in a single DB transaction for atomicity.
+    const client = await pool.connect();
     try {
+      await client.query('BEGIN');
+
       if (typeof body.displayName === 'string' && body.displayName.trim().length > 0) {
-        await contactService.updateDisplayName(id, body.displayName);
+        await contactService.updateDisplayName(id, body.displayName, client);
       }
       if (typeof body.role === 'string') {
-        await contactService.setRole(id, body.role);
+        await contactService.setRole(id, body.role, client);
       } else if (body.role === null) {
         // Explicit null means "clear the role field" — setRole doesn't accept null so go direct.
-        await pool.query(`UPDATE contacts SET role = NULL, updated_at = $2 WHERE id = $1`, [
+        await client.query(`UPDATE contacts SET role = NULL, updated_at = $2 WHERE id = $1`, [
           id,
           new Date().toISOString(),
         ]);
       }
-      if (typeof body.status === 'string') {
-        await contactService.setStatus(id, body.status as ContactStatus);
+      if (typeof body.tier === 'string') {
+        await contactService.setTier(id, body.tier as ContactTier, client);
       }
-      if ('trustLevel' in body) {
-        await contactService.setTrustLevel(id, (body.trustLevel as TrustLevel | null));
+      if (typeof body.kind === 'string') {
+        await contactService.setKind(id, body.kind as ContactKind, client);
       }
 
       // Notes and kgNodeId are updated directly by preserving the rest of the contact.
@@ -977,9 +1031,10 @@ export async function knowledgeGraphRoutes(
       if (typeof body.notes === 'string' || typeof body.kgNodeId === 'string' || body.notes === null || body.kgNodeId === null) {
         const refreshed = await contactService.getContact(id);
         if (!refreshed) {
+          await client.query('ROLLBACK');
           return reply.status(404).send({ error: 'Contact not found.' });
         }
-        await pool.query(
+        await client.query(
           `UPDATE contacts
            SET notes = $2, kg_node_id = $3, updated_at = $4
            WHERE id = $1`,
@@ -999,29 +1054,28 @@ export async function knowledgeGraphRoutes(
       ];
       const hasCanonicalFields = CANONICAL_KEYS.some(k => k in (body as Record<string, unknown>));
       if (hasCanonicalFields) {
-        try {
-          await contactService.updateContactFields(id, canonicalFields);
-        } catch (err) {
-          if (err instanceof ContactValidationError) {
-            // Client sent invalid data (e.g., primaryEmail not linked to this contact)
-            return reply.status(400).send({ error: err.message });
-          }
-          // All other errors (DB failures, etc.) propagate to the outer catch → 500
-          throw err;
-        }
+        await contactService.updateContactFields(id, canonicalFields, client);
       }
 
-      const updated = await contactService.getContact(id);
-      if (!updated) {
-        return reply.status(404).send({ error: 'Contact not found after update.' });
-      }
-      return reply.send({
-        contact: serializeContact(updated),
-      });
+      await client.query('COMMIT');
     } catch (err) {
+      await client.query('ROLLBACK');
+      if (err instanceof ContactValidationError) {
+        return reply.status(400).send({ error: err.message });
+      }
       request.log.error({ err }, 'contacts: PATCH mutation failed');
       return reply.status(500).send({ error: 'An error occurred while updating the contact.' });
+    } finally {
+      client.release();
     }
+
+    const updated = await contactService.getContact(id);
+    if (!updated) {
+      return reply.status(404).send({ error: 'Contact not found after update.' });
+    }
+    return reply.send({
+      contact: serializeContact(updated),
+    });
   });
 
   app.delete('/api/kg/contacts/:id', KG_RATE, async (request, reply) => {

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -732,6 +732,19 @@ export class ContactService {
   }
 
   /**
+   * Persist a fully-constructed Contact in one write, applying display-name sanitization.
+   *
+   * Use this when the caller has already assembled all pending field changes in memory
+   * and wants a single transactional write rather than the per-field read+write cycle
+   * that individual setters (setTier, updateDisplayName, etc.) perform internally.
+   *
+   * Pass an optional PoolClient to participate in a caller-managed transaction.
+   */
+  async saveContact(contact: Contact, client?: DbPoolClient): Promise<Contact> {
+    return this.updateStoredContact(contact, client);
+  }
+
+  /**
    * Update a contact's display name with sanitization.
    * This is the only sanctioned way to change a display name after creation —
    * callers must go through this method so the sanitization gate is enforced.

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -10,7 +10,7 @@
 //   backends are pure storage
 
 import { randomUUID } from 'node:crypto';
-import type { DbPool } from '../db/connection.js';
+import type { DbPool, DbPoolClient } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import { sanitizeDisplayName } from '../skills/sanitize.js';
@@ -195,7 +195,7 @@ interface ContactServiceBackend {
   findContactByRole(role: string): Promise<Contact[]>;
   findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null>;
   listContacts(filters?: { status?: ContactStatus; tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]>;
-  updateContact(contact: Contact): Promise<void>;
+  updateContact(contact: Contact, client?: DbPoolClient): Promise<void>;
   createIdentity(identity: ChannelIdentity): Promise<void>;
   getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]>;
   resolveByChannelIdentity(channel: string, channelIdentifier: string): Promise<ResolvedSender | null>;
@@ -709,7 +709,7 @@ export class ContactService {
    * sanitization gate (PR #63), and ensures any future update path that
    * routes through here cannot bypass sanitization. See issue #64 / #39.
    */
-  private async updateStoredContact(contact: Contact): Promise<Contact> {
+  private async updateStoredContact(contact: Contact, client?: DbPoolClient): Promise<Contact> {
     const safeName = sanitizeDisplayName(contact.displayName);
     const updatedContact =
       safeName === contact.displayName
@@ -727,7 +727,7 @@ export class ContactService {
       );
     }
 
-    await this.backend.updateContact(updatedContact);
+    await this.backend.updateContact(updatedContact, client);
     return updatedContact;
   }
 
@@ -736,7 +736,7 @@ export class ContactService {
    * This is the only sanctioned way to change a display name after creation —
    * callers must go through this method so the sanitization gate is enforced.
    */
-  async updateDisplayName(contactId: string, displayName: string): Promise<Contact> {
+  async updateDisplayName(contactId: string, displayName: string, client?: DbPoolClient): Promise<Contact> {
     const contact = await this.backend.getContact(contactId);
     if (!contact) {
       throw new Error(`Contact not found: ${contactId}`);
@@ -748,11 +748,11 @@ export class ContactService {
       updatedAt: new Date(),
     };
 
-    return this.updateStoredContact(updated);
+    return this.updateStoredContact(updated, client);
   }
 
   /** Update a contact's role and updatedAt timestamp. */
-  async setRole(contactId: string, role: string): Promise<Contact> {
+  async setRole(contactId: string, role: string, client?: DbPoolClient): Promise<Contact> {
     const contact = await this.backend.getContact(contactId);
     if (!contact) {
       throw new Error(`Contact not found: ${contactId}`);
@@ -764,7 +764,7 @@ export class ContactService {
       updatedAt: new Date(),
     };
 
-    return this.updateStoredContact(updated);
+    return this.updateStoredContact(updated, client);
   }
 
   /**
@@ -941,6 +941,50 @@ export class ContactService {
   }
 
   /**
+   * Directly set a contact's tier. Accepts the four user-settable tiers only
+   * (blocked/unknown/known/trusted); 'principal' is structural and must not be
+   * hand-set — enforce that guard at the API layer before calling this method.
+   *
+   * Pass an optional PoolClient to participate in a caller-managed transaction.
+   */
+  async setTier(contactId: string, tier: ContactTier, client?: DbPoolClient): Promise<Contact> {
+    const contact = await this.backend.getContact(contactId);
+    if (!contact) {
+      throw new Error(`Contact not found: ${contactId}`);
+    }
+
+    const updated: Contact = {
+      ...contact,
+      tier,
+      updatedAt: new Date(),
+    };
+
+    return this.updateStoredContact(updated, client);
+  }
+
+  /**
+   * Directly set a contact's kind. Accepts the three user-settable kinds only
+   * (person/organization/automated); 'principal' and 'agent' are structural —
+   * enforce that guard at the API layer before calling this method.
+   *
+   * Pass an optional PoolClient to participate in a caller-managed transaction.
+   */
+  async setKind(contactId: string, kind: ContactKind, client?: DbPoolClient): Promise<Contact> {
+    const contact = await this.backend.getContact(contactId);
+    if (!contact) {
+      throw new Error(`Contact not found: ${contactId}`);
+    }
+
+    const updated: Contact = {
+      ...contact,
+      kind,
+      updatedAt: new Date(),
+    };
+
+    return this.updateStoredContact(updated, client);
+  }
+
+  /**
    * Validate that `primaryEmail` is present in `contact_channel_identities` for this
    * contact (channel = 'email', case-insensitive). Throws `ContactValidationError` if not.
    * Call this before any writes when the PATCH handler needs to reject invalid emails
@@ -970,6 +1014,7 @@ export class ContactService {
   async updateContactFields(
     contactId: string,
     fields: ContactCanonicalFields,
+    client?: DbPoolClient,
   ): Promise<Contact> {
     const contact = await this.backend.getContact(contactId);
     if (!contact) {
@@ -1007,7 +1052,7 @@ export class ContactService {
       updatedAt: new Date(),
     };
 
-    return this.updateStoredContact(updated);
+    return this.updateStoredContact(updated, client);
   }
 
   /**
@@ -1514,13 +1559,14 @@ class PostgresContactBackend implements ContactServiceBackend {
     return result.rows.map((row) => this.rowToContact(row));
   }
 
-  async updateContact(contact: Contact): Promise<void> {
+  async updateContact(contact: Contact, client?: DbPoolClient): Promise<void> {
     this.logger.debug({ contactId: contact.id }, 'contacts: updating contact');
     // trust_level is included because ContactService.setTrustLevel writes through this path.
     // system_role is included so bootstrap and any future setter can persist it through the standard update path.
     // tier and kind (migration 055) are included so setStatus/setTrustLevel keep them in sync.
     // contact_confidence and last_seen_at remain scoring-owned and are not updated here.
-    await this.pool.query(
+    const queryFn = client ?? this.pool;
+    await queryFn.query(
       `UPDATE contacts SET
          kg_node_id = $2, display_name = $3, role = $4, system_role = $5, status = $6,
          notes = $7, trust_level = $8, tier = $9, kind = $10, updated_at = $11,
@@ -2173,7 +2219,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return results;
   }
 
-  async updateContact(contact: Contact): Promise<void> {
+  async updateContact(contact: Contact, _client?: DbPoolClient): Promise<void> {
     // Enforce system_role uniqueness on update, to match Postgres partial unique indexes.
     // Exclude the contact being updated from the duplicate check.
     if (contact.systemRole) {

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -3,9 +3,10 @@ import type { Logger } from '../logger.js';
 
 const { Pool } = pg;
 
-// Re-export the pg Pool type so callers don't need to import pg directly.
+// Re-export the pg Pool and PoolClient types so callers don't need to import pg directly.
 // This keeps the rest of the codebase decoupled from the pg driver's type surface.
 export type DbPool = pg.Pool;
+export type DbPoolClient = pg.PoolClient;
 
 /**
  * Create a managed connection pool to Postgres.

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -28,6 +28,7 @@ function createContactService(): ContactService {
     setTrustLevel: vi.fn(),
     setTier: vi.fn(),
     setKind: vi.fn(),
+    saveContact: vi.fn(),
     updateDisplayName: vi.fn(),
     setRole: vi.fn(),
     setStatus: vi.fn(),
@@ -483,9 +484,8 @@ describe('knowledgeGraphRoutes', () => {
     it('rolls back the transaction and returns 500 when a mutation fails mid-PATCH', async () => {
       const contactService = createContactService();
       vi.mocked(contactService.getContact).mockResolvedValue(makeContact() as never);
-      // updateDisplayName succeeds; setTier throws to simulate a mid-tx failure.
-      vi.mocked(contactService.updateDisplayName).mockResolvedValue(makeContact() as never);
-      vi.mocked(contactService.setTier).mockRejectedValue(new Error('DB error'));
+      // saveContact throws to simulate a DB failure inside the transaction.
+      vi.mocked(contactService.saveContact).mockRejectedValue(new Error('DB error'));
 
       const clientQuery = vi.fn().mockResolvedValue({ rows: [] });
       const clientRelease = vi.fn();
@@ -520,12 +520,11 @@ describe('knowledgeGraphRoutes', () => {
       await app.close();
     });
 
-    it('accepts valid tier and kind values and calls setTier/setKind', async () => {
+    it('accepts valid tier and kind values and writes them via saveContact', async () => {
       const contactService = createContactService();
       const contact = makeContact();
       vi.mocked(contactService.getContact).mockResolvedValue(contact as never);
-      vi.mocked(contactService.setTier).mockResolvedValue(contact as never);
-      vi.mocked(contactService.setKind).mockResolvedValue(contact as never);
+      vi.mocked(contactService.saveContact).mockResolvedValue(contact as never);
 
       const clientQuery = vi.fn().mockResolvedValue({ rows: [] });
       const client: Partial<PoolClient> = { query: clientQuery, release: vi.fn() };
@@ -548,20 +547,42 @@ describe('knowledgeGraphRoutes', () => {
         payload: { tier: 'trusted', kind: 'organization' },
       });
 
-      // The getContact call after the transaction returns undefined (not mocked for
-      // that second call), so Fastify returns 404 — that's fine; we only verify
-      // setTier and setKind were called with the right arguments.
-      expect(contactService.setTier).toHaveBeenCalledWith(
-        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        'trusted',
-        client,
-      );
-      expect(contactService.setKind).toHaveBeenCalledWith(
-        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        'organization',
-        client,
-      );
+      // saveContact must have been called with a contact snapshot that has the updated
+      // tier and kind merged in, and with the transaction client.
+      expect(contactService.saveContact).toHaveBeenCalledTimes(1);
+      const [savedContact, savedClient] = (contactService.saveContact as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      expect(savedContact.tier).toBe('trusted');
+      expect(savedContact.kind).toBe('organization');
+      expect(savedClient).toBe(client);
       expect(res.statusCode).not.toBe(400);
+      await app.close();
+    });
+
+    it('rejects kind changes for agent contacts with 400', async () => {
+      const contactService = createContactService();
+      vi.mocked(contactService.getContact).mockResolvedValue(
+        makeContact({ systemRole: 'agent', kind: 'agent' }) as never,
+      );
+
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool: { query: vi.fn() } as unknown as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/kg/contacts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { kind: 'person' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/system contact/i);
       await app.close();
     });
   });

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -554,7 +554,7 @@ describe('knowledgeGraphRoutes', () => {
       expect(savedContact.tier).toBe('trusted');
       expect(savedContact.kind).toBe('organization');
       expect(savedClient).toBe(client);
-      expect(res.statusCode).not.toBe(400);
+      expect(res.statusCode).toBe(200);
       await app.close();
     });
 

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -1,7 +1,7 @@
 import Fastify from 'fastify';
 import type { LightMyRequestResponse } from 'fastify';
 import rateLimit from '@fastify/rate-limit';
-import type { Pool } from 'pg';
+import type { Pool, PoolClient } from 'pg';
 import type { Logger } from '../../../../src/logger.js';
 import type { ContactService } from '../../../../src/contacts/contact-service.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -26,7 +26,57 @@ function createContactService(): ContactService {
     createContact: vi.fn(),
     getContact: vi.fn(),
     setTrustLevel: vi.fn(),
+    setTier: vi.fn(),
+    setKind: vi.fn(),
+    updateDisplayName: vi.fn(),
+    setRole: vi.fn(),
+    setStatus: vi.fn(),
+    updateContactFields: vi.fn(),
+    validatePrimaryEmail: vi.fn(),
   } as unknown as ContactService;
+}
+
+// Creates a pool mock that also supports pool.connect() for transaction tests.
+function createTransactionalPool(client: Partial<PoolClient>): Pick<Pool, 'query' | 'connect'> {
+  return {
+    query: vi.fn(),
+    connect: vi.fn().mockResolvedValue(client),
+  } as unknown as Pick<Pool, 'query' | 'connect'>;
+}
+
+// A minimal valid Contact shape returned by contactService.getContact() stubs.
+function makeContact(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    displayName: 'Test User',
+    role: null,
+    status: 'confirmed',
+    trustLevel: null,
+    tier: 'known',
+    kind: 'person',
+    systemRole: null,
+    kgNodeId: null,
+    notes: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    preferredName: null,
+    title: null,
+    organization: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    timezone: null,
+    locale: null,
+    location: null,
+    pronouns: null,
+    linkedinUrl: null,
+    bio: null,
+    birthday: null,
+    contactConfidence: 0,
+    lastSeenAt: null,
+    inboundMessageCount: 0,
+    outboundMessageCount: 0,
+    ...overrides,
+  };
 }
 
 describe('knowledgeGraphRoutes', () => {
@@ -263,5 +313,307 @@ describe('knowledgeGraphRoutes', () => {
     expect(statuses).toContain(429);
 
     await app.close();
+  });
+
+  // ── Tier / kind validation (issue #1055) ────────────────────────────────────
+
+  describe('PATCH /api/kg/contacts/:id — tier/kind validation', () => {
+    it('rejects an invalid tier value with 400', async () => {
+      const contactService = createContactService();
+      vi.mocked(contactService.getContact).mockResolvedValue(makeContact() as never);
+
+      const client: Partial<PoolClient> = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        release: vi.fn(),
+      };
+      const txPool = createTransactionalPool(client);
+
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool: txPool as unknown as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/kg/contacts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { tier: 'superuser' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/Invalid tier/);
+      await app.close();
+    });
+
+    it('rejects tier="principal" (structural guard) with 400', async () => {
+      const contactService = createContactService();
+      vi.mocked(contactService.getContact).mockResolvedValue(makeContact() as never);
+
+      const client: Partial<PoolClient> = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        release: vi.fn(),
+      };
+      const txPool = createTransactionalPool(client);
+
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool: txPool as unknown as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/kg/contacts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { tier: 'principal' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/Invalid tier/);
+      await app.close();
+    });
+
+    it('rejects kind="principal" (structural guard) with 400', async () => {
+      const contactService = createContactService();
+      vi.mocked(contactService.getContact).mockResolvedValue(makeContact() as never);
+
+      const client: Partial<PoolClient> = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        release: vi.fn(),
+      };
+      const txPool = createTransactionalPool(client);
+
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool: txPool as unknown as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/kg/contacts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { kind: 'principal' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/Invalid kind/);
+      await app.close();
+    });
+
+    it('rejects kind="agent" (structural guard) with 400', async () => {
+      const contactService = createContactService();
+      vi.mocked(contactService.getContact).mockResolvedValue(makeContact() as never);
+
+      const client: Partial<PoolClient> = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        release: vi.fn(),
+      };
+      const txPool = createTransactionalPool(client);
+
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool: txPool as unknown as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/kg/contacts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { kind: 'agent' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/Invalid kind/);
+      await app.close();
+    });
+
+    it('rejects tier changes on the principal contact with 400', async () => {
+      const contactService = createContactService();
+      vi.mocked(contactService.getContact).mockResolvedValue(
+        makeContact({ systemRole: 'principal', tier: 'principal', kind: 'principal' }) as never,
+      );
+
+      const client: Partial<PoolClient> = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        release: vi.fn(),
+      };
+      const txPool = createTransactionalPool(client);
+
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool: txPool as unknown as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/kg/contacts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { tier: 'known' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/principal/i);
+      await app.close();
+    });
+
+    it('rolls back the transaction and returns 500 when a mutation fails mid-PATCH', async () => {
+      const contactService = createContactService();
+      vi.mocked(contactService.getContact).mockResolvedValue(makeContact() as never);
+      // updateDisplayName succeeds; setTier throws to simulate a mid-tx failure.
+      vi.mocked(contactService.updateDisplayName).mockResolvedValue(makeContact() as never);
+      vi.mocked(contactService.setTier).mockRejectedValue(new Error('DB error'));
+
+      const clientQuery = vi.fn().mockResolvedValue({ rows: [] });
+      const clientRelease = vi.fn();
+      const client: Partial<PoolClient> = { query: clientQuery, release: clientRelease };
+      const txPool = createTransactionalPool(client);
+
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool: txPool as unknown as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/kg/contacts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { displayName: 'New Name', tier: 'trusted' },
+      });
+
+      expect(res.statusCode).toBe(500);
+      // ROLLBACK must have been called after the failure.
+      const rollbackCall = vi.mocked(clientQuery).mock.calls.find(
+        args => args[0] === 'ROLLBACK',
+      );
+      expect(rollbackCall).toBeDefined();
+      // The client must always be released (finally block).
+      expect(clientRelease).toHaveBeenCalledTimes(1);
+      await app.close();
+    });
+
+    it('accepts valid tier and kind values and calls setTier/setKind', async () => {
+      const contactService = createContactService();
+      const contact = makeContact();
+      vi.mocked(contactService.getContact).mockResolvedValue(contact as never);
+      vi.mocked(contactService.setTier).mockResolvedValue(contact as never);
+      vi.mocked(contactService.setKind).mockResolvedValue(contact as never);
+
+      const clientQuery = vi.fn().mockResolvedValue({ rows: [] });
+      const client: Partial<PoolClient> = { query: clientQuery, release: vi.fn() };
+      const txPool = createTransactionalPool(client);
+
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool: txPool as unknown as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/kg/contacts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { tier: 'trusted', kind: 'organization' },
+      });
+
+      // The getContact call after the transaction returns undefined (not mocked for
+      // that second call), so Fastify returns 404 — that's fine; we only verify
+      // setTier and setKind were called with the right arguments.
+      expect(contactService.setTier).toHaveBeenCalledWith(
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        'trusted',
+        client,
+      );
+      expect(contactService.setKind).toHaveBeenCalledWith(
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        'organization',
+        client,
+      );
+      expect(res.statusCode).not.toBe(400);
+      await app.close();
+    });
+  });
+
+  describe('POST /api/kg/contacts — tier/kind validation', () => {
+    it('rejects an invalid tier value with 400', async () => {
+      const contactService = createContactService();
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/kg/contacts',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { displayName: 'Test', tier: 'superuser' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/Invalid tier/);
+      expect(contactService.createContact).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('rejects tier="principal" in POST (structural guard)', async () => {
+      const contactService = createContactService();
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/kg/contacts',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: { displayName: 'Test', tier: 'principal' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(contactService.createContact).not.toHaveBeenCalled();
+      await app.close();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1055

- **API**: `PATCH` and `POST /api/kg/contacts` now accept `tier` and `kind` as first-class fields with full enum validation and structural guards (`tier='principal'` → 400, `kind ∈ {principal, agent}` → 400). The principal contact's tier/kind cannot be changed via the API.
- **Atomicity**: All non-legacy PATCH mutations are now wrapped in a single DB transaction (absorbs #860). `ContactValidationError` → 400 after rollback; other errors → 500.
- **Service**: Added `ContactService.setTier()` and `setKind()`; extended `updateDisplayName`, `setRole`, and `updateContactFields` to accept an optional `pg.PoolClient` for caller-managed transactions. Added `DbPoolClient` export to `src/db/connection.ts`.
- **Console**: Contacts page drawer now edits `tier` and `kind` instead of `status`/`trust_level`; list view replaces the status pill/filter chips with a tier pill and kind column, filters by tier + kind facet, and sorts by tier. Principal and agent contacts show their tier/kind as read-only.

## Test plan

- [ ] `PATCH /api/kg/contacts/:id` with `tier: 'superuser'` → 400 with "Invalid tier"
- [ ] `PATCH` with `tier: 'principal'` → 400 (structural guard)
- [ ] `PATCH` with `kind: 'principal'` or `kind: 'agent'` → 400 (structural guard)
- [ ] `PATCH` on a principal contact with any tier/kind change → 400
- [ ] `PATCH` with valid `tier: 'trusted'` + `kind: 'organization'` → 200, values persisted
- [ ] Mid-PATCH failure (mocked `setTier` throws) → 500, ROLLBACK called, client released
- [ ] Console: Contacts list shows Tier + Kind columns, no Status pill
- [ ] Console: Filter chips show Blocked / Unknown / Known / Trusted + kind facet
- [ ] Console: Edit drawer shows Tier and Kind selects (not Status/Trust-level)
- [ ] Console: Save with tier=trusted persists and reloads correctly
- [ ] Console: Principal contact's tier/kind selects are disabled