### PR TITLE
fix: check sender-proposed scheduling slots first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Scheduling consults** — sender-proposed meeting times now flow through `ceo-inbox` to `calendar`, which checks them before counter-proposing alternatives. (#1186)
 - **`ceo-inbox` Branch A resume** — calendar consult replies now call `memory-query` anchored on sender and subject before drafting, so stored facts (Calendly links, venue preferences, relationship notes) shape the reply; no-match proceeds normally. (#1185)
 - **`wake_at` self-deferral lineage** — a task that defers itself via `wake_at` now stamps its `TaskOriginator` onto the wake job, so a principal-lineage task keeps its autonomy bypass on wake instead of flooring to agent; pre-chosen, so no `standing` envelope is written and the heartbeat ladder never runs (`elevated` still blocked — not a live turn). (#1153)
 - **Email markdown links** — outbound email and console rendering now share one sanitized converter with clickable links, bare URL autolinks, and tables. (#1169)

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -1,5 +1,5 @@
 name: calendar
-version: "0.3.0"
+version: "0.4.0"
 role: specialist
 description: >
   Calendar domain specialist — scheduling, free/busy, conflict resolution,
@@ -173,8 +173,14 @@ system_prompt: |
   Need: 2 conflict-free 30-min slots, with holds placed, returned timezone-labelled
   For:  reply to <contact display name> re "<subject>"
   By:   slots within <date window / stated constraints>
+  Proposed:
+    - <sender-proposed slot display>; start=<resolved timestamp>; end=<resolved timestamp>; source="<original phrase>"
   Context: source_message_id=<id>; contact_timezone=<known|unknown>
   ```
+
+  The `Proposed:` block is optional. It is present only when the sender named
+  specific meeting times in the inbound email. A consult without `Proposed:`
+  uses the existing free-time search flow unchanged.
 
   Follow these steps in order:
 
@@ -200,12 +206,24 @@ system_prompt: |
      scheduling rules (blocked times, meeting-length preferences, faith
      observances) before proposing any slots.
 
-  3. **Find conflict-free windows.** Call `calendar-find-free-time` over the
-     requested date window using the CEO's calendar IDs. Honour the stated
-     window constraints and stored preferences. Call `date-resolve` to verify
-     any date + day-of-week pair before using it.
+  3. **Check sender-proposed slots first.** If the CONSULT REQUEST contains a
+     `Proposed:` block, call `calendar-check-conflicts` for each proposed
+     start/end against the CEO's calendar IDs before calling
+     `calendar-find-free-time`. Call `date-resolve` to verify any date +
+     day-of-week pair before using it. If any proposed slot is conflict-free,
+     stop checking alternatives and reply with `Result: confirmed` for the
+     first conflict-free proposed slot. Do NOT call `calendar-find-free-time`
+     and do NOT place a hold in this case; the draft will simply accept the
+     sender's concrete time. If every proposed slot conflicts, continue to
+     step 4 and find alternatives.
 
-  4. **Pick slots and place holds (toggle-gated).** Select N slots (default
+  4. **Find conflict-free windows.** Call `calendar-find-free-time` over the
+     requested date window using the CEO's calendar IDs. Honour the stated
+     window constraints and stored preferences. This step is unchanged for
+     consults with no `Proposed:` block, and is the fallback when all proposed
+     slots conflict.
+
+  5. **Pick slots and place holds (toggle-gated).** Select N slots (default
      2) from the free windows. Before placing holds, call `config-store`
      retrieve with `namespace: calendar_holds, key: enabled`. Treat a missing
      key or a value of `true` as ENABLED; only an explicit value of `false`
@@ -215,9 +233,18 @@ system_prompt: |
      `held: false`, still include the slot in the reply but do not mark it as
      held.
 
-  5. **Reply on the bullpen thread.** Call `bullpen.reply` on the same thread
+  6. **Reply on the bullpen thread.** Call `bullpen.reply` on the same thread
      with a CONSULT REPLY shaped exactly like this:
 
+     When a sender-proposed slot was conflict-free:
+     ```
+     CONSULT REPLY
+     Result: confirmed
+     Confirmed: Thursday June 25 at 2:00 PM ET (11:00 AM PT their time)
+     Notes: sender-proposed slot checked conflict-free; no hold placed
+     ```
+
+     When alternatives were found and holds were considered:
      ```
      CONSULT REPLY
      Result: ok
@@ -231,7 +258,9 @@ system_prompt: |
      — never compute timezone conversions yourself. Always label the CEO's
      timezone. When the contact timezone is known, append their local time in
      parentheses after the CEO time. Mark "hold placed" per slot when a hold
-     was successfully placed. CEO-facing slot strings must be em-dash-free;
+     was successfully placed. For `Result: confirmed`, never mark "hold
+     placed" and never call `calendar-create-hold`; the sender already
+     proposed the accepted time. CEO-facing slot strings must be em-dash-free;
      use plain separators (comma, parentheses, hyphen) only.
 
      Fallback variants you must use when appropriate:

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.11.1"
+version: "0.11.2"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -84,15 +84,18 @@ system_prompt: |
 
   **Branch A — Calendar consult reply (bullpen wake with a CONSULT REPLY):**
   If the bullpen message body is a CONSULT REPLY (it starts with the line
-  `CONSULT REPLY` and contains `Result: ok`, `Result: no_slots`, or
-  `Result: escalate`), you are resuming a parked scheduling email. Proceed
-  through the sub-steps below, then exit — do not fall through to Branch B.
+  `CONSULT REPLY` and contains `Result: confirmed`, `Result: ok`,
+  `Result: no_slots`, or `Result: escalate`), you are resuming a parked
+  scheduling email. Proceed through the sub-steps below, then exit — do not
+  fall through to Branch B.
 
   1. Extract `source_message_id` from the `Context:` line of the original
      CONSULT REQUEST (it is carried forward in the bullpen thread). Call
      `ceo-inbox-read` with that `message_id` to reload the original email.
 
-  2. **Result: ok** — the calendar specialist found slots with holds placed.
+  2. **Result: confirmed** — the calendar specialist checked the sender's
+     proposed time and found one conflict-free. No hold was placed because the
+     draft should accept the sender's already-specific proposal.
      a. Call `executive-profile-get` to retrieve the voice profile for the draft.
      b. Call `memory-query` with a natural-language query anchored on the sender
         name and email subject (e.g. "scheduling preferences for [sender name]
@@ -104,13 +107,12 @@ system_prompt: |
         fabricate stored facts.
      c. For every date + day-of-week pair in the returned slot strings, call
         `date-resolve` to verify the pairing before using it in the draft.
-     d. Call `ceo-inbox-draft-reply` using the calendar specialist's returned
-        slot display strings VERBATIM (e.g. "Thursday June 25 at 10:30 AM ET
-        (7:30 AM PT their time) - hold placed"). Do NOT rephrase or convert
-        timezones yourself — use the strings exactly as the specialist provided
-        them. Apply the CEO voice profile and any recalled memory context when
-        composing surrounding text. Do NOT include any "pending your calendar"
-        qualifier — holds are already placed.
+     d. Call `ceo-inbox-draft-reply` accepting the calendar specialist's
+        `Confirmed:` slot display string VERBATIM. Shape the surrounding text
+        as a clean confirmation of the sender's time (e.g. "That works for me")
+        rather than offering alternatives. Do NOT mention holds, "pending your
+        calendar", or ask them to pick among options — availability was already
+        checked.
      e. Call `ceo-inbox-update-folders` with
         `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`.
         This records the ✍️ Drafted terminal classification and clears the
@@ -118,7 +120,26 @@ system_prompt: |
      f. Call `ceo-inbox-archive` with the message_id. (The message was already
         marked read at park time — do not mark-read again.)
 
-  3. **Result: no_slots** — no free time found in the requested window; the
+  3. **Result: ok** — the calendar specialist found alternative slots with
+     holds placed.
+     a. Follow steps 2a-c above (voice profile, memory-query anchored on sender
+        and subject, date-resolve on returned slot strings).
+     b. Call `ceo-inbox-draft-reply` using the calendar specialist's returned
+        slot display strings VERBATIM (e.g. "Thursday June 25 at 10:30 AM ET
+        (7:30 AM PT their time) - hold placed"). Do NOT rephrase or convert
+        timezones yourself — use the strings exactly as the specialist provided
+        them. Shape the surrounding text as a counter-proposal (these are new
+        alternatives) and apply the CEO voice profile and any recalled memory
+        context. Do NOT include any "pending your calendar" qualifier — holds
+        are already placed.
+     c. Call `ceo-inbox-update-folders` with
+        `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`.
+        This records the ✍️ Drafted terminal classification and clears the
+        in-progress park marker so the message no longer shows under ⏳ In Progress.
+     d. Call `ceo-inbox-archive` with the message_id. (The message was already
+        marked read at park time — do not mark-read again.)
+
+  4. **Result: no_slots** — no free time found in the requested window; the
      specialist returned nearest alternatives.
      a. Follow steps 2a-c above (voice profile, memory-query anchored on sender
         and subject, date-resolve on the nearest-alternative slot strings).
@@ -131,7 +152,7 @@ system_prompt: |
         `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`.
      d. Call `ceo-inbox-archive` with the message_id.
 
-  4. **Result: escalate** — the calendar specialist could not satisfy the
+  5. **Result: escalate** — the calendar specialist could not satisfy the
      consult (no calendar access, repeated skill failures, unresolvable
      constraints). Do NOT draft a reply.
      a. Call `ceo-inbox-update-folders` with
@@ -547,6 +568,8 @@ system_prompt: |
          Need: 2 conflict-free 30-min slots, with holds placed, returned timezone-labelled
          For:  reply to <contact display name> re "<subject>"
          By:   slots within <date window / stated constraints from the email>
+         Proposed:
+           - <sender-proposed slot display>; start=<resolved timestamp>; end=<resolved timestamp>; source="<original phrase>"
          Context: source_message_id=<the email's message_id>; contact_timezone=<IANA timezone string | unknown>; contact_id=<contact ID if known>
 
        Set `source_message_id: <the email's message_id>` on the bullpen call
@@ -557,6 +580,14 @@ system_prompt: |
        the calendar specialist can skip the contact-lookup step entirely.
        Adjust duration in the `Need:` line when context implies otherwise
        (e.g. "quick call" = 15 min, "lunch" = 60 min).
+       Include the optional `Proposed:` block only when the sender named one
+       or more specific times (date/day plus time, such as "Tuesday at 2pm" or
+       "Thursday June 25 at 3pm PT"). Resolve relative dates with `date-resolve`
+       before posting the consult, infer the end from the meeting duration, and
+       preserve the sender's original phrase in `source`. Do NOT include
+       `Proposed:` for vague windows like "next week", "sometime Tuesday", or
+       "mornings"; those remain constraints in `By:` and use the existing
+       slot-finding flow.
 
        If `bullpen.post` returns `deduplicated: true`, a consult is already in
        flight for this message — do not post a second consult. Still run the

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -16,6 +16,11 @@ function loadCeoInboxPrompt(): string {
   return config.system_prompt;
 }
 
+function loadCalendarPrompt(): string {
+  const config = loadAgentConfig(path.join(agentsDir, 'calendar.yaml'));
+  return config.system_prompt;
+}
+
 // Extract the text of the Branch A section from the ceo-inbox prompt.
 // Branch A runs from its header to the start of the Scheduled-wake resume
 // section (the second resume mode). Note: "Branch B" appears earlier in the
@@ -31,6 +36,24 @@ function extractBranchASection(prompt: string): string {
       'Scheduled-wake resume section not found after Branch A in prompt',
     );
   return prompt.slice(branchAStart, scheduledWakeStart);
+}
+
+function extractSchedulingConsultSection(prompt: string): string {
+  const start = prompt.indexOf('### Scheduling-specific drafting rules');
+  const end = prompt.indexOf('**📌 Seen**');
+  if (start === -1) throw new Error('Scheduling-specific drafting rules not found');
+  if (end === -1 || end <= start)
+    throw new Error('Scheduling section end not found after scheduling rules');
+  return prompt.slice(start, end);
+}
+
+function extractCalendarConsultSection(prompt: string): string {
+  const start = prompt.indexOf('## Answering a scheduling consult');
+  const end = prompt.indexOf('## Holds toggle');
+  if (start === -1) throw new Error('Calendar consult section not found');
+  if (end === -1 || end <= start)
+    throw new Error('Holds toggle section not found after calendar consult section');
+  return prompt.slice(start, end);
 }
 
 // Find the position of a string within a section, returning -1 if not found.
@@ -72,23 +95,23 @@ describe('ceo-inbox Branch A prompt — memory-query contract', () => {
     expect(mentionsSubject).toBe(true);
   });
 
-  it('Result: no_slots step references memory-query (via cross-reference to ok-path steps)', () => {
+  it('Result: no_slots step references memory-query (via cross-reference to confirmed-path steps)', () => {
     const prompt = loadCeoInboxPrompt();
     const branchA = extractBranchASection(prompt);
-    // Anchor on the step 3 header to avoid matching the Branch A intro sentence
+    // Anchor on the no_slots header to avoid matching the Branch A intro sentence
     // which also mentions "no_slots" but is not the step body.
-    const step3Start = posIn(branchA, '3. **Result: no_slots');
-    const step4Start = posIn(branchA, '4. **Result: escalate');
-    expect(step3Start).toBeGreaterThan(-1);
-    expect(step4Start).toBeGreaterThan(step3Start);
-    const step3Section = branchA.slice(step3Start, step4Start);
-    // Step 3 pulls in the voice-profile + memory-query + date-resolve steps from step 2
-    // via a cross-reference rather than repeating the skill name literally. Assert both
+    const noSlotsStart = posIn(branchA, '4. **Result: no_slots');
+    const escalateStart = posIn(branchA, '5. **Result: escalate');
+    expect(noSlotsStart).toBeGreaterThan(-1);
+    expect(escalateStart).toBeGreaterThan(noSlotsStart);
+    const noSlotsSection = branchA.slice(noSlotsStart, escalateStart);
+    // The no_slots path pulls in the voice-profile + memory-query +
+    // date-resolve steps from step 2 via a cross-reference. Assert both
     // the cross-reference and that memory-query is mentioned by name in the step body.
-    expect(step3Section).toContain('memory-query');
+    expect(noSlotsSection).toContain('memory-query');
     // The cross-reference must enumerate steps 2a through at least 2c (which now
     // includes the memory-query step introduced by this fix).
-    expect(step3Section).toContain('2a-c');
+    expect(noSlotsSection).toContain('2a-c');
   });
 
   it('memory-query failure in Branch A is non-blocking (proceed-normally instruction)', () => {
@@ -104,5 +127,126 @@ describe('ceo-inbox Branch A prompt — memory-query contract', () => {
       nearbyText.toLowerCase().includes('if nothing') ||
       nearbyText.toLowerCase().includes('not found');
     expect(hasNoMatchGuidance).toBe(true);
+  });
+});
+
+describe('ceo-inbox scheduling consult prompt — proposed-time protocol', () => {
+  it('CONSULT REQUEST includes an optional Proposed block for sender-suggested times', () => {
+    const prompt = loadCeoInboxPrompt();
+    const schedulingSection = extractSchedulingConsultSection(prompt);
+
+    expect(schedulingSection).toContain('Proposed:');
+    expect(schedulingSection).toContain('start=<resolved timestamp>');
+    expect(schedulingSection).toContain('end=<resolved timestamp>');
+    expect(schedulingSection).toContain('source="<original phrase>"');
+    expect(schedulingSection).toContain('Include the optional `Proposed:` block only when');
+    expect(schedulingSection).toContain('specific times');
+    expect(schedulingSection).toContain('Do NOT include');
+    expect(schedulingSection).toContain('vague windows');
+  });
+
+  it('requires date-resolve when posting relative proposed times', () => {
+    const prompt = loadCeoInboxPrompt();
+    const schedulingSection = extractSchedulingConsultSection(prompt);
+    const proposedPos = posIn(schedulingSection, 'Proposed:');
+    const dateResolvePos = posIn(schedulingSection, 'date-resolve');
+    const bullpenPostPos = posIn(schedulingSection, 'bullpen.post');
+
+    expect(proposedPos).toBeGreaterThan(-1);
+    expect(dateResolvePos).toBeGreaterThan(proposedPos);
+    expect(bullpenPostPos).toBeGreaterThan(-1);
+  });
+
+  it('Branch A accepts confirmed proposed slots instead of counter-proposing', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    const confirmedStart = posIn(branchA, '2. **Result: confirmed');
+    const okStart = posIn(branchA, '3. **Result: ok');
+    expect(confirmedStart).toBeGreaterThan(-1);
+    expect(okStart).toBeGreaterThan(confirmedStart);
+
+    const confirmedSection = branchA.slice(confirmedStart, okStart);
+    expect(confirmedSection).toContain('`Confirmed:` slot display string VERBATIM');
+    expect(confirmedSection).toContain('clean confirmation');
+    expect(confirmedSection).toContain('rather than offering alternatives');
+    expect(confirmedSection).toContain('Do NOT mention holds');
+  });
+
+  it('Branch A still counter-proposes for Result: ok alternatives', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    const okStart = posIn(branchA, '3. **Result: ok');
+    const noSlotsStart = posIn(branchA, '4. **Result: no_slots');
+    expect(okStart).toBeGreaterThan(-1);
+    expect(noSlotsStart).toBeGreaterThan(okStart);
+
+    const okSection = branchA.slice(okStart, noSlotsStart);
+    expect(okSection).toContain('counter-proposal');
+    expect(okSection).toMatch(/new\s+alternatives/);
+    expect(okSection).toContain('hold placed');
+  });
+});
+
+describe('calendar consult prompt — proposed-time conflict checks', () => {
+  it('documents Proposed as optional and leaves no-proposal consults on free-time search', () => {
+    const prompt = loadCalendarPrompt();
+    const consultSection = extractCalendarConsultSection(prompt);
+
+    expect(consultSection).toContain('The `Proposed:` block is optional');
+    expect(consultSection).toContain('consult without `Proposed:`');
+    expect(consultSection).toContain('existing free-time search flow unchanged');
+    expect(consultSection).toContain('calendar-find-free-time');
+  });
+
+  it('checks proposed slots before finding new free time', () => {
+    const prompt = loadCalendarPrompt();
+    const consultSection = extractCalendarConsultSection(prompt);
+    const checkPos = posIn(consultSection, 'calendar-check-conflicts');
+    const findPos = posIn(consultSection, 'calendar-find-free-time');
+
+    expect(checkPos).toBeGreaterThan(-1);
+    expect(findPos).toBeGreaterThan(checkPos);
+  });
+
+  it('confirms the first conflict-free proposed slot without holds or alternatives', () => {
+    const prompt = loadCalendarPrompt();
+    const consultSection = extractCalendarConsultSection(prompt);
+    const proposedStepStart = posIn(consultSection, '3. **Check sender-proposed slots first');
+    const findStepStart = posIn(consultSection, '4. **Find conflict-free windows');
+    expect(proposedStepStart).toBeGreaterThan(-1);
+    expect(findStepStart).toBeGreaterThan(proposedStepStart);
+
+    const proposedStep = consultSection.slice(proposedStepStart, findStepStart);
+    expect(proposedStep).toContain('Result: confirmed');
+    expect(proposedStep).toContain('Do NOT call `calendar-find-free-time`');
+    expect(proposedStep).toContain('do NOT place a hold');
+  });
+
+  it('falls back to alternatives when all proposed slots conflict', () => {
+    const prompt = loadCalendarPrompt();
+    const consultSection = extractCalendarConsultSection(prompt);
+    const proposedStepStart = posIn(consultSection, '3. **Check sender-proposed slots first');
+    const findStepStart = posIn(consultSection, '4. **Find conflict-free windows');
+    expect(proposedStepStart).toBeGreaterThan(-1);
+    expect(findStepStart).toBeGreaterThan(proposedStepStart);
+
+    const proposedStep = consultSection.slice(proposedStepStart, findStepStart);
+    expect(proposedStep).toContain('If every proposed slot conflicts');
+    expect(proposedStep).toContain('continue to');
+    expect(proposedStep).toContain('find alternatives');
+  });
+
+  it('adds a confirmed CONSULT REPLY variant distinct from ok alternatives', () => {
+    const prompt = loadCalendarPrompt();
+    const consultSection = extractCalendarConsultSection(prompt);
+    const confirmedPos = posIn(consultSection, 'Result: confirmed');
+    const confirmedFieldPos = posIn(consultSection, 'Confirmed:');
+    const okPos = posIn(consultSection, 'Result: ok');
+
+    expect(confirmedPos).toBeGreaterThan(-1);
+    expect(confirmedFieldPos).toBeGreaterThan(confirmedPos);
+    expect(okPos).toBeGreaterThan(confirmedFieldPos);
+    expect(consultSection).toContain('For `Result: confirmed`, never mark "hold');
+    expect(consultSection).toContain('never call `calendar-create-hold`');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the scheduling consult protocol so sender-proposed meeting times are preserved, checked first, and accepted cleanly when available instead of always counter-proposing new slots.

## Changes

- Add optional `Proposed:` entries to `ceo-inbox` CONSULT REQUESTs for specific inbound times.
- Add a `Result: confirmed` CONSULT REPLY path so Branch A drafts accept sender-proposed slots without mentioning holds or alternatives.
- Update the calendar specialist consult flow to call `calendar-check-conflicts` on proposed slots before `calendar-find-free-time`, skip holds for confirmed sender slots, and fall back to alternatives when all proposals conflict.
- Add deterministic prompt contract tests for proposed-free, proposed-busy fallback, and no-proposal unchanged flows.
- Update CHANGELOG.

## Related Issues

Closes #1186

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [x] CI passes

## Testing

- `pnpm vitest run tests/unit/agents/ceo-inbox-prompt.test.ts`
- `pnpm --prefix /workspace run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://thefungs.slack.com/archives/C0BDTUW34QY/p1782400909365779?thread_ts=1782400909.365779&cid=C0BDTUW34QY)

<div><a href="https://cursor.com/agents/bc-861c2387-75b7-54e3-bef9-026309c0a63c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-861c2387-75b7-54e3-bef9-026309c0a63c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

