### PR TITLE
fix: thread TaskOriginator onto wake_at self-deferral wake jobs (#1153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`wake_at` self-deferral lineage** — a task that defers itself via `wake_at` now stamps its `TaskOriginator` onto the wake job, so a principal-lineage task keeps its autonomy bypass on wake instead of flooring to agent; pre-chosen, so no `standing` envelope is written and the heartbeat ladder never runs (`elevated` still blocked — not a live turn). (#1153)
 - **Health LLM canary** — derives tier failure from an explicit most-recent-outcome flag instead of comparing `lastErrorAt > lastSuccessAt`, which tied (and masked the error as healthy) when both landed in the same millisecond. (#1163)
 - **`outbound-gateway`** — content-filter blocks now return the principal-safe reason and rule names so agents can self-correct and retry. (#1051)
 - **`outbound-gateway` draft path** — `sendEmailDraft()` blocks now return the same principal-safe reason and rule names, so blocked draft sends are self-correctable too. (#1158)

--- a/docs/wip/2026-06-22-woken-task-authorization-design.md
+++ b/docs/wip/2026-06-22-woken-task-authorization-design.md
@@ -102,22 +102,24 @@ That cleanly separates the three cases:
 |---|---|---|---|
 | BacklogHeartbeat wake | yes | yes | laddered (may downgrade) |
 | `scheduler-create` job | yes | no | keeps originator, no ladder (pre-authorized) |
-| task `wake_at` self-defer | see §3b | no | keeps originator, no ladder (pre-authorized) |
+| task `wake_at` self-defer | yes (#1153) | no | keeps originator, no ladder (pre-authorized) |
 
 The marker is keyed on the envelope, not on `job.originator`, so a heartbeat wake of a
 pre-065 / unstamped task (null originator) still gets a `wakeContext` — the ladder is a
 no-op on null lineage, but the path stays uniform. **"Derived" is structural:**
 `source = 'agent' OR parent_task_id IS NOT NULL`, computed in `selectHeartbeatCandidates`.
 
-### 3b. Known gap: task `wake_at` self-deferral drops lineage
+### 3b. Resolved (#1153): task `wake_at` self-deferral keeps lineage
 
-A task that defers itself via its own `wake_at` column currently mints a one-shot wake job
-with **no** originator and no `standing` envelope (see the `@TODO(#1125/#1127)` in
-[`task-repo.ts`](../../src/db/task-repo.ts)), so it fires with `metadata: undefined` and
-floors to agent / no-bypass. But a `wake_at` time is *pre-chosen*, so it should be treated
-like `scheduler-create` — **keep** the originator at fire time, **not** laddered, **not**
-floored. As shipped it under-authorizes a principal-lineage task that self-defers. Out of
-scope for #1125 (heartbeat path only); tracked as #1153.
+**Status: shipped in #1153.** Previously a task that defers itself via its own `wake_at` column
+minted a one-shot wake job with **no** originator and no `standing` envelope, so it fired with
+`metadata: undefined` and floored to agent / no-bypass — under-authorizing a principal-lineage
+self-deferral. A `wake_at` time is *pre-chosen*, so it is now treated like `scheduler-create`:
+both `wake_at` mint sites in [`task-repo.ts`](../../src/db/task-repo.ts) (the `createTask` CTE and
+the `updateTask` `_new_wake` arm) now persist the task's `originator` onto the wake job's
+`scheduled_jobs` row, while still writing **no** `standing` envelope. `fireJob` therefore threads
+the originator with no `wakeContext` — the bypass ladder never runs (the time was already decided)
+and the originator is **kept** at fire time, not floored.
 
 > **Interaction with #1126.** Fixing #1153 restores only the *autonomy* principal-bypass
 > (for `normal` skills) — it carries no `standing` envelope, so it mints no `wakeContext` and
@@ -285,9 +287,10 @@ Three issues, completed in order:
   propose-only). Scope is durable **lineage** only; whether a *live* console interaction sets
   the `liveTurn` signal is a dispatch-path question now that #1126 has shipped the mechanism —
   see the note on the issue.
-- **#1153 (follow-up, depends on #1125):** thread `TaskOriginator` onto task `wake_at`
-  self-deferral wake jobs so a pre-chosen deferral keeps its originator at fire time
-  (no ladder) instead of flooring to agent — see §3b.
+- **#1153 (follow-up, depends on #1125) — SHIPPED.** Threaded `TaskOriginator` onto task
+  `wake_at` self-deferral wake jobs (both the `createTask` CTE and the `updateTask` `_new_wake`
+  arm) so a pre-chosen deferral keeps its originator at fire time (no ladder) instead of flooring
+  to agent — see §3b.
 
 Doc-sync lands with the implementation PRs (specs describe shipped behaviour): ADR-011,
 ADR-017 (+ ADR-018 cross-ref), spec 03 (Skills & Execution), spec 14 (Autonomy Engine),

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -164,12 +164,13 @@ export class TaskRepo {
       // The task_payload carries minimal context; the dispatcher (issue 4) loads the full
       // task from tasks.id via the scheduled_jobs.task_id FK.
       //
-      // @TODO(#1125/#1127): this specific-`wake_at` wake job does NOT carry the originator on its
-      // scheduled_jobs row (and stamps no `standing`), so fireJob fires it with metadata: undefined
-      // — the woken task gets no lineage, no wakeContext, and therefore no bypass. That is the
-      // conservative/safe direction (propose-only), and deliberately out of #1125's scope, which
-      // covers only the open-ended BacklogHeartbeat path. Threading lineage onto specific wakes is
-      // a follow-up (it must NOT be subject to the heartbeat ladder — the time was pre-chosen).
+      // The wake job carries the task's `originator` (selected straight from new_task, so it is
+      // definitionally the same, parent-capped lineage stamped on the task) but writes NO `standing`
+      // envelope (#1153). A `wake_at` time is pre-chosen, so this is a pre-authorized deferral, the
+      // same category as a `scheduler-create` job: fireJob threads `job.originator` onto the fired
+      // agent.task but mints no `wakeContext`, so it KEEPS its originator at fire time and is NOT
+      // subject to the heartbeat bypass ladder (the time was already decided). It is still not a live
+      // principal turn, so `elevated` authority primitives remain blocked on wake (see design §3b).
       const cteSql = `
         WITH new_task AS (
           INSERT INTO tasks (
@@ -182,8 +183,8 @@ export class TaskRepo {
           RETURNING ${TASK_COLUMNS}
         ),
         _wake_job AS (
-          INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id)
-          SELECT $17, $18, '{"type":"task-wake"}'::jsonb, 'pending', $18, $19, $20, new_task.id
+          INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id, originator)
+          SELECT $17, $18, '{"type":"task-wake"}'::jsonb, 'pending', $18, $19, $20, new_task.id, new_task.originator
           FROM new_task
         )
         SELECT * FROM new_task
@@ -390,6 +391,7 @@ export class TaskRepo {
       const wakeRunAtIdx = updates.wakeAt ? whereIdx + 2 : null;
       const wakeCreatedByIdx = updates.wakeAt ? whereIdx + 3 : null;
       const wakeTzIdx = updates.wakeAt ? whereIdx + 4 : null;
+      const wakeOriginatorIdx = updates.wakeAt ? whereIdx + 5 : null;
 
       const cteSql = `
         WITH updated_task AS (
@@ -400,9 +402,9 @@ export class TaskRepo {
           WHERE task_id = $${whereIdx} AND status = 'pending'
         )${updates.wakeAt ? `,
         _new_wake AS (
-          INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id)
+          INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id, originator)
           VALUES ($${wakeAgentIdx}, $${wakeRunAtIdx}, '{"type":"task-wake"}'::jsonb, 'pending',
-                  $${wakeRunAtIdx}, $${wakeCreatedByIdx}, $${wakeTzIdx}, $${whereIdx})
+                  $${wakeRunAtIdx}, $${wakeCreatedByIdx}, $${wakeTzIdx}, $${whereIdx}, $${wakeOriginatorIdx}::jsonb)
         )` : ''}
         SELECT * FROM updated_task
       `;
@@ -419,6 +421,10 @@ export class TaskRepo {
           updates.wakeAt,                                             // $wakeRunAtIdx
           callerAgentId ?? current.agentId,                          // $wakeCreatedByIdx
           this.timezone,                                             // $wakeTzIdx
+          // Carry the task's (immutable) lineage onto the new wake job so a self-deferral keeps its
+          // originator at fire time — no `standing` envelope, so fireJob mints no wakeContext and the
+          // bypass ladder never runs (a pre-chosen wake_at is pre-authorized, like scheduler-create) (#1153).
+          current.originator ? JSON.stringify(current.originator) : null, // $wakeOriginatorIdx
         );
       }
       const { rows } = await this.pool.query(cteSql, allParams);

--- a/tests/integration/task-repo-originator.test.ts
+++ b/tests/integration/task-repo-originator.test.ts
@@ -25,6 +25,13 @@ const SYSTEM: TaskOriginator = {
 };
 
 async function cleanup(pool: pg.Pool): Promise<void> {
+  // scheduled_jobs.task_id is ON DELETE SET NULL, so the wake-job rows minted by the wake_at
+  // tests must be deleted FIRST (while the task link still exists) — otherwise they'd survive
+  // the task delete as task_id=NULL orphans, polluting the shared test DB (#1153).
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [`${PREFIX}%`],
+  );
   // Children reference parents via parent_task_id — delete all test rows in one statement.
   await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
 }
@@ -70,5 +77,58 @@ describeIf('TaskRepo originator lineage (#1125)', () => {
       parentTaskId: parent.id, originator: PRINCIPAL,
     });
     expect(child.originator).toBeNull();
+  });
+
+  // #1153: a wake_at deferral is pre-chosen, so its wake job must carry the task's originator
+  // (like a scheduler-create job) and write NO `standing` envelope — fireJob then threads the
+  // originator with no wakeContext, keeping the principal autonomy-bypass without the heartbeat ladder.
+  describe('wake_at deferral threads originator onto the wake job (#1153)', () => {
+    /** Fetch every wake job linked to a task (newest first), for asserting originator + payload. */
+    async function wakeJobsFor(taskId: string) {
+      const { rows } = await pool.query<{
+        originator: TaskOriginator | null;
+        task_payload: Record<string, unknown>;
+        status: string;
+      }>(
+        `SELECT originator, task_payload, status FROM scheduled_jobs WHERE task_id = $1 ORDER BY created_at DESC`,
+        [taskId],
+      );
+      return rows;
+    }
+
+    it('createTask with wake_at persists the task originator (no standing envelope)', async () => {
+      const task = await repo.createTask({
+        agentId: 'coordinator', title: `${PREFIX} wake-create`, source: 'coordinator',
+        originator: PRINCIPAL, wakeAt: new Date(Date.now() + 3_600_000),
+      });
+      const jobs = await wakeJobsFor(task.id);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]!.originator).toEqual(PRINCIPAL);
+      // No standing envelope: payload is the bare task-wake marker. This is what keeps the wake
+      // out of the bypass ladder at fire time (the time was already decided).
+      expect(jobs[0]!.task_payload).toEqual({ type: 'task-wake' });
+    });
+
+    it('updateTask with wake_at persists the existing task originator onto the new wake job', async () => {
+      const task = await repo.createTask({
+        agentId: 'coordinator', title: `${PREFIX} wake-update`, source: 'coordinator', originator: PRINCIPAL,
+      });
+      const updated = await repo.updateTask(task.id, { wakeAt: new Date(Date.now() + 3_600_000) }, 'coordinator');
+      expect(updated).not.toBeNull();
+      const pending = (await wakeJobsFor(task.id)).filter((j) => j.status === 'pending');
+      expect(pending).toHaveLength(1);
+      expect(pending[0]!.originator).toEqual(PRINCIPAL);
+      expect(pending[0]!.task_payload).toEqual({ type: 'task-wake' });
+    });
+
+    it('a null-lineage task mints a wake job with null originator (no regression)', async () => {
+      const task = await repo.createTask({
+        agentId: 'coordinator', title: `${PREFIX} wake-nolineage`, source: 'coordinator',
+        wakeAt: new Date(Date.now() + 3_600_000),
+      });
+      const jobs = await wakeJobsFor(task.id);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]!.originator).toBeNull();
+    });
   });
 });

--- a/tests/integration/woken-task-authorization.test.ts
+++ b/tests/integration/woken-task-authorization.test.ts
@@ -18,6 +18,7 @@ import pg from 'pg';
 import pino from 'pino';
 import { selectHeartbeatCandidates } from '../../src/db/queries/tasks.js';
 import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+import { TaskRepo } from '../../src/db/task-repo.js';
 import { makePrincipalOriginator } from '../../src/contacts/principal.js';
 import { makeWakeContext } from '../../src/autonomy/effective-standing.js';
 import { ExecutionLayer } from '../../src/skills/execution.js';
@@ -55,14 +56,19 @@ function makeManifest(
   };
 }
 
-/** Rebuild the agent.task metadata exactly as Scheduler.fireJob does from a persisted wake row. */
+/** Rebuild the agent.task metadata exactly as Scheduler.fireJob does from a persisted wake row.
+ *  Mirrors fireJob precisely: the wakeContext marker is keyed on the `standing` envelope being
+ *  PRESENT, not merely on the task-wake payload type. A wake_at self-defer job (#1153) carries a
+ *  task-wake payload with NO standing, so it threads the originator but mints no wakeContext — i.e.
+ *  it keeps its originator like a scheduler-create fire and is not subject to the bypass ladder. */
 function metadataFromWakeRow(row: { originator: Record<string, unknown> | null; task_payload: Record<string, unknown> }) {
-  if (!row.originator) return undefined;
-  const meta: Record<string, unknown> = { originator: row.originator };
-  if (row.task_payload?.['type'] === 'task-wake') {
-    const standing = (row.task_payload as { standing?: { derived?: boolean } }).standing;
-    meta.wakeContext = makeWakeContext(standing?.derived === true);
-  }
+  const standing = row.task_payload?.['type'] === 'task-wake'
+    ? (row.task_payload as { standing?: { derived?: boolean } }).standing
+    : undefined;
+  if (!row.originator && !standing) return undefined;
+  const meta: Record<string, unknown> = {};
+  if (row.originator) meta.originator = row.originator;
+  if (standing) meta.wakeContext = makeWakeContext(standing.derived === true);
   return meta;
 }
 
@@ -256,5 +262,53 @@ describeIf('woken-task authorization (#1060 dedup scenario)', () => {
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toContain('live principal turn');
     }
+  });
+
+  it('a principal-lineage task self-deferring via wake_at keeps the autonomy bypass (no ladder), but elevated stays blocked (#1153)', async () => {
+    // The actual self-deferral path: TaskRepo mints the wake_at wake job. Unlike a heartbeat wake,
+    // it carries the task's originator but NO `standing` envelope — the time was pre-chosen, so the
+    // fire keeps the originator (like scheduler-create) and is not laddered.
+    const repo = new TaskRepo(
+      pool,
+      { publish: async () => {}, subscribe: () => {} } as unknown as EventBus,
+      logger as never,
+      'UTC',
+    );
+    const task = await repo.createTask({
+      agentId: 'coordinator', title: `${PREFIX} wake_at self-defer`, source: 'ceo',
+      originator: CONSOLE_PRINCIPAL_LINEAGE, wakeAt: new Date(Date.now() + 3_600_000),
+    });
+
+    const { rows } = await pool.query<{ originator: Record<string, unknown> | null; task_payload: Record<string, unknown> }>(
+      `SELECT originator, task_payload FROM scheduled_jobs WHERE task_id = $1`, [task.id],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.originator).toEqual(CONSOLE_PRINCIPAL_LINEAGE);
+    expect(rows[0]!.task_payload).toEqual({ type: 'task-wake' }); // no standing envelope
+
+    const taskMetadata = metadataFromWakeRow(rows[0]!);
+    // Originator threaded; no wakeContext (so computeEffectiveTaskMetadata applies no ladder).
+    expect(taskMetadata).toBeDefined();
+    expect(taskMetadata).not.toHaveProperty('wakeContext');
+
+    const handler: SkillHandler = { execute: async () => ({ success: true, data: 'acted as principal' }) };
+
+    // A `normal` + action_risk:'critical' skill (min score 90). At score 75 a non-principal task is
+    // blocked by Gate B; the wake's retained principal standing bypasses it — proof the bypass is
+    // intact on a self-deferral (the very asymmetry #1153 closes: heartbeat floors, wake_at keeps).
+    const registry = new SkillRegistry();
+    registry.register(makeManifest('commit-funds', 'normal', 'critical'), handler);
+    const allowed = await new ExecutionLayer(registry, logger, { autonomyService: makeAutonomyService(75) })
+      .invoke('commit-funds', {}, undefined, { taskMetadata });
+    expect(allowed.success).toBe(true);
+
+    // But a wake_at fire is NOT a live principal turn, so an `elevated` authority primitive stays
+    // blocked at any score — a pre-chosen deferral resumes work, it must not exercise authority.
+    const elevatedRegistry = new SkillRegistry();
+    elevatedRegistry.register(makeManifest('exercise-authority', 'elevated', 'none'), handler);
+    const blocked = await new ExecutionLayer(elevatedRegistry, logger, { autonomyService: makeAutonomyService(90) })
+      .invoke('exercise-authority', {}, undefined, { taskMetadata });
+    expect(blocked.success).toBe(false);
+    if (!blocked.success) expect(blocked.error).toContain('live principal turn');
   });
 });

--- a/tests/integration/woken-task-authorization.test.ts
+++ b/tests/integration/woken-task-authorization.test.ts
@@ -63,7 +63,8 @@ function makeManifest(
  *  it keeps its originator like a scheduler-create fire and is not subject to the bypass ladder. */
 function metadataFromWakeRow(row: { originator: Record<string, unknown> | null; task_payload: Record<string, unknown> }) {
   const standing = row.task_payload?.['type'] === 'task-wake'
-    ? (row.task_payload as { standing?: { derived?: boolean } }).standing
+    // Cast through `unknown` first per the repo's Record<string, unknown> narrowing rule (CLAUDE.md).
+    ? (row.task_payload as unknown as { standing?: { derived?: boolean } }).standing
     : undefined;
   if (!row.originator && !standing) return undefined;
   const meta: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Closes #1153. Follow-up to #1125 (depends on it); independent of #1126/#1127.

A task that defers itself via its own `wake_at` column minted a one-shot wake job with **no** `originator` and no `standing` envelope, so `fireJob` fired it with `metadata: undefined` and it floored to **agent / no-bypass**. A `wake_at` time is *pre-chosen*, which under the design note (§3) makes it **pre-authorized** — the same category as a `scheduler-create` job, which keeps its originator at fire time. As shipped, a principal-lineage task that self-deferred silently lost its principal-bypass on wake (fail-closed, but a real asymmetry: heartbeat wakes ladder, scheduler-create keeps principal, `wake_at` floored).

## What changed

Persist the task's `originator` onto the `wake_at` wake job's `scheduled_jobs` row at **both** mint sites in `src/db/task-repo.ts`, while writing **no** `standing` envelope:

- **`createTask` CTE** (`_wake_job`) — now `SELECT … new_task.originator` (definitionally the same parent-capped lineage stamped on the task).
- **`updateTask` `_new_wake` arm** — the literal self-deferral path (a running task rescheduling itself via `task-update`); now binds `current.originator` (the immutable lineage from the pre-update row) as a `::jsonb` param.

The issue scoped only the `createTask` CTE, but the same drop exists in `updateTask`'s `_new_wake` arm — which is the more literal "a task defers itself" path — and AC #1 reads generically ("a `wake_at` wake job"). Fixing only one would leave the headline scenario broken, so both are addressed.

`fireJob` keys the `wakeContext`/bypass-ladder marker on the `standing` field being present, **not** on the originator. So: originator present + no standing → `fireJob` threads `job.originator` but mints no `wakeContext` → the task **keeps** its principal autonomy-bypass and the heartbeat ladder never runs. The fire side needed no change (verified). `elevated` authority primitives stay blocked (a wake carries no `liveTurn` — see §3b).

No migration needed: `scheduled_jobs.originator` already exists (migration 040).

## Acceptance criteria

- [x] A `wake_at` wake job carries the task's `originator` on its `scheduled_jobs` row.
- [x] On fire, a principal-lineage `wake_at` task is treated as principal-originated for the **autonomy** principal-bypass (`normal` skills), with no ladder applied; `elevated` skills remain blocked.
- [x] The `@TODO(#1125/#1127)` in `task-repo.ts` is removed.
- [x] Test covering a principal-lineage task self-deferring via `wake_at` and waking with the autonomy bypass intact.

## Tests

All against real Postgres (`curia-test-pg`); written first (red), then green.

- `task-repo-originator.test.ts` — new `#1153` block: `createTask` + `updateTask` `wake_at` jobs carry the originator with a bare `{type:'task-wake'}` payload (no `standing`); a null-lineage task writes a null originator (no regression).
- `woken-task-authorization.test.ts` — end-to-end fire-path: a principal-lineage task self-defers via `wake_at`, fed through the real `ExecutionLayer`; the principal-bypass fires for a `normal`+`critical` skill at score 75 (no ladder), while an `elevated` skill stays blocked at any score. The `metadataFromWakeRow` helper was corrected to mirror `fireJob` exactly (keys `wakeContext` on `standing` presence, not the payload type).

Full run: 12/12 new + 184 scheduler/heartbeat regression tests pass; `typecheck` + `eslint` clean.

## Docs

- CHANGELOG `## [Unreleased]` → Fixed.
- Design note `docs/wip/2026-06-22-woken-task-authorization-design.md` §3b marked resolved; the §3a table row and status list updated.