### PR TITLE
docs: sync woken-authz design note to shipped #1126 model

### DIFF
--- a/docs/wip/2026-06-22-woken-task-authorization-design.md
+++ b/docs/wip/2026-06-22-woken-task-authorization-design.md
@@ -119,27 +119,60 @@ like `scheduler-create` — **keep** the originator at fire time, **not** ladder
 floored. As shipped it under-authorizes a principal-lineage task that self-defers. Out of
 #1125's scope (heartbeat path only); tracked as #1153.
 
+> **Interaction with #1126.** Fixing #1153 restores only the *autonomy* principal-bypass
+> (for `normal` skills) — it carries no `standing` envelope, so it mints no `wakeContext` and
+> is not subject to the ladder. A `wake_at` fire is still **not a live principal turn** (it
+> carries no `liveTurn`), so `elevated` authority primitives stay blocked on wake. That is
+> correct and intended: a pre-chosen self-deferral may resume CEO-authorized *work*, but must
+> not *exercise authority* without the CEO present. #1153 must therefore thread the originator
+> only — it must not attempt to thread `liveTurn`.
+
 ### 4. `elevated` means a **live** principal turn
 
 `sensitivity: elevated` is redefined to require a **live principal turn** — the current
 turn originated from a fresh principal inbound. It is never satisfiable by system, agent,
