### PR TITLE
chore: track CodeAnt review config in-repo to cut false-positive noise

### DIFF
--- a/.codeant/README.md
+++ b/.codeant/README.md
@@ -33,6 +33,25 @@ We use `instructions.json` (not `review.json`) because we are correcting over-ea
 flags, not adding new things to enforce — and its scoping is *positive*, which matters
 (see caveats).
 
+## The six instructions
+
+These consolidate ~190 narrowly-scoped, near-duplicate CodeAnt dashboard "learnings"
+(each recorded when the same base rule re-fired on a different file) into a few broadly
+scoped rules:
+
+1. `tests-relax-production-rules` — async/null/error/naming rules don't apply to test files.
+2. `nullish-equality-idiom` — `!= null` / `== null` is the intentional combined guard.
+3. `agent-error-is-bus-boundary-only` — `AgentError` is bus-layer only; skills return `SkillResult`, routes/services/frontend use their own patterns.
+4. `error-propagation-and-pg-codes` — services may propagate to the caller's error boundary; direct `pgCode` checks are fine.
+5. `scripts-maintenance-conventions` — `scripts/` use log + exit-code, not `AgentError`.
+6. `apps-console-frontend-conventions` — Vite/React frontend ≠ Node backend (extensionless imports, `console.error`, etc.).
+
+~30 genuinely *specific* dashboard learnings (real architectural decisions, not generic
+patterns — e.g. the dispatch outbound-context design, the system-origin skill bypass,
+Gate C semantics) are intentionally **not** folded in here; they stay in the dashboard.
+The dashboard cleanup (delete the duplicates these six replace, keep the specifics) is a
+separate manual step, gated on the precedence question below.
+
 ## Open questions / caveats (verify before relying on this)
 
 The CodeAnt docs are thin and partly self-contradictory here. Two things are unverified:

