### PR TITLE
Honor retryable:false at the delegation layer (#1171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`delegate`** — honors `retryable: false` on specialist failures with an enforceable per-turn guard: identical re-delegations are blocked and non-retryable failures escalate to the CEO backlog via `task-create`. (#1171)
 - **`delegate`** — specialist failures now propagate structured `reason` and `retryable` from the runtime (e.g. `maxTurns`) instead of generic timeout/error strings, so the coordinator can report the real cause. (#1170)
 - **`web-browser`** — waits through edge WAF challenge pages and resolves hidden custom form controls. (v1.5.0)
 

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -25,6 +25,7 @@ import { createAgentTask, type AgentResponseEvent, type AgentResponseFailureReas
 // Resume-token format lives in ONE place (#995): decode + version via the shared helper, so a
 // future format change can't silently desync this handler from runtime.ts and the resume subscriber.
 import { decodeResumeToken, RESUME_TOKEN_VERSION } from '../../src/agents/resume-token.js';
+import { delegationKey } from '../../src/agents/delegation-guard.js';
 
 // Default wait for the specialist to respond — appropriate for interactive tasks.
 // Long-running scheduled tasks should pass timeout_ms explicitly (injected by the runtime
@@ -129,6 +130,33 @@ export class DelegateHandler implements SkillHandler {
     }
 
     const conversationId = conversation_id ?? `delegate-${randomUUID()}`;
+
+    // Identical-delegation guard (#1171): resume continuations are exempt — they carry new
+    // CEO direction and a different effective brief. Without a resume_token, block when the
+    // runtime has already recorded a non-retryable failure for this agent+task pair.
+    const hasResumeToken = typeof resume_token === 'string' && resume_token !== '';
+    if (!hasResumeToken && ctx.delegationGuard) {
+      const dKey = delegationKey(agent, task);
+      if (!ctx.delegationGuard.canAttempt(dKey)) {
+        const prior = ctx.delegationGuard.getFailure(dKey);
+        ctx.log.warn(
+          { targetAgent: agent, reason: prior?.reason },
+          'Blocked identical re-delegation at delegate handler',
+        );
+        return {
+          success: true,
+          data: {
+            agent,
+            failed: true,
+            blocked: true,
+            reason: prior?.reason ?? 'blocked',
+            retryable: false,
+            message: prior?.message ?? formatStructuredFailureMessage(agent, 'blocked'),
+            escalated: ctx.delegationGuard.isEscalated(dKey),
+          },
+        };
+      }
+    }
 
     // Resume flow: when resume_token is provided, decode it and construct a
     // full task brief from the original context + the CEO's direction (the

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -156,6 +156,7 @@ export class DelegateHandler implements SkillHandler {
           },
         };
       }
+      ctx.delegationGuard.recordInvocation(dKey);
     }
 
     // Resume flow: when resume_token is provided, decode it and construct a

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "delegate",
   "description": "Delegate a task to a specialist agent. Use this when the user's request requires specialized expertise (research, expense tracking, etc.). Provide the specialist's name and a clear task description.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -19,10 +19,12 @@
     "context": "string?",
     "resume_token": "string?",
     "failed": "boolean?",
+    "blocked": "boolean?",
     "reason": "string?",
     "retryable": "boolean?",
     "errorType": "string?",
-    "message": "string?"
+    "message": "string?",
+    "escalated": "boolean?"
   },
   "permissions": [],
   "secrets": [],

--- a/src/agents/delegation-guard.test.ts
+++ b/src/agents/delegation-guard.test.ts
@@ -67,6 +67,14 @@ describe('DelegationGuard', () => {
     expect(guard.canAttempt(otherKey)).toBe(true);
   });
 
