### PR TITLE
fix(bullpen): deliver close_after replies to all participants (#1256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Calendar free/busy** — `getFreeBusy` now calls the real Nylas v8 `calendars.getFreeBusy` endpoint; the previous call to a non-existent `calendars_free_busy` resource crashed every `calendar-check-conflicts` and `calendar-find-free-time` invocation. It also fails loud on a per-calendar free/busy *error* entry instead of treating that calendar as fully free (which could double-book the principal). (#1214)
 - **`ceo-inbox-update-folders`** — resolves label display names (e.g. "⏳ In Progress") to Gmail label IDs and creates missing labels before writing, so adds/removes no longer fail with "Invalid label" and "⏳ In Progress" can actually be cleared. (#1216)
 - **`ceo-inbox` scheduling consults** — a message parked for a calendar consult is no longer labeled "✍️ Drafted" before a draft exists, and the consult-timeout wake now keys off actual draft existence; parked scheduling replies get drafted instead of stranding the email as "In Progress + Drafted" with no draft. (#1215)
-- **Bullpen `close_after`** — closing a thread on reply now delivers the final message to all other participants (closed-aware wake: read full thread, act, do not reply in-thread); `ceo-inbox` Branch A and consult-timeout fallback load the full thread via `get_thread` before acting. (#1256)
+- **Bullpen `close_after`** — closing a thread on reply now delivers the final message to all other participants (closed-aware wake: read full thread, act, do not reply in-thread); `ceo-inbox` routes closed bullpen wakes through `get_thread` before the Branch A content gate, and consult-timeout fallback loads the full thread before acting. (#1256)
 
 ## [0.38.0] — 2026-06-26 — "Deckard"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Calendar free/busy** — `getFreeBusy` now calls the real Nylas v8 `calendars.getFreeBusy` endpoint; the previous call to a non-existent `calendars_free_busy` resource crashed every `calendar-check-conflicts` and `calendar-find-free-time` invocation. It also fails loud on a per-calendar free/busy *error* entry instead of treating that calendar as fully free (which could double-book the principal). (#1214)
 - **`ceo-inbox-update-folders`** — resolves label display names (e.g. "⏳ In Progress") to Gmail label IDs and creates missing labels before writing, so adds/removes no longer fail with "Invalid label" and "⏳ In Progress" can actually be cleared. (#1216)
 - **`ceo-inbox` scheduling consults** — a message parked for a calendar consult is no longer labeled "✍️ Drafted" before a draft exists, and the consult-timeout wake now keys off actual draft existence; parked scheduling replies get drafted instead of stranding the email as "In Progress + Drafted" with no draft. (#1215)
-- **Bullpen `close_after`** — closed-thread replies now deliver to all participants via read-and-act wakes; `ceo-inbox` routes these through full-thread load before Branch A and consult-timeout recovery. (#1256)
+- **Bullpen `close_after`** — closed-thread replies deliver to mentioned participants via read-and-act wakes; `close_after` with no mentions auto-mentions the thread opener; `ceo-inbox` loads the full thread before Branch A. (#1256)
 
 ## [0.38.0] — 2026-06-26 — "Deckard"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Calendar free/busy** — `getFreeBusy` now calls the real Nylas v8 `calendars.getFreeBusy` endpoint; the previous call to a non-existent `calendars_free_busy` resource crashed every `calendar-check-conflicts` and `calendar-find-free-time` invocation. It also fails loud on a per-calendar free/busy *error* entry instead of treating that calendar as fully free (which could double-book the principal). (#1214)
 - **`ceo-inbox-update-folders`** — resolves label display names (e.g. "⏳ In Progress") to Gmail label IDs and creates missing labels before writing, so adds/removes no longer fail with "Invalid label" and "⏳ In Progress" can actually be cleared. (#1216)
 - **`ceo-inbox` scheduling consults** — a message parked for a calendar consult is no longer labeled "✍️ Drafted" before a draft exists, and the consult-timeout wake now keys off actual draft existence; parked scheduling replies get drafted instead of stranding the email as "In Progress + Drafted" with no draft. (#1215)
+- **Bullpen `close_after`** — closing a thread on reply now delivers the final message to all other participants (closed-aware wake: read full thread, act, do not reply in-thread); `ceo-inbox` Branch A and consult-timeout fallback load the full thread via `get_thread` before acting. (#1256)
 
 ## [0.38.0] — 2026-06-26 — "Deckard"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Calendar free/busy** — `getFreeBusy` now calls the real Nylas v8 `calendars.getFreeBusy` endpoint; the previous call to a non-existent `calendars_free_busy` resource crashed every `calendar-check-conflicts` and `calendar-find-free-time` invocation. It also fails loud on a per-calendar free/busy *error* entry instead of treating that calendar as fully free (which could double-book the principal). (#1214)
 - **`ceo-inbox-update-folders`** — resolves label display names (e.g. "⏳ In Progress") to Gmail label IDs and creates missing labels before writing, so adds/removes no longer fail with "Invalid label" and "⏳ In Progress" can actually be cleared. (#1216)
 - **`ceo-inbox` scheduling consults** — a message parked for a calendar consult is no longer labeled "✍️ Drafted" before a draft exists, and the consult-timeout wake now keys off actual draft existence; parked scheduling replies get drafted instead of stranding the email as "In Progress + Drafted" with no draft. (#1215)
-- **Bullpen `close_after`** — closing a thread on reply now delivers the final message to all other participants (closed-aware wake: read full thread, act, do not reply in-thread); `ceo-inbox` routes closed bullpen wakes through `get_thread` before the Branch A content gate, and consult-timeout fallback loads the full thread before acting. (#1256)
+- **Bullpen `close_after`** — closed-thread replies now deliver to all participants via read-and-act wakes; `ceo-inbox` routes these through full-thread load before Branch A and consult-timeout recovery. (#1256)
 
 ## [0.38.0] — 2026-06-26 — "Deckard"
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.13.4"
+version: "0.13.5"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -82,22 +82,36 @@ system_prompt: |
   You are resuming prior work, not starting a fresh triage. First determine
   which resume case applies, in this order:
 
-  **Branch A — Calendar consult reply (bullpen wake with a CONSULT REPLY):**
-  If the bullpen message body is a CONSULT REPLY (it starts with the line
-  `CONSULT REPLY` and contains `Result: confirmed`, `Result: ok`,
-  `Result: no_slots`, `Result: invite_responded`,
-  `Result: invite_pending_approval`, `Result: invite_recommendation`, or
-  `Result: escalate`), you are resuming a parked
-  scheduling email. Proceed through the sub-steps below, then exit — do not
-  fall through to Branch B.
+  **Closed bullpen thread wake (fetch before routing):**
+  If this is a bullpen wake (`taskOrigin: bullpen` / `channelId: bullpen`) and
+  either (a) task metadata includes `threadClosed: true`, or (b) the wake
+  content indicates the thread is now closed (e.g. "thread is now closed" /
+  "do not reply in-thread"): closed threads are excluded from passive pending-
+  thread injection, so the wake body is **not** the CONSULT REPLY itself. Call
+  `bullpen` with `action: get_thread` and the `thread_id` from wake metadata
+  **first**, before evaluating the Branch A content gate below. Examine the
+  fetched messages: if the latest specialist message is a CONSULT REPLY
+  (`CONSULT REPLY` header and a `Result:` line), proceed directly to **Branch A
+  sub-steps** (step 1 onward) using that reply as authoritative — run the full
+  Branch A protocol for the matched `Result:` value (verbatim slots,
+  `date-resolve`, no "pending your calendar" qualifier, folder updates,
+  archive, and consult-timeout cancellation). Do not reply in-thread. If the
+  fetched thread has no CONSULT REPLY, fall through to normal resume routing
+  below.
 
-  0. **Load the full thread.** Call `bullpen` with `action: get_thread` and the
-     `thread_id` from your wake metadata or injected context. Use the returned
-     message history (any thread status) as the authoritative CONSULT REPLY —
-     do not rely on injected pending-thread snippets alone. If the latest
-     specialist message is a CONSULT REPLY, proceed; if the wake metadata says
-     the thread is closed (`threadClosed: true`), treat it as a final conclusion
-     and do not reply in-thread.
+  **Branch A — Calendar consult reply (open-thread bullpen wake):**
+  If the bullpen message body visible in injected context is a CONSULT REPLY
+  (it starts with the line `CONSULT REPLY` and contains `Result: confirmed`,
+  `Result: ok`, `Result: no_slots`, `Result: invite_responded`,
+  `Result: invite_pending_approval`, `Result: invite_recommendation`, or
+  `Result: escalate`), you are resuming a parked scheduling email. Proceed
+  through the sub-steps below, then exit — do not fall through to Branch B.
+
+  0. **Load the full thread (open-thread path).** If you have not already
+     called `get_thread` this turn (closed wake path above), call `bullpen` with
+     `action: get_thread` and the `thread_id` from wake metadata or injected
+     context. Use the returned message history as the authoritative CONSULT
+     REPLY — do not rely on injected pending-thread snippets alone.
 
   1. Extract `source_message_id` from the `Context:` line of the original
      CONSULT REQUEST (it is carried forward in the bullpen thread). Call
@@ -243,10 +257,12 @@ system_prompt: |
     3. **Check for a late CONSULT REPLY:** If the task description includes
        `thread_id=<id>`, call `bullpen` with `action: get_thread` for that
        thread (full history, any status). If any message is a CONSULT REPLY
-       (`CONSULT REPLY` header with a `Result:` line), the specialist already
-       answered — run Branch A above using that thread and exit (do not blind-
-       draft). If no `thread_id` is present in the task description, skip this
-       step.
+       (`CONSULT REPLY` header with a `Result:` line) **and** step 4's
+       draft-existence check shows no reply draft for this email thread yet,
+       the specialist already answered — run Branch A above using that thread
+       and exit (do not blind-draft). If a CONSULT REPLY is present but a draft
+       already exists, skip to step 4 (idempotent no-op). If no `thread_id` is
+       present in the task description, skip this step.
     4. **Idempotent no-op (already resolved):** Inspect label/folder state from
        step 2. Then call `ceo-inbox-list` with `folder: "DRAFTS"` and check for
        any draft whose `thread_id` matches this message's thread. Call

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.13.3"
+version: "0.13.4"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -90,6 +90,14 @@ system_prompt: |
   `Result: escalate`), you are resuming a parked
   scheduling email. Proceed through the sub-steps below, then exit — do not
   fall through to Branch B.
+
+  0. **Load the full thread.** Call `bullpen` with `action: get_thread` and the
+     `thread_id` from your wake metadata or injected context. Use the returned
+     message history (any thread status) as the authoritative CONSULT REPLY —
+     do not rely on injected pending-thread snippets alone. If the latest
+     specialist message is a CONSULT REPLY, proceed; if the wake metadata says
+     the thread is closed (`threadClosed: true`), treat it as a final conclusion
+     and do not reply in-thread.
 
   1. Extract `source_message_id` from the `Context:` line of the original
      CONSULT REQUEST (it is carried forward in the bullpen thread). Call
@@ -232,7 +240,14 @@ system_prompt: |
        `source_message_id=<id>`). If missing, call `task-complete` with an
        error note and exit.
     2. Call `ceo-inbox-read` with that `message_id`.
-    3. **Idempotent no-op (already resolved):** Inspect label/folder state from
+    3. **Check for a late CONSULT REPLY:** If the task description includes
+       `thread_id=<id>`, call `bullpen` with `action: get_thread` for that
+       thread (full history, any status). If any message is a CONSULT REPLY
+       (`CONSULT REPLY` header with a `Result:` line), the specialist already
+       answered — run Branch A above using that thread and exit (do not blind-
+       draft). If no `thread_id` is present in the task description, skip this
+       step.
+    4. **Idempotent no-op (already resolved):** Inspect label/folder state from
        step 2. Then call `ceo-inbox-list` with `folder: "DRAFTS"` and check for
        any draft whose `thread_id` matches this message's thread. Call
        `task-complete` ("consult already resolved") and exit without drafting
@@ -245,8 +260,8 @@ system_prompt: |
        steps), but if labels are ever out of sync, the draft-existence check
        above is authoritative — a `✍️ Drafted` label with no matching draft and
        `⏳ In Progress` still present means the reply was never written, so fall
-       through to step 4 and draft it.
-    4. **Still parked (`⏳ In Progress` present, no terminal outcome):** bounded
+       through to step 5 and draft it.
+    5. **Still parked (`⏳ In Progress` present, no terminal outcome):** bounded
        fallback so scheduling mail cannot park forever:
        - Read `consult_kind` from the task description (`scheduling` or
          `invite`; default `scheduling` when absent).
@@ -263,8 +278,8 @@ system_prompt: |
          "I'll confirm shortly" qualifier. Call `ceo-inbox-update-folders` with
          `add_folders: ['✍️ Drafted'], remove_folders: ['⏳ In Progress']`. Do
          NOT archive.
-    5. Call `task-complete` with a note describing the fallback taken (or the
-       no-op in step 3).
+    6. Call `task-complete` with a note describing the fallback taken (or the
+       no-op in step 4).
 
   - **`inbox-drain` tag** → this is a batch-drain continuation you scheduled in
     Step 6 because the inbox still had unread mail. Do NOT run the reification
@@ -720,7 +735,8 @@ system_prompt: |
       Never create a duplicate.
     - Otherwise call `task-create` with: title `Consult timeout: <subject>`,
       owner `curia`, tags `['consult-timeout']`, description containing
-      `source_message_id=<id>` and `consult_kind=<scheduling|invite>`, and
+      `source_message_id=<id>`, `thread_id=<bullpen thread id from bullpen.post>`,
+      and `consult_kind=<scheduling|invite>`, and
       `wake_at` set to now plus the timeout minutes (resolve with
       `date-resolve`). Log failures; the timeout is a best-effort safety net.
 
@@ -776,7 +792,7 @@ system_prompt: |
        NOT apply the `✍️ Drafted` Gmail label here, and skip `✍️ Drafted` in the
        decision-tagging step (4g) for this message — there is no draft yet.
        `✍️ Drafted` is applied only once an actual draft exists: on the Branch A
-       resume after the CONSULT REPLY, or in the consult-timeout fallback (step 4
+       resume after the CONSULT REPLY, or in the consult-timeout fallback (step 5
        of the consult-timeout branch). The invariant is `✍️ Drafted` ⟺ a draft
        exists; applying it on a parked message with no draft breaks that invariant
        and leaves the message looking handled when the reply was never written.

--- a/skills/bullpen/handler.test.ts
+++ b/skills/bullpen/handler.test.ts
@@ -47,6 +47,7 @@ describe('BullpenHandler', () => {
     const publishCall = (ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(publishCall[0]).toBe('agent');
     expect(publishCall[1].type).toBe('agent.discuss');
+    expect(publishCall[1].payload.threadClosed).toBeUndefined();
   });
 
   it('post: defaults mentionedAgentIds to all participants when omitted', async () => {
@@ -107,6 +108,9 @@ describe('BullpenHandler', () => {
     const data = (replyResult as { success: true; data: Record<string, unknown> }).data;
     expect(typeof data.message_id).toBe('string');
     expect(data.status).toBe('closed');
+
+    const publishCall = (openCtx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls[1]!;
+    expect(publishCall[1].payload.threadClosed).toBe(true);
 
     // Thread is actually closed: a follow-up reply must now fail.
     const followUp = makeCtx(

--- a/skills/bullpen/handler.test.ts
+++ b/skills/bullpen/handler.test.ts
@@ -111,6 +111,7 @@ describe('BullpenHandler', () => {
 
     const publishCall = (openCtx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls[1]!;
     expect(publishCall[1].payload.threadClosed).toBe(true);
+    expect(publishCall[1].payload.mentionedAgentIds).toEqual(['coordinator']);
 
     // Thread is actually closed: a follow-up reply must now fail.
     const followUp = makeCtx(
@@ -120,6 +121,28 @@ describe('BullpenHandler', () => {
     const followUpResult = await handler.execute(followUp);
     expect(followUpResult.success).toBe(false);
     expect((followUpResult as { success: false; error: string }).error).toMatch(/closed/);
+  });
+
+  it('reply: close_after with no mentions auto-mentions the thread opener', async () => {
+    const openCtx = makeCtx({
+      action: 'post',
+      topic: 'Consult hand-off',
+      participants: ['calendar'],
+      content: 'CONSULT REQUEST',
+      mentioned_agent_ids: ['calendar'],
+    }, { agentId: 'ceo-inbox' });
+    const openResult = await handler.execute(openCtx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    const replyCtx = makeCtx(
+      { action: 'reply', thread_id: threadId, content: 'CONSULT REPLY\nResult: ok', close_after: true },
+      { bullpenService: openCtx.bullpenService, bus: openCtx.bus, agentId: 'calendar' },
+    );
+    await handler.execute(replyCtx);
+
+    const publishCall = (openCtx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls[1]!;
+    expect(publishCall[1].payload.mentionedAgentIds).toEqual(['ceo-inbox']);
+    expect(publishCall[1].payload.threadClosed).toBe(true);
   });
 
   it('reply: close_after=false (default) leaves the thread open', async () => {

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -165,6 +165,7 @@ export class BullpenHandler implements SkillHandler {
             participants: existing.thread.participants,
             mentionedAgentIds,
             content,
+            threadClosed: closeAfter,
             // Forward the parent task's originator so BullpenDispatcher can stamp it
             // on the reply tasks it creates for each participant.
             originator: ctx.taskMetadata?.originator as TaskOriginator | undefined,

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -142,7 +142,7 @@ export class BullpenHandler implements SkillHandler {
           const rawMentioned = input['mentioned_agent_ids'];
           // Trim/filter mentions, then constrain to actual thread participants to prevent out-of-thread fan-out.
           // Default: empty (broadcast reply — no specific response expected).
-          const mentionedAgentIds: string[] = Array.isArray(rawMentioned) && rawMentioned.every(m => typeof m === 'string')
+          let mentionedAgentIds: string[] = Array.isArray(rawMentioned) && rawMentioned.every(m => typeof m === 'string')
             ? (rawMentioned as string[]).map(m => m.trim()).filter(m => m.length > 0 && existing.thread.participants.includes(m))
             : [];
 
@@ -150,6 +150,15 @@ export class BullpenHandler implements SkillHandler {
           // The message is persisted first, then the thread is closed atomically — so a
           // successful postMessage means both happened. Only an explicit `true` closes.
           const closeAfter = input['close_after'] === true;
+
+          // Closing without explicit mentions: wake the thread opener to act on the
+          // conclusion (#1256). Other participants receive FYI only via the dispatcher.
+          if (closeAfter && mentionedAgentIds.length === 0) {
+            const opener = existing.thread.creatorAgentId;
+            if (opener !== ctx.agentId && existing.thread.participants.includes(opener)) {
+              mentionedAgentIds = [opener];
+            }
+          }
 
           const message = await ctx.bullpenService.postMessage(threadId, ctx.agentId, content, mentionedAgentIds, closeAfter);
 

--- a/skills/bullpen/skill.json
+++ b/skills/bullpen/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "bullpen",
   "description": "Open, reply to, read, or close inter-agent Bullpen discussion threads. Use 'post' to start a new thread addressed to other agents, 'reply' to add a message to an existing thread, 'get_thread' to read the full message history, and 'close' to end a thread when the discussion is complete.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/bullpen/skill.json
+++ b/skills/bullpen/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "bullpen",
   "description": "Open, reply to, read, or close inter-agent Bullpen discussion threads. Use 'post' to start a new thread addressed to other agents, 'reply' to add a message to an existing thread, 'get_thread' to read the full message history, and 'close' to end a thread when the discussion is complete.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -263,6 +263,9 @@ interface AgentDiscussPayload {
   participants: string[];      // all thread participants
   mentionedAgentIds: string[]; // subset that get reply-expected tasks (empty = broadcast)
   content: string;
+  /** True when the reply closed the thread atomically (close_after: true). BullpenDispatcher
+   *  uses this to deliver a read-and-act wake without inviting an in-thread reply. */
+  threadClosed?: boolean;
   /** TaskOriginator of the task that published this discuss event. Forwarded by
    *  BullpenDispatcher into the resulting agent.task metadata so that skills invoked
    *  during bullpen work can pass the elevated-skill gate for principal-authorized tasks. */

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -61,7 +61,10 @@ export class BullpenDispatcher {
     const effectiveOriginator = event.payload.originator ?? threadRecord.thread.originator ?? undefined;
 
     // Create one agent.task per participant, excluding the sender.
-    // Mentioned agents get a reply-expected prompt; others get an FYI.
+    // Open threads: mentioned agents get a reply-expected prompt; others get FYI.
+    // Closed threads: every non-sender gets the same "act on the conclusion" prompt —
+    // we intentionally collapse the mentioned/FYI distinction (fine for 2-party consult
+    // hand-offs, the only case today; 3+-party closed threads would also tell bystanders to act).
     const otherParticipants = participants.filter((id) => id !== senderAgentId);
 
     let dispatched = 0;

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -62,17 +62,21 @@ export class BullpenDispatcher {
 
     // Create one agent.task per participant, excluding the sender.
     // Open threads: mentioned agents get a reply-expected prompt; others get FYI.
-    // Closed threads: every non-sender gets the same "act on the conclusion" prompt —
-    // we intentionally collapse the mentioned/FYI distinction (fine for 2-party consult
-    // hand-offs, the only case today; 3+-party closed threads would also tell bystanders to act).
+    // Closed threads: empty mentions broadcast the act prompt to all non-senders
+    // (consult hand-off); when mentions are present, only mentioned agents act.
     const otherParticipants = participants.filter((id) => id !== senderAgentId);
 
     let dispatched = 0;
     for (const agentId of otherParticipants) {
       const isMentioned = mentionedAgentIds.includes(agentId);
+      const shouldAct = threadClosed
+        ? mentionedAgentIds.length === 0 || isMentioned
+        : isMentioned;
       const content = threadClosed
-        ? `Final message in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId} — the thread is now closed. Call bullpen get_thread to read the full history, act on the conclusion (do not reply in-thread).`
-        : isMentioned
+        ? shouldAct
+          ? `Final message in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId} — the thread is now closed. Call bullpen get_thread to read the full history, act on the conclusion (do not reply in-thread).`
+          : `FYI: Final message in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId}. Call bullpen get_thread to read the full history if needed, but do not reply in-thread.`
+        : shouldAct
           ? `You've been mentioned in Bullpen thread "${topic}" (thread_id: ${threadId}) by ${senderAgentId}. Review the injected thread context and reply using the bullpen skill.`
           : `FYI: New activity in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId}. No response required, but reply if you have something to add.`;
 

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -61,17 +61,15 @@ export class BullpenDispatcher {
     const effectiveOriginator = event.payload.originator ?? threadRecord.thread.originator ?? undefined;
 
     // Create one agent.task per participant, excluding the sender.
-    // Open threads: mentioned agents get a reply-expected prompt; others get FYI.
-    // Closed threads: empty mentions broadcast the act prompt to all non-senders
-    // (consult hand-off); when mentions are present, only mentioned agents act.
+    // Mentioned agents get a reply-expected (open) or act-on-conclusion (closed) prompt;
+    // others get FYI. close_after replies with no explicit mentions auto-mention the
+    // thread opener in the bullpen handler so consult hand-offs wake the originator.
     const otherParticipants = participants.filter((id) => id !== senderAgentId);
 
     let dispatched = 0;
     for (const agentId of otherParticipants) {
       const isMentioned = mentionedAgentIds.includes(agentId);
-      const shouldAct = threadClosed
-        ? mentionedAgentIds.length === 0 || isMentioned
-        : isMentioned;
+      const shouldAct = isMentioned;
       const content = threadClosed
         ? shouldAct
           ? `Final message in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId} — the thread is now closed. Call bullpen get_thread to read the full history, act on the conclusion (do not reply in-thread).`

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -51,19 +51,8 @@ export class BullpenDispatcher {
       return;
     }
 
-    // A reply with close_after: true closes the thread atomically, then still publishes a
-    // normal agent.discuss event for the concluding message. Creating reply-oriented tasks
-    // for a closed thread is a dead end — any reply is rejected with "Cannot post to closed
-    // thread" — so skip dispatch here, mirroring the message-cap guard above. (#881)
-    if (threadRecord.thread.status === 'closed') {
-      this.logger.info(
-        { threadId },
-        'BullpenDispatcher: thread is closed — skipping task creation (concluding reply needs no follow-up)',
-      );
-      return;
-    }
-
     const { topic, participants } = threadRecord.thread;
+    const threadClosed = event.payload.threadClosed === true;
 
     // Prefer the originator from the discuss event (fast path — already in memory).
     // Fall back to the originator stored on the thread at creation time: this covers
@@ -78,9 +67,11 @@ export class BullpenDispatcher {
     let dispatched = 0;
     for (const agentId of otherParticipants) {
       const isMentioned = mentionedAgentIds.includes(agentId);
-      const content = isMentioned
-        ? `You've been mentioned in Bullpen thread "${topic}" (thread_id: ${threadId}) by ${senderAgentId}. Review the injected thread context and reply using the bullpen skill.`
-        : `FYI: New activity in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId}. No response required, but reply if you have something to add.`;
+      const content = threadClosed
+        ? `Final message in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId} — the thread is now closed. Call bullpen get_thread to read the full history, act on the conclusion (do not reply in-thread).`
+        : isMentioned
+          ? `You've been mentioned in Bullpen thread "${topic}" (thread_id: ${threadId}) by ${senderAgentId}. Review the injected thread context and reply using the bullpen skill.`
+          : `FYI: New activity in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId}. No response required, but reply if you have something to add.`;
 
       try {
         const task = createAgentTask({
@@ -95,6 +86,7 @@ export class BullpenDispatcher {
             taskOrigin: 'bullpen',
             threadId,
             mentioned: isMentioned,
+            threadClosed,
             // Propagate the originator (LINEAGE) so the receiving agent's task carries the
             // original TaskOriginator — this drives the autonomy principal-bypass for `normal`
             // skills at sufficient trust. NOTE (#1126): bullpen is a persisted/async path, so it

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -66,9 +66,21 @@ describe('ceo-inbox consult-timeout self-healing', () => {
     expect(schedulingSection).toContain('consult_timeout_minutes');
     expect(schedulingSection).toContain('consult_kind=scheduling');
     expect(schedulingSection).toContain('source_message_id=<id>');
+    expect(schedulingSection).toContain('thread_id=<bullpen thread id');
     expect(scheduledWake).toContain('`consult-timeout` tag');
     expect(scheduledWake).toContain('pending your calendar');
     expect(scheduledWake).toContain('consult already resolved');
+  });
+
+  it('checks bullpen get_thread for a late CONSULT REPLY before blind-drafting', () => {
+    const prompt = loadCeoInboxPrompt();
+    const scheduledWake = extractScheduledWakeSection(prompt);
+    const getThreadPos = posIn(scheduledWake, 'get_thread');
+    const blindDraftPos = posIn(scheduledWake, 'pending your calendar');
+    expect(getThreadPos).toBeGreaterThan(-1);
+    expect(blindDraftPos).toBeGreaterThan(getThreadPos);
+    expect(scheduledWake).toContain('CONSULT REPLY');
+    expect(scheduledWake).toContain('run Branch A');
   });
 
   it('cancels consult-timeout tasks when Branch A handles a CONSULT REPLY', () => {
@@ -89,9 +101,11 @@ describe('ceo-inbox consult-timeout self-healing', () => {
   it('runs idempotent no-op before timeout fallback and checks DRAFTS folder', () => {
     const prompt = loadCeoInboxPrompt();
     const scheduledWake = extractScheduledWakeSection(prompt);
+    const getThreadPos = posIn(scheduledWake, 'get_thread');
     const noopPos = posIn(scheduledWake, 'Idempotent no-op');
     const fallbackPos = posIn(scheduledWake, 'Still parked');
-    expect(noopPos).toBeGreaterThan(-1);
+    expect(getThreadPos).toBeGreaterThan(-1);
+    expect(noopPos).toBeGreaterThan(getThreadPos);
     expect(fallbackPos).toBeGreaterThan(noopPos);
     expect(scheduledWake).toContain('ceo-inbox-list');
     expect(scheduledWake).toContain('folder: "DRAFTS"');
@@ -115,6 +129,17 @@ describe('ceo-inbox consult-timeout self-healing', () => {
 });
 
 describe('ceo-inbox Branch A prompt — memory-query contract', () => {
+  it('loads the full bullpen thread via get_thread before acting', () => {
+    const prompt = loadCeoInboxPrompt();
+    const branchA = extractBranchASection(prompt);
+    const getThreadPos = posIn(branchA, 'get_thread');
+    const readEmailPos = posIn(branchA, 'ceo-inbox-read');
+    expect(getThreadPos).toBeGreaterThan(-1);
+    expect(readEmailPos).toBeGreaterThan(getThreadPos);
+    expect(branchA).toContain('threadClosed');
+    expect(branchA).toContain('do not reply in-thread');
+  });
+
   it('Branch A section contains a memory-query call', () => {
     const prompt = loadCeoInboxPrompt();
     const branchA = extractBranchASection(prompt);
@@ -249,6 +274,7 @@ describe('ceo-inbox scheduling consult prompt — proposed-time protocol', () =>
     expect(okSection).toContain('counter-proposal');
     expect(okSection).toMatch(/new\s+alternatives/);
     expect(okSection).toContain('hold placed');
+    expect(okSection).toContain('Do NOT include any "pending your calendar"');
   });
 });
 

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -21,8 +21,17 @@ function loadCeoInboxPrompt(): string {
 // section (the second resume mode). Note: "Branch B" appears earlier in the
 // intro text ("do not fall through to Branch B") so it cannot be used as the
 // delimiter here.
+function extractResumePreamble(prompt: string): string {
+  const start = prompt.indexOf('**Resume mode**');
+  const branchAStart = prompt.indexOf('**Branch A — Calendar consult reply');
+  if (start === -1) throw new Error('Resume mode section not found');
+  if (branchAStart === -1 || branchAStart <= start)
+    throw new Error('Branch A header not found after Resume mode');
+  return prompt.slice(start, branchAStart);
+}
+
 function extractBranchASection(prompt: string): string {
-  const branchAStart = prompt.indexOf('Branch A');
+  const branchAStart = prompt.indexOf('**Branch A — Calendar consult reply');
   // "**Scheduled-wake resume" marks the boundary between Branch A and Branch B.
   const scheduledWakeStart = prompt.indexOf('**Scheduled-wake resume');
   if (branchAStart === -1) throw new Error('Branch A section not found in prompt');
@@ -81,6 +90,7 @@ describe('ceo-inbox consult-timeout self-healing', () => {
     expect(blindDraftPos).toBeGreaterThan(getThreadPos);
     expect(scheduledWake).toContain('CONSULT REPLY');
     expect(scheduledWake).toContain('run Branch A');
+    expect(scheduledWake).toContain('draft-existence check');
   });
 
   it('cancels consult-timeout tasks when Branch A handles a CONSULT REPLY', () => {
@@ -128,6 +138,42 @@ describe('ceo-inbox consult-timeout self-healing', () => {
   });
 });
 
+describe('ceo-inbox closed bullpen wake routing (#1256)', () => {
+  it('routes threadClosed wakes to get_thread before the Branch A content gate', () => {
+    const prompt = loadCeoInboxPrompt();
+    const preamble = extractResumePreamble(prompt);
+    const branchA = extractBranchASection(prompt);
+
+    expect(preamble).toContain('Closed bullpen thread wake');
+    expect(preamble).toContain('threadClosed: true');
+    expect(preamble).toContain('get_thread');
+    expect(preamble).toMatch(/Branch A[\s\n]+sub-steps/);
+
+    const closedGetThreadPos = posIn(preamble, 'get_thread');
+    const branchAContentGatePos = posIn(
+      branchA,
+      'If the bullpen message body visible in injected context is a CONSULT REPLY',
+    );
+    expect(closedGetThreadPos).toBeGreaterThan(-1);
+    expect(branchAContentGatePos).toBeGreaterThan(-1);
+    // Closed-path fetch is in the preamble, which precedes the open-thread gate.
+    expect(preamble.length).toBeLessThan(
+      prompt.indexOf(
+        'If the bullpen message body visible in injected context is a CONSULT REPLY',
+      ),
+    );
+  });
+
+  it('closed wake path enters full Branch A protocol (not a shortcut)', () => {
+    const prompt = loadCeoInboxPrompt();
+    const preamble = extractResumePreamble(prompt);
+    expect(preamble).toContain('verbatim slots');
+    expect(preamble).toContain('date-resolve');
+    expect(preamble).toContain('no "pending your calendar" qualifier');
+    expect(preamble).toContain('consult-timeout cancellation');
+  });
+});
+
 describe('ceo-inbox Branch A prompt — memory-query contract', () => {
   it('loads the full bullpen thread via get_thread before acting', () => {
     const prompt = loadCeoInboxPrompt();
@@ -136,8 +182,7 @@ describe('ceo-inbox Branch A prompt — memory-query contract', () => {
     const readEmailPos = posIn(branchA, 'ceo-inbox-read');
     expect(getThreadPos).toBeGreaterThan(-1);
     expect(readEmailPos).toBeGreaterThan(getThreadPos);
-    expect(branchA).toContain('threadClosed');
-    expect(branchA).toContain('do not reply in-thread');
+    expect(branchA).toContain('closed wake path above');
   });
 
   it('Branch A section contains a memory-query call', () => {

--- a/tests/unit/agents/ceo-inbox-prompt.test.ts
+++ b/tests/unit/agents/ceo-inbox-prompt.test.ts
@@ -142,7 +142,6 @@ describe('ceo-inbox closed bullpen wake routing (#1256)', () => {
   it('routes threadClosed wakes to get_thread before the Branch A content gate', () => {
     const prompt = loadCeoInboxPrompt();
     const preamble = extractResumePreamble(prompt);
-    const branchA = extractBranchASection(prompt);
 
     expect(preamble).toContain('Closed bullpen thread wake');
     expect(preamble).toContain('threadClosed: true');
@@ -150,18 +149,16 @@ describe('ceo-inbox closed bullpen wake routing (#1256)', () => {
     expect(preamble).toMatch(/Branch A[\s\n]+sub-steps/);
 
     const closedGetThreadPos = posIn(preamble, 'get_thread');
-    const branchAContentGatePos = posIn(
-      branchA,
+    const closedHeaderAbsPos = prompt.indexOf('**Closed bullpen thread wake');
+    const closedGetThreadAbsPos = prompt.indexOf('get_thread', closedHeaderAbsPos);
+    const branchAContentGateAbsPos = prompt.indexOf(
       'If the bullpen message body visible in injected context is a CONSULT REPLY',
     );
+    expect(closedHeaderAbsPos).toBeGreaterThan(-1);
     expect(closedGetThreadPos).toBeGreaterThan(-1);
-    expect(branchAContentGatePos).toBeGreaterThan(-1);
-    // Closed-path fetch is in the preamble, which precedes the open-thread gate.
-    expect(preamble.length).toBeLessThan(
-      prompt.indexOf(
-        'If the bullpen message body visible in injected context is a CONSULT REPLY',
-      ),
-    );
+    expect(branchAContentGateAbsPos).toBeGreaterThan(-1);
+    expect(closedGetThreadAbsPos).toBeGreaterThan(closedHeaderAbsPos);
+    expect(branchAContentGateAbsPos).toBeGreaterThan(closedGetThreadAbsPos);
   });
 
   it('closed wake path enters full Branch A protocol (not a shortcut)', () => {

--- a/tests/unit/dispatch/bullpen-close-after-consult.test.ts
+++ b/tests/unit/dispatch/bullpen-close-after-consult.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BullpenDispatcher } from '../../../src/dispatch/bullpen-dispatcher.js';
+import { BullpenService } from '../../../src/memory/bullpen.js';
+import { createLogger } from '../../../src/logger.js';
+import { createAgentDiscuss } from '../../../src/bus/events.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+
+// Regression for #1256: calendar closes a scheduling consult with close_after;
+// ceo-inbox must be woken so Branch A can draft (not wait for consult-timeout).
+
+function makeBus() {
+  const handlers = new Map<string, ((event: unknown) => void)[]>();
+  return {
+    subscribe: vi.fn((type: string, _layer: string, handler: (event: unknown) => void) => {
+      const list = handlers.get(type) ?? [];
+      list.push(handler);
+      handlers.set(type, list);
+    }),
+    publish: vi.fn(async () => undefined),
+    _trigger: async (type: string, event: unknown) => {
+      for (const h of handlers.get(type) ?? []) await h(event);
+    },
+  };
+}
+
+const CONSULT_REPLY = [
+  'CONSULT REPLY',
+  'Result: ok',
+  'Slots:',
+  '  - Thursday June 25 at 10:30 AM ET (7:30 AM PT their time) - hold placed',
+  '  - Friday June 26 at 2:00 PM ET (11:00 AM PT their time) - hold placed',
+].join('\n');
+
+describe('bullpen close_after scheduling consult regression (#1256)', () => {
+  let bus: ReturnType<typeof makeBus>;
+  let bullpenService: BullpenService;
+
+  beforeEach(() => {
+    bus = makeBus();
+    bullpenService = BullpenService.createInMemory();
+    const dispatcher = new BullpenDispatcher(bus as unknown as EventBus, createLogger('error'), bullpenService);
+    dispatcher.register();
+  });
+
+  it('wakes ceo-inbox when calendar closes consult with Result: ok and empty mentions', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Scheduling: coffee with Alice',
+      'ceo-inbox',
+      ['ceo-inbox', 'calendar'],
+      'CONSULT REQUEST\nContext: source_message_id=msg-sched-1',
+      [],
+    );
+    await bullpenService.postMessage(thread.id, 'calendar', CONSULT_REPLY, [], true);
+
+    const event = createAgentDiscuss({
+      threadId: thread.id,
+      messageId: 'reply-1',
+      topic: 'Scheduling: coffee with Alice',
+      senderAgentId: 'calendar',
+      participants: ['ceo-inbox', 'calendar'],
+      mentionedAgentIds: [],
+      content: CONSULT_REPLY,
+      threadClosed: true,
+      parentEventId: 'calendar-task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+
+    const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task')
+      .map(([_l, e]) => e as { payload: { agentId: string; content: string; metadata: Record<string, unknown> } });
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.payload.agentId).toBe('ceo-inbox');
+    expect(tasks[0]!.payload.metadata.threadClosed).toBe(true);
+    expect(tasks[0]!.payload.content.toLowerCase()).toContain('do not reply in-thread');
+    expect(tasks[0]!.payload.content).toContain('get_thread');
+  });
+});

--- a/tests/unit/dispatch/bullpen-close-after-consult.test.ts
+++ b/tests/unit/dispatch/bullpen-close-after-consult.test.ts
@@ -42,15 +42,15 @@ describe('bullpen close_after scheduling consult regression (#1256)', () => {
     dispatcher.register();
   });
 
-  it('wakes ceo-inbox when calendar closes consult with Result: ok and empty mentions', async () => {
+  it('wakes ceo-inbox when calendar closes consult with Result: ok (handler auto-mentions opener)', async () => {
     const { thread } = await bullpenService.openThread(
       'Scheduling: coffee with Alice',
       'ceo-inbox',
-      ['ceo-inbox', 'calendar'],
+      ['calendar'],
       'CONSULT REQUEST\nContext: source_message_id=msg-sched-1',
       [],
     );
-    await bullpenService.postMessage(thread.id, 'calendar', CONSULT_REPLY, [], true);
+    await bullpenService.postMessage(thread.id, 'calendar', CONSULT_REPLY, ['ceo-inbox'], true);
 
     const event = createAgentDiscuss({
       threadId: thread.id,
@@ -58,7 +58,7 @@ describe('bullpen close_after scheduling consult regression (#1256)', () => {
       topic: 'Scheduling: coffee with Alice',
       senderAgentId: 'calendar',
       participants: ['ceo-inbox', 'calendar'],
-      mentionedAgentIds: [],
+      mentionedAgentIds: ['ceo-inbox'],
       content: CONSULT_REPLY,
       threadClosed: true,
       parentEventId: 'calendar-task-1',

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -241,6 +241,29 @@ describe('BullpenDispatcher', () => {
     expect(tasks[0]!.payload.metadata?.threadClosed).toBe(true);
   });
 
+  it('closed thread with explicit mentions: only mentioned agents get act prompt', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Multi-party close', 'coordinator', ['coordinator', 'agent-b', 'agent-c'], 'Start', [],
+    );
+    await bullpenService.postMessage(thread.id, 'agent-b', 'Done', ['coordinator'], true);
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-closed', topic: 'Multi-party close',
+      senderAgentId: 'agent-b', participants: ['coordinator', 'agent-b', 'agent-c'],
+      mentionedAgentIds: ['coordinator'], content: 'Done', threadClosed: true,
+      parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task')
+      .map(([_l, e]) => e as { payload: { agentId: string; content: string } });
+    expect(tasks).toHaveLength(2);
+    const coordTask = tasks.find(t => t.payload.agentId === 'coordinator');
+    const cTask = tasks.find(t => t.payload.agentId === 'agent-c');
+    expect(coordTask?.payload.content).toContain('act on the conclusion');
+    expect(cTask?.payload.content).toContain('FYI: Final message');
+    expect(cTask?.payload.content).not.toContain('act on the conclusion');
+  });
+
   it('sets threadClosed false on open-thread dispatch tasks', async () => {
     const { thread } = await bullpenService.openThread(
       'Open thread', 'coordinator', ['coordinator', 'agent-b'], 'Hi', ['agent-b'],

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -215,9 +215,8 @@ describe('BullpenDispatcher', () => {
     expect(tasks).toHaveLength(0);
   });
 
-  it('creates agent.task for originator when thread is closed via close_after (even with empty mentions)', async () => {
-    // A close_after reply closes the thread atomically; the concluding message must
-    // still wake other participants so consult hand-offs complete. (#1256)
+  it('creates agent.task for originator when thread is closed via close_after', async () => {
+    // Handler auto-mentions the thread opener on close_after; dispatcher acts only on mentions.
     const { thread } = await bullpenService.openThread(
       'Scheduling consult', 'ceo-inbox', ['ceo-inbox', 'calendar'], 'CONSULT REQUEST', [],
     );
@@ -225,7 +224,7 @@ describe('BullpenDispatcher', () => {
     const event = createAgentDiscuss({
       threadId: thread.id, messageId: 'msg-closed', topic: 'Scheduling consult',
       senderAgentId: 'calendar', participants: ['ceo-inbox', 'calendar'],
-      mentionedAgentIds: [], content: 'CONSULT REPLY\nResult: ok', threadClosed: true,
+      mentionedAgentIds: ['ceo-inbox'], content: 'CONSULT REPLY\nResult: ok', threadClosed: true,
       parentEventId: 'task-1',
     });
     await bus._trigger('agent.discuss', event);
@@ -239,6 +238,28 @@ describe('BullpenDispatcher', () => {
     expect(tasks[0]!.payload.content).toContain('do not reply in-thread');
     expect(tasks[0]!.payload.content).not.toContain('reply using the bullpen skill');
     expect(tasks[0]!.payload.metadata?.threadClosed).toBe(true);
+  });
+
+  it('closed thread with no mentions: non-mentioned participants get FYI only', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Closed FYI test', 'coordinator', ['coordinator', 'agent-b', 'agent-c'], 'Start', [],
+    );
+    await bullpenService.postMessage(thread.id, 'agent-b', 'Done', [], true);
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-closed', topic: 'Closed FYI test',
+      senderAgentId: 'agent-b', participants: ['coordinator', 'agent-b', 'agent-c'],
+      mentionedAgentIds: [], content: 'Done', threadClosed: true,
+      parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task')
+      .map(([_l, e]) => e as { payload: { agentId: string; content: string } });
+    expect(tasks).toHaveLength(2);
+    for (const task of tasks) {
+      expect(task.payload.content).toContain('FYI: Final message');
+      expect(task.payload.content).not.toContain('act on the conclusion');
+    }
   });
 
   it('closed thread with explicit mentions: only mentioned agents get act prompt', async () => {

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -215,21 +215,46 @@ describe('BullpenDispatcher', () => {
     expect(tasks).toHaveLength(0);
   });
 
-  it('skips task creation when the thread is closed (e.g. reply with close_after)', async () => {
-    // A close_after reply closes the thread atomically and then publishes the concluding
-    // agent.discuss; the dispatcher must not fan out reply tasks for a closed thread. (#881)
+  it('creates agent.task for originator when thread is closed via close_after (even with empty mentions)', async () => {
+    // A close_after reply closes the thread atomically; the concluding message must
+    // still wake other participants so consult hand-offs complete. (#1256)
     const { thread } = await bullpenService.openThread(
-      'Close-after dispatch test', 'coordinator', ['coordinator', 'agent-b'], 'Start', [],
+      'Scheduling consult', 'ceo-inbox', ['ceo-inbox', 'calendar'], 'CONSULT REQUEST', [],
     );
-    await bullpenService.postMessage(thread.id, 'agent-b', 'Concluding reply', [], true);
+    await bullpenService.postMessage(thread.id, 'calendar', 'CONSULT REPLY\nResult: ok\n...', [], true);
     const event = createAgentDiscuss({
-      threadId: thread.id, messageId: 'msg-closed', topic: 'Close-after dispatch test',
-      senderAgentId: 'agent-b', participants: ['coordinator', 'agent-b'],
-      mentionedAgentIds: ['coordinator'], content: 'Concluding reply', parentEventId: 'task-1',
+      threadId: thread.id, messageId: 'msg-closed', topic: 'Scheduling consult',
+      senderAgentId: 'calendar', participants: ['ceo-inbox', 'calendar'],
+      mentionedAgentIds: [], content: 'CONSULT REPLY\nResult: ok', threadClosed: true,
+      parentEventId: 'task-1',
     });
     await bus._trigger('agent.discuss', event);
     const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
-      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task');
-    expect(tasks).toHaveLength(0);
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task')
+      .map(([_l, e]) => e as { payload: { agentId: string; content: string; metadata: Record<string, unknown> } });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.payload.agentId).toBe('ceo-inbox');
+    expect(tasks[0]!.payload.content).toContain('thread is now closed');
+    expect(tasks[0]!.payload.content).toContain('get_thread');
+    expect(tasks[0]!.payload.content).toContain('do not reply in-thread');
+    expect(tasks[0]!.payload.content).not.toContain('reply using the bullpen skill');
+    expect(tasks[0]!.payload.metadata?.threadClosed).toBe(true);
+  });
+
+  it('sets threadClosed false on open-thread dispatch tasks', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Open thread', 'coordinator', ['coordinator', 'agent-b'], 'Hi', ['agent-b'],
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'Open thread',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', threadClosed: false,
+      parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const task = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([_l, e]) => (e as { type: string }).type === 'agent.task')?.[1] as
+      { payload: { metadata: Record<string, unknown> } };
+    expect(task?.payload.metadata?.threadClosed).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1256.

When a specialist (e.g. `calendar`) replied to a Bullpen consult with `close_after: true`, the concluding message was persisted and the thread closed, but **BullpenDispatcher skipped all task creation** for closed threads. The originator (`ceo-inbox`) never woke, so scheduling consults that needed a redraft sat parked until the 90-minute consult-timeout fallback drafted a blind "pending your calendar" reply — discarding slots the specialist had already found and held.

## Changes

### Primary — deliver closing messages
- **Remove** the `status === 'closed'` delivery suppression in `BullpenDispatcher`
- **Add** `threadClosed: boolean` to `AgentDiscussPayload`; populate from `close_after` in the bullpen reply handler
- **Closed-aware wake content**: instructs the agent to `get_thread`, act on the conclusion, and **not** reply in-thread
- Propagate `threadClosed` into dispatched `agent.task` metadata

### Deterministic closed-thread → Branch A routing (review follow-up)
- New **resume preamble** rule: bullpen wakes with `threadClosed: true` (or closed-content wording) call `get_thread` **before** the open-thread CONSULT REPLY content gate
- If fetched thread contains a CONSULT REPLY, enter Branch A sub-steps (full protocol — verbatim slots, `date-resolve`, no qualifier, folders, archive, timeout cancellation)
- Open-thread trigger unchanged (injected-context pattern match)

### Robust resume
- Consult-timeout fallback checks `get_thread` for late CONSULT REPLY, gated on no existing draft (avoids double-draft edge case)
- Consult-timeout `task-create` description includes `thread_id`

## Acceptance criteria

- [x] `close_after: true` reply creates `agent.task` for originator with empty mentions
- [x] Closed-thread task instructs read-and-act, not in-thread reply
- [x] `threadClosed` carried through payload → task metadata
- [x] Closed bullpen wake routes to `get_thread` before Branch A content gate (prompt + test)
- [x] Regression test: calendar `Result: ok` + `close_after` wakes `ceo-inbox`
- [x] Open-thread dispatch behavior unchanged

## Test plan

- [x] `pnpm run typecheck`
- [x] Unit tests: bullpen-dispatcher, close-after-consult regression, ceo-inbox-prompt (including closed-thread routing tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e9995ee-c0b1-4616-a2d3-6c32ab9b2f76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e9995ee-c0b1-4616-a2d3-6c32ab9b2f76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

