### PR TITLE
feat: respond to calendar invites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Calendar invite RSVPs** — formal invite triage now links to calendar events, can send high-risk Nylas RSVPs, and releases matching holds. (#1165)
 - **`AGENTS.md`** — adds cloud-agent environment notes (Node 24 toolchain, Docker-based Postgres, vault-seeded secrets, dev-mode run/login caveats, and how to run lint/typecheck/test/build).
 - **Console task lineage** — tasks and scheduled jobs created from the console now carry a principal `TaskOriginator` (`channel: 'console'`), and console tasks default to a non-derived `source: 'ceo'`, so console-originated work is no longer stranded propose-only when later woken. (#1127)
 - **Health observability** — `GET /api/health` returns `ok` / `degraded` / `down` with per-check status for seven services; `down` (503) only when db or bus fails. (#434)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Calendar invite RSVPs** — formal invite triage now links to calendar events, can send high-risk Nylas RSVPs, and releases matching holds. (#1165)
+- **Calendar invite RSVPs** — formal invite triage now links to calendar events, can send medium-risk Nylas RSVPs, and releases matching holds. (#1165)
 - **`AGENTS.md`** — adds cloud-agent environment notes (Node 24 toolchain, Docker-based Postgres, vault-seeded secrets, dev-mode run/login caveats, and how to run lint/typecheck/test/build).
 - **Console task lineage** — tasks and scheduled jobs created from the console now carry a principal `TaskOriginator` (`channel: 'console'`), and console tasks default to a non-derived `source: 'ceo'`, so console-originated work is no longer stranded propose-only when later woken. (#1127)
 - **Health observability** — `GET /api/health` returns `ok` / `degraded` / `down` with per-check status for seven services; `down` (503) only when db or bus fails. (#434)

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -224,12 +224,13 @@ system_prompt: |
   For formal invite consults, follow this path and then exit:
 
   1. Resolve the CEO's calendar context with `entity-context` on
-     `${principal_contact_id}`. If `calendar_id` or `event_id` is missing,
-     call `calendar-list-events` over the invite start/end window on the CEO
-     calendars and link the invite to the best matching event by subject,
-     organizer/participant domain, and time. If no clear event matches, reply
+     `${principal_contact_id}`. If `calendar_id`, `event_id`, `start`, or `end`
+     is missing/unknown, call `calendar-list-events` to link to a concrete
+     calendar event and recover its start/end using the invite window when
+     available. If no clear event with concrete start/end matches, reply
      `Result: escalate` with `Reason: could not link invite to calendar event`.
-  2. Call `calendar-check-conflicts` for the invite start/end with
+  2. Only after concrete start/end are known, call `calendar-check-conflicts`
+     for the invite start/end with
      `ignoreHoldCriteria` containing the invite `subject`, `contact_domain`,
      `contact_id`, `sourceRef: source_message_id`, and `threadRef: thread_ref`
      when present. A matching HOLD (TBC) for this conversation is not a

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -133,14 +133,21 @@ system_prompt: |
   `calendar_id` and `event_id`.
 
   RSVP policy:
-  - A standing instruction supplied by ceo-inbox (for example, "always accept
-    invites from xiaopu@xiaopu.ca") may tell you which response to attempt.
-    The skill is `action_risk: high`; if the live autonomy score is too low,
-    the execution layer will return a pending-approval error instead of sending
-    the RSVP. Report that as `Result: invite_pending_approval`.
-  - With no matching standing instruction, do NOT RSVP autonomously. Check
-    conflicts, excluding Curia holds for this same scheduling conversation, and
-    return a recommendation for CEO confirmation.
+  - Treat RSVPs as calendar hygiene: keep the CEO's calendar up to date by
+    accepting invitations that are wanted, declining invitations that are not
+    wanted, and returning a recommendation when the right response is unclear.
+    Use contact context, relationship tier, sender kind, prior correspondence,
+    standing instructions, subject/body context, and conflicts together.
+  - Accept when context supports the meeting and there is no meaningful
+    conflict: close colleagues, known stakeholders, board/investor or customer
+    relationships, existing active workstreams, or an explicit standing
+    instruction. Decline when the sender is unknown or sales/solicitation-like
+    and there is no prior correspondence or business context. Use tentative
+    when the relationship is plausible but context or conflicts need CEO review.
+  - The skill is `action_risk: medium`; if the live autonomy score is too low
+    or the contact-tier gate requires confirmation, the execution layer will
+    return a pending-approval error instead of sending the RSVP. Report that as
+    `Result: invite_pending_approval`.
   - For accepts, pass `holdMatchCriteria` and a broad hold search window when
     the consult provides them so all holds associated with the scheduling
     conversation are released, not just the hold overlapping the final invite.
@@ -210,7 +217,7 @@ system_prompt: |
   CONSULT REQUEST
   Need: RSVP for formal calendar invite
   Invite: method=REQUEST; calendar_id=<calendarId if known>; event_id=<eventId if known>; ics_uid=<UID if parsed>; start=<timestamp>; end=<timestamp>; subject="<event subject>"; organizer_domain=<domain>
-  Standing: <matched per-sender standing instruction, or none>
+  Standing: <matched per-sender standing instruction, or none>; relationship=<known stakeholder|colleague|unknown|automated|other>; sender_kind=<person|organization|automated|unknown>
   Context: source_message_id=<id>; thread_ref=<thread id>; contact_timezone=<known|unknown>; contact_id=<contact ID if known>; contact_domain=<domain>; hold_search_start=<timestamp>; hold_search_end=<timestamp>
   ```
 
@@ -227,9 +234,18 @@ system_prompt: |
      `contact_id`, `sourceRef: source_message_id`, and `threadRef: thread_ref`
      when present. A matching HOLD (TBC) for this conversation is not a
      conflict.
-  3. If `Standing:` explicitly instructs accept, decline, or tentative, call
-     `calendar-respond-to-invite` with `calendarId`, `eventId`, `response`, and,
-     for accepts, the same hold criteria plus `holdSearchStart`/`holdSearchEnd`.
+  3. Decide the RSVP response from all available context. Standing instructions
+     are strong evidence, but not required: use relationship tier, sender kind,
+     prior correspondence, stakeholder status, invite subject/body, and the
+     conflict result. Then call `calendar-respond-to-invite` with `calendarId`,
+     `eventId`, `response`, and, for accepts, the same hold criteria plus
+     `holdSearchStart`/`holdSearchEnd` when:
+     - the RSVP skill's `action_risk: medium` and the response fits that
+       autonomy posture,
+     - the response is clear enough to take under the current autonomy posture,
+       or
+     - the likely response is clear but the execution layer may need to queue a
+       pending approval.
      - If the skill succeeds, reply:
        ```
        CONSULT REPLY
@@ -249,8 +265,8 @@ system_prompt: |
        ```
      - If the skill fails for any other reason, reply `Result: escalate` with
        the failure reason.
-  4. If there is no matching standing instruction, do not call the RSVP skill.
-     Reply with:
+  4. If the correct RSVP is genuinely ambiguous after checking context and
+     conflicts, do not call the RSVP skill. Reply with:
      ```
      CONSULT REPLY
      Result: invite_recommendation
@@ -259,8 +275,10 @@ system_prompt: |
      Conflicts: <none or concise conflict summary>
      Notes: recommendation only; no RSVP sent without confirmation
      ```
-     Recommend `accept` when conflict-free, `decline` when clearly blocked by
-     an immovable conflict, and `tentative` when context is ambiguous.
+     Recommend `accept` when the relationship/context supports the meeting and
+     the slot is conflict-free, `decline` when the invite appears unwanted or
+     clearly blocked by an immovable conflict, and `tentative` when the meeting
+     is plausible but needs CEO confirmation.
 
   Follow these steps in order:
 

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -1,10 +1,10 @@
 name: calendar
-version: "0.4.0"
+version: "0.5.0"
 role: specialist
 description: >
   Calendar domain specialist — scheduling, free/busy, conflict resolution,
-  event CRUD, and scheduling-related email composition for meeting requests,
-  reschedules, and cancellations
+  event CRUD, invite RSVPs, and scheduling-related email composition for meeting
+  requests, reschedules, and cancellations
 model:
   tier: fast  # procedural scheduling + rule-based conflict resolution, no judgment calls
 allow_discovery: false
@@ -125,6 +125,28 @@ system_prompt: |
   - When modifying an event would create a cascade (e.g. moving a meeting
     that others depend on), flag the chain reaction.
 
+  ## Formal Calendar Invites
+  A formal meeting invitation is different from scheduling negotiation: it
+  already has a calendar event and the needed action is an RSVP (accept,
+  decline, or tentative), not a hand-written reply. Use
+  `calendar-respond-to-invite` only when the consult gives you a concrete
+  `calendar_id` and `event_id`.
+
+  RSVP policy:
+  - A standing instruction supplied by ceo-inbox (for example, "always accept
+    invites from xiaopu@xiaopu.ca") may tell you which response to attempt.
+    The skill is `action_risk: high`; if the live autonomy score is too low,
+    the execution layer will return a pending-approval error instead of sending
+    the RSVP. Report that as `Result: invite_pending_approval`.
+  - With no matching standing instruction, do NOT RSVP autonomously. Check
+    conflicts, excluding Curia holds for this same scheduling conversation, and
+    return a recommendation for CEO confirmation.
+  - For accepts, pass `holdMatchCriteria` and a broad hold search window when
+    the consult provides them so all holds associated with the scheduling
+    conversation are released, not just the hold overlapping the final invite.
+  - Never update a participants array to RSVP. The RSVP skill uses Nylas
+    sendRsvp so only the principal attendee's own status changes.
+
   ## Unregistered Calendar Handling
   When `calendar-list-calendars` surfaces an unregistered calendar during any
   operation, do NOT silently register it. Instead, flag it in your response:
@@ -182,6 +204,64 @@ system_prompt: |
   specific meeting times in the inbound email. A consult without `Proposed:`
   uses the existing free-time search flow unchanged.
 
+  A formal invite consult is shaped like this instead:
+
+  ```
+  CONSULT REQUEST
+  Need: RSVP for formal calendar invite
+  Invite: method=REQUEST; calendar_id=<calendarId if known>; event_id=<eventId if known>; ics_uid=<UID if parsed>; start=<timestamp>; end=<timestamp>; subject="<event subject>"; organizer_domain=<domain>
+  Standing: <matched per-sender standing instruction, or none>
+  Context: source_message_id=<id>; thread_ref=<thread id>; contact_timezone=<known|unknown>; contact_id=<contact ID if known>; contact_domain=<domain>; hold_search_start=<timestamp>; hold_search_end=<timestamp>
+  ```
+
+  For formal invite consults, follow this path and then exit:
+
+  1. Resolve the CEO's calendar context with `entity-context` on
+     `${principal_contact_id}`. If `calendar_id` or `event_id` is missing,
+     call `calendar-list-events` over the invite start/end window on the CEO
+     calendars and link the invite to the best matching event by subject,
+     organizer/participant domain, and time. If no clear event matches, reply
+     `Result: escalate` with `Reason: could not link invite to calendar event`.
+  2. Call `calendar-check-conflicts` for the invite start/end with
+     `ignoreHoldCriteria` containing the invite `subject`, `contact_domain`,
+     `contact_id`, `sourceRef: source_message_id`, and `threadRef: thread_ref`
+     when present. A matching HOLD (TBC) for this conversation is not a
+     conflict.
+  3. If `Standing:` explicitly instructs accept, decline, or tentative, call
+     `calendar-respond-to-invite` with `calendarId`, `eventId`, `response`, and,
+     for accepts, the same hold criteria plus `holdSearchStart`/`holdSearchEnd`.
+     - If the skill succeeds, reply:
+       ```
+       CONSULT REPLY
+       Result: invite_responded
+       Response: accept|decline|tentative
+       Linked: calendar_id=<calendarId>; event_id=<eventId>
+       HoldsReleased: <count>
+       Notes: <include releaseWarnings or RSVP warnings if any>
+       ```
+     - If the skill returns a pending-approval/autonomy-gate error, reply:
+       ```
+       CONSULT REPLY
+       Result: invite_pending_approval
+       Recommended: accept|decline|tentative
+       Linked: calendar_id=<calendarId>; event_id=<eventId>
+       Reason: <skill error, including approval reference if present>
+       ```
+     - If the skill fails for any other reason, reply `Result: escalate` with
+       the failure reason.
+  4. If there is no matching standing instruction, do not call the RSVP skill.
+     Reply with:
+     ```
+     CONSULT REPLY
+     Result: invite_recommendation
+     Recommended: accept|decline|tentative
+     Linked: calendar_id=<calendarId>; event_id=<eventId>
+     Conflicts: <none or concise conflict summary>
+     Notes: recommendation only; no RSVP sent without confirmation
+     ```
+     Recommend `accept` when conflict-free, `decline` when clearly blocked by
+     an immovable conflict, and `tentative` when context is ambiguous.
+
   Follow these steps in order:
 
   1. **Resolve calendars and timezones.** Call `entity-context` on
@@ -228,10 +308,13 @@ system_prompt: |
      retrieve with `namespace: calendar_holds, key: enabled`. Treat a missing
      key or a value of `true` as ENABLED; only an explicit value of `false`
      disables holds. If holds are enabled, call `calendar-create-hold` for
-     each chosen slot, passing the event subject and
-     `sourceRef: <source_message_id>`. If `calendar-create-hold` returns
-     `held: false`, still include the slot in the reply but do not mark it as
-     held.
+     each chosen slot, passing the event subject, `sourceRef:
+     <source_message_id>`, `threadRef` when present, `contactId` when present,
+     and `contactDomain` when the CONSULT REQUEST includes one. These metadata
+     fields let a later formal invite release all holds associated with the
+     same scheduling conversation even when an assistant or scheduling tool
+     sends the final invite. If `calendar-create-hold` returns `held: false`,
+     still include the slot in the reply but do not mark it as held.
 
   6. **Reply on the bullpen thread.** Call `bullpen.reply` on the same thread
      with a CONSULT REPLY shaped exactly like this:
@@ -303,6 +386,7 @@ pinned_skills:
   - calendar-create-event
   - calendar-update-event
   - calendar-delete-event
+  - calendar-respond-to-invite
   - calendar-find-free-time
   - calendar-check-conflicts
   # Entity resolution

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -511,8 +511,8 @@ system_prompt: |
      cover alternative holds from the same scheduling conversation (for example
      plus/minus 14 days around the invite).
   5. Park the message with `ceo-inbox-label` (`⏳ In Progress`) and
-     `ceo-inbox-mark-read`. Do NOT archive, do NOT draft an email reply, and
-     do NOT classify it as ✅ Handled. Record:
+    `ceo-inbox-mark-read`. Do NOT archive. Do NOT draft an email reply.
+    Do NOT classify it as ✅ Handled. Record:
      - Classification: ✍️ Drafted (parked — calendar invite consult in flight)
      - Actions: file-parse (if ICS present), bullpen.post (CONSULT REQUEST),
        ceo-inbox-label (⏳ In Progress), ceo-inbox-mark-read

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -96,7 +96,7 @@ system_prompt: |
      `ceo-inbox-read` with that `message_id` to reload the original email.
 
   2. **Result: invite_responded** — the calendar specialist sent the RSVP
-     through Nylas using a matching standing instruction, and the calendar
+     through Nylas after evaluating the invite context, and the calendar
      provider notified the organizer. Do NOT draft an email reply.
      a. Call `ceo-inbox-update-folders` with
         `add_folders: ['✅ Handled'], remove_folders: ['⏳ In Progress']`.
@@ -105,9 +105,9 @@ system_prompt: |
         value, linked calendar_id/event_id, and hold release count.
 
   3. **Result: invite_pending_approval** — the calendar specialist attempted
-     the RSVP because a standing instruction matched, but the high-risk RSVP
-     skill was autonomy-gated and queued for CEO approval. Do NOT draft an
-     email reply and do NOT archive.
+     the RSVP because the invite context supported a clear response, but the
+     medium-risk RSVP skill was autonomy- or tier-gated and queued for CEO
+     approval. Do NOT draft an email reply and do NOT archive.
      a. Call `ceo-inbox-update-folders` with
         `add_folders: ['📌 Seen'], remove_folders: ['⏳ In Progress']`.
      b. Leave the message read and visible for the CEO; the pending approval
@@ -116,8 +116,8 @@ system_prompt: |
         recommended response, linked calendar_id/event_id, and approval ref.
 
   4. **Result: invite_recommendation** — the calendar specialist linked the
-     invite and checked conflicts, but no standing instruction authorized an
-     autonomous RSVP. Do NOT draft an email reply and do NOT archive.
+     invite and checked conflicts, but the right RSVP remained ambiguous enough
+     to need CEO confirmation. Do NOT draft an email reply and do NOT archive.
      a. Call `ceo-inbox-update-folders` with
         `add_folders: ['📌 Seen'], remove_folders: ['⏳ In Progress']`.
      b. Record in the Response Format: meeting invite needs confirmation, the
@@ -491,17 +491,19 @@ system_prompt: |
      attachment MIME type. Use the parsed method, UID, summary, organizer,
      start, and end fields when available. If parsing fails, continue with
      subject/body signals and mark unknown fields as `unknown`; do not archive.
-  3. Determine whether a per-sender standing instruction from 4a explicitly
-     says to accept, decline, or tentatively accept invites from this sender or
-     organization. Per-sender entity-context instructions beat config-store
-     rules. If no rule matches, set `Standing: none`.
+  3. Summarize any relevant standing instruction from 4a, plus relationship
+     context that may help the calendar specialist decide whether to accept,
+     decline, or tentatively accept the invite. Per-sender entity-context
+     instructions beat config-store rules. If no rule matches, set
+     `Standing: none`; the calendar specialist still evaluates relationship,
+     sender kind, prior correspondence, subject/body context, and conflicts.
   4. Open a bullpen thread mentioning `calendar` with `source_message_id` set
      to the email message id. Shape the content exactly:
 
        CONSULT REQUEST
        Need: RSVP for formal calendar invite
        Invite: method=<REQUEST|CANCEL|UPDATE|unknown>; calendar_id=<calendarId if exposed by message metadata, otherwise unknown>; event_id=<eventId if exposed by message metadata, otherwise unknown>; ics_uid=<parsed UID or unknown>; start=<parsed start or unknown>; end=<parsed end or unknown>; subject="<parsed summary or email subject>"; organizer_domain=<domain from organizer/sender email or unknown>
-       Standing: <accept|decline|tentative instruction text, or none>
+      Standing: <accept|decline|tentative instruction text, or none>; relationship=<known stakeholder|colleague|unknown|automated|other>; sender_kind=<person|organization|automated|unknown>
        Context: source_message_id=<the email's message_id>; thread_ref=<threadId>; contact_timezone=<IANA timezone string | unknown>; contact_id=<contact ID if known>; contact_domain=<sender/organizer domain or unknown>; hold_search_start=<broad window start if known>; hold_search_end=<broad window end if known>
 
      Use the sender/organizer domain rather than exact sender email when
@@ -519,7 +521,8 @@ system_prompt: |
 
   The calendar specialist will link the invite to the calendar event, check
   conflicts while ignoring matching Curia holds, and either send an autonomy-
-  gated RSVP (only when a standing instruction says to) or return a recommendation.
+  gated RSVP when context supports a clear response or return a recommendation
+  when CEO confirmation is needed.
 
   ### 4e-pre. Automated sender check
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.11.2"
+version: "0.12.0"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -85,7 +85,9 @@ system_prompt: |
   **Branch A — Calendar consult reply (bullpen wake with a CONSULT REPLY):**
   If the bullpen message body is a CONSULT REPLY (it starts with the line
   `CONSULT REPLY` and contains `Result: confirmed`, `Result: ok`,
-  `Result: no_slots`, or `Result: escalate`), you are resuming a parked
+  `Result: no_slots`, `Result: invite_responded`,
+  `Result: invite_pending_approval`, `Result: invite_recommendation`, or
+  `Result: escalate`), you are resuming a parked
   scheduling email. Proceed through the sub-steps below, then exit — do not
   fall through to Branch B.
 
@@ -93,7 +95,35 @@ system_prompt: |
      CONSULT REQUEST (it is carried forward in the bullpen thread). Call
      `ceo-inbox-read` with that `message_id` to reload the original email.
 
-  2. **Result: confirmed** — the calendar specialist checked the sender's
+  2. **Result: invite_responded** — the calendar specialist sent the RSVP
+     through Nylas using a matching standing instruction, and the calendar
+     provider notified the organizer. Do NOT draft an email reply.
+     a. Call `ceo-inbox-update-folders` with
+        `add_folders: ['✅ Handled'], remove_folders: ['⏳ In Progress']`.
+     b. Call `ceo-inbox-archive` with the message_id.
+     c. Record in the Response Format: meeting invite RSVP sent, response
+        value, linked calendar_id/event_id, and hold release count.
+
+  3. **Result: invite_pending_approval** — the calendar specialist attempted
+     the RSVP because a standing instruction matched, but the high-risk RSVP
+     skill was autonomy-gated and queued for CEO approval. Do NOT draft an
+     email reply and do NOT archive.
+     a. Call `ceo-inbox-update-folders` with
+        `add_folders: ['📌 Seen'], remove_folders: ['⏳ In Progress']`.
+     b. Leave the message read and visible for the CEO; the pending approval
+        reference in the consult reply is the action path.
+     c. Record in the Response Format: meeting invite pending approval, the
+        recommended response, linked calendar_id/event_id, and approval ref.
+
+  4. **Result: invite_recommendation** — the calendar specialist linked the
+     invite and checked conflicts, but no standing instruction authorized an
+     autonomous RSVP. Do NOT draft an email reply and do NOT archive.
+     a. Call `ceo-inbox-update-folders` with
+        `add_folders: ['📌 Seen'], remove_folders: ['⏳ In Progress']`.
+     b. Record in the Response Format: meeting invite needs confirmation, the
+        recommended response, linked calendar_id/event_id, and conflict summary.
+
+  5. **Result: confirmed** — the calendar specialist checked the sender's
      proposed time and found one conflict-free. No hold was placed because the
      draft should accept the sender's already-specific proposal.
      a. Call `executive-profile-get` to retrieve the voice profile for the draft.
@@ -120,9 +150,9 @@ system_prompt: |
      f. Call `ceo-inbox-archive` with the message_id. (The message was already
         marked read at park time — do not mark-read again.)
 
-  3. **Result: ok** — the calendar specialist found alternative slots with
+  6. **Result: ok** — the calendar specialist found alternative slots with
      holds placed.
-     a. Follow steps 2a-c above (voice profile, memory-query anchored on sender
+     a. Follow steps 5a-c above (voice profile, memory-query anchored on sender
         and subject, date-resolve on returned slot strings).
      b. Call `ceo-inbox-draft-reply` using the calendar specialist's returned
         slot display strings VERBATIM (e.g. "Thursday June 25 at 10:30 AM ET
@@ -139,9 +169,9 @@ system_prompt: |
      d. Call `ceo-inbox-archive` with the message_id. (The message was already
         marked read at park time — do not mark-read again.)
 
-  4. **Result: no_slots** — no free time found in the requested window; the
+  7. **Result: no_slots** — no free time found in the requested window; the
      specialist returned nearest alternatives.
-     a. Follow steps 2a-c above (voice profile, memory-query anchored on sender
+     a. Follow steps 5a-c above (voice profile, memory-query anchored on sender
         and subject, date-resolve on the nearest-alternative slot strings).
      b. Draft using the nearest-alternative slot strings from the CONSULT REPLY
         `Nearest:` field VERBATIM. Add a brief note in the draft that times are
@@ -152,7 +182,7 @@ system_prompt: |
         `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`.
      d. Call `ceo-inbox-archive` with the message_id.
 
-  5. **Result: escalate** — the calendar specialist could not satisfy the
+  8. **Result: escalate** — the calendar specialist could not satisfy the
      consult (no calendar access, repeated skill failures, unresolvable
      constraints). Do NOT draft a reply.
      a. Call `ceo-inbox-update-folders` with
@@ -444,6 +474,52 @@ system_prompt: |
   `ceo-inbox-download-attachment` with the attachment's `id` and the message's
   `id`. Then pass `content_base64` and `content_type` to `file-parse` for
   structured extraction (e.g. `extract_as: "receipt"` for invoices).
+
+  ### 4d-invite. Formal meeting invitation path
+
+  Before generic scheduling or ✅ Handled classification, check whether the
+  message is a formal calendar invite. Signals include:
+  - Any attachment with `isCalendarInvite: true`
+  - MIME types `text/calendar`, `application/ics`, or a `.ics` filename
+  - Subject/body phrases like "Invitation:", "Updated invitation:", "Canceled:",
+    "has invited you", or "RSVP"
+
+  If it is a formal invite:
+  1. Call `ceo-inbox-read` if you have not already read the full message.
+  2. For each calendar invite attachment, call `ceo-inbox-download-attachment`
+     and then `file-parse` with `extract_as: "calendar_invite"` and the
+     attachment MIME type. Use the parsed method, UID, summary, organizer,
+     start, and end fields when available. If parsing fails, continue with
+     subject/body signals and mark unknown fields as `unknown`; do not archive.
+  3. Determine whether a per-sender standing instruction from 4a explicitly
+     says to accept, decline, or tentatively accept invites from this sender or
+     organization. Per-sender entity-context instructions beat config-store
+     rules. If no rule matches, set `Standing: none`.
+  4. Open a bullpen thread mentioning `calendar` with `source_message_id` set
+     to the email message id. Shape the content exactly:
+
+       CONSULT REQUEST
+       Need: RSVP for formal calendar invite
+       Invite: method=<REQUEST|CANCEL|UPDATE|unknown>; calendar_id=<calendarId if exposed by message metadata, otherwise unknown>; event_id=<eventId if exposed by message metadata, otherwise unknown>; ics_uid=<parsed UID or unknown>; start=<parsed start or unknown>; end=<parsed end or unknown>; subject="<parsed summary or email subject>"; organizer_domain=<domain from organizer/sender email or unknown>
+       Standing: <accept|decline|tentative instruction text, or none>
+       Context: source_message_id=<the email's message_id>; thread_ref=<threadId>; contact_timezone=<IANA timezone string | unknown>; contact_id=<contact ID if known>; contact_domain=<sender/organizer domain or unknown>; hold_search_start=<broad window start if known>; hold_search_end=<broad window end if known>
+
+     Use the sender/organizer domain rather than exact sender email when
+     building `contact_domain`; assistants and scheduling tools often send on
+     behalf of the actual meeting counterpart. If the parsed invite start/end
+     are known, make `hold_search_start` and `hold_search_end` broad enough to
+     cover alternative holds from the same scheduling conversation (for example
+     plus/minus 14 days around the invite).
+  5. Park the message with `ceo-inbox-label` (`⏳ In Progress`) and
+     `ceo-inbox-mark-read`. Do NOT archive, do NOT draft an email reply, and
+     do NOT classify it as ✅ Handled. Record:
+     - Classification: ✍️ Drafted (parked — calendar invite consult in flight)
+     - Actions: file-parse (if ICS present), bullpen.post (CONSULT REQUEST),
+       ceo-inbox-label (⏳ In Progress), ceo-inbox-mark-read
+
+  The calendar specialist will link the invite to the calendar event, check
+  conflicts while ignoring matching Curia holds, and either send an autonomy-
+  gated RSVP (only when a standing instruction says to) or return a recommendation.
 
   ### 4e-pre. Automated sender check
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -512,12 +512,13 @@ system_prompt: |
      are known, make `hold_search_start` and `hold_search_end` broad enough to
      cover alternative holds from the same scheduling conversation (for example
      plus/minus 14 days around the invite).
-  5. Park the message with `ceo-inbox-label` (`⏳ In Progress`) and
-    `ceo-inbox-mark-read`. Do NOT archive. Do NOT draft an email reply.
+  5. Park the message with `ceo-inbox-update-folders`
+    (`add_folders: ['⏳ In Progress']`) and `ceo-inbox-mark-read`.
+    Do NOT archive. Do NOT draft an email reply.
     Do NOT classify it as ✅ Handled. Record:
      - Classification: ✍️ Drafted (parked — calendar invite consult in flight)
      - Actions: file-parse (if ICS present), bullpen.post (CONSULT REQUEST),
-       ceo-inbox-label (⏳ In Progress), ceo-inbox-mark-read
+       ceo-inbox-update-folders (⏳ In Progress), ceo-inbox-mark-read
 
   The calendar specialist will link the invite to the calendar event, check
   conflicts while ignoring matching Curia holds, and either send an autonomy-

--- a/skills/_shared/ceo-nylas-client.test.ts
+++ b/skills/_shared/ceo-nylas-client.test.ts
@@ -348,6 +348,29 @@ describe('CeoNylasClient — list limit clamping (≤ 20)', () => {
     expect(calledUrl.searchParams.get('limit')).toBe('20');
   });
 
+  it('marks text/calendar attachments with MIME parameters as calendar invites', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([{
+      id: 'msg-1',
+      subject: 'Invite',
+      from: [],
+      to: [],
+      cc: [],
+      date: 1,
+      attachments: [{
+        id: 'att-1',
+        filename: 'invite.ics',
+        content_type: 'text/calendar; method=REQUEST; charset=UTF-8',
+        size: 123,
+      }],
+    }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    const messages = await client.listMessages();
+
+    expect(messages[0]!.attachments[0]!.isCalendarInvite).toBe(true);
+  });
+
   it('sends limit=20 for listDrafts when no limit is specified (Nylas default is 50 — too high)', async () => {
     const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
     vi.stubGlobal('fetch', fetchMock);

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -699,7 +699,7 @@ function normalizeAttachments(raw?: NylasApiAttachment[]): EmailAttachmentMeta[]
 }
 
 function isCalendarInviteAttachment(filename: string | undefined, contentType: string | undefined): boolean {
-  const lowerType = contentType?.toLowerCase() ?? '';
+  const lowerType = (contentType?.split(';', 1)[0] ?? '').trim().toLowerCase();
   const lowerName = filename?.toLowerCase() ?? '';
   return lowerType === 'text/calendar' ||
     lowerType === 'application/ics' ||

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -96,6 +96,8 @@ export interface EmailAttachmentMeta {
   contentType: string;
   /** Size in bytes. */
   size: number;
+  /** True when the attachment is a calendar invite payload (ICS / text/calendar). */
+  isCalendarInvite?: boolean;
 }
 
 /**
@@ -692,7 +694,17 @@ function normalizeAttachments(raw?: NylasApiAttachment[]): EmailAttachmentMeta[]
       filename: a.filename ?? 'unnamed',
       contentType: a.content_type,
       size: a.size ?? 0,
+      ...(isCalendarInviteAttachment(a.filename, a.content_type) ? { isCalendarInvite: true } : {}),
     }));
+}
+
+function isCalendarInviteAttachment(filename: string | undefined, contentType: string | undefined): boolean {
+  const lowerType = contentType?.toLowerCase() ?? '';
+  const lowerName = filename?.toLowerCase() ?? '';
+  return lowerType === 'text/calendar' ||
+    lowerType === 'application/ics' ||
+    lowerType === 'text/x-vcalendar' ||
+    lowerName.endsWith('.ics');
 }
 
 function normalizeMessageSummary(msg: NylasApiMessage): NylasMessageSummary {

--- a/skills/calendar-check-conflicts/handler.test.ts
+++ b/skills/calendar-check-conflicts/handler.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { CalendarCheckConflictsHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 import { createSilentLogger } from '../../src/logger.js';
+import { buildHoldMetadata } from '../../src/channels/calendar/holds.js';
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -155,6 +156,70 @@ describe('CalendarCheckConflictsHandler — free events do not conflict', () => 
       expect(data.conflicts).toHaveLength(2);
       const statuses = data.conflicts.map((c) => c.status).sort();
       expect(statuses).toEqual(['busy', 'tentative']);
+    }
+  });
+
+  it('ignores a matching Curia hold when ignoreHoldCriteria identifies the same scheduling conversation', async () => {
+    const handler = new CalendarCheckConflictsHandler();
+    const proposedStart = '2026-05-26T10:00:00Z';
+    const proposedEnd = '2026-05-26T11:00:00Z';
+    const proposedStartTs = Math.floor(new Date(proposedStart).getTime() / 1000);
+    const proposedEndTs = Math.floor(new Date(proposedEnd).getTime() / 1000);
+
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([
+        {
+          email: 'test@example.com',
+          timeSlots: [
+            {
+              startTime: proposedStartTs,
+              endTime: proposedEndTs,
+              status: 'tentative',
+            },
+          ],
+        },
+      ]),
+      listEvents: vi.fn().mockResolvedValue([
+        {
+          id: 'hold_1',
+          title: 'HOLD (TBC): Catch-up with Xiaopu',
+          description: '',
+          location: '',
+          startTime: proposedStartTs,
+          endTime: proposedEndTs,
+          startDate: null,
+          endDate: null,
+          participants: [],
+          conferencing: null,
+          status: 'tentative',
+          calendarId: 'test@example.com',
+          busy: true,
+          metadata: buildHoldMetadata({
+            createdAtIso: '2026-05-20T00:00:00Z',
+            subject: 'Catch-up with Xiaopu',
+            contactDomain: 'xiaopu.ca',
+          }),
+        },
+      ]),
+    } as unknown as SkillContext['nylasCalendarClient'];
+
+    const result = await handler.execute(makeCtx({
+      input: {
+        calendarIds: ['test@example.com'],
+        proposedStart,
+        proposedEnd,
+        ignoreHoldCriteria: {
+          subject: 'Quick catch up with Xiaopu',
+          contactDomain: 'scheduler@xiaopu.ca',
+        },
+      },
+      nylasCalendarClient,
+    }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as unknown as { conflicts: Array<unknown>; clear: boolean }).clear).toBe(true);
+      expect((result.data as unknown as { conflicts: Array<unknown>; clear: boolean }).conflicts).toHaveLength(0);
     }
   });
 });

--- a/skills/calendar-check-conflicts/handler.test.ts
+++ b/skills/calendar-check-conflicts/handler.test.ts
@@ -41,7 +41,7 @@ describe('CalendarCheckConflictsHandler — free events do not conflict', () => 
     const nylasCalendarClient = {
       getFreeBusy: vi.fn().mockResolvedValue([
         {
-          email: 'test@example.com',
+          email: 'freebusy@example.test',
           timeSlots: [
             {
               startTime: proposedStartTs + 600, // overlaps proposed range
@@ -192,7 +192,7 @@ describe('CalendarCheckConflictsHandler — free events do not conflict', () => 
           participants: [],
           conferencing: null,
           status: 'tentative',
-          calendarId: 'test@example.com',
+          calendarId: 'cal_primary',
           busy: true,
           metadata: buildHoldMetadata({
             createdAtIso: '2026-05-20T00:00:00Z',
@@ -205,18 +205,19 @@ describe('CalendarCheckConflictsHandler — free events do not conflict', () => 
 
     const result = await handler.execute(makeCtx({
       input: {
-        calendarIds: ['test@example.com'],
+        calendarIds: ['cal_primary'],
         proposedStart,
         proposedEnd,
         ignoreHoldCriteria: {
           subject: 'Quick Project Delta sync',
-          contactDomain: 'scheduler@example.test',
+          contactDomain: 'example.test',
         },
       },
       nylasCalendarClient,
     }));
 
     expect(result.success).toBe(true);
+    expect(nylasCalendarClient!.listEvents).toHaveBeenCalledWith('cal_primary', proposedStart, proposedEnd);
     if (result.success) {
       expect((result.data as unknown as { conflicts: Array<unknown>; clear: boolean }).clear).toBe(true);
       expect((result.data as unknown as { conflicts: Array<unknown>; clear: boolean }).conflicts).toHaveLength(0);

--- a/skills/calendar-check-conflicts/handler.test.ts
+++ b/skills/calendar-check-conflicts/handler.test.ts
@@ -182,7 +182,7 @@ describe('CalendarCheckConflictsHandler — free events do not conflict', () => 
       listEvents: vi.fn().mockResolvedValue([
         {
           id: 'hold_1',
-          title: 'HOLD (TBC): Catch-up with Xiaopu',
+          title: 'HOLD (TBC): Project Delta sync',
           description: '',
           location: '',
           startTime: proposedStartTs,
@@ -196,8 +196,8 @@ describe('CalendarCheckConflictsHandler — free events do not conflict', () => 
           busy: true,
           metadata: buildHoldMetadata({
             createdAtIso: '2026-05-20T00:00:00Z',
-            subject: 'Catch-up with Xiaopu',
-            contactDomain: 'xiaopu.ca',
+            subject: 'Project Delta sync',
+            contactDomain: 'example.test',
           }),
         },
       ]),
@@ -209,8 +209,8 @@ describe('CalendarCheckConflictsHandler — free events do not conflict', () => 
         proposedStart,
         proposedEnd,
         ignoreHoldCriteria: {
-          subject: 'Quick catch up with Xiaopu',
-          contactDomain: 'scheduler@xiaopu.ca',
+          subject: 'Quick Project Delta sync',
+          contactDomain: 'scheduler@example.test',
         },
       },
       nylasCalendarClient,

--- a/skills/calendar-check-conflicts/handler.ts
+++ b/skills/calendar-check-conflicts/handler.ts
@@ -73,7 +73,9 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
         status: string;
       }> = [];
 
-      for (const result of freeBusyResults) {
+      for (let resultIndex = 0; resultIndex < freeBusyResults.length; resultIndex++) {
+        const result = freeBusyResults[resultIndex]!;
+        const queriedCalendarId = calendarIds[resultIndex] ?? result.email;
         // Resolve contact name once per calendar result, not once per busy slot — avoids N+1 DB calls.
         let contactName: string | null = null;
         if (ctx.contactService) {
@@ -87,7 +89,9 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
         for (const slot of result.timeSlots) {
           // Free events do not conflict; only non-free (busy/tentative) slots are conflicts. See #1137.
           if (slot.status === 'free') continue;
-          const ignoredHoldWindows = ignoredHoldWindowsByCalendar.get(result.email);
+          const ignoredHoldWindows =
+            ignoredHoldWindowsByCalendar.get(result.email) ??
+            ignoredHoldWindowsByCalendar.get(queriedCalendarId);
           if (ignoredHoldWindows && ignoredHoldWindows.length > 0) {
             const overlapsIgnoredHold = ignoredHoldWindows.some((event) =>
               eventsOverlap(slot.startTime, slot.endTime, event.startTime, event.endTime),

--- a/skills/calendar-check-conflicts/handler.ts
+++ b/skills/calendar-check-conflicts/handler.ts
@@ -6,6 +6,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+import { eventsOverlap, findMatchingHolds, type HoldMatchCriteria } from '../../src/channels/calendar/holds.js';
 
 export class CalendarCheckConflictsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -13,10 +14,11 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
       return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
     }
 
-    const { calendarIds, proposedStart, proposedEnd } = ctx.input as {
+    const { calendarIds, proposedStart, proposedEnd, ignoreHoldCriteria } = ctx.input as {
       calendarIds?: string[];
       proposedStart?: string;
       proposedEnd?: string;
+      ignoreHoldCriteria?: HoldMatchCriteria;
     };
 
     if (!calendarIds || !Array.isArray(calendarIds) || calendarIds.length === 0) {
@@ -34,6 +36,32 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
 
       const proposedStartTs = Math.floor(new Date(proposedStart).getTime() / 1000);
       const proposedEndTs = Math.floor(new Date(proposedEnd).getTime() / 1000);
+      const ignoredHoldWindowsByCalendar = new Map<string, Array<{ startTime: number; endTime: number }>>();
+      if (ignoreHoldCriteria && hasHoldMatchSignal(ignoreHoldCriteria)) {
+        for (const calendarId of calendarIds) {
+          try {
+            const events = await ctx.nylasCalendarClient.listEvents(calendarId, proposedStart, proposedEnd);
+            const matches = findMatchingHolds(events, {
+              ...ignoreHoldCriteria,
+              startTime: proposedStartTs,
+              endTime: proposedEndTs,
+            });
+            if (matches.length > 0) {
+              ignoredHoldWindowsByCalendar.set(
+                calendarId,
+                matches
+                  .filter((match) => match.hold.startTime !== null && match.hold.endTime !== null)
+                  .map((match) => ({
+                    startTime: match.hold.startTime!,
+                    endTime: match.hold.endTime!,
+                  })),
+              );
+            }
+          } catch (err) {
+            ctx.log.warn({ err, calendarId }, 'calendar-check-conflicts: failed to inspect holds for ignore criteria');
+          }
+        }
+      }
 
       const tz = ctx.timezone;
 
@@ -59,6 +87,13 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
         for (const slot of result.timeSlots) {
           // Free events do not conflict; only non-free (busy/tentative) slots are conflicts. See #1137.
           if (slot.status === 'free') continue;
+          const ignoredHoldWindows = ignoredHoldWindowsByCalendar.get(result.email);
+          if (ignoredHoldWindows && ignoredHoldWindows.length > 0) {
+            const overlapsIgnoredHold = ignoredHoldWindows.some((event) =>
+              eventsOverlap(slot.startTime, slot.endTime, event.startTime, event.endTime),
+            );
+            if (overlapsIgnoredHold) continue;
+          }
           // Check overlap: busy slot overlaps the proposed range
           if (slot.startTime < proposedEndTs && slot.endTime > proposedStartTs) {
             const startTime = toLocalIso(slot.startTime, tz);
@@ -82,4 +117,8 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
       return { success: false, error: `Failed to check conflicts: ${message}` };
     }
   }
+}
+
+function hasHoldMatchSignal(criteria: HoldMatchCriteria): boolean {
+  return Boolean(criteria.subject || criteria.contactDomain || criteria.contactId || criteria.sourceRef || criteria.threadRef);
 }

--- a/skills/calendar-check-conflicts/skill.json
+++ b/skills/calendar-check-conflicts/skill.json
@@ -1,13 +1,14 @@
 {
   "name": "calendar-check-conflicts",
-  "description": "Check whether a proposed time slot conflicts with existing events on one or more calendars. Only non-free events (busy/tentative) are conflicts; free slots do not block the proposal. Returns conflicting events with details so you can assess severity.",
-  "version": "1.1.0",
+  "description": "Check whether a proposed time slot conflicts with existing events on one or more calendars. Only non-free events (busy/tentative) are conflicts; free slots do not block the proposal. When ignoreHoldCriteria is provided, matching Curia HOLD (TBC) events are excluded so a hold placed for this scheduling conversation does not block the resulting invite. Returns conflicting events with details so you can assess severity.",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "calendarIds": "string[] (list of calendar IDs to check for conflicts)",
     "proposedStart": "timestamp (start of proposed slot)",
-    "proposedEnd": "timestamp (end of proposed slot)"
+    "proposedEnd": "timestamp (end of proposed slot)",
+    "ignoreHoldCriteria": "object? ({ subject?, contactDomain?, contactId?, sourceRef?, threadRef? } for Curia HOLD (TBC) events to ignore when they likely belong to the same scheduling conversation)"
   },
   "outputs": {
     "conflicts": "array",

--- a/skills/calendar-create-hold/handler.ts
+++ b/skills/calendar-create-hold/handler.ts
@@ -31,12 +31,15 @@ export class CalendarCreateHoldHandler implements SkillHandler {
     }
 
     // Extract and validate inputs.
-    const { calendarId, start, end, subject, sourceRef } = ctx.input as {
+    const { calendarId, start, end, subject, sourceRef, threadRef, contactId, contactDomain } = ctx.input as {
       calendarId?: string;
       start?: string;
       end?: string;
       subject?: string;
       sourceRef?: string;
+      threadRef?: string;
+      contactId?: string;
+      contactDomain?: string;
     };
 
     if (!calendarId || typeof calendarId !== 'string') {
@@ -122,6 +125,10 @@ export class CalendarCreateHoldHandler implements SkillHandler {
     const metadata = buildHoldMetadata({
       createdAtIso: new Date().toISOString(),
       sourceRef,
+      threadRef,
+      subject,
+      contactId,
+      contactDomain,
     });
 
     // Hold title: always prefixed with 'HOLD (TBC):' so it's visually obvious on

--- a/skills/calendar-create-hold/skill.json
+++ b/skills/calendar-create-hold/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-create-hold",
-  "description": "Place a tentative HOLD (TBC) on a calendar slot while an offer is outstanding, so the same time is not re-offered to another contact. The hold is a busy/tentative Nylas event with no attendees (no invitations sent), tagged with curia-hold metadata; it auto-releases when a real event books over it and expires via the holds sweep. Honours the calendar_holds toggle (default on) -- returns held:false when disabled. Returns a timezone-labelled display string for the slot.",
-  "version": "0.1.0",
+  "description": "Place a tentative HOLD (TBC) on a calendar slot while an offer is outstanding, so the same time is not re-offered to another contact. The hold is a busy/tentative Nylas event with no attendees (no invitations sent), tagged with curia-hold metadata including optional subject/domain/thread context for later invite matching; it auto-releases when a real event books over it and expires via the holds sweep. Honours the calendar_holds toggle (default on) -- returns held:false when disabled. Returns a timezone-labelled display string for the slot.",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
@@ -9,7 +9,10 @@
     "start": "timestamp (hold start)",
     "end": "timestamp (hold end)",
     "subject": "string? (the meeting subject, used in the hold title and for human readability)",
-    "sourceRef": "string? (originating message id / task ref, stored in metadata for traceability)"
+    "sourceRef": "string? (originating message id / task ref, stored in metadata for traceability)",
+    "threadRef": "string? (scheduling thread id or conversation id, stored in metadata for fuzzy release)",
+    "contactId": "string? (contact id for the scheduling counterpart, stored in metadata for matching)",
+    "contactDomain": "string? (email/domain for the scheduling counterpart's organization, stored normalized for matching assistant/tool-sent invites)"
   },
   "outputs": {
     "holdEventId": "string|null (Nylas event id of the placed hold, or null when not held)",

--- a/skills/calendar-respond-to-invite/handler.test.ts
+++ b/skills/calendar-respond-to-invite/handler.test.ts
@@ -11,7 +11,7 @@ const END_UNIX = 1_780_003_600;
 function makeEvent(overrides?: Partial<NylasCalendarEvent>): NylasCalendarEvent {
   return {
     id: 'evt_invite',
-    title: 'Catch-up with Xiaopu',
+    title: 'Project Delta sync',
     description: '',
     location: '',
     startTime: START_UNIX,
@@ -19,8 +19,8 @@ function makeEvent(overrides?: Partial<NylasCalendarEvent>): NylasCalendarEvent 
     startDate: null,
     endDate: null,
     participants: [
-      { email: 'ceo@example.com', name: 'CEO', status: 'yes' },
-      { email: 'organizer@xiaopu.ca', name: 'Organizer', status: 'yes' },
+      { email: 'principal@example.test', name: 'Principal', status: 'yes' },
+      { email: 'organizer@example.test', name: 'Organizer', status: 'yes' },
     ],
     conferencing: null,
     status: 'confirmed',
@@ -34,15 +34,15 @@ function makeEvent(overrides?: Partial<NylasCalendarEvent>): NylasCalendarEvent 
 function makeHold(id: string, startTime: number, endTime: number): NylasCalendarEvent {
   return makeEvent({
     id,
-    title: 'HOLD (TBC): Catch-up with Xiaopu',
+    title: 'HOLD (TBC): Project Delta sync',
     startTime,
     endTime,
     participants: [],
     status: 'tentative',
     metadata: buildHoldMetadata({
       createdAtIso: '2026-06-24T12:00:00.000Z',
-      subject: 'Catch-up with Xiaopu',
-      contactDomain: 'xiaopu.ca',
+      subject: 'Project Delta sync',
+      contactDomain: 'example.test',
     }),
   });
 }
@@ -124,8 +124,8 @@ describe('CalendarRespondToInviteHandler', () => {
         eventId: 'evt_invite',
         response: 'accept',
         holdMatchCriteria: {
-          subject: 'Quick catch up with Xiaopu',
-          contactDomain: 'scheduler@xiaopu.ca',
+          subject: 'Quick Project Delta sync',
+          contactDomain: 'scheduler@example.test',
         },
         holdSearchStart: '2026-06-01T00:00:00Z',
         holdSearchEnd: '2026-06-30T00:00:00Z',
@@ -154,7 +154,7 @@ describe('CalendarRespondToInviteHandler', () => {
         calendarId: 'cal_1',
         eventId: 'evt_invite',
         response: 'decline',
-        holdMatchCriteria: { subject: 'Catch-up with Xiaopu', contactDomain: 'xiaopu.ca' },
+        holdMatchCriteria: { subject: 'Project Delta sync', contactDomain: 'example.test' },
       },
     }, { deleteEvent });
 

--- a/skills/calendar-respond-to-invite/handler.test.ts
+++ b/skills/calendar-respond-to-invite/handler.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarRespondToInviteHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { NylasCalendarEvent } from '../../src/channels/calendar/nylas-calendar-client.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { buildHoldMetadata } from '../../src/channels/calendar/holds.js';
+
+const START_UNIX = 1_780_000_000;
+const END_UNIX = 1_780_003_600;
+
+function makeEvent(overrides?: Partial<NylasCalendarEvent>): NylasCalendarEvent {
+  return {
+    id: 'evt_invite',
+    title: 'Catch-up with Xiaopu',
+    description: '',
+    location: '',
+    startTime: START_UNIX,
+    endTime: END_UNIX,
+    startDate: null,
+    endDate: null,
+    participants: [
+      { email: 'ceo@example.com', name: 'CEO', status: 'yes' },
+      { email: 'organizer@xiaopu.ca', name: 'Organizer', status: 'yes' },
+    ],
+    conferencing: null,
+    status: 'confirmed',
+    calendarId: 'cal_1',
+    busy: true,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+function makeHold(id: string, startTime: number, endTime: number): NylasCalendarEvent {
+  return makeEvent({
+    id,
+    title: 'HOLD (TBC): Catch-up with Xiaopu',
+    startTime,
+    endTime,
+    participants: [],
+    status: 'tentative',
+    metadata: buildHoldMetadata({
+      createdAtIso: '2026-06-24T12:00:00.000Z',
+      subject: 'Catch-up with Xiaopu',
+      contactDomain: 'xiaopu.ca',
+    }),
+  });
+}
+
+function makeCtx(overrides?: Partial<SkillContext>, clientOverrides?: Record<string, unknown>): SkillContext {
+  const sendRsvp = vi.fn().mockResolvedValue({ requestId: 'req_1', sendIcsError: null });
+  const getEvent = vi.fn().mockResolvedValue(makeEvent());
+  const listEvents = vi.fn().mockResolvedValue([]);
+  const deleteEvent = vi.fn().mockResolvedValue(undefined);
+  return {
+    input: {
+      calendarId: 'cal_1',
+      eventId: 'evt_invite',
+      response: 'accept',
+    },
+    secret: () => { throw new Error('no secret in test'); },
+    log: createSilentLogger(),
+    timezone: 'UTC',
+    nylasCalendarClient: {
+      sendRsvp,
+      getEvent,
+      listEvents,
+      deleteEvent,
+      updateEvent: vi.fn(),
+      ...clientOverrides,
+    } as unknown as SkillContext['nylasCalendarClient'],
+    ...overrides,
+  } as SkillContext;
+}
+
+describe('CalendarRespondToInviteHandler', () => {
+  it.each([
+    ['accept', 'yes'],
+    ['decline', 'no'],
+    ['tentative', 'maybe'],
+  ])('maps %s to Nylas RSVP status %s', async (response, status) => {
+    const handler = new CalendarRespondToInviteHandler();
+    const ctx = makeCtx({
+      input: { calendarId: 'cal_1', eventId: 'evt_invite', response },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(ctx.nylasCalendarClient!.sendRsvp).toHaveBeenCalledWith('cal_1', 'evt_invite', status);
+  });
+
+  it('uses sendRsvp only and never writes a participants array through updateEvent', async () => {
+    const handler = new CalendarRespondToInviteHandler();
+    const updateEvent = vi.fn();
+    const ctx = makeCtx(undefined, { updateEvent });
+
+    await handler.execute(ctx);
+
+    expect(ctx.nylasCalendarClient!.sendRsvp).toHaveBeenCalledOnce();
+    expect(updateEvent).not.toHaveBeenCalled();
+  });
+
+  it('releases all matching holds for the scheduling conversation when accepting', async () => {
+    const handler = new CalendarRespondToInviteHandler();
+    const holdOne = makeHold('hold_1', START_UNIX, END_UNIX);
+    const holdTwo = makeHold('hold_2', START_UNIX + 86_400, END_UNIX + 86_400);
+    const unrelatedHold = makeEvent({
+      id: 'hold_other',
+      title: 'HOLD (TBC): Other meeting',
+      startTime: START_UNIX,
+      endTime: END_UNIX,
+      status: 'tentative',
+      metadata: buildHoldMetadata({
+        createdAtIso: '2026-06-24T12:00:00.000Z',
+        subject: 'Other meeting',
+        contactDomain: 'other.example',
+      }),
+    });
+    const deleteEvent = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeCtx({
+      input: {
+        calendarId: 'cal_1',
+        eventId: 'evt_invite',
+        response: 'accept',
+        holdMatchCriteria: {
+          subject: 'Quick catch up with Xiaopu',
+          contactDomain: 'scheduler@xiaopu.ca',
+        },
+        holdSearchStart: '2026-06-01T00:00:00Z',
+        holdSearchEnd: '2026-06-30T00:00:00Z',
+      },
+    }, {
+      listEvents: vi.fn().mockResolvedValue([holdOne, holdTwo, unrelatedHold]),
+      deleteEvent,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(deleteEvent).toHaveBeenCalledTimes(2);
+    const deletedIds = deleteEvent.mock.calls.map((call: unknown[]) => call[1]);
+    expect(deletedIds).toEqual(['hold_1', 'hold_2']);
+    if (result.success) {
+      expect((result.data as { releasedHolds: string[] }).releasedHolds).toEqual(['hold_1', 'hold_2']);
+    }
+  });
+
+  it('does not release holds for decline responses', async () => {
+    const handler = new CalendarRespondToInviteHandler();
+    const deleteEvent = vi.fn();
+    const ctx = makeCtx({
+      input: {
+        calendarId: 'cal_1',
+        eventId: 'evt_invite',
+        response: 'decline',
+        holdMatchCriteria: { subject: 'Catch-up with Xiaopu', contactDomain: 'xiaopu.ca' },
+      },
+    }, { deleteEvent });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(deleteEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns a validation error for unknown responses', async () => {
+    const handler = new CalendarRespondToInviteHandler();
+    const result = await handler.execute(makeCtx({
+      input: { calendarId: 'cal_1', eventId: 'evt_invite', response: 'join' },
+    }));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('accept, decline, or tentative');
+    }
+  });
+});

--- a/skills/calendar-respond-to-invite/handler.test.ts
+++ b/skills/calendar-respond-to-invite/handler.test.ts
@@ -125,7 +125,7 @@ describe('CalendarRespondToInviteHandler', () => {
         response: 'accept',
         holdMatchCriteria: {
           subject: 'Quick Project Delta sync',
-          contactDomain: 'scheduler@example.test',
+          contactDomain: 'example.test',
         },
         holdSearchStart: '2026-06-01T00:00:00Z',
         holdSearchEnd: '2026-06-30T00:00:00Z',

--- a/skills/calendar-respond-to-invite/handler.ts
+++ b/skills/calendar-respond-to-invite/handler.ts
@@ -1,0 +1,210 @@
+// skills/calendar-respond-to-invite/handler.ts
+//
+// Responds to an existing calendar invitation via Nylas sendRsvp. This endpoint
+// scopes the change to the authenticated attendee, so we never write a full
+// participants array or risk changing another attendee's status.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { NylasCalendarEvent, NylasRsvpStatus } from '../../src/channels/calendar/nylas-calendar-client.js';
+import {
+  findMatchingHolds,
+  type HoldMatchCriteria,
+} from '../../src/channels/calendar/holds.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+
+type InviteResponse = 'accept' | 'decline' | 'tentative';
+
+const RESPONSE_TO_NYLAS: Record<InviteResponse, NylasRsvpStatus> = {
+  accept: 'yes',
+  decline: 'no',
+  tentative: 'maybe',
+};
+
+const HOLD_SEARCH_PADDING_MS = 14 * 24 * 60 * 60 * 1000;
+
+export class CalendarRespondToInviteHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.nylasCalendarClient) {
+      return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
+    }
+
+    const input = ctx.input as {
+      calendarId?: string;
+      eventId?: string;
+      response?: string;
+      account?: string;
+      comment?: string;
+      holdMatchCriteria?: HoldMatchCriteria;
+      holdSearchStart?: string;
+      holdSearchEnd?: string;
+    };
+
+    const calendarId = input.calendarId;
+    const eventId = input.eventId;
+    if (!calendarId || typeof calendarId !== 'string') {
+      return { success: false, error: 'Missing required input: calendarId' };
+    }
+    if (!eventId || typeof eventId !== 'string') {
+      return { success: false, error: 'Missing required input: eventId' };
+    }
+
+    const normalizedResponse = typeof input.response === 'string'
+      ? input.response.trim().toLowerCase()
+      : '';
+    if (!isInviteResponse(normalizedResponse)) {
+      return {
+        success: false,
+        error: 'Invalid input: response must be one of accept, decline, or tentative',
+      };
+    }
+
+    if (input.holdSearchStart && isNaN(new Date(input.holdSearchStart).getTime())) {
+      return { success: false, error: 'Invalid input: holdSearchStart is not a valid date' };
+    }
+    if (input.holdSearchEnd && isNaN(new Date(input.holdSearchEnd).getTime())) {
+      return { success: false, error: 'Invalid input: holdSearchEnd is not a valid date' };
+    }
+    if (input.holdSearchStart && input.holdSearchEnd && new Date(input.holdSearchEnd) <= new Date(input.holdSearchStart)) {
+      return { success: false, error: 'Invalid input: holdSearchEnd must be after holdSearchStart' };
+    }
+
+    const warnings: string[] = [];
+    if (input.account) {
+      warnings.push('account is informational in this deployment; RSVP used the configured principal calendar grant');
+    }
+    if (input.comment) {
+      warnings.push('comment was not sent because the installed Nylas sendRsvp SDK accepts RSVP status only');
+    }
+
+    try {
+      if (ctx.contactService) {
+        const registry = await ctx.contactService.resolveCalendar(calendarId);
+        if (registry?.readOnly) {
+          return { success: false, error: 'Calendar is read-only' };
+        }
+      }
+
+      const participantStatus = RESPONSE_TO_NYLAS[normalizedResponse];
+      const rsvp = await ctx.nylasCalendarClient.sendRsvp(calendarId, eventId, participantStatus);
+      ctx.log.info({ calendarId, eventId, response: normalizedResponse }, 'Responded to calendar invite');
+
+      let event: NylasCalendarEvent | null = null;
+      try {
+        event = await ctx.nylasCalendarClient.getEvent(calendarId, eventId);
+      } catch (err) {
+        ctx.log.warn({ err, calendarId, eventId }, 'calendar-respond-to-invite: RSVP succeeded but event fetch failed');
+        warnings.push('RSVP succeeded, but fetching the updated event failed');
+      }
+
+      const releaseResult = normalizedResponse === 'accept'
+        ? await this.releaseMatchingHolds(ctx, calendarId, input.holdMatchCriteria, event, input.holdSearchStart, input.holdSearchEnd)
+        : { releasedHolds: [] as string[], releaseWarnings: [] as string[] };
+
+      const tz = ctx.timezone;
+      const formattedEvent = event
+        ? {
+            ...event,
+            startTime: toLocalIso(event.startTime, tz),
+            endTime: toLocalIso(event.endTime, tz),
+          }
+        : null;
+
+      return {
+        success: true,
+        data: {
+          responded: true,
+          response: normalizedResponse,
+          participantStatus,
+          event: formattedEvent,
+          rsvp,
+          releasedHolds: releaseResult.releasedHolds,
+          releaseWarnings: releaseResult.releaseWarnings,
+          warnings,
+          displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, calendarId, eventId, response: normalizedResponse }, 'Failed to respond to calendar invite');
+      return { success: false, error: `Failed to respond to calendar invite: ${message}` };
+    }
+  }
+
+  private async releaseMatchingHolds(
+    ctx: SkillContext,
+    calendarId: string,
+    criteria: HoldMatchCriteria | undefined,
+    event: NylasCalendarEvent | null,
+    holdSearchStart?: string,
+    holdSearchEnd?: string,
+  ): Promise<{ releasedHolds: string[]; releaseWarnings: string[] }> {
+    if (!ctx.nylasCalendarClient || !criteria || !hasHoldMatchSignal(criteria)) {
+      return { releasedHolds: [], releaseWarnings: [] };
+    }
+
+    const window = deriveHoldSearchWindow(event, holdSearchStart, holdSearchEnd);
+    if (!window) {
+      return {
+        releasedHolds: [],
+        releaseWarnings: ['Skipped hold cleanup because no hold search window or timed event window was available'],
+      };
+    }
+
+    let events: NylasCalendarEvent[];
+    try {
+      events = await ctx.nylasCalendarClient.listEvents(calendarId, window.start, window.end);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.warn({ err, calendarId }, 'calendar-respond-to-invite: failed to list holds for cleanup');
+      return {
+        releasedHolds: [],
+        releaseWarnings: [`Failed to list holds for cleanup: ${message}`],
+      };
+    }
+
+    const matches = findMatchingHolds(events, criteria);
+    const releasedHolds: string[] = [];
+    const releaseWarnings: string[] = [];
+    for (const match of matches) {
+      try {
+        await ctx.nylasCalendarClient.deleteEvent(calendarId, match.hold.id, false);
+        releasedHolds.push(match.hold.id);
+        ctx.log.info(
+          { calendarId, holdId: match.hold.id, score: match.score, reasons: match.reasons },
+          'calendar-respond-to-invite: released matching hold',
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        releaseWarnings.push(`Failed to release hold ${match.hold.id}: ${message}`);
+        ctx.log.warn({ err, calendarId, holdId: match.hold.id }, 'calendar-respond-to-invite: failed to release matching hold');
+      }
+    }
+
+    return { releasedHolds, releaseWarnings };
+  }
+}
+
+function isInviteResponse(response: string): response is InviteResponse {
+  return response === 'accept' || response === 'decline' || response === 'tentative';
+}
+
+function hasHoldMatchSignal(criteria: HoldMatchCriteria): boolean {
+  return Boolean(criteria.subject || criteria.contactDomain || criteria.contactId || criteria.sourceRef || criteria.threadRef);
+}
+
+function deriveHoldSearchWindow(
+  event: NylasCalendarEvent | null,
+  holdSearchStart?: string,
+  holdSearchEnd?: string,
+): { start: string; end: string } | null {
+  if (holdSearchStart && holdSearchEnd) {
+    return { start: holdSearchStart, end: holdSearchEnd };
+  }
+  if (event?.startTime === null || event?.endTime === null || event?.startTime === undefined || event?.endTime === undefined) {
+    return null;
+  }
+  return {
+    start: new Date(event.startTime * 1000 - HOLD_SEARCH_PADDING_MS).toISOString(),
+    end: new Date(event.endTime * 1000 + HOLD_SEARCH_PADDING_MS).toISOString(),
+  };
+}

--- a/skills/calendar-respond-to-invite/skill.json
+++ b/skills/calendar-respond-to-invite/skill.json
@@ -3,7 +3,7 @@
   "description": "Accept, decline, or tentatively accept an existing calendar invitation as the authenticated principal attendee. Uses Nylas sendRsvp so only the principal's own RSVP status changes and the organizer receives the provider-standard RSVP notification. On accept, optional holdMatchCriteria can release Curia HOLD (TBC) events for the same scheduling conversation.",
   "version": "0.1.0",
   "sensitivity": "normal",
-  "action_risk": "high",
+  "action_risk": "medium",
   "inputs": {
     "calendarId": "string (Nylas calendar ID containing the invite)",
     "eventId": "string (Nylas event ID to RSVP to)",

--- a/skills/calendar-respond-to-invite/skill.json
+++ b/skills/calendar-respond-to-invite/skill.json
@@ -1,0 +1,33 @@
+{
+  "name": "calendar-respond-to-invite",
+  "description": "Accept, decline, or tentatively accept an existing calendar invitation as the authenticated principal attendee. Uses Nylas sendRsvp so only the principal's own RSVP status changes and the organizer receives the provider-standard RSVP notification. On accept, optional holdMatchCriteria can release Curia HOLD (TBC) events for the same scheduling conversation.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "high",
+  "inputs": {
+    "calendarId": "string (Nylas calendar ID containing the invite)",
+    "eventId": "string (Nylas event ID to RSVP to)",
+    "response": "string (accept | decline | tentative)",
+    "account": "string? (named account hint; currently informational because the calendar client is bound to the configured principal grant)",
+    "comment": "string? (optional RSVP comment; currently returned as a warning if provided because Nylas sendRsvp only accepts status in this SDK)",
+    "holdMatchCriteria": "object? ({ subject?, contactDomain?, contactId?, sourceRef?, threadRef? } used only when response is accept to release matching Curia holds)",
+    "holdSearchStart": "timestamp? (start of hold cleanup search window; defaults around the invite time)",
+    "holdSearchEnd": "timestamp? (end of hold cleanup search window; defaults around the invite time)"
+  },
+  "outputs": {
+    "responded": "boolean",
+    "response": "string (accept | decline | tentative)",
+    "participantStatus": "string (Nylas RSVP status: yes | no | maybe)",
+    "event": "object|null (updated event when fetch succeeds)",
+    "rsvp": "object (Nylas RSVP request result, including sendIcsError if present)",
+    "releasedHolds": "array (hold event IDs released after accepting)",
+    "releaseWarnings": "array (non-fatal hold cleanup failures)",
+    "warnings": "array (non-fatal RSVP/fetch/comment warnings)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": [
+    "nylasCalendarClient"
+  ]
+}

--- a/skills/ceo-inbox-list/skill.json
+++ b/skills/ceo-inbox-list/skill.json
@@ -10,7 +10,7 @@
     "unread_only": "boolean? (if true, only return unread messages, default true; ignored for DRAFTS)"
   },
   "outputs": {
-    "messages": "array of { id, threadId, from, to, cc, subject, date, snippet, unread, folders, attachments: [{ id, filename, contentType, size }] } (for non-draft folders)",
+    "messages": "array of { id, threadId, from, to, cc, subject, date, snippet, unread, folders, attachments: [{ id, filename, contentType, size, isCalendarInvite? }] } (for non-draft folders)",
     "drafts": "array of { id, threadId, subject, to, cc, snippet, date } (returned instead of messages when folder is DRAFTS, alongside folder: 'DRAFTS')",
     "count": "number of items returned",
     "has_more": "boolean — true when more unread messages remain beyond this batch (lets the caller drain the inbox in batches); absent for DRAFTS"

--- a/skills/ceo-inbox-read/skill.json
+++ b/skills/ceo-inbox-read/skill.json
@@ -20,7 +20,7 @@
     "body_html": "string (HTML body)",
     "date": "number (unix timestamp)",
     "labels": "array of strings (messages only)",
-    "attachments": "array of { id, filename, contentType, size } (messages only; non-inline file attachments; pass id + message id to ceo-inbox-download-attachment)",
+    "attachments": "array of { id, filename, contentType, size, isCalendarInvite? } (messages only; non-inline file attachments; pass id + message id to ceo-inbox-download-attachment; isCalendarInvite=true for ICS/text-calendar parts)",
     "is_draft": "boolean (true when a draft was read; absent for messages)"
   },
   "permissions": [],

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -401,6 +401,58 @@ describe('FileParseHandler', () => {
     });
   });
 
+  describe('ICS handling', () => {
+    const handler = new FileParseHandler();
+
+    it('extracts calendar invite fields without LLM calls', async () => {
+      const infraLlm = makeInfraLlm('{}');
+      const ics = [
+        'BEGIN:VCALENDAR',
+        'METHOD:REQUEST',
+        'BEGIN:VEVENT',
+        'UID:invite-123',
+        'SUMMARY:Catch-up with Xiaopu',
+        'DTSTART:20260625T140000Z',
+        'DTEND:20260625T143000Z',
+        'ORGANIZER;CN=Xiaopu:mailto:xiaopu@xiaopu.ca',
+        'ATTENDEE;CN=Joseph;PARTSTAT=NEEDS-ACTION:mailto:joseph@example.com',
+        'END:VEVENT',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      const result = await handler.execute(makeCtx({
+        content_base64: Buffer.from(ics).toString('base64'),
+        mime_type: 'text/calendar; method=REQUEST',
+        extract_as: 'calendar_invite',
+      }, infraLlm));
+
+      expect(result.success).toBe(true);
+      expect(infraLlm.extract).not.toHaveBeenCalled();
+      if (result.success) {
+        const data = result.data as {
+          type: string;
+          structured: {
+            method: string;
+            uid: string;
+            summary: string;
+            start: string;
+            end: string;
+            organizer: { email: string; name: string };
+            attendees: Array<{ email: string; participationStatus: string }>;
+          };
+        };
+        expect(data.type).toBe('calendar_invite');
+        expect(data.structured.method).toBe('REQUEST');
+        expect(data.structured.uid).toBe('invite-123');
+        expect(data.structured.summary).toBe('Catch-up with Xiaopu');
+        expect(data.structured.start).toBe('2026-06-25T14:00:00.000Z');
+        expect(data.structured.end).toBe('2026-06-25T14:30:00.000Z');
+        expect(data.structured.organizer.email).toBe('xiaopu@xiaopu.ca');
+        expect(data.structured.attendees[0]!.participationStatus).toBe('NEEDS-ACTION');
+      }
+    });
+  });
+
   describe('PDF handling', () => {
     // A minimal, valid text-layer PDF with known content. Guards against the
     // pdf-parse v1→v2 API regression where the library was called as a function

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -411,11 +411,11 @@ describe('FileParseHandler', () => {
         'METHOD:REQUEST',
         'BEGIN:VEVENT',
         'UID:invite-123',
-        'SUMMARY:Catch-up with Xiaopu',
+        'SUMMARY:Project Delta sync',
         'DTSTART:20260625T140000Z',
         'DTEND:20260625T143000Z',
-        'ORGANIZER;CN=Xiaopu:mailto:xiaopu@xiaopu.ca',
-        'ATTENDEE;CN=Joseph;PARTSTAT=NEEDS-ACTION:mailto:joseph@example.com',
+        'ORGANIZER;CN=Alex Example:mailto:alex@example.test',
+        'ATTENDEE;CN=Morgan Example;PARTSTAT=NEEDS-ACTION:mailto:morgan@example.test',
         'END:VEVENT',
         'END:VCALENDAR',
       ].join('\r\n');
@@ -444,10 +444,10 @@ describe('FileParseHandler', () => {
         expect(data.type).toBe('calendar_invite');
         expect(data.structured.method).toBe('REQUEST');
         expect(data.structured.uid).toBe('invite-123');
-        expect(data.structured.summary).toBe('Catch-up with Xiaopu');
+        expect(data.structured.summary).toBe('Project Delta sync');
         expect(data.structured.start).toBe('2026-06-25T14:00:00.000Z');
         expect(data.structured.end).toBe('2026-06-25T14:30:00.000Z');
-        expect(data.structured.organizer.email).toBe('xiaopu@xiaopu.ca');
+        expect(data.structured.organizer.email).toBe('alex@example.test');
         expect(data.structured.attendees[0]!.participationStatus).toBe('NEEDS-ACTION');
       }
     });

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -5,6 +5,7 @@
 // - Image: InfraLlm vision (passes base64 image blocks)
 // - PDF: pdf-parse text extraction, then optional LLM structuring
 // - HTML: tag stripping, then optional LLM structuring
+// - ICS: deterministic calendar invite field extraction
 //
 // All LLM calls go through the constrained InfraLlm service (classify + extract
 // only) so costs and latency are tracked by the telemetry infrastructure.
@@ -25,7 +26,7 @@ import { parseCsv } from './csv.js';
 import { getExtractionPrompt, type ExtractAs } from './prompts.js';
 
 // MIME types we support, mapped to our internal content categories.
-const MIME_MAP: Record<string, 'csv' | 'pdf' | 'image' | 'html'> = {
+const MIME_MAP: Record<string, 'csv' | 'pdf' | 'image' | 'html' | 'ics'> = {
   'text/csv': 'csv',
   'application/pdf': 'pdf',
   'image/jpeg': 'image',
@@ -34,6 +35,9 @@ const MIME_MAP: Record<string, 'csv' | 'pdf' | 'image' | 'html'> = {
   'image/webp': 'image',
   'image/gif': 'image',
   'text/html': 'html',
+  'text/calendar': 'ics',
+  'application/ics': 'ics',
+  'text/x-vcalendar': 'ics',
 };
 
 // extract_as is open-ended: 'receipt', 'bank_statement', 'invoice' have tailored prompts;
@@ -54,7 +58,7 @@ export class FileParseHandler implements SkillHandler {
     const tempFileUrl = typeof ctx.input.temp_file_url === 'string'
       ? ctx.input.temp_file_url.trim() : '';
     const mimeType = typeof ctx.input.mime_type === 'string'
-      ? ctx.input.mime_type.trim().toLowerCase() : '';
+      ? ctx.input.mime_type.trim().toLowerCase().split(';')[0]!.trim() : '';
     const extractAs = typeof ctx.input.extract_as === 'string'
       ? ctx.input.extract_as.trim().toLowerCase() as ExtractAs : 'raw';
 
@@ -117,6 +121,8 @@ export class FileParseHandler implements SkillHandler {
           return await this.handlePdf(ctx, infraLlm, buffer, extractAs);
         case 'html':
           return await this.handleHtml(ctx, infraLlm, buffer, extractAs);
+        case 'ics':
+          return this.handleIcs(buffer, extractAs);
       }
     } catch (err) {
       ctx.log.error({ err, mimeType }, 'file-parse: unexpected error');
@@ -135,6 +141,22 @@ export class FileParseHandler implements SkillHandler {
         type: 'csv',
         raw_text: text,
         structured: rows,
+        confidence: 1.0,
+      },
+    };
+  }
+
+  // --- ICS: deterministic calendar invite parsing ---
+
+  private handleIcs(buffer: Buffer, extractAs: ExtractAs): SkillResult {
+    const text = buffer.toString('utf-8');
+    const structured = extractAs === 'raw' ? null : parseIcsInvite(text);
+    return {
+      success: true,
+      data: {
+        type: 'calendar_invite',
+        raw_text: text,
+        structured,
         confidence: 1.0,
       },
     };
@@ -397,6 +419,123 @@ export class FileParseHandler implements SkillHandler {
 
     return realPath;
   }
+}
+
+interface IcsProperty {
+  name: string;
+  params: Record<string, string>;
+  value: string;
+}
+
+function parseIcsInvite(text: string): Record<string, unknown> {
+  const properties = unfoldIcsLines(text).map(parseIcsProperty).filter((prop): prop is IcsProperty => prop !== null);
+  const method = firstValue(properties, 'METHOD');
+  const eventProperties = firstEventProperties(properties);
+  const uid = firstValue(eventProperties, 'UID');
+  const summary = firstValue(eventProperties, 'SUMMARY');
+  const status = firstValue(eventProperties, 'STATUS');
+  const sequence = firstValue(eventProperties, 'SEQUENCE');
+  const startProp = firstProperty(eventProperties, 'DTSTART');
+  const endProp = firstProperty(eventProperties, 'DTEND');
+  const organizerProp = firstProperty(eventProperties, 'ORGANIZER');
+  const attendees = eventProperties
+    .filter((prop) => prop.name === 'ATTENDEE')
+    .map((prop) => ({
+      email: mailtoValue(prop.value),
+      name: prop.params.CN ?? null,
+      participationStatus: prop.params.PARTSTAT ?? null,
+      role: prop.params.ROLE ?? null,
+    }));
+
+  return {
+    method: method ?? null,
+    uid: uid ?? null,
+    summary: summary ?? null,
+    status: status ?? null,
+    sequence: sequence ?? null,
+    start: startProp ? parseIcsDate(startProp.value) : null,
+    end: endProp ? parseIcsDate(endProp.value) : null,
+    startTimezone: startProp?.params.TZID ?? null,
+    endTimezone: endProp?.params.TZID ?? null,
+    organizer: organizerProp
+      ? {
+          email: mailtoValue(organizerProp.value),
+          name: organizerProp.params.CN ?? null,
+        }
+      : null,
+    attendees,
+  };
+}
+
+function unfoldIcsLines(text: string): string[] {
+  const lines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  const unfolded: string[] = [];
+  for (const line of lines) {
+    if ((line.startsWith(' ') || line.startsWith('\t')) && unfolded.length > 0) {
+      const previous = unfolded[unfolded.length - 1]!;
+      unfolded[unfolded.length - 1] = previous + line.slice(1);
+    } else if (line.trim()) {
+      unfolded.push(line);
+    }
+  }
+  return unfolded;
+}
+
+function parseIcsProperty(line: string): IcsProperty | null {
+  const colon = line.indexOf(':');
+  if (colon === -1) return null;
+  const head = line.slice(0, colon);
+  const value = unescapeIcsText(line.slice(colon + 1));
+  const [rawName, ...rawParams] = head.split(';');
+  if (!rawName) return null;
+  const params: Record<string, string> = {};
+  for (const rawParam of rawParams) {
+    const eq = rawParam.indexOf('=');
+    if (eq === -1) continue;
+    const key = rawParam.slice(0, eq).toUpperCase();
+    const paramValue = rawParam.slice(eq + 1).replace(/^"|"$/g, '');
+    params[key] = unescapeIcsText(paramValue);
+  }
+  return { name: rawName.toUpperCase(), params, value };
+}
+
+function firstEventProperties(properties: IcsProperty[]): IcsProperty[] {
+  const begin = properties.findIndex((prop) => prop.name === 'BEGIN' && prop.value.toUpperCase() === 'VEVENT');
+  if (begin === -1) return properties;
+  const end = properties.findIndex((prop, index) => index > begin && prop.name === 'END' && prop.value.toUpperCase() === 'VEVENT');
+  return properties.slice(begin + 1, end === -1 ? undefined : end);
+}
+
+function firstProperty(properties: IcsProperty[], name: string): IcsProperty | null {
+  return properties.find((prop) => prop.name === name) ?? null;
+}
+
+function firstValue(properties: IcsProperty[], name: string): string | null {
+  return firstProperty(properties, name)?.value ?? null;
+}
+
+function parseIcsDate(value: string): string {
+  const dateMatch = /^(\d{4})(\d{2})(\d{2})$/.exec(value);
+  if (dateMatch) {
+    return `${dateMatch[1]!}-${dateMatch[2]!}-${dateMatch[3]!}`;
+  }
+  const dateTimeMatch = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(Z?)$/.exec(value);
+  if (!dateTimeMatch) return value;
+  const hasUtcSuffix = dateTimeMatch[7] === 'Z';
+  const iso = `${dateTimeMatch[1]!}-${dateTimeMatch[2]!}-${dateTimeMatch[3]!}T${dateTimeMatch[4]!}:${dateTimeMatch[5]!}:${dateTimeMatch[6]!}${hasUtcSuffix ? 'Z' : ''}`;
+  return hasUtcSuffix ? new Date(iso).toISOString() : iso;
+}
+
+function mailtoValue(value: string): string {
+  return value.replace(/^mailto:/i, '').trim();
+}
+
+function unescapeIcsText(value: string): string {
+  return value
+    .replace(/\\n/gi, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\');
 }
 
 const BLOCK_ELEMENTS = new Set([

--- a/skills/file-parse/skill.json
+++ b/skills/file-parse/skill.json
@@ -1,17 +1,17 @@
 {
   "name": "file-parse",
-  "description": "Parse a document (CSV, PDF, HTML, or image) and extract structured data. Accepts base64-encoded content OR a temp_file_url (file:// URL from ceo-inbox-download-attachment), plus a MIME type. Optionally provide extract_as to get structured fields (receipt, bank_statement, invoice) instead of raw text. For CSV files, parsing is direct and deterministic. For images, PDFs, and HTML, uses Claude for text extraction and structuring. Returns a confidence score (0–1) for LLM-extracted results.",
-  "version": "1.0.1",
+  "description": "Parse a document (CSV, PDF, HTML, image, or calendar ICS invite) and extract structured data. Accepts base64-encoded content OR a temp_file_url (file:// URL from ceo-inbox-download-attachment), plus a MIME type. Optionally provide extract_as to get structured fields (receipt, bank_statement, invoice, calendar_invite) instead of raw text. CSV and ICS parsing are direct and deterministic. For images, PDFs, and HTML, uses Claude for text extraction and structuring. Returns a confidence score (0–1) for LLM-extracted results.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
     "content_base64": "string? (base64-encoded file content — required unless temp_file_url is provided)",
     "temp_file_url": "string? (file:// URL pointing to a temp file on disk — alternative to content_base64; use the temp_file_url returned by ceo-inbox-download-attachment or email-download-attachment)",
-    "mime_type": "string (MIME type, e.g. 'text/csv', 'application/pdf', 'image/jpeg', 'text/html')",
-    "extract_as": "string? (optional extraction schema hint; defaults to 'raw'. Known schemas with tailored prompts: 'receipt', 'bank_statement', 'invoice'. Use 'raw' to skip LLM structuring. Any other non-empty string (e.g. 'purchase_order', 'business_card') triggers a generic extraction prompt using the schema name as a hint.)"
+    "mime_type": "string (MIME type, e.g. 'text/csv', 'application/pdf', 'image/jpeg', 'text/html', 'text/calendar', 'application/ics')",
+    "extract_as": "string? (optional extraction schema hint; defaults to 'raw'. Known schemas with tailored prompts: 'receipt', 'bank_statement', 'invoice'; 'calendar_invite' on ICS returns deterministic invite fields. Use 'raw' to skip LLM structuring. Any other non-empty string (e.g. 'purchase_order', 'business_card') triggers a generic extraction prompt using the schema name as a hint.)"
   },
   "outputs": {
-    "type": "string (detected content category: 'csv', 'pdf', 'image', 'html')",
+    "type": "string (detected content category: 'csv', 'pdf', 'image', 'html', 'calendar_invite')",
     "raw_text": "string (extracted plain text content)",
     "structured": "object (extracted fields per extract_as schema; null when extract_as is 'raw' or omitted)",
     "confidence": "number (0–1 confidence in the extraction; 1.0 for deterministic CSV parsing)"

--- a/src/autonomy/approval-trigger.test.ts
+++ b/src/autonomy/approval-trigger.test.ts
@@ -30,6 +30,12 @@ describe('buildDescription', () => {
     expect(desc).toContain('Lunch with Dana');
   });
 
+  it('formats calendar-respond-to-invite as an RSVP action', () => {
+    const desc = buildDescription('calendar-respond-to-invite', { subject: 'Board sync' });
+    expect(desc).toContain('Respond to calendar invite');
+    expect(desc).toContain('Board sync');
+  });
+
   it('formats email-reply with to and subject', () => {
     const desc = buildDescription('email-reply', { to: 'dana@example.com', subject: 'Re: Budget' });
     expect(desc).toContain('Send email reply');

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -46,6 +46,7 @@ const VERB_RULES: Array<{ test: (name: string) => boolean; verb: string }> = [
   { test: (n) => n === 'calendar-create-event', verb: 'Create calendar event' },
   { test: (n) => n === 'calendar-update-event', verb: 'Update calendar event' },
   { test: (n) => n === 'calendar-delete-event', verb: 'Delete calendar event' },
+  { test: (n) => n === 'calendar-respond-to-invite', verb: 'Respond to calendar invite' },
   { test: (n) => n === 'email-reply', verb: 'Send email reply' },
   { test: (n) => n === 'email-draft-save', verb: 'Save email draft' },
   { test: (n) => n === 'store-fact', verb: 'Store fact' },

--- a/src/channels/calendar/holds.test.ts
+++ b/src/channels/calendar/holds.test.ts
@@ -56,14 +56,14 @@ describe('buildHoldMetadata', () => {
   it('includes optional subject and contact-domain metadata for later invite matching', () => {
     const meta = buildHoldMetadata({
       createdAtIso: '2026-06-24T12:00:00.000Z',
-      subject: 'Quick sync — Xiaopu / Joseph',
-      contactDomain: 'assistant@xiaopu.ca',
+      subject: 'Quick sync - Project Delta',
+      contactDomain: 'assistant@example.test',
       contactId: 'contact-1',
       threadRef: 'thread-1',
     });
 
-    expect(meta.subject).toBe('Quick sync — Xiaopu / Joseph');
-    expect(meta['contact-domain']).toBe('xiaopu.ca');
+    expect(meta.subject).toBe('Quick sync - Project Delta');
+    expect(meta['contact-domain']).toBe('example.test');
     expect(meta['contact-id']).toBe('contact-1');
     expect(meta['thread-ref']).toBe('thread-1');
   });
@@ -72,29 +72,29 @@ describe('buildHoldMetadata', () => {
 describe('hold invite matching helpers', () => {
   const hold = {
     id: 'hold-1',
-    title: 'HOLD (TBC): Catch-up with Xiaopu',
+    title: 'HOLD (TBC): Project Delta sync',
     startTime: 1_780_000_000,
     endTime: 1_780_003_600,
     metadata: buildHoldMetadata({
       createdAtIso: '2026-06-24T12:00:00.000Z',
-      subject: 'Catch-up with Xiaopu',
-      contactDomain: 'xiaopu.ca',
+      subject: 'Project Delta sync',
+      contactDomain: 'example.test',
       sourceRef: 'msg-1',
     }),
   };
 
   it('normalizes reply prefixes and HOLD titles out of scheduling subjects', () => {
-    expect(normalizeSchedulingSubject('Re: HOLD (TBC): Quick sync — Xiaopu / Joseph')).toBe('quick sync xiaopu joseph');
+    expect(normalizeSchedulingSubject('Re: HOLD (TBC): Quick sync - Project Delta')).toBe('quick sync project delta');
   });
 
   it('normalizes email addresses to organization domains', () => {
-    expect(normalizeContactDomain('assistant@xiaopu.ca')).toBe('xiaopu.ca');
+    expect(normalizeContactDomain('assistant@example.test')).toBe('example.test');
   });
 
   it('matches a hold by organization domain plus similar subject, not exact sender email', () => {
     const match = matchHoldCandidate(hold, {
-      subject: 'Quick catch up with Xiaopu',
-      contactDomain: 'scheduler@xiaopu.ca',
+      subject: 'Quick Project Delta sync',
+      contactDomain: 'scheduler@example.test',
       startTime: 1_780_000_000,
       endTime: 1_780_003_600,
     });
@@ -106,7 +106,7 @@ describe('hold invite matching helpers', () => {
 
   it('does not match a same-subject hold from a different organization domain', () => {
     const match = matchHoldCandidate(hold, {
-      subject: 'Catch-up with Xiaopu',
+      subject: 'Project Delta sync',
       contactDomain: 'other.example',
       startTime: 1_780_000_000,
       endTime: 1_780_003_600,
@@ -123,14 +123,14 @@ describe('hold invite matching helpers', () => {
       endTime: 1_780_090_000,
       metadata: buildHoldMetadata({
         createdAtIso: '2026-06-24T12:00:00.000Z',
-        subject: 'Catch-up with Xiaopu',
-        contactDomain: 'xiaopu.ca',
+        subject: 'Project Delta sync',
+        contactDomain: 'example.test',
       }),
     };
 
     const matches = findMatchingHolds([secondHold, hold], {
-      subject: 'Catch-up with Xiaopu',
-      contactDomain: 'xiaopu.ca',
+      subject: 'Project Delta sync',
+      contactDomain: 'example.test',
     });
 
     expect(matches.map((match) => match.hold.id)).toEqual(['hold-2', 'hold-1']);

--- a/src/channels/calendar/holds.test.ts
+++ b/src/channels/calendar/holds.test.ts
@@ -7,7 +7,11 @@ import { describe, it, expect } from 'vitest';
 import {
   CURIA_HOLD_KEY,
   buildHoldMetadata,
+  findMatchingHolds,
   isHoldEvent,
+  matchHoldCandidate,
+  normalizeContactDomain,
+  normalizeSchedulingSubject,
   eventsOverlap,
   isHoldStale,
 } from './holds.js';
@@ -47,6 +51,89 @@ describe('buildHoldMetadata', () => {
       sourceRef: 'task-7',
     });
     expect(Object.keys(meta).sort()).toEqual(['created-at', 'curia-hold', 'source-ref']);
+  });
+
+  it('includes optional subject and contact-domain metadata for later invite matching', () => {
+    const meta = buildHoldMetadata({
+      createdAtIso: '2026-06-24T12:00:00.000Z',
+      subject: 'Quick sync — Xiaopu / Joseph',
+      contactDomain: 'assistant@xiaopu.ca',
+      contactId: 'contact-1',
+      threadRef: 'thread-1',
+    });
+
+    expect(meta.subject).toBe('Quick sync — Xiaopu / Joseph');
+    expect(meta['contact-domain']).toBe('xiaopu.ca');
+    expect(meta['contact-id']).toBe('contact-1');
+    expect(meta['thread-ref']).toBe('thread-1');
+  });
+});
+
+describe('hold invite matching helpers', () => {
+  const hold = {
+    id: 'hold-1',
+    title: 'HOLD (TBC): Catch-up with Xiaopu',
+    startTime: 1_780_000_000,
+    endTime: 1_780_003_600,
+    metadata: buildHoldMetadata({
+      createdAtIso: '2026-06-24T12:00:00.000Z',
+      subject: 'Catch-up with Xiaopu',
+      contactDomain: 'xiaopu.ca',
+      sourceRef: 'msg-1',
+    }),
+  };
+
+  it('normalizes reply prefixes and HOLD titles out of scheduling subjects', () => {
+    expect(normalizeSchedulingSubject('Re: HOLD (TBC): Quick sync — Xiaopu / Joseph')).toBe('quick sync xiaopu joseph');
+  });
+
+  it('normalizes email addresses to organization domains', () => {
+    expect(normalizeContactDomain('assistant@xiaopu.ca')).toBe('xiaopu.ca');
+  });
+
+  it('matches a hold by organization domain plus similar subject, not exact sender email', () => {
+    const match = matchHoldCandidate(hold, {
+      subject: 'Quick catch up with Xiaopu',
+      contactDomain: 'scheduler@xiaopu.ca',
+      startTime: 1_780_000_000,
+      endTime: 1_780_003_600,
+    });
+
+    expect(match).not.toBeNull();
+    expect(match!.score).toBeGreaterThanOrEqual(75);
+    expect(match!.reasons).toContain('contact-domain');
+  });
+
+  it('does not match a same-subject hold from a different organization domain', () => {
+    const match = matchHoldCandidate(hold, {
+      subject: 'Catch-up with Xiaopu',
+      contactDomain: 'other.example',
+      startTime: 1_780_000_000,
+      endTime: 1_780_003_600,
+    });
+
+    expect(match).toBeNull();
+  });
+
+  it('returns all associated holds sorted by score', () => {
+    const secondHold = {
+      ...hold,
+      id: 'hold-2',
+      startTime: 1_780_086_400,
+      endTime: 1_780_090_000,
+      metadata: buildHoldMetadata({
+        createdAtIso: '2026-06-24T12:00:00.000Z',
+        subject: 'Catch-up with Xiaopu',
+        contactDomain: 'xiaopu.ca',
+      }),
+    };
+
+    const matches = findMatchingHolds([secondHold, hold], {
+      subject: 'Catch-up with Xiaopu',
+      contactDomain: 'xiaopu.ca',
+    });
+
+    expect(matches.map((match) => match.hold.id)).toEqual(['hold-2', 'hold-1']);
   });
 });
 

--- a/src/channels/calendar/holds.ts
+++ b/src/channels/calendar/holds.ts
@@ -117,10 +117,10 @@ export function normalizeContactDomain(value?: string): string | null {
 
 export function normalizeSchedulingSubject(subject?: string): string {
   let normalized = subject?.trim().toLowerCase() ?? '';
-  normalized = normalized.replace(HOLD_TITLE_PREFIX_RE, '');
   while (REPLY_PREFIX_RE.test(normalized)) {
     normalized = normalized.replace(REPLY_PREFIX_RE, '');
   }
+  normalized = normalized.replace(HOLD_TITLE_PREFIX_RE, '');
   return normalized
     .normalize('NFKD')
     .replace(/[^\p{Letter}\p{Number}\s]/gu, ' ')

--- a/src/channels/calendar/holds.ts
+++ b/src/channels/calendar/holds.ts
@@ -12,6 +12,10 @@
 // Stored as a string 'true' because Nylas metadata values must be strings.
 export const CURIA_HOLD_KEY = 'curia-hold';
 
+const HOLD_TITLE_PREFIX_RE = /^hold\s*\(tbc\)\s*:\s*/i;
+const REPLY_PREFIX_RE = /^(re|fw|fwd)\s*:\s*/i;
+const METADATA_VALUE_MAX = 1024;
+
 // ---------------------------------------------------------------------------
 // buildHoldMetadata
 // ---------------------------------------------------------------------------
@@ -31,6 +35,10 @@ export const CURIA_HOLD_KEY = 'curia-hold';
  */
 export function buildHoldMetadata(opts: {
   sourceRef?: string;
+  threadRef?: string;
+  subject?: string;
+  contactId?: string;
+  contactDomain?: string;
   createdAtIso: string;
 }): Record<string, string> {
   const base: Record<string, string> = {
@@ -39,7 +47,20 @@ export function buildHoldMetadata(opts: {
   };
   // Only include source-ref when provided -- keeps the metadata map minimal
   if (opts.sourceRef) {
-    base['source-ref'] = opts.sourceRef;
+    base['source-ref'] = sanitizeMetadataValue(opts.sourceRef);
+  }
+  if (opts.threadRef) {
+    base['thread-ref'] = sanitizeMetadataValue(opts.threadRef);
+  }
+  if (opts.subject) {
+    base.subject = sanitizeMetadataValue(opts.subject);
+  }
+  if (opts.contactId) {
+    base['contact-id'] = sanitizeMetadataValue(opts.contactId);
+  }
+  const contactDomain = normalizeContactDomain(opts.contactDomain);
+  if (contactDomain) {
+    base['contact-domain'] = contactDomain;
   }
   return base;
 }
@@ -60,6 +81,130 @@ export function buildHoldMetadata(opts: {
 export function isHoldEvent(e: { metadata?: Record<string, string> | null }): boolean {
   // Use optional chaining so null/undefined metadata both fall through to false.
   return e.metadata?.[CURIA_HOLD_KEY] === 'true';
+}
+
+export interface HoldMatchCriteria {
+  subject?: string;
+  contactDomain?: string;
+  contactId?: string;
+  sourceRef?: string;
+  threadRef?: string;
+  startTime?: number;
+  endTime?: number;
+}
+
+export interface HoldMatchResult<T> {
+  hold: T;
+  score: number;
+  reasons: string[];
+}
+
+export interface HoldLike {
+  title?: string;
+  startTime: number | null;
+  endTime: number | null;
+  metadata?: Record<string, string> | null;
+}
+
+export function normalizeContactDomain(value?: string): string | null {
+  const trimmed = value?.trim().toLowerCase();
+  if (!trimmed) return null;
+  const domain = trimmed.includes('@') ? trimmed.split('@').pop() : trimmed;
+  if (!domain) return null;
+  const normalized = domain.replace(/^mailto:/, '').replace(/^[\s.]+|[\s.]+$/g, '');
+  return normalized.includes('.') ? normalized : null;
+}
+
+export function normalizeSchedulingSubject(subject?: string): string {
+  let normalized = subject?.trim().toLowerCase() ?? '';
+  normalized = normalized.replace(HOLD_TITLE_PREFIX_RE, '');
+  while (REPLY_PREFIX_RE.test(normalized)) {
+    normalized = normalized.replace(REPLY_PREFIX_RE, '');
+  }
+  return normalized
+    .normalize('NFKD')
+    .replace(/[^\p{Letter}\p{Number}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function matchHoldCandidate<T extends HoldLike>(
+  hold: T,
+  criteria: HoldMatchCriteria,
+): HoldMatchResult<T> | null {
+  if (!isHoldEvent(hold)) return null;
+
+  const reasons: string[] = [];
+  let score = 0;
+
+  const exactSourceRef = metadataEquals(hold, 'source-ref', criteria.sourceRef);
+  const exactThreadRef = metadataEquals(hold, 'thread-ref', criteria.threadRef);
+  if (exactSourceRef) {
+    score += 100;
+    reasons.push('source-ref');
+  }
+  if (exactThreadRef) {
+    score += 70;
+    reasons.push('thread-ref');
+  }
+
+  const requestedDomain = normalizeContactDomain(criteria.contactDomain);
+  const holdDomain = normalizeContactDomain(hold.metadata?.['contact-domain']);
+  if (requestedDomain && holdDomain) {
+    if (requestedDomain === holdDomain) {
+      score += 45;
+      reasons.push('contact-domain');
+    } else if (!exactSourceRef && !exactThreadRef) {
+      return null;
+    }
+  }
+
+  if (criteria.contactId && hold.metadata?.['contact-id'] === criteria.contactId) {
+    score += 40;
+    reasons.push('contact-id');
+  }
+
+  const requestedSubject = normalizeSchedulingSubject(criteria.subject);
+  const holdSubject = normalizeSchedulingSubject(hold.metadata?.subject ?? hold.title);
+  if (requestedSubject && holdSubject) {
+    if (requestedSubject === holdSubject) {
+      score += 45;
+      reasons.push('subject-exact');
+    } else if (requestedSubject.includes(holdSubject) || holdSubject.includes(requestedSubject)) {
+      score += 38;
+      reasons.push('subject-contained');
+    } else {
+      const similarity = tokenSimilarity(requestedSubject, holdSubject);
+      if (similarity >= 0.5) {
+        score += Math.round(similarity * 35);
+        reasons.push(`subject-similar:${similarity.toFixed(2)}`);
+      }
+    }
+  }
+
+  if (
+    typeof criteria.startTime === 'number' &&
+    typeof criteria.endTime === 'number' &&
+    hold.startTime !== null &&
+    hold.endTime !== null &&
+    eventsOverlap(criteria.startTime, criteria.endTime, hold.startTime, hold.endTime)
+  ) {
+    score += 20;
+    reasons.push('time-overlap');
+  }
+
+  return score > 0 ? { hold, score, reasons } : null;
+}
+
+export function findMatchingHolds<T extends HoldLike>(
+  events: T[],
+  criteria: HoldMatchCriteria,
+  minScore = 75,
+): Array<HoldMatchResult<T>> {
+  return events
+    .map((event) => matchHoldCandidate(event, criteria))
+    .filter((match): match is HoldMatchResult<T> => match !== null && match.score >= minScore)
+    .sort((a, b) => b.score - a.score);
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +236,26 @@ export function eventsOverlap(
   // Standard open-interval overlap test.
   // Equivalent to: NOT (A ends before B starts OR B ends before A starts).
   return aStart < bEnd && aEnd > bStart;
+}
+
+function metadataEquals(e: { metadata?: Record<string, string> | null }, key: string, value?: string): boolean {
+  return Boolean(value && e.metadata?.[key] === value);
+}
+
+function sanitizeMetadataValue(value: string): string {
+  return value.trim().slice(0, METADATA_VALUE_MAX);
+}
+
+function tokenSimilarity(left: string, right: string): number {
+  const leftTokens = new Set(left.split(' ').filter(Boolean));
+  const rightTokens = new Set(right.split(' ').filter(Boolean));
+  if (leftTokens.size === 0 || rightTokens.size === 0) return 0;
+  let intersection = 0;
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) intersection++;
+  }
+  const union = new Set([...leftTokens, ...rightTokens]).size;
+  return union === 0 ? 0 : intersection / union;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/channels/calendar/nylas-calendar-client.test.ts
+++ b/src/channels/calendar/nylas-calendar-client.test.ts
@@ -120,7 +120,7 @@ describe('NylasCalendarClient — RSVP plumbing', () => {
       data: {
         id: 'evt_1',
         title: 'Invite',
-        participants: [{ email: 'ceo@example.com', status: 'yes' }],
+        participants: [{ email: 'principal@example.test', status: 'yes' }],
         when: { startTime: 1_780_000_000, endTime: 1_780_003_600 },
         calendarId: 'cal_1',
       },

--- a/src/channels/calendar/nylas-calendar-client.test.ts
+++ b/src/channels/calendar/nylas-calendar-client.test.ts
@@ -96,3 +96,45 @@ describe('NylasCalendarClient — metadata/status/busy plumbing', () => {
     expect(body).not.toHaveProperty('busy');
   });
 });
+
+describe('NylasCalendarClient — RSVP plumbing', () => {
+  it('sends RSVP status through the Nylas sendRsvp endpoint', async () => {
+    const sendRsvp = vi.fn().mockResolvedValue({
+      requestId: 'req_123',
+    });
+    const client = makeClientWith({ events: { sendRsvp } as unknown as NylasCalendarLike['events'] });
+
+    const result = await client.sendRsvp('cal_1', 'evt_1', 'yes');
+
+    expect(sendRsvp).toHaveBeenCalledWith({
+      identifier: 'grant_test',
+      eventId: 'evt_1',
+      queryParams: { calendar_id: 'cal_1' },
+      requestBody: { status: 'yes' },
+    });
+    expect(result).toEqual({ requestId: 'req_123', sendIcsError: null });
+  });
+
+  it('fetches and normalizes one event by id', async () => {
+    const find = vi.fn().mockResolvedValue({
+      data: {
+        id: 'evt_1',
+        title: 'Invite',
+        participants: [{ email: 'ceo@example.com', status: 'yes' }],
+        when: { startTime: 1_780_000_000, endTime: 1_780_003_600 },
+        calendarId: 'cal_1',
+      },
+    });
+    const client = makeClientWith({ events: { find } as unknown as NylasCalendarLike['events'] });
+
+    const event = await client.getEvent('cal_1', 'evt_1');
+
+    expect(find).toHaveBeenCalledWith({
+      identifier: 'grant_test',
+      eventId: 'evt_1',
+      queryParams: { calendar_id: 'cal_1' },
+    });
+    expect(event.id).toBe('evt_1');
+    expect(event.participants[0]!.status).toBe('yes');
+  });
+});

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -54,7 +54,7 @@ export interface NylasCalendarLike {
     sendRsvp(params: {
       identifier: string;
       eventId: string;
-      queryParams?: Record<string, unknown>;
+      queryParams: Record<string, unknown>;
       requestBody: { status: NylasRsvpStatus };
     }): Promise<NylasRawRsvpResponse>;
 

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -32,6 +32,12 @@ export interface NylasCalendarLike {
       queryParams?: Record<string, unknown>;
     }): Promise<{ data: NylasRawEvent[] }>;
 
+    find(params: {
+      identifier: string;
+      eventId: string;
+      queryParams?: Record<string, unknown>;
+    }): Promise<{ data: NylasRawEvent }>;
+
     create(params: {
       identifier: string;
       queryParams?: Record<string, unknown>;
@@ -44,6 +50,13 @@ export interface NylasCalendarLike {
       queryParams?: Record<string, unknown>;
       requestBody: Record<string, unknown>;
     }): Promise<{ data: NylasRawEvent }>;
+
+    sendRsvp(params: {
+      identifier: string;
+      eventId: string;
+      queryParams?: Record<string, unknown>;
+      requestBody: { status: NylasRsvpStatus };
+    }): Promise<NylasRawRsvpResponse>;
 
     destroy(params: {
       identifier: string;
@@ -115,6 +128,11 @@ interface NylasRawFreeBusy {
   }>;
 }
 
+interface NylasRawRsvpResponse {
+  requestId?: string;
+  sendIcsError?: unknown;
+}
+
 // -- Normalized types --
 
 export interface NylasCalendar {
@@ -152,6 +170,13 @@ export interface NylasFreeBusyResult {
     endTime: number;
     status: string;
   }>;
+}
+
+export type NylasRsvpStatus = 'yes' | 'no' | 'maybe';
+
+export interface NylasRsvpResult {
+  requestId: string | null;
+  sendIcsError: unknown | null;
 }
 
 export interface CreateEventInput {
@@ -248,6 +273,22 @@ export class NylasCalendarClient {
     }
   }
 
+  /** Fetch one event by ID from a calendar. */
+  async getEvent(calendarId: string, eventId: string): Promise<NylasCalendarEvent> {
+    this.log.debug({ calendarId, eventId }, 'Fetching event');
+    try {
+      const response = await this.nylas.events.find({
+        identifier: this.grantId,
+        eventId,
+        queryParams: { calendar_id: calendarId },
+      });
+      return this.normalizeEvent(response.data);
+    } catch (err) {
+      this.log.error({ err, calendarId, eventId }, 'Nylas getEvent failed');
+      throw err;
+    }
+  }
+
   /** Create a new event on a calendar. */
   async createEvent(calendarId: string, event: CreateEventInput): Promise<NylasCalendarEvent> {
     this.log.debug({ calendarId, title: event.title }, 'Creating event');
@@ -329,6 +370,26 @@ export class NylasCalendarClient {
       return this.normalizeEvent(response.data);
     } catch (err) {
       this.log.error({ err, calendarId, eventId }, 'Nylas updateEvent failed');
+      throw err;
+    }
+  }
+
+  /** Respond to an event invitation as the authenticated attendee. */
+  async sendRsvp(calendarId: string, eventId: string, status: NylasRsvpStatus): Promise<NylasRsvpResult> {
+    this.log.debug({ calendarId, eventId, status }, 'Sending event RSVP');
+    try {
+      const response = await this.nylas.events.sendRsvp({
+        identifier: this.grantId,
+        eventId,
+        queryParams: { calendar_id: calendarId },
+        requestBody: { status },
+      });
+      return {
+        requestId: typeof response.requestId === 'string' ? response.requestId : null,
+        sendIcsError: response.sendIcsError ?? null,
+      };
+    } catch (err) {
+      this.log.error({ err, calendarId, eventId, status }, 'Nylas sendRsvp failed');
       throw err;
     }
   }

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -134,6 +134,8 @@ export interface EmailAttachment {
   contentType: string;
   /** Size in bytes. */
   size: number;
+  /** True when the attachment is a calendar invite payload (ICS / text/calendar). */
+  isCalendarInvite?: boolean;
 }
 
 /**
@@ -580,6 +582,7 @@ export class NylasClient {
             filename: a.filename ?? 'unnamed',
             contentType: a.contentType ?? 'application/octet-stream',
             size: a.size ?? 0,
+            ...(isCalendarInviteAttachment(a.filename, a.contentType) ? { isCalendarInvite: true } : {}),
           }));
         if (allAttachments.length > attachments.length) {
           this.log.debug(
@@ -611,4 +614,13 @@ export class NylasClient {
       throw err;
     }
   }
+}
+
+function isCalendarInviteAttachment(filename: string | undefined, contentType: string | undefined): boolean {
+  const lowerType = contentType?.toLowerCase() ?? '';
+  const lowerName = filename?.toLowerCase() ?? '';
+  return lowerType === 'text/calendar' ||
+    lowerType === 'application/ics' ||
+    lowerType === 'text/x-vcalendar' ||
+    lowerName.endsWith('.ics');
 }

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -617,7 +617,7 @@ export class NylasClient {
 }
 
 function isCalendarInviteAttachment(filename: string | undefined, contentType: string | undefined): boolean {
-  const lowerType = contentType?.toLowerCase() ?? '';
+  const lowerType = (contentType?.split(';', 1)[0] ?? '').trim().toLowerCase();
   const lowerName = filename?.toLowerCase() ?? '';
   return lowerType === 'text/calendar' ||
     lowerType === 'application/ics' ||

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -1520,6 +1520,40 @@ describe('approval trigger on gate block', () => {
     expect(trigger.request).toHaveBeenCalledOnce();
   });
 
+  it('calendar-respond-to-invite is high-risk and routes to pending approval below score 80', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('should not run');
+    registry.register(makeRiskyManifest('calendar-respond-to-invite', 'high'), handler);
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'rsvp-1', notificationSent: true });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(79),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const input = { calendarId: 'cal_1', eventId: 'evt_1', response: 'accept' };
+    const result = await layer.invoke('calendar-respond-to-invite', input, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('rsvp-1');
+      expect(result.error).toContain('approval request has been sent');
+    }
+    expect(handler.execute).not.toHaveBeenCalled();
+    expect(trigger.request).toHaveBeenCalledWith(expect.objectContaining({
+      skillName: 'calendar-respond-to-invite',
+      actionRisk: 'high',
+      input,
+      currentScore: 79,
+      requiredScore: 80,
+    }));
+  });
+
   it('Gate A calls trigger and enriches error with shortRef', async () => {
     const registry = new SkillRegistry();
     registry.register(makeRiskyManifest('store-fact', 'low'), makeHandler('no'));

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -1520,16 +1520,16 @@ describe('approval trigger on gate block', () => {
     expect(trigger.request).toHaveBeenCalledOnce();
   });
 
-  it('calendar-respond-to-invite is high-risk and routes to pending approval below score 80', async () => {
+  it('calendar-respond-to-invite is medium-risk and routes to pending approval below score 70', async () => {
     const registry = new SkillRegistry();
     const handler = makeHandler('should not run');
-    registry.register(makeRiskyManifest('calendar-respond-to-invite', 'high'), handler);
+    registry.register(makeRiskyManifest('calendar-respond-to-invite', 'medium'), handler);
 
     const trigger = makeApprovalTrigger({ created: true, shortRef: 'rsvp-1', notificationSent: true });
     const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
 
     const layer = new ExecutionLayer(registry, logger, {
-      autonomyService: makeAutonomyService(79),
+      autonomyService: makeAutonomyService(69),
       bus: mockBus,
       approvalTrigger: trigger,
     });
@@ -1547,10 +1547,10 @@ describe('approval trigger on gate block', () => {
     expect(handler.execute).not.toHaveBeenCalled();
     expect(trigger.request).toHaveBeenCalledWith(expect.objectContaining({
       skillName: 'calendar-respond-to-invite',
-      actionRisk: 'high',
+      actionRisk: 'medium',
       input,
-      currentScore: 79,
-      requiredScore: 80,
+      currentScore: 69,
+      requiredScore: 70,
     }));
   });
 

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -100,8 +100,8 @@ describe('ceo-inbox Branch A prompt — memory-query contract', () => {
     const branchA = extractBranchASection(prompt);
     // Anchor on the no_slots header to avoid matching the Branch A intro sentence
     // which also mentions "no_slots" but is not the step body.
-    const noSlotsStart = posIn(branchA, '4. **Result: no_slots');
-    const escalateStart = posIn(branchA, '5. **Result: escalate');
+    const noSlotsStart = posIn(branchA, '7. **Result: no_slots');
+    const escalateStart = posIn(branchA, '8. **Result: escalate');
     expect(noSlotsStart).toBeGreaterThan(-1);
     expect(escalateStart).toBeGreaterThan(noSlotsStart);
     const noSlotsSection = branchA.slice(noSlotsStart, escalateStart);
@@ -111,7 +111,7 @@ describe('ceo-inbox Branch A prompt — memory-query contract', () => {
     expect(noSlotsSection).toContain('memory-query');
     // The cross-reference must enumerate steps 2a through at least 2c (which now
     // includes the memory-query step introduced by this fix).
-    expect(noSlotsSection).toContain('2a-c');
+    expect(noSlotsSection).toContain('5a-c');
   });
 
   it('memory-query failure in Branch A is non-blocking (proceed-normally instruction)', () => {
@@ -160,8 +160,8 @@ describe('ceo-inbox scheduling consult prompt — proposed-time protocol', () =>
   it('Branch A accepts confirmed proposed slots instead of counter-proposing', () => {
     const prompt = loadCeoInboxPrompt();
     const branchA = extractBranchASection(prompt);
-    const confirmedStart = posIn(branchA, '2. **Result: confirmed');
-    const okStart = posIn(branchA, '3. **Result: ok');
+    const confirmedStart = posIn(branchA, '5. **Result: confirmed');
+    const okStart = posIn(branchA, '6. **Result: ok');
     expect(confirmedStart).toBeGreaterThan(-1);
     expect(okStart).toBeGreaterThan(confirmedStart);
 
@@ -175,8 +175,8 @@ describe('ceo-inbox scheduling consult prompt — proposed-time protocol', () =>
   it('Branch A still counter-proposes for Result: ok alternatives', () => {
     const prompt = loadCeoInboxPrompt();
     const branchA = extractBranchASection(prompt);
-    const okStart = posIn(branchA, '3. **Result: ok');
-    const noSlotsStart = posIn(branchA, '4. **Result: no_slots');
+    const okStart = posIn(branchA, '6. **Result: ok');
+    const noSlotsStart = posIn(branchA, '7. **Result: no_slots');
     expect(okStart).toBeGreaterThan(-1);
     expect(noSlotsStart).toBeGreaterThan(okStart);
 
@@ -184,6 +184,42 @@ describe('ceo-inbox scheduling consult prompt — proposed-time protocol', () =>
     expect(okSection).toContain('counter-proposal');
     expect(okSection).toMatch(/new\s+alternatives/);
     expect(okSection).toContain('hold placed');
+  });
+});
+
+describe('ceo-inbox formal invite prompt — RSVP consult contract', () => {
+  it('detects formal meeting invites before generic scheduling classification', () => {
+    const prompt = loadCeoInboxPrompt();
+    const invitePos = posIn(prompt, '### 4d-invite. Formal meeting invitation path');
+    const schedulingPos = posIn(prompt, '### Scheduling-specific drafting rules');
+
+    expect(invitePos).toBeGreaterThan(-1);
+    expect(schedulingPos).toBeGreaterThan(invitePos);
+    expect(prompt).toContain('isCalendarInvite: true');
+    expect(prompt).toContain('extract_as: "calendar_invite"');
+  });
+
+  it('parks formal invites for calendar consults instead of archiving as handled', () => {
+    const prompt = loadCeoInboxPrompt();
+    const inviteStart = posIn(prompt, '### 4d-invite. Formal meeting invitation path');
+    const inviteEnd = posIn(prompt, '### 4e-pre. Automated sender check');
+    expect(inviteStart).toBeGreaterThan(-1);
+    expect(inviteEnd).toBeGreaterThan(inviteStart);
+    const inviteSection = prompt.slice(inviteStart, inviteEnd);
+
+    expect(inviteSection).toContain('Need: RSVP for formal calendar invite');
+    expect(inviteSection).toContain('Standing: <accept|decline|tentative instruction text, or none>');
+    expect(inviteSection).toContain('Do NOT archive');
+    expect(inviteSection).toContain('Do NOT classify it as ✅ Handled');
+  });
+
+  it('handles invite recommendation and pending approval replies without archiving', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    expect(branchA).toContain('Result: invite_pending_approval');
+    expect(branchA).toContain('Result: invite_recommendation');
+    expect(branchA).toContain('Do NOT archive');
+    expect(branchA).toContain('pending approval');
   });
 });
 
@@ -248,5 +284,37 @@ describe('calendar consult prompt — proposed-time conflict checks', () => {
     expect(okPos).toBeGreaterThan(confirmedFieldPos);
     expect(consultSection).toContain('For `Result: confirmed`, never mark "hold');
     expect(consultSection).toContain('never call `calendar-create-hold`');
+  });
+});
+
+describe('calendar consult prompt — formal invite RSVP behavior', () => {
+  it('links formal invite consults to Nylas calendar events when needed', () => {
+    const prompt = loadCalendarPrompt();
+    const consultSection = extractCalendarConsultSection(prompt);
+
+    expect(consultSection).toContain('Need: RSVP for formal calendar invite');
+    expect(consultSection).toContain('calendar-list-events');
+    expect(consultSection).toContain('could not link invite to calendar event');
+  });
+
+  it('requires standing instructions before calling the RSVP skill', () => {
+    const prompt = loadCalendarPrompt();
+    const consultSection = extractCalendarConsultSection(prompt);
+    const noRulePos = posIn(consultSection, 'If there is no matching standing instruction');
+    const rsvpPos = posIn(consultSection, 'calendar-respond-to-invite');
+
+    expect(rsvpPos).toBeGreaterThan(-1);
+    expect(noRulePos).toBeGreaterThan(-1);
+    expect(consultSection).toContain('do not call the RSVP skill');
+    expect(consultSection).toContain('Result: invite_recommendation');
+    expect(consultSection).toContain('ignoreHoldCriteria');
+  });
+
+  it('documents pending approval when high-risk RSVP is autonomy-gated', () => {
+    const prompt = loadCalendarPrompt();
+    const consultSection = extractCalendarConsultSection(prompt);
+
+    expect(consultSection).toContain('Result: invite_pending_approval');
+    expect(consultSection).toContain('pending-approval/autonomy-gate error');
   });
 });

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -297,24 +297,27 @@ describe('calendar consult prompt — formal invite RSVP behavior', () => {
     expect(consultSection).toContain('could not link invite to calendar event');
   });
 
-  it('requires standing instructions before calling the RSVP skill', () => {
+  it('allows context-aware RSVP attempts and reserves recommendations for ambiguity', () => {
     const prompt = loadCalendarPrompt();
     const consultSection = extractCalendarConsultSection(prompt);
-    const noRulePos = posIn(consultSection, 'If there is no matching standing instruction');
+    const decidePos = posIn(consultSection, 'Decide the RSVP response from all available context');
     const rsvpPos = posIn(consultSection, 'calendar-respond-to-invite');
+    const ambiguousPos = posIn(consultSection, 'If the correct RSVP is genuinely ambiguous');
 
     expect(rsvpPos).toBeGreaterThan(-1);
-    expect(noRulePos).toBeGreaterThan(-1);
-    expect(consultSection).toContain('do not call the RSVP skill');
+    expect(decidePos).toBeGreaterThan(-1);
+    expect(ambiguousPos).toBeGreaterThan(rsvpPos);
+    expect(consultSection).toContain('relationship tier, sender kind');
     expect(consultSection).toContain('Result: invite_recommendation');
     expect(consultSection).toContain('ignoreHoldCriteria');
   });
 
-  it('documents pending approval when high-risk RSVP is autonomy-gated', () => {
+  it('documents pending approval when medium-risk RSVP is autonomy-gated', () => {
     const prompt = loadCalendarPrompt();
     const consultSection = extractCalendarConsultSection(prompt);
 
     expect(consultSection).toContain('Result: invite_pending_approval');
     expect(consultSection).toContain('pending-approval/autonomy-gate error');
+    expect(consultSection).toContain('action_risk: medium');
   });
 });

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -211,6 +211,8 @@ describe('ceo-inbox formal invite prompt — RSVP consult contract', () => {
     expect(inviteSection).toContain('Standing: <accept|decline|tentative instruction text, or none>');
     expect(inviteSection).toContain('Do NOT archive');
     expect(inviteSection).toContain('Do NOT classify it as ✅ Handled');
+    expect(inviteSection).toContain('ceo-inbox-update-folders');
+    expect(inviteSection).not.toContain('ceo-inbox-label (⏳ In Progress)');
   });
 
   it('handles invite recommendation and pending approval replies without archiving', () => {
@@ -295,6 +297,8 @@ describe('calendar consult prompt — formal invite RSVP behavior', () => {
     expect(consultSection).toContain('Need: RSVP for formal calendar invite');
     expect(consultSection).toContain('calendar-list-events');
     expect(consultSection).toContain('could not link invite to calendar event');
+    expect(consultSection).toContain('start`, or `end`');
+    expect(consultSection).toContain('Only after concrete start/end are known');
   });
 
   it('allows context-aware RSVP attempts and reserves recommendations for ambiguity', () => {

--- a/tests/unit/channels/email/nylas-client-list.test.ts
+++ b/tests/unit/channels/email/nylas-client-list.test.ts
@@ -104,4 +104,26 @@ describe('NylasClient.listMessages — folder/search filters', () => {
     expect(callArg.queryParams).toHaveProperty('limit', 10);
     expect(callArg.queryParams).toHaveProperty('threadId', 'th-1');
   });
+
+  it('marks text/calendar attachments with MIME parameters as calendar invites', async () => {
+    mockMessages.list.mockResolvedValueOnce(emptyListResponse([{
+      id: 'msg-1',
+      subject: 'Invite',
+      from: [],
+      to: [],
+      cc: [],
+      bcc: [],
+      date: 1,
+      attachments: [{
+        id: 'att-1',
+        filename: 'invite.ics',
+        contentType: 'text/calendar; method=REQUEST; charset=UTF-8',
+        size: 123,
+      }],
+    }]));
+
+    const messages = await client.listMessages();
+
+    expect(messages[0]!.attachments[0]!.isCalendarInvite).toBe(true);
+  });
 });

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -24,8 +24,10 @@ function makeMockSdk(): NylasCalendarLike {
     },
     events: {
       list: vi.fn().mockResolvedValue({ data: [] }),
+      find: vi.fn().mockResolvedValue({ data: { id: 'evt-1' } }),
       create: vi.fn().mockResolvedValue({ data: { id: 'evt-1' } }),
       update: vi.fn().mockResolvedValue({ data: { id: 'evt-1' } }),
+      sendRsvp: vi.fn().mockResolvedValue({ requestId: 'req-1' }),
       destroy: vi.fn().mockResolvedValue(undefined),
     },
     calendars_free_busy: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds first-class calendar invite RSVP handling so formal meeting invites can be detected in CEO inbox triage, delegated to the calendar specialist, and answered through Nylas `sendRsvp` under the existing autonomy gate.

## Changes

- Adds `calendar-respond-to-invite` with `action_risk: medium`, Nylas `sendRsvp` client support, updated-event fetch, and accept-time hold cleanup.
- Adds invite-aware CEO inbox/calendar prompt contracts, ICS attachment detection/parsing, and matching hold metadata for subject/domain/thread-based cleanup.
- Updates the calendar specialist stance so it can accept wanted invites, decline unwanted invites, or recommend/tentative when context is ambiguous, using relationship/sender/conflict context rather than requiring an explicit standing rule.
- Extends conflict checks to ignore matching Curia holds for the same scheduling conversation, including when free/busy emails differ from queried calendar IDs.
- Scrubs the new RSVP/ICS/hold tests and prompts to use synthetic names and reserved `.test` fixture addresses only.
- Addresses CodeRabbit review feedback for concrete invite start/end relinking, symmetric folder parking, parameterized calendar MIME detection, and required Nylas RSVP query params.

## Related Issues

Closes #1165

## Verification

- `pnpm vitest run tests/unit/agents/ceo-inbox-prompt.test.ts skills/calendar-check-conflicts/handler.test.ts skills/calendar-respond-to-invite/handler.test.ts skills/_shared/ceo-nylas-client.test.ts tests/unit/channels/email/nylas-client-list.test.ts src/channels/calendar/nylas-calendar-client.test.ts` — 6 files / 65 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm run lint` — passed with one pre-existing warning in `src/pii/scrubber.ts` about an unused eslint-disable directive.
- `pnpm test` — 326 files / 4,261 tests passed; 31 files / 193 tests skipped.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [x] CI passes locally
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://thefungs.slack.com/archives/C0BDTUW34QY/p1782401724519159?thread_ts=1782401724.519159&cid=C0BDTUW34QY)

<div><a href="https://cursor.com/agents/bc-d333fb4b-adf2-547d-a95f-a6ae50fe7f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d333fb4b-adf2-547d-a95f-a6ae50fe7f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

