### PR TITLE
fix: return actionable block reason from outbound content filter so agents can self-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`outbound-gateway`** — a content-filter block now returns the principal-safe reason summary and the triggering rule name(s) in the skill result instead of a generic string, so the agent's tool loop can self-correct and retry; the CEO alert softens to an FYI. (#1051)
 - **`approveGrantRecommendation` / `declineGrantRecommendation`** — concurrent calls on the same pending recommendation no longer produce an auth-state contradiction; both operations now run inside a single transaction so approve's permission override and status transition are atomic. (#1068)
 - **`ceo-nylas-client`** — 429 responses retry with exponential backoff (up to 3 attempts), honoring `Retry-After`; exhaustion throws a typed `NylasApiError(429)` that cannot be misread as an auth failure. (#1058)
 - **`ceo-nylas-client` list endpoints** — `limit` is always sent and capped at ≤ 20; previously an unspecified limit caused Nylas to default to 50, exceeding the safety cap. (#1058)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`outbound-gateway`** — a content-filter block now returns the principal-safe reason summary and the triggering rule name(s) in the skill result instead of a generic string, so the agent's tool loop can self-correct and retry; the CEO alert softens to an FYI. (#1051)
+- **`outbound-gateway`** — content-filter blocks now return the principal-safe reason and rule names so agents can self-correct and retry. (#1051)
 - **`approveGrantRecommendation` / `declineGrantRecommendation`** — concurrent calls on the same pending recommendation no longer produce an auth-state contradiction; both operations now run inside a single transaction so approve's permission override and status transition are atomic. (#1068)
 - **`ceo-nylas-client`** — 429 responses retry with exponential backoff (up to 3 attempts), honoring `Retry-After`; exhaustion throws a typed `NylasApiError(429)` that cannot be misread as an auth failure. (#1058)
 - **`ceo-nylas-client` list endpoints** — `limit` is always sent and capped at ≤ 20; previously an unspecified limit caused Nylas to default to 50, exceeding the safety cap. (#1058)

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -105,6 +105,13 @@ export interface OutboundSendResult {
   messageId?: string;
   /** Human-readable reason when success is false */
   blockedReason?: string;
+  /**
+   * Content-filter rule name(s) that triggered a block (e.g. `llm-judge-audience-leak`).
+   * Present only when the content filter rejected the send. Gives the agent's tool
+   * loop the specific rule category so it can address the root cause and retry (#1051).
+   * Rule names only — never the (potentially sensitive) finding detail.
+   */
+  blockedRules?: string[];
   /** True when the autonomy gate blocked this send */
   gated?: boolean;
   /** Short reference for the action_log row (e.g. 'a3f7c12b'). Present when gated is true. */
@@ -733,9 +740,14 @@ export class OutboundGateway {
           {
             notificationType: 'blocked_content',
             ceoEmail: principalEmailForBlock,
-            subject: 'Action needed — blocked outbound reply',
+            // Softened from a call-to-action to informational (#1051): the agent now
+            // receives the block reason in the skill result and may self-correct and
+            // resend on its own. The audit log remains the ground truth; this alert is
+            // an FYI, not a task the principal must action.
+            subject: 'FYI — outbound message blocked',
             body: [
               'An outbound message was blocked by the content filter.',
+              'The agent received the reason and may rewrite the message and retry on its own.',
               '',
               `Reason: ${reasonSummary}`,
               // blockedEvent.timestamp is the audit row's own clock. No principal
@@ -771,7 +783,18 @@ export class OutboundGateway {
           'outbound-gateway: principal notification skipped — no principal email identity configured. Block recorded in audit log only.',
         );
       }
-      return { success: false, blockedReason: 'Content blocked by filter' };
+      // Surface the principal-safe reason summary and the rule name(s) to the
+      // caller (#1051). reasonSummary (computed above via buildBlockReasonSummary)
+      // obeys the same per-rule safety contract as the CEO notification — it only
+      // includes an LLM-judge finding's abstract detail, never a Stage-1 rule's
+      // matched fragment. Surfacing it here gives the agent's tool-use loop enough
+      // signal to rewrite the message and retry organically; blockedRules carries
+      // the specific rule category (rule names only) so it can fix the root cause.
+      return {
+        success: false,
+        blockedReason: reasonSummary,
+        blockedRules: filterFindings.map((f) => f.rule),
+      };
     }
 
     // ------------------------------------------------------------------

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -107,9 +107,13 @@ export interface OutboundSendResult {
   blockedReason?: string;
   /**
    * Content-filter rule name(s) that triggered a block (e.g. `llm-judge-audience-leak`).
-   * Present only when the content filter rejected the send. Gives the agent's tool
-   * loop the specific rule category so it can address the root cause and retry (#1051).
+   * Populated by `send()` when the content filter rejects the send, giving the agent's
+   * tool loop the specific rule category so it can address the root cause and retry (#1051).
    * Rule names only — never the (potentially sensitive) finding detail.
+   *
+   * Note: the `sendEmailDraft()` block path does not yet populate this (or surface the
+   * reason summary); bringing it in line is tracked in #1158. Optional by design so that
+   * gap is forward-compatible — callers must treat absence as "no rule info available".
    */
   blockedRules?: string[];
   /** True when the autonomy gate blocked this send */

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -357,7 +357,107 @@ describe('OutboundGateway', () => {
       expect(result.success).toBe(false);
       // The original blocked message must not be sent via nylasClient. The CEO
       // notification now routes through the bus as outbound.notification (#206).
-      expect(result.blockedReason).toBe('Content blocked by filter');
+      // The blocked result now carries the principal-safe reason summary and the
+      // rule name(s) so the agent's tool loop can self-correct and retry (#1051).
+      // For a Stage-1 deterministic rule, the summary is the rule name only.
+      expect(result.blockedReason).toBe('secret-pattern');
+      expect(result.blockedRules).toEqual(['secret-pattern']);
+    });
+
+    it('returns the judge\'s abstract reason and rule name so the agent can self-correct (LLM-judge block)', async () => {
+      // #1051: when a Stage-2 LLM judge blocks the send, the skill result must
+      // carry the judge's abstract reason (safe to surface — it never quotes the
+      // offending value) plus the rule name, giving the agent's tool loop enough
+      // signal to rewrite the message and retry organically.
+      const judgeReason = 'internal fallback reasoning leaked into the reply body';
+      (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+        passed: false,
+        findings: [{ rule: 'llm-judge-audience-leak', detail: judgeReason }],
+        stage: 'llm',
+      });
+
+      const gateway = new OutboundGateway({
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
+        contactService: mocks.contactService,
+        contentFilter: mocks.contentFilter,
+        bus: mocks.bus,
+        principalIdentities: [makePrincipalIdentity('ceo@example.com')],
+        logger: mocks.logger,
+      });
+
+      const result = await gateway.send(baseRequest);
+
+      expect(result.success).toBe(false);
+      // The judge's reason IS surfaced — it's what lets the agent address the root cause.
+      expect(result.blockedReason).toContain(judgeReason);
+      expect(result.blockedReason).toContain('llm-judge-audience-leak');
+      expect(result.blockedRules).toEqual(['llm-judge-audience-leak']);
+    });
+
+    it('never leaks a Stage-1 deterministic finding\'s detail into the blocked result', async () => {
+      // #1051 safety contract: the blocked result is LLM-facing, so it must obey
+      // the same per-rule policy as the CEO notification — a deterministic rule's
+      // detail can embed the matched secret, so only its rule NAME may appear.
+      const secretFragment = 'sk-ant-zzzzzzzzzzzzzzzzzzzz0987654321ZZ';
+      (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+        passed: false,
+        findings: [{ rule: 'secret-pattern', detail: `API key: ${secretFragment}` }],
+        stage: 'deterministic',
+      });
+
+      const gateway = new OutboundGateway({
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
+        contactService: mocks.contactService,
+        contentFilter: mocks.contentFilter,
+        bus: mocks.bus,
+        principalIdentities: [makePrincipalIdentity('ceo@example.com')],
+        logger: mocks.logger,
+      });
+
+      const result = await gateway.send(baseRequest);
+
+      expect(result.success).toBe(false);
+      // The matched secret must never reach the LLM-facing result...
+      expect(result.blockedReason).not.toContain(secretFragment);
+      // ...but the rule name is safe and tells the agent which class of rule fired.
+      expect(result.blockedReason).toBe('secret-pattern');
+      expect(result.blockedRules).toEqual(['secret-pattern']);
+    });
+
+    it('with mixed findings, surfaces only the judge detail but all rule names (#1051 safety contract)', async () => {
+      // When a send trips both a Stage-1 deterministic rule (whose detail embeds a
+      // secret) and a Stage-2 judge rule (whose detail is abstract), the LLM-facing
+      // reason must surface ONLY the judge's detail — the secret stays hidden — while
+      // blockedRules lists every rule so the agent knows the full set it tripped.
+      const secretFragment = 'sk-ant-yyyyyyyyyyyyyyyyyyyy1122334455YY';
+      const judgeReason = 'reply mixes confidential and external content';
+      (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+        passed: false,
+        findings: [
+          { rule: 'secret-pattern', detail: `API key: ${secretFragment}` },
+          { rule: 'llm-judge-audience-leak', detail: judgeReason },
+        ],
+        stage: 'llm',
+      });
+
+      const gateway = new OutboundGateway({
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
+        contactService: mocks.contactService,
+        contentFilter: mocks.contentFilter,
+        bus: mocks.bus,
+        principalIdentities: [makePrincipalIdentity('ceo@example.com')],
+        logger: mocks.logger,
+      });
+
+      const result = await gateway.send(baseRequest);
+
+      expect(result.success).toBe(false);
+      // The Stage-1 secret must never appear, even alongside a judge finding.
+      expect(result.blockedReason).not.toContain(secretFragment);
+      // The judge's abstract reason is surfaced.
+      expect(result.blockedReason).toContain(judgeReason);
+      // Both rule names land in the structured rules list, order preserved.
+      expect(result.blockedRules).toEqual(['secret-pattern', 'llm-judge-audience-leak']);
     });
 
     it('publishes outbound.blocked event to the bus when filter rejects', async () => {
@@ -1918,7 +2018,9 @@ describe('humanApproved option on send()', () => {
     );
 
     expect(result.success).toBe(false);
-    expect(result.blockedReason).toBe('Content blocked by filter');
+    // The blocked result now surfaces the rule name as the reason (#1051).
+    expect(result.blockedReason).toBe('test-rule');
+    expect(result.blockedRules).toEqual(['test-rule']);
     expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
   });
 });
@@ -2377,7 +2479,9 @@ describe('isSystemNotification option on send()', () => {
     );
 
     expect(result.success).toBe(false);
-    expect(result.blockedReason).toBe('Content blocked by filter');
+    // The blocked result now surfaces the rule name as the reason (#1051).
+    expect(result.blockedReason).toBe('test-rule');
+    expect(result.blockedRules).toEqual(['test-rule']);
     expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
   });
 });
@@ -2613,7 +2717,9 @@ describe('CEO recipient bypass on send()', () => {
     );
 
     expect(result.success).toBe(false);
-    expect(result.blockedReason).toBe('Content blocked by filter');
+    // The blocked result now surfaces the rule name as the reason (#1051).
+    expect(result.blockedReason).toBe('test-rule');
+    expect(result.blockedRules).toEqual(['test-rule']);
     expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Closes #1051.

When the outbound content filter blocks a message, `src/skills/outbound-gateway.ts` returned a generic `'Content blocked by filter'` string, so the agent's tool-use loop saw a failed skill call with no correction path and could not self-correct.

This surfaces the principal-safe `reasonSummary` (already computed at the block site via `buildBlockReasonSummary()` for the CEO notification) plus the triggering rule name(s) in the skill result. The agent's existing tool loop handles retries organically; no retry counter or state machinery added.

### What changed

- **`OutboundSendResult`** — new optional `blockedRules?: string[]` field (rule names only; additive, backward compatible).
- **`send()` filter-block return** — now returns `{ success: false, blockedReason: reasonSummary, blockedRules: filterFindings.map(f => f.rule) }` instead of the generic string.
- **CEO notification** — subject softened from `Action needed — blocked outbound reply` to `FYI — outbound message blocked`, with a body line noting the agent may rewrite and retry. The audit log remains ground truth.

The three send skills (`email-reply`, `email-send`, `signal-send`) already forward `result.blockedReason` into their `error` field, so the reason (which embeds the rule name) now reaches the LLM with no handler changes.

### Safety

`blockedReason` reuses `reasonSummary`, whose per-rule policy only surfaces an `llm-judge-*` / `disclosure-tier-gate` finding's abstract detail and never a Stage-1 deterministic rule's matched fragment. `blockedRules` carries rule names only. Tests assert a `sk-ant-…` secret never reaches the result, including in a mixed judge + secret-pattern case.

### Out of scope

The parallel `sendEmailDraft()` block path still returns the generic string. It's the same latent inconsistency but the issue scoped the fix to the `send()` path; flagging for a possible follow-up.

## Testing

- `tests/unit/skills/outbound-gateway.test.ts` — added LLM-judge, Stage-1 deterministic, mixed-finding, and negative-leak cases; updated existing block assertions. 91/91 pass.
- `pnpm run typecheck` clean.

## Acceptance criteria

- [x] Returns `reasonSummary` and rule name(s) in the blocked skill result
- [x] LLM-facing payload verified against `buildBlockReasonSummary()`'s safety contract — no Stage-1 detail leaks
- [x] CEO notification still fires on every block (no regression)
- [x] Unit tests cover the updated shape for LLM-judge and Stage-1 deterministic blocks
- [x] TypeScript interface updated (`OutboundSendResult.blockedRules`)