### PR TITLE
Propagate structured executor failure reason to coordinator (#1170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`delegate`** — specialist failures now propagate structured `reason` and `retryable` from the runtime (e.g. `maxTurns`) instead of generic timeout/error strings, so the coordinator can report the real cause. (#1170)
 - **`web-browser`** — waits through edge WAF challenge pages and resolves hidden custom form controls. (v1.5.0)
 
 ## [0.38.0] — 2026-06-26 — "Deckard"

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -21,7 +21,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import { createAgentTask, type AgentResponseEvent } from '../../src/bus/events.js';
+import { createAgentTask, type AgentResponseEvent, type AgentResponseFailureReason } from '../../src/bus/events.js';
 // Resume-token format lives in ONE place (#995): decode + version via the shared helper, so a
 // future format change can't silently desync this handler from runtime.ts and the resume subscriber.
 import { decodeResumeToken, RESUME_TOKEN_VERSION } from '../../src/agents/resume-token.js';
@@ -30,6 +30,41 @@ import { decodeResumeToken, RESUME_TOKEN_VERSION } from '../../src/agents/resume
 // Long-running scheduled tasks should pass timeout_ms explicitly (injected by the runtime
 // from the originating agent.task event's expectedDurationSeconds).
 const DEFAULT_SPECIALIST_TIMEOUT_MS = 90000;
+
+/** Sentinel shape rejected by the response promise when a specialist returns isError with
+ *  structured failure fields — caught in execute() and turned into a typed delegate result. */
+interface StructuredDelegateFailure {
+  __structuredDelegateFailure: true;
+  agent: string;
+  reason: AgentResponseFailureReason;
+  retryable: boolean;
+  errorType?: string;
+}
+
+function isStructuredDelegateFailure(err: unknown): err is StructuredDelegateFailure {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as StructuredDelegateFailure).__structuredDelegateFailure === true
+  );
+}
+
+function formatStructuredFailureMessage(agent: string, reason: AgentResponseFailureReason): string {
+  switch (reason) {
+    case 'maxTurns':
+      return `Specialist '${agent}' exceeded its turn budget and could not complete the task`;
+    case 'maxConsecutiveErrors':
+      return `Specialist '${agent}' exceeded its consecutive error budget and could not complete the task`;
+    case 'tool_error':
+      return `Specialist '${agent}' failed due to a tool error`;
+    case 'api_error':
+      return `Specialist '${agent}' failed due to an API error`;
+    case 'blocked':
+      return `Specialist '${agent}' was blocked from completing the task`;
+    default:
+      return `Specialist '${agent}' could not complete the task`;
+  }
+}
 
 export class DelegateHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -251,8 +286,19 @@ export class DelegateHandler implements SkillHandler {
             clearTimeout(timeoutHandle);
             // isError means the specialist hit an unrecoverable error (context overflow,
             // LLM failure, budget exhaustion). Reject so the catch block returns
-            // { success: false } instead of forwarding the fallback message as a result.
+            // { success: false } or a structured failure result when reason is present.
             if (responseEvent.payload.isError) {
+              const { errorType, reason, retryable } = responseEvent.payload;
+              if (reason !== undefined && retryable !== undefined) {
+                reject({
+                  __structuredDelegateFailure: true,
+                  agent,
+                  reason,
+                  retryable,
+                  ...(errorType !== undefined && { errorType }),
+                } satisfies StructuredDelegateFailure);
+                return;
+              }
               reject(new Error(`Specialist '${agent}' encountered an error and could not complete the task`));
             } else {
               resolve(responseEvent.payload.content);
@@ -346,6 +392,24 @@ export class DelegateHandler implements SkillHandler {
         },
       };
     } catch (err) {
+      if (isStructuredDelegateFailure(err)) {
+        const message = formatStructuredFailureMessage(err.agent, err.reason);
+        ctx.log.error(
+          { targetAgent: err.agent, reason: err.reason, retryable: err.retryable, errorType: err.errorType },
+          'Delegation failed with structured specialist error',
+        );
+        return {
+          success: true,
+          data: {
+            agent: err.agent,
+            failed: true,
+            reason: err.reason,
+            retryable: err.retryable,
+            ...(err.errorType !== undefined && { errorType: err.errorType }),
+            message,
+          },
+        };
+      }
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err, targetAgent: agent }, 'Delegation failed');
       return { success: false, error: message };

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "delegate",
   "description": "Delegate a task to a specialist agent. Use this when the user's request requires specialized expertise (research, expense tracking, etc.). Provide the specialist's name and a clear task description.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -17,7 +17,12 @@
     "needs_clarification": "boolean?",
     "question": "string?",
     "context": "string?",
