### PR TITLE
Resumable tasks: promote deliverable to knowledge graph (#1241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Plan completion reconciliation** — terminal plan parents now cancel open descendants and their pending wakes. (#1239)
 - **Plan auto-complete** — fully-resolved plans now finish automatically using the deliverable step output. (#1239)
 - **Plan deliverable surfacing** — parent auto-complete honors `deliverableStepId` for the completion summary, defaulting to a plan-order rollup of child outputs when unset. (#1240)
+- **Deliverable KG promotion** — planned-parent completion promotes the curated deliverable via `extract-facts` / `extract-relationships` (capped, audited, best-effort), then archives project workspace docs; per-task `error_budget.kg_promotion: false` or `documentWorkspace.kgPromotion.enabled: false` skips it. (#1241)
 - **Plan frontier circuit breaker** — planned-parent wakes now escalate after repeated stalls without frontier progress. (#1239)
 - **`plan`** — rows-direct goal decomposition skill writing child task rows and `progress.plan`; platform plan-altitude guidance and per-turn dynamic pin for complex bound tasks. (#1237)
 - **`progress.plan`** — typed plan block with child-step descriptors, deliverable step pointer, and "X of Y" rollup helper; round-trip persistence via `getPlanBlock` / `setPlanBlock`. (#1236)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -85,6 +85,13 @@ documentWorkspace:
   # set `ttl_days: 0` on a scratch doc to opt out. `/projects/…` documents are never
   # auto-archived.
   scratchTtlDays: 7
+  # When a planned parent completes, promote its curated deliverable into the KG via
+  # extract-facts / extract-relationships, then archive the project's workspace docs.
+  # Per-task override: error_budget.kg_promotion: false skips promotion for that task.
+  kgPromotion:
+    enabled: true
+    maxFacts: 50
+    maxRelationships: 50
 
 skillOutput:
   # Maximum character length of a sanitized skill result before truncation.

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -98,7 +98,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "scratchTtlDays": { "type": "integer", "minimum": 1, "maximum": 36500 }
+        "scratchTtlDays": { "type": "integer", "minimum": 1, "maximum": 36500 },
+        "kgPromotion": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "maxFacts": { "type": "integer", "minimum": 0 },
+            "maxRelationships": { "type": "integer", "minimum": 0 }
+          }
+        }
       }
     },
     "skillOutput": {

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -62,6 +62,11 @@ export class ExtractFactsHandler implements SkillHandler {
         ? Math.floor(max_stored)
         : undefined;
 
+      if (maxStored === 0) {
+        ctx.log.info({ stored: 0, redirected: 0, failed: 0 }, 'extract-facts: complete');
+        return { success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 0 } };
+      }
+
       // -- Step 1: Classifier gate --
       // Cheap fast-tier call — exits early on messages that carry no facts about a
       // single entity (e.g. action requests, scheduling, relationship-only text).
@@ -260,6 +265,7 @@ ${text}`,
                 }
 
                 if (contact) {
+                  if (maxStored !== undefined && stored + redirected >= maxStored) break;
                   try {
                     await ctx.contactService.updateContactFields(contact.id, patch.fields);
                     ctx.log.info(
@@ -308,6 +314,8 @@ ${text}`,
               'extract-facts: memoryWriteSource not set — using input source fallback',
             );
           }
+
+          if (maxStored !== undefined && stored + redirected >= maxStored) break;
 
           const result = await ctx.entityMemory.storeFact({
             entityNodeId: entityNode.id,

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -35,7 +35,7 @@ const DECAY_CLASSES_LIST = DECAY_CLASSES.join(', ');
 
 export class ExtractFactsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { text, source } = ctx.input as { text?: string; source?: string };
+    const { text, source, max_stored } = ctx.input as { text?: string; source?: string; max_stored?: number };
 
     if (!text || typeof text !== 'string') {
       // Log only safe metadata — never log ctx.input directly (contains full transcript)
@@ -58,6 +58,10 @@ export class ExtractFactsHandler implements SkillHandler {
     }
 
     try {
+      const maxStored = typeof max_stored === 'number' && Number.isFinite(max_stored) && max_stored >= 0
+        ? Math.floor(max_stored)
+        : undefined;
+
       // -- Step 1: Classifier gate --
       // Cheap fast-tier call — exits early on messages that carry no facts about a
       // single entity (e.g. action requests, scheduling, relationship-only text).
@@ -263,6 +267,7 @@ ${text}`,
                       'extract-facts: canonical attribute redirected to ContactService',
                     );
                     redirected++;
+                    if (maxStored !== undefined && stored + redirected >= maxStored) break;
                     continue;
                   } catch (err) {
                     if (err instanceof ContactValidationError) {
@@ -322,6 +327,7 @@ ${text}`,
               );
             }
             stored++;
+            if (maxStored !== undefined && stored + redirected >= maxStored) break;
           } else if (result.action === 'rate_limited') {
             // The 50-writes-per-task limit is exhausted — all remaining storeFact calls
             // in this batch will also fail, so break immediately rather than burning

--- a/skills/extract-facts/skill.json
+++ b/skills/extract-facts/skill.json
@@ -1,12 +1,13 @@
 {
   "name": "extract-facts",
   "description": "Extract single-entity attribute facts from a passage of text and persist them as knowledge graph fact nodes. Self-classifies internally — always safe to call; exits early if no facts are found.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
     "text": "string (the message or turn text to extract facts from)",
-    "source": "string (provenance string, e.g. 'system:checkpoint/conversation:abc/agent:coordinator/channel:cli')"
+    "source": "string (provenance string, e.g. 'system:checkpoint/conversation:abc/agent:coordinator/channel:cli')",
+    "max_stored": "number? (optional cap on facts persisted in this invocation)"
   },
   "outputs": {
     "stored": "number (new or updated fact nodes persisted to the KG)",

--- a/skills/extract-facts/skill.json
+++ b/skills/extract-facts/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "extract-facts",
   "description": "Extract single-entity attribute facts from a passage of text and persist them as knowledge graph fact nodes. Self-classifies internally — always safe to call; exits early if no facts are found.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -29,7 +29,7 @@ const NODE_TYPES_LIST = NODE_TYPES.join(', ');
 
 export class ExtractRelationshipsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { text, source } = ctx.input as { text?: string; source?: string };
+    const { text, source, max_stored } = ctx.input as { text?: string; source?: string; max_stored?: number };
 
     if (!text || typeof text !== 'string') {
       // Log only safe metadata — never log ctx.input directly (contains full transcript)
@@ -52,7 +52,11 @@ export class ExtractRelationshipsHandler implements SkillHandler {
     }
 
     try {
-    // -- Step 1: Classifier gate --
+      const maxStored = typeof max_stored === 'number' && Number.isFinite(max_stored) && max_stored >= 0
+        ? Math.floor(max_stored)
+        : undefined;
+
+      // -- Step 1: Classifier gate --
     // Cheap fast-tier call — exits early on the majority of messages (scheduling,
     // email drafts, lookups) that contain no entity-to-entity relationships.
     const classifyResult = await ctx.infraLlm.classify(
@@ -210,6 +214,7 @@ ${text}`,
         } else {
           confirmed++;
         }
+        if (maxStored !== undefined && extracted + confirmed >= maxStored) break;
       } catch (err) {
         // Log at error (not warn) — persistence failures are infrastructure errors
         // (DB outage, connection loss) that must surface in Sentry, not soft warnings.

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -56,6 +56,11 @@ export class ExtractRelationshipsHandler implements SkillHandler {
         ? Math.floor(max_stored)
         : undefined;
 
+      if (maxStored === 0) {
+        ctx.log.info({ extracted: 0, confirmed: 0, failed: 0 }, 'extract-relationships: complete');
+        return { success: true, data: { extracted: 0, confirmed: 0, failed: 0, skipped: false } };
+      }
+
       // -- Step 1: Classifier gate --
     // Cheap fast-tier call — exits early on the majority of messages (scheduling,
     // email drafts, lookups) that contain no entity-to-entity relationships.
@@ -199,6 +204,8 @@ ${text}`,
         const confidence = typeof triple.confidence === 'number'
           ? Math.min(1, Math.max(0, triple.confidence))
           : 0.7;
+
+        if (maxStored !== undefined && extracted + confirmed >= maxStored) break;
 
         const { created } = await ctx.entityMemory.upsertEdge(
           subjectNode.id,

--- a/skills/extract-relationships/skill.json
+++ b/skills/extract-relationships/skill.json
@@ -1,12 +1,13 @@
 {
   "name": "extract-relationships",
   "description": "Extract entity-to-entity relationships from a passage of text and persist them as knowledge graph edges. Self-classifies internally — always safe to call; exits early if no relationships are found.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
     "text": "string (the message or turn text to extract relationships from)",
-    "source": "string (provenance string, e.g. 'agent:coordinator/task:abc123/channel:cli')"
+    "source": "string (provenance string, e.g. 'agent:coordinator/task:abc123/channel:cli')",
+    "max_stored": "number? (optional cap on relationships persisted in this invocation)"
   },
   "outputs": {
     "extracted": "number (new edges created)",

--- a/skills/extract-relationships/skill.json
+++ b/skills/extract-relationships/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "extract-relationships",
   "description": "Extract entity-to-entity relationships from a passage of text and persist them as knowledge graph edges. Self-classifies internally — always safe to call; exits early if no relationships are found.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/src/agents/deliverable-kg-promotion.test.ts
+++ b/src/agents/deliverable-kg-promotion.test.ts
@@ -186,19 +186,24 @@ describe('deliverable-kg-promotion (#1241)', () => {
     expect(logger.error).toHaveBeenCalled();
   });
 
-  it('skips promotion when disabled via error_budget', async () => {
+  it('skips promotion when disabled via error_budget but still archives workspace docs', async () => {
     const invoke = vi.fn();
+    const archiveProjectWorkspaceDocs = vi.fn().mockResolvedValue(2);
     const result = await promoteDeliverableToKg({
       task: makeParent({ errorBudget: { kg_promotion: false } }),
       parentEventId: 'evt-parent',
-      taskRepo: { getTask: vi.fn() } as unknown as TaskRepo,
-      workingDocsRepo: { archiveProjectWorkspaceDocs: vi.fn() } as unknown as WorkingDocsRepo,
+      taskRepo: {
+        getTask: vi.fn(),
+        resolveProjectRootTaskId: vi.fn().mockResolvedValue(PARENT_ID),
+      } as unknown as TaskRepo,
+      workingDocsRepo: { archiveProjectWorkspaceDocs } as unknown as WorkingDocsRepo,
       executionLayer: { invoke } as unknown as ExecutionLayer,
       config: resolveKgPromotionConfig(),
       logger: makeLogger(),
     });
-    expect(result).toEqual({ promoted: false, reason: 'disabled' });
+    expect(result).toEqual({ promoted: false, reason: 'disabled', archivedDocs: 2 });
     expect(invoke).not.toHaveBeenCalled();
+    expect(archiveProjectWorkspaceDocs).toHaveBeenCalledWith(PARENT_ID);
   });
 
   describe('DeliverableKgPromotionSubscriber', () => {
@@ -250,7 +255,9 @@ describe('deliverable-kg-promotion (#1241)', () => {
       expect(handler).toBeDefined();
       await handler!(createTaskCompleted({ taskId: PARENT_ID, completionNote: 'Done', agentId: 'coordinator' }));
 
-      expect(invoke).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => {
+        expect(invoke).toHaveBeenCalledTimes(2);
+      });
     });
 
     it('ignores task.completed without a plan block', async () => {

--- a/src/agents/deliverable-kg-promotion.test.ts
+++ b/src/agents/deliverable-kg-promotion.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { EventBus } from '../bus/bus.js';
+import type { ExecutionLayer } from '../skills/execution.js';
+import type { Logger } from '../logger.js';
+import type { TaskRepo } from '../db/task-repo.js';
+import type { WorkingDocsRepo } from '../db/working-docs-repo.js';
+import { createTaskCompleted } from '../bus/events.js';
+import type { TaskRow } from '../db/queries/tasks.js';
+import {
+  DeliverableKgPromotionSubscriber,
+  isKgPromotionDisabled,
+  promoteDeliverableToKg,
+  resolveKgPromotionConfig,
+} from './deliverable-kg-promotion.js';
+
+const PARENT_ID = '00000000-0000-4000-8000-00000000aa01';
+const CHILD_DELIVERABLE = '00000000-0000-4000-8000-00000000bb01';
+const CHILD_WORKLOG = '00000000-0000-4000-8000-00000000bb02';
+
+function makeParent(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    id: PARENT_ID,
+    agentId: 'coordinator',
+    sourceAgentId: 'coordinator',
+    conversationId: 'conv-1',
+    title: 'Kickoff plan',
+    description: null,
+    status: 'done',
+    progress: {
+      plan: {
+        steps: [
+          { id: 'worklog', taskId: CHILD_WORKLOG },
+          { id: 'deliverable', taskId: CHILD_DELIVERABLE },
+        ],
+        deliverableStepId: 'deliverable',
+        done: 2,
+        total: 2,
+        next: 'Done',
+      },
+    },
+    errorBudget: {},
+    intentAnchor: '',
+    owner: '',
+    waitingOnContactId: null,
+    waitingOnText: null,
+    parentTaskId: null,
+    blockedByTaskId: null,
+    priority: 0,
+    dueAt: null,
+    source: 'agent',
+    createdBy: 'agent',
+    tags: [],
+    originator: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as Logger;
+}
+
+describe('deliverable-kg-promotion (#1241)', () => {
+  it('resolveKgPromotionConfig applies defaults', () => {
+    expect(resolveKgPromotionConfig()).toEqual({
+      enabled: true,
+      maxFacts: 50,
+      maxRelationships: 50,
+    });
+    expect(resolveKgPromotionConfig({ enabled: false, maxFacts: 10 })).toEqual({
+      enabled: false,
+      maxFacts: 10,
+      maxRelationships: 50,
+    });
+  });
+
+  it('isKgPromotionDisabled respects global and per-task flags', () => {
+    const config = resolveKgPromotionConfig();
+    expect(isKgPromotionDisabled({ errorBudget: {} }, config)).toBe(false);
+    expect(isKgPromotionDisabled({ errorBudget: { kg_promotion: false } }, config)).toBe(true);
+    expect(isKgPromotionDisabled({ errorBudget: {} }, { ...config, enabled: false })).toBe(true);
+  });
+
+  it('promotes deliverable text with caps and archives workspace docs', async () => {
+    const invoke = vi.fn()
+      .mockResolvedValueOnce({ success: true, data: { extracted: 2, confirmed: 1 } })
+      .mockResolvedValueOnce({ success: true, data: { stored: 3, redirected: 0 } });
+    const executionLayer = { invoke } as unknown as ExecutionLayer;
+    const archiveProjectWorkspaceDocs = vi.fn().mockResolvedValue(2);
+    const workingDocsRepo = { archiveProjectWorkspaceDocs } as unknown as WorkingDocsRepo;
+    const getTask = vi.fn(async (id: string) => {
+      if (id === CHILD_DELIVERABLE) {
+        return {
+          ...makeParent(),
+          id: CHILD_DELIVERABLE,
+          title: 'Synthesis',
+          progress: { notes: [{ at: 't', note: 'Final curated deliverable' }] },
+        };
+      }
+      if (id === CHILD_WORKLOG) {
+        return {
+          ...makeParent(),
+          id: CHILD_WORKLOG,
+          title: 'Findings',
+          errorBudget: { resumable: true },
+          progress: { notes: [{ at: 't', note: '1300 row worklog' }] },
+        };
+      }
+      return null;
+    });
+    const taskRepo = {
+      getTask,
+      resolveProjectRootTaskId: vi.fn().mockResolvedValue(PARENT_ID),
+    } as unknown as TaskRepo;
+
+    const result = await promoteDeliverableToKg({
+      task: makeParent(),
+      parentEventId: 'evt-parent',
+      taskRepo,
+      workingDocsRepo,
+      executionLayer,
+      config: resolveKgPromotionConfig({ maxFacts: 5, maxRelationships: 7 }),
+      logger: makeLogger(),
+    });
+
+    expect(result.promoted).toBe(true);
+    expect(result.factsStored).toBe(3);
+    expect(result.relationshipsStored).toBe(3);
+    expect(result.archivedDocs).toBe(2);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls[0]![1]).toMatchObject({
+      text: 'Final curated deliverable',
+      max_stored: 7,
+    });
+    expect(invoke.mock.calls[1]![1]).toMatchObject({
+      text: 'Final curated deliverable',
+      max_stored: 5,
+    });
+    expect(archiveProjectWorkspaceDocs).toHaveBeenCalledWith(PARENT_ID);
+  });
+
+  it('is non-fatal when extraction skills fail', async () => {
+    const invoke = vi.fn()
+      .mockRejectedValueOnce(new Error('relationships blew up'))
+      .mockResolvedValueOnce({ success: false, error: 'facts failed' });
+    const executionLayer = { invoke } as unknown as ExecutionLayer;
+    const archiveProjectWorkspaceDocs = vi.fn().mockResolvedValue(1);
+    const workingDocsRepo = { archiveProjectWorkspaceDocs } as unknown as WorkingDocsRepo;
+    const getTask = vi.fn(async (id: string) => {
+      if (id === CHILD_DELIVERABLE) {
+        return {
+          ...makeParent(),
+          id: CHILD_DELIVERABLE,
+          progress: { notes: [{ at: 't', note: 'Deliverable text' }] },
+        };
+      }
+      return null;
+    });
+    const taskRepo = {
+      getTask,
+      resolveProjectRootTaskId: vi.fn().mockResolvedValue(PARENT_ID),
+    } as unknown as TaskRepo;
+    const logger = makeLogger();
+
+    const result = await promoteDeliverableToKg({
+      task: makeParent(),
+      parentEventId: 'evt-parent',
+      taskRepo,
+      workingDocsRepo,
+      executionLayer,
+      config: resolveKgPromotionConfig(),
+      logger,
+    });
+
+    expect(result.promoted).toBe(true);
+    expect(result.errors).toHaveLength(2);
+    expect(archiveProjectWorkspaceDocs).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('skips promotion when disabled via error_budget', async () => {
+    const invoke = vi.fn();
+    const result = await promoteDeliverableToKg({
+      task: makeParent({ errorBudget: { kg_promotion: false } }),
+      parentEventId: 'evt-parent',
+      taskRepo: { getTask: vi.fn() } as unknown as TaskRepo,
+      workingDocsRepo: { archiveProjectWorkspaceDocs: vi.fn() } as unknown as WorkingDocsRepo,
+      executionLayer: { invoke } as unknown as ExecutionLayer,
+      config: resolveKgPromotionConfig(),
+      logger: makeLogger(),
+    });
+    expect(result).toEqual({ promoted: false, reason: 'disabled' });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  describe('DeliverableKgPromotionSubscriber', () => {
+    let subscribeHandlers: Map<string, (event: unknown) => Promise<void>>;
+
+    beforeEach(() => {
+      subscribeHandlers = new Map();
+    });
+
+    it('runs promotion on task.completed for planned parents', async () => {
+      const bus = {
+        subscribe: vi.fn((eventType: string, _layer: string, handler: (e: unknown) => Promise<void>) => {
+          subscribeHandlers.set(eventType, handler);
+        }),
+      } as unknown as EventBus;
+      const invoke = vi.fn()
+        .mockResolvedValueOnce({ success: true, data: { extracted: 0, confirmed: 0 } })
+        .mockResolvedValueOnce({ success: true, data: { stored: 0, redirected: 0 } });
+      const getTask = vi.fn(async (id: string) => {
+        if (id === PARENT_ID) return makeParent();
+        if (id === CHILD_DELIVERABLE) {
+          return {
+            ...makeParent(),
+            id: CHILD_DELIVERABLE,
+            progress: { notes: [{ at: 't', note: 'Done' }] },
+          };
+        }
+        return null;
+      });
+      const taskRepo = {
+        getTask,
+        resolveProjectRootTaskId: vi.fn().mockResolvedValue(PARENT_ID),
+      } as unknown as TaskRepo;
+      const workingDocsRepo = {
+        archiveProjectWorkspaceDocs: vi.fn().mockResolvedValue(0),
+      } as unknown as WorkingDocsRepo;
+
+      const subscriber = new DeliverableKgPromotionSubscriber({
+        bus,
+        taskRepo,
+        workingDocsRepo,
+        executionLayer: { invoke } as unknown as ExecutionLayer,
+        config: resolveKgPromotionConfig(),
+        logger: makeLogger(),
+      });
+      subscriber.start();
+
+      const handler = subscribeHandlers.get('task.completed');
+      expect(handler).toBeDefined();
+      await handler!(createTaskCompleted({ taskId: PARENT_ID, completionNote: 'Done', agentId: 'coordinator' }));
+
+      expect(invoke).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores task.completed without a plan block', async () => {
+      const bus = {
+        subscribe: vi.fn((eventType: string, _layer: string, handler: (e: unknown) => Promise<void>) => {
+          subscribeHandlers.set(eventType, handler);
+        }),
+      } as unknown as EventBus;
+      const invoke = vi.fn();
+      const getTask = vi.fn().mockResolvedValue({
+        ...makeParent(),
+        progress: {},
+      });
+      const subscriber = new DeliverableKgPromotionSubscriber({
+        bus,
+        taskRepo: { getTask } as unknown as TaskRepo,
+        workingDocsRepo: { archiveProjectWorkspaceDocs: vi.fn() } as unknown as WorkingDocsRepo,
+        executionLayer: { invoke } as unknown as ExecutionLayer,
+        config: resolveKgPromotionConfig(),
+        logger: makeLogger(),
+      });
+      subscriber.start();
+      await subscribeHandlers.get('task.completed')!(
+        createTaskCompleted({ taskId: PARENT_ID, completionNote: 'Done', agentId: 'coordinator' }),
+      );
+      expect(invoke).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/agents/deliverable-kg-promotion.ts
+++ b/src/agents/deliverable-kg-promotion.ts
@@ -113,86 +113,90 @@ export async function promoteDeliverableToKg(
   opts: PromoteDeliverableOptions,
 ): Promise<PromoteDeliverableResult> {
   const { task, config, logger } = opts;
-
-  if (isKgPromotionDisabled(task, config)) {
-    logger.debug({ taskId: task.id }, 'Deliverable KG promotion: disabled — skipping');
-    return { promoted: false, reason: 'disabled' };
-  }
+  const errors: string[] = [];
 
   const plan = readPlanBlock(task.progress);
   if (!plan) {
     return { promoted: false, reason: 'no_plan' };
   }
 
-  const children = await loadPlanChildren(opts.taskRepo, task);
-  const text = resolvePromotionText(plan, children);
-  if (!text) {
-    logger.debug({ taskId: task.id }, 'Deliverable KG promotion: no promotion text — skipping extraction');
-    return { promoted: false, reason: 'no_text' };
-  }
-
   const rootTaskId = (await opts.taskRepo.resolveProjectRootTaskId(task.id)) ?? task.id;
-  const source = promotionSource(task.id, rootTaskId);
-  const agentId = task.sourceAgentId ?? task.agentId ?? 'system';
-  const conversationId = task.conversationId ?? `task:${task.id}`;
-  const invokeOptions = {
-    agentId,
-    conversationId,
-    parentEventId: opts.parentEventId,
-    taskEventId: task.id,
-  };
-  const callerContext = {
-    contactId: 'system',
-    role: null as string | null,
-    channel: 'system',
-  };
-
-  const errors: string[] = [];
+  let promoted = false;
   let factsStored = 0;
   let relationshipsStored = 0;
+  let skipReason: PromoteDeliverableResult['reason'];
 
-  const skillResults = await Promise.allSettled([
-    opts.executionLayer.invoke(
-      'extract-relationships',
-      { text, source, max_stored: config.maxRelationships },
-      callerContext,
-      invokeOptions,
-    ),
-    opts.executionLayer.invoke(
-      'extract-facts',
-      { text, source, max_stored: config.maxFacts },
-      callerContext,
-      invokeOptions,
-    ),
-  ]);
+  if (isKgPromotionDisabled(task, config)) {
+    skipReason = 'disabled';
+    logger.debug({ taskId: task.id }, 'Deliverable KG promotion: disabled — skipping extraction');
+  } else {
+    const children = await loadPlanChildren(opts.taskRepo, task);
+    const text = resolvePromotionText(plan, children);
+    if (!text) {
+      skipReason = 'no_text';
+      logger.debug({ taskId: task.id }, 'Deliverable KG promotion: no promotion text — skipping extraction');
+    } else {
+      const source = promotionSource(task.id, rootTaskId);
+      const agentId = task.sourceAgentId ?? task.agentId ?? 'system';
+      const conversationId = task.conversationId ?? `task:${task.id}`;
+      const invokeOptions = {
+        agentId,
+        conversationId,
+        parentEventId: opts.parentEventId,
+        taskEventId: task.id,
+      };
+      const callerContext = {
+        contactId: 'system',
+        role: null as string | null,
+        channel: 'system',
+      };
 
-  for (const [index, result] of skillResults.entries()) {
-    const skillName = index === 0 ? 'extract-relationships' : 'extract-facts';
-    if (result.status === 'rejected') {
-      const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
-      errors.push(`${skillName}: ${message}`);
-      logger.error(
-        { err: result.reason as Error, taskId: task.id, skill: skillName },
-        'Deliverable KG promotion: skill threw unexpectedly',
-      );
-      continue;
-    }
-    const skillResult = result.value as SkillResult;
-    if (!skillResult.success) {
-      errors.push(`${skillName}: ${skillResult.error ?? 'unknown error'}`);
-      logger.warn(
-        { taskId: task.id, skill: skillName, error: skillResult.error },
-        'Deliverable KG promotion: skill returned failure',
-      );
-      continue;
-    }
-    if (skillName === 'extract-relationships' && skillResult.data) {
-      const data = skillResult.data as { extracted?: number; confirmed?: number };
-      relationshipsStored = (data.extracted ?? 0) + (data.confirmed ?? 0);
-    }
-    if (skillName === 'extract-facts' && skillResult.data) {
-      const data = skillResult.data as { stored?: number; redirected?: number };
-      factsStored = (data.stored ?? 0) + (data.redirected ?? 0);
+      const skillResults = await Promise.allSettled([
+        opts.executionLayer.invoke(
+          'extract-relationships',
+          { text, source, max_stored: config.maxRelationships },
+          callerContext,
+          invokeOptions,
+        ),
+        opts.executionLayer.invoke(
+          'extract-facts',
+          { text, source, max_stored: config.maxFacts },
+          callerContext,
+          invokeOptions,
+        ),
+      ]);
+
+      for (const [index, result] of skillResults.entries()) {
+        const skillName = index === 0 ? 'extract-relationships' : 'extract-facts';
+        if (result.status === 'rejected') {
+          const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+          errors.push(`${skillName}: ${message}`);
+          logger.error(
+            { err: result.reason as Error, taskId: task.id, skill: skillName },
+            'Deliverable KG promotion: skill threw unexpectedly',
+          );
+          continue;
+        }
+        const skillResult = result.value as SkillResult;
+        if (!skillResult.success) {
+          errors.push(`${skillName}: ${skillResult.error ?? 'unknown error'}`);
+          logger.warn(
+            { taskId: task.id, skill: skillName, error: skillResult.error },
+            'Deliverable KG promotion: skill returned failure',
+          );
+          continue;
+        }
+        if (skillName === 'extract-relationships' && skillResult.data) {
+          const data = skillResult.data as { extracted?: number; confirmed?: number };
+          relationshipsStored = (data.extracted ?? 0) + (data.confirmed ?? 0);
+        }
+        if (skillName === 'extract-facts' && skillResult.data) {
+          const data = skillResult.data as { stored?: number; redirected?: number };
+          factsStored = (data.stored ?? 0) + (data.redirected ?? 0);
+        }
+      }
+
+      promoted = true;
     }
   }
 
@@ -210,6 +214,8 @@ export async function promoteDeliverableToKg(
       taskId: task.id,
       rootTaskId,
       deliverableStepId: plan.deliverableStepId,
+      promoted,
+      skipReason,
       factsStored,
       relationshipsStored,
       archivedDocs,
@@ -217,6 +223,15 @@ export async function promoteDeliverableToKg(
     },
     'Deliverable KG promotion complete',
   );
+
+  if (!promoted) {
+    return {
+      promoted: false,
+      reason: skipReason,
+      archivedDocs,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  }
 
   return {
     promoted: true,
@@ -251,7 +266,7 @@ export class DeliverableKgPromotionSubscriber {
         const task = await this.opts.taskRepo.getTask(taskId);
         if (!task || !readPlanBlock(task.progress)) return;
 
-        await promoteDeliverableToKg({
+        void promoteDeliverableToKg({
           task,
           parentEventId: completed.id,
           taskRepo: this.opts.taskRepo,
@@ -259,6 +274,11 @@ export class DeliverableKgPromotionSubscriber {
           executionLayer: this.opts.executionLayer,
           config: this.opts.config,
           logger: this.opts.logger,
+        }).catch((err) => {
+          this.opts.logger.error(
+            { err, taskId },
+            'Deliverable KG promotion: unexpected error in background task — parent completion unaffected',
+          );
         });
       } catch (err) {
         this.opts.logger.error(

--- a/src/agents/deliverable-kg-promotion.ts
+++ b/src/agents/deliverable-kg-promotion.ts
@@ -1,0 +1,276 @@
+// deliverable-kg-promotion.ts — promote curated plan deliverables to the KG (#1241).
+//
+// On planned-parent completion, feeds the deliverable text (never per-item worklogs) through
+// extract-facts / extract-relationships, then archives the project's workspace documents.
+// Best-effort and non-fatal — failures are logged but never block parent completion.
+
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+import type { ExecutionLayer } from '../skills/execution.js';
+import type { TaskRepo } from '../db/task-repo.js';
+import type { WorkingDocsRepo } from '../db/working-docs-repo.js';
+import type { TaskRow } from '../db/queries/tasks.js';
+import type { TaskCompletedEvent } from '../bus/events.js';
+import { readPlanBlock } from '../db/plan-progress.js';
+import { resolvePromotionText } from './plan-execution.js';
+import type { SkillResult } from '../skills/types.js';
+
+export interface KgPromotionConfig {
+  enabled: boolean;
+  maxFacts: number;
+  maxRelationships: number;
+}
+
+export const DEFAULT_KG_PROMOTION_CONFIG: KgPromotionConfig = {
+  enabled: true,
+  maxFacts: 50,
+  maxRelationships: 50,
+};
+
+export function resolveKgPromotionConfig(
+  yaml?: { enabled?: boolean; maxFacts?: number; maxRelationships?: number },
+): KgPromotionConfig {
+  return {
+    enabled: yaml?.enabled !== false,
+    maxFacts: yaml?.maxFacts ?? DEFAULT_KG_PROMOTION_CONFIG.maxFacts,
+    maxRelationships: yaml?.maxRelationships ?? DEFAULT_KG_PROMOTION_CONFIG.maxRelationships,
+  };
+}
+
+/** True when KG promotion is disabled globally or on the task's error_budget. */
+export function isKgPromotionDisabled(
+  task: Pick<TaskRow, 'errorBudget'>,
+  config: KgPromotionConfig,
+): boolean {
+  if (!config.enabled) return true;
+  const budget = task.errorBudget ?? {};
+  if (budget['kg_promotion'] === false || budget['kgPromotion'] === false) return true;
+  return false;
+}
+
+export interface PromoteDeliverableOptions {
+  task: TaskRow;
+  parentEventId: string;
+  taskRepo: TaskRepo;
+  workingDocsRepo: WorkingDocsRepo;
+  executionLayer: ExecutionLayer;
+  config: KgPromotionConfig;
+  logger: Logger;
+}
+
+export interface PromoteDeliverableResult {
+  promoted: boolean;
+  reason?: 'disabled' | 'no_plan' | 'no_text' | 'skipped';
+  factsStored?: number;
+  relationshipsStored?: number;
+  archivedDocs?: number;
+  errors?: string[];
+}
+
+function promotionSource(taskId: string, rootTaskId: string): string {
+  return `system:deliverable-kg-promotion/task:${taskId}/project:${rootTaskId}`;
+}
+
+async function loadPlanChildren(
+  taskRepo: TaskRepo,
+  task: TaskRow,
+): Promise<Map<string, {
+  title: string;
+  description: string | null;
+  progress: Record<string, unknown>;
+  errorBudget: Record<string, unknown>;
+}>> {
+  const plan = readPlanBlock(task.progress);
+  if (!plan) return new Map();
+
+  const children = new Map<string, {
+    title: string;
+    description: string | null;
+    progress: Record<string, unknown>;
+    errorBudget: Record<string, unknown>;
+  }>();
+
+  for (const step of plan.steps) {
+    if (!step.taskId) continue;
+    const child = await taskRepo.getTask(step.taskId);
+    if (!child) continue;
+    children.set(step.taskId, {
+      title: child.title,
+      description: child.description,
+      progress: child.progress,
+      errorBudget: child.errorBudget,
+    });
+  }
+
+  return children;
+}
+
+/**
+ * Promote a completed planned parent's curated deliverable to the KG and archive workspace docs.
+ * Never throws — callers may fire-and-forget.
+ */
+export async function promoteDeliverableToKg(
+  opts: PromoteDeliverableOptions,
+): Promise<PromoteDeliverableResult> {
+  const { task, config, logger } = opts;
+
+  if (isKgPromotionDisabled(task, config)) {
+    logger.debug({ taskId: task.id }, 'Deliverable KG promotion: disabled — skipping');
+    return { promoted: false, reason: 'disabled' };
+  }
+
+  const plan = readPlanBlock(task.progress);
+  if (!plan) {
+    return { promoted: false, reason: 'no_plan' };
+  }
+
+  const children = await loadPlanChildren(opts.taskRepo, task);
+  const text = resolvePromotionText(plan, children);
+  if (!text) {
+    logger.debug({ taskId: task.id }, 'Deliverable KG promotion: no promotion text — skipping extraction');
+    return { promoted: false, reason: 'no_text' };
+  }
+
+  const rootTaskId = (await opts.taskRepo.resolveProjectRootTaskId(task.id)) ?? task.id;
+  const source = promotionSource(task.id, rootTaskId);
+  const agentId = task.sourceAgentId ?? task.agentId ?? 'system';
+  const conversationId = task.conversationId ?? `task:${task.id}`;
+  const invokeOptions = {
+    agentId,
+    conversationId,
+    parentEventId: opts.parentEventId,
+    taskEventId: task.id,
+  };
+  const callerContext = {
+    contactId: 'system',
+    role: null as string | null,
+    channel: 'system',
+  };
+
+  const errors: string[] = [];
+  let factsStored = 0;
+  let relationshipsStored = 0;
+
+  const skillResults = await Promise.allSettled([
+    opts.executionLayer.invoke(
+      'extract-relationships',
+      { text, source, max_stored: config.maxRelationships },
+      callerContext,
+      invokeOptions,
+    ),
+    opts.executionLayer.invoke(
+      'extract-facts',
+      { text, source, max_stored: config.maxFacts },
+      callerContext,
+      invokeOptions,
+    ),
+  ]);
+
+  for (const [index, result] of skillResults.entries()) {
+    const skillName = index === 0 ? 'extract-relationships' : 'extract-facts';
+    if (result.status === 'rejected') {
+      const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      errors.push(`${skillName}: ${message}`);
+      logger.error(
+        { err: result.reason as Error, taskId: task.id, skill: skillName },
+        'Deliverable KG promotion: skill threw unexpectedly',
+      );
+      continue;
+    }
+    const skillResult = result.value as SkillResult;
+    if (!skillResult.success) {
+      errors.push(`${skillName}: ${skillResult.error ?? 'unknown error'}`);
+      logger.warn(
+        { taskId: task.id, skill: skillName, error: skillResult.error },
+        'Deliverable KG promotion: skill returned failure',
+      );
+      continue;
+    }
+    if (skillName === 'extract-relationships' && skillResult.data) {
+      const data = skillResult.data as { extracted?: number; confirmed?: number };
+      relationshipsStored = (data.extracted ?? 0) + (data.confirmed ?? 0);
+    }
+    if (skillName === 'extract-facts' && skillResult.data) {
+      const data = skillResult.data as { stored?: number; redirected?: number };
+      factsStored = (data.stored ?? 0) + (data.redirected ?? 0);
+    }
+  }
+
+  let archivedDocs = 0;
+  try {
+    archivedDocs = await opts.workingDocsRepo.archiveProjectWorkspaceDocs(rootTaskId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    errors.push(`archive: ${message}`);
+    logger.error({ err, taskId: task.id, rootTaskId }, 'Deliverable KG promotion: workspace archival failed');
+  }
+
+  logger.info(
+    {
+      taskId: task.id,
+      rootTaskId,
+      deliverableStepId: plan.deliverableStepId,
+      factsStored,
+      relationshipsStored,
+      archivedDocs,
+      errorCount: errors.length,
+    },
+    'Deliverable KG promotion complete',
+  );
+
+  return {
+    promoted: true,
+    factsStored,
+    relationshipsStored,
+    archivedDocs,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}
+
+export interface DeliverableKgPromotionSubscriberOptions {
+  bus: EventBus;
+  taskRepo: TaskRepo;
+  workingDocsRepo: WorkingDocsRepo;
+  executionLayer: ExecutionLayer;
+  config: KgPromotionConfig;
+  logger: Logger;
+}
+
+/**
+ * System-layer subscriber: on planned-parent task.completed, promote the deliverable to the KG.
+ */
+export class DeliverableKgPromotionSubscriber {
+  constructor(private readonly opts: DeliverableKgPromotionSubscriberOptions) {}
+
+  start(): void {
+    this.opts.bus.subscribe('task.completed', 'system', async (event) => {
+      const completed = event as TaskCompletedEvent;
+      const { taskId } = completed.payload;
+
+      try {
+        const task = await this.opts.taskRepo.getTask(taskId);
+        if (!task || !readPlanBlock(task.progress)) return;
+
+        await promoteDeliverableToKg({
+          task,
+          parentEventId: completed.id,
+          taskRepo: this.opts.taskRepo,
+          workingDocsRepo: this.opts.workingDocsRepo,
+          executionLayer: this.opts.executionLayer,
+          config: this.opts.config,
+          logger: this.opts.logger,
+        });
+      } catch (err) {
+        this.opts.logger.error(
+          { err, taskId },
+          'Deliverable KG promotion: unexpected error in subscriber — parent completion unaffected',
+        );
+      }
+    });
+
+    this.opts.logger.info(
+      { kgPromotion: this.opts.config },
+      'DeliverableKgPromotionSubscriber started',
+    );
+  }
+}

--- a/src/agents/plan-execution.test.ts
+++ b/src/agents/plan-execution.test.ts
@@ -10,6 +10,7 @@ import {
   preflightPlanBlockWrite,
   resolveBlockedByTaskId,
   resolvePlanCompletionNote,
+  resolvePromotionText,
   validateDeliverableStepId,
   validatePlanStepsGraph,
 } from './plan-execution.js';
@@ -284,5 +285,61 @@ describe('plan completion helpers (#1239, #1240)', () => {
     expect(resolvePlanCompletionNote(rollupPlan, children)).toBe(
       'Research: Found 12 competitors\n\nDraft: Outline complete',
     );
+  });
+});
+
+describe('resolvePromotionText (#1241)', () => {
+  it('uses only the deliverable step output when marked', () => {
+    const plan: PlanProgressBlock = {
+      steps: [
+        { id: 'iterate', taskId: 'child-1' },
+        { id: 'deliverable', taskId: 'child-2' },
+      ],
+      deliverableStepId: 'deliverable',
+      done: 2,
+      total: 2,
+      next: 'Done',
+    };
+    const children = new Map([
+      ['child-1', {
+        title: 'Findings worklog',
+        description: null,
+        progress: { notes: [{ at: 't', note: '1300 rows of flagged accounts' }] },
+        errorBudget: { resumable: true },
+      }],
+      ['child-2', {
+        title: 'Synthesis',
+        description: null,
+        progress: { notes: [{ at: 't', note: 'Audit complete — 42 flagged for review' }] },
+      }],
+    ]);
+    expect(resolvePromotionText(plan, children)).toBe('Audit complete — 42 flagged for review');
+  });
+
+  it('skips resumable iterate leaves when rolling up without a deliverable step', () => {
+    const plan: PlanProgressBlock = {
+      steps: [
+        { id: 'iterate', taskId: 'child-1' },
+        { id: 'research', taskId: 'child-2' },
+      ],
+      deliverableStepId: null,
+      done: 2,
+      total: 2,
+      next: 'Done',
+    };
+    const children = new Map([
+      ['child-1', {
+        title: 'Findings worklog',
+        description: null,
+        progress: { notes: [{ at: 't', note: 'row 1300' }] },
+        errorBudget: { resumable: true },
+      }],
+      ['child-2', {
+        title: 'Research',
+        description: null,
+        progress: { notes: [{ at: 't', note: 'Themes identified' }] },
+      }],
+    ]);
+    expect(resolvePromotionText(plan, children)).toBe('Research: Themes identified');
   });
 });

--- a/src/agents/plan-execution.test.ts
+++ b/src/agents/plan-execution.test.ts
@@ -316,6 +316,24 @@ describe('resolvePromotionText (#1241)', () => {
     expect(resolvePromotionText(plan, children)).toBe('Audit complete — 42 flagged for review');
   });
 
+  it('returns null for a deliverable step with only a title fallback', () => {
+    const plan: PlanProgressBlock = {
+      steps: [{ id: 'deliverable', taskId: 'child-1' }],
+      deliverableStepId: 'deliverable',
+      done: 1,
+      total: 1,
+      next: 'Done',
+    };
+    const children = new Map([
+      ['child-1', {
+        title: 'Synthesis',
+        description: null,
+        progress: {},
+      }],
+    ]);
+    expect(resolvePromotionText(plan, children)).toBeNull();
+  });
+
   it('skips resumable iterate leaves when rolling up without a deliverable step', () => {
     const plan: PlanProgressBlock = {
       steps: [

--- a/src/agents/plan-execution.ts
+++ b/src/agents/plan-execution.ts
@@ -224,6 +224,22 @@ export function countMaterializationKinds(steps: readonly PlanStepInput[]): {
   return { iterateLeaves, heterogeneousRows, lazySteps };
 }
 
+/** Extract note/description output from a completed child — no title fallback. */
+export function extractTaskWrittenOutput(task: {
+  description: string | null;
+  progress: Record<string, unknown>;
+}): string | null {
+  const notes = task.progress.notes;
+  if (Array.isArray(notes) && notes.length > 0) {
+    for (let i = notes.length - 1; i >= 0; i--) {
+      const entry = notes[i] as { note?: string } | null;
+      if (entry?.note && entry.note.trim().length > 0) return entry.note.trim();
+    }
+  }
+  if (task.description && task.description.trim().length > 0) return task.description.trim();
+  return null;
+}
+
 /** Extract the best available output text from a completed child task. */
 export function extractTaskOutputNote(task: {
   title: string;
@@ -282,8 +298,7 @@ export function resolvePromotionText(
     const step = plan.steps.find((s) => s.id === plan.deliverableStepId);
     const child = step?.taskId ? children.get(step.taskId) : undefined;
     if (!child) return null;
-    const text = extractTaskOutputNote(child);
-    return text.trim().length > 0 ? text : null;
+    return extractTaskWrittenOutput(child);
   }
 
   const lines: string[] = [];

--- a/src/agents/plan-execution.ts
+++ b/src/agents/plan-execution.ts
@@ -262,6 +262,43 @@ export function resolvePlanCompletionNote(
   return lines.join('\n\n');
 }
 
+export interface PromotionChildSnapshot {
+  title: string;
+  description: string | null;
+  progress: Record<string, unknown>;
+  errorBudget?: Record<string, unknown>;
+}
+
+/**
+ * Text to promote into the KG on project completion — curated deliverable only.
+ * When a deliverable step is marked, uses that step's output exclusively. Otherwise
+ * rolls up non-resumable child summaries (skipping iterate-leaf worklogs).
+ */
+export function resolvePromotionText(
+  plan: PlanProgressBlock,
+  children: ReadonlyMap<string, PromotionChildSnapshot>,
+): string | null {
+  if (plan.deliverableStepId) {
+    const step = plan.steps.find((s) => s.id === plan.deliverableStepId);
+    const child = step?.taskId ? children.get(step.taskId) : undefined;
+    if (!child) return null;
+    const text = extractTaskOutputNote(child);
+    return text.trim().length > 0 ? text : null;
+  }
+
+  const lines: string[] = [];
+  for (const step of plan.steps) {
+    if (!step.taskId) continue;
+    const child = children.get(step.taskId);
+    if (!child) continue;
+    if (child.errorBudget?.['resumable'] === true) continue;
+    const note = extractTaskOutputNote(child);
+    if (note.trim().length === 0) continue;
+    lines.push(`${child.title}: ${note}`);
+  }
+  return lines.length > 0 ? lines.join('\n\n') : null;
+}
+
 /** True when every planned child is resolved and the deliverable step (if any) is done. */
 export function isPlanReadyForAutoComplete(
   plan: PlanProgressBlock,

--- a/src/config.ts
+++ b/src/config.ts
@@ -248,6 +248,12 @@ export interface YamlConfig {
   documentWorkspace?: {
     /** Days of inactivity before `/scratch/<conversation-id>/…` documents are archived by DreamEngine. Default: 7. */
     scratchTtlDays?: number;
+    /** KG promotion when a planned parent completes (#1241). */
+    kgPromotion?: {
+      enabled?: boolean;
+      maxFacts?: number;
+      maxRelationships?: number;
+    };
   };
   skillOutput?: {
     /** Max character length for skill results before truncation. Default: 200_000. */
@@ -756,6 +762,28 @@ export function loadYamlConfig(configDir: string): YamlConfig {
         throw new Error(
           `documentWorkspace.scratchTtlDays must be a positive integer no greater than 36500, got: ${scratchTtlDays}`,
         );
+      }
+    }
+
+    const kgPromotion = documentWorkspace.kgPromotion;
+    if (kgPromotion !== undefined) {
+      if (kgPromotion === null || typeof kgPromotion !== 'object' || Array.isArray(kgPromotion)) {
+        throw new Error('documentWorkspace.kgPromotion must be a YAML mapping');
+      }
+      if (kgPromotion.enabled !== undefined && typeof kgPromotion.enabled !== 'boolean') {
+        throw new Error(`documentWorkspace.kgPromotion.enabled must be a boolean, got: ${String(kgPromotion.enabled)}`);
+      }
+      if (kgPromotion.maxFacts !== undefined) {
+        if (!Number.isInteger(kgPromotion.maxFacts) || kgPromotion.maxFacts < 0) {
+          throw new Error(`documentWorkspace.kgPromotion.maxFacts must be a non-negative integer, got: ${String(kgPromotion.maxFacts)}`);
+        }
+      }
+      if (kgPromotion.maxRelationships !== undefined) {
+        if (!Number.isInteger(kgPromotion.maxRelationships) || kgPromotion.maxRelationships < 0) {
+          throw new Error(
+            `documentWorkspace.kgPromotion.maxRelationships must be a non-negative integer, got: ${String(kgPromotion.maxRelationships)}`,
+          );
+        }
       }
     }
   }

--- a/src/db/working-docs-repo.test.ts
+++ b/src/db/working-docs-repo.test.ts
@@ -170,4 +170,27 @@ describe('WorkingDocsRepo (unit)', () => {
     const repo = new WorkingDocsRepo(pool, createSilentLogger());
     await expect(repo.purgeExpiredScratch(7)).resolves.toBe(0);
   });
+
+  it('archiveProjectWorkspaceDocs archives by task_id and project path prefix', async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const client = makeClient({
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql === 'BEGIN' || sql === 'COMMIT') return { rows: [], rowCount: 0 } as unknown as QueryResult;
+        if (sql.includes('WITH archived AS')) {
+          return { rows: [{ archived_count: '3' }], rowCount: 1 } as QueryResult;
+        }
+        throw new Error(`unexpected sql: ${sql}`);
+      },
+    });
+    const { pool } = makePool(client);
+    const repo = new WorkingDocsRepo(pool, createSilentLogger());
+    const rootTaskId = '00000000-0000-4000-8000-000000000001';
+    const archived = await repo.archiveProjectWorkspaceDocs(rootTaskId);
+    expect(archived).toBe(3);
+    const archiveQuery = queries.find(q => q.sql.includes('WITH archived AS'));
+    expect(archiveQuery?.params?.[0]).toBe(rootTaskId);
+    expect(archiveQuery?.params?.[1]).toBe('/projects/00000000-0000-4000-8000-000000000001/%');
+    expect(archiveQuery?.sql).toContain('task_id = $1::uuid');
+  });
 });

--- a/src/db/working-docs-repo.ts
+++ b/src/db/working-docs-repo.ts
@@ -447,6 +447,52 @@ export class WorkingDocsRepo {
     }
   }
 
+  /**
+   * Archive all live workspace documents for a completed project (#1241).
+   * Matches rows by task_id and by `/projects/<rootTaskId>/…` path prefix.
+   */
+  async archiveProjectWorkspaceDocs(rootTaskId: string): Promise<number> {
+    const pathPrefix = `/projects/${rootTaskId}/`;
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const { rows } = await client.query<{ archived_count: string }>(
+        `WITH archived AS (
+           UPDATE working_documents
+              SET archived_at = now(),
+                  updated_at = now()
+            WHERE archived_at IS NULL
+              AND (
+                task_id = $1::uuid
+                OR path LIKE $2 ESCAPE '\\'
+              )
+           RETURNING path
+         ),
+         _links AS (
+           DELETE FROM working_document_links
+            WHERE source_path IN (SELECT path FROM archived)
+         )
+         SELECT COUNT(*)::text AS archived_count FROM archived`,
+        [rootTaskId, `${escapeLikePattern(pathPrefix)}%`],
+      );
+
+      await client.query('COMMIT');
+      const archived = Number.parseInt(rows[0]?.archived_count ?? '0', 10);
+      this.logger.info(
+        { rootTaskId, archived },
+        'working-docs-repo: archived project workspace documents',
+      );
+      return archived;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      this.logger.error({ err, rootTaskId }, 'working-docs-repo: archiveProjectWorkspaceDocs failed');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   async softDelete(path: string): Promise<WorkingDocRow | null> {
     const normalized = normalizeDocPath(path);
     const client = await this.pool.connect();

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,10 @@ import { applyDocumentWorkspace, DEFAULT_SCRATCH_DOC_TTL_DAYS } from './agents/d
 import { BacklogHeartbeat } from './scheduler/backlog-heartbeat.js';
 import { ResumableContinuationSubscriber } from './agents/resumable-continuation-subscriber.js';
 import { PlanFrontierSubscriber } from './agents/plan-frontier-subscriber.js';
+import {
+  DeliverableKgPromotionSubscriber,
+  resolveKgPromotionConfig,
+} from './agents/deliverable-kg-promotion.js';
 import * as fs from 'node:fs';
 import * as yaml from 'js-yaml';
 import { RegistryRepo } from './registry/registry-repo.js';
@@ -2043,6 +2047,18 @@ async function main(): Promise<void> {
     resumableCeilings: tasksConfig.resumableCeilings,
   });
   planFrontierSubscriber.start();
+
+  if (workingDocsRepo) {
+    const deliverableKgPromotionSubscriber = new DeliverableKgPromotionSubscriber({
+      bus,
+      taskRepo,
+      workingDocsRepo,
+      executionLayer,
+      config: resolveKgPromotionConfig(yamlConfig.documentWorkspace?.kgPromotion),
+      logger,
+    });
+    deliverableKgPromotionSubscriber.start();
+  }
 
   logger.info('Scheduler started');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1241

When a planned parent task completes, the platform now promotes its **curated deliverable** into the knowledge graph through the existing `extract-facts` / `extract-relationships` skills, then archives the project's workspace documents.

## What changed

- **`DeliverableKgPromotionSubscriber`** — listens for `task.completed` on planned parents and runs best-effort KG promotion + workspace archival. Failures are logged but never block parent completion.
- **`resolvePromotionText`** — selects deliverable-step output when `deliverableStepId` is set; otherwise rolls up non-resumable child summaries (skipping iterate-leaf worklogs).
- **`WorkingDocsRepo.archiveProjectWorkspaceDocs`** — sets `archived_at` on live docs matching the project root `task_id` or `/projects/<rootId>/…` path prefix.
- **Config** — `documentWorkspace.kgPromotion` (`enabled`, `maxFacts`, `maxRelationships`); per-task override via `error_budget.kg_promotion: false`.
- **`max_stored` input** — optional cap on `extract-facts` / `extract-relationships` invocations for promotion.

## Acceptance criteria

- [x] On deliverable completion, curated deliverable promoted via `extract-facts` / `extract-relationships`; per-item worklog excluded
- [x] Promotion capped per project and audited (via existing `memory.store` observer + typed source attribution)
- [x] Best-effort + non-fatal: promotion failure does not fail parent completion
- [x] Disable flag skips promotion (config + per-task)
- [x] After promotion, project workspace docs archived (`archived_at` set)
- [x] Tests: promotion path (capped, worklog excluded), non-fatal on failure, disable flag, archival
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42ded3e9-7c87-4c07-9418-69920b2a71dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42ded3e9-7c87-4c07-9418-69920b2a71dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

