### PR TITLE
fix(ceo-inbox): call memory-query in Branch A resume before drafting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`ceo-inbox` Branch A resume** — calendar consult replies now call `memory-query` anchored on sender and subject before drafting, so stored facts (Calendly links, venue preferences, relationship notes) shape the reply; no-match proceeds normally. (#1185)
 - **`wake_at` self-deferral lineage** — a task that defers itself via `wake_at` now stamps its `TaskOriginator` onto the wake job, so a principal-lineage task keeps its autonomy bypass on wake instead of flooring to agent; pre-chosen, so no `standing` envelope is written and the heartbeat ladder never runs (`elevated` still blocked — not a live turn). (#1153)
 - **Email markdown links** — outbound email and console rendering now share one sanitized converter with clickable links, bare URL autolinks, and tables. (#1169)
 - **Health LLM canary** — derives tier failure from an explicit most-recent-outcome flag instead of comparing `lastErrorAt > lastSuccessAt`, which tied (and masked the error as healthy) when both landed in the same millisecond. (#1163)

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.11.0"
+version: "0.11.1"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -94,28 +94,39 @@ system_prompt: |
 
   2. **Result: ok** — the calendar specialist found slots with holds placed.
      a. Call `executive-profile-get` to retrieve the voice profile for the draft.
-     b. For every date + day-of-week pair in the returned slot strings, call
+     b. Call `memory-query` with a natural-language query anchored on the sender
+        name and email subject (e.g. "scheduling preferences for [sender name]",
+        "meeting with [sender name] re [subject]"). Use any returned context to
+        shape the surrounding draft text — for example, appending a stored Calendly
+        link, avoiding a venue the CEO has noted a dislike for, or honouring a
+        known relationship note about the contact. If nothing is found, or if the
+        skill returns an error, treat it as no match and proceed normally — do not
+        fabricate stored facts.
+     c. For every date + day-of-week pair in the returned slot strings, call
         `date-resolve` to verify the pairing before using it in the draft.
-     c. Call `ceo-inbox-draft-reply` using the calendar specialist's returned
+     d. Call `ceo-inbox-draft-reply` using the calendar specialist's returned
         slot display strings VERBATIM (e.g. "Thursday June 25 at 10:30 AM ET
         (7:30 AM PT their time) - hold placed"). Do NOT rephrase or convert
         timezones yourself — use the strings exactly as the specialist provided
-        them. Apply the CEO voice profile when composing surrounding text. Do
-        NOT include any "pending your calendar" qualifier — holds are already
-        placed.
-     d. Call `ceo-inbox-update-folders` with
+        them. Apply the CEO voice profile and any recalled memory context when
+        composing surrounding text. Do NOT include any "pending your calendar"
+        qualifier — holds are already placed.
+     e. Call `ceo-inbox-update-folders` with
         `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`.
         This records the ✍️ Drafted terminal classification and clears the
         in-progress park marker so the message no longer shows under ⏳ In Progress.
-     e. Call `ceo-inbox-archive` with the message_id. (The message was already
+     f. Call `ceo-inbox-archive` with the message_id. (The message was already
         marked read at park time — do not mark-read again.)
 
   3. **Result: no_slots** — no free time found in the requested window; the
      specialist returned nearest alternatives.
-     a. Follow steps 2a-b above (voice profile, date-resolve on alternatives).
+     a. Follow steps 2a-c above (voice profile, memory-query anchored on sender
+        and subject, date-resolve on the nearest-alternative slot strings).
      b. Draft using the nearest-alternative slot strings from the CONSULT REPLY
         `Nearest:` field VERBATIM. Add a brief note in the draft that times are
         outside the originally requested window (plain language, no em dashes).
+        Apply any recalled context from memory-query to shape the surrounding
+        draft text (e.g. a stored Calendly link or relationship note).
      c. Call `ceo-inbox-update-folders` with
         `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`.
      d. Call `ceo-inbox-archive` with the message_id.

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -95,8 +95,8 @@ system_prompt: |
   2. **Result: ok** — the calendar specialist found slots with holds placed.
      a. Call `executive-profile-get` to retrieve the voice profile for the draft.
      b. Call `memory-query` with a natural-language query anchored on the sender
-        name and email subject (e.g. "scheduling preferences for [sender name]",
-        "meeting with [sender name] re [subject]"). Use any returned context to
+        name and email subject (e.g. "scheduling preferences for [sender name]
+        re [subject]", "meeting with [sender name] re [subject]"). Use any returned context to
         shape the surrounding draft text — for example, appending a stored Calendly
         link, avoiding a venue the CEO has noted a dislike for, or honouring a
         known relationship note about the contact. If nothing is found, or if the

--- a/tests/smoke/cases/ceo-inbox-branch-a-location-preference.yaml
+++ b/tests/smoke/cases/ceo-inbox-branch-a-location-preference.yaml
@@ -1,0 +1,51 @@
+name: Branch A Resume Avoids Disliked Venue from Memory
+description: |
+  When ceo-inbox resumes from a calendar consult reply (Branch A) and a stored
+  memory note says the CEO dislikes a venue the sender mentioned, the drafted
+  reply should acknowledge the stored preference and avoid endorsing that venue.
+tags:
+  - ceo-inbox
+  - resume-mode
+  - memory-recall
+  - scheduling
+
+turns:
+  - role: user
+    content: |
+      [Resume mode — bullpen wake]
+
+      CONSULT REPLY
+      Result: ok
+      Slots:
+        - Wednesday July 9 at 1:00 PM ET - hold placed
+        - Thursday July 10 at 3:00 PM ET - hold placed
+      Context: source_message_id=msg-def456
+
+      ---
+      Original email context:
+      From: bob@partnerco.com (Bob Martinez)
+      Subject: Coffee meeting at Lighthouse Cafe?
+      Body excerpt: "Would love to catch up — maybe at Lighthouse Cafe on King St?"
+
+      [Memory: CEO dislikes Lighthouse Cafe — prefers meetings at the office or
+       nearby alternatives on Queen St]
+
+expected_behaviors:
+  - id: calls-memory-query
+    description: Agent calls memory-query anchored on the sender (Bob Martinez) and/or subject before drafting
+    weight: critical
+  - id: avoids-disliked-venue
+    description: The drafted reply does not endorse or suggest Lighthouse Cafe; it either omits the venue or proposes an alternative consistent with the stored preference
+    weight: critical
+  - id: slot-strings-verbatim
+    description: The slot strings ("Wednesday July 9..." and "Thursday July 10...") appear verbatim in the draft
+    weight: critical
+  - id: no-memory-fabrication
+    description: Agent does not invent memory facts beyond what is described in the stored context
+    weight: important
+
+failure_modes:
+  - Suggests or accepts Lighthouse Cafe despite the stored dislike
+  - Ignores the stored venue preference entirely
+  - Invents a stored memory fact not present in the context
+  - Paraphrases the slot strings rather than using them verbatim

--- a/tests/smoke/cases/ceo-inbox-branch-a-no-memory-match.yaml
+++ b/tests/smoke/cases/ceo-inbox-branch-a-no-memory-match.yaml
@@ -1,0 +1,51 @@
+name: Branch A Resume Proceeds Normally with No Memory Match
+description: |
+  When ceo-inbox resumes from a calendar consult reply (Branch A) and memory-query
+  returns no results for the sender, the draft should still proceed correctly using
+  the slot strings verbatim. A missing memory match must not block or degrade the draft.
+tags:
+  - ceo-inbox
+  - resume-mode
+  - memory-recall
+  - scheduling
+  - non-blocking
+
+turns:
+  - role: user
+    content: |
+      [Resume mode — bullpen wake]
+
+      CONSULT REPLY
+      Result: ok
+      Slots:
+        - Monday July 14 at 11:00 AM ET (8:00 AM PT their time) - hold placed
+        - Tuesday July 15 at 2:00 PM ET (11:00 AM PT their time) - hold placed
+      Context: source_message_id=msg-ghi789
+
+      ---
+      Original email context:
+      From: carol@newco.com (Carol Singh)
+      Subject: Scheduling our intro call
+      Body excerpt: "Looking forward to connecting!"
+
+      [Memory: no stored facts found for carol@newco.com or "Scheduling our intro call"]
+
+expected_behaviors:
+  - id: draft-proceeds
+    description: Agent drafts a reply despite no memory match — the missing context does not block the draft or cause an error response
+    weight: critical
+  - id: slot-strings-verbatim
+    description: The slot strings ("Monday July 14..." and "Tuesday July 15...") appear verbatim in the draft
+    weight: critical
+  - id: no-fabricated-memory
+    description: Agent does not invent stored facts about Carol Singh; the draft is based only on the slot strings and voice profile
+    weight: critical
+  - id: professional-tone
+    description: The draft is well-formed, professional, and coherent despite having no memory context to enrich it
+    weight: important
+
+failure_modes:
+  - Refuses to draft or returns an error when memory-query finds nothing
+  - Invents stored preferences or relationship facts not present in context
+  - Paraphrases the slot strings rather than using them verbatim
+  - Omits the slot times from the draft entirely

--- a/tests/smoke/cases/ceo-inbox-branch-a-no-slots.yaml
+++ b/tests/smoke/cases/ceo-inbox-branch-a-no-slots.yaml
@@ -1,0 +1,57 @@
+name: Branch A Resume no_slots Path Uses Memory and Nearest Slots
+description: |
+  When ceo-inbox resumes from a calendar consult reply (Branch A) and the result
+  is no_slots (no holds available within the requested window), the agent should
+  still call memory-query before drafting, date-resolve the Nearest alternatives,
+  and produce a reply that uses the Nearest slot strings verbatim with a plain-
+  language note that they fall outside the originally requested window.
+tags:
+  - ceo-inbox
+  - resume-mode
+  - memory-recall
+  - scheduling
+  - no-slots
+
+turns:
+  - role: user
+    content: |
+      [Resume mode — bullpen wake]
+
+      CONSULT REPLY
+      Result: no_slots
+      Nearest:
+        - Monday July 21 at 10:00 AM ET - earliest available
+        - Tuesday July 22 at 2:00 PM ET - also available
+      Context: source_message_id=msg-jkl012
+
+      ---
+      Original email context:
+      From: diana@startupco.com (Diana Park)
+      Subject: Intro call request
+      Body excerpt: "Would love to find a time this week if you have it."
+
+      [Memory: CEO prefers video calls over phone; no other stored facts for diana@startupco.com]
+
+expected_behaviors:
+  - id: calls-memory-query
+    description: Agent calls memory-query anchored on the sender (Diana Park / diana@startupco.com) and/or the email subject before drafting
+    weight: critical
+  - id: nearest-slots-verbatim
+    description: The Nearest slot strings ("Monday July 21..." and "Tuesday July 22...") appear verbatim in the draft
+    weight: critical
+  - id: outside-window-note
+    description: The draft includes a plain-language note that the proposed times fall outside the originally requested window (this week)
+    weight: critical
+  - id: stored-preference-applied
+    description: The draft reflects the stored preference (video call over phone) when relevant
+    weight: important
+  - id: no-memory-fabrication
+    description: Agent does not invent stored facts beyond the video-call preference in context
+    weight: important
+
+failure_modes:
+  - Skips memory-query and drafts without attempting recall
+  - Paraphrases the Nearest slot strings instead of using them verbatim
+  - Omits any acknowledgement that the slots are outside the requested window
+  - Invents stored memory facts not present in the context
+  - Refuses to draft because no slots were available within the window

--- a/tests/smoke/cases/ceo-inbox-branch-a-stored-preference.yaml
+++ b/tests/smoke/cases/ceo-inbox-branch-a-stored-preference.yaml
@@ -1,0 +1,48 @@
+name: Branch A Resume Uses Stored Calendly Preference
+description: |
+  When ceo-inbox resumes from a calendar consult reply (Branch A) and a Calendly
+  link is stored in memory for this contact, the drafted reply should include it.
+tags:
+  - ceo-inbox
+  - resume-mode
+  - memory-recall
+  - scheduling
+
+turns:
+  - role: user
+    content: |
+      [Resume mode — bullpen wake]
+
+      CONSULT REPLY
+      Result: ok
+      Slots:
+        - Thursday July 3 at 2:00 PM ET (11:00 AM PT their time) - hold placed
+        - Friday July 4 at 10:00 AM ET (7:00 AM PT their time) - hold placed
+      Context: source_message_id=msg-abc123
+
+      ---
+      Original email context:
+      From: alice@acmecorp.com (Alice Chen)
+      Subject: Let's find a time to connect
+
+      [Memory: CEO has a Calendly link stored — https://calendly.com/ceo/30min]
+
+expected_behaviors:
+  - id: calls-memory-query
+    description: Agent calls memory-query anchored on the sender (Alice Chen / alice@acmecorp.com) and/or the email subject before drafting
+    weight: critical
+  - id: includes-calendly-link
+    description: The drafted reply includes the stored Calendly link (https://calendly.com/ceo/30min) as an additional option or note
+    weight: critical
+  - id: slot-strings-verbatim
+    description: The slot strings from the CONSULT REPLY appear verbatim in the draft (exact wording from "Thursday July 3..." through "hold placed")
+    weight: critical
+  - id: voice-profile-applied
+    description: The draft applies the CEO's voice profile (calls executive-profile-get before drafting)
+    weight: important
+
+failure_modes:
+  - Drafts the reply without mentioning the Calendly link
+  - Paraphrases or reformats the slot strings instead of using them verbatim
+  - Fabricates memory facts not present in the stored context
+  - Calls memory-query after ceo-inbox-draft-reply instead of before

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -1,0 +1,107 @@
+// tests/unit/agents/ceo-inbox-prompt.test.ts
+//
+// Structural contract tests for the ceo-inbox agent prompt.
+// These assert that the YAML system_prompt text satisfies specific ordering and
+// content requirements — without invoking an LLM. They are fast, deterministic,
+// and serve as a living spec for the Branch A resume section.
+
+import { describe, it, expect } from 'vitest';
+import { loadAgentConfig } from '../../../src/agents/loader.js';
+import * as path from 'node:path';
+
+const agentsDir = path.resolve(import.meta.dirname, '../../../agents');
+
+function loadCeoInboxPrompt(): string {
+  const config = loadAgentConfig(path.join(agentsDir, 'ceo-inbox.yaml'));
+  return config.system_prompt;
+}
+
+// Extract the text of the Branch A section from the ceo-inbox prompt.
+// Branch A runs from its header to the start of the Scheduled-wake resume
+// section (the second resume mode). Note: "Branch B" appears earlier in the
+// intro text ("do not fall through to Branch B") so it cannot be used as the
+// delimiter here.
+function extractBranchASection(prompt: string): string {
+  const branchAStart = prompt.indexOf('Branch A');
+  // "**Scheduled-wake resume" marks the boundary between Branch A and Branch B.
+  const scheduledWakeStart = prompt.indexOf('**Scheduled-wake resume');
+  if (branchAStart === -1) throw new Error('Branch A section not found in prompt');
+  if (scheduledWakeStart === -1 || scheduledWakeStart <= branchAStart)
+    throw new Error(
+      'Scheduled-wake resume section not found after Branch A in prompt',
+    );
+  return prompt.slice(branchAStart, scheduledWakeStart);
+}
+
+// Find the position of a string within a section, returning -1 if not found.
+function posIn(section: string, term: string): number {
+  return section.indexOf(term);
+}
+
+describe('ceo-inbox Branch A prompt — memory-query contract', () => {
+  it('Branch A section contains a memory-query call', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    expect(branchA).toContain('memory-query');
+  });
+
+  it('memory-query appears before ceo-inbox-draft-reply in Branch A', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    const memoryQueryPos = posIn(branchA, 'memory-query');
+    const draftReplyPos = posIn(branchA, 'ceo-inbox-draft-reply');
+    expect(memoryQueryPos).toBeGreaterThan(-1);
+    expect(draftReplyPos).toBeGreaterThan(-1);
+    expect(memoryQueryPos).toBeLessThan(draftReplyPos);
+  });
+
+  it('Branch A memory-query is anchored on sender and subject context', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    // The recall query must reference the sender and/or email subject so it
+    // surfaces relevant stored facts (Calendly links, venue preferences, etc.).
+    const memoryQueryPos = posIn(branchA, 'memory-query');
+    const nearbyText = branchA.slice(memoryQueryPos, memoryQueryPos + 600);
+    const mentionsSender =
+      nearbyText.toLowerCase().includes('sender') ||
+      nearbyText.toLowerCase().includes('contact');
+    const mentionsSubject =
+      nearbyText.toLowerCase().includes('subject') ||
+      nearbyText.toLowerCase().includes('email');
+    expect(mentionsSender || mentionsSubject).toBe(true);
+  });
+
+  it('Result: no_slots step references memory-query (via cross-reference to ok-path steps)', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    // Anchor on the step 3 header to avoid matching the Branch A intro sentence
+    // which also mentions "no_slots" but is not the step body.
+    const step3Start = posIn(branchA, '3. **Result: no_slots');
+    const step4Start = posIn(branchA, '4. **Result: escalate');
+    expect(step3Start).toBeGreaterThan(-1);
+    expect(step4Start).toBeGreaterThan(step3Start);
+    const step3Section = branchA.slice(step3Start, step4Start);
+    // Step 3 pulls in the voice-profile + memory-query + date-resolve steps from step 2
+    // via a cross-reference rather than repeating the skill name literally. Assert both
+    // the cross-reference and that memory-query is mentioned by name in the step body.
+    expect(step3Section).toContain('memory-query');
+    // The cross-reference must enumerate steps 2a through at least 2c (which now
+    // includes the memory-query step introduced by this fix).
+    expect(step3Section).toContain('2a-c');
+  });
+
+  it('memory-query failure in Branch A is non-blocking (proceed-normally instruction)', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    const memoryQueryPos = posIn(branchA, 'memory-query');
+    // Look for language indicating a no-match is gracefully handled.
+    const nearbyText = branchA.slice(memoryQueryPos, memoryQueryPos + 800);
+    const hasNoMatchGuidance =
+      nearbyText.toLowerCase().includes('no match') ||
+      nearbyText.toLowerCase().includes('no result') ||
+      nearbyText.toLowerCase().includes('proceed normally') ||
+      nearbyText.toLowerCase().includes('if nothing') ||
+      nearbyText.toLowerCase().includes('not found');
+    expect(hasNoMatchGuidance).toBe(true);
+  });
+});

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -58,7 +58,7 @@ describe('ceo-inbox Branch A prompt — memory-query contract', () => {
   it('Branch A memory-query is anchored on sender and subject context', () => {
     const prompt = loadCeoInboxPrompt();
     const branchA = extractBranchASection(prompt);
-    // The recall query must reference the sender and/or email subject so it
+    // The recall query must reference both the sender and email subject so it
     // surfaces relevant stored facts (Calendly links, venue preferences, etc.).
     const memoryQueryPos = posIn(branchA, 'memory-query');
     const nearbyText = branchA.slice(memoryQueryPos, memoryQueryPos + 600);
@@ -68,7 +68,8 @@ describe('ceo-inbox Branch A prompt — memory-query contract', () => {
     const mentionsSubject =
       nearbyText.toLowerCase().includes('subject') ||
       nearbyText.toLowerCase().includes('email');
-    expect(mentionsSender || mentionsSubject).toBe(true);
+    expect(mentionsSender).toBe(true);
+    expect(mentionsSubject).toBe(true);
   });
 
   it('Result: no_slots step references memory-query (via cross-reference to ok-path steps)', () => {


### PR DESCRIPTION
## Summary

Closes #1185

- **`ceo-inbox` Branch A** was skipping the `memory-query` step that the main ✍️ Drafted path always runs. When resuming from a calendar consult reply, stored facts (Calendly links, venue preferences, relationship notes about the contact) were invisible to the draft.
- Added `memory-query` as step **2b** in the `Result: ok` sub-branch, after `executive-profile-get` and before `date-resolve`. Step letters shift accordingly (b→c, c→d, d→e, e→f).
- Updated the `Result: no_slots` cross-reference from `2a-b` → `2a-c` to include the new step. Added a note to shape surrounding draft text with any recalled context.
- No-match and skill errors are explicitly non-blocking: treated as no match, draft proceeds normally.
- Bumped `ceo-inbox` version `0.11.0 → 0.11.1`.

## Test plan

- [x] 5 new unit tests in `tests/unit/agents/ceo-inbox-prompt.test.ts` checking the prompt structure: memory-query present in Branch A, appears before `ceo-inbox-draft-reply`, anchored on sender/subject, step 3 cross-reference updated, non-blocking instruction present
- [x] 3 new smoke test cases:
  - `ceo-inbox-branch-a-stored-preference.yaml` — stored Calendly link → appears in draft
  - `ceo-inbox-branch-a-location-preference.yaml` — stored venue dislike → draft avoids it
  - `ceo-inbox-branch-a-no-memory-match.yaml` — no memory match → proceeds normally
- [x] Full unit test suite passes (325 files, 4239 tests)