-    "resume_token": "string?"
+    "resume_token": "string?",
+    "failed": "boolean?",
+    "reason": "string?",
+    "retryable": "boolean?",
+    "errorType": "string?",
+    "message": "string?"
   },
   "permissions": [],
   "secrets": [],

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1663,5 +1663,8 @@ function mapAgentErrorToResponseFields(agentErr: AgentError): {
   if (agentErr.type === 'SKILL_ERROR') {
     return { errorType: agentErr.type, reason: 'tool_error', retryable: agentErr.retryable };
   }
+  if (agentErr.type === 'AUTH_FAILURE' || agentErr.type === 'VALIDATION_ERROR') {
+    return { errorType: agentErr.type, reason: 'blocked', retryable: agentErr.retryable };
+  }
   return { errorType: agentErr.type, reason: 'api_error', retryable: agentErr.retryable };
 }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1,6 +1,6 @@
 import type { LLMProvider, LLMResponse, LLMUsage, Message, ToolDefinition, ContentBlock, ToolUseContent, ToolResultContent, TextContent } from './llm/provider.js';
 import type { EventBus } from '../bus/bus.js';
-import { createAgentResponse, createAgentError, createSkillInvoke, createSkillResult, createLlmCall, createLlmError, createContextBudget, createModelFallbackEngaged, type AgentTaskEvent } from '../bus/events.js';
+import { createAgentResponse, createAgentError, createSkillInvoke, createSkillResult, createLlmCall, createLlmError, createContextBudget, createModelFallbackEngaged, type AgentResponseFailureReason, type AgentTaskEvent } from '../bus/events.js';
 import type { Tier } from './llm/model-router.js';
 import { ContextBudget } from './llm/context-budget.js';
 import { DEFAULT_SAFETY_MARGIN } from './llm/token-estimator.js';
@@ -1459,7 +1459,7 @@ export class AgentRuntime {
             logger.error({ err: telemetryErr, agentId }, 'Failed to publish llm.error for fallback exception');
           }
           await this.publishAgentError(thrownErr, taskEvent);
-          await this.sendErrorResponse(taskEvent);
+          await this.sendErrorResponse(taskEvent, thrownErr);
           return null;
         }
         const fallbackLatencyMs = Date.now() - fallbackStartMs;
@@ -1482,7 +1482,7 @@ export class AgentRuntime {
         );
         await publishLlmErrorEvent(fallbackResponse, this.config.fallbackModel, this.config.fallbackProvider.id);
         await this.publishAgentError(fallbackErr, taskEvent);
-        await this.sendErrorResponse(taskEvent);
+        await this.sendErrorResponse(taskEvent, fallbackErr);
         return null;
       }
 
@@ -1494,7 +1494,7 @@ export class AgentRuntime {
       budget.turnsUsed += increment;
       logger.error({ agentId, errorType: agentErr.type, source: agentErr.source }, 'Non-retryable LLM error');
       await this.publishAgentError(agentErr, taskEvent);
-      await this.sendErrorResponse(taskEvent);
+      await this.sendErrorResponse(taskEvent, agentErr);
       return null;
     }
 
@@ -1535,7 +1535,7 @@ export class AgentRuntime {
       if (!latestErr.retryable) {
         logger.error({ agentId, errorType: latestErr.type }, 'Retry returned non-retryable error');
         await this.publishAgentError(latestErr, taskEvent);
-        await this.sendErrorResponse(taskEvent);
+        await this.sendErrorResponse(taskEvent, latestErr);
         return null;
       }
 
@@ -1548,7 +1548,7 @@ export class AgentRuntime {
     // All retries exhausted — publish the most recent error
     logger.error({ agentId, retries: RETRY_BACKOFF_MS.length }, 'All LLM retries exhausted');
     await this.publishAgentError(latestErr, taskEvent);
-    await this.sendErrorResponse(taskEvent);
+    await this.sendErrorResponse(taskEvent, latestErr);
     return null;
   }
 
@@ -1577,7 +1577,7 @@ export class AgentRuntime {
       timestamp: new Date(),
     };
     await this.publishAgentError(agentErr, taskEvent);
-    await this.sendErrorResponse(taskEvent);
+    await this.sendErrorResponse(taskEvent, agentErr);
   }
 
   /**
@@ -1627,10 +1627,13 @@ export class AgentRuntime {
 
   /**
    * Send a user-facing error response so the user isn't left waiting.
+   * When agentErr is provided, structured failure fields are copied onto the
+   * agent.response so delegation consumers can report the real cause (#1170).
    */
