### PR TITLE
feat: doc-read/list/write/search skills + workspace harness injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Calendar scheduling rules** — calendar agent loads CEO scheduling rules from `config-store` by key at task start, replacing semantic `memory-query`. (#1223)
 - **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)
 - **Document workspace** — `working_documents` / `working_document_links` Postgres store with `WorkingDocsRepo`, OKF frontmatter round-trip, backlink index, and optimistic concurrency (document + per-section). (#1208)
+- **`doc-read` / `doc-list` / `doc-write` / `doc-search`** — OKF workspace skills with harness-injected guidance, auto-pin on task-management agents, manifest-only tail injection, and `log.md` append on writes. (#1209)
 
 ### Changed
 

--- a/skills/_shared/doc-workspace.ts
+++ b/skills/_shared/doc-workspace.ts
@@ -12,6 +12,7 @@ import {
   logPathForDocument,
   normalizeDirectoryPrefix,
   RESERVED_LEAF_NAMES,
+  LOG_FILENAME,
 } from '../../src/agents/document-workspace.js';
 import { normalizeDocPath } from '../../src/memory/okf.js';
 
@@ -66,22 +67,43 @@ export async function appendDirectoryLog(
   const logPath = logPathForDocument(documentPath);
   const iso = new Date().toISOString();
   const entry = formatLogEntry(iso, operation, summary);
-  const existing = await repo.read(logPath);
-  if (!existing) {
-    await repo.create({
-      path: logPath,
-      type: 'log',
-      body: entry,
-      conversationId: ctx.conversationId ?? undefined,
-      agentId: ctx.agentId ?? undefined,
-    });
-    return;
-  }
-  const result = await repo.append(logPath, { content: entry.trimEnd(), expectedVersion: existing.version });
-  if (!result.ok) {
+
+  try {
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const existing = await repo.read(logPath);
+      if (!existing) {
+        try {
+          await repo.create({
+            path: logPath,
+            type: 'log',
+            body: entry,
+            conversationId: ctx.conversationId ?? undefined,
+            agentId: ctx.agentId ?? undefined,
+          });
+          return;
+        } catch (err) {
+          // Another writer may have created log.md between read and create — retry.
+          if (attempt === maxAttempts - 1) throw err;
+          continue;
+        }
+      }
+      const result = await repo.append(logPath, {
+        content: entry.trimEnd(),
+        expectedVersion: existing.version,
+      });
+      if (result.ok) return;
+      if (attempt === maxAttempts - 1) {
+        ctx.log.warn(
+          { path: logPath, version: existing.version },
+          'doc-write: log.md append conflict after retries — change record may be missing for this write',
+        );
+      }
+    }
+  } catch (err) {
     ctx.log.warn(
-      { path: logPath, version: existing.version },
-      'doc-write: log.md append conflict — change record may be missing for this write',
+      { err, path: logPath },
+      'doc-write: log.md append failed — document write succeeded; audit entry may be missing',
     );
   }
 }
@@ -117,7 +139,7 @@ export async function readDocument(
   }
 
   const timezone = ctx.timezone ?? 'UTC';
-  const { content, section: resolvedSection } = extractSectionContent(doc.body, section);
+  const sectionResult = extractSectionContent(doc.body, section);
   const displayTimezone = timezone === 'UTC' ? 'UTC' : formatDisplayTimezone(timezone, new Date());
   const updatedUnix = Math.floor(new Date(doc.updatedAt).getTime() / 1000);
   const data: Record<string, unknown> = {
@@ -131,9 +153,9 @@ export async function readDocument(
     displayTimezone,
   };
   if (section && section.trim()) {
-    data.section = resolvedSection ?? section.trim();
-    data.content = content;
-    data.section_found = resolvedSection !== undefined && content.length > 0;
+    data.section = sectionResult.section ?? section.trim();
+    data.content = sectionResult.content;
+    data.section_found = sectionResult.found === true;
   } else {
     data.body = doc.body;
     data.okf = ctx.workingDocs!.toOkf(doc);
@@ -170,11 +192,12 @@ export async function searchDocuments(
   };
 }
 
-export function validateWritePath(path: string, mode: string): string | null {
+export function validateWritePath(path: string, _mode: string): string | null {
   const normalized = normalizeDocPath(path);
   const leaf = normalized.split('/').pop() ?? '';
-  if (mode === 'create' && RESERVED_LEAF_NAMES.has(leaf)) {
-    return `Cannot create reserved file ${leaf} directly — use doc-list for index projection and let doc-write append log.md automatically`;
+  if (!RESERVED_LEAF_NAMES.has(leaf)) return null;
+  if (leaf === LOG_FILENAME) {
+    return `Cannot write to reserved file ${leaf} — log entries are appended automatically by doc-write`;
   }
-  return null;
+  return `Cannot write to reserved file ${leaf} — use doc-list for the index projection`;
 }

--- a/skills/_shared/doc-workspace.ts
+++ b/skills/_shared/doc-workspace.ts
@@ -1,0 +1,180 @@
+// Shared helpers for doc-* skills (#1209).
+
+import type { SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { WorkingDocRow, WorkingDocWriteResult } from '../../src/db/working-docs-repo.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+import {
+  buildIndexProjection,
+  extractSectionContent,
+  formatLogEntry,
+  grepDocuments,
+  indexPathForDirectory,
+  logPathForDocument,
+  normalizeDirectoryPrefix,
+  RESERVED_LEAF_NAMES,
+} from '../../src/agents/document-workspace.js';
+import { normalizeDocPath } from '../../src/memory/okf.js';
+
+export function requireWorkingDocs(ctx: SkillContext): SkillResult | null {
+  if (!ctx.workingDocs) {
+    ctx.log.error('doc-*: workingDocs not available');
+    return { success: false, error: 'Document workspace not available — database not configured' };
+  }
+  return null;
+}
+
+export function mapDocumentRow(doc: WorkingDocRow, timezone: string) {
+  const updatedUnix = Math.floor(new Date(doc.updatedAt).getTime() / 1000);
+  const createdUnix = Math.floor(new Date(doc.createdAt).getTime() / 1000);
+  return {
+    path: doc.path,
+    type: doc.type,
+    frontmatter: doc.frontmatter,
+    body: doc.body,
+    version: doc.version,
+    section_versions: doc.sectionVersions,
+    byte_size: doc.byteSize,
+    task_id: doc.taskId,
+    conversation_id: doc.conversationId,
+    agent_id: doc.agentId,
+    created_at: toLocalIso(createdUnix, timezone),
+    updated_at: toLocalIso(updatedUnix, timezone),
+    displayTimezone: formatDisplayTimezone(timezone, new Date()),
+  };
+}
+
+export function mapWriteConflict(result: WorkingDocWriteResult, timezone: string) {
+  if (result.ok) return null;
+  const updatedUnix = Math.floor(new Date(result.document.updatedAt).getTime() / 1000);
+  return {
+    conflict: true,
+    path: result.document.path,
+    version: result.document.version,
+    section_versions: result.document.sectionVersions,
+    updated_at: toLocalIso(updatedUnix, timezone),
+    displayTimezone: formatDisplayTimezone(timezone, new Date()),
+  };
+}
+
+export async function appendDirectoryLog(
+  ctx: SkillContext,
+  documentPath: string,
+  operation: string,
+  summary: string,
+): Promise<void> {
+  const repo = ctx.workingDocs!;
+  const logPath = logPathForDocument(documentPath);
+  const iso = new Date().toISOString();
+  const entry = formatLogEntry(iso, operation, summary);
+  const existing = await repo.read(logPath);
+  if (!existing) {
+    await repo.create({
+      path: logPath,
+      type: 'log',
+      body: entry,
+      conversationId: ctx.conversationId ?? undefined,
+      agentId: ctx.agentId ?? undefined,
+    });
+    return;
+  }
+  const result = await repo.append(logPath, { content: entry.trimEnd(), expectedVersion: existing.version });
+  if (!result.ok) {
+    ctx.log.warn(
+      { path: logPath, version: existing.version },
+      'doc-write: log.md append conflict — change record may be missing for this write',
+    );
+  }
+}
+
+export async function listDirectoryProjection(
+  ctx: SkillContext,
+  prefix: string,
+): Promise<{ directory: string; index_path: string; manifest: string; documents: WorkingDocRow[] }> {
+  const repo = ctx.workingDocs!;
+  const directory = normalizeDirectoryPrefix(prefix);
+  const documents = await repo.listByPrefix(directory);
+  const manifest = buildIndexProjection(directory, documents);
+  return {
+    directory,
+    index_path: indexPathForDirectory(directory),
+    manifest,
+    documents,
+  };
+}
+
+export async function readDocument(
+  ctx: SkillContext,
+  path: string,
+  section?: string,
+): Promise<SkillResult> {
+  const guard = requireWorkingDocs(ctx);
+  if (guard) return guard;
+
+  const normalized = normalizeDocPath(path);
+  const doc = await ctx.workingDocs!.read(normalized);
+  if (!doc) {
+    return { success: true, data: { found: false, path: normalized } };
+  }
+
+  const timezone = ctx.timezone ?? 'UTC';
+  const { content, section: resolvedSection } = extractSectionContent(doc.body, section);
+  const displayTimezone = timezone === 'UTC' ? 'UTC' : formatDisplayTimezone(timezone, new Date());
+  const updatedUnix = Math.floor(new Date(doc.updatedAt).getTime() / 1000);
+  const data: Record<string, unknown> = {
+    found: true,
+    path: doc.path,
+    type: doc.type,
+    frontmatter: doc.frontmatter,
+    version: doc.version,
+    section_versions: doc.sectionVersions,
+    updated_at: toLocalIso(updatedUnix, timezone),
+    displayTimezone,
+  };
+  if (section && section.trim()) {
+    data.section = resolvedSection ?? section.trim();
+    data.content = content;
+    data.section_found = resolvedSection !== undefined && content.length > 0;
+  } else {
+    data.body = doc.body;
+    data.okf = ctx.workingDocs!.toOkf(doc);
+  }
+  return { success: true, data };
+}
+
+export async function searchDocuments(
+  ctx: SkillContext,
+  query: string,
+  pathPrefix?: string,
+): Promise<SkillResult> {
+  const guard = requireWorkingDocs(ctx);
+  if (guard) return guard;
+
+  const prefix = pathPrefix ? normalizeDirectoryPrefix(pathPrefix) : '/';
+  const documents = await ctx.workingDocs!.listByPrefix(prefix);
+  const matches = grepDocuments(documents, query);
+  const timezone = ctx.timezone ?? 'UTC';
+  const displayTimezone = timezone === 'UTC' ? 'UTC' : formatDisplayTimezone(timezone, new Date());
+  return {
+    success: true,
+    data: {
+      query,
+      path_prefix: prefix,
+      match_count: matches.length,
+      matches: matches.map(m => ({
+        path: m.path,
+        line_number: m.lineNumber,
+        line: m.line,
+      })),
+      displayTimezone,
+    },
+  };
+}
+
+export function validateWritePath(path: string, mode: string): string | null {
+  const normalized = normalizeDocPath(path);
+  const leaf = normalized.split('/').pop() ?? '';
+  if (mode === 'create' && RESERVED_LEAF_NAMES.has(leaf)) {
+    return `Cannot create reserved file ${leaf} directly — use doc-list for index projection and let doc-write append log.md automatically`;
+  }
+  return null;
+}

--- a/skills/doc-list/handler.test.ts
+++ b/skills/doc-list/handler.test.ts
@@ -19,6 +19,12 @@ function makeCtx(docs: WorkingDocRow[], input: Record<string, unknown> = { path:
 }
 
 describe('DocListHandler', () => {
+  it('rejects document file paths', async () => {
+    const result = await new DocListHandler().execute(makeCtx([], { path: '/projects/x/brief.md' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/directory prefix/i);
+  });
+
   it('returns index projection for direct children', async () => {
     const docs: WorkingDocRow[] = [
       {

--- a/skills/doc-list/handler.test.ts
+++ b/skills/doc-list/handler.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { DocListHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { WorkingDocsRepo, WorkingDocRow } from '../../src/db/working-docs-repo.js';
+
+const silentLog = pino({ level: 'silent' });
+
+function makeCtx(docs: WorkingDocRow[], input: Record<string, unknown> = { path: '/projects/x/' }): SkillContext {
+  const repo = {
+    listByPrefix: vi.fn().mockResolvedValue(docs),
+  } as unknown as WorkingDocsRepo;
+  return {
+    input,
+    log: silentLog,
+    timezone: 'America/Toronto',
+    workingDocs: repo,
+  } as unknown as SkillContext;
+}
+
+describe('DocListHandler', () => {
+  it('returns index projection for direct children', async () => {
+    const docs: WorkingDocRow[] = [
+      {
+        id: '1', path: '/projects/x/brief.md', type: 'project-brief', frontmatter: { title: 'Brief' },
+        body: '', version: 1, sectionVersions: {}, byteSize: 0, taskId: null, conversationId: null,
+        agentId: null, createdAt: '2026-06-28T10:00:00.000Z', updatedAt: '2026-06-28T10:00:00.000Z', archivedAt: null,
+      },
+    ];
+    const result = await new DocListHandler().execute(makeCtx(docs));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { directory: string; index_path: string; manifest: string; document_count: number };
+      expect(data.directory).toBe('/projects/x/');
+      expect(data.index_path).toBe('/projects/x/index.md');
+      expect(data.manifest).toContain('[Brief](/projects/x/brief.md)');
+      expect(data.document_count).toBe(1);
+    }
+  });
+});

--- a/skills/doc-list/handler.ts
+++ b/skills/doc-list/handler.ts
@@ -6,6 +6,7 @@ import {
   listDirectoryProjection,
   requireWorkingDocs,
 } from '../_shared/doc-workspace.js';
+import { looksLikeDocumentPath } from '../../src/agents/document-workspace.js';
 
 export class DocListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -13,6 +14,12 @@ export class DocListHandler implements SkillHandler {
 
     if (!path || typeof path !== 'string' || !path.trim()) {
       return { success: false, error: 'Missing required input: path (directory prefix string)' };
+    }
+    if (looksLikeDocumentPath(path)) {
+      return {
+        success: false,
+        error: 'path must be a directory prefix (e.g. /projects/x/), not a document file path — use doc-read for documents',
+      };
     }
 
     const guard = requireWorkingDocs(ctx);

--- a/skills/doc-list/handler.ts
+++ b/skills/doc-list/handler.ts
@@ -1,0 +1,52 @@
+// handler.ts — doc-list skill (#1209).
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+import {
+  listDirectoryProjection,
+  requireWorkingDocs,
+} from '../_shared/doc-workspace.js';
+
+export class DocListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { path } = ctx.input as { path?: string };
+
+    if (!path || typeof path !== 'string' || !path.trim()) {
+      return { success: false, error: 'Missing required input: path (directory prefix string)' };
+    }
+
+    const guard = requireWorkingDocs(ctx);
+    if (guard) return guard;
+
+    try {
+      const timezone = ctx.timezone ?? 'UTC';
+      const displayTimezone = timezone === 'UTC' ? 'UTC' : formatDisplayTimezone(timezone, new Date());
+      const { directory, index_path, manifest, documents } = await listDirectoryProjection(ctx, path);
+      const directChildren = documents.filter(d => {
+        const remainder = d.path.slice(directory.length);
+        return remainder.length > 0 && !remainder.includes('/');
+      });
+
+      return {
+        success: true,
+        data: {
+          directory,
+          index_path,
+          manifest,
+          document_count: directChildren.length,
+          documents: directChildren.map(d => ({
+            path: d.path,
+            type: d.type,
+            title: typeof d.frontmatter.title === 'string' ? d.frontmatter.title : undefined,
+            updated_at: toLocalIso(Math.floor(new Date(d.updatedAt).getTime() / 1000), timezone),
+          })),
+          updated_at: toLocalIso(Math.floor(Date.now() / 1000), timezone),
+          displayTimezone,
+        },
+      };
+    } catch (err) {
+      ctx.log.error({ err, path }, 'doc-list: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/skills/doc-list/skill.json
+++ b/skills/doc-list/skill.json
@@ -1,0 +1,23 @@
+{
+  "name": "doc-list",
+  "description": "List a directory in the OKF document workspace — like `ls` on a path prefix. Returns the `index.md` projection (manifest) listing direct child documents with titles and types, plus structured metadata. Does not return full document bodies; use `doc-read` for content.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "path": "string (directory prefix, e.g. '/projects/bluesky-audit/' or '/projects/bluesky-audit')"
+  },
+  "outputs": {
+    "directory": "string (normalized directory prefix)",
+    "index_path": "string (conventional index.md path for this directory)",
+    "manifest": "string (index.md projection markdown)",
+    "document_count": "number",
+    "documents": "array of {path, type, title?, updated_at}",
+    "updated_at": "string",
+    "displayTimezone": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["workingDocs"]
+}

--- a/skills/doc-read/handler.test.ts
+++ b/skills/doc-read/handler.test.ts
@@ -85,4 +85,20 @@ describe('DocReadHandler', () => {
       expect(data.section_found).toBe(true);
     }
   });
+
+  it('returns section_found:true for an existing empty section', async () => {
+    const repo = makeRepo({
+      read: vi.fn().mockResolvedValue(makeDoc({ body: '## Goal\n\n## Notes\n\nfilled\n' })),
+    });
+    const result = await new DocReadHandler().execute(makeCtx({
+      path: '/projects/x/brief.md',
+      section: 'Goal',
+    }, repo));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { section_found?: boolean; content?: string };
+      expect(data.section_found).toBe(true);
+      expect(data.content).toBe('');
+    }
+  });
 });

--- a/skills/doc-read/handler.test.ts
+++ b/skills/doc-read/handler.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { DocReadHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { WorkingDocsRepo, WorkingDocRow } from '../../src/db/working-docs-repo.js';
+
+const silentLog = pino({ level: 'silent' });
+
+function makeDoc(overrides: Partial<WorkingDocRow> = {}): WorkingDocRow {
+  return {
+    id: 'doc-1',
+    path: '/projects/x/brief.md',
+    type: 'project-brief',
+    frontmatter: { title: 'Brief' },
+    body: '## Goal\n\nReview follows.\n',
+    version: 2,
+    sectionVersions: { Goal: 1 },
+    byteSize: 100,
+    taskId: null,
+    conversationId: null,
+    agentId: null,
+    createdAt: '2026-06-28T10:00:00.000Z',
+    updatedAt: '2026-06-28T11:00:00.000Z',
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function makeRepo(overrides: Partial<WorkingDocsRepo> = {}): WorkingDocsRepo {
+  return {
+    read: vi.fn().mockResolvedValue(makeDoc()),
+    toOkf: vi.fn().mockReturnValue('---\ntype: project-brief\n---\nbody'),
+    ...overrides,
+  } as unknown as WorkingDocsRepo;
+}
+
+function makeCtx(input: Record<string, unknown>, workingDocs?: WorkingDocsRepo | null): SkillContext {
+  return {
+    input,
+    log: silentLog,
+    timezone: 'America/Toronto',
+    workingDocs: workingDocs === null ? undefined : (workingDocs ?? makeRepo()),
+  } as unknown as SkillContext;
+}
+
+describe('DocReadHandler', () => {
+  it('requires path', async () => {
+    const result = await new DocReadHandler().execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/path/i);
+  });
+
+  it('returns found:false when the document is missing', async () => {
+    const repo = makeRepo({ read: vi.fn().mockResolvedValue(null) });
+    const result = await new DocReadHandler().execute(makeCtx({ path: '/missing.md' }, repo));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { found: boolean };
+      expect(data.found).toBe(false);
+    }
+  });
+
+  it('returns full body and okf when no section is requested', async () => {
+    const result = await new DocReadHandler().execute(makeCtx({ path: '/projects/x/brief.md' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { found: boolean; body?: string; okf?: string; displayTimezone?: string };
+      expect(data.found).toBe(true);
+      expect(data.body).toContain('Review follows');
+      expect(data.okf).toBeTruthy();
+      expect(data.displayTimezone).toBeTruthy();
+    }
+  });
+
+  it('returns section content when section is requested', async () => {
+    const result = await new DocReadHandler().execute(makeCtx({
+      path: '/projects/x/brief.md',
+      section: 'Goal',
+    }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { section?: string; content?: string; section_found?: boolean };
+      expect(data.section).toBe('Goal');
+      expect(data.content).toContain('Review follows');
+      expect(data.section_found).toBe(true);
+    }
+  });
+});

--- a/skills/doc-read/handler.ts
+++ b/skills/doc-read/handler.ts
@@ -1,0 +1,27 @@
+// handler.ts — doc-read skill (#1209).
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { readDocument, requireWorkingDocs } from '../_shared/doc-workspace.js';
+
+export class DocReadHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { path, section } = ctx.input as { path?: string; section?: string };
+
+    if (!path || typeof path !== 'string' || !path.trim()) {
+      return { success: false, error: 'Missing required input: path (string)' };
+    }
+    if (section !== undefined && typeof section !== 'string') {
+      return { success: false, error: 'section must be a string when provided' };
+    }
+
+    const guard = requireWorkingDocs(ctx);
+    if (guard) return guard;
+
+    try {
+      return await readDocument(ctx, path, section);
+    } catch (err) {
+      ctx.log.error({ err, path }, 'doc-read: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/skills/doc-read/skill.json
+++ b/skills/doc-read/skill.json
@@ -1,0 +1,30 @@
+{
+  "name": "doc-read",
+  "description": "Read a document from the OKF document workspace by path. Optionally pass `section` to read only a `##` heading's body — keeps per-burst context cost down. Returns full OKF markdown when no section is requested; returns `content` + `section_found` when a section is requested. Documents not found return `found: false`.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "path": "string (absolute document path, e.g. '/projects/audit/brief.md')",
+    "section": "string? (optional `##` section heading — case-insensitive match)"
+  },
+  "outputs": {
+    "found": "boolean",
+    "path": "string",
+    "type": "string? (OKF frontmatter type when found)",
+    "frontmatter": "object? (parsed frontmatter when found)",
+    "body": "string? (full markdown body when no section requested)",
+    "okf": "string? (serialized OKF document when no section requested)",
+    "section": "string? (resolved section heading when section input provided)",
+    "content": "string? (section body when section input provided)",
+    "section_found": "boolean? (false when the section heading does not exist)",
+    "version": "number?",
+    "section_versions": "object?",
+    "updated_at": "string?",
+    "displayTimezone": "string?"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["workingDocs"]
+}

--- a/skills/doc-search/handler.test.ts
+++ b/skills/doc-search/handler.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { DocSearchHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { WorkingDocsRepo, WorkingDocRow } from '../../src/db/working-docs-repo.js';
+
+const silentLog = pino({ level: 'silent' });
+
+describe('DocSearchHandler', () => {
+  it('greps documents under a prefix', async () => {
+    const docs: WorkingDocRow[] = [
+      {
+        id: '1', path: '/projects/x/a.md', type: 'note', frontmatter: {}, body: 'alpha\nneedle\n',
+        version: 1, sectionVersions: {}, byteSize: 1, taskId: null, conversationId: null, agentId: null,
+        createdAt: '2026-06-28T10:00:00.000Z', updatedAt: '2026-06-28T10:00:00.000Z', archivedAt: null,
+      },
+    ];
+    const repo = {
+      listByPrefix: vi.fn().mockResolvedValue(docs),
+    } as unknown as WorkingDocsRepo;
+    const ctx = {
+      input: { query: 'needle', path_prefix: '/projects/x/' },
+      log: silentLog,
+      timezone: 'America/Toronto',
+      workingDocs: repo,
+    } as unknown as SkillContext;
+
+    const result = await new DocSearchHandler().execute(ctx);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { match_count: number; matches: Array<{ path: string }> };
+      expect(data.match_count).toBe(1);
+      expect(data.matches[0]!.path).toBe('/projects/x/a.md');
+    }
+  });
+});

--- a/skills/doc-search/handler.ts
+++ b/skills/doc-search/handler.ts
@@ -1,0 +1,27 @@
+// handler.ts — doc-search skill (#1209).
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { searchDocuments, requireWorkingDocs } from '../_shared/doc-workspace.js';
+
+export class DocSearchHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { query, path_prefix } = ctx.input as { query?: string; path_prefix?: string };
+
+    if (!query || typeof query !== 'string' || !query.trim()) {
+      return { success: false, error: 'Missing required input: query (string)' };
+    }
+    if (path_prefix !== undefined && typeof path_prefix !== 'string') {
+      return { success: false, error: 'path_prefix must be a string when provided' };
+    }
+
+    const guard = requireWorkingDocs(ctx);
+    if (guard) return guard;
+
+    try {
+      return await searchDocuments(ctx, query, path_prefix);
+    } catch (err) {
+      ctx.log.error({ err, query }, 'doc-search: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/skills/doc-search/skill.json
+++ b/skills/doc-search/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "doc-search",
+  "description": "Search the OKF document workspace with a case-sensitive substring grep. Optionally limit to a path prefix (defaults to the whole workspace). Returns matching paths, line numbers, and line text — up to 50 matches. Use `doc-read` to pull full context around a hit.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "query": "string (substring to grep for in document bodies)",
+    "path_prefix": "string? (optional directory prefix to scope the search, e.g. '/projects/audit/')"
+  },
+  "outputs": {
+    "query": "string",
+    "path_prefix": "string",
+    "match_count": "number",
+    "matches": "array of {path, line_number, line}",
+    "displayTimezone": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["workingDocs"]
+}

--- a/skills/doc-write/handler.test.ts
+++ b/skills/doc-write/handler.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { DocWriteHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { WorkingDocsRepo, WorkingDocRow } from '../../src/db/working-docs-repo.js';
+
+const silentLog = pino({ level: 'silent' });
+
+function makeDoc(overrides: Partial<WorkingDocRow> = {}): WorkingDocRow {
+  return {
+    id: 'doc-1',
+    path: '/projects/x/brief.md',
+    type: 'project-brief',
+    frontmatter: {},
+    body: 'seed',
+    version: 1,
+    sectionVersions: {},
+    byteSize: 10,
+    taskId: null,
+    conversationId: null,
+    agentId: null,
+    createdAt: '2026-06-28T10:00:00.000Z',
+    updatedAt: '2026-06-28T10:00:00.000Z',
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function makeRepo(overrides: Partial<WorkingDocsRepo> = {}): WorkingDocsRepo {
+  const created = makeDoc({ path: '/projects/x/new.md', version: 1, body: 'hello' });
+  const appended = makeDoc({ version: 2, body: 'seed\n\nmore' });
+  return {
+    read: vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(created),
+    append: vi.fn().mockResolvedValue({ ok: true, document: appended }),
+    update: vi.fn(),
+    editSection: vi.fn(),
+    ...overrides,
+  } as unknown as WorkingDocsRepo;
+}
+
+function makeCtx(input: Record<string, unknown>, repo?: WorkingDocsRepo): SkillContext {
+  return {
+    input,
+    log: silentLog,
+    timezone: 'America/Toronto',
+    agentId: 'coordinator',
+    workingDocs: repo ?? makeRepo(),
+  } as unknown as SkillContext;
+}
+
+describe('DocWriteHandler', () => {
+  it('creates a document and appends log.md', async () => {
+    const repo = makeRepo({
+      read: vi.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null),
+    });
+    const result = await new DocWriteHandler().execute(makeCtx({
+      path: '/projects/x/new.md',
+      mode: 'create',
+      type: 'note',
+      body: 'hello',
+      summary: 'Created note',
+    }, repo));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { action?: string };
+      expect(data.action).toBe('created');
+    }
+    expect(repo.create).toHaveBeenCalled();
+  });
+
+  it('rejects direct create of reserved index.md', async () => {
+    const result = await new DocWriteHandler().execute(makeCtx({
+      path: '/projects/x/index.md',
+      mode: 'create',
+      type: 'index',
+    }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/reserved/i);
+  });
+
+  it('returns conflict data on version mismatch', async () => {
+    const repo = makeRepo({
+      read: vi.fn().mockResolvedValue(makeDoc()),
+      append: vi.fn().mockResolvedValue({
+        ok: false,
+        conflict: true,
+        document: makeDoc({ version: 3 }),
+      }),
+    });
+    const result = await new DocWriteHandler().execute(makeCtx({
+      path: '/projects/x/brief.md',
+      mode: 'append',
+      content: 'more',
+      expected_version: 1,
+    }, repo));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { conflict?: boolean; version?: number };
+      expect(data.conflict).toBe(true);
+      expect(data.version).toBe(3);
+    }
+  });
+});

--- a/skills/doc-write/handler.test.ts
+++ b/skills/doc-write/handler.test.ts
@@ -83,6 +83,41 @@ describe('DocWriteHandler', () => {
     if (!result.success) expect(result.error).toMatch(/reserved/i);
   });
 
+  it('rejects append to reserved log.md', async () => {
+    const result = await new DocWriteHandler().execute(makeCtx({
+      path: '/projects/x/log.md',
+      mode: 'append',
+      content: 'tamper',
+      expected_version: 1,
+    }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/reserved/i);
+  });
+
+  it('succeeds when log append fails after the document write', async () => {
+    const repo = makeRepo({
+      read: vi.fn().mockImplementation(async (path: string) => {
+        if (path.endsWith('/new.md') || path.endsWith('/log.md')) return null;
+        return null;
+      }),
+      create: vi.fn().mockImplementation(async (params: { path: string }) => {
+        if (params.path.endsWith('/log.md')) throw new Error('log create failed');
+        return makeDoc({ path: '/projects/x/new.md', version: 1, body: 'hello' });
+      }),
+    });
+    const result = await new DocWriteHandler().execute(makeCtx({
+      path: '/projects/x/new.md',
+      mode: 'create',
+      type: 'note',
+      body: 'hello',
+    }, repo));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { action?: string };
+      expect(data.action).toBe('created');
+    }
+  });
+
   it('returns conflict data on version mismatch', async () => {
     const repo = makeRepo({
       read: vi.fn().mockResolvedValue(makeDoc()),

--- a/skills/doc-write/handler.ts
+++ b/skills/doc-write/handler.ts
@@ -1,0 +1,171 @@
+// handler.ts — doc-write skill (#1209).
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { normalizeDocPath } from '../../src/memory/okf.js';
+import {
+  appendDirectoryLog,
+  mapDocumentRow,
+  mapWriteConflict,
+  requireWorkingDocs,
+  validateWritePath,
+} from '../_shared/doc-workspace.js';
+
+const VALID_MODES = new Set(['create', 'append', 'replace', 'section-edit']);
+
+export class DocWriteHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input = ctx.input as {
+      path?: string;
+      mode?: string;
+      type?: string;
+      body?: string;
+      content?: string;
+      frontmatter?: Record<string, unknown>;
+      section?: string;
+      expected_version?: number;
+      expected_section_version?: number;
+      summary?: string;
+      task_id?: string;
+      conversation_id?: string;
+    };
+
+    if (!input.path || typeof input.path !== 'string' || !input.path.trim()) {
+      return { success: false, error: 'Missing required input: path (string)' };
+    }
+    if (!input.mode || !VALID_MODES.has(input.mode)) {
+      return {
+        success: false,
+        error: "Missing or invalid mode — must be 'create', 'append', 'replace', or 'section-edit'",
+      };
+    }
+
+    const guard = requireWorkingDocs(ctx);
+    if (guard) return guard;
+
+    const reservedError = validateWritePath(input.path, input.mode);
+    if (reservedError) {
+      return { success: false, error: reservedError };
+    }
+
+    const timezone = ctx.timezone ?? 'UTC';
+    const normalized = normalizeDocPath(input.path);
+    const summary = typeof input.summary === 'string' ? input.summary : `${input.mode} ${normalized}`;
+
+    try {
+      const repo = ctx.workingDocs!;
+      let result;
+
+      switch (input.mode) {
+        case 'create': {
+          if (!input.type || typeof input.type !== 'string' || !input.type.trim()) {
+            return { success: false, error: 'create mode requires type (string)' };
+          }
+          const existing = await repo.read(normalized);
+          if (existing) {
+            return { success: false, error: `Document already exists at ${normalized} — use append, replace, or section-edit` };
+          }
+          const created = await repo.create({
+            path: normalized,
+            type: input.type.trim(),
+            frontmatter: input.frontmatter,
+            body: input.body ?? '',
+            taskId: input.task_id,
+            conversationId: input.conversation_id ?? ctx.conversationId ?? undefined,
+            agentId: ctx.agentId ?? undefined,
+          });
+          await appendDirectoryLog(ctx, normalized, 'create', summary);
+          return {
+            success: true,
+            data: { action: 'created', document: mapDocumentRow(created, timezone) },
+          };
+        }
+        case 'append': {
+          if (input.content === undefined || typeof input.content !== 'string') {
+            return { success: false, error: 'append mode requires content (string)' };
+          }
+          if (input.expected_version === undefined || typeof input.expected_version !== 'number') {
+            return { success: false, error: 'append mode requires expected_version (number)' };
+          }
+          const current = await repo.read(normalized);
+          if (!current) {
+            return { success: false, error: `Document not found at ${normalized} — use create mode first` };
+          }
+          result = await repo.append(normalized, {
+            content: input.content,
+            expectedVersion: input.expected_version,
+          });
+          if (!result.ok) {
+            return { success: true, data: mapWriteConflict(result, timezone) };
+          }
+          await appendDirectoryLog(ctx, normalized, 'append', summary);
+          return {
+            success: true,
+            data: { action: 'appended', document: mapDocumentRow(result.document, timezone) },
+          };
+        }
+        case 'replace': {
+          if (input.body === undefined || typeof input.body !== 'string') {
+            return { success: false, error: 'replace mode requires body (string)' };
+          }
+          if (input.expected_version === undefined || typeof input.expected_version !== 'number') {
+            return { success: false, error: 'replace mode requires expected_version (number)' };
+          }
+          const current = await repo.read(normalized);
+          if (!current) {
+            return { success: false, error: `Document not found at ${normalized} — use create mode first` };
+          }
+          result = await repo.update(normalized, {
+            type: input.type,
+            frontmatter: input.frontmatter,
+            body: input.body,
+            expectedVersion: input.expected_version,
+          });
+          if (!result.ok) {
+            return { success: true, data: mapWriteConflict(result, timezone) };
+          }
+          await appendDirectoryLog(ctx, normalized, 'replace', summary);
+          return {
+            success: true,
+            data: { action: 'replaced', document: mapDocumentRow(result.document, timezone) },
+          };
+        }
+        case 'section-edit': {
+          if (!input.section || typeof input.section !== 'string' || !input.section.trim()) {
+            return { success: false, error: 'section-edit mode requires section (string)' };
+          }
+          if (input.content === undefined || typeof input.content !== 'string') {
+            return { success: false, error: 'section-edit mode requires content (string)' };
+          }
+          const current = await repo.read(normalized);
+          if (!current) {
+            return { success: false, error: `Document not found at ${normalized} — use create mode first` };
+          }
+          result = await repo.editSection(normalized, {
+            section: input.section.trim(),
+            content: input.content,
+            mode: 'replace',
+            expectedSectionVersion: input.expected_section_version,
+          });
+          if (!result.ok) {
+            return { success: true, data: mapWriteConflict(result, timezone) };
+          }
+          await appendDirectoryLog(
+            ctx,
+            normalized,
+            'section-edit',
+            `${summary} (${input.section.trim()})`,
+          );
+          return {
+            success: true,
+            data: { action: 'section-edited', document: mapDocumentRow(result.document, timezone) },
+          };
+        }
+        default:
+          return { success: false, error: `Unhandled mode: ${input.mode}` };
+      }
+    } catch (err) {
+      ctx.log.error({ err, path: input.path, mode: input.mode }, 'doc-write: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/skills/doc-write/skill.json
+++ b/skills/doc-write/skill.json
@@ -1,0 +1,35 @@
+{
+  "name": "doc-write",
+  "description": "Write to the OKF document workspace. Modes: `create` (new document — requires `type`, optional `body`/`frontmatter`), `append` (add content — requires `content` + `expected_version`), `replace` (swap full body — requires `body` + `expected_version`), `section-edit` (replace a `##` section — requires `section`, `content`, optional `expected_section_version`). Every successful write appends an entry to the directory's reserved `log.md`. On version mismatch returns `conflict: true` with the latest document versions — re-read and retry.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "path": "string",
+    "mode": "string (create | append | replace | section-edit)",
+    "type": "string? (required for create — OKF frontmatter type)",
+    "body": "string? (required for replace; optional for create)",
+    "content": "string? (required for append and section-edit)",
+    "frontmatter": "object? (optional YAML frontmatter fields except type)",
+    "section": "string? (required for section-edit — `##` heading)",
+    "expected_version": "number? (required for append/replace — from last doc-read)",
+    "expected_section_version": "number? (optional for section-edit — per-section optimistic version)",
+    "summary": "string? (one-line description for log.md — defaults to mode + path)",
+    "task_id": "string? (optional association)",
+    "conversation_id": "string? (optional association)"
+  },
+  "outputs": {
+    "action": "string? (created | appended | replaced | section-edited)",
+    "document": "object? (written document metadata on success)",
+    "conflict": "boolean? (true when optimistic concurrency failed)",
+    "path": "string?",
+    "version": "number?",
+    "section_versions": "object?",
+    "updated_at": "string?",
+    "displayTimezone": "string?"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["workingDocs"]
+}

--- a/src/agents/document-workspace.ts
+++ b/src/agents/document-workspace.ts
@@ -132,7 +132,10 @@ export function indexPathForDirectory(directoryPrefix: string): string {
 }
 
 /** Extract a `##` section body, or the full document when section is omitted. */
-export function extractSectionContent(body: string, section?: string): { content: string; section?: string } {
+export function extractSectionContent(
+  body: string,
+  section?: string,
+): { content: string; section?: string; found?: boolean } {
   if (!section || !section.trim()) {
     return { content: body };
   }
@@ -140,10 +143,17 @@ export function extractSectionContent(body: string, section?: string): { content
   const { sections } = splitSections(body);
   const match = sections.find(s => s.heading.toLowerCase() === key.toLowerCase());
   if (!match) {
-    return { content: '', section: key };
+    return { content: '', found: false };
   }
   const content = match.content.length > 0 ? `${match.content.replace(/\n$/, '')}\n` : '';
-  return { content, section: match.heading };
+  return { content, section: match.heading, found: true };
+}
+
+/** True when the path names a document leaf (e.g. ends in `.md`), not a directory prefix. */
+export function looksLikeDocumentPath(path: string): boolean {
+  const normalized = normalizeDocPath(path);
+  const leaf = normalized.split('/').pop() ?? '';
+  return leaf.includes('.');
 }
 
 export interface GrepMatch {

--- a/src/agents/document-workspace.ts
+++ b/src/agents/document-workspace.ts
@@ -1,0 +1,225 @@
+import type { AgentYamlConfig } from './loader.js';
+import type { WorkingDocRow } from '../db/working-docs-repo.js';
+import {
+  docDirectory,
+  normalizeDocPath,
+  splitSections,
+} from '../memory/okf.js';
+import type { ResumableDocumentPointer } from '../db/resumable-progress.js';
+import { isDocumentPointer } from '../db/resumable-progress.js';
+
+/** The four skills every document-workspace-enabled agent can call. */
+export const DOCUMENT_WORKSPACE_SKILLS = [
+  'doc-read',
+  'doc-list',
+  'doc-write',
+  'doc-search',
+] as const;
+
+export const INDEX_FILENAME = 'index.md';
+export const LOG_FILENAME = 'log.md';
+
+/** Reserved leaf names — not overwritten by generic create/replace. */
+export const RESERVED_LEAF_NAMES = new Set([INDEX_FILENAME, LOG_FILENAME]);
+
+/** Single source of truth for the workspace discipline block injected into every
+ *  document-workspace-enabled agent's effective system prompt (#1209). */
+export const DOCUMENT_WORKSPACE_BLOCK = [
+  '## Document Workspace',
+  '',
+  'You have an OKF document workspace — a filesystem of markdown concept-files addressed',
+  'by path. Use your `doc-*` skills to read, list, write, and search it.',
+  '',
+  '**Paths.** Documents live at paths like `/projects/<slug>/brief.md` or',
+  '`/scratch/<conversation-id>/outline.md`. Directories are path prefixes — `doc-list` on',
+  'a prefix is like `ls` on a folder. Each directory has reserved `index.md` (navigation',
+  'catalog) and `log.md` (append-only change history).',
+  '',
+  '**Manifest first, bodies on demand.** On resume you may receive a directory manifest',
+  '(the `index.md` projection) at the tail of your task message — that is the map, not',
+  'the content. Pull document bodies and specific `##` sections with `doc-read` as tool',
+  'results so working text stays out of the cached system prefix.',
+  '',
+  '**Writes.** `doc-write` creates, appends, replaces, or section-edits at a path and',
+  'appends a `log.md` entry in that directory. Re-read with `doc-read` after writes that',
+  'need the latest `expected_version`. On conflict, merge from the returned document and',
+  'retry with the new version.',
+  '',
+  '**Conventions.** YAML frontmatter requires `type`; `title`, `tags`, and `timestamp` are',
+  'conventional. Link between documents with markdown path links or `[[wikilinks]]`.',
+  'Distill durable conclusions to the knowledge graph via `memory-store` / `extract-facts`',
+  'when a project completes — the workspace is for mutable working state, not validated facts.',
+].join('\n');
+
+export interface DocumentWorkspaceResult {
+  systemPrompt: string;
+  pinnedSkills: string[];
+}
+
+/** Apply the document workspace capability to an agent's prompt + skills.
+ *  Gated on `enable_task_management` — resumable-task agents get the workspace surface.
+ *  Pure function — no side effects. */
+export function applyDocumentWorkspace(
+  config: AgentYamlConfig,
+  systemPrompt: string,
+  pinnedSkills: string[],
+): DocumentWorkspaceResult {
+  if (!config.enable_task_management) {
+    return { systemPrompt, pinnedSkills: [...pinnedSkills] };
+  }
+  const merged = [...pinnedSkills];
+  for (const skill of DOCUMENT_WORKSPACE_SKILLS) {
+    if (!merged.includes(skill)) merged.push(skill);
+  }
+  return {
+    systemPrompt: `${systemPrompt}\n\n${DOCUMENT_WORKSPACE_BLOCK}`,
+    pinnedSkills: merged,
+  };
+}
+
+/** Normalize a directory prefix — always ends with `/`, never bare `/` unless root. */
+export function normalizeDirectoryPrefix(prefix: string): string {
+  const normalized = normalizeDocPath(prefix);
+  if (normalized === '/') return '/';
+  return normalized.endsWith('/') ? normalized : `${normalized}/`;
+}
+
+/** True when `path` is a direct child of `directoryPrefix`. */
+export function isDirectChild(directoryPrefix: string, path: string): boolean {
+  const dir = normalizeDirectoryPrefix(directoryPrefix);
+  if (!path.startsWith(dir)) return false;
+  const remainder = path.slice(dir.length);
+  if (!remainder || remainder.includes('/')) return false;
+  return true;
+}
+
+/** Build the index.md projection for a directory prefix from live document rows. */
+export function buildIndexProjection(directoryPrefix: string, documents: WorkingDocRow[]): string {
+  const dir = normalizeDirectoryPrefix(directoryPrefix);
+  const children = documents
+    .filter(d => isDirectChild(dir, d.path))
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  const lines: string[] = ['# Index', ''];
+  if (children.length === 0) {
+    lines.push('_No documents in this directory yet._');
+    return `${lines.join('\n')}\n`;
+  }
+
+  for (const doc of children) {
+    const leaf = doc.path.slice(dir.length);
+    const title = typeof doc.frontmatter.title === 'string' && doc.frontmatter.title.trim()
+      ? doc.frontmatter.title.trim()
+      : leaf.replace(/\.md$/, '');
+    lines.push(`- [${title}](${doc.path}) — \`${doc.type}\``);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+/** Format a log.md append entry per OKF / LLM-Wiki convention. */
+export function formatLogEntry(isoTimestamp: string, operation: string, summary: string): string {
+  const op = operation.trim() || 'write';
+  const sum = summary.trim() || op;
+  return `## [${isoTimestamp}] ${op} | ${sum}\n`;
+}
+
+export function logPathForDocument(documentPath: string): string {
+  return `${docDirectory(documentPath)}${LOG_FILENAME}`;
+}
+
+export function indexPathForDirectory(directoryPrefix: string): string {
+  return `${normalizeDirectoryPrefix(directoryPrefix)}${INDEX_FILENAME}`;
+}
+
+/** Extract a `##` section body, or the full document when section is omitted. */
+export function extractSectionContent(body: string, section?: string): { content: string; section?: string } {
+  if (!section || !section.trim()) {
+    return { content: body };
+  }
+  const key = section.trim();
+  const { sections } = splitSections(body);
+  const match = sections.find(s => s.heading.toLowerCase() === key.toLowerCase());
+  if (!match) {
+    return { content: '', section: key };
+  }
+  const content = match.content.length > 0 ? `${match.content.replace(/\n$/, '')}\n` : '';
+  return { content, section: match.heading };
+}
+
+export interface GrepMatch {
+  path: string;
+  lineNumber: number;
+  line: string;
+}
+
+/** Case-sensitive substring grep across document bodies. */
+export function grepDocuments(
+  documents: WorkingDocRow[],
+  query: string,
+  options?: { maxMatches?: number },
+): GrepMatch[] {
+  const max = options?.maxMatches ?? 50;
+  const matches: GrepMatch[] = [];
+  for (const doc of documents) {
+    const lines = doc.body.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (!line.includes(query)) continue;
+      matches.push({ path: doc.path, lineNumber: i + 1, line });
+      if (matches.length >= max) return matches;
+    }
+  }
+  return matches;
+}
+
+/** Parse scheduler / task-wake JSON content for a workspace directory prefix. */
+export function resolveWorkspacePrefixFromTaskContent(content: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const progress = obj.progress;
+  if (progress && typeof progress === 'object' && !Array.isArray(progress)) {
+    const resumable = (progress as Record<string, unknown>).resumable;
+    if (resumable && typeof resumable === 'object' && !Array.isArray(resumable)) {
+      const accumulator = (resumable as Record<string, unknown>).accumulator;
+      if (isDocumentPointer(accumulator)) {
+        return docDirectory(accumulator.path);
+      }
+    }
+  }
+
+  const taskId = obj.task_id;
+  if (typeof taskId === 'string' && taskId.length > 0) {
+    // Convention: project documents live under /projects/<task-id>/
+    return `/projects/${taskId}/`;
+  }
+  return null;
+}
+
+/** Build the tail message block injected on task resume (manifest only). */
+export function formatWorkspaceManifestBlock(directoryPrefix: string, indexBody: string): string {
+  const dir = normalizeDirectoryPrefix(directoryPrefix);
+  return [
+    '## Workspace Manifest',
+    '',
+    `Directory \`${dir}\` — index projection only. Use \`doc-read\` for document bodies.`,
+    '',
+    '```markdown',
+    indexBody.trimEnd(),
+    '```',
+  ].join('\n');
+}
+
+export function documentPointerFromProgress(progress: unknown): ResumableDocumentPointer | null {
+  if (!progress || typeof progress !== 'object' || Array.isArray(progress)) return null;
+  const resumable = (progress as Record<string, unknown>).resumable;
+  if (!resumable || typeof resumable !== 'object' || Array.isArray(resumable)) return null;
+  const accumulator = (resumable as Record<string, unknown>).accumulator;
+  return isDocumentPointer(accumulator) ? accumulator : null;
+}

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -31,6 +31,12 @@ import {
   parseDelegateFailureData,
   type DelegationFailureInfo,
 } from './delegation-guard.js';
+import type { WorkingDocsRepo } from '../db/working-docs-repo.js';
+import {
+  buildIndexProjection,
+  formatWorkspaceManifestBlock,
+  resolveWorkspacePrefixFromTaskContent,
+} from './document-workspace.js';
 
 export interface AgentConfig {
   agentId: string;
@@ -135,6 +141,10 @@ export interface AgentConfig {
    *  system prompt (immediately after the identity block) on every task. When omitted,
    *  no injection occurs. */
   securityContextBlock?: string;
+  /** When true, append workspace index manifests to the user message tail on task resume (#1209). */
+  documentWorkspaceEnabled?: boolean;
+  /** Working document repo — required when documentWorkspaceEnabled is true. */
+  workingDocsRepo?: WorkingDocsRepo;
 }
 
 // LLM retry backoff schedule (milliseconds). Three attempts with exponential backoff.
@@ -228,7 +238,24 @@ export class AgentRuntime {
 
   private async processTask(taskEvent: AgentTaskEvent): Promise<void> {
     const { agentId, systemPrompt, provider, bus, logger, memory, executionLayer, skillToolDefs, autonomyService, officeIdentityService } = this.config;
-    const { content, conversationId } = taskEvent.payload;
+    let { content } = taskEvent.payload;
+    const { conversationId } = taskEvent.payload;
+
+    // Manifest-only workspace injection at the message tail — keeps document bodies out
+    // of the cached system prefix (#1209). Best-effort: a missing repo or parse failure
+    // must not abort the task.
+    if (this.config.documentWorkspaceEnabled && this.config.workingDocsRepo) {
+      try {
+        const prefix = resolveWorkspacePrefixFromTaskContent(content);
+        if (prefix) {
+          const documents = await this.config.workingDocsRepo.listByPrefix(prefix);
+          const manifest = buildIndexProjection(prefix, documents);
+          content = `${content}\n\n${formatWorkspaceManifestBlock(prefix, manifest)}`;
+        }
+      } catch (err) {
+        logger.warn({ err, agentId }, 'Document workspace manifest injection failed — proceeding without manifest');
+      }
+    }
 
     // Per-task mutable working copy of the tool list so discovered skills can be
     // appended mid-turn without mutating the shared startup list. Concurrent tasks

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -238,7 +238,8 @@ export class AgentRuntime {
 
   private async processTask(taskEvent: AgentTaskEvent): Promise<void> {
     const { agentId, systemPrompt, provider, bus, logger, memory, executionLayer, skillToolDefs, autonomyService, officeIdentityService } = this.config;
-    let { content } = taskEvent.payload;
+    const originalContent = taskEvent.payload.content;
+    let promptContent = originalContent;
     const { conversationId } = taskEvent.payload;
 
     // Manifest-only workspace injection at the message tail — keeps document bodies out
@@ -246,11 +247,11 @@ export class AgentRuntime {
     // must not abort the task.
     if (this.config.documentWorkspaceEnabled && this.config.workingDocsRepo) {
       try {
-        const prefix = resolveWorkspacePrefixFromTaskContent(content);
+        const prefix = resolveWorkspacePrefixFromTaskContent(originalContent);
         if (prefix) {
           const documents = await this.config.workingDocsRepo.listByPrefix(prefix);
           const manifest = buildIndexProjection(prefix, documents);
-          content = `${content}\n\n${formatWorkspaceManifestBlock(prefix, manifest)}`;
+          promptContent = `${promptContent}\n\n${formatWorkspaceManifestBlock(prefix, manifest)}`;
         }
       } catch (err) {
         logger.warn({ err, agentId }, 'Document workspace manifest injection failed — proceeding without manifest');
@@ -466,7 +467,7 @@ export class AgentRuntime {
     // This matches the design spec priority order and ensures higher-priority tiers
     // (especially security-relevant sender context) aren't starved by greedy history.
     ctxBudget.allocateRequired('system_prompt', [{ role: 'system', content: effectiveSystemPrompt }]);
-    ctxBudget.allocateRequired('user_message', [{ role: 'user', content }]);
+    ctxBudget.allocateRequired('user_message', [{ role: 'user', content: promptContent }]);
     if (ctxBudget.remaining < 0) {
       logger.error(
         { agentId, remaining: ctxBudget.remaining, availableBudget: ctxBudget.availableBudget },
@@ -705,13 +706,13 @@ export class AgentRuntime {
     // Append history and user message to complete the messages array.
     // Final order: system prompt → sender context → bullpen → history → user message.
     messages.push(...budgetedHistory);
-    messages.push({ role: 'user', content });
+    messages.push({ role: 'user', content: promptContent });
 
     logger.info({ agentId, conversationId, historyLength: history.length }, 'Agent processing task');
 
     // Persist the incoming user message
     if (memory) {
-      await memory.addTurn(conversationId, agentId, { role: 'user', content });
+      await memory.addTurn(conversationId, agentId, { role: 'user', content: originalContent });
     }
 
     // Publish context budget telemetry — captures per-tier token estimates even if

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ import { runReadinessChecks } from './startup/readiness.js';
 import { compileSecurityContextBlock } from './security/security-context.js';
 import { OutboundContextService } from './dispatch/outbound-context.js';
 import { applyTaskManagement } from './agents/task-management.js';
+import { applyDocumentWorkspace } from './agents/document-workspace.js';
 import { BacklogHeartbeat } from './scheduler/backlog-heartbeat.js';
 import * as fs from 'node:fs';
 import * as yaml from 'js-yaml';
@@ -1809,10 +1810,14 @@ async function main(): Promise<void> {
     // discipline block, and register heartbeat-eligibility. No-op when the flag is off.
     const taskMgmt = applyTaskManagement(agentConfig, systemPrompt, agentPinnedSkills);
     systemPrompt = taskMgmt.systemPrompt;
-    const effectivePinnedSkills = taskMgmt.pinnedSkills;
+    let effectivePinnedSkills = taskMgmt.pinnedSkills;
     if (taskMgmt.heartbeatEligible) {
       taskManagementAgents.add(agentConfig.name);
     }
+
+    const docWorkspace = applyDocumentWorkspace(agentConfig, systemPrompt, effectivePinnedSkills);
+    systemPrompt = docWorkspace.systemPrompt;
+    effectivePinnedSkills = docWorkspace.pinnedSkills;
 
     // was: const agentToolDefs = skillRegistry.toToolDefinitions(agentPinnedSkills);
     const agentToolDefs = skillRegistry.toToolDefinitions(effectivePinnedSkills);
@@ -1946,6 +1951,8 @@ async function main(): Promise<void> {
       } : undefined,
       bullpenService,
       bullpenWindowMinutes: 60,
+      documentWorkspaceEnabled: agentConfig.enable_task_management === true,
+      workingDocsRepo,
     });
     agent.register();
 

--- a/tests/unit/agents/document-workspace.test.ts
+++ b/tests/unit/agents/document-workspace.test.ts
@@ -95,9 +95,24 @@ describe('extractSectionContent', () => {
   });
 
   it('returns a matching section body', () => {
-    const { content, section } = extractSectionContent('## Alpha\n\none\n\n## Beta\n\ntwo', 'beta');
-    expect(section).toBe('Beta');
-    expect(content.trim()).toBe('two');
+    const result = extractSectionContent('## Alpha\n\none\n\n## Beta\n\ntwo', 'beta');
+    expect(result.section).toBe('Beta');
+    expect(result.found).toBe(true);
+    expect(result.content.trim()).toBe('two');
+  });
+
+  it('marks missing sections with found:false and no section name', () => {
+    const result = extractSectionContent('## Alpha\n\none', 'missing');
+    expect(result.found).toBe(false);
+    expect(result.section).toBeUndefined();
+    expect(result.content).toBe('');
+  });
+
+  it('marks empty sections as found with empty content', () => {
+    const result = extractSectionContent('## Empty\n\n## Next\n\nbody', 'Empty');
+    expect(result.found).toBe(true);
+    expect(result.section).toBe('Empty');
+    expect(result.content).toBe('');
   });
 });
 

--- a/tests/unit/agents/document-workspace.test.ts
+++ b/tests/unit/agents/document-workspace.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyDocumentWorkspace,
+  buildIndexProjection,
+  DOCUMENT_WORKSPACE_BLOCK,
+  DOCUMENT_WORKSPACE_SKILLS,
+  extractSectionContent,
+  formatLogEntry,
+  formatWorkspaceManifestBlock,
+  grepDocuments,
+  indexPathForDirectory,
+  logPathForDocument,
+  resolveWorkspacePrefixFromTaskContent,
+} from '../../../src/agents/document-workspace.js';
+import type { AgentYamlConfig } from '../../../src/agents/loader.js';
+import type { WorkingDocRow } from '../../../src/db/working-docs-repo.js';
+
+function cfg(overrides: Partial<AgentYamlConfig> = {}): AgentYamlConfig {
+  return {
+    name: 'test-agent',
+    model: { tier: 'standard' },
+    system_prompt: 'BASE PROMPT',
+    ...overrides,
+  };
+}
+
+function doc(path: string, overrides: Partial<WorkingDocRow> = {}): WorkingDocRow {
+  return {
+    id: 'id',
+    path,
+    type: 'note',
+    frontmatter: {},
+    body: '',
+    version: 1,
+    sectionVersions: {},
+    byteSize: 0,
+    taskId: null,
+    conversationId: null,
+    agentId: null,
+    createdAt: '2026-06-28T12:00:00.000Z',
+    updatedAt: '2026-06-28T12:00:00.000Z',
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+describe('applyDocumentWorkspace', () => {
+  it('is a no-op when task management is disabled', () => {
+    const r = applyDocumentWorkspace(cfg(), 'BASE PROMPT', ['a']);
+    expect(r.systemPrompt).toBe('BASE PROMPT');
+    expect(r.pinnedSkills).toEqual(['a']);
+  });
+
+  it('appends the block and pins doc skills when task management is enabled', () => {
+    const r = applyDocumentWorkspace(cfg({ enable_task_management: true }), 'BASE PROMPT', ['x']);
+    expect(r.systemPrompt).toBe(`BASE PROMPT\n\n${DOCUMENT_WORKSPACE_BLOCK}`);
+    expect(r.pinnedSkills).toEqual(['x', ...DOCUMENT_WORKSPACE_SKILLS]);
+  });
+
+  it('does not duplicate already-pinned doc skills', () => {
+    const r = applyDocumentWorkspace(
+      cfg({ enable_task_management: true }),
+      'P',
+      ['doc-read', 'other'],
+    );
+    expect(r.pinnedSkills.filter(s => s === 'doc-read')).toHaveLength(1);
+    expect(r.pinnedSkills).toEqual(['doc-read', 'other', 'doc-list', 'doc-write', 'doc-search']);
+  });
+});
+
+describe('buildIndexProjection', () => {
+  it('lists direct children with titles and types', () => {
+    const manifest = buildIndexProjection('/projects/x/', [
+      doc('/projects/x/brief.md', { type: 'project-brief', frontmatter: { title: 'Brief' } }),
+      doc('/projects/x/findings.md', { type: 'findings' }),
+      doc('/projects/x/nested/deep.md'),
+    ]);
+    expect(manifest).toContain('[Brief](/projects/x/brief.md)');
+    expect(manifest).toContain('`project-brief`');
+    expect(manifest).toContain('[findings](/projects/x/findings.md)');
+    expect(manifest).not.toContain('nested/deep');
+  });
+
+  it('returns an empty-directory message when there are no children', () => {
+    const manifest = buildIndexProjection('/scratch/empty/', []);
+    expect(manifest).toContain('No documents');
+  });
+});
+
+describe('extractSectionContent', () => {
+  it('returns the full body when no section is requested', () => {
+    const { content } = extractSectionContent('hello\n\n## One\n\nalpha', undefined);
+    expect(content).toContain('hello');
+    expect(content).toContain('## One');
+  });
+
+  it('returns a matching section body', () => {
+    const { content, section } = extractSectionContent('## Alpha\n\none\n\n## Beta\n\ntwo', 'beta');
+    expect(section).toBe('Beta');
+    expect(content.trim()).toBe('two');
+  });
+});
+
+describe('grepDocuments', () => {
+  it('finds substring matches with line numbers', () => {
+    const matches = grepDocuments([
+      doc('/a.md', { body: 'line one\nneedle here\n' }),
+      doc('/b.md', { body: 'nothing' }),
+    ], 'needle');
+    expect(matches).toEqual([{ path: '/a.md', lineNumber: 2, line: 'needle here' }]);
+  });
+});
+
+describe('resolveWorkspacePrefixFromTaskContent', () => {
+  it('reads a document pointer from progress.resumable.accumulator', () => {
+    const prefix = resolveWorkspacePrefixFromTaskContent(JSON.stringify({
+      progress: {
+        resumable: {
+          accumulator: { kind: 'document', path: '/projects/audit/findings.md', section: 'Flagged' },
+        },
+      },
+    }));
+    expect(prefix).toBe('/projects/audit/');
+  });
+
+  it('falls back to /projects/<task_id>/ when task_id is present', () => {
+    const prefix = resolveWorkspacePrefixFromTaskContent(JSON.stringify({
+      task_id: 'abc-123',
+      title: 'Audit',
+    }));
+    expect(prefix).toBe('/projects/abc-123/');
+  });
+
+  it('returns null for non-JSON content', () => {
+    expect(resolveWorkspacePrefixFromTaskContent('hello')).toBeNull();
+  });
+});
+
+describe('reserved path helpers', () => {
+  it('builds log and index paths', () => {
+    expect(logPathForDocument('/projects/x/brief.md')).toBe('/projects/x/log.md');
+    expect(indexPathForDirectory('/projects/x')).toBe('/projects/x/index.md');
+  });
+
+  it('formats log entries and manifest blocks', () => {
+    expect(formatLogEntry('2026-06-28T12:00:00Z', 'append', 'Added findings')).toContain('append | Added findings');
+    const block = formatWorkspaceManifestBlock('/projects/x/', '# Index\n');
+    expect(block).toContain('Workspace Manifest');
+    expect(block).toContain('# Index');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1209

Implements the agent-facing document workspace surface on top of the #1208 store: four OKF workspace skills, harness-injected guidance, auto-pinning, and manifest-only tail injection for prompt-cache safety.

## Changes

- **`doc-read`** (`action_risk: none`) — read by path, optional `##` section
- **`doc-list`** (`none`) — list a directory prefix; returns the `index.md` projection
- **`doc-write`** (`low`) — create / append / replace / section-edit; appends a `log.md` entry per write
- **`doc-search`** (`none`) — prefix-scoped substring grep across workspace bodies
- **`src/agents/document-workspace.ts`** — shared guidance block, skill list, index/log helpers, manifest formatting
- **Harness injection** — `applyDocumentWorkspace()` gates on `enable_task_management`: appends the workspace discipline block and auto-pins all four `doc-*` skills (no agent YAML edits)
- **Runtime manifest injection** — on task resume, when task JSON carries a resumable document pointer or `task_id`, append the directory `index.md` manifest to the **user message tail** (bodies still fetched via `doc-read` as tool results)
- **Tests** — unit tests for the document-workspace module and each skill handler

## Acceptance criteria

- [x] All four skills callable, gated by `action_risk`, with manifests + handler tests
- [x] Workspace guidance injected at a fixed platform slot for eligible agents; `doc-*` auto-pinned
- [x] Manifest-only injection by default; body/section fetched via `doc-read` as tail tool results
- [x] `doc-write` appends to `log.md`; reserved `index.md` / `log.md` conventions honored

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efbd3d43-0475-4e15-8c2a-1d48951e742f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efbd3d43-0475-4e15-8c2a-1d48951e742f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

