### PR TITLE
chore: bring skills/** handler code under typecheck (#1075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **`skills/**` typecheck** — `pnpm run typecheck` (and CI) now type-checks skill handler code via `tsconfig.skills.json`, closing the blind spot where `skills/**` sat outside `tsconfig`'s `src/**` scope. Skill `*.test.ts` files are deferred to phase 2. (#1075)
+
 ### Fixed
 
+- **Latent skill handler type errors** — fixed 34 real type errors surfaced by the new skills typecheck, including `calendar-list-events` reading `.value`/`.reason` off a `PromiseSettledResult` without narrowing on `.status`, and `noUncheckedIndexedAccess` violations in `date-resolve` and `file-parse/csv`. (#1075)
+- **`drive-download-file`** — dropped the unsupported `supportsAllDrives` flag from `files.export` (the Drive API ignores it on that endpoint), which was breaking overload resolution. (#1075)
 - **Contacts dedup task lifecycle** — the contacts specialist now closes dedup review tasks (`task-complete`) and self-sweeps the exchange's outbound-context entry on every terminal outcome (merge, exclude, defer), so resolved dedups no longer linger as `open` in the morning digest. (#1052)
 - **Silent context sweep** — `context-bridge-release` drops its `coordinator`-only `allowed_callers` restriction; specialists (`contacts`, `ceo-inbox`) can release their own exchange entries instead of asking "Sweep those too?". (#1052)
 - **Coordinator sweep trigger** — tightened from the ambiguous "after the exchange is complete" to an explicit close-on-result rule, so stale `[ACTIVE OUTBOUND CONTEXT]` entries stop accumulating across multi-turn specialist conversations. (#1052)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
-- **`skills/**` typecheck** — `pnpm run typecheck` (and CI) now type-checks skill handler code via `tsconfig.skills.json`, closing the blind spot where `skills/**` sat outside `tsconfig`'s `src/**` scope. Skill `*.test.ts` files are deferred to phase 2. (#1075)
+- **`skills/**` typecheck** — `tsconfig.skills.json` now type-checks skill handlers in CI; test files deferred to phase 2. (#1075)
 
 ### Fixed
 
-- **Latent skill handler type errors** — fixed 34 real type errors surfaced by the new skills typecheck, including `calendar-list-events` reading `.value`/`.reason` off a `PromiseSettledResult` without narrowing on `.status`, and `noUncheckedIndexedAccess` violations in `date-resolve` and `file-parse/csv`. (#1075)
-- **`drive-download-file`** — dropped the unsupported `supportsAllDrives` flag from `files.export` (the Drive API ignores it on that endpoint), which was breaking overload resolution. (#1075)
+- **Latent skill handler type errors** — fixed 34 errors surfaced by the new skills typecheck (`calendar-list-events` `PromiseSettledResult` narrowing, indexed-access guards). (#1075)
+- **`drive-download-file`** — dropped the unsupported `supportsAllDrives` flag from `files.export` that broke overload resolution. (#1075)
 - **Contacts dedup task lifecycle** — the contacts specialist now closes dedup review tasks (`task-complete`) and self-sweeps the exchange's outbound-context entry on every terminal outcome (merge, exclude, defer), so resolved dedups no longer linger as `open` in the morning digest. (#1052)
 - **Silent context sweep** — `context-bridge-release` drops its `coordinator`-only `allowed_callers` restriction; specialists (`contacts`, `ceo-inbox`) can release their own exchange entries instead of asking "Sweep those too?". (#1052)
 - **Coordinator sweep trigger** — tightened from the ambiguous "after the exchange is complete" to an explicit close-on-result rule, so stale `[ACTIVE OUTBOUND CONTEXT]` entries stop accumulating across multi-turn specialist conversations. (#1052)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json",
     "lint": "eslint src/ tests/",
     "migrate": "tsx --env-file=.env node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql",
     "smoke": "tsx --env-file=.env tests/smoke/cli.ts",

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -384,7 +384,10 @@ export class CeoNylasClient {
       res = await fetch(url, {
         method: 'GET',
         headers: {
-          Authorization: this.headers.Authorization,
+          // Always set in the constructor; the Record<string, string> index access types
+          // it as possibly-undefined, which the DOM HeadersInit (in scope for the skills
+          // typecheck) rejects.
+          Authorization: this.headers.Authorization!,
           Accept: 'application/octet-stream',
         },
       });
@@ -450,7 +453,14 @@ export class CeoNylasClient {
     form.append('message', JSON.stringify(messagePayload));
     for (let i = 0; i < attachments.length; i++) {
       const att = attachments[i]!;
-      form.append(`file${i}`, new Blob([att.content], { type: att.contentType }), att.filename);
+      // Node's `Buffer` (typed `Buffer<ArrayBufferLike>`) is not assignable to the DOM
+      // `BlobPart` union (in scope for the skills typecheck), which requires an
+      // ArrayBufferView backed specifically by ArrayBuffer — a zero-copy view over the
+      // Buffer keeps the ArrayBufferLike (possibly SharedArrayBuffer) buffer type. Copy
+      // into a fresh ArrayBuffer-backed Uint8Array; attachments are email-sized, so the
+      // copy is negligible and the bytes are identical.
+      const bytes = new Uint8Array(att.content);
+      form.append(`file${i}`, new Blob([bytes], { type: att.contentType }), att.filename);
     }
 
     // Omit Content-Type — fetch sets it automatically with the multipart boundary.

--- a/skills/approve-action/handler.ts
+++ b/skills/approve-action/handler.ts
@@ -84,7 +84,9 @@ export class ApproveActionHandler implements SkillHandler {
           skillName: row.skillName,
           actionRisk: row.actionRisk,
           outcome: childOutcome,
-          taskSummary: reResult.success ? null : (reResult as { error: string }).error,
+          // taskSummary is `string | undefined`; insert() maps undefined → NULL, so
+          // use undefined (not null) for the success case to satisfy the field type.
+          taskSummary: reResult.success ? undefined : (reResult as { error: string }).error,
           parentActionId: row.id,
         });
       } catch (err) {

--- a/skills/calendar-find-free-time/handler.ts
+++ b/skills/calendar-find-free-time/handler.ts
@@ -53,8 +53,11 @@ export class CalendarFindFreeTimeHandler implements SkillHandler {
       allBusy.sort((a, b) => a.start - b.start);
       const merged: Array<{ start: number; end: number }> = [];
       for (const slot of allBusy) {
-        if (merged.length > 0 && slot.start <= merged[merged.length - 1].end) {
-          merged[merged.length - 1].end = Math.max(merged[merged.length - 1].end, slot.end);
+        // Capture the last merged entry in a local — a truthy check narrows it from
+        // `T | undefined` (noUncheckedIndexedAccess) and replaces the length>0 guard.
+        const last = merged[merged.length - 1];
+        if (last && slot.start <= last.end) {
+          last.end = Math.max(last.end, slot.end);
         } else {
           merged.push({ ...slot });
         }

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -123,12 +123,17 @@ export class CalendarListEventsHandler implements SkillHandler {
       const failedCalendarIds: string[] = [];
       const successfulEvents: NylasCalendarEvent[][] = [];
       for (let i = 0; i < settled.length; i++) {
-        const result = settled[i];
+        // settled is mapped 1:1 from calendarIds and i is bounded by settled.length, so
+        // both indexed accesses are guaranteed present (noUncheckedIndexedAccess types
+        // them as possibly-undefined). The guard on .status then narrows the
+        // PromiseSettledResult to its fulfilled/rejected member (.value / .reason).
+        const result = settled[i]!;
+        const calendarId = calendarIds[i]!;
         if (result.status === 'fulfilled') {
           successfulEvents.push(result.value);
         } else {
-          failedCalendarIds.push(calendarIds[i]);
-          ctx.log.error({ err: result.reason, calendarId: calendarIds[i] }, 'Failed to fetch events for calendar');
+          failedCalendarIds.push(calendarId);
+          ctx.log.error({ err: result.reason, calendarId }, 'Failed to fetch events for calendar');
         }
       }
 

--- a/skills/context-for-email/handler.ts
+++ b/skills/context-for-email/handler.ts
@@ -10,7 +10,7 @@
 //   - entityMemory (to resolve email policies and meeting links from KG)
 //   - contactService (to look up recipient contact info)
 
-import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { resolveSignature, resolvePolicy } from '../_shared/template-base.js';
 
 // Map email_type input values to KG template labels

--- a/skills/date-resolve/handler.ts
+++ b/skills/date-resolve/handler.ts
@@ -18,7 +18,9 @@ type DayName = (typeof DAY_NAMES)[number];
 /** Map lowercase day name to luxon weekday number (1=Monday … 7=Sunday). */
 const DAY_TO_WEEKDAY: Record<string, number> = {};
 for (let i = 0; i < DAY_NAMES.length; i++) {
-  DAY_TO_WEEKDAY[DAY_NAMES[i].toLowerCase()] = i + 1;
+  // i is bounded by DAY_NAMES.length, so the element is always present
+  // (noUncheckedIndexedAccess types it as possibly-undefined).
+  DAY_TO_WEEKDAY[DAY_NAMES[i]!.toLowerCase()] = i + 1;
 }
 
 /**
@@ -63,7 +65,12 @@ function resolveRelative(raw: string, now: DateTime, timezone: string): DateTime
   // "next <day>" — the soonest future occurrence, never today
   const nextMatch = lower.match(/^next\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
   if (nextMatch) {
-    const targetWeekday = DAY_TO_WEEKDAY[nextMatch[1]];
+    // The capture group is required (always present when the match succeeds) and the
+    // regex only matches the seven day names that DAY_TO_WEEKDAY is keyed by — so both
+    // the index and the lookup are guaranteed (noUncheckedIndexedAccess types the group
+    // as `string | undefined` and the Record lookup as `number | undefined`). This same
+    // pairing of assertions repeats for the other relative-date patterns below.
+    const targetWeekday = DAY_TO_WEEKDAY[nextMatch[1]!]!;
     const daysAhead = ((targetWeekday - now.weekday + 7) % 7) || 7;
     return now.plus({ days: daysAhead }).startOf('day');
   }
@@ -71,7 +78,7 @@ function resolveRelative(raw: string, now: DateTime, timezone: string): DateTime
   // "this <day>" — this week's occurrence (ISO week: Mon=1)
   const thisMatch = lower.match(/^this\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
   if (thisMatch) {
-    const targetWeekday = DAY_TO_WEEKDAY[thisMatch[1]];
+    const targetWeekday = DAY_TO_WEEKDAY[thisMatch[1]!]!;
     const diff = targetWeekday - now.weekday;
     return now.plus({ days: diff }).startOf('day');
   }
@@ -81,8 +88,8 @@ function resolveRelative(raw: string, now: DateTime, timezone: string): DateTime
     /^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\s+of\s+the\s+week\s+of\s+(.+)$/,
   );
   if (weekOfMatch) {
-    const targetWeekday = DAY_TO_WEEKDAY[weekOfMatch[1]];
-    const anchor = parseDate(weekOfMatch[2], timezone);
+    const targetWeekday = DAY_TO_WEEKDAY[weekOfMatch[1]!]!;
+    const anchor = parseDate(weekOfMatch[2]!, timezone);
     if (!anchor) return null;
     // Find Monday of the anchor's week, then jump to target day
     const monday = anchor.startOf('week'); // luxon ISO: Monday
@@ -94,8 +101,8 @@ function resolveRelative(raw: string, now: DateTime, timezone: string): DateTime
     /^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\s+after\s+(.+)$/,
   );
   if (afterMatch) {
-    const targetWeekday = DAY_TO_WEEKDAY[afterMatch[1]];
-    const anchor = parseDate(afterMatch[2], timezone);
+    const targetWeekday = DAY_TO_WEEKDAY[afterMatch[1]!]!;
+    const anchor = parseDate(afterMatch[2]!, timezone);
     if (!anchor) return null;
     const daysAhead = ((targetWeekday - anchor.weekday + 7) % 7) || 7;
     return anchor.plus({ days: daysAhead }).startOf('day');

--- a/skills/drive-download-file/handler.ts
+++ b/skills/drive-download-file/handler.ts
@@ -169,8 +169,12 @@ export class DriveDownloadFileHandler implements SkillHandler {
     let contentType: string;
     try {
       if (isGoogleNative) {
+        // files.export accepts only fileId + mimeType (plus standard params) — unlike
+        // files.get it has no supportsAllDrives flag (the Drive API ignores it on this
+        // endpoint). Passing it was a no-op that also broke overload resolution, leaving
+        // res typed as void so res.data failed to type-check.
         const res = await drive.files.export(
-          { fileId, mimeType: exportMime, supportsAllDrives: true },
+          { fileId, mimeType: exportMime },
           { responseType: 'stream' },
         );
         buffer = await streamToBuffer(res.data as unknown as Readable, MAX_TEMP_FILE_BYTES);

--- a/skills/file-parse/csv.ts
+++ b/skills/file-parse/csv.ts
@@ -14,14 +14,17 @@ export function parseCsv(text: string): Record<string, string>[] {
   const rows = splitCsvRows(trimmed);
   if (rows.length < 2) return []; // header only or empty
 
-  const headers = splitCsvFields(rows[0]).map(h => h.trim());
+  // rows.length >= 2 is guaranteed above, and the loop indices below are bounded by
+  // their array lengths — so these accesses are always present (noUncheckedIndexedAccess
+  // types them as possibly-undefined).
+  const headers = splitCsvFields(rows[0]!).map(h => h.trim());
   const result: Record<string, string>[] = [];
 
   for (let i = 1; i < rows.length; i++) {
-    const fields = splitCsvFields(rows[i]);
+    const fields = splitCsvFields(rows[i]!);
     const row: Record<string, string> = {};
     for (let j = 0; j < headers.length; j++) {
-      row[headers[j]] = (fields[j] ?? '').trim();
+      row[headers[j]!] = (fields[j] ?? '').trim();
     }
     result.push(row);
   }

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -304,7 +304,10 @@ export class FileParseHandler implements SkillHandler {
       // Extract JSON from the LLM response. The LLM may wrap it in markdown fences
       // despite instructions; the capture-group approach handles prose before/after the block.
       const fenceMatch = llmText.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
-      const cleaned = (fenceMatch ? fenceMatch[1] : llmText).trim();
+      // fenceMatch[1] is the capture group; under noUncheckedIndexedAccess it's typed
+      // `string | undefined`, but a successful match always populates the group (possibly
+      // empty). `?? llmText` is a no-op at runtime and satisfies the type.
+      const cleaned = (fenceMatch?.[1] ?? llmText).trim();
       const structured = JSON.parse(cleaned);
       return {
         success: true,

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -341,13 +341,30 @@ export class MemoryStoreHandler implements SkillHandler {
           // the `if (result.stored)` block above. StoreFactResult is not a discriminated
           // union (stored and action are independent fields), so TypeScript cannot narrow
           // result.action through the stored boolean check — these cases are required to
-          // keep the exhaustive switch type-correct.
-          throw new Error(`memory-store: unreachable — ${result.action} must be handled in the stored=true branch`);
+          // keep the exhaustive switch type-correct. Per the skill contract (handlers
+          // resolve to a SkillResult, never throw), surface the impossible state as a
+          // logged failure rather than a thrown Error.
+          ctx.log.error(
+            { entity, field, action: result.action },
+            'memory-store: impossible storeFact state (stored-only action reached the stored=false branch)',
+          );
+          return {
+            success: false,
+            error: `Internal invariant violation: storeFact action "${result.action}" requires stored=true`,
+          };
         default: {
-          // Exhaustive check — TypeScript will error here if a new action variant is added
-          // to StoreFactResult without a corresponding case above.
+          // Exhaustive compile-time check — TypeScript errors on the `never` assignment if a
+          // new action variant is added to StoreFactResult without a case above. At runtime we
+          // return a logged failure rather than throw, per the skill contract.
           const _exhaustive: never = result.action;
-          throw new Error(`memory-store: unhandled storeFact action: ${String(_exhaustive)}`);
+          ctx.log.error(
+            { entity, field, action: String(_exhaustive) },
+            'memory-store: unhandled storeFact action',
+          );
+          return {
+            success: false,
+            error: `memory-store: unhandled storeFact action: ${String(_exhaustive)}`,
+          };
         }
       }
     } catch (err) {

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -335,11 +335,14 @@ export class MemoryStoreHandler implements SkillHandler {
             },
           };
         case 'auto_resolved':
-          // Unreachable at runtime: auto_resolved has stored=true and is handled by
-          // the `if (result.stored)` block above. TypeScript cannot narrow result.action
-          // through the stored boolean check, so this case is required to keep the
-          // exhaustive switch type-correct.
-          throw new Error('memory-store: unreachable — auto_resolved must be handled in the stored=true branch');
+        case 'created':
+        case 'updated':
+          // Unreachable at runtime: these actions all carry stored=true and are handled by
+          // the `if (result.stored)` block above. StoreFactResult is not a discriminated
+          // union (stored and action are independent fields), so TypeScript cannot narrow
+          // result.action through the stored boolean check — these cases are required to
+          // keep the exhaustive switch type-correct.
+          throw new Error(`memory-store: unreachable — ${result.action} must be handled in the stored=true branch`);
         default: {
           // Exhaustive check — TypeScript will error here if a new action variant is added
           // to StoreFactResult without a corresponding case above.

--- a/skills/web-browser/dom-extract.ts
+++ b/skills/web-browser/dom-extract.ts
@@ -1,0 +1,56 @@
+/// <reference lib="dom" />
+//
+// dom-extract.ts — DOM-extraction routine that runs *inside the browser* via
+// Playwright's frame.evaluate(). It uses browser globals (document, CSS,
+// HTMLInputElement, …) that the project's base tsconfig `lib` deliberately omits,
+// because server code must never see them. The triple-slash directive above scopes
+// the DOM lib to THIS file only — rather than adding "dom" to compilerOptions.lib,
+// which would expose DOM globals to every skill and mask real errors elsewhere.
+//
+// The exported function must stay self-contained (no module-scope references, no
+// imports, no closures): Playwright serializes it to source and runs it in the page,
+// where this module's scope does not exist. Keep it that way.
+
+/**
+ * DOM-extraction routine run *inside the browser* for one frame. Returns cleaned,
+ * LLM-friendly text (rendered DOM, not raw HTML) plus a labelled list of form fields.
+ * Defined once and passed to each frame's evaluate() so main-frame and iframe content
+ * are extracted identically.
+ */
+export function extractFrameContent(): string {
+  // Clone the body before stripping noise elements — mutating the live DOM would
+  // destroy scripts/styles/etc. for subsequent actions in the same session.
+  const root = document.body?.cloneNode(true) as HTMLBodyElement | null;
+  if (!root) return '';
+
+  // Remove noise elements from the clone — we want content, not chrome. (iframe
+  // elements are stripped here too: their *contents* are extracted separately per
+  // frame, so leaving the empty <iframe> shell in would add nothing.)
+  const noiseSelectors = ['script', 'style', 'noscript', 'svg', 'iframe', 'template'];
+  for (const sel of noiseSelectors) {
+    root.querySelectorAll(sel).forEach(el => el.remove());
+  }
+
+  // Extract form fields with their labels — the LLM needs to know what
+  // fields exist and what they're called to fill them correctly.
+  // Query the live DOM for form fields so we can look up labels by ID.
+  const formFields: string[] = [];
+  document.querySelectorAll('input, select, textarea').forEach(el => {
+    const input = el as HTMLInputElement;
+    if (input.type === 'hidden') return;
+    const id = input.id;
+    const labelEl = id ? document.querySelector(`label[for="${CSS.escape(id)}"]`) : null;
+    const label = labelEl?.textContent?.trim()
+      ?? input.getAttribute('placeholder')
+      ?? input.getAttribute('name')
+      ?? input.type;
+    formFields.push(`[${input.type ?? 'field'}: ${label}]`);
+  });
+
+  const bodyText = (root.innerText ?? root.textContent ?? '').trim();
+  const formSummary = formFields.length > 0
+    ? '\n\n--- Form fields ---\n' + formFields.join('\n')
+    : '';
+
+  return bodyText + formSummary;
+}