+  it('does not block successful repeat delegations before any failure is recorded', () => {
+    const guard = new DelegationGuard();
+    for (let i = 0; i < MAX_RETRYABLE_IDENTICAL_DELEGATIONS + 1; i++) {
+      guard.recordInvocation(key);
+    }
+    expect(guard.canAttempt(key)).toBe(true);
+  });
+
   it(`allows up to ${MAX_RETRYABLE_IDENTICAL_DELEGATIONS} attempts for retryable failures`, () => {
     const guard = new DelegationGuard();
     for (let i = 0; i < MAX_RETRYABLE_IDENTICAL_DELEGATIONS - 1; i++) {

--- a/src/agents/delegation-guard.test.ts
+++ b/src/agents/delegation-guard.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { DelegationGuard, delegationKey, MAX_RETRYABLE_IDENTICAL_DELEGATIONS } from './delegation-guard.js';
+
+describe('DelegationGuard', () => {
+  const key = delegationKey('social-media', 'Post to Bluesky');
+
+  it('blocks identical re-delegation after a non-retryable failure', () => {
+    const guard = new DelegationGuard();
+    guard.recordInvocation(key);
+    guard.recordFailure(key, {
+      agent: 'social-media',
+      reason: 'maxTurns',
+      retryable: false,
+      message: 'exceeded turn budget',
+    });
+    expect(guard.canAttempt(key)).toBe(false);
+    expect(guard.shouldEscalate(key)).toBe(true);
+  });
+
+  it('allows one retry for retryable failures then blocks', () => {
+    const guard = new DelegationGuard();
+    guard.recordInvocation(key);
+    guard.recordFailure(key, {
+      agent: 'social-media',
+      reason: 'api_error',
+      retryable: true,
+      message: 'provider timeout',
+    });
+    expect(guard.canAttempt(key)).toBe(true);
+    expect(guard.shouldEscalate(key)).toBe(false);
+
+    guard.recordInvocation(key);
+    guard.recordFailure(key, {
+      agent: 'social-media',
+      reason: 'api_error',
+      retryable: true,
+      message: 'provider timeout again',
+    });
+    expect(guard.canAttempt(key)).toBe(false);
+    expect(guard.shouldEscalate(key)).toBe(true);
+  });
+
+  it('does not escalate twice for the same key', () => {
+    const guard = new DelegationGuard();
+    guard.recordInvocation(key);
+    guard.recordFailure(key, {
+      agent: 'social-media',
+      reason: 'maxTurns',
+      retryable: false,
+      message: 'exceeded turn budget',
+    });
+    expect(guard.shouldEscalate(key)).toBe(true);
+    guard.markEscalated(key);
+    expect(guard.shouldEscalate(key)).toBe(false);
+  });
+
+  it('treats different tasks as distinct keys', () => {
+    const guard = new DelegationGuard();
+    const otherKey = delegationKey('social-media', 'Different task');
+    guard.recordInvocation(key);
+    guard.recordFailure(key, {
+      agent: 'social-media',
+      reason: 'maxTurns',
+      retryable: false,
+      message: 'exceeded turn budget',
+    });
+    expect(guard.canAttempt(otherKey)).toBe(true);
+  });
+
+  it(`allows up to ${MAX_RETRYABLE_IDENTICAL_DELEGATIONS} attempts for retryable failures`, () => {
+    const guard = new DelegationGuard();
+    for (let i = 0; i < MAX_RETRYABLE_IDENTICAL_DELEGATIONS - 1; i++) {
+      expect(guard.canAttempt(key)).toBe(true);
+      guard.recordInvocation(key);
+      guard.recordFailure(key, {
+        agent: 'social-media',
+        reason: 'api_error',
+        retryable: true,
+        message: `attempt ${i + 1}`,
+      });
+    }
+    expect(guard.canAttempt(key)).toBe(true);
+    guard.recordInvocation(key);
+    guard.recordFailure(key, {
+      agent: 'social-media',
+      reason: 'api_error',
+      retryable: true,
+      message: 'final attempt',
+    });
+    expect(guard.canAttempt(key)).toBe(false);
+  });
+});

--- a/src/agents/delegation-guard.ts
+++ b/src/agents/delegation-guard.ts
@@ -36,7 +36,8 @@ export class DelegationGuard {
   canAttempt(key: string): boolean {
     const entry = this.entries.get(key);
     if (!entry) return true;
-    if (entry.lastFailure?.retryable === false) return false;
+    if (!entry.lastFailure) return true;
+    if (entry.lastFailure.retryable === false) return false;
     return entry.attempts < MAX_RETRYABLE_IDENTICAL_DELEGATIONS;
   }
 
@@ -82,13 +83,17 @@ export interface DelegateFailureResult extends DelegationFailureInfo {
 }
 
 /** Parse a delegate skill success payload that carries structured failure fields. */
-export function parseDelegateFailureData(data: unknown): DelegateFailureResult | null {
+export function parseDelegateFailureData(data: unknown, logger?: Logger): DelegateFailureResult | null {
   if (data === null || data === undefined) return null;
   let record: Record<string, unknown>;
   if (typeof data === 'string') {
     try {
       record = JSON.parse(data) as Record<string, unknown>;
-    } catch {
+    } catch (err) {
+      logger?.warn(
+        { err, dataPreview: data.slice(0, 200) },
+        'Failed to parse delegate failure payload — treating as non-failure',
+      );
       return null;
     }
   } else if (typeof data === 'object' && !Array.isArray(data)) {

--- a/src/agents/delegation-guard.ts
+++ b/src/agents/delegation-guard.ts
@@ -1,0 +1,162 @@
+// delegation-guard.ts — per-task-turn guard against blind identical re-delegation (#1171).
+//
+// Tracks delegate(agent, task) attempts within a single coordinator task turn.
+// Non-retryable specialist failures block further identical delegations; retryable
+// failures allow a bounded number of attempts before blocking.
+
+import type { AgentResponseFailureReason } from '../bus/events.js';
+import type { ExecutionLayer, InvokeOptions } from '../skills/execution.js';
+import type { CallerContext } from '../skills/types.js';
+import type { Logger } from '../logger.js';
+
+/** Total identical delegate calls allowed when the specialist failure was retryable. */
+export const MAX_RETRYABLE_IDENTICAL_DELEGATIONS = 2;
+
+export interface DelegationFailureInfo {
+  agent: string;
+  reason: AgentResponseFailureReason | string;
+  retryable: boolean;
+  message: string;
+}
+
+interface DelegationEntry {
+  attempts: number;
+  lastFailure?: DelegationFailureInfo;
+  escalated: boolean;
+}
+
+export function delegationKey(agent: string, task: string): string {
+  return `${agent}\0${task.trim()}`;
+}
+
+export class DelegationGuard {
+  private readonly entries = new Map<string, DelegationEntry>();
+
+  /** Whether another identical delegation may be invoked. */
+  canAttempt(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry) return true;
+    if (entry.lastFailure?.retryable === false) return false;
+    return entry.attempts < MAX_RETRYABLE_IDENTICAL_DELEGATIONS;
+  }
+
+  /** Record an in-flight delegate invocation (before the specialist runs). */
+  recordInvocation(key: string): void {
+    const entry = this.entries.get(key) ?? { attempts: 0, escalated: false };
+    entry.attempts += 1;
+    this.entries.set(key, entry);
+  }
+
+  recordFailure(key: string, failure: DelegationFailureInfo): void {
+    const entry = this.entries.get(key) ?? { attempts: 1, escalated: false };
+    entry.lastFailure = failure;
+    this.entries.set(key, entry);
+  }
+
+  shouldEscalate(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry?.lastFailure) return false;
+    if (entry.escalated) return false;
+    if (entry.lastFailure.retryable === false) return true;
+    return entry.attempts >= MAX_RETRYABLE_IDENTICAL_DELEGATIONS;
+  }
+
+  markEscalated(key: string): void {
+    const entry = this.entries.get(key);
+    if (entry) entry.escalated = true;
+  }
+
+  getFailure(key: string): DelegationFailureInfo | undefined {
+    return this.entries.get(key)?.lastFailure;
+  }
+
+  isEscalated(key: string): boolean {
+    return this.entries.get(key)?.escalated === true;
+  }
+}
+
+export interface DelegateFailureResult extends DelegationFailureInfo {
+  failed: true;
+  blocked?: boolean;
+  escalated?: boolean;
+}
+
+/** Parse a delegate skill success payload that carries structured failure fields. */
+export function parseDelegateFailureData(data: unknown): DelegateFailureResult | null {
+  if (data === null || data === undefined) return null;
+  let record: Record<string, unknown>;
+  if (typeof data === 'string') {
+    try {
+      record = JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  } else if (typeof data === 'object' && !Array.isArray(data)) {
+    record = data as Record<string, unknown>;
+  } else {
+    return null;
+  }
+  if (record['failed'] !== true) return null;
+  if (typeof record['agent'] !== 'string' || typeof record['retryable'] !== 'boolean') return null;
+  if (typeof record['message'] !== 'string') return null;
+  const reason = record['reason'];
+  if (typeof reason !== 'string') return null;
+  return {
+    failed: true,
+    agent: record['agent'],
+    reason,
+    retryable: record['retryable'],
+    message: record['message'],
+    ...(record['blocked'] === true && { blocked: true }),
+    ...(record['escalated'] === true && { escalated: true }),
+  };
+}
+
+/** Surface a non-retryable delegation failure on the CEO backlog via task-create (#1171). */
+export async function escalateDelegationFailure(
+  executionLayer: ExecutionLayer,
+  caller: CallerContext | undefined,
+  options: InvokeOptions,
+  failure: DelegationFailureInfo & { task: string },
+  logger: Logger,
+): Promise<boolean> {
+  try {
+    const result = await executionLayer.invoke(
+      'task-create',
+      {
+        title: `Review: ${failure.agent} could not complete delegated work`,
+        description: [
+          failure.message,
+          '',
+          `Reason: ${failure.reason}`,
+          '',
+          'Original delegated task:',
+          failure.task,
+        ].join('\n'),
+        owner: 'ceo',
+        source: 'coordinator',
+        tags: ['delegation-failure', failure.agent],
+      },
+      caller,
+      options,
+    );
+    if (!result.success) {
+      logger.error(
+        { agent: failure.agent, reason: failure.reason, error: result.error },
+        'Failed to escalate delegation failure to CEO backlog via task-create',
+      );
+      return false;
+    }
+    logger.info(
+      { agent: failure.agent, reason: failure.reason },
+      'Escalated delegation failure to CEO backlog via task-create',
+    );
+    return true;
+  } catch (err) {
+    logger.error(
+      { err, agent: failure.agent, reason: failure.reason },
+      'Unexpected error escalating delegation failure to CEO backlog',
+    );
+    return false;
+  }
+}

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -763,7 +763,7 @@ export class AgentRuntime {
     // Delegation circuit-breaker state (#1171). Tracks identical delegate(agent, task)
     // calls within this turn so non-retryable specialist failures cannot be blind-retried.
     const delegationGuard = new DelegationGuard();
-    let pendingDelegationEscalation: (DelegationFailureInfo & { task: string }) | null = null;
+    let pendingDelegationEscalation: (DelegationFailureInfo & { task: string; escalated: boolean }) | null = null;
 
     while (response.type === 'tool_use' && executionLayer) {
       // Check turn budget before processing this round of tool calls
@@ -940,7 +940,6 @@ export class AgentRuntime {
                 },
               };
             } else {
-              delegationGuard.recordInvocation(dKey);
               result = await executionLayer.invoke(toolCall.name, skillInput, caller, invokeOptions);
             }
           } else {
@@ -1049,7 +1048,7 @@ export class AgentRuntime {
             skillInput !== null &&
             !Array.isArray(skillInput)
           ) {
-            const delegateFailure = parseDelegateFailureData(result.data);
+            const delegateFailure = parseDelegateFailureData(result.data, logger);
             if (delegateFailure) {
               const delegateInput = skillInput as Record<string, unknown>;
               const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
@@ -1066,7 +1065,7 @@ export class AgentRuntime {
                 if (escalated) {
                   delegationGuard.markEscalated(dKey);
                 }
-                pendingDelegationEscalation = { ...delegateFailure, task: delegateTask };
+                pendingDelegationEscalation = { ...delegateFailure, task: delegateTask, escalated };
               }
             }
           }
@@ -1077,6 +1076,9 @@ export class AgentRuntime {
             tool_use_id: toolCall.id,
             content: resultContent,
           } as ToolResultContent);
+          if (pendingDelegationEscalation) {
+            break;
+          }
         } else {
           // Failure: classify the error and format as a structured <task_error> block
           // so the LLM gets machine-readable error context instead of raw strings.
@@ -1168,7 +1170,7 @@ export class AgentRuntime {
           reason: pendingDelegationEscalation.reason,
           retryable: false,
           message: pendingDelegationEscalation.message,
-          escalated: true,
+          escalated: pendingDelegationEscalation.escalated,
         });
 
         if (memory) {
@@ -1190,8 +1192,11 @@ export class AgentRuntime {
             conversationId,
             targetAgent: pendingDelegationEscalation.agent,
             reason: pendingDelegationEscalation.reason,
+            escalated: pendingDelegationEscalation.escalated,
           },
-          'Task stopped after non-retryable delegation failure — escalated to CEO backlog',
+          pendingDelegationEscalation.escalated
+            ? 'Task stopped after non-retryable delegation failure — escalated to CEO backlog'
+            : 'Task stopped after non-retryable delegation failure — CEO backlog escalation failed',
         );
         return;
       }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -24,6 +24,13 @@ import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js'
 import { buildRateLimitSourceKey } from '../memory/rate-limit-key.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { encodeResumeToken } from './resume-token.js';
+import {
+  DelegationGuard,
+  delegationKey,
+  escalateDelegationFailure,
+  parseDelegateFailureData,
+  type DelegationFailureInfo,
+} from './delegation-guard.js';
 
 export interface AgentConfig {
   agentId: string;
@@ -753,6 +760,11 @@ export class AgentRuntime {
     // into code: the runtime produces it, the DelegateHandler parses it.
     let pendingClarification: { question: string; context: string } | null = null;
 
+    // Delegation circuit-breaker state (#1171). Tracks identical delegate(agent, task)
+    // calls within this turn so non-retryable specialist failures cannot be blind-retried.
+    const delegationGuard = new DelegationGuard();
+    let pendingDelegationEscalation: (DelegationFailureInfo & { task: string }) | null = null;
+
     while (response.type === 'tool_use' && executionLayer) {
       // Check turn budget before processing this round of tool calls
       budget.turnsUsed++;
@@ -880,22 +892,63 @@ export class AgentRuntime {
         });
         await bus.publish('agent', invokeEvent);
 
-        const startTime = Date.now();
-        // Thread task context so the execution layer can emit memory.store audit events
-        // for any KG writes that happen inside this skill invocation (#200).
-        const result = await executionLayer.invoke(toolCall.name, skillInput, caller, {
+        const invokeOptions = {
           taskEventId: taskEvent.id,
           agentId,
           channelId: taskEvent.payload.channelId,
           conversationId,
           parentEventId: invokeEvent.id,
-          // Pass task-level metadata so skill handlers can inspect task-wide signals
-          // without bus or dispatcher access.
           taskMetadata: taskEvent.payload.metadata,
-          // Live-principal-turn signal (#1126) — a distinct payload field (never in metadata), so
-          // it can't be persisted. Drives the elevated-skill gate; `delegate` forwards it onward.
           liveTurn: taskEvent.payload.liveTurn,
-        });
+          delegationGuard,
+        };
+
+        const startTime = Date.now();
+        let delegateBlocked = false;
+        let result: Awaited<ReturnType<ExecutionLayer['invoke']>>;
+        if (
+          toolCall.name === 'delegate' &&
+          typeof skillInput === 'object' &&
+          skillInput !== null &&
+          !Array.isArray(skillInput)
+        ) {
+          const delegateInput = skillInput as Record<string, unknown>;
+          const delegateAgent = typeof delegateInput['agent'] === 'string' ? delegateInput['agent'] : '';
+          const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
+          const hasResumeToken =
+            typeof delegateInput['resume_token'] === 'string' && delegateInput['resume_token'] !== '';
+          if (!hasResumeToken && delegateAgent && delegateTask) {
+            const dKey = delegationKey(delegateAgent, delegateTask);
+            if (!delegationGuard.canAttempt(dKey)) {
+              delegateBlocked = true;
+              const prior = delegationGuard.getFailure(dKey);
+              logger.warn(
+                { agentId, targetAgent: delegateAgent, reason: prior?.reason },
+                'Blocked identical re-delegation after specialist failure',
+              );
+              result = {
+                success: true,
+                data: {
+                  agent: delegateAgent,
+                  failed: true,
+                  blocked: true,
+                  reason: prior?.reason ?? 'blocked',
+                  retryable: false,
+                  message: prior?.message
+                    ?? `Re-delegation to '${delegateAgent}' is blocked for this task.`,
+                  escalated: delegationGuard.isEscalated(dKey),
+                },
+              };
+            } else {
+              delegationGuard.recordInvocation(dKey);
+              result = await executionLayer.invoke(toolCall.name, skillInput, caller, invokeOptions);
+            }
+          } else {
+            result = await executionLayer.invoke(toolCall.name, skillInput, caller, invokeOptions);
+          }
+        } else {
+          result = await executionLayer.invoke(toolCall.name, skillInput, caller, invokeOptions);
+        }
         const durationMs = Date.now() - startTime;
 
         // Publish skill.result for audit trail
@@ -985,6 +1038,39 @@ export class AgentRuntime {
             }
           }
 
+          // Delegation failure circuit-breaker (#1171): when delegate returns failed{retryable},
+          // record the outcome and escalate to the CEO backlog when retries are exhausted or
+          // the failure is non-retryable. Short-circuit the turn after escalation so the LLM
+          // cannot blind-re-delegate in subsequent rounds.
+          if (
+            toolCall.name === 'delegate' &&
+            !delegateBlocked &&
+            typeof skillInput === 'object' &&
+            skillInput !== null &&
+            !Array.isArray(skillInput)
+          ) {
+            const delegateFailure = parseDelegateFailureData(result.data);
+            if (delegateFailure) {
+              const delegateInput = skillInput as Record<string, unknown>;
+              const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
+              const dKey = delegationKey(delegateFailure.agent, delegateTask);
+              delegationGuard.recordFailure(dKey, delegateFailure);
+              if (delegationGuard.shouldEscalate(dKey)) {
+                const escalated = await escalateDelegationFailure(
+                  executionLayer,
+                  caller,
+                  invokeOptions,
+                  { ...delegateFailure, task: delegateTask },
+                  logger,
+                );
+                if (escalated) {
+                  delegationGuard.markEscalated(dKey);
+                }
+                pendingDelegationEscalation = { ...delegateFailure, task: delegateTask };
+              }
+            }
+          }
+
           const resultContent = typeof result.data === 'string' ? result.data : JSON.stringify(result.data);
           toolResultBlocks.push({
             type: 'tool_result',
@@ -1068,6 +1154,44 @@ export class AgentRuntime {
         logger.info(
           { agentId, conversationId, question: pendingClarification.question.slice(0, 100) },
           'Task paused for clarification — specialist requested CEO direction',
+        );
+        return;
+      }
+
+      // Delegation failure short-circuit (#1171): after a non-retryable specialist failure
+      // (or exhausted retryable attempts), emit a deterministic protocol response so the
+      // coordinator reports the honest reason instead of confabulating or re-delegating.
+      if (pendingDelegationEscalation) {
+        const escalationContent = JSON.stringify({
+          _curia_protocol: 'delegation_failure',
+          agent: pendingDelegationEscalation.agent,
+          reason: pendingDelegationEscalation.reason,
+          retryable: false,
+          message: pendingDelegationEscalation.message,
+          escalated: true,
+        });
+
+        if (memory) {
+          await memory.addTurn(conversationId, agentId, { role: 'assistant', content: escalationContent });
+        }
+
+        const escalationResponse = createAgentResponse({
+          agentId,
+          conversationId,
+          content: escalationContent,
+          skillsCalled,
+          parentEventId: taskEvent.id,
+        });
+        await bus.publish('agent', escalationResponse);
+
+        logger.info(
+          {
+            agentId,
+            conversationId,
+            targetAgent: pendingDelegationEscalation.agent,
+            reason: pendingDelegationEscalation.reason,
+          },
+          'Task stopped after non-retryable delegation failure — escalated to CEO backlog',
         );
         return;
       }

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -88,6 +88,9 @@ export interface InvokeOptions {
    *  All other checks (elevated-skill gate, content filter, blocked-contact) still run.
    *  See ADR-018. */
   humanApproved?: boolean;
+  /** Per-task-turn guard against blind identical re-delegation (#1171). Owned by the agent
+   *  runtime; forwarded to the delegate skill for defense in depth. */
+  delegationGuard?: import('../agents/delegation-guard.js').DelegationGuard;
 }
 
 /** Cap on the input rendering passed to the escalation judge — keeps full email bodies and
@@ -989,6 +992,7 @@ export class ExecutionLayer {
       // a synchronously-delegated specialist (a specialist acting inside the CEO's live turn).
       // Distinct from taskMetadata so no persistence skill can sweep it into a wakeable row.
       liveTurn: options?.liveTurn,
+      delegationGuard: options?.delegationGuard,
       // Expose the configured timezone so skills can format output timestamps
       // in the user's local time. See toLocalIso() in src/time/timestamp.ts.
       timezone: this.timezone,

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -289,6 +289,9 @@ export interface SkillContext {
   /** Local HTTP port the SPA is served on, used as the dev fallback origin when appOrigin
    *  is unset. Sourced from config.httpPort. */
   httpPort?: number;
+  /** Per-task-turn guard against blind identical re-delegation (#1171). Populated by the
+   *  agent runtime and read by the delegate skill. */
+  delegationGuard?: import('../agents/delegation-guard.js').DelegationGuard;
 }
 
 /**

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -3345,6 +3345,7 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
     expect(taskCreateCount.n).toBe(1);
     expect(provider.chat).toHaveBeenCalledTimes(1);
 
+    expect(agentResponses).toHaveLength(1);
     const response = agentResponses[0]!;
     expect(response.payload.content).toContain('delegation_failure');
     expect(response.payload.content).toContain('maxTurns');

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -3255,3 +3255,99 @@ describe('AgentRuntime bullpen read-watermark (#1065)', () => {
     expect(seenResponses[0]!.payload.isError).toBeFalsy();
   });
 });
+
+describe('Delegation failure circuit-breaker (#1171)', () => {
+  const delegateToolDef = {
+    name: 'delegate',
+    description: 'Delegate to a specialist',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        agent: { type: 'string' },
+        task: { type: 'string' },
+      },
+      required: ['agent', 'task'] as string[],
+    },
+  };
+
+  it('blocks a second identical delegate call and escalates once after BUDGET_EXCEEDED failure', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const delegateInvokeCount = { n: 0 };
+    const taskCreateCount = { n: 0 };
+
+    const mockExecution = {
+      invoke: vi.fn(async (skillName: string, input: Record<string, unknown>) => {
+        if (skillName === 'task-create') {
+          taskCreateCount.n += 1;
+          return { success: true, data: { task_id: 'escalation-task-1' } };
+        }
+        if (skillName === 'delegate') {
+          delegateInvokeCount.n += 1;
+          return {
+            success: true,
+            data: {
+              agent: input['agent'],
+              failed: true,
+              reason: 'maxTurns',
+              retryable: false,
+              message: "Specialist 'social-media' exceeded its turn budget and could not complete the task",
+            },
+          };
+        }
+        return { success: true, data: {} };
+      }),
+      getToolDefinitions: vi.fn(() => [delegateToolDef]),
+    } as unknown as ExecutionLayer;
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'tool_use' as const,
+        toolCalls: [
+          { id: 'call-delegate-1', name: 'delegate', input: { agent: 'social-media', task: 'Post to Bluesky' } },
+          { id: 'call-delegate-2', name: 'delegate', input: { agent: 'social-media', task: 'Post to Bluesky' } },
+        ],
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: [delegateToolDef],
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-delegate-guard-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Post this to Bluesky',
+      parentEventId: 'inbound-delegate-guard-1',
+    }));
+
+    expect(delegateInvokeCount.n).toBe(1);
+    expect(taskCreateCount.n).toBe(1);
+    expect(provider.chat).toHaveBeenCalledTimes(1);
+
+    const response = agentResponses[0]!;
+    expect(response.payload.content).toContain('delegation_failure');
+    expect(response.payload.content).toContain('maxTurns');
+    expect(response.payload.content).toContain('"escalated":true');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1171

Builds on #1170: when a specialist returns `failed{retryable:false}`, the coordinator can no longer blind-re-delegate the same `agent + task` within a turn. Non-retryable failures escalate to the CEO backlog via `task-create` and the turn short-circuits with an honest `delegation_failure` protocol response.

## Changes

- **`DelegationGuard`** (`src/agents/delegation-guard.ts`) — per-turn tracker for identical `delegate(agent, task)` calls.
- **Agent runtime** — blocks repeat delegations before `invoke`, escalates via `task-create` when retries are exhausted or `retryable: false`, and short-circuits the tool loop (mirrors clarification short-circuit).
- **`delegate` skill** — defense-in-depth guard when `delegationGuard` is present on `SkillContext`.

## Behavior

| Outcome | Effect |
|---|---|
| `failed{retryable:false}` | One attempt → escalate → no further identical delegations this turn |
| `failed{retryable:true}` | Up to 2 identical attempts → escalate on exhaustion |
| `resume_token` present | Guard bypassed (CEO-directed continuation) |

## Acceptance criteria

- [x] `failed{retryable:false}` does not trigger an identical re-delegation
- [x] `failed{retryable:true}` retries within a bounded count, then escalates
- [x] Escalation uses existing `task-create` CEO backlog path
- [x] Test: BUDGET_EXCEEDED-style failure → one delegate invoke, one escalation, zero re-delegations
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14f4bbcc-4ce1-4c14-b0c0-6ad4ea8127cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14f4bbcc-4ce1-4c14-b0c0-6ad4ea8127cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

