### PR TITLE
feat(contacts): read-only View drawer, sensible defaults, KG & identity links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Console Contacts: read-only View drawer** — clicking a contact opens a read-only view (editing is an explicit Edit button), so a single click can't mutate data. Shows only populated fields with smart links (mailto:/tel:/LinkedIn/`/kg?node=`), created/updated timestamps, and linked channel identities. (#1069)
+- **Console Contacts: defaults + KG links** — the page loads filtered to Known + Person by default (chips widen to All), and each row with a `kgNodeId` shows a KG deep-link icon. (#1069)
+- **`GET /api/kg/contacts/:id/identities`** — returns a contact's serialized channel identities for the Contacts View drawer. (#1069)
 - **`rederive:contact-tiers` script** — one-shot backfill that recomputes contact confidence and elevates `unknown→known` for contacts past the judgment threshold. (#955)
 - **`contact-set-tier` skill** — sets a contact's tier directly from chat ("treat Dana as trusted"); principal-auth guarded, rejects `tier='principal'`. (#952)
 - **Proactive grant recommendations** — weekly LLM-judge scan (`scan-grant-recommendations`) evaluates known-tier contacts and surfaces scheduling-access recommendations for CEO approval. (#952)

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -4,12 +4,35 @@ import { Sidebar } from '../components/Sidebar.js';
 import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
 import { apiFetch } from '../api.js';
 import { useTheme } from '../hooks/useTheme.js';
+import { buildContactViewFields, kgNodeHref, formatDateTime } from './contacts-utils.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 type ContactTier = 'blocked' | 'unknown' | 'known' | 'trusted' | 'principal';
 type ContactKind = 'person' | 'organization' | 'automated' | 'principal' | 'agent';
 type SystemRole = 'principal' | 'agent' | 'system' | null;
+type IdentityStatus = 'active' | 'defunct' | 'bounced';
+
+// Which drawer (if any) is open. `view` is read-only; `edit`/`create` show the
+// editable form. Splitting view from edit means a single row click can never
+// mutate data (#1069).
+type DrawerMode = 'view' | 'edit' | 'create' | null;
+
+// A contact's linked channel identity, as serialized by
+// GET /api/kg/contacts/:id/identities (Date fields are ISO strings here).
+interface ContactIdentity {
+  id: string;
+  contactId: string;
+  channel: string;
+  channelIdentifier: string;
+  label: string | null;
+  verified: boolean;
+  verifiedAt: string | null;
+  status: IdentityStatus;
+  source: string;
+  createdAt: string;
+  updatedAt: string;
+}
 
 // Numeric rank for tier-aware sorting (ascending capability).
 const TIER_ORDER: Record<ContactTier, number> = {
@@ -458,6 +481,155 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
   );
 }
 
+// ── Read-only view drawer ───────────────────────────────────────────────────────
+
+interface ViewDrawerProps {
+  contact: Contact;
+  onClose: () => void;
+  onEdit: () => void;
+}
+
+// Render a single field value with the right affordance: email → mailto:,
+// phone → tel:, LinkedIn → external link, KG node → /kg deep link, else plain.
+function ViewFieldValue({ kind, value }: { kind: string; value: string }) {
+  switch (kind) {
+    case 'email':
+      return <a href={`mailto:${value}`}>{value}</a>;
+    case 'phone':
+      return <a href={`tel:${value}`}>{value}</a>;
+    case 'url':
+      return <a href={value} target="_blank" rel="noreferrer noopener">{value}</a>;
+    case 'kg':
+      return <a href={kgNodeHref(value)} title="Open in knowledge graph">{value}</a>;
+    default:
+      return <span style={{ whiteSpace: 'pre-wrap' }}>{value}</span>;
+  }
+}
+
+function ContactViewDrawer({ contact, onClose, onEdit }: ViewDrawerProps) {
+  const [identities, setIdentities] = useState<ContactIdentity[]>([]);
+  const [identitiesError, setIdentitiesError] = useState<string | null>(null);
+  const [identitiesLoaded, setIdentitiesLoaded] = useState(false);
+
+  // Permission grants for read-only display. Reuses the existing overrides endpoint.
+  const [overrides, setOverrides] = useState<AuthOverride[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIdentitiesLoaded(false);
+    setIdentitiesError(null);
+    apiFetch(`/api/kg/contacts/${contact.id}/identities`)
+      .then(async res => {
+        if (cancelled) return;
+        if (!res.ok) { setIdentitiesError('Failed to load identities'); return; }
+        const d = await res.json() as { identities: ContactIdentity[] };
+        setIdentities(d.identities);
+      })
+      .catch((_err: unknown) => { if (!cancelled) setIdentitiesError('Failed to load identities'); })
+      .finally(() => { if (!cancelled) setIdentitiesLoaded(true); });
+    return () => { cancelled = true; };
+  }, [contact.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch(`/api/kg/contacts/${contact.id}/overrides`)
+      .then(async res => {
+        if (cancelled || !res.ok) return;
+        const d = await res.json() as { overrides: AuthOverride[] };
+        setOverrides(d.overrides);
+      })
+      .catch((_err: unknown) => { /* grants are supplementary; failure is non-fatal */ });
+    return () => { cancelled = true; };
+  }, [contact.id]);
+
+  const fields = buildContactViewFields(contact);
+
+  return (
+    <aside className="drawer">
+      <div className="drawer-header">
+        <div className="drawer-header-top">
+          <span className="badge badge-person">contact</span>
+          <button className="drawer-close" onClick={onClose} aria-label="Close">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="6" y1="6" x2="18" y2="18" /><line x1="18" y1="6" x2="6" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <h2 className="drawer-title-h2">{contact.displayName}</h2>
+        {[contact.title, contact.organization].filter(Boolean).length > 0 && (
+          <div className="drawer-subtitle">{[contact.title, contact.organization].filter(Boolean).join(' · ')}</div>
+        )}
+      </div>
+
+      <div className="drawer-body">
+        <div className="view-drawer">
+          {/* Populated profile fields only — no blank rows. */}
+          <dl style={{ display: 'grid', gridTemplateColumns: 'minmax(110px, max-content) 1fr', gap: '6px 16px', margin: 0, fontSize: 13 }}>
+            {fields.map(f => (
+              <div key={f.key} style={{ display: 'contents' }}>
+                <dt style={{ color: 'var(--app-fg-muted)' }}>{f.label}</dt>
+                <dd style={{ margin: 0, wordBreak: 'break-word' }}>
+                  <ViewFieldValue kind={f.kind} value={f.value} />
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          {/* Channel identities — the addresses Curia actually has on file. */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '20px 0 6px' }}>Channel identities</p>
+          {identitiesError && <p style={{ color: 'var(--app-destructive)', fontSize: 12, margin: 0 }}>{identitiesError}</p>}
+          {!identitiesError && identitiesLoaded && identities.length === 0 && (
+            <p style={{ color: 'var(--app-fg-muted)', fontSize: 12, margin: 0 }}>No channel identities on file.</p>
+          )}
+          {identities.map(idn => (
+            <div key={idn.id} style={{ display: 'flex', alignItems: 'baseline', gap: 8, fontSize: 13, marginBottom: 6, flexWrap: 'wrap' }}>
+              <span style={{ fontSize: 11, color: 'var(--app-fg-muted)', textTransform: 'uppercase', minWidth: 48 }}>{idn.channel}</span>
+              <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }}>{idn.channelIdentifier}</span>
+              {idn.label && <span style={{ color: 'var(--app-fg-muted)', fontSize: 12 }}>({idn.label})</span>}
+              <span style={{ fontSize: 11, color: idn.verified ? 'var(--app-success, #22c55e)' : 'var(--app-fg-muted)' }}>
+                {idn.verified ? 'verified' : 'unverified'}
+              </span>
+              <span style={{ fontSize: 11, color: 'var(--app-fg-muted)' }}>· {idn.status}</span>
+            </div>
+          ))}
+
+          {/* Permission grants — read-only here; managed in the Edit drawer. */}
+          {overrides.length > 0 && (
+            <>
+              <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '20px 0 6px' }}>Permission grants</p>
+              {overrides.map(o => (
+                <div key={o.permission} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginBottom: 4 }}>
+                  <span style={{
+                    display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
+                    background: o.granted ? 'var(--app-success, #22c55e)' : 'var(--app-destructive)',
+                  }} />
+                  <span style={{ flex: 1, fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }}>{o.permission}</span>
+                  <span style={{ color: 'var(--app-fg-muted)', fontSize: 12 }}>{o.granted ? 'granted' : 'denied'}</span>
+                </div>
+              ))}
+            </>
+          )}
+
+          {/* Timestamps */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '20px 0 6px' }}>Record</p>
+          <dl style={{ display: 'grid', gridTemplateColumns: 'minmax(110px, max-content) 1fr', gap: '6px 16px', margin: 0, fontSize: 13 }}>
+            <dt style={{ color: 'var(--app-fg-muted)' }}>Created</dt>
+            <dd style={{ margin: 0 }}>{formatDateTime(contact.createdAt)}</dd>
+            <dt style={{ color: 'var(--app-fg-muted)' }}>Updated</dt>
+            <dd style={{ margin: 0 }}>{formatDateTime(contact.updatedAt)}</dd>
+          </dl>
+        </div>
+      </div>
+
+      <div className="drawer-footer">
+        <div style={{ flex: 1 }} />
+        <button className="btn btn-secondary btn-sm" onClick={onClose}>Close</button>
+        <button className="btn btn-primary btn-sm" onClick={onEdit}>Edit</button>
+      </div>
+    </aside>
+  );
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function ContactsPage() {
@@ -467,13 +639,17 @@ export default function ContactsPage() {
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
-  const [tierFilter, setTierFilter] = useState<'all' | ContactTier>('all');
-  const [kindFilter, setKindFilter] = useState<'all' | ContactKind>('all');
+  // Default to the list you actually work from — Known people — rather than the
+  // full pile of every tier/kind. Chips still let you widen to All (#1069).
+  const [tierFilter, setTierFilter] = useState<'all' | ContactTier>('known');
+  const [kindFilter, setKindFilter] = useState<'all' | ContactKind>('person');
   const [sort, setSort] = useState<{ key: keyof Contact; dir: 'asc' | 'desc' }>({ key: 'tier', dir: 'desc' });
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const [editing, setEditing] = useState<Contact | null>(null);
-  const [creating, setCreating] = useState(false);
+  // Selected contact + which drawer is open. `view` opens on a single row click
+  // (read-only); `edit`/`create` show the editable form (#1069).
+  const [selected, setSelected] = useState<Contact | null>(null);
+  const [drawerMode, setDrawerMode] = useState<DrawerMode>(null);
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
@@ -549,18 +725,40 @@ export default function ContactsPage() {
         next[idx] = contact;
         return next;
       }
-      // New contact: switch tier filter so it's immediately visible.
+      // New contact: widen filters so it's immediately visible regardless of its
+      // tier/kind (defaults are Known + Person).
       setTierFilter(contact.tier);
+      if (contact.kind === 'person' || contact.kind === 'organization' || contact.kind === 'automated') {
+        setKindFilter(contact.kind);
+      } else {
+        setKindFilter('all');
+      }
       return [...prev, contact];
     });
