### PR TITLE
fix: pin update_drive_file to coordinator so it can move Drive files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Coordinator Drive moves** — pinned `update_drive_file` to the coordinator and documented reparenting (`add_parents`/`remove_parents`), so "move this doc into a folder" requests are performed instead of declined. (#1062)
 - **`skills/**` typecheck** — CI now type-checks all skill handlers and tests, closing the scope blind spot. (#1075)
 
 ### Fixed

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.8.5"
+version: "0.9.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -409,11 +409,16 @@ system_prompt: |
   these URLs — those tools have no Google credentials and will only return a
   login page.
 
-  **Drive management:** You can also search for files, browse folders, and manage
-  sharing permissions on Google Drive. If the CEO asks you to share a file or
-  folder, find something on Drive, or change who has access, use the appropriate
-  Drive skill (search_drive_files, list_drive_items, manage_drive_access,
-  set_drive_file_permissions). If you don't have the right skill pinned, search
+  **Drive management:** You can also search for files, browse folders, manage
+  sharing permissions, and move or rename files on Google Drive. If the CEO asks
+  you to share a file or folder, find something on Drive, or change who has access,
+  use the appropriate Drive skill (search_drive_files, list_drive_items,
+  manage_drive_access, set_drive_file_permissions). To **move a file into a
+  folder** (or reorganize where it lives), use update_drive_file with `add_parents`
+  set to the destination folder ID and `remove_parents` set to the current parent
+  folder ID (find the current parent with list_drive_items / search_drive_files
+  first). update_drive_file also renames a file via its `name` field. If you don't
+  have the right skill pinned, search
   for it with skill-registry before saying you can't. If neither your tools nor
   skill-registry have any Drive skills, the Google Drive integration is likely
   down — tell the CEO it appears to be temporarily unavailable.
@@ -563,6 +568,7 @@ pinned_skills:
   - create_drive_file
   - create_drive_folder
   - copy_drive_file
+  - update_drive_file
   - manage_drive_access
   - set_drive_file_permissions
   - get_drive_shareable_link


### PR DESCRIPTION
## Summary

The coordinator handles all inbound CEO email, but a "move this Google Doc into a folder" request was being declined with "I don't have a way to move files between folders." The reparenting capability already exists in the platform (the workspace-mcp `update_drive_file` tool, which supports `add_parents`/`remove_parents`), but it was pinned only to the essay-editor, not the coordinator.

This pins `update_drive_file` to the coordinator and documents the move/rename capability in its Drive-management prompt section.

Closes #1062

## Changes

- `agents/coordinator.yaml`: add `update_drive_file` to `pinned_skills`; document move/reparent (`add_parents`/`remove_parents`) and rename in the Drive-management prompt section. Version bumped `0.8.5` → `0.9.0` (minor: new pinned capability).
- `CHANGELOG.md`: entry under `## [Unreleased]` → Changed.

## Notes

- Per the issue's risk consideration, the prompt guidance is scoped to **moving/reparenting and renaming** rather than advertising the tool's broader destructive surface (`update_drive_file` can also trash files — `destructiveHint: true`). The tool itself is pinned in full; this just shapes how the coordinator is told to use it.
- Out of scope (follow-up in curia-deploy, noted in the issue): the eval mock schema `tests/eval/tool-schemas/_mcp-drive.json` omits `add_parents`/`remove_parents`, so the essay-editor smoke tests don't exercise real reparenting params.