### PR TITLE
fix: stop scheduler double-firing cron jobs under overlapping polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`outbound-gateway`** — content-filter blocks now return the principal-safe reason and rule names so agents can self-correct and retry. (#1051)
+- **Scheduler double-fire** — the cron-branch claim UPDATE now re-checks `next_run_at <= now()`, so overlapping poll cycles can no longer re-claim a just-completed recurring job and send a duplicate (e.g. two daily digests). (#1159)
 - **`approveGrantRecommendation` / `declineGrantRecommendation`** — concurrent calls on the same pending recommendation no longer produce an auth-state contradiction; both operations now run inside a single transaction so approve's permission override and status transition are atomic. (#1068)
 - **`ceo-nylas-client`** — 429 responses retry with exponential backoff (up to 3 attempts), honoring `Retry-After`; exhaustion throws a typed `NylasApiError(429)` that cannot be misread as an auth failure. (#1058)
 - **`ceo-nylas-client` list endpoints** — `limit` is always sent and capped at ≤ 20; previously an unspecified limit caused Nylas to default to 50, exceeding the safety cap. (#1058)

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -408,13 +408,26 @@ export class Scheduler {
       // the expression between the poll SELECT and this claim UPDATE, the WHERE won't
       // match (rowCount=0), the job skips as "already claimed", and the next poll fires
       // it with the correct (updated) expression and next_run_at.
+      //
+      // next_run_at <= now() re-checks the SAME predicate the poll SELECT used, so the
+      // claim is idempotent against overlapping poll cycles. The agent runs synchronously
+      // inside fireJob (bus.publish awaits handlers), so a single poll can take minutes to
+      // drain while the 30s interval keeps launching new polls. A job still 'pending' when
+      // poll B's SELECT runs gets captured into poll B's in-memory list; poll A then claims
+      // and fires it, and completeJobRun resets the recurring job to 'pending'. Without this
+      // guard, poll B's later claim would succeed (status is 'pending' again) and fire a
+      // duplicate — e.g. two daily digests on 2026-06-24. With it, the first claim advances
+      // next_run_at to the future, so any stale concurrent claim matches 0 rows and skips.
+      // (#1124 advanced next_run_at but only shielded the NEXT poll's SELECT, not a
+      // concurrent poll already holding the row.)
       claimResult = await this.pool.query(
         `UPDATE scheduled_jobs
             SET status = $1, run_started_at = now(), next_run_at = $3
           WHERE id = $2
             AND status IN ('pending', 'failed')
             AND cron_expr = $4
-            AND timezone = $5`,
+            AND timezone = $5
+            AND next_run_at <= now()`,
         ['running', job.id, nextRunAt, job.cronExpr, job.timezone],
       );
     } else {
@@ -424,7 +437,15 @@ export class Scheduler {
       );
     }
     if (claimResult.rowCount === 0) {
-      this.logger.debug({ jobId: job.id }, 'Job already claimed; skipping fire');
+      // 0 rows now has three distinct causes, all benign: another poller/instance
+      // claimed the row first, cron_expr/timezone drifted between SELECT and claim, or
+      // (cron jobs) next_run_at was already advanced into the future by a prior poll's
+      // claim — the overlapping-poll de-dup this guard exists for. Word the message so a
+      // missed-fire investigation isn't misled into thinking a real claim happened.
+      this.logger.debug(
+        { jobId: job.id, cronExpr: job.cronExpr },
+        'Claim matched 0 rows; skipping fire (already claimed, cron/timezone drift, or next_run_at already advanced by a prior poll)',
+      );
       return;
     }
     // rowCount === null is an anomalous pg driver state (UPDATE always returns a count).

--- a/tests/integration/scheduler-claim-idempotency.test.ts
+++ b/tests/integration/scheduler-claim-idempotency.test.ts
@@ -1,0 +1,101 @@
+// scheduler-claim-idempotency.test.ts — the cron claim is idempotent against overlapping
+// poll cycles, against real Postgres (#1159).
+//
+// Reproduces the duplicate-daily-digest double-fire: the agent runs synchronously inside
+// fireJob, so one pollDueJobs() drain takes minutes while the 30s interval keeps launching
+// fresh polls. A job still 'pending' when poll B's SELECT runs is captured into poll B's
+// in-memory list; poll A then claims and fires it, completeJobRun resets the recurring job
+// to 'pending', and poll B — still holding the stale row — reaches it and fires a duplicate.
+// The fix re-checks next_run_at <= now() in the claim UPDATE, so the stale re-claim sees a
+// future next_run_at (advanced by the first claim) and matches 0 rows.
+//
+// We drive the REAL Scheduler.fireJob against a REAL row so the production claim SQL is the
+// thing under test — a SQL-substring unit assertion would pass even if the predicate were
+// logically wrong. fireJob is private; the cast is deliberate and scoped to this test.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { EventBus } from '../../src/bus/bus.js';
+import { Scheduler } from '../../src/scheduler/scheduler.js';
+import { SchedulerService, type JobRow } from '../../src/scheduler/scheduler-service.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const AGENT_ID = 'claim-idem-test-agent';
+const logger = pino({ level: 'silent' });
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(`DELETE FROM scheduled_jobs WHERE agent_id = $1`, [AGENT_ID]);
+}
+
+describeIf('Scheduler cron claim idempotency (#1159)', () => {
+  let pool: pg.Pool;
+  let bus: EventBus;
+  let schedulerService: SchedulerService;
+  let scheduler: Scheduler;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    bus = new EventBus(logger as never);
+    schedulerService = new SchedulerService(pool, bus, logger as never, 'UTC');
+    scheduler = new Scheduler({ pool, bus, logger: logger as never, schedulerService });
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  it('fires a due cron job once even when a stale concurrent poll re-claims it after completion', async () => {
+    // Insert a recurring cron job that is due now (next_run_at in the past).
+    const pastDue = new Date(Date.now() - 60_000).toISOString();
+    const insert = await pool.query(
+      `INSERT INTO scheduled_jobs
+         (agent_id, source_agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone)
+       VALUES ($1, $1, $2, $3, 'pending', $4, 'system', 'UTC')
+       RETURNING id`,
+      [AGENT_ID, '0 9 * * *', JSON.stringify({ task: 'send digest' }), pastDue],
+    );
+    const jobId = insert.rows[0]!.id as string;
+
+    // The stale in-memory row both overlapping polls hold: next_run_at still in the past.
+    const staleRow: JobRow = {
+      id: jobId, agentId: AGENT_ID, cronExpr: '0 9 * * *', runAt: null,
+      taskPayload: { task: 'send digest' }, status: 'pending',
+      lastRunAt: null, nextRunAt: pastDue, lastError: null, consecutiveFailures: 0,
+      createdBy: 'system', createdAt: new Date().toISOString(), timezone: 'UTC',
+      agentTaskId: null, intentAnchor: null, progress: null, taskTitle: null,
+      runStartedAt: null, expectedDurationSeconds: null, lastRunOutcome: null,
+      lastRunSummary: null, lastRunContext: null, originator: null,
+    };
+
+    // Count agent.task fires. (Use a real bus subscription on the system layer — fireJob
+    // publishes the task there.)
+    let fireCount = 0;
+    bus.subscribe('agent.task', 'system', () => { fireCount += 1; });
+
+    // fireJob is private; the cast is intentional so the production claim SQL is exercised.
+    const fireJob = (job: JobRow) =>
+      (scheduler as unknown as { fireJob(j: JobRow): Promise<void> }).fireJob(job);
+
+    // Poll A fires the job → claims it, advances next_run_at to the next occurrence.
+    await fireJob(staleRow);
+    // The recurring job completes and reverts to 'pending' (the window that reopened the claim).
+    await schedulerService.completeJobRun(jobId, true);
+    // Poll B reaches the same stale row and attempts to fire it again.
+    await fireJob(staleRow);
+
+    // Without the next_run_at guard this is 2 (duplicate digest). With it, the second claim
+    // matches 0 rows because the first claim already advanced next_run_at into the future.
+    expect(fireCount).toBe(1);
+
+    // The row is back to 'pending' (from completeJobRun) with next_run_at in the future,
+    // not stuck 'running' from a phantom second claim.
+    const after = await pool.query(
+      `SELECT status, next_run_at > now() AS in_future FROM scheduled_jobs WHERE id = $1`,
+      [jobId],
+    );
+    expect(after.rows[0]!.status).toBe('pending');
+    expect(after.rows[0]!.in_future).toBe(true);
+  });
+});

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -325,7 +325,7 @@ describe('Scheduler', () => {
       expect(bus.publish).not.toHaveBeenCalled();
       expect(logger.debug).toHaveBeenCalledWith(
         expect.objectContaining({ jobId: 'job-1' }),
-        'Job already claimed; skipping fire',
+        expect.stringContaining('skipping fire'),
       );
     });
 
@@ -365,7 +365,7 @@ describe('Scheduler', () => {
       expect(claimParams[4]).toBe('UTC');
       expect(logger.debug).toHaveBeenCalledWith(
         expect.objectContaining({ jobId: 'job-1' }),
-        'Job already claimed; skipping fire',
+        expect.stringContaining('skipping fire'),
       );
     });
 
@@ -425,6 +425,27 @@ describe('Scheduler', () => {
       expect(claimSql).toContain('timezone = $5');
       expect(claimParams[3]).toBe('0 9 * * *');
       expect(claimParams[4]).toBe('UTC');
+    });
+
+    // Regression (duplicate daily digest, 2026-06-24): two overlapping pollDueJobs cycles
+    // each captured the same still-pending cron job in their in-memory list. Poll A claimed
+    // and fired it; completeJobRun reset the recurring job to status='pending'; Poll B then
+    // re-claimed it because the claim UPDATE gated only on status — NOT on next_run_at. The
+    // claim must re-check next_run_at <= now() (the same predicate the SELECT used) so that a
+    // stale concurrent claim, whose row's next_run_at was already advanced to the future by
+    // the first claim, matches 0 rows and skips. (#1124 advanced next_run_at but only protected
+    // the NEXT poll's SELECT, not a concurrent poll already holding the row.)
+    it('gates the cron claim UPDATE on next_run_at <= now() to block stale concurrent re-claims', async () => {
+      const row = fakeDbRow();
+      schedulerService.nextRunFromCron.mockReturnValueOnce(new Date('2026-06-25T09:00:00.000Z'));
+
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [claimSql] = pool.query.mock.calls[1] as [string, unknown[]];
+      expect(claimSql).toContain('next_run_at <= now()');
     });
 
     it('does not include next_run_at in claim UPDATE for one-shot jobs', async () => {


### PR DESCRIPTION
## Summary

Fixes the duplicate **daily digest** (the CEO got two digests at 08:02 and 08:03 ET on 2026-06-24). The same `scheduled_jobs` row fired twice; the same morning two other jobs (`16fd5a5b` approval-expiry-sweep, `7da82d21` ceo-inbox) also double-fired.

Closes #1159.

### Root cause

1. The agent runs **synchronously inside `fireJob`** — `bus.publish` awaits its subscribers, and the agent runtime is one — so a single `pollDueJobs()` that finds N due jobs takes N × agent-runtime (~15-25s each) to drain.
2. `setInterval(POLL_INTERVAL_MS = 30s)` launches a fresh poll every 30s regardless, so **poll cycles overlap**.
3. `FOR UPDATE … SKIP LOCKED` gives no cross-poll protection: `pool.query` autocommits, releasing the row lock the instant the SELECT returns.
4. A job still `pending` when poll B's SELECT runs is captured into poll B's in-memory list. Poll A claims + fires it; `completeJobRun` resets the recurring job to `status='pending'`. Poll B then reaches it and the claim UPDATE — gating only on `status IN ('pending','failed')` + cron + timezone, **not on `next_run_at`** — succeeds again and fires a duplicate.

The #1124 fix (advance `next_run_at` at claim time) only shielded the *next poll's SELECT*, not a concurrent poll already holding the row.

### Fix

Add `AND next_run_at <= now()` to the cron-branch claim UPDATE so the claim re-checks the **same predicate the SELECT used**. The first claim advances `next_run_at` into the future; any stale concurrent re-claim matches 0 rows and skips. One-shot (`run_at`) jobs are unaffected — they complete to `status='completed'` and cannot re-claim. The `rowCount === 0` skip log is reworded since it now also covers this benign de-dup case (previously it asserted "already claimed", which would mislead a missed-fire investigation).

The deeper structural cause — the agent executing synchronously inside `fireJob`, which is what makes polls overlap at all — is tracked separately in #1160.

## Testing

- **New real-Postgres integration test** (`tests/integration/scheduler-claim-idempotency.test.ts`) drives the real `fireJob` against a real row: fire → complete → stale re-fire, asserting the job fires exactly once. Verified it **fails without the guard** (`fireCount` = 2) and passes with it.
- Unit test asserts the cron claim UPDATE carries the `next_run_at <= now()` predicate.
- Full scheduler suite green (166 tests); typecheck clean.

## Risk

Low. Two-line WHERE addition scoped to the cron claim path + a log message reword. Reviewed for permanent-skip and retry-starvation: the failure path leaves `next_run_at` in the past (so retries still fire), and only legitimate post-run states (completion, recovery, the winning claim) advance it into the future.