### PR TITLE
Guard missing Nylas data envelopes

### DIFF
--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -522,7 +522,11 @@ export class CeoNylasClient {
       throw new NylasApiError(res.status, operation, `Nylas ${operation}: HTTP ${res.status} — ${text}`);
     }
 
-    const json = (await res.json()) as { data: T; next_cursor?: string };
+    const json = (await res.json()) as { data?: T; next_cursor?: string };
+    if (json.data === undefined) {
+      this.log.error({ status: res.status, operation }, `nylas: ${operation} response missing data envelope`);
+      throw new NylasApiError(res.status, operation, `Nylas ${operation}: response missing data envelope`);
+    }
     return { data: json.data, nextCursor: json.next_cursor };
   }
 }

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -522,8 +522,8 @@ export class CeoNylasClient {
       throw new NylasApiError(res.status, operation, `Nylas ${operation}: HTTP ${res.status} — ${text}`);
     }
 
-    const json = (await res.json()) as { data?: T; next_cursor?: string };
-    if (json.data === undefined) {
+    const json = (await res.json()) as { data?: T; next_cursor?: string } | null;
+    if (json == null || json.data === undefined) {
       this.log.error({ status: res.status, operation }, `nylas: ${operation} response missing data envelope`);
       throw new NylasApiError(res.status, operation, `Nylas ${operation}: response missing data envelope`);
     }

--- a/tests/unit/skills/ceo-nylas-client.test.ts
+++ b/tests/unit/skills/ceo-nylas-client.test.ts
@@ -11,11 +11,13 @@ const logger = pino({ level: 'silent' });
 // Dynamically import after setting up the fetch mock so the module-level
 // constant (`NYLAS_BASE`) picks up correctly.
 let CeoNylasClient: typeof import('../../../skills/_shared/ceo-nylas-client.js').CeoNylasClient;
+let NylasApiError: typeof import('../../../skills/_shared/ceo-nylas-client.js').NylasApiError;
 
 beforeEach(async () => {
   vi.restoreAllMocks();
   const mod = await import('../../../skills/_shared/ceo-nylas-client.js');
   CeoNylasClient = mod.CeoNylasClient;
+  NylasApiError = mod.NylasApiError;
 });
 
 function mockFetchSuccess(data: unknown = []) {
@@ -78,6 +80,27 @@ describe('htmlToPlainText', () => {
 
   it('decodes HTML entities', () => {
     expect(htmlToPlainText('&amp; &lt; &gt;')).toBe('& < >');
+  });
+});
+
+describe('CeoNylasClient request envelope handling', () => {
+  it('throws a NylasApiError when a successful response has no data envelope', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ request_id: 'req-1' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const client = new CeoNylasClient('key', 'grant', logger);
+    const request = client.listFolders();
+
+    await expect(request).rejects.toMatchObject({
+      name: 'NylasApiError',
+      status: 200,
+      endpoint: 'listFolders',
+      message: 'Nylas listFolders: response missing data envelope',
+    });
+    await expect(request).rejects.toBeInstanceOf(NylasApiError);
   });
 });
 

--- a/tests/unit/skills/ceo-nylas-client.test.ts
+++ b/tests/unit/skills/ceo-nylas-client.test.ts
@@ -102,6 +102,25 @@ describe('CeoNylasClient request envelope handling', () => {
     });
     await expect(request).rejects.toBeInstanceOf(NylasApiError);
   });
+
+  it('throws a NylasApiError when a successful response body is null', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(null), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const client = new CeoNylasClient('key', 'grant', logger);
+    const request = client.listFolders();
+
+    await expect(request).rejects.toMatchObject({
+      name: 'NylasApiError',
+      status: 200,
+      endpoint: 'listFolders',
+      message: 'Nylas listFolders: response missing data envelope',
+    });
+    await expect(request).rejects.toBeInstanceOf(NylasApiError);
+  });
 });
 
 describe('CeoNylasClient.listMessages — folder alias normalization', () => {


### PR DESCRIPTION
Fixes #597.

`requestWithCursor()` was trusting the JSON response shape after any successful Nylas HTTP response and returning `json.data` directly. If Nylas returned a 2xx response without the usual `data` envelope, callers would get `undefined` typed as the expected payload and fail later in normalization code.

This checks the envelope before returning from the shared request path and raises a `NylasApiError` with the operation name when `data` is missing. I added a client-level test through `listFolders()` so the missing-envelope case is covered without reaching into the private method.

Checked locally:

- `pnpm vitest run tests/unit/skills/ceo-nylas-client.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.skills.json`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

`pnpm run lint` finishes with the existing warning in `src/pii/scrubber.ts` about an unused eslint-disable directive; no errors were reported.