### PR TITLE
Resumable tasks: progress.resumable block on tasks (+ accumulator bounding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **`progress.resumable`** — typed checkpoint block on `tasks.progress` with shared read/write helpers, inline accumulator cap (4 KB), document-workspace spill pointer shape, and round-trip/stress tests. (#1172)
+
 ### Changed
 
 - **`delegate`** — honors `retryable: false` on specialist failures with an enforceable per-turn guard: identical re-delegations are blocked and non-retryable failures escalate to the CEO backlog via `task-create`. (#1171)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **`progress.resumable`** — typed checkpoint block on `tasks.progress` with shared read/write helpers, inline accumulator cap (4 KB), document-workspace spill pointer shape, and round-trip/stress tests. (#1172)
+- **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)
 
 ### Changed
 

--- a/src/db/resumable-progress.test.ts
+++ b/src/db/resumable-progress.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RESUMABLE_BLOCK_MAX_BYTES,
+  RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
+  documentAccumulatorPointer,
+  inlineAccumulatorBytes,
+  isDocumentPointer,
+  mergeResumableIntoProgress,
+  parseResumableBlock,
+  prepareResumableBlock,
+  readResumableBlock,
+  resumableBlockBytes,
+  writeResumableBlock,
+} from './resumable-progress.js';
+
+const BASE_INPUT = {
+  cursor: 'page:3',
+  done: 300,
+  total: 1300,
+  accumulator: ['did:plc:abc', 'did:plc:def'],
+  lastSliceUnits: 25,
+  next: 'Review page 4 and unfollow obvious accounts',
+};
+
+describe('parseResumableBlock', () => {
+  it('parses a valid block', () => {
+    const block = parseResumableBlock({
+      cursor: 'page:3',
+      done: 300,
+      total: 1300,
+      accumulator: ['a', 'b'],
+      lastSliceUnits: 25,
+      next: 'Continue',
+      checkpointedAt: '2026-06-27T00:00:00.000Z',
+    });
+    expect(block).toEqual({
+      cursor: 'page:3',
+      done: 300,
+      total: 1300,
+      accumulator: ['a', 'b'],
+      lastSliceUnits: 25,
+      next: 'Continue',
+      checkpointedAt: '2026-06-27T00:00:00.000Z',
+    });
+  });
+
+  it('accepts snake_case last_slice_units from persisted JSON', () => {
+    const block = parseResumableBlock({
+      cursor: 'page:3',
+      done: 300,
+      total: 1300,
+      accumulator: ['a'],
+      last_slice_units: 12,
+      next: 'Continue',
+    });
+    expect(block?.lastSliceUnits).toBe(12);
+  });
+
+  it('accepts a document pointer accumulator', () => {
+    const block = parseResumableBlock({
+      ...BASE_INPUT,
+      accumulator: { kind: 'document', path: '/projects/audit/findings.md', section: 'flagged' },
+    });
+    expect(block?.accumulator).toEqual({
+      kind: 'document',
+      path: '/projects/audit/findings.md',
+      section: 'flagged',
+    });
+  });
+
+  it('accepts an object cursor', () => {
+    const block = parseResumableBlock({
+      ...BASE_INPUT,
+      cursor: { page: 3, offset: 'abc123' },
+    });
+    expect(block?.cursor).toEqual({ page: 3, offset: 'abc123' });
+  });
+
+  it('returns null for invalid blocks', () => {
+    expect(parseResumableBlock(null)).toBeNull();
+    expect(parseResumableBlock({ ...BASE_INPUT, done: -1 })).toBeNull();
+    expect(parseResumableBlock({ ...BASE_INPUT, next: '   ' })).toBeNull();
+    expect(parseResumableBlock({ ...BASE_INPUT, accumulator: { kind: 'document', path: '' } })).toBeNull();
+  });
+});
+
+describe('readResumableBlock / mergeResumableIntoProgress round-trip', () => {
+  it('writes and reads back from progress JSON', () => {
+    const progress = { notes: [{ at: '2026-06-27T00:00:00.000Z', note: 'started' }] };
+    const written = writeResumableBlock(progress, BASE_INPUT);
+    expect(written.ok).toBe(true);
+    if (!written.ok) return;
+
+    expect(written.progress.notes).toEqual(progress.notes);
+    const reread = readResumableBlock(written.progress);
+    expect(reread?.cursor).toBe('page:3');
+    expect(reread?.done).toBe(300);
+    expect(reread?.total).toBe(1300);
+    expect(reread?.accumulator).toEqual(['did:plc:abc', 'did:plc:def']);
+    expect(reread?.lastSliceUnits).toBe(25);
+    expect(reread?.next).toBe(BASE_INPUT.next);
+    expect(reread?.checkpointedAt).toBeDefined();
+  });
+
+  it('resume can continue from the persisted cursor', () => {
+    const progress = { notes: [] };
+    const first = writeResumableBlock(progress, BASE_INPUT);
+    if (!first.ok) throw new Error('expected write to succeed');
+
+    const resumed = readResumableBlock(first.progress);
+    expect(resumed?.cursor).toBe('page:3');
+
+    const second = writeResumableBlock(first.progress, {
+      cursor: 'page:4',
+      done: 325,
+      total: 1300,
+      accumulator: [...(resumed?.accumulator as string[]), 'did:plc:ghi'],
+      lastSliceUnits: 25,
+      next: 'Review page 5',
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(readResumableBlock(second.progress)?.cursor).toBe('page:4');
+    expect(readResumableBlock(second.progress)?.done).toBe(325);
+  });
+});
+
+describe('accumulator bounding', () => {
+  it('rejects inline accumulators over the cap', () => {
+    const big = 'x'.repeat(RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES);
+    const result = prepareResumableBlock({
+      ...BASE_INPUT,
+      accumulator: [big],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok || result.code !== 'inline_accumulator_overflow') return;
+    expect(result.bytes).toBeGreaterThan(RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES);
+  });
+
+  it('allows a document pointer regardless of inline cap', () => {
+    const pointer = documentAccumulatorPointer('/projects/audit/findings.md', 'flagged');
+    expect(isDocumentPointer(pointer)).toBe(true);
+    expect(inlineAccumulatorBytes(pointer)).toBeLessThan(RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES);
+
+    const result = prepareResumableBlock({
+      ...BASE_INPUT,
+      accumulator: pointer,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('stress: a long job cannot grow progress.resumable past the block cap', () => {
+    let progress: Record<string, unknown> = { notes: [] };
+    let cursor = 0;
+    let flagged: string[] = [];
+
+    for (let i = 0; i < 500; i++) {
+      flagged = [...flagged, `did:plc:${String(i).padStart(6, '0')}`];
+      const result = writeResumableBlock(progress, {
+        cursor: String(cursor),
+        done: i + 1,
+        total: 1300,
+        accumulator: flagged,
+        lastSliceUnits: 25,
+        next: 'Keep paging',
+      });
+
+      if (!result.ok) {
+        expect(result.code).toBe('inline_accumulator_overflow');
+        const block = readResumableBlock(progress);
+        expect(block).not.toBeNull();
+        expect(resumableBlockBytes(block!)).toBeLessThanOrEqual(RESUMABLE_BLOCK_MAX_BYTES);
+        return;
+      }
+
+      progress = result.progress;
+      cursor = i + 1;
+      const block = readResumableBlock(progress)!;
+      expect(resumableBlockBytes(block)).toBeLessThanOrEqual(RESUMABLE_BLOCK_MAX_BYTES);
+      expect(inlineAccumulatorBytes(block.accumulator)).toBeLessThanOrEqual(
+        RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
+      );
+    }
+
+    throw new Error('expected accumulator overflow before 500 iterations');
+  });
+});
+
+describe('mergeResumableIntoProgress', () => {
+  it('preserves unrelated progress keys', () => {
+    const block = prepareResumableBlock(BASE_INPUT);
+    if (!block.ok) throw new Error('expected valid block');
+    const merged = mergeResumableIntoProgress({ custom: true, notes: [] }, block.block);
+    expect(merged.custom).toBe(true);
+    expect(merged.resumable).toEqual(block.block);
+  });
+});

--- a/src/db/resumable-progress.test.ts
+++ b/src/db/resumable-progress.test.ts
@@ -82,6 +82,13 @@ describe('parseResumableBlock', () => {
     expect(parseResumableBlock({ ...BASE_INPUT, next: '   ' })).toBeNull();
     expect(parseResumableBlock({ ...BASE_INPUT, accumulator: { kind: 'document', path: '' } })).toBeNull();
   });
+
+  it('rejects non-JSON-serializable cursor values', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(parseResumableBlock({ ...BASE_INPUT, cursor: circular })).toBeNull();
+    expect(parseResumableBlock({ ...BASE_INPUT, cursor: BigInt(1) })).toBeNull();
+  });
 });
 
 describe('readResumableBlock / mergeResumableIntoProgress round-trip', () => {

--- a/src/db/resumable-progress.ts
+++ b/src/db/resumable-progress.ts
@@ -1,0 +1,261 @@
+// resumable-progress.ts — typed read/write helpers for tasks.progress.resumable.
+//
+// Shared representation for the runtime and the checkpoint primitive (#1173).
+// Persisted under the existing tasks.progress JSONB — no schema migration.
+
+/** Max serialized size (UTF-8 bytes) of an inline accumulator value. */
+export const RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES = 4096;
+
+/** Max serialized size (UTF-8 bytes) of the entire resumable block. */
+export const RESUMABLE_BLOCK_MAX_BYTES = 8192;
+
+/** Opaque cursor — LLM-authored position in the collection being iterated. */
+export type ResumableCursor = string | Record<string, unknown> | null;
+
+/** Spill target when the inline accumulator exceeds its cap (#1210). */
+export interface ResumableDocumentPointer {
+  kind: 'document';
+  path: string;
+  section?: string;
+}
+
+export type ResumableInlineAccumulator = unknown;
+
+export type ResumableAccumulator = ResumableInlineAccumulator | ResumableDocumentPointer;
+
+export interface ResumableProgressBlock {
+  cursor: ResumableCursor;
+  done: number;
+  total: number;
+  accumulator: ResumableAccumulator;
+  lastSliceUnits: number;
+  next: string;
+  /** ISO timestamp of the last checkpoint write. */
+  checkpointedAt?: string;
+}
+
+export interface TaskProgress {
+  notes?: Array<{ at: string; note: string }>;
+  resumable?: ResumableProgressBlock;
+  [key: string]: unknown;
+}
+
+export type ResumableWriteResult =
+  | { ok: true; block: ResumableProgressBlock; progress: TaskProgress }
+  | { ok: false; code: 'inline_accumulator_overflow'; bytes: number; maxBytes: number }
+  | { ok: false; code: 'block_overflow'; bytes: number; maxBytes: number }
+  | { ok: false; code: 'invalid_block'; message: string };
+
+export function isDocumentPointer(value: unknown): value is ResumableDocumentPointer {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  return obj.kind === 'document' && typeof obj.path === 'string' && obj.path.length > 0
+    && (obj.section === undefined || typeof obj.section === 'string');
+}
+
+export function serializedUtf8Bytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+export function inlineAccumulatorBytes(value: unknown): number {
+  return serializedUtf8Bytes(value);
+}
+
+export function isInlineAccumulatorWithinCap(value: unknown): boolean {
+  return inlineAccumulatorBytes(value) <= RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES;
+}
+
+export function resumableBlockBytes(block: ResumableProgressBlock): number {
+  return serializedUtf8Bytes(block);
+}
+
+export function isResumableBlockWithinCap(block: ResumableProgressBlock): boolean {
+  return resumableBlockBytes(block) <= RESUMABLE_BLOCK_MAX_BYTES;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseCursor(raw: unknown): ResumableCursor | undefined {
+  if (raw === null) return null;
+  if (typeof raw === 'string') return raw;
+  if (isPlainObject(raw)) return raw;
+  return undefined;
+}
+
+function parseNonNegativeInt(raw: unknown): number | undefined {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0 || !Number.isInteger(raw)) {
+    return undefined;
+  }
+  return raw;
+}
+
+function parseNext(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseAccumulator(raw: unknown): ResumableAccumulator | undefined {
+  if (raw !== undefined && isPlainObject(raw) && raw.kind === 'document') {
+    return isDocumentPointer(raw) ? raw : undefined;
+  }
+  if (raw === undefined) return undefined;
+  // Any JSON-serializable inline value (array, object, string, number, etc.).
+  try {
+    JSON.stringify(raw);
+    return raw as ResumableInlineAccumulator;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse a resumable block from persisted progress JSON. Returns null when absent or invalid. */
+export function parseResumableBlock(raw: unknown): ResumableProgressBlock | null {
+  if (!isPlainObject(raw)) return null;
+
+  const cursor = parseCursor(raw.cursor);
+  const done = parseNonNegativeInt(raw.done);
+  const total = parseNonNegativeInt(raw.total);
+  const lastSliceUnits = parseNonNegativeInt(raw.lastSliceUnits ?? raw.last_slice_units);
+  const next = parseNext(raw.next);
+  const accumulator = parseAccumulator(raw.accumulator);
+
+  if (
+    cursor === undefined
+    || done === undefined
+    || total === undefined
+    || lastSliceUnits === undefined
+    || next === undefined
+    || accumulator === undefined
+  ) {
+    return null;
+  }
+
+  const block: ResumableProgressBlock = {
+    cursor,
+    done,
+    total,
+    accumulator,
+    lastSliceUnits,
+    next,
+  };
+
+  if (typeof raw.checkpointedAt === 'string') {
+    block.checkpointedAt = raw.checkpointedAt;
+  } else if (typeof raw.checkpointed_at === 'string') {
+    block.checkpointedAt = raw.checkpointed_at;
+  }
+
+  return block;
+}
+
+/** Read the resumable block from a task progress object. */
+export function readResumableBlock(progress: Record<string, unknown>): ResumableProgressBlock | null {
+  return parseResumableBlock(progress.resumable);
+}
+
+function validateAccumulatorForWrite(accumulator: ResumableAccumulator): ResumableWriteResult | null {
+  if (isDocumentPointer(accumulator)) return null;
+  const bytes = inlineAccumulatorBytes(accumulator);
+  if (bytes > RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES) {
+    return {
+      ok: false,
+      code: 'inline_accumulator_overflow',
+      bytes,
+      maxBytes: RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
+    };
+  }
+  return null;
+}
+
+function validateBlockForWrite(block: ResumableProgressBlock): ResumableWriteResult | null {
+  const accError = validateAccumulatorForWrite(block.accumulator);
+  if (accError) return accError;
+
+  const bytes = resumableBlockBytes(block);
+  if (bytes > RESUMABLE_BLOCK_MAX_BYTES) {
+    return {
+      ok: false,
+      code: 'block_overflow',
+      bytes,
+      maxBytes: RESUMABLE_BLOCK_MAX_BYTES,
+    };
+  }
+  return null;
+}
+
+export interface PrepareResumableBlockInput {
+  cursor: ResumableCursor;
+  done: number;
+  total: number;
+  accumulator: ResumableAccumulator;
+  lastSliceUnits: number;
+  next: string;
+  checkpointedAt?: string;
+}
+
+/** Validate and normalize a resumable block before persistence. */
+export function prepareResumableBlock(input: PrepareResumableBlockInput): ResumableWriteResult {
+  const parsed = parseResumableBlock({
+    cursor: input.cursor,
+    done: input.done,
+    total: input.total,
+    accumulator: input.accumulator,
+    lastSliceUnits: input.lastSliceUnits,
+    next: input.next,
+    checkpointedAt: input.checkpointedAt,
+  });
+
+  if (!parsed) {
+    return { ok: false, code: 'invalid_block', message: 'resumable block failed validation' };
+  }
+
+  const block: ResumableProgressBlock = {
+    ...parsed,
+    checkpointedAt: input.checkpointedAt ?? new Date().toISOString(),
+  };
+
+  const capError = validateBlockForWrite(block);
+  if (capError) return capError;
+
+  return { ok: true, block, progress: {} };
+}
+
+/** Merge a validated resumable block into an existing progress object (preserves notes, etc.). */
+export function mergeResumableIntoProgress(
+  progress: Record<string, unknown>,
+  block: ResumableProgressBlock,
+): TaskProgress {
+  return { ...progress, resumable: block };
+}
+
+/** Validate, merge, and return the updated progress object. */
+export function writeResumableBlock(
+  progress: Record<string, unknown>,
+  input: PrepareResumableBlockInput,
+): ResumableWriteResult {
+  const prepared = prepareResumableBlock(input);
+  if (!prepared.ok) return prepared;
+
+  const merged = mergeResumableIntoProgress(progress, prepared.block);
+  const mergedBytes = serializedUtf8Bytes(merged.resumable);
+  if (mergedBytes > RESUMABLE_BLOCK_MAX_BYTES) {
+    return {
+      ok: false,
+      code: 'block_overflow',
+      bytes: mergedBytes,
+      maxBytes: RESUMABLE_BLOCK_MAX_BYTES,
+    };
+  }
+
+  return { ok: true, block: prepared.block, progress: merged };
+}
+
+/** Build a document pointer accumulator (used after spill in #1210). */
+export function documentAccumulatorPointer(path: string, section?: string): ResumableDocumentPointer {
+  const pointer: ResumableDocumentPointer = { kind: 'document', path };
+  if (section !== undefined) pointer.section = section;
+  return pointer;
+}

--- a/src/db/resumable-progress.ts
+++ b/src/db/resumable-progress.ts
@@ -77,10 +77,21 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function isJsonSerializable(value: unknown): boolean {
+  try {
+    JSON.stringify(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function parseCursor(raw: unknown): ResumableCursor | undefined {
   if (raw === null) return null;
   if (typeof raw === 'string') return raw;
-  if (isPlainObject(raw)) return raw;
+  if (isPlainObject(raw)) {
+    return isJsonSerializable(raw) ? raw : undefined;
+  }
   return undefined;
 }
 
@@ -103,12 +114,7 @@ function parseAccumulator(raw: unknown): ResumableAccumulator | undefined {
   }
   if (raw === undefined) return undefined;
   // Any JSON-serializable inline value (array, object, string, number, etc.).
-  try {
-    JSON.stringify(raw);
-    return raw as ResumableInlineAccumulator;
-  } catch {
-    return undefined;
-  }
+  return isJsonSerializable(raw) ? (raw as ResumableInlineAccumulator) : undefined;
 }
 
 /** Parse a resumable block from persisted progress JSON. Returns null when absent or invalid. */

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -16,6 +16,13 @@ import type { DbTaskRow, TaskRow } from './queries/tasks.js';
 import { mapTaskRow } from './queries/tasks.js';
 import type { TaskOriginator } from '../contacts/types.js';
 import { capOriginatorToParent } from '../contacts/principal.js';
+import {
+  readResumableBlock,
+  writeResumableBlock,
+  type PrepareResumableBlockInput,
+  type ResumableProgressBlock,
+  type ResumableWriteResult,
+} from './resumable-progress.js';
 
 // All SELECT / RETURNING clauses use this column list. Centralised so a schema
 // change only needs updating in one place.
@@ -557,5 +564,64 @@ export class TaskRepo {
       [taskId],
     );
     this.logger.info({ taskId, rowsAffected: result.rowCount }, 'task-repo: cancelled wake-up jobs');
+  }
+
+  /** Read the typed resumable block from a task's progress JSONB. */
+  async getResumableBlock(taskId: string): Promise<ResumableProgressBlock | null> {
+    const task = await this.getTask(taskId);
+    if (!task) return null;
+    return readResumableBlock(task.progress);
+  }
+
+  /**
+   * Persist a resumable checkpoint under progress.resumable. Enforces inline accumulator
+   * and block size caps — overflow requires spilling to the document workspace (#1210).
+   */
+  async setResumableBlock(
+    taskId: string,
+    input: PrepareResumableBlockInput,
+    callerAgentId?: string,
+  ): Promise<{ task: TaskRow; block: ResumableProgressBlock } | ResumableWriteResult> {
+    const current = await this.getTask(taskId);
+    if (!current) {
+      return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
+    }
+
+    const written = writeResumableBlock(current.progress, input);
+    if (!written.ok) return written;
+
+    const { rows } = await this.pool.query(
+      `UPDATE tasks SET progress = $1::jsonb, updated_at = now()
+       WHERE id = $2 AND status NOT IN ('done', 'cancelled')
+       RETURNING ${TASK_COLUMNS}`,
+      [JSON.stringify(written.progress), taskId],
+    );
+    const row = rows[0] as DbTaskRow | undefined;
+    if (!row) {
+      try {
+        await this.resolveEmptyUpdateReturning(taskId);
+        return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
+      } catch {
+        return { ok: false, code: 'invalid_block', message: `task ${taskId} is in a terminal state` };
+      }
+    }
+
+    const updated = mapTaskRow(row);
+
+    try {
+      await this.bus.publish('execution', createTaskUpdated({
+        taskId: updated.id,
+        previousStatus: current.status,
+        agentId: callerAgentId ?? null,
+      }));
+    } catch (busErr) {
+      this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after setResumableBlock');
+    }
+
+    this.logger.info(
+      { taskId: updated.id, done: written.block.done, total: written.block.total },
+      'task-repo: persisted resumable checkpoint',
+    );
+    return { task: updated, block: written.block };
   }
 }

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -18,7 +18,7 @@ import type { TaskOriginator } from '../contacts/types.js';
 import { capOriginatorToParent } from '../contacts/principal.js';
 import {
   readResumableBlock,
-  writeResumableBlock,
+  prepareResumableBlock,
   type PrepareResumableBlockInput,
   type ResumableProgressBlock,
   type ResumableWriteResult,
@@ -587,23 +587,28 @@ export class TaskRepo {
       return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
     }
 
-    const written = writeResumableBlock(current.progress, input);
-    if (!written.ok) return written;
+    const prepared = prepareResumableBlock(input);
+    if (!prepared.ok) return prepared;
 
     const { rows } = await this.pool.query(
-      `UPDATE tasks SET progress = $1::jsonb, updated_at = now()
-       WHERE id = $2 AND status NOT IN ('done', 'cancelled')
-       RETURNING ${TASK_COLUMNS}`,
-      [JSON.stringify(written.progress), taskId],
+      `UPDATE tasks
+          SET progress = jsonb_set(COALESCE(progress, '{}'::jsonb), '{resumable}', $1::jsonb, true),
+              updated_at = now()
+        WHERE id = $2
+          AND status NOT IN ('done', 'cancelled')
+        RETURNING ${TASK_COLUMNS}`,
+      [JSON.stringify(prepared.block), taskId],
     );
     const row = rows[0] as DbTaskRow | undefined;
     if (!row) {
-      try {
-        await this.resolveEmptyUpdateReturning(taskId);
+      const currentTask = await this.getTask(taskId);
+      if (!currentTask) {
         return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
-      } catch {
+      }
+      if (TERMINAL_STATUSES.has(currentTask.status)) {
         return { ok: false, code: 'invalid_block', message: `task ${taskId} is in a terminal state` };
       }
+      throw new Error(`task-repo: setResumableBlock update returned no row for non-terminal task ${taskId}`);
     }
 
     const updated = mapTaskRow(row);
@@ -619,9 +624,9 @@ export class TaskRepo {
     }
 
     this.logger.info(
-      { taskId: updated.id, done: written.block.done, total: written.block.total },
+      { taskId: updated.id, done: prepared.block.done, total: prepared.block.total },
       'task-repo: persisted resumable checkpoint',
     );
-    return { task: updated, block: written.block };
+    return { task: updated, block: prepared.block };
   }
 }

--- a/tests/integration/task-resumable-progress.test.ts
+++ b/tests/integration/task-resumable-progress.test.ts
@@ -1,0 +1,148 @@
+// task-resumable-progress.test.ts — round-trip persistence for progress.resumable (#1172).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import {
+  RESUMABLE_BLOCK_MAX_BYTES,
+  RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
+  documentAccumulatorPointer,
+  resumableBlockBytes,
+  inlineAccumulatorBytes,
+} from '../../src/db/resumable-progress.js';
+import type { EventBus } from '../../src/bus/bus.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'ResumableProgress Test';
+const logger = pino({ level: 'silent' });
+const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [`${PREFIX}%`],
+  );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+describeIf('TaskRepo resumable progress (#1172)', () => {
+  let pool: pg.Pool;
+  let repo: TaskRepo;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  it('round-trips a resumable block and resumes from the cursor', async () => {
+    const task = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} audit`,
+      source: 'coordinator',
+    });
+
+    const first = await repo.setResumableBlock(task.id, {
+      cursor: 'page:3',
+      done: 300,
+      total: 1300,
+      accumulator: ['did:plc:abc', 'did:plc:def'],
+      lastSliceUnits: 25,
+      next: 'Review page 4',
+    });
+    expect('task' in first).toBe(true);
+    if (!('task' in first)) return;
+
+    const reread = await repo.getResumableBlock(task.id);
+    expect(reread?.cursor).toBe('page:3');
+    expect(reread?.done).toBe(300);
+    expect(reread?.accumulator).toEqual(['did:plc:abc', 'did:plc:def']);
+
+    const second = await repo.setResumableBlock(task.id, {
+      cursor: 'page:4',
+      done: 325,
+      total: 1300,
+      accumulator: ['did:plc:abc', 'did:plc:def', 'did:plc:ghi'],
+      lastSliceUnits: 25,
+      next: 'Review page 5',
+    });
+    expect('task' in second).toBe(true);
+    if (!('task' in second)) return;
+
+    const resumed = await repo.getResumableBlock(task.id);
+    expect(resumed?.cursor).toBe('page:4');
+    expect(resumed?.done).toBe(325);
+
+    const reloaded = await repo.getTask(task.id);
+    expect((reloaded?.progress as { notes?: unknown[] }).notes).toEqual([]);
+  });
+
+  it('persists a document pointer accumulator', async () => {
+    const task = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} spilled`,
+      source: 'coordinator',
+    });
+
+    const pointer = documentAccumulatorPointer('/projects/audit/findings.md', 'flagged');
+    const result = await repo.setResumableBlock(task.id, {
+      cursor: 'page:10',
+      done: 1000,
+      total: 1300,
+      accumulator: pointer,
+      lastSliceUnits: 25,
+      next: 'Finish remaining pages from workspace doc',
+    });
+    expect('task' in result).toBe(true);
+
+    const block = await repo.getResumableBlock(task.id);
+    expect(block?.accumulator).toEqual(pointer);
+  });
+
+  it('stress: repeated checkpoints cannot grow progress.resumable past the cap', async () => {
+    const task = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} stress`,
+      source: 'coordinator',
+    });
+
+    let flagged: string[] = [];
+    let lastGoodBlock = await repo.getResumableBlock(task.id);
+
+    for (let i = 0; i < 500; i++) {
+      flagged = [...flagged, `did:plc:${String(i).padStart(6, '0')}`];
+      const result = await repo.setResumableBlock(task.id, {
+        cursor: String(i),
+        done: i + 1,
+        total: 1300,
+        accumulator: flagged,
+        lastSliceUnits: 25,
+        next: 'Keep paging',
+      });
+
+      if (!('task' in result)) {
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.code).toBe('inline_accumulator_overflow');
+        expect(lastGoodBlock).not.toBeNull();
+        expect(resumableBlockBytes(lastGoodBlock!)).toBeLessThanOrEqual(RESUMABLE_BLOCK_MAX_BYTES);
+        expect(inlineAccumulatorBytes(lastGoodBlock!.accumulator)).toBeLessThanOrEqual(
+          RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
+        );
+        return;
+      }
+
+      lastGoodBlock = result.block;
+      const persisted = await repo.getResumableBlock(task.id);
+      expect(persisted).not.toBeNull();
+      expect(resumableBlockBytes(persisted!)).toBeLessThanOrEqual(RESUMABLE_BLOCK_MAX_BYTES);
+    }
+
+    throw new Error('expected inline accumulator overflow before 500 iterations');
+  });
+});

--- a/tests/integration/task-resumable-progress.test.ts
+++ b/tests/integration/task-resumable-progress.test.ts
@@ -82,6 +82,31 @@ describeIf('TaskRepo resumable progress (#1172)', () => {
     expect((reloaded?.progress as { notes?: unknown[] }).notes).toEqual([]);
   });
 
+  it('does not clobber concurrent progress.notes when checkpointing', async () => {
+    const task = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} notes`,
+      source: 'coordinator',
+    });
+
+    await repo.updateTask(task.id, { progressNote: 'Slice 1 complete' }, 'social-media');
+
+    const result = await repo.setResumableBlock(task.id, {
+      cursor: 'page:2',
+      done: 50,
+      total: 1300,
+      accumulator: ['did:plc:abc'],
+      lastSliceUnits: 25,
+      next: 'Review page 3',
+    });
+    expect('task' in result).toBe(true);
+
+    const reloaded = await repo.getTask(task.id);
+    const notes = (reloaded?.progress as { notes?: Array<{ note: string }> }).notes ?? [];
+    expect(notes.some((n) => n.note === 'Slice 1 complete')).toBe(true);
+    expect(await repo.getResumableBlock(task.id)).toMatchObject({ cursor: 'page:2', done: 50 });
+  });
+
   it('persists a document pointer accumulator', async () => {
     const task = await repo.createTask({
       agentId: 'social-media',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1172.

Adds the durable-state foundation for resumable iterate leaves: a typed `progress.resumable` block persisted under the existing `tasks.progress` JSONB column (no migration).

### Schema (`progress.resumable`)

- `cursor` — opaque LLM-authored position (string, object, or null)
- `done` / `total` — progress counts
- `accumulator` — inline JSON value **or** `{ kind: "document", path, section? }` pointer (spill target for #1210)
- `lastSliceUnits` — units processed in the last slice
- `next` — one-line "what's next"
- `checkpointedAt` — ISO timestamp of last write

### Bounding policy

- **Inline accumulator cap:** 4 KB serialized UTF-8 (`RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES = 4096`)
- **Whole block cap:** 8 KB serialized UTF-8 (`RESUMABLE_BLOCK_MAX_BYTES = 8192`)
- Overflow returns `inline_accumulator_overflow` — callers (#1210) spill to the document workspace and store a document pointer instead

### Helpers

- `src/db/resumable-progress.ts` — parse/read/write/merge helpers shared by runtime and future `checkpoint` primitive (#1173)
- `TaskRepo.getResumableBlock()` / `TaskRepo.setResumableBlock()` — persistence layer (atomic `jsonb_set` patch)

### Tests

- Unit: round-trip, document pointer, JSON-safe cursor validation, accumulator overflow, stress loop
- Integration: DB round-trip, notes-preservation on checkpoint, stress (skips without `DATABASE_URL`)

## Test plan

- [x] `pnpm exec vitest run src/db/resumable-progress.test.ts`
- [x] `pnpm run typecheck`
- [ ] `DATABASE_URL=... pnpm exec vitest run tests/integration/task-resumable-progress.test.ts` (CI)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38b6eb73-cb07-4b3c-a6e6-34f0a4dad5f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38b6eb73-cb07-4b3c-a6e6-34f0a4dad5f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