--- a/.codeant/README.md
+++ b/.codeant/README.md
@@ -1,0 +1,51 @@
+# CodeAnt review configuration
+
+In-repo configuration for the [CodeAnt](https://www.codeant.ai/) AI reviewer, so the
+rule set is versioned, diff-reviewable, and a single source of truth instead of living
+only in the dashboard.
+
+CodeAnt reads three files from this `.codeant/` folder (repo root, beside `.git`):
+
+| File | Purpose |
+| --- | --- |
+| `instructions.json` | Guidance / suppression — tells the reviewer how to interpret the code and what **not** to flag. This is where we correct over-eager findings. |
+| `review.json` | Custom rules to **enforce** (not used yet — see below). |
+| `configuration.json` | `file_filters` for what gets reviewed at all (not used yet; default reviews everything). |
+
+Each `instructions`/`rules` entry: `id`, `description`, `files` (glob array), `scope`
+(`["ide", "pr"]`). Docs: https://docs.codeant.ai/ide/review/code_review_instructions
+
+## Why these instructions exist
+
+Across the contacts-cutover review (curia#1074), CodeAnt's style/error-handling
+`[custom_rule]` findings were ~95% false positives we declined, while its semantic
+findings (`[logic error]`, `[api mismatch]`, etc.) were genuinely useful. The noise had
+two roots, both fixed by `instructions.json`:
+
+1. **Production rules applied to test files and one-shot scripts** — Vitest already
+   fails on unhandled rejections; `!` in a test documents a test-established invariant;
+   scripts use a log-plus-exit-code contract, not `AgentError`.
+2. **Rules that didn't know project idioms** — `!= null` as the combined null/undefined
+   guard; "log + record + surface via exit/return" is not swallowing; `AgentError` is
+   judged at the user/bus boundary, not every internal throw.
+
+We use `instructions.json` (not `review.json`) because we are correcting over-eager
+flags, not adding new things to enforce — and its scoping is *positive*, which matters
+(see caveats).
+
+## Open questions / caveats (verify before relying on this)
+
+The CodeAnt docs are thin and partly self-contradictory here. Two things are unverified:
+
+1. **Precedence: does `.codeant/` override or only augment dashboard-configured rules?**
+   If it only augments, the noisy dashboard `[custom_rule]` rules will keep firing and
+   must also be disabled in the dashboard. Confirm with a test PR.
+2. **Glob syntax / negation.** The configuration page says Python `fnmatch` (where `*`
+   crosses `/`, so `**` is redundant) and that a leading `!` is **treated literally and
+   silently fails to match** — so negation cannot be used to exclude paths. The
+   instructions page says minimatch. We therefore scope **positively** (target the files
+   we want quiet) and hedge by listing both `*.test.ts` and `**/*.test.ts` forms. Do not
+   add `!`-negation patterns until confirmed.
+
+When these are answered, update this README and, if useful, add narrowed enforce-rules to
+`review.json`.

--- a/.codeant/README.md
+++ b/.codeant/README.md
@@ -50,16 +50,42 @@ scoped rules:
 patterns — e.g. the dispatch outbound-context design, the system-origin skill bypass,
 Gate C semantics) are intentionally **not** folded in here; they stay in the dashboard.
 The dashboard cleanup (delete the duplicates these six replace, keep the specifics) is a
-separate manual step, gated on the precedence question below.
+separate manual step — see the precedence note below for why it's still required and why
+it's safe.
+
+## Precedence: repo config vs dashboard "learnings"
+
+Researched against CodeAnt's docs (2026-06):
+
+- **Override is documented for exactly one file — `quality_gates_conditions.json`:** *"its
+  settings take full precedence… [and] override any organization or repository database
+  settings."* ([docs](https://docs.codeant.ai/pull_request/quality_gates/repository_configuration))
+- **For `instructions.json` / `review.json` vs the dashboard learnings, precedence is NOT
+  documented.** "Learnings" are a dashboard/DB-managed store (created from review
+  interactions, edited/deleted in the dashboard, applied across repos) with no documented
+  file-based deletion — which implies `instructions.json` **coexists with (augments)** them
+  rather than replacing them. This is inference, not a quoted spec.
+
+**Why this doesn't block the cleanup:** the six instructions here and the ~158 dashboard
+learnings they replace are *both suppressions* of the same patterns. If the repo file
+overrides → deleting the learnings is a no-op. If it only augments → deleting them removes
+now-redundant suppressions while the repo equivalents still suppress. Either way, deleting a
+learning that's fully covered by an equivalent repo instruction cannot increase false
+positives. Two consequences:
+
+1. The dashboard duplicates **won't auto-clear** by adding this file — delete them in the
+   dashboard (use the triage sheet). This file is for going-forward suppression + versioning.
+2. The real prerequisite is simply that `instructions.json` is **honored as a suppression**
+   (its documented purpose). Confirm empirically on the first normal code PR after this
+   merges: if the test / `!= null` / `AgentError` noise is gone, the six rules are working
+   and the 158 are safe to bulk-delete. The 3 enforcement learnings (#37/#86/#22) *generate*
+   findings and must be deleted in the dashboard directly — the repo file won't suppress them.
 
 ## Open questions / caveats (verify before relying on this)
 
-The CodeAnt docs are thin and partly self-contradictory here. Two things are unverified:
+One item remains genuinely unverified:
 
-1. **Precedence: does `.codeant/` override or only augment dashboard-configured rules?**
-   If it only augments, the noisy dashboard `[custom_rule]` rules will keep firing and
-   must also be disabled in the dashboard. Confirm with a test PR.
-2. **Glob syntax / negation.** The configuration page says Python `fnmatch` (where `*`
+1. **Glob syntax / negation.** The configuration page says Python `fnmatch` (where `*`
    crosses `/`, so `**` is redundant) and that a leading `!` is **treated literally and
    silently fails to match** — so negation cannot be used to exclude paths. The
    instructions page says minimatch. We therefore scope **positively** (target the files

--- a/.codeant/instructions.json
+++ b/.codeant/instructions.json
@@ -1,21 +1,39 @@
 {
   "instructions": [
     {
-      "id": "tests-skip-production-grade-rules",
-      "description": "These are Vitest test files. Do NOT flag: (1) awaited calls lacking try/catch or .catch() — Vitest already fails a test on any unhandled rejection with a full stack, so wrapping the body hides the signal; (2) non-null assertions (`x!`) — the test's own setup establishes the value a line or two earlier, and a null there should throw and fail the test; (3) requests to normalize thrown errors into AgentError — tests assert on thrown errors directly. Production-grade async/null/error-handling rules do not apply to test files.",
-      "files": ["*.test.ts", "**/*.test.ts", "tests/*", "tests/**", "**/__tests__/**"],
+      "id": "tests-relax-production-rules",
+      "description": "Test files (Vitest). Do NOT apply production-grade async/null/error/naming rules here. (1) Awaited calls need no try/catch or .catch() — Vitest fails the test on any unhandled rejection with the original stack, and wrapping it hides the signal; this covers setup, act, request execution, and teardown. (2) Non-null assertions (`x!`, `mock.calls[0]!`, indexed array access) are fine when prior setup deterministically establishes the value — a null there should fail the test loudly; do not require runtime guards, optional chaining, or null-checks on already-asserted response payloads or inline-constructed fixtures. (3) Abbreviated test-helper names (`makeCtx`, `buildCtx`, `fakeX`) follow repo convention — do not flag. (4) Mock failures use `new Error(...)`; `AgentError` is a payload interface, not a throwable class. (5) Best-effort `finally`/`.catch` cleanup in teardown that swallows already-stopped / never-started cases is acceptable; do not require logging or rethrow for non-actionable test cleanup. (6) Assess only the routes/behavior registered in an isolated route-module test — do not require the full production route stack or reachability.",
+      "files": ["**/*.test.ts", "**/*.test.tsx", "**/*.test.js", "**/test/**", "**/tests/**", "**/__tests__/**"],
       "scope": ["ide", "pr"]
     },
     {
-      "id": "scripts-are-not-agent-runtime",
-      "description": "Files under scripts/ are one-shot CLI/ops scripts, not part of the agent or skill runtime. Their error contract is a structured pino log plus a process exit code. Do NOT require errors to be normalized into the AgentError shape, and do NOT flag a catch that logs and re-throws the original error (preserving the stack) before the CLI entry exits non-zero.",
-      "files": ["scripts/*", "scripts/**", "scripts/*.ts", "scripts/**/*.ts"],
+      "id": "nullish-equality-idiom",
+      "description": "`x != null` / `x == null` is the intentional combined null-OR-undefined guard, used consistently across this codebase (no `eqeqeq` lint is enforced for the nullish case). Do NOT flag it as a loose-equality violation — converting to `=== undefined` / `!== null` changes semantics (these inputs may be `undefined` when omitted or `null` from a JSON payload). Reserve any strict-equality rule for `==`/`!=` against non-null literals (`== 0`, `== ''`, `== false`).",
+      "files": ["**/*.ts", "**/*.tsx", "**/*.js"],
       "scope": ["ide", "pr"]
     },
     {
-      "id": "project-error-and-null-conventions",
-      "description": "Production-code conventions. (1) `x != null` / `x == null` is the intentional combined null-or-undefined guard and is used consistently across the codebase — do NOT flag it under the loose-equality rule; reserve that rule for == / != against non-null literals (== 0, == '', == false). (2) A catch is NOT swallowing a failure when it logs with context AND records the failure (a counter, a failed-id list, or a {success:false} return) AND the caller acts on it (non-zero exit, aggregated throw, error result); a documented best-effort cleanup catch that runs after the primary operation already succeeded and logs at warn for a later sweep is intentional. (3) AgentError normalization is judged at the boundary that reaches the user or bus (skill handler / agent runtime), not at every internal throw — a plain `throw new Error(...)` inside a service method is fine when sibling guards throw the same way and the single caller normalizes it into a structured result.",
-      "files": ["src/*", "src/**", "skills/*", "skills/**"],
+      "id": "agent-error-is-bus-boundary-only",
+      "description": "`AgentError` is a structured payload type for the bus/dispatch layer only — it is NOT a general throwable class. Do NOT require AgentError normalization elsewhere. (1) Skill handlers return the `SkillResult` contract (`{ success: true, data }` or `{ success: false, error: string }`), including not-found cases — never throw AgentError; a raw `throw new Error(...)` inside a handler is fine because the execution layer normalizes at the skill boundary. (2) HTTP route handlers (`src/channels/http/routes/**`) log the raw error with pino and return a generic 500, or map typed domain errors like `ContactValidationError` to a 400 — do not convert to AgentError. (3) Service/computation modules (`src/contacts/**`, `src/dispatch/**`) and utility helpers may throw plain `Error` and let the caller normalize; `throw new Error(...)` for not-found/guard cases in `contact-service.ts`/`ceo-bootstrap.ts`/`mergeContacts` is correct. (4) The frontend (`apps/console/**`) uses plain string error state for UI display.",
+      "files": ["skills/**", "src/**", "apps/console/**"],
+      "scope": ["ide", "pr"]
+    },
+    {
+      "id": "error-propagation-and-pg-codes",
+      "description": "Established server-side error-handling patterns — do not require blanket per-call try/catch or AgentError wrapping. (1) Service/DB-layer methods (`src/contacts/**`, `src/secrets/**`, `skills/_shared/**` clients, etc.) may let database/lookup errors propagate to the caller's intentional error boundary (a route handler maps to 500, the skill boundary maps to a SkillResult) rather than wrapping locally; a shared `request()` helper that already normalizes/throws typed errors should not be re-wrapped per method. (2) Direct Postgres SQLSTATE/`pgCode` checks (e.g. `pgCode === '23505'` for unique-violation / concurrency races) are the project's established pattern at the DB boundary. (3) A catch that only logs and swallows a non-actionable failure does not need AgentError normalization; reserve that for errors that are rethrown or cross a boundary where the caller needs typed info. (4) One-shot bootstrap/startup awaits (route registration, wiring) may bubble to the top-level `main().catch` instead of per-await try/catch.",
+      "files": ["src/**", "skills/**"],
+      "scope": ["ide", "pr"]
+    },
+    {
+      "id": "scripts-maintenance-conventions",
+      "description": "Files under `scripts/` are one-shot CLI/ops scripts, not part of the agent/skill runtime. (1) Do NOT require `AgentError` — structured `pino` logging plus failure counting and a non-zero exit code is the contract; logging and re-throwing the original error (preserving the stack) so the process exits non-zero is also fine. (2) A per-item catch in a batch/backfill loop that aggregates failures (records failed IDs/counts) and exits non-zero at the end is acceptable — continuing the loop is intended. (3) Best-effort `.catch` logging on event-publish / side-effect calls is fine when the durable operation already succeeded and the exit code is driven by the primary failure count.",
+      "files": ["scripts/**"],
+      "scope": ["ide", "pr"]
+    },
+    {
+      "id": "apps-console-frontend-conventions",
+      "description": "`apps/console` is a Vite/React frontend, not the Node backend — backend rules do not apply. (1) Relative imports intentionally omit `.js` extensions (Vite resolves them at bundle time); do not flag extensionless relative or package imports. (2) `console.error` / console logging is acceptable in client-side code — the no-console / structured-logging rule is server-side only. (3) Do not require `React.memo` for small, conditionally-mounted drawer/field components absent evidence of measurable render cost. (4) A file may export a differently-named PascalCase page component, matching the sibling convention; do not require component-name == file-name. (5) Content-type-gated JSON parsing with a try/catch fall-through to a generic error message (no console logging) is acceptable in page components when the malformed body is non-actionable. (6) Keyboard accessibility on clickable table rows is deferred to a single dedicated cross-table a11y pass — do not raise one-off per-page row-a11y fixes.",
+      "files": ["apps/console/**"],
       "scope": ["ide", "pr"]
     }
   ]

--- a/.codeant/instructions.json
+++ b/.codeant/instructions.json
@@ -1,0 +1,22 @@
+{
+  "instructions": [
+    {
+      "id": "tests-skip-production-grade-rules",
+      "description": "These are Vitest test files. Do NOT flag: (1) awaited calls lacking try/catch or .catch() — Vitest already fails a test on any unhandled rejection with a full stack, so wrapping the body hides the signal; (2) non-null assertions (`x!`) — the test's own setup establishes the value a line or two earlier, and a null there should throw and fail the test; (3) requests to normalize thrown errors into AgentError — tests assert on thrown errors directly. Production-grade async/null/error-handling rules do not apply to test files.",
+      "files": ["*.test.ts", "**/*.test.ts", "tests/*", "tests/**", "**/__tests__/**"],
+      "scope": ["ide", "pr"]
+    },
+    {
+      "id": "scripts-are-not-agent-runtime",
+      "description": "Files under scripts/ are one-shot CLI/ops scripts, not part of the agent or skill runtime. Their error contract is a structured pino log plus a process exit code. Do NOT require errors to be normalized into the AgentError shape, and do NOT flag a catch that logs and re-throws the original error (preserving the stack) before the CLI entry exits non-zero.",
+      "files": ["scripts/*", "scripts/**", "scripts/*.ts", "scripts/**/*.ts"],
+      "scope": ["ide", "pr"]
+    },
+    {
+      "id": "project-error-and-null-conventions",
+      "description": "Production-code conventions. (1) `x != null` / `x == null` is the intentional combined null-or-undefined guard and is used consistently across the codebase — do NOT flag it under the loose-equality rule; reserve that rule for == / != against non-null literals (== 0, == '', == false). (2) A catch is NOT swallowing a failure when it logs with context AND records the failure (a counter, a failed-id list, or a {success:false} return) AND the caller acts on it (non-zero exit, aggregated throw, error result); a documented best-effort cleanup catch that runs after the primary operation already succeeded and logs at warn for a later sweep is intentional. (3) AgentError normalization is judged at the boundary that reaches the user or bus (skill handler / agent runtime), not at every internal throw — a plain `throw new Error(...)` inside a service method is fine when sibling guards throw the same way and the single caller normalizes it into a structured result.",
+      "files": ["src/*", "src/**", "skills/*", "skills/**"],
+      "scope": ["ide", "pr"]
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **CodeAnt review config** — `.codeant/instructions.json` scopes the AI reviewer's style/error-handling rules away from test files and one-shot scripts and documents project null/error idioms, cutting false-positive review noise. Dev tooling only; no runtime effect.
 - **Console Contacts: read-only View drawer** — clicking a contact opens a read-only view (editing is an explicit Edit button), so a single click can't mutate data. Shows only populated fields with smart links (mailto:/tel:/LinkedIn/`/kg?node=`), created/updated timestamps, and linked channel identities. (#1069)
 - **Console Contacts: defaults + KG links** — the page loads filtered to Known + Person by default (chips widen to All), and each row with a `kgNodeId` shows a KG deep-link icon. (#1069)
 - **`GET /api/kg/contacts/:id/identities`** — returns a contact's serialized channel identities for the Contacts View drawer. (#1069)


### PR DESCRIPTION
## Summary

Tracks the [CodeAnt](https://www.codeant.ai/) AI reviewer's configuration in-repo (versioned, diff-reviewable, single source of truth) instead of dashboard-only, and uses it to cut the false-positive review noise we kept declining on #1074.

This is **dev tooling only** — no runtime code, no behavior change.

## Why

Sorting the #1074 review feedback by CodeAnt's own tag: its `[custom_rule]` (style/error-handling) findings were ~95% false positives we declined, while its semantic findings (`[logic error]`, `[api mismatch]`, `[incomplete implementation]`, `[incorrect condition logic]`) were genuinely useful. The noise had two roots, both addressed here:

1. **Production rules applied to test files and one-shot scripts** — Vitest already fails on unhandled rejections; `!` in a test documents a test-established invariant; scripts use a log-plus-exit-code contract, not `AgentError`.
2. **Rules that didn't know project idioms** — `!= null` as the intentional null/undefined guard; "log + record + surface via exit/return" is not swallowing; `AgentError` is judged at the user/bus boundary, not every internal throw.

## Changes

- **`.codeant/instructions.json`** — three positively-scoped instructions covering the above. `instructions.json` (not `review.json`) because we're correcting over-eager flags, not adding things to enforce — and its scoping is positive (see caveats).
- **`.codeant/README.md`** — documents the file roles, the rationale, and the open questions.

## Caveats (documented in the README; to verify when we revisit)

The CodeAnt docs are thin and partly self-contradictory, so two things are unverified:

1. **Precedence** — does `.codeant/` override or only *augment* dashboard-configured rules? If only augment, the noisy dashboard `[custom_rule]` rules must also be disabled there.
2. **Glob syntax / negation** — the configuration page says Python `fnmatch` and that leading-`!` negation "silently fails to match"; the instructions page says minimatch. So this PR scopes **positively** (no `!`) and hedges by listing both `*.test.ts` and `**/*.test.ts` forms.

**How we'll verify:** the next normal code PR after this merges is the test — watch whether the test-file / `!= null` / script noise drops. If it persists, the dashboard rules need disabling (answering the precedence question). No throwaway fixtures committed for this.

## Test plan

- `jq` validates `instructions.json` as well-formed.
- No code paths touched; nothing to unit-test.

Deferred per discussion: revisit (and answer the two caveats) after #1074 and curia-deploy#131 are deployed.
