### PR TITLE
fix: warn when skill directory name diverges from manifest.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Skill discovery** — `discoverSkillManifests` now warns at startup when a skill directory name diverges from `manifest.name`, surfacing registry/enrollment mismatches before they silently disable skills. (#938)
 - **Setup Node version gate** — `scripts/setup.sh` now rejects Node 22/23 to match the documented Node >=24 requirement. (#1139)
 - **Scheduling consults** — sender-proposed meeting times now flow through `ceo-inbox` to `calendar`, which checks them before counter-proposing alternatives. (#1186)
 - **`ceo-inbox` Branch A resume** — calendar consult replies now call `memory-query` anchored on sender and subject before drafting, so stored facts (Calendly links, venue preferences, relationship notes) shape the reply; no-match proceeds normally. (#1185)

--- a/src/index.ts
+++ b/src/index.ts
@@ -812,7 +812,7 @@ async function main(): Promise<void> {
   let skillDiscovery: SkillDiscovery[];
   let agentDiscovery: AgentDiscovery[];
   try {
-    skillDiscovery = discoverSkillManifests(skillsDir);
+    skillDiscovery = discoverSkillManifests(skillsDir, logger);
     agentDiscovery = discoverAgentManifests(agentsDir);
   } catch (err) {
     logger.fatal({ err }, 'Failed to discover skills/agents on disk');

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -12,7 +12,7 @@
 //   8. Frozen manifests reject mutation attempts at runtime
 //   9. allowed_callers freeze and startup validation
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -82,6 +82,33 @@ describe('discoverSkillManifests', () => {
     const found = discoverSkillManifests(dir);
     expect(found[0]!.metadata).toBeNull();
     expect(found[0]!.error).toBeTruthy();
+  });
+
+  it('warns when directory name does not match manifest.name', () => {
+    const warnFn = vi.fn();
+    const mockLogger = { warn: warnFn } as never;
+    writeSkill(
+      dir,
+      'dir-name',
+      { name: 'manifest-name', description: 'd', version: '1.0.0', action_risk: 'none' },
+      'export default { async execute() { return { success: true, data: {} }; } };',
+    );
+    const found = discoverSkillManifests(dir, mockLogger);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.name).toBe('manifest-name');
+    expect(warnFn).toHaveBeenCalledOnce();
+    expect(warnFn.mock.calls[0]![0]).toMatchObject({
+      dir: path.join(dir, 'dir-name'),
+      manifestName: 'manifest-name',
+    });
+  });
+
+  it('does not warn when directory name matches manifest.name', () => {
+    const warnFn = vi.fn();
+    const mockLogger = { warn: warnFn } as never;
+    writeSkill(dir, 'good', { name: 'good', description: 'd', version: '1.0.0', action_risk: 'none' }, 'throw new Error("should not import");');
+    discoverSkillManifests(dir, mockLogger);
+    expect(warnFn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -51,7 +51,7 @@ export interface SkillDiscovery {
  * skill never crashes startup. Used by the registry UI, reconciliation, and as
  * the input to loadSkillsFromDirectory.
  */
-export function discoverSkillManifests(skillsDir: string): SkillDiscovery[] {
+export function discoverSkillManifests(skillsDir: string, logger?: Logger): SkillDiscovery[] {
   if (!fs.existsSync(skillsDir)) {
     throw new Error(`Skills directory not found: ${skillsDir}`);
   }
@@ -84,6 +84,12 @@ export function discoverSkillManifests(skillsDir: string): SkillDiscovery[] {
       const requiresSecrets = Array.isArray(rawRequires)
         ? rawRequires.filter((s): s is string => typeof s === 'string')
         : undefined;
+      if (entry.name !== manifest.name) {
+        logger?.warn(
+          { dir, manifestName: manifest.name },
+          'skill discovery: directory name does not match manifest.name',
+        );
+      }
       out.push({
         name: manifest.name,
         dir,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a skill's on-disk directory name does not match its `manifest.name`, registry enrollment and skill loading can diverge silently — a default-set row may be keyed by one name while agents reference the other. This adds a startup warning at discovery time so operators can spot the mismatch before it causes confusing disabled/orphaned skills.

Closes #938

## Changes

- `discoverSkillManifests` accepts an optional `logger` and emits `logger.warn` when `entry.name !== manifest.name`, including both `dir` and `manifestName` in the structured log fields
- Production bootstrap passes the app logger into discovery
- Unit tests cover both the mismatch-warning path and the no-warning path for well-formed skills

## Related Issues

Closes #938

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [ ] Spec docs updated if behavior changes
- [ ] CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06a14f56-1032-4022-bb69-4e36af977239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06a14f56-1032-4022-bb69-4e36af977239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

