### PR TITLE
feat: progress.plan block + plan-state helpers (#1236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`progress.plan`** — typed plan block with child-step descriptors, deliverable step pointer, and "X of Y" rollup helper; round-trip persistence via `getPlanBlock` / `setPlanBlock`. (#1236)
 - **Resumable circuit breaker** — stall counter and aggregate ceilings fail stuck resumable tasks instead of looping. (#1176)
 - **Resumable executor contract** — checkpointed budget-hit pauses instead of `BUDGET_EXCEEDED`; coordinator treats `paused` as success. (#1174)
 - **Resumable self-continuation** — paused resumable tasks schedule a single near-term `scheduled_jobs` wake routed to `source_agent_id` (config: `tasks.resumableContinuationSeconds`); the hourly BacklogHeartbeat remains the backstop. (#1175)

--- a/src/db/plan-progress.test.ts
+++ b/src/db/plan-progress.test.ts
@@ -136,7 +136,11 @@ describe('computePlanRollup', () => {
       { id: 'a', taskId: CHILD_A },
       { id: 'b', taskId: null },
     ];
-    const rollup = computePlanRollup(steps, { [CHILD_A]: 'done' });
+    const rollup = computePlanRollup(steps, {
+      [CHILD_A]: 'done',
+      [CHILD_B]: 'done',
+      'dddddddd-dddd-dddd-dddd-dddddddddddd': 'done',
+    });
     expect(rollup).toEqual({ done: 1, total: 2 });
   });
 
@@ -147,6 +151,16 @@ describe('computePlanRollup', () => {
       [CHILD_C]: 'failed',
     });
     expect(rollup).toEqual({ done: 0, total: 3 });
+  });
+});
+
+describe('preparePlanBlock', () => {
+  it('always stamps plannedAt at write time', () => {
+    const result = preparePlanBlock(BASE_INPUT);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.block.plannedAt).toBeDefined();
+    expect(Number.isNaN(Date.parse(result.block.plannedAt!))).toBe(false);
   });
 });
 

