### PR TITLE
feat: augment setup wizard with principal operational profile (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Setup wizard — name step** — Step 1 no longer auto-skips when a principal exists; it pre-populates the current name so it can be corrected. (#392)
 - **MCP Skills icon** — added missing plug icon to the MCP Skills sidebar nav item to match all other Settings sub-items.
 
 ### Added
 
+- **Setup wizard — principal operational profile** — new "Your details" step captures the principal's timezone, email, preferred name, title, and working hours; email is stored as a verified identity that comes online after the wizard's restart. (#392)
 - **Wizard name suggestion** — the onboarding wizard prefills the assistant name and email signature from an LLM-suggested first name via `POST /api/setup/suggest-name`, doubling as an early smoke test of the Anthropic key; silent static fallback on any failure. (#799)
 - **Email accounts** — manage one or many agent-owned mailboxes from the console; per-account Nylas grants stored in the vault. (#1101)
 - **Specialist secret-capture resume** — a delegated specialist (or the setup-wizard) that mints a secret-capture link is now resumed on redeem: migration 061 adds `resume_token` to `secret_capture_tokens`, re-entry routes through the coordinator, which re-delegates to the specialist via the `delegate` resume_token. Preserves the no-value and originator invariants. (#995)

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -18,11 +18,15 @@ import {
   assistantFullName,
   defaultSignature,
   DEFAULT_ASSISTANT_FIRST_NAME,
+  detectBrowserTimezone,
+  validateProfileEmail,
+  buildProfilePayload,
   type WizardState,
+  type WizardWorkingHours,
   type LocalIdentity,
 } from './wizard-utils.js';
 
-const TOTAL_STEPS = 5;
+const TOTAL_STEPS = 6;
 
 // localStorage key consumed by useChatSession to fire the auto-kickoff message
 // on the first chat mount after the wizard completes. Must match the constant
@@ -41,6 +45,18 @@ interface SetupStatusResponse {
   identityConfigured: boolean;
   externalAdaptersPending: boolean;
   bootStartedAt: string;
+}
+
+// Response from GET /api/setup/principal — returns existing principal profile
+// data for pre-filling Step 2 on a wizard re-run (#392).
+interface PrincipalProfileResponse {
+  exists: boolean;
+  displayName: string | null;
+  timezone: string | null;
+  preferredName: string | null;
+  title: string | null;
+  email: string | null;
+  workingHours: string | null; // serialized string; the form keeps its own structured state
 }
 
 // State machine for the post-save restart flow. `idle` covers both "haven't
@@ -90,6 +106,7 @@ export default function WizardPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [principalError, setPrincipalError] = useState('');
   const [principalSubmitting, setPrincipalSubmitting] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
   const [assistantNameError, setAssistantNameError] = useState('');
   const [submitError, setSubmitError] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -109,17 +126,18 @@ export default function WizardPage() {
   // it exists for.
   const [identityConfigured, setIdentityConfigured] = useState<boolean | null>(null);
 
-  // Pre-populate form from current identity and check setup status on mount.
-  // Run both fetches in parallel; setup status drives the Step 1 auto-skip
-  // (deployments that already have a principal — e.g. CEO_PRIMARY_EMAIL — go
-  // straight to step 2). identity drives the form's pre-fill so a wizard
-  // re-run shows the existing values instead of defaults.
+  // Pre-populate form from current identity, setup status, and existing principal
+  // profile on mount. All three fetches run in parallel. Identity and status are
+  // required — errors bubble to the load-error render. The principal fetch is
+  // best-effort: a 404 or network blip just falls back to browser-detected
+  // timezone and blank optionals (#392).
   useEffect(() => {
     async function load() {
       try {
-        const [identityRes, statusRes] = await Promise.all([
+        const [identityRes, statusRes, principalRes] = await Promise.all([
           apiFetch('/api/identity'),
           apiFetch('/api/setup/status'),
+          apiFetch('/api/setup/principal'),
         ]);
         if (!identityRes.ok) throw new Error(await extractError(identityRes));
         if (!statusRes.ok) throw new Error(await extractError(statusRes));
@@ -147,7 +165,30 @@ export default function WizardPage() {
           directness: id.tone.directness ?? DEFAULT_WIZARD_STATE.directness,
           posture: id.decisionStyle.externalActions || DEFAULT_WIZARD_STATE.posture,
           preferences: '', // always blank on entry — append mode
+          // Step 2 profile fields — defaults until the principal fetch resolves below
+          timezone: DEFAULT_WIZARD_STATE.timezone,
+          email: DEFAULT_WIZARD_STATE.email,
+          preferredName: DEFAULT_WIZARD_STATE.preferredName,
+          principalTitle: DEFAULT_WIZARD_STATE.principalTitle,
+          workingHours: DEFAULT_WIZARD_STATE.workingHours,
         });
+        // Merge existing principal profile into state; fall back to browser timezone
+        // detection if the principal doesn't exist yet or the fetch failed.
+        if (principalRes.ok) {
+          const p = await principalRes.json() as PrincipalProfileResponse;
+          setState(s => ({
+            ...s,
+            principalName: p.displayName ?? s.principalName,
+            timezone: p.timezone ?? detectBrowserTimezone(),
+            email: p.email ?? '',
+            preferredName: p.preferredName ?? '',
+            principalTitle: p.title ?? '',
+            // workingHours stays structured in the form; a returning operator re-enters
+            // it if they want to change it. (The string is shown as the current value hint.)
+          }));
+        } else {
+          setState(s => ({ ...s, timezone: detectBrowserTimezone() }));
+        }
       } catch (err) {
         setLoadError(err instanceof Error ? err.message : 'Failed to load identity');
       }
@@ -206,16 +247,6 @@ export default function WizardPage() {
     void suggest();
     return () => { cancelled = true; };
   }, [existingIdentity, identityConfigured]);
-
-  // Auto-skip Step 1 when the principal already exists. Runs after the mount
-  // fetch sets principalExists and on any subsequent step change. The route
-  // navigation updates `currentStep`, which re-runs this effect; the guard
-  // (`principalExists && currentStep === 1`) keeps it from looping.
-  useEffect(() => {
-    if (principalExists && currentStep === 1) {
-      void navigate({ to: '/setup', search: { step: 2 } });
-    }
-  }, [principalExists, currentStep, navigate]);
 
   // Post-restart polling loop. Runs only while restartState === 'waiting'.
   // Polls /api/setup/status every RESTART_POLL_INTERVAL_MS, tolerating
@@ -320,25 +351,47 @@ export default function WizardPage() {
     }
   }
 
+  // Step 2 ("Your details") validates timezone + optional email, then POSTs the
+  // profile to /api/setup/principal/profile and advances to Step 3.
+  async function handleProfileContinue(): Promise<void> {
+    const tzError = state.timezone.trim() ? null : 'Select your timezone.';
+    const emailError = validateProfileEmail(state.email);
+    if (tzError || emailError) {
+      setProfileError(tzError ?? emailError);
+      return;
+    }
+    setProfileError(null);
+    try {
+      const res = await apiFetch('/api/setup/principal/profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildProfilePayload(state)),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({})) as { error?: string };
+        setProfileError(data.error ?? 'Could not save your details. Please try again.');
+        return;
+      }
+      await goTo(3);
+    } catch {
+      setProfileError('Could not save your details. Please try again.');
+    }
+  }
+
   function handleContinue() {
-    // Step 2 is the assistant identity form (formerly step 1). Same non-empty
-    // assertion as before — the renamed validator is the only difference.
-    if (currentStep === 2) {
+    // Step 3 is the assistant identity form. Validate the name before advancing.
+    if (currentStep === 3) {
       if (!validateNonEmptyName(state.name)) {
         setAssistantNameError('Assistant name is required.');
         return;
       }
       setAssistantNameError('');
     }
-    if (currentStep < TOTAL_STEPS) goTo(currentStep + 1);
+    if (currentStep < TOTAL_STEPS) void goTo(currentStep + 1);
   }
 
   function handleBack() {
-    // When the principal already exists, Step 1 is auto-skipped; going Back from
-    // Step 2 would bounce back to Step 2 via the auto-skip effect, so just no-op
-    // for clarity instead of flickering.
-    if (currentStep === 2 && principalExists) return;
-    if (currentStep > 1) goTo(currentStep - 1);
+    if (currentStep > 1) void goTo(currentStep - 1);
   }
 
   async function handleSubmit() {
@@ -453,16 +506,12 @@ export default function WizardPage() {
     );
   }
 
-  // Wait for BOTH the identity prefill AND the setup-status snapshot before
-  // rendering any step. Without this gate:
-  //   - Step 1 was reachable before principalExists resolved, so the auto-skip
-  //     effect couldn't decide whether to bounce the user forward — they could
-  //     fill in their name and submit before the wizard knew they shouldn't be
-  //     on this step in the first place.
-  //   - The Step 2 Back button rendered with `principalExists === null` (falsy),
-  //     so a Back click went to Step 1 and immediately bounced back, producing
-  //     a flicker.
-  // Both go away once we hold the render until both pieces of state are known.
+  // Wait for the identity prefill AND the setup-status snapshot before rendering
+  // any step. The three fetches (identity, status, principal) all run in parallel
+  // inside load(); existingIdentity and principalExists (null until the status
+  // fetch resolves) serve as the gate. Without the gate, Step 1 could render
+  // before state.principalName and state.timezone are pre-populated from the
+  // principal response, leaving the fields momentarily blank on a re-run.
   if (!existingIdentity || principalExists === null) {
     return (
       <div className="wizard-page">
@@ -540,8 +589,8 @@ export default function WizardPage() {
   //
   // Captures the operator's own name and POSTs it to /api/setup/principal so
   // the principal contact exists before the assistant identity is saved on
-  // step 5. Auto-skipped (via the effect above) when a principal is already
-  // present — typically CEO_PRIMARY_EMAIL deployments that bootstrapped one.
+  // Step 6. The input is pre-populated from the loaded principal when one
+  // already exists (e.g. a wizard re-run). Step 1 is never auto-skipped.
 
   const step1 = (
     <div className="wizard-content">
@@ -583,9 +632,190 @@ export default function WizardPage() {
     </div>
   );
 
-  // ── Step 2: Assistant identity ─────────────────────────────────────────────
+  // ── Step 2: Your details (principal operational profile) ───────────────────
+  //
+  // Collects the operator's timezone (required), contact email, preferred name,
+  // title, and optional working hours. POSTs to /api/setup/principal/profile.
+  // All fields except timezone are optional — skipping them is fine (#392).
 
-  const step2Identity = (
+  // IANA timezone list. Intl.supportedValuesOf is available in ES2022+ browsers;
+  // guard with typeof so the app still works in older environments that don't
+  // support it (the small fallback list covers the most common zones).
+  const ianaZones: string[] = (typeof Intl !== 'undefined' && typeof (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf === 'function')
+    ? (Intl as { supportedValuesOf: (key: string) => string[] }).supportedValuesOf('timeZone')
+    : [
+        'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
+        'America/Toronto', 'America/Vancouver', 'America/Sao_Paulo',
+        'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Amsterdam',
+        'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Singapore', 'Asia/Kolkata',
+        'Australia/Sydney', 'Australia/Melbourne', 'Pacific/Auckland', 'UTC',
+      ];
+
+  // Weekday labels for the working-hours toggle buttons (0=Sun..6=Sat).
+  const WEEKDAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const;
+
+  // Working hours helpers — only assembled when the operator has set start/end times.
+  const wh = state.workingHours;
+
+  function setWorkingHoursStart(val: string): void {
+    setState(s => ({
+      ...s,
+      workingHours: s.workingHours
+        ? { ...s.workingHours, start: val }
+        : { start: val, end: '17:00', days: [1, 2, 3, 4, 5] },
+    }));
+  }
+
+  function setWorkingHoursEnd(val: string): void {
+    setState(s => ({
+      ...s,
+      workingHours: s.workingHours
+        ? { ...s.workingHours, end: val }
+        : { start: '09:00', end: val, days: [1, 2, 3, 4, 5] },
+    }));
+  }
+
+  function toggleWorkingHoursDay(day: number): void {
+    setState(s => {
+      // If workingHours is null, initialise with sensible defaults before toggling.
+      const existing: WizardWorkingHours = s.workingHours ?? { start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] };
+      const days = existing.days.includes(day)
+        ? existing.days.filter(d => d !== day)
+        : [...existing.days, day].sort((a, b) => a - b);
+      return { ...s, workingHours: { ...existing, days } };
+    });
+  }
+
+  const step2Profile = (
+    <div className="wizard-content">
+      <div className="wizard-heading">Your details</div>
+      <div className="wizard-subheading">
+        Help your assistant work in your context. Timezone is required; everything else is optional.
+      </div>
+
+      <div className="wizard-field">
+        <label htmlFor="w-timezone">Timezone *</label>
+        <select
+          id="w-timezone"
+          value={state.timezone}
+          onChange={e => setState(s => ({ ...s, timezone: e.target.value }))}
+        >
+          {state.timezone === '' && (
+            <option value="" disabled>Select a timezone…</option>
+          )}
+          {ianaZones.map(tz => (
+            <option key={tz} value={tz}>{tz}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="wizard-field">
+        <label htmlFor="w-profile-email">
+          Email <span style={{ fontWeight: 400 }}>(Optional)</span>
+        </label>
+        <input
+          id="w-profile-email"
+          type="email"
+          value={state.email}
+          placeholder="you@example.com"
+          onChange={e => {
+            setState(s => ({ ...s, email: e.target.value }));
+            if (profileError) setProfileError(null);
+          }}
+        />
+      </div>
+
+      <div className="wizard-field">
+        <label htmlFor="w-preferred-name">
+          Preferred name <span style={{ fontWeight: 400 }}>(Optional — how your assistant addresses you)</span>
+        </label>
+        <input
+          id="w-preferred-name"
+          type="text"
+          value={state.preferredName}
+          placeholder="e.g. Jamie"
+          onChange={e => setState(s => ({ ...s, preferredName: e.target.value }))}
+        />
+      </div>
+
+      <div className="wizard-field">
+        <label htmlFor="w-principal-title">
+          Your title <span style={{ fontWeight: 400 }}>(Optional)</span>
+        </label>
+        <input
+          id="w-principal-title"
+          type="text"
+          value={state.principalTitle}
+          placeholder="e.g. Chief Executive Officer"
+          onChange={e => setState(s => ({ ...s, principalTitle: e.target.value }))}
+        />
+      </div>
+
+      <div className="wizard-label" style={{ marginTop: 16 }}>
+        Working hours{' '}
+        <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(Optional)</span>
+      </div>
+      <div className="wizard-subheading" style={{ marginTop: 0, marginBottom: 12 }}>
+        Leave blank to skip — your assistant will work around the clock.
+      </div>
+
+      <div className="wizard-field">
+        <label htmlFor="w-wh-start">Start</label>
+        <input
+          id="w-wh-start"
+          type="time"
+          value={wh?.start ?? ''}
+          onChange={e => setWorkingHoursStart(e.target.value)}
+        />
+      </div>
+      <div className="wizard-field">
+        <label htmlFor="w-wh-end">End</label>
+        <input
+          id="w-wh-end"
+          type="time"
+          value={wh?.end ?? ''}
+          onChange={e => setWorkingHoursEnd(e.target.value)}
+        />
+      </div>
+
+      <div className="wizard-label" style={{ marginTop: 8 }}>Days</div>
+      <div style={{ display: 'flex', gap: 6, marginBottom: 16 }}>
+        {WEEKDAY_LABELS.map((label, idx) => {
+          const selected = wh?.days.includes(idx) ?? false;
+          return (
+            <button
+              key={label}
+              type="button"
+              className={`tone-pill${selected ? ' selected' : ''}`}
+              onClick={() => toggleWorkingHoursDay(idx)}
+              style={{ minWidth: 36 }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {profileError && <div className="wizard-step1-error">{profileError}</div>}
+
+      <div className="wizard-nav">
+        <button type="button" className="btn-wizard-back" onClick={handleBack}>
+          ← Back
+        </button>
+        <button
+          type="button"
+          className="btn-wizard-next"
+          onClick={() => void handleProfileContinue()}
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  );
+
+  // ── Step 3: Assistant identity ─────────────────────────────────────────────
+
+  const step3Identity = (
     <div className="wizard-content">
       <div className="wizard-heading">What should your assistant be called?</div>
       <div className="wizard-subheading">
@@ -630,13 +860,9 @@ export default function WizardPage() {
         />
       </div>
       <div className="wizard-nav">
-        {principalExists ? (
-          <span />
-        ) : (
-          <button type="button" className="btn-wizard-back" onClick={handleBack}>
-            ← Back
-          </button>
-        )}
+        <button type="button" className="btn-wizard-back" onClick={handleBack}>
+          ← Back
+        </button>
         <button type="button" className="btn-wizard-next" onClick={handleContinue}>
           Next →
         </button>
@@ -644,11 +870,11 @@ export default function WizardPage() {
     </div>
   );
 
-  // ── Step 3: Tone ───────────────────────────────────────────────────────────
+  // ── Step 4: Tone ───────────────────────────────────────────────────────────
 
   const atToneMax = state.toneBaseline.length >= 3;
 
-  const step3Tone = (
+  const step4Tone = (
     <div className="wizard-content">
       <div className="wizard-heading">How should your assistant communicate?</div>
       <div className="wizard-subheading">Pick 1–3 words that describe the tone you want.</div>
@@ -715,7 +941,7 @@ export default function WizardPage() {
     </div>
   );
 
-  // ── Step 4: Posture & preferences ──────────────────────────────────────────
+  // ── Step 5: Posture & preferences ──────────────────────────────────────────
 
   const POSTURE_OPTIONS: Array<{
     value: WizardState['posture'];
@@ -727,7 +953,7 @@ export default function WizardPage() {
     { value: 'proactive',    title: 'Proactive',    desc: 'Bias toward action; less checking in' },
   ];
 
-  const step4Posture = (
+  const step5Posture = (
     <div className="wizard-content">
       <div className="wizard-heading">How should your assistant decide?</div>
       <div className="wizard-subheading">
@@ -775,7 +1001,7 @@ export default function WizardPage() {
     </div>
   );
 
-  // ── Step 5: Review ─────────────────────────────────────────────────────────
+  // ── Step 6: Review ─────────────────────────────────────────────────────────
 
   const words = state.toneBaseline;
   const tonePhrase =
@@ -799,7 +1025,7 @@ export default function WizardPage() {
     reviewRows.push({ label: 'Preference', value: `"${state.preferences.trim()}"` });
   }
 
-  const step5Review = (
+  const step6Review = (
     <div className="wizard-content">
       <div className="wizard-heading">Does everything look right?</div>
       <div className="wizard-subheading">Go back to change anything, or save to get started.</div>
@@ -832,10 +1058,11 @@ export default function WizardPage() {
 
   const steps: Record<number, JSX.Element> = {
     1: step1,
-    2: step2Identity,
-    3: step3Tone,
-    4: step4Posture,
-    5: step5Review,
+    2: step2Profile,
+    3: step3Identity,
+    4: step4Tone,
+    5: step5Posture,
+    6: step6Review,
   };
 
   return (

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -33,6 +33,24 @@ const TOTAL_STEPS = 6;
 // in useChatSession.ts exactly.
 const ONBOARDING_KICKOFF_KEY = 'curia:onboarding:welcome-banner-pending';
 
+// ── Module-level constants ────────────────────────────────────────────────────
+
+// IANA timezone list. Intl.supportedValuesOf is available in ES2022+ browsers;
+// guard with typeof so the app still works in older environments that don't
+// support it (the small fallback list covers the most common zones).
+const IANA_ZONES: string[] = (typeof Intl !== 'undefined' && typeof (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf === 'function')
+  ? (Intl as { supportedValuesOf: (key: string) => string[] }).supportedValuesOf('timeZone')
+  : [
+      'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
+      'America/Toronto', 'America/Vancouver', 'America/Sao_Paulo',
+      'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Amsterdam',
+      'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Singapore', 'Asia/Kolkata',
+      'Australia/Sydney', 'Australia/Melbourne', 'Pacific/Auckland', 'UTC',
+    ];
+
+// Weekday labels for the working-hours toggle buttons (0=Sun..6=Sat).
+const WEEKDAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const;
+
 // ── Identity API types ────────────────────────────────────────────────────────
 
 interface IdentityResponse {
@@ -638,22 +656,6 @@ export default function WizardPage() {
   // title, and optional working hours. POSTs to /api/setup/principal/profile.
   // All fields except timezone are optional — skipping them is fine (#392).
 
-  // IANA timezone list. Intl.supportedValuesOf is available in ES2022+ browsers;
-  // guard with typeof so the app still works in older environments that don't
-  // support it (the small fallback list covers the most common zones).
-  const ianaZones: string[] = (typeof Intl !== 'undefined' && typeof (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf === 'function')
-    ? (Intl as { supportedValuesOf: (key: string) => string[] }).supportedValuesOf('timeZone')
-    : [
-        'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
-        'America/Toronto', 'America/Vancouver', 'America/Sao_Paulo',
-        'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Amsterdam',
-        'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Singapore', 'Asia/Kolkata',
-        'Australia/Sydney', 'Australia/Melbourne', 'Pacific/Auckland', 'UTC',
-      ];
-
-  // Weekday labels for the working-hours toggle buttons (0=Sun..6=Sat).
-  const WEEKDAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const;
-
   // Working hours helpers — only assembled when the operator has set start/end times.
   const wh = state.workingHours;
 
@@ -703,7 +705,7 @@ export default function WizardPage() {
           {state.timezone === '' && (
             <option value="" disabled>Select a timezone…</option>
           )}
-          {ianaZones.map(tz => (
+          {IANA_ZONES.map(tz => (
             <option key={tz} value={tz}>{tz}</option>
           ))}
         </select>

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -205,6 +205,9 @@ export default function WizardPage() {
             // it if they want to change it. (The string is shown as the current value hint.)
           }));
         } else {
+          if (principalRes.status !== 404) {
+            console.warn('[WizardPage] GET /api/setup/principal returned', principalRes.status, '— falling back to browser timezone');
+          }
           setState(s => ({ ...s, timezone: detectBrowserTimezone() }));
         }
       } catch (err) {
@@ -340,7 +343,7 @@ export default function WizardPage() {
 
   // Step 1 ("About you") writes through to the backend before advancing so the
   // principal contact exists by the time the assistant identity is saved at
-  // step 5. The endpoint is idempotent — a retry after a transient failure is
+  // step 6 (the review step). The endpoint is idempotent — a retry after a transient failure is
   // safe and will return alreadyExisted=true on success.
   async function handlePrincipalContinue() {
     const validationError = validatePrincipalName(state.principalName);
@@ -391,8 +394,9 @@ export default function WizardPage() {
         return;
       }
       await goTo(3);
-    } catch {
-      setProfileError('Could not save your details. Please try again.');
+    } catch (err) {
+      console.debug('[WizardPage] profile save failed:', err);
+      setProfileError(err instanceof Error ? err.message : 'Could not save your details. Please try again.');
     }
   }
 

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -145,17 +145,16 @@ export default function WizardPage() {
   const [identityConfigured, setIdentityConfigured] = useState<boolean | null>(null);
 
   // Pre-populate form from current identity, setup status, and existing principal
-  // profile on mount. All three fetches run in parallel. Identity and status are
-  // required — errors bubble to the load-error render. The principal fetch is
-  // best-effort: a 404 or network blip just falls back to browser-detected
-  // timezone and blank optionals (#392).
+  // profile on mount. Identity and status are required — errors bubble to the
+  // load-error render. The principal fetch is best-effort: a 404 or network
+  // blip falls back to browser-detected timezone and blank optionals (#392).
+  // It runs separately so a flaky /api/setup/principal never breaks the wizard.
   useEffect(() => {
     async function load() {
       try {
-        const [identityRes, statusRes, principalRes] = await Promise.all([
+        const [identityRes, statusRes] = await Promise.all([
           apiFetch('/api/identity'),
           apiFetch('/api/setup/status'),
-          apiFetch('/api/setup/principal'),
         ]);
         if (!identityRes.ok) throw new Error(await extractError(identityRes));
         if (!statusRes.ok) throw new Error(await extractError(statusRes));
@@ -190,8 +189,15 @@ export default function WizardPage() {
           principalTitle: DEFAULT_WIZARD_STATE.principalTitle,
           workingHours: DEFAULT_WIZARD_STATE.workingHours,
         });
-        // Merge existing principal profile into state; fall back to browser timezone
-        // detection if the principal doesn't exist yet or the fetch failed.
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load identity');
+      }
+
+      // Best-effort: merge existing principal profile into state.
+      // A 404 (no principal yet) or any network error falls back to browser
+      // timezone; it must NOT throw into the outer catch above.
+      try {
+        const principalRes = await apiFetch('/api/setup/principal');
         if (principalRes.ok) {
           const p = await principalRes.json() as PrincipalProfileResponse;
           setState(s => ({
@@ -202,7 +208,7 @@ export default function WizardPage() {
             preferredName: p.preferredName ?? '',
             principalTitle: p.title ?? '',
             // workingHours stays structured in the form; a returning operator re-enters
-            // it if they want to change it. (The string is shown as the current value hint.)
+            // it if they want to change it.
           }));
         } else {
           if (principalRes.status !== 404) {
@@ -210,8 +216,8 @@ export default function WizardPage() {
           }
           setState(s => ({ ...s, timezone: detectBrowserTimezone() }));
         }
-      } catch (err) {
-        setLoadError(err instanceof Error ? err.message : 'Failed to load identity');
+      } catch {
+        setState(s => ({ ...s, timezone: detectBrowserTimezone() }));
       }
     }
     void load();
@@ -757,9 +763,18 @@ export default function WizardPage() {
         />
       </div>
 
-      <div className="wizard-label" style={{ marginTop: 16 }}>
+      <div className="wizard-label" style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
         Working hours{' '}
         <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(Optional)</span>
+        {wh !== null && (
+          <button
+            type="button"
+            style={{ marginLeft: 'auto', fontSize: 12, fontWeight: 400, background: 'none', border: 'none', color: 'var(--color-muted)', cursor: 'pointer', textTransform: 'none', letterSpacing: 0 }}
+            onClick={() => setState(s => ({ ...s, workingHours: null }))}
+          >
+            Clear
+          </button>
+        )}
       </div>
       <div className="wizard-subheading" style={{ marginTop: 0, marginBottom: 12 }}>
         Leave blank to skip — your assistant will work around the clock.

--- a/apps/console/src/pages/wizard-utils.test.ts
+++ b/apps/console/src/pages/wizard-utils.test.ts
@@ -14,6 +14,9 @@ import {
   assistantFullName,
   defaultSignature,
   DEFAULT_WIZARD_STATE,
+  detectBrowserTimezone,
+  validateProfileEmail,
+  buildProfilePayload,
   type WizardState,
   type LocalIdentity,
 } from './wizard-utils.js';
@@ -259,5 +262,48 @@ describe('buildIdentityPayload', () => {
   it('sets note to "Saved via onboarding wizard"', () => {
     const { note } = buildIdentityPayload(state, existingIdentity);
     expect(note).toBe('Saved via onboarding wizard');
+  });
+});
+
+// ── validateProfileEmail ──────────────────────────────────────────────────────
+
+describe('validateProfileEmail', () => {
+  it('returns null for empty (optional field)', () => {
+    expect(validateProfileEmail('')).toBeNull();
+    expect(validateProfileEmail('   ')).toBeNull();
+  });
+  it('returns null for a valid address', () => {
+    expect(validateProfileEmail('a@b.com')).toBeNull();
+  });
+  it('returns an error for a malformed address', () => {
+    expect(validateProfileEmail('not-an-email')).toMatch(/valid/i);
+  });
+});
+
+// ── buildProfilePayload ───────────────────────────────────────────────────────
+
+describe('buildProfilePayload', () => {
+  it('includes timezone and omits empty optionals', () => {
+    const state = { ...DEFAULT_WIZARD_STATE, timezone: 'America/Vancouver' };
+    expect(buildProfilePayload(state)).toEqual({ timezone: 'America/Vancouver' });
+  });
+  it('includes provided optionals and trims them', () => {
+    const state = {
+      ...DEFAULT_WIZARD_STATE, timezone: 'America/Toronto',
+      email: '  Me@Example.com ', preferredName: ' Jo ', principalTitle: ' CEO ',
+      workingHours: { start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] },
+    };
+    expect(buildProfilePayload(state)).toEqual({
+      timezone: 'America/Toronto', email: 'Me@Example.com', preferredName: 'Jo',
+      title: 'CEO', workingHours: { start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] },
+    });
+  });
+});
+
+// ── detectBrowserTimezone ─────────────────────────────────────────────────────
+
+describe('detectBrowserTimezone', () => {
+  it('returns a non-empty IANA-looking string', () => {
+    expect(detectBrowserTimezone()).toMatch(/^[A-Za-z]+\/[A-Za-z_]+/);
   });
 });

--- a/apps/console/src/pages/wizard-utils.test.ts
+++ b/apps/console/src/pages/wizard-utils.test.ts
@@ -220,6 +220,11 @@ describe('buildIdentityPayload', () => {
     directness: 80,
     posture: 'conservative',
     preferences: 'Flag investor emails',
+    timezone: 'America/Toronto',
+    email: '',
+    preferredName: '',
+    principalTitle: '',
+    workingHours: null,
   };
 
   it('maps WizardState onto identity correctly', () => {

--- a/apps/console/src/pages/wizard-utils.test.ts
+++ b/apps/console/src/pages/wizard-utils.test.ts
@@ -309,6 +309,10 @@ describe('buildProfilePayload', () => {
 
 describe('detectBrowserTimezone', () => {
   it('returns a non-empty IANA-looking string', () => {
-    expect(detectBrowserTimezone()).toMatch(/^[A-Za-z]+\/[A-Za-z_]+/);
+    // CI environments often report 'UTC' — a valid IANA zone without a slash.
+    // Accept any non-empty string that Intl recognises as a real zone.
+    const tz = detectBrowserTimezone();
+    expect(tz.length).toBeGreaterThan(0);
+    expect(() => Intl.DateTimeFormat(undefined, { timeZone: tz })).not.toThrow();
   });
 });

--- a/apps/console/src/pages/wizard-utils.ts
+++ b/apps/console/src/pages/wizard-utils.ts
@@ -1,5 +1,11 @@
 // Pure helper functions for the wizard — no React, no DOM, fully testable.
 
+export interface WizardWorkingHours {
+  start: string; // "HH:MM"
+  end: string;   // "HH:MM"
+  days: number[]; // 0=Sun..6=Sat
+}
+
 export interface WizardState {
   // Step 1 — About you. Captured separately from the assistant identity below
   // and POSTed to /api/setup/principal so the principal contact exists before
@@ -15,6 +21,12 @@ export interface WizardState {
   directness: number;  // 0–100
   posture: 'conservative' | 'balanced' | 'proactive';
   preferences: string;
+  // Step 2 — Your details (principal operational profile, #392).
+  timezone: string;
+  email: string;
+  preferredName: string;
+  principalTitle: string; // distinct from `title` (the assistant's title, Step 3)
+  workingHours: WizardWorkingHours | null;
 }
 
 // Local mirror of the OfficeIdentity shape from the backend identity API.
@@ -69,6 +81,11 @@ export const DEFAULT_WIZARD_STATE: WizardState = {
   directness: 75,
   posture: 'conservative',
   preferences: '',
+  timezone: '',
+  email: '',
+  preferredName: '',
+  principalTitle: '',
+  workingHours: null,
 };
 
 // Backend's POST /api/setup/principal accepts up to 200 characters; enforce the
@@ -200,4 +217,42 @@ export function buildIdentityPayload(
   };
 
   return { identity, note: 'Saved via onboarding wizard' };
+}
+
+// Browser timezone detection for the Step 2 prefill (#392). Falls back to the
+// backend default if the platform doesn't expose a resolved zone.
+export function detectBrowserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/Toronto';
+  } catch {
+    return 'America/Toronto';
+  }
+}
+
+const PROFILE_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Email is optional in Step 2. Returns null when blank (allowed) or valid; an error
+// string when present-but-malformed.
+export function validateProfileEmail(email: string): string | null {
+  const trimmed = email.trim();
+  if (trimmed.length === 0) return null;
+  if (!PROFILE_EMAIL_RE.test(trimmed)) return 'Enter a valid email address.';
+  return null;
+}
+
+// Builds the POST /api/setup/principal/profile body, omitting empty optionals so the
+// backend never clobbers an existing value with a blank.
+export function buildProfilePayload(state: WizardState): {
+  timezone: string; email?: string; preferredName?: string; title?: string;
+  workingHours?: WizardWorkingHours;
+} {
+  const payload: {
+    timezone: string; email?: string; preferredName?: string; title?: string;
+    workingHours?: WizardWorkingHours;
+  } = { timezone: state.timezone.trim() };
+  if (state.email.trim()) payload.email = state.email.trim();
+  if (state.preferredName.trim()) payload.preferredName = state.preferredName.trim();
+  if (state.principalTitle.trim()) payload.title = state.principalTitle.trim();
+  if (state.workingHours) payload.workingHours = state.workingHours;
+  return payload;
 }

--- a/apps/console/src/pages/wizard-utils.ts
+++ b/apps/console/src/pages/wizard-utils.ts
@@ -9,10 +9,9 @@ export interface WizardWorkingHours {
 export interface WizardState {
   // Step 1 — About you. Captured separately from the assistant identity below
   // and POSTed to /api/setup/principal so the principal contact exists before
-  // the rest of the form is saved. Auto-skipped when a principal is already
-  // present (e.g. from a prior wizard run on this instance).
+  // the rest of the form is saved. Pre-populated on a re-run; never auto-skipped.
   principalName: string;
-  // Steps 2–5 — assistant identity, tone, posture, review.
+  // Steps 3–6 — assistant identity, tone, posture, review.
   name: string;
   title: string;
   signature: string;
@@ -224,7 +223,9 @@ export function buildIdentityPayload(
 export function detectBrowserTimezone(): string {
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/Toronto';
-  } catch {
+  } catch (err) {
+    // Should never fire in a modern browser — defensive guard only.
+    console.warn('[wizard-utils] detectBrowserTimezone failed, using default:', err);
     return 'America/Toronto';
   }
 }

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -82,7 +82,7 @@ in a separate terminal — it attaches a CLI channel to the running stack.
 
 After logging in for the first time, the app detects that the office identity
 has not been configured and redirects you to `/setup` automatically. This is
-a five-step React form wizard:
+a six-step React form wizard:
 
 1. **About you** — the CEO's name (the principal contact). This step no longer
    auto-skips when a principal already exists; it pre-populates the current

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -84,14 +84,23 @@ After logging in for the first time, the app detects that the office identity
 has not been configured and redirects you to `/setup` automatically. This is
 a five-step React form wizard:
 
-1. **About you** — the CEO's name (the principal contact). Auto-skipped if
-   a principal already exists (e.g. from a prior wizard run on this instance).
-2. **Identity** — assistant name, title, optional email signature.
-3. **Tone** — 1–3 baseline tone words + verbosity and directness sliders.
-4. **Posture** — decision-making posture + initial behavioral preferences.
-5. **Review** — confirm and save.
+1. **About you** — the CEO's name (the principal contact). This step no longer
+   auto-skips when a principal already exists; it pre-populates the current
+   name so it can be corrected if needed.
+2. **Your details** — the principal's operational profile. Captures timezone
+   (required), email (required), preferred name, title, and working hours
+   (all optional). The email is stored as a verified principal identity that
+   comes online after the wizard's restart. The selected timezone informs agent
+   reasoning via entity-context enrichment. Note: the system timezone (cron
+   scheduler, environment variable `TIMEZONE`) remains env-driven separate
+   from the wizard selection. Aligning the system clock to match the principal's
+   contact timezone is tracked as a follow-up.
+3. **Identity** — assistant name, title, optional email signature.
+4. **Tone** — 1–3 baseline tone words + verbosity and directness sliders.
+5. **Posture** — decision-making posture + initial behavioral preferences.
+6. **Review** — confirm and save.
 
-When you submit step 5, the wizard saves the identity, hot reloads it, and
+When you submit step 6, the wizard saves the identity, hot reloads it, and
 (if the process booted in setup-required mode) asks the supervisor to
 restart so the email and Signal channels can come online. You'll see a
 brief "Setting up channels…" screen during the restart, then land directly

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -88,13 +88,13 @@ a six-step React form wizard:
    auto-skips when a principal already exists; it pre-populates the current
    name so it can be corrected if needed.
 2. **Your details** — the principal's operational profile. Captures timezone
-   (required), email (required), preferred name, title, and working hours
-   (all optional). The email is stored as a verified principal identity that
-   comes online after the wizard's restart. The selected timezone informs agent
-   reasoning via entity-context enrichment. Note: the system timezone (cron
-   scheduler, environment variable `TIMEZONE`) remains env-driven separate
-   from the wizard selection. Aligning the system clock to match the principal's
-   contact timezone is tracked as a follow-up.
+   (required), email, preferred name, title, and working hours (all optional).
+   The email is stored as a verified principal identity that comes online after
+   the wizard's restart. The selected timezone informs agent reasoning via
+   entity-context enrichment. Note: the system timezone (cron scheduler,
+   environment variable `TIMEZONE`) remains env-driven separate from the wizard
+   selection. Aligning the system clock to match the principal's contact
+   timezone is tracked as a follow-up.
 3. **Identity** — assistant name, title, optional email signature.
 4. **Tone** — 1–3 baseline tone words + verbosity and directness sliders.
 5. **Posture** — decision-making posture + initial behavioral preferences.

--- a/docs/wip/2026-06-22-setup-wizard-principal-profile-design.md
+++ b/docs/wip/2026-06-22-setup-wizard-principal-profile-design.md
@@ -1,0 +1,180 @@
+# Setup wizard — principal operational profile
+
+**Issue:** [#392](https://github.com/josephfung/curia/issues/392) — feat: augment setup wizard with principal operational profile
+**Date:** 2026-06-22
+**Status:** Design approved
+
+## Summary
+
+The form-based setup wizard (`apps/console/src/pages/WizardPage.tsx`) currently captures the
+principal's name (Step 1) and the assistant's identity/tone/posture (Steps 2–4). This change
+adds a **principal operational profile** step that captures the timezone, email, preferred name,
+title, and working hours Curia needs to function well from day one, and fixes a bug where the
+name step can never be re-edited once a principal exists.
+
+## Findings that reshaped the issue
+
+The issue text was written against an older architecture. Two premises are stale; the design
+reflects current reality:
+
+1. **`CEO_PRIMARY_EMAIL` env bootstrap is gone** (removed in #1049). The principal is now created
+   **only** by the wizard (`POST /api/setup/principal`), and the principal's email is derived at
+   startup from a **verified + active email channel identity** (`contact_channel_identities`),
+   not an env var. There is no code path that creates a principal with `display_name = 'CEO'`.
+   - The *real* current bug behind the issue's "auto-skip" item: Step 1 hard-skips whenever a
+     principal exists (it only checks a `principalExists` boolean), so once a principal is created
+     its display name can **never** be corrected via the wizard.
+
+2. **No new table or column is needed.** The `contacts` table already has canonical columns
+   `timezone`, `preferred_name`, `title`, `primary_email`, `locale` (migration 048). The
+   `canonical-attribute-guard` enforces a single read path: canonical attributes live on contact
+   columns and are surfaced to agents by the entity-context assembler; non-canonical attributes
+   (like working hours) flow to the KG as facts.
+
+## Storage model
+
+All profile data lives on the principal **contact** or its **KG node** — no migration.
+
+| Field | Storage | Mechanism |
+|-------|---------|-----------|
+| Timezone | `contacts.timezone` (canonical column) | `ContactService.updateContactFields` |
+| Preferred name | `contacts.preferred_name` (canonical) | `updateContactFields` |
+| Title | `contacts.title` (canonical) | `updateContactFields` |
+| Email | `contact_channel_identities` (verified) + `contacts.primary_email` | `linkIdentity(source='ceo_stated', verified=true)`, then `updateContactFields({ primaryEmail })` |
+| Working hours | KG **fact** on the principal's `kg_node_id` | `EntityMemory.storeFact` |
+
+### Email ordering constraint
+
+`updateContactFields` validates `primaryEmail` against existing channel identities
+([contact-service.ts:917](../../src/contacts/contact-service.ts)). So the email must be linked
+**first** via `linkIdentity`, then written to `primary_email`. Source `ceo_stated` is in
+`AUTO_VERIFIED_SOURCES`, so the identity is created `verified=true`. After the wizard-end restart,
+`index.ts` resolves `principalEmail` from this identity immediately — email-dependent features
+(outbound allow-list, CEO notifiers) work from day one instead of waiting for first inbound.
+
+### Working hours as a KG fact
+
+`working_hours` is **not** in `CANONICAL_ATTRIBUTE_MAP`, so it survives the assembler's canonical
+filter and surfaces to agents through entity-context enrichment. Stored as:
+
+```
+storeFact({
+  entityNodeId: principalContact.kgNodeId,
+  label: 'Working hours',
+  properties: { attribute: 'working_hours', value: '<readable string>', category: 'preference' },
+  confidence: 1.0,
+  decayClass: 'permanent',
+  source: 'system:setup-wizard',
+})
+```
+
+The value is a natural-language string (e.g. `"Mon–Fri, 9:00 AM–5:00 PM"`) — richer for KG
+browsing and better for LLM consumption than raw JSON. The wizard collects it structured
+(time range + weekday toggles) and serializes. Because the fact carries `properties.attribute`,
+`storeFact` runs contradiction detection, so re-running the wizard updates the existing fact
+rather than accumulating duplicates.
+
+## Timezone behavior (system clock untouched)
+
+`config.timezone` is read once at boot from `process.env.TIMEZONE ?? 'America/Toronto'`
+([config.ts:819](../../src/config.ts)) and consumed by reference (scheduler, runtime, task repo,
+skill registry). It is **not** persisted to any DB-backed config and is **not** reloaded at runtime.
+
+This change stores the principal's timezone on `contacts.timezone`, which the entity-context
+assembler surfaces to agents **live** ([assembler.ts:170](../../src/entity-context/assembler.ts)) —
+agents become timezone-aware of the principal with no restart.
+
+**Explicitly out of scope (deferred to a follow-up issue):** overriding `config.timezone` /
+the system clock / cron scheduler from the principal's contact timezone. The system timezone
+stays env-driven. Rationale: principals travel, so a contact-timezone → system-clock override is
+an unnatural patch; making the system timezone dynamic deserves its own design.
+
+**AC impact (stated honestly):** "selected timezone … used by the runtime" is satisfied for agent
+*reasoning* (enrichment, live, no restart) but **not** the cron scheduler / system clock, which
+remains env-bound. This split is called out in the PR and the follow-up issue.
+
+## Wizard step structure
+
+`apps/console/src/pages/WizardPage.tsx`, `wizard-utils.ts`. `TOTAL_STEPS` 5 → 6.
+
+- **Step 1 "About you"** — principal name. **Never auto-skips.** On mount, load the existing
+  principal (if any) and pre-populate the input so the deployer can confirm/correct it. Removes
+  the auto-skip effect ([WizardPage.tsx:214](../../apps/console/src/pages/WizardPage.tsx)).
+- **Step 2 "Your details" (NEW)** — operational profile:
+  - **Timezone** (required) — IANA dropdown, pre-filled from
+    `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+  - **Email** (optional) — text input, pre-filled from the existing verified principal email.
+  - **Preferred name** (optional).
+  - **Title** (optional).
+  - **Working hours** (optional, skippable) — start/end time + weekday toggles.
+- **Steps 3–6** — existing Assistant identity / Tone / Posture / Review, renumbered from 2–5,
+  otherwise unchanged.
+
+A dedicated step (vs. merging into Step 1) keeps the existing name-create POST flow isolated and
+the new fields independently testable.
+
+## API surface
+
+`src/channels/http/routes/setup.ts`.
+
+- **`GET /api/setup/principal`** (new) → `{ exists, displayName, timezone, preferredName, title,
+  email, workingHours }` (nulls when absent). Wizard mount uses it to pre-populate Steps 1 & 2.
+- **`POST /api/setup/principal`** (existing) → extended: when the principal already exists,
+  **update** `display_name` (and the linked KG node label) instead of no-op'ing. Still creates on
+  first call. Enables the name correction.
+- **`POST /api/setup/principal/profile`** (new) → body
+  `{ timezone, email?, preferredName?, title?, workingHours? }`. Requires the principal to exist.
+  1. Validate `timezone` is a real IANA zone (`Intl.DateTimeFormat` guard) → 422 otherwise.
+  2. If `email` present and syntactically valid → `linkIdentity(ceo_stated, verified=true)`.
+  3. `updateContactFields({ timezone, preferredName?, title?, primaryEmail? })` — only defined fields.
+  4. If `workingHours` present → serialize + `storeFact` on the principal KG node.
+  Step 2 "Continue" calls this.
+
+### `workingHours` request shape
+
+```ts
+{ start: string /* "09:00" */, end: string /* "17:00" */, days: number[] /* 0=Sun..6=Sat */ }
+```
+
+Serialized server-side to the readable string stored in the fact.
+
+## Error handling
+
+- Timezone: server-side `Intl.DateTimeFormat` validation (mirrors config.ts); 422 on bad zone.
+- Email: syntactic address validation; 422 on malformed. Lower-cased before linking (matches
+  existing identity normalization).
+- Optional fields: skipped/empty → no write (never clobber an existing value with an empty one).
+- Working hours: validate `start`/`end` are `HH:MM` and `days` are 0–6; 422 otherwise.
+- Name update: when the new name equals the current display name, skip the write (idempotent).
+  KG node label rename handled defensively (conflict on `lower(label)` logged, contact name still
+  updated — the contact column is the authoritative display name).
+
+## Testing (TDD)
+
+Integration (real Postgres):
+- `POST /api/setup/principal` creates a principal; second call with a different name **updates**
+  display name + KG label.
+- `GET /api/setup/principal` returns persisted profile (incl. verified email + working-hours fact)
+  and `{ exists: false }` when none.
+- `POST /api/setup/principal/profile`: writes canonical fields; links a verified `ceo_stated`
+  email then sets `primary_email`; stores a `working_hours` fact retrievable via the assembler;
+  rejects an invalid timezone (422); leaves omitted optional fields untouched.
+
+Unit:
+- Working-hours serializer (structured → readable string) incl. all-days, weekdays-only, single day.
+- Wizard step gating: Step 1 shows pre-populated (no skip); Step 2 timezone required to continue;
+  optional fields skippable.
+
+## Out of scope
+
+- Overriding the system timezone / cron scheduler from the contact (follow-up issue).
+- `ExecutiveProfile` writing-voice fields.
+- Calendar (Nylas) and Signal channel setup — separate post-wizard flows.
+- Email *mailbox* (which inbox Curia polls) — that's `email_accounts` + Nylas grant, configured in
+  the console, distinct from the principal's own address captured here.
+
+## Documentation
+
+- `docs/dev/setup.md` — reference the wizard for operational-profile configuration (AC).
+- CHANGELOG.md — Added entry under `[Unreleased]`.
+- File a follow-up issue: "make system timezone track the principal's contact timezone".

--- a/docs/wip/2026-06-22-setup-wizard-principal-profile.md
+++ b/docs/wip/2026-06-22-setup-wizard-principal-profile.md
@@ -1,0 +1,1119 @@
+# Setup Wizard — Principal Operational Profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a principal operational-profile step (timezone, email, preferred name, title, working hours) to the form-based setup wizard, and stop Step 1 from permanently auto-skipping so the principal's name can be confirmed/corrected.
+
+**Architecture:** All profile data persists on the existing principal **contact** (canonical columns `timezone`, `preferred_name`, `title`, `primary_email`) and its **KG node** (a `working_hours` fact). Email is written as a verified `ceo_stated` channel identity so `index.ts` resolves `principalEmail` from it after the wizard-end restart. The system clock / `config.timezone` is **not** touched (deferred to a follow-up). Three setup endpoints back the flow: `GET /api/setup/principal` (load), extended `POST /api/setup/principal` (create-or-rename), new `POST /api/setup/principal/profile` (write profile).
+
+**Tech Stack:** TypeScript (ESM, Node 24+), Fastify, PostgreSQL + pgvector, Vitest, React (apps/console, TanStack Router).
+
+## Global Constraints
+
+- ESM only; `.js` extensions on all relative imports; `import.meta.dirname` not `__dirname`.
+- No `any`; no `console.log` (pino only); no empty `catch {}` — log, then handle/propagate.
+- Parameterized SQL only (`$1` placeholders); never interpolate into SQL strings.
+- Run `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-setup-profile-392 run typecheck` before every commit touching `.ts`.
+- Integration tests use real Postgres; they `describe.skip` when `DATABASE_URL` is unset. Run with `DATABASE_URL` pointed at an **empty** test DB (the partial unique index on `system_role='principal'` trips otherwise).
+- Commit style: `feat:` / `fix:` / `chore:`; **no** `Co-Authored-By`, **no** Claude attribution anywhere.
+- Conventions doc to honour: `CLAUDE.md` "Strict TypeScript Patterns" (array access `arr[0]!`, cast through `unknown`).
+- All test/run commands below use the worktree path; the shell's CWD does not persist between calls, so always pass `-C <worktree>` / `--prefix <worktree>`.
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-setup-profile-392` (branch `feat/setup-profile-392`). Abbreviated `$WT` below.
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `src/contacts/working-hours.ts` — pure types + serializer (structured working hours → readable string).
+- `src/contacts/working-hours.test.ts` — unit tests for the serializer.
+
+**Backend (modify):**
+- `src/channels/http/routes/setup.ts` — add `contactService` + `entityMemory` to options; extend `POST /api/setup/principal`; add `GET /api/setup/principal` and `POST /api/setup/principal/profile`.
+- `src/channels/http/http-adapter.ts` — add `entityMemory` to config; pass `contactService` + `entityMemory` into `setupRoutes`.
+- `src/index.ts` — pass `entityMemory` into the `HttpAdapter` config.
+- `tests/integration/setup-routes.test.ts` — build real `ContactService` + `EntityMemory`; new endpoint tests.
+
+**Frontend (modify):**
+- `apps/console/src/pages/wizard-utils.ts` — profile fields on `WizardState`, working-hours type, timezone detect + validators, profile payload builder.
+- `apps/console/src/pages/wizard-utils.test.ts` — unit tests for the new helpers.
+- `apps/console/src/pages/WizardPage.tsx` — remove auto-skip; pre-populate Step 1; add Step 2 "Your details"; renumber; mount-load via `GET /api/setup/principal`; submit Step 2 via `POST /api/setup/principal/profile`.
+
+**Docs (modify):**
+- `docs/dev/setup.md` — reference the wizard for operational-profile configuration.
+- `CHANGELOG.md` — `[Unreleased]` entries.
+
+---
+
+## Task 1: Working-hours serializer (pure, backend)
+
+**Files:**
+- Create: `src/contacts/working-hours.ts`
+- Test: `src/contacts/working-hours.test.ts`
+
+**Interfaces:**
+- Produces: `interface WorkingHours { start: string; end: string; days: number[] }` (days: 0=Sun..6=Sat); `function serializeWorkingHours(wh: WorkingHours): string`; `function validateWorkingHours(value: unknown): WorkingHours | null` (returns the normalized object or `null` if malformed).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/contacts/working-hours.test.ts
+import { describe, it, expect } from 'vitest';
+import { serializeWorkingHours, validateWorkingHours } from './working-hours.js';
+
+describe('serializeWorkingHours', () => {
+  it('formats weekdays as a Mon–Fri range', () => {
+    expect(serializeWorkingHours({ start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] }))
+      .toBe('Mon–Fri, 9:00 AM–5:00 PM');
+  });
+  it('formats all seven days as Sun–Sat', () => {
+    expect(serializeWorkingHours({ start: '08:30', end: '16:00', days: [0, 1, 2, 3, 4, 5, 6] }))
+      .toBe('Sun–Sat, 8:30 AM–4:00 PM');
+  });
+  it('lists non-contiguous days individually', () => {
+    expect(serializeWorkingHours({ start: '10:00', end: '14:00', days: [1, 3, 5] }))
+      .toBe('Mon, Wed, Fri, 10:00 AM–2:00 PM');
+  });
+  it('formats a single day', () => {
+    expect(serializeWorkingHours({ start: '00:00', end: '12:00', days: [2] }))
+      .toBe('Tue, 12:00 AM–12:00 PM');
+  });
+});
+
+describe('validateWorkingHours', () => {
+  it('accepts a well-formed object and sorts/dedupes days', () => {
+    expect(validateWorkingHours({ start: '09:00', end: '17:00', days: [5, 1, 1, 3] }))
+      .toEqual({ start: '09:00', end: '17:00', days: [1, 3, 5] });
+  });
+  it('rejects a bad time', () => {
+    expect(validateWorkingHours({ start: '9am', end: '17:00', days: [1] })).toBeNull();
+  });
+  it('rejects an out-of-range day', () => {
+    expect(validateWorkingHours({ start: '09:00', end: '17:00', days: [7] })).toBeNull();
+  });
+  it('rejects an empty day list', () => {
+    expect(validateWorkingHours({ start: '09:00', end: '17:00', days: [] })).toBeNull();
+  });
+  it('rejects non-objects', () => {
+    expect(validateWorkingHours(null)).toBeNull();
+    expect(validateWorkingHours('mon-fri')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `npx --prefix $WT vitest run src/contacts/working-hours.test.ts`
+Expected: FAIL — `Cannot find module './working-hours.js'`.
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+// src/contacts/working-hours.ts
+//
+// Pure helpers for the principal's working-hours profile (issue #392).
+//
+// Working hours are NOT a canonical contact column (see canonical-attribute-guard.ts),
+// so they are stored as a KG fact on the principal's node and surfaced to agents by the
+// entity-context assembler. The wizard collects them structured; the setup endpoint
+// serializes to a human-readable string for the fact value (richer for KG browsing and
+// better for LLM consumption than raw JSON).
+
+/** Structured working hours. days: 0=Sunday .. 6=Saturday. */
+export interface WorkingHours {
+  start: string; // "HH:MM" 24h
+  end: string;   // "HH:MM" 24h
+  days: number[];
+}
+
+const HHMM = /^([01]\d|2[0-3]):([0-5]\d)$/;
+const DAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+/** Validate + normalize an untrusted value into WorkingHours, or null if malformed. */
+export function validateWorkingHours(value: unknown): WorkingHours | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.start !== 'string' || !HHMM.test(v.start)) return null;
+  if (typeof v.end !== 'string' || !HHMM.test(v.end)) return null;
+  if (!Array.isArray(v.days) || v.days.length === 0) return null;
+  const days: number[] = [];
+  for (const d of v.days) {
+    if (typeof d !== 'number' || !Number.isInteger(d) || d < 0 || d > 6) return null;
+    if (!days.includes(d)) days.push(d);
+  }
+  days.sort((a, b) => a - b);
+  return { start: v.start, end: v.end, days };
+}
+
+/** "09:00" → "9:00 AM"; "17:00" → "5:00 PM"; "00:00" → "12:00 AM". */
+function formatTime(hhmm: string): string {
+  const [h, m] = hhmm.split(':').map((n) => parseInt(n, 10));
+  const hour = h!;
+  const meridiem = hour < 12 ? 'AM' : 'PM';
+  const twelve = hour % 12 === 0 ? 12 : hour % 12;
+  return `${twelve}:${String(m!).padStart(2, '0')} ${meridiem}`;
+}
+
+/** Render days: a fully-contiguous run becomes "Mon–Fri"; otherwise "Mon, Wed, Fri". */
+function formatDays(days: number[]): string {
+  const isContiguous =
+    days.length >= 2 && days.every((d, i) => i === 0 || d === days[i - 1]! + 1);
+  if (isContiguous) return `${DAY_ABBR[days[0]!]}–${DAY_ABBR[days[days.length - 1]!]}`;
+  return days.map((d) => DAY_ABBR[d]).join(', ');
+}
+
+/** Structured working hours → readable string stored in the KG fact value. */
+export function serializeWorkingHours(wh: WorkingHours): string {
+  return `${formatDays(wh.days)}, ${formatTime(wh.start)}–${formatTime(wh.end)}`;
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `npx --prefix $WT vitest run src/contacts/working-hours.test.ts`
+Expected: PASS (10 assertions).
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm -C $WT run typecheck
+git -C $WT add src/contacts/working-hours.ts src/contacts/working-hours.test.ts
+git -C $WT commit -m "feat: add working-hours serializer for principal profile (#392)"
+```
+
+---
+
+## Task 2: Thread `contactService` + `entityMemory` into setup routes
+
+This is enabling plumbing for Tasks 3–5: the new endpoints need `ContactService` (canonical writes, identity link, display-name update) and `EntityMemory` (working-hours fact). Make both **required** options and update every call site + the test harness so existing tests keep compiling and passing.
+
+**Files:**
+- Modify: `src/channels/http/routes/setup.ts:27-61` (SetupRouteOptions), `:75-84` (destructure)
+- Modify: `src/channels/http/http-adapter.ts:60-80` (HttpAdapterConfig — add `entityMemory`), `:314-336` (register call)
+- Modify: `src/index.ts` (HttpAdapter construction — pass `entityMemory`)
+- Modify: `tests/integration/setup-routes.test.ts:49-95` (build real services, pass them)
+
+**Interfaces:**
+- Consumes: `ContactService` from `../../../contacts/contact-service.js`; `EntityMemory` from `../../../memory/entity-memory.js`.
+- Produces: `SetupRouteOptions` now has `contactService: ContactService` and `entityMemory: EntityMemory`.
+
+- [ ] **Step 1: Add the two required options to `SetupRouteOptions`**
+
+In `src/channels/http/routes/setup.ts`, add imports near the top:
+
+```ts
+import type { ContactService } from '../../../contacts/contact-service.js';
+import type { EntityMemory } from '../../../memory/entity-memory.js';
+```
+
+Add to the `SetupRouteOptions` interface (after `pool`):
+
+```ts
+  /** Canonical contact writes + identity linking for the principal profile step (#392). */
+  contactService: ContactService;
+  /** KG fact store for the principal's working-hours fact (#392). */
+  entityMemory: EntityMemory;
+```
+
+And add them to the destructure in `setupRoutes`:
+
+```ts
+  const {
+    webAppBootstrapSecret,
+    sessions,
+    pool,
+    logger,
+    setupRequiredAtBoot,
+    bootStartedAt,
+    scheduleProcessExit,
+    infraLlmService,
+    contactService,
+    entityMemory,
+  } = options;
+```
+
+- [ ] **Step 2: Add `entityMemory` to `HttpAdapterConfig` and pass both through**
+
+In `src/channels/http/http-adapter.ts`, the config interface already has `contactService: ContactService;` (line ~67). Add alongside it:
+
+```ts
+  entityMemory: EntityMemory;
+```
+
+Add the import if absent: `import type { EntityMemory } from '../../memory/entity-memory.js';`
+
+In the `setupRoutes` registration (line ~314), add:
+
+```ts
+        contactService: this.config.contactService,
+        entityMemory: this.config.entityMemory,
+```
+
+- [ ] **Step 3: Pass `entityMemory` into `HttpAdapter` from `index.ts`**
+
+In `src/index.ts`, the `new HttpAdapter({ ... })` config (line ~2044) already passes `contactService`. Add `entityMemory,` to that object. `entityMemory` is in scope (assigned at `src/index.ts:531`).
+
+> Note: `entityMemory` may be typed `EntityMemory | undefined` at that point if construction is conditional. Verify: if it can be `undefined`, the setup routes only register when `webAppBootstrapSecret` is set; gate or assert non-null. Inspect `src/index.ts:531` — if `entityMemory` is unconditional, pass directly. If conditional, pass `entityMemory` and widen `HttpAdapterConfig.entityMemory` to `EntityMemory` only if guaranteed; otherwise make the new endpoints 503 when it's absent. Prefer: confirm it's always constructed (the wizard requires the KG) and keep the type non-optional.
+
+- [ ] **Step 4: Update the integration-test harness to build + pass the services**
+
+In `tests/integration/setup-routes.test.ts`, add imports:
+
+```ts
+import { ContactService } from '../../src/contacts/contact-service.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { createSilentLogger } from '../../src/logger.js';
+```
+
+In `beforeAll`, after `pool` is created, build the services (mirrors `tests/integration/contacts.test.ts:36-40`):
+
+```ts
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    const entityMemory = new EntityMemory(kgStore, validator, embeddingService, createSilentLogger());
+    const contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
+```
+
+Pass them into both `buildApp` registrations by adding to the `setupRoutes` options inside `buildApp`:
+
+```ts
+        contactService,
+        entityMemory,
+```
+
+(Make `buildApp` close over the outer `contactService`/`entityMemory`, or add them as params — closing over is simplest.)
+
+Extend the `afterAll` cleanup to clear KG rows the new tests create:
+
+```ts
+    await pool.query('DELETE FROM kg_edges');
+    await pool.query('DELETE FROM kg_nodes');
+```
+(Keep the existing principal/identity deletes; order: identities → contacts → edges → nodes.)
+
+- [ ] **Step 5: Typecheck + run existing setup tests, verify still green**
+
+```bash
+pnpm -C $WT run typecheck
+npx --prefix $WT vitest run tests/integration/setup-routes.test.ts
+```
+Expected: PASS (existing cases) when `DATABASE_URL` is set; SKIP otherwise. Typecheck clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C $WT add src/channels/http/routes/setup.ts src/channels/http/http-adapter.ts src/index.ts tests/integration/setup-routes.test.ts
+git -C $WT commit -m "chore: wire contactService + entityMemory into setup routes (#392)"
+```
+
+---
+
+## Task 3: Extend `POST /api/setup/principal` to rename an existing principal
+
+When the principal already exists and the submitted name differs from the current display name, update it (so Step 1 can correct a name) instead of the current no-op. Best-effort sync of the KG person-node label so KG browsing shows the right name.
+
+**Files:**
+- Modify: `src/channels/http/routes/setup.ts:102-135`
+- Test: `tests/integration/setup-routes.test.ts`
+
+**Interfaces:**
+- Consumes: `contactService.updateDisplayName(contactId, name)`, `contactService.findContactBySystemRole('principal')`.
+- Produces: response unchanged shape `{ contactId, kgNodeId, alreadyExisted, renamed: boolean }` (adds `renamed`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/integration/setup-routes.test.ts` (inside the principal describe block):
+
+```ts
+it('renames the principal when called again with a different name', async () => {
+  const first = await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+    payload: { name: 'Original Name' },
+  });
+  expect(first.statusCode).toBe(200);
+  const { contactId } = first.json();
+
+  const second = await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+    payload: { name: 'Corrected Name' },
+  });
+  expect(second.statusCode).toBe(200);
+  const body = second.json();
+  expect(body.alreadyExisted).toBe(true);
+  expect(body.renamed).toBe(true);
+  expect(body.contactId).toBe(contactId);
+
+  const row = await pool.query<{ display_name: string }>(
+    `SELECT display_name FROM contacts WHERE id = $1`, [contactId],
+  );
+  expect(row.rows[0]!.display_name).toBe('Corrected Name');
+});
+
+it('does not rename when the same name is submitted', async () => {
+  await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+    payload: { name: 'Same Name' },
+  });
+  const again = await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+    payload: { name: 'Same Name' },
+  });
+  expect(again.json().renamed).toBe(false);
+});
+```
+
+> Each `it` must start from a clean principal. Add a `beforeEach` in this block that runs the same delete as `beforeAll` (`DELETE FROM contact_channel_identities WHERE contact_id IN (...principal...)` then `DELETE FROM contacts WHERE system_role='principal'`), if one isn't already present.
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `npx --prefix $WT vitest run tests/integration/setup-routes.test.ts -t "renames the principal"`
+Expected: FAIL — `renamed` is `undefined` (route doesn't set it / doesn't rename).
+
+- [ ] **Step 3: Implement the rename branch**
+
+Replace the `try` block body in `POST /api/setup/principal`:
+
+```ts
+    try {
+      const result = await ensurePrincipalContact({ displayName: trimmed }, pool, logger);
+      let renamed = false;
+      if (result.alreadyExisted) {
+        // The principal already exists. Step 1 is no longer auto-skipped (#392), so a
+        // second submit is the operator correcting the name — apply it instead of no-op'ing.
+        const current = await contactService.findContactBySystemRole('principal');
+        if (current && current.displayName !== trimmed) {
+          await contactService.updateDisplayName(result.contactId, trimmed);
+          renamed = true;
+          // Best-effort: keep the KG person-node label in sync so KG browsing shows the
+          // corrected name. The unique index idx_kg_nodes_unique (lower(label), type) can
+          // reject the rename if another non-fact node already owns that label; that's
+          // non-fatal — the contact column is the authoritative display name.
+          try {
+            await pool.query(
+              `UPDATE kg_nodes SET label = $1, last_confirmed_at = now()
+                 WHERE id = $2 AND type = 'person'`,
+              [trimmed, result.kgNodeId],
+            );
+          } catch (kgErr) {
+            logger.warn(
+              { kgErr, kgNodeId: result.kgNodeId },
+              'POST /api/setup/principal: KG label rename skipped (likely label collision); contact display_name still updated',
+            );
+          }
+        }
+      }
+      return reply.send({
+        contactId: result.contactId,
+        kgNodeId: result.kgNodeId,
+        alreadyExisted: result.alreadyExisted,
+        renamed,
+      });
+    } catch (err) {
+      logger.error({ err }, 'POST /api/setup/principal: failed to ensure principal contact');
+      return reply.status(500).send({
+        error: 'Failed to create principal contact. Check server logs.',
+      });
+    }
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npx --prefix $WT vitest run tests/integration/setup-routes.test.ts -t "principal"`
+Expected: PASS (new rename cases + existing principal cases).
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm -C $WT run typecheck
+git -C $WT add src/channels/http/routes/setup.ts tests/integration/setup-routes.test.ts
+git -C $WT commit -m "feat: allow setup wizard to rename an existing principal (#392)"
+```
+
+---
+
+## Task 4: `GET /api/setup/principal` — load the principal profile
+
+Returns the current principal's name + profile so the wizard can pre-populate Steps 1 and 2.
+
+**Files:**
+- Modify: `src/channels/http/routes/setup.ts` (add route)
+- Test: `tests/integration/setup-routes.test.ts`
+
+**Interfaces:**
+- Consumes: `contactService.findContactBySystemRole`, `contactService.getContactWithIdentities`.
+- Produces: `GET /api/setup/principal` → `{ exists: boolean, displayName: string | null, timezone: string | null, preferredName: string | null, title: string | null, email: string | null, workingHours: string | null }`. `email` is the verified+active email identity's identifier; `workingHours` is the stored fact's value string.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('GET /api/setup/principal returns { exists:false } when no principal', async () => {
+  // beforeEach has cleared the principal
+  const res = await appSetupMode.inject({
+    method: 'GET', url: '/api/setup/principal', headers: AUTH_HEADER,
+  });
+  expect(res.statusCode).toBe(200);
+  expect(res.json()).toMatchObject({ exists: false, displayName: null });
+});
+
+it('GET /api/setup/principal returns the persisted profile', async () => {
+  await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+    payload: { name: 'Profile Owner' },
+  });
+  await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+    payload: {
+      timezone: 'America/Vancouver',
+      email: 'owner@example.com',
+      preferredName: 'Owner',
+      title: 'CEO',
+      workingHours: { start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] },
+    },
+  });
+
+  const res = await appSetupMode.inject({
+    method: 'GET', url: '/api/setup/principal', headers: AUTH_HEADER,
+  });
+  expect(res.statusCode).toBe(200);
+  expect(res.json()).toMatchObject({
+    exists: true,
+    displayName: 'Profile Owner',
+    timezone: 'America/Vancouver',
+    preferredName: 'Owner',
+    title: 'CEO',
+    email: 'owner@example.com',
+    workingHours: 'Mon–Fri, 9:00 AM–5:00 PM',
+  });
+});
+```
+
+> This test depends on Task 5's profile endpoint. Implement Task 4's route first (so the GET exists), then Task 5; run this test green at the end of Task 5. To keep Task 4 independently runnable, also keep the `{exists:false}` case (passes without Task 5).
+
+- [ ] **Step 2: Run, verify the `{exists:false}` case fails**
+
+Run: `npx --prefix $WT vitest run tests/integration/setup-routes.test.ts -t "exists:false"`
+Expected: FAIL — 404 (route not found).
+
+- [ ] **Step 3: Implement the route**
+
+Add after the existing `POST /api/setup/principal` handler. Helper to read the working-hours fact uses the same KG traversal the assembler uses (`relates_to` edges to `type='fact'` nodes, `properties.attribute='working_hours'`):
+
+```ts
+  // -- GET /api/setup/principal --
+  //
+  // Loads the principal's name + operational profile so the wizard can pre-populate
+  // Steps 1 and 2 (#392). Returns { exists:false } (not 404) when no principal yet —
+  // the wizard treats that as a fresh install.
+  app.get('/api/setup/principal', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+    try {
+      const principal = await contactService.findContactBySystemRole('principal');
+      if (!principal) {
+        return reply.send({
+          exists: false, displayName: null, timezone: null,
+          preferredName: null, title: null, email: null, workingHours: null,
+        });
+      }
+      const withIdentities = await contactService.getContactWithIdentities(principal.id);
+      const email = (withIdentities?.identities ?? [])
+        .find((i) => i.channel === 'email' && i.verified && i.status === 'active')
+        ?.channelIdentifier ?? null;
+
+      // Working-hours fact: a 'fact' node linked to the principal's KG node whose
+      // properties.attribute === 'working_hours'. Mirrors the assembler's getFacts query.
+      let workingHours: string | null = null;
+      if (principal.kgNodeId) {
+        const facts = await pool.query<{ value: string | null }>(
+          `SELECT n.properties->>'value' AS value
+             FROM kg_edges e JOIN kg_nodes n ON n.id = e.target_node_id
+            WHERE e.source_node_id = $1 AND e.type = 'relates_to'
+              AND n.type = 'fact' AND lower(n.properties->>'attribute') = 'working_hours'
+            ORDER BY n.last_confirmed_at DESC LIMIT 1`,
+          [principal.kgNodeId],
+        );
+        workingHours = facts.rows[0]?.value ?? null;
+      }
+
+      return reply.send({
+        exists: true,
+        displayName: principal.displayName,
+        timezone: principal.timezone ?? null,
+        preferredName: principal.preferredName ?? null,
+        title: principal.title ?? null,
+        email,
+        workingHours,
+      });
+    } catch (err) {
+      logger.error({ err }, 'GET /api/setup/principal: failed to load principal profile');
+      return reply.status(500).send({ error: 'Failed to load principal profile. Check server logs.' });
+    }
+  });
+```
+
+> Verify `Contact` exposes `displayName`, `timezone`, `preferredName`, `title`, `kgNodeId` (it does — `src/contacts/types.ts:3-53`). Verify `getContactWithIdentities` returns `{ identities }` (used at `src/index.ts:669`).
+
+- [ ] **Step 4: Run the `{exists:false}` case, verify pass**
+
+Run: `npx --prefix $WT vitest run tests/integration/setup-routes.test.ts -t "exists:false"`
+Expected: PASS. (The full-profile case goes green after Task 5.)
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm -C $WT run typecheck
+git -C $WT add src/channels/http/routes/setup.ts tests/integration/setup-routes.test.ts
+git -C $WT commit -m "feat: add GET /api/setup/principal profile load (#392)"
+```
+
+---
+
+## Task 5: `POST /api/setup/principal/profile` — persist the profile
+
+Writes timezone/preferred-name/title to canonical columns, links a verified `ceo_stated` email then sets `primary_email`, and stores working hours as a KG fact.
+
+**Files:**
+- Modify: `src/channels/http/routes/setup.ts` (add route; import working-hours helpers, `Intl` guard)
+- Test: `tests/integration/setup-routes.test.ts`
+
+**Interfaces:**
+- Consumes: `contactService.findContactBySystemRole`, `contactService.linkIdentity`, `contactService.updateContactFields`, `entityMemory.storeFact`; `validateWorkingHours`, `serializeWorkingHours` from `../../../contacts/working-hours.js`.
+- Produces: `POST /api/setup/principal/profile` → `{ ok: true }` on success; `400`/`422` on validation; `409` when no principal; `500` on failure.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('POST profile rejects an invalid timezone with 422', async () => {
+  await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER, payload: { name: 'TZ Tester' },
+  });
+  const res = await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+    payload: { timezone: 'Mars/Olympus_Mons' },
+  });
+  expect(res.statusCode).toBe(422);
+});
+
+it('POST profile 409s when no principal exists', async () => {
+  const res = await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+    payload: { timezone: 'America/Toronto' },
+  });
+  expect(res.statusCode).toBe(409);
+});
+
+it('POST profile writes canonical fields, links a verified email, and stores a working-hours fact', async () => {
+  const created = await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER, payload: { name: 'Full Profile' },
+  });
+  const { contactId, kgNodeId } = created.json();
+
+  const res = await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+    payload: {
+      timezone: 'America/Vancouver', email: 'FULL@Example.com',
+      preferredName: 'Full', title: 'Founder',
+      workingHours: { start: '08:00', end: '16:00', days: [1, 2, 3, 4, 5] },
+    },
+  });
+  expect(res.statusCode).toBe(200);
+
+  const contact = await pool.query<{ timezone: string; preferred_name: string; title: string; primary_email: string }>(
+    `SELECT timezone, preferred_name, title, primary_email FROM contacts WHERE id = $1`, [contactId],
+  );
+  expect(contact.rows[0]).toMatchObject({
+    timezone: 'America/Vancouver', preferred_name: 'Full', title: 'Founder',
+    primary_email: 'full@example.com', // lower-cased
+  });
+
+  const ident = await pool.query<{ verified: boolean; status: string; source: string }>(
+    `SELECT verified, status, source FROM contact_channel_identities
+       WHERE contact_id = $1 AND channel = 'email'`, [contactId],
+  );
+  expect(ident.rows[0]).toMatchObject({ verified: true, status: 'active', source: 'ceo_stated' });
+
+  const fact = await pool.query<{ value: string }>(
+    `SELECT n.properties->>'value' AS value FROM kg_edges e JOIN kg_nodes n ON n.id = e.target_node_id
+       WHERE e.source_node_id = $1 AND n.type = 'fact'
+         AND lower(n.properties->>'attribute') = 'working_hours' LIMIT 1`, [kgNodeId],
+  );
+  expect(fact.rows[0]!.value).toBe('Mon–Fri, 8:00 AM–4:00 PM');
+});
+
+it('POST profile leaves omitted optional fields untouched', async () => {
+  const created = await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER, payload: { name: 'Partial' },
+  });
+  const { contactId } = created.json();
+  await appSetupMode.inject({
+    method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+    payload: { timezone: 'America/Toronto', title: 'CTO' },
+  });
+  const row = await pool.query<{ preferred_name: string | null; primary_email: string | null }>(
+    `SELECT preferred_name, primary_email FROM contacts WHERE id = $1`, [contactId],
+  );
+  expect(row.rows[0]).toMatchObject({ preferred_name: null, primary_email: null });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `npx --prefix $WT vitest run tests/integration/setup-routes.test.ts -t "POST profile"`
+Expected: FAIL — 404 (route not found).
+
+- [ ] **Step 3: Implement the route**
+
+Add imports at the top of `setup.ts`:
+
+```ts
+import { validateWorkingHours, serializeWorkingHours } from '../../../contacts/working-hours.js';
+```
+
+Add a simple email syntactic check near the other constants:
+
+```ts
+// Pragmatic address shape check — full RFC validation is unnecessary; the address is
+// the principal's own and is normalized to lowercase before linking.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+```
+
+Add the route:
+
+```ts
+  // -- POST /api/setup/principal/profile --
+  //
+  // Persists the principal operational profile collected in the wizard's "Your details"
+  // step (#392): timezone + preferred name + title onto canonical contact columns; the
+  // email as a verified ceo_stated channel identity (so index.ts resolves principalEmail
+  // after the wizard-end restart); working hours as a KG fact surfaced by entity-context.
+  // Requires the principal to exist (created in Step 1). Omitted optional fields are not
+  // written, so a partial submit never clobbers an existing value.
+  app.post('/api/setup/principal/profile', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+
+    const body = (request.body ?? {}) as {
+      timezone?: unknown; email?: unknown; preferredName?: unknown;
+      title?: unknown; workingHours?: unknown;
+    };
+
+    // timezone is required and must be a real IANA zone (same guard as config.ts).
+    if (typeof body.timezone !== 'string' || body.timezone.trim().length === 0) {
+      return reply.status(400).send({ error: 'timezone is required.' });
+    }
+    const timezone = body.timezone.trim();
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    } catch {
+      return reply.status(422).send({ error: `"${timezone}" is not a recognized IANA timezone.` });
+    }
+
+    // Optional fields — validate shape before any write.
+    let email: string | undefined;
+    if (body.email !== undefined && body.email !== null && body.email !== '') {
+      if (typeof body.email !== 'string' || !EMAIL_RE.test(body.email.trim())) {
+        return reply.status(422).send({ error: 'email is not a valid address.' });
+      }
+      email = body.email.trim().toLowerCase();
+    }
+    const preferredName =
+      typeof body.preferredName === 'string' && body.preferredName.trim() ? body.preferredName.trim() : undefined;
+    const title =
+      typeof body.title === 'string' && body.title.trim() ? body.title.trim() : undefined;
+
+    let workingHoursValue: string | undefined;
+    if (body.workingHours !== undefined && body.workingHours !== null) {
+      const wh = validateWorkingHours(body.workingHours);
+      if (!wh) return reply.status(422).send({ error: 'workingHours is malformed.' });
+      workingHoursValue = serializeWorkingHours(wh);
+    }
+
+    try {
+      const principal = await contactService.findContactBySystemRole('principal');
+      if (!principal) {
+        return reply.status(409).send({ error: 'No principal exists yet — complete Step 1 first.' });
+      }
+
+      // Email first: updateContactFields validates primaryEmail against existing channel
+      // identities, so the identity must be linked before primary_email is set. ceo_stated
+      // is auto-verified (AUTO_VERIFIED_SOURCES), so this lands verified+active.
+      if (email) {
+        await contactService.linkIdentity({
+          contactId: principal.id, channel: 'email', channelIdentifier: email,
+          source: 'ceo_stated', verified: true,
+        });
+      }
+
+      // Canonical columns — only defined fields are written (updateContactFields drops
+      // undefined entries, so omitted optionals are never clobbered).
+      await contactService.updateContactFields(principal.id, {
+        timezone,
+        ...(preferredName !== undefined ? { preferredName } : {}),
+        ...(title !== undefined ? { title } : {}),
+        ...(email !== undefined ? { primaryEmail: email } : {}),
+      });
+
+      // Working hours → KG fact on the principal's node. Carries properties.attribute so
+      // storeFact runs contradiction detection (a wizard re-run updates, not duplicates).
+      if (workingHoursValue && principal.kgNodeId) {
+        await entityMemory.storeFact({
+          entityNodeId: principal.kgNodeId,
+          label: 'Working hours',
+          properties: { attribute: 'working_hours', value: workingHoursValue, category: 'preference' },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'system:setup-wizard',
+        });
+      }
+
+      return reply.send({ ok: true });
+    } catch (err) {
+      logger.error({ err }, 'POST /api/setup/principal/profile: failed to persist profile');
+      return reply.status(500).send({ error: 'Failed to save profile. Check server logs.' });
+    }
+  });
+```
+
+- [ ] **Step 4: Run profile + GET full-profile tests, verify pass**
+
+Run: `npx --prefix $WT vitest run tests/integration/setup-routes.test.ts`
+Expected: PASS (all setup-routes cases, including Task 4's full-profile case).
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm -C $WT run typecheck
+git -C $WT add src/channels/http/routes/setup.ts tests/integration/setup-routes.test.ts
+git -C $WT commit -m "feat: add POST /api/setup/principal/profile (#392)"
+```
+
+---
+
+## Task 6: Wizard utils — profile state, helpers, validators (frontend, pure)
+
+**Files:**
+- Modify: `apps/console/src/pages/wizard-utils.ts`
+- Test: `apps/console/src/pages/wizard-utils.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface WizardWorkingHours { start: string; end: string; days: number[] }`
+  - `WizardState` gains: `timezone: string`, `email: string`, `preferredName: string`, `principalTitle: string`, `workingHours: WizardWorkingHours | null`.
+  - `function detectBrowserTimezone(): string` — `Intl.DateTimeFormat().resolvedOptions().timeZone` with a safe `'America/Toronto'` fallback.
+  - `function validateProfileEmail(email: string): string | null` — `null` when empty (optional) or valid; error string when malformed.
+  - `function buildProfilePayload(state: WizardState): { timezone: string; email?: string; preferredName?: string; title?: string; workingHours?: WizardWorkingHours }` — omits empties.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/console/src/pages/wizard-utils.test.ts`:
+
+```ts
+import {
+  detectBrowserTimezone, validateProfileEmail, buildProfilePayload, DEFAULT_WIZARD_STATE,
+} from './wizard-utils.js';
+
+describe('validateProfileEmail', () => {
+  it('returns null for empty (optional field)', () => {
+    expect(validateProfileEmail('')).toBeNull();
+    expect(validateProfileEmail('   ')).toBeNull();
+  });
+  it('returns null for a valid address', () => {
+    expect(validateProfileEmail('a@b.com')).toBeNull();
+  });
+  it('returns an error for a malformed address', () => {
+    expect(validateProfileEmail('not-an-email')).toMatch(/valid/i);
+  });
+});
+
+describe('buildProfilePayload', () => {
+  it('includes timezone and omits empty optionals', () => {
+    const state = { ...DEFAULT_WIZARD_STATE, timezone: 'America/Vancouver' };
+    expect(buildProfilePayload(state)).toEqual({ timezone: 'America/Vancouver' });
+  });
+  it('includes provided optionals and trims them', () => {
+    const state = {
+      ...DEFAULT_WIZARD_STATE, timezone: 'America/Toronto',
+      email: '  Me@Example.com ', preferredName: ' Jo ', principalTitle: ' CEO ',
+      workingHours: { start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] },
+    };
+    expect(buildProfilePayload(state)).toEqual({
+      timezone: 'America/Toronto', email: 'Me@Example.com', preferredName: 'Jo',
+      title: 'CEO', workingHours: { start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] },
+    });
+  });
+});
+
+describe('detectBrowserTimezone', () => {
+  it('returns a non-empty IANA-looking string', () => {
+    expect(detectBrowserTimezone()).toMatch(/^[A-Za-z]+\/[A-Za-z_]+/);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `npx --prefix $WT vitest run apps/console/src/pages/wizard-utils.test.ts`
+Expected: FAIL — new exports undefined.
+
+- [ ] **Step 3: Implement**
+
+In `wizard-utils.ts`, add the type and extend `WizardState`:
+
+```ts
+export interface WizardWorkingHours {
+  start: string; // "HH:MM"
+  end: string;   // "HH:MM"
+  days: number[]; // 0=Sun..6=Sat
+}
+```
+
+Add to the `WizardState` interface (after `principalName`):
+
+```ts
+  // Step 2 — Your details (principal operational profile, #392).
+  timezone: string;
+  email: string;
+  preferredName: string;
+  principalTitle: string; // distinct from `title` (the assistant's title, Step 3)
+  workingHours: WizardWorkingHours | null;
+```
+
+Extend `DEFAULT_WIZARD_STATE`:
+
+```ts
+  timezone: '',
+  email: '',
+  preferredName: '',
+  principalTitle: '',
+  workingHours: null,
+```
+
+Add helpers:
+
+```ts
+// Browser timezone detection for the Step 2 prefill (#392). Falls back to the
+// backend default if the platform doesn't expose a resolved zone.
+export function detectBrowserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/Toronto';
+  } catch {
+    return 'America/Toronto';
+  }
+}
+
+const PROFILE_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Email is optional in Step 2. Returns null when blank (allowed) or valid; an error
+// string when present-but-malformed.
+export function validateProfileEmail(email: string): string | null {
+  const trimmed = email.trim();
+  if (trimmed.length === 0) return null;
+  if (!PROFILE_EMAIL_RE.test(trimmed)) return 'Enter a valid email address.';
+  return null;
+}
+
+// Builds the POST /api/setup/principal/profile body, omitting empty optionals so the
+// backend never clobbers an existing value with a blank.
+export function buildProfilePayload(state: WizardState): {
+  timezone: string; email?: string; preferredName?: string; title?: string;
+  workingHours?: WizardWorkingHours;
+} {
+  const payload: {
+    timezone: string; email?: string; preferredName?: string; title?: string;
+    workingHours?: WizardWorkingHours;
+  } = { timezone: state.timezone.trim() };
+  if (state.email.trim()) payload.email = state.email.trim();
+  if (state.preferredName.trim()) payload.preferredName = state.preferredName.trim();
+  if (state.principalTitle.trim()) payload.title = state.principalTitle.trim();
+  if (state.workingHours) payload.workingHours = state.workingHours;
+  return payload;
+}
+```
+
+> The existing `buildIdentityPayload` and other helpers are unaffected. `principalTitle` is deliberately named to avoid colliding with `state.title` (the assistant's title).
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npx --prefix $WT vitest run apps/console/src/pages/wizard-utils.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm -C $WT run typecheck
+git -C $WT add apps/console/src/pages/wizard-utils.ts apps/console/src/pages/wizard-utils.test.ts
+git -C $WT commit -m "feat: wizard-utils profile state + helpers (#392)"
+```
+
+---
+
+## Task 7: WizardPage — pre-populate Step 1, add Step 2, wire endpoints
+
+**Files:**
+- Modify: `apps/console/src/pages/WizardPage.tsx`
+
+**Interfaces:**
+- Consumes: `GET /api/setup/principal`, `POST /api/setup/principal`, `POST /api/setup/principal/profile`; helpers from Task 6.
+
+- [ ] **Step 1: Bump `TOTAL_STEPS` and add the principal-profile response type**
+
+`const TOTAL_STEPS = 6;` (was 5).
+
+Add a response interface near `SetupStatusResponse`:
+
+```ts
+interface PrincipalProfileResponse {
+  exists: boolean;
+  displayName: string | null;
+  timezone: string | null;
+  preferredName: string | null;
+  title: string | null;
+  email: string | null;
+  workingHours: string | null; // serialized string; the form keeps its own structured state
+}
+```
+
+- [ ] **Step 2: Remove the auto-skip effect and pre-populate from the principal**
+
+Delete the auto-skip `useEffect` (`WizardPage.tsx:214-218`). In the mount `load()` effect, after fetching identity/status, also fetch the principal and merge into state:
+
+```ts
+        const principalRes = await apiFetch('/api/setup/principal');
+        if (principalRes.ok) {
+          const p = await principalRes.json() as PrincipalProfileResponse;
+          setState(s => ({
+            ...s,
+            principalName: p.displayName ?? s.principalName,
+            timezone: p.timezone ?? detectBrowserTimezone(),
+            email: p.email ?? '',
+            preferredName: p.preferredName ?? '',
+            principalTitle: p.title ?? '',
+            // workingHours stays structured in the form; a returning operator re-enters it
+            // if they want to change it. (The string is shown as the current value hint.)
+          }));
+        } else {
+          setState(s => ({ ...s, timezone: detectBrowserTimezone() }));
+        }
+```
+
+Add the import: `detectBrowserTimezone, validateProfileEmail, buildProfilePayload` to the existing `wizard-utils.js` import block. `setPrincipalExists` is no longer needed for skipping — keep it only if other code reads it; otherwise remove the state and its setter.
+
+- [ ] **Step 3: Renumber the existing render branches**
+
+The render switches on `currentStep`. Shift the existing Assistant identity / Tone / Posture / Review branches from steps 2/3/4/5 to **3/4/5/6**. Insert the new Step 2 between Step 1 and the (now) Step 3. The Step 1 "About you" render (currently `WizardPage.tsx:539-584`) stays as step 1; ensure its input is bound to `state.principalName` (pre-populated) and has no skip.
+
+- [ ] **Step 4: Implement the Step 2 "Your details" render + continue handler**
+
+Add a `handleProfileContinue` that validates and POSTs, mirroring `handlePrincipalContinue`'s pattern (it already POSTs the name; ensure the principal exists before profile by calling `POST /api/setup/principal` with `state.principalName` in Step 1's continue, which already happens):
+
+```tsx
+async function handleProfileContinue(): Promise<void> {
+  const tzError = state.timezone.trim() ? null : 'Select your timezone.';
+  const emailError = validateProfileEmail(state.email);
+  if (tzError || emailError) {
+    setProfileError(tzError ?? emailError);
+    return;
+  }
+  setProfileError(null);
+  try {
+    const res = await apiFetch('/api/setup/principal/profile', {
+      method: 'POST',
+      body: JSON.stringify(buildProfilePayload(state)),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({})) as { error?: string };
+      setProfileError(data.error ?? 'Could not save your details. Please try again.');
+      return;
+    }
+    await goTo(3);
+  } catch {
+    setProfileError('Could not save your details. Please try again.');
+  }
+}
+```
+
+Step 2 form fields (follow the existing wizard's input/label styling already in the file):
+- **Timezone** (required): a `<select>` of IANA zones. Source the list from `Intl.supportedValuesOf('timeZone')` with a fallback to a small hardcoded list if unavailable; default the selected value to `state.timezone`.
+- **Email** (optional): `<input type="email">` bound to `state.email`; show `emailError` inline.
+- **Preferred name** (optional): `<input>` bound to `state.preferredName`.
+- **Title** (optional): `<input>` bound to `state.principalTitle`.
+- **Working hours** (optional): start/end `<input type="time">` bound to `state.workingHours?.start/.end` and 7 weekday toggle buttons updating `state.workingHours.days`. Leaving it untouched keeps `workingHours: null` (skippable). When the operator sets times/days, assemble a `WizardWorkingHours`.
+- A "Continue" button calling `handleProfileContinue`, and a "Back" to step 1.
+
+Add `const [profileError, setProfileError] = useState<string | null>(null);` with the other `useState` hooks.
+
+- [ ] **Step 5: Verify typecheck + console build**
+
+```bash
+pnpm -C $WT run typecheck
+pnpm -C $WT run build
+```
+Expected: both succeed. (If the console app has a separate build script, e.g. `build:console`, run that; check `package.json` scripts.)
+
+- [ ] **Step 6: Manual smoke (document, not automated)**
+
+With a local empty DB and the app running (`pnpm -C $WT dev`), load `/setup`: Step 1 shows the name input (pre-populated if a principal exists), Step 2 shows timezone pre-filled from the browser, optional fields skippable, Continue advances to the assistant-identity step. Note the result in the PR description.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C $WT add apps/console/src/pages/WizardPage.tsx
+git -C $WT commit -m "feat: add principal operational-profile step to setup wizard (#392)"
+```
+
+---
+
+## Task 8: Docs, changelog, follow-up issue
+
+**Files:**
+- Modify: `docs/dev/setup.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update `docs/dev/setup.md`**
+
+Add a short subsection under the setup/onboarding section: the wizard now collects the principal's operational profile (timezone, email, preferred name, title, working hours) on the "Your details" step; the email is stored as a verified principal identity used after the wizard-end restart; **the system timezone (`TIMEZONE` env / cron scheduler) is still env-driven** — the wizard's timezone informs agent reasoning via entity-context, and aligning the system clock is tracked as a follow-up. Read the file first and match its existing heading style.
+
+- [ ] **Step 2: Update `CHANGELOG.md`**
+
+Under `## [Unreleased]`:
+
+```markdown
+### Added
+- **Setup wizard — principal operational profile** — new "Your details" step captures the principal's timezone, email, preferred name, title, and working hours; email is stored as a verified identity that comes online after the wizard's restart. (#392)
+
+### Fixed
+- **Setup wizard — name step** — Step 1 no longer auto-skips when a principal exists; it pre-populates the current name so it can be corrected. (#392)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C $WT add docs/dev/setup.md CHANGELOG.md
+git -C $WT commit -m "docs: document setup wizard principal profile + changelog (#392)"
+```
+
+- [ ] **Step 4: File the follow-up issue (after PR, manual)**
+
+Create a GitHub issue: "make system timezone track the principal's contact timezone" — labels per repo convention (`enhancement`, `identities`, a `size:` label), acceptance criteria covering the cron scheduler / `config.timezone` reading the principal's contact timezone at boot, and how a mid-session timezone change is handled. Reference #392. (Draft as markdown first per upstream-workflow preference; do not file without confirmation.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- AC "Step 1 does not auto-skip; pre-populated" → Task 7 Step 2.
+- AC "wizard captures timezone (required)" → Task 5 (server validation) + Task 7 (required select).
+- AC "timezone pre-populates from browser locale" → Task 6 `detectBrowserTimezone` + Task 7 mount.
+- AC "selected timezone persists to DB and is used by the runtime without env change/restart" → `contacts.timezone` (Task 5), surfaced live to agents via entity-context (existing assembler). **System clock/scheduler explicitly deferred** — documented in spec + Task 8 + follow-up issue.
+- AC "collects/confirms principal email; persists to DB-backed config the restart picks up" → verified `ceo_stated` identity (Task 5); `index.ts` resolves `principalEmail` from it post-restart (existing).
+- AC "working hours, preferred name, title optional/skippable" → Task 5 (optional handling) + Task 6/7.
+- AC "first-time deployer ends timezone-aware" → agent reasoning timezone-aware via enrichment; system-clock caveat documented.
+- AC "Steps 2–4 (assistant identity) unaffected" → Task 7 renumbers only; no behavior change.
+- AC "docs/dev/setup.md references the wizard" → Task 8.
+
+**Placeholder scan:** none — every code step has full code; manual-smoke step is explicitly documentation, not a code placeholder.
+
+**Type consistency:** `WizardWorkingHours` (frontend) vs `WorkingHours` (backend) are intentionally separate (different packages, identical shape). `principalTitle` (Step 2, principal) is distinct from `title` (Step 3, assistant) — checked across Tasks 6 and 7. Response field names (`displayName`, `timezone`, `preferredName`, `title`, `email`, `workingHours`) match between Task 4 (GET) and Task 7 (consumer).

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -101,7 +101,8 @@ export interface HttpAdapterConfig {
   /**
    * KG fact store for principal profile endpoints (#392). Optional — only available
    * when OPENAI_API_KEY is configured (entity memory requires embeddings). Passed
-   * through to setupRoutes; individual endpoints 503 when absent.
+   * through to setupRoutes; working-hours fact storage is skipped gracefully when absent
+   * (timezone/email/name writes still succeed).
    */
   entityMemory?: import('../../memory/entity-memory.js').EntityMemory;
 }

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -98,6 +98,12 @@ export interface HttpAdapterConfig {
    * suggestion, #799). Optional — the endpoint degrades to "unavailable" when absent.
    */
   infraLlmService?: import('../../skills/infra-llm.js').InfraLlmService;
+  /**
+   * KG fact store for principal profile endpoints (#392). Optional — only available
+   * when OPENAI_API_KEY is configured (entity memory requires embeddings). Passed
+   * through to setupRoutes; individual endpoints 503 when absent.
+   */
+  entityMemory?: import('../../memory/entity-memory.js').EntityMemory;
 }
 
 export class HttpAdapter implements Channel {
@@ -333,6 +339,8 @@ export class HttpAdapter implements Channel {
           setTimeout(() => process.exit(0), delayMs);
         },
         infraLlmService: this.config.infraLlmService,
+        contactService: this.config.contactService,
+        entityMemory: this.config.entityMemory,
       });
     }
 

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -23,12 +23,18 @@ import { ensurePrincipalContact } from '../../../contacts/ensure-principal.js';
 import { isIdentityConfigured } from './identity.js';
 import type { InfraLlmService } from '../../../skills/infra-llm.js';
 import { parseSuggestedFirstName, SUGGEST_NAME_PROMPT } from './suggest-name.js';
+import type { ContactService } from '../../../contacts/contact-service.js';
+import type { EntityMemory } from '../../../memory/entity-memory.js';
 
 export interface SetupRouteOptions {
   webAppBootstrapSecret: string;
   sessions: SessionStore;
   pool: Pool;
   logger: Logger;
+  /** Canonical contact writes + identity linking for the principal profile step (#392). */
+  contactService: ContactService;
+  /** KG fact store for the principal's working-hours fact (#392). */
+  entityMemory: EntityMemory | undefined;
   /**
    * Whether the process booted in setup-required mode (no principal at boot, so
    * email + Signal adapters were skipped). Captured at startup and never changes

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -284,11 +284,19 @@ export async function setupRoutes(
       // Email first: updateContactFields validates primaryEmail against existing channel
       // identities, so the identity must be linked before primary_email is set. ceo_stated
       // is auto-verified (AUTO_VERIFIED_SOURCES), so this lands verified+active.
+      // Guard against re-running the wizard with the same email: linkIdentity does a plain
+      // INSERT and would hit the unique index on (channel, lower(channel_identifier)).
       if (email) {
-        await contactService.linkIdentity({
-          contactId: principal.id, channel: 'email', channelIdentifier: email,
-          source: 'ceo_stated', verified: true,
-        });
+        const existing = await contactService.getIdentitiesForContact(principal.id);
+        const alreadyLinked = existing.some(
+          (id) => id.channel === 'email' && id.channelIdentifier === email,
+        );
+        if (!alreadyLinked) {
+          await contactService.linkIdentity({
+            contactId: principal.id, channel: 'email', channelIdentifier: email,
+            source: 'ceo_stated', verified: true,
+          });
+        }
       }
 
       // Canonical columns — only defined fields are written (updateContactFields drops

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -248,8 +248,11 @@ export async function setupRoutes(
     const timezone = body.timezone.trim();
     try {
       Intl.DateTimeFormat(undefined, { timeZone: timezone });
-    } catch {
-      return reply.status(422).send({ error: `"${timezone}" is not a recognized IANA timezone.` });
+    } catch (err) {
+      if (err instanceof RangeError) {
+        return reply.status(422).send({ error: `"${timezone}" is not a recognized IANA timezone.` });
+      }
+      throw err; // unexpected — propagate to the outer catch for structured logging + 500
     }
 
     // Optional fields — validate shape before any write.
@@ -319,6 +322,13 @@ export async function setupRoutes(
             'POST /api/setup/principal/profile: working hours not persisted — entityMemory is unavailable (KG disabled)',
           );
         }
+      } else if (workingHoursValue && !principal.kgNodeId) {
+        // Principal exists but has no KG node yet — working hours cannot be stored
+        // as a KG fact. The canonical contact fields are still persisted above.
+        logger.warn(
+          { contactId: principal.id },
+          'POST /api/setup/principal/profile: principal has no kg_node_id, working hours not persisted',
+        );
       }
 
       return reply.send({ ok: true });

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -83,6 +83,7 @@ export async function setupRoutes(
     sessions,
     pool,
     logger,
+    contactService,
     setupRequiredAtBoot,
     bootStartedAt,
     scheduleProcessExit,
@@ -104,7 +105,8 @@ export async function setupRoutes(
   // Creates the principal contact with `system_role='principal'` from a display
   // name alone. No channel identity is bound — verification flows handle that
   // later, per channel. Idempotent: a second call when the principal already
-  // exists returns the existing IDs and does not rename.
+  // exists returns the existing IDs. If the submitted name differs from the
+  // stored name, the contact is renamed so Step 1 can correct a typo (#392).
   app.post('/api/setup/principal', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
@@ -125,10 +127,37 @@ export async function setupRoutes(
 
     try {
       const result = await ensurePrincipalContact({ displayName: trimmed }, pool, logger);
+      let renamed = false;
+      if (result.alreadyExisted) {
+        // The principal already exists. Step 1 is no longer auto-skipped (#392), so a
+        // second submit is the operator correcting the name — apply it instead of no-op'ing.
+        const current = await contactService.findContactBySystemRole('principal');
+        if (current && current.displayName !== trimmed) {
+          await contactService.updateDisplayName(result.contactId, trimmed);
+          renamed = true;
+          // Best-effort: keep the KG person-node label in sync so KG browsing shows the
+          // corrected name. The unique index idx_kg_nodes_unique (lower(label), type) can
+          // reject the rename if another non-fact node already owns that label; that's
+          // non-fatal — the contact column is the authoritative display name.
+          try {
+            await pool.query(
+              `UPDATE kg_nodes SET label = $1, last_confirmed_at = now()
+                 WHERE id = $2 AND type = 'person'`,
+              [trimmed, result.kgNodeId],
+            );
+          } catch (kgErr) {
+            logger.warn(
+              { kgErr, kgNodeId: result.kgNodeId },
+              'POST /api/setup/principal: KG label rename skipped (likely label collision); contact display_name still updated',
+            );
+          }
+        }
+      }
       return reply.send({
         contactId: result.contactId,
         kgNodeId: result.kgNodeId,
         alreadyExisted: result.alreadyExisted,
+        renamed,
       });
     } catch (err) {
       logger.error({ err }, 'POST /api/setup/principal: failed to ensure principal contact');

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -25,6 +25,7 @@ import type { InfraLlmService } from '../../../skills/infra-llm.js';
 import { parseSuggestedFirstName, SUGGEST_NAME_PROMPT } from './suggest-name.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import type { EntityMemory } from '../../../memory/entity-memory.js';
+import { validateWorkingHours, serializeWorkingHours } from '../../../contacts/working-hours.js';
 
 export interface SetupRouteOptions {
   webAppBootstrapSecret: string;
@@ -74,6 +75,10 @@ const AUTH_RATE = { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } }
 
 const MAX_DISPLAY_NAME_LENGTH = 200;
 
+// Pragmatic address shape check — full RFC validation is unnecessary; the address is
+// the principal's own and is normalized to lowercase before linking.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export async function setupRoutes(
   app: FastifyInstance,
   options: SetupRouteOptions,
@@ -84,6 +89,7 @@ export async function setupRoutes(
     pool,
     logger,
     contactService,
+    entityMemory,
     setupRequiredAtBoot,
     bootStartedAt,
     scheduleProcessExit,
@@ -166,6 +172,159 @@ export async function setupRoutes(
       return reply.status(500).send({
         error: 'Failed to create principal contact. Check server logs.',
       });
+    }
+  });
+
+  // -- GET /api/setup/principal --
+  //
+  // Loads the principal's name + operational profile so the wizard can pre-populate
+  // Steps 1 and 2 (#392). Returns { exists:false } (not 404) when no principal yet —
+  // the wizard treats that as a fresh install.
+  app.get('/api/setup/principal', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+    try {
+      const principal = await contactService.findContactBySystemRole('principal');
+      if (!principal) {
+        return reply.send({
+          exists: false, displayName: null, timezone: null,
+          preferredName: null, title: null, email: null, workingHours: null,
+        });
+      }
+      const withIdentities = await contactService.getContactWithIdentities(principal.id);
+      const email = (withIdentities?.identities ?? [])
+        .find((i) => i.channel === 'email' && i.verified && i.status === 'active')
+        ?.channelIdentifier ?? null;
+
+      // Working-hours fact: a 'fact' node linked to the principal's KG node whose
+      // properties.attribute === 'working_hours'. Mirrors the assembler's getFacts query.
+      let workingHours: string | null = null;
+      if (principal.kgNodeId) {
+        const facts = await pool.query<{ value: string | null }>(
+          `SELECT n.properties->>'value' AS value
+             FROM kg_edges e JOIN kg_nodes n ON n.id = e.target_node_id
+            WHERE e.source_node_id = $1 AND e.type = 'relates_to'
+              AND n.type = 'fact' AND lower(n.properties->>'attribute') = 'working_hours'
+            ORDER BY n.last_confirmed_at DESC LIMIT 1`,
+          [principal.kgNodeId],
+        );
+        workingHours = facts.rows[0]?.value ?? null;
+      }
+
+      return reply.send({
+        exists: true,
+        displayName: principal.displayName,
+        timezone: principal.timezone ?? null,
+        preferredName: principal.preferredName ?? null,
+        title: principal.title ?? null,
+        email,
+        workingHours,
+      });
+    } catch (err) {
+      logger.error({ err }, 'GET /api/setup/principal: failed to load principal profile');
+      return reply.status(500).send({ error: 'Failed to load principal profile. Check server logs.' });
+    }
+  });
+
+  // -- POST /api/setup/principal/profile --
+  //
+  // Persists the principal operational profile collected in the wizard's "Your details"
+  // step (#392): timezone + preferred name + title onto canonical contact columns; the
+  // email as a verified ceo_stated channel identity (so index.ts resolves principalEmail
+  // after the wizard-end restart); working hours as a KG fact surfaced by entity-context.
+  // Requires the principal to exist (created in Step 1). Omitted optional fields are not
+  // written, so a partial submit never clobbers an existing value.
+  app.post('/api/setup/principal/profile', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+
+    const body = (request.body ?? {}) as {
+      timezone?: unknown; email?: unknown; preferredName?: unknown;
+      title?: unknown; workingHours?: unknown;
+    };
+
+    // timezone is required and must be a real IANA zone (same guard as config.ts).
+    if (typeof body.timezone !== 'string' || body.timezone.trim().length === 0) {
+      return reply.status(400).send({ error: 'timezone is required.' });
+    }
+    const timezone = body.timezone.trim();
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    } catch {
+      return reply.status(422).send({ error: `"${timezone}" is not a recognized IANA timezone.` });
+    }
+
+    // Optional fields — validate shape before any write.
+    let email: string | undefined;
+    if (body.email !== undefined && body.email !== null && body.email !== '') {
+      if (typeof body.email !== 'string' || !EMAIL_RE.test(body.email.trim())) {
+        return reply.status(422).send({ error: 'email is not a valid address.' });
+      }
+      email = body.email.trim().toLowerCase();
+    }
+    const preferredName =
+      typeof body.preferredName === 'string' && body.preferredName.trim() ? body.preferredName.trim() : undefined;
+    const title =
+      typeof body.title === 'string' && body.title.trim() ? body.title.trim() : undefined;
+
+    let workingHoursValue: string | undefined;
+    if (body.workingHours !== undefined && body.workingHours !== null) {
+      const wh = validateWorkingHours(body.workingHours);
+      if (!wh) return reply.status(422).send({ error: 'workingHours is malformed.' });
+      workingHoursValue = serializeWorkingHours(wh);
+    }
+
+    try {
+      const principal = await contactService.findContactBySystemRole('principal');
+      if (!principal) {
+        return reply.status(409).send({ error: 'No principal exists yet — complete Step 1 first.' });
+      }
+
+      // Email first: updateContactFields validates primaryEmail against existing channel
+      // identities, so the identity must be linked before primary_email is set. ceo_stated
+      // is auto-verified (AUTO_VERIFIED_SOURCES), so this lands verified+active.
+      if (email) {
+        await contactService.linkIdentity({
+          contactId: principal.id, channel: 'email', channelIdentifier: email,
+          source: 'ceo_stated', verified: true,
+        });
+      }
+
+      // Canonical columns — only defined fields are written (updateContactFields drops
+      // undefined entries, so omitted optionals are never clobbered).
+      await contactService.updateContactFields(principal.id, {
+        timezone,
+        ...(preferredName !== undefined ? { preferredName } : {}),
+        ...(title !== undefined ? { title } : {}),
+        ...(email !== undefined ? { primaryEmail: email } : {}),
+      });
+
+      // Working hours → KG fact on the principal's node. Carries properties.attribute so
+      // storeFact runs contradiction detection (a wizard re-run updates, not duplicates).
+      // entityMemory is optional (disabled when OPENAI_API_KEY is unset) — skip gracefully
+      // rather than failing the whole profile save; timezone/email/name don't need the KG.
+      if (workingHoursValue && principal.kgNodeId) {
+        if (entityMemory) {
+          await entityMemory.storeFact({
+            entityNodeId: principal.kgNodeId,
+            label: 'Working hours',
+            properties: { attribute: 'working_hours', value: workingHoursValue, category: 'preference' },
+            confidence: 1.0,
+            decayClass: 'permanent',
+            source: 'system:setup-wizard',
+          });
+        } else {
+          // KG is unavailable (no OPENAI_API_KEY) — log and continue. The canonical
+          // contact fields (timezone, email, name) are already persisted above.
+          logger.warn(
+            { kgNodeId: principal.kgNodeId },
+            'POST /api/setup/principal/profile: working hours not persisted — entityMemory is unavailable (KG disabled)',
+          );
+        }
+      }
+
+      return reply.send({ ok: true });
+    } catch (err) {
+      logger.error({ err }, 'POST /api/setup/principal/profile: failed to persist profile');
+      return reply.status(500).send({ error: 'Failed to save profile. Check server logs.' });
     }
   });
 

--- a/src/contacts/working-hours.test.ts
+++ b/src/contacts/working-hours.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { serializeWorkingHours, validateWorkingHours } from './working-hours.js';
+
+describe('serializeWorkingHours', () => {
+  it('formats weekdays as a Mon–Fri range', () => {
+    expect(serializeWorkingHours({ start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] }))
+      .toBe('Mon–Fri, 9:00 AM–5:00 PM');
+  });
+  it('formats all seven days as Sun–Sat', () => {
+    expect(serializeWorkingHours({ start: '08:30', end: '16:00', days: [0, 1, 2, 3, 4, 5, 6] }))
+      .toBe('Sun–Sat, 8:30 AM–4:00 PM');
+  });
+  it('lists non-contiguous days individually', () => {
+    expect(serializeWorkingHours({ start: '10:00', end: '14:00', days: [1, 3, 5] }))
+      .toBe('Mon, Wed, Fri, 10:00 AM–2:00 PM');
+  });
+  it('formats a single day', () => {
+    expect(serializeWorkingHours({ start: '00:00', end: '12:00', days: [2] }))
+      .toBe('Tue, 12:00 AM–12:00 PM');
+  });
+});
+
+describe('validateWorkingHours', () => {
+  it('accepts a well-formed object and sorts/dedupes days', () => {
+    expect(validateWorkingHours({ start: '09:00', end: '17:00', days: [5, 1, 1, 3] }))
+      .toEqual({ start: '09:00', end: '17:00', days: [1, 3, 5] });
+  });
+  it('rejects a bad time', () => {
+    expect(validateWorkingHours({ start: '9am', end: '17:00', days: [1] })).toBeNull();
+  });
+  it('rejects an out-of-range day', () => {
+    expect(validateWorkingHours({ start: '09:00', end: '17:00', days: [7] })).toBeNull();
+  });
+  it('rejects an empty day list', () => {
+    expect(validateWorkingHours({ start: '09:00', end: '17:00', days: [] })).toBeNull();
+  });
+  it('rejects non-objects', () => {
+    expect(validateWorkingHours(null)).toBeNull();
+    expect(validateWorkingHours('mon-fri')).toBeNull();
+  });
+});

--- a/src/contacts/working-hours.ts
+++ b/src/contacts/working-hours.ts
@@ -1,0 +1,56 @@
+//
+// Pure helpers for the principal's working-hours profile (issue #392).
+//
+// Working hours are NOT a canonical contact column (see canonical-attribute-guard.ts),
+// so they are stored as a KG fact on the principal's node and surfaced to agents by the
+// entity-context assembler. The wizard collects them structured; the setup endpoint
+// serializes to a human-readable string for the fact value (richer for KG browsing and
+// better for LLM consumption than raw JSON).
+
+/** Structured working hours. days: 0=Sunday .. 6=Saturday. */
+export interface WorkingHours {
+  start: string; // "HH:MM" 24h
+  end: string;   // "HH:MM" 24h
+  days: number[];
+}
+
+const HHMM = /^([01]\d|2[0-3]):([0-5]\d)$/;
+const DAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+/** Validate + normalize an untrusted value into WorkingHours, or null if malformed. */
+export function validateWorkingHours(value: unknown): WorkingHours | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.start !== 'string' || !HHMM.test(v.start)) return null;
+  if (typeof v.end !== 'string' || !HHMM.test(v.end)) return null;
+  if (!Array.isArray(v.days) || v.days.length === 0) return null;
+  const days: number[] = [];
+  for (const d of v.days) {
+    if (typeof d !== 'number' || !Number.isInteger(d) || d < 0 || d > 6) return null;
+    if (!days.includes(d)) days.push(d);
+  }
+  days.sort((a, b) => a - b);
+  return { start: v.start, end: v.end, days };
+}
+
+/** "09:00" → "9:00 AM"; "17:00" → "5:00 PM"; "00:00" → "12:00 AM". */
+function formatTime(hhmm: string): string {
+  const [h, m] = hhmm.split(':').map((n) => parseInt(n, 10));
+  const hour = h!;
+  const meridiem = hour < 12 ? 'AM' : 'PM';
+  const twelve = hour % 12 === 0 ? 12 : hour % 12;
+  return `${twelve}:${String(m!).padStart(2, '0')} ${meridiem}`;
+}
+
+/** Render days: a fully-contiguous run becomes "Mon–Fri"; otherwise "Mon, Wed, Fri". */
+function formatDays(days: number[]): string {
+  const isContiguous =
+    days.length >= 2 && days.every((d, i) => i === 0 || d === days[i - 1]! + 1);
+  if (isContiguous) return `${DAY_ABBR[days[0]!]}–${DAY_ABBR[days[days.length - 1]!]}`;
+  return days.map((d) => DAY_ABBR[d]).join(', ');
+}
+
+/** Structured working hours → readable string stored in the KG fact value. */
+export function serializeWorkingHours(wh: WorkingHours): string {
+  return `${formatDays(wh.days)}, ${formatTime(wh.start)}–${formatTime(wh.end)}`;
+}

--- a/src/contacts/working-hours.ts
+++ b/src/contacts/working-hours.ts
@@ -35,18 +35,23 @@ export function validateWorkingHours(value: unknown): WorkingHours | null {
 
 /** "09:00" → "9:00 AM"; "17:00" → "5:00 PM"; "00:00" → "12:00 AM". */
 function formatTime(hhmm: string): string {
-  const [h, m] = hhmm.split(':').map((n) => parseInt(n, 10));
-  const hour = h!;
+  const parts = hhmm.split(':').map((n) => parseInt(n, 10));
+  const hour = parts[0] ?? 0;
+  const min = parts[1] ?? 0;
   const meridiem = hour < 12 ? 'AM' : 'PM';
   const twelve = hour % 12 === 0 ? 12 : hour % 12;
-  return `${twelve}:${String(m!).padStart(2, '0')} ${meridiem}`;
+  return `${twelve}:${String(min).padStart(2, '0')} ${meridiem}`;
 }
 
 /** Render days: a fully-contiguous run becomes "Mon–Fri"; otherwise "Mon, Wed, Fri". */
 function formatDays(days: number[]): string {
   const isContiguous =
-    days.length >= 2 && days.every((d, i) => i === 0 || d === days[i - 1]! + 1);
-  if (isContiguous) return `${DAY_ABBR[days[0]!]}–${DAY_ABBR[days[days.length - 1]!]}`;
+    days.length >= 2 && days.every((d, i) => i === 0 || d === (days[i - 1] ?? -1) + 1);
+  const first = days[0];
+  const last = days[days.length - 1];
+  if (isContiguous && first !== undefined && last !== undefined) {
+    return `${DAY_ABBR[first]}–${DAY_ABBR[last]}`;
+  }
   return days.map((d) => DAY_ABBR[d]).join(', ');
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2066,6 +2066,10 @@ async function main(): Promise<void> {
     bootStartedAt,
     // Powers POST /api/setup/suggest-name (wizard starter-name suggestion, #799).
     infraLlmService,
+    // Powers principal profile endpoints in setup routes (#392). Undefined when
+    // OPENAI_API_KEY is not set (entity memory requires embeddings); individual
+    // endpoints handle the absent case in Tasks 3–5.
+    entityMemory,
   });
 
   try {

--- a/tests/integration/setup-routes.test.ts
+++ b/tests/integration/setup-routes.test.ts
@@ -18,7 +18,12 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 import pg from 'pg';
 import { setupRoutes } from '../../src/channels/http/routes/setup.js';
-import { createLogger } from '../../src/logger.js';
+import { createLogger, createSilentLogger } from '../../src/logger.js';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
 
 const { Pool } = pg;
 
@@ -59,6 +64,16 @@ describeIf('/api/setup/* routes', () => {
     );
     await pool.query(`DELETE FROM contacts WHERE system_role = 'principal'`);
 
+    // Build the services needed by setup routes (#392). Mirrors the pattern in
+    // tests/integration/contacts.test.ts — EmbeddingService.createForTesting()
+    // produces a no-op embedder (no OpenAI key required), which is fine here
+    // since the existing tests don't exercise KG-backed endpoints yet.
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    const entityMemory = new EntityMemory(kgStore, validator, embeddingService, createSilentLogger());
+    const contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
+
     // Each test app gets its own bootStartedAt — when we exercise the polling
     // loop's "different boot" detection in the frontend later, the same logic
     // applies here: a new process produces a strictly-later timestamp.
@@ -82,6 +97,8 @@ describeIf('/api/setup/* routes', () => {
         setupRequiredAtBoot,
         bootStartedAt,
         scheduleProcessExit,
+        contactService,
+        entityMemory,
       });
       await app.ready();
       return app;
@@ -98,6 +115,14 @@ describeIf('/api/setup/* routes', () => {
   afterAll(async () => {
     await appSetupMode.close();
     await appNormalMode.close();
+    // Clean up in FK dependency order: identities → contacts → edges → nodes.
+    await pool.query(
+      `DELETE FROM contact_channel_identities WHERE contact_id IN
+         (SELECT id FROM contacts WHERE system_role = 'principal')`,
+    );
+    await pool.query(`DELETE FROM contacts WHERE system_role = 'principal'`);
+    await pool.query('DELETE FROM kg_edges');
+    await pool.query('DELETE FROM kg_nodes');
     await pool.end();
   });
 

--- a/tests/integration/setup-routes.test.ts
+++ b/tests/integration/setup-routes.test.ts
@@ -504,4 +504,144 @@ describeIf('/api/setup/* routes', () => {
       expect(processExitCalls).toHaveLength(0);
     });
   });
+
+  describe('GET /api/setup/principal', () => {
+    // Each test creates/deletes a principal — clear before each so the partial
+    // unique index doesn't collide across tests.
+    beforeEach(async () => {
+      await pool.query(
+        `DELETE FROM contact_channel_identities WHERE contact_id IN
+           (SELECT id FROM contacts WHERE system_role = 'principal')`,
+      );
+      await pool.query(`DELETE FROM contacts WHERE system_role = 'principal'`);
+      await pool.query('DELETE FROM kg_edges');
+      await pool.query('DELETE FROM kg_nodes');
+    });
+
+    it('GET /api/setup/principal returns { exists:false } when no principal', async () => {
+      // beforeEach has cleared the principal
+      const res = await appSetupMode.inject({
+        method: 'GET', url: '/api/setup/principal', headers: AUTH_HEADER,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ exists: false, displayName: null });
+    });
+
+    it('GET /api/setup/principal returns the persisted profile', async () => {
+      await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+        payload: { name: 'Profile Owner' },
+      });
+      await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+        payload: {
+          timezone: 'America/Vancouver',
+          email: 'owner@example.com',
+          preferredName: 'Owner',
+          title: 'CEO',
+          workingHours: { start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] },
+        },
+      });
+
+      const res = await appSetupMode.inject({
+        method: 'GET', url: '/api/setup/principal', headers: AUTH_HEADER,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        exists: true,
+        displayName: 'Profile Owner',
+        timezone: 'America/Vancouver',
+        preferredName: 'Owner',
+        title: 'CEO',
+        email: 'owner@example.com',
+        workingHours: 'Mon–Fri, 9:00 AM–5:00 PM',
+      });
+    });
+  });
+
+  describe('POST /api/setup/principal/profile', () => {
+    // Each test creates a principal — clear before each so the partial unique
+    // index doesn't collide.
+    beforeEach(async () => {
+      await pool.query(
+        `DELETE FROM contact_channel_identities WHERE contact_id IN
+           (SELECT id FROM contacts WHERE system_role = 'principal')`,
+      );
+      await pool.query(`DELETE FROM contacts WHERE system_role = 'principal'`);
+      await pool.query('DELETE FROM kg_edges');
+      await pool.query('DELETE FROM kg_nodes');
+    });
+
+    it('POST profile rejects an invalid timezone with 422', async () => {
+      await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER, payload: { name: 'TZ Tester' },
+      });
+      const res = await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+        payload: { timezone: 'Mars/Olympus_Mons' },
+      });
+      expect(res.statusCode).toBe(422);
+    });
+
+    it('POST profile 409s when no principal exists', async () => {
+      const res = await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+        payload: { timezone: 'America/Toronto' },
+      });
+      expect(res.statusCode).toBe(409);
+    });
+
+    it('POST profile writes canonical fields, links a verified email, and stores a working-hours fact', async () => {
+      const created = await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER, payload: { name: 'Full Profile' },
+      });
+      const { contactId, kgNodeId } = created.json() as { contactId: string; kgNodeId: string };
+
+      const res = await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+        payload: {
+          timezone: 'America/Vancouver', email: 'FULL@Example.com',
+          preferredName: 'Full', title: 'Founder',
+          workingHours: { start: '08:00', end: '16:00', days: [1, 2, 3, 4, 5] },
+        },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const contact = await pool.query<{ timezone: string; preferred_name: string; title: string; primary_email: string }>(
+        `SELECT timezone, preferred_name, title, primary_email FROM contacts WHERE id = $1`, [contactId],
+      );
+      expect(contact.rows[0]).toMatchObject({
+        timezone: 'America/Vancouver', preferred_name: 'Full', title: 'Founder',
+        primary_email: 'full@example.com', // lower-cased
+      });
+
+      const ident = await pool.query<{ verified: boolean; status: string; source: string }>(
+        `SELECT verified, status, source FROM contact_channel_identities
+           WHERE contact_id = $1 AND channel = 'email'`, [contactId],
+      );
+      expect(ident.rows[0]).toMatchObject({ verified: true, status: 'active', source: 'ceo_stated' });
+
+      const fact = await pool.query<{ value: string }>(
+        `SELECT n.properties->>'value' AS value FROM kg_edges e JOIN kg_nodes n ON n.id = e.target_node_id
+           WHERE e.source_node_id = $1 AND n.type = 'fact'
+             AND lower(n.properties->>'attribute') = 'working_hours' LIMIT 1`, [kgNodeId],
+      );
+      expect(fact.rows[0]!.value).toBe('Mon–Fri, 8:00 AM–4:00 PM');
+    });
+
+    it('POST profile leaves omitted optional fields untouched', async () => {
+      const created = await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER, payload: { name: 'Partial' },
+      });
+      const { contactId } = created.json() as { contactId: string };
+      await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal/profile', headers: AUTH_HEADER,
+        payload: { timezone: 'America/Toronto', title: 'CTO' },
+      });
+      const row = await pool.query<{ preferred_name: string | null; primary_email: string | null }>(
+        `SELECT preferred_name, primary_email FROM contacts WHERE id = $1`, [contactId],
+      );
+      expect(row.rows[0]).toMatchObject({ preferred_name: null, primary_email: null });
+    });
+  });
 });

--- a/tests/integration/setup-routes.test.ts
+++ b/tests/integration/setup-routes.test.ts
@@ -229,6 +229,7 @@ describeIf('/api/setup/* routes', () => {
       const row = await pool.query<{ display_name: string }>(
         `SELECT display_name FROM contacts WHERE id = $1`, [contactId],
       );
+      expect(row.rows).toHaveLength(1);
       expect(row.rows[0]!.display_name).toBe('Corrected Name');
     });
 
@@ -610,6 +611,7 @@ describeIf('/api/setup/* routes', () => {
       const contact = await pool.query<{ timezone: string; preferred_name: string; title: string; primary_email: string }>(
         `SELECT timezone, preferred_name, title, primary_email FROM contacts WHERE id = $1`, [contactId],
       );
+      expect(contact.rows).toHaveLength(1);
       expect(contact.rows[0]).toMatchObject({
         timezone: 'America/Vancouver', preferred_name: 'Full', title: 'Founder',
         primary_email: 'full@example.com', // lower-cased
@@ -619,6 +621,7 @@ describeIf('/api/setup/* routes', () => {
         `SELECT verified, status, source FROM contact_channel_identities
            WHERE contact_id = $1 AND channel = 'email'`, [contactId],
       );
+      expect(ident.rows).toHaveLength(1);
       expect(ident.rows[0]).toMatchObject({ verified: true, status: 'active', source: 'ceo_stated' });
 
       const fact = await pool.query<{ value: string }>(
@@ -626,6 +629,7 @@ describeIf('/api/setup/* routes', () => {
            WHERE e.source_node_id = $1 AND n.type = 'fact'
              AND lower(n.properties->>'attribute') = 'working_hours' LIMIT 1`, [kgNodeId],
       );
+      expect(fact.rows).toHaveLength(1);
       expect(fact.rows[0]!.value).toBe('Mon–Fri, 8:00 AM–4:00 PM');
     });
 

--- a/tests/integration/setup-routes.test.ts
+++ b/tests/integration/setup-routes.test.ts
@@ -88,7 +88,9 @@ describeIf('/api/setup/* routes', () => {
       const app = Fastify();
       // rate-limit plugin is required because setup routes attach { config: { rateLimit: ... } }
       // per route — without it Fastify errors on registration.
-      await app.register(rateLimit, { max: 1000, timeWindow: '1 minute' });
+      // allowList bypasses rate-limit enforcement in tests so that the route-level
+      // max:10 cap doesn't throttle requests as the test count grows.
+      await app.register(rateLimit, { max: 1000, timeWindow: '1 minute', allowList: () => true });
       await app.register(setupRoutes, {
         webAppBootstrapSecret: TEST_SECRET,
         sessions,
@@ -148,6 +150,17 @@ describeIf('/api/setup/* routes', () => {
   });
 
   describe('POST /api/setup/principal', () => {
+    // Each test in this block creates a principal, but the partial unique index on
+    // system_role='principal' allows at most one row. Clear it before each test so
+    // tests that create a principal don't collide with one another.
+    beforeEach(async () => {
+      await pool.query(
+        `DELETE FROM contact_channel_identities WHERE contact_id IN
+           (SELECT id FROM contacts WHERE system_role = 'principal')`,
+      );
+      await pool.query(`DELETE FROM contacts WHERE system_role = 'principal'`);
+    });
+
     it('creates a principal contact and returns its IDs', async () => {
       const res = await appSetupMode.inject({
         method: 'POST',
@@ -193,6 +206,42 @@ describeIf('/api/setup/* routes', () => {
       const secondBody = JSON.parse(second.body);
       expect(secondBody.alreadyExisted).toBe(true);
       expect(secondBody.contactId).toBe(firstBody.contactId);
+    });
+
+    it('renames the principal when called again with a different name', async () => {
+      const first = await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+        payload: { name: 'Original Name' },
+      });
+      expect(first.statusCode).toBe(200);
+      const { contactId } = first.json() as { contactId: string };
+
+      const second = await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+        payload: { name: 'Corrected Name' },
+      });
+      expect(second.statusCode).toBe(200);
+      const body = second.json() as { alreadyExisted: boolean; renamed: boolean; contactId: string };
+      expect(body.alreadyExisted).toBe(true);
+      expect(body.renamed).toBe(true);
+      expect(body.contactId).toBe(contactId);
+
+      const row = await pool.query<{ display_name: string }>(
+        `SELECT display_name FROM contacts WHERE id = $1`, [contactId],
+      );
+      expect(row.rows[0]!.display_name).toBe('Corrected Name');
+    });
+
+    it('does not rename when the same name is submitted', async () => {
+      await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+        payload: { name: 'Same Name' },
+      });
+      const again = await appSetupMode.inject({
+        method: 'POST', url: '/api/setup/principal', headers: AUTH_HEADER,
+        payload: { name: 'Same Name' },
+      });
+      expect((again.json() as { renamed: boolean }).renamed).toBe(false);
     });
 
     it('returns 400 when the name is missing', async () => {


### PR DESCRIPTION
## Summary

Closes #392.

Adds a **principal operational profile** step to the form-based setup wizard, and fixes a bug where Step 1 (principal name) could never be corrected once a principal existed.

The wizard now captures, on a new **Step 2 "Your details"**:
- **Timezone** (required) prefilled from the browser locale
- **Email** (optional) stored as a verified `ceo_stated` channel identity
- **Preferred name**, **Title** (optional) on canonical contact columns
- **Working hours** (optional) stored as a KG fact on the principal

All profile data lives on the existing principal contact / its KG node, so there is **no schema migration**.

## What changed

- **`src/contacts/working-hours.ts`** (new) plus unit tests: validates + serializes structured working hours to a readable string.
- **`src/channels/http/routes/setup.ts`**:
  - `GET /api/setup/principal` (new) loads the profile so the wizard can pre-populate.
  - `POST /api/setup/principal` (extended) renames the principal when called again with a different name (and best-effort syncs the KG label), fixing the "name uneditable once set" bug.
  - `POST /api/setup/principal/profile` (new) persists timezone/preferred-name/title to canonical columns, links a verified `ceo_stated` email (before setting `primary_email`), and stores a `working_hours` KG fact.
- **`apps/console`**: new Step 2 form, Step 1 no longer auto-skips (pre-populated for correction), steps renumbered 5 -> 6, plus pure `wizard-utils` helpers with unit tests.
- Docs (`docs/dev/setup.md`) + CHANGELOG.

## Deliberate descope (follow-up)

The principal's timezone lands on `contacts.timezone` and is surfaced to agents **live** via entity-context enrichment (no restart). The **system clock / cron scheduler** continues to read the `TIMEZONE` env var. Making the system timezone track the principal's contact timezone is intentionally out of scope and tracked as a follow-up (a one-word note is in `docs/dev/setup.md`). Rationale: principals travel, so a contact-timezone -> system-clock override deserves its own design.

The email becomes authoritative after the wizard's existing end-of-flow restart (`index.ts` resolves `principalEmail` from the verified identity).

## Test plan

- `working-hours` unit: 9/9
- `wizard-utils` unit: 44/44
- `setup-routes` integration (real Postgres): 23/23 (create, rename, GET profile incl. verified email + working-hours fact, POST profile validation 400/422/409, omitted-optionals untouched)
- Backend typecheck, console typecheck, console build: all clean
- Reviews: per-task + whole-branch + dedicated security review (clean), silent-failure + code-review findings addressed

Manual smoke (pending): load `/setup`, confirm Step 1 pre-populates, Step 2 timezone prefilled from browser, optionals skippable, Continue advances.