### PR TITLE
docs: add AGENTS.md with Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+Project-wide engineering conventions live in `CLAUDE.md` (architecture, code style,
+migrations, release process). Read that first. This file adds environment/run notes.
+
+## Cursor Cloud specific instructions
+
+These notes are for cloud agents working in an already-provisioned VM (the startup
+update script has already run `pnpm install`). They capture non-obvious setup/run
+caveats; standard commands live in `package.json` scripts and `scripts/setup.sh`.
+
+### Toolchain
+- **Node 24** is the target (`.nvmrc` = 24, `engines.node` >= 24). The VM's default
+  system `node` (at `/exec-daemon`) is v22; Node 24 is installed via nvm and prepended
+  to `PATH` in `~/.bashrc`, so `node`/`pnpm` already resolve to v24 + pnpm 11.7.0
+  (corepack). Confirm with `node --version` if something looks off.
+- Package manager is **pnpm** (workspace with `apps/console`). Use `pnpm`, never npm/yarn.
+
+### Postgres (required for running the app and integration tests)
+- Postgres 16 + pgvector + pgAudit runs via Docker Compose (`docker/postgres.Dockerfile`).
+- **Docker is not auto-started** (no systemd in the VM) and **docker needs `sudo`**
+  (the `ubuntu` user is not in the `docker` group). Start the daemon once per session:
+  `sudo dockerd > /tmp/dockerd.log 2>&1 &` (a tmux session works well), then
+  `sudo docker compose up -d postgres`. Wait for the container to be `healthy`.
+- Host-side tools (`pnpm migrate`, `pnpm dev`) connect via `DATABASE_URL` in `.env`
+  (localhost:5432). Inside the `curia` container the URL is overridden to use the
+  `postgres` service name.
+
+### Secrets / `.env` / vault (why the app may refuse to boot)
+- `.env` holds only the values needed to *unlock* the vault: `DB_USER`, `DB_PASSWORD`,
+  `DATABASE_URL`, `SECRET_ENCRYPTION_KEY` (+ optional `HTTP_PORT`, `TIMEZONE`, `LOG_LEVEL`).
+  `pnpm run setup` generates it interactively; for non-interactive setup, template it
+  from `.env.example` and fill those four values (see `scripts/setup.sh`).
+- All API keys live in an **encrypted vault** (Postgres `secrets` table), NOT in `.env`.
+  Seed them after migrations with `pnpm run seed-vault` (reads UPPER_SNAKE env vars).
+- The app **fails to boot** unless three secrets are present in the vault:
+  `anthropic_api_key`, `api_token`, `web_app_bootstrap_secret` (see `src/index.ts`
+  boot guards and `scripts/seed-vault.ts`). The boot guard only checks they are
+  non-empty, so a **placeholder `ANTHROPIC_API_KEY` lets the app boot and the web
+  console / onboarding work, but any agent/LLM call (chat, the wizard's
+  `suggest-name`) returns `401 invalid x-api-key`.** A real Anthropic key is required
+  to exercise agents end to end.
+
+### Running in development
+- `pnpm dev` runs migrations (`predev`) then, via `concurrently`, the backend
+  (`tsx watch`, HTTP API on **:3000**) and the console Vite dev server on **:5173**
+  (Vite proxies `/api` and `/auth` to :3000). The backend also serves the built
+  console from `apps/console/dist` at :3000 if that build exists.
+- **Backend logs go to `curia.log`** (pino), not the `pnpm dev` stdout — tail that file
+  to see backend errors. `GET /api/health` is the readiness check.
+- Login: enter the `web_app_bootstrap_secret` value as the "Access key" on the login
+  page (`POST /auth` sets a session cookie).
+- First-run **onboarding wizard** shows until a principal exists AND the office identity
+  has been saved (an `office_identity_versions` row with `changed_by` in
+  `wizard`/`api`). The wizard's final step calls `POST /api/setup/restart`, which
+  exits the process expecting a supervisor (Docker) to restart it — there is **no
+  supervisor in `pnpm dev`**, so that restart-to-chat flow won't auto-recover. To
+  reach the main console without it, `PUT /api/identity` (body `{identity, changedBy:"wizard"}`)
+  to mark identity configured, then restart the backend yourself.
+
+### Lint / typecheck / test / build (commands in `package.json`)
+- Lint: `pnpm run lint`. Typecheck: `pnpm run typecheck` (3 tsconfigs) and
+  `pnpm --filter @curia/console run typecheck`. Build console: `pnpm --filter @curia/console run build`.
+- Tests: `pnpm test` (vitest). Integration tests **require `DATABASE_URL`** and applied
+  migrations; they `describe.skip` when it is unset. Mirror CI by using a separate
+  `curia_test` DB: create it, migrate it, then
+  `DATABASE_URL=postgres://curia:<pw>@localhost:5432/curia_test LOG_LEVEL=error pnpm test`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`AGENTS.md`** — adds cloud-agent environment notes (Node 24 toolchain, Docker-based Postgres, vault-seeded secrets, dev-mode run/login caveats, and how to run lint/typecheck/test/build).
 - **Console task lineage** — tasks and scheduled jobs created from the console now carry a principal `TaskOriginator` (`channel: 'console'`), and console tasks default to a non-derived `source: 'ceo'`, so console-originated work is no longer stranded propose-only when later woken. (#1127)
 - **Health observability** — `GET /api/health` returns `ok` / `degraded` / `down` with per-check status for seven services; `down` (503) only when db or bus fails. (#434)
 - **Daily canary job** — scheduler job validates LLM tiers, credentials, and external deps on a cron schedule; pings configured heartbeat URLs on success. (#434)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Curia development environment for Cursor Cloud agents and documents the
non-obvious bits so future agents can start services without re-discovering them. No
application code changed — only `AGENTS.md` (new) and a `CHANGELOG.md` entry.

The startup **update script** is configured to `pnpm install --frozen-lockfile`
(dependency refresh only). Service startup (Docker/Postgres) and secret seeding are
documented in `AGENTS.md`, not baked into the update script.

## Changes

- Add `AGENTS.md` `## Cursor Cloud specific instructions`: Node 24 toolchain (the VM's
  default `node` is v22; Node 24 is on `PATH` via `~/.bashrc`), Docker-based Postgres
  (needs `sudo`, not auto-started), the encrypted-vault secrets model (the app refuses
  to boot without `anthropic_api_key`/`api_token`/`web_app_bootstrap_secret`), `pnpm dev`
  run/login caveats (backend logs to `curia.log`; wizard's final step expects a
  supervisor restart), and the lint/typecheck/test/build commands.
- Add a `CHANGELOG.md` `[Unreleased] → Added` entry for `AGENTS.md`.

## Verification

Ran against a fully provisioned VM (Node 24, pnpm 11.7.0, Docker + Postgres 16/pgvector/pgAudit):

- `pnpm run lint` — passes (1 pre-existing warning)
- `pnpm run typecheck` + `pnpm --filter @curia/console run typecheck` — pass
- `pnpm --filter @curia/console run build` — passes
- `pnpm test` (against migrated `curia_test` DB) — 4336 passed, 23 skipped
- `pnpm dev` — backend healthy on :3000 (`/api/health` `ok`), Vite console on :5173;
  logged in, walked onboarding (created the `Ada Lovelace` principal), saved a contact
  edit via the UI, and held a full agent chat (coordinator replied via Anthropic Claude
  once the real `ANTHROPIC_API_KEY` was seeded into the vault).

## Related Issues

n/a

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [ ] Tests added/updated for new functionality (docs-only change)
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes (n/a)
- [x] CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05583206-3d2f-4947-9dfb-4903a51c7762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05583206-3d2f-4947-9dfb-4903a51c7762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

