### PR TITLE
feat: progress-based resumable circuit breaker (stall counter + ceilings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Resumable circuit breaker** — progress-based stall counter plus per-task iteration/wallclock/cost ceilings; K consecutive no-progress pauses or a ceiling breach fails the task and escalates via the backlog path instead of looping. Config: `tasks.resumableCeilings` (defaults documented in `config/default.yaml`). (#1176)
 - **Resumable executor contract** — checkpointed budget-hit pauses instead of `BUDGET_EXCEEDED`; coordinator treats `paused` as success. (#1174)
 - **Resumable self-continuation** — paused resumable tasks schedule a single near-term `scheduled_jobs` wake routed to `source_agent_id` (config: `tasks.resumableContinuationSeconds`); the hourly BacklogHeartbeat remains the backstop. (#1175)
 - **`checkpoint`** — resumable-task primitive writing `progress.resumable`; dedicated skill (not folded into `task-update`) with platform guidance, checkpoint resume injection, a one-time ~15% budget nudge at the message tail, auto-pin even for tool-less agents, and no raw UTC in skill results when timezone is absent. (#1173)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Resumable circuit breaker** — progress-based stall counter plus per-task iteration/wallclock/cost ceilings; K consecutive no-progress pauses or a ceiling breach fails the task and escalates via the backlog path instead of looping. Config: `tasks.resumableCeilings` (defaults documented in `config/default.yaml`). (#1176)
+- **Resumable circuit breaker** — stall counter and aggregate ceilings fail stuck resumable tasks instead of looping. (#1176)
 - **Resumable executor contract** — checkpointed budget-hit pauses instead of `BUDGET_EXCEEDED`; coordinator treats `paused` as success. (#1174)
 - **Resumable self-continuation** — paused resumable tasks schedule a single near-term `scheduled_jobs` wake routed to `source_agent_id` (config: `tasks.resumableContinuationSeconds`); the hourly BacklogHeartbeat remains the backstop. (#1175)
 - **`checkpoint`** — resumable-task primitive writing `progress.resumable`; dedicated skill (not folded into `task-update`) with platform guidance, checkpoint resume injection, a one-time ~15% budget nudge at the message tail, auto-pin even for tool-less agents, and no raw UTC in skill results when timezone is absent. (#1173)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -415,6 +415,15 @@ tasks:
   # threshold (idleThresholdHours, typically 4). At most one pending wake per task —
   # a lost continuation is re-surfaced by the heartbeat once idleThresholdHours elapses.
   resumableContinuationSeconds: 30
+  # Progress-based circuit breaker for resumable iterate leaves (#1176).
+  # Per-task error_budget may override any key (max_stalls, max_iterations,
+  # max_wallclock_hours, max_cost_usd). A breach fails the task and escalates
+  # via the backlog-surfacing path instead of looping silently.
+  resumableCeilings:
+    maxStalls: 3          # K — consecutive paused slices with no cursor/done advance
+    maxIterations: 100    # hard cap on continuation slices
+    maxWallclockHours: 24 # hours from first processed pause
+    maxCostUsd: 10.00     # aggregate LLM spend across slices (USD)
 
 # Autonomy authorization (#1125). The bypass ladder governs how much LINEAGE standing a
 # heartbeat-woken/derived task inherits at the live autonomy score. The score can only ever

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -350,7 +350,17 @@
         "heartbeatMaxWakesPerTick": { "type": "integer", "minimum": 1 },
         "idleThresholdHours": { "type": "number", "minimum": 0 },
         "staleWaitThresholdHours": { "type": "number", "minimum": 0 },
-        "resumableContinuationSeconds": { "type": "integer", "minimum": 1 }
+        "resumableContinuationSeconds": { "type": "integer", "minimum": 1 },
+        "resumableCeilings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "maxStalls": { "type": "integer", "minimum": 1 },
+            "maxIterations": { "type": "integer", "minimum": 1 },
+            "maxWallclockHours": { "type": "number", "exclusiveMinimum": 0 },
+            "maxCostUsd": { "type": "number", "exclusiveMinimum": 0 }
+          }
+        }
       }
     },
     "autonomy": {

--- a/src/agents/resumable-circuit-breaker.test.ts
+++ b/src/agents/resumable-circuit-breaker.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  cursorsEqual,
+  hasForwardProgress,
+  processPausedSliceOutcome,
+  readCircuitState,
+  resolveResumableCeilings,
+  mergeCircuitState,
+} from './resumable-circuit-breaker.js';
+import { DEFAULT_RESUMABLE_CEILINGS } from '../config.js';
+import type { ExecutionPausedPayload } from './resumable-task.js';
+
+function paused(overrides: Partial<ExecutionPausedPayload> = {}): ExecutionPausedPayload {
+  return {
+    _curia_protocol: 'execution_paused',
+    done: 25,
+    total: 100,
+    cursor: 'page:3',
+    last_slice_units: 25,
+    next: 'continue',
+    ...overrides,
+  };
+}
+
+describe('resumable-circuit-breaker (#1176)', () => {
+  it('detects forward progress via done-count or cursor change', () => {
+    expect(hasForwardProgress({ done: 10, cursor: 'a' }, { done: 11, cursor: 'a' })).toBe(true);
+    expect(hasForwardProgress({ done: 10, cursor: 'a' }, { done: 10, cursor: 'b' })).toBe(true);
+    expect(hasForwardProgress({ done: 10, cursor: 'a' }, { done: 10, cursor: 'a' })).toBe(false);
+    expect(cursorsEqual({ x: 1 }, { x: 1 })).toBe(true);
+    expect(cursorsEqual('page:1', 'page:2')).toBe(false);
+  });
+
+  it('resets stall counter on forward progress', () => {
+    const circuit = {
+      stallCount: 2,
+      iterationCount: 5,
+      startedAt: '2026-06-01T00:00:00.000Z',
+      totalCostUsd: 0,
+      lastProgress: { done: 20, cursor: 'page:2' },
+    };
+    const result = processPausedSliceOutcome({
+      paused: paused({ done: 25, cursor: 'page:3' }),
+      circuit,
+      ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 3 },
+      now: new Date('2026-06-01T01:00:00.000Z'),
+    });
+    expect(result.action).toBe('continue');
+    if (result.action === 'continue') {
+      expect(result.state.stallCount).toBe(0);
+      expect(result.state.iterationCount).toBe(6);
+    }
+  });
+
+  it('increments stall counter when paused with no progress', () => {
+    const circuit = {
+      stallCount: 0,
+      iterationCount: 1,
+      startedAt: '2026-06-01T00:00:00.000Z',
+      totalCostUsd: 0,
+      lastProgress: { done: 25, cursor: 'page:3' },
+    };
+    const result = processPausedSliceOutcome({
+      paused: paused({ done: 25, cursor: 'page:3' }),
+      circuit,
+      ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 3 },
+      now: new Date('2026-06-01T01:00:00.000Z'),
+    });
+    expect(result.action).toBe('continue');
+    if (result.action === 'continue') {
+      expect(result.state.stallCount).toBe(1);
+    }
+  });
+
+  it('breaches after K consecutive stalls', () => {
+    const circuit = {
+      stallCount: 2,
+      iterationCount: 10,
+      startedAt: '2026-06-01T00:00:00.000Z',
+      totalCostUsd: 0,
+      lastProgress: { done: 25, cursor: 'page:3' },
+    };
+    const result = processPausedSliceOutcome({
+      paused: paused({ done: 25, cursor: 'page:3' }),
+      circuit,
+      ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 3 },
+      now: new Date('2026-06-01T01:00:00.000Z'),
+    });
+    expect(result.action).toBe('breach');
+    if (result.action === 'breach') {
+      expect(result.breach.reason).toBe('stall_limit');
+    }
+  });
+
+  it('breaches on iteration, wallclock, and cost ceilings', () => {
+    const base = {
+      stallCount: 0,
+      iterationCount: 99,
+      startedAt: '2026-06-01T00:00:00.000Z',
+      totalCostUsd: 9.5,
+      lastProgress: { done: 25, cursor: 'page:3' },
+    };
+    expect(processPausedSliceOutcome({
+      paused: paused({ done: 30, cursor: 'page:4' }),
+      circuit: base,
+      ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxIterations: 100 },
+      now: new Date('2026-06-01T01:00:00.000Z'),
+    }).action).toBe('breach');
+
+    expect(processPausedSliceOutcome({
+      paused: paused({ done: 30, cursor: 'page:4' }),
+      circuit: { ...base, iterationCount: 5 },
+      ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxWallclockHours: 1 },
+      now: new Date('2026-06-01T02:00:00.000Z'),
+    }).action).toBe('breach');
+
+    expect(processPausedSliceOutcome({
+      paused: paused({ done: 30, cursor: 'page:4' }),
+      circuit: base,
+      ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxCostUsd: 10 },
+      sliceCostUsd: 0.6,
+      now: new Date('2026-06-01T01:00:00.000Z'),
+    }).action).toBe('breach');
+  });
+
+  it('resolves per-task error_budget overrides', () => {
+    expect(resolveResumableCeilings(DEFAULT_RESUMABLE_CEILINGS, { max_stalls: 5 })).toMatchObject({
+      maxStalls: 5,
+    });
+  });
+
+  it('round-trips circuit state in progress JSON', () => {
+    const state = {
+      stallCount: 1,
+      iterationCount: 4,
+      startedAt: '2026-06-01T00:00:00.000Z',
+      totalCostUsd: 1.25,
+      lastProgress: { done: 10, cursor: null },
+    };
+    const merged = mergeCircuitState({ notes: [] }, state);
+    expect(readCircuitState(merged)).toEqual(state);
+  });
+});

