### PR TITLE
feat: model-tier fallback resilience on NOT_FOUND (#813)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Model-tier fallback resilience** — when a tier's primary model returns `NOT_FOUND` (e.g. OpenRouter drops a model from its catalog), the agent runtime automatically re-routes to the fallback tier's model (`fast`→`standard`, `standard`→`powerful`, `powerful`→`standard`) instead of surfacing an error. Engagement is logged as a `model.fallback` audit event. (#813)
+- **Model-tier fallback resilience** — reroutes `NOT_FOUND` across fixed tier rules and emits a `model.fallback` audit event (spec 05, #813).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **Model-tier fallback resilience** — when a tier's primary model returns `NOT_FOUND` (e.g. OpenRouter drops a model from its catalog), the agent runtime automatically re-routes to the fallback tier's model (`fast`→`standard`, `standard`→`powerful`, `powerful`→`standard`) instead of surfacing an error. Engagement is logged as a `model.fallback` audit event. (#813)
+
 ### Changed
 
 - **TypeScript test coverage** — `tests/**/*.ts` is now covered by typecheck (`tsconfig.tests.json`, third pass in the `typecheck` script); type drift between shared types and test fixtures is now caught by CI. (#1105)

--- a/docs/specs/05-error-recovery.md
+++ b/docs/specs/05-error-recovery.md
@@ -160,6 +160,35 @@ with the cursor persisted in `last_run_context` so successive runs advance throu
 without re-scanning. The contacts agent's `error_budget` is raised to 30 turns to accommodate the
 batched work. See [spec 09 — Contacts & Identity](09-contacts-and-identity.md).
 
+### Provider model fallback (#813)
+
+When OpenRouter (or another provider) removes a model from its catalog, every agent
+using that tier starts returning `NOT_FOUND` errors until the operator manually remaps
+the tier — typically hours later, with silent `agent.error` accumulation in between.
+
+The runtime handles this transparently: on a `NOT_FOUND` response from the primary
+model, it automatically re-routes to the **fallback tier's** model before surfacing
+the error. Fallback rules are fixed and require no configuration:
+
+| Primary tier | Fallback tier |
+|---|---|
+| `fast` | `standard` |
+| `standard` | `powerful` |
+| `powerful` | `standard` |
+
+When the fallback succeeds, the agent completes normally and the caller sees no error.
+If the fallback also fails, the fallback's error is surfaced (not the original NOT_FOUND).
+
+Fallback engagement is always logged: a pino `warn` fires immediately, and a durable
+`model.fallback` bus event is written to the audit log with the agent ID, tier, failed
+model, fallback model, and reason. This gives operators a grep-able signal without
+requiring an emergency page. The `model.fallback` event appears in the audit dashboard
+alongside `llm.call` events so the pattern is visible at a glance.
+
+**Out of scope:** only `NOT_FOUND` triggers fallback. `AUTH_FAILURE`, `VALIDATION_ERROR`,
+and other non-retryable errors still fail hard — they indicate caller or config problems,
+not model availability.
+
 ---
 
 ## Error Classification

--- a/src/agents/llm/model-router.test.ts
+++ b/src/agents/llm/model-router.test.ts
@@ -88,3 +88,27 @@ describe('ModelRouter', () => {
     expect(() => new ModelRouter(config, registry, logger)).toThrow('not found in the model registry');
   });
 });
+
+describe('ModelRouter.getFallbackTier', () => {
+  const router = new ModelRouter(defaultConfig, registry, logger);
+
+  it('fast falls back to standard', () => {
+    expect(router.getFallbackTier('fast')).toBe('standard');
+  });
+
+  it('standard falls back to powerful', () => {
+    expect(router.getFallbackTier('standard')).toBe('powerful');
+  });
+
+  it('powerful falls back to standard', () => {
+    expect(router.getFallbackTier('powerful')).toBe('standard');
+  });
+
+  it('fallback tier resolves to a valid model', () => {
+    // Fallback tier always succeeds — all tiers are validated at construction.
+    const fastFallback = router.getFallbackTier('fast');
+    const resolved = router.resolve(fastFallback);
+    expect(resolved.model).toBe('claude-sonnet-4-6');
+    expect(resolved.tier).toBe('standard');
+  });
+});

--- a/src/agents/llm/model-router.ts
+++ b/src/agents/llm/model-router.ts
@@ -8,6 +8,13 @@
 // Capability needs (vision, large_context, etc.) are accepted but not
 // validated in this version — they are documentary-only, logged at debug
 // level for observability. Validation deferred to #379.
+//
+// Fallback tier rules (#813): when a tier's primary model is unavailable
+// (NOT_FOUND from the provider), the runtime re-routes to the fallback tier.
+// Rules are fixed — no config knob needed:
+//   fast     → standard  (lateral upgrade to a capable model)
+//   standard → powerful  (upgrade to strongest model)
+//   powerful → standard  (degrade gracefully rather than fail)
 
 import type { Logger } from '../../logger.js';
 import type { ModelRegistry } from './model-registry.js';
@@ -29,6 +36,14 @@ export interface ResolvedModel {
 }
 
 const VALID_TIERS: ReadonlySet<string> = new Set<string>(['fast', 'standard', 'powerful']);
+
+// Fixed fallback tier for each tier (#813). No config needed — these rules are intentional:
+// fast→standard (upgrade), standard→powerful (upgrade), powerful→standard (graceful degrade).
+const FALLBACK_TIER: Record<Tier, Tier> = {
+  fast: 'standard',
+  standard: 'powerful',
+  powerful: 'standard',
+};
 
 export class ModelRouter {
   private readonly config: ModelRoutingConfig;
@@ -87,5 +102,13 @@ export class ModelRouter {
       model: tierConfig.model,
       tier: effectiveTier as Tier,
     };
+  }
+
+  /**
+   * Return the fallback tier to use when this tier's primary model is unavailable.
+   * Rules are fixed (#813): fast→standard, standard→powerful, powerful→standard.
+   */
+  getFallbackTier(tier: Tier): Tier {
+    return FALLBACK_TIER[tier];
   }
 }

