### PR TITLE
fix: reject per-invocation error_budget keys on tasks (#883)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Per-task error_budget** — HTTP and scheduler paths now reject per-invocation turn-limit keys (`maxTurns`, `maxConsecutiveErrors`); per-agent YAML remains the sole source of truth for slice budgets, while the column keeps resumable flags and aggregate ceiling overrides. (#883)
 - **`delegate`** — honors `retryable: false` on specialist failures with an enforceable per-turn guard: identical re-delegations are blocked and non-retryable failures escalate to the CEO backlog via `task-create`. (#1171)
 - **`delegate`** — specialist failures now propagate structured `reason` and `retryable` from the runtime (e.g. `maxTurns`) instead of generic timeout/error strings, so the coordinator can report the real cause. (#1170)
 - **`web-browser`** — waits through edge WAF challenge pages and resolves hidden custom form controls. (v1.5.0)

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -445,8 +445,9 @@ function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted, lookupTas
           )}
 
           <div className="form-field">
-            <label htmlFor="tf-budget">Error budget JSON</label>
-            <textarea id="tf-budget" rows={4} value={errorBudget} onChange={e => setErrorBudget(e.target.value)} placeholder='{"maxTurns": 12, "maxConsecutiveErrors": 3}' style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }} />
+            <label htmlFor="tf-budget">Resumable config JSON</label>
+            <textarea id="tf-budget" rows={4} value={errorBudget} onChange={e => setErrorBudget(e.target.value)} placeholder='{"resumable": true, "max_iterations": 50}' style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }} />
+            <p style={{ fontSize: 12, margin: '4px 0 0', opacity: 0.75 }}>Per-invocation turn limits are set in agent YAML, not here. Use resumable flags and aggregate ceiling overrides only.</p>
           </div>
           <div className="form-field">
             <label htmlFor="tf-progress">Progress JSON</label>

