### PR TITLE
fix: wire channel-vault creds into email/signal adapters (#964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **Channel registry** — email/signal creds saved via the Channels UI (`channel.*` vault keys) now wire up the adapter at boot, so the registry's `enabled + resolvable` state and real adapter boot can no longer disagree. (#964)
+- **Channel registry** — email/signal creds saved via the Channels UI (`channel.*` vault keys) now wire up the adapter at boot, so the registry's `enabled + resolvable` state and real adapter boot can no longer disagree; the gate and the runtime overlay share one `normalizeSecretValue()` so a whitespace-only vault value reads as absent on both. (#964)
 - **Bullpen duplicate out-of-band actions** — a per-agent read watermark (`bullpen_thread_reads`) stops a thread an agent has already had in context from being re-injected on a later wake until newer activity arrives, so a request fulfilled out-of-band (a send, a spreadsheet write, anything) is no longer re-actioned. Action-agnostic. (#1065)
 - **Drift detector false-positives on wake jobs** — the scheduler no longer drift-checks task-bound `wake_at` jobs (whose payload is the contentless `{"type":"task-wake"}` envelope), so meeting-debriefs and reminders complete instead of being wrongly paused; the drift-pause notification is now review-only and carries no re-executable intent, ending the duplicate outbound send. (#1064)
 - **Autonomy test skips** — `autonomy-routes` and `autonomy-service-pagination` tests now `describe.skip` when `DATABASE_URL` is unset instead of throwing in `beforeAll`, matching the other integration tests and removing 2 spurious local failures. (#519)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Channel registry** — email/signal creds saved via the Channels UI (`channel.*` vault keys) now wire up the adapter at boot, so the registry's `enabled + resolvable` state and real adapter boot can no longer disagree. (#964)
 - **Bullpen duplicate out-of-band actions** — a per-agent read watermark (`bullpen_thread_reads`) stops a thread an agent has already had in context from being re-injected on a later wake until newer activity arrives, so a request fulfilled out-of-band (a send, a spreadsheet write, anything) is no longer re-actioned. Action-agnostic. (#1065)
 - **Drift detector false-positives on wake jobs** — the scheduler no longer drift-checks task-bound `wake_at` jobs (whose payload is the contentless `{"type":"task-wake"}` envelope), so meeting-debriefs and reminders complete instead of being wrongly paused; the drift-pause notification is now review-only and carries no re-executable intent, ending the duplicate outbound send. (#1064)
 - **Autonomy test skips** — `autonomy-routes` and `autonomy-service-pagination` tests now `describe.skip` when `DATABASE_URL` is unset instead of throwing in `beforeAll`, matching the other integration tests and removing 2 spurious local failures. (#519)

--- a/apps/console/src/pages/ChannelSettings.tsx
+++ b/apps/console/src/pages/ChannelSettings.tsx
@@ -218,6 +218,9 @@ function ChannelDrawer({ entry, onClose, onChanged }: {
           {!locked && entry.credentialFields.length > 0 && (
             <div className="form-field">
               <label>Credentials</label>
+              <p className="settings-page-sub" style={{ margin: '0 0 4px' }}>
+                Saved credentials take effect on the next restart.
+              </p>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 {entry.credentialFields.map(field => (
                   <CredentialRow

--- a/docs/wip/2026-06-21-channel-vault-adapter-wiring-design.md
+++ b/docs/wip/2026-06-21-channel-vault-adapter-wiring-design.md
@@ -72,8 +72,11 @@ so the gate and the adapter never disagree.
 Resolution rules, matching `applyVaultSecrets` / `channelCredentialStatus`:
 - Each vault read is isolated in a `try/catch`; a transient vault failure is logged and
   treated as absent (fall through to env/current-config), never aborting boot.
-- Values are `clean()`-normalized (trim; blank-after-trim reads as absent), the same guard
-  used by `applyVaultSecrets`, so a whitespace-only row doesn't wire up a broken channel.
+- Values are normalized via the shared `normalizeSecretValue()` (trim; blank-after-trim reads
+  as absent). **The gate resolver (`channelCredentialStatus`) uses the same helper** — so a
+  whitespace-only vault row reads as absent on BOTH paths, never `resolvable`-but-unbootable.
+  (Without the shared helper the gate's `if (vaultVal)` truthy check would mark `"   "`
+  resolvable while the overlay cleared it — re-opening the divergence.)
 - Never log secret values — log a names-only `present` map like `applyVaultSecrets` does.
 
 ### Namespace safety (invariant — do not relax)

--- a/docs/wip/2026-06-21-channel-vault-adapter-wiring-design.md
+++ b/docs/wip/2026-06-21-channel-vault-adapter-wiring-design.md
@@ -76,6 +76,27 @@ Resolution rules, matching `applyVaultSecrets` / `channelCredentialStatus`:
   used by `applyVaultSecrets`, so a whitespace-only row doesn't wire up a broken channel.
 - Never log secret values — log a names-only `present` map like `applyVaultSecrets` does.
 
+### Namespace safety (invariant — do not relax)
+
+The overlay reads a **fixed, hardcoded allowlist of exactly five `channel.*` keys** —
+`channel.email.{nylas_api_key,nylas_grant_id,nylas_self_email}`,
+`channel.signal.{phone_number,socket_path}`. It MUST NOT:
+- enumerate the vault (`secrets.list()`), nor
+- scan by prefix (`channel.*`, or anything else), nor
+- read any key it does not name literally.
+
+This keeps it structurally unable to touch the other two vault namespaces:
+- **`user.<slug>`** — secrets captured by specialist / general-purpose agents
+  (`resolveUserSecretName`). The `user.` prefix is a sandbox that "cannot be produced by
+  snake_case system keys or `channel.*` credential keys" (secret-capture-service.ts:33-36),
+  so an agent literally cannot name a key this overlay reads.
+- **dot-free snake_case** — skill secrets (`tavily_api_key`, `ceo_nylas_grant_id`) and
+  system/bootstrap secrets. None match `channel.<name>.<key>`.
+
+Only operator-provided channel credentials (written by the Channels UI to `channel.*`) are
+ever consumed here. A test asserts the overlay performs no `list()` call and reads only the
+five named keys, locking the invariant against a future "just scan the prefix" refactor.
+
 ### Wiring in `index.ts`
 
 Call it immediately after `applyVaultSecrets` (index.ts:313), inside the same fatal-on-error
@@ -134,6 +155,9 @@ No hot-reload of adapters (that would be a much larger lifecycle change, out of 
 - **whitespace-only vault row** → treated as absent (falls through to env/config).
 - **vault read throws** → logged, treated as absent, no throw.
 - Secret values never appear in logged output (assert on the `present` names-only map).
+- **namespace safety**: the fake `secrets` port records every `get(name)` call; assert the
+  overlay calls `get` only with the five named `channel.*` keys, never `list()`, and never a
+  `user.*` or dot-free key — locking the allowlist against a future prefix-scan refactor.
 
 Integration coverage tying overlay → `resolveChannelAccounts` → registry agreement:
 - vault-only email creds → `resolveChannelAccounts` yields one `curia` account **and**

--- a/docs/wip/2026-06-21-channel-vault-adapter-wiring-design.md
+++ b/docs/wip/2026-06-21-channel-vault-adapter-wiring-design.md
@@ -1,0 +1,155 @@
+# Channel vault → adapter wiring (close the credential-resolution seam)
+
+Issue: #964 · Refs: #543, #963, #962 · Milestone: v0.37
+
+## Problem
+
+The channel registry resolves credentials **vault-first** (`channel.<name>.<key>` ▸ env ▸
+config) to compute `requiredResolvable`, which gates `enable()` and `channelShouldStart`.
+But the email and signal **adapters** are constructed from the legacy config/env runtime
+objects (`nylasClientMap` / `resolvedEmailAccounts` / `config.nylasApiKey`, and
+`signalRpcClient` / `config.signalPhoneNumber` / `config.signalSocketPath`).
+
+These read **two disjoint vault namespaces**:
+
+| Namespace | Keys | Written by | Read by |
+|---|---|---|---|
+| Channel-scoped | `channel.email.*`, `channel.signal.*` | **Channels UI** (`ChannelSettings.tsx`) | `channelCredentialStatus()` → registry gate |
+| Bootstrap-scoped | `nylas_api_key`, `nylas_grant_id`, `nylas_self_email`, `signal_phone_number` | `seed-vault.ts` (from env) | `applyVaultSecrets()` → `config.*` → adapters |
+
+(Signal's `socket_path` has *no* bootstrap-scoped equivalent at all — `config.signalSocketPath`
+comes only from env `SIGNAL_SOCKET_PATH`.)
+
+The two namespaces never meet. A credential set saved entirely through the Channels UI
+(`channel.email.*`) makes the registry report `enabled + resolvable`, but `config.nylasApiKey`
+stays undefined → `nylasClientMap` empty → no adapter constructs. **Silent no-op.** The UI's
+save path has zero runtime effect.
+
+## Goal
+
+Make the enablement gate and the adapter wiring share a single source of truth, so that
+`enabled + resolvable` always implies the adapter can actually boot — across all four
+combinations of `{vault-only, env/config-only, both, neither}`. (Issue option **1**, the
+preferred direction: vault-backed provisioning, "configure a channel entirely from the
+console.")
+
+## Design
+
+### Single overlay point, before any consumer reads config
+
+Rather than patch each adapter construction site (adapters, `OutboundGateway`, calendar
+client, and the principal-contact block all read `config.*`), resolve the channel-scoped
+vault values **once, early at boot**, and overlay them onto `config.*`. Everything
+downstream then reads consistent values for free.
+
+New function:
+
+```ts
+// src/channels/apply-channel-vault-secrets.ts
+export async function applyChannelVaultSecrets(
+  config: Config,
+  secrets: { get(name: string): Promise<string | null> },
+  env: Record<string, string | undefined>,
+  logger: Logger,
+): Promise<void>
+```
+
+It resolves each runtime field with the **same precedence the registry resolver uses**, and
+writes the result back onto `config`:
+
+| `config` field | precedence (first hit wins) |
+|---|---|
+| `nylasApiKey`      | `channel.email.nylas_api_key` ▸ env `NYLAS_API_KEY` ▸ current `config.nylasApiKey` |
+| `nylasGrantId`     | `channel.email.nylas_grant_id` ▸ env `NYLAS_GRANT_ID` ▸ current `config.nylasGrantId` |
+| `nylasSelfEmail`   | `channel.email.nylas_self_email` ▸ env `NYLAS_SELF_EMAIL` ▸ current `config.nylasSelfEmail` |
+| `signalPhoneNumber`| `channel.signal.phone_number` ▸ env `SIGNAL_PHONE_NUMBER` ▸ current `config.signalPhoneNumber` |
+| `signalSocketPath` | `channel.signal.socket_path` ▸ env `SIGNAL_SOCKET_PATH` ▸ current `config.signalSocketPath` |
+
+**Precedence decision (confirmed):** channel-scoped vault wins. The Channels UI is the
+most-specific, most-recently-saved source, and the registry resolver already reads it first,
+so the gate and the adapter never disagree.
+
+Resolution rules, matching `applyVaultSecrets` / `channelCredentialStatus`:
+- Each vault read is isolated in a `try/catch`; a transient vault failure is logged and
+  treated as absent (fall through to env/current-config), never aborting boot.
+- Values are `clean()`-normalized (trim; blank-after-trim reads as absent), the same guard
+  used by `applyVaultSecrets`, so a whitespace-only row doesn't wire up a broken channel.
+- Never log secret values — log a names-only `present` map like `applyVaultSecrets` does.
+
+### Wiring in `index.ts`
+
+Call it immediately after `applyVaultSecrets` (index.ts:313), inside the same fatal-on-error
+guard family:
+
+```ts
+await applyVaultSecrets(config, secretsService, logger);
+await applyChannelVaultSecrets(config, secretsService, process.env, logger);
+```
+
+Both run **before** `resolveChannelAccounts` (index.ts:700) and before `nylasClientMap` /
+`signalRpcClient` / `outboundGateway` construction. No other change to the construction sites
+is required.
+
+### Why email multi-account needs no new machinery
+
+`resolveChannelAccounts` already has a legacy single-account fallback: when
+`channel_accounts.email` YAML is absent, it synthesizes a `curia` account from
+`config.nylasGrantId` + `config.nylasSelfEmail`. After the overlay populates those from
+`channel.email.*`, a **vault-only email setup flows through that existing path** as one
+`curia` account. Explicit YAML `channel_accounts.email` still wins when present (power-user
+multi-account config); the vault single-account form is the console-config default.
+
+### Why the gate and adapter now agree (AC1)
+
+Because the overlay uses the registry's precedence, any required field the registry reports
+`resolvable` now also yields a runtime value in `config`. The four combinations:
+
+| Source of creds | Registry `requiredResolvable` | Adapter constructs | Agree? |
+|---|---|---|---|
+| vault-only (`channel.*`) | true (vault) | true (overlay → config) | ✓ |
+| env/config-only | true (env/config) | true (env/current config) | ✓ |
+| both | true | true (channel-vault wins, consistently) | ✓ |
+| neither | false | false | ✓ |
+
+### Console UI (AC4)
+
+After the backend fix, the Channels UI save path has real effect (on restart). The drawer
+already notes "Enabling or disabling takes effect on the next restart." for lifecycle; the
+Credentials section has no such hint. Add a single truthful line under the Credentials label
+(e.g. "Saved credentials take effect on the next restart."). No other console change.
+
+**Apply timing (confirmed):** restart-to-apply, matching the existing setup-required model.
+No hot-reload of adapters (that would be a much larger lifecycle change, out of scope).
+
+## Testing (TDD)
+
+`src/channels/apply-channel-vault-secrets.test.ts` (unit, injected fake `secrets` + `env`):
+- **vault-only** email: `channel.email.*` set, env empty, config undefined → all three
+  `config` fields populated from vault.
+- **vault-only** signal: `channel.signal.*` set → `signalPhoneNumber` + `signalSocketPath`
+  populated.
+- **env-only**: vault empty, env set → config takes env values.
+- **both**: channel-vault and env differ → channel-vault wins (precedence assertion).
+- **neither**: nothing set → config fields stay at their prior values (undefined / '').
+- **whitespace-only vault row** → treated as absent (falls through to env/config).
+- **vault read throws** → logged, treated as absent, no throw.
+- Secret values never appear in logged output (assert on the `present` names-only map).
+
+Integration coverage tying overlay → `resolveChannelAccounts` → registry agreement:
+- vault-only email creds → `resolveChannelAccounts` yields one `curia` account **and**
+  `channelCredentialStatus` reports `requiredResolvable: true` (the gate and the wiring agree).
+
+## Out of scope
+
+- Hot-reload of adapters on credential save (restart-to-apply is sufficient).
+- Per-account vault provisioning for multi-account email (YAML remains the multi-account
+  path; vault provides the single-account default).
+- Sibling issue #962.
+
+## Acceptance criteria (from #964)
+
+- [x] Vault-only creds for email & signal → constructed, started adapter when enabled
+      (overlay → config → existing construction), and gate/adapter agree in all four combos.
+- [x] Existing env/config deployments start unchanged (env/current-config is the fallback tier).
+- [x] Unit + integration coverage for vault-only and mixed-source cases.
+- [x] Channels UI does not advertise a no-op save path (save now has effect; restart hint added).

--- a/docs/wip/2026-06-21-channel-vault-adapter-wiring.md
+++ b/docs/wip/2026-06-21-channel-vault-adapter-wiring.md
@@ -1,0 +1,521 @@
+# Channel vault → adapter wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make channel credentials saved via the Channels UI (`channel.*` vault keys) actually reach the email/signal adapters, so the registry's `enabled + resolvable` state and real adapter boot agree.
+
+**Architecture:** A new boot-time function `applyChannelVaultSecrets` overlays the five channel-scoped vault keys onto `config.*` (channel-vault ▸ env ▸ current config), run right after `applyVaultSecrets` and before any consumer reads config. Everything downstream (adapters, outbound gateway, calendar client, registry gate) then reads consistent values. No per-construction-site patching.
+
+**Tech Stack:** TypeScript (ESM, Node 24+), Vitest, pino.
+
+## Global Constraints
+
+- ESM only — `.js` extensions on all relative imports; `import type` for type-only imports.
+- No `any`. No `console.log` (pino only). No empty catch blocks.
+- Never log secret values — log a names-only `present` map.
+- The overlay reads a **fixed 5-key allowlist** of `channel.*` keys. NEVER `secrets.list()`, never a prefix scan. (Keeps `user.*` specialist secrets and dot-free skill/system secrets structurally untouchable.)
+- Precedence (confirmed): channel-scoped vault ▸ env (`envFallback`) ▸ current config value.
+- Apply timing: restart-to-apply. No adapter hot-reload.
+- Run typecheck with `pnpm -C <worktree> run typecheck` before each commit touching `.ts`.
+- CHANGELOG.md must be updated under `## [Unreleased]` before the PR.
+
+The five mapped credentials (config field ← vault key ▸ env var), per `src/channels/catalog.ts`:
+
+| config field | vault key | env var |
+|---|---|---|
+| `nylasApiKey` | `channel.email.nylas_api_key` | `NYLAS_API_KEY` |
+| `nylasGrantId` | `channel.email.nylas_grant_id` | `NYLAS_GRANT_ID` |
+| `nylasSelfEmail` | `channel.email.nylas_self_email` | `NYLAS_SELF_EMAIL` |
+| `signalPhoneNumber` | `channel.signal.phone_number` | `SIGNAL_PHONE_NUMBER` |
+| `signalSocketPath` | `channel.signal.socket_path` | `SIGNAL_SOCKET_PATH` |
+
+---
+
+## File Structure
+
+- **Create** `src/channels/apply-channel-vault-secrets.ts` — the overlay function (single responsibility: resolve the 5 channel creds onto config).
+- **Create** `src/channels/apply-channel-vault-secrets.test.ts` — unit tests + four-combo agreement tests.
+- **Modify** `src/index.ts` (~L313) — call the overlay right after `applyVaultSecrets`.
+- **Modify** `apps/console/src/pages/ChannelSettings.tsx` (~L218-232) — restart-to-apply hint under Credentials.
+- **Modify** `CHANGELOG.md` — Fixed entry.
+
+---
+
+### Task 1: `applyChannelVaultSecrets` overlay function
+
+**Files:**
+- Create: `src/channels/apply-channel-vault-secrets.ts`
+- Test: `src/channels/apply-channel-vault-secrets.test.ts`
+
+**Interfaces:**
+- Consumes: `Config` (`src/config.ts`), `Logger` (`src/logger.ts`), `channelCredentialStatus` + `getChannelDescriptor` (`src/channels/credential-resolver.ts`, `src/channels/catalog.ts`) and `resolveChannelAccounts` (`src/config.ts`) — for agreement tests only.
+- Produces: `export async function applyChannelVaultSecrets(config: Config, secrets: { get(name: string): Promise<string | null> }, env: Record<string, string | undefined>, logger: Logger): Promise<void>` — mutates `config` in place, returns nothing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/channels/apply-channel-vault-secrets.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import type { Config } from '../config.js';
+import type { YamlConfig } from '../config.js';
+import { resolveChannelAccounts } from '../config.js';
+import { channelCredentialStatus } from './credential-resolver.js';
+import { getChannelDescriptor } from './catalog.js';
+import { applyChannelVaultSecrets } from './apply-channel-vault-secrets.js';
+
+const logger = pino({ level: 'silent' });
+
+// Minimal config covering every field the overlay touches (mirrors apply-vault-secrets.test.ts).
+function baseConfig(): Config {
+  return {
+    databaseUrl: 'postgres://x',
+    anthropicApiKey: undefined,
+    openaiApiKey: undefined,
+    openrouterApiKey: undefined,
+    logLevel: 'info',
+    httpPort: 3000,
+    apiToken: undefined,
+    webAppBootstrapSecret: undefined,
+    appOrigin: undefined,
+    timezone: 'UTC',
+    nylasApiKey: undefined,
+    nylasGrantId: undefined,
+    nylasPollingIntervalMs: 30000,
+    nylasSelfEmail: '',
+    ceoPrimaryEmail: undefined,
+    ceoSignalNumber: undefined,
+    signalSocketPath: undefined,
+    signalPhoneNumber: undefined,
+  } as Config;
+}
+
+// A vault fake whose get() is a spy, so tests can assert exactly which keys were read.
+function fakeSecrets(values: Record<string, string>) {
+  return { get: vi.fn(async (name: string) => values[name] ?? null) };
+}
+
+describe('applyChannelVaultSecrets', () => {
+  it('populates config from vault-only channel.email.* / channel.signal.* keys', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({
+      'channel.email.nylas_api_key': 'nyk_vault',
+      'channel.email.nylas_grant_id': 'grant_vault',
+      'channel.email.nylas_self_email': 'curia@vault.test',
+      'channel.signal.phone_number': '+15550001111',
+      'channel.signal.socket_path': '/run/signal/socket',
+    });
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_vault');
+    expect(config.nylasGrantId).toBe('grant_vault');
+    expect(config.nylasSelfEmail).toBe('curia@vault.test');
+    expect(config.signalPhoneNumber).toBe('+15550001111');
+    expect(config.signalSocketPath).toBe('/run/signal/socket');
+  });
+
+  it('falls back to env when the vault is empty', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({});
+    const env = {
+      NYLAS_API_KEY: 'nyk_env',
+      NYLAS_GRANT_ID: 'grant_env',
+      NYLAS_SELF_EMAIL: 'curia@env.test',
+      SIGNAL_PHONE_NUMBER: '+15550002222',
+      SIGNAL_SOCKET_PATH: '/env/signal/socket',
+    };
+
+    await applyChannelVaultSecrets(config, secrets, env, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_env');
+    expect(config.signalSocketPath).toBe('/env/signal/socket');
+  });
+
+  it('channel vault wins over env when both are present', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({ 'channel.email.nylas_api_key': 'nyk_vault' });
+    const env = { NYLAS_API_KEY: 'nyk_env' };
+
+    await applyChannelVaultSecrets(config, secrets, env, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_vault');
+  });
+
+  it('keeps the current config value when neither vault nor env supplies one', async () => {
+    const config = baseConfig();
+    config.nylasApiKey = 'nyk_bootstrap'; // e.g. already set by applyVaultSecrets
+    const secrets = fakeSecrets({});
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_bootstrap');
+    expect(config.nylasGrantId).toBeUndefined();
+    expect(config.nylasSelfEmail).toBe(''); // string-typed field stays ''
+    expect(config.signalSocketPath).toBeUndefined();
+  });
+
+  it('treats a whitespace-only vault value as absent and falls through', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({ 'channel.email.nylas_api_key': '   ' });
+    const env = { NYLAS_API_KEY: 'nyk_env' };
+
+    await applyChannelVaultSecrets(config, secrets, env, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_env');
+  });
+
+  it('treats a vault read error as absent (no throw)', async () => {
+    const config = baseConfig();
+    const secrets = {
+      get: vi.fn(async (name: string) => {
+        if (name === 'channel.email.nylas_api_key') throw new Error('vault down');
+        return null;
+      }),
+    };
+    const env = { NYLAS_API_KEY: 'nyk_env' };
+
+    await expect(applyChannelVaultSecrets(config, secrets, env, logger)).resolves.toBeUndefined();
+    expect(config.nylasApiKey).toBe('nyk_env');
+  });
+
+  it('reads ONLY the five named channel.* keys — never list(), never user.* / dot-free keys', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({});
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    const readKeys = secrets.get.mock.calls.map(c => c[0]).sort();
+    expect(readKeys).toEqual([
+      'channel.email.nylas_api_key',
+      'channel.email.nylas_grant_id',
+      'channel.email.nylas_self_email',
+      'channel.signal.phone_number',
+      'channel.signal.socket_path',
+    ]);
+    // No list() method should even be invoked (the fake doesn't have one).
+    expect('list' in secrets).toBe(false);
+  });
+});
+
+// AC1: the registry gate and the adapter wiring agree across all four source combinations.
+describe('applyChannelVaultSecrets — gate/adapter agreement (AC1)', () => {
+  const emailDesc = getChannelDescriptor('email')!;
+  const emptyYaml = {} as unknown as YamlConfig; // resolveChannelAccounts only reads channel_accounts
+
+  it('vault-only email: adapter constructs AND registry reports resolvable', async () => {
+    const config = baseConfig();
+    const vault = {
+      'channel.email.nylas_api_key': 'nyk_vault',
+      'channel.email.nylas_grant_id': 'grant_vault',
+      'channel.email.nylas_self_email': 'curia@vault.test',
+    };
+    const secrets = fakeSecrets(vault);
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    // Adapter path: config is populated → legacy single-account synthesis yields one account.
+    const accounts = resolveChannelAccounts(emptyYaml, config);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]!.name).toBe('curia');
+    expect(config.nylasApiKey).toBe('nyk_vault');
+
+    // Gate path: registry resolves the same vault keys → resolvable.
+    const status = await channelCredentialStatus({ secrets: fakeSecrets(vault), env: {} }, emailDesc);
+    expect(status.requiredResolvable).toBe(true);
+  });
+
+  it('neither: adapter skips AND registry reports not resolvable', async () => {
+    const config = baseConfig();
+    await applyChannelVaultSecrets(config, fakeSecrets({}), {}, logger);
+
+    expect(resolveChannelAccounts(emptyYaml, config)).toHaveLength(0);
+    const status = await channelCredentialStatus({ secrets: fakeSecrets({}), env: {} }, emailDesc);
+    expect(status.requiredResolvable).toBe(false);
+  });
+
+  it('both: channel vault wins for the adapter, registry agrees (resolvable)', async () => {
+    const config = baseConfig();
+    const vault = {
+      'channel.email.nylas_api_key': 'nyk_vault',
+      'channel.email.nylas_grant_id': 'grant_vault',
+      'channel.email.nylas_self_email': 'curia@vault.test',
+    };
+    const env = { NYLAS_API_KEY: 'nyk_env', NYLAS_GRANT_ID: 'grant_env', NYLAS_SELF_EMAIL: 'curia@env.test' };
+
+    await applyChannelVaultSecrets(config, fakeSecrets(vault), env, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_vault'); // vault wins
+    const status = await channelCredentialStatus({ secrets: fakeSecrets(vault), env }, emailDesc);
+    expect(status.requiredResolvable).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 exec vitest run src/channels/apply-channel-vault-secrets.test.ts`
+Expected: FAIL — cannot find module `./apply-channel-vault-secrets.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/channels/apply-channel-vault-secrets.ts`:
+
+```ts
+// apply-channel-vault-secrets.ts — overlays the channel-scoped vault credentials
+// (channel.email.* / channel.signal.*, written by the Channels UI) onto Config, so
+// the email/signal adapters actually boot from creds configured entirely through the
+// console (#964). Closes the seam where the registry gate read channel.* but the
+// adapters read config (populated only from the unprefixed bootstrap keys / env).
+//
+// Runs right after applyVaultSecrets() and before any config consumer (resolveChannelAccounts,
+// nylasClientMap, outbound gateway). Precedence per field mirrors the registry resolver
+// (channelCredentialStatus): channel.<name>.<key> (vault) ▸ env (catalog envFallback) ▸
+// the current config value (which already carries the bootstrap-vault result). Because the
+// precedence matches the gate, "enabled + resolvable" and actual adapter boot agree.
+//
+// NAMESPACE SAFETY (do not relax): this reads a FIXED allowlist of five channel.* keys.
+// It must never call secrets.list() or scan by prefix — that keeps user.* (agent-captured)
+// secrets and dot-free skill/system secrets structurally out of reach.
+import type { Config } from '../config.js';
+import type { Logger } from '../logger.js';
+
+/** Narrow view of the vault — only get() is needed (and only get() must ever be called). */
+interface ChannelSecretsPort {
+  get(name: string): Promise<string | null>;
+}
+
+/** Trim; collapse a blank/whitespace-only value to undefined (absent). Matches applyVaultSecrets. */
+function clean(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/** Read one vault key, isolated: a transient failure logs and reads as absent, never aborts boot. */
+async function readVaultKey(
+  secrets: ChannelSecretsPort,
+  key: string,
+  logger: Logger,
+): Promise<string | undefined> {
+  try {
+    return clean(await secrets.get(key));
+  } catch (err) {
+    logger.warn({ err, key }, 'channel credential vault read failed; treating as missing and falling back to env/config');
+    return undefined;
+  }
+}
+
+export async function applyChannelVaultSecrets(
+  config: Config,
+  secrets: ChannelSecretsPort,
+  env: Record<string, string | undefined>,
+  logger: Logger,
+): Promise<void> {
+  // Resolve channel-vault ▸ env ▸ current-config for one field. Reads are concurrent.
+  const resolve = async (
+    vaultKey: string,
+    envVar: string,
+    current: string | undefined,
+  ): Promise<string | undefined> =>
+    (await readVaultKey(secrets, vaultKey, logger)) ?? clean(env[envVar]) ?? clean(current);
+
+  const [nylasApiKey, nylasGrantId, nylasSelfEmail, signalPhoneNumber, signalSocketPath] =
+    await Promise.all([
+      resolve('channel.email.nylas_api_key', 'NYLAS_API_KEY', config.nylasApiKey),
+      resolve('channel.email.nylas_grant_id', 'NYLAS_GRANT_ID', config.nylasGrantId),
+      resolve('channel.email.nylas_self_email', 'NYLAS_SELF_EMAIL', config.nylasSelfEmail),
+      resolve('channel.signal.phone_number', 'SIGNAL_PHONE_NUMBER', config.signalPhoneNumber),
+      resolve('channel.signal.socket_path', 'SIGNAL_SOCKET_PATH', config.signalSocketPath),
+    ]);
+
+  config.nylasApiKey = nylasApiKey;
+  config.nylasGrantId = nylasGrantId;
+  // nylasSelfEmail is typed `string` (defaults to ''), matching loadConfig/applyVaultSecrets.
+  config.nylasSelfEmail = nylasSelfEmail ?? '';
+  config.signalPhoneNumber = signalPhoneNumber;
+  config.signalSocketPath = signalSocketPath;
+
+  // Names only — never values. Lets an operator confirm which channel creds the vault/env
+  // supplied vs. which are absent (feature-off), the same debuggability win as applyVaultSecrets.
+  const present = {
+    'channel.email.nylas_api_key': nylasApiKey !== undefined,
+    'channel.email.nylas_grant_id': nylasGrantId !== undefined,
+    'channel.email.nylas_self_email': nylasSelfEmail !== undefined,
+    'channel.signal.phone_number': signalPhoneNumber !== undefined,
+    'channel.signal.socket_path': signalSocketPath !== undefined,
+  };
+  logger.info({ present }, 'Applied channel credentials onto config (vault ▸ env ▸ config)');
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 exec vitest run src/channels/apply-channel-vault-secrets.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 add src/channels/apply-channel-vault-secrets.ts src/channels/apply-channel-vault-secrets.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 commit -m "feat: overlay channel-scoped vault creds onto config (#964)"
+```
+
+---
+
+### Task 2: Wire the overlay into bootstrap
+
+**Files:**
+- Modify: `src/index.ts` (~L106 import, ~L313 call site)
+
+**Interfaces:**
+- Consumes: `applyChannelVaultSecrets` (Task 1).
+
+- [ ] **Step 1: Add the import**
+
+In `src/index.ts`, next to the existing `applyVaultSecrets` import (L106):
+
+```ts
+import { applyVaultSecrets } from './secrets/apply-vault-secrets.js';
+import { applyChannelVaultSecrets } from './channels/apply-channel-vault-secrets.js';
+```
+
+- [ ] **Step 2: Call it right after applyVaultSecrets**
+
+Find the existing block (L312-317):
+
+```ts
+  try {
+    await applyVaultSecrets(config, secretsService, logger);
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to resolve bootstrap secrets from vault');
+    process.exit(1);
+  }
+```
+
+Replace with:
+
+```ts
+  try {
+    await applyVaultSecrets(config, secretsService, logger);
+    // Overlay channel-scoped vault creds (channel.email.* / channel.signal.*, written by the
+    // Channels UI) onto config so the email/signal adapters boot from console-configured
+    // creds. Same fatal-on-error contract as applyVaultSecrets. Must run before
+    // resolveChannelAccounts and adapter/gateway construction below. (#964)
+    await applyChannelVaultSecrets(config, secretsService, process.env, logger);
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to resolve bootstrap secrets from vault');
+    process.exit(1);
+  }
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 run typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Run the full channels test suite (no regressions)**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 exec vitest run src/channels/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 add src/index.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 commit -m "feat: apply channel vault creds at boot before adapter wiring (#964)"
+```
+
+---
+
+### Task 3: Console — restart-to-apply hint under Credentials (AC4)
+
+**Files:**
+- Modify: `apps/console/src/pages/ChannelSettings.tsx` (~L218-232, the Credentials `form-field`)
+
+**Interfaces:** none (copy-only change).
+
+- [ ] **Step 1: Add the hint line**
+
+In the Credentials `form-field` block, add a sub-note under the `<label>Credentials</label>`:
+
+```tsx
+          {/* Credential form — only for toggleable channels that declare fields.
+              Always-on channels (http, cli) have no credentials. */}
+          {!locked && entry.credentialFields.length > 0 && (
+            <div className="form-field">
+              <label>Credentials</label>
+              <p className="settings-page-sub" style={{ margin: '0 0 4px' }}>
+                Saved credentials take effect on the next restart.
+              </p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {entry.credentialFields.map(field => (
+                  <CredentialRow
+                    key={field.key}
+                    channel={entry.name}
+                    field={field}
+                    onSaved={onChanged}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+```
+
+- [ ] **Step 2: Typecheck the console package**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964/apps/console run typecheck`
+Expected: no errors. (If the console has no `typecheck` script, run the repo-root `pnpm -C <worktree> run typecheck`, which covers the workspace.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 add apps/console/src/pages/ChannelSettings.tsx
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 commit -m "feat: note channel creds apply on restart in console (#964)"
+```
+
+---
+
+### Task 4: CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (under `## [Unreleased]`, `### Fixed`)
+
+- [ ] **Step 1: Add the entry**
+
+Under `## [Unreleased]` → `### Fixed` (create the `### Fixed` subsection if absent):
+
+```markdown
+- **Channel registry** — email/signal creds saved via the Channels UI (`channel.*` vault keys) now actually wire up the adapter at boot; the registry's `enabled + resolvable` state and real adapter boot can no longer disagree. (#964)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-channel-vault-964 commit -m "docs: changelog for #964"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Overlay function + precedence + clean/error handling → Task 1.
+- Namespace-safety invariant + test → Task 1 (Step 1 "reads ONLY the five named keys" test; Step 3 comment).
+- Single source of truth / boot wiring before consumers → Task 2.
+- Four-combo gate/adapter agreement (AC1) → Task 1 agreement describe block.
+- Existing env/config deployments unchanged (AC2) → Task 1 env-only + neither tests; env tier preserved.
+- Unit + integration coverage (AC3) → Task 1.
+- Console no-op save path (AC4) → Task 3.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `applyChannelVaultSecrets(config, secrets, env, logger)` signature identical across Tasks 1-2. `clean` / `readVaultKey` are file-private. Config field names (`nylasApiKey`, `nylasGrantId`, `nylasSelfEmail`, `signalPhoneNumber`, `signalSocketPath`) match `src/config.ts`. `nylasSelfEmail` handled as `string` (`?? ''`).
+
+**Note on test runner:** uses `pnpm -C <worktree> exec vitest run <file>` for single files and `pnpm -C <worktree> run typecheck` for types, per project CLAUDE.md (worktree `-C`, never `--prefix`).

--- a/src/channels/apply-channel-vault-secrets.test.ts
+++ b/src/channels/apply-channel-vault-secrets.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import type { Config } from '../config.js';
+import type { YamlConfig } from '../config.js';
+import { resolveChannelAccounts } from '../config.js';
+import { channelCredentialStatus } from './credential-resolver.js';
+import { getChannelDescriptor } from './catalog.js';
+import { applyChannelVaultSecrets } from './apply-channel-vault-secrets.js';
+
+const logger = pino({ level: 'silent' });
+
+// Minimal config covering every field the overlay touches (mirrors apply-vault-secrets.test.ts).
+function baseConfig(): Config {
+  return {
+    databaseUrl: 'postgres://x',
+    anthropicApiKey: undefined,
+    openaiApiKey: undefined,
+    openrouterApiKey: undefined,
+    logLevel: 'info',
+    httpPort: 3000,
+    apiToken: undefined,
+    webAppBootstrapSecret: undefined,
+    appOrigin: undefined,
+    timezone: 'UTC',
+    nylasApiKey: undefined,
+    nylasGrantId: undefined,
+    nylasPollingIntervalMs: 30000,
+    nylasSelfEmail: '',
+    ceoPrimaryEmail: undefined,
+    ceoSignalNumber: undefined,
+    signalSocketPath: undefined,
+    signalPhoneNumber: undefined,
+  } as Config;
+}
+
+// A vault fake whose get() is a spy, so tests can assert exactly which keys were read.
+function fakeSecrets(values: Record<string, string>) {
+  return { get: vi.fn(async (name: string) => values[name] ?? null) };
+}
+
+describe('applyChannelVaultSecrets', () => {
+  it('populates config from vault-only channel.email.* / channel.signal.* keys', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({
+      'channel.email.nylas_api_key': 'nyk_vault',
+      'channel.email.nylas_grant_id': 'grant_vault',
+      'channel.email.nylas_self_email': 'curia@vault.test',
+      'channel.signal.phone_number': '+15550001111',
+      'channel.signal.socket_path': '/run/signal/socket',
+    });
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_vault');
+    expect(config.nylasGrantId).toBe('grant_vault');
+    expect(config.nylasSelfEmail).toBe('curia@vault.test');
+    expect(config.signalPhoneNumber).toBe('+15550001111');
+    expect(config.signalSocketPath).toBe('/run/signal/socket');
+  });
+
+  it('falls back to env when the vault is empty', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({});
+    const env = {
+      NYLAS_API_KEY: 'nyk_env',
+      NYLAS_GRANT_ID: 'grant_env',
+      NYLAS_SELF_EMAIL: 'curia@env.test',
+      SIGNAL_PHONE_NUMBER: '+15550002222',
+      SIGNAL_SOCKET_PATH: '/env/signal/socket',
+    };
+
+    await applyChannelVaultSecrets(config, secrets, env, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_env');
+    expect(config.signalSocketPath).toBe('/env/signal/socket');
+  });
+
+  it('channel vault wins over env when both are present', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({ 'channel.email.nylas_api_key': 'nyk_vault' });
+    const env = { NYLAS_API_KEY: 'nyk_env' };
+
+    await applyChannelVaultSecrets(config, secrets, env, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_vault');
+  });
+
+  it('keeps the current config value when neither vault nor env supplies one', async () => {
+    const config = baseConfig();
+    config.nylasApiKey = 'nyk_bootstrap'; // e.g. already set by applyVaultSecrets
+    const secrets = fakeSecrets({});
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_bootstrap');
+    expect(config.nylasGrantId).toBeUndefined();
+    expect(config.nylasSelfEmail).toBe(''); // string-typed field stays ''
+    expect(config.signalSocketPath).toBeUndefined();
+  });
+
+  it('treats a whitespace-only vault value as absent and falls through', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({ 'channel.email.nylas_api_key': '   ' });
+    const env = { NYLAS_API_KEY: 'nyk_env' };
+
+    await applyChannelVaultSecrets(config, secrets, env, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_env');
+  });
+
+  it('treats a vault read error as absent (no throw)', async () => {
+    const config = baseConfig();
+    const secrets = {
+      get: vi.fn(async (name: string) => {
+        if (name === 'channel.email.nylas_api_key') throw new Error('vault down');
+        return null;
+      }),
+    };
+    const env = { NYLAS_API_KEY: 'nyk_env' };
+
+    await expect(applyChannelVaultSecrets(config, secrets, env, logger)).resolves.toBeUndefined();
+    expect(config.nylasApiKey).toBe('nyk_env');
+  });
+
+  it('reads ONLY the five named channel.* keys — never list(), never user.* / dot-free keys', async () => {
+    const config = baseConfig();
+    const secrets = fakeSecrets({});
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    const readKeys = secrets.get.mock.calls.map(c => c[0]).sort();
+    expect(readKeys).toEqual([
+      'channel.email.nylas_api_key',
+      'channel.email.nylas_grant_id',
+      'channel.email.nylas_self_email',
+      'channel.signal.phone_number',
+      'channel.signal.socket_path',
+    ]);
+    // No list() method should even be invoked (the fake doesn't have one).
+    expect('list' in secrets).toBe(false);
+  });
+});
+
+// AC1: the registry gate and the adapter wiring agree across all four source combinations.
+describe('applyChannelVaultSecrets — gate/adapter agreement (AC1)', () => {
+  const emailDesc = getChannelDescriptor('email')!;
+  const emptyYaml = {} as unknown as YamlConfig; // resolveChannelAccounts only reads channel_accounts
+
+  it('vault-only email: adapter constructs AND registry reports resolvable', async () => {
+    const config = baseConfig();
+    const vault = {
+      'channel.email.nylas_api_key': 'nyk_vault',
+      'channel.email.nylas_grant_id': 'grant_vault',
+      'channel.email.nylas_self_email': 'curia@vault.test',
+    };
+    const secrets = fakeSecrets(vault);
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    // Adapter path: config is populated → legacy single-account synthesis yields one account.
+    const accounts = resolveChannelAccounts(emptyYaml, config);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]!.name).toBe('curia');
+    expect(config.nylasApiKey).toBe('nyk_vault');
+
+    // Gate path: registry resolves the same vault keys → resolvable.
+    const status = await channelCredentialStatus({ secrets: fakeSecrets(vault), env: {} }, emailDesc);
+    expect(status.requiredResolvable).toBe(true);
+  });
+
+  it('neither: adapter skips AND registry reports not resolvable', async () => {
+    const config = baseConfig();
+    await applyChannelVaultSecrets(config, fakeSecrets({}), {}, logger);
+
+    expect(resolveChannelAccounts(emptyYaml, config)).toHaveLength(0);
+    const status = await channelCredentialStatus({ secrets: fakeSecrets({}), env: {} }, emailDesc);
+    expect(status.requiredResolvable).toBe(false);
+  });
+
+  it('both: channel vault wins for the adapter, registry agrees (resolvable)', async () => {
+    const config = baseConfig();
+    const vault = {
+      'channel.email.nylas_api_key': 'nyk_vault',
+      'channel.email.nylas_grant_id': 'grant_vault',
+      'channel.email.nylas_self_email': 'curia@vault.test',
+    };
+    const env = { NYLAS_API_KEY: 'nyk_env', NYLAS_GRANT_ID: 'grant_env', NYLAS_SELF_EMAIL: 'curia@env.test' };
+
+    await applyChannelVaultSecrets(config, fakeSecrets(vault), env, logger);
+
+    expect(config.nylasApiKey).toBe('nyk_vault'); // vault wins
+    const status = await channelCredentialStatus({ secrets: fakeSecrets(vault), env }, emailDesc);
+    expect(status.requiredResolvable).toBe(true);
+  });
+});

--- a/src/channels/apply-channel-vault-secrets.test.ts
+++ b/src/channels/apply-channel-vault-secrets.test.ts
@@ -177,6 +177,25 @@ describe('applyChannelVaultSecrets — gate/adapter agreement (AC1)', () => {
     expect(status.requiredResolvable).toBe(false);
   });
 
+  it('whitespace-only vault creds: adapter sees absent AND registry reports not resolvable (agree)', async () => {
+    const config = baseConfig();
+    const vault = {
+      'channel.email.nylas_api_key': '   ',
+      'channel.email.nylas_grant_id': '  ',
+      'channel.email.nylas_self_email': ' ',
+    };
+
+    await applyChannelVaultSecrets(config, fakeSecrets(vault), {}, logger);
+
+    // Adapter path: whitespace trimmed to absent → no synthesized account.
+    expect(config.nylasApiKey).toBeUndefined();
+    expect(resolveChannelAccounts(emptyYaml, config)).toHaveLength(0);
+
+    // Gate path: same normalization → not resolvable. The two agree (no silent no-op).
+    const status = await channelCredentialStatus({ secrets: fakeSecrets(vault), env: {} }, emailDesc);
+    expect(status.requiredResolvable).toBe(false);
+  });
+
   it('both: channel vault wins for the adapter, registry agrees (resolvable)', async () => {
     const config = baseConfig();
     const vault = {

--- a/src/channels/apply-channel-vault-secrets.ts
+++ b/src/channels/apply-channel-vault-secrets.ts
@@ -1,0 +1,84 @@
+// apply-channel-vault-secrets.ts — overlays the channel-scoped vault credentials
+// (channel.email.* / channel.signal.*, written by the Channels UI) onto Config, so
+// the email/signal adapters actually boot from creds configured entirely through the
+// console (#964). Closes the seam where the registry gate read channel.* but the
+// adapters read config (populated only from the unprefixed bootstrap keys / env).
+//
+// Runs right after applyVaultSecrets() and before any config consumer (resolveChannelAccounts,
+// nylasClientMap, outbound gateway). Precedence per field mirrors the registry resolver
+// (channelCredentialStatus): channel.<name>.<key> (vault) ▸ env (catalog envFallback) ▸
+// the current config value (which already carries the bootstrap-vault result). Because the
+// precedence matches the gate, "enabled + resolvable" and actual adapter boot agree.
+//
+// NAMESPACE SAFETY (do not relax): this reads a FIXED allowlist of five channel.* keys.
+// It must never call secrets.list() or scan by prefix — that keeps user.* (agent-captured)
+// secrets and dot-free skill/system secrets structurally out of reach.
+import type { Config } from '../config.js';
+import type { Logger } from '../logger.js';
+
+/** Narrow view of the vault — only get() is needed (and only get() must ever be called). */
+interface ChannelSecretsPort {
+  get(name: string): Promise<string | null>;
+}
+
+/** Trim; collapse a blank/whitespace-only value to undefined (absent). Matches applyVaultSecrets. */
+function clean(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/** Read one vault key, isolated: a transient failure logs and reads as absent, never aborts boot. */
+async function readVaultKey(
+  secrets: ChannelSecretsPort,
+  key: string,
+  logger: Logger,
+): Promise<string | undefined> {
+  try {
+    return clean(await secrets.get(key));
+  } catch (err) {
+    logger.warn({ err, key }, 'channel credential vault read failed; treating as missing and falling back to env/config');
+    return undefined;
+  }
+}
+
+export async function applyChannelVaultSecrets(
+  config: Config,
+  secrets: ChannelSecretsPort,
+  env: Record<string, string | undefined>,
+  logger: Logger,
+): Promise<void> {
+  // Resolve channel-vault ▸ env ▸ current-config for one field. Reads are concurrent.
+  const resolve = async (
+    vaultKey: string,
+    envVar: string,
+    current: string | undefined,
+  ): Promise<string | undefined> =>
+    (await readVaultKey(secrets, vaultKey, logger)) ?? clean(env[envVar]) ?? clean(current);
+
+  const [nylasApiKey, nylasGrantId, nylasSelfEmail, signalPhoneNumber, signalSocketPath] =
+    await Promise.all([
+      resolve('channel.email.nylas_api_key', 'NYLAS_API_KEY', config.nylasApiKey),
+      resolve('channel.email.nylas_grant_id', 'NYLAS_GRANT_ID', config.nylasGrantId),
+      resolve('channel.email.nylas_self_email', 'NYLAS_SELF_EMAIL', config.nylasSelfEmail),
+      resolve('channel.signal.phone_number', 'SIGNAL_PHONE_NUMBER', config.signalPhoneNumber),
+      resolve('channel.signal.socket_path', 'SIGNAL_SOCKET_PATH', config.signalSocketPath),
+    ]);
+
+  config.nylasApiKey = nylasApiKey;
+  config.nylasGrantId = nylasGrantId;
+  // nylasSelfEmail is typed `string` (defaults to ''), matching loadConfig/applyVaultSecrets.
+  config.nylasSelfEmail = nylasSelfEmail ?? '';
+  config.signalPhoneNumber = signalPhoneNumber;
+  config.signalSocketPath = signalSocketPath;
+
+  // Names only — never values. Lets an operator confirm which channel creds the vault/env
+  // supplied vs. which are absent (feature-off), the same debuggability win as applyVaultSecrets.
+  const present = {
+    'channel.email.nylas_api_key': nylasApiKey !== undefined,
+    'channel.email.nylas_grant_id': nylasGrantId !== undefined,
+    'channel.email.nylas_self_email': nylasSelfEmail !== undefined,
+    'channel.signal.phone_number': signalPhoneNumber !== undefined,
+    'channel.signal.socket_path': signalSocketPath !== undefined,
+  };
+  logger.info({ present }, 'Applied channel credentials onto config (vault ▸ env ▸ config)');
+}

--- a/src/channels/apply-channel-vault-secrets.ts
+++ b/src/channels/apply-channel-vault-secrets.ts
@@ -15,16 +15,13 @@
 // secrets and dot-free skill/system secrets structurally out of reach.
 import type { Config } from '../config.js';
 import type { Logger } from '../logger.js';
+// Shared so the gate (channelCredentialStatus) and this overlay make the SAME present/absent
+// decision — in particular both treat a whitespace-only value as absent (#964).
+import { normalizeSecretValue } from './credential-resolver.js';
 
 /** Narrow view of the vault — only get() is needed (and only get() must ever be called). */
 interface ChannelSecretsPort {
   get(name: string): Promise<string | null>;
-}
-
-/** Trim; collapse a blank/whitespace-only value to undefined (absent). Matches applyVaultSecrets. */
-function clean(value: string | null | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
 }
 
 /** Read one vault key, isolated: a transient failure logs and reads as absent, never aborts boot. */
@@ -34,7 +31,7 @@ async function readVaultKey(
   logger: Logger,
 ): Promise<string | undefined> {
   try {
-    return clean(await secrets.get(key));
+    return normalizeSecretValue(await secrets.get(key));
   } catch (err) {
     logger.warn({ err, key }, 'channel credential vault read failed; treating as missing and falling back to env/config');
     return undefined;
@@ -53,7 +50,7 @@ export async function applyChannelVaultSecrets(
     envVar: string,
     current: string | undefined,
   ): Promise<string | undefined> =>
-    (await readVaultKey(secrets, vaultKey, logger)) ?? clean(env[envVar]) ?? clean(current);
+    (await readVaultKey(secrets, vaultKey, logger)) ?? normalizeSecretValue(env[envVar]) ?? normalizeSecretValue(current);
 
   const [nylasApiKey, nylasGrantId, nylasSelfEmail, signalPhoneNumber, signalSocketPath] =
     await Promise.all([

--- a/src/channels/credential-resolver.test.ts
+++ b/src/channels/credential-resolver.test.ts
@@ -47,6 +47,23 @@ describe('channelCredentialStatus', () => {
     expect(res.fields.map(f => f.source)).toEqual(['config', 'config']);
   });
 
+  it('treats a whitespace-only vault value as absent (not resolvable), matching the runtime overlay', async () => {
+    // A "   " vault row must NOT report resolvable: applyChannelVaultSecrets trims it to
+    // undefined, so reporting it resolvable here would reintroduce the #964 divergence.
+    const secrets = fakeSecrets({ 'channel.signal.socket_path': '   ', 'channel.signal.phone_number': '+15551234567' });
+    const res = await channelCredentialStatus({ secrets, env: {} }, signal);
+    expect(res.requiredResolvable).toBe(false);
+    expect(res.fields.find(f => f.key === 'socket_path')!.source).toBe('missing');
+  });
+
+  it('falls through a whitespace-only vault value to a usable env fallback', async () => {
+    const secrets = fakeSecrets({ 'channel.signal.socket_path': '  ' });
+    const env = { SIGNAL_SOCKET_PATH: '/run/sig.sock', SIGNAL_PHONE_NUMBER: '+15551234567' };
+    const res = await channelCredentialStatus({ secrets, env }, signal);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.find(f => f.key === 'socket_path')!.source).toBe('env');
+  });
+
   it('a channel with no required keys is always resolvable', async () => {
     const http: ChannelDescriptor = { name: 'http', description: '', isToggleable: false, credentialFields: [], requiredSecretKeys: [] };
     const res = await channelCredentialStatus({ secrets: fakeSecrets({}), env: {} }, http);

--- a/src/channels/credential-resolver.ts
+++ b/src/channels/credential-resolver.ts
@@ -7,6 +7,21 @@ import type { ChannelDescriptor } from './catalog.js';
 
 export type CredentialSource = 'vault' | 'env' | 'config' | 'missing';
 
+/**
+ * Normalize a raw secret value: trim surrounding whitespace and collapse a blank/
+ * whitespace-only result to `undefined` (absent). A whitespace-only credential is unusable
+ * at runtime, so it must read as absent.
+ *
+ * Shared by this gate resolver AND `applyChannelVaultSecrets` so both make the SAME
+ * present/absent decision. If only one side trimmed, a whitespace-only vault row could read
+ * as `resolvable` on the gate while the adapter sees an empty config value — reintroducing the
+ * exact gate/runtime divergence #964 closes.
+ */
+export function normalizeSecretValue(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 export interface CredentialFieldStatus {
   key: string;
   label: string;
@@ -54,9 +69,14 @@ export async function channelCredentialStatus(
         'channel credential vault read failed; treating as missing and falling back to env/config',
       );
     }
+    // Normalize before the present/absent check so a whitespace-only value reads as absent —
+    // the SAME decision applyChannelVaultSecrets makes when populating config. Without this,
+    // a `"   "` vault row would report 'vault'/resolvable here while the adapter saw nothing.
+    const vaultClean = normalizeSecretValue(vaultVal);
+    const envClean = field.envFallback ? normalizeSecretValue(env[field.envFallback]) : undefined;
     let source: CredentialSource;
-    if (vaultVal) source = 'vault';
-    else if (field.envFallback && env[field.envFallback]) source = 'env';
+    if (vaultClean) source = 'vault';
+    else if (envClean) source = 'env';
     else if (configKeys.has(field.key)) source = 'config';
     else source = 'missing';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1376,6 +1376,7 @@ async function main(): Promise<void> {
   // events have no subscriber and are permanently dropped because each adapter advances
   // its own high-water mark on poll).
   if (outboundGateway && channelShouldStart.has('email')) {
+    const emailAdaptersBefore = emailAdapters.length;
     for (const account of resolvedEmailAccounts) {
       if (!nylasClientMap.has(account.name)) continue; // skip accounts with no client (NYLAS_API_KEY missing)
 
@@ -1397,6 +1398,14 @@ async function main(): Promise<void> {
         configStore: entityMemory ? new ConfigStore(entityMemory, logger) : undefined,
       }));
     }
+    // Divergence guard (#964): the registry gate marked email enabled + resolvable, yet no
+    // adapter constructed — the runtime config has no usable Nylas client. This is the silent
+    // no-op the channel-vault fix exists to prevent; it can still arise if a transient vault
+    // read error hit applyChannelVaultSecrets but not the gate's independent read. Surface it
+    // loudly instead of booting a dead channel, rather than letting the gate and runtime disagree.
+    if (emailAdapters.length === emailAdaptersBefore) {
+      logger.warn('channel email is enabled + resolvable but no Nylas client is configured at runtime; no email adapter constructed — check vault/env credentials and restart');
+    }
   }
 
   // Construct the Signal adapter (but don't start it yet — same ordering rule as email:
@@ -1410,6 +1419,12 @@ async function main(): Promise<void> {
       contactService,
       phoneNumber: config.signalPhoneNumber,
     });
+  } else if (outboundGateway && channelShouldStart.has('signal') && (!signalRpcClient || !config.signalPhoneNumber)) {
+    // Divergence guard (#964): same silent-no-op class as the email block above — the gate
+    // says signal should start but its runtime client/credentials (socket path or phone
+    // number) are absent from config, so no adapter was constructed. Warn instead of skipping
+    // silently. (Only reachable outside setup-required mode, where outboundGateway is set.)
+    logger.warn('channel signal is enabled + resolvable but its runtime client/credentials are missing (socket path or phone number); no Signal adapter constructed — check vault/env credentials and restart');
   }
 
   // Scheduler — Postgres-backed job scheduler for cron and one-shot tasks.

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ import { SecretCaptureService } from './secrets/secret-capture-service.js';
 import { SecretCaptureResumeSubscriber } from './secrets/secret-capture-resume-subscriber.js';
 import { channelCredentialKeys } from './channels/http/routes/vault.js';
 import { applyVaultSecrets } from './secrets/apply-vault-secrets.js';
+import { applyChannelVaultSecrets } from './channels/apply-channel-vault-secrets.js';
 import { SensitivityClassifier } from './memory/sensitivity.js';
 import { DreamEngine } from './memory/dream-engine.js';
 import type { DecayConfig } from './memory/dream-engine.js';
@@ -311,6 +312,11 @@ async function main(): Promise<void> {
   // with a structured fatal line to match the migration/encryption-key blocks above.
   try {
     await applyVaultSecrets(config, secretsService, logger);
+    // Overlay channel-scoped vault creds (channel.email.* / channel.signal.*, written by the
+    // Channels UI) onto config so the email/signal adapters boot from console-configured
+    // creds. Same fatal-on-error contract as applyVaultSecrets. Must run before
+    // resolveChannelAccounts and adapter/gateway construction below. (#964)
+    await applyChannelVaultSecrets(config, secretsService, process.env, logger);
   } catch (err) {
     logger.fatal({ err }, 'Failed to resolve bootstrap secrets from vault');
     process.exit(1);


### PR DESCRIPTION
## Summary

Closes #964.

The channel registry resolved credentials **vault-first** (`channel.<name>.<key>` ▸ env ▸ config) to compute `requiredResolvable`, which gates `channelShouldStart`. But the email/signal **adapters** were constructed from the legacy config/env runtime objects. These read **two disjoint vault namespaces**:

- **Channels UI** writes `channel.email.*` / `channel.signal.*` → read by the registry gate.
- **Adapters** read `config.*`, populated from the *unprefixed* bootstrap keys (`nylas_api_key`, …) / env.

So a credential set saved entirely through the Channels UI made the registry report `enabled + resolvable`, but `config.nylasApiKey` stayed undefined → no adapter constructed. Silent no-op.

## Fix (issue option 1 — vault-backed provisioning)

A new boot-time function **`applyChannelVaultSecrets`** overlays the five channel-scoped vault keys onto `config.*` (precedence `channel.<name>.<key>` ▸ env ▸ current config), run right after `applyVaultSecrets` and **before** any consumer reads config (`resolveChannelAccounts`, `nylasClientMap`, outbound gateway). Because the overlay uses the registry's exact precedence, `enabled + resolvable` and actual adapter boot now agree across all four `{vault-only, env/config-only, both, neither}` combinations. Existing env/config deployments are unchanged (env/current-config remains the fallback tier).

Vault-only email rides the existing legacy single-account fallback in `resolveChannelAccounts` (synthesized `curia` account) — no new multi-account machinery. Signal's `socket_path` becomes vault-configurable for the first time.

### Namespace safety (invariant)

The overlay reads a **fixed 5-key allowlist** of `channel.*` keys — never `secrets.list()`, never a prefix scan. This keeps `user.*` (agent-captured) secrets and dot-free skill/system secrets structurally out of reach. A test locks the invariant (asserts exactly those 5 keys are read and `list()` is never called).

### Divergence guard

The gate and the overlay read the vault independently, so a transient vault error on one read alone could still recreate a "resolvable-but-not-started" channel. The email/signal construction blocks now **warn loudly** in that case instead of skipping silently (surfaced in review).

## Changes

- `src/channels/apply-channel-vault-secrets.ts` (new) + tests (13 cases incl. four-combo gate/adapter agreement + namespace-safety).
- `src/index.ts` — call the overlay at boot; warn on gate/runtime divergence in the adapter blocks.
- `apps/console/src/pages/ChannelSettings.tsx` — "Saved credentials take effect on the next restart." hint under Credentials (AC4 — the save path now has runtime effect).
- `CHANGELOG.md`, design + plan docs in `docs/wip/`.

## Testing

- `vitest run src/channels/ src/secrets/ src/config.test.ts` → 130 passed.
- `tsc --noEmit` (root + skills) clean; console `tsc --noEmit` clean.
- Reviewed by code-reviewer (no high-priority issues), silent-failure-hunter (deliberate swallow confirmed correct; Concern 1 addressed via the divergence guard), and a security review (CLEAN — no secret leakage, namespace isolation honored, precedence safe under the vault PUT authz model).

## Acceptance criteria

- [x] Vault-only creds for email & signal → constructed adapter when enabled; gate/adapter agree in all four combos.
- [x] Existing env/config deployments start unchanged.
- [x] Unit + integration-of-pure-functions coverage for vault-only and mixed-source cases.
- [x] Channels UI no longer advertises a no-op save path.