### PR TITLE
fix: contacts closes dedup tasks; specialists self-sweep context (#1052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Contacts dedup task lifecycle** — the contacts specialist now closes dedup review tasks (`task-complete`) and self-sweeps the exchange's outbound-context entry on every terminal outcome (merge, exclude, defer), so resolved dedups no longer linger as `open` in the morning digest. (#1052)
+- **Silent context sweep** — `context-bridge-release` drops its `coordinator`-only `allowed_callers` restriction; specialists (`contacts`, `ceo-inbox`) can release their own exchange entries instead of asking "Sweep those too?". (#1052)
+- **Coordinator sweep trigger** — tightened from the ambiguous "after the exchange is complete" to an explicit close-on-result rule, so stale `[ACTIVE OUTBOUND CONTEXT]` entries stop accumulating across multi-turn specialist conversations. (#1052)
+
 ## [0.36.0] — 2026-06-20 — "Reverend Mother"
 
 > **Reverend Mother Gaius Helen Mohiam** *(Dune, 1965, Frank Herbert)* — the Bene Gesserit who holds the gom jabbar to your throat and decides, by what you do under the test, who is human enough to pass. v0.36 gives Curia the same discernment: every sender is met at the gate, sorted by tier, and let only as far as earned trust allows.

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.8.0"
+version: "0.9.0"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -38,6 +38,9 @@ pinned_skills:
   - contact-update
   - date-resolve
   - scheduler-report
+  # Outbound context — self-sweep the exchange entry when a multi-turn email
+  # exchange completes (see "Closing a multi-turn exchange" in the prompt).
+  - context-bridge-release
 
 allow_discovery: false
 enable_task_management: true
@@ -87,11 +90,26 @@ system_prompt: |
      profile (call executive-profile-get) and the ✍️ Drafted drafting rules.
      Then call task-complete with a brief completion note. If task-complete fails,
      log it in the Response Format ("task-complete FAILED — draft was saved but
-     task remains open") and do not retry; the draft is already created.
+     task remains open") and do not retry; the draft is already created. The
+     exchange is now done — sweep its context entry per "Closing a multi-turn
+     exchange" below.
   4. If the dependency is still unavailable: call task-update to set status
      'waiting', add a progress note, and set a new wake_at. If task-update fails,
      log it in the Response Format ("task-update FAILED — task may be stale").
      Do not re-send an interim acknowledgment; the original was already sent.
+     Do NOT sweep the context entry — the exchange is still open.
+
+  **Closing a multi-turn exchange:** When a delegated or follow-up email exchange
+  reaches its end — the final reply is drafted and no further round-trip is
+  expected — sweep the outbound-context entry for that exchange yourself. Look for
+  an `[ACTIVE OUTBOUND CONTEXT]` block in your input; if one is present, find the
+  entry whose thread/subject matches the exchange you just completed and call
+  `context-bridge-release` with its `entry_id`. Sweep only that one entry — never
+  release entries for other threads or other agents' conversations visible in the
+  block. If no entry matches, or no block is present, skip the call. This is
+  silent cleanup: do not ask the CEO or the coordinator for permission, and do not
+  offer to sweep. A release failure is non-critical — log it and move on; the
+  reply has already been drafted.
 
   **Composing a new email (cold outreach):** When the coordinator asks you to
   draft a new email to someone (not a reply to an existing thread), use

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -1,5 +1,5 @@
 name: contacts
-version: "0.7.0"
+version: "0.8.0"
 role: specialist
 description: >
   Contact domain specialist — briefings, CRUD, deduplication, relationship management,
@@ -7,6 +7,13 @@ description: >
 model:
   tier: fast  # structured CRUD + briefings, no judgment calls, never user-facing
 allow_discovery: false
+# Dedup work spans multiple turns and ends in a terminal outcome (merge, exclude,
+# or defer). The agent owns closing those tasks (task-complete) and sweeping the
+# outbound-context entry for the exchange (context-bridge-release) — see the
+# "Closing a dedup task" section in the prompt. enable_task_management auto-pins
+# task-create/list/update/complete and makes contacts heartbeat-eligible so it
+# drains its own dedup queue.
+enable_task_management: true
 error_budget:
   max_turns: 30  # dedup scan: 1 find + up to 20 tasks filed + 1 report; grant scan: 1 scan + up to 3 notifications + 1 report
 system_prompt: |
@@ -163,12 +170,42 @@ system_prompt: |
   2. Apply the primary heuristic above to identify which would be primary.
   3. Call contact-merge dry_run: true to preview the golden record.
   4. Present both contacts side-by-side and ask the CEO whether to merge.
-  5. On confirmation: call contact-merge with dry_run: false.
-  6. If the CEO explicitly says they are not the same person ("not a duplicate",
-     "different people", "don't merge them"): call contact-dedup-exclude with both
-     contact IDs. This prevents the pair from resurfacing on future sweeps.
-  7. If the CEO defers or wants to decide later: close the task without calling
-     contact-dedup-exclude. The pair may resurface on a future sweep.
+  5. **Merge confirmed.** Call contact-merge with dry_run: false. Once it
+     succeeds, close out the task (see "Closing a dedup task" below).
+  6. **Pair excluded.** If the CEO explicitly says they are not the same person
+     ("not a duplicate", "different people", "don't merge them"): call
+     contact-dedup-exclude with both contact IDs (this prevents the pair from
+     resurfacing on future sweeps), then close out the task.
+  7. **Deferred.** If the CEO defers or wants to decide later: do NOT call
+     contact-dedup-exclude (the pair may resurface on a future sweep), but still
+     close out the task — a deferral is a terminal outcome for this review.
+
+  ### Closing a dedup task
+  Every dedup review ends in one of the three terminal outcomes above (merge,
+  exclude, defer). The moment you reach one, close out the task yourself — do not
+  leave it open, do not ask the CEO, and do not offer to "sweep" anything. This is
+  routine cleanup that Curia handles silently.
+
+  Two calls, in this order:
+
+  1. **`task-complete`** with the dedup task's `task_id`. Find the id from the
+     coordinator's delegation message if it included one. If it did not, call
+     `task-list` with `tag: "dedup"` (the filter input is a single scalar `tag`,
+     not an array) and match on the two contact names to find the right task,
+     then complete that one. Add a short completion_note
+     stating the outcome (e.g. "Merged into <primary>", "Excluded — CEO confirmed
+     not a duplicate", "Deferred at CEO request").
+
+  2. **`context-bridge-release`** with the `entry_id` of THIS exchange from the
+     `[ACTIVE OUTBOUND CONTEXT]` block. Sweep only the entry for the dedup review
+     you just finished — identify it by matching the contact names / subject of
+     this exchange. Never release other entries visible in the block; they belong
+     to other agents' in-flight conversations. If no entry in the block matches
+     this exchange, skip this call (there is nothing to release).
+
+  Both calls are best-effort cleanup: if `task-complete` returns `success: false`,
+  note it in your response and still attempt `context-bridge-release`. Never block
+  the dedup outcome on either call succeeding.
 
   ### Weekly contacts dedup scan
   When the scheduler sends "Run your weekly contacts dedup scan":
@@ -303,6 +340,9 @@ pinned_skills:
   - calendar-list-events
   # Scheduler observability — required for all scheduled tasks.
   - scheduler-report
+  # Outbound context — self-sweep the exchange entry when a dedup review closes.
+  # (task-create/list/update/complete are auto-pinned by enable_task_management.)
+  - context-bridge-release
 
 schedule:
   - cron: "0 9 * * 1"   # Mondays at 9 AM

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.8.4"
+version: "0.8.5"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -156,10 +156,19 @@ system_prompt: |
   - A matched entry **without** a `delegation_hint` → handle directly or
     borrow-then-answer as the content warrants.
   - Clearly unrelated to all active entries → apply the normal three-way decision.
-  - After delegating and the exchange is complete, call context-bridge-release
-    with the entry_id from the matched entry. Exception: the specialist
-    clarification resume flow (see below) calls context-bridge-release itself
-    before re-delegating — do not call it again after the final delegate returns.
+  - **Sweep on close.** When a specialist returns a result that closes an
+    exchange — the task is marked done, a final answer has been delivered, or no
+    further reply is expected — immediately call context-bridge-release with the
+    entry_id of the matched entry, before responding to the CEO. Do not wait for
+    a later turn; release it the moment the exchange ends. If the specialist
+    response is interim (it expects another round-trip — a clarification, an
+    awaited reply, a deferred follow-up), leave the entry active. Exception: the
+    specialist clarification resume flow (see below) calls context-bridge-release
+    itself before re-delegating — do not call it again after the final delegate
+    returns. Note: specialists that own their own lifecycle (e.g. contacts closing
+    a dedup task, ceo-inbox closing a multi-turn email exchange) may release their
+    own exchange entry; if the entry is already released when you go to sweep it,
+    that is expected — no action needed.
 
   When you call signal-send, email-send, or email-reply and you know which specialist
   should handle any reply, pass the `context_bridge` parameter to add a delegation hint

--- a/skills/context-bridge-release/skill.json
+++ b/skills/context-bridge-release/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "context-bridge-release",
   "description": "Mark an outbound context bridge entry as released — stop expecting replies for this outbound message. Use this when a delegated conversation is complete or when you want to clear stale context. The entry_id is shown in the [ACTIVE OUTBOUND CONTEXT] block.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -15,8 +15,5 @@
   "timeout": 10000,
   "capabilities": [
     "outboundContext"
-  ],
-  "allowed_callers": [
-    "coordinator"
   ]
 }


### PR DESCRIPTION
## Summary

Closes #1052. Fixes two lifecycle gaps that left stale state after the contacts specialist completed dedup work.

**1. Dedup tasks stayed open forever.** `contacts.yaml` had no task-management capability, so the agent could not call `task-complete` after a merge/exclude/defer — every dedup task lingered as `open` and re-appeared in the morning digest.

- Add `enable_task_management: true` — auto-pins `task-create/list/update/complete` and makes contacts BacklogHeartbeat-eligible so it drains its own dedup queue.
- Rewrite the dedup workflow's three terminal outcomes (steps 5/6/7) and add a **"Closing a dedup task"** section: after each outcome, call `task-complete` (task_id from the delegation message, or `task-list` with `tag: "dedup"` matched on contact names) then `context-bridge-release` for this exchange's entry — no prompting, no asking.

**2. Context-bridge entries piled up; the agent asked permission to sweep.** `context-bridge-release` was restricted to the coordinator, so even when the contacts agent offered to "Sweep those too?" it couldn't.

- Drop `allowed_callers` from `context-bridge-release/skill.json` entirely. The skill is `action_risk: low`; worst case of a premature release is degraded reply routing, not data loss. (Caller gate is only enforced when the list is non-empty, so removal opens it to any pinned caller.)
- Pin `context-bridge-release` to `contacts` and `ceo-inbox` so they can self-sweep. Each prompt constrains the agent to release **only** the entry matching the exchange it just closed.
- `ceo-inbox.yaml`: new **"Closing a multi-turn exchange"** section — silently sweep the matched entry after a follow-up reply is drafted (resume-mode step 3); leave it active if the exchange is still open.
- `coordinator.yaml`: tighten the sweep trigger from the ambiguous "after the exchange is complete" to an explicit close-on-result rule, and note that specialists may release their own exchange entry (already-released is expected, not an error).

## Versioning

- `contacts` 0.7.0 → 0.8.0 (new capability + pin)
- `ceo-inbox` 0.8.0 → 0.9.0 (new pin)
- `coordinator` 0.8.4 → 0.8.5 (prompt clarification)
- `context-bridge-release` 1.0.0 → 1.1.0 (manifest schema change: dropped restriction)

## Testing

Config-only change (agent prompts + a skill manifest). Validated:
- All three agent YAMLs and the skill JSON parse.
- `pnpm` unit suites pass for the affected subsystems: skill loader, skill execution (caller gate), task-management, agent loaders, startup validator/readiness — 149 tests green.
- Verified against the runtime: `enable_task_management` wiring (`src/agents/task-management.ts`, `src/index.ts`), the caller gate (`src/skills/execution.ts`), and the dedup task tag (`['dedup','contacts']` in `skills/contact-find-duplicates/handler.ts`).

A pre-PR review flagged a `tag` vs `tags` schema mismatch in the prompt, now fixed to match the singular scalar `tag` input of `task-list`.

## Acceptance criteria

- [x] Merge/exclusion/deferral each transition the dedup task to `status=done` (agent now calls `task-complete`)
- [x] Contacts sweeps only the entry_id of the exchange it completed
- [x] Contacts never asks "Sweep those too?" — sweep is silent, part of task close
- [x] Morning digest no longer lists resolved dedup tasks
- [x] `ceo-inbox` can self-sweep after a multi-turn email exchange
- [x] All specialist agents can call `context-bridge-release` without a permission error
- [x] Coordinator continues to sweep entries it creates (no regression)