### PR TITLE
fix: align default assistant title with signature role line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **Default assistant signature** — the seeded `DEFAULT_OFFICE_IDENTITY` email signature is now `--\n<name> Curia\nDigital EA`, pre-populated (not just placeheld) in the onboarding wizard. (#799)
+- **Default assistant title** — the seeded `DEFAULT_OFFICE_IDENTITY` title is now `Digital EA`, matching the role line in the default signature so the onboarding wizard shows a consistent title and signature. (#799)
 - **Principal identity is contacts-only** — `findContactBySystemRole('principal')` is now the single startup source of truth; the `PiiRedactor` bypass, CEO notifiers, outbound filter, and email adapter all read the principal contact (resolved once at boot) instead of `config.ceoPrimaryEmail`. Fixes principal-bound messages being wrongly redacted in fresh-setup mode. (#1049)
 - **`SecretCapturedPayload`** — gained an optional `resumeToken` field (public bus event surface). (#995)
 - **Coordinator Drive moves** — pinned `update_drive_file` to the coordinator and documented reparenting (`add_parents`/`remove_parents`), so "move this doc into a folder" requests are performed instead of declined. (#1062)

--- a/src/identity/defaults.test.ts
+++ b/src/identity/defaults.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_OFFICE_IDENTITY } from './defaults.js';
+
+describe('DEFAULT_OFFICE_IDENTITY', () => {
+  it('defaults the assistant title to "Digital EA"', () => {
+    expect(DEFAULT_OFFICE_IDENTITY.assistant.title).toBe('Digital EA');
+  });
+
+  // Regression guard for the wizard nit where the seeded Title ("Agent EA") did not
+  // match the role line in the seeded signature ("Digital EA"). The two are surfaced
+  // side by side in the onboarding wizard, so they must stay consistent.
+  it('keeps the title aligned with the signature role line', () => {
+    const signatureRoleLine = DEFAULT_OFFICE_IDENTITY.assistant.emailSignature
+      .split('\n')
+      .at(-1);
+    expect(signatureRoleLine).toBe(DEFAULT_OFFICE_IDENTITY.assistant.title);
+  });
+});

--- a/src/identity/defaults.ts
+++ b/src/identity/defaults.ts
@@ -22,7 +22,9 @@ import type { OfficeIdentity } from './types.js';
 export const DEFAULT_OFFICE_IDENTITY: OfficeIdentity = {
   assistant: {
     name: 'Alex Curia',
-    title: 'Agent EA',
+    // Matches the role line ("Digital EA") in the default email signature below, so
+    // the wizard shows a consistent title and signature on a fresh install.
+    title: 'Digital EA',
     // Default email signature shown (pre-populated) in the onboarding wizard on
     // a fresh install. Kept in sync with the wizard's `defaultSignature()` helper
     // in apps/console/src/pages/wizard-utils.ts so the wizard's no-clobber and


### PR DESCRIPTION
## Summary

The onboarding wizard showed an inconsistent assistant Title vs email signature on a fresh install: the seeded `DEFAULT_OFFICE_IDENTITY` title was `Agent EA`, while the default signature's role line read `Digital EA`. This aligns the default title to `Digital EA` so both fields match.

This was flagged during #799 (the title/signature wording mismatch was noted but left out of scope at the time).

### Before / After (wizard, fresh install)

| Field | Before | After |
|---|---|---|
| Title | `Agent EA` | `Digital EA` |
| Signature role line | `Digital EA` | `Digital EA` |

## Changes

- `src/identity/defaults.ts` — `DEFAULT_OFFICE_IDENTITY.assistant.title`: `Agent EA` → `Digital EA` (+ comment noting the alignment).
- `src/identity/defaults.test.ts` — new regression test: the seed title must equal the signature's role line.
- `CHANGELOG.md` — Changed entry.

## Notes

- This is a backend **default seed** change: it only affects **new** installs (the seed runs when no identity row exists). Existing deployments keep their already-saved title.

## Testing

- `vitest run src/identity/defaults.test.ts` — 2 passing
- `pnpm run typecheck` — clean
