### PR TITLE
fix: stop drift detector false-positives on task-wake jobs (#1064)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Drift detector false-positives on wake jobs** — the scheduler no longer drift-checks task-bound `wake_at` jobs (whose payload is the contentless `{"type":"task-wake"}` envelope), so meeting-debriefs and reminders complete instead of being wrongly paused; the drift-pause notification is now review-only and carries no re-executable intent, ending the duplicate outbound send. (#1064)
 - **Latent skill handler type errors** — fixed 34 errors surfaced by the new skills typecheck (`calendar-list-events` `PromiseSettledResult` narrowing, indexed-access guards). (#1075)
 - **`drive-download-file`** — dropped the unsupported `supportsAllDrives` flag from `files.export` that broke overload resolution. (#1075)
 - **Debrief clear** — "clear meeting X" now releases *all* active outbound-context entries for each named meeting via the new `context-bridge-clear` skill (matches by meeting subject across the whole active table, not just the injected window) and confirms from what was actually released, surfacing any names it couldn't match instead of reporting blanket success. meeting-debrief stamps a `{subject, eventId}` key on every debrief send and self-clears both prompt and reminder when a debrief closes. `context-bridge-clear` is pinned to coordinator, contacts, ceo-inbox, and meeting-debrief. (#975)

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -84,9 +84,18 @@ export function computeRecoveryTimeout(expectedDurationSeconds: number): number 
  * produced by wake_at / SchedulerService.enqueueTaskWake. Such payloads carry no task
  * description (the real intent lives in intent_anchor and the linked task row), so they
  * must be excluded from drift detection — see the guard in handleCompletion (#1064).
+ *
+ * Accepts `unknown` and null-checks before dereferencing: although job.taskPayload is typed
+ * Record<string, unknown>, it ultimately comes from DB JSONB. The column is NOT NULL, but a
+ * JSON-null literal (distinct from SQL NULL) can still round-trip to JS `null`, so reading
+ * `['type']` off it unguarded would throw a TypeError inside the drift-check guard — where
+ * handleCompletion's outer try/catch would swallow it and skip completeJobRun, stranding the
+ * run in 'running' until watchdog recovery. Anything that isn't a non-null object is "not a
+ * task-wake envelope" → false.
  */
-function isTaskWakePayload(payload: Record<string, unknown>): boolean {
-  return payload['type'] === 'task-wake';
+function isTaskWakePayload(payload: unknown): boolean {
+  if (typeof payload !== 'object' || payload === null) return false;
+  return (payload as Record<string, unknown>)['type'] === 'task-wake';
 }
 
 export interface SchedulerConfig {

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -505,11 +505,18 @@ export class Scheduler {
                   // message to the principal (#1064). Reference the job by id + reason only,
                   // and explicitly instruct the coordinator not to act on the paused task. The
                   // full intent/payload remains on the schedule.drift_paused audit event above.
+                  //
+                  // verdict.reason is LLM-generated free text. Normalise it before embedding so
+                  // it stays a single short sentence and can't smuggle imperative multi-line
+                  // phrasing back into the coordinator's instructions (it's constrained to one
+                  // sentence by the detector prompt, but defend at the boundary anyway).
+                  const safeReason = verdict.reason.replace(/[\r\n]+/g, ' ').trim().slice(0, 280);
+
                   const notifyContent = [
                     `A scheduled job was automatically paused for review because its behaviour may have drifted from its original goal.`,
                     ``,
                     `Job: ${jobId}`,
-                    `Reason: ${verdict.reason} (confidence: ${verdict.confidence})`,
+                    `Reason: ${safeReason} (confidence: ${verdict.confidence})`,
                     ``,
                     `This is a review notice only — do not re-run, re-send, or otherwise act on the paused task. Let the principal know the job is paused and awaiting their review; they can resume it with corrected instructions or cancel it.`,
                   ].join('\n');

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -79,6 +79,16 @@ export function computeRecoveryTimeout(expectedDurationSeconds: number): number 
   );
 }
 
+/**
+ * True when a job's payload is the contentless wake envelope `{"type":"task-wake"}`
+ * produced by wake_at / SchedulerService.enqueueTaskWake. Such payloads carry no task
+ * description (the real intent lives in intent_anchor and the linked task row), so they
+ * must be excluded from drift detection — see the guard in handleCompletion (#1064).
+ */
+function isTaskWakePayload(payload: Record<string, unknown>): boolean {
+  return payload['type'] === 'task-wake';
+}
+
 export interface SchedulerConfig {
   pool: Pool;
   bus: EventBus;
@@ -440,7 +450,14 @@ export class Scheduler {
       if (success && this.driftDetector) {
         const job = await this.schedulerService.getJob(jobId);
 
-        if (job?.agentTaskId && job.intentAnchor) {
+        // Skip drift detection for task-bound wake jobs. These are created via wake_at /
+        // enqueueTaskWake and carry the contentless envelope `{"type":"task-wake"}` as their
+        // payload — the real task context lives in intent_anchor and the linked task row, not
+        // the payload. Feeding the rich intent vs. the empty envelope to the detector made it
+        // report drift on every such job, hard-pausing healthy meeting-debriefs/reminders and
+        // triggering a duplicate outbound send via the drift-pause notification (#1064). A
+        // one-shot wake also cannot meaningfully "drift" — it fires exactly once.
+        if (job?.agentTaskId && job.intentAnchor && !isTaskWakePayload(job.taskPayload)) {
           // Enforce checkEveryNBursts: only check on the Nth burst.
           const burstCount = (this.burstCounts.get(jobId) ?? 0) + 1;
           this.burstCounts.set(jobId, burstCount);
@@ -481,16 +498,20 @@ export class Scheduler {
                   await this.bus.publish('system', driftEvent);
 
                   // Notify the CEO via the coordinator (same pattern as schedule.suspended).
+                  // IMPORTANT: this is a review-only notice — it must NOT embed the original
+                  // intent or the raw payload. Previously it echoed `Original intent: …` /
+                  // `Current task: …` verbatim, which the coordinator re-interpreted as an
+                  // actionable instruction and re-executed, causing a duplicate outbound
+                  // message to the principal (#1064). Reference the job by id + reason only,
+                  // and explicitly instruct the coordinator not to act on the paused task. The
+                  // full intent/payload remains on the schedule.drift_paused audit event above.
                   const notifyContent = [
-                    `Task has been paused because its current instructions may have drifted from its original goal.`,
+                    `A scheduled job was automatically paused for review because its behaviour may have drifted from its original goal.`,
                     ``,
-                    `Original intent: ${job.intentAnchor}`,
-                    ``,
-                    `Current task: ${JSON.stringify(job.taskPayload)}`,
-                    ``,
+                    `Job: ${jobId}`,
                     `Reason: ${verdict.reason} (confidence: ${verdict.confidence})`,
                     ``,
-                    `Please review the task and either resume it with corrected instructions or cancel it.`,
+                    `This is a review notice only — do not re-run, re-send, or otherwise act on the paused task. Let the principal know the job is paused and awaiting their review; they can resume it with corrected instructions or cancel it.`,
                   ].join('\n');
 
                   const notifyEvent = createAgentTask({

--- a/tests/integration/scheduler-task-dispatch.test.ts
+++ b/tests/integration/scheduler-task-dispatch.test.ts
@@ -155,6 +155,105 @@ describe('Scheduler task-bound dispatch integration', () => {
     expect(coordinatorLlm.chat).not.toHaveBeenCalled();
   });
 
+  // Repro for #1064 (the "Lisa" meeting-debrief): a task-wake job carries the contentless
+  // `{"type":"task-wake"}` payload but a rich intent_anchor. Before the fix, the drift detector
+  // compared the two, returned drifted:true/high, and the job was hard-paused — and the
+  // drift-pause notification triggered a SECOND outbound to the coordinator. After the fix the
+  // wake is excluded from drift detection: it ends in terminal completion, and the specialist's
+  // single fire is the ONLY outbound (no drift-pause notify to the coordinator).
+  it('task-wake job with a drift detector present completes (not paused) with exactly one outbound', async () => {
+    const logger = createLogger('silent');
+    const bus = new EventBus(logger);
+    const schedulerService = mockSchedulerService();
+
+    // Capture every agent.task event published to the bus (specialist fire + any drift notify).
+    const agentTaskEvents: Array<{ agentId: string }> = [];
+    bus.subscribe('agent.task', 'system', (event) => {
+      const e = event as { payload: { agentId: string } };
+      agentTaskEvents.push({ agentId: e.payload.agentId });
+    });
+
+    const specialistLlm: LLMProvider = {
+      id: 'mock-specialist',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Debrief prompt sent.',
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+    new AgentRuntime({
+      agentId: 'meeting-debrief',
+      systemPrompt: 'You process meeting debriefs.',
+      provider: specialistLlm,
+      bus,
+      logger,
+    }).register();
+
+    // Coordinator is a canary: it must receive NO drift-pause notification.
+    const coordinatorLlm: LLMProvider = { id: 'mock-coordinator', chat: vi.fn() };
+    new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are the coordinator.',
+      provider: coordinatorLlm,
+      bus,
+      logger,
+    }).register();
+
+    schedulerService.getJob.mockResolvedValue({
+      id: 'job-task-wake-1',
+      agentId: 'meeting-debrief',
+      agentTaskId: 'task-abc-123',
+      intentAnchor: 'Follow up with board on Q3 results',
+      taskPayload: { type: 'task-wake' },
+      lastRunSummary: null,
+    });
+
+    // A drift detector that WOULD flag drift if it were ever consulted — proving the wake
+    // path bypasses it rather than relying on the verdict happening to be benign.
+    const driftDetector = {
+      checkEveryNBursts: 1,
+      check: vi.fn().mockResolvedValue({ drifted: true, reason: 'No meeting context.', confidence: 'high' }),
+      shouldPause: vi.fn().mockReturnValue(true),
+    };
+
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [fakeTaskWakeRow()] })  // SELECT due jobs
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] }),     // UPDATE claim
+    };
+
+    const scheduler = new Scheduler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pool: pool as any,
+      bus,
+      logger,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      schedulerService: schedulerService as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      driftDetector: driftDetector as any,
+    });
+
+    scheduler.start();
+    await scheduler.pollDueJobs();
+
+    await vi.waitFor(() => {
+      expect(schedulerService.completeJobRun).toHaveBeenCalled();
+    });
+
+    scheduler.stop();
+
+    // Terminal completion, not a drift pause.
+    expect(driftDetector.check).not.toHaveBeenCalled();
+    expect(schedulerService.pauseJobForDrift).not.toHaveBeenCalled();
+    expect(schedulerService.completeJobRun).toHaveBeenCalledWith('job-task-wake-1', true, undefined, 'Debrief prompt sent.');
+
+    // Exactly one outbound: the specialist fire. No drift-pause notify to the coordinator.
+    expect(agentTaskEvents).toHaveLength(1);
+    expect(agentTaskEvents[0]!.agentId).toBe('meeting-debrief');
+    expect(coordinatorLlm.chat).not.toHaveBeenCalled();
+  });
+
   it('falls back to coordinator when agent_id is coordinator (CEO-created task with no specialist)', async () => {
     const logger = createLogger('silent');
     const bus = new EventBus(logger);

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -940,6 +940,46 @@ describe('Scheduler', () => {
       });
     });
 
+    // Regression: job.taskPayload comes from DB JSONB and can round-trip to JS `null` (a
+    // JSON-null literal, distinct from SQL NULL which the NOT NULL column blocks). The
+    // task-wake guard must null-check before reading `['type']`, otherwise it throws a
+    // TypeError that handleCompletion's try/catch swallows — skipping completeJobRun and
+    // stranding the run in 'running' until watchdog recovery (#1086 review).
+    it('does not throw when taskPayload is null; job still completes', async () => {
+      driftPool.query.mockResolvedValueOnce({ rows: [persistentRow] });
+      driftPool.query.mockResolvedValueOnce({ rows: [] });
+      await driftScheduler.pollDueJobs();
+      const [, taskEvent] = driftBus.publish.mock.calls[1] as [string, { id: string }];
+
+      driftSchedulerService.getJob.mockResolvedValueOnce({
+        id: 'job-1',
+        agentId: 'agent-1',
+        agentTaskId: 'task-99',
+        intentAnchor: 'Research AI safety articles weekly.',
+        taskPayload: null, // JSONB null round-tripped from the DB
+        lastRunSummary: null,
+      });
+      // Guard must not throw, so the (non-task-wake) drift check still runs; keep it benign.
+      driftDetector.check.mockResolvedValueOnce(null);
+      driftSchedulerService.completeJobRun.mockResolvedValueOnce({ suspended: false });
+
+      driftScheduler.start();
+      const responseHandler = driftBus.subscribe.mock.calls[0]?.[2] as (event: unknown) => Promise<void>;
+      await responseHandler({
+        id: 'resp-drift-nullpayload',
+        type: 'agent.response',
+        sourceLayer: 'agent',
+        parentEventId: taskEvent.id,
+        timestamp: new Date(),
+        payload: { agentId: 'agent-1', conversationId: 'c1', content: 'done' },
+      });
+
+      await vi.waitFor(() => {
+        // The job must still reach terminal completion — no swallowed TypeError in the guard.
+        expect(driftSchedulerService.completeJobRun).toHaveBeenCalledWith('job-1', true, undefined, 'done');
+      });
+    });
+
     // Regression: the drift-pause notification used to embed the original intent and the raw
     // payload verbatim, so the coordinator re-interpreted it as an actionable instruction and
     // re-sent the original outbound message (#1064). The notification must be review-only and

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -975,13 +975,17 @@ describe('Scheduler', () => {
         payload: { agentId: 'agent-1', conversationId: 'c1', content: 'done' },
       });
 
+      // The coordinator notification is published *after* pauseJobForDrift resolves, so wait
+      // for the agent.task publish itself (not just the pause call) before reading its content
+      // — otherwise the read can race ahead of the publish and flake.
+      let notifyCall: [string, { type: string; payload: { agentId: string; content: string } }] | undefined;
       await vi.waitFor(() => {
         expect(driftSchedulerService.pauseJobForDrift).toHaveBeenCalledWith('job-1');
+        notifyCall = (driftBus.publish.mock.calls as [string, { type: string; payload: { agentId: string; content: string } }][])
+          .find(([, ev]) => ev.type === 'agent.task' && ev.payload.agentId === 'coordinator');
+        expect(notifyCall).toBeDefined();
       });
 
-      const notifyCall = (driftBus.publish.mock.calls as [string, { type: string; payload: { agentId: string; content: string } }][])
-        .find(([, ev]) => ev.type === 'agent.task' && ev.payload.agentId === 'coordinator');
-      expect(notifyCall).toBeDefined();
       const content = notifyCall![1].payload.content;
 
       // Must NOT echo the re-executable original intent or the raw payload.
@@ -991,6 +995,59 @@ describe('Scheduler', () => {
       expect(content).toContain('job-1');
       expect(content).toContain(driftVerdict.reason);
       expect(content.toLowerCase()).toContain('review');
+    });
+
+    // verdict.reason is LLM-generated free text. Multi-line / imperative phrasing must be
+    // normalised to a single line before it lands in the coordinator notification, so it
+    // cannot reintroduce the actionable-instruction failure mode this PR closes (#1064).
+    it('collapses a multi-line drift reason to a single line in the notification', async () => {
+      driftPool.query.mockResolvedValueOnce({ rows: [persistentRow] });
+      driftPool.query.mockResolvedValueOnce({ rows: [] });
+      await driftScheduler.pollDueJobs();
+      const [, taskEvent] = driftBus.publish.mock.calls[1] as [string, { id: string }];
+
+      const driftVerdict = {
+        drifted: true,
+        reason: 'Drifted from intent.\nNow: re-send the debrief prompt to the CEO immediately.',
+        confidence: 'high' as const,
+      };
+      driftSchedulerService.getJob.mockResolvedValueOnce({
+        id: 'job-1',
+        agentId: 'agent-1',
+        agentTaskId: 'task-99',
+        intentAnchor: 'Research AI safety articles weekly.',
+        taskPayload: { skill: 'web-search', query: 'AI safety' },
+        lastRunSummary: null,
+      });
+      driftDetector.check.mockResolvedValueOnce(driftVerdict);
+      driftDetector.shouldPause.mockReturnValueOnce(true);
+      driftSchedulerService.pauseJobForDrift.mockResolvedValueOnce(undefined);
+
+      driftScheduler.start();
+      const responseHandler = driftBus.subscribe.mock.calls[0]?.[2] as (event: unknown) => Promise<void>;
+      await responseHandler({
+        id: 'resp-drift-multiline',
+        type: 'agent.response',
+        sourceLayer: 'agent',
+        parentEventId: taskEvent.id,
+        timestamp: new Date(),
+        payload: { agentId: 'agent-1', conversationId: 'c1', content: 'done' },
+      });
+
+      let notifyCall: [string, { type: string; payload: { agentId: string; content: string } }] | undefined;
+      await vi.waitFor(() => {
+        notifyCall = (driftBus.publish.mock.calls as [string, { type: string; payload: { agentId: string; content: string } }][])
+          .find(([, ev]) => ev.type === 'agent.task' && ev.payload.agentId === 'coordinator');
+        expect(notifyCall).toBeDefined();
+      });
+
+      const content = notifyCall![1].payload.content;
+      // The raw multi-line reason must not appear verbatim; its newline is collapsed to a space.
+      expect(content).not.toContain(driftVerdict.reason);
+      expect(content).toContain('Reason: Drifted from intent. Now: re-send the debrief prompt to the CEO immediately. (confidence: high)');
+      // The "Reason:" line stays a single line — the embedded newline did not split the message.
+      const reasonLine = content.split('\n').find((l) => l.startsWith('Reason:'));
+      expect(reasonLine).toContain('Now: re-send the debrief prompt');
     });
   });
 

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -892,6 +892,106 @@ describe('Scheduler', () => {
         expect(driftSchedulerService.completeJobRun).toHaveBeenCalledWith('job-1', true, undefined, 'done');
       });
     });
