### PR TITLE
feat: stamp principal TaskOriginator on console-created tasks and jobs (#1127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Console task lineage** — tasks and scheduled jobs created from the console now carry a principal `TaskOriginator` (`channel: 'console'`), so console-originated work is no longer stranded propose-only when later woken. (#1127)
 - **Health observability** — `GET /api/health` returns `ok` / `degraded` / `down` with per-check status for seven services; `down` (503) only when db or bus fails. (#434)
 - **Daily canary job** — scheduler job validates LLM tiers, credentials, and external deps on a cron schedule; pings configured heartbeat URLs on success. (#434)
 - **LLM error telemetry** — `llm.error` bus events on failed provider calls let the health layer track per-tier outcomes without billed probes. (#434)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Console task lineage** — tasks and scheduled jobs created from the console now carry a principal `TaskOriginator` (`channel: 'console'`), so console-originated work is no longer stranded propose-only when later woken. (#1127)
+- **Console task lineage** — tasks and scheduled jobs created from the console now carry a principal `TaskOriginator` (`channel: 'console'`), and console tasks default to a non-derived `source: 'ceo'`, so console-originated work is no longer stranded propose-only when later woken. (#1127)
 - **Health observability** — `GET /api/health` returns `ok` / `degraded` / `down` with per-check status for seven services; `down` (503) only when db or bus fails. (#434)
 - **Daily canary job** — scheduler job validates LLM tiers, credentials, and external deps on a cron schedule; pings configured heartbeat URLs on success. (#434)
 - **LLM error telemetry** — `llm.error` bus events on failed provider calls let the health layer track per-tier outcomes without billed probes. (#434)

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -175,7 +175,10 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted, lookupTas
   const [owner, setOwner] = useState<TaskOwner>(task?.owner ?? 'curia');
   const [priority, setPriority] = useState(String(task?.priority ?? 50));
   const [dueAt, setDueAt] = useState(task?.dueAt ? task.dueAt.slice(0, 10) : '');
-  const [source, setSource] = useState<TaskSource>(task?.source ?? 'agent');
+  // New console tasks default to 'ceo' (#1127): the console is a principal surface, so a task
+  // created here is CEO-authorized work, not an agent-spawned side-effect. A 'ceo' source keeps
+  // it non-derived so its principal lineage survives the woken-task bypass ladder.
+  const [source, setSource] = useState<TaskSource>(task?.source ?? 'ceo');
   const [tags, setTags] = useState((task?.tags ?? []).join(', '));
   const [conversationId, setConversationId] = useState(task?.conversationId ?? '');
   const [waitingOnText, setWaitingOnText] = useState(task?.waitingOnText ?? '');

--- a/src/channels/http/console-originator.ts
+++ b/src/channels/http/console-originator.ts
@@ -1,0 +1,48 @@
+// console-originator.ts — resolve the principal TaskOriginator to stamp on rows
+// created from the console (dashboard) surface. Issue #1127.
+//
+// The console's bootstrap secret is CEO-only, so any authenticated console request is
+// unambiguously the principal. Tasks and scheduled_jobs created from console routes must
+// therefore carry principal **lineage** (#1125's TaskOriginator) — otherwise, under the
+// woken-task-authorization model, a missing originator defaults to the conservative agent /
+// no-bypass standing and would silently strand console-created work in propose-only mode.
+//
+// This stamps lineage only. It deliberately never sets the `liveTurn` signal: these are
+// persisted, async-wakeable rows, never a live principal turn (see the design note §4).
+
+import type { ContactService } from '../../contacts/contact-service.js';
+import { makePrincipalOriginator } from '../../contacts/principal.js';
+import type { TaskOriginator } from '../../contacts/types.js';
+import type { Logger } from '../../logger.js';
+
+/** Channel value stamped on the originator for console-created rows. */
+export const CONSOLE_CHANNEL = 'console';
+
+/**
+ * Resolve the principal TaskOriginator for a console-initiated row.
+ *
+ * Returns a principal-lineage originator when the principal contact can be resolved.
+ * Returns null — and logs a warning — when no principal contact exists yet (e.g. a fresh
+ * install before seeding) or the lookup fails. A null degrades gracefully to the
+ * pre-#1127 behaviour (conservative agent / no-bypass standing); it does not fail the
+ * request, because creating the task/job is more important than stamping its lineage.
+ */
+export async function resolveConsoleOriginator(
+  contactService: ContactService,
+  logger: Logger,
+): Promise<TaskOriginator | null> {
+  try {
+    const principal = await contactService.findContactBySystemRole('principal');
+    if (!principal) {
+      logger.warn(
+        'console-originator: no principal contact found — console row will carry no lineage (conservative default)',
+      );
+      return null;
+    }
+    return makePrincipalOriginator(principal.id, CONSOLE_CHANNEL);
+  } catch (err) {
+    // Don't fail the create on a lineage-stamp failure; fall back to the conservative default.
+    logger.error({ err }, 'console-originator: failed to resolve principal — stamping no lineage');
+    return null;
+  }
+}

--- a/src/channels/http/console-originator.ts
+++ b/src/channels/http/console-originator.ts
@@ -26,6 +26,13 @@ export const CONSOLE_CHANNEL = 'console';
  * install before seeding) or the lookup fails. A null degrades gracefully to the
  * pre-#1127 behaviour (conservative agent / no-bypass standing); it does not fail the
  * request, because creating the task/job is more important than stamping its lineage.
+ *
+ * Contract: this NEVER throws — callers invoke it outside their DB try/catch and rely on
+ * that. The catch fails closed (toward LESS privilege) for any error, including infra-level
+ * faults (e.g. a transient DB outage), which means such a fault silently produces a
+ * conservatively-under-authorized row. That is the safe direction for an authorization gate,
+ * but callers should re-log with the created row id (the id isn't known here yet) so the
+ * later propose-only consequence is correlatable back to this drop.
  */
 export async function resolveConsoleOriginator(
   contactService: ContactService,

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -323,6 +323,9 @@ export class HttpAdapter implements Channel {
         schedulerService: this.config.schedulerService,
         webAppBootstrapSecret,
         sessions,
+        // Needed so console-created jobs carry principal lineage (#1127).
+        contactService: this.config.contactService,
+        logger,
       });
     }
 

--- a/src/channels/http/routes/jobs.ts
+++ b/src/channels/http/routes/jobs.ts
@@ -12,7 +12,10 @@
 
 import type { FastifyInstance } from 'fastify';
 import type { SchedulerService } from '../../../scheduler/scheduler-service.js';
+import type { ContactService } from '../../../contacts/contact-service.js';
+import type { Logger } from '../../../logger.js';
 import { assertSecret, type SessionStore } from '../session-auth.js';
+import { resolveConsoleOriginator } from '../console-originator.js';
 
 export interface JobRouteOptions {
   schedulerService: SchedulerService;
@@ -21,13 +24,18 @@ export interface JobRouteOptions {
   // can access job endpoints.
   webAppBootstrapSecret: string | undefined;
   sessions: SessionStore;
+  // Used to resolve the principal contact so console-created jobs carry principal lineage
+  // (#1127). The console is a CEO-only surface; a job created here must be stamped principal-
+  // originated, consistent with scheduler-create's principal path.
+  contactService: ContactService;
+  logger: Logger;
 }
 
 export async function jobRoutes(
   app: FastifyInstance,
   options: JobRouteOptions,
 ): Promise<void> {
-  const { schedulerService, webAppBootstrapSecret, sessions } = options;
+  const { schedulerService, webAppBootstrapSecret, sessions, contactService, logger } = options;
 
   // -- GET /api/jobs — list jobs with optional filters --
 
@@ -95,6 +103,11 @@ export async function jobRoutes(
       return reply.status(400).send({ error: 'Either cron_expr or run_at must be provided' });
     }
 
+    // Stamp principal lineage (#1127) — the console is a CEO-only surface, so a job created
+    // here is principal-originated, consistent with scheduler-create's principal path. Lineage
+    // only: the scheduled_jobs row is a persisted, async-fired artifact, never a live turn.
+    const originator = await resolveConsoleOriginator(contactService, logger);
+
     try {
       const result = await schedulerService.createJob({
         agentId,
@@ -104,6 +117,8 @@ export async function jobRoutes(
         createdBy: 'api',
         intentAnchor: body.intent_anchor,
         errorBudget: body.error_budget,
+        // createJob takes TaskOriginator | undefined; coalesce the null fallback.
+        originator: originator ?? undefined,
       });
 
       // Fetch the full job row so the caller can render it immediately without

--- a/src/channels/http/routes/jobs.ts
+++ b/src/channels/http/routes/jobs.ts
@@ -121,6 +121,16 @@ export async function jobRoutes(
         originator: originator ?? undefined,
       });
 
+      // Correlatable breadcrumb (#1127): resolveConsoleOriginator's warning fires before the job
+      // exists, so re-log here with the job id when lineage was dropped — otherwise this job
+      // firing propose-only surfaces later with no link back to the missing-lineage root cause.
+      if (!originator) {
+        logger.warn(
+          { jobId: result.jobId, channel: 'console' },
+          'jobs: console job created WITHOUT principal lineage — it will be propose-only when fired (no principal contact resolved)',
+        );
+      }
+
       // Fetch the full job row so the caller can render it immediately without
       // a separate GET request.
       const job = await schedulerService.getJob(result.jobId);

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -9,6 +9,7 @@ import { ContactValidationError } from '../../../contacts/contact-service.js';
 import type { ChannelIdentity, Contact, ContactCanonicalFields, ContactKind, ContactTier } from '../../../contacts/types.js';
 import type { EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
+import { resolveConsoleOriginator } from '../console-originator.js';
 import { markdownToHtml } from '../../../utils/markdown-to-html.js';
 import { stripOutboundContextPreamble } from '../../../dispatch/outbound-context.js';
 
@@ -463,14 +464,21 @@ export async function knowledgeGraphRoutes(
       ? body.waitingOnText.trim()
       : null;
 
+    // Stamp principal lineage (#1127). The console is a principal-only surface, so a task
+    // created here must carry principal originator — otherwise, when the heartbeat later wakes
+    // it, the woken-task-authorization model would floor it to agent / no-bypass. This is a
+    // top-level task (no parent_task_id on this path), so capOriginatorToParent is a no-op and
+    // a direct stamp is correct. Lineage only — never the live-turn signal (persisted row).
+    const originator = await resolveConsoleOriginator(contactService, logger);
+
     try {
       const inserted = await pool.query(
         `INSERT INTO tasks (
            agent_id, title, intent_anchor, description, status, owner, priority,
            due_at, source, source_agent_id, tags, waiting_on_text,
-           progress, error_budget, conversation_id, updated_at
+           progress, error_budget, conversation_id, originator, updated_at
          )
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb, $15, now())
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb, $15, $16::jsonb, now())
          RETURNING ${TASK_SELECT}`,
         [
           body.agentId.trim(),
@@ -488,6 +496,8 @@ export async function knowledgeGraphRoutes(
           JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? {}),
           JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? {}),
           conversationId,
+          // Serialize as JSON string for pg JSONB — null when no principal could be resolved.
+          originator ? JSON.stringify(originator) : null,
         ],
       );
       if (!inserted.rowCount) {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -504,6 +504,17 @@ export async function knowledgeGraphRoutes(
         logger.error('kg: INSERT tasks returned no rows');
         return reply.status(500).send({ error: 'Failed to create task.' });
       }
+      // Correlatable breadcrumb (#1127): the lineage-resolution warning (in resolveConsoleOriginator)
+      // fires before the row exists, so it can't carry an id. Re-log here with the task id when
+      // lineage was dropped — otherwise the consequence (this task stranded propose-only when the
+      // heartbeat later wakes it) surfaces as a generic autonomy-gate block with no link back here.
+      if (!originator) {
+        const createdId = (inserted.rows[0] as { id?: string } | undefined)?.id;
+        logger.warn(
+          { taskId: createdId, channel: 'console' },
+          'kg: console task created WITHOUT principal lineage — it will be propose-only if woken (no principal contact resolved)',
+        );
+      }
       return reply.status(201).send({
         task: serializeTask(inserted.rows[0]! as DbTaskRow),
       });

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -417,7 +417,13 @@ export async function knowledgeGraphRoutes(
     }
     // Resolve with defaults first, then validate — avoids dual-layer guard maintenance trap.
     const owner = typeof body.owner === 'string' ? body.owner : 'curia';
-    const source = typeof body.source === 'string' ? body.source : 'agent';
+    // Default source to 'ceo', not 'agent' (#1127). The console is a principal surface, so a task
+    // created here with no explicit source is the original unit of CEO-authorized work — NOT an
+    // agent-spawned side-effect. selectHeartbeatCandidates derives `derived = source='agent' OR
+    // parent_task_id IS NOT NULL`; a default of 'agent' would mark the task derived and the bypass
+    // ladder would downgrade its principal lineage at posture B (70-89), stranding it propose-only
+    // — defeating the originator stamp below. An explicit source from the client is still honoured.
+    const source = typeof body.source === 'string' ? body.source : 'ceo';
     if (!validOwners.includes(owner)) {
       return reply.status(400).send({ error: 'Invalid owner. Must be curia, ceo, or external.' });
     }

--- a/src/contacts/principal.ts
+++ b/src/contacts/principal.ts
@@ -127,6 +127,34 @@ export function makeSystemOriginator(): TaskOriginator {
 }
 
 /**
+ * Create a TaskOriginator representing principal-initiated work from a principal-only
+ * surface (the console / dashboard) — issue #1127. The console's bootstrap secret is
+ * CEO-only, so any authenticated console request is unambiguously the principal; the
+ * durable `tasks` / `scheduled_jobs` rows it creates must carry principal **lineage** so
+ * they don't default to the conservative agent / no-bypass standing when later woken.
+ *
+ * This stamps lineage only. It deliberately does NOT confer a live principal turn — the
+ * `liveTurn` signal is computed by the dispatcher on the live inbound chat path and is
+ * never persisted on a wakeable row (see the woken-task-authorization design note §4).
+ *
+ * A factory (not a constant) so `initiatedAt` reflects the actual creation time. Tier is
+ * always 'principal' — the platform guarantees the principal contact's tier via
+ * repairPrincipalMetadata() at startup.
+ *
+ * @param contactId  The principal contact's id (resolve via findContactBySystemRole('principal')).
+ * @param channel    Where the work was initiated from (e.g. 'console').
+ */
+export function makePrincipalOriginator(contactId: string, channel: string): TaskOriginator {
+  return {
+    contactId,
+    systemRole: 'principal',
+    channel,
+    initiatedAt: new Date().toISOString(),
+    tier: 'principal',
+  };
+}
+
+/**
  * Extract the initiating contact's tier for the execution-layer action gate (issue #950).
  *
  * Returns null when:

--- a/tests/integration/woken-task-authorization.test.ts
+++ b/tests/integration/woken-task-authorization.test.ts
@@ -18,6 +18,7 @@ import pg from 'pg';
 import pino from 'pino';
 import { selectHeartbeatCandidates } from '../../src/db/queries/tasks.js';
 import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+import { makePrincipalOriginator } from '../../src/contacts/principal.js';
 import { makeWakeContext } from '../../src/autonomy/effective-standing.js';
 import { ExecutionLayer } from '../../src/skills/execution.js';
 import { SkillRegistry } from '../../src/skills/registry.js';
@@ -82,6 +83,24 @@ describeIf('woken-task authorization (#1060 dedup scenario)', () => {
   });
   afterAll(async () => { await cleanup(pool); await pool.end(); });
   beforeEach(async () => { await cleanup(pool); });
+
+  // The principal contact id a console row's originator carries (#1127). Value is cosmetic for
+  // the gate — only systemRole='principal' drives the bypass — but mirrors the real shape.
+  const CONSOLE_PRINCIPAL_LINEAGE = makePrincipalOriginator('contact-principal', 'console');
+
+  /** Seed a top-level console-created task: source='ceo' (NOT derived), principal lineage. */
+  async function seedConsoleTask(): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO tasks
+         (agent_id, title, intent_anchor, status, progress, error_budget, owner,
+          priority, source, source_agent_id, created_by, tags, updated_at, originator)
+       VALUES ('coordinator',$1,'seeded','open','{}'::jsonb,'{}'::jsonb,'curia',50,'ceo',NULL,'console','{console}',
+               now() - interval '10 hours', $2::jsonb)
+       RETURNING id`,
+      [`${PREFIX} console task`, JSON.stringify(CONSOLE_PRINCIPAL_LINEAGE)],
+    );
+    return rows[0]!.id;
+  }
 
   async function seedReviewTask(): Promise<string> {
     // Mirrors contact-find-duplicates: source='agent' (derived child), lineage='system' (the cron).
@@ -155,6 +174,55 @@ describeIf('woken-task authorization (#1060 dedup scenario)', () => {
     const allowed = await new ExecutionLayer(registryHigh, logger, { autonomyService: makeAutonomyService(75) })
       .invoke('contact-merge', {}, undefined, { taskMetadata });
     expect(allowed.success).toBe(true); // 75 >= 70 → auto-merge
+  });
+
+  it('a principal-bypass action initiated from a console-created task behaves as principal-originated (#1127)', async () => {
+    // The console is a principal-only surface, so a task created there carries principal lineage
+    // (channel='console'). When the heartbeat later wakes this top-level, non-derived task, the
+    // ladder keeps principal standing at posture B (70-89), so its EFFECTIVE standing is principal
+    // — and the autonomy gate's principal-bypass fires for a normal skill that the raw score alone
+    // would block. This is the end-to-end proof that console rows are not stranded propose-only.
+    const taskId = await seedConsoleTask();
+
+    const candidate = (await selectHeartbeatCandidates(pool, {
+      eligibleAgents: ['coordinator'], idleThresholdHours: 4, staleWaitThresholdHours: 48, maxWakes: 5,
+    })).find((c) => c.id === taskId);
+    if (!candidate) throw new Error(`heartbeat candidate not found for seeded console task ${taskId}`);
+    // A console task is top-level principal work, not an agent-spawned child → not derived.
+    expect(candidate.originator).toEqual(CONSOLE_PRINCIPAL_LINEAGE);
+    expect(candidate.derived).toBe(false);
+
+    const { jobId } = await scheduler.enqueueTaskWake({
+      taskId, agentId: candidate.agentId, runAt: new Date(),
+      originator: candidate.originator, derived: candidate.derived,
+    });
+    const { rows } = await pool.query<{ originator: Record<string, unknown> | null; task_payload: Record<string, unknown> }>(
+      `SELECT originator, task_payload FROM scheduled_jobs WHERE id = $1`, [jobId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.originator).toEqual(CONSOLE_PRINCIPAL_LINEAGE);
+    const taskMetadata = metadataFromWakeRow(rows[0]!);
+
+    const handler: SkillHandler = { execute: async () => ({ success: true, data: 'acted as principal' }) };
+
+    // A `normal` skill with action_risk:'critical' (min score 90). At score 75 a non-principal task
+    // is blocked by Gate B; the console task's retained principal standing bypasses gates A/B/C.
+    const registry = new SkillRegistry();
+    registry.register(makeManifest('commit-funds', 'normal', 'critical'), handler);
+    const allowed = await new ExecutionLayer(registry, logger, { autonomyService: makeAutonomyService(75) })
+      .invoke('commit-funds', {}, undefined, { taskMetadata });
+    expect(allowed.success).toBe(true); // principal-bypass fired despite score 75 < 90
+
+    // Control: the SAME wake metadata but with agent lineage gets no bypass and is blocked at 75.
+    const agentMetadata = {
+      originator: { contactId: 'a', systemRole: 'agent', channel: 'console', initiatedAt: CONSOLE_PRINCIPAL_LINEAGE.initiatedAt, tier: null },
+      wakeContext: makeWakeContext(false),
+    };
+    const registryControl = new SkillRegistry();
+    registryControl.register(makeManifest('commit-funds', 'normal', 'critical'), handler);
+    const blocked = await new ExecutionLayer(registryControl, logger, { autonomyService: makeAutonomyService(75) })
+      .invoke('commit-funds', {}, undefined, { taskMetadata: agentMetadata });
+    expect(blocked.success).toBe(false); // no principal lineage → Gate B blocks (75 < 90)
   });
 
   it('the #1126 elevated gate rejects a woken system-lineage task at ANY score (never a live turn)', async () => {

--- a/tests/unit/channels/http/jobs-routes.test.ts
+++ b/tests/unit/channels/http/jobs-routes.test.ts
@@ -238,6 +238,12 @@ describe('Job routes', () => {
     expect(scheduler.createJob).toHaveBeenLastCalledWith(
       expect.objectContaining({ originator: undefined }),
     );
+    // The dropped lineage must be observable with the job id so the later propose-only
+    // consequence is correlatable back to creation (#1127 observability).
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: 'job-1', channel: 'console' }),
+      expect.stringContaining('WITHOUT principal lineage'),
+    );
   });
 
   it('POST /api/jobs returns 400 when agent_id is missing', async () => {

--- a/tests/unit/channels/http/jobs-routes.test.ts
+++ b/tests/unit/channels/http/jobs-routes.test.ts
@@ -185,6 +185,9 @@ describe('Job routes', () => {
   });
 
   it('POST /api/jobs stamps a principal TaskOriginator (#1127)', async () => {
+    // Stub createJob to return the SAME id the read-back resolves, so the test can't pass with a
+    // mismatched row id (CodeRabbit) — the route must read back / log the id createJob returned.
+    vi.mocked(scheduler.createJob).mockResolvedValueOnce({ jobId: 'job-2', agentTaskId: undefined });
     const createdJob = {
       id: 'job-2',
       agentId: 'agent-a',
@@ -215,11 +218,14 @@ describe('Job routes', () => {
         }),
       }),
     );
+    expect(scheduler.getJob).toHaveBeenCalledWith('job-2');
   });
 
   it('POST /api/jobs falls back to no originator when no principal exists (#1127)', async () => {
     // Fresh-install case: no principal contact yet → conservative null lineage, no failure.
     vi.mocked(contactService.findContactBySystemRole).mockResolvedValueOnce(null);
+    // createJob and getJob share the same id so the correlation assertion is meaningful.
+    vi.mocked(scheduler.createJob).mockResolvedValueOnce({ jobId: 'job-3', agentTaskId: undefined });
     const createdJob = { id: 'job-3', agentId: 'agent-a', originator: null } as unknown as JobRow;
     vi.mocked(scheduler.getJob).mockResolvedValueOnce(createdJob);
 
@@ -238,12 +244,13 @@ describe('Job routes', () => {
     expect(scheduler.createJob).toHaveBeenLastCalledWith(
       expect.objectContaining({ originator: undefined }),
     );
-    // The dropped lineage must be observable with the job id so the later propose-only
-    // consequence is correlatable back to creation (#1127 observability).
+    // The dropped lineage must be observable with the job id createJob returned, so the later
+    // propose-only consequence is correlatable back to creation (#1127 observability).
     expect(mockLogger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ jobId: 'job-1', channel: 'console' }),
+      expect.objectContaining({ jobId: 'job-3', channel: 'console' }),
       expect.stringContaining('WITHOUT principal lineage'),
     );
+    expect(scheduler.getJob).toHaveBeenCalledWith('job-3');
   });
 
   it('POST /api/jobs returns 400 when agent_id is missing', async () => {

--- a/tests/unit/channels/http/jobs-routes.test.ts
+++ b/tests/unit/channels/http/jobs-routes.test.ts
@@ -5,11 +5,15 @@ import { jobRoutes } from '../../../../src/channels/http/routes/jobs.js';
 import type { SchedulerService } from '../../../../src/scheduler/scheduler-service.js';
 import type { JobRow } from '../../../../src/scheduler/scheduler-service.js';
 import type { SessionStore } from '../../../../src/channels/http/session-auth.js';
+import type { ContactService } from '../../../../src/contacts/contact-service.js';
+import type { Logger } from '../../../../src/logger.js';
 
 // Shared bootstrap secret used across all tests.
 const TEST_SECRET = 'test-bootstrap-secret';
 // Auth header included in every inject call so assertSecret passes.
 const AUTH = { 'x-web-bootstrap-secret': TEST_SECRET };
+// The principal contact resolveConsoleOriginator() looks up to stamp lineage (#1127).
+const PRINCIPAL_CONTACT_ID = 'contact-principal';
 
 /** Build a mock SchedulerService with vi.fn() stubs for every method the routes call. */
 function mockSchedulerService(): SchedulerService {
@@ -23,8 +27,23 @@ function mockSchedulerService(): SchedulerService {
   } as unknown as SchedulerService;
 }
 
+/** Minimal ContactService stub: resolves the principal so jobs get principal lineage. */
+function mockContactService(): ContactService {
+  return {
+    findContactBySystemRole: vi.fn().mockResolvedValue({ id: PRINCIPAL_CONTACT_ID }),
+  } as unknown as ContactService;
+}
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as unknown as Logger;
+
 describe('Job routes', () => {
   const scheduler = mockSchedulerService();
+  const contactService = mockContactService();
   const sessions: SessionStore = new Map();
   const app = Fastify();
 
@@ -35,6 +54,8 @@ describe('Job routes', () => {
       schedulerService: scheduler,
       webAppBootstrapSecret: TEST_SECRET,
       sessions,
+      contactService,
+      logger: mockLogger,
     });
     await app.ready();
   });
@@ -160,6 +181,62 @@ describe('Job routes', () => {
         cronExpr: '0 9 * * *',
         createdBy: 'api',
       }),
+    );
+  });
+
+  it('POST /api/jobs stamps a principal TaskOriginator (#1127)', async () => {
+    const createdJob = {
+      id: 'job-2',
+      agentId: 'agent-a',
+      originator: null,
+    } as unknown as JobRow;
+    vi.mocked(scheduler.getJob).mockResolvedValueOnce(createdJob);
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/jobs',
+      headers: AUTH,
+      payload: {
+        agent_id: 'agent-a',
+        cron_expr: '0 9 * * *',
+        task_payload: { task: 'daily-report' },
+      },
+    });
+
+    // The console is a CEO-only surface, so the job must carry principal lineage.
+    expect(contactService.findContactBySystemRole).toHaveBeenCalledWith('principal');
+    expect(scheduler.createJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        originator: expect.objectContaining({
+          contactId: PRINCIPAL_CONTACT_ID,
+          systemRole: 'principal',
+          channel: 'console',
+          tier: 'principal',
+        }),
+      }),
+    );
+  });
+
+  it('POST /api/jobs falls back to no originator when no principal exists (#1127)', async () => {
+    // Fresh-install case: no principal contact yet → conservative null lineage, no failure.
+    vi.mocked(contactService.findContactBySystemRole).mockResolvedValueOnce(null);
+    const createdJob = { id: 'job-3', agentId: 'agent-a', originator: null } as unknown as JobRow;
+    vi.mocked(scheduler.getJob).mockResolvedValueOnce(createdJob);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/jobs',
+      headers: AUTH,
+      payload: {
+        agent_id: 'agent-a',
+        cron_expr: '0 9 * * *',
+        task_payload: { task: 'daily-report' },
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(scheduler.createJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({ originator: undefined }),
     );
   });
 

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -34,8 +34,13 @@ function createContactService(): ContactService {
     setRole: vi.fn(),
     updateContactFields: vi.fn(),
     validatePrimaryEmail: vi.fn(),
+    // Resolves the principal so console-created tasks carry principal lineage (#1127).
+    findContactBySystemRole: vi.fn().mockResolvedValue({ id: PRINCIPAL_CONTACT_ID }),
   } as unknown as ContactService;
 }
+
+// The principal contact id resolveConsoleOriginator() stamps on console-created tasks (#1127).
+const PRINCIPAL_CONTACT_ID = 'contact-principal';
 
 // Creates a pool mock that also supports pool.connect() for transaction tests.
 function createTransactionalPool(client: Partial<PoolClient>): Pick<Pool, 'query' | 'connect'> {
@@ -693,6 +698,85 @@ describe('knowledgeGraphRoutes', () => {
 
       expect(res.statusCode).toBe(400);
       expect(contactService.createContact).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe('POST /api/kg/tasks — principal lineage (#1127)', () => {
+    // Helper: register the routes with a contactService stub and return both so tests can
+    // inspect findContactBySystemRole and the INSERT params.
+    async function setupTasksApp(contactService: ContactService) {
+      const app = Fastify();
+      await app.register(knowledgeGraphRoutes, {
+        pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'secret-1',
+        secureCookies: false,
+        sessions: new Map(),
+        contactService,
+        bus: createMockBus(),
+        eventRouter: createMockEventRouter(),
+      });
+      return app;
+    }
+
+    const validPayload = { agentId: 'coordinator', intentAnchor: 'follow up with vendor' };
+
+    it('stamps a principal TaskOriginator on the inserted task row', async () => {
+      const contactService = createContactService();
+      // INSERT returns the created row.
+      (pool.query as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'task-1', agent_id: 'coordinator', title: 'follow up with vendor' }],
+      });
+      const app = await setupTasksApp(contactService);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/kg/tasks',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: validPayload,
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(contactService.findContactBySystemRole).toHaveBeenCalledWith('principal');
+
+      // The INSERT is the single pool.query call; its last param is the originator JSON.
+      const insertCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      const sql = insertCall[0] as string;
+      const params = insertCall[1] as unknown[];
+      expect(sql).toContain('originator');
+      const originatorJson = params[params.length - 1] as string;
+      expect(JSON.parse(originatorJson)).toMatchObject({
+        contactId: PRINCIPAL_CONTACT_ID,
+        systemRole: 'principal',
+        channel: 'console',
+        tier: 'principal',
+      });
+      await app.close();
+    });
+
+    it('falls back to null originator when no principal contact exists', async () => {
+      const contactService = createContactService();
+      vi.mocked(contactService.findContactBySystemRole).mockResolvedValueOnce(null);
+      (pool.query as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'task-2', agent_id: 'coordinator', title: 'follow up with vendor' }],
+      });
+      const app = await setupTasksApp(contactService);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/kg/tasks',
+        headers: { 'x-web-bootstrap-secret': 'secret-1' },
+        payload: validPayload,
+      });
+
+      expect(res.statusCode).toBe(201);
+      const insertCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      const params = insertCall[1] as unknown[];
+      // Conservative default: no lineage stamped, but the task is still created.
+      expect(params[params.length - 1]).toBeNull();
       await app.close();
     });
   });

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -707,9 +707,10 @@ describe('knowledgeGraphRoutes', () => {
     // inspect findContactBySystemRole and the INSERT params.
     async function setupTasksApp(contactService: ContactService) {
       const app = Fastify();
+      const logger = createLogger();
       await app.register(knowledgeGraphRoutes, {
         pool,
-        logger: createLogger(),
+        logger,
         webAppBootstrapSecret: 'secret-1',
         secureCookies: false,
         sessions: new Map(),
@@ -717,7 +718,7 @@ describe('knowledgeGraphRoutes', () => {
         bus: createMockBus(),
         eventRouter: createMockEventRouter(),
       });
-      return app;
+      return { app, logger };
     }
 
     const validPayload = { agentId: 'coordinator', intentAnchor: 'follow up with vendor' };
@@ -729,7 +730,7 @@ describe('knowledgeGraphRoutes', () => {
         rowCount: 1,
         rows: [{ id: 'task-1', agent_id: 'coordinator', title: 'follow up with vendor' }],
       });
-      const app = await setupTasksApp(contactService);
+      const { app } = await setupTasksApp(contactService);
 
       const res = await app.inject({
         method: 'POST',
@@ -763,7 +764,7 @@ describe('knowledgeGraphRoutes', () => {
         rowCount: 1,
         rows: [{ id: 'task-2', agent_id: 'coordinator', title: 'follow up with vendor' }],
       });
-      const app = await setupTasksApp(contactService);
+      const { app, logger } = await setupTasksApp(contactService);
 
       const res = await app.inject({
         method: 'POST',
@@ -777,6 +778,11 @@ describe('knowledgeGraphRoutes', () => {
       const params = insertCall[1] as unknown[];
       // Conservative default: no lineage stamped, but the task is still created.
       expect(params[params.length - 1]).toBeNull();
+      // The drop must be observable with the created task id for later correlation (#1127).
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'task-2', channel: 'console' }),
+        expect.stringContaining('WITHOUT principal lineage'),
+      );
       await app.close();
     });
   });

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -754,6 +754,10 @@ describe('knowledgeGraphRoutes', () => {
         channel: 'console',
         tier: 'principal',
       });
+      // Omitted source defaults to 'ceo' (non-derived), not 'agent' (#1127) — otherwise the
+      // heartbeat would mark the task derived and the ladder would downgrade the lineage we
+      // just stamped. source is the 9th INSERT param ($9).
+      expect(params[8]).toBe('ceo');
       await app.close();
     });
 

--- a/tests/unit/contacts/principal.test.ts
+++ b/tests/unit/contacts/principal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { isPrincipalOriginated, isAgentOriginated, isSystemOriginated, isLivePrincipalTurn, makeSystemOriginator, capOriginatorToParent } from '../../../src/contacts/principal.js';
+import { isPrincipalOriginated, isAgentOriginated, isSystemOriginated, isLivePrincipalTurn, makeSystemOriginator, makePrincipalOriginator, capOriginatorToParent } from '../../../src/contacts/principal.js';
 import type { TaskOriginator } from '../../../src/contacts/types.js';
 
 describe('isPrincipalOriginated', () => {
@@ -162,6 +162,33 @@ describe('makeSystemOriginator', () => {
 
     expect(new Date(a.initiatedAt).getTime()).not.toBeNaN();
     expect(new Date(b.initiatedAt).getTime()).not.toBeNaN();
+    expect(a.initiatedAt).not.toBe(b.initiatedAt);
+  });
+});
+
+describe('makePrincipalOriginator (#1127 — console / principal surface)', () => {
+  it('returns a principal-lineage TaskOriginator stamped with the given contactId and channel', () => {
+    const originator = makePrincipalOriginator('contact-principal', 'console');
+    expect(originator.contactId).toBe('contact-principal');
+    expect(originator.systemRole).toBe('principal');
+    expect(originator.channel).toBe('console');
+    expect(originator.tier).toBe('principal');
+    expect(originator.initiatedAt).toBeTruthy();
+  });
+
+  it('reads as principal-originated but never as a live turn (lineage only)', () => {
+    const metadata = { originator: makePrincipalOriginator('contact-principal', 'console') };
+    expect(isPrincipalOriginated(metadata)).toBe(true);
+    // Lineage alone must not satisfy the live-principal (elevated) gate — no liveTurn signal.
+    expect(isLivePrincipalTurn(false, metadata)).toBe(false);
+  });
+
+  it('generates a fresh initiatedAt timestamp on each call', () => {
+    vi.useFakeTimers({ now: new Date('2026-01-01T00:00:00Z') });
+    const a = makePrincipalOriginator('c', 'console');
+    vi.advanceTimersByTime(1000);
+    const b = makePrincipalOriginator('c', 'console');
+    vi.useRealTimers();
     expect(a.initiatedAt).not.toBe(b.initiatedAt);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1127 (step 3 of 3 of #1060).

Tasks and `scheduled_jobs` created from the **console** (`apps/console`) are now stamped with a principal `TaskOriginator` (`systemRole: 'principal'`, the principal's `contactId`, `channel: 'console'`, `tier: 'principal'`). The console's bootstrap secret is CEO-only, so console-initiated work is unambiguously principal-originated. Under the woken-task-authorization model (#1125/#1126) a missing originator defaults to the conservative agent / no-bypass standing, which would silently strand console-created work in propose-only mode once the heartbeat wakes it.

**Scope is durable lineage only.** These are persisted, async-wakeable rows — never a live principal turn — so they deliberately never set the `liveTurn` signal. Setting it on a wakeable row would be a self-approval hazard (per design note §4).

## Changes

- `makePrincipalOriginator(contactId, channel)` factory in `src/contacts/principal.ts` (mirrors `makeSystemOriginator`).
- `resolveConsoleOriginator()` helper (`src/channels/http/console-originator.ts`): resolves the principal contact and stamps `channel='console'` lineage; degrades to `null` (conservative default, with a logged warning) when no principal exists or the lookup fails — it never throws and never fails the create.
- **POST `/api/kg/tasks`** stamps the originator on the inserted task row (top-level task, so the #1125 parent-cap is a no-op).
- **POST `/api/jobs`** passes the originator to `createJob` (consistent with `scheduler-create`'s principal path); `contactService` + `logger` wired into `jobRoutes`.
- Observability: when lineage is dropped, a warning is re-logged **after** the row is created, carrying the row id + `channel`, so the later propose-only consequence is correlatable back to creation.

## Live console chat path (verification, no code change)

Per the #1126 update on the issue: the live console chat path (`POST /api/kg/chat/messages`) publishes on the `web` channel, which `contact-resolver.ts` resolves to the principal (`systemRole: 'principal'`). So the dispatcher's channel-agnostic `liveTurn = (originator.systemRole === 'principal')` stamp already fires for live console turns — no work needed here. Confirmed in `src/contacts/contact-resolver.ts:44-73`.

## Tests

- Unit: `makePrincipalOriginator` (principal lineage, never a live turn).
- Route: both console creation paths assert a principal originator is stamped, plus the conservative null-fallback path (request still succeeds, drop is logged with the row id).
- Integration (`woken-task-authorization.test.ts`): a console-created top-level task, heartbeat-woken at posture B, retains principal standing and its principal-bypass fires for a `normal`+`critical` skill at score 75 — with an agent-lineage control that is correctly blocked.

All unit tests (4165) + the touched integration suites pass; typecheck + lint clean.

## Acceptance criteria

- [x] Tasks created via the console carry a principal `TaskOriginator`.
- [x] Scheduled jobs created via the console carry a principal `TaskOriginator` (consistent with `scheduler-create`).
- [x] Tests assert the originator is principal for each console creation path.
- [x] Integration test: a principal-bypass action initiated from a console-created task behaves as principal-originated.
- [x] Verified the live console chat path resolves the sender to the principal so the dispatcher's `liveTurn` stamp fires.