--- a/src/db/plan-progress.test.ts
+++ b/src/db/plan-progress.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PLAN_BLOCK_MAX_BYTES,
+  computePlanRollup,
+  isPlannedStep,
+  mergePlanIntoProgress,
+  parsePlanBlock,
+  planBlockBytes,
+  preparePlanBlock,
+  readPlanBlock,
+  writePlanBlock,
+  type PlanStepDescriptor,
+} from './plan-progress.js';
+
+const CHILD_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const CHILD_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const CHILD_C = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+const STEPS: PlanStepDescriptor[] = [
+  { id: 'gather-exec-input', taskId: CHILD_A },
+  { id: 'synthesize-themes', taskId: CHILD_B },
+  { id: 'assemble-kickoff', taskId: CHILD_C },
+];
+
+const BASE_INPUT = {
+  steps: STEPS,
+  deliverableStepId: 'assemble-kickoff',
+  done: 1,
+  total: 3,
+  next: 'Wait for exec input, then synthesize themes',
+};
+
+describe('parsePlanBlock', () => {
+  it('parses a valid block', () => {
+    const block = parsePlanBlock({
+      steps: STEPS,
+      deliverableStepId: 'assemble-kickoff',
+      done: 1,
+      total: 3,
+      next: 'Continue planning',
+      plannedAt: '2026-06-29T00:00:00.000Z',
+    });
+    expect(block).toEqual({
+      steps: STEPS,
+      deliverableStepId: 'assemble-kickoff',
+      done: 1,
+      total: 3,
+      next: 'Continue planning',
+      plannedAt: '2026-06-29T00:00:00.000Z',
+    });
+  });
+
+  it('accepts snake_case fields from persisted JSON', () => {
+    const block = parsePlanBlock({
+      steps: [{ id: 'step-1', task_id: CHILD_A }],
+      deliverable_step_id: null,
+      done: 0,
+      total: 1,
+      next: 'Materialize first step',
+      planned_at: '2026-06-29T00:00:00.000Z',
+    });
+    expect(block?.steps[0]?.taskId).toBe(CHILD_A);
+    expect(block?.deliverableStepId).toBeNull();
+    expect(block?.plannedAt).toBe('2026-06-29T00:00:00.000Z');
+  });
+
+  it('accepts unmaterialized steps with null taskId', () => {
+    const block = parsePlanBlock({
+      steps: [
+        { id: 'step-1', taskId: CHILD_A },
+        { id: 'step-2', taskId: null },
+      ],
+      deliverableStepId: null,
+      done: 0,
+      total: 2,
+      next: 'Create step 2 when step 1 completes',
+    });
+    expect(block?.steps[1]?.taskId).toBeNull();
+  });
+
+  it('returns null for invalid blocks', () => {
+    expect(parsePlanBlock(null)).toBeNull();
+    expect(parsePlanBlock({ ...BASE_INPUT, done: -1 })).toBeNull();
+    expect(parsePlanBlock({ ...BASE_INPUT, next: '   ' })).toBeNull();
+    expect(parsePlanBlock({ ...BASE_INPUT, total: 99 })).toBeNull();
+    expect(parsePlanBlock({ ...BASE_INPUT, done: 5 })).toBeNull();
+    expect(parsePlanBlock({ ...BASE_INPUT, deliverableStepId: 'missing-step' })).toBeNull();
+    expect(parsePlanBlock({ ...BASE_INPUT, steps: [] })).toBeNull();
+    expect(parsePlanBlock({ ...BASE_INPUT, steps: [{ id: 'dup' }, { id: 'dup' }] })).toBeNull();
+    expect(parsePlanBlock({ ...BASE_INPUT, steps: [{ id: 'bad', taskId: 'not-a-uuid' }] })).toBeNull();
+  });
+});
+
+describe('isPlannedStep', () => {
+  it('detects a planned step solely from the plan block', () => {
+    const progress = { notes: [], resumable: { cursor: 'x', done: 0, total: 1 } };
+    expect(isPlannedStep(progress)).toBe(false);
+
+    const written = writePlanBlock(progress, BASE_INPUT);
+    expect(written.ok).toBe(true);
+    if (!written.ok) return;
+    expect(isPlannedStep(written.progress)).toBe(true);
+  });
+});
+
+describe('readPlanBlock / writePlanBlock round-trip', () => {
+  it('writes and reads back from progress JSON', () => {
+    const progress = { notes: [{ at: '2026-06-29T00:00:00.000Z', note: 'started' }] };
+    const written = writePlanBlock(progress, BASE_INPUT);
+    expect(written.ok).toBe(true);
+    if (!written.ok) return;
+
+    expect(written.progress.notes).toEqual(progress.notes);
+    const reread = readPlanBlock(written.progress);
+    expect(reread?.deliverableStepId).toBe('assemble-kickoff');
+    expect(reread?.done).toBe(1);
+    expect(reread?.total).toBe(3);
+    expect(reread?.steps).toEqual(STEPS);
+    expect(reread?.next).toBe(BASE_INPUT.next);
+    expect(reread?.plannedAt).toBeDefined();
+  });
+});
+
+describe('computePlanRollup', () => {
+  it('counts done and cancelled children as resolved', () => {
+    const rollup = computePlanRollup(STEPS, {
+      [CHILD_A]: 'done',
+      [CHILD_B]: 'in_progress',
+      [CHILD_C]: 'cancelled',
+    });
+    expect(rollup).toEqual({ done: 2, total: 3 });
+  });
+
+  it('ignores unmaterialized steps and unknown task ids', () => {
+    const steps: PlanStepDescriptor[] = [
+      { id: 'a', taskId: CHILD_A },
+      { id: 'b', taskId: null },
+    ];
+    const rollup = computePlanRollup(steps, { [CHILD_A]: 'done' });
+    expect(rollup).toEqual({ done: 1, total: 2 });
+  });
+
+  it('returns zero done when no children are resolved', () => {
+    const rollup = computePlanRollup(STEPS, {
+      [CHILD_A]: 'in_progress',
+      [CHILD_B]: 'open',
+      [CHILD_C]: 'failed',
+    });
+    expect(rollup).toEqual({ done: 0, total: 3 });
+  });
+});
+
+describe('block bounding', () => {
+  it('rejects blocks over the cap', () => {
+    const manySteps: PlanStepDescriptor[] = Array.from({ length: 200 }, (_, i) => ({
+      id: `step-${String(i).padStart(4, '0')}-with-a-long-descriptor-id-suffix`,
+      taskId: `${String(i).padStart(8, '0')}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`,
+    }));
+
+    const result = preparePlanBlock({
+      steps: manySteps,
+      deliverableStepId: null,
+      done: 0,
+      total: manySteps.length,
+      next: 'This plan is intentionally wide to test the block size cap',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok || result.code !== 'block_overflow') return;
+    expect(result.bytes).toBeGreaterThan(PLAN_BLOCK_MAX_BYTES);
+  });
+
+  it('keeps a typical plan well under the cap', () => {
+    const result = preparePlanBlock(BASE_INPUT);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(planBlockBytes(result.block)).toBeLessThanOrEqual(PLAN_BLOCK_MAX_BYTES);
+  });
+});
+
+describe('mergePlanIntoProgress', () => {
+  it('preserves sibling progress blocks', () => {
+    const block = preparePlanBlock(BASE_INPUT);
+    if (!block.ok) throw new Error('expected valid block');
+
+    const resumable = { cursor: 'page:1', done: 0, total: 10 };
+    const merged = mergePlanIntoProgress(
+      {
+        notes: [],
+        resumable,
+        resumableCircuit: { stallCount: 0 },
+        custom: true,
+      },
+      block.block,
+    );
+
+    expect(merged.custom).toBe(true);
+    expect(merged.notes).toEqual([]);
+    expect(merged.resumable).toEqual(resumable);
+    expect(merged.resumableCircuit).toEqual({ stallCount: 0 });
+    expect(merged.plan).toEqual(block.block);
+  });
+});

--- a/src/db/plan-progress.ts
+++ b/src/db/plan-progress.ts
@@ -1,0 +1,280 @@
+// plan-progress.ts — typed read/write helpers for tasks.progress.plan.
+//
+// Shared representation for the plan primitive (#1236). Persisted under the existing
+// tasks.progress JSONB — no schema migration.
+
+import { serializedUtf8Bytes } from './resumable-progress.js';
+
+/** Max serialized size (UTF-8 bytes) of the entire plan block. */
+export const PLAN_BLOCK_MAX_BYTES = 8192;
+
+/** Lightweight pointer to a materialized child task row — no per-item payloads inline. */
+export interface PlanStepDescriptor {
+  /** Stable step id within this plan (referenced by deliverableStepId). */
+  id: string;
+  /** Child task row id once materialized; null until the step is created. */
+  taskId: string | null;
+}
+
+export interface PlanProgressBlock {
+  /** Ordered planned child-step descriptors (pointers only). */
+  steps: PlanStepDescriptor[];
+  /** Which step's output is the parent's result; null = default child-summary rollup. */
+  deliverableStepId: string | null;
+  done: number;
+  total: number;
+  next: string;
+  /** ISO timestamp of the last plan write. */
+  plannedAt?: string;
+}
+
+export interface TaskProgressWithPlan {
+  notes?: Array<{ at: string; note: string }>;
+  plan?: PlanProgressBlock;
+  [key: string]: unknown;
+}
+
+export type PlanWriteResult =
+  | { ok: true; block: PlanProgressBlock; progress: TaskProgressWithPlan }
+  | { ok: false; code: 'block_overflow'; bytes: number; maxBytes: number }
+  | { ok: false; code: 'invalid_block'; message: string };
+
+/** Child statuses that count as resolved for the "X of Y" rollup. */
+const RESOLVED_CHILD_STATUSES = new Set(['done', 'cancelled']);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function planBlockBytes(block: PlanProgressBlock): number {
+  return serializedUtf8Bytes(block);
+}
+
+export function isPlanBlockWithinCap(block: PlanProgressBlock): boolean {
+  return planBlockBytes(block) <= PLAN_BLOCK_MAX_BYTES;
+}
+
+/** A task is a planned step iff progress.plan is present and valid. */
+export function isPlannedStep(progress: Record<string, unknown>): boolean {
+  return readPlanBlock(progress) !== null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseNonNegativeInt(raw: unknown): number | undefined {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0 || !Number.isInteger(raw)) {
+    return undefined;
+  }
+  return raw;
+}
+
+function parseNext(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseStepId(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseTaskId(raw: unknown): string | null | undefined {
+  if (raw === null) return null;
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return UUID_RE.test(trimmed) ? trimmed : undefined;
+}
+
+function readTaskIdField(raw: Record<string, unknown>): unknown {
+  if ('taskId' in raw) return raw.taskId;
+  if ('task_id' in raw) return raw.task_id;
+  return undefined;
+}
+
+function parseStepDescriptor(raw: unknown): PlanStepDescriptor | undefined {
+  if (!isPlainObject(raw)) return undefined;
+
+  const id = parseStepId(raw.id);
+  const taskId = parseTaskId(readTaskIdField(raw));
+  if (id === undefined || taskId === undefined) return undefined;
+
+  return { id, taskId };
+}
+
+function parseSteps(raw: unknown): PlanStepDescriptor[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+
+  const steps: PlanStepDescriptor[] = [];
+  const seenIds = new Set<string>();
+
+  for (const item of raw) {
+    const step = parseStepDescriptor(item);
+    if (!step || seenIds.has(step.id)) return undefined;
+    seenIds.add(step.id);
+    steps.push(step);
+  }
+
+  return steps;
+}
+
+function parseDeliverableStepId(raw: unknown): string | null | undefined {
+  if (raw === null) return null;
+  return parseStepId(raw);
+}
+
+function readDeliverableStepIdField(raw: Record<string, unknown>): unknown {
+  if ('deliverableStepId' in raw) return raw.deliverableStepId;
+  if ('deliverable_step_id' in raw) return raw.deliverable_step_id;
+  return undefined;
+}
+
+/** Parse a plan block from persisted progress JSON. Returns null when absent or invalid. */
+export function parsePlanBlock(raw: unknown): PlanProgressBlock | null {
+  if (!isPlainObject(raw)) return null;
+
+  const steps = parseSteps(raw.steps);
+  const deliverableStepId = parseDeliverableStepId(readDeliverableStepIdField(raw));
+  const done = parseNonNegativeInt(raw.done);
+  const total = parseNonNegativeInt(raw.total);
+  const next = parseNext(raw.next);
+
+  if (
+    steps === undefined
+    || deliverableStepId === undefined
+    || done === undefined
+    || total === undefined
+    || next === undefined
+  ) {
+    return null;
+  }
+
+  if (done > total || total !== steps.length) return null;
+
+  if (deliverableStepId !== null && !steps.some((s) => s.id === deliverableStepId)) {
+    return null;
+  }
+
+  const block: PlanProgressBlock = {
+    steps,
+    deliverableStepId,
+    done,
+    total,
+    next,
+  };
+
+  if (typeof raw.plannedAt === 'string') {
+    block.plannedAt = raw.plannedAt;
+  } else if (typeof raw.planned_at === 'string') {
+    block.plannedAt = raw.planned_at;
+  }
+
+  return block;
+}
+
+/** Read the plan block from a task progress object. */
+export function readPlanBlock(progress: Record<string, unknown>): PlanProgressBlock | null {
+  return parsePlanBlock(progress.plan);
+}
+
+function validateBlockForWrite(block: PlanProgressBlock): PlanWriteResult | null {
+  const bytes = planBlockBytes(block);
+  if (bytes > PLAN_BLOCK_MAX_BYTES) {
+    return {
+      ok: false,
+      code: 'block_overflow',
+      bytes,
+      maxBytes: PLAN_BLOCK_MAX_BYTES,
+    };
+  }
+  return null;
+}
+
+export interface PreparePlanBlockInput {
+  steps: PlanStepDescriptor[];
+  deliverableStepId: string | null;
+  done: number;
+  total: number;
+  next: string;
+  plannedAt?: string;
+}
+
+/** Validate and normalize a plan block before persistence. */
+export function preparePlanBlock(input: PreparePlanBlockInput): PlanWriteResult {
+  const parsed = parsePlanBlock({
+    steps: input.steps,
+    deliverableStepId: input.deliverableStepId,
+    done: input.done,
+    total: input.total,
+    next: input.next,
+    plannedAt: input.plannedAt,
+  });
+
+  if (!parsed) {
+    return { ok: false, code: 'invalid_block', message: 'plan block failed validation' };
+  }
+
+  const block: PlanProgressBlock = {
+    ...parsed,
+    plannedAt: input.plannedAt ?? new Date().toISOString(),
+  };
+
+  const capError = validateBlockForWrite(block);
+  if (capError) return capError;
+
+  return { ok: true, block, progress: {} };
+}
+
+/** Merge a validated plan block into an existing progress object (preserves sibling blocks). */
+export function mergePlanIntoProgress(
+  progress: Record<string, unknown>,
+  block: PlanProgressBlock,
+): TaskProgressWithPlan {
+  return { ...progress, plan: block };
+}
+
+/** Validate, merge, and return the updated progress object. */
+export function writePlanBlock(
+  progress: Record<string, unknown>,
+  input: PreparePlanBlockInput,
+): PlanWriteResult {
+  const prepared = preparePlanBlock(input);
+  if (!prepared.ok) return prepared;
+
+  const merged = mergePlanIntoProgress(progress, prepared.block);
+  const mergedBytes = serializedUtf8Bytes(merged.plan);
+  if (mergedBytes > PLAN_BLOCK_MAX_BYTES) {
+    return {
+      ok: false,
+      code: 'block_overflow',
+      bytes: mergedBytes,
+      maxBytes: PLAN_BLOCK_MAX_BYTES,
+    };
+  }
+
+  return { ok: true, block: prepared.block, progress: merged };
+}
+
+/**
+ * Pure "X of Y" rollup for a planned parent: resolved children / total planned steps.
+ * done and cancelled child statuses count as resolved.
+ */
+export function computePlanRollup(
+  steps: readonly PlanStepDescriptor[],
+  childStatusByTaskId: Readonly<Record<string, string>>,
+): { done: number; total: number } {
+  const total = steps.length;
+  let done = 0;
+
+  for (const step of steps) {
+    if (!step.taskId) continue;
+    const status = childStatusByTaskId[step.taskId];
+    if (status !== undefined && RESOLVED_CHILD_STATUSES.has(status)) {
+      done++;
+    }
+  }
+
+  return { done, total };
+}

--- a/src/db/plan-progress.ts
+++ b/src/db/plan-progress.ts
@@ -198,7 +198,6 @@ export interface PreparePlanBlockInput {
   done: number;
   total: number;
   next: string;
-  plannedAt?: string;
 }
 
 /** Validate and normalize a plan block before persistence. */
@@ -209,7 +208,6 @@ export function preparePlanBlock(input: PreparePlanBlockInput): PlanWriteResult 
     done: input.done,
     total: input.total,
     next: input.next,
-    plannedAt: input.plannedAt,
   });
 
   if (!parsed) {
@@ -218,7 +216,7 @@ export function preparePlanBlock(input: PreparePlanBlockInput): PlanWriteResult 
 
   const block: PlanProgressBlock = {
     ...parsed,
-    plannedAt: input.plannedAt ?? new Date().toISOString(),
+    plannedAt: new Date().toISOString(),
   };
 
   const capError = validateBlockForWrite(block);

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -17,6 +17,13 @@ import { mapTaskRow } from './queries/tasks.js';
 import type { TaskOriginator } from '../contacts/types.js';
 import { capOriginatorToParent } from '../contacts/principal.js';
 import {
+  readPlanBlock,
+  preparePlanBlock,
+  type PreparePlanBlockInput,
+  type PlanProgressBlock,
+  type PlanWriteResult,
+} from './plan-progress.js';
+import {
   readResumableBlock,
   prepareResumableBlock,
   type PrepareResumableBlockInput,
@@ -668,6 +675,73 @@ export class TaskRepo {
     this.logger.info(
       { taskId: updated.id, done: prepared.block.done, total: prepared.block.total },
       'task-repo: persisted resumable checkpoint',
+    );
+    return { task: updated, block: prepared.block };
+  }
+
+  /** Read the typed plan block from a task's progress JSONB. */
+  async getPlanBlock(taskId: string): Promise<PlanProgressBlock | null> {
+    const task = await this.getTask(taskId);
+    if (!task) return null;
+    return readPlanBlock(task.progress);
+  }
+
+  /**
+   * Persist a plan under progress.plan. Enforces the block size cap — descriptors only,
+   * no per-item payloads inline (#1236).
+   */
+  async setPlanBlock(
+    taskId: string,
+    input: PreparePlanBlockInput,
+    callerAgentId?: string,
+  ): Promise<{ task: TaskRow; block: PlanProgressBlock } | PlanWriteResult> {
+    const current = await this.getTask(taskId);
+    if (!current) {
+      return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
+    }
+    if (TERMINAL_STATUSES.has(current.status)) {
+      return { ok: false, code: 'invalid_block', message: `task ${taskId} is in a terminal state` };
+    }
+
+    const prepared = preparePlanBlock(input);
+    if (!prepared.ok) return prepared;
+
+    const { rows } = await this.pool.query(
+      `UPDATE tasks
+          SET progress = jsonb_set(COALESCE(progress, '{}'::jsonb), '{plan}', $1::jsonb, true),
+              updated_at = now()
+        WHERE id = $2
+          AND status NOT IN ('done', 'cancelled')
+        RETURNING ${TASK_COLUMNS}`,
+      [JSON.stringify(prepared.block), taskId],
+    );
+    const row = rows[0] as DbTaskRow | undefined;
+    if (!row) {
+      const currentTask = await this.getTask(taskId);
+      if (!currentTask) {
+        return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
+      }
+      if (TERMINAL_STATUSES.has(currentTask.status)) {
+        return { ok: false, code: 'invalid_block', message: `task ${taskId} is in a terminal state` };
+      }
+      throw new Error(`task-repo: setPlanBlock update returned no row for non-terminal task ${taskId}`);
+    }
+
+    const updated = mapTaskRow(row);
+
+    try {
+      await this.bus.publish('execution', createTaskUpdated({
+        taskId: updated.id,
+        previousStatus: current.status,
+        agentId: callerAgentId ?? null,
+      }));
+    } catch (busErr) {
+      this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after setPlanBlock');
+    }
+
+    this.logger.info(
+      { taskId: updated.id, done: prepared.block.done, total: prepared.block.total },
+      'task-repo: persisted plan block',
     );
     return { task: updated, block: prepared.block };
   }

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -363,14 +363,6 @@ export class TaskRepo {
       }
     }
 
-    // Append progress note to progress.notes if provided.
-    let newProgress = current.progress;
-    if (updates.progressNote) {
-      const notes = (Array.isArray(newProgress.notes) ? newProgress.notes : []) as Array<unknown>;
-      notes.push({ at: new Date().toISOString(), note: updates.progressNote });
-      newProgress = { ...newProgress, notes };
-    }
-
     // Build the SET clause dynamically — only update columns that were supplied.
     const setClauses: string[] = ['updated_at = now()'];
     const updateParams: unknown[] = [];
@@ -396,9 +388,16 @@ export class TaskRepo {
       setClauses.push(`tags = $${idx++}`);
       updateParams.push(updates.tags);
     }
-    if (updates.progressNote !== undefined) {
-      setClauses.push(`progress = $${idx++}::jsonb`);
-      updateParams.push(JSON.stringify(newProgress));
+    // Append progress note atomically — jsonb_set preserves sibling blocks (plan, resumable, etc.).
+    if (updates.progressNote) {
+      const noteEntry = { at: new Date().toISOString(), note: updates.progressNote };
+      setClauses.push(`progress = jsonb_set(
+        COALESCE(progress, '{}'::jsonb),
+        '{notes}',
+        COALESCE(progress->'notes', '[]'::jsonb) || $${idx++}::jsonb,
+        true
+      )`);
+      updateParams.push(JSON.stringify([noteEntry]));
     }
     if ('blockedByTaskId' in updates) {
       setClauses.push(`blocked_by_task_id = $${idx++}`);
@@ -539,19 +538,22 @@ export class TaskRepo {
       );
     }
 
-    // Append completion note to progress.notes if provided.
-    const notes = (Array.isArray(current.progress.notes) ? current.progress.notes : []) as Array<unknown>;
-    if (completionNote) {
-      notes.push({ at: new Date().toISOString(), note: completionNote });
-    }
-    const newProgress = { ...current.progress, notes };
+    const noteEntry = completionNote
+      ? { at: new Date().toISOString(), note: completionNote }
+      : null;
 
-    // The WHERE guard prevents a concurrent write from moving the task to a terminal
-    // state between our pre-check read and this UPDATE.
-    const cteSql = `
+    const cteSql = noteEntry
+      ? `
       WITH done_task AS (
         UPDATE tasks
-        SET status = 'done', progress = $1::jsonb, updated_at = now()
+        SET status = 'done',
+            progress = jsonb_set(
+              COALESCE(progress, '{}'::jsonb),
+              '{notes}',
+              COALESCE(progress->'notes', '[]'::jsonb) || $1::jsonb,
+              true
+            ),
+            updated_at = now()
         WHERE id = $2 AND status NOT IN ('done', 'cancelled')
         RETURNING ${TASK_COLUMNS}
       ),
@@ -560,9 +562,26 @@ export class TaskRepo {
         WHERE task_id = $2 AND status = 'pending'
       )
       SELECT * FROM done_task
+    `
+      : `
+      WITH done_task AS (
+        UPDATE tasks
+        SET status = 'done', updated_at = now()
+        WHERE id = $1 AND status NOT IN ('done', 'cancelled')
+        RETURNING ${TASK_COLUMNS}
+      ),
+      _cancel_wake AS (
+        UPDATE scheduled_jobs SET status = 'cancelled'
+        WHERE task_id = $1 AND status = 'pending'
+      )
+      SELECT * FROM done_task
     `;
 
-    const { rows } = await this.pool.query(cteSql, [JSON.stringify(newProgress), taskId]);
+    const queryParams = noteEntry
+      ? [JSON.stringify([noteEntry]), taskId]
+      : [taskId];
+
+    const { rows } = await this.pool.query(cteSql, queryParams);
     const row = rows[0] as DbTaskRow | undefined;
     if (!row) {
       // Task existed at pre-check time and was not terminal — if RETURNING is empty,

--- a/tests/integration/task-plan-progress.test.ts
+++ b/tests/integration/task-plan-progress.test.ts
@@ -19,7 +19,13 @@ const describeIf = DATABASE_URL ? describe : describe.skip;
 
 const PREFIX = 'PlanProgress Test';
 const logger = pino({ level: 'silent' });
-const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+const publishedEvents: Array<{ topic: string; event: unknown }> = [];
+const recordingBus = {
+  publish: async (topic: string, event: unknown) => {
+    publishedEvents.push({ topic, event });
+  },
+  subscribe: () => {},
+} as unknown as EventBus;
 
 const CHILD_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 const CHILD_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
@@ -39,12 +45,15 @@ describeIf('TaskRepo plan progress (#1236)', () => {
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
-    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+    repo = new TaskRepo(pool, recordingBus, logger as never, 'UTC');
   });
   afterAll(async () => { await cleanup(pool); await pool.end(); });
-  beforeEach(async () => { await cleanup(pool); });
+  beforeEach(async () => {
+    publishedEvents.length = 0;
+    await cleanup(pool);
+  });
 
-  it('round-trips a plan block', async () => {
+  it('round-trips a plan block and publishes task.updated', async () => {
     const task = await repo.createTask({
       agentId: 'coordinator',
       title: `${PREFIX} kickoff`,
@@ -65,6 +74,13 @@ describeIf('TaskRepo plan progress (#1236)', () => {
     });
     expect('task' in first).toBe(true);
     if (!('task' in first)) return;
+
+    expect(publishedEvents).toContainEqual(
+      expect.objectContaining({
+        topic: 'execution',
+        event: expect.objectContaining({ type: 'task.updated', taskId: task.id }),
+      }),
+    );
 
     const reread = await repo.getPlanBlock(task.id);
     expect(reread?.deliverableStepId).toBe('assemble-plan');
@@ -135,6 +151,30 @@ describeIf('TaskRepo plan progress (#1236)', () => {
     expect(planBlockBytes(persisted!)).toBeLessThanOrEqual(PLAN_BLOCK_MAX_BYTES);
   });
 
+  it('rejects plan blocks over PLAN_BLOCK_MAX_BYTES', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} overflow`,
+      source: 'coordinator',
+    });
+
+    const manySteps = Array.from({ length: 200 }, (_, i) => ({
+      id: `step-${String(i).padStart(4, '0')}-with-a-long-descriptor-id-suffix`,
+      taskId: `${String(i).padStart(8, '0')}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`,
+    }));
+
+    const result = await repo.setPlanBlock(task.id, {
+      steps: manySteps,
+      deliverableStepId: null,
+      done: 0,
+      total: manySteps.length,
+      next: 'This plan is intentionally wide to test the block size cap',
+    });
+    expect('ok' in result && result.ok === false).toBe(true);
+    if (!('ok' in result) || result.ok !== false) return;
+    expect(result.code).toBe('block_overflow');
+  });
+
   it('rollup helper reflects child statuses from the database', async () => {
     const parent = await repo.createTask({
       agentId: 'coordinator',
@@ -160,9 +200,13 @@ describeIf('TaskRepo plan progress (#1236)', () => {
       { id: 'first', taskId: childDone.id },
       { id: 'second', taskId: childOpen.id },
     ];
+    const [reloadedDone, reloadedOpen] = await Promise.all([
+      repo.getTask(childDone.id),
+      repo.getTask(childOpen.id),
+    ]);
     const rollup = computePlanRollup(steps, {
-      [childDone.id]: 'done',
-      [childOpen.id]: 'open',
+      [childDone.id]: reloadedDone!.status,
+      [childOpen.id]: reloadedOpen!.status,
     });
     expect(rollup).toEqual({ done: 1, total: 2 });
 

--- a/tests/integration/task-plan-progress.test.ts
+++ b/tests/integration/task-plan-progress.test.ts
@@ -75,12 +75,13 @@ describeIf('TaskRepo plan progress (#1236)', () => {
     expect('task' in first).toBe(true);
     if (!('task' in first)) return;
 
-    expect(publishedEvents).toContainEqual(
-      expect.objectContaining({
-        topic: 'execution',
-        event: expect.objectContaining({ type: 'task.updated', taskId: task.id }),
-      }),
-    );
+    expect(
+      publishedEvents.some((entry) =>
+        entry.topic === 'execution'
+        && (entry.event as { type?: string }).type === 'task.updated'
+        && (entry.event as { payload?: { taskId?: string } }).payload?.taskId === task.id
+      ),
+    ).toBe(true);
 
     const reread = await repo.getPlanBlock(task.id);
     expect(reread?.deliverableStepId).toBe('assemble-plan');

--- a/tests/integration/task-plan-progress.test.ts
+++ b/tests/integration/task-plan-progress.test.ts
@@ -1,0 +1,178 @@
+// task-plan-progress.test.ts — round-trip persistence for progress.plan (#1236).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import {
+  PLAN_BLOCK_MAX_BYTES,
+  computePlanRollup,
+  isPlannedStep,
+  planBlockBytes,
+  readPlanBlock,
+} from '../../src/db/plan-progress.js';
+import type { EventBus } from '../../src/bus/bus.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'PlanProgress Test';
+const logger = pino({ level: 'silent' });
+const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+
+const CHILD_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const CHILD_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  const titleLike = `${PREFIX}%`;
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [titleLike],
+  );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [titleLike]);
+}
+
+describeIf('TaskRepo plan progress (#1236)', () => {
+  let pool: pg.Pool;
+  let repo: TaskRepo;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  it('round-trips a plan block', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} kickoff`,
+      source: 'coordinator',
+    });
+
+    const steps = [
+      { id: 'gather-input', taskId: CHILD_A },
+      { id: 'assemble-plan', taskId: CHILD_B },
+    ];
+
+    const first = await repo.setPlanBlock(task.id, {
+      steps,
+      deliverableStepId: 'assemble-plan',
+      done: 0,
+      total: 2,
+      next: 'Gather exec input',
+    });
+    expect('task' in first).toBe(true);
+    if (!('task' in first)) return;
+
+    const reread = await repo.getPlanBlock(task.id);
+    expect(reread?.deliverableStepId).toBe('assemble-plan');
+    expect(reread?.steps).toEqual(steps);
+    expect(isPlannedStep((await repo.getTask(task.id))!.progress)).toBe(true);
+  });
+
+  it('does not clobber resumable or notes when writing the plan block', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} siblings`,
+      source: 'coordinator',
+    });
+
+    await repo.updateTask(task.id, { progressNote: 'Planning started' }, 'coordinator');
+    await repo.setResumableBlock(task.id, {
+      cursor: 'page:1',
+      done: 0,
+      total: 100,
+      accumulator: [],
+      lastSliceUnits: 10,
+      next: 'Keep paging',
+    });
+
+    const result = await repo.setPlanBlock(task.id, {
+      steps: [{ id: 'only-step', taskId: CHILD_A }],
+      deliverableStepId: null,
+      done: 0,
+      total: 1,
+      next: 'Run the only step',
+    });
+    expect('task' in result).toBe(true);
+
+    const reloaded = await repo.getTask(task.id);
+    const progress = reloaded?.progress ?? {};
+    const notes = (progress as { notes?: Array<{ note: string }> }).notes ?? [];
+    expect(notes.some((n) => n.note === 'Planning started')).toBe(true);
+    expect(await repo.getResumableBlock(task.id)).toMatchObject({ cursor: 'page:1' });
+    expect(await repo.getPlanBlock(task.id)).toMatchObject({ total: 1 });
+    expect(readPlanBlock(progress)).not.toBeNull();
+  });
+
+  it('persists plan block under the size cap', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} cap`,
+      source: 'coordinator',
+    });
+
+    const steps = Array.from({ length: 10 }, (_, i) => ({
+      id: `step-${i}`,
+      taskId: `${String(i).padStart(8, '0')}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`,
+    }));
+
+    const result = await repo.setPlanBlock(task.id, {
+      steps,
+      deliverableStepId: 'step-9',
+      done: 3,
+      total: 10,
+      next: 'Advance frontier on child completion',
+    }, 'coordinator');
+    expect('task' in result).toBe(true);
+    if (!('task' in result)) return;
+
+    expect(planBlockBytes(result.block)).toBeLessThanOrEqual(PLAN_BLOCK_MAX_BYTES);
+    const persisted = await repo.getPlanBlock(task.id);
+    expect(persisted).not.toBeNull();
+    expect(planBlockBytes(persisted!)).toBeLessThanOrEqual(PLAN_BLOCK_MAX_BYTES);
+  });
+
+  it('rollup helper reflects child statuses from the database', async () => {
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} parent rollup`,
+      source: 'coordinator',
+    });
+    const childDone = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} child done`,
+      source: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    const childOpen = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} child open`,
+      source: 'coordinator',
+      parentTaskId: parent.id,
+    });
+
+    await repo.updateTask(childDone.id, { status: 'done' }, 'coordinator');
+
+    const steps = [
+      { id: 'first', taskId: childDone.id },
+      { id: 'second', taskId: childOpen.id },
+    ];
+    const rollup = computePlanRollup(steps, {
+      [childDone.id]: 'done',
+      [childOpen.id]: 'open',
+    });
+    expect(rollup).toEqual({ done: 1, total: 2 });
+
+    await repo.setPlanBlock(parent.id, {
+      steps,
+      deliverableStepId: null,
+      done: rollup.done,
+      total: rollup.total,
+      next: 'Wait for second child',
+    });
+    expect(await repo.getPlanBlock(parent.id)).toMatchObject({ done: 1, total: 2 });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1236