--- a/skills/web-browser/handler.ts
+++ b/skills/web-browser/handler.ts
@@ -10,6 +10,10 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { BrowserAction } from '../../src/browser/types.js';
 import type { Page, Frame, Locator } from 'playwright';
+// extractFrameContent runs inside the browser (passed to frame.evaluate). It lives in
+// its own module so the DOM lib it needs is scoped there, not leaked into this
+// server-side handler. See dom-extract.ts.
+import { extractFrameContent } from './dom-extract.js';
 
 // Maximum cleaned DOM content length before truncation.
 // Prevents token blowout on content-heavy pages.
@@ -452,50 +456,6 @@ async function resolveInScope(scope: Page | Frame, selector: string): Promise<Lo
   if (textCount > 0) return textCount === 1 ? textLocator : textLocator.first();
 
   return null;
-}
-
-/**
- * DOM-extraction routine run *inside the browser* for one frame. Returns cleaned,
- * LLM-friendly text (rendered DOM, not raw HTML) plus a labelled list of form fields.
- * Defined once and passed to each frame's evaluate() so main-frame and iframe content
- * are extracted identically.
- */
-function extractFrameContent(): string {
-  // Clone the body before stripping noise elements — mutating the live DOM would
-  // destroy scripts/styles/etc. for subsequent actions in the same session.
-  const root = document.body?.cloneNode(true) as HTMLBodyElement | null;
-  if (!root) return '';
-
-  // Remove noise elements from the clone — we want content, not chrome. (iframe
-  // elements are stripped here too: their *contents* are extracted separately per
-  // frame, so leaving the empty <iframe> shell in would add nothing.)
-  const noiseSelectors = ['script', 'style', 'noscript', 'svg', 'iframe', 'template'];
-  for (const sel of noiseSelectors) {
-    root.querySelectorAll(sel).forEach(el => el.remove());
-  }
-
-  // Extract form fields with their labels — the LLM needs to know what
-  // fields exist and what they're called to fill them correctly.
-  // Query the live DOM for form fields so we can look up labels by ID.
-  const formFields: string[] = [];
-  document.querySelectorAll('input, select, textarea').forEach(el => {
-    const input = el as HTMLInputElement;
-    if (input.type === 'hidden') return;
-    const id = input.id;
-    const labelEl = id ? document.querySelector(`label[for="${CSS.escape(id)}"]`) : null;
-    const label = labelEl?.textContent?.trim()
-      ?? input.getAttribute('placeholder')
-      ?? input.getAttribute('name')
-      ?? input.type;
-    formFields.push(`[${input.type ?? 'field'}: ${label}]`);
-  });
-
-  const bodyText = (root.innerText ?? root.textContent ?? '').trim();
-  const formSummary = formFields.length > 0
-    ? '\n\n--- Form fields ---\n' + formFields.join('\n')
-    : '';
-
-  return bodyText + formSummary;
 }
 
 /**

--- a/tsconfig.skills.json
+++ b/tsconfig.skills.json
@@ -1,0 +1,19 @@
+{
+  // Type-check the skills/ tree, which sits outside the main tsconfig's `src/**`
+  // rootDir and was therefore never covered by `pnpm run typecheck`. Skill handlers
+  // import from ../../src, so tsc follows those references; we set rootDir to the repo
+  // root and emit nothing. Run via the `typecheck` script alongside the base project.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    // declaration/declarationMap/outDir are meaningless for a noEmit check and the
+    // base values (rootDir: src) conflict with this wider rootDir — null them out.
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "composite": false
+  },
+  "include": ["skills/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.skills.json
+++ b/tsconfig.skills.json
@@ -15,5 +15,11 @@
     "composite": false
   },
   "include": ["skills/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  // Phase 1 covers production handler code only. Skill *.test.ts files still have ~117
+  // type errors (mostly SkillContext→Record casts that need `as unknown as`, `unknown`
+  // result.data narrowing, and possibly-undefined array access). Bringing them under the
+  // check is tracked as phase 2 of #1075; until then they are excluded so
+  // `pnpm run typecheck` stays green with handler code included.
+  // @TODO(#1075 phase 2): drop the *.test.ts exclusion and fix the remaining test errors.
+  "exclude": ["node_modules", "dist", "skills/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

**Phase 1 of #1075** (handlers only). This does **not** close the issue — phase 2 (the ~117 `skills/**/*.test.ts` errors) is still outstanding. See *Follow-up* below.

`skills/**` sat outside `tsconfig.json`'s `src/**` rootDir, so `pnpm run typecheck` (`tsc --noEmit`) never type-checked skill handlers — a real CI blind spot (the #955 contacts cutover left `contact-set-trust` calling a removed function and stayed green). This PR wires `tsconfig.skills.json` into the `typecheck` script and fixes the **34 latent handler-level type errors** it surfaces, with real narrowing/guards (no `any`, no `@ts-ignore`).

`skills/**/*.test.ts` (~117 errors) stay excluded — documented in `tsconfig.skills.json` with a searchable `@TODO(#1075 phase 2)`.

## Fixes by class

- **`calendar-list-events`** — the motivating bug: narrows the `PromiseSettledResult` on `.status` before reading `.value`/`.reason`.
- **`noUncheckedIndexedAccess`** — `date-resolve`, `file-parse/csv`, `calendar-find-free-time`: in-bounds guards / assertions (loop indices, regex capture groups, length-checked rows).
- **`web-browser`** — the `page.evaluate()` DOM callback (`extractFrameContent`) is isolated into `dom-extract.ts` with a scoped `/// <reference lib="dom" />`, keeping `src/` DOM-free. The function stays self-contained for Playwright serialization.
- **`drive-download-file`** — drops the unsupported `supportsAllDrives` flag from `files.export` (the param doesn't exist on that endpoint; it was a no-op breaking overload resolution).
- **`_shared/ceo-nylas-client`** — `Buffer`→`BlobPart` copy; always-set `Authorization` assertion.
- **`memory-store`** (exhaustive switch), **`approve-action`** (`null`→`undefined`), **`file-parse/handler`** (optional chain), **`context-for-email`** (unused import).

## Verification

- `pnpm run typecheck` green locally (both base + skills configs).
- 309 skill unit tests pass; **no runtime behavior change** (all fixes are type-only).
- Reviewed by `code-reviewer` and `silent-failure-hunter` — no blocking findings.

## Follow-up (phase 2)

Drop the `*.test.ts` exclusion in `tsconfig.skills.json` and fix the remaining ~117 test-file errors (mostly `SkillContext`→`Record` casts needing `as unknown as`, `unknown` `result.data` narrowing, and possibly-undefined array access). #1075 stays open to track this.

## Notes

- Lands after #1074 (merged) — that PR deleted `contact-set-trust/handler.ts`, removing one of the original 35 errors.