-or any inherited/woken standing (even principal *lineage* on a wake). "Live principal" is
-stamped only when the dispatcher processes a real principal message; wakes, derivations,
-and scheduler fires never carry it.
+or any inherited/woken standing (even principal *lineage* on a wake).
+
+**As shipped (#1126), the live signal is a distinct `liveTurn` boolean on the `agent.task`
+payload — deliberately *not* a metadata-bag key.** Keeping it off the metadata bag is a
+*structural* guarantee, not a discipline: no persistence skill (`scheduler-create`,
+`task-create`, bullpen, `enqueueTaskWake`) can sweep it into a wakeable row, because those
+copy named metadata fields by name and never the payload's `liveTurn`. The dispatcher
+*computes* it (`originator.systemRole === 'principal'`) and never copies it from inbound
+input, so it cannot be forged from a message. The gate predicate (`isLivePrincipalTurn`)
+requires **both** `liveTurn === true` **and** a principal originator on the effective
+metadata, so a stray flag without principal lineage still fails closed.
+
+**It is forwarded across *synchronous* delegation.** The `delegate` skill threads
+`ctx.liveTurn` onto the sub-task it publishes, so "the CEO is live" spans the whole
+synchronous call tree: a delegated specialist (the contacts specialist, the setup-wizard)
+acting *inside* the CEO's live turn inherits live-ness and may exercise an authority
+primitive on the CEO's behalf. This is safe precisely because `delegate` is **ephemeral** —
+an in-process bus request/response with no `tasks` row and no persistence — so the forwarded
+signal evaporates at the async boundary and can never reach a wake. The **bullpen** path, by
+contrast, carries lineage but deliberately **not** `liveTurn` (it is persisted/async), so a
+bullpen specialist correctly cannot invoke elevated skills. Wakes, derivations, and scheduler
+fires never carry it.
 
 This is enforced **only at the execution-layer gate**
-([`execution.ts:591`](../../src/skills/execution.ts)). All handler-level
+([`execution.ts`](../../src/skills/execution.ts), `isLivePrincipalTurn`). All handler-level
 `isPrincipalOriginated` re-checks are abolished — they froze the *old* "principal only"
 definition, drifted out of sync when the gate widened to "principal or system" in
 `3bd3d224`, and are exactly the whack-a-mole hazard a single definition removes.
 
-> **Status after #1125:** the handler re-checks are *not yet* abolished — #1126 does that.
-> In the interim #1125 made them safe rather than removing them: the execution layer forwards
-> **effective** (post-ladder) standing to handlers (`ctx.taskMetadata = effectiveTaskMetadata`,
-> `execution.ts:969`), so a re-check on a woken principal-lineage task now sees the downgraded
-> standing instead of raw lineage. These re-checks are therefore load-bearing until #1126
-> replaces them — confirm the gate (or an `action_risk` + autonomy gate) covers each one
-> before deleting it. See the caveat posted on #1126.
+**Defence in depth (#1126).** Beyond the predicate above, the gate **rejects any task
+carrying a `wakeContext` marker outright** — a wake is never a live turn, so even if
+`liveTurn` somehow leaked onto a woken task the gate still fails closed. The dispatcher also
+scrubs any inbound `liveTurn` (and the legacy `livePrincipal` alias) from the metadata bag.
+The self-approval-hole closure is therefore pinned to the gate itself, not to the
+dispatcher/scheduler behaving perfectly.
+
+> **Shipped in #1126.** The interim #1125 state (handler re-checks kept but made safe by
+> forwarding post-ladder *effective* standing to handlers) is superseded: the re-checks on
+> the authority-primitive skills were removed and the gate is the single enforcement point.
+> The two handler-level checks that remain (`send-draft`, `calendar-list-events`) are *not*
+> elevated re-checks — they are the ADR-017 Option C `action_risk: none` + handler-origin
+> pattern, a different mechanism intentionally left in place.
 
 "Live principal" closes the **self-approval hole** with zero per-skill exceptions: a
 woken principal-*lineage* task can never approve its own pending action, because lineage
@@ -157,7 +190,10 @@ The current `elevated` label does triple duty across 19 skills. It is decomposed
 
 - **Stay `elevated` (live-principal authority primitive):** `approve-action`,
   `deny-action`, `dismiss-action`, `set-autonomy`, `approve-grant-recommendation`,
-  `decline-grant-recommendation`. "The CEO is exercising authority."
+  `decline-grant-recommendation` — and, resolved in #1126, the authorization-altering
+  contact skills `contact-set-tier`, `contact-set-role`, `contact-grant-permission`,
+  `contact-revoke-permission`, plus `system-secret-capture-request`. "The CEO is exercising
+  authority." (See the resolved Bucket-D note below for the rationale.)
 - **→ `normal` + `action_risk` (autonomy-governed; inherits the ADR-018 approval flow
   for free):** `contact-merge`, `contact-update`, `contact-rename`,
   `behavioral-preferences-update`, `executive-profile-update`, `scheduler-create`,
@@ -167,11 +203,22 @@ The current `elevated` label does triple duty across 19 skills. It is decomposed
   the task*; the 8am digest job runs as the coordinator. This is the **sole** reason
   `system` was ever allowed through the gate (`3bd3d224`), so handling it this way is
   what makes the live-principal definition safe.
-- **Decide explicitly (issue #1126):** `contact-grant-permission`,
-  `contact-revoke-permission`, `contact-set-tier`, `contact-set-role` (these alter
-  authorization itself — authority-primitive vs. high-risk mutation?); `web-browser` (an
-  egress/injection gate, not authority or a mutation — likely `allowed_callers` +
-  `action_risk`).
+- **Resolved in #1126** (was "decide explicitly"):
+  - `contact-grant-permission`, `contact-revoke-permission`, `contact-set-tier`,
+    `contact-set-role` → **`elevated`**. They alter *who can do what*, so they are authority
+    primitives, not mutations: minting or revoking authorization must require a live CEO and
+    must never run autonomously on a schedule or job. Threading `liveTurn` through synchronous
+    delegation (§4) is what makes this practical — a delegated contacts specialist can still
+    run them *inside* the CEO's live turn.
+  - `system-secret-capture-request` → **`elevated`** (`action_risk: none`,
+    `allowed_callers: [setup-wizard]`). A secret-capture link is an authority artifact; gating
+    it on a live turn ensures one can never be minted by a schedule or job. The setup-wizard
+    only ever runs as a live, delegated turn, so this stays reachable in practice.
+  - `web-browser` → **`normal`** + `action_risk: medium` + `allowed_callers: [coordinator]`.
+    It is an egress/injection surface, not authority or a mutation — the right controls are
+    which agent may call it plus the autonomy score, not the live-principal gate.
+  - `contact-merge` → **`normal`** + `action_risk: medium` (surface-and-confirm below 70,
+    auto at/above), per the dedup-case decision below.
 
 After this, **`system` standing loses all gate power** and becomes pure audit lineage +
 the "skip the external-contact tier gate" signal in
@@ -226,12 +273,18 @@ Three issues, completed in order:
   `enqueueTaskWake`; the score-keyed effective-standing computation + ladder, wired into
   both the principal-bypass and the `elevated` gate's *input* (gate requirement stays
   principal-or-system here). Prerequisite for the other two.
-- **#1126 (step 2, depends on #1125):** redefine `elevated` = live principal; audit &
-  reclassify all 19 elevated skills; abolish handler re-checks; resolve the Bucket-D
-  borderlines. Gate change + reclassification land atomically.
-- **#1127 (step 3, depends on #1125; parallel to #1126):** stamp `TaskOriginator` on
+- **#1126 (step 2, depends on #1125) — SHIPPED.** Redefined `elevated` = live principal
+  turn, carried by a distinct off-bag `liveTurn` payload field and forwarded through
+  *synchronous* delegation (§4); audited & reclassified all 19 elevated skills; abolished the
+  handler re-checks (gate is the single enforcement point); resolved the Bucket-D borderlines
+  (§5 — contact-auth skills + `system-secret-capture-request` to `elevated`, `web-browser` to
+  `normal`). Added the `wakeContext` defence-in-depth at the gate. Gate change +
+  reclassification landed atomically. ADR-011/017/018 + specs 03/14 updated.
+- **#1127 (step 3, depends on #1125; parallel to #1126) — OPEN.** Stamp `TaskOriginator` on
   console-created tasks/scheduled jobs (a principal surface — must not default to
-  propose-only).
+  propose-only). Scope is durable **lineage** only; whether a *live* console interaction sets
+  the `liveTurn` signal is a dispatch-path question now that #1126 has shipped the mechanism —
+  see the note on the issue.
 - **#1153 (follow-up, depends on #1125):** thread `TaskOriginator` onto task `wake_at`
   self-deferral wake jobs so a pre-chosen deferral keeps its originator at fire time
   (no ladder) instead of flooring to agent — see §3b.