--- a/src/agents/resumable-circuit-breaker.test.ts
+++ b/src/agents/resumable-circuit-breaker.test.ts
@@ -100,27 +100,62 @@ describe('resumable-circuit-breaker (#1176)', () => {
       totalCostUsd: 9.5,
       lastProgress: { done: 25, cursor: 'page:3' },
     };
-    expect(processPausedSliceOutcome({
+    const iteration = processPausedSliceOutcome({
       paused: paused({ done: 30, cursor: 'page:4' }),
       circuit: base,
       ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxIterations: 100 },
       now: new Date('2026-06-01T01:00:00.000Z'),
-    }).action).toBe('breach');
+    });
+    expect(iteration.action).toBe('breach');
+    if (iteration.action === 'breach') expect(iteration.breach.reason).toBe('max_iterations');
 
-    expect(processPausedSliceOutcome({
+    const wallclock = processPausedSliceOutcome({
       paused: paused({ done: 30, cursor: 'page:4' }),
       circuit: { ...base, iterationCount: 5 },
       ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxWallclockHours: 1 },
       now: new Date('2026-06-01T02:00:00.000Z'),
-    }).action).toBe('breach');
+    });
+    expect(wallclock.action).toBe('breach');
+    if (wallclock.action === 'breach') expect(wallclock.breach.reason).toBe('max_wallclock');
 
