### PR TITLE
feat: near-term self-continuation scheduling for paused resumable tasks (#1175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-<<<<<<< HEAD
 - **Resumable executor contract** — checkpointed budget-hit pauses instead of `BUDGET_EXCEEDED`; coordinator treats `paused` as success. (#1174)
-=======
 - **Resumable self-continuation** — paused resumable tasks schedule a single near-term `scheduled_jobs` wake routed to `source_agent_id` (config: `tasks.resumableContinuationSeconds`); the hourly BacklogHeartbeat remains the backstop. (#1175)
->>>>>>> c58d0e50 (feat: schedule near-term continuation wakes for paused resumable tasks (#1175))
 - **`checkpoint`** — resumable-task primitive writing `progress.resumable`; dedicated skill (not folded into `task-update`) with platform guidance, checkpoint resume injection, a one-time ~15% budget nudge at the message tail, auto-pin even for tool-less agents, and no raw UTC in skill results when timezone is absent. (#1173)
 - **Calendar scheduling rules** — calendar agent loads CEO scheduling rules from `config-store` by key at task start, replacing semantic `memory-query`. (#1223)
 - **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+<<<<<<< HEAD
 - **Resumable executor contract** — checkpointed budget-hit pauses instead of `BUDGET_EXCEEDED`; coordinator treats `paused` as success. (#1174)
+=======
+- **Resumable self-continuation** — paused resumable tasks schedule a single near-term `scheduled_jobs` wake routed to `source_agent_id` (config: `tasks.resumableContinuationSeconds`); the hourly BacklogHeartbeat remains the backstop. (#1175)
+>>>>>>> c58d0e50 (feat: schedule near-term continuation wakes for paused resumable tasks (#1175))
 - **`checkpoint`** — resumable-task primitive writing `progress.resumable`; dedicated skill (not folded into `task-update`) with platform guidance, checkpoint resume injection, a one-time ~15% budget nudge at the message tail, auto-pin even for tool-less agents, and no raw UTC in skill results when timezone is absent. (#1173)
 - **Calendar scheduling rules** — calendar agent loads CEO scheduling rules from `config-store` by key at task start, replacing semantic `memory-query`. (#1223)
 - **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -401,6 +401,12 @@ tasks:
   heartbeatMaxWakesPerTick: 5
   idleThresholdHours: 4
   staleWaitThresholdHours: 48
+  # Seconds after a paused resumable task before its self-continuation wake fires.
+  # Default 30s loops iterate leaves promptly (seconds → low minutes) instead of waiting
+  # for the BacklogHeartbeat (heartbeatIntervalMinutes, typically 60) or its idle
+  # threshold (idleThresholdHours, typically 4). At most one pending wake per task —
+  # a lost continuation is re-surfaced by the heartbeat once idleThresholdHours elapses.
+  resumableContinuationSeconds: 30
 
 # Autonomy authorization (#1125). The bypass ladder governs how much LINEAGE standing a
 # heartbeat-woken/derived task inherits at the live autonomy score. The score can only ever

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -342,7 +342,8 @@
         "heartbeatIntervalMinutes": { "type": "integer", "minimum": 1 },
         "heartbeatMaxWakesPerTick": { "type": "integer", "minimum": 1 },
         "idleThresholdHours": { "type": "number", "minimum": 0 },
-        "staleWaitThresholdHours": { "type": "number", "minimum": 0 }
+        "staleWaitThresholdHours": { "type": "number", "minimum": 0 },
+        "resumableContinuationSeconds": { "type": "integer", "minimum": 1 }
       }
     },
     "autonomy": {

--- a/src/agents/resumable-continuation-subscriber.ts
+++ b/src/agents/resumable-continuation-subscriber.ts
@@ -1,0 +1,66 @@
+// resumable-continuation-subscriber.ts — schedules near-term wakes on execution_paused (#1175).
+
+import type { Pool } from 'pg';
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+import type { AgentResponseEvent } from '../bus/events.js';
+import type { SchedulerService } from '../scheduler/scheduler-service.js';
+import { parseExecutionPausedPayload } from './resumable-task.js';
+import { scheduleResumableContinuation } from './resumable-continuation.js';
+
+export interface ResumableContinuationSubscriberOptions {
+  pool: Pool;
+  bus: EventBus;
+  logger: Logger;
+  schedulerService: SchedulerService;
+  eligibleAgents: Set<string>;
+  continuationDelaySeconds: number;
+  fallbackAgentId?: string;
+}
+
+/**
+ * System-layer subscriber: when a specialist emits execution_paused, enqueue a single
+ * near-term continuation wake routed to the task's source_agent_id (or coordinator).
+ */
+export class ResumableContinuationSubscriber {
+  constructor(private readonly opts: ResumableContinuationSubscriberOptions) {}
+
+  start(): void {
+    this.opts.bus.subscribe('agent.response', 'system', (event) => {
+      const responseEvent = event as AgentResponseEvent;
+      if (responseEvent.payload.isError) return;
+
+      const paused = parseExecutionPausedPayload(responseEvent.payload.content);
+      if (!paused) return;
+
+      const taskId = paused.task_id;
+      if (!taskId) {
+        this.opts.logger.warn(
+          { agentId: responseEvent.payload.agentId },
+          'execution_paused response missing task_id — cannot schedule continuation',
+        );
+        return;
+      }
+
+      scheduleResumableContinuation({
+        pool: this.opts.pool,
+        schedulerService: this.opts.schedulerService,
+        logger: this.opts.logger,
+        taskId,
+        delaySeconds: this.opts.continuationDelaySeconds,
+        eligibleAgents: this.opts.eligibleAgents,
+        fallbackAgentId: this.opts.fallbackAgentId,
+      }).catch((err) => {
+        this.opts.logger.error(
+          { err, taskId, agentId: responseEvent.payload.agentId },
+          'Failed to schedule resumable continuation wake',
+        );
+      });
+    });
+
+    this.opts.logger.info(
+      { continuationDelaySeconds: this.opts.continuationDelaySeconds },
+      'ResumableContinuationSubscriber started',
+    );
+  }
+}

--- a/src/agents/resumable-continuation-subscriber.ts
+++ b/src/agents/resumable-continuation-subscriber.ts
@@ -26,7 +26,7 @@ export class ResumableContinuationSubscriber {
   constructor(private readonly opts: ResumableContinuationSubscriberOptions) {}
 
   start(): void {
-    this.opts.bus.subscribe('agent.response', 'system', (event) => {
+    this.opts.bus.subscribe('agent.response', 'system', async (event) => {
       const responseEvent = event as AgentResponseEvent;
       if (responseEvent.payload.isError) return;
 
@@ -42,20 +42,23 @@ export class ResumableContinuationSubscriber {
         return;
       }
 
-      scheduleResumableContinuation({
-        pool: this.opts.pool,
-        schedulerService: this.opts.schedulerService,
-        logger: this.opts.logger,
-        taskId,
-        delaySeconds: this.opts.continuationDelaySeconds,
-        eligibleAgents: this.opts.eligibleAgents,
-        fallbackAgentId: this.opts.fallbackAgentId,
-      }).catch((err) => {
+      try {
+        await scheduleResumableContinuation({
+          pool: this.opts.pool,
+          schedulerService: this.opts.schedulerService,
+          logger: this.opts.logger,
+          taskId,
+          delaySeconds: this.opts.continuationDelaySeconds,
+          eligibleAgents: this.opts.eligibleAgents,
+          fallbackAgentId: this.opts.fallbackAgentId,
+        });
+      } catch (err) {
         this.opts.logger.error(
           { err, taskId, agentId: responseEvent.payload.agentId },
           'Failed to schedule resumable continuation wake',
         );
-      });
+        throw err;
+      }
     });
 
     this.opts.logger.info(

--- a/src/agents/resumable-continuation.ts
+++ b/src/agents/resumable-continuation.ts
@@ -1,0 +1,119 @@
+// resumable-continuation.ts — near-term self-wake for paused resumable tasks (#1175).
+//
+// When a specialist emits execution_paused, the platform schedules exactly one pending
+// continuation via scheduled_jobs (created_by = 'resumable-continuation'). The hourly
+// BacklogHeartbeat remains the backstop when a continuation is lost.
+
+import type { Pool } from 'pg';
+import type { Logger } from '../logger.js';
+import type { SchedulerService } from '../scheduler/scheduler-service.js';
+import type { TaskRow } from '../db/queries/tasks.js';
+import { getTaskById } from '../db/queries/tasks.js';
+import { readResumableBlock } from '../db/resumable-progress.js';
+import { isResumableTask } from './resumable-task.js';
+
+/** created_by marker on continuation wakes — distinguishes them from heartbeat wakes. */
+export const RESUMABLE_CONTINUATION_CREATED_BY = 'resumable-continuation';
+
+export interface ScheduleResumableContinuationOptions {
+  pool: Pool;
+  schedulerService: SchedulerService;
+  logger: Logger;
+  taskId: string;
+  /** Seconds until the continuation fires. From tasks.resumableContinuationSeconds. */
+  delaySeconds: number;
+  /** Heartbeat-eligible agent names — source_agent_id must be in this set or we fall back. */
+  eligibleAgents: Set<string>;
+  /** Wake target when source_agent_id is null or not eligible. Default 'coordinator'. */
+  fallbackAgentId?: string;
+}
+
+export type ScheduleResumableContinuationResult =
+  | { scheduled: true; jobId: string; agentId: string; runAt: Date }
+  | { scheduled: false; reason: 'task_not_found' | 'not_resumable' | 'no_checkpoint' | 'pending_wake_exists' };
+
+/** True when the task already has a pending or running scheduled_jobs wake. */
+export async function taskHasPendingWake(pool: Pool, taskId: string): Promise<boolean> {
+  const { rows } = await pool.query(
+    `SELECT EXISTS(
+       SELECT 1 FROM scheduled_jobs
+        WHERE task_id = $1 AND status IN ('pending', 'running')
+     ) AS pending`,
+    [taskId],
+  );
+  return (rows[0] as { pending: boolean }).pending;
+}
+
+/** Resolve the agent that should receive the continuation wake. */
+export function resolveContinuationAgent(
+  task: Pick<TaskRow, 'sourceAgentId'>,
+  eligibleAgents: Set<string>,
+  fallbackAgentId = 'coordinator',
+): string {
+  if (task.sourceAgentId && eligibleAgents.has(task.sourceAgentId)) {
+    return task.sourceAgentId;
+  }
+  return fallbackAgentId;
+}
+
+/** Whether a task row is eligible for a resumable continuation wake. */
+export function isContinuationEligible(task: TaskRow): boolean {
+  const bound = {
+    taskId: task.id,
+    errorBudget: task.errorBudget,
+    tags: task.tags,
+    progress: task.progress,
+  };
+  if (!isResumableTask(bound)) return false;
+  return readResumableBlock(task.progress) !== null;
+}
+
+/**
+ * Enqueue a single near-term continuation wake for a paused resumable task.
+ * Idempotent while a pending/running wake already exists for the task.
+ */
+export async function scheduleResumableContinuation(
+  opts: ScheduleResumableContinuationOptions,
+): Promise<ScheduleResumableContinuationResult> {
+  const { pool, schedulerService, logger, taskId, delaySeconds, eligibleAgents } = opts;
+  const fallbackAgentId = opts.fallbackAgentId ?? 'coordinator';
+
+  const task = await getTaskById(pool, taskId);
+  if (!task) {
+    logger.debug({ taskId }, 'Resumable continuation: task not found — skipping');
+    return { scheduled: false, reason: 'task_not_found' };
+  }
+
+  if (!isContinuationEligible(task)) {
+    logger.debug({ taskId }, 'Resumable continuation: task not resumable or has no checkpoint — skipping');
+    if (!isResumableTask({ errorBudget: task.errorBudget, tags: task.tags, progress: task.progress })) {
+      return { scheduled: false, reason: 'not_resumable' };
+    }
+    return { scheduled: false, reason: 'no_checkpoint' };
+  }
+
+  if (await taskHasPendingWake(pool, taskId)) {
+    logger.debug({ taskId }, 'Resumable continuation: pending wake already exists — skipping');
+    return { scheduled: false, reason: 'pending_wake_exists' };
+  }
+
+  const agentId = resolveContinuationAgent(task, eligibleAgents, fallbackAgentId);
+  const derived = task.source === 'agent' || task.parentTaskId !== null;
+  const runAt = new Date(Date.now() + delaySeconds * 1000);
+
+  const { jobId } = await schedulerService.enqueueTaskWake({
+    taskId,
+    agentId,
+    runAt,
+    createdBy: RESUMABLE_CONTINUATION_CREATED_BY,
+    originator: task.originator,
+    derived,
+  });
+
+  logger.info(
+    { taskId, jobId, agentId, runAt: runAt.toISOString(), delaySeconds },
+    'Resumable continuation wake scheduled',
+  );
+
+  return { scheduled: true, jobId, agentId, runAt };
+}

--- a/src/agents/resumable-continuation.ts
+++ b/src/agents/resumable-continuation.ts
@@ -32,16 +32,20 @@ export type ScheduleResumableContinuationResult =
   | { scheduled: true; jobId: string; agentId: string; runAt: Date }
   | { scheduled: false; reason: 'task_not_found' | 'not_resumable' | 'no_checkpoint' | 'pending_wake_exists' };
 
+function isPgUniqueViolation(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === '23505';
+}
+
 /** True when the task already has a pending or running scheduled_jobs wake. */
 export async function taskHasPendingWake(pool: Pool, taskId: string): Promise<boolean> {
-  const { rows } = await pool.query(
+  const { rows } = await pool.query<{ pending: boolean }>(
     `SELECT EXISTS(
        SELECT 1 FROM scheduled_jobs
         WHERE task_id = $1 AND status IN ('pending', 'running')
      ) AS pending`,
     [taskId],
   );
-  return (rows[0] as { pending: boolean }).pending;
+  return rows[0]!.pending;
 }
 
 /** Resolve the agent that should receive the continuation wake. */
@@ -71,6 +75,7 @@ export function isContinuationEligible(task: TaskRow): boolean {
 /**
  * Enqueue a single near-term continuation wake for a paused resumable task.
  * Idempotent while a pending/running wake already exists for the task.
+ * Duplicate inserts are also blocked by migration 067's partial unique index.
  */
 export async function scheduleResumableContinuation(
   opts: ScheduleResumableContinuationOptions,
@@ -92,6 +97,7 @@ export async function scheduleResumableContinuation(
     return { scheduled: false, reason: 'no_checkpoint' };
   }
 
+  // Fast path — the DB unique index (067) is the atomic guarantee under concurrency.
   if (await taskHasPendingWake(pool, taskId)) {
     logger.debug({ taskId }, 'Resumable continuation: pending wake already exists — skipping');
     return { scheduled: false, reason: 'pending_wake_exists' };
@@ -101,19 +107,27 @@ export async function scheduleResumableContinuation(
   const derived = task.source === 'agent' || task.parentTaskId !== null;
   const runAt = new Date(Date.now() + delaySeconds * 1000);
 
-  const { jobId } = await schedulerService.enqueueTaskWake({
-    taskId,
-    agentId,
-    runAt,
-    createdBy: RESUMABLE_CONTINUATION_CREATED_BY,
-    originator: task.originator,
-    derived,
-  });
+  try {
+    const { jobId } = await schedulerService.enqueueTaskWake({
+      taskId,
+      agentId,
+      runAt,
+      createdBy: RESUMABLE_CONTINUATION_CREATED_BY,
+      originator: task.originator,
+      derived,
+    });
 
-  logger.info(
-    { taskId, jobId, agentId, runAt: runAt.toISOString(), delaySeconds },
-    'Resumable continuation wake scheduled',
-  );
+    logger.info(
+      { taskId, jobId, agentId, runAt: runAt.toISOString(), delaySeconds },
+      'Resumable continuation wake scheduled',
+    );
 
-  return { scheduled: true, jobId, agentId, runAt };
+    return { scheduled: true, jobId, agentId, runAt };
+  } catch (err) {
+    if (isPgUniqueViolation(err)) {
+      logger.debug({ taskId }, 'Resumable continuation: concurrent wake insert lost race — skipping');
+      return { scheduled: false, reason: 'pending_wake_exists' };
+    }
+    throw err;
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,8 @@ export interface TasksConfig {
   heartbeatMaxWakesPerTick: number;
   idleThresholdHours: number;
   staleWaitThresholdHours: number;
+  /** Seconds until a paused resumable task's self-continuation wake fires. */
+  resumableContinuationSeconds: number;
 }
 
 export const DEFAULT_TASKS_CONFIG: TasksConfig = {
@@ -59,6 +61,7 @@ export const DEFAULT_TASKS_CONFIG: TasksConfig = {
   heartbeatMaxWakesPerTick: 5,
   idleThresholdHours: 4,
   staleWaitThresholdHours: 48,
+  resumableContinuationSeconds: 30,
 };
 
 /** Resolve the optional YAML tasks block to a fully-populated config with defaults. */
@@ -68,6 +71,7 @@ export function resolveTasksConfig(yaml: YamlConfig['tasks']): TasksConfig {
     heartbeatMaxWakesPerTick: yaml?.heartbeatMaxWakesPerTick ?? DEFAULT_TASKS_CONFIG.heartbeatMaxWakesPerTick,
     idleThresholdHours: yaml?.idleThresholdHours ?? DEFAULT_TASKS_CONFIG.idleThresholdHours,
     staleWaitThresholdHours: yaml?.staleWaitThresholdHours ?? DEFAULT_TASKS_CONFIG.staleWaitThresholdHours,
+    resumableContinuationSeconds: yaml?.resumableContinuationSeconds ?? DEFAULT_TASKS_CONFIG.resumableContinuationSeconds,
   };
 }
 
@@ -419,6 +423,8 @@ export interface YamlConfig {
     /** Hours a waiting/blocked task with no pending wake may sit before the
      *  heartbeat surfaces it as an orphaned wait. Default 48. */
     staleWaitThresholdHours?: number;
+    /** Seconds until a paused resumable task's self-continuation wake fires. Default 30. */
+    resumableContinuationSeconds?: number;
   };
   health?: {
     liveness?: {
@@ -909,6 +915,11 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       !Number.isFinite(t.staleWaitThresholdHours) || t.staleWaitThresholdHours < 0
     )) {
       throw new Error(`tasks.staleWaitThresholdHours must be a non-negative finite number, got: ${String(t.staleWaitThresholdHours)}`);
+    }
+    if (t.resumableContinuationSeconds !== undefined && (
+      !Number.isInteger(t.resumableContinuationSeconds) || t.resumableContinuationSeconds < 1
+    )) {
+      throw new Error(`tasks.resumableContinuationSeconds must be a positive integer, got: ${String(t.resumableContinuationSeconds)}`);
     }
   }
 

--- a/src/db/migrations/067_scheduled_jobs_one_active_wake_per_task.sql
+++ b/src/db/migrations/067_scheduled_jobs_one_active_wake_per_task.sql
@@ -1,0 +1,13 @@
+-- 067_scheduled_jobs_one_active_wake_per_task.sql
+--
+-- Enforce at most one pending or running wake per task_id. Resumable continuation
+-- scheduling (#1175) and the BacklogHeartbeat both assume this invariant; the
+-- partial unique index makes duplicate inserts fail atomically under concurrency.
+
+-- Up Migration
+CREATE UNIQUE INDEX scheduled_jobs_one_active_wake_per_task_uq
+  ON scheduled_jobs (task_id)
+  WHERE task_id IS NOT NULL AND status IN ('pending', 'running');
+
+-- Down Migration
+DROP INDEX IF EXISTS scheduled_jobs_one_active_wake_per_task_uq;

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ import { OutboundContextService } from './dispatch/outbound-context.js';
 import { applyTaskManagement } from './agents/task-management.js';
 import { applyDocumentWorkspace } from './agents/document-workspace.js';
 import { BacklogHeartbeat } from './scheduler/backlog-heartbeat.js';
+import { ResumableContinuationSubscriber } from './agents/resumable-continuation-subscriber.js';
 import * as fs from 'node:fs';
 import * as yaml from 'js-yaml';
 import { RegistryRepo } from './registry/registry-repo.js';
@@ -1998,6 +1999,17 @@ async function main(): Promise<void> {
 
   scheduler.start();
   backlogHeartbeat.start();
+
+  const resumableContinuationSubscriber = new ResumableContinuationSubscriber({
+    pool,
+    bus,
+    logger,
+    schedulerService,
+    eligibleAgents: taskManagementAgents,
+    continuationDelaySeconds: tasksConfig.resumableContinuationSeconds,
+  });
+  resumableContinuationSubscriber.start();
+
   logger.info('Scheduler started');
 
   // Log the scrubber status after the logger is available (patterns are loaded at module

--- a/tests/integration/resumable-continuation.test.ts
+++ b/tests/integration/resumable-continuation.test.ts
@@ -193,34 +193,37 @@ describeIf('Resumable continuation scheduling (#1175)', () => {
       schedulerService,
     });
     scheduler.start();
-    await scheduler.pollDueJobs();
+    try {
+      await scheduler.pollDueJobs();
 
-    await vi.waitFor(() => {
-      expect(agentTaskEvents.length).toBeGreaterThan(0);
-      expect(specialistLlm.chat).toHaveBeenCalled();
-    });
-    scheduler.stop();
+      await vi.waitFor(() => {
+        expect(agentTaskEvents.length).toBeGreaterThan(0);
+        expect(specialistLlm.chat).toHaveBeenCalled();
+      });
 
-    expect(agentTaskEvents[0]!.agentId).toBe('social-media');
-    const boundTask = (agentTaskEvents[0]!.metadata?.boundTask ?? {}) as {
-      progress?: { resumable?: { done?: number; total?: number } };
-    };
-    expect(boundTask.progress?.resumable?.done).toBe(25);
-    expect(boundTask.progress?.resumable?.total).toBe(1300);
-    expect(capturedSystemPrompt).toContain('## Last Checkpoint (resume from here)');
-    expect(capturedSystemPrompt).toContain('25 / 1300');
+      expect(agentTaskEvents[0]!.agentId).toBe('social-media');
+      const boundTask = (agentTaskEvents[0]!.metadata?.boundTask ?? {}) as {
+        progress?: { resumable?: { done?: number; total?: number } };
+      };
+      expect(boundTask.progress?.resumable?.done).toBe(25);
+      expect(boundTask.progress?.resumable?.total).toBe(1300);
+      expect(capturedSystemPrompt).toContain('## Last Checkpoint (resume from here)');
+      expect(capturedSystemPrompt).toContain('25 / 1300');
 
-    const advanced = await repo.setResumableBlock(task.id, {
-      cursor: 'page:4',
-      done: 50,
-      total: 1300,
-      accumulator: ['did:plc:abc', 'did:plc:def'],
-      lastSliceUnits: 25,
-      next: 'Review page 5',
-    }, 'social-media');
-    expect('task' in advanced).toBe(true);
-    const block = await repo.getResumableBlock(task.id);
-    expect(block?.done).toBe(50);
-    expect(block?.cursor).toBe('page:4');
+      const advanced = await repo.setResumableBlock(task.id, {
+        cursor: 'page:4',
+        done: 50,
+        total: 1300,
+        accumulator: ['did:plc:abc', 'did:plc:def'],
+        lastSliceUnits: 25,
+        next: 'Review page 5',
+      }, 'social-media');
+      expect('task' in advanced).toBe(true);
+      const block = await repo.getResumableBlock(task.id);
+      expect(block?.done).toBe(50);
+      expect(block?.cursor).toBe('page:4');
+    } finally {
+      scheduler.stop();
+    }
   });
 });

--- a/tests/integration/resumable-continuation.test.ts
+++ b/tests/integration/resumable-continuation.test.ts
@@ -1,0 +1,226 @@
+// resumable-continuation.test.ts — pause → continuation → resume integration (#1175).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { EventBus } from '../../src/bus/bus.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { Scheduler } from '../../src/scheduler/scheduler.js';
+import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import { ResumableContinuationSubscriber } from '../../src/agents/resumable-continuation-subscriber.js';
+import { RESUMABLE_CONTINUATION_CREATED_BY } from '../../src/agents/resumable-continuation.js';
+import { createAgentResponse } from '../../src/bus/events.js';
+import type { LLMProvider, Message } from '../../src/agents/llm/provider.js';
+import type { EventBus as EventBusType } from '../../src/bus/bus.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'ResumableContinuation Test';
+const logger = pino({ level: 'silent' });
+const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBusType;
+
+const MOCK_PROVENANCE = {
+  requestedModel: 'mock-model',
+  actualModel: 'mock-model',
+  providerRequestId: 'msg_mock_000',
+} as const;
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [`${PREFIX}%`],
+  );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+describeIf('Resumable continuation scheduling (#1175)', () => {
+  let pool: pg.Pool;
+  let repo: TaskRepo;
+  let schedulerService: SchedulerService;
+  let bus: EventBus;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+    bus = new EventBus(logger as never);
+    schedulerService = new SchedulerService(pool, bus, logger as never, 'UTC');
+  });
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  it('pause → continuation scheduled → resumes from checkpoint → makes forward progress', async () => {
+    const task = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} audit`,
+      source: 'coordinator',
+      sourceAgentId: 'social-media',
+      resumable: true,
+      tags: ['resumable'],
+    });
+    await repo.setResumableBlock(task.id, {
+      cursor: 'page:3',
+      done: 25,
+      total: 1300,
+      accumulator: ['did:plc:abc'],
+      lastSliceUnits: 25,
+      next: 'Review page 4',
+    }, 'social-media');
+    await repo.updateTask(task.id, { status: 'in_progress' }, 'social-media');
+
+    const subscriber = new ResumableContinuationSubscriber({
+      pool,
+      bus,
+      logger: logger as never,
+      schedulerService,
+      eligibleAgents: new Set(['social-media', 'coordinator']),
+      continuationDelaySeconds: 1,
+    });
+    subscriber.start();
+
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-pause',
+      content: JSON.stringify({
+        _curia_protocol: 'execution_paused',
+        task_id: task.id,
+        done: 25,
+        total: 1300,
+        cursor: 'page:3',
+        last_slice_units: 25,
+        next: 'Review page 4',
+      }),
+      parentEventId: 'parent-pause',
+    }));
+
+    const { rows: wakeRows } = await pool.query(
+      `SELECT id, agent_id, created_by, status, next_run_at, task_id
+         FROM scheduled_jobs
+        WHERE task_id = $1`,
+      [task.id],
+    );
+    expect(wakeRows).toHaveLength(1);
+    const wake = wakeRows[0] as {
+      id: string;
+      agent_id: string;
+      created_by: string;
+      status: string;
+      task_id: string;
+    };
+    expect(wake.agent_id).toBe('social-media');
+    expect(wake.created_by).toBe(RESUMABLE_CONTINUATION_CREATED_BY);
+    expect(wake.status).toBe('pending');
+
+    // Duplicate pause must not enqueue a second continuation.
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-pause-2',
+      content: JSON.stringify({
+        _curia_protocol: 'execution_paused',
+        task_id: task.id,
+        done: 25,
+        total: 1300,
+        cursor: 'page:3',
+        last_slice_units: 25,
+        next: 'Review page 4',
+      }),
+      parentEventId: 'parent-pause-2',
+    }));
+    const { rows: afterDup } = await pool.query(
+      `SELECT id FROM scheduled_jobs WHERE task_id = $1`,
+      [task.id],
+    );
+    expect(afterDup).toHaveLength(1);
+
+    // Fire the continuation immediately and verify the specialist receives checkpoint context.
+    await pool.query(
+      `UPDATE scheduled_jobs SET next_run_at = now() - interval '1 second' WHERE id = $1`,
+      [wake.id],
+    );
+
+    const agentTaskEvents: Array<{
+      agentId: string;
+      content: string;
+      metadata?: Record<string, unknown>;
+    }> = [];
+    bus.subscribe('agent.task', 'system', (event) => {
+      const e = event as { payload: { agentId: string; content: string; metadata?: Record<string, unknown> } };
+      agentTaskEvents.push({
+        agentId: e.payload.agentId,
+        content: e.payload.content,
+        metadata: e.payload.metadata,
+      });
+    });
+
+    let capturedSystemPrompt = '';
+    const specialistLlm: LLMProvider = {
+      id: 'mock-specialist',
+      chat: vi.fn().mockImplementation(async (params: { messages: Message[] }) => {
+        const system = params.messages.find((m: Message) => m.role === 'system');
+        capturedSystemPrompt = typeof system?.content === 'string' ? system.content : '';
+        return {
+          type: 'text' as const,
+          content: 'Slice advanced.',
+          usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      }),
+    };
+
+    const specialist = new AgentRuntime({
+      agentId: 'social-media',
+      systemPrompt: 'You process social audits.',
+      provider: specialistLlm,
+      bus,
+      logger: logger as never,
+      errorBudget: { maxTurns: 10, maxConsecutiveErrors: 5 },
+    });
+    specialist.register();
+
+    const scheduler = new Scheduler({
+      pool,
+      bus,
+      logger: logger as never,
+      schedulerService,
+    });
+    scheduler.start();
+    await scheduler.pollDueJobs();
+
+    await vi.waitFor(() => {
+      expect(agentTaskEvents.length).toBeGreaterThan(0);
+      expect(specialistLlm.chat).toHaveBeenCalled();
+    });
+    scheduler.stop();
+
+    expect(agentTaskEvents[0]!.agentId).toBe('social-media');
+    const boundTask = (agentTaskEvents[0]!.metadata?.boundTask ?? {}) as {
+      progress?: { resumable?: { done?: number; total?: number } };
+    };
+    expect(boundTask.progress?.resumable?.done).toBe(25);
+    expect(boundTask.progress?.resumable?.total).toBe(1300);
+    expect(capturedSystemPrompt).toContain('## Last Checkpoint (resume from here)');
+    expect(capturedSystemPrompt).toContain('25 / 1300');
+
+    const advanced = await repo.setResumableBlock(task.id, {
+      cursor: 'page:4',
+      done: 50,
+      total: 1300,
+      accumulator: ['did:plc:abc', 'did:plc:def'],
+      lastSliceUnits: 25,
+      next: 'Review page 5',
+    }, 'social-media');
+    expect('task' in advanced).toBe(true);
+    const block = await repo.getResumableBlock(task.id);
+    expect(block?.done).toBe(50);
+    expect(block?.cursor).toBe('page:4');
+  });
+});

--- a/tests/unit/agents/resumable-continuation-subscriber.test.ts
+++ b/tests/unit/agents/resumable-continuation-subscriber.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventBus } from '../../../src/bus/bus.js';
+import { createAgentResponse } from '../../../src/bus/events.js';
+import { ResumableContinuationSubscriber } from '../../../src/agents/resumable-continuation-subscriber.js';
+import * as continuation from '../../../src/agents/resumable-continuation.js';
+
+function mockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() };
+}
+
+describe('ResumableContinuationSubscriber', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('schedules a continuation when execution_paused is emitted', async () => {
+    const scheduleSpy = vi.spyOn(continuation, 'scheduleResumableContinuation')
+      .mockResolvedValue({ scheduled: true, jobId: 'job-1', agentId: 'social-media', runAt: new Date() });
+
+    const bus = new EventBus(mockLogger() as never);
+    const subscriber = new ResumableContinuationSubscriber({
+      pool: {} as never,
+      bus,
+      logger: mockLogger() as never,
+      schedulerService: {} as never,
+      eligibleAgents: new Set(['social-media']),
+      continuationDelaySeconds: 30,
+    });
+    subscriber.start();
+
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-1',
+      content: JSON.stringify({
+        _curia_protocol: 'execution_paused',
+        task_id: 'task-abc',
+        done: 25,
+        total: 1300,
+        cursor: 'page:3',
+        last_slice_units: 25,
+        next: 'Review page 4',
+      }),
+      parentEventId: 'parent-1',
+    }));
+
+    expect(scheduleSpy).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: 'task-abc',
+      delaySeconds: 30,
+    }));
+  });
+
+  it('ignores non-paused responses', async () => {
+    const scheduleSpy = vi.spyOn(continuation, 'scheduleResumableContinuation')
+      .mockResolvedValue({ scheduled: true, jobId: 'job-1', agentId: 'social-media', runAt: new Date() });
+
+    const bus = new EventBus(mockLogger() as never);
+    const subscriber = new ResumableContinuationSubscriber({
+      pool: {} as never,
+      bus,
+      logger: mockLogger() as never,
+      schedulerService: {} as never,
+      eligibleAgents: new Set(['social-media']),
+      continuationDelaySeconds: 30,
+    });
+    subscriber.start();
+
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-1',
+      content: 'All done.',
+      parentEventId: 'parent-1',
+    }));
+
+    expect(scheduleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/agents/resumable-continuation.test.ts
+++ b/tests/unit/agents/resumable-continuation.test.ts
@@ -167,4 +167,23 @@ describe('scheduleResumableContinuation', () => {
     expect(result).toEqual({ scheduled: false, reason: 'no_checkpoint' });
     expect(enqueueTaskWake).not.toHaveBeenCalled();
   });
+
+  it('treats a unique-index race on enqueue as pending_wake_exists', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ pending: false }] }),
+    };
+    vi.spyOn(tasksQueries, 'getTaskById').mockResolvedValue(sampleTask());
+    enqueueTaskWake.mockRejectedValueOnce(Object.assign(new Error('duplicate key'), { code: '23505' }));
+
+    const result = await scheduleResumableContinuation({
+      pool: pool as never,
+      schedulerService: schedulerService as never,
+      logger: mockLogger() as never,
+      taskId: 'task-1',
+      delaySeconds: 30,
+      eligibleAgents,
+    });
+
+    expect(result).toEqual({ scheduled: false, reason: 'pending_wake_exists' });
+  });
 });

--- a/tests/unit/agents/resumable-continuation.test.ts
+++ b/tests/unit/agents/resumable-continuation.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  RESUMABLE_CONTINUATION_CREATED_BY,
+  isContinuationEligible,
+  resolveContinuationAgent,
+  scheduleResumableContinuation,
+} from '../../../src/agents/resumable-continuation.js';
+import type { TaskRow } from '../../../src/db/queries/tasks.js';
+import * as tasksQueries from '../../../src/db/queries/tasks.js';
+
+function mockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() };
+}
+
+function sampleTask(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    id: 'task-1',
+    agentId: 'social-media',
+    intentAnchor: 'Audit follows',
+    status: 'in_progress',
+    progress: {
+      resumable: {
+        cursor: 'page:3',
+        done: 25,
+        total: 1300,
+        accumulator: [],
+        lastSliceUnits: 25,
+        next: 'Review page 4',
+      },
+    },
+    errorBudget: { resumable: true },
+    conversationId: null,
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+    title: 'Audit',
+    description: null,
+    owner: 'curia',
+    waitingOnContactId: null,
+    waitingOnText: null,
+    parentTaskId: null,
+    blockedByTaskId: null,
+    priority: 0,
+    dueAt: null,
+    source: 'coordinator',
+    sourceAgentId: 'social-media',
+    createdBy: 'coordinator',
+    tags: ['resumable'],
+    originator: null,
+    ...overrides,
+  };
+}
+
+describe('resolveContinuationAgent', () => {
+  const eligible = new Set(['coordinator', 'social-media']);
+
+  it('routes to source_agent_id when eligible', () => {
+    expect(resolveContinuationAgent(sampleTask(), eligible)).toBe('social-media');
+  });
+
+  it('falls back to coordinator when source_agent_id is null', () => {
+    expect(resolveContinuationAgent(sampleTask({ sourceAgentId: null }), eligible)).toBe('coordinator');
+  });
+
+  it('falls back when source_agent_id is not heartbeat-eligible', () => {
+    expect(resolveContinuationAgent(sampleTask({ sourceAgentId: 'essay-editor' }), eligible)).toBe('coordinator');
+  });
+});
+
+describe('isContinuationEligible', () => {
+  it('requires resumable marker and checkpoint', () => {
+    expect(isContinuationEligible(sampleTask())).toBe(true);
+    expect(isContinuationEligible(sampleTask({ progress: {}, errorBudget: {}, tags: [] }))).toBe(false);
+    expect(isContinuationEligible(sampleTask({ progress: {}, errorBudget: { resumable: true }, tags: ['resumable'] }))).toBe(false);
+  });
+});
+
+describe('scheduleResumableContinuation', () => {
+  const eligibleAgents = new Set(['coordinator', 'social-media']);
+  let enqueueTaskWake: ReturnType<typeof vi.fn>;
+  let schedulerService: { enqueueTaskWake: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    enqueueTaskWake = vi.fn().mockResolvedValue({ jobId: 'job-cont' });
+    schedulerService = { enqueueTaskWake };
+  });
+
+  it('enqueues exactly one near-term wake routed to source_agent_id', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ pending: false }] }),
+    };
+    vi.spyOn(tasksQueries, 'getTaskById').mockResolvedValue(sampleTask());
+
+    const before = Date.now();
+    const result = await scheduleResumableContinuation({
+      pool: pool as never,
+      schedulerService: schedulerService as never,
+      logger: mockLogger() as never,
+      taskId: 'task-1',
+      delaySeconds: 30,
+      eligibleAgents,
+    });
+
+    expect(result).toMatchObject({ scheduled: true, jobId: 'job-cont', agentId: 'social-media' });
+    if (!('scheduled' in result) || !result.scheduled) return;
+    expect(result.runAt.getTime()).toBeGreaterThanOrEqual(before + 29_000);
+    expect(result.runAt.getTime()).toBeLessThanOrEqual(before + 31_000);
+
+    expect(enqueueTaskWake).toHaveBeenCalledTimes(1);
+    expect(enqueueTaskWake).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: 'task-1',
+      agentId: 'social-media',
+      createdBy: RESUMABLE_CONTINUATION_CREATED_BY,
+      derived: false,
+    }));
+  });
+
+  it('threads derived=true for agent-spawned child tasks', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ pending: false }] }),
+    };
+    vi.spyOn(tasksQueries, 'getTaskById').mockResolvedValue(sampleTask({ source: 'agent', parentTaskId: 'parent-1' }));
+
+    await scheduleResumableContinuation({
+      pool: pool as never,
+      schedulerService: schedulerService as never,
+      logger: mockLogger() as never,
+      taskId: 'task-1',
+      delaySeconds: 30,
+      eligibleAgents,
+    });
+
+    expect(enqueueTaskWake).toHaveBeenCalledWith(expect.objectContaining({ derived: true }));
+  });
+
+  it('skips when a pending wake already exists', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ pending: true }] }),
+    };
+    vi.spyOn(tasksQueries, 'getTaskById').mockResolvedValue(sampleTask());
+
+    const result = await scheduleResumableContinuation({
+      pool: pool as never,
+      schedulerService: schedulerService as never,
+      logger: mockLogger() as never,
+      taskId: 'task-1',
+      delaySeconds: 30,
+      eligibleAgents,
+    });
+
+    expect(result).toEqual({ scheduled: false, reason: 'pending_wake_exists' });
+    expect(enqueueTaskWake).not.toHaveBeenCalled();
+  });
+
+  it('skips when task has no checkpoint', async () => {
+    vi.spyOn(tasksQueries, 'getTaskById').mockResolvedValue(sampleTask({ progress: {} }));
+
+    const result = await scheduleResumableContinuation({
+      pool: { query: vi.fn() } as never,
+      schedulerService: schedulerService as never,
+      logger: mockLogger() as never,
+      taskId: 'task-1',
+      delaySeconds: 30,
+      eligibleAgents,
+    });
+
+    expect(result).toEqual({ scheduled: false, reason: 'no_checkpoint' });
+    expect(enqueueTaskWake).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/config-tasks.test.ts
+++ b/tests/unit/config-tasks.test.ts
@@ -6,12 +6,13 @@ describe('resolveTasksConfig', () => {
     expect(resolveTasksConfig(undefined)).toEqual(DEFAULT_TASKS_CONFIG);
   });
 
-  it('defaults are 60 / 5 / 4 / 48', () => {
+  it('defaults are 60 / 5 / 4 / 48 / 30', () => {
     expect(DEFAULT_TASKS_CONFIG).toEqual({
       heartbeatIntervalMinutes: 60,
       heartbeatMaxWakesPerTick: 5,
       idleThresholdHours: 4,
       staleWaitThresholdHours: 48,
+      resumableContinuationSeconds: 30,
     });
   });
 
@@ -21,6 +22,7 @@ describe('resolveTasksConfig', () => {
       heartbeatMaxWakesPerTick: 5,
       idleThresholdHours: 2,
       staleWaitThresholdHours: 48,
+      resumableContinuationSeconds: 30,
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **#1175** (Phase 1 resumable iterate leaves). Builds on **#1174** (merged via #1230).

When a specialist emits `execution_paused`, a system-layer subscriber schedules exactly **one** near-term `scheduled_jobs` wake for the existing task:

- Routed to `source_agent_id` (falls back to `coordinator` when null or not heartbeat-eligible)
- `created_by = resumable-continuation` (distinct from heartbeat wakes)
- Cadence from `tasks.resumableContinuationSeconds` (**30s** default)
- Deduped while any pending/running wake already exists for the task

The hourly **BacklogHeartbeat** remains the backstop for lost continuations.

Closes #1175

## Changes

- **`src/agents/resumable-continuation.ts`** — scheduling helper (`scheduleResumableContinuation`, agent routing, dedup)
- **`src/agents/resumable-continuation-subscriber.ts`** — listens for `execution_paused` on `agent.response`
- **`config/default.yaml`** — `tasks.resumableContinuationSeconds: 30` with documented interaction vs heartbeat thresholds
- **`src/config.ts`** — config type, default, validation
- **`src/index.ts`** — wires subscriber at startup

## Tests

- Unit: scheduling logic (routing, dedup, derived flag), subscriber wiring, config defaults
- Integration: pause → continuation row → scheduler fire → checkpoint resume → forward progress

## Acceptance criteria

- [x] A `paused` resumable task enqueues exactly one near-term continuation `scheduled_jobs` row routed to its `source_agent_id`
- [x] Continuation fires well before the hourly heartbeat; heartbeat backstop intact
- [x] Cadence is config-driven with a documented default; no duplicate continuation wakes
- [x] Test: pause → continuation scheduled → resumes from checkpoint → makes forward progress

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-899aba73-d7df-4008-88bd-f8fbe67a6596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-899aba73-d7df-4008-88bd-f8fbe67a6596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