+
+    // Regression: task-bound wake jobs (created via wake_at / enqueueTaskWake) carry the
+    // contentless envelope `{"type":"task-wake"}` as their payload — the real intent lives
+    // in intent_anchor and the linked task row, not the payload. Comparing the rich intent
+    // against the empty envelope made the detector report drift on EVERY such job (#1064).
+    // The drift check must be skipped entirely for these jobs, and the job completed normally.
+    it('skips drift check for task-wake envelope payloads and completes normally', async () => {
+      driftPool.query.mockResolvedValueOnce({ rows: [persistentRow] });
+      driftPool.query.mockResolvedValueOnce({ rows: [] });
+      await driftScheduler.pollDueJobs();
+      const [, taskEvent] = driftBus.publish.mock.calls[1] as [string, { id: string }];
+
+      // A task-bound wake job: agentTaskId + intentAnchor set, but payload is the
+      // contentless wake envelope.
+      driftSchedulerService.getJob.mockResolvedValueOnce({
+        id: 'job-1',
+        agentId: 'agent-1',
+        agentTaskId: 'task-99',
+        intentAnchor: "Debrief the CEO's meeting 'Lisa' — prompt at meeting end.",
+        taskPayload: { type: 'task-wake', task_id: 'task-99' },
+        lastRunSummary: null,
+      });
+      driftSchedulerService.completeJobRun.mockResolvedValueOnce({ suspended: false });
+
+      driftScheduler.start();
+      const responseHandler = driftBus.subscribe.mock.calls[0]?.[2] as (event: unknown) => Promise<void>;
+      await responseHandler({
+        id: 'resp-drift-wake',
+        type: 'agent.response',
+        sourceLayer: 'agent',
+        parentEventId: taskEvent.id,
+        timestamp: new Date(),
+        payload: { agentId: 'agent-1', conversationId: 'c1', content: 'Debrief prompt sent.' },
+      });
+
+      await vi.waitFor(() => {
+        // No drift check, no pause — the job must reach terminal completion.
+        expect(driftDetector.check).not.toHaveBeenCalled();
+        expect(driftSchedulerService.pauseJobForDrift).not.toHaveBeenCalled();
+        expect(driftSchedulerService.completeJobRun).toHaveBeenCalledWith(
+          'job-1',
+          true,
+          undefined,
+          'Debrief prompt sent.',
+        );
+      });
+    });
+
+    // Regression: the drift-pause notification used to embed the original intent and the raw
+    // payload verbatim, so the coordinator re-interpreted it as an actionable instruction and
+    // re-sent the original outbound message (#1064). The notification must be review-only and
+    // must NOT carry the re-executable intent or payload.
+    it('drift-pause notification is review-only and carries no re-executable intent', async () => {
+      driftPool.query.mockResolvedValueOnce({ rows: [persistentRow] });
+      driftPool.query.mockResolvedValueOnce({ rows: [] });
+      await driftScheduler.pollDueJobs();
+      const [, taskEvent] = driftBus.publish.mock.calls[1] as [string, { id: string }];
+
+      const intentAnchor = "Debrief the CEO's meeting 'Lisa' — prompt at meeting end.";
+      const driftVerdict = { drifted: true, reason: 'Generic wake with no meeting context.', confidence: 'high' as const };
+      driftSchedulerService.getJob.mockResolvedValueOnce({
+        id: 'job-1',
+        agentId: 'agent-1',
+        agentTaskId: 'task-99',
+        intentAnchor,
+        taskPayload: { skill: 'web-search', query: 'AI safety' },
+        lastRunSummary: null,
+      });
+      driftDetector.check.mockResolvedValueOnce(driftVerdict);
+      driftDetector.shouldPause.mockReturnValueOnce(true);
+      driftSchedulerService.pauseJobForDrift.mockResolvedValueOnce(undefined);
+
+      driftScheduler.start();
+      const responseHandler = driftBus.subscribe.mock.calls[0]?.[2] as (event: unknown) => Promise<void>;
+      await responseHandler({
+        id: 'resp-drift-notify',
+        type: 'agent.response',
+        sourceLayer: 'agent',
+        parentEventId: taskEvent.id,
+        timestamp: new Date(),
+        payload: { agentId: 'agent-1', conversationId: 'c1', content: 'done' },
+      });
+
+      await vi.waitFor(() => {
+        expect(driftSchedulerService.pauseJobForDrift).toHaveBeenCalledWith('job-1');
+      });
+
+      const notifyCall = (driftBus.publish.mock.calls as [string, { type: string; payload: { agentId: string; content: string } }][])
+        .find(([, ev]) => ev.type === 'agent.task' && ev.payload.agentId === 'coordinator');
+      expect(notifyCall).toBeDefined();
+      const content = notifyCall![1].payload.content;
+
+      // Must NOT echo the re-executable original intent or the raw payload.
+      expect(content).not.toContain(intentAnchor);
+      expect(content).not.toContain('web-search');
+      // Must be framed as review-only and reference the paused job + reason.
+      expect(content).toContain('job-1');
+      expect(content).toContain(driftVerdict.reason);
+      expect(content.toLowerCase()).toContain('review');
+    });
   });
 
   // -- loadDeclarativeJobs --


