### PR TITLE
feat: grant mechanism + proactive recommendations (#952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Grant mechanism + proactive recommendations** — contacts can be granted or blocked by tier (`contact-set-tier`) and per-capability overrides (`contact-grant-permission`, `contact-revoke-permission`); a weekly LLM-judge scan surfaces scheduling grant recommendations; CEO can approve or decline each; declined recommendations never resurface (anti-nag). Contacts UI now shows and revokes per-contact auth overrides. (#952)
 - **Console Contacts: tier/kind editing** — the admin Contacts page now edits `tier` and `kind` directly; Status and Trust-level controls are removed. List view filters, sorts, and displays by tier + kind facet. (#1055)
 - **PATCH/POST `/api/kg/contacts` accept `tier` and `kind`** — validated against the migration-055 enums with structural guards rejecting `tier='principal'` and `kind ∈ {principal, agent}`. Principal contacts cannot be demoted via the API. (#1055)
 - **Atomic PATCH mutations** — all non-legacy mutations in `PATCH /api/kg/contacts/:id` now run in a single DB transaction; partial failures roll back cleanly. (#1055)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Grant mechanism + proactive recommendations** — contacts can be granted or blocked by tier (`contact-set-tier`) and per-capability overrides (`contact-grant-permission`, `contact-revoke-permission`); a weekly LLM-judge scan surfaces scheduling grant recommendations; CEO can approve or decline each; declined recommendations never resurface (anti-nag). Contacts UI now shows and revokes per-contact auth overrides. (#952)
+- **`contact-set-tier` skill** — sets a contact's tier directly from chat ("treat Dana as trusted"); principal-auth guarded, rejects `tier='principal'`. (#952)
+- **Proactive grant recommendations** — weekly LLM-judge scan (`scan-grant-recommendations`) evaluates known-tier contacts and surfaces scheduling-access recommendations for CEO approval. (#952)
+- **Approve/decline recommendations** — `approve-grant-recommendation` writes a `contact_auth_overrides` row; `decline-grant-recommendation` permanently records the decline so the recommendation never resurfaces (anti-nag via UNIQUE DB constraint). (#952)
+- **Contacts UI: permission grants section** — contact drawer lists active auth overrides with per-override revoke buttons. (#952)
 - **Console Contacts: tier/kind editing** — the admin Contacts page now edits `tier` and `kind` directly; Status and Trust-level controls are removed. List view filters, sorts, and displays by tier + kind facet. (#1055)
 - **PATCH/POST `/api/kg/contacts` accept `tier` and `kind`** — validated against the migration-055 enums with structural guards rejecting `tier='principal'` and `kind ∈ {principal, agent}`. Principal contacts cannot be demoted via the API. (#1055)
 - **Atomic PATCH mutations** — all non-legacy mutations in `PATCH /api/kg/contacts/:id` now run in a single DB transaction; partial failures roll back cleanly. (#1055)

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -260,19 +260,18 @@ system_prompt: |
 
   1. Call scan-grant-recommendations (no extra inputs needed for defaults).
      The skill evaluates known-tier contacts with high confidence scores and
-     creates up to 3 new grant recommendations per run.
+     creates up to 3 new grant recommendations per run. It returns
+     recommendations_created — an array of the newly created recommendations
+     including each one's id, contact_name, and reasoning.
 
-  2. Fetch pending recommendations: call scan-grant-recommendations again
-     only if the first call returned created > 0; otherwise skip step 3.
-
-  3. For each new recommendation created: surface it to the coordinator as
-     a natural-language message describing the suggested grant. Example:
-     "I've noticed that [Name] coordinates scheduling with you regularly.
-     Would you like me to formally grant them scheduling access? [rec_id: <uuid>]"
-     Include the recommendation UUID in brackets so the coordinator can pass
+  2. For each entry in recommendations_created: surface it to the coordinator
+     as a natural-language message describing the suggested grant. Example:
+     "I've noticed that [contact_name] coordinates scheduling with you regularly.
+     Would you like me to formally grant them scheduling access? [rec_id: <id>]"
+     Include the recommendation id in brackets so the coordinator can pass
      it to approve-grant-recommendation or decline-grant-recommendation.
 
-  4. Call scheduler-report with the job_id and a summary of how many
+  3. Call scheduler-report with the job_id and a summary of how many
      recommendations were evaluated, created, and surfaced.
 
   When the CEO approves: call approve-grant-recommendation with the recommendation_id.

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -1,5 +1,5 @@
 name: contacts
-version: "0.4.0"
+version: "0.5.0"
 role: specialist
 description: >
   Contact domain specialist — briefings, CRUD, deduplication, relationship management,
@@ -239,6 +239,46 @@ system_prompt: |
   | Named person not in contacts | `contact-create` name only → `kg_node_id` |
   | Non-person entity (org, venue, concept) | Pass name directly to `memory-store`; skill auto-creates |
 
+  ## Tier & Permission Grants
+
+  When the coordinator relays that the CEO wants to change a contact's trust
+  level ("treat Dana as trusted", "block this sender", "John is trusted"),
+  use contact-set-tier to set the tier directly:
+  - "treat X as trusted" / "X is trusted" → tier: "trusted"
+  - "block X" / "X is blocked"            → tier: "blocked"
+  - "downgrade X" / "X is provisional"    → tier: "unknown"
+
+  Use contact-grant-permission for specific per-capability grants
+  (e.g. "grant Dana schedule_meetings") when the CEO names a specific
+  permission rather than a broad tier change.
+  Use contact-revoke-permission to remove a specific override.
+
+  ## Grant Recommendations
+
+  When the scheduler runs the weekly grant recommendation scan, you will
+  receive a task with the job_id. Steps:
+
+  1. Call scan-grant-recommendations (no extra inputs needed for defaults).
+     The skill evaluates known-tier contacts with high confidence scores and
+     creates up to 3 new grant recommendations per run.
+
+  2. Fetch pending recommendations: call scan-grant-recommendations again
+     only if the first call returned created > 0; otherwise skip step 3.
+
+  3. For each new recommendation created: surface it to the coordinator as
+     a natural-language message describing the suggested grant. Example:
+     "I've noticed that [Name] coordinates scheduling with you regularly.
+     Would you like me to formally grant them scheduling access? [rec_id: <uuid>]"
+     Include the recommendation UUID in brackets so the coordinator can pass
+     it to approve-grant-recommendation or decline-grant-recommendation.
+
+  4. Call scheduler-report with the job_id and a summary of how many
+     recommendations were evaluated, created, and surfaced.
+
+  When the CEO approves: call approve-grant-recommendation with the recommendation_id.
+  When the CEO declines: call decline-grant-recommendation with the recommendation_id.
+  Declining is permanent — never resurface a declined recommendation.
+
 pinned_skills:
   # Identity & CRUD
   - contact-create
@@ -248,6 +288,7 @@ pinned_skills:
   - contact-set-identity-status
   - contact-set-role
   - contact-set-trust
+  - contact-set-tier
   - contact-rename
   - contact-update
   - contact-list
@@ -257,6 +298,10 @@ pinned_skills:
   - contact-dedup-exclude
   - contact-grant-permission
   - contact-revoke-permission
+  # Grant recommendations (issue #952)
+  - scan-grant-recommendations
+  - approve-grant-recommendation
+  - decline-grant-recommendation
   # Knowledge graph
   - query-relationships
   - delete-relationship
@@ -362,3 +407,28 @@ schedule:
            and the next offset so operators can track progress.
          - context: { "next_offset": <computed value from step 5> }
     expectedDurationSeconds: 540
+
+  - cron: "0 10 * * 3"   # Wednesdays at 10 AM
+    task: >
+      Run the weekly grant recommendation scan. Extract the scheduler_job_id
+      from the task payload before starting.
+
+      Steps:
+
+      1. Call scan-grant-recommendations with default inputs. It evaluates
+         known-tier contacts with high confidence scores and creates up to 3
+         new scheduling grant recommendations. The skill is idempotent —
+         contacts that already have a recommendation (any status) are skipped.
+
+      2. If created > 0 in the result: surface each new recommendation to the
+         coordinator. For each, write a natural-language message such as:
+         "I noticed that [Name] schedules with you regularly — would you like
+         me to grant them formal scheduling access? [rec_id: <uuid>]"
+         Use the recommendation UUID so the coordinator can route approve or
+         decline to the right skill.
+
+      3. Call scheduler-report with:
+         - job_id: the scheduler_job_id from the task payload
+         - summary: evaluated count, created count, skipped counts, and
+           whether any recommendations were surfaced to the coordinator.
+    expectedDurationSeconds: 60

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -157,13 +157,15 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
 
   useEffect(() => {
     if (!contact || creating) return;
+    setOverridesError(null);
     apiFetch(`/api/kg/contacts/${contact.id}/overrides`)
       .then(async res => {
         if (!res.ok) { setOverridesError('Failed to load permissions'); return; }
         const d = await res.json() as { overrides: AuthOverride[] };
+        setOverridesError(null);
         setOverrides(d.overrides);
       })
-      .catch(() => setOverridesError('Failed to load permissions'));
+      .catch((_err: unknown) => setOverridesError('Failed to load permissions'));
   }, [contact, creating]);
 
   async function handleRevokeOverride(permission: string) {
@@ -173,7 +175,7 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
       const res = await apiFetch(`/api/kg/contacts/${contact.id}/overrides/${permission}`, { method: 'DELETE' });
       if (!res.ok) { setOverridesError('Failed to revoke permission'); return; }
       setOverrides(prev => prev.filter(o => o.permission !== permission));
-    } catch {
+    } catch (_err: unknown) {
       setOverridesError('Failed to revoke permission');
     } finally {
       setRevoking(null);

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -122,6 +122,11 @@ interface DrawerProps {
   onDeleted: (id: string) => void;
 }
 
+interface AuthOverride {
+  permission: string;
+  granted: boolean;
+}
+
 function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: DrawerProps) {
   const [displayName, setDisplayName] = useState(contact?.displayName ?? '');
   const [role, setRole] = useState(contact?.role ?? '');
@@ -144,6 +149,36 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Auth overrides state
+  const [overrides, setOverrides] = useState<AuthOverride[]>([]);
+  const [overridesError, setOverridesError] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!contact || creating) return;
+    apiFetch(`/api/kg/contacts/${contact.id}/overrides`)
+      .then(async res => {
+        if (!res.ok) { setOverridesError('Failed to load permissions'); return; }
+        const d = await res.json() as { overrides: AuthOverride[] };
+        setOverrides(d.overrides);
+      })
+      .catch(() => setOverridesError('Failed to load permissions'));
+  }, [contact, creating]);
+
+  async function handleRevokeOverride(permission: string) {
+    if (!contact) return;
+    setRevoking(permission);
+    try {
+      const res = await apiFetch(`/api/kg/contacts/${contact.id}/overrides/${permission}`, { method: 'DELETE' });
+      if (!res.ok) { setOverridesError('Failed to revoke permission'); return; }
+      setOverrides(prev => prev.filter(o => o.permission !== permission));
+    } catch {
+      setOverridesError('Failed to revoke permission');
+    } finally {
+      setRevoking(null);
+    }
+  }
 
   async function handleSave() {
     if (!displayName.trim()) {
@@ -371,6 +406,35 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
             <label htmlFor="cf-notes">Notes</label>
             <textarea id="cf-notes" rows={4} value={notes} onChange={e => setNotes(e.target.value)} />
           </div>
+
+          {/* Section: Permission grants */}
+          {!creating && (
+            <>
+              <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Permission grants</p>
+              {overridesError && <p style={{ color: 'var(--app-destructive)', fontSize: 12, margin: 0 }}>{overridesError}</p>}
+              {overrides.length === 0 && !overridesError && (
+                <p style={{ color: 'var(--app-fg-muted)', fontSize: 12, margin: 0 }}>No explicit grants or denials on file.</p>
+              )}
+              {overrides.map(o => (
+                <div key={o.permission} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginBottom: 4 }}>
+                  <span style={{
+                    display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
+                    background: o.granted ? 'var(--app-success, #22c55e)' : 'var(--app-destructive)',
+                  }} />
+                  <span style={{ flex: 1, fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }}>{o.permission}</span>
+                  <span style={{ color: 'var(--app-fg-muted)', fontSize: 12 }}>{o.granted ? 'granted' : 'denied'}</span>
+                  <button
+                    className="btn btn-secondary btn-sm"
+                    style={{ padding: '2px 8px', fontSize: 11 }}
+                    onClick={() => void handleRevokeOverride(o.permission)}
+                    disabled={revoking === o.permission}
+                  >
+                    {revoking === o.permission ? '…' : 'Revoke'}
+                  </button>
+                </div>
+              ))}
+            </>
+          )}
         </div>
       </div>
 

--- a/skills/approve-grant-recommendation/handler.ts
+++ b/skills/approve-grant-recommendation/handler.ts
@@ -1,0 +1,57 @@
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { isPrincipalOriginated } from '../../src/contacts/principal.js';
+import type { TaskOriginator } from '../../src/contacts/types.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class ApproveGrantRecommendationHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!isPrincipalOriginated(ctx.taskMetadata)) {
+      ctx.log.warn('approve-grant-recommendation: rejected — task not originated by principal');
+      return { success: false, error: 'This skill requires principal authorization.' };
+    }
+
+    const { recommendation_id } = ctx.input as { recommendation_id?: string };
+    if (!recommendation_id || !UUID_RE.test(recommendation_id)) {
+      return { success: false, error: 'Missing or invalid required input: recommendation_id (UUID)' };
+    }
+    if (!ctx.contactService) {
+      return { success: false, error: 'approve-grant-recommendation: contactService not available' };
+    }
+
+    const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+    const actorId = ctx.caller?.contactId ?? originator?.contactId;
+    if (!actorId || !UUID_RE.test(actorId)) {
+      return { success: false, error: 'Cannot determine valid actor identity for audit trail' };
+    }
+
+    // Fetch the recommendation first so we can return context in the result
+    const rec = await ctx.contactService.getGrantRecommendation(recommendation_id);
+    if (!rec) {
+      return { success: false, error: `Grant recommendation '${recommendation_id}' not found.` };
+    }
+    if (rec.status !== 'pending') {
+      return { success: false, error: `Recommendation is already ${rec.status} — cannot approve.` };
+    }
+
+    try {
+      const approved = await ctx.contactService.approveGrantRecommendation(recommendation_id, actorId);
+      if (!approved) {
+        return { success: false, error: 'Approval failed — recommendation may have been concurrently resolved.' };
+      }
+      ctx.log.info({ recommendationId: recommendation_id, contactId: rec.contactId, permission: rec.permission, actorId }, 'approve-grant-recommendation: approved');
+      return {
+        success: true,
+        data: {
+          recommendation_id,
+          contact_id: rec.contactId,
+          permission: rec.permission,
+          status: 'approved',
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to approve recommendation: ${message}` };
+    }
+  }
+}

--- a/skills/approve-grant-recommendation/handler.ts
+++ b/skills/approve-grant-recommendation/handler.ts
@@ -25,16 +25,15 @@ export class ApproveGrantRecommendationHandler implements SkillHandler {
       return { success: false, error: 'Cannot determine valid actor identity for audit trail' };
     }
 
-    // Fetch the recommendation first so we can return context in the result
-    const rec = await ctx.contactService.getGrantRecommendation(recommendation_id);
-    if (!rec) {
-      return { success: false, error: `Grant recommendation '${recommendation_id}' not found.` };
-    }
-    if (rec.status !== 'pending') {
-      return { success: false, error: `Recommendation is already ${rec.status} — cannot approve.` };
-    }
-
     try {
+      const rec = await ctx.contactService.getGrantRecommendation(recommendation_id);
+      if (!rec) {
+        return { success: false, error: `Grant recommendation '${recommendation_id}' not found.` };
+      }
+      if (rec.status !== 'pending') {
+        return { success: false, error: `Recommendation is already ${rec.status} — cannot approve.` };
+      }
+
       const approved = await ctx.contactService.approveGrantRecommendation(recommendation_id, actorId);
       if (!approved) {
         return { success: false, error: 'Approval failed — recommendation may have been concurrently resolved.' };
@@ -50,6 +49,7 @@ export class ApproveGrantRecommendationHandler implements SkillHandler {
         },
       };
     } catch (err) {
+      ctx.log.error({ err, recommendationId: recommendation_id, actorId }, 'approve-grant-recommendation: failed');
       const message = err instanceof Error ? err.message : String(err);
       return { success: false, error: `Failed to approve recommendation: ${message}` };
     }

--- a/skills/approve-grant-recommendation/skill.json
+++ b/skills/approve-grant-recommendation/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "approve-grant-recommendation",
+  "description": "Approve a pending grant recommendation. Marks the recommendation as approved and immediately grants the underlying permission to the contact. Use when the CEO says yes to a suggested grant ('yes, grant Dana scheduling access', 'approve that recommendation'). recommendation_id must be the UUID from the recommendation.",
+  "version": "0.1.0",
+  "sensitivity": "elevated",
+  "action_risk": "low",
+  "inputs": {
+    "recommendation_id": "string (UUID of the pending grant recommendation)"
+  },
+  "outputs": {
+    "recommendation_id": "string",
+    "contact_id": "string",
+    "permission": "string",
+    "status": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": []
+}

--- a/skills/contact-set-tier/handler.ts
+++ b/skills/contact-set-tier/handler.ts
@@ -52,6 +52,7 @@ export class ContactSetTierHandler implements SkillHandler {
         },
       };
     } catch (err) {
+      ctx.log.error({ err, contactId: contact_id, tier }, 'contact-set-tier: setTier failed');
       const message = err instanceof Error ? err.message : String(err);
       return { success: false, error: `Failed to set tier: ${message}` };
     }

--- a/skills/contact-set-tier/handler.ts
+++ b/skills/contact-set-tier/handler.ts
@@ -1,0 +1,59 @@
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ContactTier, TaskOriginator } from '../../src/contacts/types.js';
+import { isPrincipalOriginated } from '../../src/contacts/principal.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// 'principal' is a structural tier assigned only to the CEO contact. It cannot
+// be granted via chat or UI — it is set at bootstrap and protected by API guards.
+const SETTABLE_TIERS: ContactTier[] = ['blocked', 'unknown', 'known', 'trusted'];
+
+export class ContactSetTierHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!isPrincipalOriginated(ctx.taskMetadata)) {
+      ctx.log.warn('contact-set-tier: rejected — task not originated by principal');
+      return { success: false, error: 'This skill requires principal authorization.' };
+    }
+
+    const { contact_id, tier, reason } = ctx.input as {
+      contact_id?: string;
+      tier?: string;
+      reason?: string;
+    };
+
+    if (!contact_id || typeof contact_id !== 'string' || !UUID_RE.test(contact_id)) {
+      return { success: false, error: 'Missing or invalid required input: contact_id (UUID)' };
+    }
+    if (!tier || typeof tier !== 'string') {
+      return { success: false, error: 'Missing required input: tier (string)' };
+    }
+    if (!(SETTABLE_TIERS as string[]).includes(tier)) {
+      return { success: false, error: `Invalid tier '${tier}'. Must be one of: ${SETTABLE_TIERS.join(', ')}` };
+    }
+    if (!ctx.contactService) {
+      return { success: false, error: 'contact-set-tier: contactService not available' };
+    }
+
+    const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+    const actorId = ctx.caller?.contactId ?? originator?.contactId;
+    if (!actorId || !UUID_RE.test(actorId)) {
+      return { success: false, error: 'Cannot determine valid actor identity — neither caller nor originator provides a valid UUID contactId' };
+    }
+
+    try {
+      const updated = await ctx.contactService.setTier(contact_id, tier as ContactTier);
+      ctx.log.info({ contactId: contact_id, tier, reason: reason ?? null, actorId }, 'contact-set-tier: tier updated');
+      return {
+        success: true,
+        data: {
+          contact_id: updated.id,
+          display_name: updated.displayName,
+          tier: updated.tier,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to set tier: ${message}` };
+    }
+  }
+}

--- a/skills/contact-set-tier/skill.json
+++ b/skills/contact-set-tier/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "contact-set-tier",
+  "description": "Set a contact's capability tier directly. Use when the CEO explicitly says to trust or block someone ('treat Dana as trusted', 'block this sender', 'John is a principal'). tier must be one of: blocked, unknown, known, trusted. (The 'principal' tier is structural and cannot be set via this skill.) contact_id must be a UUID from contact-lookup.",
+  "version": "0.1.0",
+  "sensitivity": "elevated",
+  "action_risk": "low",
+  "inputs": {
+    "contact_id": "string (UUID from contact-lookup or contact-create)",
+    "tier": "string (one of 'blocked', 'unknown', 'known', 'trusted')",
+    "reason": "string? (optional — why the tier is being changed; stored in audit log)"
+  },
+  "outputs": {
+    "contact_id": "string",
+    "display_name": "string",
+    "tier": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": []
+}

--- a/skills/decline-grant-recommendation/handler.ts
+++ b/skills/decline-grant-recommendation/handler.ts
@@ -1,0 +1,56 @@
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { isPrincipalOriginated } from '../../src/contacts/principal.js';
+import type { TaskOriginator } from '../../src/contacts/types.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class DeclineGrantRecommendationHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!isPrincipalOriginated(ctx.taskMetadata)) {
+      ctx.log.warn('decline-grant-recommendation: rejected — task not originated by principal');
+      return { success: false, error: 'This skill requires principal authorization.' };
+    }
+
+    const { recommendation_id } = ctx.input as { recommendation_id?: string };
+    if (!recommendation_id || !UUID_RE.test(recommendation_id)) {
+      return { success: false, error: 'Missing or invalid required input: recommendation_id (UUID)' };
+    }
+    if (!ctx.contactService) {
+      return { success: false, error: 'decline-grant-recommendation: contactService not available' };
+    }
+
+    const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+    const actorId = ctx.caller?.contactId ?? originator?.contactId;
+    if (!actorId || !UUID_RE.test(actorId)) {
+      return { success: false, error: 'Cannot determine valid actor identity for audit trail' };
+    }
+
+    const rec = await ctx.contactService.getGrantRecommendation(recommendation_id);
+    if (!rec) {
+      return { success: false, error: `Grant recommendation '${recommendation_id}' not found.` };
+    }
+    if (rec.status !== 'pending') {
+      return { success: false, error: `Recommendation is already ${rec.status} — cannot decline.` };
+    }
+
+    try {
+      const declined = await ctx.contactService.declineGrantRecommendation(recommendation_id, actorId);
+      if (!declined) {
+        return { success: false, error: 'Decline failed — recommendation may have been concurrently resolved.' };
+      }
+      ctx.log.info({ recommendationId: recommendation_id, contactId: rec.contactId, permission: rec.permission, actorId }, 'decline-grant-recommendation: declined (anti-nag recorded)');
+      return {
+        success: true,
+        data: {
+          recommendation_id,
+          contact_id: rec.contactId,
+          permission: rec.permission,
+          status: 'declined',
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to decline recommendation: ${message}` };
+    }
+  }
+}

--- a/skills/decline-grant-recommendation/handler.ts
+++ b/skills/decline-grant-recommendation/handler.ts
@@ -25,15 +25,15 @@ export class DeclineGrantRecommendationHandler implements SkillHandler {
       return { success: false, error: 'Cannot determine valid actor identity for audit trail' };
     }
 
-    const rec = await ctx.contactService.getGrantRecommendation(recommendation_id);
-    if (!rec) {
-      return { success: false, error: `Grant recommendation '${recommendation_id}' not found.` };
-    }
-    if (rec.status !== 'pending') {
-      return { success: false, error: `Recommendation is already ${rec.status} — cannot decline.` };
-    }
-
     try {
+      const rec = await ctx.contactService.getGrantRecommendation(recommendation_id);
+      if (!rec) {
+        return { success: false, error: `Grant recommendation '${recommendation_id}' not found.` };
+      }
+      if (rec.status !== 'pending') {
+        return { success: false, error: `Recommendation is already ${rec.status} — cannot decline.` };
+      }
+
       const declined = await ctx.contactService.declineGrantRecommendation(recommendation_id, actorId);
       if (!declined) {
         return { success: false, error: 'Decline failed — recommendation may have been concurrently resolved.' };
@@ -49,6 +49,7 @@ export class DeclineGrantRecommendationHandler implements SkillHandler {
         },
       };
     } catch (err) {
+      ctx.log.error({ err, recommendationId: recommendation_id, actorId }, 'decline-grant-recommendation: failed');
       const message = err instanceof Error ? err.message : String(err);
       return { success: false, error: `Failed to decline recommendation: ${message}` };
     }

--- a/skills/decline-grant-recommendation/skill.json
+++ b/skills/decline-grant-recommendation/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "decline-grant-recommendation",
+  "description": "Decline a pending grant recommendation. Permanently marks it as declined — Curia will never surface this specific recommendation again (anti-nag). Use when the CEO says no to a suggested grant ('no', 'not Dana', 'don't recommend that again'). recommendation_id must be the UUID from the recommendation.",
+  "version": "0.1.0",
+  "sensitivity": "elevated",
+  "action_risk": "low",
+  "inputs": {
+    "recommendation_id": "string (UUID of the pending grant recommendation)"
+  },
+  "outputs": {
+    "recommendation_id": "string",
+    "contact_id": "string",
+    "permission": "string",
+    "status": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": []
+}

--- a/skills/scan-grant-recommendations/handler.ts
+++ b/skills/scan-grant-recommendations/handler.ts
@@ -67,17 +67,24 @@ export class ScanGrantRecommendationsHandler implements SkillHandler {
       ? Math.min(Math.max(1, input.cadence_ceiling), 10)
       : 3;
 
-    // Load known-tier contacts as candidates
-    const candidates = await svc.listContacts({ tier: 'known', limit: maxCandidates });
+    // Load known-tier contacts and pre-fetch all existing recommendations
+    let candidates: Awaited<ReturnType<typeof svc.listContacts>>;
+    let allRecs: Awaited<ReturnType<typeof svc.listGrantRecommendations>>;
+    try {
+      candidates = await svc.listContacts({ tier: 'known', limit: maxCandidates });
+      allRecs = await svc.listGrantRecommendations({ limit: 10000 });
+    } catch (err) {
+      ctx.log.error({ err }, 'scan-grant-recommendations: failed to load candidates or existing recommendations');
+      return { success: false, error: 'Failed to load contacts or existing recommendations.' };
+    }
 
-    // Pre-fetch all existing recommendations once to avoid N per-contact DB queries
-    const allRecs = await svc.listGrantRecommendations({ limit: 10000 });
     const existingPairs = new Set(allRecs.map(r => `${r.contactId}:${r.permission}`));
 
     let evaluated = 0;
     let created = 0;
     let skippedExisting = 0;
     let skippedJudge = 0;
+    const recommendationsCreated: Array<{ id: string; contact_id: string; contact_name: string; permission: string; reasoning: string }> = [];
 
     for (const contact of candidates) {
       if (created >= cadenceCeiling) break;
@@ -136,7 +143,7 @@ export class ScanGrantRecommendationsHandler implements SkillHandler {
         continue;
       }
 
-      const { created: wasCreated } = await svc.createGrantRecommendation(
+      const { created: wasCreated, recommendation } = await svc.createGrantRecommendation(
         contact.id,
         CANDIDATE_PERMISSION,
         verdict.reasoning,
@@ -145,6 +152,13 @@ export class ScanGrantRecommendationsHandler implements SkillHandler {
       if (wasCreated) {
         ctx.log.info({ contactId: contact.id, permission: CANDIDATE_PERMISSION }, 'scan-grant-recommendations: recommendation created');
         existingPairs.add(`${contact.id}:${CANDIDATE_PERMISSION}`);
+        recommendationsCreated.push({
+          id: recommendation.id,
+          contact_id: contact.id,
+          contact_name: contact.displayName,
+          permission: CANDIDATE_PERMISSION,
+          reasoning: verdict.reasoning,
+        });
         created++;
       } else {
         skippedExisting++;
@@ -153,7 +167,13 @@ export class ScanGrantRecommendationsHandler implements SkillHandler {
 
     return {
       success: true,
-      data: { evaluated, created, skipped_existing: skippedExisting, skipped_judge: skippedJudge },
+      data: {
+        evaluated,
+        created,
+        skipped_existing: skippedExisting,
+        skipped_judge: skippedJudge,
+        recommendations_created: recommendationsCreated,
+      },
     };
   }
 }

--- a/skills/scan-grant-recommendations/handler.ts
+++ b/skills/scan-grant-recommendations/handler.ts
@@ -1,0 +1,159 @@
+// handler.ts — scan-grant-recommendations skill.
+//
+// Implements the LLM-judge-driven recommendation engine from issue #952.
+// For each high-confidence known-tier contact without a scheduling grant,
+// the judge decides (yes/no/reasoning) whether to surface a recommendation.
+//
+// Anti-nag: a row in grant_recommendations for (contact_id, permission) — at
+// any status — permanently blocks re-suggestion for that pair.
+//
+// Cadence ceiling: the run stops creating new recommendations once
+// cadence_ceiling new ones have been produced, preventing a burst.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const CANDIDATE_PERMISSION = 'schedule_meetings';
+
+const JUDGE_SYSTEM_PROMPT = `You are a trust assessment judge for an AI executive assistant. Decide whether a contact has demonstrated sufficient collaborative behavior to be formally granted scheduling access on the executive's behalf.
+
+Respond only in this exact JSON format:
+{"recommend": true | false, "reasoning": "One sentence explaining your recommendation."}
+
+Recommend only when the evidence clearly shows the contact regularly and productively coordinates the executive's schedule (frequent confirmed meetings, calendar coordination). Default to false when evidence is weak or ambiguous. The reasoning field is shown to the executive.`;
+
+function buildJudgePrompt(
+  displayName: string,
+  organization: string | null,
+  role: string | null,
+  confidence: number,
+  inbound: number,
+  outbound: number,
+): string {
+  const context = [
+    `Contact: ${displayName}`,
+    role ? `Role: ${role}` : null,
+    organization ? `Organization: ${organization}` : null,
+    `Confidence score: ${confidence.toFixed(2)} (0–1; ≥0.65 means meaningful interaction history)`,
+    `Messages received from them: ${inbound}`,
+    `Messages sent to them: ${outbound}`,
+  ].filter(Boolean).join('\n');
+  return `${context}\n\nShould this contact be granted scheduling access (schedule_meetings) on the executive's behalf?`;
+}
+
+export class ScanGrantRecommendationsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.infraLlm) {
+      return { success: false, error: 'scan-grant-recommendations: infraLlm capability missing' };
+    }
+    if (!ctx.contactService) {
+      return { success: false, error: 'scan-grant-recommendations: contactService not available' };
+    }
+
+    const svc = ctx.contactService;
+
+    const input = ctx.input as {
+      confidence_threshold?: number;
+      max_candidates?: number;
+      cadence_ceiling?: number;
+    };
+
+    const confidenceThreshold = typeof input.confidence_threshold === 'number'
+      ? Math.max(0, Math.min(1, input.confidence_threshold))
+      : 0.65;
+    const maxCandidates = typeof input.max_candidates === 'number'
+      ? Math.min(Math.max(1, input.max_candidates), 50)
+      : 20;
+    const cadenceCeiling = typeof input.cadence_ceiling === 'number'
+      ? Math.min(Math.max(1, input.cadence_ceiling), 10)
+      : 3;
+
+    // Load known-tier contacts as candidates
+    const candidates = await svc.listContacts({ tier: 'known', limit: maxCandidates });
+
+    // Pre-fetch all existing recommendations once to avoid N per-contact DB queries
+    const allRecs = await svc.listGrantRecommendations({ limit: 10000 });
+    const existingPairs = new Set(allRecs.map(r => `${r.contactId}:${r.permission}`));
+
+    let evaluated = 0;
+    let created = 0;
+    let skippedExisting = 0;
+    let skippedJudge = 0;
+
+    for (const contact of candidates) {
+      if (created >= cadenceCeiling) break;
+      // Skip automated senders and agents — they are exempt from tier gates
+      if (contact.kind === 'automated' || contact.kind === 'agent') continue;
+      if (contact.contactConfidence < confidenceThreshold) continue;
+
+      evaluated++;
+
+      // Skip if a recommendation for this pair already exists (any status)
+      if (existingPairs.has(`${contact.id}:${CANDIDATE_PERMISSION}`)) {
+        skippedExisting++;
+        continue;
+      }
+
+      // Skip if the permission is already explicitly granted or denied via an override
+      const overrides = await svc.getAuthOverrides(contact.id);
+      if (overrides.some(o => o.permission === CANDIDATE_PERMISSION)) {
+        skippedExisting++;
+        continue;
+      }
+
+      // Ask the LLM judge
+      const judgeResult = await ctx.infraLlm.extract(
+        `${JUDGE_SYSTEM_PROMPT}\n\n${buildJudgePrompt(
+          contact.displayName,
+          contact.organization ?? null,
+          contact.role ?? null,
+          contact.contactConfidence,
+          contact.inboundMessageCount,
+          contact.outboundMessageCount,
+        )}`,
+      );
+
+      if (!judgeResult.ok) {
+        ctx.log.warn({ contactId: contact.id, error: judgeResult.error }, 'scan-grant-recommendations: judge call failed');
+        skippedJudge++;
+        continue;
+      }
+
+      let verdict: { recommend: boolean; reasoning: string } | null = null;
+      try {
+        const parsed = JSON.parse(judgeResult.text) as { recommend?: unknown; reasoning?: unknown };
+        if (typeof parsed.recommend === 'boolean' && typeof parsed.reasoning === 'string') {
+          verdict = { recommend: parsed.recommend, reasoning: parsed.reasoning };
+        }
+      } catch {
+        ctx.log.warn({ contactId: contact.id, raw: judgeResult.text.slice(0, 200) }, 'scan-grant-recommendations: unparseable judge response');
+        skippedJudge++;
+        continue;
+      }
+
+      if (!verdict?.recommend) {
+        ctx.log.debug({ contactId: contact.id, reasoning: verdict?.reasoning }, 'scan-grant-recommendations: judge declined');
+        skippedJudge++;
+        continue;
+      }
+
+      const { created: wasCreated } = await svc.createGrantRecommendation(
+        contact.id,
+        CANDIDATE_PERMISSION,
+        verdict.reasoning,
+      );
+
+      if (wasCreated) {
+        ctx.log.info({ contactId: contact.id, permission: CANDIDATE_PERMISSION }, 'scan-grant-recommendations: recommendation created');
+        existingPairs.add(`${contact.id}:${CANDIDATE_PERMISSION}`);
+        created++;
+      } else {
+        skippedExisting++;
+      }
+    }
+
+    return {
+      success: true,
+      data: { evaluated, created, skipped_existing: skippedExisting, skipped_judge: skippedJudge },
+    };
+  }
+}

--- a/skills/scan-grant-recommendations/handler.ts
+++ b/skills/scan-grant-recommendations/handler.ts
@@ -84,6 +84,7 @@ export class ScanGrantRecommendationsHandler implements SkillHandler {
     let created = 0;
     let skippedExisting = 0;
     let skippedJudge = 0;
+    let skippedErrors = 0;
     const recommendationsCreated: Array<{ id: string; contact_id: string; contact_name: string; permission: string; reasoning: string }> = [];
 
     for (const contact of candidates) {
@@ -101,27 +102,41 @@ export class ScanGrantRecommendationsHandler implements SkillHandler {
       }
 
       // Skip if the permission is already explicitly granted or denied via an override
-      const overrides = await svc.getAuthOverrides(contact.id);
+      let overrides: Awaited<ReturnType<typeof svc.getAuthOverrides>>;
+      try {
+        overrides = await svc.getAuthOverrides(contact.id);
+      } catch (err) {
+        ctx.log.warn({ err, contactId: contact.id }, 'scan-grant-recommendations: override lookup failed, skipping contact');
+        skippedErrors++;
+        continue;
+      }
       if (overrides.some(o => o.permission === CANDIDATE_PERMISSION)) {
         skippedExisting++;
         continue;
       }
 
       // Ask the LLM judge
-      const judgeResult = await ctx.infraLlm.extract(
-        `${JUDGE_SYSTEM_PROMPT}\n\n${buildJudgePrompt(
-          contact.displayName,
-          contact.organization ?? null,
-          contact.role ?? null,
-          contact.contactConfidence,
-          contact.inboundMessageCount,
-          contact.outboundMessageCount,
-        )}`,
-      );
+      let judgeResult: Awaited<ReturnType<typeof ctx.infraLlm.extract>>;
+      try {
+        judgeResult = await ctx.infraLlm.extract(
+          `${JUDGE_SYSTEM_PROMPT}\n\n${buildJudgePrompt(
+            contact.displayName,
+            contact.organization ?? null,
+            contact.role ?? null,
+            contact.contactConfidence,
+            contact.inboundMessageCount,
+            contact.outboundMessageCount,
+          )}`,
+        );
+      } catch (err) {
+        ctx.log.warn({ err, contactId: contact.id }, 'scan-grant-recommendations: judge transport error, skipping contact');
+        skippedErrors++;
+        continue;
+      }
 
       if (!judgeResult.ok) {
         ctx.log.warn({ contactId: contact.id, error: judgeResult.error }, 'scan-grant-recommendations: judge call failed');
-        skippedJudge++;
+        skippedErrors++;
         continue;
       }
 
@@ -133,7 +148,7 @@ export class ScanGrantRecommendationsHandler implements SkillHandler {
         }
       } catch {
         ctx.log.warn({ contactId: contact.id, raw: judgeResult.text.slice(0, 200) }, 'scan-grant-recommendations: unparseable judge response');
-        skippedJudge++;
+        skippedErrors++;
         continue;
       }
 
@@ -172,6 +187,7 @@ export class ScanGrantRecommendationsHandler implements SkillHandler {
         created,
         skipped_existing: skippedExisting,
         skipped_judge: skippedJudge,
+        skipped_errors: skippedErrors,
         recommendations_created: recommendationsCreated,
       },
     };

--- a/skills/scan-grant-recommendations/skill.json
+++ b/skills/scan-grant-recommendations/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "scan-grant-recommendations",
+  "description": "Scan contacts and proactively suggest capability grants for contacts who have earned them through demonstrated trust patterns. Runs the LLM-judge recommendation engine. Returns a summary of new recommendations created. Invoke on a schedule — not in response to user requests.",
+  "version": "0.1.0",
+  "sensitivity": "internal",
+  "action_risk": "none",
+  "inputs": {
+    "confidence_threshold": "number? (minimum contact_confidence to consider; default 0.65)",
+    "max_candidates": "number? (max contacts to evaluate per run; default 20)",
+    "cadence_ceiling": "number? (max new pending recommendations to create in one run; default 3)"
+  },
+  "outputs": {
+    "evaluated": "number (contacts evaluated)",
+    "created": "number (new recommendations created)",
+    "skipped_existing": "number (candidates skipped because a recommendation already exists)",
+    "skipped_judge": "number (candidates skipped because the judge declined to recommend)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 60000,
+  "capabilities": ["infraLlm"]
+}

--- a/skills/scan-grant-recommendations/skill.json
+++ b/skills/scan-grant-recommendations/skill.json
@@ -13,7 +13,8 @@
     "evaluated": "number (contacts evaluated)",
     "created": "number (new recommendations created)",
     "skipped_existing": "number (candidates skipped because a recommendation already exists)",
-    "skipped_judge": "number (candidates skipped because the judge declined to recommend)",
+    "skipped_judge": "number (candidates where the judge explicitly declined to recommend)",
+    "skipped_errors": "number (candidates skipped due to transport/parse failures — not judge decisions)",
     "recommendations_created": "array of { id, contact_id, contact_name, permission, reasoning } for each newly created recommendation"
   },
   "permissions": [],

--- a/skills/scan-grant-recommendations/skill.json
+++ b/skills/scan-grant-recommendations/skill.json
@@ -2,7 +2,7 @@
   "name": "scan-grant-recommendations",
   "description": "Scan contacts and proactively suggest capability grants for contacts who have earned them through demonstrated trust patterns. Runs the LLM-judge recommendation engine. Returns a summary of new recommendations created. Invoke on a schedule — not in response to user requests.",
   "version": "0.1.0",
-  "sensitivity": "internal",
+  "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "confidence_threshold": "number? (minimum contact_confidence to consider; default 0.65)",
@@ -13,7 +13,8 @@
     "evaluated": "number (contacts evaluated)",
     "created": "number (new recommendations created)",
     "skipped_existing": "number (candidates skipped because a recommendation already exists)",
-    "skipped_judge": "number (candidates skipped because the judge declined to recommend)"
+    "skipped_judge": "number (candidates skipped because the judge declined to recommend)",
+    "recommendations_created": "array of { id, contact_id, contact_name, permission, reasoning } for each newly created recommendation"
   },
   "permissions": [],
   "secrets": [],

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1138,7 +1138,7 @@ export async function knowledgeGraphRoutes(
     const statusFilter = query.status === 'pending' || query.status === 'approved' || query.status === 'declined'
       ? query.status
       : 'pending';
-    const limit = Math.min(Number.parseInt(query.limit ?? '50', 10) || 50, 200);
+    const limit = Math.max(1, Math.min(Number.parseInt(query.limit ?? '50', 10) || 50, 200));
 
     try {
       const recommendations = await contactService.listGrantRecommendations({ status: statusFilter, limit });

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1093,6 +1093,62 @@ export async function knowledgeGraphRoutes(
     return reply.status(204).send();
   });
 
+  // GET /api/kg/contacts/:id/overrides — list active auth overrides for a contact.
+  app.get('/api/kg/contacts/:id/overrides', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+    const { id } = request.params as { id: string };
+    if (!UUID_RE.test(id)) return reply.status(400).send({ error: 'Invalid contact ID.' });
+
+    try {
+      const contact = await contactService.getContact(id);
+      if (!contact) return reply.status(404).send({ error: 'Contact not found.' });
+      const overrides = await contactService.getAuthOverrides(id);
+      return reply.send({ overrides });
+    } catch (err) {
+      logger.error({ err, contactId: id }, 'GET /api/kg/contacts/:id/overrides failed');
+      return reply.status(500).send({ error: 'Failed to load auth overrides.' });
+    }
+  });
+
+  // DELETE /api/kg/contacts/:id/overrides/:permission — revoke a specific override.
+  app.delete('/api/kg/contacts/:id/overrides/:permission', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+    const { id, permission } = request.params as { id: string; permission: string };
+    if (!UUID_RE.test(id)) return reply.status(400).send({ error: 'Invalid contact ID.' });
+    if (!/^[a-z][a-z0-9_]*$/.test(permission)) {
+      return reply.status(400).send({ error: 'Invalid permission name.' });
+    }
+
+    try {
+      const contact = await contactService.getContact(id);
+      if (!contact) return reply.status(404).send({ error: 'Contact not found.' });
+      const revoked = await contactService.revokePermission(id, permission);
+      if (!revoked) return reply.status(404).send({ error: 'No active override found for this permission.' });
+      return reply.status(204).send();
+    } catch (err) {
+      logger.error({ err, contactId: id, permission }, 'DELETE /api/kg/contacts/:id/overrides/:permission failed');
+      return reply.status(500).send({ error: 'Failed to revoke override.' });
+    }
+  });
+
+  // GET /api/kg/grant-recommendations — list pending (or all) grant recommendations.
+  app.get('/api/kg/grant-recommendations', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+    const query = request.query as { status?: string; limit?: string };
+    const statusFilter = query.status === 'pending' || query.status === 'approved' || query.status === 'declined'
+      ? query.status
+      : 'pending';
+    const limit = Math.min(Number.parseInt(query.limit ?? '50', 10) || 50, 200);
+
+    try {
+      const recommendations = await contactService.listGrantRecommendations({ status: statusFilter, limit });
+      return reply.send({ recommendations });
+    } catch (err) {
+      logger.error({ err }, 'GET /api/kg/grant-recommendations failed');
+      return reply.status(500).send({ error: 'Failed to load grant recommendations.' });
+    }
+  });
+
   // ── Chat endpoints ──────────────────────────────────────────────────────
   //
   // The chat endpoints let the KG web app send messages to the agent layer

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -27,6 +27,8 @@ import type {
   CreateContactOptions,
   DedupConfidence,
   DuplicatePair,
+  GrantRecommendation,
+  GrantRecommendationStatus,
   LinkIdentityOptions,
   MergeGoldenRecord,
   MergeProposal,
@@ -220,6 +222,13 @@ interface ContactServiceBackend {
   getAuthOverrides(contactId: string): Promise<Array<{ permission: string; granted: boolean }>>;
   createAuthOverride(override: AuthOverride): Promise<void>;
   revokeAuthOverride(contactId: string, permission: string): Promise<boolean>;
+
+  // -- Grant recommendations (issue #952) --
+  createGrantRecommendation(rec: GrantRecommendation): Promise<void>;
+  getGrantRecommendation(id: string): Promise<GrantRecommendation | null>;
+  findGrantRecommendation(contactId: string, permission: string): Promise<GrantRecommendation | null>;
+  listGrantRecommendations(filters?: { status?: GrantRecommendationStatus; limit?: number }): Promise<GrantRecommendation[]>;
+  resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string): Promise<boolean>;
   createCalendarLink(calendar: ContactCalendar): Promise<void>;
   deleteCalendarLink(nylasCalendarId: string): Promise<boolean>;
   getCalendarsForContact(contactId: string): Promise<ContactCalendar[]>;
@@ -1151,6 +1160,86 @@ export class ContactService {
     return this.backend.revokeAuthOverride(contactId, permission);
   }
 
+  // ---- Grant recommendations (issue #952) ----
+
+  /**
+   * Create a new grant recommendation for a contact+permission pair.
+   * Returns false (no-op) when a recommendation already exists for this pair —
+   * the caller must check first if dedup is desired at the service layer.
+   */
+  async createGrantRecommendation(
+    contactId: string,
+    permission: string,
+    reasoning: string,
+  ): Promise<{ created: boolean; recommendation: GrantRecommendation }> {
+    const existing = await this.backend.findGrantRecommendation(contactId, permission);
+    if (existing) {
+      return { created: false, recommendation: existing };
+    }
+
+    const rec: GrantRecommendation = {
+      id: randomUUID(),
+      contactId,
+      permission,
+      reasoning,
+      status: 'pending',
+      suggestedAt: new Date(),
+      resolvedAt: null,
+      resolvedBy: null,
+    };
+    await this.backend.createGrantRecommendation(rec);
+    this.logger?.info({ contactId, permission }, 'contacts: grant recommendation created');
+    return { created: true, recommendation: rec };
+  }
+
+  /** Fetch a single grant recommendation by ID. */
+  async getGrantRecommendation(id: string): Promise<GrantRecommendation | null> {
+    return this.backend.getGrantRecommendation(id);
+  }
+
+  /** List grant recommendations, optionally filtered by status. */
+  async listGrantRecommendations(
+    filters?: { status?: GrantRecommendationStatus; limit?: number },
+  ): Promise<GrantRecommendation[]> {
+    return this.backend.listGrantRecommendations(filters);
+  }
+
+  /**
+   * Approve a pending grant recommendation.
+   * Also writes the contact_auth_overrides row so the permission takes effect immediately.
+   * Returns false if the recommendation was not found or not in 'pending' status.
+   */
+  async approveGrantRecommendation(id: string, actorId: string): Promise<boolean> {
+    const rec = await this.backend.getGrantRecommendation(id);
+    if (!rec || rec.status !== 'pending') return false;
+
+    // Grant the permission before resolving the recommendation, so any failure
+    // here leaves the recommendation pending (retryable) rather than approved-but-not-granted.
+    await this.grantPermission(rec.contactId, rec.permission, true, actorId);
+    const resolved = await this.backend.resolveGrantRecommendation(id, 'approved', actorId);
+    if (resolved) {
+      this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation approved');
+    }
+    return resolved;
+  }
+
+  /**
+   * Decline a pending grant recommendation.
+   * The row is permanently retained in 'declined' state as an anti-nag ledger entry —
+   * the recommendation engine must check for declined rows before suggesting again.
+   * Returns false if the recommendation was not found or not in 'pending' status.
+   */
+  async declineGrantRecommendation(id: string, actorId: string): Promise<boolean> {
+    const rec = await this.backend.getGrantRecommendation(id);
+    if (!rec || rec.status !== 'pending') return false;
+
+    const resolved = await this.backend.resolveGrantRecommendation(id, 'declined', actorId);
+    if (resolved) {
+      this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation declined (anti-nag recorded)');
+    }
+    return resolved;
+  }
+
   /**
    * Link a calendar to a contact (or null for org-wide calendars).
    * Validates the contact exists (if contactId is non-null) and enforces
@@ -1876,6 +1965,97 @@ class PostgresContactBackend implements ContactServiceBackend {
     return (result.rowCount ?? 0) > 0;
   }
 
+  // ---- Grant recommendations (issue #952) ----
+
+  async createGrantRecommendation(rec: GrantRecommendation): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO grant_recommendations
+         (id, contact_id, permission, reasoning, status, suggested_at, resolved_at, resolved_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (contact_id, permission) DO NOTHING`,
+      [rec.id, rec.contactId, rec.permission, rec.reasoning, rec.status, rec.suggestedAt, rec.resolvedAt, rec.resolvedBy],
+    );
+  }
+
+  async getGrantRecommendation(id: string): Promise<GrantRecommendation | null> {
+    const result = await this.pool.query<{
+      id: string; contact_id: string; permission: string; reasoning: string;
+      status: string; suggested_at: Date; resolved_at: Date | null; resolved_by: string | null;
+    }>(
+      `SELECT id, contact_id, permission, reasoning, status, suggested_at, resolved_at, resolved_by
+       FROM grant_recommendations WHERE id = $1`,
+      [id],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return this.rowToGrantRecommendation(row);
+  }
+
+  async findGrantRecommendation(contactId: string, permission: string): Promise<GrantRecommendation | null> {
+    const result = await this.pool.query<{
+      id: string; contact_id: string; permission: string; reasoning: string;
+      status: string; suggested_at: Date; resolved_at: Date | null; resolved_by: string | null;
+    }>(
+      `SELECT id, contact_id, permission, reasoning, status, suggested_at, resolved_at, resolved_by
+       FROM grant_recommendations WHERE contact_id = $1 AND permission = $2`,
+      [contactId, permission],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return this.rowToGrantRecommendation(row);
+  }
+
+  async listGrantRecommendations(
+    filters?: { status?: GrantRecommendationStatus; limit?: number },
+  ): Promise<GrantRecommendation[]> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters?.status) {
+      params.push(filters.status);
+      conditions.push(`status = $${params.length}`);
+    }
+
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const limitClause = filters?.limit ? `LIMIT ${filters.limit}` : '';
+
+    const result = await this.pool.query<{
+      id: string; contact_id: string; permission: string; reasoning: string;
+      status: string; suggested_at: Date; resolved_at: Date | null; resolved_by: string | null;
+    }>(
+      `SELECT id, contact_id, permission, reasoning, status, suggested_at, resolved_at, resolved_by
+       FROM grant_recommendations ${where} ORDER BY suggested_at DESC ${limitClause}`,
+      params,
+    );
+    return result.rows.map(row => this.rowToGrantRecommendation(row));
+  }
+
+  async resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `UPDATE grant_recommendations
+       SET status = $2, resolved_at = now(), resolved_by = $3
+       WHERE id = $1 AND status = 'pending'`,
+      [id, status, resolvedBy],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  private rowToGrantRecommendation(row: {
+    id: string; contact_id: string; permission: string; reasoning: string;
+    status: string; suggested_at: Date; resolved_at: Date | null; resolved_by: string | null;
+  }): GrantRecommendation {
+    return {
+      id: row.id,
+      contactId: row.contact_id,
+      permission: row.permission,
+      reasoning: row.reasoning,
+      status: row.status as GrantRecommendationStatus,
+      suggestedAt: row.suggested_at,
+      resolvedAt: row.resolved_at,
+      resolvedBy: row.resolved_by,
+    };
+  }
+
   async createCalendarLink(calendar: ContactCalendar): Promise<void> {
     this.logger.debug({ calendarId: calendar.id, nylasCalendarId: calendar.nylasCalendarId }, 'contacts: linking calendar');
     await this.pool.query(
@@ -2526,5 +2706,52 @@ class InMemoryContactBackend implements ContactServiceBackend {
     for (const [oid, override] of this.overrides) {
       if (override.contactId === id) this.overrides.delete(oid);
     }
+  }
+
+  // ---- Grant recommendations (issue #952) — in-memory stubs ----
+
+  private recommendations = new Map<string, GrantRecommendation>();
+
+  async createGrantRecommendation(rec: GrantRecommendation): Promise<void> {
+    const key = `${rec.contactId}:${rec.permission}`;
+    // Mimic ON CONFLICT DO NOTHING
+    for (const r of this.recommendations.values()) {
+      if (r.contactId === rec.contactId && r.permission === rec.permission) return;
+    }
+    this.recommendations.set(key, rec);
+  }
+
+  async getGrantRecommendation(id: string): Promise<GrantRecommendation | null> {
+    for (const rec of this.recommendations.values()) {
+      if (rec.id === id) return rec;
+    }
+    return null;
+  }
+
+  async findGrantRecommendation(contactId: string, permission: string): Promise<GrantRecommendation | null> {
+    for (const rec of this.recommendations.values()) {
+      if (rec.contactId === contactId && rec.permission === permission) return rec;
+    }
+    return null;
+  }
+
+  async listGrantRecommendations(
+    filters?: { status?: GrantRecommendationStatus; limit?: number },
+  ): Promise<GrantRecommendation[]> {
+    let results = Array.from(this.recommendations.values());
+    if (filters?.status) results = results.filter(r => r.status === filters.status);
+    results.sort((a, b) => b.suggestedAt.getTime() - a.suggestedAt.getTime());
+    if (filters?.limit) results = results.slice(0, filters.limit);
+    return results;
+  }
+
+  async resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string): Promise<boolean> {
+    for (const [key, rec] of this.recommendations) {
+      if (rec.id === id && rec.status === 'pending') {
+        this.recommendations.set(key, { ...rec, status, resolvedAt: new Date(), resolvedBy });
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -2017,7 +2017,10 @@ class PostgresContactBackend implements ContactServiceBackend {
     }
 
     const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
-    const limitClause = filters?.limit ? `LIMIT ${filters.limit}` : '';
+    if (filters?.limit) {
+      params.push(filters.limit);
+    }
+    const limitClause = filters?.limit ? `LIMIT $${params.length}` : '';
 
     const result = await this.pool.query<{
       id: string; contact_id: string; permission: string; reasoning: string;
@@ -2706,6 +2709,9 @@ class InMemoryContactBackend implements ContactServiceBackend {
     for (const [oid, override] of this.overrides) {
       if (override.contactId === id) this.overrides.delete(oid);
     }
+    for (const [rk, rec] of this.recommendations) {
+      if (rec.contactId === id) this.recommendations.delete(rk);
+    }
   }
 
   // ---- Grant recommendations (issue #952) — in-memory stubs ----
@@ -2713,6 +2719,10 @@ class InMemoryContactBackend implements ContactServiceBackend {
   private recommendations = new Map<string, GrantRecommendation>();
 
   async createGrantRecommendation(rec: GrantRecommendation): Promise<void> {
+    // Mimic Postgres FK constraint: contact must exist
+    if (!this.contacts.has(rec.contactId)) {
+      throw new Error(`Foreign key violation: contact '${rec.contactId}' does not exist`);
+    }
     const key = `${rec.contactId}:${rec.permission}`;
     // Mimic ON CONFLICT DO NOTHING
     for (const r of this.recommendations.values()) {

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -451,6 +451,23 @@ export class IdentityNotFoundError extends Error {
   }
 }
 
+// -- Grant recommendation types (issue #952) --
+
+export type GrantRecommendationStatus = 'pending' | 'approved' | 'declined';
+
+export interface GrantRecommendation {
+  id: string;
+  contactId: string;
+  /** The permission string being recommended (e.g. 'schedule_meetings'). */
+  permission: string;
+  /** LLM-authored rationale surfaced to the CEO for context. */
+  reasoning: string;
+  status: GrantRecommendationStatus;
+  suggestedAt: Date;
+  resolvedAt: Date | null;
+  resolvedBy: string | null;
+}
+
 // -- ContactService dependency injection for dedup wiring --
 
 export interface ContactServiceOptions {

--- a/src/db/migrations/058_create_grant_recommendations.sql
+++ b/src/db/migrations/058_create_grant_recommendations.sql
@@ -1,0 +1,40 @@
+-- Up Migration
+--
+-- Issue #952: grant_recommendations table.
+--
+-- Stores proactive grant suggestions that Curia surfaces to the CEO.
+-- The table acts as both the recommendation queue and the permanent
+-- anti-nag ledger: a declined row is never deleted, so the judge can
+-- check UNIQUE(contact_id, permission) and never re-suggest the same
+-- capability for the same contact.
+--
+-- status flow:
+--   pending   → approved  (CEO approves; contact_auth_overrides row also written)
+--   pending   → declined  (CEO declines; permanent — never resurfaces)
+--
+-- Only one row per (contact_id, permission) pair is ever created.
+-- The judge must check for an existing row before inserting.
+
+CREATE TABLE grant_recommendations (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contact_id      UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  permission      TEXT NOT NULL,
+  reasoning       TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'approved', 'declined')),
+  suggested_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at     TIMESTAMPTZ,
+  resolved_by     TEXT,
+
+  -- One lifetime record per contact+permission pair prevents re-nag.
+  UNIQUE (contact_id, permission)
+);
+
+CREATE INDEX idx_gr_pending    ON grant_recommendations (suggested_at)
+  WHERE status = 'pending';
+CREATE INDEX idx_gr_contact    ON grant_recommendations (contact_id);
+
+-- Down Migration
+DROP INDEX IF EXISTS idx_gr_contact;
+DROP INDEX IF EXISTS idx_gr_pending;
+DROP TABLE IF EXISTS grant_recommendations;