-  private async sendErrorResponse(taskEvent: AgentTaskEvent): Promise<void> {
+  private async sendErrorResponse(taskEvent: AgentTaskEvent, agentErr?: AgentError): Promise<void> {
     const { agentId, bus } = this.config;
     const { conversationId } = taskEvent.payload;
+    const structuredFailure = agentErr ? mapAgentErrorToResponseFields(agentErr) : undefined;
     const responseEvent = createAgentResponse({
       agentId,
       conversationId,
@@ -1638,8 +1641,27 @@ export class AgentRuntime {
       // Mark as an error response so consumers (e.g. the delegate skill) can distinguish
       // a failure from a real specialist result and surface it as { success: false }.
       isError: true,
+      ...structuredFailure,
       parentEventId: taskEvent.id,
     });
     await bus.publish('agent', responseEvent);
   }
+}
+
+/** Map an AgentError to the structured failure fields on agent.response (#1170). */
+function mapAgentErrorToResponseFields(agentErr: AgentError): {
+  errorType: AgentError['type'];
+  reason: AgentResponseFailureReason;
+  retryable: boolean;
+} {
+  if (agentErr.type === 'BUDGET_EXCEEDED') {
+    const budgetReason = agentErr.context.reason;
+    const reason: AgentResponseFailureReason =
+      budgetReason === 'maxConsecutiveErrors' ? 'maxConsecutiveErrors' : 'maxTurns';
+    return { errorType: agentErr.type, reason, retryable: agentErr.retryable };
+  }
+  if (agentErr.type === 'SKILL_ERROR') {
+    return { errorType: agentErr.type, reason: 'tool_error', retryable: agentErr.retryable };
+  }
+  return { errorType: agentErr.type, reason: 'api_error', retryable: agentErr.retryable };
 }

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -67,6 +67,16 @@ interface AgentTaskPayload {
   expectedDurationSeconds?: number;
 }
 
+/** Coarse failure reason propagated on agent.response when isError is true.
+ *  Lets delegation consumers (e.g. the delegate skill) report the real cause
+ *  instead of confabulating an external timeout or generic error. */
+export type AgentResponseFailureReason =
+  | 'maxTurns'
+  | 'maxConsecutiveErrors'
+  | 'tool_error'
+  | 'api_error'
+  | 'blocked';
+
 interface AgentResponsePayload {
   agentId: string;
   conversationId: string;
@@ -75,6 +85,14 @@ interface AgentResponsePayload {
   // is a generic fallback message rather than a real response. Consumers (e.g. the
   // delegate skill) should treat this as a failure rather than a usable result.
   isError?: boolean;
+  /** Structured error type from the originating AgentError. Present when isError is true
+   *  and the runtime had a classified failure (budget exhaustion, LLM error, etc.). */
+  errorType?: ErrorType;
+  /** Coarse failure reason for planner consumption. Present when isError is true and
+   *  the runtime could determine the cause (see AgentResponseFailureReason). */
+  reason?: AgentResponseFailureReason;
+  /** Whether retrying the same delegation may succeed. Mirrors AgentError.retryable. */
+  retryable?: boolean;
   // Names of skills invoked during the task (in call order, may contain duplicates).
   // Populated by the agent runtime's tool-use loop; absent on error-path responses
   // where the runtime bailed before completing the loop.

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1723,8 +1723,10 @@ describe('AgentRuntime error budget', () => {
     bus.subscribe('agent.error', 'system', (event) => {
       agentErrors.push(event as AgentErrorEvent);
     });
-    // Need a dispatch subscriber for agent.response so the bus allows it
-    bus.subscribe('agent.response', 'dispatch', () => {});
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
 
     const agent = new AgentRuntime({
       agentId: 'coordinator',
@@ -1757,6 +1759,13 @@ describe('AgentRuntime error budget', () => {
     expect(agentErrors).toHaveLength(1);
     expect(agentErrors[0]?.payload.errorType).toBe('BUDGET_EXCEEDED');
     expect(agentErrors[0]?.payload.message).toContain('turn budget');
+
+    // agent.response should carry structured failure fields for delegation consumers (#1170)
+    expect(agentResponses).toHaveLength(1);
+    expect(agentResponses[0]?.payload.isError).toBe(true);
+    expect(agentResponses[0]?.payload.errorType).toBe('BUDGET_EXCEEDED');
+    expect(agentResponses[0]?.payload.reason).toBe('maxTurns');
+    expect(agentResponses[0]?.payload.retryable).toBe(false);
   });
 
   it('stops after maxConsecutiveErrors is exceeded', async () => {

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -211,13 +211,11 @@ describe('DelegateHandler', () => {
 
   it('propagates runtime BUDGET_EXCEEDED(maxTurns) to delegate result (#1170)', async () => {
     const { AgentRuntime } = await import('../../../src/agents/runtime.js');
-    const { createLogger } = await import('../../../src/logger.js');
     const { vi } = await import('vitest');
     type LLMProvider = import('../../../src/agents/llm/provider.js').LLMProvider;
     type ExecutionLayer = import('../../../src/skills/execution.js').ExecutionLayer;
 
-    const testLogger = createLogger('error');
-    const bus = new EventBus(testLogger);
+    const bus = new EventBus(logger);
     const agentRegistry = new AgentRegistry();
     agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
     agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research' });
@@ -253,7 +251,7 @@ describe('DelegateHandler', () => {
       provider: alwaysToolUseProvider,
       resolvedModel: 'mock-model',
       bus,
-      logger: testLogger,
+      logger,
       executionLayer: mockExecution,
       skillToolDefs: [toolDef],
       errorBudget: { maxTurns: 3, maxConsecutiveErrors: 10 },

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -211,7 +211,6 @@ describe('DelegateHandler', () => {
 
   it('propagates runtime BUDGET_EXCEEDED(maxTurns) to delegate result (#1170)', async () => {
     const { AgentRuntime } = await import('../../../src/agents/runtime.js');
-    const { createAgentTask } = await import('../../../src/bus/events.js');
     const { createLogger } = await import('../../../src/logger.js');
     const { vi } = await import('vitest');
     type LLMProvider = import('../../../src/agents/llm/provider.js').LLMProvider;

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -127,6 +127,55 @@ describe('DelegateHandler', () => {
     }
   });
 
+  it('returns structured failure when specialist responds with isError and structured reason (#1170)', async () => {
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+    agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research' });
+    const bus = new EventBus(logger);
+
+    bus.subscribe('agent.task', 'agent', async (event) => {
+      if (event.type === 'agent.task' && event.payload.agentId === 'research-analyst') {
+        const { createAgentResponse } = await import('../../../src/bus/events.js');
+        const response = createAgentResponse({
+          agentId: 'research-analyst',
+          conversationId: event.payload.conversationId,
+          content: "I'm sorry, I was unable to process that request. Please try again.",
+          isError: true,
+          errorType: 'BUDGET_EXCEEDED',
+          reason: 'maxTurns',
+          retryable: false,
+          parentEventId: event.id,
+        });
+        await bus.publish('agent', response);
+      }
+    });
+
+    const result = await handler.execute(makeCtx(
+      { agent: 'research-analyst', task: 'Research AI training costs', conversation_id: 'conv-2' },
+      { bus, agentRegistry },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        agent: string;
+        failed: boolean;
+        reason: string;
+        retryable: boolean;
+        errorType: string;
+        message: string;
+      };
+      expect(data.failed).toBe(true);
+      expect(data.agent).toBe('research-analyst');
+      expect(data.reason).toBe('maxTurns');
+      expect(data.retryable).toBe(false);
+      expect(data.errorType).toBe('BUDGET_EXCEEDED');
+      expect(data.message).toContain('turn budget');
+      expect(data.message).not.toContain('did not respond');
+      expect(data.message).not.toContain('encountered an error');
+    }
+  });
+
   it('returns failure when specialist responds with isError: true', async () => {
     const agentRegistry = new AgentRegistry();
     agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
@@ -156,7 +205,82 @@ describe('DelegateHandler', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain('error');
+      expect(result.error).toContain('encountered an error');
+    }
+  });
+
+  it('propagates runtime BUDGET_EXCEEDED(maxTurns) to delegate result (#1170)', async () => {
+    const { AgentRuntime } = await import('../../../src/agents/runtime.js');
+    const { createAgentTask } = await import('../../../src/bus/events.js');
+    const { createLogger } = await import('../../../src/logger.js');
+    const { vi } = await import('vitest');
+    type LLMProvider = import('../../../src/agents/llm/provider.js').LLMProvider;
+    type ExecutionLayer = import('../../../src/skills/execution.js').ExecutionLayer;
+
+    const testLogger = createLogger('error');
+    const bus = new EventBus(testLogger);
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+    agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research' });
+
+    let callId = 0;
+    const alwaysToolUseProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async () => ({
+        type: 'tool_use' as const,
+        toolCalls: [{ id: `call-${callId++}`, name: 'web-fetch', input: {} }],
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: {
+          requestedModel: 'mock-model',
+          actualModel: 'mock-model',
+          providerRequestId: 'msg_mock_budget',
+        },
+      })),
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+    } as unknown as ExecutionLayer;
+
+    const toolDef = {
+      name: 'web-fetch',
+      description: 'Fetch',
+      input_schema: { type: 'object' as const, properties: {}, required: [] as string[] },
+    };
+
+    const specialist = new AgentRuntime({
+      agentId: 'research-analyst',
+      systemPrompt: 'You are a research analyst.',
+      provider: alwaysToolUseProvider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger: testLogger,
+      executionLayer: mockExecution,
+      skillToolDefs: [toolDef],
+      errorBudget: { maxTurns: 3, maxConsecutiveErrors: 10 },
+    });
+    specialist.register();
+
+    // Dispatch subscriber required so agent.response publish is permitted
+    bus.subscribe('agent.response', 'dispatch', () => {});
+
+    const result = await handler.execute(makeCtx(
+      { agent: 'research-analyst', task: 'Post to Bluesky', conversation_id: 'conv-budget-delegate' },
+      { bus, agentRegistry },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        agent: string;
+        failed: boolean;
+        reason: string;
+        retryable: boolean;
+      };
+      expect(data.failed).toBe(true);
+      expect(data.agent).toBe('research-analyst');
+      expect(data.reason).toBe('maxTurns');
+      expect(data.retryable).toBe(false);
     }
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1170

When a specialist hits `BUDGET_EXCEEDED` (or another classified runtime error), the coordinator previously only saw generic delegate failure strings ("did not respond", "encountered an error") and would confabulate external causes. This PR propagates the real failure reason through the bus so the coordinator can report the truth.

## Changes

- **`AgentResponsePayload`** — optional `errorType`, `reason`, and `retryable` fields when `isError` is true (public bus API surface).
- **`sendErrorResponse()`** — copies structured fields from the originating `AgentError` onto `agent.response`.
- **`delegate` skill** — reads structured fields from the matched `agent.response` and returns a typed failure result (`failed: true`, `reason`, `retryable`) instead of hard-coded generic strings. Falls back to the old generic message when no structured reason is present.

## Acceptance criteria

- [x] `AgentResponsePayload` carries `errorType`, `reason`, and `retryable` when `isError` is true
- [x] Budget-exhausted specialist surfaces `reason: maxTurns` in the delegate failure result
- [x] Generic "did not respond" / "encountered an error" strings used only as fallback
- [x] Test: runtime `BUDGET_EXCEEDED(maxTurns)` → delegate result with `reason: maxTurns`, `retryable: false`
- [x] No change to audit `agent.error` event shape

Honoring `retryable: false` at the delegation layer (stop blind re-delegation) is tracked separately in #1171.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14f4bbcc-4ce1-4c14-b0c0-6ad4ea8127cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14f4bbcc-4ce1-4c14-b0c0-6ad4ea8127cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