### PR DESCRIPTION
## Summary

Fixes the scheduler drift detector false-positive that paused healthy task-bound wake jobs and caused duplicate outbound messages to the principal.

The drift check ran whenever a job had both `agentTaskId` and `intentAnchor`, passing `job.taskPayload` to the detector as the "current task description." For `wake_at` jobs (created via `enqueueTaskWake` / `task-create … wake_at`) that payload is always the contentless envelope `{"type":"task-wake"}` — the real context lives in `intent_anchor` and the linked task row. So the detector structurally always saw "rich intent vs. empty task" and reported drift on **every** such job (meeting-debriefs, reminders, expiry wakes). The verdict hard-paused the job and the drift-pause notification, which embedded the original intent verbatim, was re-executed by the coordinator as the original task — a duplicate send.

## Changes

- **Skip drift detection for task-wake jobs** (`src/scheduler/scheduler.ts`). New `isTaskWakePayload()` guard excludes `{"type":"task-wake"}` payloads from the drift check. A one-shot wake fires exactly once and cannot meaningfully "drift." Genuine recurring tasks (real payloads like `{ task: … }` / `{ skill: … }`) are still checked.
- **Make the drift-pause notification non-actionable** (`src/scheduler/scheduler.ts`). The coordinator notice no longer embeds the verbatim `Original intent` / `Current task` payload; it references the job by id + reason and explicitly instructs the coordinator not to re-run or re-send. The full intent/payload is retained on the `schedule.drift_paused` audit event.

