### PR TITLE
fix(scheduler): advance next_run_at at claim time to prevent duplicate fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Bullpen long-thread context** — agents woken by a new reply in a thread with more than 15 messages now always see the original request (first message) in their ambient context, alongside the 14 most recent messages; the first message no longer silently falls off the window. (#1090)
+- **Scheduler duplicate-fire race condition** — claim-time `next_run_at` advancement and null-safe `rowCount` guard prevent duplicate cron fires. (#1124)
 
 ### Security
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -351,11 +351,31 @@ export class Scheduler {
     // Atomically claim the job by setting status to 'running' only if it's still
     // in a claimable state. The rowCount check prevents double-firing if another
     // scheduler instance (or overlapping poll) claimed the same job.
-    const claimResult = await this.pool.query(
-      `UPDATE scheduled_jobs SET status = $1, run_started_at = now() WHERE id = $2 AND status IN ('pending', 'failed')`,
-      ['running', job.id],
-    );
-    if (claimResult.rowCount === 0) {
+    //
+    // For cron jobs, also advance next_run_at to the next scheduled occurrence at
+    // claim time — not just at completion. This closes a second re-fire window:
+    // if the publish step throws and the error handler reverts status to 'pending',
+    // the row's next_run_at is already in the future so the next poll's SELECT
+    // (WHERE next_run_at <= now()) skips it instead of re-firing it. (#1124)
+    //
+    // rowCount is typed number|null by pg; null must be treated the same as 0 —
+    // both mean 0 rows updated, i.e. another poller already claimed the job.
+    let claimResult: { rowCount: number | null };
+    if (job.cronExpr) {
+      const nextRunAt = this.schedulerService.nextRunFromCron(job.cronExpr, job.timezone);
+      claimResult = await this.pool.query(
+        `UPDATE scheduled_jobs
+            SET status = $1, run_started_at = now(), next_run_at = $3
+          WHERE id = $2 AND status IN ('pending', 'failed')`,
+        ['running', job.id, nextRunAt],
+      );
+    } else {
+      claimResult = await this.pool.query(
+        `UPDATE scheduled_jobs SET status = $1, run_started_at = now() WHERE id = $2 AND status IN ('pending', 'failed')`,
+        ['running', job.id],
+      );
+    }
+    if (claimResult.rowCount === 0 || claimResult.rowCount === null) {
       this.logger.debug({ jobId: job.id }, 'Job already claimed; skipping fire');
       return;
     }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -372,14 +372,23 @@ export class Scheduler {
       let nextRunAt: Date;
       try {
         nextRunAt = this.schedulerService.nextRunFromCron(job.cronExpr, job.timezone);
-      } catch (err) {
+      } catch (err: unknown) {
+        const agentErr = classifyError(err, 'scheduler-fire-job');
         this.logger.error(
-          { err, jobId: job.id, cronExpr: job.cronExpr, timezone: job.timezone },
+          { err: agentErr, jobId: job.id, cronExpr: job.cronExpr, timezone: job.timezone },
           'Invalid cron expression — marking job failed to prevent retry storm',
         );
+        // Set next_run_at = NULL so the poll SELECT (WHERE next_run_at <= now()) never
+        // re-selects this job. Without it, the job stays 'failed' with a past next_run_at
+        // and fires again on every poll. Guard with status IN (...) to avoid clobbering
+        // a concurrent cancellation that could have occurred after the SELECT.
         await this.pool.query(
-          `UPDATE scheduled_jobs SET status = 'failed', last_error = $2 WHERE id = $1`,
-          [job.id, String(err)],
+          `UPDATE scheduled_jobs
+              SET status = 'failed',
+                  last_error = $2,
+                  next_run_at = NULL
+            WHERE id = $1 AND status IN ('pending', 'failed')`,
+          [job.id, agentErr.message],
         );
         return;
       }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -382,21 +382,34 @@ export class Scheduler {
         // re-selects this job. Without it, the job stays 'failed' with a past next_run_at
         // and fires again on every poll. Guard with status IN (...) to avoid clobbering
         // a concurrent cancellation that could have occurred after the SELECT.
+        // Guard on cron_expr/timezone: if updateJob() changed the cron between poll and
+        // here, this UPDATE won't match (rowCount=0) and the job stays 'pending' with the
+        // new (now-valid) expression — correctly deferring until the next poll.
         await this.pool.query(
           `UPDATE scheduled_jobs
               SET status = 'failed',
                   last_error = $2,
                   next_run_at = NULL
-            WHERE id = $1 AND status IN ('pending', 'failed')`,
-          [job.id, agentErr.message],
+            WHERE id = $1
+              AND status IN ('pending', 'failed')
+              AND cron_expr = $3
+              AND timezone = $4`,
+          [job.id, agentErr.message, job.cronExpr, job.timezone],
         );
         return;
       }
+      // Optimistic-concurrency guard on cron_expr/timezone: if updateJob() changes
+      // the expression between the poll SELECT and this claim UPDATE, the WHERE won't
+      // match (rowCount=0), the job skips as "already claimed", and the next poll fires
+      // it with the correct (updated) expression and next_run_at.
       claimResult = await this.pool.query(
         `UPDATE scheduled_jobs
             SET status = $1, run_started_at = now(), next_run_at = $3
-          WHERE id = $2 AND status IN ('pending', 'failed')`,
-        ['running', job.id, nextRunAt],
+          WHERE id = $2
+            AND status IN ('pending', 'failed')
+            AND cron_expr = $4
+            AND timezone = $5`,
+        ['running', job.id, nextRunAt, job.cronExpr, job.timezone],
       );
     } else {
       claimResult = await this.pool.query(

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -362,7 +362,27 @@ export class Scheduler {
     // both mean 0 rows updated, i.e. another poller already claimed the job.
     let claimResult: { rowCount: number | null };
     if (job.cronExpr) {
-      const nextRunAt = this.schedulerService.nextRunFromCron(job.cronExpr, job.timezone);
+      // Compute next_run_at before the claim UPDATE so it can be written atomically.
+      // nextRunFromCron() can throw on a corrupt cron expression (e.g. direct DB insert
+      // bypassing createJob validation). Guard it here so a throw does NOT cause the outer
+      // pollDueJobs error handler to attempt reverting status = 'running' when the job was
+      // never claimed — that revert would be a silent no-op, leaving next_run_at in the past
+      // and causing an infinite tight-loop re-fire on every poll. Transition to 'failed'
+      // instead so the job stops being selected.
+      let nextRunAt: Date;
+      try {
+        nextRunAt = this.schedulerService.nextRunFromCron(job.cronExpr, job.timezone);
+      } catch (err) {
+        this.logger.error(
+          { err, jobId: job.id, cronExpr: job.cronExpr, timezone: job.timezone },
+          'Invalid cron expression — marking job failed to prevent retry storm',
+        );
+        await this.pool.query(
+          `UPDATE scheduled_jobs SET status = 'failed', last_error = $2 WHERE id = $1`,
+          [job.id, String(err)],
+        );
+        return;
+      }
       claimResult = await this.pool.query(
         `UPDATE scheduled_jobs
             SET status = $1, run_started_at = now(), next_run_at = $3
@@ -375,8 +395,14 @@ export class Scheduler {
         ['running', job.id],
       );
     }
-    if (claimResult.rowCount === 0 || claimResult.rowCount === null) {
+    if (claimResult.rowCount === 0) {
       this.logger.debug({ jobId: job.id }, 'Job already claimed; skipping fire');
+      return;
+    }
+    // rowCount === null is an anomalous pg driver state (UPDATE always returns a count).
+    // Treat it as 0 but log at warn so it's visible in production.
+    if (claimResult.rowCount === null) {
+      this.logger.warn({ jobId: job.id }, 'Claim UPDATE returned null rowCount — treating as already claimed, skipping fire');
       return;
     }
 

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -337,6 +337,37 @@ describe('Scheduler', () => {
       await scheduler.pollDueJobs();
 
       expect(bus.publish).not.toHaveBeenCalled();
+      // null rowCount is anomalous — should be visible in prod logs, not silently swallowed at debug
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId: 'job-1' }),
+        expect.stringContaining('null rowCount'),
+      );
+    });
+
+    it('marks cron job failed (not pending) when nextRunFromCron throws, preventing retry storm', async () => {
+      // If nextRunFromCron throws (e.g. corrupt cron_expr inserted directly into DB),
+      // the outer pollDueJobs error handler would try to revert status='running' — but
+      // the job was never claimed, so the revert is a silent no-op. The job stays 'pending'
+      // with next_run_at in the past and the scheduler loops forever. Guard: mark failed.
+      const row = fakeDbRow({ cron_expr: 'bad-expr' });
+      const badExprError = new Error('Invalid cron expression');
+      schedulerService.nextRunFromCron.mockImplementationOnce(() => { throw badExprError; });
+
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rows: [] }); // mark-failed UPDATE
+
+      await scheduler.pollDueJobs();
+
+      expect(bus.publish).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId: 'job-1', cronExpr: 'bad-expr' }),
+        'Invalid cron expression — marking job failed to prevent retry storm',
+      );
+      // Confirm the mark-failed UPDATE was issued (not the standard claim UPDATE)
+      const [failSql, failParams] = pool.query.mock.calls[1] as [string, unknown[]];
+      expect(failSql).toContain("status = 'failed'");
+      expect(failSql).toContain('last_error');
+      expect(failParams[0]).toBe('job-1');
     });
 
     it('advances next_run_at in claim UPDATE for cron jobs', async () => {

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -311,6 +311,63 @@ describe('Scheduler', () => {
       expect(claimParams).toContain('job-1');
     });
 
+    // Regression: scheduler fired same cron job 3x in 80s (#1124). The atomic claim UPDATE
+    // uses rowCount to detect concurrent claims — rowCount=0 means another poller claimed
+    // first, so this poller must skip. pg types rowCount as number|null; both 0 and null
+    // must abort, otherwise a null rowCount bypasses the guard and fires a duplicate.
+    it('skips firing when claim UPDATE returns rowCount=0 (concurrent claim)', async () => {
+      const row = fakeDbRow();
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 0, rows: [] }); // already claimed
+
+      await scheduler.pollDueJobs();
+
+      expect(bus.publish).not.toHaveBeenCalled();
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId: 'job-1' }),
+        'Job already claimed; skipping fire',
+      );
+    });
+
+    it('skips firing when claim UPDATE returns rowCount=null (pg null-safety)', async () => {
+      const row = fakeDbRow();
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: null, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      expect(bus.publish).not.toHaveBeenCalled();
+    });
+
+    it('advances next_run_at in claim UPDATE for cron jobs', async () => {
+      const row = fakeDbRow(); // cron_expr: '0 9 * * *', timezone: 'UTC'
+      const nextRun = new Date('2026-06-24T09:00:00.000Z');
+      schedulerService.nextRunFromCron.mockReturnValueOnce(nextRun);
+
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [claimSql, claimParams] = pool.query.mock.calls[1] as [string, unknown[]];
+      expect(claimSql).toContain('next_run_at');
+      expect(claimParams).toContain(nextRun);
+      expect(schedulerService.nextRunFromCron).toHaveBeenCalledWith('0 9 * * *', 'UTC');
+    });
+
+    it('does not include next_run_at in claim UPDATE for one-shot jobs', async () => {
+      const row = fakeDbRow({ cron_expr: null, run_at: new Date('2026-06-24T09:00:00.000Z').toISOString() });
+
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      expect(schedulerService.nextRunFromCron).not.toHaveBeenCalled();
+      const [claimSql] = pool.query.mock.calls[1] as [string, unknown[]];
+      expect(claimSql).not.toContain('next_run_at');
+    });
+
     it('uses a unique conversationId per run (not job ID)', async () => {
       const jobId = 'job-unique-conv';
       const firedEvent = { id: 'fired-evt-1' };

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -344,6 +344,31 @@ describe('Scheduler', () => {
       );
     });
 
+    it('skips firing when cron expression changed between poll and claim (optimistic-concurrency guard)', async () => {
+      // Scenario: updateJob() changes cron_expr after the poll SELECT but before the
+      // claim UPDATE. The WHERE includes cron_expr/timezone so the UPDATE matches 0 rows,
+      // and the job is skipped. The next poll fires it with the corrected expression.
+      const row = fakeDbRow(); // cron_expr: '0 9 * * *', timezone: 'UTC'
+      const nextRun = new Date('2026-06-24T09:00:00.000Z');
+      schedulerService.nextRunFromCron.mockReturnValueOnce(nextRun);
+
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 0, rows: [] }); // cron changed, WHERE didn't match
+
+      await scheduler.pollDueJobs();
+
+      expect(bus.publish).not.toHaveBeenCalled();
+      const [claimSql, claimParams] = pool.query.mock.calls[1] as [string, unknown[]];
+      expect(claimSql).toContain('cron_expr = $4');
+      expect(claimSql).toContain('timezone = $5');
+      expect(claimParams[3]).toBe('0 9 * * *');
+      expect(claimParams[4]).toBe('UTC');
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId: 'job-1' }),
+        'Job already claimed; skipping fire',
+      );
+    });
+
     it('marks cron job failed (not pending) when nextRunFromCron throws, preventing retry storm', async () => {
       // If nextRunFromCron throws (e.g. corrupt cron_expr inserted directly into DB),
       // the outer pollDueJobs error handler would try to revert status='running' — but
@@ -371,7 +396,13 @@ describe('Scheduler', () => {
       expect(failSql).toContain('next_run_at = NULL');
       // Status guard prevents clobbering a concurrent cancellation
       expect(failSql).toContain("status IN ('pending', 'failed')");
+      // Optimistic-concurrency guard: if updateJob() fixed the cron between poll and here,
+      // this WHERE won't match and the job stays 'pending' with the corrected expression
+      expect(failSql).toContain('cron_expr = $3');
+      expect(failSql).toContain('timezone = $4');
       expect(failParams[0]).toBe('job-1');
+      expect(failParams[2]).toBe('bad-expr');
+      expect(failParams[3]).toBe('UTC');
     });
 
     it('advances next_run_at in claim UPDATE for cron jobs', async () => {
@@ -388,6 +419,12 @@ describe('Scheduler', () => {
       expect(claimSql).toContain('next_run_at');
       expect(claimParams).toContain(nextRun);
       expect(schedulerService.nextRunFromCron).toHaveBeenCalledWith('0 9 * * *', 'UTC');
+      // Optimistic-concurrency guard: cron_expr/timezone in WHERE prevents overwriting a
+      // next_run_at that updateJob() just set with a concurrent cron-expression change
+      expect(claimSql).toContain('cron_expr = $4');
+      expect(claimSql).toContain('timezone = $5');
+      expect(claimParams[3]).toBe('0 9 * * *');
+      expect(claimParams[4]).toBe('UTC');
     });
 
     it('does not include next_run_at in claim UPDATE for one-shot jobs', async () => {

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -367,6 +367,10 @@ describe('Scheduler', () => {
       const [failSql, failParams] = pool.query.mock.calls[1] as [string, unknown[]];
       expect(failSql).toContain("status = 'failed'");
       expect(failSql).toContain('last_error');
+      // next_run_at = NULL prevents the poll SELECT from re-selecting this job on every tick
+      expect(failSql).toContain('next_run_at = NULL');
+      // Status guard prevents clobbering a concurrent cancellation
+      expect(failSql).toContain("status IN ('pending', 'failed')");
       expect(failParams[0]).toBe('job-1');
     });
 


### PR DESCRIPTION
## Summary

Fixes the scheduler race condition that caused cron job `948e69b7` to fire 3 times in 80 seconds on 2026-06-22.

**Root cause — two gaps in the original claim sequence:**

1. `next_run_at` was only advanced at job *completion*, not at claim time. When `bus.publish()` threw after the claim UPDATE set `status = 'running'`, the error handler reverted `status = 'pending'` but left `next_run_at` in the past. The next poll's `SELECT WHERE next_run_at <= now()` re-selected and re-fired the same job.

2. The `rowCount` guard used `=== 0`, but pg types it `number | null`. A `null` return silently bypassed the guard and allowed a second fire.

**Fix:**

- For cron jobs, the claim UPDATE now also sets `next_run_at = nextRunFromCron(cronExpr, timezone)` atomically. If `bus.publish()` fails and the revert sets `status = 'pending'`, `next_run_at` is already in the future — the next poll's SELECT skips the job until its next scheduled occurrence.
- One-shot jobs are unchanged (they complete to `'finished'` and don't recur).
- `rowCount` guard hardened: `=== 0 || === null` (both mean 0 rows updated).
- `nextRunFromCron()` is now guarded: if it throws (e.g. corrupt cron expression inserted directly into DB bypassing `createJob` validation), the job is immediately transitioned to `'failed'` rather than relying on the outer error handler — which would try to revert `status = 'running'` when the job was never claimed, a silent no-op that left `next_run_at` in the past and caused an infinite retry loop.
- `rowCount === null` (anomalous driver state) now logs at `warn` instead of `debug` so it's visible in production.

**Belt-and-suspenders:** `completeJobRun()` still advances `next_run_at` on successful completion. Because both calls compute `nextRunFromCron()` from current wall-clock time and the minimum cron interval is 5 minutes (enforced by `validateCronFrequency`), they produce the same "next" occurrence when the run completes within one interval. No double-skip risk.

## Tests

6 new unit tests:
- `skips firing when claim UPDATE returns rowCount=0 (concurrent claim)` — regression for the double-fire guard
- `skips firing when claim UPDATE returns rowCount=null (pg null-safety)` — includes warn-level log assertion
- `advances next_run_at in claim UPDATE for cron jobs` — verifies the SQL shape
- `does not include next_run_at in claim UPDATE for one-shot jobs`
- `marks cron job failed (not pending) when nextRunFromCron throws, preventing retry storm` — regression for the infinite-loop guard

All 4009 tests pass. Typecheck clean.

Closes #1124