### PR TITLE
feat: ceo-inbox consult-timeout self-healing for parked consults (#1195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Skill discovery** — `discoverSkillManifests` now warns at startup when a skill directory name diverges from `manifest.name`, surfacing registry/enrollment mismatches before they silently disable skills. (#938)
 - **Setup Node version gate** — `scripts/setup.sh` now rejects Node 22/23 to match the documented Node >=24 requirement. (#1139)
+- **`ceo-inbox` consult timeout** — parked scheduling consults now schedule a `consult-timeout` safety wake (default ~90 min); stale parks fall back to blind draft or escalation instead of waiting forever. (#1195)
 - **Scheduling consults** — sender-proposed meeting times now flow through `ceo-inbox` to `calendar`, which checks them before counter-proposing alternatives. (#1186)
 - **Calendar hold release** — RSVP accept now releases holds by recovered conversation ref (`source-ref` / `thread-ref`) or time-overlap anchor, not fuzzy contact-domain + subject scoring; prevents over-release across concurrent negotiations. (#1196)
 - **`ceo-inbox` Branch A resume** — calendar consult replies now call `memory-query` anchored on sender and subject before drafting, so stored facts (Calendly links, venue preferences, relationship notes) shape the reply; no-match proceeds normally. (#1185)

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,9 @@
 name: ceo-inbox
+<<<<<<< HEAD
 version: "0.12.1"
+=======
+version: "0.13.0"
+>>>>>>> 1a911823 (feat: ceo-inbox consult-timeout self-healing for parked consults (#1195))
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -199,17 +203,59 @@ system_prompt: |
 
      c. Do NOT archive — leave the message in the inbox for the CEO to handle.
 
+  9. **Cancel consult-timeout safety task.** After any Branch A outcome above,
+     call `task-list` with status `open,in_progress,waiting` and tag
+     `consult-timeout`. For any returned task whose description contains
+     `source_message_id=<this message's id>`, call `task-complete` with a note
+     that the CONSULT REPLY was handled. This prevents a stale timeout wake
+     from drafting after a normal reply path. Idempotent — skip when none
+     match.
+
   **Failure handling for calendar consult resume:** If `bullpen.post` returned
   `deduplicated: true` when the original consult was posted, it was already
   parked — exit without re-labelling or re-consulting. If the consult was
-  posted but a CONSULT REPLY never arrives, the message stays read +
-  ⏳ In Progress + unarchived: it remains visible under the label, is never
-  silently dropped, and is never re-triaged (it is already read, so
+  posted but a CONSULT REPLY never arrives, the `consult-timeout` safety wake
+  scheduled at park time (default ~90 min, configurable via
+  `ceo_inbox.consult_timeout_minutes`) falls back to drafting or escalation —
+  see the `consult-timeout` branch below. Until that wake fires, the message
+  stays read + ⏳ In Progress + unarchived: it remains visible under the label,
+  is never silently dropped, and is never re-triaged (it is already read, so
   `unread_only: true` will not surface it again).
 
   **Scheduled-wake resume (task id + progress notes, no CONSULT REPLY):**
   If the wake does not match Branch A — it is a scheduled wake that includes a
   task id, title, and progress notes — branch on the task's tags:
+
+  - **`consult-timeout` tag** → safety wake for a parked scheduling consult
+    whose CONSULT REPLY never arrived. Do NOT run triage, `inbox-drain`, or
+    `inbox-follow-up` flows. Instead:
+    1. Read `source_message_id` from the task description (must appear as
+       `source_message_id=<id>`). If missing, call `task-complete` with an
+       error note and exit.
+    2. Call `ceo-inbox-read` with that `message_id`.
+    3. **Idempotent no-op (already resolved):** If the message does NOT have
+       `⏳ In Progress`, OR it already has `✍️ Drafted` or `✅ Handled`, OR a
+       reply draft for this thread already exists — call `task-complete`
+       ("consult already resolved") and exit without drafting.
+    4. **Still parked (`⏳ In Progress` present, no terminal outcome):** bounded
+       fallback so scheduling mail cannot park forever:
+       - Read `consult_kind` from the task description (`scheduling` or
+         `invite`; default `scheduling` when absent).
+       - **`consult_kind=invite`:** Do NOT draft a blind email reply. Call
+         `ceo-inbox-update-folders` with `remove_folders: ['⏳ In Progress']`.
+         Post a bullpen thread mentioning the coordinator with a structured
+         send request (🚨 Urgent): explain that the formal-invite calendar
+         consult timed out without a CONSULT REPLY. Do NOT archive.
+       - **`consult_kind=scheduling`:** Call `executive-profile-get`, then
+         `memory-query` anchored on sender and subject. Call
+         `ceo-inbox-draft-reply` with the pre-v0.38 blind-scheduling fallback:
+         acknowledge the scheduling request, propose concrete times subject to
+         calendar confirmation, and include a "pending your calendar" /
+         "I'll confirm shortly" qualifier. Call `ceo-inbox-update-folders` with
+         `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`. Do
+         NOT archive.
+    5. Call `task-complete` with a note describing the fallback taken (or the
+       no-op in step 3).
 
   - **`inbox-drain` tag** → this is a batch-drain continuation you scheduled in
     Step 6 because the inbox still had unread mail. Do NOT run the reification
@@ -521,6 +567,8 @@ system_prompt: |
      - Classification: ✍️ Drafted (parked — calendar invite consult in flight)
      - Actions: file-parse (if ICS present), bullpen.post (CONSULT REQUEST),
        ceo-inbox-update-folders (⏳ In Progress), ceo-inbox-mark-read
+  6. **Schedule consult-timeout safety wake** — see the consult-timeout contract
+     in Scheduling-specific drafting rules below (`consult_kind=invite`).
 
   The calendar specialist will link the invite to the calendar event, check
   conflicts while ignoring matching Curia holds, and either send an autonomy-
@@ -643,6 +691,22 @@ system_prompt: |
     asks the CEO to suggest a time, or is negotiating a meeting slot), do NOT
     draft blind. Instead, consult the calendar specialist and park the work:
 
+    **Consult-timeout safety wake (after parking any calendar consult):**
+    After a successful `bullpen.post` (when `deduplicated` is not `true`), or
+    when recovering a deduplicated consult (ensure a wake still exists), schedule
+    a bounded fallback so a lost CONSULT REPLY cannot park mail forever:
+    - Call `config-store` retrieve `namespace: ceo_inbox, key:
+      consult_timeout_minutes`. Default **90** when missing or unparseable.
+    - Call `task-list` with status `open,in_progress,waiting` and tag
+      `consult-timeout`. If a task already exists whose description contains
+      `source_message_id=<this message's id>`, call `task-update` to refresh
+      `wake_at` only — never create a duplicate.
+    - Otherwise call `task-create` with: title `Consult timeout: <subject>`,
+      owner `curia`, tags `['consult-timeout']`, description containing
+      `source_message_id=<id>` and `consult_kind=<scheduling|invite>`, and
+      `wake_at` set to now plus the timeout minutes (resolve with
+      `date-resolve`). Log failures; the timeout is a best-effort safety net.
+
     1. **Tap — post a CONSULT REQUEST to the bullpen.** Call `bullpen.post`
        with `participants: ['calendar']` (the required routing field — dispatch
        wakes only thread participants, not mentions) and content shaped exactly
@@ -678,7 +742,8 @@ system_prompt: |
        parking steps idempotently: call `ceo-inbox-label` with `⏳ In Progress`
        and call `ceo-inbox-mark-read` with the message_id. Both are safe to
        repeat (they are no-ops if already done). This recovers a run that died
-       after `bullpen.post` but before Step 2. Then exit without drafting.
+       after `bullpen.post` but before Step 2. Still run Step 4 (consult-timeout
+       safety wake) to ensure a fallback exists. Then exit without drafting.
 
     2. **Park — label + mark-read.** Call `ceo-inbox-label` to apply the label
        `⏳ In Progress` to the message. Then call `ceo-inbox-mark-read` with
@@ -690,6 +755,9 @@ system_prompt: |
        - Classification: ✍️ Drafted (parked — calendar consult in flight)
        - Actions: bullpen.post (CONSULT REQUEST), ceo-inbox-label (⏳ In Progress),
          ceo-inbox-mark-read
+
+    4. **Schedule consult-timeout safety wake** with `consult_kind=scheduling`
+       (see contract above). Skip only when `bullpen.post` failed entirely.
 
     The calendar specialist will reply on the bullpen thread with a CONSULT REPLY.
     On the next bullpen wake, Resume mode Branch A above handles drafting the

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,9 +1,5 @@
 name: ceo-inbox
-<<<<<<< HEAD
-version: "0.12.1"
-=======
-version: "0.13.0"
->>>>>>> 1a911823 (feat: ceo-inbox consult-timeout self-healing for parked consults (#1195))
+version: "0.13.1"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -209,7 +205,10 @@ system_prompt: |
      `source_message_id=<this message's id>`, call `task-complete` with a note
      that the CONSULT REPLY was handled. This prevents a stale timeout wake
      from drafting after a normal reply path. Idempotent — skip when none
-     match.
+     match. **Idempotency boundary:** label/folder state is read in the Branch A
+     steps above and written in this same turn; that read-then-write within one
+     ceo-inbox invocation is what prevents double-handling with a late timeout
+     wake (single-instance dispatch — no scheduler-style claim lock needed).
 
   **Failure handling for calendar consult resume:** If `bullpen.post` returned
   `deduplicated: true` when the original consult was posted, it was already
@@ -233,10 +232,12 @@ system_prompt: |
        `source_message_id=<id>`). If missing, call `task-complete` with an
        error note and exit.
     2. Call `ceo-inbox-read` with that `message_id`.
-    3. **Idempotent no-op (already resolved):** If the message does NOT have
-       `⏳ In Progress`, OR it already has `✍️ Drafted` or `✅ Handled`, OR a
-       reply draft for this thread already exists — call `task-complete`
-       ("consult already resolved") and exit without drafting.
+    3. **Idempotent no-op (already resolved):** Inspect label/folder state from
+       step 2. Then call `ceo-inbox-list` with `folder: "DRAFTS"` and check for
+       any draft whose `thread_id` matches this message's thread. If the message
+       does NOT have `⏳ In Progress`, OR it already has `✍️ Drafted` or
+       `✅ Handled`, OR a reply draft exists for this thread — call
+       `task-complete` ("consult already resolved") and exit without drafting.
     4. **Still parked (`⏳ In Progress` present, no terminal outcome):** bounded
        fallback so scheduling mail cannot park forever:
        - Read `consult_kind` from the task description (`scheduling` or
@@ -699,8 +700,12 @@ system_prompt: |
       consult_timeout_minutes`. Default **90** when missing or unparseable.
     - Call `task-list` with status `open,in_progress,waiting` and tag
       `consult-timeout`. If a task already exists whose description contains
-      `source_message_id=<this message's id>`, call `task-update` to refresh
-      `wake_at` only — never create a duplicate.
+      `source_message_id=<this message's id>`:
+      - When `next_wake_at` from task-list is still in the future, leave the
+        task unchanged — do not slide the timeout forward on retries.
+      - When `next_wake_at` is absent or already in the past, call `task-update`
+        to set a fresh `wake_at` now plus the timeout minutes.
+      Never create a duplicate.
     - Otherwise call `task-create` with: title `Consult timeout: <subject>`,
       owner `curia`, tags `['consult-timeout']`, description containing
       `source_message_id=<id>` and `consult_kind=<scheduling|invite>`, and

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -100,6 +100,24 @@ describe('ceo-inbox consult-timeout self-healing', () => {
     expect(scheduledWake).toContain('Do NOT draft a blind email reply');
   });
 
+  it('runs idempotent no-op before timeout fallback and checks DRAFTS folder', () => {
+    const prompt = loadCeoInboxPrompt();
+    const scheduledWake = extractScheduledWakeSection(prompt);
+    const noopPos = posIn(scheduledWake, 'Idempotent no-op');
+    const fallbackPos = posIn(scheduledWake, 'Still parked');
+    expect(noopPos).toBeGreaterThan(-1);
+    expect(fallbackPos).toBeGreaterThan(noopPos);
+    expect(scheduledWake).toContain('ceo-inbox-list');
+    expect(scheduledWake).toContain('folder: "DRAFTS"');
+  });
+
+  it('does not slide consult-timeout wake_at forward while still pending', () => {
+    const prompt = loadCeoInboxPrompt();
+    const schedulingSection = extractSchedulingConsultSection(prompt);
+    expect(schedulingSection).toContain('next_wake_at');
+    expect(schedulingSection).toContain('still in the future');
+  });
+
   it('schedules consult-timeout on formal invite park', () => {
     const prompt = loadCeoInboxPrompt();
     const inviteStart = posIn(prompt, '### 4d-invite. Formal meeting invitation path');

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -38,6 +38,15 @@ function extractBranchASection(prompt: string): string {
   return prompt.slice(branchAStart, scheduledWakeStart);
 }
 
+function extractScheduledWakeSection(prompt: string): string {
+  const start = prompt.indexOf('**Scheduled-wake resume');
+  const end = prompt.indexOf('**Closing a multi-turn exchange');
+  if (start === -1) throw new Error('Scheduled-wake resume section not found');
+  if (end === -1 || end <= start)
+    throw new Error('Closing a multi-turn exchange not found after scheduled wake');
+  return prompt.slice(start, end);
+}
+
 function extractSchedulingConsultSection(prompt: string): string {
   const start = prompt.indexOf('### Scheduling-specific drafting rules');
   const end = prompt.indexOf('**📌 Seen**');
@@ -60,6 +69,46 @@ function extractCalendarConsultSection(prompt: string): string {
 function posIn(section: string, term: string): number {
   return section.indexOf(term);
 }
+
+describe('ceo-inbox consult-timeout self-healing', () => {
+  it('documents consult-timeout scheduled wake with configurable delay', () => {
+    const prompt = loadCeoInboxPrompt();
+    const schedulingSection = extractSchedulingConsultSection(prompt);
+    const scheduledWake = extractScheduledWakeSection(prompt);
+
+    expect(schedulingSection).toContain('consult-timeout');
+    expect(schedulingSection).toContain('consult_timeout_minutes');
+    expect(schedulingSection).toContain('consult_kind=scheduling');
+    expect(schedulingSection).toContain('source_message_id=<id>');
+    expect(scheduledWake).toContain('`consult-timeout` tag');
+    expect(scheduledWake).toContain('pending your calendar');
+    expect(scheduledWake).toContain('consult already resolved');
+  });
+
+  it('cancels consult-timeout tasks when Branch A handles a CONSULT REPLY', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    expect(branchA).toContain('Cancel consult-timeout safety task');
+    expect(branchA).toContain('consult-timeout');
+    expect(branchA).toContain('task-complete');
+  });
+
+  it('escalates invite consult timeouts instead of blind-drafting', () => {
+    const prompt = loadCeoInboxPrompt();
+    const scheduledWake = extractScheduledWakeSection(prompt);
+    expect(scheduledWake).toContain('consult_kind=invite');
+    expect(scheduledWake).toContain('Do NOT draft a blind email reply');
+  });
+
+  it('schedules consult-timeout on formal invite park', () => {
+    const prompt = loadCeoInboxPrompt();
+    const inviteStart = posIn(prompt, '### 4d-invite. Formal meeting invitation path');
+    const inviteEnd = posIn(prompt, '### 4e-pre. Automated sender check');
+    const inviteSection = prompt.slice(inviteStart, inviteEnd);
+    expect(inviteSection).toContain('Schedule consult-timeout safety wake');
+    expect(inviteSection).toContain('consult_kind=invite');
+  });
+});
 
 describe('ceo-inbox Branch A prompt — memory-query contract', () => {
   it('Branch A section contains a memory-query call', () => {
@@ -155,9 +204,14 @@ describe('ceo-inbox scheduling consult prompt — proposed-time protocol', () =>
   it('requires date-resolve when posting relative proposed times', () => {
     const prompt = loadCeoInboxPrompt();
     const schedulingSection = extractSchedulingConsultSection(prompt);
-    const proposedPos = posIn(schedulingSection, 'Proposed:');
-    const dateResolvePos = posIn(schedulingSection, 'date-resolve');
-    const bullpenPostPos = posIn(schedulingSection, 'bullpen.post');
+    const tapStart = posIn(schedulingSection, '1. **Tap — post a CONSULT REQUEST');
+    const parkStart = posIn(schedulingSection, '2. **Park — label + mark-read');
+    expect(tapStart).toBeGreaterThan(-1);
+    expect(parkStart).toBeGreaterThan(tapStart);
+    const tapSection = schedulingSection.slice(tapStart, parkStart);
+    const proposedPos = posIn(tapSection, 'Proposed:');
+    const dateResolvePos = posIn(tapSection, 'date-resolve');
+    const bullpenPostPos = posIn(tapSection, 'bullpen.post');
 
     expect(proposedPos).toBeGreaterThan(-1);
     expect(dateResolvePos).toBeGreaterThan(proposedPos);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1195

Adds self-healing timeout for parked scheduling consults so a lost CONSULT REPLY cannot leave email parked forever:

1. **On park** — after `bullpen.post`, schedule a `consult-timeout` task with configurable delay (default ~90 min via `ceo_inbox.consult_timeout_minutes`), keyed by `source_message_id` and `consult_kind`.
2. **On timeout wake** — reload email; no-op if already resolved (idempotent); otherwise fall back to blind scheduling draft (`consult_kind=scheduling`) or coordinator escalation (`consult_kind=invite`).
3. **On CONSULT REPLY (Branch A)** — cancel matching `consult-timeout` tasks to prevent double-draft.

## Acceptance criteria

- [x] Parking schedules `consult-timeout` wake keyed to `source_message_id`
- [x] Timeout wake is no-op when CONSULT REPLY already handled
- [x] Still-parked timeout produces fallback draft or escalation; clears `⏳ In Progress`
- [x] Normal reply path cancels timeout task (no double-draft)
- [x] Prompt spec tests cover timeout contract
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22b1619d-9aa9-43d5-8bdc-7ac38aa4e30d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22b1619d-9aa9-43d5-8bdc-7ac38aa4e30d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

