### PR TITLE
fix: consolidate Signal phone number onto channel.signal.phone_number (#1140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **Signal phone number** — consolidated onto a single canonical vault key, `channel.signal.phone_number`; the divergent legacy flat `signal_phone_number` read is removed and an existing value is backfilled by migration. Console-only entry now activates Signal. (#1140)
+- **Signal phone number** — consolidated onto one canonical vault key (`channel.signal.phone_number`), backfilled by migration; console entry alone now activates Signal. (#1140)
 - **Outbound content filter** — Stage 2.5 escalation judge no longer calls the LLM for principal-tier recipients; `classifyDisclosure()` is fail-closed, so a transient provider failure was incorrectly blocking principal-bound emails (e.g. the daily recap) even though the policy unconditionally permits all disclosure classes for the principal. (#1225)
 - **Calendar free/busy** — `getFreeBusy` now calls the real Nylas v8 `calendars.getFreeBusy` endpoint; the previous call to a non-existent `calendars_free_busy` resource crashed every `calendar-check-conflicts` and `calendar-find-free-time` invocation. It also fails loud on a per-calendar free/busy *error* entry instead of treating that calendar as fully free (which could double-book the principal). (#1214)
 - **`ceo-inbox-update-folders`** — resolves label display names (e.g. "⏳ In Progress") to Gmail label IDs and creates missing labels before writing, so adds/removes no longer fail with "Invalid label" and "⏳ In Progress" can actually be cleared. (#1216)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Signal phone number** — consolidated onto a single canonical vault key, `channel.signal.phone_number`; the divergent legacy flat `signal_phone_number` read is removed and an existing value is backfilled by migration. Console-only entry now activates Signal. (#1140)
 - **Outbound content filter** — Stage 2.5 escalation judge no longer calls the LLM for principal-tier recipients; `classifyDisclosure()` is fail-closed, so a transient provider failure was incorrectly blocking principal-bound emails (e.g. the daily recap) even though the policy unconditionally permits all disclosure classes for the principal. (#1225)
 - **Calendar free/busy** — `getFreeBusy` now calls the real Nylas v8 `calendars.getFreeBusy` endpoint; the previous call to a non-existent `calendars_free_busy` resource crashed every `calendar-check-conflicts` and `calendar-find-free-time` invocation. It also fails loud on a per-calendar free/busy *error* entry instead of treating that calendar as fully free (which could double-book the principal). (#1214)
 - **`ceo-inbox-update-folders`** — resolves label display names (e.g. "⏳ In Progress") to Gmail label IDs and creates missing labels before writing, so adds/removes no longer fail with "Invalid label" and "⏳ In Progress" can actually be cleared. (#1216)

--- a/docs/wip/2026-06-29-signal-phone-vault-key-consolidation-design.md
+++ b/docs/wip/2026-06-29-signal-phone-vault-key-consolidation-design.md
@@ -1,0 +1,165 @@
+# Signal phone number — vault key consolidation
+
+**Issue:** [#1140](https://github.com/josephfung/curia/issues/1140) — Signal phone number has two divergent vault keys (`signal_phone_number` vs `channel.signal.phone_number`)
+**Date:** 2026-06-29
+**Status:** Approved — ready for implementation plan
+
+## Problem
+
+The Signal phone number is read from two different vault keys by two different
+code paths, and the two paths feed two different runtime *gates*:
+
+| Gate | What it decides | Phone-number source |
+| --- | --- | --- |
+| **Registry gate** — `channelCredentialStatus()` → `channelShouldStart` (`src/channels/credential-resolver.ts`, `src/index.ts:1353,1375`) | Whether the **inbound** Signal adapter starts | `channel.signal.phone_number` (vault) ▸ `SIGNAL_PHONE_NUMBER` (env). **Never sees the flat key.** |
+| **Adapter / outbound boot** — `config.signalPhoneNumber` (`src/index.ts:752,1305,1454`) | The Signal RPC client + OutboundGateway egress + agent context | flat `signal_phone_number` (vault, via `applyVaultSecrets`) ▸ `channel.signal.phone_number` ▸ `SIGNAL_PHONE_NUMBER` env (via `applyChannelVaultSecrets`) |
+
+`applyChannelVaultSecrets` runs immediately after `applyVaultSecrets` and
+overwrites `config.signalPhoneNumber` with precedence
+`channel.signal.phone_number ▸ env ▸ current-config` — so the *field* is
+reconciled. The divergence is that the legacy flat key influences **only** the
+adapter/outbound boot, never the registry gate.
+
+### Concrete failure
+
+A deployment whose number lives **only** under the legacy flat
+`signal_phone_number`:
+
+- the inbound Signal adapter does **not** start (the gate never sees the flat
+  key, so `channelShouldStart` excludes `signal`), yet
+- the OutboundGateway **can** still send Signal, because it reads
+  `config.signalPhoneNumber` which the flat key populated
+  (`src/index.ts:1305-1306`).
+
+That is the silent, registry-invisible misconfiguration the issue describes:
+the console/registry reports Signal as unconfigured while outbound Signal egress
+silently works.
+
+### Root asymmetry
+
+For **email**, `src/index.ts:1338` (`channelConfigKeys`) feeds config-resolved
+keys into the registry gate, so the gate and the adapter agree. For **Signal**,
+`channelConfigKeys` returns an empty set, so the flat-key-derived config value is
+invisible to the gate.
+
+A second, narrower asymmetry sits inside the Signal channel itself: of the two
+Signal credential fields, only `phone_number` has a flat-key seeder path
+(`signal_phone_number` in `SEED_SECRET_NAMES`). Its sibling `socket_path` was
+**never** seeded — it relies on the console-written `channel.signal.socket_path`
+or the `SIGNAL_SOCKET_PATH` env fallback. The fix makes `phone_number` behave
+exactly like `socket_path`.
+
+## Goal
+
+Exactly one authoritative vault key for the Signal phone number —
+`channel.signal.phone_number` — read by every runtime path. The console alone
+is sufficient to activate Signal. `SIGNAL_PHONE_NUMBER` remains only as
+documented env back-compat (symmetric with `socket_path`).
+
+## Canonical key
+
+`channel.signal.phone_number` — consistent with the channel-registry model, it
+is what the console credential flow writes and what the registry gate already
+reads.
+
+## Changes
+
+### 1. Remove the flat-key read — `src/secrets/apply-vault-secrets.ts`
+
+Remove `signal_phone_number` from the `Promise.all` destructure, the
+`secrets.get(...)` list, the `config.signalPhoneNumber = clean(...)` assignment,
+and the `present` log object. Update the comment block that uses a blank Signal
+phone number as the motivating example for `clean()` (the helper still serves
+`anthropic_api_key`, `api_token`, etc. — re-anchor the example on those) and the
+header comment that lists "nylas/signal channels" as consumers.
+
+After this, `config.signalPhoneNumber` is set **only** by
+`applyChannelVaultSecrets`. Both the registry gate and the adapter/outbound boot
+then resolve `channel.signal.phone_number ▸ SIGNAL_PHONE_NUMBER env` and agree.
+No change to `channelConfigKeys` is needed.
+
+### 2. Backfill migration — `src/db/migrations/068_consolidate_signal_phone_number.sql`
+
+Forward-only data migration (the repo's migrations are plain forward-only SQL):
+
+- `INSERT INTO secrets (name, value_format, encrypted_value, iv, created_at, updated_at)
+  SELECT 'channel.signal.phone_number', value_format, encrypted_value, iv, now(), now()
+  FROM secrets WHERE name = 'signal_phone_number'
+  AND NOT EXISTS (SELECT 1 FROM secrets WHERE name = 'channel.signal.phone_number');`
+  — copy the legacy row's ciphertext+iv verbatim. This is safe because the vault's
+  AES-256-GCM encryption uses **no per-name AAD** (`src/secrets/crypto.ts`), so the
+  ciphertext decrypts identically under the new key name. The `NOT EXISTS` guard
+  never clobbers an existing console-written value.
+- `DELETE FROM secrets WHERE name = 'signal_phone_number';` — remove the legacy
+  row so exactly one key remains.
+
+Idempotent: re-running is a no-op (the copy is guarded; the delete is a no-op
+once the row is gone). No-op for env-only or console-only deployments that never
+had the flat key.
+
+**Migration numbering:** `068` is the next free slot after `067`. Re-verify
+uniqueness (`ls src/db/migrations/ | sort`) at PR time per the rebase-hazard note
+in CLAUDE.md.
+
+### 3. Drop the flat key from the seeder — `scripts/seed-vault.ts`
+
+Remove `'signal_phone_number'` from `SEED_SECRET_NAMES`. This matches
+`socket_path` (never seeded) and is **required** for the migration's delete to
+stick: the seeder runs after migrations in `setup.sh`, so a retained entry would
+re-create the flat key from `SIGNAL_PHONE_NUMBER` right after the migration
+deleted it.
+
+### 4. Keep env fallback (no change)
+
+`SIGNAL_PHONE_NUMBER` stays as `envFallback` in `src/channels/catalog.ts` and as
+the env read in `src/channels/apply-channel-vault-secrets.ts` — documented
+back-compat, symmetric with `socket_path`, and the safety net for any deployment
+that configures the number via env rather than the vault.
+
+## Tests (TDD)
+
+- **`src/channels/apply-channel-vault-secrets.test.ts`** — console-only entry:
+  `channel.signal.phone_number` set, no flat key, no env ⇒ `config.signalPhoneNumber`
+  populated. (Extends the existing channel-only test.)
+- **`src/channels/credential-resolver.test.ts`** — console-only Signal:
+  `channel.signal.phone_number` + `channel.signal.socket_path` set ⇒
+  `requiredResolvable === true`. (Already present at line 21; assert it remains
+  the only path needed.)
+- **Migration test** (integration, real Postgres) — seed a flat
+  `signal_phone_number`, run the migration, assert: the namespaced key now exists
+  and decrypts to the same value, the flat key is gone, an existing namespaced
+  value is never clobbered, and a second run is a no-op.
+- **`tests/unit/apply-vault-secrets.test.ts`** — drop the `signal_phone_number`
+  assertions (lines 49, 60-62); assert `applyVaultSecrets` no longer sets
+  `config.signalPhoneNumber`.
+- **`tests/integration/seed-vault.test.ts`** — update expectations now that
+  `signal_phone_number` is no longer in `SEED_SECRET_NAMES`.
+
+## Out of scope (noted, not touched)
+
+- **Email's identical dual-key shape** — email keeps flat `nylas_*` keys plus
+  `channel.email.*`, but its registry gate already accounts for config-resolved
+  keys (`channelConfigKeys`), so no divergence. Left as-is per issue scope.
+- **Broader "kill all env fallbacks"** — removing env fallback for email and
+  `socket_path` to go fully vault/console-only is a larger change with a higher
+  deployment blast radius; deferred to its own issue.
+
+## Docs / admin
+
+- **CHANGELOG.md** — `Fixed` entry under `## [Unreleased]`.
+- **curia-docs** — separate PR referencing only `channel.signal.phone_number`,
+  drafted as markdown for human approval first; closes
+  [curia-docs#26](https://github.com/josephfung/curia-docs/issues/26).
+- **No version bump** — regular PR (per CLAUDE.md, version bumps happen only at
+  release time).
+
+## Acceptance criteria mapping
+
+| Acceptance criterion (#1140) | Addressed by |
+| --- | --- |
+| Exactly one authoritative key, all runtime paths read it | §1 (remove flat read) + §2 (migration) |
+| Console-only entry activates Signal, no second write | §1 makes gate + boot agree on `channel.signal.phone_number` |
+| Legacy read removed (not a silent divergent source) | §1 |
+| Existing-deployment migration path addressed | §2 (backfill + delete) + §3 (seeder) |
+| curia-docs references only the canonical key | Docs/admin |
+| Tests cover console-only entry activating Signal | Tests |

--- a/docs/wip/2026-06-29-signal-phone-vault-key-consolidation.md
+++ b/docs/wip/2026-06-29-signal-phone-vault-key-consolidation.md
@@ -1,0 +1,473 @@
+# Signal Phone Vault Key Consolidation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `channel.signal.phone_number` the single authoritative vault key for the Signal phone number, removing the divergent legacy flat `signal_phone_number` read.
+
+**Architecture:** Remove the flat-key read from the bootstrap secrets resolver so both the registry gate and the adapter/outbound boot resolve the same key (`channel.signal.phone_number ▸ SIGNAL_PHONE_NUMBER` env). A forward-only SQL migration backfills any existing flat value onto the namespaced key (copying ciphertext verbatim — no per-name AAD) and drops the flat row. The seeder stops writing the flat key so the migration's delete sticks.
+
+**Tech Stack:** TypeScript (ESM, Node 24+), PostgreSQL 16 (node-pg-migrate, plain SQL), Vitest (unit + real-Postgres integration), pino, AES-256-GCM vault.
+
+## Global Constraints
+
+- ESM only — `.js` extensions on all relative imports; no `__dirname` (use `import.meta.*`). (CLAUDE.md)
+- No `any`; parameterized SQL only; no `console.log` (pino only). (CLAUDE.md)
+- Run `pnpm -C <worktree> run typecheck` before every commit touching `.ts`. (CLAUDE.md)
+- Conventional commits (`fix:` / `test:` / `docs:`); **no** `Co-Authored-By` trailers; **no** Claude/AI attribution anywhere. (global CLAUDE.md)
+- Migration prefix must be unique — re-verify `ls src/db/migrations/ | sort` before merge; `068` is the next free slot after `067`. (CLAUDE.md)
+- Every PR updates `CHANGELOG.md` under `## [Unreleased]`. No version bump (regular PR). (CLAUDE.md)
+- Integration tests skip without `DATABASE_URL` (and `SECRET_ENCRYPTION_KEY` where the vault is used); they connect to a real Postgres, never mocks. (CLAUDE.md)
+- Worktree: `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key`, branch `fix/signal-phone-vault-key`. All commands use `pnpm -C <worktree>` / `git -C <worktree>`.
+- Test DB env (from memory `reference_curia_test_db`): `DATABASE_URL=postgres://curia:curia@localhost:5433/curia_test`, `SECRET_ENCRYPTION_KEY` must be set for vault integration tests.
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `src/db/migrations/068_consolidate_signal_phone_number.sql` | One-time backfill flat→namespaced + drop flat row | **Create** |
+| `tests/integration/migrate-signal-phone-consolidation.test.ts` | Verifies the migration SQL (backfill, no-clobber, no-op, idempotent) | **Create** |
+| `src/secrets/apply-vault-secrets.ts` | Bootstrap secrets resolver — remove flat `signal_phone_number` read + stale comments | **Modify** |
+| `tests/unit/apply-vault-secrets.test.ts` | Unit cover that the resolver no longer touches `signalPhoneNumber` | **Modify** |
+| `scripts/seed-vault.ts` | Drop `signal_phone_number` from `SEED_SECRET_NAMES` | **Modify** |
+| `tests/integration/seed-vault.test.ts` | Update expectations (signal no longer seeded) | **Modify** |
+| `src/channels/apply-channel-vault-secrets.test.ts` | Add console-only Signal activation test | **Modify** |
+| `src/channels/credential-resolver.test.ts` | Assert console-only resolvable against the real catalog descriptor | **Modify** |
+| `CHANGELOG.md` | `Fixed` entry | **Modify** |
+
+---
+
+## Task 1: Backfill migration + integration test
+
+**Files:**
+- Create: `src/db/migrations/068_consolidate_signal_phone_number.sql`
+- Test: `tests/integration/migrate-signal-phone-consolidation.test.ts`
+
+**Interfaces:**
+- Consumes: `SecretsService` (`set(name, value)`, `get(name)`), `loadEncryptionKey()` from `src/secrets/`.
+- Produces: vault key `channel.signal.phone_number` populated from legacy `signal_phone_number`; flat row removed. No code symbols.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/migrate-signal-phone-consolidation.test.ts`:
+
+```ts
+// Integration test — runs the 068 migration SQL against a live Postgres and asserts the
+// flat→namespaced Signal phone consolidation. Skips without DATABASE_URL + SECRET_ENCRYPTION_KEY.
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { readFile } from 'node:fs/promises';
+import { loadEncryptionKey } from '../../src/secrets/crypto.js';
+import { SecretsService } from '../../src/secrets/secrets-service.js';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL && process.env.SECRET_ENCRYPTION_KEY ? describe : describe.skip;
+const logger = pino({ level: 'silent' });
+
+const MIGRATION_SQL_URL = new URL(
+  '../../src/db/migrations/068_consolidate_signal_phone_number.sql',
+  import.meta.url,
+);
+const FLAT = 'signal_phone_number';
+const NAMESPACED = 'channel.signal.phone_number';
+
+describeIf('migration 068: consolidate signal phone number', () => {
+  let pool: pg.Pool;
+  let secrets: SecretsService;
+  let migrationSql: string;
+
+  beforeAll(async () => {
+    pool = new pg.Pool({ connectionString: DATABASE_URL });
+    secrets = new SecretsService(pool, loadEncryptionKey(), logger);
+    migrationSql = await readFile(MIGRATION_SQL_URL, 'utf8');
+  });
+
+  afterEach(async () => {
+    await pool.query('DELETE FROM secrets WHERE name = ANY($1)', [[FLAT, NAMESPACED]]);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('backfills the namespaced key from the legacy flat key, then drops the flat row', async () => {
+    await secrets.set(FLAT, '+12223334444');
+    await pool.query(migrationSql);
+    expect(await secrets.get(NAMESPACED)).toBe('+12223334444');
+    expect(await secrets.get(FLAT)).toBeNull();
+  });
+
+  it('never clobbers an existing console-written namespaced value', async () => {
+    await secrets.set(FLAT, '+19999999999');      // stale legacy value
+    await secrets.set(NAMESPACED, '+12223334444'); // console entry must win
+    await pool.query(migrationSql);
+    expect(await secrets.get(NAMESPACED)).toBe('+12223334444');
+    expect(await secrets.get(FLAT)).toBeNull();    // flat row still removed
+  });
+
+  it('is a no-op when neither key exists (env-only / unconfigured deployment)', async () => {
+    await pool.query(migrationSql);
+    expect(await secrets.get(NAMESPACED)).toBeNull();
+    expect(await secrets.get(FLAT)).toBeNull();
+  });
+
+  it('is idempotent — a second run changes nothing', async () => {
+    await secrets.set(FLAT, '+12223334444');
+    await pool.query(migrationSql);
+    await pool.query(migrationSql);
+    expect(await secrets.get(NAMESPACED)).toBe('+12223334444');
+    expect(await secrets.get(FLAT)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key exec vitest run tests/integration/migrate-signal-phone-consolidation.test.ts`
+Expected: FAIL — `readFile` rejects with `ENOENT` (the migration file does not exist yet). (If `DATABASE_URL`/`SECRET_ENCRYPTION_KEY` are unset the suite is skipped — set the test-DB env from Global Constraints so it actually runs and fails.)
+
+- [ ] **Step 3: Create the migration**
+
+Create `src/db/migrations/068_consolidate_signal_phone_number.sql`:
+
+```sql
+-- Migration 068: consolidate the Signal phone number onto one authoritative vault key,
+-- channel.signal.phone_number (#1140).
+--
+-- The number was read from two divergent vault keys: the legacy flat `signal_phone_number`
+-- (read by applyVaultSecrets) and the namespaced `channel.signal.phone_number` (written by
+-- the console, read by the registry gate and applyChannelVaultSecrets). Only the namespaced
+-- key gates inbound Signal activation, so a flat-key-only deployment could enable outbound
+-- Signal egress while the registry reported Signal unconfigured. We standardize on the
+-- namespaced key and remove the flat-key read in the same change.
+--
+-- This migration backfills any existing flat value onto the namespaced key, then drops the
+-- flat row. Safe to run on every deployment:
+--   * Copies encrypted_value + iv verbatim — the vault's AES-256-GCM encryption uses no
+--     per-name AAD (src/secrets/crypto.ts), so the ciphertext decrypts identically under the
+--     new name. No encryption key is needed here.
+--   * The NOT EXISTS guard never clobbers a value already written via the console.
+--   * Idempotent: a second run copies nothing (guard) and deletes nothing (row already gone).
+--   * No-op for env-only or console-only deployments that never had the flat key.
+
+INSERT INTO secrets (name, value_format, encrypted_value, iv)
+SELECT 'channel.signal.phone_number', value_format, encrypted_value, iv
+FROM secrets
+WHERE name = 'signal_phone_number'
+  AND NOT EXISTS (
+    SELECT 1 FROM secrets WHERE name = 'channel.signal.phone_number'
+  );
+
+DELETE FROM secrets WHERE name = 'signal_phone_number';
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key exec vitest run tests/integration/migrate-signal-phone-consolidation.test.ts`
+Expected: PASS — all four cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key add src/db/migrations/068_consolidate_signal_phone_number.sql tests/integration/migrate-signal-phone-consolidation.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key commit -m "feat: migration to consolidate signal phone onto channel.signal.phone_number (#1140)"
+```
+
+---
+
+## Task 2: Remove the flat-key read from `apply-vault-secrets.ts`
+
+**Files:**
+- Modify: `src/secrets/apply-vault-secrets.ts`
+- Test: `tests/unit/apply-vault-secrets.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `applyVaultSecrets(config, secrets, logger)` no longer reads `signal_phone_number` nor writes `config.signalPhoneNumber` (now owned solely by `applyChannelVaultSecrets`).
+
+- [ ] **Step 1: Update the unit test to express the new contract (failing)**
+
+In `tests/unit/apply-vault-secrets.test.ts`:
+
+Replace the "trims surrounding whitespace" test (currently lines 45–54) so it no longer references signal:
+
+```ts
+  it('trims surrounding whitespace from vault values', async () => {
+    const config = blankConfig();
+    await applyVaultSecrets(
+      config,
+      stubSecrets({ anthropic_api_key: '  sk-ant-x\n', api_token: '  tok-x \n' }),
+      logger,
+    );
+    expect(config.anthropicApiKey).toBe('sk-ant-x');
+    expect(config.apiToken).toBe('tok-x');
+  });
+```
+
+Replace the "collapses a whitespace-only value" test (currently lines 56–67) to drop the signal example:
+
+```ts
+  it('collapses a whitespace-only value to undefined so feature/boot guards stay honest', async () => {
+    const config = blankConfig();
+    await applyVaultSecrets(
+      config,
+      // A blank api_token must trip the !config.apiToken boot guard rather than read as present.
+      stubSecrets({ api_token: ' ', nylas_api_key: '   ' }),
+      logger,
+    );
+    expect(config.apiToken).toBeUndefined();
+    expect(config.nylasApiKey).toBeUndefined();
+  });
+```
+
+Add a regression test asserting the flat key is no longer read (place after the test above):
+
+```ts
+  it('does not read or write signalPhoneNumber — that key is owned by applyChannelVaultSecrets', async () => {
+    const config = blankConfig();
+    // Even with a legacy flat signal_phone_number present in the vault, applyVaultSecrets
+    // must leave config.signalPhoneNumber untouched (#1140 consolidation).
+    await applyVaultSecrets(
+      config,
+      stubSecrets({ signal_phone_number: '+12223334444' }),
+      logger,
+    );
+    expect(config.signalPhoneNumber).toBeUndefined();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key exec vitest run tests/unit/apply-vault-secrets.test.ts`
+Expected: FAIL — the new regression test fails because the current code sets `config.signalPhoneNumber = '+12223334444'`.
+
+- [ ] **Step 3: Remove the flat-key read from the implementation**
+
+In `src/secrets/apply-vault-secrets.ts`:
+
+(a) Header comment — the consumers list no longer includes Signal. Change line 6:
+
+```ts
+// embeddings, nylas/signal channels). Reads run concurrently; values are never logged.
+```
+to:
+```ts
+// embeddings, nylas channel). Reads run concurrently; values are never logged.
+// Note: the Signal phone number is NOT resolved here — it is owned by applyChannelVaultSecrets
+// under the canonical channel.signal.phone_number key (#1140).
+```
+
+(b) Remove `signalPhoneNumber,` from the destructure (current line 25).
+
+(c) Remove `secrets.get('signal_phone_number'),` from the `Promise.all` (current line 35).
+
+(d) Replace the `clean()` comment block (current lines 38–49) so it no longer uses Signal as the example:
+
+```ts
+  // Normalize each vault value: trim surrounding whitespace (copy-paste artifacts) and
+  // collapse a blank/whitespace-only result to `undefined` (absent). A whitespace-only
+  // secret is unusable at runtime — the Anthropic client and HTTP auth both reject it — so
+  // it must read as absent here, keeping the boot guard (`if (!config.apiToken)`) and the
+  // feature-on checks honest rather than letting a truthy-but-empty string slip through.
+  // The seeder already trims on write; this is the matching read-side guard for rows set by
+  // any other path.
+  const clean = (value: string | null): string | undefined => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+  };
+```
+
+(e) Remove the assignment `config.signalPhoneNumber = clean(signalPhoneNumber);` (current line 61).
+
+(f) Remove the `signal_phone_number: clean(signalPhoneNumber) !== undefined,` entry from the `present` object (current line 76).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key exec vitest run tests/unit/apply-vault-secrets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key run typecheck`
+Expected: no errors (the now-unused `signalPhoneNumber` binding is gone, so no unused-var failure).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key add src/secrets/apply-vault-secrets.ts tests/unit/apply-vault-secrets.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key commit -m "fix: stop reading legacy flat signal_phone_number key (#1140)"
+```
+
+---
+
+## Task 3: Drop the flat key from the seeder
+
+**Files:**
+- Modify: `scripts/seed-vault.ts`
+- Test: `tests/integration/seed-vault.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `SEED_SECRET_NAMES` no longer contains `'signal_phone_number'`; the seeder never writes the flat key.
+
+- [ ] **Step 1: Add a failing test**
+
+In `tests/integration/seed-vault.test.ts`, add inside the `describeIf('seedVault', …)` block:
+
+```ts
+  it('does not seed the legacy signal_phone_number key (consolidated to channel.signal.phone_number, #1140)', async () => {
+    expect([...SEED_SECRET_NAMES]).not.toContain('signal_phone_number');
+    const { seeded, skipped } = await seedVault(secrets, { SIGNAL_PHONE_NUMBER: '+12223334444' }, logger);
+    expect(seeded).not.toContain('signal_phone_number');
+    expect(skipped).not.toContain('signal_phone_number');
+    expect(await secrets.get('signal_phone_number')).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key exec vitest run tests/integration/seed-vault.test.ts`
+Expected: FAIL — `SEED_SECRET_NAMES` still contains `'signal_phone_number'`, so the first `expect(...).not.toContain` fails (and the seeder would seed it).
+
+- [ ] **Step 3: Remove the flat key from the seeder**
+
+In `scripts/seed-vault.ts`, delete the `'signal_phone_number',` line from `SEED_SECRET_NAMES` (current line 32). Add a short comment in its place so a future reader knows why Signal's number is absent:
+
+```ts
+  'nylas_self_email',
+  // Signal phone number is NOT seeded — it is the canonical channel.signal.phone_number key
+  // written via the console (or read from SIGNAL_PHONE_NUMBER env as back-compat), the same
+  // as signal_socket_path which was never seeded (#1140).
+  // skill-scoped (resolved at call time by ctx.secret)
+  'ceo_nylas_grant_id',
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key exec vitest run tests/integration/seed-vault.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key add scripts/seed-vault.ts tests/integration/seed-vault.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key commit -m "fix: stop seeding legacy flat signal_phone_number key (#1140)"
+```
+
+---
+
+## Task 4: Cover the console-only activation path
+
+**Files:**
+- Modify: `src/channels/apply-channel-vault-secrets.test.ts`
+- Modify: `src/channels/credential-resolver.test.ts`
+
+**Interfaces:**
+- Consumes: `applyChannelVaultSecrets`, `channelCredentialStatus`, `getChannelDescriptor` from `src/channels/`.
+- Produces: tests only.
+
+- [ ] **Step 1: Write the failing/clarifying tests**
+
+In `src/channels/apply-channel-vault-secrets.test.ts`, add inside the `describe('applyChannelVaultSecrets', …)` block:
+
+```ts
+  it('activates Signal from a console-only entry — channel.signal.phone_number alone, no flat bootstrap, no env', async () => {
+    // baseConfig().signalPhoneNumber is undefined: there is no flat-key bootstrap value to
+    // fall back on, so this proves the console-written key alone populates config (#1140).
+    const config = baseConfig();
+    const secrets = fakeSecrets({
+      'channel.signal.phone_number': '+15550009999',
+      'channel.signal.socket_path': '/run/signal/socket',
+    });
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    expect(config.signalPhoneNumber).toBe('+15550009999');
+    expect(config.signalSocketPath).toBe('/run/signal/socket');
+  });
+```
+
+In `src/channels/credential-resolver.test.ts`, add an import for the real catalog at the top (after the existing imports):
+
+```ts
+import { getChannelDescriptor } from './catalog.js';
+```
+
+Then add inside `describe('channelCredentialStatus', …)`:
+
+```ts
+  it('reports the real Signal catalog descriptor resolvable from console-only vault keys (#1140)', async () => {
+    const descriptor = getChannelDescriptor('signal')!;
+    const secrets = fakeSecrets({
+      'channel.signal.socket_path': '/run/sig.sock',
+      'channel.signal.phone_number': '+15551234567',
+    });
+    const res = await channelCredentialStatus({ secrets, env: {} }, descriptor);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.map(f => f.source)).toEqual(['vault', 'vault']);
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key exec vitest run src/channels/apply-channel-vault-secrets.test.ts src/channels/credential-resolver.test.ts`
+Expected: PASS — the runtime overlay and the gate already resolve the console-written key; these tests lock that behavior in. (They are characterization tests for the now-canonical path; they pass against the unchanged channel code, which is the point — console-only is sufficient.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key run typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key add src/channels/apply-channel-vault-secrets.test.ts src/channels/credential-resolver.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key commit -m "test: cover console-only Signal activation via channel.signal.phone_number (#1140)"
+```
+
+---
+
+## Task 5: CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the entry**
+
+Under `## [Unreleased]`, in the `### Fixed` section (create the section if absent), add:
+
+```markdown
+- **Signal phone number** — consolidated onto a single canonical vault key, `channel.signal.phone_number`; the divergent legacy flat `signal_phone_number` read is removed and an existing value is backfilled by migration. Console-only entry now activates Signal. (#1140)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key commit -m "docs: changelog for signal phone vault key consolidation (#1140)"
+```
+
+---
+
+## Final verification (run after all tasks)
+
+- [ ] **Migration numbering unique:** `ls /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key/src/db/migrations/ | sort` — confirm `068` appears exactly once.
+- [ ] **Full typecheck:** `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key run typecheck` — no errors.
+- [ ] **Full test suite:** `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key test` — all green (integration suites need the test-DB env from Global Constraints; otherwise they skip).
+- [ ] **Grep for stragglers:** `grep -rn "signal_phone_number" /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key/src /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key/scripts /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-phone-vault-key/tests` — the only remaining hits should be the migration `068` SQL (and its test) that intentionally reference the legacy name during backfill.
+
+## Out of scope (do NOT touch)
+
+- Email's flat `nylas_*` + `channel.email.*` dual-key shape (its gate already accounts for config-resolved keys via `channelConfigKeys` in `src/index.ts`).
+- The broader "remove all channel env fallbacks" cleanup (`SIGNAL_SOCKET_PATH`, `NYLAS_*`) — deferred to its own issue. `SIGNAL_PHONE_NUMBER` env fallback is deliberately **kept** as documented back-compat.
+- Version bump (release-time only).
+
+## Follow-up (separate repo, separate PR — not part of this plan's tasks)
+
+- **curia-docs** — update any page referencing `signal_phone_number` to use only `channel.signal.phone_number`; close [curia-docs#26](https://github.com/josephfung/curia-docs/issues/26). Draft as markdown for human approval first (per the upstream-workflow rule).
+```

--- a/scripts/seed-vault.ts
+++ b/scripts/seed-vault.ts
@@ -29,7 +29,9 @@ export const SEED_SECRET_NAMES = [
   'nylas_api_key',
   'nylas_grant_id',
   'nylas_self_email',
-  'signal_phone_number',
+  // Signal phone number is NOT seeded — it is the canonical channel.signal.phone_number key
+  // written via the console (or read from SIGNAL_PHONE_NUMBER env as back-compat), the same
+  // as signal_socket_path which was never seeded (#1140).
   // skill-scoped (resolved at call time by ctx.secret)
   'ceo_nylas_grant_id',
   'ceo_self_email',

--- a/src/channels/apply-channel-vault-secrets.test.ts
+++ b/src/channels/apply-channel-vault-secrets.test.ts
@@ -53,6 +53,21 @@ describe('applyChannelVaultSecrets', () => {
     expect(config.signalSocketPath).toBe('/run/signal/socket');
   });
 
+  it('activates Signal from a console-only entry — channel.signal.phone_number alone, no flat bootstrap, no env', async () => {
+    // baseConfig().signalPhoneNumber is undefined: there is no flat-key bootstrap value to
+    // fall back on, so this proves the console-written key alone populates config (#1140).
+    const config = baseConfig();
+    const secrets = fakeSecrets({
+      'channel.signal.phone_number': '+15550009999',
+      'channel.signal.socket_path': '/run/signal/socket',
+    });
+
+    await applyChannelVaultSecrets(config, secrets, {}, logger);
+
+    expect(config.signalPhoneNumber).toBe('+15550009999');
+    expect(config.signalSocketPath).toBe('/run/signal/socket');
+  });
+
   it('falls back to env when the vault is empty', async () => {
     const config = baseConfig();
     const secrets = fakeSecrets({});

--- a/src/channels/credential-resolver.test.ts
+++ b/src/channels/credential-resolver.test.ts
@@ -1,6 +1,7 @@
 // src/channels/credential-resolver.test.ts
 import { describe, it, expect } from 'vitest';
 import { channelCredentialStatus } from './credential-resolver.js';
+import { getChannelDescriptor } from './catalog.js';
 import type { ChannelDescriptor } from './catalog.js';
 
 const signal: ChannelDescriptor = {
@@ -62,6 +63,17 @@ describe('channelCredentialStatus', () => {
     const res = await channelCredentialStatus({ secrets, env }, signal);
     expect(res.requiredResolvable).toBe(true);
     expect(res.fields.find(f => f.key === 'socket_path')!.source).toBe('env');
+  });
+
+  it('reports the real Signal catalog descriptor resolvable from console-only vault keys (#1140)', async () => {
+    const descriptor = getChannelDescriptor('signal')!;
+    const secrets = fakeSecrets({
+      'channel.signal.socket_path': '/run/sig.sock',
+      'channel.signal.phone_number': '+15551234567',
+    });
+    const res = await channelCredentialStatus({ secrets, env: {} }, descriptor);
+    expect(res.requiredResolvable).toBe(true);
+    expect(res.fields.map(f => f.source)).toEqual(['vault', 'vault']);
   });
 
   it('a channel with no required keys is always resolvable', async () => {

--- a/src/db/migrations/068_consolidate_signal_phone_number.sql
+++ b/src/db/migrations/068_consolidate_signal_phone_number.sql
@@ -1,0 +1,28 @@
+-- Migration 068: consolidate the Signal phone number onto one authoritative vault key,
+-- channel.signal.phone_number (#1140).
+--
+-- The number was read from two divergent vault keys: the legacy flat `signal_phone_number`
+-- (read by applyVaultSecrets) and the namespaced `channel.signal.phone_number` (written by
+-- the console, read by the registry gate and applyChannelVaultSecrets). Only the namespaced
+-- key gates inbound Signal activation, so a flat-key-only deployment could enable outbound
+-- Signal egress while the registry reported Signal unconfigured. We standardize on the
+-- namespaced key and remove the flat-key read in the same change.
+--
+-- This migration backfills any existing flat value onto the namespaced key, then drops the
+-- flat row. Safe to run on every deployment:
+--   * Copies encrypted_value + iv verbatim — the vault's AES-256-GCM encryption uses no
+--     per-name AAD (src/secrets/crypto.ts), so the ciphertext decrypts identically under the
+--     new name. No encryption key is needed here.
+--   * The NOT EXISTS guard never clobbers a value already written via the console.
+--   * Idempotent: a second run copies nothing (guard) and deletes nothing (row already gone).
+--   * No-op for env-only or console-only deployments that never had the flat key.
+
+INSERT INTO secrets (name, value_format, encrypted_value, iv)
+SELECT 'channel.signal.phone_number', value_format, encrypted_value, iv
+FROM secrets
+WHERE name = 'signal_phone_number'
+  AND NOT EXISTS (
+    SELECT 1 FROM secrets WHERE name = 'channel.signal.phone_number'
+  );
+
+DELETE FROM secrets WHERE name = 'signal_phone_number';

--- a/src/index.ts
+++ b/src/index.ts
@@ -760,7 +760,10 @@ async function main(): Promise<void> {
     // in any log aggregation pipeline. The socket path is sufficient for diagnostics.
     logger.info({ socketPath: config.signalSocketPath }, 'Signal RPC client created');
   } else {
-    logger.warn('SIGNAL_SOCKET_PATH/SIGNAL_PHONE_NUMBER not set — Signal channel disabled');
+    // Point operators at the canonical config path first: the console writes
+    // channel.signal.socket_path / channel.signal.phone_number to the vault (#1140).
+    // SIGNAL_SOCKET_PATH / SIGNAL_PHONE_NUMBER env remain only as back-compat fallbacks.
+    logger.warn('Signal socket path or phone number not configured — Signal channel disabled. Set them in the console (Settings → Channels → Signal), or via the SIGNAL_SOCKET_PATH / SIGNAL_PHONE_NUMBER env fallbacks.');
   }
 
   // Calendar client — uses the primary email account's Nylas credentials.

--- a/src/secrets/apply-vault-secrets.ts
+++ b/src/secrets/apply-vault-secrets.ts
@@ -3,7 +3,9 @@
 // fallback. loadConfig() no longer reads these from process.env; this is the single
 // place they enter Config. Must run after the vault is constructed and migrations
 // have run, and before any consumer reads config (anthropic provider, openai
-// embeddings, nylas/signal channels). Reads run concurrently; values are never logged.
+// embeddings, nylas channel). Reads run concurrently; values are never logged.
+// Note: the Signal phone number is NOT resolved here — it is owned by applyChannelVaultSecrets
+// under the canonical channel.signal.phone_number key (#1140).
 import type { Logger } from '../logger.js';
 import type { Config } from '../config.js';
 import type { SecretsService } from './secrets-service.js';
@@ -22,7 +24,6 @@ export async function applyVaultSecrets(
     nylasApiKey,
     nylasGrantId,
     nylasSelfEmail,
-    signalPhoneNumber,
   ] = await Promise.all([
     secrets.get('anthropic_api_key'),
     secrets.get('openai_api_key'),
@@ -32,17 +33,15 @@ export async function applyVaultSecrets(
     secrets.get('nylas_api_key'),
     secrets.get('nylas_grant_id'),
     secrets.get('nylas_self_email'),
-    secrets.get('signal_phone_number'),
   ]);
 
   // Normalize each vault value: trim surrounding whitespace (copy-paste artifacts) and
   // collapse a blank/whitespace-only result to `undefined` (absent). A whitespace-only
-  // secret is unusable at runtime — the Anthropic client and HTTP auth reject it, and a
-  // blank Signal phone number would otherwise stay truthy and wire up the channel with an
-  // invalid account id — so it must read as absent here, keeping the boot guards and the
-  // feature-on checks (`if (config.signalPhoneNumber)`) honest rather than letting a
-  // truthy-but-empty string slip through. The seeder already trims on write; this is the
-  // matching read-side guard for rows set by any other path.
+  // secret is unusable at runtime — the Anthropic client and HTTP auth both reject it — so
+  // it must read as absent here, keeping the boot guard (`if (!config.apiToken)`) and the
+  // feature-on checks honest rather than letting a truthy-but-empty string slip through.
+  // The seeder already trims on write; this is the matching read-side guard for rows set by
+  // any other path.
   const clean = (value: string | null): string | undefined => {
     const trimmed = value?.trim();
     return trimmed ? trimmed : undefined;
@@ -58,7 +57,6 @@ export async function applyVaultSecrets(
   // nylasSelfEmail is typed `string`, so it defaults to '' — matching the previous
   // `process.env.NYLAS_SELF_EMAIL ?? ''` behavior, not an env read.
   config.nylasSelfEmail = clean(nylasSelfEmail) ?? '';
-  config.signalPhoneNumber = clean(signalPhoneNumber);
 
   // Names only — never values. Lets an operator confirm what the vault supplied
   // vs. what's absent (feature-disabled), which is the whole debuggability win.
@@ -73,7 +71,6 @@ export async function applyVaultSecrets(
     nylas_api_key: clean(nylasApiKey) !== undefined,
     nylas_grant_id: clean(nylasGrantId) !== undefined,
     nylas_self_email: clean(nylasSelfEmail) !== undefined,
-    signal_phone_number: clean(signalPhoneNumber) !== undefined,
   };
   logger.info({ present }, 'Resolved bootstrap secrets from vault (vault-only, no env fallback)');
 }

--- a/tests/integration/migrate-signal-phone-consolidation.test.ts
+++ b/tests/integration/migrate-signal-phone-consolidation.test.ts
@@ -1,0 +1,68 @@
+// Integration test — runs the 068 migration SQL against a live Postgres and asserts the
+// flat→namespaced Signal phone consolidation. Skips without DATABASE_URL + SECRET_ENCRYPTION_KEY.
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { readFile } from 'node:fs/promises';
+import { loadEncryptionKey } from '../../src/secrets/crypto.js';
+import { SecretsService } from '../../src/secrets/secrets-service.js';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL && process.env.SECRET_ENCRYPTION_KEY ? describe : describe.skip;
+const logger = pino({ level: 'silent' });
+
+const MIGRATION_SQL_URL = new URL(
+  '../../src/db/migrations/068_consolidate_signal_phone_number.sql',
+  import.meta.url,
+);
+const FLAT = 'signal_phone_number';
+const NAMESPACED = 'channel.signal.phone_number';
+
+describeIf('migration 068: consolidate signal phone number', () => {
+  let pool: pg.Pool;
+  let secrets: SecretsService;
+  let migrationSql: string;
+
+  beforeAll(async () => {
+    pool = new pg.Pool({ connectionString: DATABASE_URL });
+    secrets = new SecretsService(pool, loadEncryptionKey(), logger);
+    migrationSql = await readFile(MIGRATION_SQL_URL, 'utf8');
+  });
+
+  afterEach(async () => {
+    await pool.query('DELETE FROM secrets WHERE name = ANY($1)', [[FLAT, NAMESPACED]]);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('backfills the namespaced key from the legacy flat key, then drops the flat row', async () => {
+    await secrets.set(FLAT, '+12223334444');
+    await pool.query(migrationSql);
+    expect(await secrets.get(NAMESPACED)).toBe('+12223334444');
+    expect(await secrets.get(FLAT)).toBeNull();
+  });
+
+  it('never clobbers an existing console-written namespaced value', async () => {
+    await secrets.set(FLAT, '+19999999999');      // stale legacy value
+    await secrets.set(NAMESPACED, '+12223334444'); // console entry must win
+    await pool.query(migrationSql);
+    expect(await secrets.get(NAMESPACED)).toBe('+12223334444');
+    expect(await secrets.get(FLAT)).toBeNull();    // flat row still removed
+  });
+
+  it('is a no-op when neither key exists (env-only / unconfigured deployment)', async () => {
+    await pool.query(migrationSql);
+    expect(await secrets.get(NAMESPACED)).toBeNull();
+    expect(await secrets.get(FLAT)).toBeNull();
+  });
+
+  it('is idempotent — a second run changes nothing', async () => {
+    await secrets.set(FLAT, '+12223334444');
+    await pool.query(migrationSql);
+    await pool.query(migrationSql);
+    expect(await secrets.get(NAMESPACED)).toBe('+12223334444');
+    expect(await secrets.get(FLAT)).toBeNull();
+  });
+});

--- a/tests/integration/migrate-signal-phone-consolidation.test.ts
+++ b/tests/integration/migrate-signal-phone-consolidation.test.ts
@@ -1,6 +1,6 @@
 // Integration test — runs the 068 migration SQL against a live Postgres and asserts the
 // flat→namespaced Signal phone consolidation. Skips without DATABASE_URL + SECRET_ENCRYPTION_KEY.
-import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import pg from 'pg';
 import pino from 'pino';
 import { readFile } from 'node:fs/promises';
@@ -22,18 +22,44 @@ describeIf('migration 068: consolidate signal phone number', () => {
   let pool: pg.Pool;
   let secrets: SecretsService;
   let migrationSql: string;
+  // Snapshot of any pre-existing rows for the two keys we mutate. These tests overwrite and
+  // DELETE real secret names, so if DATABASE_URL is ever pointed at a non-throwaway DB (e.g.
+  // prod), an unconditional cleanup would destroy live Signal secrets. We capture them once
+  // before any test mutates state and restore them after the suite.
+  let preExisting: Array<{ name: string; value_format: string; encrypted_value: string; iv: string }> = [];
 
   beforeAll(async () => {
     pool = new pg.Pool({ connectionString: DATABASE_URL });
     secrets = new SecretsService(pool, loadEncryptionKey(), logger);
     migrationSql = await readFile(MIGRATION_SQL_URL, 'utf8');
+    const { rows } = await pool.query<{ name: string; value_format: string; encrypted_value: string; iv: string }>(
+      'SELECT name, value_format, encrypted_value, iv FROM secrets WHERE name = ANY($1)',
+      [[FLAT, NAMESPACED]],
+    );
+    preExisting = rows;
   });
 
-  afterEach(async () => {
+  // Clean slate before each case (also clears any pre-existing rows captured above, so a real
+  // value in the vault can't interfere with the backfill/no-clobber assertions). afterAll restores.
+  beforeEach(async () => {
     await pool.query('DELETE FROM secrets WHERE name = ANY($1)', [[FLAT, NAMESPACED]]);
   });
 
   afterAll(async () => {
+    // Leave the vault exactly as found: clear the test rows, then re-insert anything captured in
+    // beforeAll. So even a mispointed DATABASE_URL (e.g. prod) keeps its original ciphertext+iv.
+    await pool.query('DELETE FROM secrets WHERE name = ANY($1)', [[FLAT, NAMESPACED]]);
+    for (const row of preExisting) {
+      await pool.query(
+        `INSERT INTO secrets (name, value_format, encrypted_value, iv)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (name) DO UPDATE
+           SET value_format = EXCLUDED.value_format,
+               encrypted_value = EXCLUDED.encrypted_value,
+               iv = EXCLUDED.iv`,
+        [row.name, row.value_format, row.encrypted_value, row.iv],
+      );
+    }
     await pool.end();
   });
 

--- a/tests/integration/seed-vault.test.ts
+++ b/tests/integration/seed-vault.test.ts
@@ -30,6 +30,14 @@ describeIf('seedVault', () => {
     await pool.end();
   });
 
+  it('does not seed the legacy signal_phone_number key (consolidated to channel.signal.phone_number, #1140)', async () => {
+    expect([...SEED_SECRET_NAMES]).not.toContain('signal_phone_number');
+    const { seeded, skipped } = await seedVault(secrets, { SIGNAL_PHONE_NUMBER: '+12223334444' }, logger);
+    expect(seeded).not.toContain('signal_phone_number');
+    expect(skipped).not.toContain('signal_phone_number');
+    expect(await secrets.get('signal_phone_number')).toBeNull();
+  });
+
   it('seeds present env values into the vault and skips absent ones', async () => {
     const env = { NYLAS_API_KEY: 'nyk_test_123', TAVILY_API_KEY: 'tvly_test_456' };
     const { seeded, skipped } = await seedVault(secrets, env, logger);

--- a/tests/unit/apply-vault-secrets.test.ts
+++ b/tests/unit/apply-vault-secrets.test.ts
@@ -46,24 +46,35 @@ describe('applyVaultSecrets', () => {
     const config = blankConfig();
     await applyVaultSecrets(
       config,
-      stubSecrets({ anthropic_api_key: '  sk-ant-x\n', signal_phone_number: ' +12223334444 ' }),
+      stubSecrets({ anthropic_api_key: '  sk-ant-x\n', api_token: '  tok-x \n' }),
       logger,
     );
     expect(config.anthropicApiKey).toBe('sk-ant-x');
-    expect(config.signalPhoneNumber).toBe('+12223334444');
+    expect(config.apiToken).toBe('tok-x');
   });
 
   it('collapses a whitespace-only value to undefined so feature/boot guards stay honest', async () => {
     const config = blankConfig();
     await applyVaultSecrets(
       config,
-      // A blank signal_phone_number must NOT wire up the Signal channel; a blank
-      // api_token must trip the !config.apiToken boot guard rather than read as present.
-      stubSecrets({ signal_phone_number: '   ', api_token: ' ' }),
+      // A blank api_token must trip the !config.apiToken boot guard rather than read as present.
+      stubSecrets({ api_token: ' ', nylas_api_key: '   ' }),
+      logger,
+    );
+    expect(config.apiToken).toBeUndefined();
+    expect(config.nylasApiKey).toBeUndefined();
+  });
+
+  it('does not read or write signalPhoneNumber — that key is owned by applyChannelVaultSecrets', async () => {
+    const config = blankConfig();
+    // Even with a legacy flat signal_phone_number present in the vault, applyVaultSecrets
+    // must leave config.signalPhoneNumber untouched (#1140 consolidation).
+    await applyVaultSecrets(
+      config,
+      stubSecrets({ signal_phone_number: '+12223334444' }),
       logger,
     );
     expect(config.signalPhoneNumber).toBeUndefined();
-    expect(config.apiToken).toBeUndefined();
   });
 
   it('defaults nylasSelfEmail to an empty string, never undefined', async () => {


### PR DESCRIPTION
## Summary

Closes #1140.

The Signal phone number was read from two divergent vault keys with no reconciliation between the two runtime gates:

- the **registry gate** (`channelCredentialStatus` → `channelShouldStart`, deciding whether the **inbound** adapter starts) read only `channel.signal.phone_number` (▸ `SIGNAL_PHONE_NUMBER` env);
- the **adapter/outbound boot** (`config.signalPhoneNumber`, feeding the RPC client + OutboundGateway) also read the legacy flat `signal_phone_number` via `applyVaultSecrets`.

So a deployment whose number lived only under the flat key could enable **outbound** Signal egress while the registry reported Signal **unconfigured** and the inbound adapter never started — a silent, registry-invisible divergence.

This consolidates onto a single authoritative key, **`channel.signal.phone_number`** (what the console writes and the gate already reads), so the gate and the adapter agree. `phone_number` now behaves exactly like its sibling `socket_path`: console-written vault key with `SIGNAL_PHONE_NUMBER` kept only as documented env back-compat.

## Changes

- **Migration `068_consolidate_signal_phone_number.sql`** — backfills any existing flat value onto `channel.signal.phone_number` (copies `encrypted_value`+`iv` verbatim; the vault uses no per-name AAD, so the ciphertext decrypts identically under the new name), guarded by `NOT EXISTS` so it never clobbers a console entry, then drops the flat row. Idempotent; no-op for env-only/console-only deployments.
- **`apply-vault-secrets.ts`** — removed the flat `signal_phone_number` read; `config.signalPhoneNumber` is now owned solely by `applyChannelVaultSecrets`.
- **`seed-vault.ts`** — dropped `signal_phone_number` from `SEED_SECRET_NAMES` (matches `socket_path`, which was never seeded; required so the migration's delete sticks given setup.sh runs migrate→seed).
- **`index.ts`** — the Signal-disabled boot warning now points at the canonical console/vault key first, with the env vars as back-compat fallbacks.
- **Kept** the `SIGNAL_PHONE_NUMBER` env fallback (catalog + overlay) as documented back-compat, symmetric with `socket_path`.

## Tests

- `migrate-signal-phone-consolidation.test.ts` (integration) — backfill, no-clobber, no-op, idempotency against live Postgres.
- `apply-vault-secrets.test.ts` — asserts the flat key is no longer read/written.
- `seed-vault.test.ts` — asserts `signal_phone_number` is not seeded.
- `apply-channel-vault-secrets.test.ts` + `credential-resolver.test.ts` — console-only entry (channel key alone) populates config and reports the real catalog descriptor resolvable.

All touched tests pass (36/36); typecheck clean across all tsconfigs.

## Acceptance criteria

- [x] Exactly one authoritative vault key, all runtime paths read it
- [x] Console-only entry activates Signal (no second flat-key write)
- [x] Legacy flat-key read removed (not a silent divergent source); `SIGNAL_PHONE_NUMBER` env retained as explicit, documented back-compat
- [x] Existing-deployment migration path addressed (backfill + delete)
- [x] Tests cover the console-only activation path
- [ ] **curia-docs** updated to reference only `channel.signal.phone_number` (closes curia-docs#26) — separate PR, drafted for approval

## Out of scope

- Email's identical dual-key shape (its gate already accounts for config-resolved keys).
- Broader removal of all channel env fallbacks (would need its own issue + deployment migration plan).

Design + plan: `docs/wip/2026-06-29-signal-phone-vault-key-consolidation-design.md`, `docs/wip/2026-06-29-signal-phone-vault-key-consolidation.md`.