### PR TITLE
fix(registry): atomic installAndEnable for reconciliation enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`outbound-gateway`** — content-filter blocks now return the principal-safe reason and rule names so agents can self-correct and retry. (#1051)
 - **`outbound-gateway` draft path** — `sendEmailDraft()` blocks now return the same principal-safe reason and rule names, so blocked draft sends are self-correctable too. (#1158)
 - **Scheduler double-fire** — the cron-branch claim UPDATE now re-checks `next_run_at <= now()`, so overlapping poll cycles can no longer re-claim a just-completed recurring job and send a duplicate (e.g. two daily digests). (#1159)
+- **Registry reconciliation** — core default enrollment now uses a single atomic `installAndEnable` instead of separate install+enable calls, so a crash between them can no longer leave skills permanently installed-but-disabled. (#937)
 - **`approveGrantRecommendation` / `declineGrantRecommendation`** — concurrent calls on the same pending recommendation no longer produce an auth-state contradiction; both operations now run inside a single transaction so approve's permission override and status transition are atomic. (#1068)
 - **`ceo-nylas-client`** — 429 responses retry with exponential backoff (up to 3 attempts), honoring `Retry-After`; exhaustion throws a typed `NylasApiError(429)` that cannot be misread as an auth failure. (#1058)
 - **`ceo-nylas-client` list endpoints** — `limit` is always sent and capped at ≤ 20; previously an unspecified limit caused Nylas to default to 50, exceeding the safety cap. (#1058)

--- a/src/registry/reconcile.test.ts
+++ b/src/registry/reconcile.test.ts
@@ -12,6 +12,11 @@ class FakeRepo implements IRegistryRepo {
     const row: RegistryRow = { name, enabled: false, installedAt: 't0', installedBy: actor, enabledAt: null, enabledBy: null, updatedAt: 't0' };
     this.rows.set(name, row); return row;
   }
+  async installAndEnable(name: string, actor: string) {
+    if (this.rows.has(name)) return null;
+    const row: RegistryRow = { name, enabled: true, installedAt: 't0', installedBy: actor, enabledAt: 't0', enabledBy: actor, updatedAt: 't0' };
+    this.rows.set(name, row); return row;
+  }
   async enable(name: string, actor: string) {
     const r = this.rows.get(name)!; const n = { ...r, enabled: true, enabledAt: 't1', enabledBy: actor, updatedAt: 't1' };
     this.rows.set(name, n); return n;
@@ -61,6 +66,14 @@ describe('reconcileRegistries', () => {
     await skillRepo.install('core-skill', 'web-app'); // row exists, enabled=false
     await run({ skills: ['core-skill'], agents: [] }, { skills: ['core-skill'], agents: [] });
     expect((await skillRepo.getRow('core-skill'))?.enabled).toBe(false);
+  });
+
+  it('respects an admin-enabled core item (row present, enabled)', async () => {
+    await skillRepo.install('core-skill', 'web-app');
+    await skillRepo.enable('core-skill', 'web-app');
+    const before = await skillRepo.getRow('core-skill');
+    await run({ skills: ['core-skill'], agents: [] }, { skills: ['core-skill'], agents: [] });
+    expect(await skillRepo.getRow('core-skill')).toEqual(before);
   });
 
   it('warns (no throw) when a core default is not on disk', async () => {

--- a/src/registry/reconcile.ts
+++ b/src/registry/reconcile.ts
@@ -46,8 +46,7 @@ async function reconcileOne(
       logger.warn({ kind, name }, 'registry: core default not found on disk; skipping enrollment');
       continue;
     }
-    await repo.install(name, 'reconciliation');
-    await repo.enable(name, 'reconciliation');
+    await repo.installAndEnable(name, 'reconciliation');
     logger.info({ kind, name }, 'registry: enrolled core default as enabled');
   }
 }

--- a/src/registry/reconcile.ts
+++ b/src/registry/reconcile.ts
@@ -46,7 +46,11 @@ async function reconcileOne(
       logger.warn({ kind, name }, 'registry: core default not found on disk; skipping enrollment');
       continue;
     }
-    await repo.installAndEnable(name, 'reconciliation');
-    logger.info({ kind, name }, 'registry: enrolled core default as enabled');
+    const enrolled = await repo.installAndEnable(name, 'reconciliation');
+    if (enrolled) {
+      logger.info({ kind, name }, 'registry: enrolled core default as enabled');
+    } else {
+      logger.info({ kind, name }, 'registry: core default already present on insert; left untouched');
+    }
   }
 }

--- a/src/registry/registry-repo.ts
+++ b/src/registry/registry-repo.ts
@@ -42,6 +42,7 @@ const SQL: Record<RegistryTable, {
   list: string;
   get: string;
   install: string;
+  installAndEnable: string;
   enable: string;
   disable: string;
   uninstall: string;
@@ -53,6 +54,10 @@ const SQL: Record<RegistryTable, {
               VALUES ($1, false, $2)
               ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
               RETURNING ${COLS}`,
+    installAndEnable: `INSERT INTO skill_registry (name, enabled, installed_by, enabled_at, enabled_by)
+                       VALUES ($1, true, $2, now(), $2)
+                       ON CONFLICT (name) DO NOTHING
+                       RETURNING ${COLS}`,
     enable: `UPDATE skill_registry
                SET enabled = true, enabled_at = now(), enabled_by = $2, updated_at = now()
              WHERE name = $1
@@ -70,6 +75,10 @@ const SQL: Record<RegistryTable, {
               VALUES ($1, false, $2)
               ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
               RETURNING ${COLS}`,
+    installAndEnable: `INSERT INTO agent_registry (name, enabled, installed_by, enabled_at, enabled_by)
+                       VALUES ($1, true, $2, now(), $2)
+                       ON CONFLICT (name) DO NOTHING
+                       RETURNING ${COLS}`,
     enable: `UPDATE agent_registry
                SET enabled = true, enabled_at = now(), enabled_by = $2, updated_at = now()
              WHERE name = $1
@@ -109,6 +118,12 @@ export class RegistryRepo implements IRegistryRepo {
     // (name = EXCLUDED.name) to trigger RETURNING without modifying any columns.
     const { rows } = await this.pool.query<DbRegistryRow>(this.sql.install, [name, actor]);
     return mapRow(rows[0]!);
+  }
+
+  async installAndEnable(name: string, actor: string): Promise<RegistryRow | null> {
+    const { rows } = await this.pool.query<DbRegistryRow>(this.sql.installAndEnable, [name, actor]);
+    const row = rows[0];
+    return row ? mapRow(row) : null;
   }
 
   async enable(name: string, actor: string): Promise<RegistryRow> {

--- a/src/registry/registry-service.test.ts
+++ b/src/registry/registry-service.test.ts
@@ -22,6 +22,14 @@ class FakeRepo implements IRegistryRepo {
     };
     this.rows.set(name, row); return row;
   }
+  async installAndEnable(name: string, actor: string) {
+    if (this.rows.has(name)) return null;
+    const row: RegistryRow = {
+      name, enabled: true, installedAt: 't0', installedBy: actor,
+      enabledAt: 't0', enabledBy: actor, updatedAt: 't0',
+    };
+    this.rows.set(name, row); return row;
+  }
   async enable(name: string, actor: string) {
     const row = this.rows.get(name);
     if (!row) throw new Error(`no row ${name}`);

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -86,6 +86,8 @@ export interface IRegistryRepo {
   getRow(name: string): Promise<RegistryRow | null>;
   /** Insert enabled=false if absent; no-op + return existing row if present. */
   install(name: string, actor: string): Promise<RegistryRow>;
+  /** Insert enabled=true if absent; no-op if present. Returns the new row, or null on conflict. */
+  installAndEnable(name: string, actor: string): Promise<RegistryRow | null>;
   /** Set enabled=true (+ enabled_at/by). Throws if no row exists. */
   enable(name: string, actor: string): Promise<RegistryRow>;
   /** Set enabled=false (+ clear enabled_at/by). Throws if no row exists. */

--- a/tests/integration/registry-repo.test.ts
+++ b/tests/integration/registry-repo.test.ts
@@ -33,6 +33,29 @@ describeIf('RegistryRepo (skill_registry)', () => {
     expect(second.installedBy).toBe(first.installedBy); // unchanged
   });
 
+  it('installAndEnable inserts an enabled row in one statement', async () => {
+    const row = await repo.installAndEnable('alpha', 'reconciliation');
+    expect(row?.enabled).toBe(true);
+    expect(row?.installedBy).toBe('reconciliation');
+    expect(row?.enabledBy).toBe('reconciliation');
+    expect(row?.enabledAt).not.toBeNull();
+  });
+
+  it('installAndEnable leaves a pre-existing row untouched (disabled)', async () => {
+    const before = await repo.install('alpha', 'admin');
+    const result = await repo.installAndEnable('alpha', 'reconciliation');
+    expect(result).toBeNull();
+    expect(await repo.getRow('alpha')).toEqual(before);
+  });
+
+  it('installAndEnable leaves a pre-existing row untouched (enabled)', async () => {
+    await repo.install('alpha', 'admin');
+    const before = await repo.enable('alpha', 'admin');
+    const result = await repo.installAndEnable('alpha', 'reconciliation');
+    expect(result).toBeNull();
+    expect(await repo.getRow('alpha')).toEqual(before);
+  });
+
   it('enable sets enabled + enabled_at/by', async () => {
     await repo.install('alpha', 'tester');
     const row = await repo.enable('alpha', 'enabler');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #937

Registry reconciliation previously enrolled core defaults with two sequential DB calls (`install` then `enable`). If the process crashed between them, the skill ended up installed-but-disabled, and subsequent boots respected that as admin-set state — leaving it permanently disabled until manual intervention.

This PR replaces the two-step sequence with a single atomic `installAndEnable` method that issues one `INSERT ... ON CONFLICT DO NOTHING` setting both `enabled=true` and audit fields in a single statement.

## Changes

- Added `installAndEnable(name, actor)` to `IRegistryRepo` and `RegistryRepo`
- Updated `reconcileOne` to call `installAndEnable` instead of `install` + `enable`
- Added integration tests for `installAndEnable` (insert + conflict no-op)
- Added reconcile test for pre-existing enabled rows

## Acceptance criteria

- [x] `reconcileOne` calls a single atomic `installAndEnable` instead of `install` + `enable`
- [x] The underlying SQL is one statement (no intermediate committed state possible)
- [x] Existing test coverage for reconciliation still passes
- [x] A new test verifies that a pre-existing row (any state) is left untouched
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ffa7b3e-68f5-4cf8-a2f5-6acd1c8cbd7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ffa7b3e-68f5-4cf8-a2f5-6acd1c8cbd7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

