### PR TITLE
fix: pin undici >=7.28.0 to clear code-scanning CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Gate C fail-closed for unstamped external tiers** — an external originator with no resolved tier now escalates instead of bypassing the gate. (#1059)
 - **Dispatcher stamps an `unknown`-tier originator for unresolved inbound senders** — defence in depth so Gate C still enforces tier policy if the channel layer skipped contact creation. (#1059)
 - **CVE-2026-53655 (pnpm bundled tar)** — removed corepack's unused pnpm cache from the production image to eliminate a bundled tar CVE.
+- **undici CVEs (12151/9697/6734 HIGH, 9678/9679 MED, 6733/11525 LOW)** — pinned `undici: '>=7.28.0'` in `pnpm-workspace.yaml` overrides; the transitive copy pulled by promptfoo now resolves to a patched 8.x.
 
 ### Added
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   ws: '>=8.21.0'
   form-data: '>=4.0.6'
   esbuild: '>=0.28.1'
+  undici: '>=7.28.0'
   '@opentelemetry/core': '>=2.8.0'
   onnxruntime-web>protobufjs: '>=7.6.3 <8'
 
@@ -156,7 +157,7 @@ importers:
         version: 13.1.3
       promptfoo:
         specifier: ^0.121.15
-        version: 0.121.15(@types/json-schema@7.0.15)(@types/node@25.9.3)(@types/pg@8.20.0)(pg@8.21.0)(playwright-core@1.61.0)(socks@2.8.9)
+        version: 0.121.15(@types/json-schema@7.0.15)(@types/node@25.9.3)(@types/pg@8.20.0)(debug@4.3.4)(pg@8.21.0)(playwright-core@1.61.0)(socks@2.8.9)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.40)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
@@ -5104,9 +5105,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
-    engines: {node: '>=20.18.1'}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -7079,13 +7080,13 @@ snapshots:
   '@slack/types@2.21.1':
     optional: true
 
-  '@slack/web-api@7.16.0':
+  '@slack/web-api@7.16.0(debug@4.3.4)':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
       '@types/node': 25.9.3
       '@types/retry': 0.12.0
-      axios: 1.17.0
+      axios: 1.17.0(debug@4.3.4)
       eventemitter3: 5.0.4
       form-data: 4.0.6
       is-electron: 2.2.2
@@ -7629,7 +7630,7 @@ snapshots:
       - supports-color
     optional: true
 
-  axios@1.17.0:
+  axios@1.17.0(debug@4.3.4):
     dependencies:
       follow-redirects: 1.16.0(debug@4.3.4)
       form-data: 4.0.6
@@ -8897,7 +8898,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.16.1)
+      retry-axios: 2.6.0(axios@1.16.1(debug@4.3.4))
       tough-cookie: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -9906,7 +9907,7 @@ snapshots:
 
   promise-limit@2.7.0: {}
 
-  promptfoo@0.121.15(@types/json-schema@7.0.15)(@types/node@25.9.3)(@types/pg@8.20.0)(pg@8.21.0)(playwright-core@1.61.0)(socks@2.8.9):
+  promptfoo@0.121.15(@types/json-schema@7.0.15)(@types/node@25.9.3)(@types/pg@8.20.0)(debug@4.3.4)(pg@8.21.0)(playwright-core@1.61.0)(socks@2.8.9):
     dependencies:
       '@anthropic-ai/sdk': 0.98.0(zod@4.4.3)
       '@apidevtools/json-schema-ref-parser': 15.3.5(@types/json-schema@7.0.15)
@@ -9982,7 +9983,7 @@ snapshots:
       socket.io-client: 4.8.3
       text-extensions: 3.1.0
       tsx: 4.22.4
-      undici: 7.27.2
+      undici: 8.5.0
       winston: 3.19.0
       ws: 8.21.0
       zod: 4.4.3
@@ -10009,7 +10010,7 @@ snapshots:
       '@opencode-ai/sdk': 1.16.2
       '@playwright/browser-chromium': 1.60.0
       '@rollup/rollup-linux-x64-gnu': 4.61.1
-      '@slack/web-api': 7.16.0
+      '@slack/web-api': 7.16.0(debug@4.3.4)
       '@smithy/node-http-handler': 4.7.7
       '@swc/core': 1.15.40
       '@swc/core-darwin-arm64': 1.15.40
@@ -10249,7 +10250,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.16.1):
+  retry-axios@2.6.0(axios@1.16.1(debug@4.3.4)):
     dependencies:
       axios: 1.16.1(debug@4.3.4)
     optional: true
@@ -10839,7 +10840,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.2: {}
+  undici@8.5.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ overrides:
   ws: '>=8.21.0'         # CVE-2026-48779
   form-data: '>=4.0.6'   # CVE-2026-12143
   esbuild: '>=0.28.1'    # GHSA-gv7w-rqvm-qjhr (dev-server SSRF)
+  undici: '>=7.28.0'     # CVEs 2026-12151/9697/6734 (HIGH), 9678/9679 (MED), 6733/11525 (LOW) via promptfoo; floor 7.28.0 patches all (resolves to 8.x)
   # Scorecard vulnerability pins (GHSA alerts flagged in code-scanning #155):
   '@opentelemetry/core': '>=2.8.0'          # GHSA-8988-4f7v-96qf (unbounded baggage header memory allocation)
   'onnxruntime-web>protobufjs': '>=7.6.3 <8' # GHSA-f38q-mgvj-vph7 (schema name shadowing DoS); targeted to onnxruntime-web only — protobufjs@8.x is patched at 8.6.0; promptfoo already resolves 8.6.1 which is clean


### PR DESCRIPTION
## Summary

Code-scanning flags the transitive **undici@7.27.2** (pulled in by `promptfoo`, a devDependency) for seven CVEs:

| Severity | CVE |
|---|---|
| HIGH | CVE-2026-12151, CVE-2026-9697, CVE-2026-6734 |
| MEDIUM | CVE-2026-9678, CVE-2026-9679 |
| LOW | CVE-2026-6733, CVE-2026-11525 |

All are patched at undici **7.28.0 / 8.5.0**. This adds an `undici: '>=7.28.0'` override to `pnpm-workspace.yaml` (the only file pnpm v10+ reads overrides from). Resolution lands on **8.5.0**, which promptfoo accepts; `pnpm why undici` confirms a single resolved version.

## Docker / curia-deploy

No Dockerfile change needed. Both `curia/Dockerfile` and `curia-deploy/.../Dockerfile.curia` copy this repo's `pnpm-lock.yaml` + `pnpm-workspace.yaml` and run `--frozen-lockfile`, so they inherit the pin on the next image build. (Runtime images install `--prod`, so promptfoo/undici isn't even in them — the flagged image is the dev-deps build.)

## Out of scope — npm-vendored undici (#173-176)

The alerts under `usr/local/lib/node_modules/npm/node_modules/undici` are undici **bundled inside npm**, not part of our dependency tree. They are **not fixable here**: npm@11.17.0 (the latest release, already pinned in both Dockerfiles) bundles undici **6.26.0**, one patch below the **6.27.0** fix. No npm release currently ships the patched bundle. These four should be dismissed as not-runtime-reachable (npm isn't invoked at runtime; CMD uses tsx) or revisited when npm publishes a patched bundle.

## Verification

- `pnpm install --frozen-lockfile` passes (lockfile consistent — the exact check the Docker build runs).
- `pnpm why undici` → single version 8.5.0 via promptfoo.
- Lockfile diff is limited to undici + benign pnpm peer-annotation churn.