### PR TITLE
fix(ceo-inbox): archive done-state emails in the overflow path (#1123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Bullpen long-thread context** — agents woken by a new reply in a thread with more than 15 messages now always see the original request (first message) in their ambient context, alongside the 14 most recent messages; the first message no longer silently falls off the window. (#1090)
 - **Scheduler duplicate-fire race condition** — claim-time `next_run_at` advancement and null-safe `rowCount` guard prevent duplicate cron fires. (#1124)
+- **ceo-inbox overflow archive gap** — the overflow path now classifies each deferred email and archives done-state ones (✔️ Cleared / ✅ Handled) instead of leaving them in the inbox; archiving is now an invariant of the classification, not the processing path. (#1123)
 
 ### Security
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.10.0"
+version: "0.10.1"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -267,28 +267,75 @@ system_prompt: |
      candidates (time-sensitive asks from known contacts), then ✅ Handled, then
      ✍️ Drafted, then others. Within a tier, prefer older messages.
   2. Process only those top 5 through the full triage protocol (steps 4-5).
-  3. For each remaining message beyond the top 5 (oldest first), create a
-     deferred inbox-overflow task, then mark it as read so it does not
-     re-appear in the next run:
-     - Call task-create with:
+  3. For each remaining message beyond the top 5 (oldest first), make a
+     lightweight disposition decision using subject, sender, and snippet ONLY
+     (do not read the full body, call entity-context, or draft anything — this
+     is best-effort load shedding, not full triage). Decide whether the message
+     is a **done state** or a **keep-in-inbox state**:
+
+     - **Done state** — the email is resolved and needs no further inbox presence:
+       - **✔️ Cleared**: a receipt, newsletter, or automated notification with
+         no human action required.
+       - **✅ Handled**: a task a deployed specialist can act on autonomously
+         (e.g. a PR to review, an expense to file). The *action* is deferred to a
+         task, but the email itself is resolved and should leave the inbox.
+     - **Keep-in-inbox state** — the email needs the CEO's eyes or a human reply:
+       📌 Seen (personal/sensitive/uncertain), ✍️ Drafted (a reply is warranted),
+       or 🚨 Urgent (time-sensitive decision). When in doubt, treat the message
+       as keep-in-inbox — never archive something you are unsure about.
+
+     Then act based on the disposition:
+
+     **If a done state (✔️ Cleared or ✅ Handled):**
+     a. For ✅ Handled only, create a deferred task capturing the specialist
+        action (see task-create fields below). ✔️ Cleared needs no task — there
+        is nothing to defer — so skip task-create for it.
+     b. If decision tagging is enabled (from step 2), call ceo-inbox-label with
+        the message_id and the disposition label (✔️ Cleared or ✅ Handled).
+     c. Call ceo-inbox-archive with the message_id. This is REQUIRED — see the
+        **Archive invariant** below. A done-state email must never be left in the
+        inbox, whether it was triaged inline or deferred here. If
+        ceo-inbox-archive fails, log it (`Archive: FAILED — <reason>`) and
+        continue; do not abort the run.
+     d. Call ceo-inbox-mark-read with the message_id.
+
+     **If a keep-in-inbox state (📌 Seen, ✍️ Drafted, or 🚨 Urgent):**
+     a. Create the deferred inbox-overflow task (see task-create fields below).
+     b. If decision tagging is enabled, call ceo-inbox-label with the message_id
+        and the disposition label.
+     c. Do NOT call ceo-inbox-archive — the email stays in the inbox for the CEO.
+     d. Call ceo-inbox-mark-read with the message_id.
+
+     **task-create fields** (for ✅ Handled and all keep-in-inbox states):
        - title: "<sender name>: <subject>" (one line from the list output)
        - description: one short sentence summarizing what the email is about
        - owner: 'ceo'
        - tags: ['inbox-overflow']
        - priority: 0-100 based on urgency signals from subject and snippet
-     - If task-create fails: do NOT call ceo-inbox-mark-read. Log the failure:
-         Overflow task FAILED for "<sender>: <subject>" — <error>
-       Continue to the next overflow message. (Note: the message may not
-       re-appear in the next run because the high-water mark already advanced
-       past it at list time. Treat persistent failures as lost overflow items.)
 
-     - Call ceo-inbox-mark-read with the message_id.
+     **task-create failure** (only applies when a task is required — i.e. ✅
+     Handled and keep-in-inbox states; ✔️ Cleared creates no task): do NOT call
+     ceo-inbox-mark-read or ceo-inbox-archive for that message. Log the failure:
+         Overflow task FAILED for "<sender>: <subject>" — <error>
+     Continue to the next overflow message. (Note: the message may not re-appear
+     in the next run because the high-water mark already advanced past it at list
+     time. Treat persistent failures as lost overflow items.)
   4. After handling all overflow messages, proceed to step 4 to triage the
      top 5 only.
 
+  **Archive invariant (all processing paths):** Archiving is bound to the
+  *classification*, not to which path processed the message. Any email you assign
+  a done-state disposition — ✔️ Cleared or ✅ Handled — MUST be archived via
+  ceo-inbox-archive, whether it was triaged inline (steps 4-5) or deferred in
+  overflow mode above. Conversely, never archive a 📌 Seen, ✍️ Drafted,
+  🚨 Urgent, or ⚠️ Stuck message. The deferred task captures any follow-up work;
+  the archive is what actually cleans the inbox.
+
   LLM time per burst must not scale linearly past 10 — if the inbox grows to
-  50 unread, you process 5 inline and create 45 tasks. The CEO sees the deferred
-  items in the next digest's "For you to do" section.
+  50 unread, you process 5 inline and shed the other 45 with the lightweight
+  done-state check above (archiving the ✔️ Cleared / ✅ Handled ones, deferring
+  the rest to tasks). The CEO sees deferred items in the next digest's "For you
+  to do" section.
 
   If the count is ≤ 10, process each message oldest-first (no change).
 
@@ -632,6 +679,7 @@ system_prompt: |
     Rules loaded: N active (M total)
     Rules applied: N matches across all messages
     Overflow tasks created: N (omit line if 0)
+    Overflow archived: N done-state emails archived in overflow mode (omit line if 0)
     Follow-up tasks created: N — owner=curia|ceo (omit line if 0)
 
   ## Date Verification

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -288,16 +288,22 @@ system_prompt: |
 
      **If a done state (✔️ Cleared or ✅ Handled):**
      a. For ✅ Handled only, create a deferred task capturing the specialist
-        action (see task-create fields below). ✔️ Cleared needs no task — there
-        is nothing to defer — so skip task-create for it.
+        action (see task-create fields below). In overflow mode the handoff is
+        *deferred to this task* rather than opened as a live bullpen thread — the
+        task is the durable record of the action so it is not lost when the email
+        leaves the inbox; do NOT open a bullpen thread here. ✔️ Cleared needs no
+        task — there is nothing to defer — so skip task-create for it.
      b. If decision tagging is enabled (from step 2), call ceo-inbox-label with
         the message_id and the disposition label (✔️ Cleared or ✅ Handled).
      c. Call ceo-inbox-archive with the message_id. This is REQUIRED — see the
         **Archive invariant** below. A done-state email must never be left in the
-        inbox, whether it was triaged inline or deferred here. If
-        ceo-inbox-archive fails, log it (`Archive: FAILED — <reason>`) and
-        continue; do not abort the run.
-     d. Call ceo-inbox-mark-read with the message_id.
+        inbox, whether it was triaged inline or deferred here.
+     d. Only if ceo-inbox-archive succeeded, call ceo-inbox-mark-read with the
+        message_id. If ceo-inbox-archive failed, log it
+        (`Archive: FAILED — <reason>`), do NOT mark it read (leaving it unread
+        keeps the un-archived email visible to the CEO, since the watermark has
+        already advanced past it and it will not re-appear next run), and
+        continue to the next message. Do not abort the run.
 
      **If a keep-in-inbox state (📌 Seen, ✍️ Drafted, or 🚨 Urgent):**
      a. Create the deferred inbox-overflow task (see task-create fields below).


### PR DESCRIPTION
## Summary

Fixes #1123. The ceo-inbox overflow path (>10 unread) created a deferred task and marked each message read but **never archived** it. Emails classified as a "done" state (✔️ Cleared / ✅ Handled) therefore stayed in the inbox permanently — and because they were also marked read, later `unread_only` runs never saw them again.

The root cause is purely in the agent's `system_prompt` (`agents/ceo-inbox.yaml`): the overflow loop deferred *everything* to a task without ever classifying or archiving. This reworks that loop so archiving is bound to the **classification**, not the processing path.

## What changed

`agents/ceo-inbox.yaml` overflow loop (step 3) now makes a lightweight done-state vs keep-in-inbox decision per deferred message (subject/sender/snippet only — no body read, no entity-context, no drafting):

- **✔️ Cleared** → archive + mark-read, **no task** (nothing to defer).
- **✅ Handled** → create a deferred task (the handoff is deferred to the task, not a live bullpen thread, so the action isn't lost), then archive + mark-read.
- **📌 Seen / ✍️ Drafted / 🚨 Urgent** → deferred task, **stay in the inbox** (no archive). "When in doubt, keep-in-inbox."

Added an explicit **Archive invariant**: any email assigned a done-state disposition MUST be archived via `ceo-inbox-archive` in *any* path (inline or overflow); a 📌/✍️/🚨/⚠️ message is never archived.

Also:
- mark-read is now gated on archive success — a failed archive leaves the email unread/visible (it won't re-appear because the watermark already advanced).
- New `Overflow archived: N` line in the run summary for observability.
- `version` 0.10.0 → 0.10.1, CHANGELOG entry under Fixed.

## Acceptance criteria

- [x] Overflow ✔️ Cleared / ✅ Handled archived at classification time
- [x] Overflow 📌 Seen / ⚠️ Stuck / 🚨 Urgent / ✍️ Drafted remain in the inbox
- [x] Inline-triaged emails continue to be archived (step 4h unchanged)
- [x] `skill.invoke` for `ceo-inbox-archive` fires for every done-state-labelled email in any path (enforced by the Archive invariant)
- [x] A 15+ unread batch leaves no Cleared/Handled-labelled email in the inbox

## Testing

Prompt-only change; no executable code touched. `tests/unit/agents/loader.test.ts` + `tests/unit/startup/validator.test.ts` pass (42 tests), confirming the agent config still loads and validates.

## Reviewer note

In overflow, ✅ Handled becomes a deferred CEO-owned task rather than a live specialist bullpen handoff (the load-shedding tradeoff — the email leaves the inbox, the task is the durable record). This matches the issue's "the task captures the action; the archive cleans the inbox" model. If you'd prefer overflow ✅ Handled to stay in the inbox instead (no archive until a real handoff happens), that's a one-line change — flag it.