### PR TITLE
fix: stop health canary masking a same-millisecond LLM error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Health LLM canary** — derives tier failure from an explicit most-recent-outcome flag instead of comparing `lastErrorAt > lastSuccessAt`, which tied (and masked the error as healthy) when both landed in the same millisecond. (#1163)
 - **`outbound-gateway`** — content-filter blocks now return the principal-safe reason and rule names so agents can self-correct and retry. (#1051)
 - **Scheduler double-fire** — the cron-branch claim UPDATE now re-checks `next_run_at <= now()`, so overlapping poll cycles can no longer re-claim a just-completed recurring job and send a duplicate (e.g. two daily digests). (#1159)
 - **`approveGrantRecommendation` / `declineGrantRecommendation`** — concurrent calls on the same pending recommendation no longer produce an auth-state contradiction; both operations now run inside a single transaction so approve's permission override and status transition are atomic. (#1068)

--- a/src/health/health-service.ts
+++ b/src/health/health-service.ts
@@ -344,17 +344,21 @@ export class HealthService {
 
   /**
    * Derive canary status from the in-memory outcome tracker.
-   * Fails if the most recent recorded outcome is an error (lastErrorAt > lastSuccessAt).
+   * Fails if the most recent recorded outcome (tracker.lastOutcome) was an error.
    */
   private canaryOutcome(key: TrackerKey, label: string): CanaryResult {
-    const { lastSuccessAt, lastErrorAt } = this.tracker.getOutcome(key);
+    const { lastErrorAt, lastOutcome } = this.tracker.getOutcome(key);
 
-    // Report fail only when there is a recorded error more recent than the last success.
-    if (lastErrorAt !== null && (lastSuccessAt === null || lastErrorAt > lastSuccessAt)) {
-      return { name: label, status: 'fail', detail: `last call errored at ${lastErrorAt.toISOString()}` };
+    // Report fail only when the most recent recorded outcome was an error. Use the explicit
+    // lastOutcome discriminator rather than `lastErrorAt > lastSuccessAt`: the timestamp
+    // comparison ties when both land in the same millisecond (Date is 1ms-granular), which
+    // would silently report a same-ms error as healthy. lastErrorAt is non-null whenever
+    // lastOutcome === 'error', so the detail timestamp is always available here.
+    if (lastOutcome === 'error') {
+      return { name: label, status: 'fail', detail: `last call errored at ${lastErrorAt!.toISOString()}` };
     }
 
-    // No errors recorded, or last success is more recent — healthy.
+    // No calls recorded yet, or the most recent outcome was a success — healthy.
     return { name: label, status: 'ok' };
   }
 

--- a/src/health/llm-outcome-tracker.ts
+++ b/src/health/llm-outcome-tracker.ts
@@ -10,16 +10,16 @@ export class LlmOutcomeTracker {
   private readonly outcomes = new Map<TrackerKey, TierOutcome>();
 
   recordSuccess(key: TrackerKey): void {
-    const existing = this.outcomes.get(key) ?? { lastSuccessAt: null, lastErrorAt: null };
-    this.outcomes.set(key, { ...existing, lastSuccessAt: new Date() });
+    const existing = this.outcomes.get(key) ?? { lastSuccessAt: null, lastErrorAt: null, lastOutcome: null };
+    this.outcomes.set(key, { ...existing, lastSuccessAt: new Date(), lastOutcome: 'success' });
   }
 
   recordError(key: TrackerKey): void {
-    const existing = this.outcomes.get(key) ?? { lastSuccessAt: null, lastErrorAt: null };
-    this.outcomes.set(key, { ...existing, lastErrorAt: new Date() });
+    const existing = this.outcomes.get(key) ?? { lastSuccessAt: null, lastErrorAt: null, lastOutcome: null };
+    this.outcomes.set(key, { ...existing, lastErrorAt: new Date(), lastOutcome: 'error' });
   }
 
   getOutcome(key: TrackerKey): TierOutcome {
-    return this.outcomes.get(key) ?? { lastSuccessAt: null, lastErrorAt: null };
+    return this.outcomes.get(key) ?? { lastSuccessAt: null, lastErrorAt: null, lastOutcome: null };
   }
 }

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -32,4 +32,8 @@ export type TrackerKey = 'fast' | 'standard' | 'powerful' | 'embeddings' | 'imag
 export interface TierOutcome {
   lastSuccessAt: Date | null;
   lastErrorAt: Date | null;
+  /** Which kind of call was recorded most recently. Authoritative for health derivation —
+   *  comparing lastErrorAt > lastSuccessAt is unreliable when both land in the same
+   *  millisecond (Date has 1ms granularity), which would silently mask a same-ms error. */
+  lastOutcome: 'success' | 'error' | null;
 }

--- a/tests/unit/health/llm-outcome-tracker.test.ts
+++ b/tests/unit/health/llm-outcome-tracker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { LlmOutcomeTracker } from '../../../src/health/llm-outcome-tracker.js';
 
 describe('LlmOutcomeTracker', () => {
@@ -6,6 +6,10 @@ describe('LlmOutcomeTracker', () => {
 
   beforeEach(() => {
     tracker = new LlmOutcomeTracker();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('starts with null outcomes for all keys', () => {
@@ -38,19 +42,31 @@ describe('LlmOutcomeTracker', () => {
     expect(tracker.getOutcome('image_gen').lastErrorAt).toBeInstanceOf(Date);
   });
 
-  it('latest error after success indicates failure', async () => {
+  it('reports error as the most recent outcome after success', () => {
     tracker.recordSuccess('fast');
-    await new Promise(resolve => setTimeout(resolve, 1));
     tracker.recordError('fast');
-    const { lastSuccessAt, lastErrorAt } = tracker.getOutcome('fast');
-    expect(lastErrorAt!.getTime()).toBeGreaterThan(lastSuccessAt!.getTime());
+    expect(tracker.getOutcome('fast').lastOutcome).toBe('error');
   });
 
-  it('latest success after error indicates ok', async () => {
+  it('reports success as the most recent outcome after error', () => {
     tracker.recordError('fast');
-    await new Promise(resolve => setTimeout(resolve, 1));
     tracker.recordSuccess('fast');
-    const { lastSuccessAt, lastErrorAt } = tracker.getOutcome('fast');
-    expect(lastSuccessAt!.getTime()).toBeGreaterThan(lastErrorAt!.getTime());
+    expect(tracker.getOutcome('fast').lastOutcome).toBe('success');
+  });
+
+  // Regression (#1163): success and error recorded in the SAME millisecond used to be
+  // indistinguishable — health derived failure from `lastErrorAt > lastSuccessAt`, which is
+  // false on a tie, so an error landing in the same ms as a success was silently reported
+  // healthy (and made the ordering unit test flaky). lastOutcome records insertion order, so
+  // the most recent outcome wins regardless of Date's 1ms granularity.
+  it('breaks same-millisecond ties by record order, not timestamp comparison', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T12:00:00.000Z'));
+    // Both calls observe the identical (frozen) clock — lastErrorAt === lastSuccessAt.
+    tracker.recordSuccess('fast');
+    tracker.recordError('fast');
+    const outcome = tracker.getOutcome('fast');
+    expect(outcome.lastErrorAt!.getTime()).toBe(outcome.lastSuccessAt!.getTime());
+    expect(outcome.lastOutcome).toBe('error');
   });
 });


### PR DESCRIPTION
## Summary

Fixes the flaky `llm-outcome-tracker` unit test that broke CI on #1162 — and the real bug behind it. `HealthService.canaryOutcome` derived LLM-tier failure from `lastErrorAt > lastSuccessAt`. Because `Date` is 1ms-granular, a success and an error recorded in the **same millisecond** tie, the comparison is false, and a genuinely failing tier is **silently reported as healthy**. The test was flaky for the same reason: it leaned on `setTimeout(1)` to push the two timestamps into different milliseconds, which doesn't reliably happen.

Closes #1163.

### Fix

Record an explicit `lastOutcome: 'success' | 'error' | null` discriminator on each `recordSuccess` / `recordError`, and key the health check off `lastOutcome === 'error'` instead of the timestamp comparison. Deterministic regardless of clock granularity; `lastSuccessAt` / `lastErrorAt` stay for the failure-detail string.

A `toBeGreaterThanOrEqual` test tweak would have made CI green while leaving the same-millisecond masking live in production — this addresses the cause, not the symptom.

## Testing

- Rewrote the two ordering tests to drop the wall-clock (`setTimeout`) dependency.
- Added a frozen-clock regression test (`vi.setSystemTime`) that records success then error at the *same* instant, asserts `lastErrorAt === lastSuccessAt`, and asserts the most recent outcome is `error`. Verified it fails before the fix.
- Full health suite green (38 tests); typecheck clean.

## Risk

Low. Additive field on an internal type (`TierOutcome` is not serialized in the `/api/health` response) plus a one-branch change in `canaryOutcome`. Semantics are identical for every non-tie case; the only behavior change is that a same-millisecond error now correctly reports `fail`.