--- a/docs/wip/2026-06-22-woken-task-authorization-design.md
+++ b/docs/wip/2026-06-22-woken-task-authorization-design.md
@@ -117,7 +117,7 @@ with **no** originator and no `standing` envelope (see the `@TODO(#1125/#1127)` 
 floors to agent / no-bypass. But a `wake_at` time is *pre-chosen*, so it should be treated
 like `scheduler-create` — **keep** the originator at fire time, **not** laddered, **not**
 floored. As shipped it under-authorizes a principal-lineage task that self-defers. Out of
-#1125's scope (heartbeat path only); tracked as #1153.
+scope for #1125 (heartbeat path only); tracked as #1153.
 
 > **Interaction with #1126.** Fixing #1153 restores only the *autonomy* principal-bypass
 > (for `normal` skills) — it carries no `standing` envelope, so it mints no `wakeContext` and


### PR DESCRIPTION
## Summary

#1126 shipped with two design evolutions beyond the original plan — (1) the live-principal signal became a **distinct off-bag `liveTurn` payload field** rather than a metadata-bag key, and (2) it is **forwarded across synchronous delegation** so a delegated specialist can act inside the CEO's live turn. The canonical design note (`docs/wip/2026-06-22-woken-task-authorization-design.md`) still described the pre-implementation model and left the Bucket-D borderlines "to be decided." This PR brings the note in line with what landed, and applies the same clarifications to the two still-open follow-up issues.

### Design note (`§4` / `§5` / `§3b` / roadmap)
- **§4** — document the distinct `liveTurn` field and its structural no-persistence guarantee, the dispatcher's *compute-not-copy* stamp, the `isLivePrincipalTurn` predicate (requires both flag + principal lineage), forwarding across the ephemeral `delegate` path, the bullpen contrast (lineage but no `liveTurn`), and the `wakeContext` defence-in-depth at the gate. Replaced the stale "#1125 hasn't abolished the re-checks yet" interim note with the shipped state (re-checks removed; `send-draft`/`calendar-list-events` are ADR-017 Option C, not elevated re-checks).
- **§5** — moved the resolved Bucket-D borderlines out of "decide explicitly": the authorization-altering contact skills + `system-secret-capture-request` are `elevated`; `web-browser` and `contact-merge` are `normal` + `action_risk`. Added the new elevated skills to the list.
- **§3b** — clarified that fixing the `wake_at` gap (#1153) restores only the *autonomy* bypass; a `wake_at` fire is never a live turn, so `elevated` skills stay correctly blocked.
- **Roadmap** — #1126 marked **SHIPPED**; #1127's live-vs-durable split clarified.

### Issues updated
- **#1127** — resolved the original "is a live console interaction a live turn?" open question: the dispatcher stamps `liveTurn` channel-agnostically from `originator.systemRole === 'principal'`, so a live console turn resolved to the principal already qualifies with no extra work; the issue's durable rows stay lineage-only. Scope unchanged + one verification added.
- **#1153** — sharpened (not changed) the scope: "bypass intact" means the autonomy bypass for `normal` skills; `elevated` skills stay blocked on a `wake_at` fire; thread the originator only, never `liveTurn`.

## Notes
- **Docs-only** wip sync. No behavior change — #1126's behavior is already recorded in CHANGELOG, so no new CHANGELOG entry (adding one for an internal design-note sync would duplicate the #1126 entry). The ADRs/specs (011/017/018, 03/14) were already updated in #1126.
- The #1125 implementation plan (`2026-06-23-woken-task-authorization-impl.md`) is left as-is — it is a historical plan for the shipped #1125 step and remains accurate.