### PR TITLE
feat: suggest assistant first name via LLM in onboarding wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Wizard name suggestion** — the onboarding wizard prefills the assistant-name field with an LLM-suggested first name via `POST /api/setup/suggest-name`, doubling as an early smoke test of the Anthropic key; falls back silently to the static placeholder on any failure. (#799)
+- **Wizard name suggestion** — the onboarding wizard prefills the assistant name and email signature from an LLM-suggested first name via `POST /api/setup/suggest-name`, doubling as an early smoke test of the Anthropic key; silent static fallback on any failure. (#799)
 - **Specialist secret-capture resume** — a delegated specialist (or the setup-wizard) that mints a secret-capture link is now resumed on redeem: migration 061 adds `resume_token` to `secret_capture_tokens`, re-entry routes through the coordinator, which re-delegates to the specialist via the `delegate` resume_token. Preserves the no-value and originator invariants. (#995)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Default assistant signature** — the seeded `DEFAULT_OFFICE_IDENTITY` email signature is now `--\n<name> Curia\nDigital EA`, pre-populated (not just placeheld) in the onboarding wizard. (#799)
 - **Principal identity is contacts-only** — `findContactBySystemRole('principal')` is now the single startup source of truth; the `PiiRedactor` bypass, CEO notifiers, outbound filter, and email adapter all read the principal contact (resolved once at boot) instead of `config.ceoPrimaryEmail`. Fixes principal-bound messages being wrongly redacted in fresh-setup mode. (#1049)
 - **`SecretCapturedPayload`** — gained an optional `resumeToken` field (public bus event surface). (#995)
 - **Coordinator Drive moves** — pinned `update_drive_file` to the coordinator and documented reparenting (`add_parents`/`remove_parents`), so "move this doc into a folder" requests are performed instead of declined. (#1062)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Wizard name suggestion** — the onboarding wizard prefills the assistant-name field with an LLM-suggested first name via `POST /api/setup/suggest-name`, doubling as an early smoke test of the Anthropic key; falls back silently to the static placeholder on any failure. (#799)
 - **Specialist secret-capture resume** — a delegated specialist (or the setup-wizard) that mints a secret-capture link is now resumed on redeem: migration 061 adds `resume_token` to `secret_capture_tokens`, re-entry routes through the coordinator, which re-delegates to the specialist via the `delegate` resume_token. Preserves the no-value and originator invariants. (#995)
 
 ### Fixed

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -101,6 +101,13 @@ export default function WizardPage() {
   // per wizard mount, surviving the re-renders that step navigation triggers.
   const [suggestedName, setSuggestedName] = useState<string | null>(null);
   const suggestFiredRef = useRef(false);
+  // Whether the operator has saved an identity through the wizard/API (vs. the
+  // in-code seed that every fresh install boots with). null until the mount
+  // fetch resolves. This — NOT the presence of an assistant name — is the
+  // "fresh install" signal: the seed always carries a non-empty name, so a name
+  // check would wrongly suppress the suggestion on exactly the first-run case
+  // it exists for.
+  const [identityConfigured, setIdentityConfigured] = useState<boolean | null>(null);
 
   // Pre-populate form from current identity and check setup status on mount.
   // Run both fetches in parallel; setup status drives the Step 1 auto-skip
@@ -121,6 +128,9 @@ export default function WizardPage() {
         const id = data.identity;
         setExistingIdentity(id);
         setPrincipalExists(status.principalExists);
+        // `configured` is false until the operator saves through the wizard/API;
+        // it gates the one-shot name suggestion below.
+        setIdentityConfigured(data.configured);
         setState({
           principalName: DEFAULT_WIZARD_STATE.principalName,
           name: id.assistant.name || DEFAULT_WIZARD_STATE.name,
@@ -145,46 +155,57 @@ export default function WizardPage() {
     void load();
   }, []);
 
-  // One-shot LLM name suggestion (issue #799). Fires once the identity prefill
-  // has resolved, and only on a fresh install — when the loaded identity has no
-  // assistant name yet (a wizard re-run pre-fills the saved name, so there's
-  // nothing to suggest and we don't waste an LLM call). On success we prefill
-  // the assistant-name field with the suggestion, but only if the user hasn't
-  // already edited it (the functional setState compares against the static
-  // default). Every failure path is silent: the static placeholders stand and
-  // no error is surfaced here — channel/key validation has its own surface later.
+  // One-shot LLM name suggestion (issue #799). Fires once the mount fetch has
+  // resolved, and only on a fresh install — i.e. when the identity has NOT been
+  // configured yet. Gating on `identityConfigured === false` (not on whether an
+  // assistant name exists) is deliberate: every fresh install boots with the
+  // in-code seed, whose assistant name is already "Alex Curia", so a name check
+  // would suppress the suggestion in exactly the first-run scenario it's for.
+  //
+  // On success we prefill the assistant name and email signature, but only for a
+  // field still holding the value it loaded with (we compare against the loaded
+  // identity, so an edit the user already made — or a value that drifts from the
+  // wizard's static default — is never clobbered). Every failure path is silent:
+  // the loaded defaults stand and no error is surfaced here, since channel/key
+  // validation has its own surface later in the wizard.
   useEffect(() => {
     if (suggestFiredRef.current) return;            // at most once per mount
-    if (!existingIdentity) return;                   // wait for the prefill
-    if (existingIdentity.assistant.name) return;     // re-run with a saved name — skip
+    if (!existingIdentity || identityConfigured === null) return; // wait for the fetch
+    if (identityConfigured) return;                  // already configured (re-run) — skip
     suggestFiredRef.current = true;
+
+    // Capture the just-loaded values as the "untouched" baseline. Comparing the
+    // current field against these (rather than a hardcoded default) keeps the
+    // no-clobber guard correct even if the seed/default values change.
+    const loadedName = existingIdentity.assistant.name;
+    const loadedSignature = existingIdentity.assistant.emailSignature;
 
     let cancelled = false;
     async function suggest() {
       try {
         const res = await apiFetch('/api/setup/suggest-name', { method: 'POST' });
-        if (!res.ok) return;                          // 4xx/5xx → keep static placeholder
+        if (!res.ok) return;                          // 4xx/5xx → keep loaded defaults
         const data = await res.json() as { name?: unknown };
         const name = typeof data.name === 'string' ? data.name : null;
         if (!name || cancelled) return;
         setSuggestedName(name);
-        // The LLM suggests only a first name; the assistant's full name and the
-        // signature both pair it with the "Curia" surname. Prefill each field
-        // only if it is still the untouched static default — never clobber a
-        // name or signature the user has already edited.
+        // The LLM suggests only a first name; the full name and the signature
+        // both pair it with the "Curia" surname. Prefill each field only if it
+        // still holds the value it loaded with — never clobber a user edit.
         setState(s => ({
           ...s,
-          name: s.name === DEFAULT_WIZARD_STATE.name ? assistantFullName(name) : s.name,
-          signature:
-            s.signature === DEFAULT_WIZARD_STATE.signature ? defaultSignature(name) : s.signature,
+          name: s.name === loadedName ? assistantFullName(name) : s.name,
+          signature: s.signature === loadedSignature ? defaultSignature(name) : s.signature,
         }));
-      } catch {
-        // Network error — silently keep the static placeholder, per #799.
+      } catch (err) {
+        // Best-effort feature: a network error must not disrupt onboarding.
+        // Log at debug for diagnosability and keep the loaded defaults (#799).
+        console.debug('[WizardPage] name suggestion request failed:', err);
       }
     }
     void suggest();
     return () => { cancelled = true; };
-  }, [existingIdentity]);
+  }, [existingIdentity, identityConfigured]);
 
   // Auto-skip Step 1 when the principal already exists. Runs after the mount
   // fetch sets principalExists and on any subsequent step change. The route

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type JSX, type CSSProperties } from 'react';
+import { useState, useEffect, useRef, type JSX, type CSSProperties } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { apiFetch } from '../api.js';
 import {
@@ -91,6 +91,13 @@ export default function WizardPage() {
   const [submitError, setSubmitError] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [restartState, setRestartState] = useState<RestartState>({ kind: 'idle' });
+  // LLM-suggested starter first name (issue #799). Null until a successful
+  // suggestion lands; drives the signature placeholder and the one-time prefill
+  // of the assistant-name field. Stays null on any failure so the static
+  // placeholders remain. suggestFiredRef guarantees the call fires at most once
+  // per wizard mount, surviving the re-renders that step navigation triggers.
+  const [suggestedName, setSuggestedName] = useState<string | null>(null);
+  const suggestFiredRef = useRef(false);
 
   // Pre-populate form from current identity and check setup status on mount.
   // Run both fetches in parallel; setup status drives the Step 1 auto-skip
@@ -131,6 +138,40 @@ export default function WizardPage() {
     }
     void load();
   }, []);
+
+  // One-shot LLM name suggestion (issue #799). Fires once the identity prefill
+  // has resolved, and only on a fresh install — when the loaded identity has no
+  // assistant name yet (a wizard re-run pre-fills the saved name, so there's
+  // nothing to suggest and we don't waste an LLM call). On success we prefill
+  // the assistant-name field with the suggestion, but only if the user hasn't
+  // already edited it (the functional setState compares against the static
+  // default). Every failure path is silent: the static placeholders stand and
+  // no error is surfaced here — channel/key validation has its own surface later.
+  useEffect(() => {
+    if (suggestFiredRef.current) return;            // at most once per mount
+    if (!existingIdentity) return;                   // wait for the prefill
+    if (existingIdentity.assistant.name) return;     // re-run with a saved name — skip
+    suggestFiredRef.current = true;
+
+    let cancelled = false;
+    async function suggest() {
+      try {
+        const res = await apiFetch('/api/setup/suggest-name', { method: 'POST' });
+        if (!res.ok) return;                          // 4xx/5xx → keep static placeholder
+        const data = await res.json() as { name?: unknown };
+        const name = typeof data.name === 'string' ? data.name : null;
+        if (!name || cancelled) return;
+        setSuggestedName(name);
+        // Prefill the value only if the field is still the untouched static
+        // default — never clobber a name the user has already typed.
+        setState(s => (s.name === DEFAULT_WIZARD_STATE.name ? { ...s, name } : s));
+      } catch {
+        // Network error — silently keep the static placeholder, per #799.
+      }
+    }
+    void suggest();
+    return () => { cancelled = true; };
+  }, [existingIdentity]);
 
   // Auto-skip Step 1 when the principal already exists. Runs after the mount
   // fetch sets principalExists and on any subsequent step change. The route
@@ -545,7 +586,10 @@ export default function WizardPage() {
         <textarea
           id="w-signature"
           value={state.signature}
-          placeholder="Best regards, Alex"
+          // Signature stays a placeholder hint (the field is optional, so its
+          // value is left empty); the hint name tracks the LLM suggestion when
+          // one landed, else the static "Alex" (issue #799).
+          placeholder={`Best regards, ${suggestedName ?? 'Alex'}`}
           onChange={e => setState(s => ({ ...s, signature: e.target.value }))}
         />
       </div>

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -15,6 +15,9 @@ import {
   validateNonEmptyName,
   validatePrincipalName,
   buildIdentityPayload,
+  assistantFullName,
+  defaultSignature,
+  DEFAULT_ASSISTANT_FIRST_NAME,
   type WizardState,
   type LocalIdentity,
 } from './wizard-utils.js';
@@ -122,7 +125,10 @@ export default function WizardPage() {
           principalName: DEFAULT_WIZARD_STATE.principalName,
           name: id.assistant.name || DEFAULT_WIZARD_STATE.name,
           title: id.assistant.title || DEFAULT_WIZARD_STATE.title,
-          signature: id.assistant.emailSignature || '',
+          // Pre-populate the default signature on a fresh install so the field
+          // ships with a usable value (not just a placeholder). A wizard re-run
+          // with a saved signature keeps it.
+          signature: id.assistant.emailSignature || DEFAULT_WIZARD_STATE.signature,
           toneBaseline:
             id.tone.baseline.length > 0
               ? id.tone.baseline
@@ -162,9 +168,16 @@ export default function WizardPage() {
         const name = typeof data.name === 'string' ? data.name : null;
         if (!name || cancelled) return;
         setSuggestedName(name);
-        // Prefill the value only if the field is still the untouched static
-        // default — never clobber a name the user has already typed.
-        setState(s => (s.name === DEFAULT_WIZARD_STATE.name ? { ...s, name } : s));
+        // The LLM suggests only a first name; the assistant's full name and the
+        // signature both pair it with the "Curia" surname. Prefill each field
+        // only if it is still the untouched static default — never clobber a
+        // name or signature the user has already edited.
+        setState(s => ({
+          ...s,
+          name: s.name === DEFAULT_WIZARD_STATE.name ? assistantFullName(name) : s.name,
+          signature:
+            s.signature === DEFAULT_WIZARD_STATE.signature ? defaultSignature(name) : s.signature,
+        }));
       } catch {
         // Network error — silently keep the static placeholder, per #799.
       }
@@ -563,7 +576,9 @@ export default function WizardPage() {
           id="w-name"
           type="text"
           value={state.name}
-          placeholder="Alex Curia"
+          // Name is pre-populated as a value; this placeholder is the fallback
+          // if the operator clears it. Tracks the LLM suggestion when one landed.
+          placeholder={assistantFullName(suggestedName ?? DEFAULT_ASSISTANT_FIRST_NAME)}
           onChange={e => {
             setState(s => ({ ...s, name: e.target.value }));
             if (assistantNameError) setAssistantNameError('');
@@ -586,10 +601,10 @@ export default function WizardPage() {
         <textarea
           id="w-signature"
           value={state.signature}
-          // Signature stays a placeholder hint (the field is optional, so its
-          // value is left empty); the hint name tracks the LLM suggestion when
-          // one landed, else the static "Alex" (issue #799).
-          placeholder={`Best regards, ${suggestedName ?? 'Alex'}`}
+          // The signature is pre-populated as a value (above); this placeholder
+          // is the fallback if the operator clears the field. Tracks the LLM
+          // suggestion's first name when one landed, else "Alex" (#799).
+          placeholder={defaultSignature(suggestedName ?? DEFAULT_ASSISTANT_FIRST_NAME)}
           onChange={e => setState(s => ({ ...s, signature: e.target.value }))}
         />
       </div>

--- a/apps/console/src/pages/wizard-utils.test.ts
+++ b/apps/console/src/pages/wizard-utils.test.ts
@@ -11,9 +11,34 @@ import {
   validatePrincipalName,
   PRINCIPAL_NAME_MAX_LENGTH,
   buildIdentityPayload,
+  assistantFullName,
+  defaultSignature,
+  DEFAULT_WIZARD_STATE,
   type WizardState,
   type LocalIdentity,
 } from './wizard-utils.js';
+
+// ── assistantFullName / defaultSignature ──────────────────────────────────────
+
+describe('assistantFullName', () => {
+  it('pairs a first name with the Curia surname', () => {
+    expect(assistantFullName('Sam')).toBe('Sam Curia');
+  });
+});
+
+describe('defaultSignature', () => {
+  it('builds the full default signature block', () => {
+    expect(defaultSignature('Sam')).toBe('--\nSam Curia\nDigital EA');
+  });
+
+  it('backs the populated DEFAULT_WIZARD_STATE signature (not blank)', () => {
+    expect(DEFAULT_WIZARD_STATE.signature).toBe('--\nAlex Curia\nDigital EA');
+  });
+
+  it('backs the DEFAULT_WIZARD_STATE name', () => {
+    expect(DEFAULT_WIZARD_STATE.name).toBe('Alex Curia');
+  });
+});
 
 // ── toggleToneSelection ───────────────────────────────────────────────────────
 

--- a/apps/console/src/pages/wizard-utils.ts
+++ b/apps/console/src/pages/wizard-utils.ts
@@ -51,6 +51,10 @@ export function assistantFullName(firstName: string): string {
 //   --
 //   Sam Curia
 //   Digital EA
+//
+// NOTE: `defaultSignature(DEFAULT_ASSISTANT_FIRST_NAME)` must match the seed
+// `DEFAULT_OFFICE_IDENTITY.assistant.emailSignature` in src/identity/defaults.ts
+// — that backend seed is what the wizard actually loads on a fresh install.
 export function defaultSignature(firstName: string): string {
   return `--\n${assistantFullName(firstName)}\nDigital EA`;
 }

--- a/apps/console/src/pages/wizard-utils.ts
+++ b/apps/console/src/pages/wizard-utils.ts
@@ -30,11 +30,36 @@ export interface LocalIdentity {
   constraints: string[];
 }
 
+// The assistant's surname. The LLM only ever suggests a first name (issue #799);
+// the wizard pairs it with this fixed brand surname to form the full name shown
+// in the name field and the email signature.
+export const ASSISTANT_SURNAME = 'Curia';
+
+// First name used in the static defaults when no LLM suggestion is available
+// (the call hasn't returned, failed, or returned an unusable value).
+export const DEFAULT_ASSISTANT_FIRST_NAME = 'Alex';
+
+// Full assistant name from a first name: "Sam" → "Sam Curia".
+export function assistantFullName(firstName: string): string {
+  return `${firstName} ${ASSISTANT_SURNAME}`;
+}
+
+// Default email signature from a first name. Pre-populated into the signature
+// field (not just shown as a placeholder) so a fresh install ships with a
+// sensible signature the operator can keep or edit:
+//
+//   --
+//   Sam Curia
+//   Digital EA
+export function defaultSignature(firstName: string): string {
+  return `--\n${assistantFullName(firstName)}\nDigital EA`;
+}
+
 export const DEFAULT_WIZARD_STATE: WizardState = {
   principalName: '',
-  name: 'Alex Curia',
+  name: assistantFullName(DEFAULT_ASSISTANT_FIRST_NAME),
   title: 'Executive Assistant to the CEO',
-  signature: '',
+  signature: defaultSignature(DEFAULT_ASSISTANT_FIRST_NAME),
   toneBaseline: ['warm', 'direct'],
   verbosity: 50,
   directness: 75,

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -88,6 +88,11 @@ export interface HttpAdapterConfig {
    * the supervisor brings the new process up). Exposed via GET /api/setup/status.
    */
   bootStartedAt: string;
+  /**
+   * Constrained LLM access for POST /api/setup/suggest-name (wizard starter-name
+   * suggestion, #799). Optional — the endpoint degrades to "unavailable" when absent.
+   */
+  infraLlmService?: import('../../skills/infra-llm.js').InfraLlmService;
 }
 
 export class HttpAdapter implements Channel {
@@ -322,6 +327,7 @@ export class HttpAdapter implements Channel {
         scheduleProcessExit: (delayMs) => {
           setTimeout(() => process.exit(0), delayMs);
         },
+        infraLlmService: this.config.infraLlmService,
       });
     }
 

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -269,11 +269,21 @@ export async function setupRoutes(
     }
 
     // extract() routes to the 'standard' tier and is errors-as-values: a provider
-    // failure comes back as { ok: false }, never a throw. Cap the output hard —
-    // we only want a single word, and a tight ceiling keeps the smoke test cheap.
-    const result = await infraLlmService
-      .scoped({ skillName: 'wizard-suggest-name', conversationId: 'setup' })
-      .extract(SUGGEST_NAME_PROMPT, { maxTokens: 16 });
+    // failure is meant to come back as { ok: false }, never a throw. The
+    // try/catch is belt-and-suspenders — an unexpected rejection (e.g. a future
+    // provider impl, or a bug in the routing layer) is funneled into the same
+    // controlled 502 fallback rather than bubbling up as an uncontrolled 500.
+    // Cap the output hard: we only want a single word, and a tight ceiling keeps
+    // the smoke test cheap.
+    let result;
+    try {
+      result = await infraLlmService
+        .scoped({ skillName: 'wizard-suggest-name', conversationId: 'setup' })
+        .extract(SUGGEST_NAME_PROMPT, { maxTokens: 16 });
+    } catch (err) {
+      logger.warn({ err }, 'POST /api/setup/suggest-name: LLM call threw unexpectedly — frontend will fall back');
+      return reply.status(502).send({ error: 'Could not generate a suggestion.' });
+    }
 
     if (!result.ok) {
       logger.info({ error: result.error }, 'POST /api/setup/suggest-name: LLM call failed — frontend will fall back');

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -21,6 +21,8 @@ import type { Logger } from '../../../logger.js';
 import { assertSecret, type SessionStore } from '../session-auth.js';
 import { ensurePrincipalContact } from '../../../contacts/ensure-principal.js';
 import { isIdentityConfigured } from './identity.js';
+import type { InfraLlmService } from '../../../skills/infra-llm.js';
+import { parseSuggestedFirstName, SUGGEST_NAME_PROMPT } from './suggest-name.js';
 
 export interface SetupRouteOptions {
   webAppBootstrapSecret: string;
@@ -48,6 +50,14 @@ export interface SetupRouteOptions {
    * passes a small wrapper around process.exit; tests pass a spy.
    */
   scheduleProcessExit: (delayMs: number) => void;
+  /**
+   * Constrained LLM access used by POST /api/setup/suggest-name to propose a
+   * starter first name for the assistant (issue #799). Optional: when absent
+   * (e.g. no LLM provider configured) the endpoint reports "unavailable" and the
+   * wizard silently keeps its static placeholder — name suggestion is a
+   * nice-to-have, never a setup blocker.
+   */
+  infraLlmService?: InfraLlmService;
 }
 
 // Match identity.ts: tighter rate limit on auth-sensitive routes (10/min vs the
@@ -70,6 +80,7 @@ export async function setupRoutes(
     setupRequiredAtBoot,
     bootStartedAt,
     scheduleProcessExit,
+    infraLlmService,
   } = options;
 
   // Delay before process.exit so Fastify can finish flushing the 200 response.
@@ -235,5 +246,46 @@ export async function setupRoutes(
       logger.error({ err }, 'POST /api/setup/restart: scheduleProcessExit threw — restart will not occur');
     }
     return reply.send({ restarting: true, exitDelayMs: RESTART_EXIT_DELAY_MS });
+  });
+
+  // -- POST /api/setup/suggest-name --
+  //
+  // One-shot LLM call that proposes a starter first name for the assistant,
+  // shown by the wizard's identity step (issue #799). Two purposes: a touch of
+  // per-install personalization, and an early smoke test that the configured
+  // Anthropic key actually works before the operator commits anything.
+  //
+  // Best-effort by contract: every failure mode (no LLM service, provider error,
+  // an unparseable response) returns a non-2xx the frontend treats as "keep the
+  // static placeholder." No error is ever surfaced to the user from here —
+  // channel/key validation has its own surface later in the wizard. POST (not
+  // GET) because the call costs tokens and must not be cached by the browser.
+  app.post('/api/setup/suggest-name', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+
+    if (!infraLlmService) {
+      // No LLM provider wired — nothing to suggest. 503 → frontend falls back.
+      return reply.status(503).send({ error: 'Name suggestion is unavailable.' });
+    }
+
+    // extract() routes to the 'standard' tier and is errors-as-values: a provider
+    // failure comes back as { ok: false }, never a throw. Cap the output hard —
+    // we only want a single word, and a tight ceiling keeps the smoke test cheap.
+    const result = await infraLlmService
+      .scoped({ skillName: 'wizard-suggest-name', conversationId: 'setup' })
+      .extract(SUGGEST_NAME_PROMPT, { maxTokens: 16 });
+
+    if (!result.ok) {
+      logger.info({ error: result.error }, 'POST /api/setup/suggest-name: LLM call failed — frontend will fall back');
+      return reply.status(502).send({ error: 'Could not generate a suggestion.' });
+    }
+
+    const name = parseSuggestedFirstName(result.text);
+    if (!name) {
+      logger.info({ raw: result.text }, 'POST /api/setup/suggest-name: response was not a clean first name — frontend will fall back');
+      return reply.status(422).send({ error: 'Suggestion was not a usable name.' });
+    }
+
+    return reply.send({ name });
   });
 }

--- a/src/channels/http/routes/suggest-name.test.ts
+++ b/src/channels/http/routes/suggest-name.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { parseSuggestedFirstName } from './suggest-name.js';
+
+// The parse/validate path is the security-relevant surface of the
+// suggest-name feature: an LLM is free-text and may return anything, so we
+// accept only a single, plausible first name and fall back otherwise. These
+// tests pin the accept/reject contract (issue #799 acceptance criteria).
+
+describe('parseSuggestedFirstName', () => {
+  it('accepts a clean single first name', () => {
+    expect(parseSuggestedFirstName('Sam')).toBe('Sam');
+  });
+
+  it('capitalises a lowercase name', () => {
+    expect(parseSuggestedFirstName('sam')).toBe('Sam');
+  });
+
+  it('preserves internal capitals (e.g. McKenzie)', () => {
+    expect(parseSuggestedFirstName('McKenzie')).toBe('McKenzie');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseSuggestedFirstName('  Sam  ')).toBe('Sam');
+  });
+
+  it('accepts accented letters (non-English names)', () => {
+    expect(parseSuggestedFirstName('Renée')).toBe('Renée');
+  });
+
+  it('rejects a multi-word response', () => {
+    expect(parseSuggestedFirstName('Sam Smith')).toBeNull();
+  });
+
+  it('rejects trailing punctuation', () => {
+    expect(parseSuggestedFirstName('Sam.')).toBeNull();
+  });
+
+  it('rejects surrounding quotes', () => {
+    expect(parseSuggestedFirstName('"Sam"')).toBeNull();
+  });
+
+  it('rejects digits', () => {
+    expect(parseSuggestedFirstName('Sam1')).toBeNull();
+  });
+
+  it('rejects an empty string', () => {
+    expect(parseSuggestedFirstName('')).toBeNull();
+  });
+
+  it('rejects a whitespace-only string', () => {
+    expect(parseSuggestedFirstName('   ')).toBeNull();
+  });
+
+  it('rejects a single letter (implausibly short)', () => {
+    expect(parseSuggestedFirstName('A')).toBeNull();
+  });
+
+  it('rejects an implausibly long token', () => {
+    expect(parseSuggestedFirstName('A'.repeat(21))).toBeNull();
+  });
+
+  it('rejects a sentence wrapping the name', () => {
+    expect(parseSuggestedFirstName('Sure! How about Sam?')).toBeNull();
+  });
+});

--- a/src/channels/http/routes/suggest-name.ts
+++ b/src/channels/http/routes/suggest-name.ts
@@ -1,0 +1,43 @@
+// suggest-name.ts — pure helpers for the wizard's LLM name-suggestion feature
+// (issue #799). The HTTP route in setup.ts calls the LLM and delegates the
+// free-text → validated-name decision to parseSuggestedFirstName below, which
+// is the only part that needs unit coverage.
+
+// The instruction sent to the LLM. Deliberately tight: a single bare word makes
+// the parse below succeed in the common case, and any deviation simply falls
+// back to the static placeholder client-side (no error surfaced to the user).
+export const SUGGEST_NAME_PROMPT =
+  'Suggest a single, friendly, professional first name for an AI executive assistant. ' +
+  'Respond with ONLY the first name: one word, letters only, no punctuation, quotes, or explanation.';
+
+// Plausibility bounds for a first name. The lower bound rejects a bare initial
+// ("A"); the upper bound rejects a run-on token that is clearly not a name.
+const MIN_NAME_LENGTH = 2;
+const MAX_NAME_LENGTH = 20;
+
+// Single token of Unicode letters only — no whitespace (rejects multi-word),
+// no digits, no punctuation/quotes. \p{L} keeps accented and non-Latin names
+// valid (e.g. "Renée") while still rejecting anything the model wraps around it.
+const SINGLE_NAME_PATTERN = /^\p{L}+$/u;
+
+/**
+ * Validate and normalise an LLM-suggested assistant first name.
+ *
+ * Returns the cleaned first name (first letter capitalised, the rest left as-is
+ * so internal capitals like "McKenzie" survive) when the model returned exactly
+ * one plausible letters-only token; returns null otherwise so the caller can
+ * fall back to the static placeholder. Strict by design — issue #799 says to
+ * reject anything that isn't a clean single name rather than try to salvage it.
+ */
+export function parseSuggestedFirstName(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length < MIN_NAME_LENGTH || trimmed.length > MAX_NAME_LENGTH) {
+    return null;
+  }
+  if (!SINGLE_NAME_PATTERN.test(trimmed)) {
+    return null;
+  }
+  // Capitalise the first letter so a lowercase model response ("sam") renders
+  // as a proper name; slice() preserves any internal capitalisation.
+  return trimmed[0]!.toUpperCase() + trimmed.slice(1);
+}

--- a/src/identity/defaults.ts
+++ b/src/identity/defaults.ts
@@ -23,7 +23,11 @@ export const DEFAULT_OFFICE_IDENTITY: OfficeIdentity = {
   assistant: {
     name: 'Alex Curia',
     title: 'Agent EA',
-    emailSignature: 'Alex Curia\nOffice of the CEO\n',
+    // Default email signature shown (pre-populated) in the onboarding wizard on
+    // a fresh install. Kept in sync with the wizard's `defaultSignature()` helper
+    // in apps/console/src/pages/wizard-utils.ts so the wizard's no-clobber and
+    // suggestion-prefill logic recognises this seed value as the untouched default.
+    emailSignature: '--\nAlex Curia\nDigital EA',
   },
   tone: {
     baseline: ['warm', 'direct'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -2025,6 +2025,8 @@ async function main(): Promise<void> {
     secretCaptureService,
     setupRequiredAtBoot,
     bootStartedAt,
+    // Powers POST /api/setup/suggest-name (wizard starter-name suggestion, #799).
+    infraLlmService,
   });
 
   try {


### PR DESCRIPTION
## Summary

Closes #799.

The onboarding wizard now suggests a starter first name for the assistant via a one-shot server-side LLM call, instead of always showing the hardcoded `Alex Curia`. Two birds: a touch of per-install personalization, and an early smoke test that the configured Anthropic key actually works before the operator commits anything irreversible.

The Anthropic key never reaches the browser: the new endpoint runs the call server-side and the browser only ever sees the suggested name.

## What changed

- **New endpoint** `POST /api/setup/suggest-name` (`src/channels/http/routes/setup.ts`) — same session-auth + tight rate limit as the other setup routes. Uses the existing `InfraLlmService` (telemetry-emitting, errors-as-values) to make one capped `extract` call, then validates the response.
- **Pure parse helper** `parseSuggestedFirstName` (`src/channels/http/routes/suggest-name.ts`) — accepts only a single, plausible, letters-only token (Unicode letters allowed for non-English names), capitalises the first letter, rejects everything else. Unit-tested in `suggest-name.test.ts`.
- **Wiring** — `infraLlmService` threaded through `HttpAdapter` → `setupRoutes` (optional; endpoint degrades to a 503 the frontend treats as fallback if it's ever absent).
- **Frontend** (`apps/console/src/pages/WizardPage.tsx`, `wizard-utils.ts`) — fires the suggestion once per mount (after the identity prefill resolves, and only on a fresh install with no saved name). On success it prefills the assistant **name** and **email signature** from the suggested first name. Every failure path is silent — the static defaults stand and no error is surfaced.

## Behaviour (per maintainer decision)

The LLM suggests only a **first name**; the wizard pairs it with the fixed `Curia` surname for the assistant's full name, and **pre-populates both the name and the signature as real editable values** (not just placeholders), so a fresh install ships with sensible, personalised defaults the operator can keep or edit in one click:

- Name field → `<Name> Curia`
- Signature field (populated value) →
  ```
  --
  <Name> Curia
  Digital EA
  ```

Shared helpers `assistantFullName()` / `defaultSignature()` in `wizard-utils.ts` are the single source of truth for the static defaults, the LLM-suggestion prefill, and the cleared-field placeholders. Each field is overwritten by the suggestion only while it still holds the untouched static default — a value the user has already edited (or a saved value from a wizard re-run) is never clobbered.

> Note: this prefills field **values** rather than only updating placeholders as the issue text literally describes. That deviation was an explicit maintainer decision (one-click-accept personalised defaults), confirmed during implementation.

## Acceptance criteria

- [x] Wizard shows an LLM-suggested first name on a fresh load when the LLM is reachable (as the full name `<Name> Curia`, prefilled as an editable value).
- [x] Signature reflects the same suggested name (now a populated value in the new `-- / <Name> Curia / Digital EA` format).
- [x] On LLM failure or invalid value, the static `Alex Curia` defaults are shown and no error is surfaced.
- [x] No call / no clobber if the user has already typed into the name field (and no call on a wizard re-run with a saved name).
- [x] Suggestion fetched at most once per wizard mount (ref-guarded).
- [x] Unit test covers the parse/validate path (plus the name/signature default helpers).

## Testing

- `pnpm run typecheck` (backend) + `apps/console` typecheck — pass
- `pnpm run lint` — clean (one pre-existing unrelated warning in `src/pii/scrubber.ts`)
- New + existing unit tests (parse path, wizard-utils, full `channels/http` unit suite) — pass