### PR TITLE
feat: TTL-sweep expired /scratch documents (DreamEngine nightly pass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Resumable accumulator spill** — inline overflow writes to `/projects/<root>/accumulator.md` and stores a workspace document pointer; resume injects the manifest and spilled doc at the message tail. (#1210)
 - **Document workspace** — `working_documents` / `working_document_links` Postgres store with `WorkingDocsRepo`, OKF frontmatter round-trip, backlink index, and optimistic concurrency (document + per-section). (#1208)
 - **`doc-read` / `doc-list` / `doc-write` / `doc-search`** — OKF workspace skills with harness-injected guidance, auto-pin on task-management agents, manifest-only tail injection, and `log.md` append on writes. (#1209)
-- **Document workspace scratch TTL** — DreamEngine nightly pass hard-deletes inactive `/scratch/` documents; configurable `documentWorkspace.scratchTtlDays` with optional per-doc `ttl_days` frontmatter override. (#1212)
+- **Document workspace scratch TTL** — DreamEngine nightly pass archives expired `/scratch/<conversation-id>/…` documents (`archived_at`); configurable `documentWorkspace.scratchTtlDays` with optional per-doc `ttl_days` frontmatter override. (#1212)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Resumable accumulator spill** — inline overflow writes to `/projects/<root>/accumulator.md` and stores a workspace document pointer; resume injects the manifest and spilled doc at the message tail. (#1210)
 - **Document workspace** — `working_documents` / `working_document_links` Postgres store with `WorkingDocsRepo`, OKF frontmatter round-trip, backlink index, and optimistic concurrency (document + per-section). (#1208)
 - **`doc-read` / `doc-list` / `doc-write` / `doc-search`** — OKF workspace skills with harness-injected guidance, auto-pin on task-management agents, manifest-only tail injection, and `log.md` append on writes. (#1209)
+- **Document workspace scratch TTL** — DreamEngine nightly pass hard-deletes inactive `/scratch/` documents; configurable `documentWorkspace.scratchTtlDays` with optional per-doc `ttl_days` frontmatter override. (#1212)
 
 ### Changed
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -80,9 +80,10 @@ workingMemory:
 
 documentWorkspace:
   # Inactivity TTL for ephemeral `/scratch/<conversation-id>/…` documents. DreamEngine's
-  # nightly pass hard-deletes live scratch rows whose updated_at is older than this many
-  # days. Omit `ttl_days` in frontmatter to inherit this default; set `ttl_days: 0` on a
-  # scratch doc to opt out. `/projects/…` documents are never auto-purged.
+  # nightly pass soft-deletes (sets archived_at) on live scratch rows whose updated_at is
+  # older than this many days. Omit `ttl_days` in frontmatter to inherit this default;
+  # set `ttl_days: 0` on a scratch doc to opt out. `/projects/…` documents are never
+  # auto-archived.
   scratchTtlDays: 7
 
 skillOutput:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -78,6 +78,13 @@ workingMemory:
     threshold: 20   # turns that trigger a summarization pass
     keepWindow: 10  # most-recent turns to retain as active after summarization
 
+documentWorkspace:
+  # Inactivity TTL for ephemeral `/scratch/<conversation-id>/…` documents. DreamEngine's
+  # nightly pass hard-deletes live scratch rows whose updated_at is older than this many
+  # days. Omit `ttl_days` in frontmatter to inherit this default; set `ttl_days: 0` on a
+  # scratch doc to opt out. `/projects/…` documents are never auto-purged.
+  scratchTtlDays: 7
+
 skillOutput:
   # Maximum character length of a sanitized skill result before truncation.
   # Skills that return more than this (search results, page crawls, long calendar

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -98,7 +98,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "scratchTtlDays": { "type": "integer", "minimum": 1 }
+        "scratchTtlDays": { "type": "integer", "minimum": 1, "maximum": 36500 }
       }
     },
     "skillOutput": {

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -94,6 +94,13 @@
         }
       }
     },
+    "documentWorkspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scratchTtlDays": { "type": "integer", "minimum": 1 }
+      }
+    },
     "skillOutput": {
       "type": "object",
       "additionalProperties": false,

--- a/skills/_shared/doc-workspace.ts
+++ b/skills/_shared/doc-workspace.ts
@@ -13,6 +13,7 @@ import {
   normalizeDirectoryPrefix,
   RESERVED_LEAF_NAMES,
   LOG_FILENAME,
+  ttlDaysFrontmatterWarning,
 } from '../../src/agents/document-workspace.js';
 import { normalizeDocPath } from '../../src/memory/okf.js';
 
@@ -201,3 +202,5 @@ export function validateWritePath(path: string, _mode: string): string | null {
   }
   return `Cannot write to reserved file ${leaf} — use doc-list for the index projection`;
 }
+
+export { ttlDaysFrontmatterWarning };

--- a/skills/doc-write/handler.test.ts
+++ b/skills/doc-write/handler.test.ts
@@ -52,6 +52,26 @@ function makeCtx(input: Record<string, unknown>, repo?: WorkingDocsRepo): SkillC
 }
 
 describe('DocWriteHandler', () => {
+  it('returns retention_warning when ttl_days is set on a project path', async () => {
+    const repo = makeRepo({
+      read: vi.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null),
+    });
+    const result = await new DocWriteHandler().execute(makeCtx({
+      path: '/projects/x/new.md',
+      mode: 'create',
+      type: 'note',
+      body: 'hello',
+      frontmatter: { ttl_days: 3 },
+    }, repo));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { retention_warning?: string };
+      expect(data.retention_warning).toMatch(/scratch/i);
+    }
+  });
+
   it('creates a document and appends log.md', async () => {
     const repo = makeRepo({
       read: vi.fn()

--- a/skills/doc-write/handler.ts
+++ b/skills/doc-write/handler.ts
@@ -7,6 +7,7 @@ import {
   mapDocumentRow,
   mapWriteConflict,
   requireWorkingDocs,
+  ttlDaysFrontmatterWarning,
   validateWritePath,
 } from '../_shared/doc-workspace.js';
 
@@ -50,6 +51,7 @@ export class DocWriteHandler implements SkillHandler {
     const timezone = ctx.timezone ?? 'UTC';
     const normalized = normalizeDocPath(input.path);
     const summary = typeof input.summary === 'string' ? input.summary : `${input.mode} ${normalized}`;
+    const ttlWarning = ttlDaysFrontmatterWarning(normalized, input.frontmatter);
 
     try {
       const repo = ctx.workingDocs!;
@@ -76,7 +78,11 @@ export class DocWriteHandler implements SkillHandler {
           await appendDirectoryLog(ctx, normalized, 'create', summary);
           return {
             success: true,
-            data: { action: 'created', document: mapDocumentRow(created, timezone) },
+            data: {
+              action: 'created',
+              document: mapDocumentRow(created, timezone),
+              ...(ttlWarning ? { retention_warning: ttlWarning } : {}),
+            },
           };
         }
         case 'append': {
@@ -126,7 +132,11 @@ export class DocWriteHandler implements SkillHandler {
           await appendDirectoryLog(ctx, normalized, 'replace', summary);
           return {
             success: true,
-            data: { action: 'replaced', document: mapDocumentRow(result.document, timezone) },
+            data: {
+              action: 'replaced',
+              document: mapDocumentRow(result.document, timezone),
+              ...(ttlWarning ? { retention_warning: ttlWarning } : {}),
+            },
           };
         }
         case 'section-edit': {

--- a/skills/doc-write/skill.json
+++ b/skills/doc-write/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "doc-write",
-  "description": "Write to the OKF document workspace. Modes: `create` (new document — requires `type`, optional `body`/`frontmatter`), `append` (add content — requires `content` + `expected_version`), `replace` (swap full body — requires `body` + `expected_version`), `section-edit` (replace a `##` section — requires `section`, `content`, optional `expected_section_version`). Every successful write appends an entry to the directory's reserved `log.md`. On version mismatch returns `conflict: true` with the latest document versions — re-read and retry.",
-  "version": "0.1.0",
+  "description": "Write to the OKF document workspace. Modes: `create` (new document — requires `type`, optional `body`/`frontmatter`), `append` (add content — requires `content` + `expected_version`), `replace` (swap full body — requires `body` + `expected_version`), `section-edit` (replace a `##` section — requires `section`, `content`, optional `expected_section_version`). Every successful write appends an entry to the directory's reserved `log.md`. On version mismatch returns `conflict: true` with the latest document versions — re-read and retry. **Retention:** `/projects/…` is durable (never auto-purged). `/scratch/<conversation-id>/…` is ephemeral — omit `ttl_days` to inherit the configured scratch TTL, set `ttl_days: <n>` to override, or `ttl_days: 0` to opt out. `ttl_days` on non-scratch paths is ignored (a `retention_warning` is returned).",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -10,7 +10,7 @@
     "type": "string? (required for create — OKF frontmatter type)",
     "body": "string? (required for replace; optional for create)",
     "content": "string? (required for append and section-edit)",
-    "frontmatter": "object? (optional YAML frontmatter fields except type)",
+    "frontmatter": "object? (optional YAML frontmatter fields except type; `ttl_days` controls scratch retention — omit to inherit default, 0 to opt out)",
     "section": "string? (required for section-edit — `##` heading)",
     "expected_version": "number? (required for append/replace — from last doc-read)",
     "expected_section_version": "number? (optional for section-edit — per-section optimistic version)",
@@ -26,7 +26,8 @@
     "version": "number?",
     "section_versions": "object?",
     "updated_at": "string?",
-    "displayTimezone": "string?"
+    "displayTimezone": "string?",
+    "retention_warning": "string? (when ttl_days is set on a non-scratch path)"
   },
   "permissions": [],
   "secrets": [],

--- a/src/agents/document-workspace.ts
+++ b/src/agents/document-workspace.ts
@@ -25,6 +25,9 @@ export const RESERVED_LEAF_NAMES = new Set([INDEX_FILENAME, LOG_FILENAME]);
 
 /** Single source of truth for the workspace discipline block injected into every
  *  document-workspace-enabled agent's effective system prompt (#1209). */
+/** Default inactivity TTL for `/scratch/` documents when config omits scratchTtlDays (#1212). */
+export const DEFAULT_SCRATCH_DOC_TTL_DAYS = 7;
+
 export const DOCUMENT_WORKSPACE_BLOCK = [
   '## Document Workspace',
   '',
@@ -35,6 +38,14 @@ export const DOCUMENT_WORKSPACE_BLOCK = [
   '`/scratch/<conversation-id>/outline.md`. Directories are path prefixes — `doc-list` on',
   'a prefix is like `ls` on a folder. Each directory has reserved `index.md` (navigation',
   'catalog) and `log.md` (append-only change history).',
+  '',
+  '**Retention.** `/projects/…` documents are durable — they are never auto-purged. Use them',
+  'for task work that must survive across days and distillation. `/scratch/<conversation-id>/…`',
+  'is ephemeral: the nightly purge removes scratch documents after a period of inactivity',
+  '(measured from `updated_at`). Omit `ttl_days` in frontmatter to inherit the configured',
+  'scratch default; set `ttl_days: <n>` on a scratch document to override retention, or',
+  '`ttl_days: 0` to opt out (prefer `/projects/` for anything that should outlive the',
+  'conversation). `ttl_days` on non-scratch paths is ignored.',
   '',
   '**Manifest first, bodies on demand.** On resume you may receive a directory manifest',
   '(the `index.md` projection) at the tail of your task message — that is the map, not',
@@ -286,4 +297,45 @@ export function documentPointerFromProgress(progress: unknown): ResumableDocumen
   if (!resumable || typeof resumable !== 'object' || Array.isArray(resumable)) return null;
   const accumulator = (resumable as Record<string, unknown>).accumulator;
   return isDocumentPointer(accumulator) ? accumulator : null;
+}
+
+/** True when `path` is under the ephemeral `/scratch/` prefix (#1212). */
+export function isScratchDocumentPath(path: string): boolean {
+  const normalized = normalizeDocPath(path);
+  return normalized === '/scratch' || normalized.startsWith('/scratch/');
+}
+
+/** Parse optional `ttl_days` from OKF frontmatter. Non-numeric values are treated as unset. */
+export function parseTtlDaysFrontmatter(frontmatter: Record<string, unknown>): number | undefined {
+  const raw = frontmatter.ttl_days;
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw === 'number' && Number.isInteger(raw)) return raw;
+  if (typeof raw === 'string' && /^[0-9]+$/.test(raw.trim())) return Number.parseInt(raw.trim(), 10);
+  return undefined;
+}
+
+/**
+ * Resolve effective scratch TTL in days for purge eligibility.
+ * Returns `null` when the document opts out (`ttl_days: 0`) or is not under `/scratch/`.
+ */
+export function resolveScratchDocTtlDays(
+  path: string,
+  frontmatter: Record<string, unknown>,
+  defaultScratchTtlDays: number,
+): number | null {
+  if (!isScratchDocumentPath(path)) return null;
+  const ttlDays = parseTtlDaysFrontmatter(frontmatter);
+  if (ttlDays === 0) return null;
+  if (ttlDays !== undefined && ttlDays > 0) return ttlDays;
+  return defaultScratchTtlDays;
+}
+
+/** Warn when frontmatter sets ttl_days on a non-scratch path (value is ignored at purge time). */
+export function ttlDaysFrontmatterWarning(
+  path: string,
+  frontmatter?: Record<string, unknown>,
+): string | null {
+  if (!frontmatter || parseTtlDaysFrontmatter(frontmatter) === undefined) return null;
+  if (isScratchDocumentPath(path)) return null;
+  return 'ttl_days in frontmatter only affects retention for /scratch/ paths — this document will not auto-expire';
 }

--- a/src/agents/document-workspace.ts
+++ b/src/agents/document-workspace.ts
@@ -25,8 +25,17 @@ export const RESERVED_LEAF_NAMES = new Set([INDEX_FILENAME, LOG_FILENAME]);
 
 /** Single source of truth for the workspace discipline block injected into every
  *  document-workspace-enabled agent's effective system prompt (#1209). */
-/** Default inactivity TTL for `/scratch/` documents when config omits scratchTtlDays (#1212). */
+/** Default inactivity TTL for `/scratch/<conversation-id>/…` when config omits scratchTtlDays (#1212). */
 export const DEFAULT_SCRATCH_DOC_TTL_DAYS = 7;
+
+/** Max per-doc / config TTL — matches `documentWorkspace.scratchTtlDays` validation in config.ts. */
+export const MAX_SCRATCH_DOC_TTL_DAYS = 36500;
+
+/**
+ * Ephemeral scratch workspace paths: `/scratch/<conversation-id>/…` with at least one
+ * leaf segment (excludes bare `/scratch` and root-level `/scratch/foo.md`).
+ */
+export const SCRATCH_CONVERSATION_PATH_RE = /^\/scratch\/[^/]+\/.+/;
 
 export const DOCUMENT_WORKSPACE_BLOCK = [
   '## Document Workspace',
@@ -299,19 +308,24 @@ export function documentPointerFromProgress(progress: unknown): ResumableDocumen
   return isDocumentPointer(accumulator) ? accumulator : null;
 }
 
-/** True when `path` is under the ephemeral `/scratch/` prefix (#1212). */
+/** True for `/scratch/<conversation-id>/…` paths subject to TTL sweep (#1212). */
 export function isScratchDocumentPath(path: string): boolean {
-  const normalized = normalizeDocPath(path);
-  return normalized === '/scratch' || normalized.startsWith('/scratch/');
+  return SCRATCH_CONVERSATION_PATH_RE.test(normalizeDocPath(path));
 }
 
-/** Parse optional `ttl_days` from OKF frontmatter. Non-numeric values are treated as unset. */
+/** Parse optional `ttl_days` from OKF frontmatter. Non-numeric / out-of-range values are unset. */
 export function parseTtlDaysFrontmatter(frontmatter: Record<string, unknown>): number | undefined {
   const raw = frontmatter.ttl_days;
   if (raw === undefined || raw === null) return undefined;
-  if (typeof raw === 'number' && Number.isInteger(raw)) return raw;
-  if (typeof raw === 'string' && /^[0-9]+$/.test(raw.trim())) return Number.parseInt(raw.trim(), 10);
-  return undefined;
+  let parsed: number | undefined;
+  if (typeof raw === 'number' && Number.isInteger(raw)) parsed = raw;
+  else if (typeof raw === 'string' && /^[0-9]+$/.test(raw.trim())) {
+    parsed = Number.parseInt(raw.trim(), 10);
+  } else {
+    return undefined;
+  }
+  if (parsed < 0 || parsed > MAX_SCRATCH_DOC_TTL_DAYS) return undefined;
+  return parsed;
 }
 
 /**

--- a/src/config.document-workspace.test.ts
+++ b/src/config.document-workspace.test.ts
@@ -22,6 +22,16 @@ describe('loadYamlConfig: documentWorkspace.scratchTtlDays', () => {
     expect(() => loadYamlConfig(dir)).toThrow('documentWorkspace.scratchTtlDays');
   });
 
+  it('rejects values above the supported maximum', () => {
+    const dir = writeTempConfig(`documentWorkspace:\n  scratchTtlDays: 36501\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('documentWorkspace.scratchTtlDays');
+  });
+
+  it('rejects a non-mapping documentWorkspace block', () => {
+    const dir = writeTempConfig(`documentWorkspace: 7\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('documentWorkspace must be a YAML mapping');
+  });
+
   it('is absent when documentWorkspace block is omitted', () => {
     const dir = writeTempConfig(`skillOutput:\n  maxLength: 100000\n`);
     const config = loadYamlConfig(dir);

--- a/src/config.document-workspace.test.ts
+++ b/src/config.document-workspace.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { loadYamlConfig } from './config.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+function writeTempConfig(content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-config-'));
+  fs.writeFileSync(path.join(dir, 'default.yaml'), content);
+  return dir;
+}
+
+describe('loadYamlConfig: documentWorkspace.scratchTtlDays', () => {
+  it('accepts a valid positive integer', () => {
+    const dir = writeTempConfig(`documentWorkspace:\n  scratchTtlDays: 14\n`);
+    const config = loadYamlConfig(dir);
+    expect(config.documentWorkspace?.scratchTtlDays).toBe(14);
+  });
+
+  it('rejects zero', () => {
+    const dir = writeTempConfig(`documentWorkspace:\n  scratchTtlDays: 0\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('documentWorkspace.scratchTtlDays');
+  });
+
+  it('is absent when documentWorkspace block is omitted', () => {
+    const dir = writeTempConfig(`skillOutput:\n  maxLength: 100000\n`);
+    const config = loadYamlConfig(dir);
+    expect(config.documentWorkspace?.scratchTtlDays).toBeUndefined();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -216,7 +216,7 @@ export interface YamlConfig {
     };
   };
   documentWorkspace?: {
-    /** Days of inactivity before `/scratch/` documents are hard-deleted by DreamEngine. Default: 7. */
+    /** Days of inactivity before `/scratch/<conversation-id>/…` documents are archived by DreamEngine. Default: 7. */
     scratchTtlDays?: number;
   };
   skillOutput?: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -215,6 +215,10 @@ export interface YamlConfig {
       keepWindow?: number;
     };
   };
+  documentWorkspace?: {
+    /** Days of inactivity before `/scratch/` documents are hard-deleted by DreamEngine. Default: 7. */
+    scratchTtlDays?: number;
+  };
   skillOutput?: {
     /** Max character length for skill results before truncation. Default: 200_000. */
     maxLength?: number;
@@ -694,6 +698,22 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       if (effectiveKeepWindow >= effectiveThreshold) {
         throw new Error(
           `workingMemory.summarization.keepWindow (${effectiveKeepWindow}) must be less than threshold (${effectiveThreshold})`,
+        );
+      }
+    }
+  }
+
+  const documentWorkspace = config.documentWorkspace;
+  if (documentWorkspace !== undefined) {
+    if (documentWorkspace === null || typeof documentWorkspace !== 'object' || Array.isArray(documentWorkspace)) {
+      throw new Error('documentWorkspace must be a YAML mapping');
+    }
+
+    if (documentWorkspace.scratchTtlDays !== undefined) {
+      const scratchTtlDays = documentWorkspace.scratchTtlDays;
+      if (!Number.isInteger(scratchTtlDays) || scratchTtlDays < 1 || scratchTtlDays > 36500) {
+        throw new Error(
+          `documentWorkspace.scratchTtlDays must be a positive integer no greater than 36500, got: ${scratchTtlDays}`,
         );
       }
     }

--- a/src/db/working-docs-repo.test.ts
+++ b/src/db/working-docs-repo.test.ts
@@ -136,4 +136,47 @@ describe('WorkingDocsRepo (unit)', () => {
     expect(sectionVersionChecked).toBe(true);
     expect(result.ok).toBe(true);
   });
+
+  it('purgeExpiredScratch deletes only expired /scratch/ rows', async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const client = makeClient({
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql === 'BEGIN' || sql === 'COMMIT') return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        if (sql.includes('SELECT path') && sql.includes("LIKE '/scratch/%'")) {
+          return {
+            rows: [{ path: '/scratch/old/note.md' }],
+            rowCount: 1,
+          } as QueryResult;
+        }
+        if (sql.startsWith('DELETE FROM working_document_links')) {
+          return { rows: [], rowCount: 1 } as unknown as QueryResult;
+        }
+        if (sql.startsWith('DELETE FROM working_documents')) {
+          expect(params?.[0]).toEqual(['/scratch/old/note.md']);
+          return { rows: [], rowCount: 1 } as unknown as QueryResult;
+        }
+        throw new Error(`unexpected sql: ${sql}`);
+      },
+    });
+    const { pool } = makePool(client);
+    const repo = new WorkingDocsRepo(pool, createSilentLogger());
+    const deleted = await repo.purgeExpiredScratch(7);
+    expect(deleted).toBe(1);
+    expect(queries.some(q => q.sql.includes("LIKE '/scratch/%'"))).toBe(true);
+    expect(queries.some(q => q.sql.startsWith('DELETE FROM working_documents'))).toBe(true);
+  });
+
+  it('purgeExpiredScratch is a no-op when nothing is expired', async () => {
+    const client = makeClient({
+      query: async (sql: string) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT') return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        if (sql.includes('SELECT path')) return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        throw new Error(`unexpected sql: ${sql}`);
+      },
+    });
+    const { pool } = makePool(client);
+    const repo = new WorkingDocsRepo(pool, createSilentLogger());
+    await expect(repo.purgeExpiredScratch(7)).resolves.toBe(0);
+  });
 });

--- a/src/db/working-docs-repo.test.ts
+++ b/src/db/working-docs-repo.test.ts
@@ -137,41 +137,32 @@ describe('WorkingDocsRepo (unit)', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('purgeExpiredScratch deletes only expired /scratch/ rows', async () => {
+  it('purgeExpiredScratch archives only expired /scratch/<conversation-id>/… rows', async () => {
     const queries: Array<{ sql: string; params?: unknown[] }> = [];
     const client = makeClient({
       query: async (sql: string, params?: unknown[]) => {
         queries.push({ sql, params });
         if (sql === 'BEGIN' || sql === 'COMMIT') return { rows: [], rowCount: 0 } as unknown as QueryResult;
-        if (sql.includes('SELECT path') && sql.includes("LIKE '/scratch/%'")) {
-          return {
-            rows: [{ path: '/scratch/old/note.md' }],
-            rowCount: 1,
-          } as QueryResult;
-        }
-        if (sql.startsWith('DELETE FROM working_document_links')) {
-          return { rows: [], rowCount: 1 } as unknown as QueryResult;
-        }
-        if (sql.startsWith('DELETE FROM working_documents')) {
-          expect(params?.[0]).toEqual(['/scratch/old/note.md']);
-          return { rows: [], rowCount: 1 } as unknown as QueryResult;
+        if (sql.includes('WITH archived AS')) {
+          return { rows: [{ archived_count: '1' }], rowCount: 1 } as QueryResult;
         }
         throw new Error(`unexpected sql: ${sql}`);
       },
     });
     const { pool } = makePool(client);
     const repo = new WorkingDocsRepo(pool, createSilentLogger());
-    const deleted = await repo.purgeExpiredScratch(7);
-    expect(deleted).toBe(1);
-    expect(queries.some(q => q.sql.includes("LIKE '/scratch/%'"))).toBe(true);
-    expect(queries.some(q => q.sql.startsWith('DELETE FROM working_documents'))).toBe(true);
+    const archived = await repo.purgeExpiredScratch(7);
+    expect(archived).toBe(1);
+    expect(queries.some(q => q.sql.includes("path ~ '^/scratch/[^/]+/'"))).toBe(true);
+    expect(queries.some(q => q.sql.includes('UPDATE working_documents'))).toBe(true);
+    expect(queries.some(q => q.sql.includes('DELETE FROM working_documents'))).toBe(false);
   });
 
   it('purgeExpiredScratch is a no-op when nothing is expired', async () => {
     const client = makeClient({
       query: async (sql: string) => {
         if (sql === 'BEGIN' || sql === 'COMMIT') return { rows: [], rowCount: 0 } as unknown as QueryResult;
-        if (sql.includes('SELECT path')) return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        if (sql.includes('WITH archived AS')) return { rows: [{ archived_count: '0' }], rowCount: 0 } as unknown as QueryResult;
         throw new Error(`unexpected sql: ${sql}`);
       },
     });

--- a/src/db/working-docs-repo.ts
+++ b/src/db/working-docs-repo.ts
@@ -375,6 +375,74 @@ export class WorkingDocsRepo {
     return rows.map(mapRow);
   }
 
+  /**
+   * Hard-delete expired `/scratch/` documents past their TTL (#1212).
+   * Non-scratch paths are never touched. TTL is derived from `updated_at` and either
+   * frontmatter `ttl_days` (scratch only) or the configured default. Returns deleted count.
+   */
+  async purgeExpiredScratch(defaultTtlDays: number): Promise<number> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const { rows } = await client.query<{ path: string }>(
+        `SELECT path
+         FROM working_documents
+         WHERE path LIKE '/scratch/%'
+           AND archived_at IS NULL
+           AND COALESCE(
+             CASE
+               WHEN (frontmatter->>'ttl_days') ~ '^[0-9]+$' THEN (frontmatter->>'ttl_days')::int
+               ELSE NULL
+             END,
+             $1
+           ) > 0
+           AND updated_at < now() - (
+             COALESCE(
+               CASE
+                 WHEN (frontmatter->>'ttl_days') ~ '^[0-9]+$' AND (frontmatter->>'ttl_days')::int > 0
+                   THEN (frontmatter->>'ttl_days')::int
+                 ELSE NULL
+               END,
+               $1
+             ) * INTERVAL '1 day'
+           )`,
+        [defaultTtlDays],
+      );
+
+      if (rows.length === 0) {
+        await client.query('COMMIT');
+        return 0;
+      }
+
+      const paths = rows.map(r => r.path);
+      await client.query(
+        `DELETE FROM working_document_links
+         WHERE source_path = ANY($1::text[]) OR target_path = ANY($1::text[])`,
+        [paths],
+      );
+      const deleteResult = await client.query(
+        `DELETE FROM working_documents
+         WHERE path = ANY($1::text[])`,
+        [paths],
+      );
+
+      await client.query('COMMIT');
+      const deleted = deleteResult.rowCount ?? 0;
+      this.logger.info(
+        { deleted, defaultTtlDays, paths },
+        'working-docs-repo: purged expired scratch documents',
+      );
+      return deleted;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      this.logger.error({ err, defaultTtlDays }, 'working-docs-repo: purgeExpiredScratch failed');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   async softDelete(path: string): Promise<WorkingDocRow | null> {
     const normalized = normalizeDocPath(path);
     const client = await this.pool.connect();

--- a/src/db/working-docs-repo.ts
+++ b/src/db/working-docs-repo.ts
@@ -376,64 +376,68 @@ export class WorkingDocsRepo {
   }
 
   /**
-   * Hard-delete expired `/scratch/` documents past their TTL (#1212).
+   * Soft-delete expired `/scratch/<conversation-id>/…` documents past their TTL (#1212).
    * Non-scratch paths are never touched. TTL is derived from `updated_at` and either
-   * frontmatter `ttl_days` (scratch only) or the configured default. Returns deleted count.
+   * frontmatter `ttl_days` (scratch only) or the configured default.
+   *
+   * Link cleanup: removes outbound `source_path` links from archived docs (same as
+   * `softDelete()`). Inbound links whose `target_path` points at an archived doc are
+   * left in place — `getBacklinks()` joins on live sources only, so they are harmless.
+   *
+   * The archive runs as a single `UPDATE … RETURNING` so the TTL predicate is enforced
+   * at write time (no snapshot-then-delete race).
    */
   async purgeExpiredScratch(defaultTtlDays: number): Promise<number> {
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
 
-      const { rows } = await client.query<{ path: string }>(
-        `SELECT path
-         FROM working_documents
-         WHERE path LIKE '/scratch/%'
-           AND archived_at IS NULL
-           AND COALESCE(
-             CASE
-               WHEN (frontmatter->>'ttl_days') ~ '^[0-9]+$' THEN (frontmatter->>'ttl_days')::int
-               ELSE NULL
-             END,
-             $1
-           ) > 0
-           AND updated_at < now() - (
-             COALESCE(
-               CASE
-                 WHEN (frontmatter->>'ttl_days') ~ '^[0-9]+$' AND (frontmatter->>'ttl_days')::int > 0
-                   THEN (frontmatter->>'ttl_days')::int
-                 ELSE NULL
-               END,
-               $1
-             ) * INTERVAL '1 day'
-           )`,
+      const { rows } = await client.query<{ archived_count: string }>(
+        `WITH archived AS (
+           UPDATE working_documents
+              SET archived_at = now(),
+                  updated_at = now()
+            WHERE path ~ '^/scratch/[^/]+/'
+              AND archived_at IS NULL
+              AND COALESCE(
+                CASE
+                  WHEN (frontmatter->>'ttl_days') ~ '^[0-9]+$'
+                    AND (frontmatter->>'ttl_days')::int = 0 THEN 0
+                  WHEN (frontmatter->>'ttl_days') ~ '^[0-9]{1,5}$'
+                    AND (frontmatter->>'ttl_days')::int BETWEEN 1 AND 36500
+                    THEN (frontmatter->>'ttl_days')::int
+                  ELSE NULL
+                END,
+                $1
+              ) > 0
+              AND updated_at < now() - (
+                COALESCE(
+                  CASE
+                    WHEN (frontmatter->>'ttl_days') ~ '^[0-9]{1,5}$'
+                      AND (frontmatter->>'ttl_days')::int BETWEEN 1 AND 36500
+                      THEN (frontmatter->>'ttl_days')::int
+                    ELSE NULL
+                  END,
+                  $1
+                ) * INTERVAL '1 day'
+              )
+           RETURNING path
+         ),
+         _links AS (
+           DELETE FROM working_document_links
+            WHERE source_path IN (SELECT path FROM archived)
+         )
+         SELECT COUNT(*)::text AS archived_count FROM archived`,
         [defaultTtlDays],
       );
 
-      if (rows.length === 0) {
-        await client.query('COMMIT');
-        return 0;
-      }
-
-      const paths = rows.map(r => r.path);
-      await client.query(
-        `DELETE FROM working_document_links
-         WHERE source_path = ANY($1::text[]) OR target_path = ANY($1::text[])`,
-        [paths],
-      );
-      const deleteResult = await client.query(
-        `DELETE FROM working_documents
-         WHERE path = ANY($1::text[])`,
-        [paths],
-      );
-
       await client.query('COMMIT');
-      const deleted = deleteResult.rowCount ?? 0;
+      const archived = Number.parseInt(rows[0]?.archived_count ?? '0', 10);
       this.logger.info(
-        { deleted, defaultTtlDays, paths },
-        'working-docs-repo: purged expired scratch documents',
+        { archived, defaultTtlDays },
+        'working-docs-repo: archived expired scratch documents',
       );
-      return deleted;
+      return archived;
     } catch (err) {
       await client.query('ROLLBACK');
       this.logger.error({ err, defaultTtlDays }, 'working-docs-repo: purgeExpiredScratch failed');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1540,8 +1540,24 @@ async function main(): Promise<void> {
   const scoringPass = new AutonomyScoringPass(actionLogRepo, autonomyService, scoringProvider, logger, scoringPassConfig);
   logger.info({ scoringPassConfig }, 'AutonomyScoringPass configured');
 
-  const dreamEngine = new DreamEngine(pool, bus, logger, decayConfig, scoringPass, memory);
-  logger.info({ decayConfig }, 'DreamEngine configured');
+  const dreamEngine = new DreamEngine(
+    pool,
+    bus,
+    logger,
+    decayConfig,
+    scoringPass,
+    memory,
+    workingDocsRepo,
+    yamlConfig.documentWorkspace?.scratchTtlDays ?? 7,
+  );
+  logger.info(
+    {
+      decayConfig,
+      scratchTtlDays: yamlConfig.documentWorkspace?.scratchTtlDays ?? 7,
+      scratchTtlFromConfig: yamlConfig.documentWorkspace?.scratchTtlDays !== undefined,
+    },
+    'DreamEngine configured',
+  );
 
   // Outbound context bridge — delegation-aware context registry for
   // specialist-initiated outbound. Requires pool (Postgres).

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ import { runReadinessChecks } from './startup/readiness.js';
 import { compileSecurityContextBlock } from './security/security-context.js';
 import { OutboundContextService } from './dispatch/outbound-context.js';
 import { applyTaskManagement } from './agents/task-management.js';
-import { applyDocumentWorkspace } from './agents/document-workspace.js';
+import { applyDocumentWorkspace, DEFAULT_SCRATCH_DOC_TTL_DAYS } from './agents/document-workspace.js';
 import { BacklogHeartbeat } from './scheduler/backlog-heartbeat.js';
 import { ResumableContinuationSubscriber } from './agents/resumable-continuation-subscriber.js';
 import * as fs from 'node:fs';
@@ -1548,12 +1548,12 @@ async function main(): Promise<void> {
     scoringPass,
     memory,
     workingDocsRepo,
-    yamlConfig.documentWorkspace?.scratchTtlDays ?? 7,
+    yamlConfig.documentWorkspace?.scratchTtlDays ?? DEFAULT_SCRATCH_DOC_TTL_DAYS,
   );
   logger.info(
     {
       decayConfig,
-      scratchTtlDays: yamlConfig.documentWorkspace?.scratchTtlDays ?? 7,
+      scratchTtlDays: yamlConfig.documentWorkspace?.scratchTtlDays ?? DEFAULT_SCRATCH_DOC_TTL_DAYS,
       scratchTtlFromConfig: yamlConfig.documentWorkspace?.scratchTtlDays !== undefined,
     },
     'DreamEngine configured',

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -5,6 +5,7 @@ import type { MemoryDecayWarningPayload } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { AutonomyScoringPass } from '../autonomy/scoring-pass.js';
 import type { WorkingMemory } from './working-memory.js';
+import type { WorkingDocsRepo } from '../db/working-docs-repo.js';
 
 // Config shape mirrors YamlConfig.dreaming.decay — all fields required at construction
 // time (caller resolves defaults before passing in).
@@ -65,14 +66,27 @@ export class DreamEngine {
   // limit backoff) could let two passes read the same unscored rows concurrently,
   // wasting LLM spend and applying the adjustment formula twice.
   private scoringPassInFlight = false;
+  private workingDocsRepo?: WorkingDocsRepo;
+  private scratchTtlDays?: number;
 
-  constructor(pool: Pool, bus: EventBus, logger: Logger, config: DecayConfig, scoringPass?: AutonomyScoringPass, workingMemory?: WorkingMemory) {
+  constructor(
+    pool: Pool,
+    bus: EventBus,
+    logger: Logger,
+    config: DecayConfig,
+    scoringPass?: AutonomyScoringPass,
+    workingMemory?: WorkingMemory,
+    workingDocsRepo?: WorkingDocsRepo,
+    scratchTtlDays?: number,
+  ) {
     this.pool = pool;
     this.bus = bus;
     this.logger = logger;
     this.config = config;
     this.scoringPass = scoringPass;
     this.workingMemory = workingMemory;
+    this.workingDocsRepo = workingDocsRepo;
+    this.scratchTtlDays = scratchTtlDays;
   }
 
   /**
@@ -115,6 +129,8 @@ export class DreamEngine {
         scoringIntervalMs: this.scoringPass?.intervalMs ?? null,
         archiveThreshold: this.config.archiveThreshold,
         hasScoringPass: !!this.scoringPass,
+        hasScratchDocPurge: !!(this.workingDocsRepo && this.scratchTtlDays != null),
+        scratchTtlDays: this.scratchTtlDays ?? null,
       },
       'DreamEngine started (decay pass scheduled)',
     );
@@ -192,6 +208,22 @@ export class DreamEngine {
             { err: purgeErr },
             'DreamEngine: working memory purge failed — will retry on next pass. ' +
             'To check backlog: SELECT COUNT(*) FROM working_memory WHERE expires_at IS NOT NULL AND expires_at < now() AND archived = false',
+          );
+        }
+      }
+
+      if (this.workingDocsRepo && this.scratchTtlDays != null) {
+        try {
+          const purgedScratchDocs = await this.workingDocsRepo.purgeExpiredScratch(this.scratchTtlDays);
+          this.logger.info(
+            { purgedScratchDocs, scratchTtlDays: this.scratchTtlDays },
+            'DreamEngine: scratch document purge complete',
+          );
+        } catch (purgeErr) {
+          this.logger.error(
+            { err: purgeErr, scratchTtlDays: this.scratchTtlDays },
+            'DreamEngine: scratch document purge failed — will retry on next pass. ' +
+            'To check backlog: SELECT COUNT(*) FROM working_documents WHERE path LIKE \'/scratch/%\' AND archived_at IS NULL',
           );
         }
       }

--- a/tests/integration/working-docs-repo.test.ts
+++ b/tests/integration/working-docs-repo.test.ts
@@ -198,23 +198,30 @@ describeIf('WorkingDocsRepo (integration)', () => {
     }
   });
 
-  it('purgeExpiredScratch hard-deletes only expired /scratch/ documents', async () => {
+  it('purgeExpiredScratch archives only expired /scratch/<conversation-id>/… documents', async () => {
     await repo.create({ path: '/scratch/expired/note.md', type: 'note', body: 'old' });
     await repo.create({ path: '/scratch/fresh/note.md', type: 'note', body: 'new' });
     await repo.create({ path: '/projects/durable/brief.md', type: 'brief', body: 'keep' });
+    await repo.create({ path: '/scratch/index.md', type: 'index', body: 'root scratch' });
 
     await pool.query(
       `UPDATE working_documents
        SET updated_at = now() - INTERVAL '10 days'
-       WHERE path = '/scratch/expired/note.md'`,
+       WHERE path IN ('/scratch/expired/note.md', '/scratch/index.md')`,
     );
 
-    const deleted = await repo.purgeExpiredScratch(7);
-    expect(deleted).toBe(1);
+    const archived = await repo.purgeExpiredScratch(7);
+    expect(archived).toBe(1);
 
     expect(await repo.read('/scratch/expired/note.md')).toBeNull();
     expect(await repo.read('/scratch/fresh/note.md')).not.toBeNull();
     expect(await repo.read('/projects/durable/brief.md')).not.toBeNull();
+    expect(await repo.read('/scratch/index.md')).not.toBeNull();
+
+    const { rows } = await pool.query<{ archived_at: Date | null }>(
+      `SELECT archived_at FROM working_documents WHERE path = '/scratch/expired/note.md'`,
+    );
+    expect(rows[0]?.archived_at).not.toBeNull();
   });
 
   it('purgeExpiredScratch respects ttl_days: 0 opt-out on scratch paths', async () => {

--- a/tests/integration/working-docs-repo.test.ts
+++ b/tests/integration/working-docs-repo.test.ts
@@ -197,4 +197,48 @@ describeIf('WorkingDocsRepo (integration)', () => {
       expect(appended.document.version).toBe(2);
     }
   });
+
+  it('purgeExpiredScratch hard-deletes only expired /scratch/ documents', async () => {
+    await repo.create({ path: '/scratch/expired/note.md', type: 'note', body: 'old' });
+    await repo.create({ path: '/scratch/fresh/note.md', type: 'note', body: 'new' });
+    await repo.create({ path: '/projects/durable/brief.md', type: 'brief', body: 'keep' });
+
+    await pool.query(
+      `UPDATE working_documents
+       SET updated_at = now() - INTERVAL '10 days'
+       WHERE path = '/scratch/expired/note.md'`,
+    );
+
+    const deleted = await repo.purgeExpiredScratch(7);
+    expect(deleted).toBe(1);
+
+    expect(await repo.read('/scratch/expired/note.md')).toBeNull();
+    expect(await repo.read('/scratch/fresh/note.md')).not.toBeNull();
+    expect(await repo.read('/projects/durable/brief.md')).not.toBeNull();
+  });
+
+  it('purgeExpiredScratch respects ttl_days: 0 opt-out on scratch paths', async () => {
+    await repo.create({
+      path: '/scratch/permanent/note.md',
+      type: 'note',
+      body: 'stay',
+      frontmatter: { ttl_days: 0 },
+    });
+    await pool.query(
+      `UPDATE working_documents
+       SET updated_at = now() - INTERVAL '30 days'
+       WHERE path = '/scratch/permanent/note.md'`,
+    );
+
+    const deleted = await repo.purgeExpiredScratch(7);
+    expect(deleted).toBe(0);
+    expect(await repo.read('/scratch/permanent/note.md')).not.toBeNull();
+  });
+
+  it('purgeExpiredScratch is idempotent when nothing is expired', async () => {
+    await repo.create({ path: '/scratch/active/note.md', type: 'note', body: 'fresh' });
+    expect(await repo.purgeExpiredScratch(7)).toBe(0);
+    expect(await repo.purgeExpiredScratch(7)).toBe(0);
+    expect(await repo.read('/scratch/active/note.md')).not.toBeNull();
+  });
 });

--- a/tests/unit/agents/document-workspace.test.ts
+++ b/tests/unit/agents/document-workspace.test.ts
@@ -174,8 +174,10 @@ describe('reserved path helpers', () => {
 });
 
 describe('scratch document TTL helpers (#1212)', () => {
-  it('identifies scratch paths', () => {
+  it('identifies conversation-scoped scratch paths only', () => {
     expect(isScratchDocumentPath('/scratch/conv/outline.md')).toBe(true);
+    expect(isScratchDocumentPath('/scratch/index.md')).toBe(false);
+    expect(isScratchDocumentPath('/scratch')).toBe(false);
     expect(isScratchDocumentPath('/projects/x/brief.md')).toBe(false);
   });
 
@@ -197,6 +199,10 @@ describe('scratch document TTL helpers (#1212)', () => {
 
   it('parses string ttl_days values', () => {
     expect(parseTtlDaysFrontmatter({ ttl_days: '5' })).toBe(5);
+  });
+
+  it('treats out-of-range ttl_days as unset in frontmatter parsing', () => {
+    expect(parseTtlDaysFrontmatter({ ttl_days: 999999 })).toBeUndefined();
   });
 
   it('warns when ttl_days is set on a non-scratch path', () => {

--- a/tests/unit/agents/document-workspace.test.ts
+++ b/tests/unit/agents/document-workspace.test.ts
@@ -11,10 +11,14 @@ import {
   formatWorkspaceManifestBlock,
   grepDocuments,
   indexPathForDirectory,
+  isScratchDocumentPath,
   logPathForDocument,
   parseTaskWakePayload,
+  parseTtlDaysFrontmatter,
+  resolveScratchDocTtlDays,
   resolveWorkspaceDirectoryPrefix,
   resolveWorkspacePrefixFromTaskContent,
+  ttlDaysFrontmatterWarning,
 } from '../../../src/agents/document-workspace.js';
 import type { AgentYamlConfig } from '../../../src/agents/loader.js';
 import type { WorkingDocRow } from '../../../src/db/working-docs-repo.js';
@@ -166,6 +170,38 @@ describe('reserved path helpers', () => {
     const block = formatWorkspaceManifestBlock('/projects/x/', '# Index\n');
     expect(block).toContain('Workspace Manifest');
     expect(block).toContain('# Index');
+  });
+});
+
+describe('scratch document TTL helpers (#1212)', () => {
+  it('identifies scratch paths', () => {
+    expect(isScratchDocumentPath('/scratch/conv/outline.md')).toBe(true);
+    expect(isScratchDocumentPath('/projects/x/brief.md')).toBe(false);
+  });
+
+  it('inherits default TTL when ttl_days is omitted on scratch paths', () => {
+    expect(resolveScratchDocTtlDays('/scratch/c/note.md', {}, 7)).toBe(7);
+  });
+
+  it('honours positive ttl_days overrides on scratch paths', () => {
+    expect(resolveScratchDocTtlDays('/scratch/c/note.md', { ttl_days: 14 }, 7)).toBe(14);
+  });
+
+  it('opts out when ttl_days is zero on scratch paths', () => {
+    expect(resolveScratchDocTtlDays('/scratch/c/note.md', { ttl_days: 0 }, 7)).toBeNull();
+  });
+
+  it('ignores ttl_days on non-scratch paths', () => {
+    expect(resolveScratchDocTtlDays('/projects/x/brief.md', { ttl_days: 3 }, 7)).toBeNull();
+  });
+
+  it('parses string ttl_days values', () => {
+    expect(parseTtlDaysFrontmatter({ ttl_days: '5' })).toBe(5);
+  });
+
+  it('warns when ttl_days is set on a non-scratch path', () => {
+    const warning = ttlDaysFrontmatterWarning('/projects/x/brief.md', { ttl_days: 3 });
+    expect(warning).toMatch(/ignored|not auto-expire/i);
   });
 });
 

--- a/tests/unit/memory/dream-engine-purge.test.ts
+++ b/tests/unit/memory/dream-engine-purge.test.ts
@@ -1,11 +1,13 @@
 /**
  * Unit test verifying DreamEngine calls workingMemory.purgeExpired()
  * after the decay pass commits — issue #220.
+ * Extended for scratch document purge — issue #1212.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { DreamEngine } from '../../../src/memory/dream-engine.js';
 import type { EventBus } from '../../../src/bus/bus.js';
 import type { WorkingMemory } from '../../../src/memory/working-memory.js';
+import type { WorkingDocsRepo } from '../../../src/db/working-docs-repo.js';
 
 function makeBus(): EventBus {
   return { publish: vi.fn().mockResolvedValue(undefined), subscribe: vi.fn() } as unknown as EventBus;
@@ -99,6 +101,74 @@ describe('DreamEngine — working memory purge', () => {
     expect(loggerMock.error).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
       expect.stringContaining('working memory purge failed'),
+    );
+  });
+});
+
+describe('DreamEngine — scratch document purge', () => {
+  it('calls purgeExpiredScratch() after the decay pass completes', async () => {
+    const { pool } = makePool();
+    const mockWorkingDocsRepo = {
+      purgeExpiredScratch: vi.fn().mockResolvedValue(2),
+    } as unknown as WorkingDocsRepo;
+
+    const engine = new DreamEngine(
+      pool as never,
+      makeBus(),
+      makeSilentLogger(),
+      baseConfig,
+      undefined,
+      undefined,
+      mockWorkingDocsRepo,
+      7,
+    );
+
+    await engine.runDecayPass();
+
+    expect(mockWorkingDocsRepo.purgeExpiredScratch).toHaveBeenCalledWith(7);
+  });
+
+  it('does not call purgeExpiredScratch when workingDocsRepo is not injected', async () => {
+    const { pool } = makePool();
+    const mockWorkingDocsRepo = {
+      purgeExpiredScratch: vi.fn(),
+    } as unknown as WorkingDocsRepo;
+
+    const engine = new DreamEngine(
+      pool as never,
+      makeBus(),
+      makeSilentLogger(),
+      baseConfig,
+    );
+
+    await engine.runDecayPass();
+
+    expect(mockWorkingDocsRepo.purgeExpiredScratch).not.toHaveBeenCalled();
+  });
+
+  it('logs a scratch purge failure but does not throw', async () => {
+    const { pool } = makePool();
+    const loggerMock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const logger = loggerMock as unknown as never;
+    const mockWorkingDocsRepo = {
+      purgeExpiredScratch: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+    } as unknown as WorkingDocsRepo;
+
+    const engine = new DreamEngine(
+      pool as never,
+      makeBus(),
+      logger,
+      baseConfig,
+      undefined,
+      undefined,
+      mockWorkingDocsRepo,
+      7,
+    );
+
+    await expect(engine.runDecayPass()).resolves.toBeDefined();
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error), scratchTtlDays: 7 }),
+      expect.stringContaining('scratch document purge failed'),
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1212.

Adds the missing retention sweep for ephemeral `/scratch/<conversation-id>/…` documents. The nightly DreamEngine pass now **archives** scratch docs (`archived_at`) whose `updated_at` is older than the configured TTL. Non-scratch paths are never touched.

## Behaviour

- **Config:** `documentWorkspace.scratchTtlDays` (default **7** days of inactivity)
- **Per-document override (scratch only):** optional `ttl_days` in OKF frontmatter
  - **Omitted** → inherit configured scratch default
  - **Positive integer (1–36500)** → override retention for that document
  - **`0`** → opt out of auto-archive (discouraged — prefer `/projects/` for durable work)
- **Path scope:** only `/scratch/<conversation-id>/…` (not `/scratch/index.md` or other root-level scratch paths)
- **Non-scratch paths** (`/projects/…`, etc.) → never auto-archived; `ttl_days` is ignored and `doc-write` returns a `retention_warning`

## Implementation notes (CodeRabbit follow-up)

- **Soft-delete** via `archived_at` (not hard-delete) — consistent with `WorkingDocsRepo.softDelete()`
- **Atomic** `UPDATE … RETURNING` enforces TTL at archive time (no snapshot race)
- **Link cleanup:** deletes outbound `source_path` links; inbound `target_path` links to archived docs are harmless (`getBacklinks()` joins live sources only)

## Test plan

- [x] `pnpm run typecheck`
- [x] Unit tests: repo purge, path helpers, config validation, DreamEngine wiring
- [x] Integration tests (`working-docs-repo`) — CI with Postgres
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6519e41-4285-4259-af59-0fbebe67cf84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6519e41-4285-4259-af59-0fbebe67cf84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