--- a/src/db/migrations/058_create_grant_recommendations.sql
+++ b/src/db/migrations/058_create_grant_recommendations.sql
@@ -26,6 +26,12 @@ CREATE TABLE grant_recommendations (
   resolved_at     TIMESTAMPTZ,
   resolved_by     TEXT,
 
+  -- Pending rows must have no resolver metadata; resolved rows must have both.
+  CHECK (
+    (status = 'pending'  AND resolved_at IS NULL AND resolved_by IS NULL) OR
+    (status != 'pending' AND resolved_at IS NOT NULL AND resolved_by IS NOT NULL)
+  ),
+
   -- One lifetime record per contact+permission pair prevents re-nag.
   UNIQUE (contact_id, permission)
 );


### PR DESCRIPTION
## Summary

- **`contact-set-tier` skill** — set a contact's tier directly from chat ("treat Dana as trusted", "block this sender") with principal-auth guard
- **`scan-grant-recommendations` skill** — LLM-judge-driven weekly scan evaluates high-confidence known-tier contacts and proposes `schedule_meetings` grants; cadence ceiling (3/run) keeps it quiet
- **`approve-grant-recommendation` / `decline-grant-recommendation` skills** — close the recommendation loop; a declined row is a permanent anti-nag ledger entry (UNIQUE constraint prevents re-suggestion)
- **Migration `058_create_grant_recommendations`** — one row per (contact_id, permission) pair; persists through approve/decline as the permanent record
- **ContactService** — `createGrantRecommendation`, `approveGrantRecommendation`, `declineGrantRecommendation`, `listGrantRecommendations` + full PostgreSQL and in-memory backend implementations; `GrantRecommendation` / `GrantRecommendationStatus` types added to `types.ts`
- **`kg.ts` API** — `GET /api/kg/contacts/:id/overrides`, `DELETE /api/kg/contacts/:id/overrides/:permission`, `GET /api/kg/grant-recommendations`
- **ContactsPage** — new "Permission grants" section in the contact drawer: shows all active auth overrides with inline revoke buttons
- **`contacts.yaml`** — tier/permission grant guidance added to system prompt; 5 new pinned skills; Wednesday 10 AM recommendation scan cron job

## Test plan

- [ ] `contact-set-tier` sets `tier` column and rejects non-principal callers
- [ ] `scan-grant-recommendations` creates at most `cadence_ceiling` recommendations per run; skips contacts already with an override or existing recommendation
- [ ] `approve-grant-recommendation` writes both a `contact_auth_overrides` row and updates the recommendation to `approved`
- [ ] `decline-grant-recommendation` sets `declined`; subsequent scan runs skip that (contact_id, permission) pair
- [ ] `GET /api/kg/contacts/:id/overrides` returns active overrides for a contact
- [ ] `DELETE /api/kg/contacts/:id/overrides/:permission` revokes the override
- [ ] ContactsPage drawer shows overrides for an existing contact; revoke button calls the API

Closes #952