### PR TITLE
chore: complete trust_level → tier collapse; retire reader/writer machinery (#1070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
-- **`trust_level` column retired as active read/write path** — the three remaining readers (confidence scorer, trust scorer, permission resolver) and all writers now key on `tier` (`ContactTier`) instead. `setTrustLevel()`, `deriveTierFromTrustLevelUpdate()`, and `meetsMinimumTrust()` removed. The `trust_level` DB column remains (dropped in #955). `config/role-defaults.yaml` `trust_level_defaults` renamed to `tier_defaults` with `ContactTier` keys. (#1070)
+- **`trust_level` column retired as active read/write path** — the three remaining readers (confidence scorer, trust scorer, permission resolver) and all writers now key on `tier` (`ContactTier`) instead. `setTrustLevel()`, `deriveTierFromTrustLevelUpdate()`, and `meetsMinimumTrust()` removed. The `trust_level` DB column remains (dropped in #955). `config/role-defaults.yaml` `trust_level_defaults` renamed to `tier_defaults` with `ContactTier` keys. **Authorization behavior change:** contacts previously stored with `trust_level=null` were backfilled to `tier='known'` (rank 1, medium-equivalent) rather than rank 0. On low-trust channels (e.g. email), medium-sensitivity permissions granted by a role are now allowed for these contacts where they were previously trust-blocked. High-sensitivity permissions remain blocked. (#1070)
 - **ceo-inbox agent** (v0.7.0 → v0.8.0) — automated senders default to Cleared; escalated only on actionable signals. (#953)
 - **`contact-list` skill** (v1.2.1 → v1.3.0) — default view excludes automated and agent contacts. (#953)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`trust_level` column retired as active read/write path** — the three remaining readers (confidence scorer, trust scorer, permission resolver) and all writers now key on `tier` (`ContactTier`) instead. `setTrustLevel()`, `deriveTierFromTrustLevelUpdate()`, and `meetsMinimumTrust()` removed. The `trust_level` DB column remains (dropped in #955). `config/role-defaults.yaml` `trust_level_defaults` renamed to `tier_defaults` with `ContactTier` keys. (#1070)
 - **ceo-inbox agent** (v0.7.0 → v0.8.0) — automated senders default to Cleared; escalated only on actionable signals. (#953)
 - **`contact-list` skill** (v1.2.1 → v1.3.0) — default view excludes automated and agent contacts. (#953)
 

--- a/config/role-defaults.yaml
+++ b/config/role-defaults.yaml
@@ -87,18 +87,18 @@ roles:
     default_deny:
       - "*"
 
-# Trust-level tier defaults — fallback when a contact's role has no config match.
-# Keyed by trust_level value. A contact with trust_level='high' and role='Sister'
-# (no 'sister' key in roles above) will use the 'high' entry below.
-trust_level_defaults:
-  ceo:
-    description: "CEO trust tier — full access"
+# Tier defaults — fallback when a contact's role has no config match.
+# Keyed by ContactTier value. A contact with tier='trusted' and role='Sister'
+# (no 'sister' key in roles above) will use the 'trusted' entry below.
+tier_defaults:
+  principal:
+    description: "Principal tier — full access"
     default_permissions:
       - "*"
     default_deny: []
 
-  high:
-    description: "High-trust contact (family, close personal)"
+  trusted:
+    description: "Trusted tier — elevated access (family, close personal)"
     default_permissions:
       - see_personal_calendar
       - book_travel
@@ -111,8 +111,8 @@ trust_level_defaults:
       - view_board_materials
       - access_internal_docs
 
-  medium:
-    description: "Medium-trust contact (professional)"
+  known:
+    description: "Known tier — standard confirmed contact"
     default_permissions:
       - schedule_meetings
       - request_action_items
@@ -121,8 +121,8 @@ trust_level_defaults:
       - view_board_materials
       - access_internal_docs
 
-  low:
-    description: "Low-trust contact (acquaintance, cold contact)"
+  unknown:
+    description: "Unknown tier — unconfirmed contact"
     default_permissions: []
     default_deny:
       - "*"

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -6,7 +6,7 @@ import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import { ContactValidationError } from '../../../contacts/contact-service.js';
-import type { Contact, ContactCanonicalFields, ContactKind, ContactStatus, ContactTier, TrustLevel } from '../../../contacts/types.js';
+import type { Contact, ContactCanonicalFields, ContactKind, ContactStatus, ContactTier } from '../../../contacts/types.js';
 import type { EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { markdownToHtml } from '../../../utils/markdown-to-html.js';
@@ -844,7 +844,6 @@ export async function knowledgeGraphRoutes(
       displayName?: unknown;
       role?: unknown;
       status?: unknown;
-      trustLevel?: unknown;
       tier?: unknown;
       kind?: unknown;
       notes?: unknown;
@@ -857,11 +856,6 @@ export async function knowledgeGraphRoutes(
     const status = typeof body.status === 'string' ? body.status : 'confirmed';
     if (!validContactStatuses.includes(status as ContactStatus)) {
       return reply.status(400).send({ error: 'Invalid status.' });
-    }
-    const validTrustLevelsCreate = ['ceo', 'high', 'medium', 'low'];
-    if (body.trustLevel !== undefined && body.trustLevel !== null &&
-        (typeof body.trustLevel !== 'string' || !validTrustLevelsCreate.includes(body.trustLevel))) {
-      return reply.status(400).send({ error: 'Invalid trustLevel.' });
     }
     if (body.tier !== undefined &&
         (typeof body.tier !== 'string' || !validContactTiers.includes(body.tier as ContactTier))) {
@@ -895,13 +889,7 @@ export async function knowledgeGraphRoutes(
       ...canonicalFields,
     });
 
-    // Apply trustLevel if provided — createContact always initialises it to null.
-    if (typeof body.trustLevel === 'string') {
-      await contactService.setTrustLevel(created.id, body.trustLevel as TrustLevel);
-    }
-
-    // Read back after create + trustLevel so the post-derivation tier is the base
-    // for any tier/kind override below.
+    // Read back so tier/kind overrides below start from the current contact state.
     let freshCreated = await contactService.getContact(created.id);
     if (!freshCreated) {
       // Should never happen — contact was just created — but guard rather than return stale data.
@@ -929,7 +917,6 @@ export async function knowledgeGraphRoutes(
       displayName?: unknown;
       role?: unknown;
       status?: unknown;
-      trustLevel?: unknown;
       tier?: unknown;
       kind?: unknown;
       notes?: unknown;
@@ -943,11 +930,6 @@ export async function knowledgeGraphRoutes(
     // Validate all inputs before any mutations to avoid partial writes on bad input.
     if (typeof body.status === 'string' && !validContactStatuses.includes(body.status as ContactStatus)) {
       return reply.status(400).send({ error: 'Invalid status.' });
-    }
-    const validTrustLevels = ['ceo', 'high', 'medium', 'low'];
-    if ('trustLevel' in body && body.trustLevel !== null &&
-        (typeof body.trustLevel !== 'string' || !validTrustLevels.includes(body.trustLevel))) {
-      return reply.status(400).send({ error: 'Invalid trustLevel.' });
     }
     // Validate tier — rejects 'principal' (structural, derived from system_role).
     if ('tier' in body) {
@@ -997,21 +979,14 @@ export async function knowledgeGraphRoutes(
       }
     }
 
-    // Legacy setStatus / setTrustLevel are not transaction-aware (retired in #955).
-    // Run them first: they carry tier-derivation side-effects (setStatus → newTier,
-    // setTrustLevel → newTier) that must be captured before building `pending`.
+    // setStatus is not transaction-aware — run it first so the tier-derivation
+    // side-effect is captured before building `pending`.
     if (typeof body.status === 'string') {
       await contactService.setStatus(id, body.status as ContactStatus);
     }
-    if ('trustLevel' in body) {
-      await contactService.setTrustLevel(id, (body.trustLevel as TrustLevel | null));
-    }
 
-    // Re-read after legacy mutations if any ran so that tier/status/trustLevel
-    // derivations from setStatus / setTrustLevel are reflected in the pending base.
-    // Without this, saveContact would overwrite the legacy-mutation writes with
-    // stale values from the pre-mutation `contact` snapshot.
-    const base: Contact = (typeof body.status === 'string' || 'trustLevel' in body)
+    // Re-read after setStatus if it ran so the tier derivation is reflected in the pending base.
+    const base: Contact = (typeof body.status === 'string')
       ? ((await contactService.getContact(id)) ?? contact)
       : contact;
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -986,9 +986,14 @@ export async function knowledgeGraphRoutes(
     }
 
     // Re-read after setStatus if it ran so the tier derivation is reflected in the pending base.
-    const base: Contact = (typeof body.status === 'string')
-      ? ((await contactService.getContact(id)) ?? contact)
-      : contact;
+    let base: Contact = contact;
+    if (typeof body.status === 'string') {
+      const refreshed = await contactService.getContact(id);
+      if (!refreshed) {
+        logger.warn({ contactId: id }, 'PATCH: contact vanished after setStatus — using stale base');
+      }
+      base = refreshed ?? contact;
+    }
 
     // Build the complete updated contact in memory. All field changes are merged
     // here so the transaction only needs one write — avoids non-transactional stale

--- a/src/contacts/authorization.ts
+++ b/src/contacts/authorization.ts
@@ -95,7 +95,7 @@ export class AuthorizationService {
     const roleName = (input.role ?? '').toLowerCase();
     const roleDefaults =
       (roleName !== '' ? this.config.roles[roleName] : undefined) ??
-      (input.trustLevel != null ? this.config.trustLevelDefaults?.[input.trustLevel] : undefined) ??
+      (input.trustLevel != null ? this.config.tierDefaults?.[input.trustLevel] : undefined) ??
       this.config.roles['unknown'] ??
       { description: 'fallback', defaultPermissions: [], defaultDeny: ['*'] };
 

--- a/src/contacts/authorization.ts
+++ b/src/contacts/authorization.ts
@@ -8,18 +8,29 @@
 // 3. Channel trust — high-sensitivity actions on low-trust channels are trust-blocked
 //
 // Role lookup is case-insensitive: LLM-assigned roles like 'Spouse' match 'spouse' in config.
-// If the role has no config match, falls back to trust_level tier defaults so confirmed
-// contacts with an explicit trust grant still get appropriate permissions.
-// Effective trust = max(channel trust, contact trust_level) — a contact's explicit trust
+// If the role has no config match, falls back to tier defaults so confirmed
+// contacts with an explicit tier grant still get appropriate permissions.
+// Effective trust = max(channel trust, contact tier rank) — a contact's tier
 // grant is not downgraded by the channel's inherent floor.
 
 import type {
   AuthConfig,
   AuthorizationResult,
   ContactStatus,
+  ContactTier,
   TrustLevel,
 } from './types.js';
 import { TRUST_RANK } from './types.js';
+
+// Map ContactTier to a trust rank comparable to TRUST_RANK for effective-trust gating.
+// principal≈ceo(3), trusted≈high(2), known≈medium(1), unknown/blocked=0.
+const TIER_TO_TRUST_RANK: Record<ContactTier, number> = {
+  blocked:   0,
+  unknown:   0,
+  known:     1,
+  trusted:   2,
+  principal: 3,
+};
 
 interface AuthOverrideInput {
   permission: string;
@@ -28,8 +39,8 @@ interface AuthOverrideInput {
 
 export interface AuthEvaluateInput {
   role: string | null;
-  /** Per-contact trust_level from DB, or null to use only the channel floor. */
-  trustLevel: TrustLevel | null;
+  /** Contact tier from DB. Used for role-defaults fallback and effective-trust gating. */
+  tier: ContactTier;
   status: ContactStatus;
   channel: string;
   overrides: AuthOverrideInput[];
@@ -42,9 +53,9 @@ export interface AuthEvaluateInput {
  * 1. Contact status (provisional/blocked → zero permissions)
  * 2. Per-contact overrides (explicit grants/denials from the CEO)
  * 3. Role defaults (from config/role-defaults.yaml, case-insensitive lookup)
- *    Falls back to trust_level tier defaults when no role match exists.
- * 4. Effective trust (max of channel trust and contact trust_level) used for
- *    sensitivity gating, so explicit high-trust grants are not channel-downgraded.
+ *    Falls back to tier_defaults when no role match exists.
+ * 4. Effective trust (max of channel trust and contact tier rank) used for
+ *    sensitivity gating, so explicit high-tier grants are not channel-downgraded.
  *
  * This is NOT an LLM decision — it's a deterministic function of config + data.
  */
@@ -68,34 +79,29 @@ export class AuthorizationService {
     }
 
     // Effective trust: the higher of the channel's inherent trust and the contact's
-    // explicit trust_level grant. A contact with trust_level='high' on email (low)
-    // should not have their CEO-granted trust overridden by the channel floor.
-    // Contacts with no explicit trust_level (null) use only the channel floor.
+    // tier rank. A contact with tier='trusted' on email (low) should not have their
+    // CEO-granted tier overridden by the channel floor.
     const channelTrustRank = TRUST_RANK[channelTrust] ?? 0;
-    const contactTrustRank = (() => {
-      if (input.trustLevel == null) return 0;
-      const rank = TRUST_RANK[input.trustLevel];
-      // Throw on unknown values: a corrupt DB row or a new enum value deployed before
-      // TRUST_RANK is updated must fail loudly. The contact-resolver.ts catch block
-      // will set authorization=null — a safe degradation that is logged and observable.
-      if (rank === undefined) {
-        throw new Error(
-          `Unknown trustLevel value '${input.trustLevel}' — not a recognized TrustLevel enum. Check migration history or DB integrity.`,
-        );
-      }
-      return rank;
-    })();
-    const effectiveTrustRank = Math.max(channelTrustRank, contactTrustRank);
+    // Contact capability is expressed as tier; map to a rank comparable to TRUST_RANK
+    // for sensitivity gating. Throws if tier is an unrecognized value (TIER_TO_TRUST_RANK
+    // covers all ContactTier members, so this only fires on a bug or future enum addition).
+    const contactTierRank = TIER_TO_TRUST_RANK[input.tier];
+    if (contactTierRank === undefined) {
+      throw new Error(
+        `Unknown tier value '${input.tier}' — not a recognized ContactTier. Check migration history or DB integrity.`,
+      );
+    }
+    const effectiveTrustRank = Math.max(channelTrustRank, contactTierRank);
 
     // Role lookup: case-insensitive so LLM-assigned 'Spouse' matches config key 'spouse'.
-    // Fall back to trust_level tier defaults when the role has no config entry, so
-    // contacts with an explicit trust grant still get appropriate permissions even when
-    // the role is a free-text description ('Sister', 'Head Instructor, …').
+    // Fall back to tier defaults when the role has no config entry, so contacts with an
+    // explicit tier grant still get appropriate permissions even when the role is a
+    // free-text description ('Sister', 'Head Instructor, …').
     // Ultimate fallback is the 'unknown' role, then a hard-deny object.
     const roleName = (input.role ?? '').toLowerCase();
     const roleDefaults =
       (roleName !== '' ? this.config.roles[roleName] : undefined) ??
-      (input.trustLevel != null ? this.config.tierDefaults?.[input.trustLevel] : undefined) ??
+      this.config.tierDefaults?.[input.tier] ??
       this.config.roles['unknown'] ??
       { description: 'fallback', defaultPermissions: [], defaultDeny: ['*'] };
 

--- a/src/contacts/authorization.ts
+++ b/src/contacts/authorization.ts
@@ -78,6 +78,22 @@ export class AuthorizationService {
       };
     }
 
+    // Gate 2: blocked-tier contacts get zero permissions, regardless of status or channel.
+    // tier and status are set independently — a contact can have status='confirmed' but
+    // tier='blocked' (e.g. blocked at the tier level before status was updated). Without
+    // this gate, Math.max(channelTrustRank, 0) for a high-trust channel would grant
+    // permissions to a blocked contact because TIER_TO_TRUST_RANK['blocked'] = 0.
+    if (input.tier === 'blocked') {
+      return {
+        allowed: [],
+        denied: ['*'],
+        escalate: [],
+        channelTrust,
+        trustBlocked: [],
+        contactStatus: input.status,
+      };
+    }
+
     // Effective trust: the higher of the channel's inherent trust and the contact's
     // tier rank. A contact with tier='trusted' on email (low) should not have their
     // CEO-granted tier overridden by the channel floor.

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -108,14 +108,10 @@ export async function bootstrapCeoContact(
     const { contact_id, contact_status, identity_verified, display_name: existingName } = existing.rows[0];
     let { kg_node_id } = existing.rows[0];
 
-    // Always ensure role = 'ceo', trust_level = 'ceo', tier = 'principal', and
-    // kind = 'principal' on the CEO contact regardless of which path brought us here.
-    // This is idempotent — the UPDATE is a no-op when all values are already correct.
-    // Without trust_level = 'ceo', a second CEO email address linked to the same contact
-    // would not match the single CEO_PRIMARY_EMAIL config string and would fail the outbound
-    // filter's trust check. Setting role keeps metadata consistent even if the contact was
-    // initially auto-created without a role.
-    // tier='principal' and kind='principal' are the new equivalents (issue #945).
+    // Always ensure role = 'ceo', tier = 'principal', and kind = 'principal' on the CEO
+    // contact regardless of which path brought us here. This is idempotent — the UPDATE
+    // is a no-op when all values are already correct. Setting role keeps metadata consistent
+    // even if the contact was initially auto-created without a role.
     // repairPrincipalMetadata logs with context and rethrows on failure (see its body).
     await repairPrincipalMetadata(contact_id, pool, logger);
 

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -43,14 +43,12 @@ export async function repairPrincipalMetadata(contactId: string, pool: DbPool, l
     await pool.query(
       `UPDATE contacts
          SET role = 'ceo',
-             trust_level = 'ceo',
              system_role = 'principal',
              tier = 'principal',
              kind = 'principal',
              updated_at = now()
        WHERE id = $1
          AND (role IS DISTINCT FROM 'ceo'
-           OR trust_level IS DISTINCT FROM 'ceo'
            OR system_role IS DISTINCT FROM 'principal'
            OR tier IS DISTINCT FROM 'principal'
            OR kind IS DISTINCT FROM 'principal')`,
@@ -65,7 +63,7 @@ export async function repairPrincipalMetadata(contactId: string, pool: DbPool, l
     // consistent. Uses a plain Error (consistent with this module's existing throws).
     logger.error(
       { err, contactId },
-      'repairPrincipalMetadata: failed to repair principal capability metadata (role/trust_level/system_role/tier/kind) — principal trust gates may not apply until resolved',
+      'repairPrincipalMetadata: failed to repair principal capability metadata (role/system_role/tier/kind) — principal trust gates may not apply until resolved',
     );
     throw err;
   }
@@ -179,8 +177,8 @@ export async function bootstrapCeoContact(
     await client.query('BEGIN');
     // tier='principal' and kind='principal' added in migration 055 (issue #945).
     await client.query(
-      `INSERT INTO contacts (id, kg_node_id, display_name, role, status, trust_level, system_role, tier, kind, created_at, updated_at)
-       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'ceo', 'principal', 'principal', 'principal', now(), now())`,
+      `INSERT INTO contacts (id, kg_node_id, display_name, role, status, system_role, tier, kind, created_at, updated_at)
+       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'principal', 'principal', 'principal', now(), now())`,
       [contactId, kgNodeId, displayName],
     );
     await client.query(

--- a/src/contacts/confidence-pipeline.ts
+++ b/src/contacts/confidence-pipeline.ts
@@ -71,7 +71,7 @@ export class ConfidencePipeline {
         break;
       case 'trust_grant':
       case 'pairing_confirmed':
-        // No stat updates — the caller already modified trust_level or
+        // No stat updates — the caller already modified the contact's tier or
         // created the verified identity. We just recompute the score.
         break;
     }
@@ -90,7 +90,7 @@ export class ConfidencePipeline {
       inboundMessageCount: contact.inboundMessageCount + inboundDelta,
       outboundMessageCount: contact.outboundMessageCount + outboundDelta,
       lastSeenAt: lastSeenAt ?? contact.lastSeenAt,
-      trustLevel: contact.trustLevel,
+      tier: contact.tier,
       verifiedIdentityCount: identities.filter(i => i.verified).length,
       hasCeoStatedIdentity: identities.some(i => i.source === 'ceo_stated'),
       now: new Date(),
@@ -125,7 +125,7 @@ export class ConfidencePipeline {
       inboundMessageCount: contact.inboundMessageCount,
       outboundMessageCount: contact.outboundMessageCount,
       lastSeenAt: contact.lastSeenAt,
-      trustLevel: contact.trustLevel,
+      tier: contact.tier,
       verifiedIdentityCount: identities.filter(i => i.verified).length,
       hasCeoStatedIdentity: identities.some(i => i.source === 'ceo_stated'),
       now: new Date(),

--- a/src/contacts/confidence-scorer.ts
+++ b/src/contacts/confidence-scorer.ts
@@ -6,7 +6,7 @@
 // Both the incremental and full-recompute paths call this function. Convergence
 // is guaranteed because both paths use the same stored columns as inputs.
 
-import { meetsMinimumTrust, type TrustLevel } from './types.js';
+import { meetsMinimumTier, type ContactTier } from './types.js';
 
 // -- Tunable constants (exported for tests and documentation) --
 
@@ -22,7 +22,7 @@ export const W_RECENCY = 0.20;
 /** Half-life for recency decay in days. Score halves every 90 days of silence. */
 export const RECENCY_HALF_LIFE_DAYS = 90;
 
-/** Confidence boost when the CEO has explicitly set a trust level on this contact. */
+/** Confidence boost when the contact is at trusted or principal tier. */
 export const GRANT_BOOST = 0.25;
 
 /** Confidence boost when the contact was manually created by the CEO (ceo_stated identity). */
@@ -41,7 +41,7 @@ export interface ConfidenceInput {
   inboundMessageCount: number;
   outboundMessageCount: number;
   lastSeenAt: Date | null;
-  trustLevel: TrustLevel | null;
+  tier: ContactTier;
   verifiedIdentityCount: number;
   hasCeoStatedIdentity: boolean;
   /** Current time — injected for testability. */
@@ -62,7 +62,7 @@ export function computeConfidence(input: ConfidenceInput): number {
     inboundMessageCount,
     outboundMessageCount,
     lastSeenAt,
-    trustLevel,
+    tier,
     verifiedIdentityCount,
     hasCeoStatedIdentity,
     now,
@@ -79,10 +79,10 @@ export function computeConfidence(input: ConfidenceInput): number {
     recencyScore = Math.exp(-daysSinceLastSeen / RECENCY_HALF_LIFE_DAYS) * W_RECENCY;
   }
 
-  // Verification score: discrete boosts from CEO actions and identity pairings
-  // Only CEO-granted trust levels (high, ceo) earn the boost — low/medium overrides are
-  // neutral or restrictive, not a positive verification signal.
-  const grantBoost = meetsMinimumTrust(trustLevel, 'high') ? GRANT_BOOST : 0;
+  // Verification score: discrete boosts from CEO actions and identity pairings.
+  // Only trusted/principal tier earns the grant boost — those contacts have an
+  // explicit CEO trust grant. known/unknown/blocked are neutral or restrictive.
+  const grantBoost = meetsMinimumTier(tier, 'trusted') ? GRANT_BOOST : 0;
   const manualBoost = hasCeoStatedIdentity ? MANUAL_BOOST : 0;
   const pairingBoost =
     (Math.min(verifiedIdentityCount, MAX_PAIRING_IDENTITIES) / MAX_PAIRING_IDENTITIES) * PAIRING_BOOST;

--- a/src/contacts/config-loader.ts
+++ b/src/contacts/config-loader.ts
@@ -46,35 +46,28 @@ export function loadAuthConfig(configDir: string): AuthConfig {
     };
   }
 
-  // Trust-level tier defaults — optional section. Used as fallback when a contact's
+  // Tier defaults — optional section. Used as fallback when a contact's
   // free-text role (e.g. 'Sister') has no matching key in `roles`.
-  const trustLevelDefaults: Record<string, RolePermissions> | undefined =
-    'trust_level_defaults' in rolesRaw
+  const tierDefaults: Record<string, RolePermissions> | undefined =
+    'tier_defaults' in rolesRaw
       ? (() => {
-          const raw = (rolesRaw as Record<string, unknown>).trust_level_defaults;
-          // Guard: the section must be a non-null object (YAML mapping), not a scalar or list.
-          // Object.entries(null) throws a confusing TypeError; this gives a clear startup error.
+          const raw = (rolesRaw as Record<string, unknown>).tier_defaults;
           if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
             throw new Error(
-              "'trust_level_defaults' in role-defaults.yaml must be a YAML mapping (object), not a scalar or list",
+              "'tier_defaults' in role-defaults.yaml must be a YAML mapping (object), not a scalar or list",
             );
           }
-          const validTiers = ['ceo', 'high', 'medium', 'low'];
+          const validTiers = ['principal', 'trusted', 'known', 'unknown', 'blocked'];
           const result: Record<string, RolePermissions> = {};
-          // Iterate with unknown entry type — each entry must be validated individually.
-          // A malformed YAML value like `high: null` or `high: "oops"` would silently
-          // coerce to empty permission lists via `??` without this guard.
           for (const [tier, entry] of Object.entries(raw as Record<string, unknown>)) {
-            // Fail hard on typos — a miskeyed tier silently makes all contacts at
-            // that trust level fall through to unknown (deny-all) at runtime.
             if (!validTiers.includes(tier)) {
               throw new Error(
-                `Invalid trust_level_defaults key '${tier}' in role-defaults.yaml — must be one of: ${validTiers.join(', ')}`,
+                `Invalid tier_defaults key '${tier}' in role-defaults.yaml — must be one of: ${validTiers.join(', ')}`,
               );
             }
             if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
               throw new Error(
-                `trust_level_defaults entry '${tier}' in role-defaults.yaml must be a YAML mapping, got ${entry === null ? 'null' : typeof entry}`,
+                `tier_defaults entry '${tier}' in role-defaults.yaml must be a YAML mapping, got ${entry === null ? 'null' : typeof entry}`,
               );
             }
             const typedEntry = entry as RawRoleEntry;
@@ -153,5 +146,5 @@ export function loadAuthConfig(configDir: string): AuthConfig {
     }
   }
 
-  return { roles, trustLevelDefaults, permissions, channelTrust, channelPolicies };
+  return { roles, tierDefaults, permissions, channelTrust, channelPolicies };
 }

--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -149,7 +149,7 @@ export class ContactResolver {
         const overrides = await this.contactService.getAuthOverrides(resolved.contactId);
         authorization = this.authService.evaluate({
           role: resolved.role,
-          trustLevel: resolved.trustLevel,
+          tier: resolved.tier,
           status: resolved.status ?? 'confirmed',
           channel,
           overrides,

--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -159,7 +159,7 @@ export class ContactResolver {
         // Log and continue with authorization=null — the coordinator still sees
         // who the sender is, just without permission context.
         this.logger.error(
-          { err, contactId: resolved.contactId },
+          { err, contactId: resolved.contactId, errMessage: err instanceof Error ? err.message : String(err) },
           'Authorization evaluation failed — proceeding without auth context',
         );
       }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -59,7 +59,7 @@ export class ContactValidationError extends Error {
 /**
  * Derive an initial tier for a freshly created contact from its status.
  * New contacts never start as 'trusted' or 'principal' — those require
- * explicit setTrustLevel() or bootstrap calls after creation.
+ * explicit setTier() or bootstrap calls after creation.
  */
 export function deriveInitialTier(status: ContactStatus): ContactTier {
   if (status === 'blocked')     return 'blocked';
@@ -87,26 +87,6 @@ export function deriveTierFromStatusUpdate(
   // confirmed: preserve elevated tiers
   if (existingTier === 'trusted' || existingTier === 'principal') return existingTier;
   return 'known';
-}
-
-/**
- * Derive the new tier when setTrustLevel() is called.
- *
- * trust_level maps to tier as follows:
- *   'ceo'    → 'principal'
- *   'high'   → 'trusted'
- *   'medium' → status-derived (same as known/unknown/blocked from status)
- *   'low'    → status-derived (same fallback)
- *   null     → status-derived (revert to status-based tier)
- */
-export function deriveTierFromTrustLevelUpdate(
-  trustLevel: TrustLevel | null,
-  status: ContactStatus,
-): ContactTier {
-  if (trustLevel === 'ceo')  return 'principal';
-  if (trustLevel === 'high') return 'trusted';
-  // medium, low, or null — fall back to the status-derived tier
-  return deriveInitialTier(status);
 }
 
 // ---------------------------------------------------------------------------
@@ -529,8 +509,8 @@ export class ContactService {
     //   provisional → tier='unknown'
     //   confirmed  → tier='known'
     //
-    // Note: new contacts always start with null trustLevel, so we never derive
-    // 'trusted' or 'principal' here — those are set via setTrustLevel / bootstrap
+    // Note: new contacts always start with the status-derived tier, so we never derive
+    // 'trusted' or 'principal' here — those are set via setTier() or bootstrap
     // after the contact exists.
     const contactTier: ContactTier = options.tier ?? deriveInitialTier(contactStatus);
 
@@ -790,48 +770,6 @@ export class ContactService {
   }
 
   /**
-   * Set or clear a contact's per-contact trust level override.
-   *
-   * trust_level = 'high' grants the contact access to third-party contact data
-   * in outbound responses (same as the CEO). Use for the CEO's EA, CFO, or any
-   * other party the CEO explicitly trusts with contact information.
-   *
-   * Pass null to remove the override and revert to the channel default.
-   */
-  async setTrustLevel(contactId: string, trustLevel: TrustLevel | null): Promise<Contact> {
-    const contact = await this.backend.getContact(contactId);
-    if (!contact) {
-      throw new Error(`Contact not found: ${contactId}`);
-    }
-
-    // Derive new tier from the trust level change, keeping existing tier context.
-    // trust_level='ceo' → principal, 'high' → trusted, 'medium'/'low' → fall back to status-derived tier.
-    // trust_level=null → revert to status-derived tier.
-    //
-    // TODO(#945-followup): TOCTOU — concurrent setStatus('blocked') can be clobbered by this tier
-    // derivation; a concurrent block landed after our getContact read above would be overwritten by
-    // the updateContact write below, leaving a blocked contact with tier='trusted'. Needs a
-    // conditional UPDATE or SELECT FOR UPDATE if concurrent same-contact writes become real.
-    // Never demote the principal via a trust-level change: trust_level is a per-contact
-    // override, but the principal's capability is structural (system_role). Clearing or
-    // lowering trust_level (null/low/medium) must not drop the principal below 'principal'.
-    // (CodeAnt review — deriveTierFromTrustLevelUpdate would otherwise fall back to the
-    // status-derived 'known' for a confirmed principal.)
-    const newTier = contact.systemRole === 'principal'
-      ? 'principal'
-      : deriveTierFromTrustLevelUpdate(trustLevel, contact.status);
-
-    const updated: Contact = {
-      ...contact,
-      trustLevel,
-      tier: newTier,
-      updatedAt: new Date(),
-    };
-
-    return this.updateStoredContact(updated);
-  }
-
-  /**
    * Link a channel identity to a contact.
    *
    * Auto-verification logic: sources ceo_stated, email_participant, crm_import,
@@ -936,7 +874,7 @@ export class ContactService {
   /** Update a contact's status (confirmed, provisional, blocked).
    *
    * Also updates `tier` to keep the two in sync. The tier derivation preserves any
-   * 'trusted' or 'principal' tier that was previously set (via setTrustLevel or
+   * 'trusted' or 'principal' tier that was previously set (via setTier or
    * bootstrap) — those are not downgraded by a status-only change. Specifically:
    *   - status='blocked'     → tier='blocked'   (always overrides)
    *   - status='provisional' → tier='unknown'   (unless already trusted/principal)
@@ -1663,22 +1601,21 @@ class PostgresContactBackend implements ContactServiceBackend {
 
   async updateContact(contact: Contact, client?: DbPoolClient): Promise<void> {
     this.logger.debug({ contactId: contact.id }, 'contacts: updating contact');
-    // trust_level is included because ContactService.setTrustLevel writes through this path.
     // system_role is included so bootstrap and any future setter can persist it through the standard update path.
-    // tier and kind (migration 055) are included so setStatus/setTrustLevel keep them in sync.
+    // tier and kind (migration 055) are included so setStatus/setTier keep them in sync.
     // contact_confidence and last_seen_at remain scoring-owned and are not updated here.
     const queryFn = client ?? this.pool;
     await queryFn.query(
       `UPDATE contacts SET
          kg_node_id = $2, display_name = $3, role = $4, system_role = $5, status = $6,
-         notes = $7, trust_level = $8, tier = $9, kind = $10, updated_at = $11,
-         preferred_name = $12, title = $13, organization = $14, primary_email = $15,
-         primary_phone = $16, timezone = $17, locale = $18, location = $19,
-         pronouns = $20, linkedin_url = $21, bio = $22, birthday = $23
+         notes = $7, tier = $8, kind = $9, updated_at = $10,
+         preferred_name = $11, title = $12, organization = $13, primary_email = $14,
+         primary_phone = $15, timezone = $16, locale = $17, location = $18,
+         pronouns = $19, linkedin_url = $20, bio = $21, birthday = $22
        WHERE id = $1`,
       [
         contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole,
-        contact.status, contact.notes, contact.trustLevel, contact.tier, contact.kind, contact.updatedAt,
+        contact.status, contact.notes, contact.tier, contact.kind, contact.updatedAt,
         contact.preferredName, contact.title, contact.organization, contact.primaryEmail,
         contact.primaryPhone, contact.timezone, contact.locale, contact.location,
         contact.pronouns, contact.linkedinUrl, contact.bio, contact.birthday,

--- a/src/contacts/ensure-principal.ts
+++ b/src/contacts/ensure-principal.ts
@@ -12,7 +12,7 @@
 //   1. If a contact with system_role='principal' already exists, return it. Backfill
 //      kg_node_id if missing (preserving the existing display_name — we don't rename).
 //   2. Otherwise create the principal contact + KG person node, mirroring the field
-//      set bootstrapCeoContact uses (role='ceo', trust_level='ceo', status='confirmed').
+//      set bootstrapCeoContact uses (role='ceo', status='confirmed').
 //      No contact_channel_identities row is inserted.
 //
 // Idempotent under serial AND concurrent execution. Handles the 23505 race on the
@@ -91,8 +91,8 @@ export async function ensurePrincipalContact(
     // the correct values must be present from the moment the row is inserted.
     await client.query(
       `INSERT INTO contacts
-         (id, kg_node_id, display_name, role, status, trust_level, system_role, tier, kind, created_at, updated_at)
-       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'ceo', 'principal', 'principal', 'principal', now(), now())`,
+         (id, kg_node_id, display_name, role, status, system_role, tier, kind, created_at, updated_at)
+       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'principal', 'principal', 'principal', now(), now())`,
       [contactId, kgNodeId, displayName],
     );
     await client.query('COMMIT');

--- a/src/contacts/types.test.ts
+++ b/src/contacts/types.test.ts
@@ -1,37 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { meetsMinimumTrust, meetsMinimumTier, TIER_RANK } from './types.js';
-
-describe('meetsMinimumTrust (legacy helper — kept for backward compat)', () => {
-  it('returns false for null trust level', () => {
-    expect(meetsMinimumTrust(null, 'low')).toBe(false);
-  });
-
-  it('ceo meets all trust levels', () => {
-    expect(meetsMinimumTrust('ceo', 'ceo')).toBe(true);
-    expect(meetsMinimumTrust('ceo', 'high')).toBe(true);
-    expect(meetsMinimumTrust('ceo', 'medium')).toBe(true);
-    expect(meetsMinimumTrust('ceo', 'low')).toBe(true);
-  });
-
-  it('high meets high and below but not ceo', () => {
-    expect(meetsMinimumTrust('high', 'ceo')).toBe(false);
-    expect(meetsMinimumTrust('high', 'high')).toBe(true);
-    expect(meetsMinimumTrust('high', 'medium')).toBe(true);
-    expect(meetsMinimumTrust('high', 'low')).toBe(true);
-  });
-
-  it('medium meets medium and below', () => {
-    expect(meetsMinimumTrust('medium', 'ceo')).toBe(false);
-    expect(meetsMinimumTrust('medium', 'high')).toBe(false);
-    expect(meetsMinimumTrust('medium', 'medium')).toBe(true);
-    expect(meetsMinimumTrust('medium', 'low')).toBe(true);
-  });
-
-  it('low meets only low', () => {
-    expect(meetsMinimumTrust('low', 'medium')).toBe(false);
-    expect(meetsMinimumTrust('low', 'low')).toBe(true);
-  });
-});
+import { meetsMinimumTier, TIER_RANK } from './types.js';
 
 // ---------------------------------------------------------------------------
 // New tier system (issue #945)

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -369,9 +369,9 @@ export interface AuthorizationResult {
 
 export interface AuthConfig {
   roles: Record<string, RolePermissions>;
-  /** Fallback permission defaults keyed by trust_level tier ('ceo'|'high'|'medium'|'low').
+  /** Fallback permission defaults keyed by ContactTier ('principal'|'trusted'|'known'|'unknown').
    *  Used when a contact's free-text role doesn't match any key in `roles`. */
-  trustLevelDefaults?: Record<string, RolePermissions>;
+  tierDefaults?: Record<string, RolePermissions>;
   permissions: Record<string, PermissionDef>;
   channelTrust: Record<string, TrustLevel>;
   channelPolicies: Record<string, ChannelPolicyConfig>;

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -247,33 +247,15 @@ export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
 export type SystemRole = 'principal' | 'agent' | 'system';
 
 // Ordinal ranking for trust level comparison. Higher rank = more trusted.
-// Used by meetsMinimumTrust() so callers don't need to enumerate every level.
-// Exported so authorization.ts and other consumers share the same single source of truth.
-// TODO(#955): Remove TRUST_RANK once all callers have migrated to TIER_RANK + ContactTier.
+// Kept for channel trust and permission sensitivity comparisons in authorization.ts
+// (channel trust config uses TrustLevel, not ContactTier). The trust_level *column*
+// is retired in #955; this constant stays for the channel/sensitivity read paths.
 export const TRUST_RANK: Record<TrustLevel, number> = {
   low: 0,
   medium: 1,
   high: 2,
   ceo: 3,
 };
-
-/**
- * Check whether an actual trust level meets or exceeds a required minimum.
- * Returns false for null (unknown contacts default to untrusted).
- *
- * @deprecated Prefer meetsMinimumTier() against contact.tier. This function
- *   operates on the legacy trust_level column. Kept alive until #955 completes
- *   the column drop — existing call sites in authorization.ts and pii-redactor.ts
- *   still need it for channel-level TrustLevel comparisons (channel trust is
- *   config-driven and not mapped to tier).
- */
-export function meetsMinimumTrust(
-  actual: TrustLevel | null,
-  required: TrustLevel,
-): boolean {
-  if (actual === null) return false;
-  return TRUST_RANK[actual] >= TRUST_RANK[required];
-}
 
 // ---------------------------------------------------------------------------
 // New tier + kind system (issue #945)

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -184,6 +184,7 @@ export interface SenderContext {
   authorization: AuthorizationResult | null;
   // Trust scoring inputs — available when contact was found in DB. Not propagated to bus events.
   contactConfidence: number;      // 0.0–1.0
+  /** @deprecated Use .tier instead — column will be dropped in #955 */
   trustLevel: TrustLevel | null;  // per-contact override, or null
   // New capability axis (issue #945). Canonical read path going forward.
   tier: ContactTier;

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -406,7 +406,7 @@ export class Dispatcher {
             channelTrustLevel: prelimChannelTrust,
             contactConfidence: 0.0,
             injectionRiskScore: 0,
-            trustLevel: null,
+            tier: null,
             weights: this.trustScorerWeights,
           });
 
@@ -574,14 +574,14 @@ export class Dispatcher {
     // Compute messageTrustScore from channel trust, contact confidence, and injection risk.
     // contactConfidence: from resolved sender context (0.0 for unknown senders)
     // channelTrustLevel: from channel policy config (default 'low' if not configured)
-    // trustLevel override: per-contact field from DB (null means use channel default)
+    // tier override: per-contact field from DB (null means use channel default)
     let messageTrustScore: number | undefined;
     if (this.channelPolicies) {
       const channelTrust = (this.channelPolicies[payload.channelId]?.trust ?? 'low') as TrustLevel;
       const contactConfidence =
         senderContext?.resolved ? senderContext.contactConfidence : 0.0;
-      const trustLevelOverride =
-        senderContext?.resolved ? senderContext.trustLevel : null;
+      const tierOverride =
+        senderContext?.resolved ? senderContext.tier : null;
       // Validate the injection risk score before use — a non-finite value (NaN, ±Infinity)
       // from a buggy scanner implementation would propagate through the formula and silently
       // produce a NaN trust score, which bypasses the floor check (NaN < floor = false).
@@ -599,7 +599,7 @@ export class Dispatcher {
         channelTrustLevel: channelTrust,
         contactConfidence,
         injectionRiskScore,
-        trustLevel: trustLevelOverride,
+        tier: tierOverride,
         weights: this.trustScorerWeights,
       });
 

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -595,13 +595,21 @@ export class Dispatcher {
         );
       }
 
-      messageTrustScore = computeTrustScore({
-        channelTrustLevel: channelTrust,
-        contactConfidence,
-        injectionRiskScore,
-        tier: tierOverride,
-        weights: this.trustScorerWeights,
-      });
+      try {
+        messageTrustScore = computeTrustScore({
+          channelTrustLevel: channelTrust,
+          contactConfidence,
+          injectionRiskScore,
+          tier: tierOverride,
+          weights: this.trustScorerWeights,
+        });
+      } catch (err) {
+        this.logger.error(
+          { err, channelId: payload.channelId, channelTrust },
+          'computeTrustScore threw unexpectedly — proceeding without trust score',
+        );
+        // messageTrustScore remains undefined; coordinator handles missing score
+      }
 
     }
 

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -606,7 +606,7 @@ export class Dispatcher {
       } catch (err) {
         this.logger.error(
           { err, channelId: payload.channelId, channelTrust },
-          'computeTrustScore threw unexpectedly — proceeding without trust score',
+          'computeTrustScore failed (possible YAML misconfiguration for channelTrustLevel) — proceeding without trust score',
         );
         // messageTrustScore remains undefined; coordinator handles missing score
       }

--- a/src/dispatch/trust-scorer.ts
+++ b/src/dispatch/trust-scorer.ts
@@ -6,11 +6,12 @@
 // Formula: (channelWeight × weights.channelWeight) + (contactConfidence × weights.contactWeight)
 //          − (injectionRiskScore × weights.maxRiskPenalty), clamped to [0.0, 1.0]
 //
-// The per-contact trust_level override, when set, replaces the channel trust level
-// for the channel weight calculation. This allows the CEO to elevate or restrict a
-// specific contact regardless of what channel they're on.
+// The per-contact tier, when set, can override the channel trust weight for the
+// channel weight calculation. trusted/principal contacts get a high-equivalent (1.0)
+// override; known contacts get a medium-equivalent (0.6) override; unknown/blocked
+// contacts and null use only the channel floor.
 
-import type { TrustLevel } from '../contacts/types.js';
+import type { ContactTier, TrustLevel } from '../contacts/types.js';
 
 // Normalized weight per trust level — used to convert enum → float for the formula.
 // 'ceo' is treated identically to 'high' for scoring (maximally trusted channel weight).
@@ -19,6 +20,15 @@ const CHANNEL_TRUST_NORMALIZED: Record<TrustLevel, number> = {
   high: 1.0,
   medium: 0.6,
   low: 0.3,
+};
+
+// Tier-derived channel weight override. trusted/principal elevate to high-equivalent;
+// known elevates to medium-equivalent; unknown/blocked use the channel floor (no entry here).
+const TIER_CHANNEL_WEIGHT_OVERRIDE: Partial<Record<ContactTier, number>> = {
+  principal: 1.0,
+  trusted:   1.0,
+  known:     0.6,
+  // unknown and blocked: no entry — channel floor applies
 };
 
 export interface TrustScorerWeights {
@@ -43,9 +53,9 @@ export interface ComputeTrustScoreInput {
   contactConfidence: number;
   /** Injection risk score from InboundScanner (0.0–1.0). 0.0 if scanner not available. */
   injectionRiskScore: number;
-  /** Per-contact trust_level override from DB. When non-null, replaces channelTrustLevel
-   *  for the channel weight calculation. */
-  trustLevel: TrustLevel | null;
+  /** Contact tier from DB. When non-null and trusted/principal/known, overrides the
+   *  channel weight for the channel component calculation. unknown/blocked use channel floor. */
+  tier: ContactTier | null;
   /** Configurable scoring weights. */
   weights: TrustScorerWeights;
 }
@@ -56,16 +66,18 @@ export interface ComputeTrustScoreInput {
  * Returns a float in [0.0, 1.0]. Higher = more trustworthy.
  */
 export function computeTrustScore(input: ComputeTrustScoreInput): number {
-  const { channelTrustLevel, contactConfidence, injectionRiskScore, trustLevel, weights } = input;
+  const { channelTrustLevel, contactConfidence, injectionRiskScore, tier, weights } = input;
 
-  // Use per-contact override if set; otherwise use channel trust level.
-  const effectiveTrustLevel = trustLevel ?? channelTrustLevel;
-  const channelNormalized = CHANNEL_TRUST_NORMALIZED[effectiveTrustLevel];
+  // Determine the channel normalized weight. Use the tier-derived override when set
+  // (trusted/principal → 1.0, known → 0.6); otherwise use the channel trust level.
+  const tierOverride = tier !== null ? TIER_CHANNEL_WEIGHT_OVERRIDE[tier] : undefined;
+  const channelNormalized =
+    tierOverride !== undefined ? tierOverride : CHANNEL_TRUST_NORMALIZED[channelTrustLevel];
 
   // Guard against unexpected trust level values (e.g. a future DB value that bypasses
   // the CHECK constraint). An undefined lookup produces NaN which propagates silently.
   if (channelNormalized === undefined) {
-    throw new Error(`computeTrustScore: unknown trust level '${effectiveTrustLevel}'`);
+    throw new Error(`computeTrustScore: unknown channel trust level '${channelTrustLevel}'`);
   }
 
   const channelComponent = channelNormalized * weights.channelWeight;

--- a/src/dispatch/trust-scorer.ts
+++ b/src/dispatch/trust-scorer.ts
@@ -71,6 +71,10 @@ export function computeTrustScore(input: ComputeTrustScoreInput): number {
   // Determine the channel normalized weight. Use the tier-derived override when set
   // (trusted/principal → 1.0, known → 0.6); otherwise use the channel trust level.
   const tierOverride = tier !== null ? TIER_CHANNEL_WEIGHT_OVERRIDE[tier] : undefined;
+  // Note: TIER_CHANNEL_WEIGHT_OVERRIDE entries for principal/trusted/known are
+  // statically defined — undefined values fall through to the channelTrustLevel
+  // branch below. The undefined guard here only fires for unknown channelTrustLevel
+  // values (e.g., a YAML misconfiguration); it does not cover the tier branch.
   const channelNormalized =
     tierOverride !== undefined ? tierOverride : CHANNEL_TRUST_NORMALIZED[channelTrustLevel];
 

--- a/tests/integration/ceo-bootstrap.test.ts
+++ b/tests/integration/ceo-bootstrap.test.ts
@@ -58,16 +58,15 @@ describeIf('bootstrapCeoContact', () => {
 
     // Verify the contact row was created with the correct fields
     const contact = await pool.query<{
-      id: string; display_name: string; role: string; status: string; trust_level: string; kg_node_id: string;
+      id: string; display_name: string; role: string; status: string; kg_node_id: string;
     }>(
-      `SELECT id, display_name, role, status, trust_level, kg_node_id FROM contacts WHERE id = $1`,
+      `SELECT id, display_name, role, status, kg_node_id FROM contacts WHERE id = $1`,
       [result.contactId],
     );
     expect(contact.rows[0]).toBeDefined();
     expect(contact.rows[0].display_name).toBe('Bootstrap Test CEO');
     expect(contact.rows[0].role).toBe('ceo');
     expect(contact.rows[0].status).toBe('confirmed');
-    expect(contact.rows[0].trust_level).toBe('ceo');
     expect(contact.rows[0].kg_node_id).toBe(result.kgNodeId);
 
     // Verify the KG node was created with correct metadata
@@ -134,13 +133,13 @@ describeIf('bootstrapCeoContact', () => {
     expect(result.contactId).toBe(contactId);
     expect(result.kgNodeId).toBeTruthy();
 
-    // Contact should now be confirmed + ceo trust
-    const contact = await pool.query<{ status: string; trust_level: string; kg_node_id: string }>(
-      `SELECT status, trust_level, kg_node_id FROM contacts WHERE id = $1`,
+    // Contact should now be confirmed with principal tier
+    const contact = await pool.query<{ status: string; tier: string; kg_node_id: string }>(
+      `SELECT status, tier, kg_node_id FROM contacts WHERE id = $1`,
       [contactId],
     );
     expect(contact.rows[0].status).toBe('confirmed');
-    expect(contact.rows[0].trust_level).toBe('ceo');
+    expect(contact.rows[0].tier).toBe('principal');
     expect(contact.rows[0].kg_node_id).toBe(result.kgNodeId);
 
     // Identity should now be verified
@@ -184,13 +183,6 @@ describeIf('bootstrapCeoContact', () => {
       [contactId],
     );
     expect(after.rows[0].kg_node_id).toBe(result.kgNodeId);
-
-    // trust_level should have been promoted from 'high' → 'ceo' by the bootstrap UPDATE
-    const trustAfter = await pool.query<{ trust_level: string }>(
-      `SELECT trust_level FROM contacts WHERE id = $1`,
-      [contactId],
-    );
-    expect(trustAfter.rows[0]!.trust_level).toBe('ceo');
 
     // KG node should be a permanent bootstrap person node
     const node = await pool.query<{ type: string; decay_class: string; source: string }>(

--- a/tests/integration/ensure-principal.test.ts
+++ b/tests/integration/ensure-principal.test.ts
@@ -83,11 +83,11 @@ describeIf('ensurePrincipalContact', () => {
       display_name: string;
       role: string;
       status: string;
-      trust_level: string;
+      tier: string;
       system_role: string;
       kg_node_id: string;
     }>(
-      `SELECT display_name, role, status, trust_level, system_role, kg_node_id
+      `SELECT display_name, role, status, tier, system_role, kg_node_id
        FROM contacts WHERE id = $1`,
       [result.contactId],
     );
@@ -95,7 +95,7 @@ describeIf('ensurePrincipalContact', () => {
     expect(contact.rows[0]!.display_name).toBe(displayName);
     expect(contact.rows[0]!.role).toBe('ceo');
     expect(contact.rows[0]!.status).toBe('confirmed');
-    expect(contact.rows[0]!.trust_level).toBe('ceo');
+    expect(contact.rows[0]!.tier).toBe('principal');
     expect(contact.rows[0]!.system_role).toBe('principal');
     expect(contact.rows[0]!.kg_node_id).toBe(result.kgNodeId);
 

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -25,7 +25,6 @@ function createContactService(): ContactService {
   return {
     createContact: vi.fn(),
     getContact: vi.fn(),
-    setTrustLevel: vi.fn(),
     setTier: vi.fn(),
     setKind: vi.fn(),
     saveContact: vi.fn(),

--- a/tests/unit/contacts/authorization.test.ts
+++ b/tests/unit/contacts/authorization.test.ts
@@ -106,6 +106,22 @@ describe('AuthorizationService', () => {
     expect(result.contactStatus).toBe('blocked');
   });
 
+  it('blocked-tier contact on high-trust channel gets no permissions', () => {
+    // tier='blocked' and status='confirmed' can diverge (tier is set independently).
+    // Without a hard gate, Math.max(channelRank=2, tierRank=0)=2 would grant high-trust
+    // permissions to a blocked contact on a cli/signal channel. Gate 2 prevents this.
+    const result = authService.evaluate({
+      role: 'cfo',
+      tier: 'blocked',
+      status: 'confirmed',
+      channel: 'cli',
+      overrides: [],
+    });
+    expect(result.allowed).toEqual([]);
+    expect(result.denied).toContain('*');
+    expect(result.trustBlocked).toEqual([]);
+  });
+
   it('applies role defaults for confirmed contacts', () => {
     const result = authService.evaluate({
       role: 'cfo',

--- a/tests/unit/contacts/authorization.test.ts
+++ b/tests/unit/contacts/authorization.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AuthorizationService } from '../../../src/contacts/authorization.js';
-import type { AuthConfig } from '../../../src/contacts/types.js';
+import type { AuthConfig, ContactTier } from '../../../src/contacts/types.js';
 
 const testConfig: AuthConfig = {
   roles: {
@@ -70,7 +70,7 @@ describe('AuthorizationService', () => {
   it('CEO gets all permissions', () => {
     const result = authService.evaluate({
       role: 'ceo',
-      trustLevel: 'ceo',
+      tier: 'principal',
       status: 'confirmed',
       channel: 'cli',
       overrides: [],
@@ -83,7 +83,7 @@ describe('AuthorizationService', () => {
   it('provisional contacts get no permissions', () => {
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'provisional',
       channel: 'email',
       overrides: [],
@@ -96,7 +96,7 @@ describe('AuthorizationService', () => {
   it('blocked contacts get no permissions', () => {
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'blocked',
       channel: 'email',
       overrides: [],
@@ -109,7 +109,7 @@ describe('AuthorizationService', () => {
   it('applies role defaults for confirmed contacts', () => {
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'cli',
       overrides: [],
@@ -122,7 +122,7 @@ describe('AuthorizationService', () => {
   it('overrides take precedence over role defaults', () => {
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'cli',
       overrides: [
@@ -137,7 +137,7 @@ describe('AuthorizationService', () => {
   it('channel trust blocks high-sensitivity actions on low-trust channels', () => {
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
@@ -146,10 +146,10 @@ describe('AuthorizationService', () => {
     expect(result.allowed).toContain('schedule_meetings');
   });
 
-  it('unknown roles with no trustLevel fall back to unknown defaults', () => {
+  it('unknown roles with unknown tier fall back to unknown tier defaults', () => {
     const result = authService.evaluate({
       role: 'some_new_role',
-      trustLevel: null,
+      tier: 'unknown',
       status: 'confirmed',
       channel: 'cli',
       overrides: [],
@@ -158,10 +158,10 @@ describe('AuthorizationService', () => {
     expect(result.allowed).toEqual([]);
   });
 
-  it('null role with no trustLevel uses unknown defaults', () => {
+  it('null role with unknown tier uses unknown tier defaults', () => {
     const result = authService.evaluate({
       role: null,
-      trustLevel: null,
+      tier: 'unknown',
       status: 'confirmed',
       channel: 'cli',
       overrides: [],
@@ -172,7 +172,7 @@ describe('AuthorizationService', () => {
   it('permissions not in role defaults or overrides go to escalate', () => {
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'cli',
       overrides: [],
@@ -183,7 +183,7 @@ describe('AuthorizationService', () => {
   it('returns correct channel trust level', () => {
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
@@ -194,7 +194,7 @@ describe('AuthorizationService', () => {
   it('unknown channels default to low trust', () => {
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'unknown_channel',
       overrides: [],
@@ -209,7 +209,7 @@ describe('AuthorizationService', () => {
     // Without normalization this falls to the 'unknown' role (denied: ['*']).
     const result = authService.evaluate({
       role: 'Spouse',
-      trustLevel: 'high',
+      tier: 'trusted',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
@@ -222,7 +222,7 @@ describe('AuthorizationService', () => {
   it('role lookup is case-insensitive: CEO matches ceo role', () => {
     const result = authService.evaluate({
       role: 'CEO',
-      trustLevel: 'ceo',
+      tier: 'principal',
       status: 'confirmed',
       channel: 'cli',
       overrides: [],
@@ -233,57 +233,57 @@ describe('AuthorizationService', () => {
 
   // --- tier fallback when role has no config match ---
 
-  it('unrecognized role with high trustLevel falls back to tierDefaults', () => {
+  it('unrecognized role with trusted tier falls back to tierDefaults', () => {
     // 'Sister' is a valid free-text role the LLM might set, but has no config key.
-    // Should fall back to tierDefaults['high'] instead of 'unknown'.
+    // Should fall back to tierDefaults['trusted'] instead of 'unknown'.
     const result = authService.evaluate({
       role: 'Sister',
-      trustLevel: 'high',
+      tier: 'trusted',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
     });
-    // tierDefaults.high grants see_personal_calendar
-    // After effective trust fix, max(low, high)=high → should not be trust-blocked
+    // tierDefaults.trusted grants see_personal_calendar
+    // After effective trust fix, max(low, trusted)=trusted → should not be trust-blocked
     expect(result.denied).not.toContain('*');
     expect(result.trustBlocked).not.toContain('see_personal_calendar');
   });
 
-  it('unrecognized role with medium trustLevel falls back to tierDefaults', () => {
+  it('unrecognized role with known tier falls back to tierDefaults', () => {
     const result = authService.evaluate({
       role: 'CEO, Communitech',
-      trustLevel: 'medium',
+      tier: 'known',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
     });
-    // tierDefaults.medium grants schedule_meetings (low sensitivity → not trust-blocked)
+    // tierDefaults.known grants schedule_meetings (low sensitivity → not trust-blocked)
     expect(result.denied).not.toContain('*');
     expect(result.allowed).toContain('schedule_meetings');
   });
 
-  it('unrecognized role with null trustLevel still uses unknown defaults', () => {
+  it('unrecognized role with unknown tier uses unknown tier defaults', () => {
     const result = authService.evaluate({
       role: 'Head Instructor, Kitchener Kicks',
-      trustLevel: null,
+      tier: 'unknown',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
     });
-    // No role match, no trustLevel → falls to unknown → denied: ['*']
+    // No role match, unknown tier → tierDefaults.unknown → denied: ['*']
     expect(result.denied).toContain('*');
     expect(result.allowed).toEqual([]);
   });
 
-  // --- Effective trust: contact trustLevel overrides channel floor for sensitivity gating ---
+  // --- Effective trust: contact tier rank overrides channel floor for sensitivity gating ---
 
   it('high-trust contact on low-trust channel gets medium-sensitivity perms (not trust-blocked)', () => {
-    // Xiaopu scenario: trust_level=high, channel=email (low).
+    // Xiaopu scenario: tier=trusted, channel=email (low).
     // Without effective trust fix, spouse's see_personal_calendar (medium) is trust-blocked.
-    // With fix: max(low, high)=high → allowed.
+    // With fix: max(low, trusted)=trusted(2) >= medium(1) → allowed.
     const result = authService.evaluate({
       role: 'spouse',
-      trustLevel: 'high',
+      tier: 'trusted',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
@@ -292,12 +292,13 @@ describe('AuthorizationService', () => {
     expect(result.allowed).toContain('see_personal_calendar');
   });
 
-  it('null-trustLevel contact on low-trust channel still gets medium-sensitivity perms trust-blocked', () => {
-    // Unrecognized sender with no explicit trust grant should still be gated by channel trust.
+  it('known-tier contact on low-trust channel still gets high-sensitivity perms trust-blocked', () => {
+    // A contact with no special trust grant (tier=known, rank=1) on email (rank=0).
     // Uses cfo role (grants view_financial_reports, schedule_meetings) for this test.
+    // effectiveTrustRank = max(0, 1) = 1; view_financial_reports sensitivity=high(rank=2) → blocked.
     const result = authService.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
@@ -309,11 +310,11 @@ describe('AuthorizationService', () => {
   });
 
   it('CEO on email gets medium-sensitivity perms via effective trust override', () => {
-    // Joseph scenario: trust_level=ceo, channel=email (low).
-    // Without fix: see_personal_calendar trust-blocked. With fix: max(low,ceo)=ceo → allowed.
+    // Joseph scenario: tier=principal, channel=email (low).
+    // Without fix: see_personal_calendar trust-blocked. With fix: max(low,principal)=principal(3) → allowed.
     const result = authService.evaluate({
       role: 'ceo',
-      trustLevel: 'ceo',
+      tier: 'principal',
       status: 'confirmed',
       channel: 'email',
       overrides: [],
@@ -341,7 +342,7 @@ describe('AuthorizationService', () => {
     const service = new AuthorizationService(minimalConfig);
     const result = service.evaluate({
       role: 'some_unrecognized_role',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'cli',
       overrides: [],
@@ -351,9 +352,9 @@ describe('AuthorizationService', () => {
     expect(result.allowed).toEqual([]);
   });
 
-  it('falls to unknown role when tierDefaults has no entry for the contact trust level', () => {
-    // A contact with trust_level='high' and an unrecognized role falls through to
-    // tierDefaults['high']. If that tier is absent from tierDefaults,
+  it('falls to unknown role when tierDefaults has no entry for the contact tier', () => {
+    // A contact with tier='trusted' and an unrecognized role falls through to
+    // tierDefaults['trusted']. If that tier is absent from tierDefaults,
     // it falls further to the unknown role.
     const configWithPartialDefaults: AuthConfig = {
       ...testConfig,
@@ -364,8 +365,8 @@ describe('AuthorizationService', () => {
     };
     const service = new AuthorizationService(configWithPartialDefaults);
     const result = service.evaluate({
-      role: 'Sister',       // No 'sister' in roles → tries trustLevelDefaults
-      trustLevel: 'high',   // 'high' not in partial trustLevelDefaults → falls to unknown
+      role: 'Sister',     // No 'sister' in roles → tries tierDefaults
+      tier: 'trusted',    // 'trusted' not in partial tierDefaults → falls to unknown role
       status: 'confirmed',
       channel: 'cli',
       overrides: [],
@@ -375,21 +376,21 @@ describe('AuthorizationService', () => {
     expect(result.allowed).toEqual([]);
   });
 
-  // --- Issue 1: throw on unknown trustLevel value (not a valid TrustLevel enum) ---
+  // --- Issue 1: throw on unknown tier value (not a valid ContactTier) ---
 
-  it('throws when trustLevel is not a recognized enum value (e.g. legacy DB value or migration gap)', () => {
+  it('throws when tier is not a recognized ContactTier value', () => {
     // A corrupt DB row or a new enum value deployed to DB before code catches up
     // must throw rather than silently collapsing to rank 0 (= low trust).
     // The contact-resolver.ts catch block will handle this with authorization=null.
     expect(() =>
       authService.evaluate({
         role: 'cfo',
-        trustLevel: 'verified' as unknown as TrustLevel,
+        tier: 'super_trusted' as unknown as ContactTier,
         status: 'confirmed',
         channel: 'email',
         overrides: [],
       }),
-    ).toThrow(/Unknown trustLevel/);
+    ).toThrow(/Unknown tier/);
   });
 
   // --- Issue 3: escalate when permission sensitivity has no TRUST_RANK entry ---
@@ -413,7 +414,7 @@ describe('AuthorizationService', () => {
     });
     const result = serviceWithBadSensitivity.evaluate({
       role: 'cfo',
-      trustLevel: null,
+      tier: 'known',
       status: 'confirmed',
       channel: 'cli',
       overrides: [],

--- a/tests/unit/contacts/authorization.test.ts
+++ b/tests/unit/contacts/authorization.test.ts
@@ -309,6 +309,27 @@ describe('AuthorizationService', () => {
     expect(result.allowed).toContain('schedule_meetings');
   });
 
+  it('known-tier contact on low-trust channel can access medium-sensitivity perms (intentional #1070 trade-off)', () => {
+    // Old behavior: trustLevel=null → rank 0; email (rank 0): see_personal_calendar (medium, rank 1) → trust-blocked.
+    // New behavior: tier='known' → rank 1 (medium-equivalent); effectiveTrust = max(0,1) = 1 >= 1 → allowed.
+    // This is a deliberate trade-off in the trust_level→tier collapse: 'known' maps to the former 'medium'
+    // trust level rather than null, so confirmed contacts with no explicit high/ceo grant get a slight
+    // permission loosening for medium-sensitivity role grants on low-trust channels.
+    // High-sensitivity permissions remain blocked (see test above).
+    const result = authService.evaluate({
+      role: 'spouse',
+      tier: 'known',
+      status: 'confirmed',
+      channel: 'email',
+      overrides: [],
+    });
+    // see_personal_calendar: medium sensitivity, spouse role grants it → now allowed (was trust-blocked pre-#1070)
+    expect(result.allowed).toContain('see_personal_calendar');
+    expect(result.trustBlocked).not.toContain('see_personal_calendar');
+    // view_financial_reports: high sensitivity, spouse role denies it → still denied (not trust-blocked)
+    expect(result.denied).toContain('view_financial_reports');
+  });
+
   it('CEO on email gets medium-sensitivity perms via effective trust override', () => {
     // Joseph scenario: tier=principal, channel=email (low).
     // Without fix: see_personal_calendar trust-blocked. With fix: max(low,principal)=principal(3) → allowed.

--- a/tests/unit/contacts/authorization.test.ts
+++ b/tests/unit/contacts/authorization.test.ts
@@ -25,24 +25,24 @@ const testConfig: AuthConfig = {
       defaultDeny: ['*'],
     },
   },
-  trustLevelDefaults: {
-    ceo: {
-      description: 'CEO trust tier',
+  tierDefaults: {
+    principal: {
+      description: 'Principal tier',
       defaultPermissions: ['*'],
       defaultDeny: [],
     },
-    high: {
-      description: 'High-trust contact',
+    trusted: {
+      description: 'Trusted tier',
       defaultPermissions: ['see_personal_calendar', 'schedule_meetings'],
       defaultDeny: ['view_financial_reports'],
     },
-    medium: {
-      description: 'Medium-trust contact',
+    known: {
+      description: 'Known tier',
       defaultPermissions: ['schedule_meetings'],
       defaultDeny: ['view_financial_reports'],
     },
-    low: {
-      description: 'Low-trust contact',
+    unknown: {
+      description: 'Unknown tier',
       defaultPermissions: [],
       defaultDeny: ['*'],
     },
@@ -231,11 +231,11 @@ describe('AuthorizationService', () => {
     expect(result.denied).toEqual([]);
   });
 
-  // --- trust_level fallback when role has no config match ---
+  // --- tier fallback when role has no config match ---
 
-  it('unrecognized role with high trustLevel falls back to trustLevelDefaults', () => {
+  it('unrecognized role with high trustLevel falls back to tierDefaults', () => {
     // 'Sister' is a valid free-text role the LLM might set, but has no config key.
-    // Should fall back to trustLevelDefaults['high'] instead of 'unknown'.
+    // Should fall back to tierDefaults['high'] instead of 'unknown'.
     const result = authService.evaluate({
       role: 'Sister',
       trustLevel: 'high',
@@ -243,13 +243,13 @@ describe('AuthorizationService', () => {
       channel: 'email',
       overrides: [],
     });
-    // trustLevelDefaults.high grants see_personal_calendar
+    // tierDefaults.high grants see_personal_calendar
     // After effective trust fix, max(low, high)=high → should not be trust-blocked
     expect(result.denied).not.toContain('*');
     expect(result.trustBlocked).not.toContain('see_personal_calendar');
   });
 
-  it('unrecognized role with medium trustLevel falls back to trustLevelDefaults', () => {
+  it('unrecognized role with medium trustLevel falls back to tierDefaults', () => {
     const result = authService.evaluate({
       role: 'CEO, Communitech',
       trustLevel: 'medium',
@@ -257,7 +257,7 @@ describe('AuthorizationService', () => {
       channel: 'email',
       overrides: [],
     });
-    // trustLevelDefaults.medium grants schedule_meetings (low sensitivity → not trust-blocked)
+    // tierDefaults.medium grants schedule_meetings (low sensitivity → not trust-blocked)
     expect(result.denied).not.toContain('*');
     expect(result.allowed).toContain('schedule_meetings');
   });
@@ -325,15 +325,15 @@ describe('AuthorizationService', () => {
 
   // --- Issue 6a/6b: fallback chain edge cases ---
 
-  it('hard-deny fallback when config has no unknown role and no trustLevelDefaults', () => {
+  it('hard-deny fallback when config has no unknown role and no tierDefaults', () => {
     // Exercises the final hardcoded-deny sentinel in the fallback chain:
-    //   role → trustLevelDefaults → unknown → { defaultDeny: ['*'] }
-    // When both unknown and trustLevelDefaults are absent, the hard-deny object applies.
+    //   role → tierDefaults → unknown → { defaultDeny: ['*'] }
+    // When both unknown and tierDefaults are absent, the hard-deny object applies.
     const { unknown: _, ...rolesWithoutUnknown } = testConfig.roles;
     void _;
     const minimalConfig: AuthConfig = {
       roles: rolesWithoutUnknown,
-      // No trustLevelDefaults
+      // No tierDefaults
       permissions: testConfig.permissions,
       channelTrust: testConfig.channelTrust,
       channelPolicies: {},
@@ -351,15 +351,15 @@ describe('AuthorizationService', () => {
     expect(result.allowed).toEqual([]);
   });
 
-  it('falls to unknown role when trustLevelDefaults has no entry for the contact trust level', () => {
+  it('falls to unknown role when tierDefaults has no entry for the contact trust level', () => {
     // A contact with trust_level='high' and an unrecognized role falls through to
-    // trustLevelDefaults['high']. If that tier is absent from trustLevelDefaults,
+    // tierDefaults['high']. If that tier is absent from tierDefaults,
     // it falls further to the unknown role.
     const configWithPartialDefaults: AuthConfig = {
       ...testConfig,
-      trustLevelDefaults: {
-        ceo: testConfig.trustLevelDefaults!.ceo!,
-        // Deliberately no 'high', 'medium', or 'low' entries
+      tierDefaults: {
+        principal: testConfig.tierDefaults!.principal!,
+        // Deliberately no 'trusted', 'known', or 'unknown' entries
       },
     };
     const service = new AuthorizationService(configWithPartialDefaults);

--- a/tests/unit/contacts/confidence-pipeline.test.ts
+++ b/tests/unit/contacts/confidence-pipeline.test.ts
@@ -73,7 +73,7 @@ describe('ConfidencePipeline', () => {
   describe('incrementalUpdate — trust_grant', () => {
     it('recomputes confidence with trust level signal', async () => {
       const contact = await createTestContact();
-      await service.setTrustLevel(contact.id, 'high');
+      await service.setTier(contact.id, 'trusted');
       await pipeline.incrementalUpdate(contact.id, { type: 'trust_grant' });
 
       const updated = await service.getContact(contact.id);

--- a/tests/unit/contacts/confidence-scorer.test.ts
+++ b/tests/unit/contacts/confidence-scorer.test.ts
@@ -14,7 +14,7 @@ function input(overrides: Partial<ConfidenceInput> = {}): ConfidenceInput {
     inboundMessageCount: 0,
     outboundMessageCount: 0,
     lastSeenAt: null,
-    trustLevel: null,
+    tier: 'known',
     verifiedIdentityCount: 0,
     hasCeoStatedIdentity: false,
     now: new Date('2026-01-15T12:00:00Z'),
@@ -85,7 +85,7 @@ describe('computeConfidence', () => {
     expect(score).toBeCloseTo(interactionOnly);
   });
 
-  it('CEO trust grant provides GRANT_BOOST', () => {
+  it('trusted tier provides GRANT_BOOST', () => {
     const withoutGrant = computeConfidence(input({
       inboundMessageCount: 10,
       lastSeenAt: new Date('2026-01-15T12:00:00Z'),
@@ -93,9 +93,36 @@ describe('computeConfidence', () => {
     const withGrant = computeConfidence(input({
       inboundMessageCount: 10,
       lastSeenAt: new Date('2026-01-15T12:00:00Z'),
-      trustLevel: 'high',
+      tier: 'trusted',
     }));
     expect(withGrant - withoutGrant).toBeCloseTo(GRANT_BOOST);
+  });
+
+  it('principal tier also provides GRANT_BOOST', () => {
+    const withoutGrant = computeConfidence(input({
+      inboundMessageCount: 10,
+      lastSeenAt: new Date('2026-01-15T12:00:00Z'),
+    }));
+    const withPrincipal = computeConfidence(input({
+      inboundMessageCount: 10,
+      lastSeenAt: new Date('2026-01-15T12:00:00Z'),
+      tier: 'principal',
+    }));
+    expect(withPrincipal - withoutGrant).toBeCloseTo(GRANT_BOOST);
+  });
+
+  it('known tier does NOT provide GRANT_BOOST', () => {
+    const known = computeConfidence(input({
+      inboundMessageCount: 10,
+      lastSeenAt: new Date('2026-01-15T12:00:00Z'),
+      tier: 'known',
+    }));
+    const trusted = computeConfidence(input({
+      inboundMessageCount: 10,
+      lastSeenAt: new Date('2026-01-15T12:00:00Z'),
+      tier: 'trusted',
+    }));
+    expect(trusted - known).toBeCloseTo(GRANT_BOOST);
   });
 
   it('CEO-verified contact scores meaningfully higher than auto-resolved with same volume', () => {
@@ -106,7 +133,7 @@ describe('computeConfidence', () => {
     const ceoVerified = computeConfidence(input({
       inboundMessageCount: 10,
       lastSeenAt: new Date('2026-01-15T12:00:00Z'),
-      trustLevel: 'high',
+      tier: 'trusted',
       hasCeoStatedIdentity: true,
     }));
     expect(ceoVerified - autoResolved).toBeGreaterThanOrEqual(0.2);
@@ -131,7 +158,7 @@ describe('computeConfidence', () => {
       inboundMessageCount: 1000,
       outboundMessageCount: 1000,
       lastSeenAt: new Date('2026-01-15T12:00:00Z'),
-      trustLevel: 'high',
+      tier: 'trusted',
       hasCeoStatedIdentity: true,
       verifiedIdentityCount: 100,
     }));

--- a/tests/unit/contacts/config-loader.test.ts
+++ b/tests/unit/contacts/config-loader.test.ts
@@ -47,4 +47,13 @@ describe('loadAuthConfig', () => {
     expect(config.channelPolicies.email.trust).toBe('low');
     expect(config.channelTrust.cli).toBe('high');
   });
+
+  it('loads tier defaults from YAML', () => {
+    const config = loadAuthConfig(CONFIG_DIR);
+    expect(config.tierDefaults).toBeDefined();
+    expect(config.tierDefaults!['trusted']).toBeDefined();
+    expect(config.tierDefaults!['trusted'].defaultPermissions).toContain('schedule_meetings');
+    expect(config.tierDefaults!['principal'].defaultPermissions).toContain('*');
+    expect(config.tierDefaults!['unknown'].defaultDeny).toContain('*');
+  });
 });

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -968,7 +968,7 @@ describe('ContactService', () => {
         source: 'email_participant',
         status: 'confirmed',
       });
-      await service.setTrustLevel(contact.id, 'high'); // drives tier to 'trusted'
+      await service.setTier(contact.id, 'trusted');
       const before = await service.getContact(contact.id);
       expect(before!.tier).toBe('trusted');
 

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -377,8 +377,9 @@ describe('Dispatcher — messageTrustScore', () => {
     }));
 
     expect(tasks).toHaveLength(1);
-    // email low=0.3, contactConfidence=0.8 → (0.3*0.4)+(0.8*0.4) = 0.12+0.32 = 0.44
-    expect(tasks[0]!.payload.messageTrustScore).toBeCloseTo(0.44);
+    // status='confirmed' → tier='known' → channel weight override 0.6 (not channel floor 0.3)
+    // (0.6*0.4)+(0.8*0.4) = 0.24+0.32 = 0.56
+    expect(tasks[0]!.payload.messageTrustScore).toBeCloseTo(0.56);
   });
 
   it('attaches messageTrustScore for unknown sender via email', async () => {

--- a/tests/unit/dispatch/trust-scorer.test.ts
+++ b/tests/unit/dispatch/trust-scorer.test.ts
@@ -10,7 +10,7 @@ describe('computeTrustScore', () => {
       channelTrustLevel: 'high',
       contactConfidence: 1.0,
       injectionRiskScore: 0,
-      trustLevel: null,
+      tier: null,
       weights,
     });
     expect(score).toBeCloseTo(0.8);
@@ -22,7 +22,7 @@ describe('computeTrustScore', () => {
       channelTrustLevel: 'low',
       contactConfidence: 0.0,
       injectionRiskScore: 0,
-      trustLevel: null,
+      tier: null,
       weights,
     });
     expect(score).toBeCloseTo(0.12);
@@ -34,23 +34,72 @@ describe('computeTrustScore', () => {
       channelTrustLevel: 'medium',
       contactConfidence: 0.5,
       injectionRiskScore: 0,
-      trustLevel: null,
+      tier: null,
       weights,
     });
     expect(score).toBeCloseTo(0.44);
   });
 
-  it('per-contact trust_level override replaces channel weight', () => {
-    // trustLevel='high' → channelWeight=1.0, overrides 'low' channel
+  it('trusted tier overrides channel weight to high-equivalent', () => {
+    // tier='trusted' → channelWeight=1.0, overrides 'low' channel
     // 1.0*0.4 + 0.5*0.4 = 0.60
     const score = computeTrustScore({
       channelTrustLevel: 'low',
       contactConfidence: 0.5,
       injectionRiskScore: 0,
-      trustLevel: 'high',
+      tier: 'trusted',
       weights,
     });
     expect(score).toBeCloseTo(0.60);
+  });
+
+  it('principal tier overrides channel weight to high-equivalent (same as trusted)', () => {
+    const score = computeTrustScore({
+      channelTrustLevel: 'low',
+      contactConfidence: 0.5,
+      injectionRiskScore: 0,
+      tier: 'principal',
+      weights,
+    });
+    expect(score).toBeCloseTo(0.60);
+  });
+
+  it('known tier overrides channel weight to medium-equivalent (0.6)', () => {
+    // tier='known' → 0.6 override on low (0.3) channel
+    // 0.6*0.4 + 0.5*0.4 = 0.44
+    const score = computeTrustScore({
+      channelTrustLevel: 'low',
+      contactConfidence: 0.5,
+      injectionRiskScore: 0,
+      tier: 'known',
+      weights,
+    });
+    expect(score).toBeCloseTo(0.44);
+  });
+
+  it('unknown tier uses channel floor (no override)', () => {
+    // tier='unknown' → channel floor (0.3)
+    // 0.3*0.4 + 0.5*0.4 = 0.32
+    const score = computeTrustScore({
+      channelTrustLevel: 'low',
+      contactConfidence: 0.5,
+      injectionRiskScore: 0,
+      tier: 'unknown',
+      weights,
+    });
+    expect(score).toBeCloseTo(0.32);
+  });
+
+  it('null tier uses channel floor (no override)', () => {
+    // same as unknown: channel floor 0.3*0.4 + 0.5*0.4 = 0.32
+    const score = computeTrustScore({
+      channelTrustLevel: 'low',
+      contactConfidence: 0.5,
+      injectionRiskScore: 0,
+      tier: null,
+      weights,
+    });
+    expect(score).toBeCloseTo(0.32);
   });
 
   it('injection risk reduces score', () => {
@@ -59,31 +108,29 @@ describe('computeTrustScore', () => {
       channelTrustLevel: 'high',
       contactConfidence: 1.0,
       injectionRiskScore: 1.0,
-      trustLevel: null,
+      tier: null,
       weights,
     });
     expect(score).toBeCloseTo(0.6);
   });
 
   it('score is clamped to 0.0 minimum', () => {
-    // Worst case: low channel, zero confidence, max risk
     const score = computeTrustScore({
       channelTrustLevel: 'low',
       contactConfidence: 0.0,
       injectionRiskScore: 1.0,
-      trustLevel: null,
+      tier: null,
       weights,
     });
     expect(score).toBe(0.0);
   });
 
   it('score is clamped to 1.0 maximum', () => {
-    // Even if weights somehow exceed 1.0, output is clamped
     const score = computeTrustScore({
       channelTrustLevel: 'high',
       contactConfidence: 1.0,
-      injectionRiskScore: -1.0, // hypothetical negative penalty
-      trustLevel: null,
+      injectionRiskScore: -1.0,
+      tier: null,
       weights: { channelWeight: 0.6, contactWeight: 0.6, maxRiskPenalty: 0.2 },
     });
     expect(score).toBe(1.0);
@@ -95,7 +142,7 @@ describe('computeTrustScore', () => {
       channelTrustLevel: 'high',
       contactConfidence: 1.0,
       injectionRiskScore: 0.5,
-      trustLevel: null,
+      tier: null,
       weights,
     });
     expect(score).toBeCloseTo(0.7);
@@ -103,12 +150,11 @@ describe('computeTrustScore', () => {
 
   it('respects custom weight configuration', () => {
     const customWeights = { channelWeight: 0.5, contactWeight: 0.5, maxRiskPenalty: 0.1 };
-    // high channel: 1.0*0.5=0.5, full confidence: 1.0*0.5=0.5, no risk → 1.0 (clamped)
     const score = computeTrustScore({
       channelTrustLevel: 'high',
       contactConfidence: 1.0,
       injectionRiskScore: 0,
-      trustLevel: null,
+      tier: null,
       weights: customWeights,
     });
     expect(score).toBe(1.0);

--- a/tests/unit/draft-fallback-flow.test.ts
+++ b/tests/unit/draft-fallback-flow.test.ts
@@ -65,7 +65,6 @@ function createMockContactService(): ContactService {
     resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
     createContact: vi.fn().mockResolvedValue({ id: 'contact-001' }),
     linkIdentity: vi.fn().mockResolvedValue(undefined),
-    setTrustLevel: vi.fn().mockResolvedValue(undefined),
     setStatus: vi.fn().mockResolvedValue(undefined),
   } as unknown as ContactService;
 }


### PR DESCRIPTION
## Summary

- Migrates the three remaining `trust_level` DB column readers (confidence scorer, trust scorer, authorization service) to use `tier` / `ContactTier` instead
- Removes all `trust_level` writers: `setTrustLevel()`, `deriveTierFromTrustLevelUpdate()`, bootstrap INSERTs, kg.ts API field
- Removes `meetsMinimumTrust()` helper (callers already use `meetsMinimumTier()`)
- Renames `trust_level_defaults` → `tier_defaults` in `config/role-defaults.yaml` and `AuthConfig`; keys are now `ContactTier` values (`principal`, `trusted`, `known`, `unknown`, `blocked`)
- The `trust_level` DB column is intentionally left in place — it is dropped by #955

**Authorization behavior change (intentional):** Contacts previously stored with `trust_level=null` were backfilled to `tier='known'` (rank 1, medium-equivalent) by migration 055. On low-trust channels (e.g. email, rank 0), medium-sensitivity role permissions are now `allowed` where they were previously `trustBlocked`. High-sensitivity permissions remain blocked. A regression-documenting test is included.

## Changed files

| File | Change |
|---|---|
| `src/contacts/confidence-scorer.ts` | `trustLevel` → `tier`; grant boost via `meetsMinimumTier(tier, 'trusted')` |
| `src/contacts/confidence-pipeline.ts` | Pass `tier: contact.tier` to `computeConfidence()` |
| `src/dispatch/trust-scorer.ts` | `trustLevel` → `tier`; new `TIER_CHANNEL_WEIGHT_OVERRIDE` table |
| `src/dispatch/dispatcher.ts` | `trustLevel` → `tier`; wrap `computeTrustScore` in try/catch |
| `config/role-defaults.yaml` | `trust_level_defaults` → `tier_defaults`; keys to `ContactTier` |
| `src/contacts/types.ts` | `AuthConfig.trustLevelDefaults` → `tierDefaults`; remove `meetsMinimumTrust()`; `@deprecated` on `SenderContext.trustLevel` |
| `src/contacts/config-loader.ts` | Load `tier_defaults`; validate against `ContactTier` values |
| `src/contacts/authorization.ts` | New `TIER_TO_TRUST_RANK`; `trustLevel` input → `tier: ContactTier`; throws on unrecognized tier |
| `src/contacts/contact-resolver.ts` | Pass `tier` to `authService.evaluate()`; enrich auth-catch log |
| `src/contacts/contact-service.ts` | Remove `trust_level` from UPDATE SQL; remove `setTrustLevel()`, `deriveTierFromTrustLevelUpdate()` |
| `src/contacts/ceo-bootstrap.ts` | Remove `trust_level` from INSERT/repair SQL |
| `src/contacts/ensure-principal.ts` | Remove `trust_level` from INSERT |
| `src/channels/http/routes/kg.ts` | Remove `trustLevel` from POST/PATCH body; remove `setTrustLevel()` calls |

## Test plan

- [ ] All 3779 existing unit tests pass (`pnpm -C apps/curia run test`)
- [ ] TypeScript typecheck passes (`pnpm -C apps/curia run typecheck`)
- [ ] Authorization unit tests: 24/24 pass, including new known-tier medium-perm regression test
- [ ] Dispatcher tests: 101/101 pass
- [ ] Verify `trust_level` column still exists in DB schema (column drop is deferred to #955)

Closes #1070