### PR TITLE
fix(bullpen): pin first message in ambient context for long threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bullpen long-thread context** — agents woken by a new reply in a thread with more than 15 messages now always see the original request (first message) in their ambient context, alongside the 14 most recent messages; the first message no longer silently falls off the window. (#1090)
+
 ### Security
 
 - **Setup wizard email ReDoS** — added a 254-char length cap before `EMAIL_RE.test()` in the principal profile route, preventing quadratic backtracking on crafted inputs (CodeQL #185).

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -386,15 +386,15 @@ class PostgresBullpenBackend implements BullpenBackend {
       }>(
         `WITH ranked AS (
            SELECT sender_id, content, mentioned_agent_ids, created_at,
-             ROW_NUMBER() OVER (ORDER BY created_at ASC)  AS rn_asc,
-             ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn_desc
+             ROW_NUMBER() OVER (ORDER BY created_at ASC,  id ASC)  AS rn_asc,
+             ROW_NUMBER() OVER (ORDER BY created_at DESC, id DESC) AS rn_desc
            FROM bullpen_messages
            WHERE thread_id = $1
          )
          SELECT sender_id, content, mentioned_agent_ids, created_at
          FROM ranked
          WHERE rn_asc = 1 OR rn_desc <= $2
-         ORDER BY created_at ASC`,
+         ORDER BY created_at ASC, id ASC`,
         [row.id, RECENT_MSG_LIMIT - 1],
       );
       if (msgsRes.rows.length === 0) {

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -377,10 +377,10 @@ class PostgresBullpenBackend implements BullpenBackend {
     for (const row of threadsRes.rows) {
       // Pin the first message (original request) plus the last (LIMIT-1) most recent
       // messages so agents on long threads always have the founding context (#1090).
-      // The CTE assigns two row numbers — one ascending (rn_asc=1 is the first message)
-      // and one descending (rn_desc<=14 are the 14 most recent) — then the WHERE picks
-      // the union of both sets. DISTINCT eliminates overlap when the thread is short
-      // enough that the first message is also among the last 14.
+      // ROW_NUMBER() produces exactly one row per physical message, so the WHERE
+      // (rn_asc=1 OR rn_desc<=14) selects a disjoint or overlapping subset with no
+      // duplicates — DISTINCT is intentionally omitted (it would collapse genuinely
+      // distinct messages that happen to share payload values).
       const msgsRes = await this.pool.query<{
         sender_id: string; content: unknown; mentioned_agent_ids: string[]; created_at: Date;
       }>(
@@ -391,12 +391,19 @@ class PostgresBullpenBackend implements BullpenBackend {
            FROM bullpen_messages
            WHERE thread_id = $1
          )
-         SELECT DISTINCT sender_id, content, mentioned_agent_ids, created_at
+         SELECT sender_id, content, mentioned_agent_ids, created_at
          FROM ranked
          WHERE rn_asc = 1 OR rn_desc <= $2
          ORDER BY created_at ASC`,
         [row.id, RECENT_MSG_LIMIT - 1],
       );
+      if (msgsRes.rows.length === 0) {
+        // The outer query confirmed this thread has messages, but the CTE found none —
+        // data inconsistency or a very tight race with deletion. Skip rather than inject
+        // an empty context block that would confuse the agent.
+        this.logger.error({ threadId: row.id }, 'Bullpen getPendingThreadsForAgent: CTE returned 0 rows for thread with messages — skipping');
+        continue;
+      }
       const recentMessages = msgsRes.rows.map(m => ({
         senderAgentId: m.sender_id,
         content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -53,6 +53,13 @@ export interface PendingThreadContext {
   }>;
 }
 
+// Maximum messages shown per thread in the ambient context. When a thread exceeds
+// this limit, the first message (original request) is always pinned so agents never
+// lose the context that gave the thread its purpose, plus the last (LIMIT-1) most
+// recent messages. At 15 the tail covers most real threads in full; the first-pin
+// only kicks in for genuinely long conversations. (#1090)
+const RECENT_MSG_LIMIT = 15;
+
 // -- Backend interface --
 
 interface BullpenBackend {
@@ -147,7 +154,13 @@ class InMemoryBullpenBackend implements BullpenBackend {
       const lastMsg = msgs[msgs.length - 1]!;
       if (lastMsg.senderId === agentId) continue;
 
-      const recentMessages = msgs.slice(-5).map(m => ({
+      // Pin the first message so the original request is always visible, then fill
+      // the rest of the window with the most recent messages (#1090). When the thread
+      // is short enough to fit in the window we take all messages as-is.
+      const selected = msgs.length <= RECENT_MSG_LIMIT
+        ? msgs
+        : [msgs[0]!, ...msgs.slice(-(RECENT_MSG_LIMIT - 1))];
+      const recentMessages = selected.map(m => ({
         senderAgentId: m.senderId,
         content: m.content,
         mentionedAgentIds: m.mentionedAgentIds,
@@ -362,15 +375,29 @@ class PostgresBullpenBackend implements BullpenBackend {
 
     const results: PendingThreadContext[] = [];
     for (const row of threadsRes.rows) {
+      // Pin the first message (original request) plus the last (LIMIT-1) most recent
+      // messages so agents on long threads always have the founding context (#1090).
+      // The CTE assigns two row numbers — one ascending (rn_asc=1 is the first message)
+      // and one descending (rn_desc<=14 are the 14 most recent) — then the WHERE picks
+      // the union of both sets. DISTINCT eliminates overlap when the thread is short
+      // enough that the first message is also among the last 14.
       const msgsRes = await this.pool.query<{
         sender_id: string; content: unknown; mentioned_agent_ids: string[]; created_at: Date;
       }>(
-        `SELECT sender_id, content, mentioned_agent_ids, created_at
-         FROM bullpen_messages WHERE thread_id = $1
-         ORDER BY created_at DESC LIMIT 5`,
-        [row.id],
+        `WITH ranked AS (
+           SELECT sender_id, content, mentioned_agent_ids, created_at,
+             ROW_NUMBER() OVER (ORDER BY created_at ASC)  AS rn_asc,
+             ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn_desc
+           FROM bullpen_messages
+           WHERE thread_id = $1
+         )
+         SELECT DISTINCT sender_id, content, mentioned_agent_ids, created_at
+         FROM ranked
+         WHERE rn_asc = 1 OR rn_desc <= $2
+         ORDER BY created_at ASC`,
+        [row.id, RECENT_MSG_LIMIT - 1],
       );
-      const recentMessages = msgsRes.rows.reverse().map(m => ({
+      const recentMessages = msgsRes.rows.map(m => ({
         senderAgentId: m.sender_id,
         content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
         mentionedAgentIds: m.mentioned_agent_ids,
@@ -533,14 +560,16 @@ export class BullpenService {
 
 /**
  * Formats pending Bullpen threads as a compact system-message block for LLM context injection.
- * Shows up to 5 threads × 5 recent messages each.
+ * Shows up to 5 threads × up to RECENT_MSG_LIMIT messages each. For threads that exceed the
+ * limit, the first message (original request) is always pinned alongside the most recent ones
+ * so agents never lose the founding context of a long conversation (#1090).
  */
 export function formatBullpenContext(pending: PendingThreadContext[]): string {
   if (pending.length === 0) return '';
   const lines: string[] = [`[Bullpen — ${pending.length} active thread${pending.length === 1 ? '' : 's'}]`];
   for (const thread of pending) {
     const showing = thread.recentMessages.length < thread.totalMessages
-      ? ` — showing last ${thread.recentMessages.length}`
+      ? ` — first + last ${thread.recentMessages.length - 1} of ${thread.totalMessages}`
       : '';
     lines.push('');
     lines.push(`Thread "${thread.topic}" (thread_id: ${thread.threadId}, ${thread.totalMessages} total messages${showing}):`);
@@ -552,7 +581,7 @@ export function formatBullpenContext(pending: PendingThreadContext[]): string {
       lines.push(`  ${msg.senderAgentId} [${ts}]: "${mentions}${msg.content}"`);
     }
     if (thread.recentMessages.length < thread.totalMessages) {
-      lines.push(`  → Call bullpen get_thread for full history.`);
+      lines.push(`  → Middle messages omitted. Call bullpen get_thread for full history.`);
     }
   }
   // Thread-closure convention (#881): bullpen threads tend to be left open because

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -385,7 +385,7 @@ class PostgresBullpenBackend implements BullpenBackend {
         sender_id: string; content: unknown; mentioned_agent_ids: string[]; created_at: Date;
       }>(
         `WITH ranked AS (
-           SELECT sender_id, content, mentioned_agent_ids, created_at,
+           SELECT id, sender_id, content, mentioned_agent_ids, created_at,
              ROW_NUMBER() OVER (ORDER BY created_at ASC,  id ASC)  AS rn_asc,
              ROW_NUMBER() OVER (ORDER BY created_at DESC, id DESC) AS rn_desc
            FROM bullpen_messages

--- a/tests/unit/memory/bullpen.test.ts
+++ b/tests/unit/memory/bullpen.test.ts
@@ -142,6 +142,20 @@ describe('BullpenService (in-memory)', () => {
     expect(pending[0]?.recentMessages[7]?.content).toBe('Msg 8');
   });
 
+  it('getPendingThreadsForAgent shows all messages without duplication at exactly the window limit', async () => {
+    // 15 messages == RECENT_MSG_LIMIT: should take the "show all" path, not the pin path.
+    const { thread } = await service.openThread('Boundary', 'coordinator', ['coordinator', 'agent-b'], 'Msg 1', []);
+    for (let i = 2; i <= 15; i++) {
+      await service.postMessage(thread.id, 'coordinator', `Msg ${i}`, []);
+    }
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending[0]?.recentMessages).toHaveLength(15);
+    // First message must appear exactly once (no duplication from the pin logic)
+    expect(pending[0]?.recentMessages.filter(m => m.content === 'Msg 1')).toHaveLength(1);
+    // totalMessages equals recentMessages.length — no truncation indicator needed
+    expect(pending[0]?.totalMessages).toBe(pending[0]?.recentMessages.length);
+  });
+
   it('getPendingThreadsForAgent pins the first message when a thread exceeds the window limit (#1090)', async () => {
     // Build a thread with 17 messages (> RECENT_MSG_LIMIT of 15).
     const { thread } = await service.openThread('Long thread', 'coordinator', ['coordinator', 'agent-b'], 'Msg 1', ['agent-b']);

--- a/tests/unit/memory/bullpen.test.ts
+++ b/tests/unit/memory/bullpen.test.ts
@@ -130,16 +130,34 @@ describe('BullpenService (in-memory)', () => {
     expect(pending).toHaveLength(0);
   });
 
-  it('getPendingThreadsForAgent includes up to 5 recent messages per thread', async () => {
+  it('getPendingThreadsForAgent shows all messages when thread is within the window limit', async () => {
     const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Msg 1', []);
     for (let i = 2; i <= 8; i++) {
       await service.postMessage(thread.id, 'coordinator', `Msg ${i}`, []);
     }
     const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    // 8 messages is below RECENT_MSG_LIMIT (15), so all are shown
     expect(pending[0]?.totalMessages).toBe(8);
-    expect(pending[0]?.recentMessages).toHaveLength(5);
-    // Should be the last 5 messages
-    expect(pending[0]?.recentMessages[4]?.content).toBe('Msg 8');
+    expect(pending[0]?.recentMessages).toHaveLength(8);
+    expect(pending[0]?.recentMessages[7]?.content).toBe('Msg 8');
+  });
+
+  it('getPendingThreadsForAgent pins the first message when a thread exceeds the window limit (#1090)', async () => {
+    // Build a thread with 17 messages (> RECENT_MSG_LIMIT of 15).
+    const { thread } = await service.openThread('Long thread', 'coordinator', ['coordinator', 'agent-b'], 'Msg 1', ['agent-b']);
+    for (let i = 2; i <= 17; i++) {
+      await service.postMessage(thread.id, 'coordinator', `Msg ${i}`, []);
+    }
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending[0]?.totalMessages).toBe(17);
+    // Exactly RECENT_MSG_LIMIT messages shown: first + last 14
+    expect(pending[0]?.recentMessages).toHaveLength(15);
+    // First message (original request) is always pinned
+    expect(pending[0]?.recentMessages[0]?.content).toBe('Msg 1');
+    // Followed by the last 14 messages (Msg 4 through Msg 17)
+    expect(pending[0]?.recentMessages[1]?.content).toBe('Msg 4');
+    // Last message is present
+    expect(pending[0]?.recentMessages[14]?.content).toBe('Msg 17');
   });
 
   // Read watermark (#1065): a thread the agent has been shown stops re-surfacing until
@@ -241,5 +259,28 @@ describe('formatBullpenContext', () => {
   it('includes the close_after convention note when threads are present', () => {
     const out = formatBullpenContext([makePending()]);
     expect(out).toContain('close_after');
+  });
+
+  it('shows "first + last N" header and middle-omitted hint when thread is truncated (#1090)', () => {
+    // Simulate a thread where recentMessages holds first + last N (14 recent) of 20 total.
+    const msgs = Array.from({ length: 15 }, (_, i) => ({
+      senderAgentId: 'coordinator',
+      content: `Msg ${i + 1}`,
+      mentionedAgentIds: [] as string[],
+      createdAt: new Date(i * 1000),
+    }));
+    const truncated: PendingThreadContext = {
+      threadId: 'thread-2',
+      topic: 'Long discussion',
+      totalMessages: 20,
+      recentMessages: msgs,
+    };
+    const out = formatBullpenContext([truncated]);
+    // Header must name the composition, not just "showing last N"
+    expect(out).toContain('first + last 14 of 20');
+    // Middle-omission hint must be present
+    expect(out).toContain('Middle messages omitted');
+    // get_thread hint still present
+    expect(out).toContain('get_thread');
   });
 });


### PR DESCRIPTION
## Summary

Closes #1090.

- **`RECENT_MSG_LIMIT = 15`** — new module-level constant governing both the per-thread message window and the first-pin threshold.
- **In-memory backend** — `getPendingThreadsForAgent` now returns `[first, ...last14]` for threads with >15 messages instead of just `last5`. Threads with ≤15 messages are unaffected (all shown).
- **Postgres backend** — messages query replaced with a CTE that uses `ROW_NUMBER()` to select `rn_asc = 1` (first message) `OR rn_desc <= 14` (last 14), ordered ascending. No `DISTINCT` (ROW_NUMBER already guarantees one row per physical message; DISTINCT on payload columns would silently collapse duplicates). Empty-rows guard added for the race where messages vanish between the outer threads query and the CTE.
- **`formatBullpenContext`** — truncation header updated from `"showing last N"` to `"first + last N of total"`, and the get_thread hint now reads `"Middle messages omitted. Call bullpen get_thread for full history."`.
- **Tests** — stale "up to 5 messages" test updated; boundary test added for exactly 15 messages (no first-pin duplication); new test for 17-message thread asserting first+last14 selection; new `formatBullpenContext` test asserting truncation format.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] All 219 unit tests pass
- [x] New tests cover: under-limit (8 msgs), at-limit (15 msgs, no duplication), over-limit (17 msgs, first+last14), `formatBullpenContext` truncation header format