### PR TITLE
fix: add plug icon to MCP Skills sidebar nav item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP Skills icon** — added missing plug icon to the MCP Skills sidebar nav item to match all other Settings sub-items.
+
 ### Added
 
 - **Wizard name suggestion** — the onboarding wizard prefills the assistant name and email signature from an LLM-suggested first name via `POST /api/setup/suggest-name`, doubling as an early smoke test of the Anthropic key; silent static fallback on any failure. (#799)

--- a/apps/console/src/components/Icons.tsx
+++ b/apps/console/src/components/Icons.tsx
@@ -158,6 +158,17 @@ export function IconAutonomy({ size }: IconProps) {
   );
 }
 
+export function IconPlug({ size }: IconProps) {
+  return (
+    <Icon size={size}>
+      <path d="M12 22v-5" />
+      <path d="M9 8V2" />
+      <path d="M15 8V2" />
+      <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
+    </Icon>
+  );
+}
+
 // Inline Curia wordmark SVG — uses currentColor for theme tracking
 export function CuriaWordmark(props: SVGProps<SVGSVGElement>) {
   return (

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   IconSettings,
   IconWand,
   IconAutonomy,
+  IconPlug,
   IconChevron,
 } from './Icons';
 
@@ -200,6 +201,7 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
                 className={`nav-sub-item${activeView === 'mcp-skills' ? ' active' : ''}`}
                 onClick={() => go('mcp-skills')}
               >
+                <IconPlug />
                 MCP Skills
               </button>
               <button


### PR DESCRIPTION
## Summary

- **MCP Skills** was the only item in the Settings submenu without an icon, making it visually inconsistent with Skills, Agents, Channels, and Workspace.
- Added `IconPlug` (a Lucide plug icon) to `Icons.tsx` and wired it into the MCP Skills nav button in `Sidebar.tsx`. The plug icon is semantically appropriate for MCP (Model Context Protocol) — it represents connecting to external tool servers.

## Test plan

- [ ] Open the console sidebar and confirm MCP Skills now shows an icon aligned with the other Settings sub-items
- [ ] Verify the icon appears in both light and dark themes (uses `currentColor`)
- [ ] No visual regressions on Skills, Agents, Channels, or Workspace items