### PR TITLE
feat: spill resumable accumulator into workspace document (#1210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`checkpoint`** — resumable-task primitive writing `progress.resumable`; dedicated skill (not folded into `task-update`) with platform guidance, checkpoint resume injection, a one-time ~15% budget nudge at the message tail, auto-pin even for tool-less agents, and no raw UTC in skill results when timezone is absent. (#1173)
 - **Calendar scheduling rules** — calendar agent loads CEO scheduling rules from `config-store` by key at task start, replacing semantic `memory-query`. (#1223)
 - **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)
+- **Resumable accumulator spill** — inline overflow writes to `/projects/<root>/accumulator.md` and stores a workspace document pointer; resume injects the manifest and spilled doc at the message tail. (#1210)
 - **Document workspace** — `working_documents` / `working_document_links` Postgres store with `WorkingDocsRepo`, OKF frontmatter round-trip, backlink index, and optimistic concurrency (document + per-section). (#1208)
 - **`doc-read` / `doc-list` / `doc-write` / `doc-search`** — OKF workspace skills with harness-injected guidance, auto-pin on task-management agents, manifest-only tail injection, and `log.md` append on writes. (#1209)
 

--- a/src/agents/document-workspace.ts
+++ b/src/agents/document-workspace.ts
@@ -2,6 +2,7 @@ import type { AgentYamlConfig } from './loader.js';
 import type { WorkingDocRow } from '../db/working-docs-repo.js';
 import {
   docDirectory,
+  markdownFenceFor,
   normalizeDocPath,
   splitSections,
 } from '../memory/okf.js';
@@ -266,14 +267,16 @@ export function formatAccumulatorResumeBlock(
 ): string {
   const sectionName = pointer.section ?? resolvedSection;
   const sectionClause = sectionName ? ` (section \`${sectionName}\`)` : '';
+  const trimmed = content.trimEnd();
+  const fence = markdownFenceFor(trimmed);
   return [
     '## Resumable Accumulator',
     '',
     `Document \`${pointer.path}\`${sectionClause} — checkpoint spill from your last run:`,
     '',
-    '```markdown',
-    content.trimEnd(),
-    '```',
+    `${fence}markdown`,
+    trimmed,
+    fence,
   ].join('\n');
 }
 

--- a/src/agents/document-workspace.ts
+++ b/src/agents/document-workspace.ts
@@ -182,8 +182,8 @@ export function grepDocuments(
   return matches;
 }
 
-/** Parse scheduler / task-wake JSON content for a workspace directory prefix. */
-export function resolveWorkspacePrefixFromTaskContent(content: string): string | null {
+/** Parse scheduler / task-wake JSON content. Returns null for non-JSON payloads. */
+export function parseTaskWakePayload(content: string): Record<string, unknown> | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
@@ -191,25 +191,57 @@ export function resolveWorkspacePrefixFromTaskContent(content: string): string |
     return null;
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
-  const obj = parsed as Record<string, unknown>;
+  return parsed as Record<string, unknown>;
+}
 
-  const progress = obj.progress;
-  if (progress && typeof progress === 'object' && !Array.isArray(progress)) {
-    const resumable = (progress as Record<string, unknown>).resumable;
-    if (resumable && typeof resumable === 'object' && !Array.isArray(resumable)) {
-      const accumulator = (resumable as Record<string, unknown>).accumulator;
-      if (isDocumentPointer(accumulator)) {
-        return docDirectory(accumulator.path);
-      }
-    }
+function resolveWorkspacePrefixFromPayload(
+  payload: Record<string, unknown>,
+  rootTaskId?: string,
+): string | null {
+  const pointer = documentPointerFromProgress(payload.progress);
+  if (pointer) {
+    return docDirectory(pointer.path);
   }
 
-  const taskId = obj.task_id;
-  if (typeof taskId === 'string' && taskId.length > 0) {
-    // Convention: project documents live under /projects/<task-id>/
-    return `/projects/${taskId}/`;
+  const taskId = typeof payload.task_id === 'string' && payload.task_id.length > 0
+    ? payload.task_id
+    : null;
+  if (!taskId) return null;
+
+  // Convention: project documents live under /projects/<root-task-id>/ (#1210).
+  const resolvedRoot = rootTaskId ?? taskId;
+  return `/projects/${resolvedRoot}/`;
+}
+
+/** Parse scheduler / task-wake JSON content for a workspace directory prefix. */
+export function resolveWorkspacePrefixFromTaskContent(content: string): string | null {
+  const payload = parseTaskWakePayload(content);
+  if (!payload) return null;
+  return resolveWorkspacePrefixFromPayload(payload);
+}
+
+/** Resolve the workspace directory prefix, optionally walking to the project-root task. */
+export async function resolveWorkspaceDirectoryPrefix(
+  content: string,
+  resolveRootTaskId?: (taskId: string) => Promise<string | null>,
+): Promise<string | null> {
+  const payload = parseTaskWakePayload(content);
+  if (!payload) return null;
+
+  let rootTaskId: string | undefined;
+  if (resolveRootTaskId && typeof payload.task_id === 'string' && payload.task_id.length > 0) {
+    const root = await resolveRootTaskId(payload.task_id);
+    if (root) rootTaskId = root;
   }
-  return null;
+
+  return resolveWorkspacePrefixFromPayload(payload, rootTaskId);
+}
+
+/** Read a document pointer from scheduler / task-wake JSON content. */
+export function documentPointerFromTaskContent(content: string): ResumableDocumentPointer | null {
+  const payload = parseTaskWakePayload(content);
+  if (!payload) return null;
+  return documentPointerFromProgress(payload.progress);
 }
 
 /** Build the tail message block injected on task resume (manifest only). */
@@ -222,6 +254,25 @@ export function formatWorkspaceManifestBlock(directoryPrefix: string, indexBody:
     '',
     '```markdown',
     indexBody.trimEnd(),
+    '```',
+  ].join('\n');
+}
+
+/** Build the tail message block for a spilled resumable accumulator document (#1210). */
+export function formatAccumulatorResumeBlock(
+  pointer: ResumableDocumentPointer,
+  content: string,
+  resolvedSection?: string,
+): string {
+  const sectionName = pointer.section ?? resolvedSection;
+  const sectionClause = sectionName ? ` (section \`${sectionName}\`)` : '';
+  return [
+    '## Resumable Accumulator',
+    '',
+    `Document \`${pointer.path}\`${sectionClause} — checkpoint spill from your last run:`,
+    '',
+    '```markdown',
+    content.trimEnd(),
     '```',
   ].join('\n');
 }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -42,10 +42,14 @@ import {
   type DelegationFailureInfo,
 } from './delegation-guard.js';
 import type { WorkingDocsRepo } from '../db/working-docs-repo.js';
+import type { TaskRepo } from '../db/task-repo.js';
 import {
   buildIndexProjection,
+  documentPointerFromTaskContent,
+  extractSectionContent,
+  formatAccumulatorResumeBlock,
   formatWorkspaceManifestBlock,
-  resolveWorkspacePrefixFromTaskContent,
+  resolveWorkspaceDirectoryPrefix,
 } from './document-workspace.js';
 
 export interface AgentConfig {
@@ -155,6 +159,8 @@ export interface AgentConfig {
   documentWorkspaceEnabled?: boolean;
   /** Working document repo — required when documentWorkspaceEnabled is true. */
   workingDocsRepo?: WorkingDocsRepo;
+  /** Task repo — used to resolve project-root workspace prefixes on resume (#1210). */
+  taskRepo?: TaskRepo;
 }
 
 // LLM retry backoff schedule (milliseconds). Three attempts with exponential backoff.
@@ -253,17 +259,37 @@ export class AgentRuntime {
     const { conversationId } = taskEvent.payload;
 
     // Manifest-only workspace injection at the message tail — keeps document bodies out
-    // of the cached system prefix (#1209). Best-effort: a missing repo or parse failure
-    // must not abort the task. Parse originalContent only — never the post-append string.
+    // of the cached system prefix (#1209). Spilled accumulator content is injected here
+    // too (#1210). Best-effort: a missing repo or parse failure must not abort the task.
+    // Parse originalContent only — never the post-append string.
     let workspaceManifestInjected = false;
     if (this.config.documentWorkspaceEnabled && this.config.workingDocsRepo) {
       try {
-        const prefix = resolveWorkspacePrefixFromTaskContent(originalContent);
+        const resolveRoot = this.config.taskRepo
+          ? (taskId: string) => this.config.taskRepo!.resolveProjectRootTaskId(taskId)
+          : undefined;
+        const prefix = await resolveWorkspaceDirectoryPrefix(originalContent, resolveRoot);
         if (prefix) {
           const documents = await this.config.workingDocsRepo.listByPrefix(prefix);
           const manifest = buildIndexProjection(prefix, documents);
           promptContent = `${promptContent}\n\n${formatWorkspaceManifestBlock(prefix, manifest)}`;
           workspaceManifestInjected = true;
+        }
+
+        const pointer = documentPointerFromTaskContent(originalContent);
+        if (pointer) {
+          const doc = await this.config.workingDocsRepo.read(pointer.path);
+          if (doc) {
+            const sectionResult = extractSectionContent(doc.body, pointer.section);
+            const content = pointer.section && sectionResult.found !== false
+              ? sectionResult.content
+              : doc.body;
+            promptContent = `${promptContent}\n\n${formatAccumulatorResumeBlock(
+              pointer,
+              content,
+              sectionResult.section,
+            )}`;
+          }
         }
       } catch (err) {
         logger.warn({ err, agentId }, 'Document workspace manifest injection failed — proceeding without manifest');

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -275,7 +275,11 @@ export class AgentRuntime {
           promptContent = `${promptContent}\n\n${formatWorkspaceManifestBlock(prefix, manifest)}`;
           workspaceManifestInjected = true;
         }
+      } catch (err) {
+        logger.warn({ err, agentId }, 'Document workspace manifest injection failed — proceeding without manifest');
+      }
 
+      try {
         const pointer = documentPointerFromTaskContent(originalContent);
         if (pointer) {
           const doc = await this.config.workingDocsRepo.read(pointer.path);
@@ -292,7 +296,10 @@ export class AgentRuntime {
           }
         }
       } catch (err) {
-        logger.warn({ err, agentId }, 'Document workspace manifest injection failed — proceeding without manifest');
+        logger.warn(
+          { err, agentId },
+          'Resumable accumulator document injection failed — proceeding without spilled accumulator content',
+        );
       }
     }
 

--- a/src/db/resumable-accumulator-spill.test.ts
+++ b/src/db/resumable-accumulator-spill.test.ts
@@ -52,6 +52,13 @@ describe('accumulatorDocPath / formatAccumulatorDocumentBody', () => {
     expect(body).toContain('```json');
     expect(body).toContain('"a"');
   });
+
+  it('uses a longer fence when serialized JSON contains backticks', () => {
+    const body = formatAccumulatorDocumentBody(['```']);
+    expect(body).toContain('````json');
+    expect(body).toContain('````\n');
+    expect(body).not.toMatch(/\n```\n\[/);
+  });
 });
 
 describe('spillInlineAccumulator', () => {
@@ -91,6 +98,25 @@ describe('spillInlineAccumulator', () => {
       expectedVersion: 2,
       taskId: 'root',
     }));
+  });
+
+  it('retries as update when concurrent writers race on first create', async () => {
+    const existing = makeDoc({ version: 1 });
+    const read = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(existing);
+    const create = vi.fn(async () => { throw new Error('duplicate key'); });
+    const update = vi.fn(async () => ({ ok: true as const, document: makeDoc({ version: 2 }) }));
+    const repo = { create, read, update } as unknown as WorkingDocsRepo;
+
+    const pointer = await spillInlineAccumulator(repo, {
+      rootTaskId: 'root',
+      inlineValue: ['did:plc:abc'],
+    });
+
+    expect(pointer.path).toBe('/projects/root/accumulator.md');
+    expect(create).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/db/resumable-accumulator-spill.test.ts
+++ b/src/db/resumable-accumulator-spill.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ACCUMULATOR_DOC_TYPE,
+  accumulatorDocPath,
+  formatAccumulatorDocumentBody,
+  prepareResumableBlockWithSpill,
+  spillInlineAccumulator,
+} from './resumable-accumulator-spill.js';
+import {
+  RESUMABLE_BLOCK_MAX_BYTES,
+  RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
+  documentAccumulatorPointer,
+  isDocumentPointer,
+  resumableBlockBytes,
+} from './resumable-progress.js';
+import type { WorkingDocsRepo, WorkingDocRow } from './working-docs-repo.js';
+
+const BASE_INPUT = {
+  cursor: 'page:3',
+  done: 300,
+  total: 1300,
+  accumulator: ['did:plc:abc'],
+  lastSliceUnits: 25,
+  next: 'Review page 4',
+};
+
+function makeDoc(overrides: Partial<WorkingDocRow> = {}): WorkingDocRow {
+  return {
+    id: 'doc-id',
+    path: '/projects/root/accumulator.md',
+    type: ACCUMULATOR_DOC_TYPE,
+    frontmatter: {},
+    body: '',
+    version: 1,
+    sectionVersions: {},
+    byteSize: 0,
+    taskId: 'root',
+    conversationId: null,
+    agentId: 'agent',
+    createdAt: '2026-06-28T12:00:00.000Z',
+    updatedAt: '2026-06-28T12:00:00.000Z',
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+describe('accumulatorDocPath / formatAccumulatorDocumentBody', () => {
+  it('builds the project-root spill path and JSON body', () => {
+    expect(accumulatorDocPath('abc-123')).toBe('/projects/abc-123/accumulator.md');
+    const body = formatAccumulatorDocumentBody(['a', 'b']);
+    expect(body).toContain('# Accumulator');
+    expect(body).toContain('```json');
+    expect(body).toContain('"a"');
+  });
+});
+
+describe('spillInlineAccumulator', () => {
+  it('creates a new workspace document on first spill', async () => {
+    const create = vi.fn(async () => makeDoc());
+    const read = vi.fn(async () => null);
+    const repo = { create, read, update: vi.fn() } as unknown as WorkingDocsRepo;
+
+    const pointer = await spillInlineAccumulator(repo, {
+      rootTaskId: 'root',
+      agentId: 'social-media',
+      inlineValue: ['did:plc:abc'],
+    });
+
+    expect(pointer).toEqual(documentAccumulatorPointer('/projects/root/accumulator.md'));
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      path: '/projects/root/accumulator.md',
+      type: ACCUMULATOR_DOC_TYPE,
+      taskId: 'root',
+      agentId: 'social-media',
+    }));
+  });
+
+  it('updates an existing spill document', async () => {
+    const existing = makeDoc({ version: 2, body: 'old' });
+    const read = vi.fn(async () => existing);
+    const update = vi.fn(async () => ({ ok: true as const, document: makeDoc({ version: 3 }) }));
+    const repo = { create: vi.fn(), read, update } as unknown as WorkingDocsRepo;
+
+    const pointer = await spillInlineAccumulator(repo, {
+      rootTaskId: 'root',
+      inlineValue: ['did:plc:def'],
+    });
+
+    expect(pointer.path).toBe('/projects/root/accumulator.md');
+    expect(update).toHaveBeenCalledWith('/projects/root/accumulator.md', expect.objectContaining({
+      expectedVersion: 2,
+      taskId: 'root',
+    }));
+  });
+});
+
+describe('prepareResumableBlockWithSpill', () => {
+  it('passes through valid inline blocks unchanged', async () => {
+    const repo = { create: vi.fn(), read: vi.fn(), update: vi.fn() } as unknown as WorkingDocsRepo;
+    const result = await prepareResumableBlockWithSpill(BASE_INPUT, {
+      workingDocsRepo: repo,
+      rootTaskId: 'root',
+      taskId: 'child',
+    });
+    expect(result.ok).toBe(true);
+    expect(repo.create).not.toHaveBeenCalled();
+  });
+
+  it('spills inline overflow and stores a document pointer', async () => {
+    const big = 'x'.repeat(RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES);
+    const create = vi.fn(async () => makeDoc());
+    const repo = {
+      create,
+      read: vi.fn(async () => null),
+      update: vi.fn(),
+    } as unknown as WorkingDocsRepo;
+
+    const result = await prepareResumableBlockWithSpill(
+      { ...BASE_INPUT, accumulator: [big] },
+      { workingDocsRepo: repo, rootTaskId: 'root', taskId: 'child', agentId: 'agent' },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(isDocumentPointer(result.block.accumulator)).toBe(true);
+    expect(resumableBlockBytes(result.block)).toBeLessThanOrEqual(RESUMABLE_BLOCK_MAX_BYTES);
+    expect(create).toHaveBeenCalledOnce();
+  });
+});

--- a/src/db/resumable-accumulator-spill.ts
+++ b/src/db/resumable-accumulator-spill.ts
@@ -1,0 +1,105 @@
+// resumable-accumulator-spill.ts — spill inline resumable accumulators into the OKF workspace (#1210).
+//
+// When progress.resumable.accumulator exceeds the inline cap (#1172), the overflow is
+// written to a workspace document and replaced with a { kind: "document", path } pointer.
+
+import type { WorkingDocsRepo } from './working-docs-repo.js';
+import {
+  documentAccumulatorPointer,
+  isDocumentPointer,
+  prepareResumableBlock,
+  type PrepareResumableBlockInput,
+  type ResumableDocumentPointer,
+  type ResumableWriteResult,
+} from './resumable-progress.js';
+
+export const ACCUMULATOR_DOC_LEAF = 'accumulator.md';
+export const ACCUMULATOR_DOC_TYPE = 'resumable-accumulator';
+
+/** Workspace path for a project's spilled accumulator document. */
+export function accumulatorDocPath(rootTaskId: string): string {
+  return `/projects/${rootTaskId}/${ACCUMULATOR_DOC_LEAF}`;
+}
+
+/** Serialize an inline accumulator value into OKF markdown body text. */
+export function formatAccumulatorDocumentBody(value: unknown): string {
+  return [
+    '# Accumulator',
+    '',
+    'Checkpoint spill from `progress.resumable`. After the initial spill, grow this document',
+    'with `doc-write` and keep the resumable block\'s accumulator as the document pointer.',
+    '',
+    '```json',
+    JSON.stringify(value, null, 2),
+    '```',
+    '',
+  ].join('\n');
+}
+
+export interface SpillInlineAccumulatorParams {
+  rootTaskId: string;
+  agentId?: string;
+  inlineValue: unknown;
+}
+
+/** Write (or replace) the spilled accumulator document and return its pointer. */
+export async function spillInlineAccumulator(
+  repo: WorkingDocsRepo,
+  params: SpillInlineAccumulatorParams,
+): Promise<ResumableDocumentPointer> {
+  const path = accumulatorDocPath(params.rootTaskId);
+  const body = formatAccumulatorDocumentBody(params.inlineValue);
+  const existing = await repo.read(path);
+
+  if (!existing) {
+    await repo.create({
+      path,
+      type: ACCUMULATOR_DOC_TYPE,
+      body,
+      taskId: params.rootTaskId,
+      agentId: params.agentId,
+    });
+    return documentAccumulatorPointer(path);
+  }
+
+  let expectedVersion = existing.version;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const result = await repo.update(path, {
+      body,
+      expectedVersion,
+      taskId: params.rootTaskId,
+    });
+    if (result.ok) {
+      return documentAccumulatorPointer(path);
+    }
+    expectedVersion = result.document.version;
+  }
+
+  throw new Error(`resumable-accumulator-spill: failed to update ${path} after retries`);
+}
+
+export interface PrepareResumableBlockWithSpillParams {
+  workingDocsRepo: WorkingDocsRepo;
+  rootTaskId: string;
+  taskId: string;
+  agentId?: string;
+}
+
+/** Validate a resumable block, spilling inline overflow to the workspace when needed. */
+export async function prepareResumableBlockWithSpill(
+  input: PrepareResumableBlockInput,
+  spill: PrepareResumableBlockWithSpillParams,
+): Promise<ResumableWriteResult> {
+  const first = prepareResumableBlock(input);
+  if (first.ok) return first;
+  if (first.code !== 'inline_accumulator_overflow') return first;
+  if (isDocumentPointer(input.accumulator)) return first;
+
+  const pointer = await spillInlineAccumulator(spill.workingDocsRepo, {
+    rootTaskId: spill.rootTaskId,
+    agentId: spill.agentId,
+    inlineValue: input.accumulator,
+  });
+
+  return prepareResumableBlock({ ...input, accumulator: pointer });
+}

--- a/src/db/resumable-accumulator-spill.ts
+++ b/src/db/resumable-accumulator-spill.ts
@@ -4,6 +4,7 @@
 // written to a workspace document and replaced with a { kind: "document", path } pointer.
 
 import type { WorkingDocsRepo } from './working-docs-repo.js';
+import { markdownFenceFor } from '../memory/okf.js';
 import {
   documentAccumulatorPointer,
   isDocumentPointer,
@@ -23,15 +24,17 @@ export function accumulatorDocPath(rootTaskId: string): string {
 
 /** Serialize an inline accumulator value into OKF markdown body text. */
 export function formatAccumulatorDocumentBody(value: unknown): string {
+  const serialized = JSON.stringify(value, null, 2) ?? 'null';
+  const fence = markdownFenceFor(serialized);
   return [
     '# Accumulator',
     '',
     'Checkpoint spill from `progress.resumable`. After the initial spill, grow this document',
     'with `doc-write` and keep the resumable block\'s accumulator as the document pointer.',
     '',
-    '```json',
-    JSON.stringify(value, null, 2),
-    '```',
+    `${fence}json`,
+    serialized,
+    fence,
     '',
   ].join('\n');
 }
@@ -49,33 +52,36 @@ export async function spillInlineAccumulator(
 ): Promise<ResumableDocumentPointer> {
   const path = accumulatorDocPath(params.rootTaskId);
   const body = formatAccumulatorDocumentBody(params.inlineValue);
-  const existing = await repo.read(path);
 
-  if (!existing) {
-    await repo.create({
-      path,
-      type: ACCUMULATOR_DOC_TYPE,
-      body,
-      taskId: params.rootTaskId,
-      agentId: params.agentId,
-    });
-    return documentAccumulatorPointer(path);
-  }
-
-  let expectedVersion = existing.version;
   for (let attempt = 0; attempt < 3; attempt++) {
+    const existing = await repo.read(path);
+    if (!existing) {
+      try {
+        await repo.create({
+          path,
+          type: ACCUMULATOR_DOC_TYPE,
+          body,
+          taskId: params.rootTaskId,
+          agentId: params.agentId,
+        });
+        return documentAccumulatorPointer(path);
+      } catch {
+        // Another writer created accumulator.md between read and create — retry.
+        continue;
+      }
+    }
+
     const result = await repo.update(path, {
       body,
-      expectedVersion,
+      expectedVersion: existing.version,
       taskId: params.rootTaskId,
     });
     if (result.ok) {
       return documentAccumulatorPointer(path);
     }
-    expectedVersion = result.document.version;
   }
 
-  throw new Error(`resumable-accumulator-spill: failed to update ${path} after retries`);
+  throw new Error(`resumable-accumulator-spill: failed to write ${path} after retries`);
 }
 
 export interface PrepareResumableBlockWithSpillParams {
@@ -95,11 +101,15 @@ export async function prepareResumableBlockWithSpill(
   if (first.code !== 'inline_accumulator_overflow') return first;
   if (isDocumentPointer(input.accumulator)) return first;
 
-  const pointer = await spillInlineAccumulator(spill.workingDocsRepo, {
+  const pointer = documentAccumulatorPointer(accumulatorDocPath(spill.rootTaskId));
+  const preparedPointer = prepareResumableBlock({ ...input, accumulator: pointer });
+  if (!preparedPointer.ok) return preparedPointer;
+
+  await spillInlineAccumulator(spill.workingDocsRepo, {
     rootTaskId: spill.rootTaskId,
     agentId: spill.agentId,
     inlineValue: input.accumulator,
   });
 
-  return prepareResumableBlock({ ...input, accumulator: pointer });
+  return preparedPointer;
 }

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -260,11 +260,11 @@ export class TaskRepo {
     const seen = new Set<string>();
 
     while (currentId) {
-      if (seen.has(currentId)) break;
+      if (seen.has(currentId)) return null;
       seen.add(currentId);
-      rootId = currentId;
       const task = await this.getTask(currentId);
-      if (!task) return rootId;
+      if (!task) return null;
+      rootId = task.id;
       currentId = task.parentTaskId;
     }
 
@@ -611,6 +611,9 @@ export class TaskRepo {
     const current = await this.getTask(taskId);
     if (!current) {
       return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
+    }
+    if (TERMINAL_STATUSES.has(current.status)) {
+      return { ok: false, code: 'invalid_block', message: `task ${taskId} is in a terminal state` };
     }
 
     let prepared = prepareResumableBlock(input);

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -23,6 +23,8 @@ import {
   type ResumableProgressBlock,
   type ResumableWriteResult,
 } from './resumable-progress.js';
+import { prepareResumableBlockWithSpill } from './resumable-accumulator-spill.js';
+import type { WorkingDocsRepo } from './working-docs-repo.js';
 
 // All SELECT / RETURNING clauses use this column list. Centralised so a schema
 // change only needs updating in one place.
@@ -96,6 +98,7 @@ export class TaskRepo {
     private readonly bus: EventBus,
     private readonly logger: Logger,
     private readonly timezone: string = 'UTC',
+    private readonly workingDocsRepo?: WorkingDocsRepo,
   ) {}
 
   /**
@@ -248,6 +251,24 @@ export class TaskRepo {
     );
     const row = rows[0] as DbTaskRow | undefined;
     return row ? mapTaskRow(row) : null;
+  }
+
+  /** Walk parent_task_id links to the project-root task (#1210). Returns null when not found. */
+  async resolveProjectRootTaskId(taskId: string): Promise<string | null> {
+    let currentId: string | null = taskId;
+    let rootId: string | null = null;
+    const seen = new Set<string>();
+
+    while (currentId) {
+      if (seen.has(currentId)) break;
+      seen.add(currentId);
+      rootId = currentId;
+      const task = await this.getTask(currentId);
+      if (!task) return rootId;
+      currentId = task.parentTaskId;
+    }
+
+    return rootId;
   }
 
   /**
@@ -580,7 +601,7 @@ export class TaskRepo {
 
   /**
    * Persist a resumable checkpoint under progress.resumable. Enforces inline accumulator
-   * and block size caps — overflow requires spilling to the document workspace (#1210).
+   * and block size caps — inline overflow spills to the document workspace (#1210).
    */
   async setResumableBlock(
     taskId: string,
@@ -592,7 +613,19 @@ export class TaskRepo {
       return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
     }
 
-    const prepared = prepareResumableBlock(input);
+    let prepared = prepareResumableBlock(input);
+    if (!prepared.ok && prepared.code === 'inline_accumulator_overflow' && this.workingDocsRepo) {
+      const rootTaskId = await this.resolveProjectRootTaskId(taskId);
+      if (!rootTaskId) {
+        return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
+      }
+      prepared = await prepareResumableBlockWithSpill(input, {
+        workingDocsRepo: this.workingDocsRepo,
+        rootTaskId,
+        taskId,
+        agentId: callerAgentId,
+      });
+    }
     if (!prepared.ok) return prepared;
 
     const { rows } = await this.pool.query(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1205,8 +1205,8 @@ async function main(): Promise<void> {
   const auditLogRepo = new AuditLogRepo(pool, logger);
 
   // TaskRepo — used by task-create, task-list, task-update, task-complete skills.
-  const taskRepo = new TaskRepo(pool, bus, logger, config.timezone);
   const workingDocsRepo = new WorkingDocsRepo(pool, logger);
+  const taskRepo = new TaskRepo(pool, bus, logger, config.timezone, workingDocsRepo);
 
   // principalContact + principalIdentities were resolved once near the top of bootstrap
   // (see the "Principal contact resolution" block above, #1049). They are reused here for
@@ -1953,6 +1953,7 @@ async function main(): Promise<void> {
       bullpenWindowMinutes: 60,
       documentWorkspaceEnabled: agentConfig.enable_task_management === true,
       workingDocsRepo,
+      taskRepo: agentConfig.enable_task_management === true ? taskRepo : undefined,
     });
     agent.register();
 

--- a/src/memory/okf.ts
+++ b/src/memory/okf.ts
@@ -248,3 +248,10 @@ export function editSectionBody(
   sections[idx] = { heading: existing.heading, content: updatedContent };
   return joinSections(preamble, sections);
 }
+
+/** Build a backtick fence long enough to wrap content that may contain nested fences. */
+export function markdownFenceFor(content: string, minTicks = 3): string {
+  const runs = content.match(/`+/g) ?? [];
+  const longest = runs.length > 0 ? Math.max(...runs.map(run => run.length)) : 0;
+  return '`'.repeat(Math.max(minTicks, longest + 1));
+}

--- a/tests/integration/task-resumable-progress.test.ts
+++ b/tests/integration/task-resumable-progress.test.ts
@@ -4,13 +4,18 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import pg from 'pg';
 import pino from 'pino';
 import { TaskRepo } from '../../src/db/task-repo.js';
+import { WorkingDocsRepo } from '../../src/db/working-docs-repo.js';
 import {
   RESUMABLE_BLOCK_MAX_BYTES,
-  RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
   documentAccumulatorPointer,
+  isDocumentPointer,
   resumableBlockBytes,
-  inlineAccumulatorBytes,
 } from '../../src/db/resumable-progress.js';
+import { accumulatorDocPath } from '../../src/db/resumable-accumulator-spill.js';
+import {
+  documentPointerFromTaskContent,
+  resolveWorkspaceDirectoryPrefix,
+} from '../../src/agents/document-workspace.js';
 import type { EventBus } from '../../src/bus/bus.js';
 
 const { Pool } = pg;
@@ -27,15 +32,19 @@ async function cleanup(pool: pg.Pool): Promise<void> {
     [`${PREFIX}%`],
   );
   await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+  await pool.query('DELETE FROM working_document_links');
+  await pool.query(`DELETE FROM working_documents WHERE path LIKE '/projects/%'`);
 }
 
-describeIf('TaskRepo resumable progress (#1172)', () => {
+describeIf('TaskRepo resumable progress (#1172, #1210)', () => {
   let pool: pg.Pool;
   let repo: TaskRepo;
+  let workingDocs: WorkingDocsRepo;
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
-    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+    workingDocs = new WorkingDocsRepo(pool, logger as never);
+    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC', workingDocs);
   });
   afterAll(async () => { await cleanup(pool); await pool.end(); });
   beforeEach(async () => { await cleanup(pool); });
@@ -129,45 +138,105 @@ describeIf('TaskRepo resumable progress (#1172)', () => {
     expect(block?.accumulator).toEqual(pointer);
   });
 
-  it('stress: repeated checkpoints cannot grow progress.resumable past the cap', async () => {
+  it('stress: inline overflow auto-spills and progress stays under the cap', async () => {
     const task = await repo.createTask({
       agentId: 'social-media',
-      title: `${PREFIX} stress`,
+      title: `${PREFIX} stress spill`,
       source: 'coordinator',
     });
 
     let flagged: string[] = [];
-    let lastGoodBlock = await repo.getResumableBlock(task.id);
+    let accumulator: unknown = flagged;
+    let spilled = false;
 
     for (let i = 0; i < 500; i++) {
-      flagged = [...flagged, `did:plc:${String(i).padStart(6, '0')}`];
+      if (!spilled) {
+        flagged = [...flagged, `did:plc:${String(i).padStart(6, '0')}`];
+        accumulator = flagged;
+      }
+
       const result = await repo.setResumableBlock(task.id, {
         cursor: String(i),
         done: i + 1,
         total: 1300,
-        accumulator: flagged,
+        accumulator,
         lastSliceUnits: 25,
         next: 'Keep paging',
-      });
+      }, 'social-media');
 
-      if (!('task' in result)) {
-        expect(result.ok).toBe(false);
-        if (result.ok) return;
-        expect(result.code).toBe('inline_accumulator_overflow');
-        expect(lastGoodBlock).not.toBeNull();
-        expect(resumableBlockBytes(lastGoodBlock!)).toBeLessThanOrEqual(RESUMABLE_BLOCK_MAX_BYTES);
-        expect(inlineAccumulatorBytes(lastGoodBlock!.accumulator)).toBeLessThanOrEqual(
-          RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
-        );
-        return;
+      expect('task' in result).toBe(true);
+      if (!('task' in result)) return;
+
+      if (!spilled && isDocumentPointer(result.block.accumulator)) {
+        spilled = true;
+        accumulator = result.block.accumulator;
+        const doc = await workingDocs.read(result.block.accumulator.path);
+        expect(doc?.body).toContain('"did:plc:');
       }
 
-      lastGoodBlock = result.block;
+      expect(resumableBlockBytes(result.block)).toBeLessThanOrEqual(RESUMABLE_BLOCK_MAX_BYTES);
       const persisted = await repo.getResumableBlock(task.id);
       expect(persisted).not.toBeNull();
       expect(resumableBlockBytes(persisted!)).toBeLessThanOrEqual(RESUMABLE_BLOCK_MAX_BYTES);
     }
 
-    throw new Error('expected inline accumulator overflow before 500 iterations');
+    expect(spilled).toBe(true);
+  });
+
+  it('round-trip: child task spill, resume prefix, and continue from pointer', async () => {
+    const parent = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} parent`,
+      source: 'coordinator',
+    });
+    const child = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} child`,
+      source: 'coordinator',
+      parentTaskId: parent.id,
+    });
+
+    const flagged = Array.from({ length: 400 }, (_, i) => `did:plc:${String(i).padStart(6, '0')}`);
+    const spill = await repo.setResumableBlock(child.id, {
+      cursor: 'page:10',
+      done: 400,
+      total: 1300,
+      accumulator: flagged,
+      lastSliceUnits: 25,
+      next: 'Review page 11 from workspace doc',
+    }, 'social-media');
+    expect('task' in spill).toBe(true);
+    if (!('task' in spill)) return;
+
+    const pointer = spill.block.accumulator;
+    expect(isDocumentPointer(pointer)).toBe(true);
+    if (!isDocumentPointer(pointer)) return;
+    expect(pointer.path).toBe(accumulatorDocPath(parent.id));
+
+    const doc = await workingDocs.read(pointer.path);
+    expect(doc?.body).toContain('"did:plc:000000"');
+
+    const wakeContent = JSON.stringify({
+      task_id: child.id,
+      progress: (await repo.getTask(child.id))?.progress ?? {},
+    });
+    expect(documentPointerFromTaskContent(wakeContent)?.path).toBe(pointer.path);
+    expect(await resolveWorkspaceDirectoryPrefix(
+      wakeContent,
+      (taskId) => repo.resolveProjectRootTaskId(taskId),
+    )).toBe(`/projects/${parent.id}/`);
+
+    const resumed = await repo.setResumableBlock(child.id, {
+      cursor: 'page:11',
+      done: 425,
+      total: 1300,
+      accumulator: pointer,
+      lastSliceUnits: 25,
+      next: 'Finish remaining pages',
+    }, 'social-media');
+    expect('task' in resumed).toBe(true);
+    if (!('task' in resumed)) return;
+    expect(resumed.block.cursor).toBe('page:11');
+    expect(resumed.block.accumulator).toEqual(pointer);
   });
 });

--- a/tests/integration/task-resumable-progress.test.ts
+++ b/tests/integration/task-resumable-progress.test.ts
@@ -27,13 +27,27 @@ const logger = pino({ level: 'silent' });
 const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
 
 async function cleanup(pool: pg.Pool): Promise<void> {
+  const titleLike = `${PREFIX}%`;
   await pool.query(
     `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
-    [`${PREFIX}%`],
+    [titleLike],
   );
-  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
-  await pool.query('DELETE FROM working_document_links');
-  await pool.query(`DELETE FROM working_documents WHERE path LIKE '/projects/%'`);
+  await pool.query(
+    `DELETE FROM working_document_links
+      WHERE source_path IN (
+        SELECT wd.path
+        FROM working_documents wd
+        INNER JOIN tasks t ON t.id = wd.task_id
+        WHERE t.title LIKE $1
+      )`,
+    [titleLike],
+  );
+  await pool.query(
+    `DELETE FROM working_documents
+      WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [titleLike],
+  );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [titleLike]);
 }
 
 describeIf('TaskRepo resumable progress (#1172, #1210)', () => {

--- a/tests/unit/agents/document-workspace.test.ts
+++ b/tests/unit/agents/document-workspace.test.ts
@@ -203,4 +203,13 @@ describe('parseTaskWakePayload / resume helpers (#1210)', () => {
     expect(block).toContain('Resumable Accumulator');
     expect(block).toContain('`/projects/x/accumulator.md`');
   });
+
+  it('uses a longer fence when spilled content already contains fences', () => {
+    const block = formatAccumulatorResumeBlock(
+      { kind: 'document', path: '/projects/x/accumulator.md' },
+      '```markdown\nnested\n```',
+    );
+    expect(block).toContain('````markdown');
+    expect(block.trimEnd()).toMatch(/````$/);
+  });
 });

--- a/tests/unit/agents/document-workspace.test.ts
+++ b/tests/unit/agents/document-workspace.test.ts
@@ -4,12 +4,16 @@ import {
   buildIndexProjection,
   DOCUMENT_WORKSPACE_BLOCK,
   DOCUMENT_WORKSPACE_SKILLS,
+  documentPointerFromTaskContent,
   extractSectionContent,
+  formatAccumulatorResumeBlock,
   formatLogEntry,
   formatWorkspaceManifestBlock,
   grepDocuments,
   indexPathForDirectory,
   logPathForDocument,
+  parseTaskWakePayload,
+  resolveWorkspaceDirectoryPrefix,
   resolveWorkspacePrefixFromTaskContent,
 } from '../../../src/agents/document-workspace.js';
 import type { AgentYamlConfig } from '../../../src/agents/loader.js';
@@ -162,5 +166,41 @@ describe('reserved path helpers', () => {
     const block = formatWorkspaceManifestBlock('/projects/x/', '# Index\n');
     expect(block).toContain('Workspace Manifest');
     expect(block).toContain('# Index');
+  });
+});
+
+describe('parseTaskWakePayload / resume helpers (#1210)', () => {
+  it('parses JSON wake payloads and rejects non-JSON', () => {
+    expect(parseTaskWakePayload(JSON.stringify({ task_id: 'abc' }))).toEqual({ task_id: 'abc' });
+    expect(parseTaskWakePayload('hello')).toBeNull();
+  });
+
+  it('reads a document pointer from task wake content', () => {
+    const pointer = documentPointerFromTaskContent(JSON.stringify({
+      task_id: 'leaf',
+      progress: {
+        resumable: {
+          accumulator: { kind: 'document', path: '/projects/root/accumulator.md' },
+        },
+      },
+    }));
+    expect(pointer?.path).toBe('/projects/root/accumulator.md');
+  });
+
+  it('walks to the project root for child task wakes', async () => {
+    const prefix = await resolveWorkspaceDirectoryPrefix(
+      JSON.stringify({ task_id: 'child-task' }),
+      async () => 'root-task',
+    );
+    expect(prefix).toBe('/projects/root-task/');
+  });
+
+  it('formats spilled accumulator content for resume injection', () => {
+    const block = formatAccumulatorResumeBlock(
+      { kind: 'document', path: '/projects/x/accumulator.md' },
+      '# Accumulator\n\n```json\n[]\n```',
+    );
+    expect(block).toContain('Resumable Accumulator');
+    expect(block).toContain('`/projects/x/accumulator.md`');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1210

Bridges the resumable-tasks accumulator cap (#1172) with the OKF document workspace (#1208): when an inline accumulator exceeds 4 KB, the checkpoint path now spills it into a workspace document and stores a `{ kind: "document", path }` pointer in `progress.resumable`.

## Changes

- **`resumable-accumulator-spill`** — writes overflow to `/projects/<root-task-id>/accumulator.md` and returns a document pointer.
- **`TaskRepo.setResumableBlock`** — auto-spills on inline overflow when `WorkingDocsRepo` is wired; resolves the project-root task by walking `parent_task_id`.
- **`AgentRuntime` resume injection** — resolves the project-root workspace prefix, injects the directory manifest (#1209), and appends the spilled accumulator document body at the message tail.

## Acceptance criteria

- [x] Inline overflow spills to a workspace doc; the resumable block stores the path pointer.
- [x] On resume, the agent receives the pointer and the doc content; `tasks.progress` stays under cap on a long job (stress test).
- [x] Round-trip: long job spills, pauses, resumes from cursor + doc, completes — no orphaned state.

## Tests

- Unit: spill helpers, workspace resume formatting, project-root prefix resolution.
- Integration: auto-spill stress loop, child-task spill to parent workspace, resume prefix + pointer round-trip.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cdd55ac-466e-4e71-980a-09a70bcda3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cdd55ac-466e-4e71-980a-09a70bcda3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

