### PR TITLE
feat: resumable paused-as-success contract + budget→pause safety-net (#1174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Resumable executor contract** — `done | paused | failed` outcomes; budget-hit on a checkpointed resumable task pauses from the last checkpoint instead of `BUDGET_EXCEEDED`, and the coordinator treats `paused` as success (no re-delegation). (#1174)
 - **`checkpoint`** — resumable-task primitive writing `progress.resumable`; dedicated skill (not folded into `task-update`) with platform guidance, checkpoint resume injection, a one-time ~15% budget nudge at the message tail, auto-pin even for tool-less agents, and no raw UTC in skill results when timezone is absent. (#1173)
 - **Calendar scheduling rules** — calendar agent loads CEO scheduling rules from `config-store` by key at task start, replacing semantic `memory-query`. (#1223)
 - **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Resumable executor contract** — `done | paused | failed` outcomes; budget-hit on a checkpointed resumable task pauses from the last checkpoint instead of `BUDGET_EXCEEDED`, and the coordinator treats `paused` as success (no re-delegation). (#1174)
+- **Resumable executor contract** — checkpointed budget-hit pauses instead of `BUDGET_EXCEEDED`; coordinator treats `paused` as success. (#1174)
 - **`checkpoint`** — resumable-task primitive writing `progress.resumable`; dedicated skill (not folded into `task-update`) with platform guidance, checkpoint resume injection, a one-time ~15% budget nudge at the message tail, auto-pin even for tool-less agents, and no raw UTC in skill results when timezone is absent. (#1173)
 - **Calendar scheduling rules** — calendar agent loads CEO scheduling rules from `config-store` by key at task start, replacing semantic `memory-query`. (#1223)
 - **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.11.0"
+version: "0.11.1"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -265,6 +265,19 @@ system_prompt: |
   4. The specialist resumes with full context automatically. Handle the result
      normally — it may be a final answer or another clarification request.
      Multiple clarification rounds are supported.
+
+  ### Handling resumable-task pauses (partial progress, not failure)
+  When delegate returns with `paused: true`, a specialist made real progress on a
+  long resumable task but hit its per-slice turn budget. This is **success at the
+  delegation layer**, not a timeout or error.
+
+  1. **Do not re-delegate** the same work in this turn or immediately retry — the
+     platform schedules a continuation automatically.
+  2. Record the progress using the `done`, `total`, and `message` fields. Optionally
+     tell the CEO "still working, X of Y" in your own voice when they are waiting
+     on synchronous channels.
+  3. Treat `paused` differently from `failed` — never confabulate an external cause
+     (API timeout, service outage) when the reason is budget exhaustion with progress.
 
   ## What I Do Directly
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -271,8 +271,9 @@ system_prompt: |
   long resumable task but hit its per-slice turn budget. This is **success at the
   delegation layer**, not a timeout or error.
 
-  1. **Do not re-delegate** the same work in this turn or immediately retry — the
-     platform schedules a continuation automatically.
+  1. **Do not re-delegate** the same work in this turn or immediately retry in this
+     conversation turn. Continuation is not automatic in this release — do not assume
+     the platform will resume the task on its own.
   2. Record the progress using the `done`, `total`, and `message` fields. Optionally
      tell the CEO "still working, X of Y" in your own voice when they are waiting
      on synchronous channels.

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -26,6 +26,11 @@ import { createAgentTask, type AgentResponseEvent, type AgentResponseFailureReas
 // future format change can't silently desync this handler from runtime.ts and the resume subscriber.
 import { decodeResumeToken, RESUME_TOKEN_VERSION } from '../../src/agents/resume-token.js';
 import { delegationKey } from '../../src/agents/delegation-guard.js';
+import {
+  EXECUTION_PAUSED_PROTOCOL,
+  formatPausedProgressMessage,
+  parseExecutionPausedPayload,
+} from '../../src/agents/resumable-task.js';
 
 // Default wait for the specialist to respond — appropriate for interactive tasks.
 // Long-running scheduled tasks should pass timeout_ms explicitly (injected by the runtime
@@ -330,6 +335,23 @@ export class DelegateHandler implements SkillHandler {
               }
               reject(new Error(`Specialist '${agent}' encountered an error and could not complete the task`));
             } else {
+              const pausedPayload = parseExecutionPausedPayload(responseEvent.payload.content);
+              if (pausedPayload) {
+                resolve(JSON.stringify({
+                  _curia_protocol: EXECUTION_PAUSED_PROTOCOL,
+                  agent,
+                  task_id: pausedPayload.task_id,
+                  done: pausedPayload.done,
+                  total: pausedPayload.total,
+                  next: pausedPayload.next,
+                  message: formatPausedProgressMessage({
+                    done: pausedPayload.done,
+                    total: pausedPayload.total,
+                    next: pausedPayload.next,
+                  }),
+                }));
+                return;
+              }
               resolve(responseEvent.payload.content);
             }
           }
@@ -398,6 +420,41 @@ export class DelegateHandler implements SkillHandler {
                 question,
                 context: ctxValue,
                 resume_token: resumeToken,
+              },
+            };
+          }
+        }
+
+        if (parsed._curia_protocol === EXECUTION_PAUSED_PROTOCOL) {
+          const done = parsed.done;
+          const total = parsed.total;
+          const next = parsed.next;
+          const message = parsed.message;
+          if (
+            typeof done !== 'number' ||
+            typeof total !== 'number' ||
+            typeof next !== 'string' ||
+            typeof message !== 'string'
+          ) {
+            ctx.log.warn(
+              { targetAgent: agent },
+              'Execution paused protocol marker present but payload fields are invalid — falling back to raw response',
+            );
+          } else {
+            ctx.log.info(
+              { targetAgent: agent, done, total },
+              'Specialist paused mid-task — returning typed paused result to coordinator',
+            );
+            return {
+              success: true,
+              data: {
+                agent,
+                paused: true,
+                done,
+                total,
+                next,
+                message,
+                ...(typeof parsed.task_id === 'string' && { task_id: parsed.task_id }),
               },
             };
           }

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -335,7 +335,7 @@ export class DelegateHandler implements SkillHandler {
               }
               reject(new Error(`Specialist '${agent}' encountered an error and could not complete the task`));
             } else {
-              const pausedPayload = parseExecutionPausedPayload(responseEvent.payload.content);
+              const pausedPayload = parseExecutionPausedPayload(responseEvent.payload.content, ctx.log);
               if (pausedPayload) {
                 resolve(JSON.stringify({
                   _curia_protocol: EXECUTION_PAUSED_PROTOCOL,

--- a/src/agents/resumable-task.test.ts
+++ b/src/agents/resumable-task.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildCheckpointBudgetNudgeMessage,
+  buildExecutionPausedResponse,
   buildResumableCheckpointResumeBlock,
   buildResumableTaskGuidanceBlock,
   boundTaskFromSchedulerContent,
   checkpointNudgeThreshold,
+  EXECUTION_PAUSED_PROTOCOL,
+  formatPausedProgressMessage,
   isResumableTask,
+  parseDelegatePausedData,
+  parseExecutionPausedPayload,
   resolveBoundTaskContext,
   shouldSendCheckpointBudgetNudge,
 } from './resumable-task.js';
 import type { ResumableProgressBlock } from '../db/resumable-progress.js';
+import { readResumableBlock } from '../db/resumable-progress.js';
 
 describe('isResumableTask', () => {
   it('returns true when error_budget.resumable is set', () => {
@@ -124,5 +130,77 @@ describe('buildCheckpointBudgetNudgeMessage', () => {
     const msg = buildCheckpointBudgetNudgeMessage(3, 20);
     expect(msg).toContain('3 of 20');
     expect(msg).toContain('checkpoint');
+  });
+});
+
+describe('executor outcome contract (#1174)', () => {
+  const checkpoint: ResumableProgressBlock = {
+    cursor: 'page-3',
+    done: 12,
+    total: 1300,
+    accumulator: [],
+    lastSliceUnits: 12,
+    next: 'Continue paging follows',
+    checkpointedAt: '2026-06-28T12:00:00.000Z',
+  };
+
+  it('round-trips execution_paused protocol JSON', () => {
+    const content = buildExecutionPausedResponse({
+      taskId: '00000000-0000-0000-0000-000000000099',
+      progress: checkpoint,
+    });
+    const parsed = parseExecutionPausedPayload(content);
+    expect(parsed?._curia_protocol).toBe(EXECUTION_PAUSED_PROTOCOL);
+    expect(parsed?.task_id).toBe('00000000-0000-0000-0000-000000000099');
+    expect(parsed?.done).toBe(12);
+    expect(parsed?.total).toBe(1300);
+    expect(parsed?.next).toBe('Continue paging follows');
+  });
+
+  it('formats paused progress message for coordinator consumption', () => {
+    expect(formatPausedProgressMessage(checkpoint)).toBe(
+      'Still working — 12 of 1300 complete. Continue paging follows',
+    );
+  });
+
+  it('parses delegate paused payload', () => {
+    const data = parseDelegatePausedData({
+      paused: true,
+      agent: 'social-media',
+      task_id: 'task-1',
+      done: 12,
+      total: 1300,
+      next: 'Continue',
+      message: 'Still working — 12 of 1300 complete. Continue',
+    });
+    expect(data?.paused).toBe(true);
+    expect(data?.agent).toBe('social-media');
+    expect(data?.task_id).toBe('task-1');
+  });
+
+  it('resolves scheduler metadata with checkpoint for budget safety-net (#1174)', () => {
+    const ctx = resolveBoundTaskContext(
+      {
+        boundTask: {
+          taskId: 'task-resumable-1',
+          errorBudget: { resumable: true },
+          progress: {
+            resumable: {
+              cursor: 'page-2',
+              done: 25,
+              total: 1300,
+              accumulator: [],
+              lastSliceUnits: 25,
+              next: 'Continue paging',
+            },
+          },
+        },
+      },
+      JSON.stringify({ task_id: 'task-resumable-1' }),
+      'scheduler',
+    );
+    expect(ctx).not.toBeNull();
+    expect(isResumableTask(ctx!)).toBe(true);
+    expect(readResumableBlock(ctx!.progress ?? {})).not.toBeNull();
   });
 });

--- a/src/agents/resumable-task.ts
+++ b/src/agents/resumable-task.ts
@@ -181,3 +181,123 @@ export function enrichBoundTaskWorkspace(ctx: BoundTaskContext, rawTaskContent: 
   const prefix = resolveWorkspacePrefixFromTaskContent(rawTaskContent);
   if (prefix) ctx.workspaceManifestPath = indexPathForDirectory(prefix);
 }
+
+// ---------------------------------------------------------------------------
+// Executor outcome contract (#1174) — done | paused | failed{reason, retryable}
+// ---------------------------------------------------------------------------
+
+/** Protocol marker on agent.response when a resumable executor pauses mid-work. */
+export const EXECUTION_PAUSED_PROTOCOL = 'execution_paused';
+
+/** Coarse failure reasons for executor invocations (planner-facing). */
+export type ExecutorFailureReason =
+  | 'budget_max_turns'
+  | 'tool_error'
+  | 'api_error'
+  | 'blocked';
+
+export type ExecutorOutcome =
+  | { status: 'done' }
+  | { status: 'paused'; taskId?: string; progress: ResumableProgressBlock }
+  | { status: 'failed'; reason: ExecutorFailureReason; retryable: boolean };
+
+export interface ExecutionPausedPayload {
+  _curia_protocol: typeof EXECUTION_PAUSED_PROTOCOL;
+  task_id?: string;
+  done: number;
+  total: number;
+  cursor: ResumableProgressBlock['cursor'];
+  last_slice_units: number;
+  next: string;
+}
+
+export interface DelegatePausedResult {
+  paused: true;
+  agent: string;
+  task_id?: string;
+  done: number;
+  total: number;
+  next: string;
+  message: string;
+}
+
+/** Human-readable progress summary for coordinator / delegate consumers. */
+export function formatPausedProgressMessage(
+  progress: Pick<ResumableProgressBlock, 'done' | 'total' | 'next'>,
+): string {
+  return `Still working — ${progress.done} of ${progress.total} complete. ${progress.next}`;
+}
+
+/** Build the deterministic JSON body for a paused executor response. */
+export function buildExecutionPausedResponse(options: {
+  taskId?: string;
+  progress: ResumableProgressBlock;
+}): string {
+  const payload: ExecutionPausedPayload = {
+    _curia_protocol: EXECUTION_PAUSED_PROTOCOL,
+    done: options.progress.done,
+    total: options.progress.total,
+    cursor: options.progress.cursor,
+    last_slice_units: options.progress.lastSliceUnits,
+    next: options.progress.next,
+  };
+  if (options.taskId) payload.task_id = options.taskId;
+  return JSON.stringify(payload);
+}
+
+/** Parse a paused protocol payload from agent.response content. */
+export function parseExecutionPausedPayload(content: string): ExecutionPausedPayload | null {
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    if (parsed['_curia_protocol'] !== EXECUTION_PAUSED_PROTOCOL) return null;
+    if (typeof parsed['done'] !== 'number' || typeof parsed['total'] !== 'number') return null;
+    if (typeof parsed['next'] !== 'string') return null;
+    if (typeof parsed['last_slice_units'] !== 'number') return null;
+    const cursor = parsed['cursor'];
+    if (cursor !== null && typeof cursor !== 'string' && !isPlainObject(cursor)) return null;
+    const payload: ExecutionPausedPayload = {
+      _curia_protocol: EXECUTION_PAUSED_PROTOCOL,
+      done: parsed['done'],
+      total: parsed['total'],
+      cursor: cursor as ResumableProgressBlock['cursor'],
+      last_slice_units: parsed['last_slice_units'],
+      next: parsed['next'],
+    };
+    if (typeof parsed['task_id'] === 'string' && parsed['task_id'].length > 0) {
+      payload.task_id = parsed['task_id'];
+    }
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse a delegate skill success payload that carries paused (not failed) fields. */
+export function parseDelegatePausedData(data: unknown): DelegatePausedResult | null {
+  if (data === null || data === undefined) return null;
+  let record: Record<string, unknown>;
+  if (typeof data === 'string') {
+    try {
+      record = JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  } else if (typeof data === 'object' && !Array.isArray(data)) {
+    record = data as Record<string, unknown>;
+  } else {
+    return null;
+  }
+  if (record['paused'] !== true) return null;
+  if (typeof record['agent'] !== 'string') return null;
+  if (typeof record['done'] !== 'number' || typeof record['total'] !== 'number') return null;
+  if (typeof record['next'] !== 'string' || typeof record['message'] !== 'string') return null;
+  return {
+    paused: true,
+    agent: record['agent'],
+    done: record['done'],
+    total: record['total'],
+    next: record['next'],
+    message: record['message'],
+    ...(typeof record['task_id'] === 'string' && { task_id: record['task_id'] }),
+  };
+}

--- a/src/agents/resumable-task.ts
+++ b/src/agents/resumable-task.ts
@@ -8,6 +8,7 @@ import {
   readResumableBlock,
   type ResumableProgressBlock,
 } from '../db/resumable-progress.js';
+import type { Logger } from '../logger.js';
 import {
   indexPathForDirectory,
   resolveWorkspacePrefixFromTaskContent,
@@ -246,7 +247,7 @@ export function buildExecutionPausedResponse(options: {
 }
 
 /** Parse a paused protocol payload from agent.response content. */
-export function parseExecutionPausedPayload(content: string): ExecutionPausedPayload | null {
+export function parseExecutionPausedPayload(content: string, logger?: Logger): ExecutionPausedPayload | null {
   try {
     const parsed = JSON.parse(content) as Record<string, unknown>;
     if (parsed['_curia_protocol'] !== EXECUTION_PAUSED_PROTOCOL) return null;
@@ -267,19 +268,27 @@ export function parseExecutionPausedPayload(content: string): ExecutionPausedPay
       payload.task_id = parsed['task_id'];
     }
     return payload;
-  } catch {
+  } catch (err) {
+    logger?.warn(
+      { err, contentPreview: content.slice(0, 200) },
+      'Failed to parse execution_paused protocol payload — treating as non-paused response',
+    );
     return null;
   }
 }
 
 /** Parse a delegate skill success payload that carries paused (not failed) fields. */
-export function parseDelegatePausedData(data: unknown): DelegatePausedResult | null {
+export function parseDelegatePausedData(data: unknown, logger?: Logger): DelegatePausedResult | null {
   if (data === null || data === undefined) return null;
   let record: Record<string, unknown>;
   if (typeof data === 'string') {
     try {
       record = JSON.parse(data) as Record<string, unknown>;
-    } catch {
+    } catch (err) {
+      logger?.warn(
+        { err, dataPreview: data.slice(0, 200) },
+        'Failed to parse delegate paused payload JSON — treating as non-paused result',
+      );
       return null;
     }
   } else if (typeof data === 'object' && !Array.isArray(data)) {

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -22,14 +22,17 @@ import { formatTurnBudgetBlock } from './turn-budget.js';
 import type { OfficeIdentityService } from '../identity/service.js';
 import {
   buildCheckpointBudgetNudgeMessage,
+  buildExecutionPausedResponse,
   buildResumableCheckpointResumeBlock,
   buildResumableTaskGuidanceBlock,
   CHECKPOINT_SKILL_NAME,
   isResumableTask,
+  parseDelegatePausedData,
   resolveBoundTaskContext,
   shouldSendCheckpointBudgetNudge,
+  type BoundTaskContext,
 } from './resumable-task.js';
-import { readResumableBlock } from '../db/resumable-progress.js';
+import { readResumableBlock, type ResumableProgressBlock } from '../db/resumable-progress.js';
 import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js';
 import { buildRateLimitSourceKey } from '../memory/rate-limit-key.js';
 import type { AgentRegistry } from './agent-registry.js';
@@ -894,7 +897,12 @@ export class AgentRuntime {
       budget.turnsUsed++;
       maybeAppendCheckpointBudgetNudge();
       if (budget.turnsUsed >= budget.maxTurns) {
-        await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns');
+        await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', {
+          conversationId,
+          skillsCalled,
+          boundTaskCtx,
+          memory,
+        });
         return;
       }
 
@@ -1166,6 +1174,7 @@ export class AgentRuntime {
           // record the outcome and escalate to the CEO backlog when retries are exhausted or
           // the failure is non-retryable. Short-circuit the turn after escalation so the LLM
           // cannot blind-re-delegate in subsequent rounds.
+          // Paused delegate results (#1174) are success at the delegation layer — do not record.
           if (
             toolCall.name === 'delegate' &&
             !delegateBlocked &&
@@ -1173,24 +1182,27 @@ export class AgentRuntime {
             skillInput !== null &&
             !Array.isArray(skillInput)
           ) {
-            const delegateFailure = parseDelegateFailureData(result.data, logger);
-            if (delegateFailure) {
-              const delegateInput = skillInput as Record<string, unknown>;
-              const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
-              const dKey = delegationKey(delegateFailure.agent, delegateTask);
-              delegationGuard.recordFailure(dKey, delegateFailure);
-              if (delegationGuard.shouldEscalate(dKey)) {
-                const escalated = await escalateDelegationFailure(
-                  executionLayer,
-                  caller,
-                  invokeOptions,
-                  { ...delegateFailure, task: delegateTask },
-                  logger,
-                );
-                if (escalated) {
-                  delegationGuard.markEscalated(dKey);
+            const delegatePaused = parseDelegatePausedData(result.data);
+            if (!delegatePaused) {
+              const delegateFailure = parseDelegateFailureData(result.data, logger);
+              if (delegateFailure) {
+                const delegateInput = skillInput as Record<string, unknown>;
+                const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
+                const dKey = delegationKey(delegateFailure.agent, delegateTask);
+                delegationGuard.recordFailure(dKey, delegateFailure);
+                if (delegationGuard.shouldEscalate(dKey)) {
+                  const escalated = await escalateDelegationFailure(
+                    executionLayer,
+                    caller,
+                    invokeOptions,
+                    { ...delegateFailure, task: delegateTask },
+                    logger,
+                  );
+                  if (escalated) {
+                    delegationGuard.markEscalated(dKey);
+                  }
+                  pendingDelegationEscalation = { ...delegateFailure, task: delegateTask, escalated };
                 }
-                pendingDelegationEscalation = { ...delegateFailure, task: delegateTask, escalated };
               }
             }
           }
@@ -1370,7 +1382,12 @@ export class AgentRuntime {
         // Count the recovery call against the turn budget — it is a real LLM round-trip.
         budget.turnsUsed++;
         if (budget.turnsUsed >= budget.maxTurns) {
-          await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns');
+          await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', {
+            conversationId,
+            skillsCalled,
+            boundTaskCtx,
+            memory,
+          });
           return;
         }
 
@@ -1810,13 +1827,40 @@ export class AgentRuntime {
   /**
    * Handle budget exhaustion: log, publish a BUDGET_EXCEEDED agent.error event,
    * and send a user-facing error response.
+   *
+   * Safety-net (#1174): on maxTurns for a resumable task with a persisted checkpoint,
+   * convert the budget hit into a paused executor outcome instead of BUDGET_EXCEEDED.
    */
   private async handleBudgetExceeded(
     budget: ErrorBudget,
     taskEvent: AgentTaskEvent,
     reason: 'maxTurns' | 'maxConsecutiveErrors',
+    handoff?: {
+      conversationId: string;
+      skillsCalled: string[];
+      boundTaskCtx: BoundTaskContext | null;
+      memory?: WorkingMemory;
+    },
   ): Promise<void> {
     const { agentId, logger } = this.config;
+
+    if (reason === 'maxTurns' && handoff?.boundTaskCtx && isResumableTask(handoff.boundTaskCtx)) {
+      const checkpoint = readResumableBlock(handoff.boundTaskCtx.progress ?? {});
+      if (checkpoint) {
+        await this.publishExecutionPaused(
+          taskEvent,
+          handoff.boundTaskCtx.taskId,
+          checkpoint,
+          handoff.conversationId,
+          handoff.skillsCalled,
+          handoff.memory,
+          budget,
+          reason,
+        );
+        return;
+      }
+    }
+
     const message = reason === 'maxTurns'
       ? `Task exceeded turn budget (${budget.turnsUsed}/${budget.maxTurns} turns used)`
       : `Task exceeded consecutive error budget (${budget.consecutiveErrors}/${budget.maxConsecutiveErrors} consecutive errors)`;
@@ -1833,6 +1877,42 @@ export class AgentRuntime {
     };
     await this.publishAgentError(agentErr, taskEvent);
     await this.sendErrorResponse(taskEvent, agentErr);
+  }
+
+  /**
+   * Emit a paused executor outcome from the last persisted checkpoint (#1174).
+   * Success at the delegation layer — not isError, no BUDGET_EXCEEDED.
+   */
+  private async publishExecutionPaused(
+    taskEvent: AgentTaskEvent,
+    taskId: string,
+    checkpoint: ResumableProgressBlock,
+    conversationId: string,
+    skillsCalled: string[],
+    memory: WorkingMemory | undefined,
+    budget: ErrorBudget,
+    reason: 'maxTurns',
+  ): Promise<void> {
+    const { agentId, bus, logger } = this.config;
+    logger.info(
+      { agentId, taskId, done: checkpoint.done, total: checkpoint.total, budget, reason },
+      'Resumable task hit turn budget — pausing from last checkpoint',
+    );
+
+    const content = buildExecutionPausedResponse({ taskId, progress: checkpoint });
+
+    if (memory) {
+      await memory.addTurn(conversationId, agentId, { role: 'assistant', content });
+    }
+
+    const responseEvent = createAgentResponse({
+      agentId,
+      conversationId,
+      content,
+      skillsCalled,
+      parentEventId: taskEvent.id,
+    });
+    await bus.publish('agent', responseEvent);
   }
 
   /**

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -483,6 +483,12 @@ export class AgentRuntime {
 
     let checkpointBudgetNudgeSent = false;
 
+    // Accumulate skill names across all tool-use turns so we can report them
+    // on the agent.response event for audit and monitoring.
+    const skillsCalled: string[] = [];
+    // Threaded into every maxTurns budget check (tool loop, recovery, chatWithRetry).
+    const budgetHandoff = { conversationId, skillsCalled, boundTaskCtx, memory };
+
     // Append intent anchor — present only for persistent scheduler tasks that have a
     // linked agent_task record. Injected near the end so it sits close to the conversation
     // and remains maximally salient. It is non-negotiable: the agent may evolve its
@@ -846,7 +852,7 @@ export class AgentRuntime {
     // The loop exits when: the LLM returns text, the budget is exhausted, or
     // consecutive errors exceed the threshold.
     maybeAppendCheckpointBudgetNudge();
-    let response = await this.chatWithRetry(provider, { messages, tools: workingToolDefs }, budget, taskEvent);
+    let response = await this.chatWithRetry(provider, { messages, tools: workingToolDefs }, budget, taskEvent, budgetHandoff);
     if (!response) return; // chatWithRetry already published error events
 
     // Extract caller context once — it doesn't change between tool-use rounds.
@@ -876,10 +882,6 @@ export class AgentRuntime {
       caller = { contactId: originator.contactId, role: null, channel: originator.channel };
     }
 
-    // Accumulate skill names across all tool-use turns so we can report them
-    // on the agent.response event for audit and monitoring.
-    const skillsCalled: string[] = [];
-
     // Clarification short-circuit state. When a specialist calls request-clarification,
     // the runtime detects the protocol marker in the skill result and short-circuits the
     // tool-use loop — emitting a deterministic JSON response instead of asking the LLM
@@ -897,12 +899,7 @@ export class AgentRuntime {
       budget.turnsUsed++;
       maybeAppendCheckpointBudgetNudge();
       if (budget.turnsUsed >= budget.maxTurns) {
-        await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', {
-          conversationId,
-          skillsCalled,
-          boundTaskCtx,
-          memory,
-        });
+        await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', budgetHandoff);
         return;
       }
 
@@ -1182,7 +1179,7 @@ export class AgentRuntime {
             skillInput !== null &&
             !Array.isArray(skillInput)
           ) {
-            const delegatePaused = parseDelegatePausedData(result.data);
+            const delegatePaused = parseDelegatePausedData(result.data, logger);
             if (!delegatePaused) {
               const delegateFailure = parseDelegateFailureData(result.data, logger);
               if (delegateFailure) {
@@ -1344,7 +1341,7 @@ export class AgentRuntime {
 
       maybeAppendCheckpointBudgetNudge();
       // Continue the loop — the full conversation history is now in messages
-      response = await this.chatWithRetry(provider, { messages, tools: workingToolDefs }, budget, taskEvent);
+      response = await this.chatWithRetry(provider, { messages, tools: workingToolDefs }, budget, taskEvent, budgetHandoff);
       if (!response) return; // chatWithRetry already published error events
     }
 
@@ -1382,17 +1379,12 @@ export class AgentRuntime {
         // Count the recovery call against the turn budget — it is a real LLM round-trip.
         budget.turnsUsed++;
         if (budget.turnsUsed >= budget.maxTurns) {
-          await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', {
-            conversationId,
-            skillsCalled,
-            boundTaskCtx,
-            memory,
-          });
+          await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', budgetHandoff);
           return;
         }
 
         // Call without tools — the LLM must produce text, it cannot call more tools.
-        const recovery = await this.chatWithRetry(provider, { messages }, budget, taskEvent);
+        const recovery = await this.chatWithRetry(provider, { messages }, budget, taskEvent, budgetHandoff);
         // chatWithRetry returns null when it has already published error events and sent an
         // error response — bail out here to avoid double-publishing a second response event
         // and writing a phantom turn to working memory.
@@ -1576,6 +1568,12 @@ export class AgentRuntime {
     params: { messages: Message[]; tools?: ToolDefinition[] },
     budget: ErrorBudget,
     taskEvent: AgentTaskEvent,
+    budgetHandoff?: {
+      conversationId: string;
+      skillsCalled: string[];
+      boundTaskCtx: BoundTaskContext | null;
+      memory?: WorkingMemory;
+    },
   ): Promise<LLMResponse | null> {
     const { agentId, bus, logger } = this.config;
 
@@ -1711,6 +1709,9 @@ export class AgentRuntime {
           };
           budget.consecutiveErrors += 1;
           budget.turnsUsed += 1;
+          if (await this.enforceMaxTurnsBudget(budget, taskEvent, budgetHandoff)) {
+            return null;
+          }
           logger.error(
             { agentId, err, fallbackModel: this.config.fallbackModel },
             'Fallback provider threw an unexpected exception',
@@ -1748,6 +1749,9 @@ export class AgentRuntime {
         const fallbackIncrement = fallbackErr.type === 'AUTH_FAILURE' ? 2 : 1;
         budget.consecutiveErrors += fallbackIncrement;
         budget.turnsUsed += fallbackIncrement;
+        if (await this.enforceMaxTurnsBudget(budget, taskEvent, budgetHandoff)) {
+          return null;
+        }
         logger.error(
           { agentId, errorType: fallbackErr.type, fallbackModel: this.config.fallbackModel },
           'Fallback model also failed',
@@ -1764,6 +1768,9 @@ export class AgentRuntime {
       const increment = agentErr.type === 'AUTH_FAILURE' ? 2 : 1;
       budget.consecutiveErrors += increment;
       budget.turnsUsed += increment;
+      if (await this.enforceMaxTurnsBudget(budget, taskEvent, budgetHandoff)) {
+        return null;
+      }
       logger.error({ agentId, errorType: agentErr.type, source: agentErr.source }, 'Non-retryable LLM error');
       await this.publishAgentError(agentErr, taskEvent);
       await this.sendErrorResponse(taskEvent, agentErr);
@@ -1779,6 +1786,10 @@ export class AgentRuntime {
       // Increment budget counters for the failed attempt.
       budget.consecutiveErrors++;
       budget.turnsUsed++;
+
+      if (await this.enforceMaxTurnsBudget(budget, taskEvent, budgetHandoff)) {
+        return null;
+      }
 
       // Check budget before waiting — if already exceeded, no point retrying
       if (budget.consecutiveErrors >= budget.maxConsecutiveErrors) {
@@ -1822,6 +1833,25 @@ export class AgentRuntime {
     await this.publishAgentError(latestErr, taskEvent);
     await this.sendErrorResponse(taskEvent, latestErr);
     return null;
+  }
+
+  /**
+   * When maxTurns is exhausted, run the pause safety-net or honest failure path.
+   * Returns true when the task should stop (paused or failed response published).
+   */
+  private async enforceMaxTurnsBudget(
+    budget: ErrorBudget,
+    taskEvent: AgentTaskEvent,
+    handoff?: {
+      conversationId: string;
+      skillsCalled: string[];
+      boundTaskCtx: BoundTaskContext | null;
+      memory?: WorkingMemory;
+    },
+  ): Promise<boolean> {
+    if (budget.turnsUsed < budget.maxTurns) return false;
+    await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', handoff);
+    return true;
   }
 
   /**

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -2117,7 +2117,7 @@ describe('AgentRuntime resumable budget safety-net (#1174)', () => {
       chat: vi.fn(async () => ({
         type: 'error' as const,
         error: {
-          type: 'RATE_LIMITED',
+          type: 'RATE_LIMIT' as const,
           source: 'mock',
           message: 'rate limited',
           retryable: true,

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -2107,6 +2107,76 @@ describe('AgentRuntime resumable budget safety-net (#1174)', () => {
     expect(agentResponses[0]?.payload.isError).toBe(true);
     expect(agentResponses[0]?.payload.reason).toBe('maxTurns');
   });
+
+  it('pauses when maxTurns is exhausted inside chatWithRetry retry path', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const retryableErrorProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async () => ({
+        type: 'error' as const,
+        error: {
+          type: 'RATE_LIMITED',
+          source: 'mock',
+          message: 'rate limited',
+          retryable: true,
+          context: {},
+          timestamp: new Date(),
+        },
+      })),
+    };
+
+    const agentErrors: AgentErrorEvent[] = [];
+    bus.subscribe('agent.error', 'system', (event) => {
+      agentErrors.push(event as AgentErrorEvent);
+    });
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'social-media',
+      systemPrompt: 'You are a social media specialist.',
+      provider: retryableErrorProvider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      errorBudget: { maxTurns: 1, maxConsecutiveErrors: 10 },
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'social-media',
+      conversationId: 'conv-resumable-retry-pause',
+      channelId: 'scheduler',
+      senderId: 'scheduler',
+      content: JSON.stringify({ task_id: 'task-resumable-retry' }),
+      metadata: {
+        boundTask: {
+          taskId: 'task-resumable-retry',
+          errorBudget: { resumable: true },
+          progress: {
+            resumable: {
+              cursor: 'page-1',
+              done: 10,
+              total: 100,
+              accumulator: [],
+              lastSliceUnits: 10,
+              next: 'Continue',
+            },
+          },
+        },
+      },
+      parentEventId: 'parent-resumable-retry',
+    }));
+
+    expect(agentErrors).toHaveLength(0);
+    expect(agentResponses).toHaveLength(1);
+    const parsed = JSON.parse(agentResponses[0]!.payload.content) as { _curia_protocol: string };
+    expect(parsed._curia_protocol).toBe('execution_paused');
+  });
 });
 
 // -- Structured error injection test --

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1717,6 +1717,7 @@ describe('AgentRuntime error budget', () => {
 
     const mockExecution = {
       invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+      getToolDefinitions: vi.fn().mockReturnValue([]),
     } as unknown as ExecutionLayer;
 
     const agentErrors: AgentErrorEvent[] = [];
@@ -1929,6 +1930,7 @@ describe('AgentRuntime error budget', () => {
 
     const mockExecution = {
       invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+      getToolDefinitions: vi.fn().mockReturnValue([]),
     } as unknown as ExecutionLayer;
 
     const agentErrors: AgentErrorEvent[] = [];
@@ -1965,6 +1967,145 @@ describe('AgentRuntime error budget', () => {
     expect(mockExecution.invoke).toHaveBeenCalledTimes(19);
     expect(agentErrors).toHaveLength(1);
     expect(agentErrors[0]?.payload.errorType).toBe('BUDGET_EXCEEDED');
+  });
+});
+
+describe('AgentRuntime resumable budget safety-net (#1174)', () => {
+  const toolDef = {
+    name: 'web-fetch',
+    description: 'Fetch',
+    input_schema: { type: 'object' as const, properties: {}, required: [] as string[] },
+  };
+
+  const resumableCheckpoint = {
+    cursor: 'page-2',
+    done: 25,
+    total: 1300,
+    accumulator: [],
+    lastSliceUnits: 25,
+    next: 'Continue paging',
+  };
+
+  function makeAlwaysToolProvider(): LLMProvider {
+    let callId = 0;
+    return {
+      id: 'mock',
+      chat: vi.fn(async () => ({
+        type: 'tool_use' as const,
+        toolCalls: [{ id: `call-${callId++}`, name: 'web-fetch', input: {} }],
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      })),
+    };
+  }
+
+  it('converts maxTurns budget hit to paused when a resumable checkpoint exists', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+      getToolDefinitions: vi.fn().mockReturnValue([]),
+    } as unknown as ExecutionLayer;
+
+    const agentErrors: AgentErrorEvent[] = [];
+    bus.subscribe('agent.error', 'system', (event) => {
+      agentErrors.push(event as AgentErrorEvent);
+    });
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'social-media',
+      systemPrompt: 'You are a social media specialist.',
+      provider: makeAlwaysToolProvider(),
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [toolDef],
+      errorBudget: { maxTurns: 3, maxConsecutiveErrors: 10 },
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'social-media',
+      conversationId: 'conv-resumable-paused',
+      channelId: 'scheduler',
+      senderId: 'scheduler',
+      content: JSON.stringify({ task_id: 'task-resumable-1' }),
+      metadata: {
+        boundTask: {
+          taskId: 'task-resumable-1',
+          errorBudget: { resumable: true },
+          progress: { resumable: resumableCheckpoint },
+        },
+      },
+      parentEventId: 'parent-resumable-paused',
+    }));
+
+    expect(agentErrors).toHaveLength(0);
+    expect(agentResponses).toHaveLength(1);
+    const response = agentResponses[0]!;
+    expect(response.payload.isError).toBeUndefined();
+    const parsed = JSON.parse(response.payload.content) as { _curia_protocol: string; done: number; total: number };
+    expect(parsed._curia_protocol).toBe('execution_paused');
+    expect(parsed.done).toBe(25);
+    expect(parsed.total).toBe(1300);
+  });
+
+  it('emits BUDGET_EXCEEDED when resumable task has no checkpoint', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+      getToolDefinitions: vi.fn().mockReturnValue([]),
+    } as unknown as ExecutionLayer;
+
+    const agentErrors: AgentErrorEvent[] = [];
+    bus.subscribe('agent.error', 'system', (event) => {
+      agentErrors.push(event as AgentErrorEvent);
+    });
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'social-media',
+      systemPrompt: 'You are a social media specialist.',
+      provider: makeAlwaysToolProvider(),
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [toolDef],
+      errorBudget: { maxTurns: 3, maxConsecutiveErrors: 10 },
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'social-media',
+      conversationId: 'conv-resumable-failed',
+      channelId: 'scheduler',
+      senderId: 'scheduler',
+      content: JSON.stringify({ task_id: 'task-resumable-2' }),
+      metadata: {
+        boundTask: {
+          taskId: 'task-resumable-2',
+          errorBudget: { resumable: true },
+          progress: {},
+        },
+      },
+      parentEventId: 'parent-resumable-failed',
+    }));
+
+    expect(agentErrors).toHaveLength(1);
+    expect(agentErrors[0]?.payload.errorType).toBe('BUDGET_EXCEEDED');
+    expect(agentResponses).toHaveLength(1);
+    expect(agentResponses[0]?.payload.isError).toBe(true);
+    expect(agentResponses[0]?.payload.reason).toBe('maxTurns');
   });
 });
 
@@ -2864,6 +3005,7 @@ describe('AgentRuntime Bullpen context refresh', () => {
 
     const mockExecution = {
       invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+      getToolDefinitions: vi.fn().mockReturnValue([]),
     } as unknown as ExecutionLayer;
 
     let bullpenCallCount = 0;
@@ -2958,6 +3100,7 @@ describe('AgentRuntime Bullpen context refresh', () => {
 
     const mockExecution = {
       invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+      getToolDefinitions: vi.fn().mockReturnValue([]),
     } as unknown as ExecutionLayer;
 
     let bullpenCallCount = 0;
@@ -3350,5 +3493,80 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
     expect(response.payload.content).toContain('delegation_failure');
     expect(response.payload.content).toContain('maxTurns');
     expect(response.payload.content).toContain('"escalated":true');
+  });
+
+  it('does not escalate or block when delegate returns paused (#1174)', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const taskCreateCount = { n: 0 };
+
+    const mockExecution = {
+      invoke: vi.fn(async (skillName: string) => {
+        if (skillName === 'task-create') {
+          taskCreateCount.n += 1;
+          return { success: true, data: { task_id: 'escalation-task-1' } };
+        }
+        if (skillName === 'delegate') {
+          return {
+            success: true,
+            data: {
+              agent: 'social-media',
+              paused: true,
+              done: 25,
+              total: 1300,
+              next: 'Continue paging',
+              message: 'Still working — 25 of 1300 complete. Continue paging',
+            },
+          };
+        }
+        return { success: true, data: {} };
+      }),
+      getToolDefinitions: vi.fn(() => [delegateToolDef]),
+    } as unknown as ExecutionLayer;
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn()
+        .mockResolvedValueOnce({
+          type: 'tool_use' as const,
+          toolCalls: [
+            { id: 'call-delegate-paused-1', name: 'delegate', input: { agent: 'social-media', task: 'Audit follows' } },
+          ],
+          usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        })
+        .mockResolvedValueOnce({
+          type: 'text' as const,
+          content: 'The audit is in progress — 25 of 1300 done so far.',
+          usage: { inputTokens: 80, outputTokens: 30, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        }),
+    };
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: [delegateToolDef],
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-delegate-paused',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Audit my Bluesky follows',
+      parentEventId: 'inbound-delegate-paused',
+    }));
+
+    expect(taskCreateCount.n).toBe(0);
+    expect(provider.chat).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -382,4 +382,58 @@ describe('DelegateHandler', () => {
     });
     expect(capturedMetadata).not.toHaveProperty('originator');
   });
+
+  it('returns paused (not failed) when specialist hits resumable budget safety-net (#1174)', async () => {
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+    agentRegistry.register('social-media', { role: 'specialist', description: 'Social' });
+    const bus = new EventBus(logger);
+
+    bus.subscribe('agent.task', 'agent', async (event) => {
+      if (event.type === 'agent.task' && event.payload.agentId === 'social-media') {
+        const { createAgentResponse } = await import('../../../src/bus/events.js');
+        const { buildExecutionPausedResponse } = await import('../../../src/agents/resumable-task.js');
+        const content = buildExecutionPausedResponse({
+          taskId: 'task-resumable-1',
+          progress: {
+            cursor: 'page-2',
+            done: 25,
+            total: 1300,
+            accumulator: [],
+            lastSliceUnits: 25,
+            next: 'Continue paging',
+          },
+        });
+        await bus.publish('agent', createAgentResponse({
+          agentId: 'social-media',
+          conversationId: event.payload.conversationId,
+          content,
+          parentEventId: event.id,
+        }));
+      }
+    });
+
+    const result = await handler.execute(makeCtx(
+      { agent: 'social-media', task: 'Audit Bluesky follows', conversation_id: 'conv-paused' },
+      { bus, agentRegistry },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        agent: string;
+        paused: boolean;
+        done: number;
+        total: number;
+        message: string;
+        failed?: boolean;
+      };
+      expect(data.paused).toBe(true);
+      expect(data.failed).toBeUndefined();
+      expect(data.agent).toBe('social-media');
+      expect(data.done).toBe(25);
+      expect(data.total).toBe(1300);
+      expect(data.message).toContain('25 of 1300');
+    }
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1174

Implements Phase 1 of the resumable-task executor contract: **`done | paused | failed`** outcomes with a deterministic budget safety-net.

- **Safety-net:** When a resumable task hits `maxTurns` **with** a persisted checkpoint, `handleBudgetExceeded()` now emits an `execution_paused` protocol response instead of `BUDGET_EXCEEDED`. Without a checkpoint it still fails honestly.
- **Delegate skill:** Detects `execution_paused` from specialists and returns `{ paused: true, done, total, next, message }` — success at the delegation layer, not `failed`.
- **Coordinator:** Skips delegation-failure recording/escalation for paused results; prompt guidance added to avoid blind re-delegation.
- **Types/helpers:** Executor outcome contract + parse/build helpers in `resumable-task.ts`.

Continuation scheduling (P1-4) is intentionally out of scope — this PR establishes the contract and safety-net only.

## Acceptance criteria

- [x] Executor contract returns `done | paused | failed{reason, retryable}`; `paused` reuses `in_progress` via existing checkpoint (no new status).
- [x] Budget-hit **with** checkpoint → `paused` (not `BUDGET_EXCEEDED`); **without** checkpoint → `failed`.
- [x] Coordinator treats `paused` as success (no re-delegation / escalation).
- [x] Tests: checkpointed budget-hit → paused; no-checkpoint budget-hit → failed; delegate paused propagation.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `vitest run` on `resumable-task.test.ts`, `runtime.test.ts`, `delegate.test.ts` (95 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4493667-a61c-415b-9d70-7bb89d5b02bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4493667-a61c-415b-9d70-7bb89d5b02bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