--- a/src/agents/runtime.test.ts
+++ b/src/agents/runtime.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AgentRuntime } from './runtime.js';
 import type { LLMProvider, LLMResponse } from './llm/provider.js';
 import { EventBus } from '../bus/bus.js';
-import { createAgentTask, type AgentResponseEvent, type ModelFallbackEngagedEvent } from '../bus/events.js';
+import { createAgentTask, type AgentErrorEvent, type AgentResponseEvent, type ModelFallbackEngagedEvent } from '../bus/events.js';
 import { createSilentLogger } from '../logger.js';
 import { randomUUID } from 'node:crypto';
 
@@ -28,13 +28,13 @@ function makeSuccessResponse(model: string): LLMResponse {
   };
 }
 
-function makeNotFoundResponse(): LLMResponse {
+function makeNotFoundResponse(source = 'openrouter', message = '404 No endpoints found'): LLMResponse {
   return {
     type: 'error',
     error: {
       type: 'NOT_FOUND',
-      source: 'openrouter',
-      message: '404 No endpoints found',
+      source,
+      message,
       retryable: false,
       context: { status: 404 },
       timestamp: new Date(),
@@ -65,8 +65,10 @@ function makeProvider(id: string, response: LLMResponse): LLMProvider {
 async function runTask(bus: EventBus, agentId: string, content = 'hello'): Promise<{
   response: AgentResponseEvent | null;
   fallbackEvents: ModelFallbackEngagedEvent[];
+  errorEvents: AgentErrorEvent[];
 }> {
   const fallbackEvents: ModelFallbackEngagedEvent[] = [];
+  const errorEvents: AgentErrorEvent[] = [];
   let resolveResponse: (ev: AgentResponseEvent) => void;
   const responsePromise = new Promise<AgentResponseEvent>(res => { resolveResponse = res; });
 
@@ -75,6 +77,9 @@ async function runTask(bus: EventBus, agentId: string, content = 'hello'): Promi
   });
   bus.subscribe('model.fallback', 'system', event => {
     fallbackEvents.push(event as ModelFallbackEngagedEvent);
+  });
+  bus.subscribe('agent.error', 'system', event => {
+    errorEvents.push(event as AgentErrorEvent);
   });
 
   const parentId = randomUUID();
@@ -95,7 +100,7 @@ async function runTask(bus: EventBus, agentId: string, content = 'hello'): Promi
     new Promise<null>(res => setTimeout(() => res(null), 5_000)),
   ]);
 
-  return { response, fallbackEvents };
+  return { response, fallbackEvents, errorEvents };
 }
 
 // ------------------------------------------------------------------
@@ -178,8 +183,9 @@ describe('AgentRuntime model fallback (#813)', () => {
   });
 
   it('(c) surfaces an error when both primary and fallback fail', async () => {
-    const primary = makeProvider('openrouter', makeNotFoundResponse());
-    const fallback = makeProvider('anthropic', makeNotFoundResponse());
+    // Use distinct sources so we can verify it's the fallback's error that surfaces.
+    const primary = makeProvider('openrouter', makeNotFoundResponse('openrouter', 'primary model gone'));
+    const fallback = makeProvider('anthropic', makeNotFoundResponse('anthropic', 'fallback model gone'));
 
     const runtime = new AgentRuntime({
       agentId: AGENT_ID,
@@ -194,7 +200,7 @@ describe('AgentRuntime model fallback (#813)', () => {
     });
     runtime.register();
 
-    const { response, fallbackEvents } = await runTask(bus, AGENT_ID);
+    const { response, fallbackEvents, errorEvents } = await runTask(bus, AGENT_ID);
 
     // Should still get a response, but it's an error response
     expect(response).not.toBeNull();
@@ -203,6 +209,11 @@ describe('AgentRuntime model fallback (#813)', () => {
     // model.fallback event was still published (we attempted the fallback)
     expect(fallbackEvents).toHaveLength(1);
     expect(fallbackEvents[0]!.payload.failedModel).toBe(PRIMARY_MODEL);
+
+    // The agent.error event must carry the fallback's source, proving it's the fallback
+    // error that was surfaced rather than the primary NOT_FOUND.
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0]!.payload.source).toBe('anthropic');
 
     expect(primary.chat).toHaveBeenCalledOnce();
     expect(fallback.chat).toHaveBeenCalledOnce();

--- a/src/agents/runtime.test.ts
+++ b/src/agents/runtime.test.ts
@@ -1,0 +1,278 @@
+// runtime.test.ts — tests for AgentRuntime model-fallback behavior (#813).
+//
+// Uses a real EventBus (with permission enforcement) and mock LLMProviders
+// to exercise the chatWithRetry() fallback path end-to-end without a real
+// API key or database. Focuses on the three acceptance criteria:
+//   (a) primary success — no fallback
+//   (b) primary NOT_FOUND → fallback success
+//   (c) all models fail → error surfaces to caller
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AgentRuntime } from './runtime.js';
+import type { LLMProvider, LLMResponse } from './llm/provider.js';
+import { EventBus } from '../bus/bus.js';
+import { createAgentTask, type AgentResponseEvent, type ModelFallbackEngagedEvent } from '../bus/events.js';
+import { createSilentLogger } from '../logger.js';
+import { randomUUID } from 'node:crypto';
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+function makeSuccessResponse(model: string): LLMResponse {
+  return {
+    type: 'text',
+    content: `response from ${model}`,
+    usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+    provenance: { requestedModel: model, actualModel: model, providerRequestId: `req-${model}` },
+  };
+}
+
+function makeNotFoundResponse(): LLMResponse {
+  return {
+    type: 'error',
+    error: {
+      type: 'NOT_FOUND',
+      source: 'openrouter',
+      message: '404 No endpoints found',
+      retryable: false,
+      context: { status: 404 },
+      timestamp: new Date(),
+    },
+  };
+}
+
+function makeAuthFailureResponse(): LLMResponse {
+  return {
+    type: 'error',
+    error: {
+      type: 'AUTH_FAILURE',
+      source: 'openrouter',
+      message: '401 Unauthorized',
+      retryable: false,
+      context: { status: 401 },
+      timestamp: new Date(),
+    },
+  };
+}
+
+function makeProvider(id: string, response: LLMResponse): LLMProvider {
+  return { id, chat: vi.fn().mockResolvedValue(response) };
+}
+
+// Publish a task and return a promise that resolves with the agent.response event.
+// Uses the system layer to capture all bus events.
+async function runTask(bus: EventBus, agentId: string, content = 'hello'): Promise<{
+  response: AgentResponseEvent | null;
+  fallbackEvents: ModelFallbackEngagedEvent[];
+}> {
+  const fallbackEvents: ModelFallbackEngagedEvent[] = [];
+  let resolveResponse: (ev: AgentResponseEvent) => void;
+  const responsePromise = new Promise<AgentResponseEvent>(res => { resolveResponse = res; });
+
+  bus.subscribe('agent.response', 'system', event => {
+    resolveResponse(event as AgentResponseEvent);
+  });
+  bus.subscribe('model.fallback', 'system', event => {
+    fallbackEvents.push(event as ModelFallbackEngagedEvent);
+  });
+
+  const parentId = randomUUID();
+  const taskEvent = createAgentTask({
+    agentId,
+    conversationId: randomUUID(),
+    channelId: 'cli',
+    senderId: 'test-sender',
+    content,
+    parentEventId: parentId,
+  });
+
+  await bus.publish('dispatch', taskEvent);
+
+  // Wait for the response with a generous timeout to avoid flaky tests
+  const response = await Promise.race([
+    responsePromise,
+    new Promise<null>(res => setTimeout(() => res(null), 5_000)),
+  ]);
+
+  return { response, fallbackEvents };
+}
+
+// ------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------
+
+describe('AgentRuntime model fallback (#813)', () => {
+  const logger = createSilentLogger();
+  const AGENT_ID = 'test-agent';
+  const PRIMARY_MODEL = 'google/gemini-2.0-flash-lite';
+  const FALLBACK_MODEL = 'claude-sonnet-4-6';
+
+  let bus: EventBus;
+
+  beforeEach(() => {
+    // Fresh bus per test so subscriber state doesn't bleed between tests.
+    bus = new EventBus(logger);
+  });
+
+  it('(a) returns the primary model response when it succeeds', async () => {
+    const primary = makeProvider('openrouter', makeSuccessResponse(PRIMARY_MODEL));
+    const fallback = makeProvider('anthropic', makeSuccessResponse(FALLBACK_MODEL));
+
+    const runtime = new AgentRuntime({
+      agentId: AGENT_ID,
+      systemPrompt: 'You are helpful.',
+      provider: primary,
+      resolvedModel: PRIMARY_MODEL,
+      tier: 'fast',
+      fallbackModel: FALLBACK_MODEL,
+      fallbackProvider: fallback,
+      bus,
+      logger,
+    });
+    runtime.register();
+
+    const { response, fallbackEvents } = await runTask(bus, AGENT_ID);
+
+    expect(response).not.toBeNull();
+    expect(response!.payload.isError).toBeFalsy();
+    expect(response!.payload.content).toContain(PRIMARY_MODEL);
+    expect(fallbackEvents).toHaveLength(0);
+    expect(primary.chat).toHaveBeenCalledOnce();
+    expect(fallback.chat).not.toHaveBeenCalled();
+  });
+
+  it('(b) falls through to the fallback model when the primary returns NOT_FOUND', async () => {
+    const primary = makeProvider('openrouter', makeNotFoundResponse());
+    const fallback = makeProvider('anthropic', makeSuccessResponse(FALLBACK_MODEL));
+
+    const runtime = new AgentRuntime({
+      agentId: AGENT_ID,
+      systemPrompt: 'You are helpful.',
+      provider: primary,
+      resolvedModel: PRIMARY_MODEL,
+      tier: 'fast',
+      fallbackModel: FALLBACK_MODEL,
+      fallbackProvider: fallback,
+      bus,
+      logger,
+    });
+    runtime.register();
+
+    const { response, fallbackEvents } = await runTask(bus, AGENT_ID);
+
+    // Final response should be the fallback's success
+    expect(response).not.toBeNull();
+    expect(response!.payload.isError).toBeFalsy();
+    expect(response!.payload.content).toContain(FALLBACK_MODEL);
+
+    // model.fallback event must be published exactly once
+    expect(fallbackEvents).toHaveLength(1);
+    expect(fallbackEvents[0]!.payload.tier).toBe('fast');
+    expect(fallbackEvents[0]!.payload.failedModel).toBe(PRIMARY_MODEL);
+    expect(fallbackEvents[0]!.payload.fallbackModel).toBe(FALLBACK_MODEL);
+    expect(fallbackEvents[0]!.payload.reason).toBe('NOT_FOUND');
+
+    expect(primary.chat).toHaveBeenCalledOnce();
+    expect(fallback.chat).toHaveBeenCalledOnce();
+  });
+
+  it('(c) surfaces an error when both primary and fallback fail', async () => {
+    const primary = makeProvider('openrouter', makeNotFoundResponse());
+    const fallback = makeProvider('anthropic', makeNotFoundResponse());
+
+    const runtime = new AgentRuntime({
+      agentId: AGENT_ID,
+      systemPrompt: 'You are helpful.',
+      provider: primary,
+      resolvedModel: PRIMARY_MODEL,
+      tier: 'fast',
+      fallbackModel: FALLBACK_MODEL,
+      fallbackProvider: fallback,
+      bus,
+      logger,
+    });
+    runtime.register();
+
+    const { response, fallbackEvents } = await runTask(bus, AGENT_ID);
+
+    // Should still get a response, but it's an error response
+    expect(response).not.toBeNull();
+    expect(response!.payload.isError).toBe(true);
+
+    // model.fallback event was still published (we attempted the fallback)
+    expect(fallbackEvents).toHaveLength(1);
+    expect(fallbackEvents[0]!.payload.failedModel).toBe(PRIMARY_MODEL);
+
+    expect(primary.chat).toHaveBeenCalledOnce();
+    expect(fallback.chat).toHaveBeenCalledOnce();
+  });
+
+  it('does not attempt fallback for non-NOT_FOUND errors', async () => {
+    const primary = makeProvider('openrouter', makeAuthFailureResponse());
+    const fallback = makeProvider('anthropic', makeSuccessResponse(FALLBACK_MODEL));
+
+    const runtime = new AgentRuntime({
+      agentId: AGENT_ID,
+      systemPrompt: 'You are helpful.',
+      provider: primary,
+      resolvedModel: PRIMARY_MODEL,
+      tier: 'fast',
+      fallbackModel: FALLBACK_MODEL,
+      fallbackProvider: fallback,
+      bus,
+      logger,
+    });
+    runtime.register();
+
+    const { response, fallbackEvents } = await runTask(bus, AGENT_ID);
+
+    // AUTH_FAILURE should hard-fail without trying the fallback
+    expect(response).not.toBeNull();
+    expect(response!.payload.isError).toBe(true);
+    expect(fallbackEvents).toHaveLength(0);
+    expect(fallback.chat).not.toHaveBeenCalled();
+  });
+
+  it('succeeds with primary model when no fallback is configured', async () => {
+    const primary = makeProvider('openrouter', makeSuccessResponse(PRIMARY_MODEL));
+
+    const runtime = new AgentRuntime({
+      agentId: AGENT_ID,
+      systemPrompt: 'You are helpful.',
+      provider: primary,
+      resolvedModel: PRIMARY_MODEL,
+      // No tier, fallbackModel, or fallbackProvider
+      bus,
+      logger,
+    });
+    runtime.register();
+
+    const { response, fallbackEvents } = await runTask(bus, AGENT_ID);
+
+    expect(response).not.toBeNull();
+    expect(response!.payload.isError).toBeFalsy();
+    expect(fallbackEvents).toHaveLength(0);
+  });
+
+  it('surfaces error when NOT_FOUND occurs and no fallback is configured', async () => {
+    const primary = makeProvider('openrouter', makeNotFoundResponse());
+
+    const runtime = new AgentRuntime({
+      agentId: AGENT_ID,
+      systemPrompt: 'You are helpful.',
+      provider: primary,
+      resolvedModel: PRIMARY_MODEL,
+      // No fallback configured
+      bus,
+      logger,
+    });
+    runtime.register();
+
+    const { response, fallbackEvents } = await runTask(bus, AGENT_ID);
+
+    expect(response).not.toBeNull();
+    expect(response!.payload.isError).toBe(true);
+    expect(fallbackEvents).toHaveLength(0);
+  });
+});

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1,6 +1,7 @@
 import type { LLMProvider, LLMResponse, LLMUsage, Message, ToolDefinition, ContentBlock, ToolUseContent, ToolResultContent, TextContent } from './llm/provider.js';
 import type { EventBus } from '../bus/bus.js';
-import { createAgentResponse, createAgentError, createSkillInvoke, createSkillResult, createLlmCall, createContextBudget, type AgentTaskEvent } from '../bus/events.js';
+import { createAgentResponse, createAgentError, createSkillInvoke, createSkillResult, createLlmCall, createContextBudget, createModelFallbackEngaged, type AgentTaskEvent } from '../bus/events.js';
+import type { Tier } from './llm/model-router.js';
 import { ContextBudget } from './llm/context-budget.js';
 import { DEFAULT_SAFETY_MARGIN } from './llm/token-estimator.js';
 import type { ModelRegistry } from './llm/model-registry.js';
@@ -34,6 +35,16 @@ export interface AgentConfig {
    *  Optional for unit-test convenience; when omitted alongside modelName, the runtime
    *  skips context-window lookup and uses a 200k-token default. */
   resolvedModel?: string;
+  /** The capability tier this agent is routed to (fast | standard | powerful).
+   *  Used to populate model.fallback events when the primary model is unavailable (#813). */
+  tier?: Tier;
+  /** Fallback model to try when the primary model returns NOT_FOUND.
+   *  Pre-resolved from the fixed fallback tier rules at bootstrap (#813).
+   *  When absent, NOT_FOUND errors are handled the same as other non-retryable errors. */
+  fallbackModel?: string;
+  /** Provider instance for the fallback model. May differ from the primary provider
+   *  when the primary and fallback tiers are served by different providers. */
+  fallbackProvider?: LLMProvider;
   bus: EventBus;
   logger: Logger;
   /** Optional working memory for conversation persistence across turns. */
@@ -1305,6 +1316,9 @@ export class AgentRuntime {
     const publishLlmCallEvent = async (
       response: LLMResponse,
       callLatencyMs: number,
+      // Override the provider ID when the call was made with a different provider
+      // than the one captured in the outer closure (e.g. fallback tier provider, #813).
+      providerIdOverride?: string,
     ): Promise<void> => {
       if (response.type === 'error') return;
       try {
@@ -1324,7 +1338,7 @@ export class AgentRuntime {
           conversationId: taskEvent.payload.conversationId,
           requestedModel: response.provenance.requestedModel,
           actualModel: response.provenance.actualModel,
-          provider: provider.id,
+          provider: providerIdOverride ?? provider.id,
           providerRequestId: response.provenance.providerRequestId,
           inputTokens: response.usage.inputTokens,
           outputTokens: response.usage.outputTokens,
@@ -1360,9 +1374,52 @@ export class AgentRuntime {
 
     const agentErr = response.error;
 
-    // Non-retryable errors: count against budget then bail immediately.
-    // AUTH_FAILURE counts double — it's a strong signal something is misconfigured.
+    // Non-retryable errors: check for model fallback first, then bail.
     if (!agentErr.retryable) {
+      // NOT_FOUND means the provider removed a model from its catalog. Before surfacing
+      // the error, try the fallback tier's model (#813). Only NOT_FOUND triggers this —
+      // AUTH_FAILURE and VALIDATION_ERROR indicate caller or config problems, not model
+      // availability, so they go straight to the hard-fail path below.
+      if (agentErr.type === 'NOT_FOUND' && this.config.fallbackModel && this.config.fallbackProvider) {
+        logger.warn(
+          { agentId, failedModel: modelForCall, fallbackModel: this.config.fallbackModel, tier: this.config.tier },
+          'Primary model NOT_FOUND — attempting fallback tier model',
+        );
+        await this.publishModelFallbackEngaged(agentErr, taskEvent, modelForCall ?? 'unknown');
+
+        // @TODO: params.messages were assembled against the primary model's context window.
+        // For powerful→standard downgrades the fallback may have a smaller window,
+        // causing the fallback call to fail with a context-overflow error. Re-budgeting
+        // mid-flight is non-trivial; for now the common cases (fast→standard,
+        // standard→powerful) are larger-or-equal so this is safe. (#813)
+        const fallbackStartMs = Date.now();
+        const fallbackResponse = await this.config.fallbackProvider.chat({ ...params, model: this.config.fallbackModel });
+        const fallbackLatencyMs = Date.now() - fallbackStartMs;
+
+        if (fallbackResponse.type !== 'error') {
+          // Fallback succeeded — behave as if the primary call succeeded.
+          budget.consecutiveErrors = 0;
+          await publishLlmCallEvent(fallbackResponse, fallbackLatencyMs, this.config.fallbackProvider.id);
+          return fallbackResponse;
+        }
+
+        // Fallback also failed — count against budget and surface the fallback error.
+        const fallbackErr = fallbackResponse.error;
+        const fallbackIncrement = fallbackErr.type === 'AUTH_FAILURE' ? 2 : 1;
+        budget.consecutiveErrors += fallbackIncrement;
+        budget.turnsUsed += fallbackIncrement;
+        logger.error(
+          { agentId, errorType: fallbackErr.type, fallbackModel: this.config.fallbackModel },
+          'Fallback model also failed',
+        );
+        await this.publishAgentError(fallbackErr, taskEvent);
+        await this.sendErrorResponse(taskEvent);
+        return null;
+      }
+
+      // All other non-retryable errors (AUTH_FAILURE, VALIDATION_ERROR, etc.), or
+      // NOT_FOUND with no fallback configured — fail immediately.
+      // AUTH_FAILURE counts double — it's a strong signal something is misconfigured.
       const increment = agentErr.type === 'AUTH_FAILURE' ? 2 : 1;
       budget.consecutiveErrors += increment;
       budget.turnsUsed += increment;
@@ -1454,6 +1511,33 @@ export class AgentRuntime {
   /**
    * Publish a structured agent.error event to the bus for audit and monitoring.
    */
+  /**
+   * Publish a model.fallback event when the primary tier model returns NOT_FOUND
+   * and the runtime is re-routing to the fallback tier's model (#813).
+   */
+  private async publishModelFallbackEngaged(
+    agentErr: AgentError,
+    taskEvent: AgentTaskEvent,
+    failedModel: string,
+  ): Promise<void> {
+    const { agentId, bus, logger } = this.config;
+    try {
+      const event = createModelFallbackEngaged({
+        agentId,
+        conversationId: taskEvent.payload.conversationId,
+        tier: this.config.tier ?? 'unknown',
+        failedModel,
+        fallbackModel: this.config.fallbackModel ?? 'unknown',
+        reason: agentErr.type,
+        parentEventId: taskEvent.id,
+      });
+      await bus.publish('agent', event);
+    } catch (err) {
+      // Telemetry failure must not abort the fallback attempt.
+      logger.error({ err, agentId }, 'Failed to publish model.fallback event');
+    }
+  }
+
   private async publishAgentError(agentErr: AgentError, taskEvent: AgentTaskEvent): Promise<void> {
     const { agentId, bus } = this.config;
     const { conversationId } = taskEvent.payload;

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1385,15 +1385,38 @@ export class AgentRuntime {
           { agentId, failedModel: modelForCall, fallbackModel: this.config.fallbackModel, tier: this.config.tier },
           'Primary model NOT_FOUND — attempting fallback tier model',
         );
-        await this.publishModelFallbackEngaged(agentErr, taskEvent, modelForCall ?? 'unknown');
+        await this.publishModelFallbackEngaged(taskEvent, modelForCall ?? 'unknown');
 
         // @TODO: params.messages were assembled against the primary model's context window.
         // For powerful→standard downgrades the fallback may have a smaller window,
         // causing the fallback call to fail with a context-overflow error. Re-budgeting
         // mid-flight is non-trivial; for now the common cases (fast→standard,
         // standard→powerful) are larger-or-equal so this is safe. (#813)
+        let fallbackResponse: LLMResponse;
         const fallbackStartMs = Date.now();
-        const fallbackResponse = await this.config.fallbackProvider.chat({ ...params, model: this.config.fallbackModel });
+        try {
+          fallbackResponse = await this.config.fallbackProvider.chat({ ...params, model: this.config.fallbackModel });
+        } catch (err) {
+          // Provider threw synchronously (network failure, misconfiguration, etc.) —
+          // normalize into AgentError so the audit trail stays complete.
+          const thrownErr: AgentError = {
+            type: 'UNKNOWN',
+            source: this.config.fallbackProvider.id,
+            message: err instanceof Error ? err.message : String(err),
+            retryable: false,
+            context: { raw: String(err) },
+            timestamp: new Date(),
+          };
+          budget.consecutiveErrors += 1;
+          budget.turnsUsed += 1;
+          logger.error(
+            { agentId, err, fallbackModel: this.config.fallbackModel },
+            'Fallback provider threw an unexpected exception',
+          );
+          await this.publishAgentError(thrownErr, taskEvent);
+          await this.sendErrorResponse(taskEvent);
+          return null;
+        }
         const fallbackLatencyMs = Date.now() - fallbackStartMs;
 
         if (fallbackResponse.type !== 'error') {
@@ -1516,7 +1539,6 @@ export class AgentRuntime {
    * and the runtime is re-routing to the fallback tier's model (#813).
    */
   private async publishModelFallbackEngaged(
-    agentErr: AgentError,
     taskEvent: AgentTaskEvent,
     failedModel: string,
   ): Promise<void> {
@@ -1528,7 +1550,7 @@ export class AgentRuntime {
         tier: this.config.tier ?? 'unknown',
         failedModel,
         fallbackModel: this.config.fallbackModel ?? 'unknown',
-        reason: agentErr.type,
+        reason: 'NOT_FOUND',
         parentEventId: taskEvent.id,
       });
       await bus.publish('agent', event);

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -425,6 +425,23 @@ interface LlmCallPayload {
   responseHash: string;
 }
 
+// ModelFallbackEngagedPayload — emitted by the agent runtime when the primary
+// model for a tier returns NOT_FOUND and execution is re-routed to the fallback
+// tier's model (#813). Visible in audit_log for operator alerting and post-incident
+// analysis without requiring a grep across pino logs.
+interface ModelFallbackEngagedPayload {
+  agentId: string;
+  conversationId: string;
+  /** Capability tier whose primary model failed (fast | standard | powerful). */
+  tier: string;
+  /** Primary model that returned NOT_FOUND. */
+  failedModel: string;
+  /** Fallback model being attempted. */
+  fallbackModel: string;
+  /** Error type that triggered the fallback — currently always NOT_FOUND. */
+  reason: string;
+}
+
 // ContextBudgetPayload — emitted by the agent runtime after assembling context
 // for each LLM call. Reports per-tier token estimates, budget utilization, and
 // which tiers were dropped. Co-located with llm.call events in audit_log for
@@ -792,6 +809,14 @@ export interface LlmCallEvent extends BaseEvent {
   payload: LlmCallPayload;
 }
 
+// ModelFallbackEngagedEvent — published when the primary tier model is unavailable
+// and execution falls through to the fallback tier's model (#813).
+export interface ModelFallbackEngagedEvent extends BaseEvent {
+  type: 'model.fallback';
+  sourceLayer: 'agent';
+  payload: ModelFallbackEngagedPayload;
+}
+
 // EmbeddingCallPayload — emitted by EmbeddingService (OpenAI backend) after each
 // successful embedding API call. Tracks model, token consumption, estimated cost,
 // and latency. Allows embedding costs to appear in the same audit log as llm.call.
@@ -989,6 +1014,7 @@ export type BusEvent =
   | ConfigChangeEvent        // System: config object changed (office identity, etc.)
   | ConversationCheckpointEvent // Checkpoint pipeline: Dispatch fires after inactivity window
   | LlmCallEvent             // Spec 10: LLM API call provenance (model, tokens, cost, hashes)
+  | ModelFallbackEngagedEvent  // #813: primary tier model unavailable, routing to fallback tier
   | ContextBudgetEvent        // #24: context budget utilization per LLM call
   | HumanDecisionEvent       // Spec 10: human-in-the-loop decision record (approve/deny/etc.)
   | SecretAccessedEvent      // Spec 06: secrets isolation audit trail (name only, never value)
@@ -1445,6 +1471,20 @@ export function createLlmCall(
     id: randomUUID(),
     timestamp: new Date(),
     type: 'llm.call',
+    sourceLayer: 'agent',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createModelFallbackEngaged(
+  payload: ModelFallbackEngagedPayload & { parentEventId: string },
+): ModelFallbackEngagedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'model.fallback',
     sourceLayer: 'agent',
     payload: rest,
     parentEventId,

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -432,14 +432,14 @@ interface LlmCallPayload {
 interface ModelFallbackEngagedPayload {
   agentId: string;
   conversationId: string;
-  /** Capability tier whose primary model failed (fast | standard | powerful). */
-  tier: string;
+  /** Capability tier whose primary model failed. 'unknown' only when tier was not configured. */
+  tier: 'fast' | 'standard' | 'powerful' | 'unknown';
   /** Primary model that returned NOT_FOUND. */
   failedModel: string;
   /** Fallback model being attempted. */
   fallbackModel: string;
   /** Error type that triggered the fallback — currently always NOT_FOUND. */
-  reason: string;
+  reason: 'NOT_FOUND';
 }
 
 // ContextBudgetPayload — emitted by the agent runtime after assembling context

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -36,12 +36,15 @@ import type { Layer, EventType } from './events.js';
 // #972 (secret-capture resume): system layer publishes secret.captured when a one-time capture
 //          link is redeemed (carries name/routing only, never the value); the resume subscriber
 //          and audit logger subscribe via the system layer.
+// #813 (model fallback): agent layer publishes model.fallback when the primary tier model is
+//          unavailable and execution falls through to the fallback tier's model.
+//          system layer subscribes for audit logging and monitoring.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message', 'channel.poll', 'channel.stalled']),
   dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'conversation.checkpoint', 'human.decision', 'autonomy.send_blocked']),
-  agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call', 'context.budget']),
+  agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call', 'context.budget', 'model.fallback']),
   execution: new Set(['skill.result', 'secret.accessed', 'autonomy.skill_blocked', 'contact.resolved']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'model.fallback', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
@@ -53,7 +56,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss', 'skill.result']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'outbound.pii-redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'context.budget', 'model.fallback', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'embedding.call', 'channel.poll', 'channel.stalled']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1821,7 +1821,23 @@ async function main(): Promise<void> {
     const fallbackTier = modelRouter.getFallbackTier(resolved.tier);
     const fallbackResolved = modelRouter.resolve(fallbackTier);
     const fallbackProviderName = modelRegistry.getProvider(fallbackResolved.model);
-    const agentFallbackProvider = fallbackProviderName ? providerRegistry.get(fallbackProviderName) : undefined;
+    if (!fallbackProviderName) {
+      // All tier models are validated at construction, so a missing provider name here
+      // means the model-registry is inconsistent with the provider-registry — fail fast.
+      logger.error(
+        { agentId: agentConfig.name, fallbackModel: fallbackResolved.model },
+        'Fallback model has no registered provider — check model-registry.ts',
+      );
+      process.exit(1);
+    }
+    const agentFallbackProvider = providerRegistry.get(fallbackProviderName);
+    if (!agentFallbackProvider) {
+      logger.error(
+        { agentId: agentConfig.name, fallbackModel: fallbackResolved.model, fallbackProviderName },
+        'Fallback provider not found in provider registry — check provider setup',
+      );
+      process.exit(1);
+    }
 
     const agent = new AgentRuntime({
       agentId: agentConfig.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1815,11 +1815,22 @@ async function main(): Promise<void> {
       process.exit(1);
     }
 
+    // Pre-resolve the fallback tier model and provider (#813).
+    // The fallback tier rules are fixed: fast→standard, standard→powerful, powerful→standard.
+    // All three tiers are already validated above, so these lookups always succeed.
+    const fallbackTier = modelRouter.getFallbackTier(resolved.tier);
+    const fallbackResolved = modelRouter.resolve(fallbackTier);
+    const fallbackProviderName = modelRegistry.getProvider(fallbackResolved.model);
+    const agentFallbackProvider = fallbackProviderName ? providerRegistry.get(fallbackProviderName) : undefined;
+
     const agent = new AgentRuntime({
       agentId: agentConfig.name,
       systemPrompt,
       provider: agentProvider,
       resolvedModel: resolved.model,
+      tier: resolved.tier,
+      fallbackModel: fallbackResolved.model,
+      fallbackProvider: agentFallbackProvider,
       bus,
       logger,
       memory,


### PR DESCRIPTION
## Summary

Closes #813

- Adds fixed-rule tier fallback in `AgentRuntime.chatWithRetry()`: on `NOT_FOUND` (provider dropped a model), the runtime automatically re-routes to the fallback tier's model before surfacing an error. Rules: `fast`→`standard`, `standard`→`powerful`, `powerful`→`standard`.
- Adds `ModelRouter.getFallbackTier()` with the `FALLBACK_TIER` constant encoding those rules.
- Adds `ModelFallbackEngagedEvent` (`model.fallback`) to the bus event registry and permissions — published as a durable audit event whenever fallback engages.
- Pre-computes fallback model + provider at bootstrap in `src/index.ts` (same pattern as primary model resolution) and passes them into `AgentRuntime` via three new optional `AgentConfig` fields (`tier`, `fallbackModel`, `fallbackProvider`).
- Adds 6 end-to-end runtime tests and 4 model-router tests. Full suite: 305 test files, 0 failures.

## Design notes

Only `NOT_FOUND` triggers fallback. `AUTH_FAILURE`, `VALIDATION_ERROR`, and other non-retryable errors still fail hard — they indicate caller or config problems, not model availability.

If the fallback also fails, its error is surfaced (not the original `NOT_FOUND`) and budget is counted normally. The `model.fallback` audit event is still published so operators can see the attempt.

A `@TODO` is left noting that `params.messages` are assembled against the primary model's context window; for `powerful→standard` downgrades the fallback could have a smaller window. This is a deferred edge case — the common `fast→standard` and `standard→powerful` paths use larger-or-equal windows.

## Test plan

- [ ] `pnpm run test src/agents/runtime.test.ts` — 6 tests covering: primary success, NOT_FOUND→fallback success + model.fallback event, both fail→error, no fallback for AUTH_FAILURE, success without fallback configured, error without fallback configured
- [ ] `pnpm run test src/agents/llm/model-router.test.ts` — includes 4 new getFallbackTier tests
- [ ] `pnpm run typecheck` passes clean
- [ ] Full test suite: 305 passed, 0 failures