### PR TITLE
feat: OKF document workspace store, repo, and backlink index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)
+- **Document workspace** — `working_documents` / `working_document_links` Postgres store with `WorkingDocsRepo`, OKF frontmatter round-trip, backlink index, and optimistic concurrency (document + per-section). (#1208)
 
 ### Changed
 

--- a/src/db/migrations/066_create_working_documents.sql
+++ b/src/db/migrations/066_create_working_documents.sql
@@ -1,0 +1,53 @@
+-- Up Migration
+-- Agent document workspace foundation (#1208): OKF-serialized working documents
+-- with a backlink index. Paths are unique among live (non-archived) rows.
+
+CREATE TABLE working_documents (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  path            TEXT NOT NULL,
+  type            TEXT NOT NULL,
+  frontmatter     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  body            TEXT NOT NULL DEFAULT '',
+  version         INTEGER NOT NULL DEFAULT 1,
+  section_versions JSONB NOT NULL DEFAULT '{}'::jsonb,
+  byte_size       INTEGER NOT NULL DEFAULT 0,
+  task_id         UUID REFERENCES tasks(id) ON DELETE SET NULL,
+  conversation_id TEXT,
+  agent_id        TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  archived_at     TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX idx_working_documents_path_live
+  ON working_documents (path)
+  WHERE archived_at IS NULL;
+
+CREATE INDEX idx_working_documents_path_prefix_live
+  ON working_documents (path text_pattern_ops)
+  WHERE archived_at IS NULL;
+
+CREATE INDEX idx_working_documents_task_id_live
+  ON working_documents (task_id)
+  WHERE archived_at IS NULL AND task_id IS NOT NULL;
+
+CREATE TABLE working_document_links (
+  id           BIGSERIAL PRIMARY KEY,
+  source_path  TEXT NOT NULL,
+  target_path  TEXT NOT NULL,
+  link_kind    TEXT NOT NULL CHECK (link_kind IN ('markdown', 'wikilink')),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_working_document_links_unique
+  ON working_document_links (source_path, target_path, link_kind);
+
+CREATE INDEX idx_working_document_links_target
+  ON working_document_links (target_path);
+
+CREATE INDEX idx_working_document_links_source
+  ON working_document_links (source_path);
+
+-- Down Migration
+DROP TABLE IF EXISTS working_document_links;
+DROP TABLE IF EXISTS working_documents;

--- a/src/db/working-docs-repo.test.ts
+++ b/src/db/working-docs-repo.test.ts
@@ -1,0 +1,139 @@
+// working-docs-repo.test.ts — unit tests with a mock pool (no Postgres required).
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Pool, PoolClient, QueryResult } from 'pg';
+import { WorkingDocsRepo } from './working-docs-repo.js';
+import { createSilentLogger } from '../logger.js';
+
+const BASE_ROW = {
+  id: 'doc-1',
+  path: '/projects/x/brief.md',
+  type: 'project-brief',
+  frontmatter: { title: 'Brief' },
+  body: '## Progress\n\nOld.\n',
+  version: 1,
+  section_versions: { Progress: 0 },
+  byte_size: 100,
+  task_id: null,
+  conversation_id: null,
+  agent_id: null,
+  created_at: '2026-06-26T00:00:00.000Z',
+  updated_at: '2026-06-26T00:00:00.000Z',
+  archived_at: null,
+};
+
+function makeClient(handlers: {
+  query: (sql: string, params?: unknown[]) => Promise<QueryResult>;
+}): PoolClient {
+  return {
+    query: vi.fn(handlers.query),
+    release: vi.fn(),
+  } as unknown as PoolClient;
+}
+
+function makePool(client: PoolClient, poolQuery?: Pool['query']): { pool: Pool; connect: ReturnType<typeof vi.fn> } {
+  const connect = vi.fn(async () => client);
+  const pool = { connect, query: poolQuery ?? client.query } as unknown as Pool;
+  return { pool, connect };
+}
+
+describe('WorkingDocsRepo (unit)', () => {
+  it('create inserts a row and indexes links in a transaction', async () => {
+    const queries: string[] = [];
+    const client = makeClient({
+      query: async (sql: string) => {
+        queries.push(sql);
+        if (sql === 'BEGIN' || sql === 'COMMIT') return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        if (sql.startsWith('INSERT INTO working_documents')) {
+          return { rows: [{ ...BASE_ROW, body: 'See [[findings]].' }], rowCount: 1 } as QueryResult;
+        }
+        if (sql.startsWith('DELETE FROM working_document_links')) {
+          return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        }
+        if (sql.startsWith('INSERT INTO working_document_links')) {
+          return { rows: [], rowCount: 1 } as unknown as QueryResult;
+        }
+        throw new Error(`unexpected sql: ${sql}`);
+      },
+    });
+    const { pool } = makePool(client);
+    const repo = new WorkingDocsRepo(pool, createSilentLogger());
+    const doc = await repo.create({
+      path: '/projects/x/brief.md',
+      type: 'project-brief',
+      body: 'See [[findings]].',
+    });
+    expect(doc.path).toBe('/projects/x/brief.md');
+    expect(queries.some(q => q.startsWith('INSERT INTO working_document_links'))).toBe(true);
+  });
+
+  it('update returns conflict when expected_version mismatches pre-check', async () => {
+    const client = makeClient({
+      query: async (sql: string) => {
+        if (sql.includes('FROM working_documents') && sql.includes('SELECT')) {
+          return { rows: [{ ...BASE_ROW, version: 2 }], rowCount: 1 } as QueryResult;
+        }
+        throw new Error(`unexpected sql: ${sql}`);
+      },
+    });
+    const { pool } = makePool(client);
+    const repo = new WorkingDocsRepo(pool, createSilentLogger());
+    const result = await repo.update('/projects/x/brief.md', {
+      body: 'new',
+      expectedVersion: 1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.conflict).toBe(true);
+      expect(result.document.version).toBe(2);
+    }
+  });
+
+  it('editSection checks per-section version, not document version', async () => {
+    let sectionVersionChecked = false;
+    const client = makeClient({
+      query: async (sql: string, params?: unknown[]) => {
+        if (sql.includes('FOR UPDATE')) {
+          return {
+            rows: [{
+              ...BASE_ROW,
+              version: 5,
+              section_versions: { Progress: 1, Decisions: 0 },
+            }],
+            rowCount: 1,
+          } as QueryResult;
+        }
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        }
+        if (sql.includes('COALESCE((section_versions->>$5)::int, 0) = $6')) {
+          sectionVersionChecked = true;
+          expect(params?.[4]).toBe('Decisions');
+          expect(params?.[5]).toBe(0);
+          return {
+            rows: [{
+              ...BASE_ROW,
+              version: 6,
+              body: '## Progress\n\nOld.\n\n## Decisions\n\nNew.\n',
+              section_versions: { Progress: 1, Decisions: 1 },
+            }],
+            rowCount: 1,
+          } as QueryResult;
+        }
+        if (sql.startsWith('DELETE FROM working_document_links')) {
+          return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        }
+        throw new Error(`unexpected sql: ${sql}`);
+      },
+    });
+    const { pool } = makePool(client);
+    const repo = new WorkingDocsRepo(pool, createSilentLogger());
+    const result = await repo.editSection('/projects/x/brief.md', {
+      section: 'Decisions',
+      content: 'New.',
+      expectedSectionVersion: 0,
+    });
+    expect(sectionVersionChecked).toBe(true);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/db/working-docs-repo.ts
+++ b/src/db/working-docs-repo.ts
@@ -1,0 +1,441 @@
+// working-docs-repo.ts — database operations for OKF working documents (#1208).
+//
+// Postgres is the store; OKF is the format agents read and write. All queries
+// are parameterized. Optimistic concurrency returns conflict results, not errors.
+
+import type { Pool, PoolClient } from 'pg';
+import type { Logger } from '../logger.js';
+import {
+  emitOkfDocument,
+  extractLinks,
+  editSectionBody,
+  okfByteSize,
+  normalizeDocPath,
+  type ExtractedLink,
+} from '../memory/okf.js';
+
+const DOC_COLUMNS = `
+  id, path, type, frontmatter, body, version, section_versions, byte_size,
+  task_id, conversation_id, agent_id, created_at, updated_at, archived_at
+`;
+
+export interface WorkingDocRow {
+  id: string;
+  path: string;
+  type: string;
+  frontmatter: Record<string, unknown>;
+  body: string;
+  version: number;
+  sectionVersions: Record<string, number>;
+  byteSize: number;
+  taskId: string | null;
+  conversationId: string | null;
+  agentId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  archivedAt: string | null;
+}
+
+export interface WorkingDocLinkRow {
+  sourcePath: string;
+  targetPath: string;
+  linkKind: 'markdown' | 'wikilink';
+}
+
+export type WorkingDocWriteResult =
+  | { ok: true; document: WorkingDocRow }
+  | { ok: false; conflict: true; document: WorkingDocRow };
+
+export interface CreateWorkingDocParams {
+  path: string;
+  type: string;
+  frontmatter?: Record<string, unknown>;
+  body?: string;
+  taskId?: string;
+  conversationId?: string;
+  agentId?: string;
+}
+
+export interface UpdateWorkingDocParams {
+  type?: string;
+  frontmatter?: Record<string, unknown>;
+  body?: string;
+  taskId?: string | null;
+  conversationId?: string | null;
+  agentId?: string | null;
+  expectedVersion: number;
+}
+
+export interface AppendWorkingDocParams {
+  content: string;
+  expectedVersion: number;
+}
+
+export interface EditSectionParams {
+  section: string;
+  content: string;
+  mode?: 'replace' | 'append';
+  /** Per-section optimistic version — independent of document version. */
+  expectedSectionVersion?: number;
+}
+
+interface DbWorkingDocRow {
+  id: string;
+  path: string;
+  type: string;
+  frontmatter: Record<string, unknown>;
+  body: string;
+  version: number;
+  section_versions: Record<string, number> | null;
+  byte_size: number;
+  task_id: string | null;
+  conversation_id: string | null;
+  agent_id: string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+  archived_at: Date | string | null;
+}
+
+function mapRow(row: DbWorkingDocRow): WorkingDocRow {
+  return {
+    id: row.id,
+    path: row.path,
+    type: row.type,
+    frontmatter: row.frontmatter ?? {},
+    body: row.body,
+    version: row.version,
+    sectionVersions: row.section_versions ?? {},
+    byteSize: row.byte_size,
+    taskId: row.task_id,
+    conversationId: row.conversation_id,
+    agentId: row.agent_id,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at),
+    archivedAt: row.archived_at
+      ? (row.archived_at instanceof Date ? row.archived_at.toISOString() : String(row.archived_at))
+      : null,
+  };
+}
+
+function stripTypeFromFrontmatter(frontmatter?: Record<string, unknown>): Record<string, unknown> {
+  const { type: _ignoredType, ...rest } = frontmatter ?? {};
+  void _ignoredType;
+  return rest;
+}
+
+/** Escape SQL LIKE wildcards so prefix matching is literal. */
+function escapeLikePattern(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+}
+
+export class WorkingDocsRepo {
+  constructor(
+    private readonly pool: Pool,
+    private readonly logger: Logger,
+  ) {}
+
+  /** Serialize a row to OKF markdown. */
+  toOkf(document: WorkingDocRow): string {
+    return emitOkfDocument({
+      type: document.type,
+      frontmatter: document.frontmatter,
+      body: document.body,
+    });
+  }
+
+  async create(params: CreateWorkingDocParams): Promise<WorkingDocRow> {
+    const path = normalizeDocPath(params.path);
+    const body = params.body ?? '';
+    const frontmatter = stripTypeFromFrontmatter(params.frontmatter);
+    const byteSize = okfByteSize({ type: params.type, frontmatter, body });
+    const links = extractLinks(path, body);
+
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const { rows } = await client.query<DbWorkingDocRow>(
+        `INSERT INTO working_documents
+           (path, type, frontmatter, body, version, section_versions, byte_size,
+            task_id, conversation_id, agent_id)
+         VALUES ($1, $2, $3::jsonb, $4, 1, '{}'::jsonb, $5, $6, $7, $8)
+         RETURNING ${DOC_COLUMNS}`,
+        [
+          path,
+          params.type,
+          JSON.stringify(frontmatter),
+          body,
+          byteSize,
+          params.taskId ?? null,
+          params.conversationId ?? null,
+          params.agentId ?? null,
+        ],
+      );
+      const row = rows[0]!;
+      await this.replaceLinks(client, path, links);
+      await client.query('COMMIT');
+      const document = mapRow(row);
+      this.logger.info({ path, type: params.type }, 'working-docs-repo: created document');
+      return document;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      this.logger.error({ err, path }, 'working-docs-repo: create transaction failed');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async read(path: string): Promise<WorkingDocRow | null> {
+    const normalized = normalizeDocPath(path);
+    const { rows } = await this.pool.query<DbWorkingDocRow>(
+      `SELECT ${DOC_COLUMNS}
+       FROM working_documents
+       WHERE path = $1 AND archived_at IS NULL`,
+      [normalized],
+    );
+    const row = rows[0];
+    return row ? mapRow(row) : null;
+  }
+
+  async update(path: string, params: UpdateWorkingDocParams): Promise<WorkingDocWriteResult> {
+    const normalized = normalizeDocPath(path);
+    const current = await this.read(normalized);
+    if (!current) {
+      throw new Error(`working-docs-repo: document not found at ${normalized}`);
+    }
+    if (current.version !== params.expectedVersion) {
+      return { ok: false, conflict: true, document: current };
+    }
+
+    const type = params.type ?? current.type;
+    const frontmatter = params.frontmatter !== undefined
+      ? stripTypeFromFrontmatter(params.frontmatter)
+      : current.frontmatter;
+    const body = params.body ?? current.body;
+    const byteSize = okfByteSize({ type, frontmatter, body });
+    const links = extractLinks(normalized, body);
+
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const { rows } = await client.query<DbWorkingDocRow>(
+        `UPDATE working_documents
+         SET type = $2,
+             frontmatter = $3::jsonb,
+             body = $4,
+             version = version + 1,
+             byte_size = $5,
+             task_id = CASE WHEN $6 THEN $7 ELSE task_id END,
+             conversation_id = CASE WHEN $8 THEN $9 ELSE conversation_id END,
+             agent_id = CASE WHEN $10 THEN $11 ELSE agent_id END,
+             updated_at = now()
+         WHERE path = $1
+           AND archived_at IS NULL
+           AND version = $12
+         RETURNING ${DOC_COLUMNS}`,
+        [
+          normalized,
+          type,
+          JSON.stringify(frontmatter),
+          body,
+          byteSize,
+          params.taskId !== undefined,
+          params.taskId ?? null,
+          params.conversationId !== undefined,
+          params.conversationId ?? null,
+          params.agentId !== undefined,
+          params.agentId ?? null,
+          params.expectedVersion,
+        ],
+      );
+      if (!rows[0]) {
+        await client.query('ROLLBACK');
+        const latest = await this.read(normalized);
+        return { ok: false, conflict: true, document: latest ?? current };
+      }
+      await this.replaceLinks(client, normalized, links);
+      await client.query('COMMIT');
+      const document = mapRow(rows[0]);
+      this.logger.info({ path: normalized, version: document.version }, 'working-docs-repo: updated document');
+      return { ok: true, document };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      this.logger.error({ err, path: normalized }, 'working-docs-repo: update transaction failed');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async append(path: string, params: AppendWorkingDocParams): Promise<WorkingDocWriteResult> {
+    const current = await this.read(path);
+    if (!current) {
+      throw new Error(`working-docs-repo: document not found at ${normalizeDocPath(path)}`);
+    }
+    const body = current.body.length > 0
+      ? `${current.body.replace(/\n$/, '')}\n\n${params.content}`
+      : params.content;
+    return this.update(path, {
+      body,
+      expectedVersion: params.expectedVersion,
+    });
+  }
+
+  async editSection(path: string, params: EditSectionParams): Promise<WorkingDocWriteResult> {
+    const normalized = normalizeDocPath(path);
+    const sectionKey = params.section.trim();
+
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const { rows: lockedRows } = await client.query<DbWorkingDocRow>(
+        `SELECT ${DOC_COLUMNS}
+         FROM working_documents
+         WHERE path = $1 AND archived_at IS NULL
+         FOR UPDATE`,
+        [normalized],
+      );
+      const lockedRow = lockedRows[0];
+      if (!lockedRow) {
+        await client.query('ROLLBACK');
+        throw new Error(`working-docs-repo: document not found at ${normalized}`);
+      }
+
+      const locked = mapRow(lockedRow);
+      const currentSectionVersion = locked.sectionVersions[sectionKey] ?? 0;
+      if (params.expectedSectionVersion !== undefined
+        && params.expectedSectionVersion !== currentSectionVersion) {
+        await client.query('ROLLBACK');
+        return { ok: false, conflict: true, document: locked };
+      }
+
+      const newBody = editSectionBody(locked.body, sectionKey, params.content, params.mode ?? 'replace');
+      const byteSize = okfByteSize({
+        type: locked.type,
+        frontmatter: locked.frontmatter,
+        body: newBody,
+      });
+      const links = extractLinks(normalized, newBody);
+      const nextSectionVersion = currentSectionVersion + 1;
+      const sectionVersions = { ...locked.sectionVersions, [sectionKey]: nextSectionVersion };
+
+      const { rows } = await client.query<DbWorkingDocRow>(
+        `UPDATE working_documents
+         SET body = $2,
+             version = version + 1,
+             section_versions = $3::jsonb,
+             byte_size = $4,
+             updated_at = now()
+         WHERE path = $1
+           AND archived_at IS NULL
+           AND COALESCE((section_versions->>$5)::int, 0) = $6
+         RETURNING ${DOC_COLUMNS}`,
+        [
+          normalized,
+          newBody,
+          JSON.stringify(sectionVersions),
+          byteSize,
+          sectionKey,
+          currentSectionVersion,
+        ],
+      );
+      if (!rows[0]) {
+        await client.query('ROLLBACK');
+        const latest = await this.read(normalized);
+        return { ok: false, conflict: true, document: latest ?? locked };
+      }
+      await this.replaceLinks(client, normalized, links);
+      await client.query('COMMIT');
+      const document = mapRow(rows[0]);
+      this.logger.info(
+        { path: normalized, section: sectionKey, sectionVersion: nextSectionVersion },
+        'working-docs-repo: edited section',
+      );
+      return { ok: true, document };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      this.logger.error({ err, path: normalized, section: sectionKey }, 'working-docs-repo: editSection transaction failed');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listByPrefix(prefix: string): Promise<WorkingDocRow[]> {
+    const normalized = normalizeDocPath(prefix);
+    const pattern = `${escapeLikePattern(normalized)}%`;
+    const { rows } = await this.pool.query<DbWorkingDocRow>(
+      `SELECT ${DOC_COLUMNS}
+       FROM working_documents
+       WHERE path LIKE $1 ESCAPE '\\'
+         AND archived_at IS NULL
+       ORDER BY path ASC`,
+      [pattern],
+    );
+    return rows.map(mapRow);
+  }
+
+  async softDelete(path: string): Promise<WorkingDocRow | null> {
+    const normalized = normalizeDocPath(path);
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const { rows } = await client.query<DbWorkingDocRow>(
+        `UPDATE working_documents
+         SET archived_at = now(), updated_at = now()
+         WHERE path = $1 AND archived_at IS NULL
+         RETURNING ${DOC_COLUMNS}`,
+        [normalized],
+      );
+      if (!rows[0]) {
+        await client.query('ROLLBACK');
+        return null;
+      }
+      await client.query(
+        `DELETE FROM working_document_links WHERE source_path = $1`,
+        [normalized],
+      );
+      await client.query('COMMIT');
+      const document = mapRow(rows[0]);
+      this.logger.info({ path: normalized }, 'working-docs-repo: soft-deleted document');
+      return document;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      this.logger.error({ err, path: normalized }, 'working-docs-repo: softDelete transaction failed');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /** Backlinks — live documents that link to `targetPath` ("what links here"). */
+  async getBacklinks(targetPath: string): Promise<WorkingDocLinkRow[]> {
+    const normalized = normalizeDocPath(targetPath);
+    const { rows } = await this.pool.query<{ source_path: string; target_path: string; link_kind: string }>(
+      `SELECT l.source_path, l.target_path, l.link_kind
+       FROM working_document_links l
+       INNER JOIN working_documents d
+         ON d.path = l.source_path AND d.archived_at IS NULL
+       WHERE l.target_path = $1
+       ORDER BY l.source_path ASC`,
+      [normalized],
+    );
+    return rows.map(r => ({
+      sourcePath: r.source_path,
+      targetPath: r.target_path,
+      linkKind: r.link_kind as 'markdown' | 'wikilink',
+    }));
+  }
+
+  private async replaceLinks(client: PoolClient, sourcePath: string, links: ExtractedLink[]): Promise<void> {
+    await client.query(`DELETE FROM working_document_links WHERE source_path = $1`, [sourcePath]);
+    for (const link of links) {
+      await client.query(
+        `INSERT INTO working_document_links (source_path, target_path, link_kind)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (source_path, target_path, link_kind) DO NOTHING`,
+        [sourcePath, link.targetPath, link.linkKind],
+      );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ import { repairPrincipalMetadata } from './contacts/ceo-bootstrap.js';
 import { AutonomyService } from './autonomy/autonomy-service.js';
 import { ActionLogRepo } from './autonomy/action-log-repo.js';
 import { TaskRepo } from './db/task-repo.js';
+import { WorkingDocsRepo } from './db/working-docs-repo.js';
 import { ApprovalTriggerService } from './autonomy/approval-trigger.js';
 import { AutonomyScoringPass } from './autonomy/scoring-pass.js';
 import type { ScoringPassConfig } from './autonomy/scoring-pass.js';
@@ -1204,6 +1205,7 @@ async function main(): Promise<void> {
 
   // TaskRepo — used by task-create, task-list, task-update, task-complete skills.
   const taskRepo = new TaskRepo(pool, bus, logger, config.timezone);
+  const workingDocsRepo = new WorkingDocsRepo(pool, logger);
 
   // principalContact + principalIdentities were resolved once near the top of bootstrap
   // (see the "Principal contact resolution" block above, #1049). They are reused here for
@@ -1669,7 +1671,7 @@ async function main(): Promise<void> {
   // validated here (the JSON-schema startup check only covers default.yaml, not local overrides,
   // and cannot express the derived_child >= same_task invariant). Throws → boot fails loudly.
   const bypassLadder = resolveBypassLadder(yamlConfig.autonomy?.bypass_ladder);
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, secretsService, executiveProfileService, officeIdentityService, browserService, bullpenService, approvalTrigger, escalationJudge, actionLogRepo, auditLogRepo, taskRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs, appOrigin: config.appOrigin, httpPort: config.httpPort, bypassLadder });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, secretsService, executiveProfileService, officeIdentityService, browserService, bullpenService, approvalTrigger, escalationJudge, actionLogRepo, auditLogRepo, taskRepo, workingDocsRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs, appOrigin: config.appOrigin, httpPort: config.httpPort, bypassLadder });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/memory/okf.ts
+++ b/src/memory/okf.ts
@@ -1,0 +1,250 @@
+// okf.ts — Open Knowledge Format (de)serialization and link extraction.
+//
+// OKF documents are YAML frontmatter + markdown body. The store persists
+// frontmatter and body separately; this module round-trips the on-disk OKF shape.
+
+import * as yaml from 'js-yaml';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+export interface OkfFrontmatter {
+  type: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  timestamp?: string;
+  resource?: string;
+  [key: string]: unknown;
+}
+
+export interface ParsedOkfDocument {
+  type: string;
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+export interface ExtractedLink {
+  targetPath: string;
+  linkKind: 'markdown' | 'wikilink';
+}
+
+/**
+ * Parse an OKF markdown document (YAML frontmatter + body).
+ * `type` is required in frontmatter.
+ */
+export function parseOkfDocument(raw: string): ParsedOkfDocument {
+  const trimmed = raw.trimStart();
+  const match = FRONTMATTER_RE.exec(trimmed);
+  if (!match) {
+    throw new Error('OKF document must begin with YAML frontmatter delimited by ---');
+  }
+
+  const frontmatterRaw = match[1]!;
+  const body = match[2] ?? '';
+  const loaded = yaml.load(frontmatterRaw, { schema: yaml.JSON_SCHEMA });
+  if (!loaded || typeof loaded !== 'object' || Array.isArray(loaded)) {
+    throw new Error('OKF frontmatter must be a YAML mapping');
+  }
+
+  const frontmatter = loaded as Record<string, unknown>;
+  const type = frontmatter.type;
+  if (typeof type !== 'string' || type.trim() === '') {
+    throw new Error('OKF frontmatter requires a non-empty type field');
+  }
+
+  return { type, frontmatter, body };
+}
+
+/**
+ * Emit an OKF markdown document from structured parts.
+ * `type` is written to frontmatter; other conventional keys are preserved.
+ */
+export function emitOkfDocument(parts: {
+  type: string;
+  frontmatter?: Record<string, unknown>;
+  body: string;
+}): string {
+  const merged: Record<string, unknown> = { ...(parts.frontmatter ?? {}), type: parts.type };
+  const yamlBlock = yaml.dump(merged, { lineWidth: -1, noRefs: true, schema: yaml.JSON_SCHEMA }).trimEnd();
+  const body = parts.body.endsWith('\n') || parts.body.length === 0 ? parts.body : `${parts.body}\n`;
+  return `---\n${yamlBlock}\n---\n${body}`;
+}
+
+/** Compute byte size of the serialized OKF document. */
+export function okfByteSize(parts: { type: string; frontmatter?: Record<string, unknown>; body: string }): number {
+  return Buffer.byteLength(emitOkfDocument(parts), 'utf8');
+}
+
+/**
+ * Normalize a document path to a canonical absolute form: leading slash, forward slashes,
+ * resolved `.` / `..` segments, optional .md suffix for extensionless leaf names.
+ */
+export function normalizeDocPath(path: string, options?: { ensureMd?: boolean }): string {
+  let normalized = path.trim().replace(/\\/g, '/');
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+
+  const segments = normalized.split('/').filter(Boolean);
+  const resolved: string[] = [];
+  for (const segment of segments) {
+    if (segment === '.') continue;
+    if (segment === '..') {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(segment);
+  }
+  normalized = resolved.length > 0 ? `/${resolved.join('/')}` : '/';
+
+  if (options?.ensureMd && normalized !== '/') {
+    const leaf = normalized.split('/').pop() ?? '';
+    if (leaf && !leaf.includes('.')) {
+      normalized = `${normalized}.md`;
+    }
+  }
+  return normalized.replace(/\/+/g, '/');
+}
+
+/** Directory prefix of a document path (always ends with /). */
+export function docDirectory(path: string): string {
+  const normalized = normalizeDocPath(path);
+  const lastSlash = normalized.lastIndexOf('/');
+  if (lastSlash <= 0) return '/';
+  return `${normalized.slice(0, lastSlash + 1)}`;
+}
+
+/** Resolve a link target relative to the source document path. */
+export function resolveDocLink(sourcePath: string, target: string, linkKind: 'markdown' | 'wikilink'): string {
+  const trimmed = target.trim();
+  if (!trimmed || trimmed.startsWith('http://') || trimmed.startsWith('https://') || trimmed.startsWith('#')) {
+    return '';
+  }
+
+  let resolved: string;
+  if (trimmed.startsWith('/')) {
+    resolved = trimmed;
+  } else {
+    resolved = `${docDirectory(sourcePath)}${trimmed}`;
+  }
+
+  resolved = normalizeDocPath(resolved);
+  if (linkKind === 'wikilink') {
+    resolved = normalizeDocPath(resolved, { ensureMd: true });
+  }
+  return resolved;
+}
+
+/**
+ * Extract markdown `[text](path)` and `[[wikilink]]` targets from a document body.
+ * External URLs and fragment-only links are ignored. Broken links are tolerated.
+ */
+export function extractLinks(sourcePath: string, body: string): ExtractedLink[] {
+  const links: ExtractedLink[] = [];
+  const seen = new Set<string>();
+
+  const markdownRe = /(?<!!)\[[^\]]*\]\(([^)]+)\)/g;
+  for (const match of body.matchAll(markdownRe)) {
+    const target = resolveDocLink(sourcePath, match[1]!, 'markdown');
+    if (!target) continue;
+    const key = `markdown:${target}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push({ targetPath: target, linkKind: 'markdown' });
+  }
+
+  const wikiRe = /\[\[([^\]]+)\]\]/g;
+  for (const match of body.matchAll(wikiRe)) {
+    const target = resolveDocLink(sourcePath, match[1]!, 'wikilink');
+    if (!target) continue;
+    const key = `wikilink:${target}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push({ targetPath: target, linkKind: 'wikilink' });
+  }
+
+  return links;
+}
+
+export interface DocSection {
+  heading: string;
+  content: string;
+}
+
+/**
+ * Split a markdown body into `##` sections. Text before the first `##` is returned
+ * as the preamble with an empty heading.
+ */
+export function splitSections(body: string): { preamble: string; sections: DocSection[] } {
+  const lines = body.split('\n');
+  const sections: DocSection[] = [];
+  let preamble = '';
+  let currentHeading: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (currentHeading === null) {
+      preamble = currentLines.join('\n');
+    } else {
+      sections.push({ heading: currentHeading, content: currentLines.join('\n') });
+    }
+    currentLines = [];
+  };
+
+  for (const line of lines) {
+    const sectionMatch = /^##\s+(.+?)\s*$/.exec(line);
+    if (sectionMatch) {
+      flush();
+      currentHeading = sectionMatch[1]!.trim();
+      continue;
+    }
+    currentLines.push(line);
+  }
+  flush();
+
+  return { preamble, sections };
+}
+
+/** Reassemble a body from preamble + sections. */
+export function joinSections(preamble: string, sections: DocSection[]): string {
+  const parts: string[] = [];
+  if (preamble.length > 0) {
+    parts.push(preamble.replace(/\n$/, ''));
+  }
+  for (const section of sections) {
+    parts.push(`## ${section.heading}`);
+    if (section.content.length > 0) {
+      parts.push(section.content.replace(/^\n/, '').replace(/\n$/, ''));
+    }
+  }
+  const joined = parts.join('\n\n');
+  return joined.length === 0 ? '' : `${joined}\n`;
+}
+
+/**
+ * Replace or append content within a `##` section. Creates the section when missing.
+ * `mode`: 'replace' swaps section body; 'append' adds after existing section content.
+ */
+export function editSectionBody(
+  body: string,
+  sectionHeading: string,
+  newContent: string,
+  mode: 'replace' | 'append' = 'replace',
+): string {
+  const normalizedHeading = sectionHeading.trim();
+  const { preamble, sections } = splitSections(body);
+  const idx = sections.findIndex(s => s.heading.toLowerCase() === normalizedHeading.toLowerCase());
+
+  if (idx === -1) {
+    const content = mode === 'append' && newContent.length > 0 ? `${newContent}\n` : newContent;
+    sections.push({ heading: normalizedHeading, content });
+    return joinSections(preamble, sections);
+  }
+
+  const existing = sections[idx]!;
+  const updatedContent = mode === 'append'
+    ? (existing.content.length > 0 ? `${existing.content.replace(/\n$/, '')}\n\n${newContent}` : newContent)
+    : newContent;
+  sections[idx] = { heading: existing.heading, content: updatedContent };
+  return joinSections(preamble, sections);
+}

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -151,6 +151,7 @@ export class ExecutionLayer {
   private actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
   private auditLogRepo?: import('../audit/audit-log-repo.js').AuditLogRepo;
   private taskRepo?: import('../db/task-repo.js').TaskRepo;
+  private workingDocsRepo?: import('../db/working-docs-repo.js').WorkingDocsRepo;
   private confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
   private tempFileStore?: TempFileStore;
   private readonly infraLlmService?: InfraLlmService;
@@ -199,6 +200,7 @@ export class ExecutionLayer {
     actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
     auditLogRepo?: import('../audit/audit-log-repo.js').AuditLogRepo;
     taskRepo?: import('../db/task-repo.js').TaskRepo;
+    workingDocsRepo?: import('../db/working-docs-repo.js').WorkingDocsRepo;
     confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
     tempFileStore?: TempFileStore;
     infraLlmService?: InfraLlmService;
@@ -234,6 +236,7 @@ export class ExecutionLayer {
     this.actionLogRepo = options?.actionLogRepo;
     this.auditLogRepo = options?.auditLogRepo;
     this.taskRepo = options?.taskRepo;
+    this.workingDocsRepo = options?.workingDocsRepo;
     this.confidencePipeline = options?.confidencePipeline;
     this.tempFileStore = options?.tempFileStore;
     this.infraLlmService = options?.infraLlmService;
@@ -1031,6 +1034,7 @@ export class ExecutionLayer {
       actionLogRepo: this.actionLogRepo,
       auditLogRepo: this.auditLogRepo,
       taskRepo: this.taskRepo,
+      workingDocs: this.workingDocsRepo,
       confidencePipeline: this.confidencePipeline,
       // tempFileStore is handled as a special case in the injection loop (writeTempFile closure).
       // Listed here so the missing-cap guard knows it's configured when this.tempFileStore is set.

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -30,7 +30,7 @@ export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'schedulerService', 'entityMemory', 'nylasCalendarClient',
   'autonomyService', 'executiveProfileService', 'officeIdentityService', 'browserService', 'bullpenService', 'skillSearch',
   'actionLogRepo', 'auditLogRepo', 'executionLayer', 'confidencePipeline', 'tempFileStore',
-  'infraLlm', 'outboundContext', 'taskRepo', 'secretCapture', 'secretResolver',
+  'infraLlm', 'outboundContext', 'taskRepo', 'workingDocs', 'secretCapture', 'secretResolver',
 ]);
 
 /** One discovered on-disk skill: lenient parse for the registry UI + reconciliation.

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -58,7 +58,7 @@ export interface SkillManifest {
    *  schedulerService, entityMemory, nylasCalendarClient, autonomyService,
    *  executiveProfileService, officeIdentityService, browserService, bullpenService, skillSearch,
    *  actionLogRepo, auditLogRepo, executionLayer, confidencePipeline, tempFileStore, infraLlm, outboundContext,
-   *  taskRepo, secretCapture, secretResolver.
+   *  taskRepo, workingDocs, secretCapture, secretResolver.
    *
    *  Services NOT listed here (contactService, entityContextAssembler, agentPersona)
    *  are universal — available to every skill without declaration. */
@@ -246,6 +246,9 @@ export interface SkillContext {
    *  Provides CRUD access to the tasks table and manages linked wake-up scheduled_jobs rows.
    *  Used by task-create, task-list, task-update, task-complete. */
   taskRepo?: import('../db/task-repo.js').TaskRepo;
+  /** Working document repo — available to skills declaring 'workingDocs' in capabilities.
+   *  OKF-serialized document workspace backed by Postgres (#1208). */
+  workingDocs?: import('../db/working-docs-repo.js').WorkingDocsRepo;
   /** Execution layer — available to skills declaring 'executionLayer' in capabilities.
    *  Allows re-invocation of skills with humanApproved bypass. Only approve-action (#428)
    *  should declare this capability; it is sensitivity: "elevated" (CEO-only). */

--- a/tests/integration/working-docs-repo.test.ts
+++ b/tests/integration/working-docs-repo.test.ts
@@ -1,0 +1,200 @@
+// Integration tests for WorkingDocsRepo — requires Postgres with migrations applied.
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import { WorkingDocsRepo } from '../../src/db/working-docs-repo.js';
+import { parseOkfDocument } from '../../src/memory/okf.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('WorkingDocsRepo (integration)', () => {
+  let pool: pg.Pool;
+  let repo: WorkingDocsRepo;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM working_documents LIMIT 0');
+    repo = new WorkingDocsRepo(pool, createSilentLogger());
+  });
+
+  afterAll(async () => { await pool.end(); });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM working_document_links');
+    await pool.query('DELETE FROM working_documents');
+  });
+
+  it('creates, reads, and round-trips OKF frontmatter', async () => {
+    const created = await repo.create({
+      path: '/projects/audit/brief.md',
+      type: 'project-brief',
+      frontmatter: {
+        title: 'Audit brief',
+        tags: ['audit'],
+        timestamp: '2026-06-26T14:30:00Z',
+      },
+      body: '# Goal\n\nReview follows.\n',
+    });
+    expect(created.version).toBe(1);
+
+    const loaded = await repo.read('/projects/audit/brief.md');
+    expect(loaded).not.toBeNull();
+    const okf = repo.toOkf(loaded!);
+    const parsed = parseOkfDocument(okf);
+    expect(parsed.type).toBe('project-brief');
+    expect(parsed.frontmatter.title).toBe('Audit brief');
+    expect(parsed.frontmatter.tags).toEqual(['audit']);
+    expect(parsed.body).toContain('# Goal');
+  });
+
+  it('enforces unique live paths and allows reuse after soft-delete', async () => {
+    await repo.create({ path: '/scratch/a/note.md', type: 'note', body: 'v1' });
+    await expect(repo.create({ path: '/scratch/a/note.md', type: 'note', body: 'v2' }))
+      .rejects.toThrow();
+    await repo.softDelete('/scratch/a/note.md');
+    const recreated = await repo.create({ path: '/scratch/a/note.md', type: 'note', body: 'v2' });
+    expect(recreated.body).toBe('v2');
+  });
+
+  it('indexes backlinks and supports list-by-prefix', async () => {
+    await repo.create({
+      path: '/projects/x/brief.md',
+      type: 'project-brief',
+      body: 'See [[findings]] and [detail](/projects/x/detail.md).',
+    });
+    await repo.create({
+      path: '/projects/x/findings.md',
+      type: 'findings',
+      body: 'Flagged accounts.',
+    });
+    await repo.create({
+      path: '/projects/y/other.md',
+      type: 'other',
+      body: 'Unrelated.',
+    });
+
+    const backlinks = await repo.getBacklinks('/projects/x/findings.md');
+    expect(backlinks.map(l => l.sourcePath)).toEqual(['/projects/x/brief.md']);
+
+    const listed = await repo.listByPrefix('/projects/x/');
+    expect(listed.map(d => d.path).sort()).toEqual([
+      '/projects/x/brief.md',
+      '/projects/x/findings.md',
+    ]);
+  });
+
+  it('returns conflict on expected_version mismatch without throwing', async () => {
+    const doc = await repo.create({ path: '/tmp/conflict.md', type: 'note', body: 'A' });
+    const result = await repo.update('/tmp/conflict.md', {
+      body: 'B',
+      expectedVersion: doc.version + 99,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.conflict).toBe(true);
+      expect(result.document.version).toBe(1);
+    }
+    const still = await repo.read('/tmp/conflict.md');
+    expect(still!.body).toBe('A');
+  });
+
+  it('allows concurrent section edits on different sections', async () => {
+    await repo.create({
+      path: '/projects/parallel.md',
+      type: 'project-brief',
+      body: '## Alpha\n\none\n\n## Beta\n\ntwo\n',
+    });
+
+    const initial = await repo.read('/projects/parallel.md');
+    const [editA, editB] = await Promise.all([
+      repo.editSection('/projects/parallel.md', {
+        section: 'Alpha',
+        content: 'ONE',
+        expectedSectionVersion: initial!.sectionVersions.Alpha ?? 0,
+      }),
+      repo.editSection('/projects/parallel.md', {
+        section: 'Beta',
+        content: 'TWO',
+        expectedSectionVersion: initial!.sectionVersions.Beta ?? 0,
+      }),
+    ]);
+
+    expect(editA.ok).toBe(true);
+    expect(editB.ok).toBe(true);
+
+    const finalDoc = await repo.read('/projects/parallel.md');
+    expect(finalDoc!.body).toContain('ONE');
+    expect(finalDoc!.body).toContain('TWO');
+    expect(finalDoc!.sectionVersions.Alpha).toBe(1);
+    expect(finalDoc!.sectionVersions.Beta).toBe(1);
+  });
+
+  it('clears nullable metadata fields when explicitly set to null', async () => {
+    const doc = await repo.create({
+      path: '/tmp/meta.md',
+      type: 'note',
+      body: 'x',
+      conversationId: 'conv-1',
+      agentId: 'agent-1',
+    });
+    expect(doc.conversationId).toBe('conv-1');
+    expect(doc.agentId).toBe('agent-1');
+
+    const updated = await repo.update('/tmp/meta.md', {
+      conversationId: null,
+      agentId: null,
+      expectedVersion: doc.version,
+    });
+    expect(updated.ok).toBe(true);
+    if (updated.ok) {
+      expect(updated.document.conversationId).toBeNull();
+      expect(updated.document.agentId).toBeNull();
+    }
+  });
+
+  it('preserves inbound backlinks after soft-delete and recreate', async () => {
+    await repo.create({
+      path: '/projects/target.md',
+      type: 'findings',
+      body: 'Target doc.',
+    });
+    await repo.create({
+      path: '/projects/source.md',
+      type: 'brief',
+      body: 'See [[target]].',
+    });
+    await repo.softDelete('/projects/target.md');
+    await repo.create({
+      path: '/projects/target.md',
+      type: 'findings',
+      body: 'Recreated target.',
+    });
+
+    const backlinks = await repo.getBacklinks('/projects/target.md');
+    expect(backlinks.map(l => l.sourcePath)).toEqual(['/projects/source.md']);
+  });
+
+  it('listByPrefix treats underscore literally', async () => {
+    await repo.create({ path: '/projects/a_b/note.md', type: 'note', body: 'underscore' });
+    await repo.create({ path: '/projects/axb/note.md', type: 'note', body: 'no match' });
+
+    const listed = await repo.listByPrefix('/projects/a_b');
+    expect(listed.map(d => d.path)).toEqual(['/projects/a_b/note.md']);
+  });
+
+  it('append adds content with optimistic concurrency', async () => {
+    const doc = await repo.create({ path: '/tmp/append.md', type: 'log', body: 'Line 1' });
+    const appended = await repo.append('/tmp/append.md', {
+      content: 'Line 2',
+      expectedVersion: doc.version,
+    });
+    expect(appended.ok).toBe(true);
+    if (appended.ok) {
+      expect(appended.document.body).toContain('Line 1');
+      expect(appended.document.body).toContain('Line 2');
+      expect(appended.document.version).toBe(2);
+    }
+  });
+});

--- a/tests/unit/memory/okf.test.ts
+++ b/tests/unit/memory/okf.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseOkfDocument,
+  emitOkfDocument,
+  extractLinks,
+  splitSections,
+  editSectionBody,
+  joinSections,
+  normalizeDocPath,
+} from '../../../src/memory/okf.js';
+
+describe('parseOkfDocument / emitOkfDocument', () => {
+  const sample = `---
+type: project-brief
+title: Bluesky follow audit
+tags:
+  - social-media
+  - audit
+timestamp: 2026-06-26T14:30:00Z
+---
+
+# Goal
+
+Page through follows.
+`;
+
+  it('parses frontmatter and body', () => {
+    const parsed = parseOkfDocument(sample);
+    expect(parsed.type).toBe('project-brief');
+    expect(parsed.frontmatter.title).toBe('Bluesky follow audit');
+    expect(parsed.frontmatter.tags).toEqual(['social-media', 'audit']);
+    expect(parsed.body).toContain('# Goal');
+  });
+
+  it('round-trips conventional frontmatter fields', () => {
+    const parsed = parseOkfDocument(sample);
+    const emitted = emitOkfDocument({
+      type: parsed.type,
+      frontmatter: parsed.frontmatter,
+      body: parsed.body,
+    });
+    const reparsed = parseOkfDocument(emitted);
+    expect(reparsed.type).toBe('project-brief');
+    expect(reparsed.frontmatter.title).toBe('Bluesky follow audit');
+    expect(reparsed.frontmatter.tags).toEqual(['social-media', 'audit']);
+    expect(reparsed.frontmatter.timestamp).toBe('2026-06-26T14:30:00Z');
+    expect(reparsed.body.trim()).toBe(parsed.body.trim());
+  });
+
+  it('requires type in frontmatter', () => {
+    expect(() => parseOkfDocument('---\ntitle: x\n---\nbody')).toThrow(/type/i);
+  });
+
+  it('requires frontmatter delimiters', () => {
+    expect(() => parseOkfDocument('# no frontmatter')).toThrow(/frontmatter/i);
+  });
+});
+
+describe('extractLinks', () => {
+  it('extracts markdown path links and wikilinks', () => {
+    const body = `
+See [findings](/projects/x/findings.md) and [[notes]].
+Also [[/playbooks/sales.md]].
+`;
+    const links = extractLinks('/projects/x/brief.md', body);
+    expect(links).toEqual([
+      { targetPath: '/projects/x/findings.md', linkKind: 'markdown' },
+      { targetPath: '/projects/x/notes.md', linkKind: 'wikilink' },
+      { targetPath: '/playbooks/sales.md', linkKind: 'wikilink' },
+    ]);
+  });
+
+  it('tolerates broken / external links', () => {
+    const links = extractLinks('/a/b.md', 'Visit [site](https://example.com) and [frag](#section).');
+    expect(links).toHaveLength(0);
+  });
+
+  it('deduplicates repeated links', () => {
+    const body = '[[findings]] and again [[findings]]';
+    const links = extractLinks('/projects/x/brief.md', body);
+    expect(links).toHaveLength(1);
+  });
+});
+
+describe('normalizeDocPath', () => {
+  it('adds leading slash and normalizes separators', () => {
+    expect(normalizeDocPath('projects/x/brief.md')).toBe('/projects/x/brief.md');
+    expect(normalizeDocPath('/projects//x/brief.md')).toBe('/projects/x/brief.md');
+  });
+
+  it('resolves . and .. segments', () => {
+    expect(normalizeDocPath('/notes/../brief.md')).toBe('/brief.md');
+    expect(normalizeDocPath('/projects/x/./findings.md')).toBe('/projects/x/findings.md');
+  });
+});
+
+describe('section helpers', () => {
+  const body = `# Title
+
+Intro text.
+
+## Progress
+
+312 / 1300 reviewed.
+
+## Decisions
+
+- Auto-unfollow stale accounts.
+`;
+
+  it('splits and joins sections', () => {
+    const { preamble, sections } = splitSections(body);
+    expect(preamble).toContain('Intro text');
+    expect(sections.map((s: { heading: string }) => s.heading)).toEqual(['Progress', 'Decisions']);
+    expect(joinSections(preamble, sections).trim()).toBe(body.trim());
+  });
+
+  it('replaces a section by heading', () => {
+    const edited = editSectionBody(body, 'Progress', '500 / 1300 reviewed.\n');
+    expect(edited).toContain('500 / 1300 reviewed');
+    expect(edited).toContain('## Decisions');
+    expect(edited).not.toContain('312 / 1300');
+  });
+
+  it('appends within a section', () => {
+    const edited = editSectionBody(body, 'Decisions', '- New decision.', 'append');
+    expect(edited).toContain('- Auto-unfollow stale accounts.');
+    expect(edited).toContain('- New decision.');
+  });
+
+  it('creates a missing section', () => {
+    const edited = editSectionBody(body, 'Risks', 'None yet.');
+    expect(edited).toContain('## Risks');
+    expect(edited).toContain('None yet.');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1208

Implements the durable-storage foundation for the Agent Document Workspace epic (#1207): Postgres-backed OKF documents with a backlink index and optimistic concurrency.

## Changes

- **Migration `066_create_working_documents`** — `working_documents` (path-keyed, unique among live rows; `type` + JSONB frontmatter, markdown `body`, `version`, `section_versions`, `byte_size`, optional `task_id` / `conversation_id` / `agent_id`, soft-delete via `archived_at`) and `working_document_links` backlink table.
- **`src/memory/okf.ts`** — OKF (de)serialization (YAML frontmatter + markdown body), markdown/`[[wikilink]]` extraction, and `##` section helpers.
- **`WorkingDocsRepo`** — create, read, update, append, section-edit, list-by-prefix, soft-delete, and `getBacklinks` ("what links here"). All queries parameterized. Version conflicts return `{ ok: false, conflict: true, document }` rather than throwing.
- **Concurrency** — full updates/append use document `expectedVersion`; section edits use per-section `expectedSectionVersion` so concurrent edits to different sections do not collide.
- **`workingDocs` capability** — added to `SkillContext` allowlist and wired through loader, execution layer, and bootstrap.
- **Tests** — unit tests for OKF parsing/links/sections and repo conflict paths; integration tests against real Postgres.

## Acceptance criteria

- [x] Migration creates both tables; `path` unique on live rows; prefix `066` verified unique
- [x] `WorkingDocsRepo` supports create / read / update / append / section-edit / list-by-prefix / soft-delete
- [x] Frontmatter round-trips (`type` required; `title` / `tags` / `timestamp` conventional); links indexed and backlinks queryable
- [x] Optimistic concurrency: `expected_version` mismatch returns conflict result; section edits to different sections do not collide
- [x] Unit + integration tests (real Postgres)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da849e12-358c-494c-8dab-356d34a2478e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da849e12-358c-494c-8dab-356d34a2478e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

