### PR TITLE
fix(outbound-filter): skip escalation judge for principal-tier recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Outbound content filter** — Stage 2.5 escalation judge no longer calls the LLM for principal-tier recipients; `classifyDisclosure()` is fail-closed, so a transient provider failure was incorrectly blocking principal-bound emails (e.g. the daily recap) even though the policy unconditionally permits all disclosure classes for the principal. (#1225)
 - **Calendar free/busy** — `getFreeBusy` now calls the real Nylas v8 `calendars.getFreeBusy` endpoint; the previous call to a non-existent `calendars_free_busy` resource crashed every `calendar-check-conflicts` and `calendar-find-free-time` invocation. It also fails loud on a per-calendar free/busy *error* entry instead of treating that calendar as fully free (which could double-book the principal). (#1214)
 - **`ceo-inbox-update-folders`** — resolves label display names (e.g. "⏳ In Progress") to Gmail label IDs and creates missing labels before writing, so adds/removes no longer fail with "Invalid label" and "⏳ In Progress" can actually be cleared. (#1216)
 - **`ceo-inbox` scheduling consults** — a message parked for a calendar consult is no longer labeled "✍️ Drafted" before a draft exists, and the consult-timeout wake now keys off actual draft existence; parked scheduling replies get drafted instead of stranding the email as "In Progress + Drafted" with no draft. (#1215)

--- a/src/dispatch/outbound-filter.ts
+++ b/src/dispatch/outbound-filter.ts
@@ -465,6 +465,13 @@ export class OutboundContentFilter {
     // every message (which is what classifyDisclosure returns when enabled=false).
     if (!this.escalationJudge || !this.escalationJudge.isEnabled()) return [];
 
+    // Principal tier allows all disclosure classes (see DISCLOSURE_ALLOWED in escalation-policy.ts).
+    // Calling the LLM is unnecessary and risky: classifyDisclosure() is fail-closed, so a transient
+    // LLM failure would return decision='escalate' without ever reaching applyDisclosurePolicy —
+    // incorrectly blocking a principal-bound message that the policy unconditionally permits.
+    // Mirrors Stage 2's principalIsSoleRecipient short-circuit in OutboundLlmJudge.review().
+    if (input.recipientTier === 'principal') return [];
+
     const verdict = await this.escalationJudge.classifyDisclosure({
       content: input.content,
       recipientTier: input.recipientTier,

--- a/tests/unit/dispatch/outbound-filter.test.ts
+++ b/tests/unit/dispatch/outbound-filter.test.ts
@@ -649,4 +649,38 @@ describe('Stage 2.5 escalation judge delegation', () => {
       expect.objectContaining({ recipientTier: 'trusted' }),
     );
   });
+
+  it('does not call the judge for principal recipients — policy always allows, LLM call is unnecessary and risky', async () => {
+    // A fail-closed LLM failure in classifyDisclosure() returns decision='escalate' without
+    // reaching applyDisclosurePolicy. For principal recipients the policy allows all classes,
+    // so calling the LLM can only cause spurious blocks. The guard short-circuits before the call.
+    const judge = makeEscalationJudge({ decision: 'escalate', reason: 'would block if called' });
+    const filter = filterWithEscalationJudge(judge);
+    const result = await filter.check({
+      ...BASE_INPUT,
+      recipientTier: 'principal',
+      content: 'Here is your daily recap: 3 open tasks, 1 pending approval.',
+    });
+    expect(result.passed).toBe(true);
+    expect(judge.classifyDisclosure).not.toHaveBeenCalled();
+  });
+
+  it('still calls the judge and blocks for non-principal recipients when the judge escalates', async () => {
+    // Belt-and-suspenders: confirm the principal short-circuit does not weaken
+    // the gate for non-principal recipients.
+    const judge = makeEscalationJudge({
+      decision: 'escalate',
+      disclosureClass: 'principal-context',
+      reason: 'CEO availability should not reach unknown contacts',
+    });
+    const filter = filterWithEscalationJudge(judge);
+    const result = await filter.check({
+      ...BASE_INPUT,
+      recipientTier: 'unknown',
+      content: 'Joseph is free on Thursday afternoon.',
+    });
+    expect(result.passed).toBe(false);
+    expect(result.stage).toBe('disclosure-gate');
+    expect(judge.classifyDisclosure).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

- Stage 2.5 (`runEscalationJudge`) now short-circuits immediately for `recipientTier === 'principal'`, returning `[]` without calling the LLM.
- `classifyDisclosure()` is fail-closed: a transient provider timeout/error returns `decision: 'escalate'` before reaching `applyDisclosurePolicy()`, which incorrectly blocks principal-bound messages even though `DISCLOSURE_ALLOWED['principal']` permits all disclosure classes.
- Two new tests cover the principal short-circuit and confirm the non-principal gate is still enforced.

Closes #1225

## What changed

`src/dispatch/outbound-filter.ts` — 6-line guard added in `runEscalationJudge()` after the disabled-judge check, before the `classifyDisclosure()` call.

`tests/unit/dispatch/outbound-filter.test.ts` — two new cases in the "Stage 2.5 escalation judge delegation" block:
- principal recipient with an escalating judge → passes, judge not called
- non-principal recipient with an escalating judge → still blocked, judge called once

## Test plan

- [x] `pnpm run typecheck` — exit 0
- [x] `vitest run tests/unit/dispatch/outbound-filter.test.ts` — 48/48 passed (46 existing + 2 new)