-    expect(processPausedSliceOutcome({
+    const cost = processPausedSliceOutcome({
       paused: paused({ done: 30, cursor: 'page:4' }),
-      circuit: base,
+      circuit: { ...base, iterationCount: 5 },
       ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxCostUsd: 10 },
       sliceCostUsd: 0.6,
       now: new Date('2026-06-01T01:00:00.000Z'),
-    }).action).toBe('breach');
+    });
+    expect(cost.action).toBe('breach');
+    if (cost.action === 'breach') expect(cost.breach.reason).toBe('max_cost');
+  });
+
+  it('rejects invalid startedAt in persisted circuit state', () => {
+    expect(readCircuitState({
+      resumableCircuit: {
+        stallCount: 0,
+        iterationCount: 1,
+        startedAt: 'not-a-date',
+        totalCostUsd: 0,
+        lastProgress: { done: 0, cursor: null },
+      },
+    })).toBeNull();
+  });
+
+  it('uses slice_cost_usd from paused payload when side-channel is absent', () => {
+    const result = processPausedSliceOutcome({
+      paused: paused({ done: 20, cursor: 'page:2', slice_cost_usd: 1.5 }),
+      circuit: {
+        stallCount: 0,
+        iterationCount: 0,
+        startedAt: '2026-06-01T00:00:00.000Z',
+        totalCostUsd: 9,
+        lastProgress: { done: 20, cursor: 'page:2' },
+      },
+      ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxCostUsd: 10 },
+      now: new Date('2026-06-01T01:00:00.000Z'),
+    });
+    expect(result.action).toBe('breach');
+    if (result.action === 'breach') expect(result.breach.reason).toBe('max_cost');
   });
 
   it('resolves per-task error_budget overrides', () => {

--- a/src/agents/resumable-circuit-breaker.ts
+++ b/src/agents/resumable-circuit-breaker.ts
@@ -1,0 +1,346 @@
+// resumable-circuit-breaker.ts — progress-based stall counter + aggregate ceilings (#1176).
+//
+// Keys the resumable-task breaker on forward progress (cursor or done-count), not error
+// count. A paused-with-no-progress continuation increments stallCount; K consecutive
+// stalls or a ceiling breach fails the task and escalates instead of looping.
+
+import type { Pool } from 'pg';
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+import type { ResumableCeilingsConfig } from '../config.js';
+import type { TaskRow } from '../db/queries/tasks.js';
+import { getTaskById } from '../db/queries/tasks.js';
+import type { TaskRepo } from '../db/task-repo.js';
+import type { ResumableCursor } from '../db/resumable-progress.js';
+import { createAgentTask } from '../bus/events.js';
+import type { ExecutionPausedPayload } from './resumable-task.js';
+
+/** Persisted under tasks.progress.resumableCircuit — separate from the bounded resumable block. */
+export interface ResumableCircuitState {
+  stallCount: number;
+  iterationCount: number;
+  /** ISO timestamp — first processed pause; drives wallclock ceiling. */
+  startedAt: string;
+  totalCostUsd: number;
+  lastProgress: { done: number; cursor: ResumableCursor };
+}
+
+export type CircuitBreachReason =
+  | 'stall_limit'
+  | 'max_iterations'
+  | 'max_wallclock'
+  | 'max_cost';
+
+export interface CircuitBreach {
+  reason: CircuitBreachReason;
+  message: string;
+  state: ResumableCircuitState;
+}
+
+export interface ProcessPausedSliceInput {
+  paused: ExecutionPausedPayload;
+  /** Prior circuit state; absent on the first pause for this task. */
+  circuit: ResumableCircuitState | null;
+  ceilings: ResumableCeilingsConfig;
+  /** Optional slice LLM cost from the runtime execution_paused payload. */
+  sliceCostUsd?: number;
+  now?: Date;
+}
+
+export type ProcessPausedSliceResult =
+  | { action: 'continue'; state: ResumableCircuitState }
+  | { action: 'breach'; breach: CircuitBreach };
+
+const PROGRESS_KEY = 'resumableCircuit';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseCursor(raw: unknown): ResumableCursor | undefined {
+  if (raw === null) return null;
+  if (typeof raw === 'string') return raw;
+  if (isPlainObject(raw)) return raw as ResumableCursor;
+  return undefined;
+}
+
+function parseLastProgress(raw: unknown): ResumableCircuitState['lastProgress'] | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  const done = raw.done;
+  const cursor = parseCursor(raw.cursor);
+  if (typeof done !== 'number' || !Number.isFinite(done) || done < 0) return undefined;
+  if (cursor === undefined) return undefined;
+  return { done, cursor };
+}
+
+/** Read circuit state from persisted task progress JSON. */
+export function readCircuitState(progress: Record<string, unknown>): ResumableCircuitState | null {
+  const raw = progress[PROGRESS_KEY];
+  if (!isPlainObject(raw)) return null;
+
+  const stallCount = raw.stallCount;
+  const iterationCount = raw.iterationCount;
+  const startedAt = raw.startedAt;
+  const totalCostUsd = raw.totalCostUsd;
+  const lastProgress = parseLastProgress(raw.lastProgress);
+
+  if (
+    typeof stallCount !== 'number' || !Number.isInteger(stallCount) || stallCount < 0
+    || typeof iterationCount !== 'number' || !Number.isInteger(iterationCount) || iterationCount < 0
+    || typeof startedAt !== 'string' || startedAt.length === 0
+    || typeof totalCostUsd !== 'number' || !Number.isFinite(totalCostUsd) || totalCostUsd < 0
+    || !lastProgress
+  ) {
+    return null;
+  }
+
+  return { stallCount, iterationCount, startedAt, totalCostUsd, lastProgress };
+}
+
+/** Merge circuit state into a progress object (preserves notes, resumable block, etc.). */
+export function mergeCircuitState(
+  progress: Record<string, unknown>,
+  state: ResumableCircuitState,
+): Record<string, unknown> {
+  return { ...progress, [PROGRESS_KEY]: state };
+}
+
+/** Compare cursors for equality (opaque LLM-authored positions). */
+export function cursorsEqual(a: ResumableCursor, b: ResumableCursor): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a === 'string' && typeof b === 'string') return a === b;
+  if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return false;
+}
+
+/**
+ * True when done-count increased or the cursor advanced/changed to a new position.
+ * Same done with an unchanged cursor is not forward progress.
+ */
+export function hasForwardProgress(
+  previous: ResumableCircuitState['lastProgress'],
+  next: ResumableCircuitState['lastProgress'],
+): boolean {
+  if (next.done > previous.done) return true;
+  if (next.done < previous.done) return false;
+  return !cursorsEqual(previous.cursor, next.cursor);
+}
+
+/** Resolve per-task ceilings: error_budget overrides win over config defaults (#1176 / #883). */
+export function resolveResumableCeilings(
+  config: ResumableCeilingsConfig,
+  errorBudget: Record<string, unknown>,
+): ResumableCeilingsConfig {
+  const pick = (key: keyof ResumableCeilingsConfig, budgetKey: string): number => {
+    const override = errorBudget[budgetKey];
+    if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
+      return override;
+    }
+    return config[key];
+  };
+  return {
+    maxStalls: pick('maxStalls', 'max_stalls'),
+    maxIterations: pick('maxIterations', 'max_iterations'),
+    maxWallclockHours: pick('maxWallclockHours', 'max_wallclock_hours'),
+    maxCostUsd: pick('maxCostUsd', 'max_cost_usd'),
+  };
+}
+
+function breachMessage(reason: CircuitBreachReason, state: ResumableCircuitState, ceilings: ResumableCeilingsConfig): string {
+  switch (reason) {
+    case 'stall_limit':
+      return `Resumable task stalled ${state.stallCount} consecutive slice(s) with no forward progress (limit ${ceilings.maxStalls}).`;
+    case 'max_iterations':
+      return `Resumable task exceeded iteration ceiling (${state.iterationCount}/${ceilings.maxIterations}).`;
+    case 'max_wallclock':
+      return `Resumable task exceeded wallclock ceiling (${ceilings.maxWallclockHours}h).`;
+    case 'max_cost':
+      return `Resumable task exceeded cost ceiling ($${state.totalCostUsd.toFixed(4)}/${ceilings.maxCostUsd.toFixed(2)}).`;
+  }
+}
+
+function detectBreach(
+  state: ResumableCircuitState,
+  ceilings: ResumableCeilingsConfig,
+  now: Date,
+): CircuitBreachReason | null {
+  if (state.stallCount >= ceilings.maxStalls) return 'stall_limit';
+  if (state.iterationCount >= ceilings.maxIterations) return 'max_iterations';
+  const elapsedHours = (now.getTime() - new Date(state.startedAt).getTime()) / 3_600_000;
+  if (elapsedHours >= ceilings.maxWallclockHours) return 'max_wallclock';
+  if (state.totalCostUsd >= ceilings.maxCostUsd) return 'max_cost';
+  return null;
+}
+
+/**
+ * Process a paused slice outcome: update counters, detect stalls/ceilings.
+ * Does not persist — caller writes state or fails the task.
+ */
+export function processPausedSliceOutcome(input: ProcessPausedSliceInput): ProcessPausedSliceResult {
+  const now = input.now ?? new Date();
+  const nextProgress = { done: input.paused.done, cursor: input.paused.cursor };
+  const sliceCostUsd = input.sliceCostUsd ?? 0;
+
+  const base: ResumableCircuitState = input.circuit ?? {
+    stallCount: 0,
+    iterationCount: 0,
+    startedAt: now.toISOString(),
+    totalCostUsd: 0,
+    lastProgress: nextProgress,
+  };
+
+  const madeProgress = input.circuit
+    ? hasForwardProgress(input.circuit.lastProgress, nextProgress)
+    : true;
+
+  const state: ResumableCircuitState = {
+    ...base,
+    iterationCount: base.iterationCount + 1,
+    totalCostUsd: base.totalCostUsd + Math.max(0, sliceCostUsd),
+    lastProgress: nextProgress,
+    stallCount: madeProgress ? 0 : base.stallCount + 1,
+  };
+
+  const reason = detectBreach(state, input.ceilings, now);
+  if (reason) {
+    return {
+      action: 'breach',
+      breach: {
+        reason,
+        message: breachMessage(reason, state, input.ceilings),
+        state,
+      },
+    };
+  }
+
+  return { action: 'continue', state };
+}
+
+export interface EscalateCircuitBreachOptions {
+  pool: Pool;
+  bus: EventBus;
+  taskRepo: TaskRepo;
+  logger: Logger;
+  task: TaskRow;
+  breach: CircuitBreach;
+  agentId: string;
+}
+
+/**
+ * Fail the resumable task, cancel continuations, surface to coordinator + CEO backlog.
+ * Mirrors the delegation-failure escalation path (#1171).
+ */
+export async function escalateCircuitBreach(opts: EscalateCircuitBreachOptions): Promise<void> {
+  const { task, breach, bus, taskRepo, logger, agentId } = opts;
+  const progressNote = [
+    breach.message,
+    `Progress at breach: ${breach.state.lastProgress.done} done, cursor ${JSON.stringify(breach.state.lastProgress.cursor)}.`,
+    `Iterations: ${breach.state.iterationCount}, stalls: ${breach.state.stallCount}, cost: $${breach.state.totalCostUsd.toFixed(4)}.`,
+  ].join(' ');
+
+  const updated = await taskRepo.failResumableTask(task.id, {
+    progressNote,
+    circuitState: breach.state,
+    tags: ['needs-attention', 'resumable-circuit-breach'],
+  });
+
+  if (!updated) {
+    logger.warn({ taskId: task.id }, 'Circuit breach escalation: task not found or already terminal');
+    return;
+  }
+
+  const notifyContent = [
+    'A resumable task hit its progress-based circuit breaker and needs attention.',
+    '',
+    `Task: ${task.id}`,
+    `Title: ${task.title}`,
+    `Agent: ${agentId}`,
+    `Reason: ${breach.reason}`,
+    breach.message,
+    '',
+    'Do not re-delegate or schedule continuations for this task. Let the principal know and help them decide next steps.',
+  ].join('\n');
+
+  const notifyEvent = createAgentTask({
+    agentId: 'coordinator',
+    conversationId: `resumable-circuit:${task.id}`,
+    channelId: 'scheduler',
+    senderId: 'system',
+    content: notifyContent,
+    parentEventId: task.id,
+  });
+  await bus.publish('system', notifyEvent);
+
+  try {
+    await taskRepo.createTask({
+      agentId: 'coordinator',
+      title: `Review: resumable task stalled (${task.title})`,
+      description: [
+        breach.message,
+        '',
+        `Task ID: ${task.id}`,
+        `Specialist: ${task.sourceAgentId ?? agentId}`,
+        '',
+        progressNote,
+      ].join('\n'),
+      owner: 'ceo',
+      source: 'coordinator',
+      tags: ['needs-attention', 'resumable-circuit-breach', breach.reason],
+      parentTaskId: task.parentTaskId ?? undefined,
+    });
+    logger.info({ taskId: task.id, reason: breach.reason }, 'Escalated resumable circuit breach to CEO backlog');
+  } catch (err) {
+    logger.error({ err, taskId: task.id }, 'Failed to create CEO backlog task for circuit breach');
+  }
+}
+
+/** Load task, process pause outcome, persist state or escalate. Returns whether to schedule continuation. */
+export async function handlePausedSliceForCircuitBreaker(opts: {
+  pool: Pool;
+  bus: EventBus;
+  taskRepo: TaskRepo;
+  logger: Logger;
+  taskId: string;
+  paused: ExecutionPausedPayload;
+  ceilings: ResumableCeilingsConfig;
+  agentId: string;
+  sliceCostUsd?: number;
+}): Promise<{ scheduleContinuation: boolean; breach?: CircuitBreach }> {
+  const task = await getTaskById(opts.pool, opts.taskId);
+  if (!task) {
+    opts.logger.warn({ taskId: opts.taskId }, 'Circuit breaker: task not found');
+    return { scheduleContinuation: false };
+  }
+
+  const ceilings = resolveResumableCeilings(opts.ceilings, task.errorBudget);
+  const circuit = readCircuitState(task.progress);
+  const outcome = processPausedSliceOutcome({
+    paused: opts.paused,
+    circuit,
+    ceilings,
+    sliceCostUsd: opts.sliceCostUsd,
+  });
+
+  if (outcome.action === 'breach') {
+    opts.logger.warn(
+      { taskId: opts.taskId, reason: outcome.breach.reason, state: outcome.breach.state },
+      'Resumable circuit breaker tripped',
+    );
+    await escalateCircuitBreach({
+      pool: opts.pool,
+      bus: opts.bus,
+      taskRepo: opts.taskRepo,
+      logger: opts.logger,
+      task,
+      breach: outcome.breach,
+      agentId: opts.agentId,
+    });
+    return { scheduleContinuation: false, breach: outcome.breach };
+  }
+
+  await opts.taskRepo.persistResumableCircuitState(opts.taskId, outcome.state);
+  return { scheduleContinuation: true };
+}

--- a/src/agents/resumable-circuit-breaker.ts
+++ b/src/agents/resumable-circuit-breaker.ts
@@ -4,6 +4,7 @@
 // count. A paused-with-no-progress continuation increments stallCount; K consecutive
 // stalls or a ceiling breach fails the task and escalates instead of looping.
 
