### PR TITLE
fix: wrap createJob() and upsertDeclarativeJob() in DB transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`createJob` / `upsertDeclarativeJob`** — scheduled_jobs INSERT/UPSERT and linked tasks CTE now run in a single DB transaction so a failure on the second query cannot leave an unlinked job row with drift detection silently disabled. (#867)
 - **Setup Node version gate** — `scripts/setup.sh` now rejects Node 22/23 to match the documented Node >=24 requirement. (#1139)
 - **Scheduling consults** — sender-proposed meeting times now flow through `ceo-inbox` to `calendar`, which checks them before counter-proposing alternatives. (#1186)
 - **`ceo-inbox` Branch A resume** — calendar consult replies now call `memory-query` anchored on sender and subject before drafting, so stored facts (Calendly links, venue preferences, relationship notes) shape the reply; no-match proceeds normally. (#1185)

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -221,18 +221,13 @@ export class SchedulerService {
       insertParams.push(rawDuration);
     }
 
-    const { rows } = await this.pool.query(insertSql, insertParams);
-    const jobId = (rows[0] as { id: string }).id;
-
-    // If an intentAnchor is provided, create a linked task row and bind it to the job.
-    // The FK direction is scheduled_jobs.task_id → tasks.id, so we INSERT the task
-    // first and then UPDATE the job row with the new task's id.
-    //
-    // The CTE surfaces both the task id and the job id from the UPDATE so that a
-    // silent UPDATE failure (scheduled_jobs row disappeared in a race) is detectable —
-    // link_job with 0 matched rows returns job_id=null via the LEFT JOIN.
+    let jobId: string;
     let agentTaskId: string | undefined;
+
     if (intentAnchor) {
+      // Wrap the scheduled_jobs INSERT and tasks link CTE in one transaction so a
+      // failure on the second query cannot leave an unlinked job row (drift detection
+      // silently disabled). See issue #867.
       const taskSql = `
         WITH new_task AS (
           INSERT INTO tasks (agent_id, title, intent_anchor, status, error_budget, source_agent_id)
@@ -256,23 +251,51 @@ export class SchedulerService {
         'active',
         JSON.stringify(errorBudget ?? {}),
         agentId,        // source_agent_id
-        jobId,
+        null as string | null, // jobId placeholder — filled after INSERT
       ];
-      const taskResult = await this.pool.query(taskSql, taskParams);
-      const taskRow = taskResult.rows[0] as { task_id: string; job_id: string | null } | undefined;
-      if (!taskRow?.task_id) {
-        throw new Error(`createJob: INSERT into tasks returned no row for job ${jobId}`);
+
+      const client = await this.pool.connect();
+      try {
+        await client.query('BEGIN');
+
+        const { rows } = await client.query(insertSql, insertParams);
+        jobId = (rows[0] as { id: string }).id;
+        taskParams[6] = jobId;
+
+        const taskResult = await client.query(taskSql, taskParams);
+        const taskRow = taskResult.rows[0] as { task_id: string; job_id: string | null } | undefined;
+        if (!taskRow?.task_id) {
+          throw new Error(`createJob: INSERT into tasks returned no row for job ${jobId}`);
+        }
+        if (!taskRow.job_id) {
+          // The INSERT succeeded but the UPDATE found no scheduled_jobs row.
+          // This means a concurrent cancel removed the job between the INSERT above and this CTE.
+          this.logger.error(
+            { agentId, jobId, taskId: taskRow.task_id },
+            'createJob: task row created but scheduled_jobs.task_id link failed — orphaned task',
+          );
+          throw new Error(`createJob: scheduled_jobs row ${jobId} not found when linking task`);
+        }
+        agentTaskId = taskRow.task_id;
+
+        await client.query('COMMIT');
+      } catch (err) {
+        this.logger.error({ err, agentId, intentAnchor }, 'createJob: transaction failed');
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackErr) {
+          this.logger.error(
+            { err: rollbackErr },
+            'createJob: ROLLBACK failed after transaction error — connection may be in bad state',
+          );
+        }
+        throw err;
+      } finally {
+        client.release();
       }
-      if (!taskRow.job_id) {
-        // The INSERT succeeded but the UPDATE found no scheduled_jobs row.
-        // This means a concurrent cancel removed the job between the INSERT above and this CTE.
-        this.logger.error(
-          { agentId, jobId, taskId: taskRow.task_id },
-          'createJob: task row created but scheduled_jobs.task_id link failed — orphaned task',
-        );
-        throw new Error(`createJob: scheduled_jobs row ${jobId} not found when linking task`);
-      }
-      agentTaskId = taskRow.task_id;
+    } else {
+      const { rows } = await this.pool.query(insertSql, insertParams);
+      jobId = (rows[0] as { id: string }).id;
     }
 
     // Publish schedule.created event for audit trail.
@@ -602,6 +625,141 @@ export class SchedulerService {
       JSON.stringify(originator),
     ];
 
+    let jobId: string;
+    let revivedFromCancelled = false;
+    let revivalContext: {
+      priorFailures: number | null;
+      priorError: string | null;
+    } | null = null;
+
+    if (schedule.intent_anchor) {
+      // Wrap the upsert and tasks link CTE in one transaction — see issue #867.
+      const taskSql = `
+        WITH new_task AS (
+          INSERT INTO tasks (agent_id, title, intent_anchor, status, error_budget, source_agent_id)
+          SELECT $1, $2, $3, $4, $5::jsonb, $6
+          WHERE NOT EXISTS (SELECT 1 FROM scheduled_jobs WHERE id = $7 AND task_id IS NOT NULL)
+          RETURNING id
+        ),
+        link_job AS (
+          UPDATE scheduled_jobs
+             SET task_id = new_task.id
+            FROM new_task
+           WHERE scheduled_jobs.id = $7
+             AND task_id IS NULL
+          RETURNING scheduled_jobs.id AS job_id
+        ),
+        cleanup_orphan AS (
+          DELETE FROM tasks
+           WHERE id = (SELECT id FROM new_task)
+             AND NOT EXISTS (SELECT 1 FROM link_job)
+        )
+        SELECT new_task.id AS task_id, link_job.job_id
+          FROM new_task
+          LEFT JOIN link_job ON true
+      `;
+      const taskParams = [
+        agentId,
+        schedule.intent_anchor,   // title
+        schedule.intent_anchor,   // intent_anchor
+        'active',
+        JSON.stringify({}),
+        agentId,                  // source_agent_id
+        null as string | null,    // jobId placeholder — filled after upsert
+      ];
+
+      const client = await this.pool.connect();
+      try {
+        await client.query('BEGIN');
+
+        const { rows } = await client.query(sql, params);
+        const resultRow = rows[0] as
+          | {
+              id: string;
+              prior_status?: string | null;
+              prior_failures?: number | null;
+              prior_error?: string | null;
+            }
+          | undefined;
+        if (!resultRow) {
+          throw new Error(
+            `upsertDeclarativeJob: upsert returned no row for ${sourceAgentId}/${agentId} (${schedule.cron})`,
+          );
+        }
+        jobId = resultRow.id;
+        revivedFromCancelled = resultRow.prior_status === 'cancelled';
+        if (revivedFromCancelled) {
+          revivalContext = {
+            priorFailures: resultRow.prior_failures ?? null,
+            priorError: resultRow.prior_error ?? null,
+          };
+          await client.query(
+            `UPDATE tasks
+                SET status = 'active', updated_at = now()
+               FROM scheduled_jobs sj
+              WHERE sj.id = $1
+                AND tasks.id = sj.task_id
+                AND tasks.status = 'cancelled'`,
+            [jobId],
+          );
+        }
+
+        taskParams[6] = jobId;
+        const taskResult = await client.query(taskSql, taskParams);
+        const taskRow = taskResult.rows[0] as { task_id: string; job_id: string | null } | undefined;
+        if (taskRow && !taskRow.job_id) {
+          this.logger.error(
+            { agentId, jobId, intentAnchor: schedule.intent_anchor, taskId: taskRow.task_id },
+            'upsertDeclarativeJob: tasks row created but scheduled_jobs.task_id link failed — orphaned task',
+          );
+          throw new Error(`upsertDeclarativeJob: scheduled_jobs row ${jobId} not found when linking task`);
+        }
+        const anchorCreated = taskRow != null;
+
+        await client.query('COMMIT');
+
+        if (revivedFromCancelled && revivalContext) {
+          this.logger.warn(
+            {
+              jobId,
+              sourceAgentId,
+              agentId,
+              cron: schedule.cron,
+              priorConsecutiveFailures: revivalContext.priorFailures,
+              priorLastError: revivalContext.priorError,
+            },
+            'Declarative job revived from cancelled — its YAML declaration still exists. ' +
+              'If this job was deliberately stopped, remove its schedule entry from the agent YAML instead of cancelling it.',
+          );
+        }
+
+        this.logger.info(
+          { agentId, jobId, intentAnchor: schedule.intent_anchor, anchorCreated },
+          anchorCreated
+            ? 'upsertDeclarativeJob: tasks row created for intent_anchor (drift detection enabled)'
+            : 'upsertDeclarativeJob: tasks row already exists — skipped (restart idempotency)',
+        );
+      } catch (err) {
+        this.logger.error(
+          { err, agentId, intentAnchor: schedule.intent_anchor },
+          'upsertDeclarativeJob: transaction failed',
+        );
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackErr) {
+          this.logger.error(
+            { err: rollbackErr },
+            'upsertDeclarativeJob: ROLLBACK failed after transaction error — connection may be in bad state',
+          );
+        }
+        throw err;
+      } finally {
+        client.release();
+      }
+
+      return jobId;
+    }
+
     const { rows } = await this.pool.query(sql, params);
     const resultRow = rows[0] as
       | {
@@ -620,9 +778,9 @@ export class SchedulerService {
         `upsertDeclarativeJob: upsert returned no row for ${sourceAgentId}/${agentId} (${schedule.cron})`,
       );
     }
-    const jobId = resultRow.id;
+    jobId = resultRow.id;
 
-    const revivedFromCancelled = resultRow.prior_status === 'cancelled';
+    revivedFromCancelled = resultRow.prior_status === 'cancelled';
 
     // Reviving overrides a terminal 'cancelled' state, so surface it loudly — the
     // symmetric cancellation path (cancelStaleDeclarativeJobs) logs per row, and a
@@ -659,83 +817,6 @@ export class SchedulerService {
             AND tasks.id = sj.task_id
             AND tasks.status = 'cancelled'`,
         [jobId],
-      );
-    }
-
-    // If intent_anchor is set, create a linked tasks row so the drift detector can
-    // fire for this job — same pattern as createJob(). The WHERE NOT EXISTS guard ensures
-    // this is a no-op on restart (preserving accumulated progress in the existing row).
-    //
-    // The CTE surfaces both outcomes via a SELECT at the end:
-    //   - rows = [] (empty): WHERE NOT EXISTS fired — existing task preserved (idempotent)
-    //   - rows = [{ task_id, job_id }]: new task created and job linked
-    //   - rows = [{ task_id, job_id: null }]: INSERT succeeded but link_job UPDATE returned
-    //     no rows — either the job was deleted concurrently, or a parallel startup already
-    //     set task_id (AND task_id IS NULL guard prevents overwriting). The cleanup_orphan
-    //     CTE deletes the just-inserted task so no orphan accumulates; treated as a hard error.
-    if (schedule.intent_anchor) {
-      const taskSql = `
-        WITH new_task AS (
-          INSERT INTO tasks (agent_id, title, intent_anchor, status, error_budget, source_agent_id)
-          SELECT $1, $2, $3, $4, $5::jsonb, $6
-          WHERE NOT EXISTS (SELECT 1 FROM scheduled_jobs WHERE id = $7 AND task_id IS NOT NULL)
-          RETURNING id
-        ),
-        link_job AS (
-          UPDATE scheduled_jobs
-             SET task_id = new_task.id
-            FROM new_task
-           WHERE scheduled_jobs.id = $7
-             AND task_id IS NULL
-          RETURNING scheduled_jobs.id AS job_id
-        ),
-        cleanup_orphan AS (
-          DELETE FROM tasks
-           WHERE id = (SELECT id FROM new_task)
-             AND NOT EXISTS (SELECT 1 FROM link_job)
-        )
-        SELECT new_task.id AS task_id, link_job.job_id
-          FROM new_task
-          LEFT JOIN link_job ON true
-      `;
-      let taskResult: { rows: unknown[] };
-      try {
-        taskResult = await this.pool.query(taskSql, [
-          agentId,
-          schedule.intent_anchor,   // title
-          schedule.intent_anchor,   // intent_anchor
-          'active',
-          JSON.stringify({}),
-          agentId,                  // source_agent_id
-          jobId,
-        ]);
-      } catch (err) {
-        // Re-throw so loadDeclarativeJobs treats the whole upsert as failed.
-        // The scheduled_jobs row was already written, but without the tasks
-        // link the drift detector cannot fire — running silently in a degraded state
-        // is worse than a loud failure that prompts operator attention.
-        this.logger.error(
-          { err, agentId, jobId, intentAnchor: schedule.intent_anchor },
-          'upsertDeclarativeJob: failed to create tasks row — job will run without drift detection until this is resolved',
-        );
-        throw err;
-      }
-      const resultRow = taskResult.rows[0] as { task_id: string; job_id: string | null } | undefined;
-      if (resultRow && !resultRow.job_id) {
-        // INSERT succeeded but the UPDATE found no scheduled_jobs row.
-        // This is a race: the job was cancelled between the upsert above and this CTE.
-        this.logger.error(
-          { agentId, jobId, intentAnchor: schedule.intent_anchor, taskId: resultRow.task_id },
-          'upsertDeclarativeJob: tasks row created but scheduled_jobs.task_id link failed — orphaned task',
-        );
-        throw new Error(`upsertDeclarativeJob: scheduled_jobs row ${jobId} not found when linking task`);
-      }
-      const anchorCreated = resultRow != null;
-      this.logger.info(
-        { agentId, jobId, intentAnchor: schedule.intent_anchor, anchorCreated },
-        anchorCreated
-          ? 'upsertDeclarativeJob: tasks row created for intent_anchor (drift detection enabled)'
-          : 'upsertDeclarativeJob: tasks row already exists — skipped (restart idempotency)',
       );
     }
 

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -5,7 +5,20 @@ import type { CreateJobParams } from '../../../src/scheduler/scheduler-service.j
 // -- Mock helpers --
 
 function mockPool() {
-  return { query: vi.fn() };
+  return { query: vi.fn(), connect: vi.fn() };
+}
+
+/** Pool mock that routes transactional work through pool.connect() → client.query(). */
+function mockTransactionalPool() {
+  const client = {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+  const pool = {
+    query: vi.fn(),
+    connect: vi.fn().mockResolvedValue(client),
+  };
+  return { pool, client };
 }
 
 function mockBus() {
@@ -100,12 +113,17 @@ describe('SchedulerService', () => {
     });
 
     it('creates a persistent task when intentAnchor is provided', async () => {
+      const { pool, client } = mockTransactionalPool();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new SchedulerService(pool as any, bus as any, logger as any);
+
       const jobId = 'job-333';
       const taskId = 'task-aaa';
-      // First call: INSERT into scheduled_jobs
-      pool.query.mockResolvedValueOnce({ rows: [{ id: jobId }] });
-      // Second call: CTE returns { task_id, job_id } confirming both INSERT and UPDATE succeeded
-      pool.query.mockResolvedValueOnce({ rows: [{ task_id: taskId, job_id: jobId }] });
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ id: jobId }] }) // INSERT scheduled_jobs
+        .mockResolvedValueOnce({ rows: [{ task_id: taskId, job_id: jobId }] }) // task CTE
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
       const params: CreateJobParams = {
         agentId: 'agent-3',
@@ -120,10 +138,44 @@ describe('SchedulerService', () => {
       expect(result.jobId).toBe(jobId);
       expect(result.agentTaskId).toBe(taskId);
 
-      // Two queries: job insert + task CTE (INSERT tasks + UPDATE scheduled_jobs.task_id)
-      expect(pool.query).toHaveBeenCalledTimes(2);
-      const taskSql = pool.query.mock.calls[1]?.[0] as string;
-      expect(taskSql).toContain('INSERT INTO tasks');
+      expect(pool.connect).toHaveBeenCalledOnce();
+      const clientCalls = client.query.mock.calls.map(([sql]) => sql as string);
+      expect(clientCalls[0]).toBe('BEGIN');
+      expect(clientCalls[1]).toContain('INSERT INTO scheduled_jobs');
+      expect(clientCalls[2]).toContain('INSERT INTO tasks');
+      expect(clientCalls[clientCalls.length - 1]).toBe('COMMIT');
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+
+    it('rolls back when the tasks CTE fails — no orphaned scheduled_jobs row', async () => {
+      const { pool, client } = mockTransactionalPool();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new SchedulerService(pool as any, bus as any, logger as any);
+
+      const jobId = 'job-rollback';
+      const cteError = new Error('tasks CTE failed');
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ id: jobId }] }) // INSERT scheduled_jobs
+        .mockRejectedValueOnce(cteError) // task CTE throws
+        .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+      const params: CreateJobParams = {
+        agentId: 'agent-3',
+        cronExpr: '0 */6 * * *',
+        taskPayload: { skill: 'report' },
+        createdBy: 'system',
+        intentAnchor: 'weekly-report',
+      };
+
+      await expect(svc.createJob(params)).rejects.toThrow('tasks CTE failed');
+
+      const clientCalls = client.query.mock.calls.map(([sql]) => sql as string);
+      expect(clientCalls).toContain('BEGIN');
+      expect(clientCalls).toContain('ROLLBACK');
+      expect(clientCalls).not.toContain('COMMIT');
+      expect(bus.publish).not.toHaveBeenCalled();
+      expect(client.release).toHaveBeenCalledOnce();
     });
 
     it('rejects when neither cronExpr nor runAt is provided', async () => {
@@ -881,10 +933,15 @@ describe('SchedulerService', () => {
     });
 
     it('creates a tasks row when intent_anchor is provided', async () => {
-      // First query: the scheduled_jobs upsert; second query: CTE returns { task_id, job_id }
-      // confirming both the tasks INSERT and scheduled_jobs UPDATE succeeded.
-      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor' }] });
-      pool.query.mockResolvedValueOnce({ rows: [{ task_id: 'task-new', job_id: 'job-anchor' }] });
+      const { pool, client } = mockTransactionalPool();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new SchedulerService(pool as any, bus as any, logger as any);
+
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ id: 'job-anchor' }] }) // upsert
+        .mockResolvedValueOnce({ rows: [{ task_id: 'task-new', job_id: 'job-anchor' }] }) // task CTE
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
       await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '0 9 * * 1',
@@ -892,24 +949,17 @@ describe('SchedulerService', () => {
         intent_anchor: 'Produce a weekly summary of key business metrics',
       });
 
-      expect(pool.query).toHaveBeenCalledTimes(2);
+      expect(pool.connect).toHaveBeenCalledOnce();
+      const clientCalls = client.query.mock.calls.map(([sql]) => sql as string);
+      expect(clientCalls[0]).toBe('BEGIN');
+      expect(clientCalls[1]).toContain('ON CONFLICT');
+      expect(clientCalls[2]).toContain('INSERT INTO tasks');
+      expect(clientCalls[2]).toContain('WHERE NOT EXISTS');
+      expect(clientCalls[2]).toContain('UPDATE scheduled_jobs');
+      expect(clientCalls[2]).toContain('AND task_id IS NULL');
+      expect(clientCalls[2]).toContain('cleanup_orphan');
+      expect(clientCalls[clientCalls.length - 1]).toBe('COMMIT');
 
-      // Second call must be the CTE: INSERT INTO tasks WHERE NOT EXISTS + UPDATE scheduled_jobs
-      // (guarded by AND task_id IS NULL) + cleanup_orphan DELETE + SELECT.
-      const [taskSql, taskParams] = pool.query.mock.calls[1] as [string, unknown[]];
-      expect(taskSql).toContain('INSERT INTO tasks');
-      expect(taskSql).toContain('WHERE NOT EXISTS');
-      expect(taskSql).toContain('UPDATE scheduled_jobs');
-      expect(taskSql).toContain('AND task_id IS NULL');
-      expect(taskSql).toContain('cleanup_orphan');
-      expect(taskSql).toContain('task_id');
-      expect(taskSql).toContain('job_id');
-      expect(taskParams).toContain('coordinator');
-      expect(taskParams).toContain('Produce a weekly summary of key business metrics');
-      expect(taskParams).toContain('active');
-      expect(taskParams).toContain('job-anchor');
-
-      // Logs at info level confirming the anchor was created.
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({ agentId: 'coordinator', jobId: 'job-anchor', anchorCreated: true }),
         expect.stringContaining('drift detection enabled'),
@@ -917,9 +967,15 @@ describe('SchedulerService', () => {
     });
 
     it('is idempotent on restart — skips tasks INSERT when row already exists', async () => {
-      // rowCount: 0 means the WHERE NOT EXISTS guard fired — the existing row was preserved.
-      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor-2' }] });
-      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const { pool, client } = mockTransactionalPool();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new SchedulerService(pool as any, bus as any, logger as any);
+
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ id: 'job-anchor-2' }] }) // upsert
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // WHERE NOT EXISTS guard fired
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
       await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '0 9 * * 1',