Phase 2 foundation for the `plan` primitive: a typed `progress.plan` block persisted under the existing `tasks.progress` JSONB (no migration), with helpers symmetric to `progress.resumable`.

## Changes

- **`src/db/plan-progress.ts`** — `PlanProgressBlock` schema with ordered step descriptors (child task pointers only), `deliverableStepId`, `done`/`total`, and `next`. Includes parse/validate (camelCase + snake_case tolerant), `preparePlanBlock` (auto-timestamp), merge/write helpers that preserve sibling blocks (`resumable`, `resumableCircuit`, `notes`), 8 KB block cap, `isPlannedStep()` detection, and pure `computePlanRollup()` ("X of Y" from child statuses; `done`/`cancelled` = resolved).
- **`TaskRepo.getPlanBlock` / `setPlanBlock`** — atomic `jsonb_set` persistence with `task.updated` bus publish, mirroring the resumable block API.
- **Tests** — unit coverage for schema, rollup, bounding, and sibling preservation; integration round-trip tests (skipped without `DATABASE_URL`).

## Acceptance criteria

- [x] `PlanProgressBlock` schema defined + typed; persisted under `tasks.progress.plan` with **no** migration.
- [x] `get/setPlanBlock` round-trip; writing the plan block preserves existing `resumable` / `resumableCircuit` / `notes`.
- [x] The "X of Y" rollup computes a parent's done/total from child statuses; covered by a unit test.
- [x] A planned parent is detectable solely from the presence of the plan block (no new column/status/`error_budget` key).
- [x] Block size is bounded; a wide plan stores child references, not per-item payloads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b7bc2c3-fc54-4525-aa25-bc2e7b8cc7a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b7bc2c3-fc54-4525-aa25-bc2e7b8cc7a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

