### PR TITLE
fix: Nylas 429 retry/backoff + list limit clamping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ceo-nylas-client`** — 429 rate-limit responses are now retried with exponential backoff and jitter (up to 3 attempts), honoring the `Retry-After` header; exhausted retries throw a typed `NylasApiError(429)` that cannot be misread as an auth/credential failure. List endpoints clamp `limit` to ≤ 20 per Nylas guidance. (#1058)
+
 ### Added
 
 - **Model-tier fallback resilience** — reroutes `NOT_FOUND` across fixed tier rules and emits a `model.fallback` audit event (spec 05, #813).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`ceo-nylas-client`** — 429 rate-limit responses are now retried with exponential backoff and jitter (up to 3 attempts), honoring the `Retry-After` header; exhausted retries throw a typed `NylasApiError(429)` that cannot be misread as an auth/credential failure. List endpoints clamp `limit` to ≤ 20 per Nylas guidance. (#1058)
+- **`ceo-nylas-client`** — 429 responses retry with exponential backoff (up to 3 attempts), honoring `Retry-After`; exhaustion throws a typed `NylasApiError(429)` that cannot be misread as an auth failure. (#1058)
+- **`ceo-nylas-client` list endpoints** — `limit` is always sent and capped at ≤ 20; previously an unspecified limit caused Nylas to default to 50, exceeding the safety cap. (#1058)
 
 ### Added
 

--- a/skills/_shared/ceo-nylas-client.test.ts
+++ b/skills/_shared/ceo-nylas-client.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CeoNylasClient, NylasApiError } from './ceo-nylas-client.js';
+import type { Logger } from '../../src/logger.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as Logger;
+}
+
+function makeClient(log: Logger = makeLogger()): CeoNylasClient {
+  return new CeoNylasClient('test-api-key', 'test-grant-id', log);
+}
+
+/** Build a Response-like object that fetch() would return. */
+function makeResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function successResponse(data: unknown): Response {
+  return makeResponse(200, { data });
+}
+
+function rateLimitResponse(retryAfter?: string): Response {
+  const headers: Record<string, string> = {};
+  if (retryAfter !== undefined) headers['retry-after'] = retryAfter;
+  return makeResponse(429, { error: { type: 'rate_limit_error', message: 'Too many requests' } }, headers);
+}
+
+// ── Retry / backoff tests ────────────────────────────────────────────────────
+
+describe('CeoNylasClient — 429 retry / backoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('retries on 429 and succeeds when the next attempt returns 200', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(rateLimitResponse())
+      .mockResolvedValue(successResponse([{ id: 'f1', name: 'INBOX' }]));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    // listFolders uses request() → requestWithCursor() internally
+    const promise = client.listFolders();
+
+    // Advance timers so the backoff delay resolves without real waiting.
+    await vi.runAllTimersAsync();
+    const folders = await promise;
+
+    expect(folders).toHaveLength(1);
+    expect(folders[0]!.name).toBe('INBOX');
+    // Called twice: once for the 429, once for the successful retry.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors the Retry-After header for the backoff delay', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(rateLimitResponse('3'))
+      .mockResolvedValue(successResponse([{ id: 'f1', name: 'INBOX' }]));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    const promise = client.listFolders();
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // The first setTimeout call should be for ~3000ms (Retry-After: 3 + ±25% jitter).
+    const firstDelay = setTimeoutSpy.mock.calls[0]?.[1];
+    expect(firstDelay).toBeGreaterThanOrEqual(3000 * 0.75);
+    expect(firstDelay).toBeLessThanOrEqual(3000 * 1.25);
+  });
+
+  it('throws a typed NylasApiError(429) when retries are exhausted', async () => {
+    // Always return 429 — exhaust all 3 retries.
+    const fetchMock = vi.fn().mockResolvedValue(rateLimitResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    let caughtErr: unknown;
+    const promise = client.listFolders().catch((err: unknown) => {
+      caughtErr = err;
+    });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(caughtErr).toBeInstanceOf(NylasApiError);
+    const err = caughtErr as NylasApiError;
+    // Must be typed status 429.
+    expect(err.status).toBe(429);
+    const msg = err.message.toLowerCase();
+    // Must NOT imply an auth failure (words that would prompt "re-auth" advice).
+    expect(msg).not.toMatch(/\bexpired\b|\bre-authoriz|\binvalid.token|\btoken.expired/);
+    // Must explicitly say rate-limited or 429 so downstream agents can identify
+    // this as transient congestion rather than an auth/credentials problem.
+    expect(msg).toMatch(/rate.limit|429/);
+
+    // 1 initial attempt + 3 retries = 4 total fetches.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not retry non-retriable errors (4xx other than 429)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(400, { error: 'bad request' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    let caughtErr: unknown;
+    const promise = client.listFolders().catch((e: unknown) => {
+      caughtErr = e;
+    });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(caughtErr).toBeInstanceOf(NylasApiError);
+    // No retry — only one fetch.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry non-retriable errors (401 Unauthorized)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(401, { error: 'unauthorized' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    let caughtErr: unknown;
+    const promise = client.listFolders().catch((e: unknown) => {
+      caughtErr = e;
+    });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(caughtErr).toBeInstanceOf(NylasApiError);
+    expect((caughtErr as NylasApiError).status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── limit clamping tests ─────────────────────────────────────────────────────
+
+describe('CeoNylasClient — list limit clamping (≤ 20)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clamps listMessages limit when caller passes > 20', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    await client.listMessages({ limit: 50 });
+
+    const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(calledUrl.searchParams.get('limit')).toBe('20');
+  });
+
+  it('preserves listMessages limit when caller passes ≤ 20', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    await client.listMessages({ limit: 10 });
+
+    const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(calledUrl.searchParams.get('limit')).toBe('10');
+  });
+
+  it('clamps listDrafts limit when caller passes > 20', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    await client.listDrafts({ limit: 100 });
+
+    const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(calledUrl.searchParams.get('limit')).toBe('20');
+  });
+
+  it('clamps listAllDrafts pageSize to 20', async () => {
+    // Return an empty page with no cursor so the loop exits after one fetch.
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    // Pass a pageSize that exceeds the cap.
+    await client.listAllDrafts({ pageSize: 100 });
+
+    const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(calledUrl.searchParams.get('limit')).toBe('20');
+  });
+
+  it('clamps listAllDrafts default pageSize (previously 100) to 20', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    await client.listAllDrafts();
+
+    const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(calledUrl.searchParams.get('limit')).toBe('20');
+  });
+});

--- a/skills/_shared/ceo-nylas-client.test.ts
+++ b/skills/_shared/ceo-nylas-client.test.ts
@@ -22,6 +22,7 @@ function makeResponse(
   status: number,
   body: unknown,
   headers: Record<string, string> = {},
+  opts: { cancelSpy?: ReturnType<typeof vi.fn> } = {},
 ): Response {
   return {
     ok: status >= 200 && status < 300,
@@ -31,6 +32,9 @@ function makeResponse(
     },
     json: async () => body,
     text: async () => JSON.stringify(body),
+    // Real Response has a ReadableStream body; we stub cancel() so the
+    // optional-chaining call in requestWithCursor is exercised, not silently skipped.
+    body: { cancel: opts.cancelSpy ?? vi.fn() },
   } as unknown as Response;
 }
 
@@ -226,6 +230,31 @@ describe('CeoNylasClient — 429 retry / backoff', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('cancels the 429 response body before sleeping (releases the connection slot)', async () => {
+    const cancelSpy = vi.fn();
+    // Inject the cancelSpy into the first 429 response.
+    const rateLimitRes = makeResponse(
+      429,
+      { error: { type: 'rate_limit_error', message: 'Too many requests' } },
+      {},
+      { cancelSpy },
+    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(rateLimitRes)
+      .mockResolvedValue(successResponse([{ id: 'f1', name: 'INBOX' }]));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    const promise = client.listFolders();
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('retries 5xx on GET methods (safe to retry idempotent reads)', async () => {
     const fetchMock = vi
       .fn()
@@ -303,6 +332,28 @@ describe('CeoNylasClient — list limit clamping (≤ 20)', () => {
 
     const client = makeClient();
     await client.listAllDrafts();
+
+    const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(calledUrl.searchParams.get('limit')).toBe('20');
+  });
+
+  it('sends limit=20 for listMessages when no limit is specified (Nylas default is 50 — too high)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    await client.listMessages();
+
+    const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(calledUrl.searchParams.get('limit')).toBe('20');
+  });
+
+  it('sends limit=20 for listDrafts when no limit is specified (Nylas default is 50 — too high)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    await client.listDrafts();
 
     const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
     expect(calledUrl.searchParams.get('limit')).toBe('20');

--- a/skills/_shared/ceo-nylas-client.test.ts
+++ b/skills/_shared/ceo-nylas-client.test.ts
@@ -160,6 +160,88 @@ describe('CeoNylasClient — 429 retry / backoff', () => {
     expect((caughtErr as NylasApiError).status).toBe(401);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('caps Retry-After at 30s when the header specifies a larger value', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(rateLimitResponse('120')) // 120s >> 30s cap
+      .mockResolvedValue(successResponse([{ id: 'f1', name: 'INBOX' }]));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const log = makeLogger();
+    const client = makeClient(log);
+    const promise = client.listFolders();
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // The delay must be ≤ 30s * 1.25 jitter ceiling.
+    const firstDelay = setTimeoutSpy.mock.calls[0]?.[1];
+    expect(firstDelay).toBeLessThanOrEqual(30_000 * 1.25);
+    // A warning should be logged that Retry-After was clamped.
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ retryAfterSeconds: 120 }),
+      expect.stringContaining('Retry-After exceeds cap'),
+    );
+  });
+
+  it('logs a warning when Retry-After is an unparseable date-format string', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(rateLimitResponse('Wed, 01 Jan 2025 00:00:00 GMT'))
+      .mockResolvedValue(successResponse([{ id: 'f1', name: 'INBOX' }]));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const log = makeLogger();
+    const client = makeClient(log);
+    const promise = client.listFolders();
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ retryAfterRaw: 'Wed, 01 Jan 2025 00:00:00 GMT' }),
+      expect.stringContaining('unparseable Retry-After'),
+    );
+  });
+
+  it('does not retry 5xx on non-GET methods (POST) to avoid duplicate sends', async () => {
+    // createFolder uses POST — a 503 on it must NOT be retried.
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(503, { error: 'service unavailable' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    let caughtErr: unknown;
+    const promise = client.createFolder('TestLabel').catch((e: unknown) => {
+      caughtErr = e;
+    });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(caughtErr).toBeInstanceOf(NylasApiError);
+    expect((caughtErr as NylasApiError).status).toBe(503);
+    // No retry — only the single initial attempt.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries 5xx on GET methods (safe to retry idempotent reads)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(503, { error: 'service unavailable' }))
+      .mockResolvedValue(successResponse([{ id: 'f1', name: 'INBOX' }]));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    const promise = client.listFolders();
+    await vi.runAllTimersAsync();
+    const folders = await promise;
+
+    expect(folders).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ── limit clamping tests ─────────────────────────────────────────────────────

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -11,6 +11,9 @@ const NYLAS_MAX_LIST_LIMIT = 20;
 const NYLAS_MAX_RETRIES = 3;
 // Base backoff delay in ms — doubles each attempt (plus ±25% jitter).
 const NYLAS_BACKOFF_BASE_MS = 500;
+// Upper cap for any computed backoff delay, including a Retry-After header value.
+// Prevents a rogue or misbehaving Retry-After from hanging a skill indefinitely.
+const NYLAS_MAX_BACKOFF_MS = 30_000;
 
 // ── Response types ──────────────────────────────────────────────────────────
 
@@ -507,10 +510,15 @@ export class CeoNylasClient {
   // Same as request<T>, but also surfaces Nylas's `next_cursor` for paginated
   // list endpoints. request<T> delegates here and drops the cursor.
   //
-  // 429 and 5xx responses are retried with exponential backoff + ±25% jitter,
-  // honoring the Retry-After header when present. After NYLAS_MAX_RETRIES
-  // attempts, a typed NylasApiError(429, ...) is thrown with an explicit
-  // rate-limit message so downstream agents never misread it as an auth failure.
+  // 429 is retried regardless of HTTP method (the request was rejected before
+  // processing, so there's no duplicate-action risk). 5xx is retried only for
+  // GET — POST/PUT mutations may have been processed before the gateway returned
+  // 502/503, so retrying them risks duplicate sends or double-writes.
+  //
+  // Backoff honors the Retry-After header (capped at NYLAS_MAX_BACKOFF_MS) and
+  // falls back to exponential + ±25% jitter. After NYLAS_MAX_RETRIES attempts,
+  // a typed NylasApiError is thrown with an explicit message so downstream
+  // agents never misread a rate-limit as an auth/credential failure.
   private async requestWithCursor<T>(
     method: string,
     url: string,
@@ -524,6 +532,8 @@ export class CeoNylasClient {
       init.body = JSON.stringify(body);
     }
 
+    const isGet = method.toUpperCase() === 'GET';
+
     let attempt = 0;
     for (;;) {
       let res: Response;
@@ -534,13 +544,33 @@ export class CeoNylasClient {
         throw new NylasApiError(0, operation, `Fetch failed: ${String(err)}`);
       }
 
-      // Retry 429 and 5xx transiently, up to NYLAS_MAX_RETRIES times.
-      if ((res.status === 429 || res.status >= 500) && attempt < NYLAS_MAX_RETRIES) {
+      // 429 is always retriable (rejected before processing). 5xx only on GET
+      // (POST/PUT may have been processed before the gateway returned 5xx).
+      const isRetriable = res.status === 429 || (res.status >= 500 && isGet);
+      if (isRetriable && attempt < NYLAS_MAX_RETRIES) {
+        // Discard the body to release the connection slot before sleeping.
+        await res.body?.cancel();
+
         const retryAfterRaw = res.headers.get('Retry-After');
         const retryAfterSeconds = retryAfterRaw !== null ? Number(retryAfterRaw) : NaN;
-        const baseDelayMs = Number.isFinite(retryAfterSeconds)
-          ? retryAfterSeconds * 1000
-          : NYLAS_BACKOFF_BASE_MS * 2 ** attempt;
+        let baseDelayMs: number;
+        if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+          baseDelayMs = retryAfterSeconds * 1000;
+          if (baseDelayMs > NYLAS_MAX_BACKOFF_MS) {
+            this.log.warn(
+              { retryAfterSeconds, operation },
+              `nylas: Retry-After exceeds cap — clamping to ${NYLAS_MAX_BACKOFF_MS}ms`,
+            );
+            baseDelayMs = NYLAS_MAX_BACKOFF_MS;
+          }
+        } else {
+          if (retryAfterRaw !== null) {
+            // Header present but not a plain-integer delta-seconds value (e.g. HTTP-date
+            // format). Log it and fall back to exponential backoff.
+            this.log.warn({ retryAfterRaw, operation }, 'nylas: unparseable Retry-After header — using backoff');
+          }
+          baseDelayMs = Math.min(NYLAS_BACKOFF_BASE_MS * 2 ** attempt, NYLAS_MAX_BACKOFF_MS);
+        }
         // ±25% jitter to spread concurrent retries from multiple ceo-inbox skills.
         const delayMs = Math.round(baseDelayMs * (0.75 + Math.random() * 0.5));
         this.log.warn(
@@ -568,7 +598,7 @@ export class CeoNylasClient {
             `Nylas ${operation}: rate limited (HTTP 429) — transient, not an auth/credential failure. ${text}`,
           );
         }
-        this.log.error({ status: res.status, operation }, `nylas: ${operation} API error`);
+        this.log.error({ status: res.status, operation, totalAttempts: attempt + 1 }, `nylas: ${operation} API error`);
         throw new NylasApiError(res.status, operation, `Nylas ${operation}: HTTP ${res.status} — ${text}`);
       }
 

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -5,6 +5,13 @@
 
 const NYLAS_BASE = 'https://api.us.nylas.com/v3/grants';
 
+// Nylas guidance: requests with limit > 20 on list endpoints trigger concurrent-user 429s.
+const NYLAS_MAX_LIST_LIMIT = 20;
+// Maximum number of retry attempts for 429 / 5xx responses before giving up.
+const NYLAS_MAX_RETRIES = 3;
+// Base backoff delay in ms — doubles each attempt (plus ±25% jitter).
+const NYLAS_BACKOFF_BASE_MS = 500;
+
 // ── Response types ──────────────────────────────────────────────────────────
 
 export interface NylasParticipant {
@@ -160,7 +167,9 @@ export class CeoNylasClient {
 
   async listMessages(options: ListMessagesOptions = {}): Promise<NylasMessageSummary[]> {
     const params = new URLSearchParams();
-    if (options.limit !== undefined) params.set('limit', String(options.limit));
+    if (options.limit !== undefined) {
+      params.set('limit', String(Math.min(options.limit, NYLAS_MAX_LIST_LIMIT)));
+    }
     if (options.query) {
       // Nylas v3: search_query_native cannot be combined with any other filter
       // param except limit and page_token — sending in/unread/received_after
@@ -263,7 +272,9 @@ export class CeoNylasClient {
   // filter here — callers must not apply inbox watermarks to drafts.
   async listDrafts(options: { limit?: number } = {}): Promise<NylasDraftSummary[]> {
     const params = new URLSearchParams();
-    if (options.limit !== undefined) params.set('limit', String(options.limit));
+    if (options.limit !== undefined) {
+      params.set('limit', String(Math.min(options.limit, NYLAS_MAX_LIST_LIMIT)));
+    }
     const url = `${this.baseUrl}/drafts?${params}`;
     const data = await this.request<NylasApiDraftFull[]>('GET', url, 'listDrafts');
     return data.map(normalizeDraftSummary);
@@ -279,7 +290,7 @@ export class CeoNylasClient {
     options: { maxScan?: number; pageSize?: number } = {},
   ): Promise<{ drafts: NylasDraftSummary[]; truncated: boolean }> {
     const maxScan = options.maxScan ?? 500;
-    const pageSize = options.pageSize ?? 100;
+    const pageSize = Math.min(options.pageSize ?? NYLAS_MAX_LIST_LIMIT, NYLAS_MAX_LIST_LIMIT);
 
     const drafts: NylasDraftSummary[] = [];
     let pageToken: string | undefined;
@@ -495,6 +506,11 @@ export class CeoNylasClient {
 
   // Same as request<T>, but also surfaces Nylas's `next_cursor` for paginated
   // list endpoints. request<T> delegates here and drops the cursor.
+  //
+  // 429 and 5xx responses are retried with exponential backoff + ±25% jitter,
+  // honoring the Retry-After header when present. After NYLAS_MAX_RETRIES
+  // attempts, a typed NylasApiError(429, ...) is thrown with an explicit
+  // rate-limit message so downstream agents never misread it as an auth failure.
   private async requestWithCursor<T>(
     method: string,
     url: string,
@@ -508,26 +524,61 @@ export class CeoNylasClient {
       init.body = JSON.stringify(body);
     }
 
-    let res: Response;
-    try {
-      res = await fetch(url, init);
-    } catch (err) {
-      this.log.error({ err, operation }, `nylas: ${operation} fetch failed`);
-      throw new NylasApiError(0, operation, `Fetch failed: ${String(err)}`);
-    }
+    let attempt = 0;
+    for (;;) {
+      let res: Response;
+      try {
+        res = await fetch(url, init);
+      } catch (err) {
+        this.log.error({ err, operation }, `nylas: ${operation} fetch failed`);
+        throw new NylasApiError(0, operation, `Fetch failed: ${String(err)}`);
+      }
 
-    if (!res.ok) {
-      const text = await res.text().catch(() => '(unreadable body)');
-      this.log.error({ status: res.status, operation }, `nylas: ${operation} API error`);
-      throw new NylasApiError(res.status, operation, `Nylas ${operation}: HTTP ${res.status} — ${text}`);
-    }
+      // Retry 429 and 5xx transiently, up to NYLAS_MAX_RETRIES times.
+      if ((res.status === 429 || res.status >= 500) && attempt < NYLAS_MAX_RETRIES) {
+        const retryAfterRaw = res.headers.get('Retry-After');
+        const retryAfterSeconds = retryAfterRaw !== null ? Number(retryAfterRaw) : NaN;
+        const baseDelayMs = Number.isFinite(retryAfterSeconds)
+          ? retryAfterSeconds * 1000
+          : NYLAS_BACKOFF_BASE_MS * 2 ** attempt;
+        // ±25% jitter to spread concurrent retries from multiple ceo-inbox skills.
+        const delayMs = Math.round(baseDelayMs * (0.75 + Math.random() * 0.5));
+        this.log.warn(
+          { status: res.status, operation, attempt, delayMs },
+          `nylas: ${operation} transient error — retrying after ${delayMs}ms`,
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+        attempt++;
+        continue;
+      }
 
-    const json = (await res.json()) as { data?: T; next_cursor?: string } | null;
-    if (json == null || json.data === undefined) {
-      this.log.error({ status: res.status, operation }, `nylas: ${operation} response missing data envelope`);
-      throw new NylasApiError(res.status, operation, `Nylas ${operation}: response missing data envelope`);
+      if (!res.ok) {
+        const text = await res.text().catch(() => '(unreadable body)');
+        if (res.status === 429) {
+          // Retries exhausted on a rate-limit. Throw a message that unambiguously
+          // identifies this as transient congestion, not an auth/credential problem,
+          // so agents cannot misnarrate it as "OAuth token expired."
+          this.log.error(
+            { status: 429, operation, totalAttempts: attempt + 1 },
+            `nylas: ${operation} rate limited — retries exhausted`,
+          );
+          throw new NylasApiError(
+            429,
+            operation,
+            `Nylas ${operation}: rate limited (HTTP 429) — transient, not an auth/credential failure. ${text}`,
+          );
+        }
+        this.log.error({ status: res.status, operation }, `nylas: ${operation} API error`);
+        throw new NylasApiError(res.status, operation, `Nylas ${operation}: HTTP ${res.status} — ${text}`);
+      }
+
+      const json = (await res.json()) as { data?: T; next_cursor?: string } | null;
+      if (json == null || json.data === undefined) {
+        this.log.error({ status: res.status, operation }, `nylas: ${operation} response missing data envelope`);
+        throw new NylasApiError(res.status, operation, `Nylas ${operation}: response missing data envelope`);
+      }
+      return { data: json.data, nextCursor: json.next_cursor };
     }
-    return { data: json.data, nextCursor: json.next_cursor };
   }
 }
 

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -170,9 +170,7 @@ export class CeoNylasClient {
 
   async listMessages(options: ListMessagesOptions = {}): Promise<NylasMessageSummary[]> {
     const params = new URLSearchParams();
-    if (options.limit !== undefined) {
-      params.set('limit', String(Math.min(options.limit, NYLAS_MAX_LIST_LIMIT)));
-    }
+    params.set('limit', String(Math.min(options.limit ?? NYLAS_MAX_LIST_LIMIT, NYLAS_MAX_LIST_LIMIT)));
     if (options.query) {
       // Nylas v3: search_query_native cannot be combined with any other filter
       // param except limit and page_token — sending in/unread/received_after
@@ -275,9 +273,7 @@ export class CeoNylasClient {
   // filter here — callers must not apply inbox watermarks to drafts.
   async listDrafts(options: { limit?: number } = {}): Promise<NylasDraftSummary[]> {
     const params = new URLSearchParams();
-    if (options.limit !== undefined) {
-      params.set('limit', String(Math.min(options.limit, NYLAS_MAX_LIST_LIMIT)));
-    }
+    params.set('limit', String(Math.min(options.limit ?? NYLAS_MAX_LIST_LIMIT, NYLAS_MAX_LIST_LIMIT)));
     const url = `${this.baseUrl}/drafts?${params}`;
     const data = await this.request<NylasApiDraftFull[]>('GET', url, 'listDrafts');
     return data.map(normalizeDraftSummary);

--- a/tests/unit/skills/ceo-nylas-client.test.ts
+++ b/tests/unit/skills/ceo-nylas-client.test.ts
@@ -176,12 +176,13 @@ describe('CeoNylasClient — drafts (issue #1000)', () => {
     it('hits the /drafts collection — NOT /messages', async () => {
       const fetchSpy = mockFetchSuccess([RAW_DRAFT_SUMMARY]);
       const client = new CeoNylasClient('key', 'grant', logger);
+      // limit: 25 exceeds the Nylas cap (20) and is silently clamped.
       await client.listDrafts({ limit: 25 });
 
       const url = new URL(fetchSpy.mock.calls[0]![0] as string);
       expect(url.pathname.endsWith('/drafts')).toBe(true);
       expect(url.pathname).not.toContain('/messages');
-      expect(url.searchParams.get('limit')).toBe('25');
+      expect(url.searchParams.get('limit')).toBe('20');
     });
 
     it('never sends a received_after / watermark param', async () => {


### PR DESCRIPTION
## Summary

- Adds exponential backoff retry (up to 3 attempts, with ±25% jitter) for 429 responses in `CeoNylasClient.requestWithCursor`. Honors `Retry-After` header (delta-seconds), capped at 30s to prevent indefinite hangs from rogue headers.
- 5xx retry is limited to GET-only — POST/PUT mutations could duplicate a send or write on retry.
- On retry the response body is consumed (`res.body?.cancel()`) before sleeping to release the HTTP connection slot.
- After retries are exhausted, throws `NylasApiError(429)` with an explicit "rate limited, not an auth failure" message — prevents downstream agents from misnarrating a transient 429 as "OAuth token expired."
- Clamps `limit` to ≤ 20 on `listMessages`, `listDrafts`, and `listAllDrafts` per Nylas guidance to reduce per-user concurrency 429s.

Closes #1058

## Test plan

- [ ] `skills/_shared/ceo-nylas-client.test.ts` — new test file, 14 tests covering: 429-then-200 retry, `Retry-After` honored, `Retry-After` cap, unparseable date-format header, retries exhausted (typed error), non-retriable 4xx (no retry), GET 5xx retried, POST 5xx not retried, limit clamping for `listMessages`/`listDrafts`/`listAllDrafts`
- [ ] `tests/unit/skills/ceo-nylas-client.test.ts` — updated one existing assertion that expected the unclamped `limit=25` to now expect `limit=20`
- [ ] Full test suite: 4060 passed, 0 failures
- [ ] Typecheck: clean