--- a/skills/scheduler-create/handler.ts
+++ b/skills/scheduler-create/handler.ts
@@ -6,6 +6,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { TaskOriginator } from '../../src/contacts/types.js';
+import { validateTaskErrorBudget } from '../../src/tasks/task-error-budget.js';
 
 export class SchedulerCreateHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -37,6 +38,12 @@ export class SchedulerCreateHandler implements SkillHandler {
     // skipped by the runtime's truthiness guard, giving the illusion of drift prevention with none.
     if (intent_anchor !== undefined && typeof intent_anchor === 'string' && intent_anchor.trim() === '') {
       return { success: false, error: 'intent_anchor must not be blank — provide a meaningful description or omit the field' };
+    }
+    if (error_budget !== undefined) {
+      const budgetError = validateTaskErrorBudget(error_budget);
+      if (budgetError) {
+        return { success: false, error: budgetError };
+      }
     }
 
     const agentId = agent_id ?? 'coordinator';

--- a/skills/scheduler-create/skill.json
+++ b/skills/scheduler-create/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "scheduler-create",
   "description": "Create a scheduled job. Supports cron expressions for recurring jobs and ISO 8601 timestamps for one-shot jobs. Provide intent_anchor to create a persistent multi-burst task.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -10,7 +10,7 @@
     "run_at": "timestamp?",
     "agent_id": "string?",
     "intent_anchor": "string?",
-    "error_budget": "object?",
+    "error_budget": "object? (resumable task config only: resumable, max_stalls, max_iterations, max_wallclock_hours, max_cost_usd — not per-invocation turn limits)",
     "timezone": "string? (IANA timezone name, e.g. America/Toronto — overrides Curia's default timezone for this job's cron schedule)"
   },
   "outputs": {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -12,6 +12,7 @@ import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../s
 import { resolveConsoleOriginator } from '../console-originator.js';
 import { markdownToHtml } from '../../../format/markdown-to-html.js';
 import { stripOutboundContextPreamble } from '../../../dispatch/outbound-context.js';
+import { validateTaskErrorBudget } from '../../../tasks/task-error-budget.js';
 
 export interface KnowledgeGraphRouteOptions {
   pool: Pool;
@@ -439,6 +440,12 @@ export async function knowledgeGraphRoutes(
     if (body.errorBudget !== undefined && (typeof body.errorBudget !== 'object' || body.errorBudget === null || Array.isArray(body.errorBudget))) {
       return reply.status(400).send({ error: 'errorBudget must be a JSON object.' });
     }
+    if (body.errorBudget !== undefined) {
+      const budgetError = validateTaskErrorBudget(body.errorBudget as Record<string, unknown>);
+      if (budgetError) {
+        return reply.status(400).send({ error: budgetError });
+      }
+    }
     if (body.progress !== undefined && (typeof body.progress !== 'object' || body.progress === null || Array.isArray(body.progress))) {
       return reply.status(400).send({ error: 'progress must be a JSON object.' });
     }
@@ -624,6 +631,12 @@ export async function knowledgeGraphRoutes(
     }
     if (body.errorBudget !== undefined && (typeof body.errorBudget !== 'object' || body.errorBudget === null || Array.isArray(body.errorBudget))) {
       return reply.status(400).send({ error: 'errorBudget must be a JSON object.' });
+    }
+    if (body.errorBudget !== undefined) {
+      const budgetError = validateTaskErrorBudget(body.errorBudget as Record<string, unknown>);
+      if (budgetError) {
+        return reply.status(400).send({ error: budgetError });
+      }
     }
     if (body.progress !== undefined && (typeof body.progress !== 'object' || body.progress === null || Array.isArray(body.progress))) {
       return reply.status(400).send({ error: 'progress must be a JSON object.' });

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -6,6 +6,7 @@ import type { Logger } from '../logger.js';
 import { createScheduleCreated } from '../bus/events.js';
 import type { TaskOriginator } from '../contacts/types.js';
 import { makeSystemOriginator } from '../contacts/principal.js';
+import { validateTaskErrorBudget } from '../tasks/task-error-budget.js';
 
 // -- Public types --
 
@@ -166,6 +167,12 @@ export class SchedulerService {
 
   async createJob(params: CreateJobParams): Promise<CreateJobResult> {
     const { agentId, cronExpr, runAt, taskPayload, createdBy, intentAnchor, errorBudget } = params;
+    if (errorBudget !== undefined) {
+      const budgetError = validateTaskErrorBudget(errorBudget);
+      if (budgetError) {
+        throw new Error(budgetError);
+      }
+    }
     // Per-job timezone: use caller's override, fall back to service default.
     // Validate LLM-supplied overrides — cron-parser accepts some invalid zone strings
     // (e.g. "UTC+99") without throwing, which would silently schedule jobs at wrong times.

--- a/src/tasks/task-error-budget.ts
+++ b/src/tasks/task-error-budget.ts
@@ -32,8 +32,18 @@ const NUMERIC_CEILING_KEYS = [
  * Validate a task error_budget object before persistence.
  * Returns an error message when invalid, or null when acceptable.
  */
-export function validateTaskErrorBudget(errorBudget: Record<string, unknown>): string | null {
-  for (const key of Object.keys(errorBudget)) {
+export function validateTaskErrorBudget(errorBudget: unknown): string | null {
+  if (
+    errorBudget === null ||
+    typeof errorBudget !== 'object' ||
+    Array.isArray(errorBudget)
+  ) {
+    return 'error_budget must be an object.';
+  }
+
+  const budget = errorBudget as Record<string, unknown>;
+
+  for (const key of Object.keys(budget)) {
     if (FORBIDDEN_PER_INVOCATION_BUDGET_KEYS.has(key)) {
       return (
         `error_budget.${key} is not supported on tasks — per-invocation turn limits are ` +
@@ -50,13 +60,13 @@ export function validateTaskErrorBudget(errorBudget: Record<string, unknown>): s
     }
   }
 
-  if ('resumable' in errorBudget && typeof errorBudget.resumable !== 'boolean') {
+  if ('resumable' in budget && typeof budget.resumable !== 'boolean') {
     return 'error_budget.resumable must be a boolean.';
   }
 
   for (const key of NUMERIC_CEILING_KEYS) {
-    if (key in errorBudget) {
-      const value = errorBudget[key];
+    if (key in budget) {
+      const value = budget[key];
       if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
         return `error_budget.${key} must be a positive number.`;
       }

--- a/src/tasks/task-error-budget.ts
+++ b/src/tasks/task-error-budget.ts
@@ -1,0 +1,67 @@
+// task-error-budget.ts — validation for per-task error_budget JSONB (#883).
+//
+// Per-invocation turn limits (maxTurns / maxConsecutiveErrors) are configured in
+// agent YAML only. The per-task column holds resumable-task metadata and aggregate
+// ceiling overrides (#1176).
+
+/** Keys that configure resumable tasks and aggregate ceilings — the only supported per-task fields. */
+export const ALLOWED_TASK_ERROR_BUDGET_KEYS = new Set([
+  'resumable',
+  'max_stalls',
+  'max_iterations',
+  'max_wallclock_hours',
+  'max_cost_usd',
+]);
+
+/** Per-invocation budget keys — rejected on tasks; belong in agent YAML (error_budget.max_turns / max_errors). */
+export const FORBIDDEN_PER_INVOCATION_BUDGET_KEYS = new Set([
+  'maxTurns',
+  'maxConsecutiveErrors',
+  'max_turns',
+  'max_errors',
+]);
+
+const NUMERIC_CEILING_KEYS = [
+  'max_stalls',
+  'max_iterations',
+  'max_wallclock_hours',
+  'max_cost_usd',
+] as const;
+
+/**
+ * Validate a task error_budget object before persistence.
+ * Returns an error message when invalid, or null when acceptable.
+ */
+export function validateTaskErrorBudget(errorBudget: Record<string, unknown>): string | null {
+  for (const key of Object.keys(errorBudget)) {
+    if (FORBIDDEN_PER_INVOCATION_BUDGET_KEYS.has(key)) {
+      return (
+        `error_budget.${key} is not supported on tasks — per-invocation turn limits are ` +
+        `configured in agent YAML (error_budget.max_turns / max_errors), not per-task. ` +
+        `Use resumable ceiling keys (max_stalls, max_iterations, max_wallclock_hours, max_cost_usd) ` +
+        `or set resumable: true.`
+      );
+    }
+    if (!ALLOWED_TASK_ERROR_BUDGET_KEYS.has(key)) {
+      return (
+        `error_budget.${key} is not a recognized task error_budget key. ` +
+        `Allowed: ${[...ALLOWED_TASK_ERROR_BUDGET_KEYS].join(', ')}.`
+      );
+    }
+  }
+
+  if ('resumable' in errorBudget && typeof errorBudget.resumable !== 'boolean') {
+    return 'error_budget.resumable must be a boolean.';
+  }
+
+  for (const key of NUMERIC_CEILING_KEYS) {
+    if (key in errorBudget) {
+      const value = errorBudget[key];
+      if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        return `error_budget.${key} must be a positive number.`;
+      }
+    }
+  }
+
+  return null;
+}

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -124,7 +124,7 @@ describe('SchedulerService', () => {
         taskPayload: { skill: 'report' },
         createdBy: 'system',
         intentAnchor: 'weekly-report',
-        errorBudget: { maxRetries: 5 },
+        errorBudget: { resumable: true, max_iterations: 50 },
       };
       const result = await svc.createJob(params);
 
@@ -138,6 +138,20 @@ describe('SchedulerService', () => {
       expect(clientCalls[2]).toContain('INSERT INTO tasks');
       expect(clientCalls[3]).toBe('COMMIT');
       expect(pool._client.release).toHaveBeenCalledOnce();
+    });
+
+    it('rejects per-invocation error_budget keys on persistent tasks (#883)', async () => {
+      const params: CreateJobParams = {
+        agentId: 'agent-3',
+        cronExpr: '0 */6 * * *',
+        taskPayload: { skill: 'report' },
+        createdBy: 'system',
+        intentAnchor: 'weekly-report',
+        errorBudget: { maxTurns: 30 },
+      };
+
+      await expect(svc.createJob(params)).rejects.toThrow(/not supported on tasks/);
+      expect(pool.connect).not.toHaveBeenCalled();
     });
 
     it('rolls back when the task CTE throws — no orphaned scheduled_jobs row', async () => {

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -154,6 +154,22 @@ describe('SchedulerService', () => {
       expect(pool.connect).not.toHaveBeenCalled();
     });
 
+    it('rejects null and array errorBudget values (#883)', async () => {
+      const base: CreateJobParams = {
+        agentId: 'agent-3',
+        cronExpr: '0 */6 * * *',
+        taskPayload: { skill: 'report' },
+        createdBy: 'system',
+        intentAnchor: 'weekly-report',
+      };
+
+      await expect(svc.createJob({ ...base, errorBudget: null as unknown as Record<string, unknown> }))
+        .rejects.toThrow(/must be an object/);
+      await expect(svc.createJob({ ...base, errorBudget: [] as unknown as Record<string, unknown> }))
+        .rejects.toThrow(/must be an object/);
+      expect(pool.connect).not.toHaveBeenCalled();
+    });
+
     it('rolls back when the task CTE throws — no orphaned scheduled_jobs row', async () => {
       const jobId = 'job-rollback';
       pool._clientQuery

--- a/tests/unit/skills/scheduler-create.test.ts
+++ b/tests/unit/skills/scheduler-create.test.ts
@@ -171,6 +171,32 @@ describe('SchedulerCreateHandler', () => {
     expect(schedulerService.createJob).not.toHaveBeenCalled();
   });
 
+  it('rejects null and array error_budget values (#883)', async () => {
+    const schedulerService = {
+      createJob: vi.fn(),
+      listJobs: vi.fn(),
+      cancelJob: vi.fn(),
+    };
+
+    for (const error_budget of [null, []]) {
+      const result = await handler.execute(makeCtx(
+        {
+          task: 'weekly report',
+          cron_expr: '0 9 * * 1',
+          intent_anchor: 'weekly-report-v1',
+          error_budget: error_budget as never,
+        },
+        { schedulerService: schedulerService as never },
+      ));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toMatch(/must be an object/);
+      }
+    }
+    expect(schedulerService.createJob).not.toHaveBeenCalled();
+  });
+
   it('returns failure when createJob throws', async () => {
     const schedulerService = {
       createJob: vi.fn().mockRejectedValue(new Error('DB connection lost')),

--- a/tests/unit/skills/scheduler-create.test.ts
+++ b/tests/unit/skills/scheduler-create.test.ts
@@ -124,7 +124,7 @@ describe('SchedulerCreateHandler', () => {
         task: 'weekly report',
         cron_expr: '0 9 * * 1',
         intent_anchor: 'weekly-report-v1',
-        error_budget: { maxRetries: 3 },
+        error_budget: { resumable: true },
       },
       { schedulerService: schedulerService as never },
     ));
@@ -142,9 +142,33 @@ describe('SchedulerCreateHandler', () => {
       taskPayload: { task: 'weekly report' },
       createdBy: 'coordinator',
       intentAnchor: 'weekly-report-v1',
-      errorBudget: { maxRetries: 3 },
+      errorBudget: { resumable: true },
       originator: undefined,
     });
+  });
+
+  it('rejects per-invocation error_budget keys (#883)', async () => {
+    const schedulerService = {
+      createJob: vi.fn(),
+      listJobs: vi.fn(),
+      cancelJob: vi.fn(),
+    };
+
+    const result = await handler.execute(makeCtx(
+      {
+        task: 'weekly report',
+        cron_expr: '0 9 * * 1',
+        intent_anchor: 'weekly-report-v1',
+        error_budget: { maxTurns: 30 },
+      },
+      { schedulerService: schedulerService as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/not supported on tasks/);
+    }
+    expect(schedulerService.createJob).not.toHaveBeenCalled();
   });
 
   it('returns failure when createJob throws', async () => {

--- a/tests/unit/tasks/task-error-budget.test.ts
+++ b/tests/unit/tasks/task-error-budget.test.ts
@@ -10,6 +10,10 @@ describe('validateTaskErrorBudget', () => {
     expect(validateTaskErrorBudget({})).toBeNull();
   });
 
+  it.each([null, [], 'string', 42])('rejects non-object input %j', (input) => {
+    expect(validateTaskErrorBudget(input)).toBe('error_budget must be an object.');
+  });
+
   it('accepts resumable flag and ceiling overrides', () => {
     expect(
       validateTaskErrorBudget({

--- a/tests/unit/tasks/task-error-budget.test.ts
+++ b/tests/unit/tasks/task-error-budget.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALLOWED_TASK_ERROR_BUDGET_KEYS,
+  FORBIDDEN_PER_INVOCATION_BUDGET_KEYS,
+  validateTaskErrorBudget,
+} from '../../../src/tasks/task-error-budget.js';
+
+describe('validateTaskErrorBudget', () => {
+  it('accepts an empty object', () => {
+    expect(validateTaskErrorBudget({})).toBeNull();
+  });
+
+  it('accepts resumable flag and ceiling overrides', () => {
+    expect(
+      validateTaskErrorBudget({
+        resumable: true,
+        max_stalls: 5,
+        max_iterations: 50,
+        max_wallclock_hours: 12,
+        max_cost_usd: 8.5,
+      }),
+    ).toBeNull();
+  });
+
+  it.each([...FORBIDDEN_PER_INVOCATION_BUDGET_KEYS])(
+    'rejects per-invocation key %s',
+    (key) => {
+      const message = validateTaskErrorBudget({ [key]: 10 });
+      expect(message).toMatch(/not supported on tasks/);
+      expect(message).toContain(key);
+    },
+  );
+
+  it('rejects unknown keys', () => {
+    const message = validateTaskErrorBudget({ maxRetries: 3 });
+    expect(message).toMatch(/not a recognized task error_budget key/);
+    expect(message).toContain('maxRetries');
+  });
+
+  it('rejects non-boolean resumable', () => {
+    expect(validateTaskErrorBudget({ resumable: 'yes' })).toBe(
+      'error_budget.resumable must be a boolean.',
+    );
+  });
+
+  it('rejects non-positive ceiling values', () => {
+    expect(validateTaskErrorBudget({ max_iterations: 0 })).toBe(
+      'error_budget.max_iterations must be a positive number.',
+    );
+    expect(validateTaskErrorBudget({ max_cost_usd: -1 })).toBe(
+      'error_budget.max_cost_usd must be a positive number.',
+    );
+  });
+
+  it('documents allowed keys for operator-facing errors', () => {
+    const allowed = [...ALLOWED_TASK_ERROR_BUDGET_KEYS].sort();
+    expect(allowed).toEqual([
+      'max_cost_usd',
+      'max_iterations',
+      'max_stalls',
+      'max_wallclock_hours',
+      'resumable',
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #883

Implements **Option A** for per-invocation turn budgets, reconciled with the resumable-tasks work (#1174, #1176):

- **Per-agent YAML** remains the sole source of truth for slice turn limits (`max_turns` / `max_errors`).
- The per-task `error_budget` column is **kept** for resumable metadata and aggregate ceiling overrides (`resumable`, `max_stalls`, `max_iterations`, `max_wallclock_hours`, `max_cost_usd`).
- HTTP, scheduler, and `scheduler-create` paths now **reject** per-invocation keys (`maxTurns`, `maxConsecutiveErrors`, `max_turns`, `max_errors`) and unknown keys with a clear 400/skill error — no more silently-ignored validated inputs.

## Changes

- Added `validateTaskErrorBudget()` in `src/tasks/task-error-budget.ts`.
- Wired validation into `SchedulerService.createJob`, KG task POST/PATCH routes, and `scheduler-create`.
- Updated console Tasks drawer label/placeholder to reflect resumable-only semantics.
- Clarified `scheduler-create` skill manifest `error_budget` input description.

## Acceptance criteria

- [x] Single source of truth for per-invocation turn budget (agent YAML only).
- [x] Exposed paths no longer silently ignore per-invocation budget inputs — they are rejected with an explicit error.
- [x] `error_budget` column retained for #1176 resumable ceilings (no drop-then-re-add).
- [x] No regression in per-agent YAML budget path (runtime unchanged).
- [x] Unit tests for validation, scheduler-service, and scheduler-create.

## Testing

- `pnpm test tests/unit/tasks/task-error-budget.test.ts tests/unit/scheduler/scheduler-service.test.ts tests/unit/skills/scheduler-create.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm --filter @curia/console run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9ce6928-0d5d-4899-a6a2-1247df8172b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9ce6928-0d5d-4899-a6a2-1247df8172b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