+import { isDeepStrictEqual } from 'node:util';
 import type { Pool } from 'pg';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
@@ -60,7 +61,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function parseCursor(raw: unknown): ResumableCursor | undefined {
   if (raw === null) return null;
   if (typeof raw === 'string') return raw;
-  if (isPlainObject(raw)) return raw as ResumableCursor;
+  if (isPlainObject(raw)) return raw as unknown as ResumableCursor;
   return undefined;
 }
 
@@ -88,6 +89,7 @@ export function readCircuitState(progress: Record<string, unknown>): ResumableCi
     typeof stallCount !== 'number' || !Number.isInteger(stallCount) || stallCount < 0
     || typeof iterationCount !== 'number' || !Number.isInteger(iterationCount) || iterationCount < 0
     || typeof startedAt !== 'string' || startedAt.length === 0
+    || !Number.isFinite(Date.parse(startedAt))
     || typeof totalCostUsd !== 'number' || !Number.isFinite(totalCostUsd) || totalCostUsd < 0
     || !lastProgress
   ) {
@@ -111,7 +113,7 @@ export function cursorsEqual(a: ResumableCursor, b: ResumableCursor): boolean {
   if (a === null || b === null) return false;
   if (typeof a === 'string' && typeof b === 'string') return a === b;
   if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
-    return JSON.stringify(a) === JSON.stringify(b);
+    return isDeepStrictEqual(a, b);
   }
   return false;
 }
@@ -169,8 +171,11 @@ function detectBreach(
 ): CircuitBreachReason | null {
   if (state.stallCount >= ceilings.maxStalls) return 'stall_limit';
   if (state.iterationCount >= ceilings.maxIterations) return 'max_iterations';
-  const elapsedHours = (now.getTime() - new Date(state.startedAt).getTime()) / 3_600_000;
-  if (elapsedHours >= ceilings.maxWallclockHours) return 'max_wallclock';
+  const startedMs = Date.parse(state.startedAt);
+  if (Number.isFinite(startedMs)) {
+    const elapsedHours = (now.getTime() - startedMs) / 3_600_000;
+    if (elapsedHours >= ceilings.maxWallclockHours) return 'max_wallclock';
+  }
   if (state.totalCostUsd >= ceilings.maxCostUsd) return 'max_cost';
   return null;
 }
