### PR TITLE
test: cover plan deliverable surfacing and child-summary rollup (#1240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Plan frontier advancement** — child terminal resolution schedules a near-term planned-parent wake; the wake recomputes `progress.plan` rollup and dispatches newly-unblocked children (BacklogHeartbeat remains the backstop). (#1238)
 - **Plan completion reconciliation** — terminal plan parents now cancel open descendants and their pending wakes. (#1239)
 - **Plan auto-complete** — fully-resolved plans now finish automatically using the deliverable step output. (#1239)
+- **Plan deliverable surfacing** — parent auto-complete honors `deliverableStepId` for the completion summary, defaulting to a plan-order rollup of child outputs when unset. (#1240)
 - **Plan frontier circuit breaker** — planned-parent wakes now escalate after repeated stalls without frontier progress. (#1239)
 - **`plan`** — rows-direct goal decomposition skill writing child task rows and `progress.plan`; platform plan-altitude guidance and per-turn dynamic pin for complex bound tasks. (#1237)
 - **`progress.plan`** — typed plan block with child-step descriptors, deliverable step pointer, and "X of Y" rollup helper; round-trip persistence via `getPlanBlock` / `setPlanBlock`. (#1236)

--- a/src/agents/plan-execution.test.ts
+++ b/src/agents/plan-execution.test.ts
@@ -179,7 +179,7 @@ describe('preflightPlanBlockWrite', () => {
   });
 });
 
-describe('plan completion helpers (#1239)', () => {
+describe('plan completion helpers (#1239, #1240)', () => {
   const plan: PlanProgressBlock = {
     steps: [
       { id: 'step-1', taskId: 'child-1' },
@@ -235,5 +235,54 @@ describe('plan completion helpers (#1239)', () => {
       }],
     ]);
     expect(resolvePlanCompletionNote(plan, children)).toBe('Real output');
+  });
+
+  it('auto-completes when all children are done and no deliverable step is marked', () => {
+    const rollupPlan: PlanProgressBlock = {
+      steps: [
+        { id: 'step-1', taskId: 'child-1' },
+        { id: 'step-2', taskId: 'child-2' },
+      ],
+      deliverableStepId: null,
+      done: 2,
+      total: 2,
+      next: 'Done',
+    };
+    expect(isPlanReadyForAutoComplete(rollupPlan, {
+      'child-1': 'done',
+      'child-2': 'done',
+    })).toBe(true);
+    expect(isPlanReadyForAutoComplete({ ...rollupPlan, done: 1 }, {
+      'child-1': 'done',
+      'child-2': 'open',
+    })).toBe(false);
+  });
+
+  it('rolls up child summaries in plan order when no deliverable step is marked', () => {
+    const rollupPlan: PlanProgressBlock = {
+      steps: [
+        { id: 'step-1', taskId: 'child-1' },
+        { id: 'step-2', taskId: 'child-2' },
+      ],
+      deliverableStepId: null,
+      done: 2,
+      total: 2,
+      next: 'Done',
+    };
+    const children = new Map([
+      ['child-1', {
+        title: 'Research',
+        description: null,
+        progress: { notes: [{ at: 't', note: 'Found 12 competitors' }] },
+      }],
+      ['child-2', {
+        title: 'Draft',
+        description: null,
+        progress: { notes: [{ at: 't', note: 'Outline complete' }] },
+      }],
+    ]);
+    expect(resolvePlanCompletionNote(rollupPlan, children)).toBe(
+      'Research: Found 12 competitors\n\nDraft: Outline complete',
+    );
   });
 });

--- a/tests/integration/plan-completion-reconciliation.test.ts
+++ b/tests/integration/plan-completion-reconciliation.test.ts
@@ -246,8 +246,9 @@ describeIf('Plan completion reconciliation (#1239)', () => {
     expect(reloadedParent?.status).toBe('done');
     const notes = reloadedParent?.progress.notes as Array<{ note: string }> | undefined;
     const completionNote = notes?.find((n) => n.note.includes('Found 12 competitors'))?.note;
-    expect(completionNote).toContain('Found 12 competitors');
-    expect(completionNote).toContain('Outline complete');
+    expect(completionNote).toBe(
+      `${PREFIX} rollup child 1: Found 12 competitors\n\n${PREFIX} rollup child 2: Outline complete`,
+    );
   });
 
   it('escalates a planned parent that wakes with no frontier progress', async () => {

--- a/tests/integration/plan-completion-reconciliation.test.ts
+++ b/tests/integration/plan-completion-reconciliation.test.ts
@@ -179,6 +179,77 @@ describeIf('Plan completion reconciliation (#1239)', () => {
     expect(notes?.some((n) => n.note === 'Deliverable synthesis output')).toBe(true);
   });
 
+  it('auto-completes the parent with a child-summary rollup when no deliverable is marked', async () => {
+    const subscriber = new PlanFrontierSubscriber({
+      pool,
+      bus,
+      logger,
+      schedulerService,
+      taskRepo: repo,
+      eligibleAgents: new Set(['coordinator']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+    subscriber.start();
+
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} rollup parent`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+    });
+    const child1 = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} rollup child 1`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    const child2 = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} rollup child 2`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    await repo.updateTask(child1.id, { progressNote: 'Found 12 competitors' }, 'coordinator');
+    await repo.updateTask(child2.id, { progressNote: 'Outline complete' }, 'coordinator');
+    await repo.updateTask(child1.id, { status: 'done' }, 'coordinator');
+    await repo.updateTask(child2.id, { status: 'done' }, 'coordinator');
+
+    await repo.setPlanBlock(parent.id, {
+      steps: [
+        { id: 'step-1', taskId: child1.id },
+        { id: 'step-2', taskId: child2.id },
+      ],
+      deliverableStepId: null,
+      done: 2,
+      total: 2,
+      next: 'Done',
+    }, 'coordinator');
+
+    const parentWake = await schedulerService.enqueueTaskWake({
+      taskId: parent.id,
+      agentId: 'coordinator',
+      runAt: new Date(),
+      createdBy: 'test',
+    });
+
+    await bus.publish('system', createScheduleFired({
+      jobId: parentWake.jobId,
+      agentId: 'coordinator',
+      agentTaskId: parent.id,
+      parentEventId: 'rollup-auto-complete-wake',
+    }));
+
+    const reloadedParent = await repo.getTask(parent.id);
+    expect(reloadedParent?.status).toBe('done');
+    const notes = reloadedParent?.progress.notes as Array<{ note: string }> | undefined;
+    const completionNote = notes?.find((n) => n.note.includes('Found 12 competitors'))?.note;
+    expect(completionNote).toContain('Found 12 competitors');
+    expect(completionNote).toContain('Outline complete');
+  });
+
   it('escalates a planned parent that wakes with no frontier progress', async () => {
     const ceilings = { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 2 };
     const subscriber = new PlanFrontierSubscriber({

--- a/tests/unit/agents/plan-frontier.test.ts
+++ b/tests/unit/agents/plan-frontier.test.ts
@@ -285,4 +285,64 @@ describe('advancePlanFrontier', () => {
       'coordinator',
     );
   });
+
+  it('auto-completes with a child-summary rollup when no deliverable step is marked', async () => {
+    const child1 = sampleChild({
+      id: CHILD_1,
+      status: 'done',
+      title: 'Research',
+      progress: { notes: [{ at: 't', note: 'Found 12 competitors' }] },
+    });
+    const child2 = sampleChild({
+      id: CHILD_2,
+      status: 'done',
+      title: 'Draft',
+      progress: { notes: [{ at: 't', note: 'Outline complete' }] },
+    });
+    const parent = sampleParent({
+      status: 'in_progress',
+      progress: {
+        plan: {
+          steps: [
+            { id: 'step-1', taskId: CHILD_1 },
+            { id: 'step-2', taskId: CHILD_2 },
+          ],
+          deliverableStepId: null,
+          done: 2,
+          total: 2,
+          next: 'Done',
+        },
+      },
+    });
+
+    const completeTask = vi.fn().mockResolvedValue({ ...parent, status: 'done' });
+    const taskRepo = {
+      getTask: vi.fn().mockResolvedValue(parent),
+      setPlanBlock: vi.fn(),
+      completeTask,
+    };
+
+    const pool = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes('scheduled_jobs')) return { rows: [{ pending: false }] };
+        return { rows: [child1, child2].map(toDbRow) };
+      }),
+    };
+
+    const result = await advancePlanFrontier({
+      pool: pool as never,
+      taskRepo: taskRepo as never,
+      schedulerService: { enqueueTaskWake: vi.fn() } as never,
+      logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() } as never,
+      parentTaskId: PARENT_1,
+      eligibleAgents: new Set(['coordinator']),
+    });
+
+    expect(result?.autoCompleted).toBe(true);
+    expect(completeTask).toHaveBeenCalledWith(
+      PARENT_1,
+      'Research: Found 12 competitors\n\nDraft: Outline complete',
+      'coordinator',
+    );
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1240.

The harness for deliverable/synthesis step → parent result surfacing landed in #1239 (`resolvePlanCompletionNote` + `advancePlanFrontier` → `completeTask`). This PR completes the issue by adding the missing acceptance tests and a CHANGELOG entry.

**Behavior (already implemented):**
- When `progress.plan.deliverableStepId` is set, parent auto-complete uses that step's output as the completion note.
- When `deliverableStepId` is null, the parent result defaults to a plan-order rollup of child summaries (`title: output`, joined by blank lines).
- The deliverable surfaces through the existing `completeTask` / `task.completed` path — no new surface.

## Tests

- **Unit (`plan-execution.test.ts`)** — rollup eligibility and note formatting when no deliverable step is marked.
- **Unit (`plan-frontier.test.ts`)** — end-to-end harness path: `advancePlanFrontier` auto-completes with rollup note.
- **Integration (`plan-completion-reconciliation.test.ts`)** — full subscriber path: planned parent with `deliverableStepId: null` auto-completes with concatenated child outputs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2da4e03f-6093-4e36-8bc1-ca3cef9dcc84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2da4e03f-6093-4e36-8bc1-ca3cef9dcc84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