## Tests

- Unit (`tests/unit/scheduler/scheduler.test.ts`): drift check is skipped for task-wake envelope payloads and the job completes normally; drift-pause notification is review-only and carries no re-executable intent.
- Integration (`tests/integration/scheduler-task-dispatch.test.ts`): the "Lisa" repro — a task-wake job with a drift detector that *would* flag drift now ends in terminal completion (not paused) with exactly **one** outbound and no coordinator drift-pause notify. Verified this test fails without the guard.
- Full scheduler suite green (153 tests), typecheck and lint clean.

## Acceptance criteria

- [x] A task-bound wake job with payload `{"type":"task-wake"}` does not produce a drift verdict solely because its payload lacks the intent's detail (unit test on the `handleCompletion` guard).
- [x] A meeting-debrief wake that completes successfully ends in terminal `completed`, not `paused` (integration repro asserts `completeJobRun(success=true)`, `pauseJobForDrift` not called).
- [x] The drift-pause notification cannot cause the coordinator to re-send the original task's outbound message (notification carries no re-executable intent).
- [x] Re-running the Lisa repro (single wake fire) results in exactly one outbound prompt to the principal.

## Notes

- The secondary bug noted in the issue (Bullpen-through-coordinator outbound thread never closed → third Lisa send) is out of scope here and should remain a separate issue.

Closes #1064