@@ -182,7 +187,8 @@ function detectBreach(
 export function processPausedSliceOutcome(input: ProcessPausedSliceInput): ProcessPausedSliceResult {
   const now = input.now ?? new Date();
   const nextProgress = { done: input.paused.done, cursor: input.paused.cursor };
-  const sliceCostUsd = input.sliceCostUsd ?? 0;
+  const rawSliceCost = input.sliceCostUsd ?? input.paused.slice_cost_usd ?? 0;
+  const sliceCostUsd = Number.isFinite(rawSliceCost) && rawSliceCost >= 0 ? rawSliceCost : 0;
 
   const base: ResumableCircuitState = input.circuit ?? {
     stallCount: 0,
@@ -272,7 +278,11 @@ export async function escalateCircuitBreach(opts: EscalateCircuitBreachOptions):
     content: notifyContent,
     parentEventId: task.id,
   });
-  await bus.publish('system', notifyEvent);
+  try {
+    await bus.publish('system', notifyEvent);
+  } catch (err) {
+    logger.error({ err, taskId: task.id }, 'Failed to notify coordinator of circuit breach');
+  }
 
   try {
     await taskRepo.createTask({

--- a/src/agents/resumable-continuation-subscriber.ts
+++ b/src/agents/resumable-continuation-subscriber.ts
@@ -50,13 +50,15 @@ export class ResumableContinuationSubscriber {
       }
 
       let sliceCostUsd: number | undefined;
-      try {
-        const parsed = JSON.parse(responseEvent.payload.content) as Record<string, unknown>;
-        if (typeof parsed.slice_cost_usd === 'number' && Number.isFinite(parsed.slice_cost_usd)) {
-          sliceCostUsd = parsed.slice_cost_usd;
+      if (paused.slice_cost_usd !== undefined) {
+        if (Number.isFinite(paused.slice_cost_usd) && paused.slice_cost_usd >= 0) {
+          sliceCostUsd = paused.slice_cost_usd;
+        } else {
+          this.opts.logger.warn(
+            { taskId, sliceCostUsd: paused.slice_cost_usd },
+            'execution_paused slice_cost_usd invalid — ignoring',
+          );
         }
-      } catch {
-        // parseExecutionPausedPayload already validated the payload above.
       }
 
       try {

--- a/src/agents/resumable-continuation-subscriber.ts
+++ b/src/agents/resumable-continuation-subscriber.ts
@@ -1,26 +1,33 @@
 // resumable-continuation-subscriber.ts — schedules near-term wakes on execution_paused (#1175).
+// Applies the progress-based circuit breaker before scheduling (#1176).
 
 import type { Pool } from 'pg';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
+import type { ResumableCeilingsConfig } from '../config.js';
 import type { AgentResponseEvent } from '../bus/events.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
+import type { TaskRepo } from '../db/task-repo.js';
 import { parseExecutionPausedPayload } from './resumable-task.js';
 import { scheduleResumableContinuation } from './resumable-continuation.js';
+import { handlePausedSliceForCircuitBreaker } from './resumable-circuit-breaker.js';
 
 export interface ResumableContinuationSubscriberOptions {
   pool: Pool;
   bus: EventBus;
   logger: Logger;
   schedulerService: SchedulerService;
+  taskRepo: TaskRepo;
   eligibleAgents: Set<string>;
   continuationDelaySeconds: number;
+  resumableCeilings: ResumableCeilingsConfig;
   fallbackAgentId?: string;
 }
 
 /**
- * System-layer subscriber: when a specialist emits execution_paused, enqueue a single
- * near-term continuation wake routed to the task's source_agent_id (or coordinator).
+ * System-layer subscriber: when a specialist emits execution_paused, evaluate the
+ * progress-based circuit breaker, then enqueue a single near-term continuation wake
+ * routed to the task's source_agent_id (or coordinator) when healthy.
  */
 export class ResumableContinuationSubscriber {
   constructor(private readonly opts: ResumableContinuationSubscriberOptions) {}
@@ -42,7 +49,33 @@ export class ResumableContinuationSubscriber {
         return;
       }
 
+      let sliceCostUsd: number | undefined;
       try {
+        const parsed = JSON.parse(responseEvent.payload.content) as Record<string, unknown>;
+        if (typeof parsed.slice_cost_usd === 'number' && Number.isFinite(parsed.slice_cost_usd)) {
+          sliceCostUsd = parsed.slice_cost_usd;
+        }
+      } catch {
+        // parseExecutionPausedPayload already validated the payload above.
+      }
+
+      try {
+        const breaker = await handlePausedSliceForCircuitBreaker({
+          pool: this.opts.pool,
+          bus: this.opts.bus,
+          taskRepo: this.opts.taskRepo,
+          logger: this.opts.logger,
+          taskId,
+          paused,
+          ceilings: this.opts.resumableCeilings,
+          agentId: responseEvent.payload.agentId,
+          sliceCostUsd,
+        });
+
+        if (!breaker.scheduleContinuation) {
+          return;
+        }
+
         await scheduleResumableContinuation({
           pool: this.opts.pool,
           schedulerService: this.opts.schedulerService,
@@ -55,14 +88,17 @@ export class ResumableContinuationSubscriber {
       } catch (err) {
         this.opts.logger.error(
           { err, taskId, agentId: responseEvent.payload.agentId },
-          'Failed to schedule resumable continuation wake',
+          'Failed to process resumable pause / schedule continuation',
         );
         throw err;
       }
     });
 
     this.opts.logger.info(
-      { continuationDelaySeconds: this.opts.continuationDelaySeconds },
+      {
+        continuationDelaySeconds: this.opts.continuationDelaySeconds,
+        resumableCeilings: this.opts.resumableCeilings,
+      },
       'ResumableContinuationSubscriber started',
     );
   }

--- a/src/agents/resumable-task.ts
+++ b/src/agents/resumable-task.ts
@@ -246,7 +246,7 @@ export function buildExecutionPausedResponse(options: {
     next: options.progress.next,
   };
   if (options.taskId) payload.task_id = options.taskId;
-  if (options.sliceCostUsd !== undefined && options.sliceCostUsd > 0) {
+  if (options.sliceCostUsd !== undefined && Number.isFinite(options.sliceCostUsd) && options.sliceCostUsd > 0) {
     payload.slice_cost_usd = options.sliceCostUsd;
   }
   return JSON.stringify(payload);
@@ -272,6 +272,9 @@ export function parseExecutionPausedPayload(content: string, logger?: Logger): E
     };
     if (typeof parsed['task_id'] === 'string' && parsed['task_id'].length > 0) {
       payload.task_id = parsed['task_id'];
+    }
+    if (typeof parsed['slice_cost_usd'] === 'number' && Number.isFinite(parsed['slice_cost_usd'])) {
+      payload.slice_cost_usd = parsed['slice_cost_usd'];
     }
     return payload;
   } catch (err) {

--- a/src/agents/resumable-task.ts
+++ b/src/agents/resumable-task.ts
@@ -210,6 +210,8 @@ export interface ExecutionPausedPayload {
   cursor: ResumableProgressBlock['cursor'];
   last_slice_units: number;
   next: string;
+  /** Aggregate LLM cost for this slice (USD) — feeds resumable cost ceiling (#1176). */
+  slice_cost_usd?: number;
 }
 
 export interface DelegatePausedResult {
@@ -233,6 +235,7 @@ export function formatPausedProgressMessage(
 export function buildExecutionPausedResponse(options: {
   taskId?: string;
   progress: ResumableProgressBlock;
+  sliceCostUsd?: number;
 }): string {
   const payload: ExecutionPausedPayload = {
     _curia_protocol: EXECUTION_PAUSED_PROTOCOL,
@@ -243,6 +246,9 @@ export function buildExecutionPausedResponse(options: {
     next: options.progress.next,
   };
   if (options.taskId) payload.task_id = options.taskId;
+  if (options.sliceCostUsd !== undefined && options.sliceCostUsd > 0) {
+    payload.slice_cost_usd = options.sliceCostUsd;
+  }
   return JSON.stringify(payload);
 }
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1633,7 +1633,7 @@ export class AgentRuntime {
           parentEventId: taskEvent.id,
         });
         const estimatedCostUsd = event.payload.estimatedCostUsd;
-        if (budgetHandoff?.sliceCostTracker && estimatedCostUsd > 0) {
+        if (budgetHandoff?.sliceCostTracker && Number.isFinite(estimatedCostUsd) && estimatedCostUsd > 0) {
           budgetHandoff.sliceCostTracker.usd += estimatedCostUsd;
         }
         await bus.publish('agent', event);

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -482,12 +482,19 @@ export class AgentRuntime {
     }
 
     let checkpointBudgetNudgeSent = false;
+    const sliceCostTracker = { usd: 0 };
 
     // Accumulate skill names across all tool-use turns so we can report them
     // on the agent.response event for audit and monitoring.
     const skillsCalled: string[] = [];
     // Threaded into every maxTurns budget check (tool loop, recovery, chatWithRetry).
-    const budgetHandoff = { conversationId, skillsCalled, boundTaskCtx, memory };
+    const budgetHandoff = {
+      conversationId,
+      skillsCalled,
+      boundTaskCtx,
+      memory,
+      sliceCostTracker: resumableActive ? sliceCostTracker : undefined,
+    };
 
     // Append intent anchor — present only for persistent scheduler tasks that have a
     // linked agent_task record. Injected near the end so it sits close to the conversation
@@ -1573,6 +1580,7 @@ export class AgentRuntime {
       skillsCalled: string[];
       boundTaskCtx: BoundTaskContext | null;
       memory?: WorkingMemory;
+      sliceCostTracker?: { usd: number };
     },
   ): Promise<LLMResponse | null> {
     const { agentId, bus, logger } = this.config;
@@ -1624,6 +1632,10 @@ export class AgentRuntime {
           responseHash,
           parentEventId: taskEvent.id,
         });
+        const estimatedCostUsd = event.payload.estimatedCostUsd;
+        if (budgetHandoff?.sliceCostTracker && estimatedCostUsd > 0) {
+          budgetHandoff.sliceCostTracker.usd += estimatedCostUsd;
+        }
         await bus.publish('agent', event);
       } catch (err) {
         // Telemetry failure must not abort the agent task. Log at error so the gap
@@ -1847,6 +1859,7 @@ export class AgentRuntime {
       skillsCalled: string[];
       boundTaskCtx: BoundTaskContext | null;
       memory?: WorkingMemory;
+      sliceCostTracker?: { usd: number };
     },
   ): Promise<boolean> {
     if (budget.turnsUsed < budget.maxTurns) return false;
@@ -1870,6 +1883,7 @@ export class AgentRuntime {
       skillsCalled: string[];
       boundTaskCtx: BoundTaskContext | null;
       memory?: WorkingMemory;
+      sliceCostTracker?: { usd: number };
     },
   ): Promise<void> {
     const { agentId, logger } = this.config;
@@ -1886,6 +1900,7 @@ export class AgentRuntime {
           handoff.memory,
           budget,
           reason,
+          handoff.sliceCostTracker?.usd,
         );
         return;
       }
@@ -1922,14 +1937,19 @@ export class AgentRuntime {
     memory: WorkingMemory | undefined,
     budget: ErrorBudget,
     reason: 'maxTurns',
+    sliceCostUsd?: number,
   ): Promise<void> {
     const { agentId, bus, logger } = this.config;
     logger.info(
-      { agentId, taskId, done: checkpoint.done, total: checkpoint.total, budget, reason },
+      { agentId, taskId, done: checkpoint.done, total: checkpoint.total, budget, reason, sliceCostUsd },
       'Resumable task hit turn budget — pausing from last checkpoint',
     );
 
-    const content = buildExecutionPausedResponse({ taskId, progress: checkpoint });
+    const content = buildExecutionPausedResponse({
+      taskId,
+      progress: checkpoint,
+      sliceCostUsd,
+    });
 
     if (memory) {
       await memory.addTurn(conversationId, agentId, { role: 'assistant', content });

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,22 @@ export interface Config {
   signalPhoneNumber: string | undefined;
 }
 
+/** Per-resumable-task aggregate ceilings — progress-based circuit breaker (#1176). */
+export interface ResumableCeilingsConfig {
+  /** Consecutive paused slices with no forward progress before fail/escalate (K). */
+  maxStalls: number;
+  maxIterations: number;
+  maxWallclockHours: number;
+  maxCostUsd: number;
+}
+
+export const DEFAULT_RESUMABLE_CEILINGS: ResumableCeilingsConfig = {
+  maxStalls: 3,
+  maxIterations: 100,
+  maxWallclockHours: 24,
+  maxCostUsd: 10,
+};
+
 export interface TasksConfig {
   heartbeatIntervalMinutes: number;
   heartbeatMaxWakesPerTick: number;
@@ -54,6 +70,8 @@ export interface TasksConfig {
   staleWaitThresholdHours: number;
   /** Seconds until a paused resumable task's self-continuation wake fires. */
   resumableContinuationSeconds: number;
+  /** Progress-based circuit-breaker defaults for resumable tasks (#1176). */
+  resumableCeilings: ResumableCeilingsConfig;
 }
 
 export const DEFAULT_TASKS_CONFIG: TasksConfig = {
@@ -62,7 +80,18 @@ export const DEFAULT_TASKS_CONFIG: TasksConfig = {
   idleThresholdHours: 4,
   staleWaitThresholdHours: 48,
   resumableContinuationSeconds: 30,
+  resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
 };
+
+function resolveResumableCeilings(yaml: YamlConfig['tasks']): ResumableCeilingsConfig {
+  const r = yaml?.resumableCeilings;
+  return {
+    maxStalls: r?.maxStalls ?? DEFAULT_RESUMABLE_CEILINGS.maxStalls,
+    maxIterations: r?.maxIterations ?? DEFAULT_RESUMABLE_CEILINGS.maxIterations,
+    maxWallclockHours: r?.maxWallclockHours ?? DEFAULT_RESUMABLE_CEILINGS.maxWallclockHours,
+    maxCostUsd: r?.maxCostUsd ?? DEFAULT_RESUMABLE_CEILINGS.maxCostUsd,
+  };
+}
 
 /** Resolve the optional YAML tasks block to a fully-populated config with defaults. */
 export function resolveTasksConfig(yaml: YamlConfig['tasks']): TasksConfig {
@@ -72,6 +101,7 @@ export function resolveTasksConfig(yaml: YamlConfig['tasks']): TasksConfig {
     idleThresholdHours: yaml?.idleThresholdHours ?? DEFAULT_TASKS_CONFIG.idleThresholdHours,
     staleWaitThresholdHours: yaml?.staleWaitThresholdHours ?? DEFAULT_TASKS_CONFIG.staleWaitThresholdHours,
     resumableContinuationSeconds: yaml?.resumableContinuationSeconds ?? DEFAULT_TASKS_CONFIG.resumableContinuationSeconds,
+    resumableCeilings: resolveResumableCeilings(yaml),
   };
 }
 
@@ -429,6 +459,17 @@ export interface YamlConfig {
     staleWaitThresholdHours?: number;
     /** Seconds until a paused resumable task's self-continuation wake fires. Default 30. */
     resumableContinuationSeconds?: number;
+    /** Progress-based circuit-breaker ceilings for resumable tasks (#1176). */
+    resumableCeilings?: {
+      /** Consecutive no-progress pauses before fail/escalate (K). Default 3. */
+      maxStalls?: number;
+      /** Max continuation slices. Default 100. */
+      maxIterations?: number;
+      /** Max wallclock hours from first pause. Default 24. */
+      maxWallclockHours?: number;
+      /** Max aggregate LLM cost (USD) across slices. Default 10. */
+      maxCostUsd?: number;
+    };
   };
   health?: {
     liveness?: {
@@ -940,6 +981,21 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       !Number.isInteger(t.resumableContinuationSeconds) || t.resumableContinuationSeconds < 1
     )) {
       throw new Error(`tasks.resumableContinuationSeconds must be a positive integer, got: ${String(t.resumableContinuationSeconds)}`);
+    }
+    if (t.resumableCeilings !== undefined) {
+      const c = t.resumableCeilings;
+      if (c.maxStalls !== undefined && (!Number.isInteger(c.maxStalls) || c.maxStalls < 1)) {
+        throw new Error(`tasks.resumableCeilings.maxStalls must be a positive integer, got: ${String(c.maxStalls)}`);
+      }
+      if (c.maxIterations !== undefined && (!Number.isInteger(c.maxIterations) || c.maxIterations < 1)) {
+        throw new Error(`tasks.resumableCeilings.maxIterations must be a positive integer, got: ${String(c.maxIterations)}`);
+      }
+      if (c.maxWallclockHours !== undefined && (!Number.isFinite(c.maxWallclockHours) || c.maxWallclockHours <= 0)) {
+        throw new Error(`tasks.resumableCeilings.maxWallclockHours must be a positive number, got: ${String(c.maxWallclockHours)}`);
+      }
+      if (c.maxCostUsd !== undefined && (!Number.isFinite(c.maxCostUsd) || c.maxCostUsd <= 0)) {
+        throw new Error(`tasks.resumableCeilings.maxCostUsd must be a positive number, got: ${String(c.maxCostUsd)}`);
+      }
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -984,6 +984,9 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     }
     if (t.resumableCeilings !== undefined) {
       const c = t.resumableCeilings;
+      if (typeof c !== 'object' || c === null || Array.isArray(c)) {
+        throw new Error(`tasks.resumableCeilings must be an object, got: ${String(c)}`);
+      }
       if (c.maxStalls !== undefined && (!Number.isInteger(c.maxStalls) || c.maxStalls < 1)) {
         throw new Error(`tasks.resumableCeilings.maxStalls must be a positive integer, got: ${String(c.maxStalls)}`);
       }

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -25,7 +25,7 @@ import {
 } from './resumable-progress.js';
 import { prepareResumableBlockWithSpill } from './resumable-accumulator-spill.js';
 import type { WorkingDocsRepo } from './working-docs-repo.js';
-import { mergeCircuitState, type ResumableCircuitState } from '../agents/resumable-circuit-breaker.js';
+import { type ResumableCircuitState } from '../agents/resumable-circuit-breaker.js';
 
 // All SELECT / RETURNING clauses use this column list. Centralised so a schema
 // change only needs updating in one place.
@@ -674,17 +674,13 @@ export class TaskRepo {
 
   /** Persist progress.resumableCircuit counters after a healthy paused slice (#1176). */
   async persistResumableCircuitState(taskId: string, state: ResumableCircuitState): Promise<void> {
-    const current = await this.getTask(taskId);
-    if (!current || TERMINAL_STATUSES.has(current.status)) return;
-
-    const merged = mergeCircuitState(current.progress, state);
     await this.pool.query(
       `UPDATE tasks
-          SET progress = $1::jsonb,
+          SET progress = COALESCE(progress, '{}'::jsonb) || jsonb_build_object('resumableCircuit', $1::jsonb),
               updated_at = now()
         WHERE id = $2
           AND status NOT IN ('done', 'cancelled', 'failed')`,
-      [JSON.stringify(merged), taskId],
+      [JSON.stringify(state), taskId],
     );
   }
 
@@ -706,28 +702,28 @@ export class TaskRepo {
       return current;
     }
 
-    const notes = (Array.isArray(current.progress.notes) ? current.progress.notes : []) as Array<unknown>;
-    notes.push({ at: new Date().toISOString(), note: options.progressNote });
+    const notes = [{ at: new Date().toISOString(), note: options.progressNote }];
     const mergedTags = [...new Set([...current.tags, ...options.tags])];
-    const progress = mergeCircuitState({ ...current.progress, notes }, options.circuitState);
 
     const { rows } = await this.pool.query(
       `WITH updated_task AS (
          UPDATE tasks
             SET status = 'failed',
-                progress = $1::jsonb,
-                tags = $2::text[],
+                progress = COALESCE(progress, '{}'::jsonb)
+                  || jsonb_build_object('resumableCircuit', $1::jsonb)
+                  || jsonb_build_object('notes', COALESCE(progress->'notes', '[]'::jsonb) || $2::jsonb),
+                tags = $3::text[],
                 updated_at = now()
-          WHERE id = $3
+          WHERE id = $4
             AND status NOT IN ('done', 'cancelled', 'failed')
           RETURNING ${TASK_COLUMNS}
        ),
        _cancel_wake AS (
          UPDATE scheduled_jobs SET status = 'cancelled'
-          WHERE task_id = $3 AND status IN ('pending', 'running')
+          WHERE task_id = $4 AND status IN ('pending', 'running')
        )
        SELECT * FROM updated_task`,
-      [JSON.stringify(progress), mergedTags, taskId],
+      [JSON.stringify(options.circuitState), JSON.stringify(notes), mergedTags, taskId],
     );
 
     const row = rows[0] as DbTaskRow | undefined;
@@ -738,6 +734,8 @@ export class TaskRepo {
       await this.bus.publish('execution', createTaskUpdated({
         taskId: updated.id,
         previousStatus: current.status,
+        newStatus: 'failed',
+        progressNote: options.progressNote,
         agentId: null,
       }));
     } catch (busErr) {

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -25,6 +25,7 @@ import {
 } from './resumable-progress.js';
 import { prepareResumableBlockWithSpill } from './resumable-accumulator-spill.js';
 import type { WorkingDocsRepo } from './working-docs-repo.js';
+import { mergeCircuitState, type ResumableCircuitState } from '../agents/resumable-circuit-breaker.js';
 
 // All SELECT / RETURNING clauses use this column list. Centralised so a schema
 // change only needs updating in one place.
@@ -669,5 +670,80 @@ export class TaskRepo {
       'task-repo: persisted resumable checkpoint',
     );
     return { task: updated, block: prepared.block };
+  }
+
+  /** Persist progress.resumableCircuit counters after a healthy paused slice (#1176). */
+  async persistResumableCircuitState(taskId: string, state: ResumableCircuitState): Promise<void> {
+    const current = await this.getTask(taskId);
+    if (!current || TERMINAL_STATUSES.has(current.status)) return;
+
+    const merged = mergeCircuitState(current.progress, state);
+    await this.pool.query(
+      `UPDATE tasks
+          SET progress = $1::jsonb,
+              updated_at = now()
+        WHERE id = $2
+          AND status NOT IN ('done', 'cancelled', 'failed')`,
+      [JSON.stringify(merged), taskId],
+    );
+  }
+
+  /**
+   * Fail a resumable task on circuit-breaker breach: status failed, cancel wakes,
+   * merge circuit state + progress note, add escalation tags.
+   */
+  async failResumableTask(
+    taskId: string,
+    options: {
+      progressNote: string;
+      circuitState: ResumableCircuitState;
+      tags: string[];
+    },
+  ): Promise<TaskRow | null> {
+    const current = await this.getTask(taskId);
+    if (!current) return null;
+    if (TERMINAL_STATUSES.has(current.status) || current.status === 'failed') {
+      return current;
+    }
+
+    const notes = (Array.isArray(current.progress.notes) ? current.progress.notes : []) as Array<unknown>;
+    notes.push({ at: new Date().toISOString(), note: options.progressNote });
+    const mergedTags = [...new Set([...current.tags, ...options.tags])];
+    const progress = mergeCircuitState({ ...current.progress, notes }, options.circuitState);
+
+    const { rows } = await this.pool.query(
+      `WITH updated_task AS (
+         UPDATE tasks
+            SET status = 'failed',
+                progress = $1::jsonb,
+                tags = $2::text[],
+                updated_at = now()
+          WHERE id = $3
+            AND status NOT IN ('done', 'cancelled', 'failed')
+          RETURNING ${TASK_COLUMNS}
+       ),
+       _cancel_wake AS (
+         UPDATE scheduled_jobs SET status = 'cancelled'
+          WHERE task_id = $3 AND status IN ('pending', 'running')
+       )
+       SELECT * FROM updated_task`,
+      [JSON.stringify(progress), mergedTags, taskId],
+    );
+
+    const row = rows[0] as DbTaskRow | undefined;
+    if (!row) return await this.getTask(taskId);
+
+    const updated = mapTaskRow(row);
+    try {
+      await this.bus.publish('execution', createTaskUpdated({
+        taskId: updated.id,
+        previousStatus: current.status,
+        agentId: null,
+      }));
+    } catch (busErr) {
+      this.logger.error({ busErr, taskId }, 'task-repo: bus publish failed after failResumableTask');
+    }
+    this.logger.warn({ taskId }, 'task-repo: resumable task failed by circuit breaker');
+    return updated;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2021,8 +2021,10 @@ async function main(): Promise<void> {
     bus,
     logger,
     schedulerService,
+    taskRepo,
     eligibleAgents: taskManagementAgents,
     continuationDelaySeconds: tasksConfig.resumableContinuationSeconds,
+    resumableCeilings: tasksConfig.resumableCeilings,
   });
   resumableContinuationSubscriber.start();
 

--- a/tests/integration/resumable-circuit-breaker.test.ts
+++ b/tests/integration/resumable-circuit-breaker.test.ts
@@ -1,0 +1,191 @@
+// resumable-circuit-breaker.test.ts — no-progress continuation escalates (#1176).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { EventBus } from '../../src/bus/bus.js';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import { ResumableContinuationSubscriber } from '../../src/agents/resumable-continuation-subscriber.js';
+import { createAgentResponse } from '../../src/bus/events.js';
+import { DEFAULT_RESUMABLE_CEILINGS } from '../../src/config.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'ResumableCircuitBreaker Test';
+const logger = pino({ level: 'silent' });
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [`${PREFIX}%`],
+  );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1 OR parent_task_id IN (
+    SELECT id FROM tasks WHERE title LIKE $1
+  )`, [`${PREFIX}%`]);
+}
+
+describeIf('Resumable circuit breaker (#1176)', () => {
+  let pool: pg.Pool;
+  let repo: TaskRepo;
+  let bus: EventBus;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    bus = new EventBus(logger as never);
+    repo = new TaskRepo(pool, bus, logger as never, 'UTC');
+  });
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  it('escalates after K no-progress pauses instead of scheduling another continuation', async () => {
+    const task = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} stalled audit`,
+      source: 'coordinator',
+      sourceAgentId: 'social-media',
+      resumable: true,
+      tags: ['resumable'],
+    });
+    await repo.setResumableBlock(task.id, {
+      cursor: 'page:3',
+      done: 25,
+      total: 1300,
+      accumulator: [],
+      lastSliceUnits: 25,
+      next: 'Review page 4',
+    }, 'social-media');
+    await repo.updateTask(task.id, { status: 'in_progress' }, 'social-media');
+
+    // Seed circuit state one stall away from the limit (K=2 for this test).
+    await repo.persistResumableCircuitState(task.id, {
+      stallCount: 1,
+      iterationCount: 5,
+      startedAt: new Date().toISOString(),
+      totalCostUsd: 0,
+      lastProgress: { done: 25, cursor: 'page:3' },
+    });
+
+    const ceilings = { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 2 };
+
+    const coordinatorTasks: Array<{ content: string }> = [];
+    bus.subscribe('agent.task', 'system', (event) => {
+      const e = event as { payload: { agentId: string; content: string } };
+      if (e.payload.agentId === 'coordinator') {
+        coordinatorTasks.push({ content: e.payload.content });
+      }
+    });
+
+    const subscriber = new ResumableContinuationSubscriber({
+      pool,
+      bus,
+      logger: logger as never,
+      schedulerService: { enqueueTaskWake: vi.fn() } as never,
+      taskRepo: repo,
+      eligibleAgents: new Set(['social-media', 'coordinator']),
+      continuationDelaySeconds: 1,
+      resumableCeilings: ceilings,
+    });
+    subscriber.start();
+
+    const pausedPayload = {
+      _curia_protocol: 'execution_paused',
+      task_id: task.id,
+      done: 25,
+      total: 1300,
+      cursor: 'page:3',
+      last_slice_units: 0,
+      next: 'Still stuck',
+    };
+
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-stall',
+      content: JSON.stringify(pausedPayload),
+      parentEventId: 'parent-stall',
+    }));
+
+    const reloaded = await repo.getTask(task.id);
+    expect(reloaded?.status).toBe('failed');
+    expect(reloaded?.tags).toContain('needs-attention');
+
+    const { rows: wakes } = await pool.query(
+      `SELECT id FROM scheduled_jobs WHERE task_id = $1 AND status = 'pending'`,
+      [task.id],
+    );
+    expect(wakes).toHaveLength(0);
+
+    expect(coordinatorTasks.length).toBeGreaterThan(0);
+    expect(coordinatorTasks[0]!.content).toContain('circuit breaker');
+
+    const { rows: ceoTasks } = await pool.query(
+      `SELECT id, owner, tags FROM tasks WHERE owner = 'ceo' AND tags @> ARRAY['resumable-circuit-breach']::text[]`,
+    );
+    expect(ceoTasks.length).toBeGreaterThan(0);
+  });
+
+  it('schedules continuation when progress advances', async () => {
+    const task = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} healthy audit`,
+      source: 'coordinator',
+      sourceAgentId: 'social-media',
+      resumable: true,
+    });
+    await repo.setResumableBlock(task.id, {
+      cursor: 'page:3',
+      done: 25,
+      total: 1300,
+      accumulator: [],
+      lastSliceUnits: 25,
+      next: 'Review page 4',
+    }, 'social-media');
+    await repo.persistResumableCircuitState(task.id, {
+      stallCount: 0,
+      iterationCount: 1,
+      startedAt: new Date().toISOString(),
+      totalCostUsd: 0,
+      lastProgress: { done: 25, cursor: 'page:3' },
+    });
+
+    const enqueueTaskWake = vi.fn().mockResolvedValue({ jobId: 'job-healthy' });
+    const subscriber = new ResumableContinuationSubscriber({
+      pool,
+      bus,
+      logger: logger as never,
+      schedulerService: { enqueueTaskWake } as never,
+      taskRepo: repo,
+      eligibleAgents: new Set(['social-media']),
+      continuationDelaySeconds: 1,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+    subscriber.start();
+
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-ok',
+      content: JSON.stringify({
+        _curia_protocol: 'execution_paused',
+        task_id: task.id,
+        done: 50,
+        total: 1300,
+        cursor: 'page:4',
+        last_slice_units: 25,
+        next: 'Review page 5',
+      }),
+      parentEventId: 'parent-ok',
+    }));
+
+    expect(enqueueTaskWake).toHaveBeenCalled();
+    const reloaded = await repo.getTask(task.id);
+    expect(reloaded?.status).toBe('open');
+  });
+});

--- a/tests/integration/resumable-circuit-breaker.test.ts
+++ b/tests/integration/resumable-circuit-breaker.test.ts
@@ -21,6 +21,7 @@ async function cleanup(pool: pg.Pool): Promise<void> {
     `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
     [`${PREFIX}%`],
   );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`Review: resumable task stalled (${PREFIX}%`]);
   await pool.query(`DELETE FROM tasks WHERE title LIKE $1 OR parent_task_id IN (
     SELECT id FROM tasks WHERE title LIKE $1
   )`, [`${PREFIX}%`]);
@@ -33,8 +34,6 @@ describeIf('Resumable circuit breaker (#1176)', () => {
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
-    bus = new EventBus(logger as never);
-    repo = new TaskRepo(pool, bus, logger as never, 'UTC');
   });
 
   afterAll(async () => {
@@ -44,6 +43,8 @@ describeIf('Resumable circuit breaker (#1176)', () => {
 
   beforeEach(async () => {
     await cleanup(pool);
+    bus = new EventBus(logger as never);
+    repo = new TaskRepo(pool, bus, logger as never, 'UTC');
   });
 
   it('escalates after K no-progress pauses instead of scheduling another continuation', async () => {

--- a/tests/integration/resumable-continuation.test.ts
+++ b/tests/integration/resumable-continuation.test.ts
@@ -82,8 +82,10 @@ describeIf('Resumable continuation scheduling (#1175)', () => {
       bus,
       logger: logger as never,
       schedulerService,
+      taskRepo: repo,
       eligibleAgents: new Set(['social-media', 'coordinator']),
       continuationDelaySeconds: 1,
+      resumableCeilings: { maxStalls: 3, maxIterations: 100, maxWallclockHours: 24, maxCostUsd: 10 },
     });
     subscriber.start();
 

--- a/tests/unit/agents/resumable-continuation-subscriber.test.ts
+++ b/tests/unit/agents/resumable-continuation-subscriber.test.ts
@@ -3,6 +3,8 @@ import { EventBus } from '../../../src/bus/bus.js';
 import { createAgentResponse } from '../../../src/bus/events.js';
 import { ResumableContinuationSubscriber } from '../../../src/agents/resumable-continuation-subscriber.js';
 import * as continuation from '../../../src/agents/resumable-continuation.js';
+import * as circuitBreaker from '../../../src/agents/resumable-circuit-breaker.js';
+import { DEFAULT_RESUMABLE_CEILINGS } from '../../../src/config.js';
 
 function mockLogger() {
   return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() };
@@ -11,7 +13,9 @@ function mockLogger() {
 describe('ResumableContinuationSubscriber', () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it('schedules a continuation when execution_paused is emitted', async () => {
+  it('schedules a continuation when execution_paused is emitted and breaker allows', async () => {
+    vi.spyOn(circuitBreaker, 'handlePausedSliceForCircuitBreaker')
+      .mockResolvedValue({ scheduleContinuation: true });
     const scheduleSpy = vi.spyOn(continuation, 'scheduleResumableContinuation')
       .mockResolvedValue({ scheduled: true, jobId: 'job-1', agentId: 'social-media', runAt: new Date() });
 
@@ -21,8 +25,10 @@ describe('ResumableContinuationSubscriber', () => {
       bus,
       logger: mockLogger() as never,
       schedulerService: {} as never,
+      taskRepo: {} as never,
       eligibleAgents: new Set(['social-media']),
       continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
     });
     subscriber.start();
 
@@ -47,6 +53,43 @@ describe('ResumableContinuationSubscriber', () => {
     }));
   });
 
+  it('does not schedule continuation when circuit breaker trips', async () => {
+    vi.spyOn(circuitBreaker, 'handlePausedSliceForCircuitBreaker')
+      .mockResolvedValue({ scheduleContinuation: false, breach: { reason: 'stall_limit', message: 'stalled', state: {} as never } });
+    const scheduleSpy = vi.spyOn(continuation, 'scheduleResumableContinuation')
+      .mockResolvedValue({ scheduled: true, jobId: 'job-1', agentId: 'social-media', runAt: new Date() });
+
+    const bus = new EventBus(mockLogger() as never);
+    const subscriber = new ResumableContinuationSubscriber({
+      pool: {} as never,
+      bus,
+      logger: mockLogger() as never,
+      schedulerService: {} as never,
+      taskRepo: {} as never,
+      eligibleAgents: new Set(['social-media']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+    subscriber.start();
+
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-1',
+      content: JSON.stringify({
+        _curia_protocol: 'execution_paused',
+        task_id: 'task-abc',
+        done: 25,
+        total: 1300,
+        cursor: 'page:3',
+        last_slice_units: 0,
+        next: 'stuck',
+      }),
+      parentEventId: 'parent-1',
+    }));
+
+    expect(scheduleSpy).not.toHaveBeenCalled();
+  });
+
   it('ignores non-paused responses', async () => {
     const scheduleSpy = vi.spyOn(continuation, 'scheduleResumableContinuation')
       .mockResolvedValue({ scheduled: true, jobId: 'job-1', agentId: 'social-media', runAt: new Date() });
@@ -57,8 +100,10 @@ describe('ResumableContinuationSubscriber', () => {
       bus,
       logger: mockLogger() as never,
       schedulerService: {} as never,
+      taskRepo: {} as never,
       eligibleAgents: new Set(['social-media']),
       continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
     });
     subscriber.start();
 

--- a/tests/unit/agents/resumable-continuation-subscriber.test.ts
+++ b/tests/unit/agents/resumable-continuation-subscriber.test.ts
@@ -14,7 +14,7 @@ describe('ResumableContinuationSubscriber', () => {
   beforeEach(() => vi.restoreAllMocks());
 
   it('schedules a continuation when execution_paused is emitted and breaker allows', async () => {
-    vi.spyOn(circuitBreaker, 'handlePausedSliceForCircuitBreaker')
+    const breakerSpy = vi.spyOn(circuitBreaker, 'handlePausedSliceForCircuitBreaker')
       .mockResolvedValue({ scheduleContinuation: true });
     const scheduleSpy = vi.spyOn(continuation, 'scheduleResumableContinuation')
       .mockResolvedValue({ scheduled: true, jobId: 'job-1', agentId: 'social-media', runAt: new Date() });
@@ -32,21 +32,33 @@ describe('ResumableContinuationSubscriber', () => {
     });
     subscriber.start();
 
+    const pausedContent = {
+      _curia_protocol: 'execution_paused',
+      task_id: 'task-abc',
+      done: 25,
+      total: 1300,
+      cursor: 'page:3',
+      last_slice_units: 25,
+      next: 'Review page 4',
+      slice_cost_usd: 0.42,
+    };
+
     await bus.publish('agent', createAgentResponse({
       agentId: 'social-media',
       conversationId: 'conv-1',
-      content: JSON.stringify({
-        _curia_protocol: 'execution_paused',
-        task_id: 'task-abc',
-        done: 25,
-        total: 1300,
-        cursor: 'page:3',
-        last_slice_units: 25,
-        next: 'Review page 4',
-      }),
+      content: JSON.stringify(pausedContent),
       parentEventId: 'parent-1',
     }));
 
+    expect(breakerSpy).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: 'task-abc',
+      paused: expect.objectContaining({
+        task_id: 'task-abc',
+        done: 25,
+        slice_cost_usd: 0.42,
+      }),
+      sliceCostUsd: 0.42,
+    }));
     expect(scheduleSpy).toHaveBeenCalledWith(expect.objectContaining({
       taskId: 'task-abc',
       delaySeconds: 30,

--- a/tests/unit/config-tasks.test.ts
+++ b/tests/unit/config-tasks.test.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { resolveTasksConfig, DEFAULT_TASKS_CONFIG } from '../../src/config.js';
+import { resolveTasksConfig, DEFAULT_TASKS_CONFIG, DEFAULT_RESUMABLE_CEILINGS } from '../../src/config.js';
 
 describe('resolveTasksConfig', () => {
   it('returns defaults when no tasks block is present', () => {
     expect(resolveTasksConfig(undefined)).toEqual(DEFAULT_TASKS_CONFIG);
   });
 
-  it('defaults are 60 / 5 / 4 / 48 / 30', () => {
+  it('defaults are 60 / 5 / 4 / 48 / 30 with resumable ceilings', () => {
     expect(DEFAULT_TASKS_CONFIG).toEqual({
       heartbeatIntervalMinutes: 60,
       heartbeatMaxWakesPerTick: 5,
       idleThresholdHours: 4,
       staleWaitThresholdHours: 48,
       resumableContinuationSeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
     });
   });
 
@@ -23,6 +24,14 @@ describe('resolveTasksConfig', () => {
       idleThresholdHours: 2,
       staleWaitThresholdHours: 48,
       resumableContinuationSeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+  });
+
+  it('merges resumableCeilings partial overrides', () => {
+    expect(resolveTasksConfig({ resumableCeilings: { maxStalls: 5 } }).resumableCeilings).toEqual({
+      ...DEFAULT_RESUMABLE_CEILINGS,
+      maxStalls: 5,
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1176

Implements the progress-based circuit breaker for resumable iterate leaves — the direct fix for futility loops where a task returns `paused` / `completed` with no forward progress.

**Stall counter:** each `execution_paused` slice compares `done` and `cursor` against the last recorded position. No advance increments `stallCount`; forward progress resets it. After **K** consecutive stalls (`tasks.resumableCeilings.maxStalls`, default 3) the task is marked `failed`, pending continuations are cancelled, and the platform escalates.

**Aggregate ceilings** (config-driven, overridable per task via `error_budget`):
- `maxIterations` (default 100)
- `maxWallclockHours` (default 24)
- `maxCostUsd` (default $10) — slice LLM cost is accumulated in the runtime and passed on `execution_paused` as `slice_cost_usd`

**Escalation path:** coordinator notification (`agent.task`) + CEO-owned `task-create` with `needs-attention` tag — same pattern as delegation-failure escalation (#1171).

## Config

Documented in `config/default.yaml` under `tasks.resumableCeilings`. Per-task overrides: `error_budget.max_stalls`, `max_iterations`, `max_wallclock_hours`, `max_cost_usd`.

## Tests

- Unit: progress detection, stall/ceiling breach logic, config resolution
- Integration: K no-progress pauses → task `failed` + no continuation wake; healthy progress → continuation scheduled
- Updated continuation subscriber + config tests

## Acceptance criteria

- [x] No-progress continuation increments stall counter; K stalls → `failed` + escalation
- [x] Per-task ceilings trip and escalate; defaults config-driven and documented
- [x] Healthy resumable task (steady progress) does not trip the breaker
- [x] Test injects artificial stall and confirms escalation rather than looping
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3470b697-fcdd-4b87-b89f-1235a37f0da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3470b697-fcdd-4b87-b89f-1235a37f0da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

