### PR TITLE
fix: atomic approve/decline grant recommendations to prevent auth-state contradiction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`approveGrantRecommendation` / `declineGrantRecommendation`** — concurrent calls on the same pending recommendation no longer produce an auth-state contradiction; both operations now run inside a single transaction so approve's permission override and status transition are atomic. (#1068)
 - **`ceo-nylas-client`** — 429 responses retry with exponential backoff (up to 3 attempts), honoring `Retry-After`; exhaustion throws a typed `NylasApiError(429)` that cannot be misread as an auth failure. (#1058)
 - **`ceo-nylas-client` list endpoints** — `limit` is always sent and capped at ≤ 20; previously an unspecified limit caused Nylas to default to 50, exceeding the safety cap. (#1058)
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -161,7 +161,7 @@ interface ContactServiceBackend {
   elevateTierToKnown(contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment'): Promise<boolean>;
 
   getAuthOverrides(contactId: string): Promise<Array<{ permission: string; granted: boolean }>>;
-  createAuthOverride(override: AuthOverride): Promise<void>;
+  createAuthOverride(override: AuthOverride, client?: DbPoolClient): Promise<void>;
   revokeAuthOverride(contactId: string, permission: string): Promise<boolean>;
 
   // -- Grant recommendations (issue #952) --
@@ -169,7 +169,15 @@ interface ContactServiceBackend {
   getGrantRecommendation(id: string): Promise<GrantRecommendation | null>;
   findGrantRecommendation(contactId: string, permission: string): Promise<GrantRecommendation | null>;
   listGrantRecommendations(filters?: { status?: GrantRecommendationStatus; limit?: number }): Promise<GrantRecommendation[]>;
-  resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string): Promise<boolean>;
+  resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string, client?: DbPoolClient): Promise<boolean>;
+
+  /**
+   * Run a callback inside a single database transaction. The client is passed
+   * into the callback and must be threaded through any backend calls that
+   * should participate in the same transaction. For in-memory backends, JS is
+   * single-threaded so the callback runs directly with no client.
+   */
+  withTransaction<T>(fn: (client?: DbPoolClient) => Promise<T>): Promise<T>;
   createCalendarLink(calendar: ContactCalendar): Promise<void>;
   deleteCalendarLink(nylasCalendarId: string): Promise<boolean>;
   getCalendarsForContact(contactId: string): Promise<ContactCalendar[]>;
@@ -1071,38 +1079,69 @@ export class ContactService {
 
   /**
    * Approve a pending grant recommendation.
-   * Also writes the contact_auth_overrides row so the permission takes effect immediately.
+   * Atomically claims the recommendation (status pending → approved) and writes the
+   * contact_auth_overrides row inside a single transaction. This prevents the race where
+   * a concurrent declineGrantRecommendation wins the status transition while the auth
+   * override written by approve is left behind (issue #1068).
    * Returns false if the recommendation was not found or not in 'pending' status.
    */
   async approveGrantRecommendation(id: string, actorId: string): Promise<boolean> {
+    // Fast path: bail early without starting a transaction if already resolved.
     const rec = await this.backend.getGrantRecommendation(id);
     if (!rec || rec.status !== 'pending') return false;
 
-    // Grant the permission before resolving the recommendation, so any failure
-    // here leaves the recommendation pending (retryable) rather than approved-but-not-granted.
-    await this.grantPermission(rec.contactId, rec.permission, true, actorId);
-    const resolved = await this.backend.resolveGrantRecommendation(id, 'approved', actorId);
-    if (resolved) {
+    // Validate the contact exists before entering the transaction (read-only, idempotent).
+    const contact = await this.backend.getContact(rec.contactId);
+    if (!contact) throw new Error(`Contact not found: ${rec.contactId}`);
+
+    return this.backend.withTransaction(async (client) => {
+      // Claim the recommendation inside the transaction. For Postgres, the UPDATE holds
+      // a row-level lock until the transaction commits — a concurrent decline blocks
+      // until we commit or roll back, then finds status ≠ 'pending' and returns false.
+      const claimed = await this.backend.resolveGrantRecommendation(id, 'approved', actorId, client);
+      if (!claimed) {
+        // A concurrent call already resolved this recommendation; produce no side effects.
+        return false;
+      }
+
+      // Write the auth override inside the same transaction so both writes are atomic.
+      // A failure here rolls back both, leaving the recommendation pending (retryable).
+      const override: AuthOverride = {
+        id: randomUUID(),
+        contactId: rec.contactId,
+        permission: rec.permission,
+        granted: true,
+        grantedBy: actorId,
+        createdAt: new Date(),
+        revokedAt: null,
+      };
+      await this.backend.createAuthOverride(override, client);
+
       this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation approved');
-    }
-    return resolved;
+      return true;
+    });
   }
 
   /**
    * Decline a pending grant recommendation.
+   * Wrapped in a transaction for parity with approveGrantRecommendation so that both
+   * operations participate in the same serialization guarantee (issue #1068).
    * The row is permanently retained in 'declined' state as an anti-nag ledger entry —
    * the recommendation engine must check for declined rows before suggesting again.
    * Returns false if the recommendation was not found or not in 'pending' status.
    */
   async declineGrantRecommendation(id: string, actorId: string): Promise<boolean> {
+    // Fast path: bail early without starting a transaction if already resolved.
     const rec = await this.backend.getGrantRecommendation(id);
     if (!rec || rec.status !== 'pending') return false;
 
-    const resolved = await this.backend.resolveGrantRecommendation(id, 'declined', actorId);
-    if (resolved) {
-      this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation declined (anti-nag recorded)');
-    }
-    return resolved;
+    return this.backend.withTransaction(async (client) => {
+      const resolved = await this.backend.resolveGrantRecommendation(id, 'declined', actorId, client);
+      if (resolved) {
+        this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation declined (anti-nag recorded)');
+      }
+      return resolved;
+    });
   }
 
   /**
@@ -1780,14 +1819,15 @@ class PostgresContactBackend implements ContactServiceBackend {
     }));
   }
 
-  async createAuthOverride(override: AuthOverride): Promise<void> {
+  async createAuthOverride(override: AuthOverride, client?: DbPoolClient): Promise<void> {
     this.logger.debug(
       { contactId: override.contactId, permission: override.permission, granted: override.granted },
       'contacts: creating auth override',
     );
     // Upsert: if an active override exists for this contact+permission, update it.
     // The UNIQUE(contact_id, permission) constraint on the table supports this.
-    await this.pool.query(
+    const q = client ?? this.pool;
+    await q.query(
       `INSERT INTO contact_auth_overrides (id, contact_id, permission, granted, granted_by, created_at, revoked_at)
        VALUES ($1, $2, $3, $4, $5, $6, $7)
        ON CONFLICT (contact_id, permission) DO UPDATE
@@ -1877,14 +1917,30 @@ class PostgresContactBackend implements ContactServiceBackend {
     return result.rows.map(row => this.rowToGrantRecommendation(row));
   }
 
-  async resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string): Promise<boolean> {
-    const result = await this.pool.query(
+  async resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string, client?: DbPoolClient): Promise<boolean> {
+    const q = client ?? this.pool;
+    const result = await q.query(
       `UPDATE grant_recommendations
        SET status = $2, resolved_at = now(), resolved_by = $3
        WHERE id = $1 AND status = 'pending'`,
       [id, status, resolvedBy],
     );
     return (result.rowCount ?? 0) > 0;
+  }
+
+  async withTransaction<T>(fn: (client?: DbPoolClient) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await fn(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 
   private rowToGrantRecommendation(row: {
@@ -2387,7 +2443,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return results;
   }
 
-  async createAuthOverride(override: AuthOverride): Promise<void> {
+  async createAuthOverride(override: AuthOverride, _client?: DbPoolClient): Promise<void> {
     // Upsert: find and replace any existing active override for the same contact+permission
     for (const [key, existing] of this.overrides.entries()) {
       if (
@@ -2574,7 +2630,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return results;
   }
 
-  async resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string): Promise<boolean> {
+  async resolveGrantRecommendation(id: string, status: 'approved' | 'declined', resolvedBy: string, _client?: DbPoolClient): Promise<boolean> {
     for (const [key, rec] of this.recommendations) {
       if (rec.id === id && rec.status === 'pending') {
         this.recommendations.set(key, { ...rec, status, resolvedAt: new Date(), resolvedBy });
@@ -2582,5 +2638,12 @@ class InMemoryContactBackend implements ContactServiceBackend {
       }
     }
     return false;
+  }
+
+  async withTransaction<T>(fn: (client?: DbPoolClient) => Promise<T>): Promise<T> {
+    // JS is single-threaded; no real database transaction is needed. Run the callback
+    // directly with no client so in-memory tests exercise the same code paths as
+    // Postgres without any pool machinery.
+    return fn(undefined);
   }
 }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1094,13 +1094,14 @@ export class ContactService {
     const contact = await this.backend.getContact(rec.contactId);
     if (!contact) throw new Error(`Contact not found: ${rec.contactId}`);
 
-    return this.backend.withTransaction(async (client) => {
+    const approved = await this.backend.withTransaction(async (client) => {
       // Claim the recommendation inside the transaction. For Postgres, the UPDATE holds
       // a row-level lock until the transaction commits — a concurrent decline blocks
       // until we commit or roll back, then finds status ≠ 'pending' and returns false.
       const claimed = await this.backend.resolveGrantRecommendation(id, 'approved', actorId, client);
       if (!claimed) {
         // A concurrent call already resolved this recommendation; produce no side effects.
+        this.logger?.debug({ id, actorId }, 'contacts: approveGrantRecommendation lost concurrent race — recommendation already resolved');
         return false;
       }
 
@@ -1116,10 +1117,14 @@ export class ContactService {
         revokedAt: null,
       };
       await this.backend.createAuthOverride(override, client);
-
-      this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation approved');
       return true;
     });
+
+    // Log AFTER withTransaction resolves so the audit entry only fires on committed state.
+    if (approved) {
+      this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation approved');
+    }
+    return approved;
   }
 
   /**
@@ -1936,7 +1941,14 @@ class PostgresContactBackend implements ContactServiceBackend {
       await client.query('COMMIT');
       return result;
     } catch (err) {
-      await client.query('ROLLBACK');
+      // Wrap ROLLBACK in its own try/catch: if ROLLBACK throws (e.g. connection severed),
+      // log and swallow that secondary error so the original err — the real root cause —
+      // is what propagates to the caller.
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackErr) {
+        this.logger.error({ rollbackErr }, 'contacts: withTransaction ROLLBACK failed');
+      }
       throw err;
     } finally {
       client.release();

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1140,13 +1140,15 @@ export class ContactService {
     const rec = await this.backend.getGrantRecommendation(id);
     if (!rec || rec.status !== 'pending') return false;
 
-    return this.backend.withTransaction(async (client) => {
-      const resolved = await this.backend.resolveGrantRecommendation(id, 'declined', actorId, client);
-      if (resolved) {
-        this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation declined (anti-nag recorded)');
-      }
-      return resolved;
+    const declined = await this.backend.withTransaction(async (client) => {
+      return this.backend.resolveGrantRecommendation(id, 'declined', actorId, client);
     });
+
+    // Log AFTER withTransaction resolves so the audit entry only fires on committed state.
+    if (declined) {
+      this.logger?.info({ id, contactId: rec.contactId, permission: rec.permission, actorId }, 'contacts: grant recommendation declined (anti-nag recorded)');
+    }
+    return declined;
   }
 
   /**

--- a/tests/unit/contacts/grant-recommendation-race.test.ts
+++ b/tests/unit/contacts/grant-recommendation-race.test.ts
@@ -1,0 +1,138 @@
+// tests/unit/contacts/grant-recommendation-race.test.ts
+//
+// Regression tests for issue #1068: approveGrantRecommendation + declineGrantRecommendation
+// must be atomic to prevent the race condition where decline wins the status transition but
+// approve's auth override is left behind (or vice versa in the future).
+//
+// Because JS is single-threaded, Promise.all() interleaves the two calls at every `await`
+// boundary in deterministic FIFO microtask order. The current (buggy) code has more awaits
+// before approveGrantRecommendation writes its status transition than declineGrantRecommendation
+// does, so decline ALWAYS wins the race in Promise.all([approve, decline]). This means the
+// "concurrent race" test below reliably reproduces the inconsistent state that the fix must
+// prevent.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ContactService } from '../../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../../src/memory/embedding.js';
+import { EntityMemory } from '../../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../../src/memory/validation.js';
+import { createSilentLogger } from '../../../src/logger.js';
+
+describe('grant recommendation race conditions (issue #1068)', () => {
+  let service: ContactService;
+
+  beforeEach(() => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+    service = ContactService.createInMemory(entityMemory);
+  });
+
+  it('concurrent approve and decline: exactly one wins and final state is internally consistent', async () => {
+    const contact = await service.createContact({ displayName: 'Race Test', source: 'test' });
+    const { recommendation: rec } = await service.createGrantRecommendation(
+      contact.id, 'schedule_meetings', 'test reasoning',
+    );
+
+    // Firing both concurrently. JS's FIFO microtask queue causes decline to win
+    // deterministically because it has fewer await points before its status write
+    // than approve does (approve validates the contact first).
+    const [approveResult, declineResult] = await Promise.all([
+      service.approveGrantRecommendation(rec.id, 'actor-approve'),
+      service.declineGrantRecommendation(rec.id, 'actor-decline'),
+    ]);
+
+    // Exactly one must win — this holds even with the buggy code
+    expect(approveResult !== declineResult).toBe(true);
+
+    const finalRec = await service.getGrantRecommendation(rec.id);
+    const overrides = await service.getAuthOverrides(contact.id);
+    const hasOverride = overrides.some(o => o.permission === 'schedule_meetings');
+
+    if (declineResult && !approveResult) {
+      // Decline won: recommendation must be 'declined' and NO auth override may exist.
+      // With the buggy code this fails because approve wrote the override before losing
+      // the status transition.
+      expect(finalRec?.status).toBe('declined');
+      expect(hasOverride).toBe(false);
+    } else {
+      // Approve won: recommendation must be 'approved' and the auth override must exist.
+      expect(finalRec?.status).toBe('approved');
+      expect(hasOverride).toBe(true);
+    }
+  });
+
+  it('when decline wins sequentially, no auth override is left behind', async () => {
+    const contact = await service.createContact({ displayName: 'Decline Wins', source: 'test' });
+    const { recommendation: rec } = await service.createGrantRecommendation(
+      contact.id, 'send_emails', 'test reasoning',
+    );
+
+    const declineResult = await service.declineGrantRecommendation(rec.id, 'actor-decline');
+    expect(declineResult).toBe(true);
+
+    // Approve must short-circuit — recommendation is no longer pending
+    const approveResult = await service.approveGrantRecommendation(rec.id, 'actor-approve');
+    expect(approveResult).toBe(false);
+
+    // Critically: no orphaned auth override may exist
+    const overrides = await service.getAuthOverrides(contact.id);
+    expect(overrides.some(o => o.permission === 'send_emails')).toBe(false);
+  });
+
+  it('when approve wins sequentially, the auth override and approved status are both present', async () => {
+    const contact = await service.createContact({ displayName: 'Approve Wins', source: 'test' });
+    const { recommendation: rec } = await service.createGrantRecommendation(
+      contact.id, 'read_calendar', 'test reasoning',
+    );
+
+    const approveResult = await service.approveGrantRecommendation(rec.id, 'actor-approve');
+    expect(approveResult).toBe(true);
+
+    // Decline must short-circuit — recommendation is already approved
+    const declineResult = await service.declineGrantRecommendation(rec.id, 'actor-decline');
+    expect(declineResult).toBe(false);
+
+    // Auth override must exist (approve won)
+    const overrides = await service.getAuthOverrides(contact.id);
+    const override = overrides.find(o => o.permission === 'read_calendar');
+    expect(override).toBeDefined();
+    expect(override?.granted).toBe(true);
+
+    // Recommendation must stay 'approved', not flip to 'declined'
+    const finalRec = await service.getGrantRecommendation(rec.id);
+    expect(finalRec?.status).toBe('approved');
+  });
+
+  it('an approved recommendation always has a corresponding active auth override', async () => {
+    const contact = await service.createContact({ displayName: 'Consistency Check', source: 'test' });
+    const { recommendation: rec } = await service.createGrantRecommendation(
+      contact.id, 'view_reports', 'test reasoning',
+    );
+
+    await service.approveGrantRecommendation(rec.id, 'actor');
+
+    const finalRec = await service.getGrantRecommendation(rec.id);
+    const overrides = await service.getAuthOverrides(contact.id);
+
+    expect(finalRec?.status).toBe('approved');
+    expect(overrides.some(o => o.permission === 'view_reports' && o.granted)).toBe(true);
+  });
+
+  it('a declined recommendation never has an active auth override', async () => {
+    const contact = await service.createContact({ displayName: 'Decline Check', source: 'test' });
+    const { recommendation: rec } = await service.createGrantRecommendation(
+      contact.id, 'approve_expenses', 'test reasoning',
+    );
+
+    await service.declineGrantRecommendation(rec.id, 'actor');
+
+    const finalRec = await service.getGrantRecommendation(rec.id);
+    const overrides = await service.getAuthOverrides(contact.id);
+
+    expect(finalRec?.status).toBe('declined');
+    expect(overrides.some(o => o.permission === 'approve_expenses')).toBe(false);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Fixes the race condition identified in #1068 where `approveGrantRecommendation` and `declineGrantRecommendation` could produce an internally inconsistent auth state.

- **Root cause:** approve wrote the `contact_auth_overrides` row before setting `status = 'approved'`. A concurrent decline could win the status transition (pending → declined) in the window between those two writes, leaving an orphaned permission override for a recommendation the principal explicitly declined.
- **Fix:** both operations now run inside a single database transaction via a new `withTransaction` hook on `ContactServiceBackend`. The `UPDATE ... WHERE status = 'pending'` inside the transaction serves as the atomic claim — Postgres serializes concurrent row updates, so only one caller can update the row. The loser finds 0 rows updated and returns `false` with no side effects.
- **In-memory backend:** `withTransaction` runs the callback directly (JS is single-threaded); the correctness comes from the reordering — claim first, then write the override.

Closes #1068

## Changes

- `ContactServiceBackend` interface: added `withTransaction<T>`, and optional `client?: DbPoolClient` to `createAuthOverride` and `resolveGrantRecommendation`
- `PostgresContactBackend`: `withTransaction` (BEGIN / COMMIT / ROLLBACK with ROLLBACK wrapped in its own try/catch), both methods use `client ?? this.pool`
- `InMemoryContactBackend`: `withTransaction` (runs callback directly), method signatures updated with `_client?`
- `ContactService.approveGrantRecommendation`: validates contact outside transaction, then atomically claims recommendation and writes auth override inside one transaction; success log fires after COMMIT not before
- `ContactService.declineGrantRecommendation`: wrapped in `withTransaction` for parity
- Regression tests in `tests/unit/contacts/grant-recommendation-race.test.ts`: 5 tests including a `Promise.all([approve, decline])` test that reliably reproduces the inconsistency via JS microtask interleaving (was failing before the fix)

## Test plan

- [x] `pnpm run test` — all 4068 tests pass (5 new)
- [x] `pnpm run typecheck` — clean across all three tsconfig targets
- [x] `Promise.all([approve, decline])` test fails before fix, passes after
- [x] Sequential approve-then-decline and decline-then-approve tests verify the contract
- [ ] Integration test against real Postgres (the in-memory tests exercise the logic; Postgres transaction semantics verified by the `withTransaction` pattern matching the standard pg node idiom)


___

## **CodeAnt-AI Description**
**Prevent grant recommendation approval and decline from leaving conflicting auth state**

### What Changed
- Approving or declining the same pending grant recommendation now happens as one atomic action, so only one outcome can win.
- If approval wins, the permission override and approved status are saved together; if decline wins, no permission override is left behind.
- Approval now waits until the change is committed before logging success, and failed retries no longer hide the original error if rollback fails.
- Added regression tests that cover concurrent approve/decline calls and verify the final state stays consistent.

### Impact
`✅ Fewer conflicting permission states`
`✅ No orphaned access grants after declines`
`✅ Safer concurrent approval handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
