### PR TITLE
feat: plan completion reconciliation + auto-complete + frontier circuit breaker (#1239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Plan frontier advancement** — child terminal resolution schedules a near-term planned-parent wake; the wake recomputes `progress.plan` rollup and dispatches newly-unblocked children (BacklogHeartbeat remains the backstop). (#1238)
+- **Plan completion reconciliation** — terminal parents reconcile open descendants (cancel with reason + cancel wakes); fully-resolved plans auto-complete with the deliverable step output; planned-parent wakes trip the progress circuit breaker on frontier stalls. (#1239)
 - **`plan`** — rows-direct goal decomposition skill writing child task rows and `progress.plan`; platform plan-altitude guidance and per-turn dynamic pin for complex bound tasks. (#1237)
 - **`progress.plan`** — typed plan block with child-step descriptors, deliverable step pointer, and "X of Y" rollup helper; round-trip persistence via `getPlanBlock` / `setPlanBlock`. (#1236)
 - **Resumable circuit breaker** — stall counter and aggregate ceilings fail stuck resumable tasks instead of looping. (#1176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Plan frontier advancement** — child terminal resolution schedules a near-term planned-parent wake; the wake recomputes `progress.plan` rollup and dispatches newly-unblocked children (BacklogHeartbeat remains the backstop). (#1238)
-- **Plan completion reconciliation** — terminal parents reconcile open descendants (cancel with reason + cancel wakes); fully-resolved plans auto-complete with the deliverable step output; planned-parent wakes trip the progress circuit breaker on frontier stalls. (#1239)
+- **Plan completion reconciliation** — terminal plan parents now cancel open descendants and their pending wakes. (#1239)
+- **Plan auto-complete** — fully-resolved plans now finish automatically using the deliverable step output. (#1239)
+- **Plan frontier circuit breaker** — planned-parent wakes now escalate after repeated stalls without frontier progress. (#1239)
 - **`plan`** — rows-direct goal decomposition skill writing child task rows and `progress.plan`; platform plan-altitude guidance and per-turn dynamic pin for complex bound tasks. (#1237)
 - **`progress.plan`** — typed plan block with child-step descriptors, deliverable step pointer, and "X of Y" rollup helper; round-trip persistence via `getPlanBlock` / `setPlanBlock`. (#1236)
 - **Resumable circuit breaker** — stall counter and aggregate ceilings fail stuck resumable tasks instead of looping. (#1176)

--- a/src/agents/plan-execution.test.ts
+++ b/src/agents/plan-execution.test.ts
@@ -220,4 +220,20 @@ describe('plan completion helpers (#1239)', () => {
     ]);
     expect(resolvePlanCompletionNote(plan, children)).toBe('Kickoff plan ready');
   });
+
+  it('skips trailing empty notes when extracting child output', () => {
+    const children = new Map([
+      ['child-3', {
+        title: 'Synthesis',
+        description: null,
+        progress: {
+          notes: [
+            { at: 't1', note: 'Real output' },
+            { at: 't2', note: '   ' },
+          ],
+        },
+      }],
+    ]);
+    expect(resolvePlanCompletionNote(plan, children)).toBe('Real output');
+  });
 });

--- a/src/agents/plan-execution.test.ts
+++ b/src/agents/plan-execution.test.ts
@@ -4,10 +4,12 @@ import {
   countMaterializationKinds,
   existingTaskIdForStep,
   findRemovedChildTaskIds,
+  isPlanReadyForAutoComplete,
   parsePlanStepsInput,
   planStepDriftsFromChild,
   preflightPlanBlockWrite,
   resolveBlockedByTaskId,
+  resolvePlanCompletionNote,
   validateDeliverableStepId,
   validatePlanStepsGraph,
 } from './plan-execution.js';
@@ -174,5 +176,48 @@ describe('preflightPlanBlockWrite', () => {
     if (!result.ok) {
       expect(result.code).toBe('block_overflow');
     }
+  });
+});
+
+describe('plan completion helpers (#1239)', () => {
+  const plan: PlanProgressBlock = {
+    steps: [
+      { id: 'step-1', taskId: 'child-1' },
+      { id: 'step-2', taskId: 'child-2' },
+      { id: 'deliverable', taskId: 'child-3' },
+    ],
+    deliverableStepId: 'deliverable',
+    done: 3,
+    total: 3,
+    next: 'Done',
+  };
+
+  it('requires the deliverable child to be done before auto-complete', () => {
+    expect(isPlanReadyForAutoComplete(plan, {
+      'child-1': 'done',
+      'child-2': 'done',
+      'child-3': 'done',
+    })).toBe(true);
+    expect(isPlanReadyForAutoComplete(plan, {
+      'child-1': 'done',
+      'child-2': 'done',
+      'child-3': 'cancelled',
+    })).toBe(false);
+    expect(isPlanReadyForAutoComplete({ ...plan, done: 2 }, {
+      'child-1': 'done',
+      'child-2': 'done',
+      'child-3': 'open',
+    })).toBe(false);
+  });
+
+  it('surfaces the deliverable step output as the completion note', () => {
+    const children = new Map([
+      ['child-3', {
+        title: 'Synthesis',
+        description: null,
+        progress: { notes: [{ at: 't', note: 'Kickoff plan ready' }] },
+      }],
+    ]);
+    expect(resolvePlanCompletionNote(plan, children)).toBe('Kickoff plan ready');
   });
 });

--- a/src/agents/plan-execution.ts
+++ b/src/agents/plan-execution.ts
@@ -223,3 +223,55 @@ export function countMaterializationKinds(steps: readonly PlanStepInput[]): {
   }
   return { iterateLeaves, heterogeneousRows, lazySteps };
 }
+
+/** Extract the best available output text from a completed child task. */
+export function extractTaskOutputNote(task: {
+  title: string;
+  description: string | null;
+  progress: Record<string, unknown>;
+}): string {
+  const notes = task.progress.notes;
+  if (Array.isArray(notes) && notes.length > 0) {
+    const last = notes[notes.length - 1] as { note?: string } | null;
+    if (last?.note && last.note.trim().length > 0) return last.note.trim();
+  }
+  if (task.description && task.description.trim().length > 0) return task.description.trim();
+  return task.title;
+}
+
+/** Build the parent completion note from the deliverable step or a child-summary rollup. */
+export function resolvePlanCompletionNote(
+  plan: PlanProgressBlock,
+  children: ReadonlyMap<string, { title: string; description: string | null; progress: Record<string, unknown> }>,
+): string {
+  if (plan.deliverableStepId) {
+    const step = plan.steps.find((s) => s.id === plan.deliverableStepId);
+    const child = step?.taskId ? children.get(step.taskId) : undefined;
+    if (child) return extractTaskOutputNote(child);
+  }
+
+  const lines: string[] = [];
+  for (const step of plan.steps) {
+    if (!step.taskId) continue;
+    const child = children.get(step.taskId);
+    if (!child) continue;
+    lines.push(`${child.title}: ${extractTaskOutputNote(child)}`);
+  }
+  return lines.join('\n\n');
+}
+
+/** True when every planned child is resolved and the deliverable step (if any) is done. */
+export function isPlanReadyForAutoComplete(
+  plan: PlanProgressBlock,
+  childStatusByTaskId: Readonly<Record<string, string>>,
+): boolean {
+  if (plan.done !== plan.total || plan.total === 0) return false;
+
+  if (plan.deliverableStepId) {
+    const step = plan.steps.find((s) => s.id === plan.deliverableStepId);
+    if (!step?.taskId) return false;
+    return childStatusByTaskId[step.taskId] === 'done';
+  }
+
+  return true;
+}

--- a/src/agents/plan-execution.ts
+++ b/src/agents/plan-execution.ts
@@ -232,8 +232,10 @@ export function extractTaskOutputNote(task: {
 }): string {
   const notes = task.progress.notes;
   if (Array.isArray(notes) && notes.length > 0) {
-    const last = notes[notes.length - 1] as { note?: string } | null;
-    if (last?.note && last.note.trim().length > 0) return last.note.trim();
+    for (let i = notes.length - 1; i >= 0; i--) {
+      const entry = notes[i] as { note?: string } | null;
+      if (entry?.note && entry.note.trim().length > 0) return entry.note.trim();
+    }
   }
   if (task.description && task.description.trim().length > 0) return task.description.trim();
   return task.title;

--- a/src/agents/plan-frontier-subscriber.ts
+++ b/src/agents/plan-frontier-subscriber.ts
@@ -1,8 +1,10 @@
 // plan-frontier-subscriber.ts — child→parent wake + frontier advancement (#1238).
+// Applies the progress-based circuit breaker on planned-parent wakes (#1239).
 
 import type { Pool } from 'pg';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
+import type { ResumableCeilingsConfig } from '../config.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
 import type { TaskRepo } from '../db/task-repo.js';
 import type {
@@ -11,6 +13,7 @@ import type {
   TaskUpdatedEvent,
 } from '../bus/events.js';
 import { readPlanBlock } from '../db/plan-progress.js';
+import { handlePlanFrontierWakeForCircuitBreaker } from './resumable-circuit-breaker.js';
 import {
   advancePlanFrontier,
   handleChildTerminalResolution,
@@ -25,6 +28,7 @@ export interface PlanFrontierSubscriberOptions {
   taskRepo: TaskRepo;
   eligibleAgents: Set<string>;
   continuationDelaySeconds: number;
+  resumableCeilings: ResumableCeilingsConfig;
   fallbackAgentId?: string;
 }
 
@@ -86,7 +90,7 @@ export class PlanFrontierSubscriber {
         const parent = await this.opts.taskRepo.getTask(parentTaskId);
         if (!parent || !readPlanBlock(parent.progress)) return;
 
-        await advancePlanFrontier({
+        const result = await advancePlanFrontier({
           pool: this.opts.pool,
           taskRepo: this.opts.taskRepo,
           schedulerService: this.opts.schedulerService,
@@ -95,6 +99,19 @@ export class PlanFrontierSubscriber {
           eligibleAgents: this.opts.eligibleAgents,
           fallbackAgentId: this.opts.fallbackAgentId,
         });
+
+        if (!result || result.autoCompleted) return;
+
+        await handlePlanFrontierWakeForCircuitBreaker({
+          pool: this.opts.pool,
+          bus: this.opts.bus,
+          taskRepo: this.opts.taskRepo,
+          logger: this.opts.logger,
+          taskId: parentTaskId,
+          snapshot: result.frontierSnapshot,
+          ceilings: this.opts.resumableCeilings,
+          agentId: fired.payload.agentId,
+        });
       } catch (err) {
         this.opts.logger.error({ err, parentTaskId }, 'Plan frontier: failed to advance on parent wake');
         throw err;
@@ -102,7 +119,10 @@ export class PlanFrontierSubscriber {
     });
 
     this.opts.logger.info(
-      { continuationDelaySeconds: this.opts.continuationDelaySeconds },
+      {
+        continuationDelaySeconds: this.opts.continuationDelaySeconds,
+        resumableCeilings: this.opts.resumableCeilings,
+      },
       'PlanFrontierSubscriber started',
     );
   }

--- a/src/agents/plan-frontier.ts
+++ b/src/agents/plan-frontier.ts
@@ -16,12 +16,17 @@ import {
   type PlanProgressBlock,
 } from '../db/plan-progress.js';
 import {
+  isPlanReadyForAutoComplete,
+  resolvePlanCompletionNote,
+} from './plan-execution.js';
+import {
   resolveContinuationAgent,
   schedulePlanParentWake,
   taskHasPendingWake,
   isPlanParentWakeEligible,
   isPgUniqueViolation,
 } from './resumable-continuation.js';
+import { snapshotPlanFrontier } from './resumable-circuit-breaker.js';
 
 /** created_by marker on child dispatches from frontier advancement. */
 export const PLAN_FRONTIER_CHILD_DISPATCH_CREATED_BY = 'plan-frontier';
@@ -99,6 +104,8 @@ export interface AdvancePlanFrontierResult {
   rollup: { done: number; total: number };
   rollupUpdated: boolean;
   dispatchedChildIds: string[];
+  autoCompleted: boolean;
+  frontierSnapshot: ReturnType<typeof snapshotPlanFrontier>;
 }
 
 async function loadTasksByIds(pool: Pool, taskIds: readonly string[]): Promise<Map<string, TaskRow>> {
@@ -243,5 +250,25 @@ export async function advancePlanFrontier(
     );
   }
 
-  return { rollup, rollupUpdated, dispatchedChildIds };
+  const childStatuses = childStatusMap(children);
+  const frontierSnapshot = snapshotPlanFrontier(currentPlan.steps, childStatuses);
+
+  let autoCompleted = false;
+  if (isPlanReadyForAutoComplete(currentPlan, childStatuses)) {
+    const completionNote = resolvePlanCompletionNote(currentPlan, children);
+    const completed = await opts.taskRepo.completeTask(
+      parent.id,
+      completionNote,
+      parent.sourceAgentId ?? parent.agentId,
+    );
+    if (completed) {
+      autoCompleted = true;
+      opts.logger.info(
+        { parentTaskId: parent.id, deliverableStepId: currentPlan.deliverableStepId },
+        'Plan frontier: parent auto-completed',
+      );
+    }
+  }
+
+  return { rollup, rollupUpdated, dispatchedChildIds, autoCompleted, frontierSnapshot };
 }

--- a/src/agents/resumable-circuit-breaker.test.ts
+++ b/src/agents/resumable-circuit-breaker.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   cursorsEqual,
   hasForwardProgress,
+  hasFrontierProgress,
   processPausedSliceOutcome,
+  processPlanFrontierWakeOutcome,
   readCircuitState,
   resolveResumableCeilings,
   mergeCircuitState,
@@ -174,5 +176,58 @@ describe('resumable-circuit-breaker (#1176)', () => {
     };
     const merged = mergeCircuitState({ notes: [] }, state);
     expect(readCircuitState(merged)).toEqual(state);
+  });
+
+  describe('planned-parent frontier progress (#1239)', () => {
+    it('detects frontier progress via rollup or terminal children', () => {
+      expect(hasFrontierProgress(
+        { rollupDone: 1, terminalChildCount: 1 },
+        { rollupDone: 2, terminalChildCount: 1 },
+      )).toBe(true);
+      expect(hasFrontierProgress(
+        { rollupDone: 2, terminalChildCount: 2 },
+        { rollupDone: 2, terminalChildCount: 3 },
+      )).toBe(true);
+      expect(hasFrontierProgress(
+        { rollupDone: 2, terminalChildCount: 3 },
+        { rollupDone: 2, terminalChildCount: 3 },
+      )).toBe(false);
+    });
+
+    it('breaches after K parent wakes with no frontier progress', () => {
+      const circuit = {
+        stallCount: 2,
+        iterationCount: 5,
+        startedAt: '2026-06-01T00:00:00.000Z',
+        totalCostUsd: 0,
+        lastProgress: { done: 1, cursor: { terminalChildren: 1 } },
+      };
+      const result = processPlanFrontierWakeOutcome({
+        snapshot: { rollupDone: 1, terminalChildCount: 1 },
+        circuit,
+        ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 3 },
+        now: new Date('2026-06-01T01:00:00.000Z'),
+      });
+      expect(result.action).toBe('breach');
+      if (result.action === 'breach') expect(result.breach.reason).toBe('stall_limit');
+    });
+
+    it('resets stall counter when the frontier advances', () => {
+      const circuit = {
+        stallCount: 2,
+        iterationCount: 5,
+        startedAt: '2026-06-01T00:00:00.000Z',
+        totalCostUsd: 0,
+        lastProgress: { done: 1, cursor: { terminalChildren: 1 } },
+      };
+      const result = processPlanFrontierWakeOutcome({
+        snapshot: { rollupDone: 2, terminalChildCount: 2 },
+        circuit,
+        ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 3 },
+        now: new Date('2026-06-01T01:00:00.000Z'),
+      });
+      expect(result.action).toBe('continue');
+      if (result.action === 'continue') expect(result.state.stallCount).toBe(0);
+    });
   });
 });

--- a/src/agents/resumable-circuit-breaker.ts
+++ b/src/agents/resumable-circuit-breaker.ts
@@ -480,6 +480,13 @@ export async function handlePlanFrontierWakeForCircuitBreaker(opts: {
     opts.logger.warn({ taskId: opts.taskId }, 'Plan frontier circuit breaker: task not found');
     return { continueParent: false };
   }
+  if (task.status === 'done' || task.status === 'cancelled' || task.status === 'failed') {
+    opts.logger.debug(
+      { taskId: opts.taskId, status: task.status },
+      'Plan frontier circuit breaker: task already terminal',
+    );
+    return { continueParent: false };
+  }
 
   const ceilings = resolveResumableCeilings(opts.ceilings, task.errorBudget);
   const circuit = readCircuitState(task.progress);

--- a/src/agents/resumable-circuit-breaker.ts
+++ b/src/agents/resumable-circuit-breaker.ts
@@ -13,6 +13,7 @@ import type { TaskRow } from '../db/queries/tasks.js';
 import { getTaskById } from '../db/queries/tasks.js';
 import type { TaskRepo } from '../db/task-repo.js';
 import type { ResumableCursor } from '../db/resumable-progress.js';
+import { computePlanRollup, type PlanStepDescriptor } from '../db/plan-progress.js';
 import { createAgentTask } from '../bus/events.js';
 import type { ExecutionPausedPayload } from './resumable-task.js';
 
@@ -353,4 +354,159 @@ export async function handlePausedSliceForCircuitBreaker(opts: {
 
   await opts.taskRepo.persistResumableCircuitState(opts.taskId, outcome.state);
   return { scheduleContinuation: true };
+}
+
+/** Snapshot of planned-parent frontier progress for the circuit breaker (#1239). */
+export interface PlanFrontierSnapshot {
+  rollupDone: number;
+  /** Children in done / cancelled / failed — terminal since last wake. */
+  terminalChildCount: number;
+}
+
+const PLAN_FRONTIER_TERMINAL_CHILD_STATUSES = new Set(['done', 'cancelled', 'failed']);
+
+/** Build a frontier snapshot from live child rows. */
+export function snapshotPlanFrontier(
+  steps: readonly PlanStepDescriptor[],
+  childStatusByTaskId: Readonly<Record<string, string>>,
+): PlanFrontierSnapshot {
+  let terminalChildCount = 0;
+  for (const step of steps) {
+    if (!step.taskId) continue;
+    const status = childStatusByTaskId[step.taskId];
+    if (status !== undefined && PLAN_FRONTIER_TERMINAL_CHILD_STATUSES.has(status)) {
+      terminalChildCount++;
+    }
+  }
+  const { done: rollupDone } = computePlanRollup(steps, childStatusByTaskId);
+  return { rollupDone, terminalChildCount };
+}
+
+/** True when rollup advanced or a child reached a terminal status since the last wake. */
+export function hasFrontierProgress(
+  previous: PlanFrontierSnapshot,
+  next: PlanFrontierSnapshot,
+): boolean {
+  if (next.rollupDone > previous.rollupDone) return true;
+  return next.terminalChildCount > previous.terminalChildCount;
+}
+
+function snapshotToLastProgress(snapshot: PlanFrontierSnapshot): ResumableCircuitState['lastProgress'] {
+  return {
+    done: snapshot.rollupDone,
+    cursor: { terminalChildren: snapshot.terminalChildCount },
+  };
+}
+
+export interface ProcessPlanFrontierWakeInput {
+  snapshot: PlanFrontierSnapshot;
+  circuit: ResumableCircuitState | null;
+  ceilings: ResumableCeilingsConfig;
+  sliceCostUsd?: number;
+  now?: Date;
+}
+
+/**
+ * Process a planned-parent wake: update counters, detect frontier stalls/ceilings.
+ * Does not persist — caller writes state or fails the task.
+ */
+export function processPlanFrontierWakeOutcome(
+  input: ProcessPlanFrontierWakeInput,
+): ProcessPausedSliceResult {
+  const now = input.now ?? new Date();
+  const nextProgress = snapshotToLastProgress(input.snapshot);
+  const rawSliceCost = input.sliceCostUsd ?? 0;
+  const sliceCostUsd = Number.isFinite(rawSliceCost) && rawSliceCost >= 0 ? rawSliceCost : 0;
+
+  const base: ResumableCircuitState = input.circuit ?? {
+    stallCount: 0,
+    iterationCount: 0,
+    startedAt: now.toISOString(),
+    totalCostUsd: 0,
+    lastProgress: nextProgress,
+  };
+
+  const madeProgress = input.circuit
+    ? hasFrontierProgress(
+      {
+        rollupDone: input.circuit.lastProgress.done,
+        terminalChildCount: typeof input.circuit.lastProgress.cursor === 'object'
+          && input.circuit.lastProgress.cursor !== null
+          && 'terminalChildren' in input.circuit.lastProgress.cursor
+          ? Number((input.circuit.lastProgress.cursor as { terminalChildren: number }).terminalChildren)
+          : 0,
+      },
+      input.snapshot,
+    )
+    : true;
+
+  const state: ResumableCircuitState = {
+    ...base,
+    iterationCount: base.iterationCount + 1,
+    totalCostUsd: base.totalCostUsd + Math.max(0, sliceCostUsd),
+    lastProgress: nextProgress,
+    stallCount: madeProgress ? 0 : base.stallCount + 1,
+  };
+
+  const reason = detectBreach(state, input.ceilings, now);
+  if (reason) {
+    return {
+      action: 'breach',
+      breach: {
+        reason,
+        message: breachMessage(reason, state, input.ceilings),
+        state,
+      },
+    };
+  }
+
+  return { action: 'continue', state };
+}
+
+/** Load task, process frontier wake, persist state or escalate. Returns whether the parent may continue. */
+export async function handlePlanFrontierWakeForCircuitBreaker(opts: {
+  pool: Pool;
+  bus: EventBus;
+  taskRepo: TaskRepo;
+  logger: Logger;
+  taskId: string;
+  snapshot: PlanFrontierSnapshot;
+  ceilings: ResumableCeilingsConfig;
+  agentId: string;
+  sliceCostUsd?: number;
+}): Promise<{ continueParent: boolean; breach?: CircuitBreach }> {
+  const task = await getTaskById(opts.pool, opts.taskId);
+  if (!task) {
+    opts.logger.warn({ taskId: opts.taskId }, 'Plan frontier circuit breaker: task not found');
+    return { continueParent: false };
+  }
+
+  const ceilings = resolveResumableCeilings(opts.ceilings, task.errorBudget);
+  const circuit = readCircuitState(task.progress);
+  const outcome = processPlanFrontierWakeOutcome({
+    snapshot: opts.snapshot,
+    circuit,
+    ceilings,
+    sliceCostUsd: opts.sliceCostUsd,
+  });
+
+  if (outcome.action === 'breach') {
+    opts.logger.warn(
+      { taskId: opts.taskId, reason: outcome.breach.reason, state: outcome.breach.state },
+      'Planned-parent frontier circuit breaker tripped',
+    );
+    await escalateCircuitBreach({
+      pool: opts.pool,
+      bus: opts.bus,
+      taskRepo: opts.taskRepo,
+      logger: opts.logger,
+      task,
+      breach: outcome.breach,
+      agentId: opts.agentId,
+    });
+    return { continueParent: false, breach: outcome.breach };
+  }
+
+  await opts.taskRepo.persistResumableCircuitState(opts.taskId, outcome.state);
+  return { continueParent: true };
 }

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -103,6 +103,13 @@ const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
 /** Active child statuses reconciled when a parent reaches a terminal state (#1239). */
 const RECONCILABLE_CHILD_STATUSES = ['open', 'in_progress', 'waiting', 'blocked'];
 
+type DbQueryable = Pick<Pool, 'query'>;
+
+interface ReconciledChildRow {
+  id: string;
+  previous_status: string;
+}
+
 export class TaskRepo {
   constructor(
     private readonly pool: Pool,
@@ -426,17 +433,19 @@ export class TaskRepo {
     const cancelOnTerminal = (updates.status === 'cancelled' || updates.status === 'done')
       && !updates.wakeAt;
 
-    let updatedRow: DbTaskRow;
+    const transitioningToTerminal = updates.status !== undefined
+      && updates.status !== current.status
+      && (updates.status === 'done' || updates.status === 'cancelled');
 
-    if (updates.wakeAt || cancelOnTerminal) {
-      // Atomic CTE: update task + cancel old wake-up jobs + optionally insert new one.
-      const wakeAgentIdx = whereIdx + 1;
-      const wakeRunAtIdx = updates.wakeAt ? whereIdx + 2 : null;
-      const wakeCreatedByIdx = updates.wakeAt ? whereIdx + 3 : null;
-      const wakeTzIdx = updates.wakeAt ? whereIdx + 4 : null;
-      const wakeOriginatorIdx = updates.wakeAt ? whereIdx + 5 : null;
+    const executeUpdate = async (executor: DbQueryable): Promise<DbTaskRow | null> => {
+      if (updates.wakeAt || cancelOnTerminal) {
+        const wakeAgentIdx = whereIdx + 1;
+        const wakeRunAtIdx = updates.wakeAt ? whereIdx + 2 : null;
+        const wakeCreatedByIdx = updates.wakeAt ? whereIdx + 3 : null;
+        const wakeTzIdx = updates.wakeAt ? whereIdx + 4 : null;
+        const wakeOriginatorIdx = updates.wakeAt ? whereIdx + 5 : null;
 
-      const cteSql = `
+        const cteSql = `
         WITH updated_task AS (
           ${updateSql}
         ),
@@ -451,36 +460,55 @@ export class TaskRepo {
         )` : ''}
         SELECT * FROM updated_task
       `;
-      const allParams: unknown[] = [...updateParams];
-      if (updates.wakeAt) {
-        allParams.push(
-          // Route the new wake-up job to the correct specialist, in priority order:
-          // 1. source_agent_id — explicit specialist set at task-create time
-          // 2. tasks.agent_id  — stable task ownership (covers legacy/manual tasks where
-          //                      source_agent_id is NULL but agent_id names a specialist)
-          // 3. callerAgentId   — last resort; avoids routing to coordinator when the
-          //                      task has no agent assignment at all
-          current.sourceAgentId ?? current.agentId ?? callerAgentId, // $wakeAgentIdx
-          updates.wakeAt,                                             // $wakeRunAtIdx
-          callerAgentId ?? current.agentId,                          // $wakeCreatedByIdx
-          this.timezone,                                             // $wakeTzIdx
-          // Carry the task's (immutable) lineage onto the new wake job so a self-deferral keeps its
-          // originator at fire time — no `standing` envelope, so fireJob mints no wakeContext and the
-          // bypass ladder never runs (a pre-chosen wake_at is pre-authorized, like scheduler-create) (#1153).
-          current.originator ? JSON.stringify(current.originator) : null, // $wakeOriginatorIdx
+        const allParams: unknown[] = [...updateParams];
+        if (updates.wakeAt) {
+          allParams.push(
+            current.sourceAgentId ?? current.agentId ?? callerAgentId,
+            updates.wakeAt,
+            callerAgentId ?? current.agentId,
+            this.timezone,
+            current.originator ? JSON.stringify(current.originator) : null,
+          );
+        }
+        const { rows } = await executor.query(cteSql, allParams);
+        return (rows[0] as DbTaskRow | undefined) ?? null;
+      }
+
+      const { rows } = await executor.query(updateSql, updateParams);
+      return (rows[0] as DbTaskRow | undefined) ?? null;
+    };
+
+    let updatedRow: DbTaskRow;
+    let reconciledChildren: ReconciledChildRow[] = [];
+
+    if (transitioningToTerminal) {
+      const client = await this.pool.connect();
+      try {
+        await client.query('BEGIN');
+        const row = await executeUpdate(client);
+        if (!row) {
+          await client.query('ROLLBACK');
+          return await this.resolveEmptyUpdateReturning(taskId);
+        }
+        reconciledChildren = await this.runReconcileChildrenQuery(
+          client,
+          taskId,
+          `reconciled: parent ${taskId} ${updates.status}`,
         );
+        await client.query('COMMIT');
+        updatedRow = row;
+      } catch (err) {
+        await client.query('ROLLBACK');
+        throw err;
+      } finally {
+        client.release();
       }
-      const { rows } = await this.pool.query(cteSql, allParams);
-      if (!rows[0]) {
-        return await this.resolveEmptyUpdateReturning(taskId);
-      }
-      updatedRow = rows[0] as DbTaskRow;
     } else {
-      const { rows } = await this.pool.query(updateSql, updateParams);
-      if (!rows[0]) {
+      const row = await executeUpdate(this.pool);
+      if (!row) {
         return await this.resolveEmptyUpdateReturning(taskId);
       }
-      updatedRow = rows[0] as DbTaskRow;
+      updatedRow = row;
     }
 
     const updated = mapTaskRow(updatedRow);
@@ -499,16 +527,9 @@ export class TaskRepo {
       this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after updateTask');
     }
 
-    if (
-      updates.status !== undefined
-      && updates.status !== current.status
-      && (updates.status === 'done' || updates.status === 'cancelled')
-    ) {
-      await this.reconcileChildrenOnParentTerminal(
-        updated.id,
-        updates.status,
-        callerAgentId,
-      );
+    if (reconciledChildren.length > 0) {
+      const reason = `reconciled: parent ${taskId} ${updates.status}`;
+      await this.publishReconcileChildEvents(reconciledChildren, reason, callerAgentId, taskId);
     }
 
     this.logger.info(
@@ -596,12 +617,28 @@ export class TaskRepo {
       ? [JSON.stringify([noteEntry]), taskId]
       : [taskId];
 
-    const { rows } = await this.pool.query(cteSql, queryParams);
-    const row = rows[0] as DbTaskRow | undefined;
-    if (!row) {
-      // Task existed at pre-check time and was not terminal — if RETURNING is empty,
-      // the row was either deleted or moved to a terminal state concurrently.
-      return await this.resolveEmptyUpdateReturning(taskId);
+    const client = await this.pool.connect();
+    let row: DbTaskRow | undefined;
+    let reconciledChildren: ReconciledChildRow[] = [];
+    try {
+      await client.query('BEGIN');
+      const { rows } = await client.query(cteSql, queryParams);
+      row = rows[0] as DbTaskRow | undefined;
+      if (!row) {
+        await client.query('ROLLBACK');
+        return await this.resolveEmptyUpdateReturning(taskId);
+      }
+      reconciledChildren = await this.runReconcileChildrenQuery(
+        client,
+        taskId,
+        `reconciled: parent ${taskId} done`,
+      );
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
     }
 
     const updated = mapTaskRow(row);
@@ -616,24 +653,27 @@ export class TaskRepo {
       this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after completeTask');
     }
 
-    await this.reconcileChildrenOnParentTerminal(taskId, 'done', callerAgentId);
+    if (reconciledChildren.length > 0) {
+      await this.publishReconcileChildEvents(
+        reconciledChildren,
+        `reconciled: parent ${taskId} done`,
+        callerAgentId,
+        taskId,
+      );
+    }
 
     this.logger.info({ taskId: updated.id }, 'task-repo: completed task');
     return updated;
   }
 
-  /**
-   * Recursively cancel non-terminal descendant tasks and their pending wakes when a
-   * parent goal completes, is cancelled, or is superseded (#1239).
-   */
-  async reconcileChildren(
+  private async runReconcileChildrenQuery(
+    executor: DbQueryable,
     taskId: string,
     reason: string,
-    callerAgentId?: string,
-  ): Promise<string[]> {
+  ): Promise<ReconciledChildRow[]> {
     const noteEntry = { at: new Date().toISOString(), note: reason };
 
-    const { rows } = await this.pool.query<{ id: string; previous_status: string }>(
+    const { rows } = await executor.query<ReconciledChildRow>(
       `WITH RECURSIVE descendants AS (
          SELECT id, status FROM tasks WHERE parent_task_id = $1
          UNION ALL
@@ -655,6 +695,7 @@ export class TaskRepo {
                 ),
                 updated_at = now()
           WHERE id IN (SELECT id FROM to_reconcile)
+            AND status = ANY($2::text[])
           RETURNING id
        ),
        _cancel_wakes AS (
@@ -668,6 +709,15 @@ export class TaskRepo {
       [taskId, RECONCILABLE_CHILD_STATUSES, JSON.stringify([noteEntry])],
     );
 
+    return rows;
+  }
+
+  private async publishReconcileChildEvents(
+    rows: readonly ReconciledChildRow[],
+    reason: string,
+    callerAgentId: string | undefined,
+    parentTaskId: string,
+  ): Promise<void> {
     for (const row of rows) {
       try {
         await this.bus.publish('execution', createTaskUpdated({
@@ -684,24 +734,24 @@ export class TaskRepo {
 
     if (rows.length > 0) {
       this.logger.info(
-        { parentTaskId: taskId, cancelledChildIds: rows.map((r) => r.id), reason },
+        { parentTaskId, cancelledChildIds: rows.map((r) => r.id), reason },
         'task-repo: reconciled open descendant children',
       );
     }
-
-    return rows.map((r) => r.id);
   }
 
-  private async reconcileChildrenOnParentTerminal(
+  /**
+   * Recursively cancel non-terminal descendant tasks and their pending wakes when a
+   * parent goal completes, is cancelled, or is superseded (#1239).
+   */
+  async reconcileChildren(
     taskId: string,
-    parentState: 'done' | 'cancelled',
+    reason: string,
     callerAgentId?: string,
-  ): Promise<void> {
-    await this.reconcileChildren(
-      taskId,
-      `reconciled: parent ${taskId} ${parentState}`,
-      callerAgentId,
-    );
+  ): Promise<string[]> {
+    const rows = await this.runReconcileChildrenQuery(this.pool, taskId, reason);
+    await this.publishReconcileChildEvents(rows, reason, callerAgentId, taskId);
+    return rows.map((r) => r.id);
   }
 
   /**

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -100,6 +100,9 @@ export interface TaskListRow extends TaskRow {
 // Terminal statuses: no transitions out of these.
 const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
 
+/** Active child statuses reconciled when a parent reaches a terminal state (#1239). */
+const RECONCILABLE_CHILD_STATUSES = ['open', 'in_progress', 'waiting', 'blocked'];
+
 export class TaskRepo {
   constructor(
     private readonly pool: Pool,
@@ -496,6 +499,18 @@ export class TaskRepo {
       this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after updateTask');
     }
 
+    if (
+      updates.status !== undefined
+      && updates.status !== current.status
+      && (updates.status === 'done' || updates.status === 'cancelled')
+    ) {
+      await this.reconcileChildrenOnParentTerminal(
+        updated.id,
+        updates.status,
+        callerAgentId,
+      );
+    }
+
     this.logger.info(
       { taskId: updated.id, previousStatus: current.status, newStatus: updated.status },
       'task-repo: updated task',
@@ -601,8 +616,92 @@ export class TaskRepo {
       this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after completeTask');
     }
 
+    await this.reconcileChildrenOnParentTerminal(taskId, 'done', callerAgentId);
+
     this.logger.info({ taskId: updated.id }, 'task-repo: completed task');
     return updated;
+  }
+
+  /**
+   * Recursively cancel non-terminal descendant tasks and their pending wakes when a
+   * parent goal completes, is cancelled, or is superseded (#1239).
+   */
+  async reconcileChildren(
+    taskId: string,
+    reason: string,
+    callerAgentId?: string,
+  ): Promise<string[]> {
+    const noteEntry = { at: new Date().toISOString(), note: reason };
+
+    const { rows } = await this.pool.query<{ id: string; previous_status: string }>(
+      `WITH RECURSIVE descendants AS (
+         SELECT id, status FROM tasks WHERE parent_task_id = $1
+         UNION ALL
+         SELECT t.id, t.status FROM tasks t
+         INNER JOIN descendants d ON t.parent_task_id = d.id
+       ),
+       to_reconcile AS (
+         SELECT id, status AS previous_status FROM descendants
+         WHERE status = ANY($2::text[])
+       ),
+       cancelled AS (
+         UPDATE tasks
+            SET status = 'cancelled',
+                progress = jsonb_set(
+                  COALESCE(progress, '{}'::jsonb),
+                  '{notes}',
+                  COALESCE(progress->'notes', '[]'::jsonb) || $3::jsonb,
+                  true
+                ),
+                updated_at = now()
+          WHERE id IN (SELECT id FROM to_reconcile)
+          RETURNING id
+       ),
+       _cancel_wakes AS (
+         UPDATE scheduled_jobs SET status = 'cancelled'
+          WHERE task_id IN (SELECT id FROM to_reconcile)
+            AND status IN ('pending', 'running')
+       )
+       SELECT c.id, tr.previous_status
+         FROM cancelled c
+         JOIN to_reconcile tr ON tr.id = c.id`,
+      [taskId, RECONCILABLE_CHILD_STATUSES, JSON.stringify([noteEntry])],
+    );
+
+    for (const row of rows) {
+      try {
+        await this.bus.publish('execution', createTaskUpdated({
+          taskId: row.id,
+          previousStatus: row.previous_status,
+          newStatus: 'cancelled',
+          progressNote: reason,
+          agentId: callerAgentId ?? null,
+        }));
+      } catch (busErr) {
+        this.logger.error({ busErr, taskId: row.id }, 'task-repo: bus publish failed after reconcileChildren');
+      }
+    }
+
+    if (rows.length > 0) {
+      this.logger.info(
+        { parentTaskId: taskId, cancelledChildIds: rows.map((r) => r.id), reason },
+        'task-repo: reconciled open descendant children',
+      );
+    }
+
+    return rows.map((r) => r.id);
+  }
+
+  private async reconcileChildrenOnParentTerminal(
+    taskId: string,
+    parentState: 'done' | 'cancelled',
+    callerAgentId?: string,
+  ): Promise<void> {
+    await this.reconcileChildren(
+      taskId,
+      `reconciled: parent ${taskId} ${parentState}`,
+      callerAgentId,
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2040,6 +2040,7 @@ async function main(): Promise<void> {
     taskRepo,
     eligibleAgents: taskManagementAgents,
     continuationDelaySeconds: tasksConfig.resumableContinuationSeconds,
+    resumableCeilings: tasksConfig.resumableCeilings,
   });
   planFrontierSubscriber.start();
 

--- a/tests/integration/plan-completion-reconciliation.test.ts
+++ b/tests/integration/plan-completion-reconciliation.test.ts
@@ -1,0 +1,311 @@
+// plan-completion-reconciliation.test.ts — completion reconciliation + frontier circuit breaker (#1239).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { EventBus } from '../../src/bus/bus.js';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+import { PlanFrontierSubscriber } from '../../src/agents/plan-frontier-subscriber.js';
+import { createScheduleFired } from '../../src/bus/events.js';
+import { DEFAULT_RESUMABLE_CEILINGS } from '../../src/config.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'PlanReconcile Test';
+const logger = pino({ level: 'silent' });
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  const titleLike = `${PREFIX}%`;
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [titleLike],
+  );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [titleLike]);
+}
+
+describeIf('Plan completion reconciliation (#1239)', () => {
+  let pool: pg.Pool;
+  let bus: EventBus;
+  let repo: TaskRepo;
+  let schedulerService: SchedulerService;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+  });
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    bus = new EventBus(logger as never);
+    repo = new TaskRepo(pool, bus, logger as never, 'UTC');
+    schedulerService = new SchedulerService(pool, bus, logger as never, 'UTC');
+  });
+
+  it('reconcile-on-done leaves no open descendant children', async () => {
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} parent reconcile`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+    });
+    const child = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} orphan child`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    const grandchild = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} orphan grandchild`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: child.id,
+    });
+
+    await schedulerService.enqueueTaskWake({
+      taskId: child.id,
+      agentId: 'coordinator',
+      runAt: new Date(Date.now() + 60_000),
+      createdBy: 'test',
+    });
+    await schedulerService.enqueueTaskWake({
+      taskId: grandchild.id,
+      agentId: 'coordinator',
+      runAt: new Date(Date.now() + 60_000),
+      createdBy: 'test',
+    });
+
+    await repo.completeTask(parent.id, 'Parent finished early', 'coordinator');
+
+    const reloadedChild = await repo.getTask(child.id);
+    const reloadedGrandchild = await repo.getTask(grandchild.id);
+    expect(reloadedChild?.status).toBe('cancelled');
+    expect(reloadedGrandchild?.status).toBe('cancelled');
+
+    const openChildren = await pool.query<{ count: string }>(
+      `WITH RECURSIVE descendants AS (
+         SELECT id, status FROM tasks WHERE parent_task_id = $1
+         UNION ALL
+         SELECT t.id, t.status FROM tasks t
+         INNER JOIN descendants d ON t.parent_task_id = d.id
+       )
+       SELECT COUNT(*)::text AS count FROM descendants WHERE status NOT IN ('done', 'cancelled', 'failed')`,
+      [parent.id],
+    );
+    expect(openChildren.rows[0]!.count).toBe('0');
+
+    const pendingWakes = await pool.query(
+      `SELECT id FROM scheduled_jobs
+        WHERE task_id = ANY($1::uuid[]) AND status IN ('pending', 'running')`,
+      [[child.id, grandchild.id]],
+    );
+    expect(pendingWakes.rows).toHaveLength(0);
+  });
+
+  it('auto-completes the parent when all children and the deliverable step are done', async () => {
+    const subscriber = new PlanFrontierSubscriber({
+      pool,
+      bus,
+      logger: logger as never,
+      schedulerService,
+      taskRepo: repo,
+      eligibleAgents: new Set(['coordinator']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+    subscriber.start();
+
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} auto-complete parent`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+    });
+    const child1 = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} auto child 1`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    const child2 = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} auto child 2 deliverable`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    await repo.updateTask(child2.id, { progressNote: 'Deliverable synthesis output' }, 'coordinator');
+    await repo.updateTask(child1.id, { status: 'done' }, 'coordinator');
+    await repo.updateTask(child2.id, { status: 'done' }, 'coordinator');
+
+    await repo.setPlanBlock(parent.id, {
+      steps: [
+        { id: 'step-1', taskId: child1.id },
+        { id: 'step-2', taskId: child2.id },
+      ],
+      deliverableStepId: 'step-2',
+      done: 2,
+      total: 2,
+      next: 'Done',
+    }, 'coordinator');
+
+    const parentWake = await schedulerService.enqueueTaskWake({
+      taskId: parent.id,
+      agentId: 'coordinator',
+      runAt: new Date(),
+      createdBy: 'test',
+    });
+
+    await bus.publish('system', createScheduleFired({
+      jobId: parentWake.jobId,
+      agentId: 'coordinator',
+      agentTaskId: parent.id,
+      parentEventId: 'auto-complete-wake',
+    }));
+
+    const reloadedParent = await repo.getTask(parent.id);
+    expect(reloadedParent?.status).toBe('done');
+    const notes = reloadedParent?.progress.notes as Array<{ note: string }> | undefined;
+    expect(notes?.some((n) => n.note === 'Deliverable synthesis output')).toBe(true);
+  });
+
+  it('escalates a planned parent that wakes with no frontier progress', async () => {
+    const ceilings = { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 2 };
+    const subscriber = new PlanFrontierSubscriber({
+      pool,
+      bus,
+      logger: logger as never,
+      schedulerService,
+      taskRepo: repo,
+      eligibleAgents: new Set(['coordinator']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: ceilings,
+    });
+    subscriber.start();
+
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} stalled parent`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+    });
+    const child = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} stalled child`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    await repo.setPlanBlock(parent.id, {
+      steps: [{ id: 'only', taskId: child.id }],
+      deliverableStepId: 'only',
+      done: 0,
+      total: 1,
+      next: 'Waiting on child',
+    }, 'coordinator');
+
+    await repo.persistResumableCircuitState(parent.id, {
+      stallCount: 1,
+      iterationCount: 3,
+      startedAt: new Date().toISOString(),
+      totalCostUsd: 0,
+      lastProgress: { done: 0, cursor: { terminalChildren: 0 } },
+    });
+
+    const parentWake = await schedulerService.enqueueTaskWake({
+      taskId: parent.id,
+      agentId: 'coordinator',
+      runAt: new Date(),
+      createdBy: 'test',
+    });
+
+    await bus.publish('system', createScheduleFired({
+      jobId: parentWake.jobId,
+      agentId: 'coordinator',
+      agentTaskId: parent.id,
+      parentEventId: 'stalled-wake',
+    }));
+
+    const reloaded = await repo.getTask(parent.id);
+    expect(reloaded?.status).toBe('failed');
+    expect(reloaded?.tags).toContain('needs-attention');
+  });
+
+  it('does not trip the breaker when the frontier advances between wakes', async () => {
+    const ceilings = { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 2 };
+
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} healthy parent`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+    });
+    const child1 = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} healthy child 1`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    const child2 = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} healthy child 2`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+      blockedByTaskId: child1.id,
+    });
+    await repo.setPlanBlock(parent.id, {
+      steps: [
+        { id: 'first', taskId: child1.id },
+        { id: 'second', taskId: child2.id },
+      ],
+      deliverableStepId: 'second',
+      done: 0,
+      total: 2,
+      next: 'Run first',
+    }, 'coordinator');
+
+    const subscriber = new PlanFrontierSubscriber({
+      pool,
+      bus,
+      logger: logger as never,
+      schedulerService,
+      taskRepo: repo,
+      eligibleAgents: new Set(['coordinator']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: ceilings,
+    });
+    subscriber.start();
+
+    await repo.updateTask(child1.id, { status: 'done' }, 'coordinator');
+
+    const parentWakes = await pool.query<{ id: string }>(
+      `SELECT id FROM scheduled_jobs WHERE task_id = $1 AND status = 'pending'`,
+      [parent.id],
+    );
+    expect(parentWakes.rows).toHaveLength(1);
+
+    await bus.publish('system', createScheduleFired({
+      jobId: parentWakes.rows[0]!.id,
+      agentId: 'coordinator',
+      agentTaskId: parent.id,
+      parentEventId: 'healthy-wake',
+    }));
+
+    const reloaded = await repo.getTask(parent.id);
+    expect(reloaded?.status).not.toBe('failed');
+    expect(reloaded?.progress.resumableCircuit).toBeDefined();
+    const circuit = reloaded?.progress.resumableCircuit as { stallCount: number };
+    expect(circuit.stallCount).toBe(0);
+  });
+});

--- a/tests/integration/plan-completion-reconciliation.test.ts
+++ b/tests/integration/plan-completion-reconciliation.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import pg from 'pg';
 import pino from 'pino';
 import { EventBus } from '../../src/bus/bus.js';
+import type { Logger } from '../../src/logger.js';
 import { TaskRepo } from '../../src/db/task-repo.js';
 import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
 import { PlanFrontierSubscriber } from '../../src/agents/plan-frontier-subscriber.js';
@@ -15,7 +16,7 @@ const DATABASE_URL = process.env.DATABASE_URL;
 const describeIf = DATABASE_URL ? describe : describe.skip;
 
 const PREFIX = 'PlanReconcile Test';
-const logger = pino({ level: 'silent' });
+const logger: Logger = pino({ level: 'silent' });
 
 async function cleanup(pool: pg.Pool): Promise<void> {
   const titleLike = `${PREFIX}%`;
@@ -43,9 +44,9 @@ describeIf('Plan completion reconciliation (#1239)', () => {
 
   beforeEach(async () => {
     await cleanup(pool);
-    bus = new EventBus(logger as never);
-    repo = new TaskRepo(pool, bus, logger as never, 'UTC');
-    schedulerService = new SchedulerService(pool, bus, logger as never, 'UTC');
+    bus = new EventBus(logger);
+    repo = new TaskRepo(pool, bus, logger, 'UTC');
+    schedulerService = new SchedulerService(pool, bus, logger, 'UTC');
   });
 
   it('reconcile-on-done leaves no open descendant children', async () => {
@@ -114,7 +115,7 @@ describeIf('Plan completion reconciliation (#1239)', () => {
     const subscriber = new PlanFrontierSubscriber({
       pool,
       bus,
-      logger: logger as never,
+      logger,
       schedulerService,
       taskRepo: repo,
       eligibleAgents: new Set(['coordinator']),
@@ -183,7 +184,7 @@ describeIf('Plan completion reconciliation (#1239)', () => {
     const subscriber = new PlanFrontierSubscriber({
       pool,
       bus,
-      logger: logger as never,
+      logger,
       schedulerService,
       taskRepo: repo,
       eligibleAgents: new Set(['coordinator']),
@@ -278,7 +279,7 @@ describeIf('Plan completion reconciliation (#1239)', () => {
     const subscriber = new PlanFrontierSubscriber({
       pool,
       bus,
-      logger: logger as never,
+      logger,
       schedulerService,
       taskRepo: repo,
       eligibleAgents: new Set(['coordinator']),

--- a/tests/integration/plan-frontier.test.ts
+++ b/tests/integration/plan-frontier.test.ts
@@ -9,6 +9,7 @@ import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
 import { PlanFrontierSubscriber } from '../../src/agents/plan-frontier-subscriber.js';
 import { createScheduleFired } from '../../src/bus/events.js';
 import { RESUMABLE_CONTINUATION_CREATED_BY } from '../../src/agents/resumable-continuation.js';
+import { DEFAULT_RESUMABLE_CEILINGS } from '../../src/config.js';
 import { PLAN_FRONTIER_CHILD_DISPATCH_CREATED_BY } from '../../src/agents/plan-frontier.js';
 
 const { Pool } = pg;
@@ -58,6 +59,7 @@ describeIf('Plan frontier advancement (#1238)', () => {
       taskRepo: repo,
       eligibleAgents: new Set(['coordinator']),
       continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
     });
     subscriber.start();
 
@@ -155,6 +157,7 @@ describeIf('Plan frontier advancement (#1238)', () => {
       taskRepo: repo,
       eligibleAgents: new Set(['coordinator']),
       continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
     });
     subscriber.start();
 

--- a/tests/unit/agents/plan-frontier-subscriber.test.ts
+++ b/tests/unit/agents/plan-frontier-subscriber.test.ts
@@ -120,7 +120,10 @@ describe('PlanFrontierSubscriber', () => {
     expect(advanceSpy).toHaveBeenCalledWith(expect.objectContaining({
       parentTaskId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
     }));
-    expect(breakerSpy).toHaveBeenCalled();
+    expect(breakerSpy).toHaveBeenCalledWith(expect.objectContaining({
+      ceilings: DEFAULT_RESUMABLE_CEILINGS,
+      snapshot: { rollupDone: 1, terminalChildCount: 1 },
+    }));
   });
 
   it('skips the circuit breaker when the parent auto-completes', async () => {

--- a/tests/unit/agents/plan-frontier-subscriber.test.ts
+++ b/tests/unit/agents/plan-frontier-subscriber.test.ts
@@ -7,9 +7,25 @@ import {
 } from '../../../src/bus/events.js';
 import { PlanFrontierSubscriber } from '../../../src/agents/plan-frontier-subscriber.js';
 import * as planFrontier from '../../../src/agents/plan-frontier.js';
+import { DEFAULT_RESUMABLE_CEILINGS } from '../../../src/config.js';
+import * as circuitBreaker from '../../../src/agents/resumable-circuit-breaker.js';
 
 function mockLogger() {
   return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() };
+}
+
+function subscriberOpts(bus: EventBus, overrides: Record<string, unknown> = {}) {
+  return {
+    pool: {} as never,
+    bus,
+    logger: mockLogger() as never,
+    schedulerService: {} as never,
+    taskRepo: { getTask: vi.fn() } as never,
+    eligibleAgents: new Set(['coordinator']),
+    continuationDelaySeconds: 30,
+    resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    ...overrides,
+  };
 }
 
 describe('PlanFrontierSubscriber', () => {
@@ -19,15 +35,7 @@ describe('PlanFrontierSubscriber', () => {
     const handleSpy = vi.spyOn(planFrontier, 'handleChildTerminalResolution').mockResolvedValue();
 
     const bus = new EventBus(mockLogger() as never);
-    const subscriber = new PlanFrontierSubscriber({
-      pool: {} as never,
-      bus,
-      logger: mockLogger() as never,
-      schedulerService: {} as never,
-      taskRepo: { getTask: vi.fn() } as never,
-      eligibleAgents: new Set(['coordinator']),
-      continuationDelaySeconds: 30,
-    });
+    const subscriber = new PlanFrontierSubscriber(subscriberOpts(bus));
     subscriber.start();
 
     await bus.publish('execution', createTaskUpdated({
@@ -44,15 +52,7 @@ describe('PlanFrontierSubscriber', () => {
     const handleSpy = vi.spyOn(planFrontier, 'handleChildTerminalResolution').mockResolvedValue();
 
     const bus = new EventBus(mockLogger() as never);
-    const subscriber = new PlanFrontierSubscriber({
-      pool: {} as never,
-      bus,
-      logger: mockLogger() as never,
-      schedulerService: {} as never,
-      taskRepo: { getTask: vi.fn() } as never,
-      eligibleAgents: new Set(['coordinator']),
-      continuationDelaySeconds: 30,
-    });
+    const subscriber = new PlanFrontierSubscriber(subscriberOpts(bus));
     subscriber.start();
 
     await bus.publish('execution', createTaskCompleted({
@@ -67,15 +67,7 @@ describe('PlanFrontierSubscriber', () => {
     const handleSpy = vi.spyOn(planFrontier, 'handleChildTerminalResolution').mockResolvedValue();
 
     const bus = new EventBus(mockLogger() as never);
-    const subscriber = new PlanFrontierSubscriber({
-      pool: {} as never,
-      bus,
-      logger: mockLogger() as never,
-      schedulerService: {} as never,
-      taskRepo: { getTask: vi.fn() } as never,
-      eligibleAgents: new Set(['coordinator']),
-      continuationDelaySeconds: 30,
-    });
+    const subscriber = new PlanFrontierSubscriber(subscriberOpts(bus));
     subscriber.start();
 
     await bus.publish('execution', createTaskUpdated({
@@ -93,7 +85,11 @@ describe('PlanFrontierSubscriber', () => {
       rollup: { done: 1, total: 3 },
       rollupUpdated: true,
       dispatchedChildIds: ['child-2'],
+      autoCompleted: false,
+      frontierSnapshot: { rollupDone: 1, terminalChildCount: 1 },
     });
+    const breakerSpy = vi.spyOn(circuitBreaker, 'handlePlanFrontierWakeForCircuitBreaker')
+      .mockResolvedValue({ continueParent: true });
 
     const bus = new EventBus(mockLogger() as never);
     const taskRepo = {
@@ -111,15 +107,7 @@ describe('PlanFrontierSubscriber', () => {
       }),
     };
 
-    const subscriber = new PlanFrontierSubscriber({
-      pool: {} as never,
-      bus,
-      logger: mockLogger() as never,
-      schedulerService: {} as never,
-      taskRepo: taskRepo as never,
-      eligibleAgents: new Set(['coordinator']),
-      continuationDelaySeconds: 30,
-    });
+    const subscriber = new PlanFrontierSubscriber(subscriberOpts(bus, { taskRepo }));
     subscriber.start();
 
     await bus.publish('system', createScheduleFired({
@@ -132,5 +120,38 @@ describe('PlanFrontierSubscriber', () => {
     expect(advanceSpy).toHaveBeenCalledWith(expect.objectContaining({
       parentTaskId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
     }));
+    expect(breakerSpy).toHaveBeenCalled();
+  });
+
+  it('skips the circuit breaker when the parent auto-completes', async () => {
+    vi.spyOn(planFrontier, 'advancePlanFrontier').mockResolvedValue({
+      rollup: { done: 3, total: 3 },
+      rollupUpdated: false,
+      dispatchedChildIds: [],
+      autoCompleted: true,
+      frontierSnapshot: { rollupDone: 3, terminalChildCount: 3 },
+    });
+    const breakerSpy = vi.spyOn(circuitBreaker, 'handlePlanFrontierWakeForCircuitBreaker')
+      .mockResolvedValue({ continueParent: true });
+
+    const bus = new EventBus(mockLogger() as never);
+    const subscriber = new PlanFrontierSubscriber(subscriberOpts(bus, {
+      taskRepo: {
+        getTask: vi.fn().mockResolvedValue({
+          id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+          progress: { plan: { steps: [], deliverableStepId: null, done: 3, total: 3, next: 'Done' } },
+        }),
+      },
+    }));
+    subscriber.start();
+
+    await bus.publish('system', createScheduleFired({
+      jobId: 'job-1',
+      agentId: 'coordinator',
+      agentTaskId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      parentEventId: 'parent-event',
+    }));
+
+    expect(breakerSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/agents/plan-frontier.test.ts
+++ b/tests/unit/agents/plan-frontier.test.ts
@@ -196,6 +196,7 @@ describe('advancePlanFrontier', () => {
           next: 'Run step 1',
         },
       }),
+      completeTask: vi.fn().mockResolvedValue(null),
     };
 
     let tasksQueryCount = 0;
@@ -227,6 +228,61 @@ describe('advancePlanFrontier', () => {
     expect(result?.rollup).toEqual({ done: 1, total: 3 });
     expect(result?.rollupUpdated).toBe(true);
     expect(result?.dispatchedChildIds).toEqual([CHILD_2, CHILD_3]);
+    expect(result?.autoCompleted).toBe(false);
     expect(enqueueTaskWake).toHaveBeenCalledTimes(2);
+  });
+
+  it('auto-completes the parent when all children and the deliverable step are done', async () => {
+    const child1 = sampleChild({ id: CHILD_1, status: 'done', progress: { notes: [{ at: 't', note: 'Step 1 done' }] } });
+    const child2 = sampleChild({ id: CHILD_2, status: 'done' });
+    const child3 = sampleChild({
+      id: CHILD_3,
+      status: 'done',
+      progress: { notes: [{ at: 't', note: 'Final deliverable output' }] },
+    });
+    const parent = sampleParent({ status: 'in_progress' });
+
+    const completeTask = vi.fn().mockResolvedValue({ ...parent, status: 'done' });
+    const taskRepo = {
+      getTask: vi.fn().mockResolvedValue(parent),
+      setPlanBlock: vi.fn().mockResolvedValue({
+        task: parent,
+        block: {
+          steps: [
+            { id: 'step-1', taskId: CHILD_1 },
+            { id: 'step-2', taskId: CHILD_2 },
+            { id: 'step-3', taskId: CHILD_3 },
+          ],
+          deliverableStepId: 'step-3',
+          done: 3,
+          total: 3,
+          next: 'Done',
+        },
+      }),
+      completeTask,
+    };
+
+    const pool = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes('scheduled_jobs')) return { rows: [{ pending: false }] };
+        return { rows: [child1, child2, child3].map(toDbRow) };
+      }),
+    };
+
+    const result = await advancePlanFrontier({
+      pool: pool as never,
+      taskRepo: taskRepo as never,
+      schedulerService: { enqueueTaskWake: vi.fn() } as never,
+      logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() } as never,
+      parentTaskId: PARENT_1,
+      eligibleAgents: new Set(['coordinator']),
+    });
+
+    expect(result?.autoCompleted).toBe(true);
+    expect(completeTask).toHaveBeenCalledWith(
+      PARENT_1,
+      'Final deliverable output',
+      'coordinator',
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1239. Stacks on #1238 (`cursor/plan-frontier-advancement-2fee`).

Implements Phase 2 completion reconciliation for planned parents:

- **Reconciliation** — when a parent transitions to `done` or `cancelled`, `TaskRepo.reconcileChildren` recursively cancels open descendants with a `reconciled: parent <id> <state>` reason and cancels their pending/running wakes.
- **Parent auto-complete** — on a planned-parent wake, when the rollup is full and the deliverable step child is `done`, the parent auto-completes and surfaces that child's output as the completion note.
- **Circuit-breaker extension** — planned-parent wakes now count rollup `done` increases or new terminal children as forward progress; K stalls without frontier movement trip the existing `needs-attention` escalation path.

## Acceptance criteria

- [x] A `done`/`cancelled` parent reconciles open descendant children and cancels their wakes (integration: reconcile-on-done leaves zero open children).
- [x] A parent whose subtree is fully resolved and whose deliverable step is done auto-completes.
- [x] A planned parent with no frontier progress across K wakes trips the circuit-breaker; a steadily-advancing parent does not.
- [x] Tests: reconcile-on-done, stalled-frontier escalates, healthy frontier doesn't.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm test` (unit + integration with Postgres)
- [x] New integration suite: `tests/integration/plan-completion-reconciliation.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ddcb1a3-5dad-4bb5-bd79-4b195ebaeb29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ddcb1a3-5dad-4bb5-bd79-4b195ebaeb29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