-    setEditing(contact);
-    setCreating(false);
+    // After a save, return to the read-only view showing the saved data.
+    setSelected(contact);
+    setDrawerMode('view');
   }
 
   function handleDeleted(id: string) {
     setContacts(prev => prev.filter(c => c.id !== id));
-    setEditing(null);
-    setCreating(false);
+    setSelected(null);
+    setDrawerMode(null);
+  }
+
+  function openView(contact: Contact) {
+    setSelected(contact);
+    setDrawerMode('view');
+  }
+
+  function openEdit(contact: Contact) {
+    setSelected(contact);
+    setDrawerMode('edit');
+  }
+
+  function closeDrawer() {
+    setSelected(null);
+    setDrawerMode(null);
   }
 
   return (
@@ -584,7 +782,7 @@ export default function ContactsPage() {
             <TopbarDivider />
             <button
               className="btn btn-primary btn-sm"
-              onClick={() => { setEditing(null); setCreating(true); }}
+              onClick={() => { setSelected(null); setDrawerMode('create'); }}
             >
               + New contact
             </button>
@@ -676,8 +874,8 @@ export default function ContactsPage() {
                         {pageRows.map(c => (
                           <tr
                             key={c.id}
-                            className={editing?.id === c.id ? 'active' : ''}
-                            onClick={() => { setCreating(false); setEditing(c); }}
+                            className={selected?.id === c.id ? 'active' : ''}
+                            onClick={() => openView(c)}
                           >
                             <td>
                               <div className="cell-with-avatar">
@@ -698,10 +896,24 @@ export default function ContactsPage() {
                             <td className="cell-mono col-updated">{formatDate(c.updatedAt)}</td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>
+                                {/* KG deep-link — only when this contact is linked to a node. */}
+                                {c.kgNodeId && (
+                                  <a
+                                    className="btn-icon"
+                                    href={kgNodeHref(c.kgNodeId)}
+                                    title="Open in knowledge graph"
+                                    aria-label="Open in knowledge graph"
+                                  >
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                      <circle cx="5" cy="6" r="2.5"/><circle cx="18" cy="6" r="2.5"/><circle cx="11.5" cy="18" r="2.5"/>
+                                      <path d="M7 7.5 10 16M16.5 7.5 13 16"/>
+                                    </svg>
+                                  </a>
+                                )}
                                 <button
                                   className="btn-icon"
                                   title="Edit"
-                                  onClick={() => { setCreating(false); setEditing(c); }}
+                                  onClick={() => openEdit(c)}
                                 >
                                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                                     <path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"/>
@@ -731,12 +943,20 @@ export default function ContactsPage() {
                   />
                 </div>
 
-                {(editing !== null || creating) && (
+                {drawerMode === 'view' && selected && (
+                  <ContactViewDrawer
+                    key={`view-${selected.id}`}
+                    contact={selected}
+                    onClose={closeDrawer}
+                    onEdit={() => setDrawerMode('edit')}
+                  />
+                )}
+                {(drawerMode === 'edit' || drawerMode === 'create') && (
                   <ContactEditDrawer
-                    key={editing?.id ?? 'new'}
-                    contact={editing}
-                    creating={creating}
-                    onClose={() => { setEditing(null); setCreating(false); }}
+                    key={drawerMode === 'edit' ? selected?.id ?? 'edit' : 'new'}
+                    contact={drawerMode === 'edit' ? selected : null}
+                    creating={drawerMode === 'create'}
+                    onClose={closeDrawer}
                     onSaved={handleSaved}
                     onDeleted={handleDeleted}
                   />

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -516,32 +516,39 @@ function ContactViewDrawer({ contact, onClose, onEdit }: ViewDrawerProps) {
 
   useEffect(() => {
     let cancelled = false;
+    // Reset before fetching. The parent keys this drawer by contact id, so it
+    // already remounts (fresh state) when you switch contacts — but clearing
+    // here keeps the effect self-contained so stale identities can never render
+    // even if that key is removed later. Also clear on failure for the same reason.
+    setIdentities([]);
     setIdentitiesLoaded(false);
     setIdentitiesError(null);
     apiFetch(`/api/kg/contacts/${contact.id}/identities`)
       .then(async res => {
         if (cancelled) return;
-        if (!res.ok) { setIdentitiesError('Failed to load identities'); return; }
+        if (!res.ok) { setIdentities([]); setIdentitiesError('Failed to load identities'); return; }
         const d = await res.json() as { identities: ContactIdentity[] };
         setIdentities(d.identities);
       })
-      .catch((_err: unknown) => { if (!cancelled) setIdentitiesError('Failed to load identities'); })
+      .catch((_err: unknown) => { if (!cancelled) { setIdentities([]); setIdentitiesError('Failed to load identities'); } })
       .finally(() => { if (!cancelled) setIdentitiesLoaded(true); });
     return () => { cancelled = true; };
   }, [contact.id]);
 
   useEffect(() => {
     let cancelled = false;
+    setOverrides([]);
     apiFetch(`/api/kg/contacts/${contact.id}/overrides`)
       .then(async res => {
-        if (cancelled || !res.ok) return;
+        if (cancelled) return;
+        if (!res.ok) { setOverrides([]); return; }
         const d = await res.json() as { overrides: AuthOverride[] };
         setOverrides(d.overrides);
       })
       // Grants are supplementary read-only display; a failure here just hides the
       // section (guarded by overrides.length) rather than blocking the view. Leave
       // a breadcrumb so a genuinely-broken overrides endpoint is still diagnosable.
-      .catch((err: unknown) => { console.error('[ContactViewDrawer] failed to load overrides:', err); });
+      .catch((err: unknown) => { if (!cancelled) setOverrides([]); console.error('[ContactViewDrawer] failed to load overrides:', err); });
     return () => { cancelled = true; };
   }, [contact.id]);
 

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -538,7 +538,10 @@ function ContactViewDrawer({ contact, onClose, onEdit }: ViewDrawerProps) {
         const d = await res.json() as { overrides: AuthOverride[] };
         setOverrides(d.overrides);
       })
-      .catch((_err: unknown) => { /* grants are supplementary; failure is non-fatal */ });
+      // Grants are supplementary read-only display; a failure here just hides the
+      // section (guarded by overrides.length) rather than blocking the view. Leave
+      // a breadcrumb so a genuinely-broken overrides endpoint is still diagnosable.
+      .catch((err: unknown) => { console.error('[ContactViewDrawer] failed to load overrides:', err); });
     return () => { cancelled = true; };
   }, [contact.id]);
 

--- a/apps/console/src/pages/contacts-utils.test.ts
+++ b/apps/console/src/pages/contacts-utils.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { buildContactViewFields, kgNodeHref, formatDateTime, type ContactViewModel } from './contacts-utils.js';
+
+// A fully-empty contact except for the always-present tier/kind.
+const EMPTY: ContactViewModel = {
+  tier: 'known',
+  kind: 'person',
+  notes: null,
+  preferredName: null,
+  pronouns: null,
+  role: null,
+  title: null,
+  organization: null,
+  primaryEmail: null,
+  primaryPhone: null,
+  timezone: null,
+  locale: null,
+  location: null,
+  linkedinUrl: null,
+  bio: null,
+  birthday: null,
+  kgNodeId: null,
+};
+
+describe('buildContactViewFields', () => {
+  it('returns only tier and kind for an otherwise-empty contact', () => {
+    const fields = buildContactViewFields(EMPTY);
+    expect(fields.map(f => f.key)).toEqual(['tier', 'kind']);
+    expect(fields.find(f => f.key === 'tier')).toMatchObject({ label: 'Tier', value: 'known', kind: 'text' });
+  });
+
+  it('omits blank and whitespace-only values (no blank rows)', () => {
+    const fields = buildContactViewFields({ ...EMPTY, title: '   ', organization: '' });
+    expect(fields.some(f => f.key === 'title')).toBe(false);
+    expect(fields.some(f => f.key === 'organization')).toBe(false);
+  });
+
+  it('trims surrounding whitespace from values', () => {
+    const fields = buildContactViewFields({ ...EMPTY, title: '  CEO  ' });
+    expect(fields.find(f => f.key === 'title')?.value).toBe('CEO');
+  });
+
+  it('tags email, phone, linkedin, and KG node with their render kinds', () => {
+    const fields = buildContactViewFields({
+      ...EMPTY,
+      primaryEmail: 'a@b.com',
+      primaryPhone: '+15551234567',
+      linkedinUrl: 'https://linkedin.com/in/x',
+      kgNodeId: 'node-1',
+    });
+    const byKey = Object.fromEntries(fields.map(f => [f.key, f.kind]));
+    expect(byKey['primaryEmail']).toBe('email');
+    expect(byKey['primaryPhone']).toBe('phone');
+    expect(byKey['linkedinUrl']).toBe('url');
+    expect(byKey['kgNodeId']).toBe('kg');
+  });
+
+  it('includes notes only when set', () => {
+    expect(buildContactViewFields(EMPTY).some(f => f.key === 'notes')).toBe(false);
+    const withNotes = buildContactViewFields({ ...EMPTY, notes: 'hello' });
+    expect(withNotes.find(f => f.key === 'notes')).toMatchObject({ value: 'hello' });
+  });
+
+  it('orders fields by section (identity → work → contact → … → system)', () => {
+    const fields = buildContactViewFields({
+      ...EMPTY,
+      preferredName: 'Al',
+      title: 'CEO',
+      primaryEmail: 'a@b.com',
+      notes: 'n',
+    });
+    const keys = fields.map(f => f.key);
+    expect(keys.indexOf('preferredName')).toBeLessThan(keys.indexOf('title'));
+    expect(keys.indexOf('title')).toBeLessThan(keys.indexOf('primaryEmail'));
+    expect(keys.indexOf('primaryEmail')).toBeLessThan(keys.indexOf('tier'));
+    expect(keys.indexOf('tier')).toBeLessThan(keys.indexOf('notes'));
+  });
+});
+
+describe('kgNodeHref', () => {
+  it('builds a /kg deep link with the node id', () => {
+    expect(kgNodeHref('abc-123')).toBe('/kg?node=abc-123');
+  });
+
+  it('URL-encodes the node id', () => {
+    expect(kgNodeHref('a b&c')).toBe('/kg?node=a%20b%26c');
+  });
+});
+
+describe('formatDateTime', () => {
+  it('returns the raw input for an unparseable timestamp', () => {
+    expect(formatDateTime('not-a-date')).toBe('not-a-date');
+  });
+
+  it('produces a non-empty localized string for a valid ISO timestamp', () => {
+    const out = formatDateTime('2024-01-02T03:04:05Z');
+    expect(out).not.toBe('2024-01-02T03:04:05Z');
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/console/src/pages/contacts-utils.ts
+++ b/apps/console/src/pages/contacts-utils.ts
@@ -1,0 +1,98 @@
+// Pure, framework-free helpers for the Contacts page View drawer (#1069).
+// Kept separate from ContactsPage.tsx so they can be unit-tested in the
+// node test environment (component .tsx files are not picked up by vitest).
+
+// How a view-drawer field should be rendered. The component switches on this to
+// decide whether to emit a plain value, a mailto:/tel:/external link, or a KG
+// deep-link.
+export type ViewFieldKind = 'text' | 'email' | 'phone' | 'url' | 'kg';
+
+export interface ViewField {
+  key: string;
+  label: string;
+  value: string;
+  kind: ViewFieldKind;
+}
+
+// The subset of a contact the view drawer needs. ContactsPage's `Contact`
+// interface is structurally compatible with this.
+export interface ContactViewModel {
+  tier: string;
+  kind: string;
+  notes: string | null;
+  preferredName: string | null;
+  pronouns: string | null;
+  role: string | null;
+  title: string | null;
+  organization: string | null;
+  primaryEmail: string | null;
+  primaryPhone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  linkedinUrl: string | null;
+  bio: string | null;
+  birthday: string | null;
+  kgNodeId: string | null;
+}
+
+// Treat empty / whitespace-only strings as unset, so the drawer never renders a
+// blank row.
+function present(v: string | null | undefined): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+/**
+ * Build the ordered list of populated fields to show in the read-only view.
+ * Only fields with a value are returned (no blank rows). `tier` and `kind` are
+ * always present on a contact, so they always appear; `notes` and the rest
+ * appear only when set. Field order mirrors the Edit drawer's sections.
+ */
+export function buildContactViewFields(c: ContactViewModel): ViewField[] {
+  const fields: ViewField[] = [];
+  const push = (key: string, label: string, value: string | null | undefined, kind: ViewFieldKind = 'text') => {
+    if (present(value)) fields.push({ key, label, value: value.trim(), kind });
+  };
+
+  // Identity
+  push('preferredName', 'Preferred name', c.preferredName);
+  push('pronouns', 'Pronouns', c.pronouns);
+  // Work
+  push('role', 'Role', c.role);
+  push('title', 'Title', c.title);
+  push('organization', 'Organization', c.organization);
+  // Contact info — smart-formatted as mailto:/tel:
+  push('primaryEmail', 'Primary email', c.primaryEmail, 'email');
+  push('primaryPhone', 'Primary phone', c.primaryPhone, 'phone');
+  // Location & locale
+  push('timezone', 'Timezone', c.timezone);
+  push('locale', 'Locale', c.locale);
+  push('location', 'Location', c.location);
+  // Links & bio
+  push('linkedinUrl', 'LinkedIn', c.linkedinUrl, 'url');
+  push('bio', 'Bio', c.bio);
+  push('birthday', 'Birthday', c.birthday);
+  // System
+  push('tier', 'Tier', c.tier);
+  push('kind', 'Kind', c.kind);
+  push('kgNodeId', 'KG node', c.kgNodeId, 'kg');
+  push('notes', 'Notes', c.notes);
+
+  return fields;
+}
+
+/** Deep-link to a KG node in the console's /kg route, which validates `node`. */
+export function kgNodeHref(nodeId: string): string {
+  return `/kg?node=${encodeURIComponent(nodeId)}`;
+}
+
+/**
+ * Format an ISO timestamp as a localized date + time for display. Returns the
+ * raw input unchanged if it is not a parseable date, so a bad value is visible
+ * rather than rendered as "Invalid Date".
+ */
+export function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}

--- a/src/channels/http/routes/kg.test.ts
+++ b/src/channels/http/routes/kg.test.ts
@@ -229,7 +229,7 @@ describe('GET /api/kg/contacts/:id/identities', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json() as { identities: Array<Record<string, unknown>> };
     expect(body.identities).toHaveLength(1);
-    expect(body.identities[0]).toMatchObject({
+    expect(body.identities[0]!).toMatchObject({
       id: IDENTITY.id,
       channel: 'email',
       channelIdentifier: 'alice@example.com',

--- a/src/channels/http/routes/kg.test.ts
+++ b/src/channels/http/routes/kg.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { knowledgeGraphRoutes } from './kg.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
-import type { Contact } from '../../../contacts/types.js';
+import type { ChannelIdentity, Contact } from '../../../contacts/types.js';
 import type { EventBus } from '../../../bus/bus.js';
 import type { EventRouter } from '../event-router.js';
 import type { Pool } from 'pg';
@@ -188,5 +188,107 @@ describe('PATCH /api/kg/contacts/:id — status field removal', () => {
       body: JSON.stringify({ displayName: 'X' }),
     });
     expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('GET /api/kg/contacts/:id/identities', () => {
+  let app: FastifyInstance;
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  // The identities route validates the id against a strict RFC-4122 UUID regex
+  // (version + variant nibbles), so use a well-formed v4 UUID here.
+  const CID = '11111111-1111-4111-8111-111111111111';
+
+  // A channel identity fixture with Date fields, so we can assert ISO serialization.
+  const IDENTITY: ChannelIdentity = {
+    id: '22222222-2222-4222-8222-222222222222',
+    contactId: CID,
+    channel: 'email',
+    channelIdentifier: 'alice@example.com',
+    label: 'Work',
+    verified: true,
+    verifiedAt: new Date('2024-02-02T03:04:05Z'),
+    status: 'active',
+    source: 'email_participant',
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    updatedAt: new Date('2024-01-02T00:00:00Z'),
+  };
+
+  it('returns the contact’s identities with Date fields serialized to ISO strings', async () => {
+    const svc = fakeContactService({
+      getIdentitiesForContact: vi.fn().mockResolvedValue([IDENTITY]),
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/kg/contacts/${CID}/identities`,
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { identities: Array<Record<string, unknown>> };
+    expect(body.identities).toHaveLength(1);
+    expect(body.identities[0]).toMatchObject({
+      id: IDENTITY.id,
+      channel: 'email',
+      channelIdentifier: 'alice@example.com',
+      label: 'Work',
+      verified: true,
+      status: 'active',
+      source: 'email_participant',
+      verifiedAt: '2024-02-02T03:04:05.000Z',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+  });
+
+  it('returns an empty array when the contact has no identities', async () => {
+    const svc = fakeContactService({
+      getIdentitiesForContact: vi.fn().mockResolvedValue([]),
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/kg/contacts/${CID}/identities`,
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ identities: [] });
+  });
+
+  it('returns 404 when the contact does not exist', async () => {
+    const svc = fakeContactService({
+      getContact: vi.fn().mockResolvedValue(undefined),
+      getIdentitiesForContact: vi.fn(),
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/kg/contacts/${CID}/identities`,
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 for a non-UUID contact id', async () => {
+    const svc = fakeContactService();
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/kg/contacts/not-a-uuid/identities',
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects an unauthenticated request', async () => {
+    const svc = fakeContactService();
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/kg/contacts/${CID}/identities`,
+    });
+    expect(res.statusCode).toBe(401);
   });
 });

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -6,7 +6,7 @@ import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import { ContactValidationError } from '../../../contacts/contact-service.js';
-import type { Contact, ContactCanonicalFields, ContactKind, ContactTier } from '../../../contacts/types.js';
+import type { ChannelIdentity, Contact, ContactCanonicalFields, ContactKind, ContactTier } from '../../../contacts/types.js';
 import type { EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { markdownToHtml } from '../../../utils/markdown-to-html.js';
@@ -754,6 +754,24 @@ export async function knowledgeGraphRoutes(
     };
   }
 
+  // Serialize a channel identity for the API: Date fields → ISO strings, so the
+  // contacts View drawer (#1069) can render them. Mirrors serializeContact above.
+  function serializeIdentity(i: ChannelIdentity) {
+    return {
+      id: i.id,
+      contactId: i.contactId,
+      channel: i.channel,
+      channelIdentifier: i.channelIdentifier,
+      label: i.label,
+      verified: i.verified,
+      verifiedAt: i.verifiedAt ? i.verifiedAt.toISOString() : null,
+      status: i.status,
+      source: i.source,
+      createdAt: i.createdAt.toISOString(),
+      updatedAt: i.updatedAt.toISOString(),
+    };
+  }
+
   // Validate canonical fields from a POST/PATCH body.
   // Returns an error string if invalid, or null if all checks pass.
   // `fields` entries are trimmed and empty-string-coerced to null.
@@ -1079,6 +1097,26 @@ export async function knowledgeGraphRoutes(
     } catch (err) {
       logger.error({ err, contactId: id }, 'GET /api/kg/contacts/:id/overrides failed');
       return reply.status(500).send({ error: 'Failed to load auth overrides.' });
+    }
+  });
+
+  // GET /api/kg/contacts/:id/identities — list a contact's linked channel identities.
+  // Read-only display surface for the contacts View drawer (#1069): the drawer shows
+  // the actual channel identities (email/phone/Signal/…) Curia has on file, not just
+  // the denormalized primaryEmail/primaryPhone columns.
+  app.get('/api/kg/contacts/:id/identities', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+    const { id } = request.params as { id: string };
+    if (!UUID_RE.test(id)) return reply.status(400).send({ error: 'Invalid contact ID.' });
+
+    try {
+      const contact = await contactService.getContact(id);
+      if (!contact) return reply.status(404).send({ error: 'Contact not found.' });
+      const identities = await contactService.getIdentitiesForContact(id);
+      return reply.send({ identities: identities.map(serializeIdentity) });
+    } catch (err) {
+      logger.error({ err, contactId: id }, 'GET /api/kg/contacts/:id/identities failed');
+      return reply.status(500).send({ error: 'Failed to load identities.' });
     }
   });
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -976,6 +976,11 @@ export class ContactService {
     }
   }
 
+  /** List all channel identities linked to a contact, oldest first. */
+  async getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]> {
+    return this.backend.getIdentitiesForContact(contactId);
+  }
+
   /** Remove a channel identity by its ID. Returns true if found and removed, false if not found. */
   async unlinkIdentity(identityId: string): Promise<boolean> {
     return this.backend.unlinkIdentity(identityId);


### PR DESCRIPTION
## Summary

Reworks the Console **Contacts** page so you can safely *look* at a contact before editing, plus sensible defaults and links out to the KG and channel identities. `Closes #1069`.

- **Default filters** — the page loads filtered to `tier = Known` + `kind = Person` (the list you actually work from); chips still widen to **All**.
- **View vs Edit split** — clicking a row now opens a **read-only View drawer**; editing is an explicit **Edit** button inside the view. `+ New contact` still opens the form directly. Page state tracks `view | edit | create` via a single `selected` + `drawerMode` pair, so a stray single click can't mutate data.
- **View drawer content** — renders **only populated fields** (no blank rows), with smart formatting: LinkedIn as a link, email as `mailto:`, phone as `tel:`, KG node as a `/kg?node=<id>` link. Shows **Created/Updated** timestamps (date + time) and the contact's **linked channel identities** (channel, identifier, label, verified + status). Permission grants render read-only when present.
- **KG link in the table** — a small icon link per row when `kgNodeId` is set, opening `/kg?node=<id>`; rows without a node show no link.
- **Backend** — new `GET /api/kg/contacts/:id/identities` returning serialized identities (mirrors the existing `/overrides` route's auth/validation/error pattern), backed by a new public `ContactService.getIdentitiesForContact` passthrough.

## Implementation notes

- Pure view logic (populated-field selection, smart link kinds, KG href, timestamp formatting) is extracted into `apps/console/src/pages/contacts-utils.ts` so it can be unit-tested in the node test env (component `.tsx` files aren't picked up by vitest).
- Adding/editing channel identities from this drawer is **out of scope** — identities are read-only display here.

## Testing

- `contacts-utils.test.ts` — 10 cases covering field selection (no blank rows, ordering, trimming), render-kind tagging, `kgNodeHref` encoding, and `formatDateTime` fallback.
- `kg.test.ts` — new endpoint covered: ISO serialization, empty array, 404 (missing contact), 400 (non-UUID), 401 (unauthenticated).
- `pnpm run typecheck` passes for both the backend root and `apps/console`.