### PR TITLE
fix(setup-wizard): guard EMAIL_RE against ReDoS (CodeQL #185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+
+- **Setup wizard email ReDoS** — added a 254-char length cap before `EMAIL_RE.test()` in the principal profile route, preventing quadratic backtracking on crafted inputs (CodeQL #185).
+
 ## [0.37.0] — 2026-06-22 — "Jane"
 
 > **Jane** *(Speaker for the Dead, 1986, Orson Scott Card)* — a hyperintelligent being who lives in the ansible network, holds every key, knows every identity, and asks one question before charting the fastest path. v0.37 gives Curia the same instincts: credentials move into the vault, principal identity resolves from contacts alone, and the setup wizard asks what you need first, then gets you there.

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -258,10 +258,14 @@ export async function setupRoutes(
     // Optional fields — validate shape before any write.
     let email: string | undefined;
     if (body.email !== undefined && body.email !== null && body.email !== '') {
-      if (typeof body.email !== 'string' || !EMAIL_RE.test(body.email.trim())) {
+      // Trim once; also caps length before EMAIL_RE runs to avoid ReDoS — the domain
+      // portion is ambiguous across '.' chars, causing quadratic backtracking on crafted
+      // inputs. RFC 5321 caps email at 254 chars so this always finishes in O(1) time.
+      const trimmedEmail = typeof body.email === 'string' ? body.email.trim() : '';
+      if (!trimmedEmail || trimmedEmail.length > 254 || !EMAIL_RE.test(trimmedEmail)) {
         return reply.status(422).send({ error: 'email is not a valid address.' });
       }
-      email = body.email.trim().toLowerCase();
+      email = trimmedEmail.toLowerCase();
     }
     const preferredName =
       typeof body.preferredName === 'string' && body.preferredName.trim() ? body.preferredName.trim() : undefined;


### PR DESCRIPTION
## Summary

- `EMAIL_RE` (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`) was tested against raw user input in the principal profile setup route with no length bound
- The domain portion `[^\s@]+\.[^\s@]+` is ambiguous across `.` characters: the regex engine tries all possible splits on non-matching strings, causing quadratic backtracking
- A crafted payload like `x@` + many repetitions of `x.` with a non-matching terminator could pin a worker for seconds

## Fix

Extract `trimmedEmail` once, then reject anything over 254 chars (RFC 5321 maximum) before calling `EMAIL_RE.test()`. This makes worst-case regex time O(1) regardless of attacker input length. Error behavior for all valid/invalid inputs is preserved.

## Test plan

- [ ] Normal valid email (`user@example.com`) still returns 200
- [ ] Invalid email (`notanemail`) still returns 422
- [ ] Non-string email (number, array) still returns 422
- [ ] Email over 254 chars returns 422
- [ ] CodeQL re-scan after merge no longer flags `setup.ts:261` as `js/polynomial-redos`

Closes #185 (CodeQL alert — js/polynomial-redos)