@@ -927,9 +983,7 @@ describe('SchedulerService', () => {
         intent_anchor: 'Produce a weekly summary of key business metrics',
       });
 
-      expect(pool.query).toHaveBeenCalledTimes(2);
-
-      // Logs at info level confirming the existing row was preserved.
+      expect(pool.connect).toHaveBeenCalledOnce();
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({ agentId: 'coordinator', jobId: 'job-anchor-2', anchorCreated: false }),
         expect.stringContaining('restart idempotency'),
@@ -949,12 +1003,15 @@ describe('SchedulerService', () => {
     });
 
     it('throws when tasks INSERT succeeds but scheduled_jobs UPDATE fails (orphan race)', async () => {
-      // Simulate the race where the scheduled_jobs row disappears (or was already linked
-      // by a concurrent startup) between the upsert and the task-link CTE.
-      // The cleanup_orphan CTE deletes the orphan task (DB-side); INSERT returns task_id
-      // but job_id is null, indicating the link failed.
-      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-race' }] });
-      pool.query.mockResolvedValueOnce({ rows: [{ task_id: 'task-orphan', job_id: null }] });
+      const { pool, client } = mockTransactionalPool();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new SchedulerService(pool as any, bus as any, logger as any);
+
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ id: 'job-race' }] }) // upsert
+        .mockResolvedValueOnce({ rows: [{ task_id: 'task-orphan', job_id: null }] }) // link failed
+        .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
 
       await expect(
         svc.upsertDeclarativeJob('coordinator', 'coordinator', {
@@ -964,10 +1021,40 @@ describe('SchedulerService', () => {
         }),
       ).rejects.toThrow(/scheduled_jobs row.*not found when linking task/);
 
+      const clientCalls = client.query.mock.calls.map(([sql]) => sql as string);
+      expect(clientCalls).toContain('ROLLBACK');
+      expect(clientCalls).not.toContain('COMMIT');
+
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({ jobId: 'job-race', taskId: 'task-orphan' }),
         expect.stringContaining('orphaned task'),
       );
+    });
+
+    it('rolls back when the tasks CTE throws — no orphaned scheduled_jobs row', async () => {
+      const { pool, client } = mockTransactionalPool();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new SchedulerService(pool as any, bus as any, logger as any);
+
+      const cteError = new Error('task link failed');
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ id: 'job-rollback' }] }) // upsert
+        .mockRejectedValueOnce(cteError) // task CTE throws
+        .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+      await expect(
+        svc.upsertDeclarativeJob('coordinator', 'coordinator', {
+          cron: '0 9 * * 1',
+          task: 'weekly digest',
+          intent_anchor: 'Produce a weekly summary',
+        }),
+      ).rejects.toThrow('task link failed');
+
+      const clientCalls = client.query.mock.calls.map(([sql]) => sql as string);
+      expect(clientCalls).toContain('BEGIN');
+      expect(clientCalls).toContain('ROLLBACK');
+      expect(clientCalls).not.toContain('COMMIT');
     });
 
     it('stamps a system originator with systemRole system and channel declarative', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #867.

`createJob()` and `upsertDeclarativeJob()` previously executed their `scheduled_jobs` INSERT/UPSERT and the subsequent `tasks` link CTE as two separate `pool.query()` calls. If the second query failed after the first committed, the job would still run but drift detection would be silently disabled.

Both code paths now use `pool.connect()` + `BEGIN` / `COMMIT` / `ROLLBACK` when a linked task row is created:

- **`createJob()`** — transaction wraps the job INSERT + tasks CTE when `intentAnchor` is provided
- **`upsertDeclarativeJob()`** — transaction wraps the UPSERT + tasks CTE when `intent_anchor` is provided (including revival task reactivation when applicable)

## Acceptance criteria

- [x] `createJob()` executes atomically when linking a task: either both rows commit or neither does
- [x] `upsertDeclarativeJob()` executes atomically when linking a task: same guarantee
- [x] Existing unit tests pass; added partial-failure tests that mock the second query throwing and assert `ROLLBACK` (no `COMMIT`)
- [x] No change to scheduler startup, job cancellation, or drift-detection behaviour for paths that do not create linked tasks

## Testing

- `pnpm test tests/unit/scheduler/scheduler-service.test.ts` — 61 passed
- `pnpm run typecheck`
- `pnpm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf80ae88-223e-4b09-8ca6-6ec1c28614a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf80ae88-223e-4b09-8ca6-6ec1c28614a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

