### PR TITLE
fix: require Node 24 in setup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Setup Node version gate** — `scripts/setup.sh` now rejects Node 22/23 to match the documented Node >=24 requirement. (#1139)
 - **Scheduling consults** — sender-proposed meeting times now flow through `ceo-inbox` to `calendar`, which checks them before counter-proposing alternatives. (#1186)
 - **`ceo-inbox` Branch A resume** — calendar consult replies now call `memory-query` anchored on sender and subject before drafting, so stored facts (Calendly links, venue preferences, relationship notes) shape the reply; no-match proceeds normally. (#1185)
 - **`wake_at` self-deferral lineage** — a task that defers itself via `wake_at` now stamps its `TaskOriginator` onto the wake job, so a principal-lineage task keeps its autonomy bypass on wake instead of flooring to agent; pre-chosen, so no `standing` envelope is written and the heartbeat ladder never runs (`elevated` still blocked — not a live turn). (#1153)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,7 +31,7 @@ PRESERVED_ENCRYPTION_KEY=""
 # seed the vault (#911). Empty on the resume path (vault already seeded on first run).
 SEED_ANTHROPIC_KEY=""
 
-# Verifies docker, docker compose, node >= 22, pnpm, and openssl are available.
+# Verifies docker, docker compose, node >= 24, pnpm, and openssl are available.
 # Exits 1 with an install link on the first missing tool.
 check_prerequisites() {
     if ! docker info &>/dev/null; then
@@ -47,14 +47,14 @@ check_prerequisites() {
     fi
 
     if ! command -v node &>/dev/null; then
-        error "node not found (requires >= 22)."
+        error "node not found (requires >= 24)."
         hint "Install at: https://nodejs.org/"
         exit 1
     fi
     local node_major
     node_major=$(node --version 2>/dev/null | sed 's/^v//' | cut -d. -f1)
-    if [[ -z "$node_major" ]] || [[ "$node_major" -lt 22 ]]; then
-        error "Node $(node --version) found, but >= 22 is required."
+    if [[ -z "$node_major" ]] || [[ "$node_major" -lt 24 ]]; then
+        error "Node $(node --version) found, but >= 24 is required."
         hint "Update at: https://nodejs.org/"
         exit 1
     fi

--- a/tests/setup/test-setup-functions.sh
+++ b/tests/setup/test-setup-functions.sh
@@ -60,8 +60,81 @@ assert_invalid_key() {
     fi
 }
 
+run_check_prerequisites_with_node() {
+    local node_version="$1"
+    local out_file="$2"
+    local tmp_bin
+    tmp_bin=$(mktemp -d)
+
+    cat > "$tmp_bin/docker" <<'DOCKER_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "info" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
+    exit 0
+fi
+echo "unexpected docker invocation: $*" >&2
+exit 1
+DOCKER_EOF
+
+    cat > "$tmp_bin/node" <<NODE_EOF
+#!/usr/bin/env bash
+echo "v${node_version}"
+NODE_EOF
+
+    cat > "$tmp_bin/pnpm" <<'PNPM_EOF'
+#!/usr/bin/env bash
+exit 0
+PNPM_EOF
+
+    cat > "$tmp_bin/openssl" <<'OPENSSL_EOF'
+#!/usr/bin/env bash
+exit 0
+OPENSSL_EOF
+
+    chmod +x "$tmp_bin/docker" "$tmp_bin/node" "$tmp_bin/pnpm" "$tmp_bin/openssl"
+
+    local rc
+    set +e
+    (PATH="$tmp_bin:$PATH"; check_prerequisites) > "$out_file" 2>&1
+    rc=$?
+    set -e
+
+    rm -rf "$tmp_bin"
+    return "$rc"
+}
+
+# --- check_prerequisites tests ---
+
+echo "=== check_prerequisites ==="
+_node_out=$(mktemp)
+if run_check_prerequisites_with_node "22.19.0" "$_node_out"; then
+    echo "  ✗ rejects Node 22"
+    FAIL=$((FAIL + 1))
+else
+    assert_true "rejects Node 22 with >= 24 message" "$_node_out" ">= 24 is required"
+fi
+
+if run_check_prerequisites_with_node "23.11.0" "$_node_out"; then
+    echo "  ✗ rejects Node 23"
+    FAIL=$((FAIL + 1))
+else
+    assert_true "rejects Node 23 with >= 24 message" "$_node_out" ">= 24 is required"
+fi
+
+if run_check_prerequisites_with_node "24.0.0" "$_node_out"; then
+    echo "  ✓ accepts Node 24"
+    PASS=$((PASS + 1))
+else
+    echo "  ✗ accepts Node 24"
+    FAIL=$((FAIL + 1))
+fi
+rm -f "$_node_out"
+
 # --- validate_anthropic_key tests ---
 
+echo ""
 echo "=== validate_anthropic_key ==="
 assert_valid_key   "accepts sk-ant-api03-..." "sk-ant-api03-abc123XYZ"
 assert_valid_key   "accepts key with hyphens in suffix" "sk-ant-abc-def-123"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the setup prerequisite gate so fresh installs fail fast on Node 22/23, matching `package.json` and the README Node >=24 requirement.

## Changes

- Require Node >=24 in `scripts/setup.sh` messages and comparison.
- Add setup shell test coverage for Node 22, 23, and 24 prerequisite outcomes.
- Record the fix in the Unreleased changelog.

## Verification

- `bash tests/setup/test-setup-functions.sh` — 36 passed, 0 failed.
- Consistency scan confirms Curia-owned setup/package/README text now states Node >=24; remaining >=22 matches are third-party package engine metadata in `pnpm-lock.yaml`.

<a href="/opt/cursor/artifacts/setup_node_gate_test.txt">Setup Node gate test output</a>

## Related Issues

Closes #1139

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [ ] CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://thefungs.slack.com/archives/C0BDTUW34QY/p1782412834519249?thread_ts=1782412834.519249&cid=C0BDTUW34QY)

<div><a href="https://cursor.com/agents/bc-fd476be9-2b25-5666-ab96-cd29dd4b2722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd476be9-2b25-5666-ab96-cd29dd4b2722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

