### PR TITLE
fix: require bullpen participants for scheduling consults (#1197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Scheduling consult agents** — `ceo-inbox` CONSULT REQUEST steps now require `participants: ['calendar']` on `bullpen.post`; `calendar` bumped to `standard` tier for RSVP judgment. (#1197)
+
 ### Fixed
 
 - **Skill discovery** — `discoverSkillManifests` now warns at startup when a skill directory name diverges from `manifest.name`, surfacing registry/enrollment mismatches before they silently disable skills. (#938)

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -1,12 +1,12 @@
 name: calendar
-version: "0.5.0"
+version: "0.5.1"
 role: specialist
 description: >
   Calendar domain specialist — scheduling, free/busy, conflict resolution,
   event CRUD, invite RSVPs, and scheduling-related email composition for meeting
   requests, reschedules, and cancellations
 model:
-  tier: fast  # procedural scheduling + rule-based conflict resolution, no judgment calls
+  tier: standard  # scheduling + RSVP judgment (relationship tier, sender kind, conflicts)
 allow_discovery: false
 system_prompt: |
   ## Role

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.12.0"
+version: "0.12.1"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -497,8 +497,10 @@ system_prompt: |
      instructions beat config-store rules. If no rule matches, set
      `Standing: none`; the calendar specialist still evaluates relationship,
      sender kind, prior correspondence, subject/body context, and conflicts.
-  4. Open a bullpen thread mentioning `calendar` with `source_message_id` set
-     to the email message id. Shape the content exactly:
+  4. Call `bullpen.post` with `participants: ['calendar']` (the required
+     routing field — dispatch wakes only thread participants, not mentions)
+     and `source_message_id` set to the email message id. Shape the content
+     exactly:
 
        CONSULT REQUEST
        Need: RSVP for formal calendar invite
@@ -642,7 +644,9 @@ system_prompt: |
     draft blind. Instead, consult the calendar specialist and park the work:
 
     1. **Tap — post a CONSULT REQUEST to the bullpen.** Call `bullpen.post`
-       mentioning `calendar`, with content shaped exactly as follows:
+       with `participants: ['calendar']` (the required routing field — dispatch
+       wakes only thread participants, not mentions) and content shaped exactly
+       as follows:
 
          CONSULT REQUEST
          Need: 2 conflict-free 30-min slots, with holds placed, returned timezone-labelled

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -131,6 +131,13 @@ describe('ceo-inbox Branch A prompt — memory-query contract', () => {
 });
 
 describe('ceo-inbox scheduling consult prompt — proposed-time protocol', () => {
+  it('CONSULT REQUEST bullpen.post sets participants to calendar', () => {
+    const prompt = loadCeoInboxPrompt();
+    const schedulingSection = extractSchedulingConsultSection(prompt);
+    expect(schedulingSection).toContain("participants: ['calendar']");
+    expect(schedulingSection).toContain('routing field');
+  });
+
   it('CONSULT REQUEST includes an optional Proposed block for sender-suggested times', () => {
     const prompt = loadCeoInboxPrompt();
     const schedulingSection = extractSchedulingConsultSection(prompt);
@@ -207,6 +214,8 @@ describe('ceo-inbox formal invite prompt — RSVP consult contract', () => {
     expect(inviteEnd).toBeGreaterThan(inviteStart);
     const inviteSection = prompt.slice(inviteStart, inviteEnd);
 
+    expect(inviteSection).toContain("participants: ['calendar']");
+    expect(inviteSection).toContain('routing field');
     expect(inviteSection).toContain('Need: RSVP for formal calendar invite');
     expect(inviteSection).toContain('Standing: <accept|decline|tentative instruction text, or none>');
     expect(inviteSection).toContain('Do NOT archive');
@@ -290,6 +299,11 @@ describe('calendar consult prompt — proposed-time conflict checks', () => {
 });
 
 describe('calendar consult prompt — formal invite RSVP behavior', () => {
+  it('uses standard model tier for RSVP judgment', async () => {
+    const config = loadAgentConfig(path.join(agentsDir, 'calendar.yaml'));
+    expect(config.model.tier).toBe('standard');
+  });
+
   it('links formal invite consults to Nylas calendar events when needed', () => {
     const prompt = loadCalendarPrompt();
     const consultSection = extractCalendarConsultSection(prompt);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1197

Two small hardening changes for v0.38 scheduling consult reliability:

1. **ceo-inbox CONSULT REQUEST steps** now explicitly instruct `bullpen.post` with `participants: ['calendar']` — the required routing field. Dispatch only wakes thread participants, so relying on "mention" alone could silently skip calendar.
2. **calendar agent** bumped from `fast` to `standard` tier — RSVP decisions require relationship/intent judgment that the old "no judgment calls" comment no longer described.

Agent versions bumped (`ceo-inbox` 0.12.1, `calendar` 0.5.1). Prompt spec tests added.

## Acceptance criteria

- [x] Both ceo-inbox CONSULT REQUEST steps explicitly set `participants: ['calendar']` (verified by prompt spec test)
- [x] `agents/calendar.yaml` `model.tier` is `standard`; stale "no judgment calls" comment removed
- [x] Agent `version` fields bumped
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22b1619d-9aa9-43d5-8bdc-7ac38aa4e30d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22b1619d-9aa9-43d5-8bdc-7ac38aa4e30d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

