### PR TITLE
chore: migrate Google Workspace OAuth secrets into the vault (#913)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,8 @@ DATABASE_URL=postgres://curia:your-db-password@localhost:5432/curia
 #   NYLAS_API_KEY=nyk_... pnpm run seed-vault
 #
 # Only the four values needed to reach and unlock the vault — plus non-secret config
-# below — belong in .env. (Google Workspace OAuth secrets are migrated separately, #913.)
+# below — belong in .env. The Google Workspace OAuth secrets now live in the vault too
+# (#913); see the Google Workspace MCP section below for how to seed them.
 
 # TLS (macOS only) — Node installed via nvm/fnm bundles its own CA store
 # and doesn't trust macOS system certificates. If HTTPS fetch fails with
@@ -92,20 +93,25 @@ TIMEZONE=America/Toronto
 
 # === Google Workspace MCP (community server — active) ===
 #
-# OAuth 2.0 credentials for taylorwilsdon/google_workspace_mcp.
-# Create a Desktop App OAuth client in Google Cloud Console, then add Curia's
-# Gmail as a test user on the consent screen.
-# See docs/dev/google-drive.md for the full setup runbook.
+# OAuth 2.0 credentials for taylorwilsdon/google_workspace_mcp. As of #913 these
+# three secrets live in the encrypted vault, NOT in .env. Both consumers (the
+# drive-download-file skill and the google-workspace MCP subprocess) read them
+# from the vault at runtime. Do not add them here.
 #
-# On first startup after these are set, the MCP server prints an OAuth URL.
-# Open it in a browser logged in as Curia's Gmail, complete the flow, and tokens
-# are cached at ~/.workspace-mcp/cli-tokens/ for all subsequent runs.
-# GOOGLE_OAUTH_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
-# GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-...
-
-# Google Workspace email for MCP tools (required if google-workspace MCP server is configured).
-# This is injected as a fixed_input — agents never see or reason about it.
-# CURIA_GOOGLE_EMAIL=curia@gmail.com
+# To seed them: create a Desktop App OAuth client in Google Cloud Console, add
+# Curia's Gmail as a test user on the consent screen, then set the three values
+# transiently and run the seeder (the vault upsert is idempotent):
+#
+#   GOOGLE_OAUTH_CLIENT_ID=<id>.apps.googleusercontent.com \
+#   GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-... \
+#   CURIA_GOOGLE_EMAIL=curia@gmail.com \
+#   pnpm run seed-vault
+#
+# The email is injected as a fixed_input, so agents never see or reason about it.
+# On first startup after seeding, the MCP server prints an OAuth URL; open it in a
+# browser logged in as Curia's Gmail, complete the flow, and tokens are cached at
+# ~/.workspace-mcp/cli-tokens/ for all subsequent runs.
+# See docs/dev/google-drive.md for the full setup runbook.
 
 # Logging
 LOG_LEVEL=info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Silent context sweep** — `context-bridge-release` drops its `coordinator`-only `allowed_callers` restriction; specialists (`contacts`, `ceo-inbox`) can release their own exchange entries instead of asking "Sweep those too?". (#1052)
 - **Coordinator sweep trigger** — tightened from the ambiguous "after the exchange is complete" to an explicit close-on-result rule, so stale `[ACTIVE OUTBOUND CONTEXT]` entries stop accumulating across multi-turn specialist conversations. (#1052)
 
+### Security
+
+- **Google Workspace OAuth secrets in the vault** — `google_oauth_client_id`, `google_oauth_client_secret`, and `curia_google_email` now resolve from the encrypted vault instead of plaintext `.env`; `drive-download-file` reads them via audited `ctx.secret()`, and the `google-workspace` MCP subprocess resolves them (and its `env:` fixed_input) from the vault at spawn time, vault-only. (#913)
+
 ## [0.36.0] — 2026-06-20 — "Reverend Mother"
 
 > **Reverend Mother Gaius Helen Mohiam** *(Dune, 1965, Frank Herbert)* — the Bene Gesserit who holds the gom jabbar to your throat and decides, by what you do under the test, who is human enough to pass. v0.36 gives Curia the same discernment: every sender is met at the gate, sorted by tier, and let only as far as earned trust allows.

--- a/config/skills.yaml
+++ b/config/skills.yaml
@@ -52,14 +52,16 @@ servers:
   # Prerequisites (one-time human setup — see docs/dev/google-drive.md):
   #   1. Create a Google Cloud Project, enable Drive/Sheets/Docs/Gmail/Calendar APIs
   #   2. Create an OAuth 2.0 Desktop App credential
-  #   3. Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET in .env
+  #   3. Seed google_oauth_client_id / google_oauth_client_secret / curia_google_email
+  #      into the vault (see .env.example: GOOGLE_OAUTH_CLIENT_ID=... pnpm run seed-vault)
   #   4. Run the OAuth flow once locally to cache tokens (~/.workspace-mcp/cli-tokens/)
   #
-  # Empty-string env values are resolved from process.env at runtime by
-  # mcp-client.ts's buildChildEnv() — only these two keys are passed to the
-  # subprocess (plus a safe base set: PATH, HOME, USER, etc.). This enforces
-  # least-privilege: DB_PASSWORD, ANTHROPIC_API_KEY, etc. never reach the
-  # third-party process.
+  # Empty-string env values below are resolved from the encrypted VAULT at spawn
+  # time by mcp-loader (vault-only, #913): the lowercased key name is the vault key
+  # (GOOGLE_OAUTH_CLIENT_ID -> google_oauth_client_id). A missing secret skips this
+  # whole server. Only these declared keys are passed to the subprocess (plus a safe
+  # base set: PATH, HOME, USER, etc.). This enforces least-privilege: DB_PASSWORD,
+  # ANTHROPIC_API_KEY, etc. never reach the third-party process.
   - name: google-workspace
     transport: stdio
     command: uvx
@@ -76,9 +78,10 @@ servers:
       # from its own STORAGE_DIR by default.
       ALLOWED_FILE_DIRS: "/run/curia-tempfiles"
     # Bind the Google Workspace user email at the tool layer so agents never see
-    # or reason about it. Resolved from CURIA_GOOGLE_EMAIL env var at startup.
-    # This replaces the system prompt injection approach (#387) which was fragile
-    # because LLMs could hallucinate different email addresses.
+    # or reason about it. The "env:CURIA_GOOGLE_EMAIL" reference resolves from the
+    # vault (key curia_google_email) at startup, vault-only (#913). This replaces
+    # the system prompt injection approach (#387) which was fragile because LLMs
+    # could hallucinate different email addresses.
     fixed_inputs:
       user_google_email: "env:CURIA_GOOGLE_EMAIL"
     action_risk: low

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -48,14 +48,27 @@ OAuth 2.0 as Curia's own Gmail user.
 3. Name it (e.g. `curia-mcp-client`).
 4. Note the **Client ID** and **Client Secret** — you will need these in the next step.
 
-#### Step 4 — Set env vars
+#### Step 4 — Seed the OAuth secrets into the vault
 
-Add to `.env` (VPS and local):
+As of #913 the Google Workspace OAuth secrets live in the **encrypted vault**, not
+in `.env`. Both consumers read them from the vault at runtime: the
+`drive-download-file` skill (via `ctx.secret()`, audited) and the `google-workspace`
+MCP subprocess (resolved at spawn time by the MCP loader, vault-only).
 
-```env
-GOOGLE_OAUTH_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
-GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-...
+Seed all three on each environment (VPS and local) by setting them transiently and
+running the seeder — the vault upsert is idempotent, so re-running is safe:
+
+```bash
+GOOGLE_OAUTH_CLIENT_ID=<your-client-id>.apps.googleusercontent.com \
+GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-... \
+CURIA_GOOGLE_EMAIL=<curia-gmail> \
+  pnpm run seed-vault
 ```
+
+This writes the vault keys `google_oauth_client_id`, `google_oauth_client_secret`,
+and `curia_google_email`. Do **not** add these to `.env` — if the vault has no row
+for them, the `google-workspace` MCP server is skipped at startup and Drive download
+fails with a clear "not set in the vault" error.
 
 #### Step 5 — Run the first OAuth flow
 

--- a/docs/wip/2026-06-21-google-vault-secrets.md
+++ b/docs/wip/2026-06-21-google-vault-secrets.md
@@ -1,0 +1,86 @@
+# Migrate Google Workspace OAuth secrets into the vault (#913)
+
+Split out of #911. Move `google_oauth_client_id`, `google_oauth_client_secret`,
+`curia_google_email` out of plaintext `.env` into the encrypted vault. Google is
+separate from #911 because the secrets have **two** independent consumers, both of
+which currently read `process.env` and must read the vault before the vars can leave
+`.env`.
+
+## The two read paths
+
+1. **`drive-download-file` handler** → `getDriveClient()` (`src/google/drive-auth.ts`).
+   Today the handler calls `getDriveClient()` with no args, so `drive-auth` reads
+   `process.env` directly and **no `secret.accessed` audit event fires**. The skill
+   manifest declares the secrets in UPPERCASE (`GOOGLE_OAUTH_CLIENT_ID`), which never
+   matches a vault key (snake_case) and is effectively dead — `ctx.secret()` is never
+   called.
+
+2. **`google-workspace` MCP subprocess** (`config/skills.yaml`). The `env:` block
+   declares `GOOGLE_OAUTH_CLIENT_ID: ""` / `GOOGLE_OAUTH_CLIENT_SECRET: ""`
+   (empty-sentinel = "inherit from process.env" via `buildChildEnv`), and
+   `fixed_inputs.user_google_email: "env:CURIA_GOOGLE_EMAIL"` resolves via
+   `resolveEnvValue()` from `process.env`. Both must become vault-aware.
+
+## Design decisions (confirmed with Joseph)
+
+- **MCP spawn path = vault-only, no env fallback.** A missing Google secret skips the
+  whole `google-workspace` server (same loud-fail contract as a missing `fixed_input`
+  today). This is the new, documented meaning of the empty-string `env:` sentinel:
+  "resolve from the vault by the lowercased key name." `google-workspace` is the only
+  server in `skills.yaml` with an `env:` block, so there is no other consumer to break.
+- **Spawn-time vault reads are NOT audited in this PR.** Boot-time system spawns have no
+  `agentId`/`taskEventId`, so a per-task `secret.accessed` event doesn't fit. Read via
+  raw `secretsService.get()`. File a follow-up for a system-scoped audit event.
+- **`ctx.secret()` path (path 1) keeps its existing #911 vault-first/env-fallback
+  behavior.** That is the established model; we are not changing it.
+
+## Work items
+
+### Path 1 — audited drive handler
+- `skills/drive-download-file/skill.json`: rename `secrets` to snake_case
+  (`google_oauth_client_id`, `google_oauth_client_secret`, `curia_google_email`);
+  bump `version` 0.1.0 → 0.1.1.
+- `skills/drive-download-file/handler.ts`: read the three via `ctx.secret(...)` and pass
+  `{ clientId, clientSecret, email }` into `getDriveClient(options)`. Surface a clean
+  skill error (not a throw) if a secret is missing.
+
+### Path 2 — vault-aware MCP spawn (the reusable pattern)
+- `src/skills/mcp-client.ts`: export `buildChildEnv`; drop its `process.env`
+  empty-sentinel fallback so it only merges the minimal base + literal overrides
+  (parent-env stripping preserved). Resolution now happens upstream in the loader.
+- `src/skills/mcp-loader.ts`:
+  - Add required `secretsService` param to `loadMcpServers`.
+  - New helper to resolve a stdio `env:` block: empty value → vault key
+    `key.toLowerCase()`, `secretsService.get()`, vault-only; missing → signal skip.
+    Non-empty value → literal passthrough.
+  - New vault-aware `fixed_inputs` resolver: `"env:VAR"` → `secretsService.get(VAR
+    .toLowerCase())`, vault-only; missing → skip server. Literal → passthrough.
+  - Pass the fully-resolved `env` into `connectStdio`.
+- `src/index.ts`: pass `secretsService` into `loadMcpServers`.
+
+### Seed + cleanup
+- `scripts/seed-vault.ts`: add the three Google keys to `SEED_SECRET_NAMES`
+  (skill-scoped section).
+- `.env.example`: remove `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`,
+  `CURIA_GOOGLE_EMAIL`; update the #913 note + the skills.yaml comments that say "set in
+  .env".
+- `config/skills.yaml`: update comments to reflect vault-sourced creds.
+- `docs/dev/google-drive.md`: vault-sourced credentials.
+- `CHANGELOG.md`: Security entry under `[Unreleased]`.
+
+## Tests (TDD)
+- `mcp-client.test.ts` (new): `buildChildEnv` includes the minimal base, excludes
+  unrelated parent env (e.g. `DB_PASSWORD`), and applies literal overrides only.
+- `mcp-loader.test.ts`: env-block resolves empty key from vault; missing vault secret
+  skips server; `fixed_inputs` `env:` ref resolves from vault, vault-only; literal
+  fixed_inputs passthrough unchanged.
+- `handler.test.ts`: `ctx.secret()` called for all three; `getDriveClient` receives the
+  resolved `{ clientId, clientSecret, email }`; missing secret → clean skill error.
+
+## Acceptance criteria (from #913)
+- [ ] `drive-download-file` reads secrets via `ctx.secret()` (audited), not `process.env`
+- [ ] MCP subprocess receives OAuth creds from the vault at spawn time, not inherited env
+- [ ] Parent-env stripping in `buildChildEnv()` still holds — only declared keys injected
+- [ ] Three Google secrets seeded in the vault and removed from `.env` / `.env.example`
+- [ ] `docs/dev/google-drive.md` updated
+- [ ] Full test suite green

--- a/scripts/seed-vault.ts
+++ b/scripts/seed-vault.ts
@@ -34,6 +34,12 @@ export const SEED_SECRET_NAMES = [
   'ceo_nylas_grant_id',
   'ceo_self_email',
   'tavily_api_key',
+  // Google Workspace OAuth (#913). Two consumers: the drive-download-file skill
+  // (via ctx.secret) and the google-workspace MCP subprocess (resolved at spawn
+  // time in mcp-loader). Seeded here so both read from the vault, not .env.
+  'google_oauth_client_id',
+  'google_oauth_client_secret',
+  'curia_google_email',
 ] as const;
 
 // The subset of secrets that MUST exist in the vault for a working install. Their

--- a/skills/drive-download-file/handler.test.ts
+++ b/skills/drive-download-file/handler.test.ts
@@ -31,10 +31,22 @@ function makeReadable(content: Buffer): Readable {
   return Readable.from([content]);
 }
 
+// Default vault values returned by the mocked ctx.secret(). Mirrors the three
+// snake_case secret keys the handler resolves before calling getDriveClient().
+const SECRET_VALUES: Record<string, string> = {
+  google_oauth_client_id: 'test-client-id.apps.googleusercontent.com',
+  google_oauth_client_secret: 'GOCSPX-test-secret',
+  curia_google_email: 'curia@test.com',
+};
+
 function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
   return {
     input: { file_id_or_url: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms' },
-    secret: () => { throw new Error('no secret in test'); },
+    secret: vi.fn((name: string): string => {
+      const value = SECRET_VALUES[name];
+      if (value === undefined) throw new Error(`Secret '${name}' is declared but not set in the environment`);
+      return value;
+    }),
     log: createSilentLogger(),
     writeTempFile: vi.fn().mockResolvedValue('file:///run/curia-tempfiles/abc123.pdf'),
     taskMetadata: {},
@@ -117,6 +129,49 @@ describe('DriveDownloadFileHandler — URL extraction', () => {
     const handler = new DriveDownloadFileHandler();
     await handler.execute(makeCtx({ input: { file_id_or_url: 'RAW_FILE_ID' } }));
     expect(mockFilesGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ fileId: 'RAW_FILE_ID' }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Vault-sourced credentials (#913)
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — vault credentials', () => {
+  it('resolves all three OAuth secrets via ctx.secret() and passes them to getDriveClient', async () => {
+    setupMetadata({ name: 'doc.pdf', mimeType: 'application/pdf', size: '9' });
+    setupDownloadStream(Buffer.from('PDF bytes'));
+    const ctx = makeCtx();
+    const handler = new DriveDownloadFileHandler();
+    await handler.execute(ctx);
+
+    // ctx.secret() is the audited read path — assert all three keys go through it.
+    expect(ctx.secret).toHaveBeenCalledWith('google_oauth_client_id');
+    expect(ctx.secret).toHaveBeenCalledWith('google_oauth_client_secret');
+    expect(ctx.secret).toHaveBeenCalledWith('curia_google_email');
+
+    const { getDriveClient } = await import('../../src/google/drive-auth.js');
+    expect(getDriveClient).toHaveBeenCalledWith({
+      clientId: 'test-client-id.apps.googleusercontent.com',
+      clientSecret: 'GOCSPX-test-secret',
+      email: 'curia@test.com',
+    });
+  });
+
+  it('returns a clean skill error (not a throw) when a secret is missing from the vault', async () => {
+    const handler = new DriveDownloadFileHandler();
+    // ctx.secret() throws for an unset declared secret — handler must catch and
+    // surface it as { success: false }, never let it propagate.
+    const ctx = makeCtx({
+      secret: vi.fn((name: string): string => {
+        if (name === 'curia_google_email') {
+          throw new Error(`Secret '${name}' is declared but not set in the environment`);
+        }
+        return SECRET_VALUES[name]!;
+      }),
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('curia_google_email');
   });
 });
 

--- a/skills/drive-download-file/handler.ts
+++ b/skills/drive-download-file/handler.ts
@@ -102,10 +102,20 @@ export class DriveDownloadFileHandler implements SkillHandler {
     const filenameHint =
       typeof rawFilename === 'string' && rawFilename.trim() ? rawFilename.trim() : undefined;
 
-    // Auth
+    // Auth — resolve the three OAuth secrets through ctx.secret() so the read is
+    // audited (secret.accessed) and prefers the encrypted vault (#913). ctx.secret()
+    // is vault-first with a process.env fallback only while a secret has not yet
+    // been seeded (the #911 migration model) — once the vars are out of .env the
+    // vault is the sole source. getDriveClient still accepts options, so the values
+    // flow in explicitly instead of being re-read from the env there. ctx.secret()
+    // throws if a declared secret is unset everywhere; catch it and surface a clean
+    // skill error rather than letting it propagate (skills never throw).
     let auth: Awaited<ReturnType<typeof getDriveClient>>;
     try {
-      auth = await getDriveClient();
+      const clientId = ctx.secret('google_oauth_client_id');
+      const clientSecret = ctx.secret('google_oauth_client_secret');
+      const email = ctx.secret('curia_google_email');
+      auth = await getDriveClient({ clientId, clientSecret, email });
     } catch (err) {
       ctx.log.error({ err }, 'drive-download-file: getDriveClient failed');
       return { success: false, error: err instanceof Error ? err.message : String(err) };

--- a/skills/drive-download-file/skill.json
+++ b/skills/drive-download-file/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "drive-download-file",
   "description": "Download a file from Google Drive to temporary storage and return a file:// URL for use with email-send or email-reply attachments. Accepts a Drive file ID or any drive.google.com / docs.google.com URL. Google Docs/Sheets/Slides are exported to PDF by default; pass export_mime_type to override. Pass the returned temp_file_url in the attachments array of email-send or email-reply.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -17,9 +17,9 @@
   },
   "permissions": [],
   "secrets": [
-    "GOOGLE_OAUTH_CLIENT_ID",
-    "GOOGLE_OAUTH_CLIENT_SECRET",
-    "CURIA_GOOGLE_EMAIL"
+    "google_oauth_client_id",
+    "google_oauth_client_secret",
+    "curia_google_email"
   ],
   "timeout": 60000,
   "capabilities": ["tempFileStore"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -892,7 +892,7 @@ async function main(): Promise<void> {
   // until the next restart.
   let mcpSessions: McpSession[] = [];
   try {
-    mcpSessions = await loadMcpServers(configDir, skillRegistry, logger);
+    mcpSessions = await loadMcpServers(configDir, skillRegistry, logger, secretsService);
   } catch (err) {
     // Malformed skills.yaml or unexpected loader error — degrade gracefully rather
     // than crashing. The startup validator catches schema violations, but a YAML

--- a/src/skills/mcp-client.test.ts
+++ b/src/skills/mcp-client.test.ts
@@ -1,0 +1,56 @@
+// mcp-client.test.ts — unit tests for buildChildEnv, the least-privilege env
+// builder for stdio MCP subprocesses. Secret resolution happens upstream in
+// mcp-loader (vault-only, #913); these tests pin the post-resolution contract:
+// minimal safe base + literal overrides only, with no process.env leakage.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildChildEnv } from './mcp-client.js';
+
+describe('buildChildEnv', () => {
+  const saved = { ...process.env };
+
+  beforeEach(() => {
+    // Deterministic base + a sensitive var that must never reach the child.
+    process.env.PATH = '/usr/bin';
+    process.env.HOME = '/home/curia';
+    process.env.DB_PASSWORD = 'super-secret-db-pw';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-should-not-leak';
+  });
+
+  afterEach(() => {
+    // Restore the original environment so tests stay isolated.
+    for (const key of Object.keys(process.env)) {
+      if (!(key in saved)) delete process.env[key];
+    }
+    Object.assign(process.env, saved);
+  });
+
+  it('includes only the minimal safe base from process.env', () => {
+    const env = buildChildEnv({});
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.HOME).toBe('/home/curia');
+  });
+
+  it('never leaks unrelated parent-env secrets (parent-env stripping holds)', () => {
+    const env = buildChildEnv({});
+    expect(env.DB_PASSWORD).toBeUndefined();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  it('applies non-empty declared keys as literal overrides', () => {
+    const env = buildChildEnv({
+      GOOGLE_OAUTH_CLIENT_ID: 'resolved-from-vault',
+      ALLOWED_FILE_DIRS: '/run/curia-tempfiles',
+    });
+    expect(env.GOOGLE_OAUTH_CLIENT_ID).toBe('resolved-from-vault');
+    expect(env.ALLOWED_FILE_DIRS).toBe('/run/curia-tempfiles');
+  });
+
+  it('drops empty (unresolved) keys instead of inheriting them from process.env', () => {
+    // An empty value used to mean "inherit from process.env"; post-#913 it means
+    // "unresolved" and must be dropped so a secret cannot leak from the parent env.
+    process.env.GOOGLE_OAUTH_CLIENT_ID = 'leaked-from-env';
+    const env = buildChildEnv({ GOOGLE_OAUTH_CLIENT_ID: '' });
+    expect(env.GOOGLE_OAUTH_CLIENT_ID).toBeUndefined();
+  });
+});

--- a/src/skills/mcp-client.ts
+++ b/src/skills/mcp-client.ts
@@ -20,7 +20,12 @@ export interface McpStdioServerConfig {
   transport: 'stdio';
   command: string;
   args?: string[];
-  /** Extra env vars merged on top of the inherited environment. */
+  /**
+   * Extra env vars to inject into the child. Values must already be resolved to
+   * literals by the caller (mcp-loader resolves secret references from the vault
+   * upstream, #913) — buildChildEnv applies non-empty values verbatim and drops
+   * empties rather than inheriting them from process.env.
+   */
   env?: Record<string, string>;
 }
 
@@ -57,25 +62,32 @@ export interface McpSession {
  *
  * Starts from the same safe base that the MCP SDK's getDefaultEnvironment()
  * uses (HOME, LOGNAME, PATH, SHELL, TERM, USER) so spawned tools can locate
- * binaries and their own config dirs. Then resolves each key declared in
- * configEnv: an empty string means "inherit the value from process.env at
- * runtime"; a non-empty string is used as a literal override.
+ * binaries and their own config dirs. Then applies each key declared in
+ * configEnv as a literal override.
+ *
+ * The caller (mcp-loader) is responsible for resolving any secret references
+ * before they reach here: the empty-string sentinel in config/skills.yaml is
+ * resolved from the encrypted vault, vault-only, upstream (#913). By the time a
+ * value reaches buildChildEnv it is already a literal. An empty value therefore
+ * means "unresolved" and is skipped — never filled from process.env — so a
+ * secret can never silently leak in from the parent environment.
  *
  * This enforces least-privilege — the full host environment (DB_PASSWORD,
  * ANTHROPIC_API_KEY, etc.) is never passed to the third-party subprocess.
  * Only keys explicitly declared in config/skills.yaml under env: reach it.
  */
-function buildChildEnv(configEnv: Record<string, string>): Record<string, string> {
+export function buildChildEnv(configEnv: Record<string, string>): Record<string, string> {
   // Minimal base matching the MCP SDK's getDefaultEnvironment() key set.
   const env: Record<string, string> = {};
   for (const key of ['HOME', 'LOGNAME', 'PATH', 'SHELL', 'TERM', 'USER']) {
     if (process.env[key] !== undefined) env[key] = process.env[key]!;
   }
 
-  // Resolve declared keys: empty value = inherit from process.env.
+  // Apply non-empty literal overrides only. Secret resolution happens upstream
+  // (vault-only); an empty value here is an unresolved key and is dropped rather
+  // than inherited from process.env.
   for (const [key, value] of Object.entries(configEnv)) {
-    const resolved = value !== '' ? value : process.env[key];
-    if (resolved !== undefined) env[key] = resolved;
+    if (value !== '') env[key] = value;
   }
 
   return env;

--- a/src/skills/mcp-loader.test.ts
+++ b/src/skills/mcp-loader.test.ts
@@ -6,8 +6,23 @@
 // argument merging.
 
 import { describe, it, expect } from 'vitest';
-import { stripFixedInputsFromSchema, mergeFixedInputs } from './mcp-loader.js';
+import {
+  stripFixedInputsFromSchema,
+  mergeFixedInputs,
+  resolveStdioEnvFromVault,
+  resolveFixedInputFromVault,
+} from './mcp-loader.js';
 import { resolveEnvValue } from '../config.js';
+import type { SecretsService } from '../secrets/secrets-service.js';
+
+// Minimal SecretsService stub: only get() is exercised by the resolvers under
+// test. Backed by a plain map of vault key -> value; unknown keys return null
+// (the vault-absent signal).
+function fakeSecrets(values: Record<string, string | null>): SecretsService {
+  return {
+    get: async (name: string): Promise<string | null> => values[name] ?? null,
+  } as unknown as SecretsService;
+}
 
 // ---------------------------------------------------------------------------
 // stripFixedInputsFromSchema
@@ -128,10 +143,13 @@ describe('mergeFixedInputs', () => {
 });
 
 // ---------------------------------------------------------------------------
-// resolveEnvValue integration (imported from config.ts)
+// resolveEnvValue — generic config helper (imported from config.ts). NOTE: as of
+// #913 fixed_inputs no longer routes through this; secrets resolve from the vault
+// (see resolveFixedInputFromVault below). These tests still pin the config helper,
+// which remains in use for channel-account env resolution in config.ts.
 // ---------------------------------------------------------------------------
 
-describe('resolveEnvValue (fixed_inputs context)', () => {
+describe('resolveEnvValue (config helper, process.env)', () => {
   it('resolves env:VAR_NAME from process.env', () => {
     const original = process.env.TEST_FIXED_INPUT_EMAIL;
     try {
@@ -157,5 +175,92 @@ describe('resolveEnvValue (fixed_inputs context)', () => {
   it('passes through literal strings unchanged', () => {
     const result = resolveEnvValue('literal@example.com', 'test context');
     expect(result).toBe('literal@example.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveStdioEnvFromVault — vault-only resolution of the stdio env: block (#913)
+// ---------------------------------------------------------------------------
+
+describe('resolveStdioEnvFromVault', () => {
+  it('resolves an empty-string sentinel from the vault by the lowercased key name', async () => {
+    const secrets = fakeSecrets({
+      google_oauth_client_id: 'client-id-from-vault',
+      google_oauth_client_secret: 'client-secret-from-vault',
+    });
+    const resolved = await resolveStdioEnvFromVault(
+      { GOOGLE_OAUTH_CLIENT_ID: '', GOOGLE_OAUTH_CLIENT_SECRET: '' },
+      secrets,
+      'google-workspace',
+    );
+    expect(resolved).toEqual({
+      GOOGLE_OAUTH_CLIENT_ID: 'client-id-from-vault',
+      GOOGLE_OAUTH_CLIENT_SECRET: 'client-secret-from-vault',
+    });
+  });
+
+  it('passes non-empty literal values through unchanged (e.g. ALLOWED_FILE_DIRS)', async () => {
+    const secrets = fakeSecrets({ google_oauth_client_id: 'x' });
+    const resolved = await resolveStdioEnvFromVault(
+      { GOOGLE_OAUTH_CLIENT_ID: '', ALLOWED_FILE_DIRS: '/run/curia-tempfiles' },
+      secrets,
+      'google-workspace',
+    );
+    expect(resolved.ALLOWED_FILE_DIRS).toBe('/run/curia-tempfiles');
+  });
+
+  it('throws (vault-only, no env fallback) when the secret is absent from the vault', async () => {
+    const secrets = fakeSecrets({}); // empty vault
+    await expect(
+      resolveStdioEnvFromVault({ GOOGLE_OAUTH_CLIENT_ID: '' }, secrets, 'google-workspace'),
+    ).rejects.toThrow(/secret "google_oauth_client_id" is not set in the vault/);
+  });
+
+  it('treats a blank/whitespace-only vault value as absent and throws', async () => {
+    const secrets = fakeSecrets({ google_oauth_client_id: '   ' });
+    await expect(
+      resolveStdioEnvFromVault({ GOOGLE_OAUTH_CLIENT_ID: '' }, secrets, 'google-workspace'),
+    ).rejects.toThrow(/is not set in the vault/);
+  });
+
+  it('does not fall back to process.env for an empty sentinel', async () => {
+    process.env.GOOGLE_OAUTH_CLIENT_ID = 'leaked-from-process-env';
+    try {
+      const secrets = fakeSecrets({}); // empty vault
+      await expect(
+        resolveStdioEnvFromVault({ GOOGLE_OAUTH_CLIENT_ID: '' }, secrets, 'google-workspace'),
+      ).rejects.toThrow(/is not set in the vault/);
+    } finally {
+      delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFixedInputFromVault — vault-only resolution of "env:VAR" fixed_inputs (#913)
+// ---------------------------------------------------------------------------
+
+describe('resolveFixedInputFromVault', () => {
+  it('resolves "env:VAR" from the vault by VAR lowercased', async () => {
+    const secrets = fakeSecrets({ curia_google_email: 'curia@example.com' });
+    const result = await resolveFixedInputFromVault('env:CURIA_GOOGLE_EMAIL', secrets, 'ctx');
+    expect(result).toBe('curia@example.com');
+  });
+
+  it('passes literal strings through unchanged', async () => {
+    const secrets = fakeSecrets({});
+    const result = await resolveFixedInputFromVault('literal@example.com', secrets, 'ctx');
+    expect(result).toBe('literal@example.com');
+  });
+
+  it('throws when the referenced secret is absent from the vault', async () => {
+    const secrets = fakeSecrets({});
+    await expect(
+      resolveFixedInputFromVault(
+        'env:CURIA_GOOGLE_EMAIL',
+        secrets,
+        "MCP server 'google-workspace' fixed_inputs.user_google_email",
+      ),
+    ).rejects.toThrow(/secret "curia_google_email" is not set in the vault/);
   });
 });

--- a/src/skills/mcp-loader.ts
+++ b/src/skills/mcp-loader.ts
@@ -16,7 +16,7 @@ import { connectStdio, connectSse } from './mcp-client.js';
 import type { McpSession } from './mcp-client.js';
 import type { Logger } from '../logger.js';
 import type { ActionRisk } from './types.js';
-import { resolveEnvValue } from '../config.js';
+import type { SecretsService } from '../secrets/secrets-service.js';
 
 // ---------------------------------------------------------------------------
 // Config types — mirrors schemas/skills-config.json
@@ -177,6 +177,80 @@ export function mergeFixedInputs(
 }
 
 // ---------------------------------------------------------------------------
+// Vault-backed secret resolution for MCP servers (#913) — exported for testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a single secret from the vault, vault-only — no process.env fallback.
+ * Trims the value and treats a blank/whitespace-only result as absent. Throws a
+ * descriptive error when the secret is missing so the caller can skip the whole
+ * server (the same loud-fail contract as a missing fixed_input) rather than
+ * spawn a third-party subprocess with a half-populated credential set.
+ */
+async function getRequiredVaultSecret(
+  vaultKey: string,
+  secrets: SecretsService,
+  context: string,
+): Promise<string> {
+  const value = (await secrets.get(vaultKey))?.trim();
+  if (!value) {
+    throw new Error(`${context}: secret "${vaultKey}" is not set in the vault`);
+  }
+  return value;
+}
+
+/**
+ * Resolve a stdio server's `env:` block from the vault. The empty-string
+ * sentinel (`KEY: ""` in config/skills.yaml) means "resolve KEY from the vault
+ * by its lowercased name" — vault-only, never process.env (#913). Non-empty
+ * values are literal passthroughs (e.g. ALLOWED_FILE_DIRS). Returns a fully
+ * resolved map of literals ready for buildChildEnv; throws if any referenced
+ * secret is missing so the caller skips the server.
+ *
+ * By design there is no way to express a literal empty-string env value: an
+ * empty value is always a vault-resolution request. No MCP server needs an empty
+ * literal today; if one ever does, give it a sentinel non-empty value instead.
+ */
+export async function resolveStdioEnvFromVault(
+  configEnv: Record<string, string>,
+  secrets: SecretsService,
+  serverName: string,
+): Promise<Record<string, string>> {
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(configEnv)) {
+    if (value !== '') {
+      resolved[key] = value;
+      continue;
+    }
+    resolved[key] = await getRequiredVaultSecret(
+      key.toLowerCase(),
+      secrets,
+      `MCP server '${serverName}' env.${key}`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Resolve a single fixed_inputs value from the vault. An "env:VAR" reference is
+ * resolved vault-only by VAR's lowercased name (#913); a literal string passes
+ * through unchanged. Throws if a referenced secret is missing. This is the
+ * vault-backed replacement for the process.env-based resolveEnvValue() that
+ * fixed_inputs used before the migration.
+ */
+export async function resolveFixedInputFromVault(
+  value: string,
+  secrets: SecretsService,
+  context: string,
+): Promise<string> {
+  if (value.startsWith('env:')) {
+    const varName = value.slice(4);
+    return getRequiredVaultSecret(varName.toLowerCase(), secrets, context);
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
@@ -187,12 +261,17 @@ export function mergeFixedInputs(
  * @param configDir - Absolute path to the config/ directory (same as used by loadYamlConfig).
  * @param registry  - The SkillRegistry to register discovered tools into.
  * @param logger    - Pino logger for structured log output.
+ * @param secrets   - Vault accessor. A server's `env:` empty-string sentinels and
+ *                    `fixed_inputs` "env:VAR" references are resolved from the vault
+ *                    at spawn time (vault-only, #913). A missing secret skips that
+ *                    server, the same as a connection failure.
  * @returns Array of live McpSession objects. Pass to the shutdown handler to close them.
  */
 export async function loadMcpServers(
   configDir: string,
   registry: SkillRegistry,
   logger: Logger,
+  secrets: SecretsService,
 ): Promise<McpSession[]> {
   const config = loadSkillsConfig(configDir);
   const servers = config.servers ?? [];
@@ -224,18 +303,20 @@ export async function loadMcpServers(
 
     // Resolve fixed_inputs once at startup. These values are captured in closures
     // and merged into every callTool invocation for this server's tools.
-    // Env-var references (e.g. "env:CURIA_GOOGLE_EMAIL") are resolved here —
-    // a missing env var skips this server entirely (same as a connection failure).
-    // This keeps google-workspace optional: deployments without CURIA_GOOGLE_EMAIL
-    // simply don't get Workspace tools, rather than crashing the process.
+    // "env:VAR" references (e.g. "env:CURIA_GOOGLE_EMAIL") are resolved from the
+    // vault here, vault-only (#913) — a missing secret skips this server entirely
+    // (same as a connection failure). This keeps google-workspace optional:
+    // deployments without the secret simply don't get Workspace tools, rather than
+    // crashing the process.
     const rawFixedInputs = 'fixed_inputs' in serverEntry ? serverEntry.fixed_inputs : undefined;
     const resolvedFixedInputs: Record<string, string> = {};
     if (rawFixedInputs) {
       let resolutionFailed = false;
       for (const [key, value] of Object.entries(rawFixedInputs)) {
         try {
-          resolvedFixedInputs[key] = resolveEnvValue(
+          resolvedFixedInputs[key] = await resolveFixedInputFromVault(
             value,
+            secrets,
             `MCP server '${serverEntry.name}' fixed_inputs.${key}`,
           );
         } catch (err) {
@@ -254,11 +335,34 @@ export async function loadMcpServers(
       );
     }
 
+    // Resolve a stdio server's env block from the vault before spawning (#913).
+    // The empty-string sentinel resolves vault-only by the lowercased key name; a
+    // missing secret skips the whole server, the same loud-fail contract as a
+    // missing fixed_input. connectEntry carries the resolved literals into
+    // connectStdio so buildChildEnv never has to touch process.env for secrets.
+    let connectEntry: McpServerEntry = serverEntry;
+    if (serverEntry.transport === 'stdio' && serverEntry.env) {
+      try {
+        const resolvedEnv = await resolveStdioEnvFromVault(
+          serverEntry.env,
+          secrets,
+          serverEntry.name,
+        );
+        connectEntry = { ...serverEntry, env: resolvedEnv };
+      } catch (err) {
+        logger.error(
+          { err, server: serverEntry.name },
+          'env secret resolution from vault failed — skipping this MCP server',
+        );
+        continue;
+      }
+    }
+
     let session: McpSession;
     try {
-      session = serverEntry.transport === 'stdio'
-        ? await connectStdio(serverEntry, logger)
-        : await connectSse(serverEntry, logger);
+      session = connectEntry.transport === 'stdio'
+        ? await connectStdio(connectEntry, logger)
+        : await connectSse(connectEntry, logger);
     } catch (err) {
       // Connection failure is non-recoverable without a restart — tools from this
       // server will be unavailable for the lifetime of this process. Log at error

--- a/tests/unit/skills/mcp-loader.test.ts
+++ b/tests/unit/skills/mcp-loader.test.ts
@@ -48,6 +48,14 @@ const { loadMcpServers } = await import('../../../src/skills/mcp-loader.js');
 
 const logger = createSilentLogger();
 
+// Vault double. These tests don't exercise vault resolution — none of their
+// fixtures use an env: sentinel or an "env:" fixed_input — so an empty vault
+// (get() always null) is sufficient. The 4th loadMcpServers arg is required
+// as of #913; vault-resolution behavior is unit-tested in src/skills/mcp-loader.test.ts.
+const secrets = {
+  get: async (): Promise<string | null> => null,
+} as unknown as import('../../../src/secrets/secrets-service.js').SecretsService;
+
 /** Write a skills.yaml file into a temp directory and return that directory. */
 function writeSkillsYaml(content: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-mcp-test-'));
@@ -67,7 +75,7 @@ function emptyConfigDir(): string {
 describe('loadMcpServers — absent / empty config', () => {
   it('returns empty array when skills.yaml is absent', async () => {
     const registry = new SkillRegistry();
-    const sessions = await loadMcpServers(emptyConfigDir(), registry, logger);
+    const sessions = await loadMcpServers(emptyConfigDir(), registry, logger, secrets);
     expect(sessions).toHaveLength(0);
     expect(registry.list()).toHaveLength(0);
   });
@@ -75,14 +83,14 @@ describe('loadMcpServers — absent / empty config', () => {
   it('returns empty array when skills.yaml is empty', async () => {
     const dir = writeSkillsYaml('');
     const registry = new SkillRegistry();
-    const sessions = await loadMcpServers(dir, registry, logger);
+    const sessions = await loadMcpServers(dir, registry, logger, secrets);
     expect(sessions).toHaveLength(0);
   });
 
   it('returns empty array when servers list is empty', async () => {
     const dir = writeSkillsYaml('servers: []');
     const registry = new SkillRegistry();
-    const sessions = await loadMcpServers(dir, registry, logger);
+    const sessions = await loadMcpServers(dir, registry, logger, secrets);
     expect(sessions).toHaveLength(0);
   });
 });
@@ -113,7 +121,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    const sessions = await loadMcpServers(dir, registry, logger);
+    const sessions = await loadMcpServers(dir, registry, logger, secrets);
 
     // Only the working server's session is returned.
     expect(sessions).toHaveLength(1);
@@ -135,7 +143,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    const sessions = await loadMcpServers(dir, registry, logger);
+    const sessions = await loadMcpServers(dir, registry, logger, secrets);
 
     expect(sessions).toHaveLength(0);
     // Session must be closed when tools/list fails.
@@ -150,7 +158,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    const sessions = await loadMcpServers(dir, registry, logger);
+    const sessions = await loadMcpServers(dir, registry, logger, secrets);
     expect(sessions).toHaveLength(0);
     expect(mockConnectStdio).not.toHaveBeenCalled();
   });
@@ -163,7 +171,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    const sessions = await loadMcpServers(dir, registry, logger);
+    const sessions = await loadMcpServers(dir, registry, logger, secrets);
     expect(sessions).toHaveLength(0);
     expect(mockConnectSse).not.toHaveBeenCalled();
   });
@@ -212,7 +220,7 @@ servers:
     timeout_ms: 15000
 `);
     const registry = new SkillRegistry();
-    const sessions = await loadMcpServers(dir, registry, logger);
+    const sessions = await loadMcpServers(dir, registry, logger, secrets);
 
     expect(sessions).toHaveLength(1);
 
@@ -251,7 +259,7 @@ servers:
     sensitivity: elevated
 `);
     const registry = new SkillRegistry();
-    await loadMcpServers(dir, registry, logger);
+    await loadMcpServers(dir, registry, logger, secrets);
 
     expect(registry.get('tool-x')!.manifest.action_risk).toBe('high');
     expect(registry.get('tool-x')!.manifest.sensitivity).toBe('elevated');
@@ -273,7 +281,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    await loadMcpServers(dir, registry, logger);
+    await loadMcpServers(dir, registry, logger, secrets);
 
     expect(registry.get('tool-z')!.manifest.sensitivity).toBe('normal');
   });
@@ -292,7 +300,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    await loadMcpServers(dir, registry, logger);
+    await loadMcpServers(dir, registry, logger, secrets);
 
     expect(registry.get('tool-t')!.manifest.timeout).toBe(30000);
   });
@@ -311,7 +319,7 @@ servers:
     action_risk: medium
 `);
     const registry = new SkillRegistry();
-    await loadMcpServers(dir, registry, logger);
+    await loadMcpServers(dir, registry, logger, secrets);
 
     expect(mockConnectSse).toHaveBeenCalledOnce();
     expect(mockConnectStdio).not.toHaveBeenCalled();
@@ -337,7 +345,7 @@ servers:
 `);
     const registry = new SkillRegistry();
     // Should not throw — duplicate registration is a warning, not a crash.
-    await expect(loadMcpServers(dir, registry, logger)).resolves.not.toThrow();
+    await expect(loadMcpServers(dir, registry, logger, secrets)).resolves.not.toThrow();
     // The first registration wins.
     expect(registry.get('duplicate_tool')).toBeDefined();
   });
@@ -367,7 +375,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    await loadMcpServers(dir, registry, logger);
+    await loadMcpServers(dir, registry, logger, secrets);
 
     const skill = registry.get('read_file')!;
     const result = await skill.handler.execute({
@@ -401,7 +409,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    await loadMcpServers(dir, registry, logger);
+    await loadMcpServers(dir, registry, logger, secrets);
 
     const result = await registry.get('bad_tool')!.handler.execute({
       input: {},
@@ -427,7 +435,7 @@ servers:
     action_risk: none
 `);
     const registry = new SkillRegistry();
-    await loadMcpServers(dir, registry, logger);
+    await loadMcpServers(dir, registry, logger, secrets);
 
     const result = await registry.get('erroring_tool')!.handler.execute({
       input: {},


### PR DESCRIPTION
## Summary

Closes #913. Migrates the three Google Workspace OAuth secrets (`google_oauth_client_id`, `google_oauth_client_secret`, `curia_google_email`) out of plaintext `.env` into the encrypted vault (#542/#911). Google was split from #911 because the secrets have **two independent consumers**, both of which read `process.env` today and had to become vault-aware before the vars could leave `.env`.

### Path 1 — `drive-download-file` (now audited)
The handler called `getDriveClient()` with no args, so `drive-auth` read `process.env` directly and **no `secret.accessed` audit event fired**; the manifest's UPPERCASE secret names never matched a vault key. The handler now resolves the three secrets via `ctx.secret()` (audited, vault-first per the #911 model) and passes them into `getDriveClient(options)`. Manifest secrets renamed to snake_case; version `0.1.0 → 0.1.1`.

### Path 2 — `google-workspace` MCP subprocess (now vault-only)
The `env:` block declared empty-string sentinels resolved from `process.env` by `buildChildEnv`, and `fixed_inputs` used an `env:` reference resolved from `process.env`. Both now resolve from the **vault at spawn time, vault-only with no env fallback** — a missing secret skips the whole server (the same loud-fail contract as a missing `fixed_input`). `buildChildEnv` was tightened to drop empty values instead of inheriting from `process.env`, so a secret can never leak from the parent env; least-privilege parent-env stripping is unchanged. `secretsService` is plumbed into `loadMcpServers`.

This establishes the reusable pattern for vault-backed MCP-server secrets: declare `KEY: ""` in `env:` (or `param: "env:VAR"` in `fixed_inputs`) and seed the lowercased name in the vault.

### Seed + cleanup
- `seed-vault`: the three keys added to `SEED_SECRET_NAMES` (skill-scoped, **not** required — Google stays optional).
- `.env.example` / `config/skills.yaml`: vars removed; vault-seeding documented.
- `docs/dev/google-drive.md`: Step 4 now seeds the vault.

## Design decisions (confirmed with the requester)
- **MCP spawn path: vault-only, no env fallback.** A missing secret skips the server.
- **`ctx.secret()` path keeps its #911 vault-first/env-fallback** behavior (unchanged). Once `.env` is cleared the fallback is moot, so the end state is vault-sourced for both consumers. The CHANGELOG/comments do not claim the skill path is no-fallback.
- **Spawn-time vault reads are not audited in this PR** (boot-time system spawn has no `agentId`/`taskEventId`). Follow-up: #1096 (system-scoped audit event for boot-time vault reads).

## Testing
- New `src/skills/mcp-client.test.ts`: `buildChildEnv` includes the minimal base, excludes unrelated parent-env secrets (`DB_PASSWORD`, `ANTHROPIC_API_KEY`), and drops empty keys (no `process.env` leak).
- `src/skills/mcp-loader.test.ts`: env-block + `fixed_inputs` resolve from the vault; vault-only (no `process.env` fallback); blank/missing → throws.
- `skills/drive-download-file/handler.test.ts`: all three `ctx.secret()` calls + pass-through to `getDriveClient`; missing secret → clean skill error.
- Full suite: 3861 passed / 169 skipped (integration), typecheck + lint clean.

## Acceptance criteria
- [x] `drive-download-file` reads secrets via `ctx.secret()` (audited), not `process.env`
- [x] MCP subprocess receives OAuth creds from the vault at spawn time, not inherited env
- [x] Parent-env stripping in `buildChildEnv()` still holds — only declared keys injected
- [x] Three Google secrets seeded in the vault and removed from `.env.example`
- [x] `docs/dev/google-drive.md` updated
- [x] Full test suite green

## Deploy note
Before this lands in prod, seed the three secrets into the vault on each environment (`GOOGLE_OAUTH_CLIENT_ID=... GOOGLE_OAUTH_CLIENT_SECRET=... CURIA_GOOGLE_EMAIL=... pnpm run seed-vault`) and remove them from the live `.env`. If the vault has no rows, the `google-workspace` server is skipped and Drive download fails with a clear "not set in the vault" error.