### PR TITLE
feat(ceo-inbox): consult-and-resume scheduling via the calendar specialist (#1137, Layers 1+3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`calendar-find-free-time` / `calendar-check-conflicts`** — `free`-status events no longer block availability or count as conflicts; only busy/tentative events do. (#1137)
 - **`calendar-create-event`** — booking a real event now auto-releases any overlapping `curia-hold` events on the same calendar. (#1137)
 - **Nylas calendar client** — normalized events now surface event `metadata`; create/update pass through `metadata`/`status`/`busy`. (#1137)
-- **`ceo-inbox` scheduling replies** — now consults the calendar specialist via the bullpen before drafting, instead of drafting blind; offered slots are conflict-checked, held, and timezone-labelled by the specialist. (#1137)
+- **`ceo-inbox` scheduling replies** — consults the calendar specialist before drafting; slots are conflict-checked, held, and timezone-labelled. (#1137)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Woken-task authorization: lineage + bypass ladder**: tasks now persist their `TaskOriginator` lineage (migration 065), threaded through the heartbeat wake path so a woken task fires with provenance instead of `metadata: undefined`. A score-keyed *bypass ladder* computes effective standing at skill-invocation time: the live autonomy score can only ever downgrade a woken/derived task's inherited standing to agent (propose-only), never grant it (same-task wake keeps lineage at score ≥70, derived child at ≥90; thresholds configurable under `autonomy.bypass_ladder`). Foundation for #1060; spec 14, spec 19. (#1125)
 - **Calendar hold primitives** — `calendar-create-hold` places tentative `HOLD (TBC)` events on offered slots to prevent re-offers; `calendar-holds-sweep` removes expired holds daily. (#1137)
 - **Calendar specialist scheduling consult** — specialist handles bullpen `CONSULT REQUEST`s: resolves free slots, places holds, and replies with timezone-labelled strings. (#1137)
+- **`ceo-inbox` consult-and-resume** — scheduling emails park pending a calendar consult and draft on reply instead of guessing blind; convention documented in ADR-023. (#1137)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`calendar-find-free-time` / `calendar-check-conflicts`** — `free`-status events no longer block availability or count as conflicts; only busy/tentative events do. (#1137)
 - **`calendar-create-event`** — booking a real event now auto-releases any overlapping `curia-hold` events on the same calendar. (#1137)
 - **Nylas calendar client** — normalized events now surface event `metadata`; create/update pass through `metadata`/`status`/`busy`. (#1137)
+- **`ceo-inbox` scheduling replies** — now consults the calendar specialist via the bullpen before drafting, instead of drafting blind; offered slots are conflict-checked, held, and timezone-labelled by the specialist. (#1137)
 
 ### Fixed
 

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -181,13 +181,20 @@ system_prompt: |
   1. **Resolve calendars and timezones.** Call `entity-context` on
      `${principal_contact_id}` to get the CEO's registered calendar IDs and
      timezone (read `contact.timezone` — this is the authoritative column; do
-     not parse the `facts` array for timezone). If the request says
-     `contact_timezone=known` (or you otherwise want the contact's timezone),
-     and the consult only carries the contact's display name (not a contact ID),
-     first call `contact-lookup` on that display name to resolve the contact ID.
-     If `contact-lookup` returns no results or is ambiguous, treat the contact
-     timezone as unknown and label the CEO timezone only. Once you have the
-     contact ID, call `entity-context` on it to get their timezone the same way.
+     not parse the `facts` array for timezone). Then resolve the contact's
+     timezone using whichever path applies:
+     - If `contact_timezone` is an IANA timezone string (e.g.
+       `America/Los_Angeles`), use it directly — no lookup needed.
+     - If `contact_id` is also present, call `entity-context` on that ID for
+       any additional contact context, but the IANA timezone already in
+       `contact_timezone` takes precedence over the `entity-context` result.
+     - If `contact_timezone=unknown`, skip the contact timezone step — label
+       the CEO timezone only.
+     - If `contact_timezone=known` but no IANA string and no `contact_id`
+       (legacy consult format), call `contact-lookup` on the display name
+       from the `For:` line to resolve a contact ID, then call `entity-context`
+       on it. If `contact-lookup` returns no results or is ambiguous, treat the
+       contact timezone as unknown.
 
   2. **Recall scheduling preferences.** Call `memory-query` for stored
      scheduling rules (blocked times, meeting-length preferences, faith

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -77,9 +77,77 @@ system_prompt: |
   partnership"), handle that request directly using your pinned skills.
   Do NOT run the triage protocol. Respond to the specific request and return.
 
-  **Resume mode** (woken by the scheduler to advance a task you scheduled):
-  If you receive a scheduled wake that includes a task id, title, and progress
-  notes in the context, branch on the task's tags:
+  **Resume mode** (woken by the scheduler to advance a task you scheduled, or
+  woken by a bullpen reply on a calendar consult thread):
+  You are resuming prior work, not starting a fresh triage. First determine
+  which resume case applies, in this order:
+
+  **Branch A — Calendar consult reply (bullpen wake with a CONSULT REPLY):**
+  If the bullpen message body is a CONSULT REPLY (it starts with the line
+  `CONSULT REPLY` and contains `Result: ok`, `Result: no_slots`, or
+  `Result: escalate`), you are resuming a parked scheduling email. Proceed
+  through the sub-steps below, then exit — do not fall through to Branch B.
+
+  1. Extract `source_message_id` from the `Context:` line of the original
+     CONSULT REQUEST (it is carried forward in the bullpen thread). Call
+     `ceo-inbox-read` with that `message_id` to reload the original email.
+
+  2. **Result: ok** — the calendar specialist found slots with holds placed.
+     a. Call `executive-profile-get` to retrieve the voice profile for the draft.
+     b. For every date + day-of-week pair in the returned slot strings, call
+        `date-resolve` to verify the pairing before using it in the draft.
+     c. Call `ceo-inbox-draft-reply` using the calendar specialist's returned
+        slot display strings VERBATIM (e.g. "Thursday June 25 at 10:30 AM ET
+        (7:30 AM PT their time) - hold placed"). Do NOT rephrase or convert
+        timezones yourself — use the strings exactly as the specialist provided
+        them. Apply the CEO voice profile when composing surrounding text. Do
+        NOT include any "pending your calendar" qualifier — holds are already
+        placed.
+     d. Call `ceo-inbox-update-folders` with
+        `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`.
+        This records the ✍️ Drafted terminal classification and clears the
+        in-progress park marker so the message no longer shows under ⏳ In Progress.
+     e. Call `ceo-inbox-archive` with the message_id. (The message was already
+        marked read at park time — do not mark-read again.)
+
+  3. **Result: no_slots** — no free time found in the requested window; the
+     specialist returned nearest alternatives.
+     a. Follow steps 2a-b above (voice profile, date-resolve on alternatives).
+     b. Draft using the nearest-alternative slot strings from the CONSULT REPLY
+        `Nearest:` field VERBATIM. Add a brief note in the draft that times are
+        outside the originally requested window (plain language, no em dashes).
+     c. Call `ceo-inbox-update-folders` with
+        `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`.
+     d. Call `ceo-inbox-archive` with the message_id.
+
+  4. **Result: escalate** — the calendar specialist could not satisfy the
+     consult (no calendar access, repeated skill failures, unresolvable
+     constraints). Do NOT draft a reply.
+     a. Call `ceo-inbox-update-folders` with
+        `remove_folders: ['⏳ In Progress']` (clear the park marker).
+     b. Post a bullpen thread mentioning the coordinator with a structured
+        send request (🚨 Urgent priority):
+
+          @coordinator I'd like you to send a message to the CEO.
+
+          Urgency: immediate
+          Channel: Signal
+          Message: "Scheduling reply could not be drafted for <subject>. Calendar consult escalated: <Reason from CONSULT REPLY>"
+          Context bridge: agent_id=ceo-inbox, expected_reply="Instruction for handling scheduling", expires_in_hours=24
+
+     c. Do NOT archive — leave the message in the inbox for the CEO to handle.
+
+  **Failure handling for calendar consult resume:** If `bullpen.post` returned
+  `deduplicated: true` when the original consult was posted, it was already
+  parked — exit without re-labelling or re-consulting. If the consult was
+  posted but a CONSULT REPLY never arrives, the message stays read +
+  ⏳ In Progress + unarchived: it remains visible under the label, is never
+  silently dropped, and is never re-triaged (it is already read, so
+  `unread_only: true` will not surface it again).
+
+  **Scheduled-wake resume (task id + progress notes, no CONSULT REPLY):**
+  If the wake does not match Branch A — it is a scheduled wake that includes a
+  task id, title, and progress notes — branch on the task's tags:
 
   - **`inbox-drain` tag** → this is a batch-drain continuation you scheduled in
     Step 6 because the inbox still had unread mail. Do NOT run the reification
@@ -458,31 +526,42 @@ system_prompt: |
     ### Scheduling-specific drafting rules
 
     When a ✍️ Drafted email involves scheduling (the sender proposes days,
-    asks the CEO to suggest a time, or is negotiating a meeting slot):
+    asks the CEO to suggest a time, or is negotiating a meeting slot), do NOT
+    draft blind. Instead, consult the calendar specialist and park the work:
 
-    1. **Be specific.** Propose a concrete date AND time (e.g. "Monday
-       May 18 at 10:30 AM"). Never write "before 2pm" or "in the morning"
-       — pick a slot. Never say "happy to suggest a time" or "let me know
-       what works" when the sender already asked you to suggest times.
+    1. **Tap — post a CONSULT REQUEST to the bullpen.** Call `bullpen.post`
+       mentioning `calendar`, with content shaped exactly as follows:
 
-    2. **Offer one alternative.** Primary time plus one backup on a different
-       day (e.g. "Would Monday May 18 at 10:30 AM work? If not, Wednesday
-       May 20 at 11:00 AM could also work.").
+         CONSULT REQUEST
+         Need: 2 conflict-free 30-min slots, with holds placed, returned timezone-labelled
+         For:  reply to <contact display name> re "<subject>"
+         By:   slots within <date window / stated constraints from the email>
+         Context: source_message_id=<the email's message_id>; contact_timezone=<known|unknown>
 
-    3. **Respect stated constraints.** If the sender said "Monday/Wednesday/
-       Friday before 2pm", only propose times matching those constraints.
+       Set `source_message_id: <the email's message_id>` on the bullpen call
+       as the dedup key. Use `contact_timezone=known` when entity-context
+       returned a timezone for this contact; otherwise use `contact_timezone=unknown`.
+       Adjust duration in the `Need:` line when context implies otherwise
+       (e.g. "quick call" = 15 min, "lunch" = 60 min).
 
-    4. **Verify dates.** See the Date Verification section — call date-resolve
-       for every date + day-of-week pair before writing it into the draft.
+       If `bullpen.post` returns `deduplicated: true`, a consult is already in
+       flight for this message — treat it as already parked and exit without
+       re-labelling or re-consulting.
 
-    5. **Defaults.** 30-minute duration unless context suggests otherwise
-       (lunch = 60 min, quick call = 15 min). Prefer mid-morning slots
-       (9:30-11:30 AM) when no time preference is stated.
+    2. **Park — label + mark-read.** Call `ceo-inbox-label` to apply the label
+       `⏳ In Progress` to the message. Then call `ceo-inbox-mark-read` with
+       the message_id. Marking the message read is what removes it from the
+       `unread_only: true` triage list on subsequent runs so it is not
+       re-triaged. Do NOT archive the message. Do NOT draft anything yet.
 
-    6. **No calendar access.** You cannot check the CEO's calendar for
-       conflicts. Include a brief qualifying phrase in the draft (e.g.
-       "pending your calendar") so the CEO knows the slot hasn't been
-       verified against existing events.
+    3. **Report classification.** Record in the Response Format:
+       - Classification: ✍️ Drafted (parked — calendar consult in flight)
+       - Actions: bullpen.post (CONSULT REQUEST), ceo-inbox-label (⏳ In Progress),
+         ceo-inbox-mark-read
+
+    The calendar specialist will reply on the bullpen thread with a CONSULT REPLY.
+    On the next bullpen wake, Resume mode Branch A above handles drafting the
+    reply using the specialist's returned slot strings verbatim.
 
   **📌 Seen** — personal, sensitive, relationship-dependent, or uncertain:
     - No draft, no notification. The email stays in the inbox for the CEO, but

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -536,17 +536,23 @@ system_prompt: |
          Need: 2 conflict-free 30-min slots, with holds placed, returned timezone-labelled
          For:  reply to <contact display name> re "<subject>"
          By:   slots within <date window / stated constraints from the email>
-         Context: source_message_id=<the email's message_id>; contact_timezone=<known|unknown>
+         Context: source_message_id=<the email's message_id>; contact_timezone=<IANA timezone string | unknown>; contact_id=<contact ID if known>
 
        Set `source_message_id: <the email's message_id>` on the bullpen call
-       as the dedup key. Use `contact_timezone=known` when entity-context
-       returned a timezone for this contact; otherwise use `contact_timezone=unknown`.
+       as the dedup key. For `contact_timezone`, pass the actual IANA timezone
+       string (e.g. `America/Los_Angeles`) when entity-context returned one for
+       this contact; otherwise pass `unknown`. When you have a contact ID from
+       entity-context or contact-register, include it as `contact_id=<id>` so
+       the calendar specialist can skip the contact-lookup step entirely.
        Adjust duration in the `Need:` line when context implies otherwise
        (e.g. "quick call" = 15 min, "lunch" = 60 min).
 
        If `bullpen.post` returns `deduplicated: true`, a consult is already in
-       flight for this message — treat it as already parked and exit without
-       re-labelling or re-consulting.
+       flight for this message — do not post a second consult. Still run the
+       parking steps idempotently: call `ceo-inbox-label` with `⏳ In Progress`
+       and call `ceo-inbox-mark-read` with the message_id. Both are safe to
+       repeat (they are no-ops if already done). This recovers a run that died
+       after `bullpen.post` but before Step 2. Then exit without drafting.
 
     2. **Park — label + mark-read.** Call `ceo-inbox-label` to apply the label
        `⏳ In Progress` to the message. Then call `ceo-inbox-mark-read` with

--- a/docs/adr/023-bullpen-consult-and-resume.md
+++ b/docs/adr/023-bullpen-consult-and-resume.md
@@ -1,0 +1,111 @@
+# ADR-023: Async bullpen consult-and-resume convention
+
+Date: 2026-06-25
+Status: Accepted
+
+## Context
+
+Agents sometimes need specialist input mid-task before they can complete their
+work — the most concrete example being `ceo-inbox` needing conflict-free,
+held, timezone-labelled slots from the calendar specialist before it can draft
+a scheduling reply. The question is how to structure that cross-agent
+consultation without violating the platform's timing and security constraints.
+
+Two constraints narrow the solution space:
+
+1. **The bullpen is asynchronous by design.** `bullpen.post` fires an
+   `agent.discuss` event fire-and-forget. This was a deliberate choice
+   (ADR-002, issue #721): holding a skill execution turn open across an
+   inter-agent round-trip risks hitting the skill timeout and then receiving
+   the reply anyway, resulting in a duplicate task thread for the same inbound
+   message.
+
+2. **The only synchronous cross-agent primitive is `delegate`, and it is
+   coordinator-locked.** `delegate` is restricted to
+   `allowed_callers: ["coordinator"]` — specialists cannot call it directly.
+   Unlocking it for peer-to-peer use would expand the security surface and
+   still not solve the timeout problem.
+
+Three approaches were considered:
+
+**A. Synchronous cross-agent RPC / unlocking `delegate` for peers.** Would let
+`ceo-inbox` block on the calendar specialist's response inline. Rejected: holds
+an execution turn open, reintroduces the #721 timeout/duplicate-thread hazard,
+and does not generalise to consulting multiple specialists in parallel (each
+would block serially).
+
+**B. A new bus event type** (e.g. `agent.consult` / `agent.consult_reply`).
+Rejected: unnecessary — the existing `bullpen.post` and `bullpen.reply`
+primitives already provide async message passing between agents. A new event
+type would add framework complexity without changing the underlying timing model.
+
+**C. An async tap / park / resume convention over the existing bullpen.**
+Use what the platform already has: `bullpen.post` to tap the specialist, a
+visible park marker on the originating work while waiting, and the specialist's
+`bullpen.reply` as the resume signal. The dispatcher already creates a task for
+thread participants when a bullpen reply arrives, so the originator is naturally
+woken without any new infrastructure.
+
+## Decision
+
+Adopt option C: the **async bullpen consult-and-resume convention**.
+
+The convention has three named phases:
+
+1. **Tap.** The originating agent sends a structured `CONSULT REQUEST` to the
+   specialist via `bullpen.post`. The request carries the full context the
+   specialist needs plus a `source_message_id` that acts as a deduplication
+   key — the originator includes it so the specialist's reply can carry it
+   back, letting the originator locate and resume the original work item
+   unambiguously even across retries.
+
+2. **Park.** The originator marks the in-progress work as waiting. For
+   `ceo-inbox` this means applying a `⏳ In Progress` label to the source
+   email and marking it read — so the message stays visible in the inbox as
+   outstanding but is not re-processed by the next poll. The exact park
+   mechanic is per-agent; the invariant is that parked work must not be
+   re-processed while waiting and must be identifiable when the resume signal
+   arrives.
+
+3. **Resume.** When the specialist calls `bullpen.reply` in the consultation
+   thread, the dispatcher creates a new task for all thread participants
+   (existing platform behaviour). The originating agent picks up the reply on
+   its next turn, uses the `source_message_id` to locate the parked work,
+   completes the task (for `ceo-inbox`: drafts the reply using the slot strings
+   verbatim and archives the email), and clears the park marker.
+
+No new event types, no new service, no new table. The convention is a usage
+pattern over existing primitives.
+
+## Consequences
+
+**Easier:**
+
+- Any agent that needs specialist input mid-task can adopt the tap/park/resume
+  pattern without platform changes — wire `bullpen.post`, a park marker, and
+  the `source_message_id` echo, and the resume falls out of normal bullpen
+  mechanics.
+- The `source_message_id` dedup key means a parked work item is safe to retry:
+  if the originator is woken more than once (e.g. due to unrelated bullpen
+  activity on the same thread), it checks whether the `source_message_id` in
+  the reply matches before resuming, preventing duplicate drafts.
+- The park marker provides operational visibility: a stale `⏳ In Progress`
+  label is a signal that a consult did not complete. A future sweep can promote
+  these to a `⚠️ Stuck` state (out of scope for this epic).
+- The convention generalises to consulting multiple specialists: tap each via
+  `bullpen.post`, accumulate replies keyed by `source_message_id`, resume once
+  all expected replies have arrived (or after a timeout).
+
+**Accepted trade-offs:**
+
+- **Resume latency is seconds to minutes**, not synchronous. This is acceptable
+  for `ceo-inbox` because scheduling reply drafts sit for human review before
+  being sent anyway — the draft quality gained from a real consult outweighs
+  the latency cost.
+- **A stuck consult leaves a visible park marker.** If the specialist never
+  replies (agent error, misconfigured bullpen routing), the originating work
+  item stays parked indefinitely. The park marker makes this detectable — a
+  stale-marker sweep is a noted follow-up, out of scope here.
+- **The convention requires per-agent implementation.** There is no central
+  framework support that enforces tap/park/resume correctly. Documentation (this
+  ADR) and the `ceo-inbox` implementation serve as the canonical reference.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,7 @@ Each ADR follows the [Nygard format](https://adr.github.io/):
 | [020](020-secrets-vault.md) | Application-layer AES-256-GCM secrets vault in PostgreSQL — structural typing, per-invocation pre-warm cache, env-var fallback for incremental migration | Accepted |
 | [021](021-vault-only-secret-resolution.md) | Vault-only secret resolution — remove the env fallback; only the four vault-bootstrap values stay in `.env`, everything else seeds via `seed-vault` | Accepted |
 | [022](022-skill-agent-registry.md) | DB-gated skill/agent registry — install/enable lifecycle with startup reconciliation and restart-based enforcement | Accepted |
+| [023](023-bullpen-consult-and-resume.md) | Async bullpen consult-and-resume convention — tap/park/resume over existing bullpen primitives, no new event types | Accepted |
 
 ## Adding new ADRs
 

--- a/tests/integration/calendar-holds-collaboration.test.ts
+++ b/tests/integration/calendar-holds-collaboration.test.ts
@@ -1,0 +1,390 @@
+// tests/integration/calendar-holds-collaboration.test.ts
+//
+// Integration tests for calendar holds + consult-and-resume behaviours.
+//
+// What these tests cover that unit tests cannot:
+//   1. No-table assertion: no migration file references 'hold' — guards AC #9
+//   2. Config-store holds toggle round-trip: real ConfigStore/EntityMemory + KG backing
+//      confirms the toggle persists, reads back, and the handler respects it end-to-end
+//   3. Hold placed → self-release on booking: metadata round-trips create→list;
+//      calendar-create-event invokes deleteEvent on the matching curia-hold
+//   4. Bullpen source_message_id dedup: real BullpenService + Postgres confirms
+//      second openThread with same sourceMessageId returns deduplicated:true
+//
+// Harness mirrors tests/integration/bullpen.test.ts (Pool, BullpenService.createWithPostgres)
+// and tests/integration/extract-facts.test.ts (KnowledgeGraphStore, EmbeddingService,
+// MemoryValidator, EntityMemory). Read those tests first if the setup looks unfamiliar.
+//
+// Prerequisites:
+//   DATABASE_URL pointing at curia-test-pg (port 5433) must be set in env.
+//   Tests skip (describe.skip) when DATABASE_URL is absent — do not hardcode it.
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import pg from 'pg';
+import pino from 'pino';
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Memory / KG stack (same construction as extract-facts.test.ts)
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { ConfigStore } from '../../src/memory/config-store.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+// Bullpen (same construction as bullpen.test.ts)
+import { BullpenService } from '../../src/memory/bullpen.js';
+
+// Skill handlers under test
+import { CalendarCreateHoldHandler } from '../../skills/calendar-create-hold/handler.js';
+import { CalendarCreateEventHandler } from '../../skills/calendar-create-event/handler.js';
+
+// Nylas types for mock events
+import type { NylasCalendarClient, NylasCalendarEvent } from '../../src/channels/calendar/nylas-calendar-client.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { Logger } from '../../src/logger.js';
+import { CURIA_HOLD_KEY, buildHoldMetadata } from '../../src/channels/calendar/holds.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+// ---------------------------------------------------------------------------
+// Slot constants shared across hold+release tests
+// ---------------------------------------------------------------------------
+
+const SLOT_START = '2026-07-15T14:00:00Z';
+const SLOT_END = '2026-07-15T15:00:00Z';
+const CAL_ID = 'cal-integration-test';
+
+// ---------------------------------------------------------------------------
+// Minimal mock builders
+// ---------------------------------------------------------------------------
+
+/** Build a NylasCalendarEvent stub tagged as a curia-hold on the given slot. */
+function makeHoldEvent(id: string, overrides?: Partial<NylasCalendarEvent>): NylasCalendarEvent {
+  return {
+    id,
+    title: 'HOLD (TBC): integration test',
+    description: '',
+    location: '',
+    startTime: Math.floor(new Date(SLOT_START).getTime() / 1000),
+    endTime: Math.floor(new Date(SLOT_END).getTime() / 1000),
+    startDate: null,
+    endDate: null,
+    participants: [],
+    conferencing: null,
+    status: 'tentative',
+    calendarId: CAL_ID,
+    busy: true,
+    metadata: buildHoldMetadata({ createdAtIso: new Date().toISOString() }),
+    ...overrides,
+  };
+}
+
+/** Build a booked (non-hold) NylasCalendarEvent stub. */
+function makeBookedEvent(id: string): NylasCalendarEvent {
+  return {
+    id,
+    title: 'Real Meeting',
+    description: '',
+    location: '',
+    startTime: Math.floor(new Date(SLOT_START).getTime() / 1000),
+    endTime: Math.floor(new Date(SLOT_END).getTime() / 1000),
+    startDate: null,
+    endDate: null,
+    participants: [],
+    conferencing: null,
+    status: 'confirmed',
+    calendarId: CAL_ID,
+    busy: true,
+    // No curia-hold metadata — this is a real event
+    metadata: null,
+  };
+}
+
+/** Build a silent pino logger (suppresses all output in tests). */
+function silentLog(): Logger {
+  return pino({ level: 'silent' }) as unknown as Logger;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: No-table assertion (no DB required)
+// ---------------------------------------------------------------------------
+
+describe('calendar-holds — no migration references holds (AC #9)', () => {
+  it('src/db/migrations/ contains no file matching /hold/i', async () => {
+    // Resolve migrations directory relative to this file's location, which is stable
+    // regardless of the process CWD at test time.
+    const thisFile = fileURLToPath(import.meta.url);
+    // tests/integration/ → project root → src/db/migrations/
+    const migrationsDir = join(thisFile, '..', '..', '..', 'src', 'db', 'migrations');
+    const files = await readdir(migrationsDir);
+    const holdFiles = files.filter((f) => /hold/i.test(f));
+    expect(holdFiles).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenarios 2–4: real Postgres required
+// ---------------------------------------------------------------------------
+
+describeIf('calendar-holds — config-store toggle (real Postgres)', () => {
+  let pool: pg.Pool;
+  let entityMemory: EntityMemory;
+
+  // Source tag used to scope all KG nodes created in this suite so cleanup is safe.
+  const SOURCE = 'integration-test-holds-toggle';
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    // Probe the DB to fail fast if the schema is not migrated.
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, pino({ level: 'silent' }));
+    const validator = new MemoryValidator(store, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    // Clean any stale KG nodes from a previous crashed run.
+    await pool.query("DELETE FROM kg_edges WHERE source = $1", [SOURCE]);
+    await pool.query("DELETE FROM kg_nodes WHERE source = $1", [SOURCE]);
+  });
+
+  afterAll(async () => {
+    // Remove all KG nodes we wrote during these tests.
+    await pool.query("DELETE FROM kg_edges WHERE source = $1", [SOURCE]);
+    await pool.query("DELETE FROM kg_nodes WHERE source = $1", [SOURCE]);
+    await pool.end();
+  });
+
+  it('toggle OFF: ConfigStore.set("calendar_holds","enabled","false") → handler returns held:false and createEvent is NOT called', async () => {
+    const configStore = new ConfigStore(entityMemory, silentLog());
+    // Write the toggle-off value into the real KG-backed store.
+    await configStore.set('calendar_holds', 'enabled', 'false');
+
+    // Verify the write actually persisted before invoking the handler.
+    const readBack = await configStore.get('calendar_holds', 'enabled');
+    expect(readBack).toBe('false');
+
+    const createEvent = vi.fn();
+    const ctx: SkillContext = {
+      input: { calendarId: CAL_ID, start: SLOT_START, end: SLOT_END, subject: 'toggle off test' },
+      secret: () => { throw new Error('no secret in integration test'); },
+      log: silentLog(),
+      entityMemory,
+      nylasCalendarClient: { createEvent } as unknown as NylasCalendarClient,
+    } as unknown as SkillContext;
+
+    const handler = new CalendarCreateHoldHandler();
+    const result = await handler.execute(ctx);
+
+    // Handler must not call createEvent when toggle is off.
+    expect(createEvent).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(data.held).toBe(false);
+      expect(data.holdEventId).toBeNull();
+      expect(data.reason).toBe('holds disabled');
+    }
+  });
+
+  it('toggle ON: after writing "true" → handler calls createEvent and returns held:true', async () => {
+    // Overwrite the toggle to 'true'. ConfigStore.set is idempotent via dedup.
+    const configStore = new ConfigStore(entityMemory, silentLog());
+    await configStore.set('calendar_holds', 'enabled', 'true');
+
+    const holdEventId = `hold-${randomUUID()}`;
+    const createdHold = makeHoldEvent(holdEventId);
+    const createEvent = vi.fn().mockResolvedValue(createdHold);
+
+    const ctx: SkillContext = {
+      input: { calendarId: CAL_ID, start: SLOT_START, end: SLOT_END, subject: 'toggle on test' },
+      secret: () => { throw new Error('no secret in integration test'); },
+      log: silentLog(),
+      entityMemory,
+      nylasCalendarClient: { createEvent } as unknown as NylasCalendarClient,
+    } as unknown as SkillContext;
+
+    const handler = new CalendarCreateHoldHandler();
+    const result = await handler.execute(ctx);
+
+    expect(createEvent).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(data.held).toBe(true);
+      expect(data.holdEventId).toBe(holdEventId);
+    }
+  });
+});
+
+describeIf('calendar-holds — hold place → self-release (real Postgres)', () => {
+  // This scenario exercises the full metadata round-trip:
+  //   1. calendar-create-hold places a hold (createEvent is called, returns a hold event)
+  //   2. calendar-create-event books the same slot (createEvent succeeds for the booking)
+  //   3. calendar-create-event then calls listEvents → finds the hold → calls deleteEvent
+  //
+  // Both createEvent calls go to the same mock, so we track them by order.
+  // listEvents is seeded to return the hold so self-release fires.
+  // deleteEvent is tracked to confirm the hold was released.
+
+  let pool: pg.Pool;
+  let entityMemory: EntityMemory;
+  const SOURCE = 'integration-test-holds-release';
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, pino({ level: 'silent' }));
+    const validator = new MemoryValidator(store, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    await pool.query("DELETE FROM kg_edges WHERE source = $1", [SOURCE]);
+    await pool.query("DELETE FROM kg_nodes WHERE source = $1", [SOURCE]);
+  });
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM kg_edges WHERE source = $1", [SOURCE]);
+    await pool.query("DELETE FROM kg_nodes WHERE source = $1", [SOURCE]);
+    await pool.end();
+  });
+
+  it('calendar-create-event releases an overlapping curia-hold event via deleteEvent', async () => {
+    const holdEventId = `hold-release-${randomUUID()}`;
+    const bookedEventId = `booked-${randomUUID()}`;
+
+    // Step 1: place the hold through the real handler (toggle unset → defaults to ON).
+    // ConfigStore.get will return null (never written in this suite) → holdsEnabled = true.
+    const createdHold = makeHoldEvent(holdEventId);
+    const holdCreateEvent = vi.fn().mockResolvedValue(createdHold);
+
+    const holdCtx: SkillContext = {
+      input: { calendarId: CAL_ID, start: SLOT_START, end: SLOT_END, subject: 'release test hold' },
+      secret: () => { throw new Error('no secret'); },
+      log: silentLog(),
+      entityMemory,
+      nylasCalendarClient: { createEvent: holdCreateEvent } as unknown as NylasCalendarClient,
+    } as unknown as SkillContext;
+
+    const holdResult = await new CalendarCreateHoldHandler().execute(holdCtx);
+    expect(holdResult.success).toBe(true);
+    if (holdResult.success) {
+      expect((holdResult.data as Record<string, unknown>).held).toBe(true);
+      expect((holdResult.data as Record<string, unknown>).holdEventId).toBe(holdEventId);
+    }
+
+    // Confirm the hold event carries curia-hold metadata — this is what self-release looks for.
+    expect(holdCreateEvent).toHaveBeenCalledOnce();
+    const [, holdArgs] = holdCreateEvent.mock.calls[0]!;
+    expect(holdArgs.metadata?.[CURIA_HOLD_KEY]).toBe('true');
+
+    // Step 2: book the same slot.
+    // listEvents returns the hold we placed (simulating what Nylas would return).
+    // deleteEvent is the call we assert.
+    const bookedEvent = makeBookedEvent(bookedEventId);
+    const bookCreateEvent = vi.fn().mockResolvedValue(bookedEvent);
+    const listEvents = vi.fn().mockResolvedValue([createdHold]);
+    const deleteEvent = vi.fn().mockResolvedValue(undefined);
+
+    const bookCtx: SkillContext = {
+      input: {
+        calendarId: CAL_ID,
+        title: 'Real Meeting',
+        start: SLOT_START,
+        end: SLOT_END,
+      },
+      secret: () => { throw new Error('no secret'); },
+      log: silentLog(),
+      nylasCalendarClient: {
+        createEvent: bookCreateEvent,
+        listEvents,
+        deleteEvent,
+      } as unknown as NylasCalendarClient,
+      // No contactService → read-only check is skipped (handled in try block)
+    } as unknown as SkillContext;
+
+    const bookResult = await new CalendarCreateEventHandler().execute(bookCtx);
+
+    // Booking must succeed.
+    expect(bookResult.success).toBe(true);
+    // listEvents must have been called to find overlapping holds.
+    expect(listEvents).toHaveBeenCalledOnce();
+    // deleteEvent must have been called for the hold, not the booked event.
+    expect(deleteEvent).toHaveBeenCalledOnce();
+    const [delCalId, delEventId] = deleteEvent.mock.calls[0]!;
+    expect(delCalId).toBe(CAL_ID);
+    expect(delEventId).toBe(holdEventId);
+  });
+});
+
+describeIf('calendar-holds — bullpen source_message_id dedup (real Postgres)', () => {
+  // Mirrors bullpen.test.ts: real BullpenService + Postgres.
+  // Verifies the backstop that the consult-and-resume flow relies on:
+  // two openThread calls with the same sourceMessageId must be idempotent —
+  // the second returns deduplicated:true and no second thread row exists.
+
+  let pool: pg.Pool;
+  let service: BullpenService;
+  // Per-run prefix keeps concurrent test runs from clobbering each other.
+  let runId: string;
+
+  beforeAll(async () => {
+    runId = randomUUID();
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM bullpen_threads LIMIT 0');
+    const logger = createSilentLogger();
+    service = BullpenService.createWithPostgres(pool, logger);
+  });
+
+  afterAll(async () => {
+    // ON DELETE CASCADE removes bullpen_messages automatically.
+    await pool.query('DELETE FROM bullpen_threads WHERE topic LIKE $1', [`${runId}%`]);
+    await pool.end();
+  });
+
+  it('second openThread with the same sourceMessageId returns deduplicated:true and no extra row', async () => {
+    const sourceMessageId = `msg-${runId}-dedup-test`;
+
+    // First open — creates the thread.
+    const first = await service.openThread(
+      `${runId} — consult dedup test`,
+      'coordinator',
+      ['coordinator', 'calendar-specialist'],
+      'Can you check availability for Tuesday?',
+      ['calendar-specialist'],
+      undefined,
+      sourceMessageId,
+    );
+    expect(first.deduplicated).toBe(false);
+
+    // Second open with the SAME sourceMessageId — must be a dedup hit.
+    const second = await service.openThread(
+      `${runId} — consult dedup test`,
+      'coordinator',
+      ['coordinator', 'calendar-specialist'],
+      'Can you check availability for Tuesday?',
+      ['calendar-specialist'],
+      undefined,
+      sourceMessageId,
+    );
+    expect(second.deduplicated).toBe(true);
+    // The returned thread ID must be the same as the original.
+    expect(second.thread.id).toBe(first.thread.id);
+
+    // Confirm at the DB level: only one thread row for this sourceMessageId.
+    const rows = await pool.query(
+      'SELECT id FROM bullpen_threads WHERE source_message_id = $1',
+      [sourceMessageId],
+    );
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0]!.id).toBe(first.thread.id);
+  });
+});

--- a/tests/integration/calendar-holds-collaboration.test.ts
+++ b/tests/integration/calendar-holds-collaboration.test.ts
@@ -156,6 +156,7 @@ describeIf('calendar-holds — config-store toggle (real Postgres)', () => {
   });
 
   afterAll(async () => {
+    if (!pool) return;
     // Remove all KG nodes we wrote during these tests.
     await pool.query("DELETE FROM kg_edges WHERE source = $1", [SOURCE]);
     await pool.query("DELETE FROM kg_nodes WHERE source = $1", [SOURCE]);
@@ -257,6 +258,7 @@ describeIf('calendar-holds — hold place → self-release (real Postgres)', () 
   });
 
   afterAll(async () => {
+    if (!pool) return;
     await pool.query("DELETE FROM kg_edges WHERE source = $1", [SOURCE]);
     await pool.query("DELETE FROM kg_nodes WHERE source = $1", [SOURCE]);
     await pool.end();
@@ -350,6 +352,7 @@ describeIf('calendar-holds — bullpen source_message_id dedup (real Postgres)',
   });
 
   afterAll(async () => {
+    if (!pool) return;
     // ON DELETE CASCADE removes bullpen_messages automatically.
     await pool.query('DELETE FROM bullpen_threads WHERE topic LIKE $1', [`${runId}%`]);
     await pool.end();

--- a/tests/integration/calendar-holds-collaboration.test.ts
+++ b/tests/integration/calendar-holds-collaboration.test.ts
@@ -198,6 +198,11 @@ describeIf('calendar-holds — config-store toggle (real Postgres)', () => {
     // Overwrite the toggle to 'true'. ConfigStore.set is idempotent via dedup.
     const configStore = new ConfigStore(entityMemory, silentLog());
     await configStore.set('calendar_holds', 'enabled', 'true');
+    // Confirm the write actually landed before invoking the handler (mirrors the
+    // toggle-OFF test). Without this, a future change to the KG dedup strategy
+    // could leave the stored value at 'false' and make the held:true assertion
+    // fail with a confusing message instead of pointing at the real cause.
+    expect(await configStore.get('calendar_holds', 'enabled')).toBe('true');
 
     const holdEventId = `hold-${randomUUID()}`;
     const createdHold = makeHoldEvent(holdEventId);


### PR DESCRIPTION
## Summary

Layers 1+3 of epic #1137 — rewires `ceo-inbox` from drafting meeting-availability replies **blind** to **consulting the calendar specialist** over the bullpen, and documents the reusable async convention. `Closes #1137`.

> **Stacked on #1181.** This PR's base is the calendar branch (`feat/calendar-holds-collaboration`), because it consumes the calendar-side primitives (holds, the consult prompt) that land in #1181. **After #1181 merges, retarget this PR's base to `main`** — then merging it closes #1137. Review this PR for the ceo-inbox + tests + ADR diff only.

## What's in this PR (Layers 1+3)

- **`ceo-inbox` scheduling rewire** (`agents/ceo-inbox.yaml`, 0.10.0 → 0.11.0):
  - Deletes "No calendar access", the "pending your calendar" disclaimer, and the fixed 9:30-11:30 AM default.
  - **Tap:** on a scheduling `✍️ Drafted` email, `bullpen.post` mentioning `calendar` with a structured `CONSULT REQUEST` and `source_message_id` (dedup key) — it does **not** draft blind.
  - **Park:** apply `⏳ In Progress` + `ceo-inbox-mark-read` (read-status is what drops it from the `unread_only:true` triage list; the label is the human-facing/stuck-sweep marker). Handles `deduplicated:true`.
  - **Resume:** on the calendar's `CONSULT REPLY`, read the original via `source_message_id`, draft with the returned timezone-labelled slots verbatim (keeping `date-resolve` discipline), transition `⏳ In Progress` → `✍️ Drafted`, then archive.
  - **Fallbacks:** `no_slots` → draft nearest alternatives; `escalate` → route a CEO note via the coordinator, do not archive.
- **Bullpen consult-and-resume convention** — documented in **ADR-023** (the reusable tap/park/resume pattern; built on the existing async bullpen + `source_message_id` dedup, no new event types).
- **Integration tests** (`tests/integration/calendar-holds-collaboration.test.ts`) — 5 scenarios against the real test Postgres (Nylas mocked at the client seam): no-table assertion, holds toggle round-trip (real `ConfigStore`/`EntityMemory`), hold place → self-release, and bullpen `source_message_id` dedup (real `BullpenService`).

## Acceptance criteria from #1137 covered here

- [x] A scheduling email causes `ceo-inbox` to tap the calendar specialist via the bullpen; it does not draft blind.
- [x] Every proposed time is labelled in the CEO's timezone (drafts copy the calendar's display strings verbatim).
- [x] Source email parked `⏳ In Progress` and not archived until the draft is written.
- [x] (verified by test) No new database table — metadata is the hold ledger; `source_message_id` dedup is the backstop.

The conflict-free / held / sweep / `onlyBusy`-removed criteria are delivered by the calendar layer in #1181.

## Testing

- 5/5 integration tests pass against `curia-test-pg` (they `describe.skip` without `DATABASE_URL`; CI provides it).
- Agent-config loader test + full `typecheck` clean.
- Per-task TDD/review throughout; final whole-branch review (prompt coherence, cross-file CONSULT contract, test realism, ADR/changelog) run before this PR.