### PR TITLE
chore: auto-delete CodeAnt promo comments via workflow

### DIFF
--- a/.github/workflows/remove-codeant-promo.yml
+++ b/.github/workflows/remove-codeant-promo.yml
@@ -1,0 +1,38 @@
+# Deletes CodeAnt's promotional issue comments (the "Thanks for using CodeAnt! 🎉"
+# / share-on-social footer) as soon as the bot posts them. This targets only
+# PR/issue *conversation* comments — line-level code-review comments are a
+# different object type (pull_request_review_comment) that this workflow never
+# sees, so CodeAnt's actual review feedback is left untouched.
+#
+# Reactive by design: GitHub has no pre-publish hook for bot comments, so the
+# comment appears briefly before this removes it. If CodeAnt rewords the promo,
+# update the `contains(...)` signature below.
+
+name: Remove CodeAnt promo comments
+
+on:
+  issue_comment:
+    types: [created]
+
+# Repo-scoped token is enough to delete the bot's comment. issue_comment
+# workflows always run from the default branch, so this covers every PR.
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  delete-promo:
+    runs-on: ubuntu-latest
+    # Two independent guards: the comment must be from the CodeAnt bot AND carry
+    # the promo signature. A real review comment matches neither.
+    if: >
+      github.event.comment.user.login == 'codeant-ai[bot]' &&
+      contains(github.event.comment.body, 'Thanks for using CodeAnt')
+    steps:
+      - name: Delete the promo comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/comments/${COMMENT_ID}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Console Contacts: read-only View drawer** — clicking a contact opens a read-only view (editing is an explicit Edit button), so a single click can't mutate data. Shows only populated fields with smart links (mailto:/tel:/LinkedIn/`/kg?node=`), created/updated timestamps, and linked channel identities. (#1069)
 - **Console Contacts: defaults + KG links** — the page loads filtered to Known + Person by default (chips widen to All), and each row with a `kgNodeId` shows a KG deep-link icon. (#1069)
 - **`GET /api/kg/contacts/:id/identities`** — returns a contact's serialized channel identities for the Contacts View drawer. (#1069)
+- **`remove-codeant-promo` workflow** — auto-deletes CodeAnt's "Thanks for using CodeAnt" promotional conversation comments when posted; leaves line-level code-review comments untouched.
 - **`rederive:contact-tiers` script** — one-shot backfill that recomputes contact confidence and elevates `unknown→known` for contacts past the judgment threshold. (#955)
 - **`contact-set-tier` skill** — sets a contact's tier directly from chat ("treat Dana as trusted"); principal-auth guarded, rejects `tier='principal'`. (#952)
 - **Proactive grant recommendations** — weekly LLM-judge scan (`scan-grant-recommendations`) evaluates known-tier contacts and surfaces scheduling-access recommendations for CEO approval. (#952)


### PR DESCRIPTION
## Summary

Adds a small GitHub Actions workflow that automatically deletes CodeAnt's promotional conversation comments (the "Thanks for using CodeAnt! 🎉" + share-on-social footer) as soon as the bot posts them, while leaving the bot's actual line-level code-review comments untouched.

The two are different object types, which is what makes this safe:
- **Promo** = an *issue comment* (`/issues/comments/` endpoint) — body contains "Thanks for using CodeAnt".
- **Code review** = a *pull request review comment* (`pull_request_review_comment`, different endpoint) — never seen by an `issue_comment` workflow.

## How it works

- Triggers on `issue_comment: created`.
- Two independent guards in the job `if:` — author must be `codeant-ai[bot]` **and** the body must contain `Thanks for using CodeAnt`. A real review comment matches neither.
- Deletes via the built-in `GITHUB_TOKEN` (`gh api -X DELETE`) — no third-party action, no extra secret.
- The workflow runs from the default branch, so it covers every PR once merged.

## Notes / trade-offs

- **Reactive, not preventive.** GitHub has no pre-publish hook for bot comments, so the promo appears for a few seconds before it's removed (a notification email may still arrive).
- **Signature-coupled.** If CodeAnt rewords the promo, the `contains(...)` match needs a one-line update. Kept deliberately narrow to eliminate any risk of deleting a genuine review comment.
- Injection-safe: `comment.body` is only referenced in the `if:` expression context, never interpolated into a shell `run:` step.