### PR TITLE
fix: close out Phase 2 (#1177) — reconcile children on circuit-breaker failure + e2e test + spec 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,34 +15,36 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Plan frontier advancement** — child terminal resolution schedules a near-term planned-parent wake; the wake recomputes `progress.plan` rollup and dispatches newly-unblocked children (BacklogHeartbeat remains the backstop). (#1238)
-- **Plan completion reconciliation** — terminal plan parents now cancel open descendants and their pending wakes. (#1239)
-- **Plan auto-complete** — fully-resolved plans now finish automatically using the deliverable step output. (#1239)
-- **Plan deliverable surfacing** — parent auto-complete honors `deliverableStepId` for the completion summary, defaulting to a plan-order rollup of child outputs when unset. (#1240)
-- **Deliverable KG promotion** — planned-parent completion promotes the curated deliverable via `extract-facts` / `extract-relationships` (capped, audited, best-effort), then archives project workspace docs; per-task `error_budget.kg_promotion: false` or `documentWorkspace.kgPromotion.enabled: false` skips it. (#1241)
-- **Plan frontier circuit breaker** — planned-parent wakes now escalate after repeated stalls without frontier progress. (#1239)
-- **`plan`** — rows-direct goal decomposition skill writing child task rows and `progress.plan`; platform plan-altitude guidance and per-turn dynamic pin for complex bound tasks. (#1237)
-- **`progress.plan`** — typed plan block with child-step descriptors, deliverable step pointer, and "X of Y" rollup helper; round-trip persistence via `getPlanBlock` / `setPlanBlock`. (#1236)
-- **Resumable circuit breaker** — stall counter and aggregate ceilings fail stuck resumable tasks instead of looping. (#1176)
-- **Resumable executor contract** — checkpointed budget-hit pauses instead of `BUDGET_EXCEEDED`; coordinator treats `paused` as success. (#1174)
-- **Resumable self-continuation** — paused resumable tasks schedule a single near-term `scheduled_jobs` wake routed to `source_agent_id` (config: `tasks.resumableContinuationSeconds`); the hourly BacklogHeartbeat remains the backstop. (#1175)
-- **`checkpoint`** — resumable-task primitive writing `progress.resumable`; dedicated skill (not folded into `task-update`) with platform guidance, checkpoint resume injection, a one-time ~15% budget nudge at the message tail, auto-pin even for tool-less agents, and no raw UTC in skill results when timezone is absent. (#1173)
+- **Spec 20 — Resumable Tasks & Projects** — as-built design promoted to a permanent spec. (#1177)
+- **Plan frontier advancement** — child completion wakes the parent, dispatches unblocked siblings. (#1238)
+- **Plan completion reconciliation** — terminal parents cancel open descendants and their wakes. (#1239)
+- **Plan auto-complete** — resolved plans finish using the deliverable output. (#1239)
+- **Plan deliverable surfacing** — parent result honors `deliverableStepId`, else child-summary rollup. (#1240)
+- **Deliverable KG promotion** — completed plans promote the curated deliverable, capped and non-fatal. (#1241)
+- **Plan frontier circuit breaker** — stalled planned parents escalate instead of looping. (#1239)
+- **`plan`** — rows-direct goal decomposition skill writing child task rows. (#1237)
+- **`progress.plan`** — typed plan block with an X-of-Y rollup helper. (#1236)
+- **Resumable circuit breaker** — stall counter and ceilings fail stuck tasks. (#1176)
+- **Resumable executor contract** — checkpointed budget-hit pauses instead of failing. (#1174)
+- **Resumable self-continuation** — paused tasks schedule a near-term continuation wake. (#1175)
+- **`checkpoint`** — resumable-task primitive writing `progress.resumable` with a budget nudge. (#1173)
 - **Calendar scheduling rules** — calendar agent loads CEO scheduling rules from `config-store` by key at task start, replacing semantic `memory-query`. (#1223)
-- **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill pointer, plus round-trip tests. (#1172)
-- **Resumable accumulator spill** — inline overflow writes to `/projects/<root>/accumulator.md` and stores a workspace document pointer; resume injects the manifest and spilled doc at the message tail. (#1210)
+- **`progress.resumable`** — typed checkpoint block with bounded accumulator and spill. (#1172)
+- **Resumable accumulator spill** — inline overflow spills to a workspace doc pointer. (#1210)
 - **Document workspace** — `working_documents` / `working_document_links` Postgres store with `WorkingDocsRepo`, OKF frontmatter round-trip, backlink index, and optimistic concurrency (document + per-section). (#1208)
 - **`doc-read` / `doc-list` / `doc-write` / `doc-search`** — OKF workspace skills with harness-injected guidance, auto-pin on task-management agents, manifest-only tail injection, and `log.md` append on writes. (#1209)
 - **Document workspace scratch TTL** — DreamEngine nightly pass archives expired `/scratch/<conversation-id>/…` documents (`archived_at`); configurable `documentWorkspace.scratchTtlDays` with optional per-doc `ttl_days` frontmatter override. (#1212)
 
 ### Changed
 
-- **Per-task error_budget** — HTTP and scheduler paths now reject per-invocation turn-limit keys (`maxTurns`, `maxConsecutiveErrors`); per-agent YAML remains the sole source of truth for slice budgets, while the column keeps resumable flags and aggregate ceiling overrides. (#883)
-- **`delegate`** — honors `retryable: false` on specialist failures with an enforceable per-turn guard: identical re-delegations are blocked and non-retryable failures escalate to the CEO backlog via `task-create`. (#1171)
-- **`delegate`** — specialist failures now propagate structured `reason` and `retryable` from the runtime (e.g. `maxTurns`) instead of generic timeout/error strings, so the coordinator can report the real cause. (#1170)
+- **Per-task error_budget** — rejects per-invocation turn-limit keys; keeps resumable ceilings. (#883)
+- **`delegate`** — honors `retryable: false`; blocks blind re-delegation and escalates. (#1171)
+- **`delegate`** — propagates structured failure `reason`/`retryable` to the coordinator. (#1170)
 - **`web-browser`** — waits through edge WAF challenge pages and resolves hidden custom form controls. (v1.5.0)
 
 ### Fixed
 
+- **Plan reconciliation on failure** — circuit-breaker `failed` parents now cancel open children. (#1177)
 - **Signal phone number** — consolidated onto one canonical vault key (`channel.signal.phone_number`), backfilled by migration; console entry alone now activates Signal. (#1140)
 - **Outbound content filter** — Stage 2.5 escalation judge no longer calls the LLM for principal-tier recipients; `classifyDisclosure()` is fail-closed, so a transient provider failure was incorrectly blocking principal-bound emails (e.g. the daily recap) even though the policy unconditionally permits all disclosure classes for the principal. (#1225)
 - **Calendar free/busy** — `getFreeBusy` now calls the real Nylas v8 `calendars.getFreeBusy` endpoint; the previous call to a non-existent `calendars_free_busy` resource crashed every `calendar-check-conflicts` and `calendar-find-free-time` invocation. It also fails loud on a per-calendar free/busy *error* entry instead of treating that calendar as fully free (which could double-book the principal). (#1214)

--- a/docs/specs/19-tasks-and-backlog.md
+++ b/docs/specs/19-tasks-and-backlog.md
@@ -349,6 +349,14 @@ config — the LLM handles nuance, config handles mechanics.
 
 ## 10. Deferred (post-v1)
 
+> **Update:** Durable multi-step projects with a weighted progress rollup and resumable
+> execution across budget boundaries shipped later as **[spec 20 — Resumable Tasks &
+> Projects](20-resumable-tasks-and-projects.md)** (the `plan` primitive, the
+> `progress.plan` "X of Y" rollup, the `paused`-as-success contract, and frontier
+> advancement). The items below that spec 20 does *not* cover — a first-class
+> `goals`/`commitments` entity, DAG dependencies beyond a single `blocked_by_task_id`, an
+> LLM groomer, and an interactive digest surface — remain deferred.
+
 Captured so future readers do not relitigate the scope decisions: a `goals` table and
 weighted progress rollup (tags carry us until a durable cluster appears); autonomous task
 generation from inferred needs; a first-class `commitments` entity (modeled today as a task

--- a/docs/specs/20-resumable-tasks-and-projects.md
+++ b/docs/specs/20-resumable-tasks-and-projects.md
@@ -183,6 +183,7 @@ Per-task overrides live in `tasks.error_budget` (`resumable`, `max_stalls`, `max
 
 This spec supersedes several items spec 19 §10 deferred: durable multi-step projects with a
 weighted progress rollup (the `progress.plan` "X of Y"), and decomposition with dependencies.
-The single-`blocked_by_task_id` DAG limitation and a first-class `goals`/`commitments` entity
-remain deferred. Everything here reuses spec 19's `tasks` + `scheduled_jobs` + heartbeat — no
-parallel "project runner" subsystem was introduced (explicitly rejected in the design memo).
+The single-`blocked_by_task_id` DAG limitation, a first-class `goals`/`commitments` entity,
+an LLM groomer, and an interactive digest surface remain deferred (spec 19 §10). Everything
+here reuses spec 19's `tasks` + `scheduled_jobs` + heartbeat — no parallel "project runner"
+subsystem was introduced (explicitly rejected in the design memo).

--- a/docs/specs/20-resumable-tasks-and-projects.md
+++ b/docs/specs/20-resumable-tasks-and-projects.md
@@ -1,0 +1,188 @@
+# 20 — Resumable Tasks & Projects
+
+**Date:** 2026-06-30
+**Status:** Shipped (Phases 0–2)
+**Builds on:** [spec 19 — Tasks & Backlog](19-tasks-and-backlog.md), [spec 07 — Scheduler](07-scheduler.md), [spec 14 — Autonomy Engine](14-autonomy-engine.md), [spec 01 — Memory System](01-memory-system.md)
+
+## Overview
+
+Spec 19 gave the platform a durable place to track work. It did not solve **work that
+exceeds a single executor invocation**. A specialist sized as a lightweight heartbeat
+(`max_turns: 25`) that is handed an unbounded job (audit ~1,300 follows, read 40 docs,
+dedupe 500 contacts) runs out of turns mid-work; the budget-hit was reported to the
+coordinator as "didn't respond," which it confabulated into an external API timeout and
+then blind-retried 51 times over 5 hours, leaving an orphaned subtask the heartbeat
+re-poked indefinitely.
+
+This spec describes the resumable-task model that fixes that class of failure. The spine
+is one idea: **a goal becomes a plan, progress is tracked as "X of Y done," and resumption
+advances the frontier until done.** Both quantitative sweeps ("process 1,300 follows") and
+qualitative goals ("design the kickoff with the 6 execs") are the same thing at the right
+altitude — a planner breaking a goal into trackable units. The only thing that
+distinguishes "kinds" of work is **materialization**: ~10 heterogeneous steps of a kickoff
+become child task rows; a 1,300-item sweep stays a single leaf that loops over a cursor (no
+row per item).
+
+Two principles shaped it:
+
+- **(A) No project foresight in agent authors.** You write a generic `social-media` agent;
+  you never anticipate a follow-audit. The structure of a project is decided at runtime by
+  the LLM through generic harness primitives, steered by platform guidance, and *guaranteed*
+  by a deterministic safety-net — never by author-declared iteration.
+- **(B) Materialization is the only reason to distinguish kinds of work.** A planned step
+  becomes a real child row (dispatchable, blockable, schedulable). A high-count homogeneous
+  step is one leaf with a cursor. One progress notion, one resume loop.
+
+**Companion design docs:** [2026-06-23-resumable-tasks-and-projects-design.md](../wip/2026-06-23-resumable-tasks-and-projects-design.md),
+[2026-06-26-agent-document-workspace-okf-design.md](../wip/2026-06-26-agent-document-workspace-okf-design.md),
+[ADR-024 — `plan` writes rows directly](../adr/024-plan-rows-direct.md). Tracking epic: #1150.
+
+---
+
+## 1. The resumable-execution contract
+
+An executor invocation returns one of three outcomes (`src/agents/resumable-task.ts`):
+
+| Outcome | Meaning | Effect |
+|---|---|---|
+| `done` | Work complete | Task → `done`; carries the final summary/deliverable |
+| `paused` | Real progress made, more remains | Task stays `in_progress`; checkpoint persisted; continuation scheduled. **Success at the delegation layer, not a timeout.** |
+| `failed` | Genuine error | Carries a structured `reason` (`budget_max_turns`, `tool_error`, `api_error`, `blocked`) and `retryable: bool`, propagated honestly upward |
+
+`paused` **reuses the existing `in_progress` status** — no new task status, no schema churn.
+It is signalled through the `EXECUTION_PAUSED_PROTOCOL` marker on the `agent.response`
+(`buildExecutionPausedResponse` / `parseExecutionPausedPayload`). The delegate layer treats
+`paused` as success (no re-delegation); `failed{retryable:false}` escalates without blind
+retry; `failed{retryable:true}` gets a bounded retry then escalates (`DelegationGuard`,
+`src/agents/delegation-guard.ts`). This ends the confabulation: the coordinator now receives
+`failed{reason: budget_max_turns}` and reports the truth.
+
+## 2. Resumable state — the `progress.resumable` block
+
+Resumable state lives in the existing `tasks.progress` JSONB under a `resumable` block (no
+migration), defined and bounded in `src/db/resumable-progress.ts`:
+
+- `cursor` (opaque, LLM-authored), `done` / `total`, `lastSliceUnits`, a one-line `next`,
+  `checkpointedAt`, and an `accumulator`.
+- The accumulator is **bounded**: an inline cap (4 KB) and an overall block cap (8 KB). On
+  overflow it spills to the document workspace (`working_documents`, spec 01 / OKF design)
+  and the block stores a `{ kind: 'document', path, section? }` pointer instead.
+
+`TaskRepo.getResumableBlock` / `setResumableBlock` are the only read/write path; writes
+publish `task.updated` for audit. A task is "resumable" when `error_budget.resumable=true`,
+a `resumable` tag is present, or a checkpoint already exists (`isResumableTask`).
+
+## 3. Checkpointing — a harness guarantee, not an author convention
+
+- **Cooperative.** The platform injects a fixed-slot resumable-task guidance block
+  (`buildResumableTaskGuidanceBlock`, `src/agents/runtime.ts`) — *not* author-editable — plus
+  a generic `checkpoint(progress)` skill (`skills/checkpoint/`, `action_risk: low`) dynamically
+  pinned per-turn for resumable tasks. When remaining budget drops below ~15%, a one-time
+  "checkpoint and pause now" nudge is appended to the **message tail** (never the cached
+  tools/system prefix, so prefix caching survives across providers).
+- **Safety-net (the real guarantee).** If the runtime hits the hard budget wall anyway,
+  `handleBudgetExceeded()` converts the budget-hit into `paused` from the last persisted
+  checkpoint instead of emitting `BUDGET_EXCEEDED`. With no checkpoint, it is an honest
+  `failed`. Correctness rests on the safety-net; the nudge is a latency optimization.
+
+## 4. The resume loop & circuit-breaker
+
+A `paused` task schedules its **own near-term continuation** wake (`scheduled_jobs`,
+default `tasks.resumableContinuationSeconds: 30`) routed to its `source_agent_id`
+(`src/agents/resumable-continuation.ts` + `resumable-continuation-subscriber.ts`), rather
+than waiting for the hourly `BacklogHeartbeat`, which remains the backstop. A partial unique
+index (migration 067) enforces at most one active wake per task.
+
+The circuit-breaker keys on **progress, not error count** (`src/agents/resumable-circuit-breaker.ts`,
+state in `progress.resumableCircuit`). A continuation that makes no forward progress (cursor
+unchanged and done-count flat) increments a stall counter; after K stalls, or on breach of a
+hard per-task ceiling, the task is failed and escalated via the existing `needs-attention`
+backlog path. Defaults (`tasks.resumableCeilings`): `maxStalls: 3`, `maxIterations: 100`,
+`maxWallclockHours: 24`, `maxCostUsd: 10`; each is overridable per task through the
+`error_budget` keys validated in `src/tasks/task-error-budget.ts` (per #883: per-task keys
+only — per-invocation `max_turns`/`max_errors` belong to agent config and are rejected on
+task rows).
+
+## 5. The `plan` primitive
+
+For goals too complex for a single leaf, the runtime LLM calls `plan(goal)` (`skills/plan/`,
+`action_risk: low`), symmetric with `checkpoint` and dynamically pinned for complex/planned
+tasks (`shouldOfferPlanSkill` / `applyPlanHarness`, `src/agents/planned-task.ts`).
+
+- **Rows-direct** ([ADR-024](../adr/024-plan-rows-direct.md)): `plan` writes child task rows
+  itself via `TaskRepo` (reusing `task-create` internals), rather than proposing a tree the
+  coordinator commits — keeping the decomposition loop out of the prompt layer that
+  confabulated. Children carry `parent_task_id`, `blocked_by_task_id`, and
+  `waiting_on_contact_id` (human-input steps the heartbeat already treats specially).
+- **Progressive & lazy** — a step decomposes further only when picked up (`materialize:false`
+  leaves it unmaterialized in the plan block until then).
+- **Adaptive** — re-running `plan` on a planned parent reconciles steps against existing
+  children by step id (reuse, cancel drift, cancel removed) without duplicating.
+- **Materialization altitude** — a high-count homogeneous step is created as a single
+  iterate leaf (`resumable=true`), not one row per item.
+
+Planned-step state lives in `tasks.progress.plan` (`src/db/plan-progress.ts`,
+`PlanProgressBlock`): the ordered step descriptors (each pointing at its child row id),
+`deliverableStepId`, and an "X of Y" rollup (`computePlanRollup`, resolved = `done`/`cancelled`).
+A task is a planned step iff this block is present (`isPlannedStep`) — no new column/status.
+The block is bounded; wide plans store references, never per-item data.
+
+## 6. Frontier advancement, reconciliation, and the deliverable
+
+- **Frontier advancement** (`PlanFrontierSubscriber`, `src/agents/plan-frontier.ts`). When a
+  child resolves, the subscriber wakes its planned parent (reusing the continuation wake +
+  dedup) routed to the parent's `source_agent_id`. On the wake, `advancePlanFrontier`
+  recomputes the rollup, dispatches newly-unblocked children, and re-evaluates the plan. The
+  heartbeat is the backstop.
+- **Completion reconciliation.** When a parent reaches a **terminal** state — `done`,
+  `cancelled` (`updateTask`/`completeTask`) **or `failed`** (`failResumableTask`, the
+  circuit-breaker path) — its open descendant children are recursively cancelled with a
+  reason and their pending wakes cancelled, in one transaction (`reconcileChildren` /
+  `runReconcileChildrenQuery`). This is the direct fix for the orphaned-subtask futility loop:
+  no terminal parent leaves children for the heartbeat to re-poke.
+- **Auto-complete + deliverable.** When the subtree is resolved and the deliverable step is
+  done, the parent auto-completes (`isPlanReadyForAutoComplete`). The parent's result is the
+  `deliverableStepId` step's output, or a rollup of child summaries in plan order when no
+  deliverable is marked (`resolvePlanCompletionNote`, `src/agents/plan-execution.ts`).
+  Synthesis is not special machinery — it is just the last planned step, surfaced through the
+  existing completion path.
+
+## 7. Promoting the deliverable to the knowledge graph
+
+On a planned parent's completion, `DeliverableKgPromotionSubscriber`
+(`src/agents/deliverable-kg-promotion.ts`) distils the **curated deliverable** (never the
+per-item worklog) into the KG through the existing `extract-facts` / `extract-relationships`
+gates — typed, source-attributed, and **capped per project** (`documentWorkspace.kgPromotion`:
+`maxFacts: 50`, `maxRelationships: 50`). Promotion is **best-effort and non-fatal**
+(fire-and-forget with a catch; it can never fail the parent's completion), is disableable
+globally or per task (`error_budget.kg_promotion: false`), and archives the project's
+workspace docs (`archived_at`) afterward.
+
+## 8. Configuration
+
+```yaml
+tasks:
+  resumableContinuationSeconds: 30   # near-term continuation cadence (vs. hourly heartbeat)
+  resumableCeilings:
+    maxStalls: 3                      # K consecutive no-progress continuations → escalate
+    maxIterations: 100               # hard cap on continuation slices
+    maxWallclockHours: 24            # elapsed cap from first pause
+    maxCostUsd: 10.00                # aggregate LLM cost cap across slices
+
+documentWorkspace:
+  kgPromotion:
+    enabled: true
+    maxFacts: 50
+    maxRelationships: 50
+```
+
+Per-task overrides live in `tasks.error_budget` (`resumable`, `max_stalls`, `max_iterations`,
+`max_wallclock_hours`, `max_cost_usd`, `kg_promotion`).
+
+## 9. Relationship to spec 19
+
+This spec supersedes several items spec 19 §10 deferred: durable multi-step projects with a
+weighted progress rollup (the `progress.plan` "X of Y"), and decomposition with dependencies.
+The single-`blocked_by_task_id` DAG limitation and a first-class `goals`/`commitments` entity
+remain deferred. Everything here reuses spec 19's `tasks` + `scheduled_jobs` + heartbeat — no
+parallel "project runner" subsystem was introduced (explicitly rejected in the design memo).

--- a/docs/wip/2026-06-23-resumable-tasks-and-projects-design.md
+++ b/docs/wip/2026-06-23-resumable-tasks-and-projects-design.md
@@ -1,7 +1,7 @@
 # Resumable Tasks & Projects — Design
 
 **Date:** 2026-06-23
-**Status:** Draft / Decision-ready (no implementation yet)
+**Status:** Shipped (Phases 0–2) — promoted to [spec 20 — Resumable Tasks & Projects](../specs/20-resumable-tasks-and-projects.md). This memo is kept as the dated design record.
 **Builds on:** [spec 19 — Tasks & Backlog](../specs/19-tasks-and-backlog.md), [spec 07 — Scheduler](../specs/07-scheduler.md), [spec 14 — Autonomy Engine](../specs/14-autonomy-engine.md)
 
 ## Context — the motivating failure

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -928,7 +928,14 @@ export class TaskRepo {
 
   /**
    * Fail a resumable task on circuit-breaker breach: status failed, cancel wakes,
-   * merge circuit state + progress note, add escalation tags.
+   * merge circuit state + progress note, add escalation tags, and reconcile
+   * (cancel) open descendant children.
+   *
+   * `failed` is a terminal state just like `done`/`cancelled`, so it must run the
+   * same child reconciliation those paths do — otherwise a planned parent that the
+   * circuit-breaker fails leaves its open children behind for the BacklogHeartbeat
+   * to re-poke forever, which is exactly the orphaned-subtask futility loop
+   * (memo gap #6) the plan primitive exists to close (#1177 closeout).
    */
   async failResumableTask(
     taskId: string,
@@ -946,30 +953,53 @@ export class TaskRepo {
 
     const notes = [{ at: new Date().toISOString(), note: options.progressNote }];
     const mergedTags = [...new Set([...current.tags, ...options.tags])];
+    const reconcileReason = `reconciled: parent ${taskId} failed`;
 
-    const { rows } = await this.pool.query(
-      `WITH updated_task AS (
-         UPDATE tasks
-            SET status = 'failed',
-                progress = COALESCE(progress, '{}'::jsonb)
-                  || jsonb_build_object('resumableCircuit', $1::jsonb)
-                  || jsonb_build_object('notes', COALESCE(progress->'notes', '[]'::jsonb) || $2::jsonb),
-                tags = $3::text[],
-                updated_at = now()
-          WHERE id = $4
-            AND status NOT IN ('done', 'cancelled', 'failed')
-          RETURNING ${TASK_COLUMNS}
-       ),
-       _cancel_wake AS (
-         UPDATE scheduled_jobs SET status = 'cancelled'
-          WHERE task_id = $4 AND status IN ('pending', 'running')
-       )
-       SELECT * FROM updated_task`,
-      [JSON.stringify(options.circuitState), JSON.stringify(notes), mergedTags, taskId],
-    );
-
-    const row = rows[0] as DbTaskRow | undefined;
-    if (!row) return await this.getTask(taskId);
+    // The parent-fail UPDATE and the descendant reconciliation run in one
+    // transaction so a failed parent can never be observed with open children
+    // (mirrors completeTask's atomic reconcile).
+    const client = await this.pool.connect();
+    let row: DbTaskRow | undefined;
+    let reconciledChildren: ReconciledChildRow[] = [];
+    try {
+      await client.query('BEGIN');
+      const { rows } = await client.query(
+        `WITH updated_task AS (
+           UPDATE tasks
+              SET status = 'failed',
+                  progress = COALESCE(progress, '{}'::jsonb)
+                    || jsonb_build_object('resumableCircuit', $1::jsonb)
+                    || jsonb_build_object('notes', COALESCE(progress->'notes', '[]'::jsonb) || $2::jsonb),
+                  tags = $3::text[],
+                  updated_at = now()
+            WHERE id = $4
+              AND status NOT IN ('done', 'cancelled', 'failed')
+            RETURNING ${TASK_COLUMNS}
+         ),
+         _cancel_wake AS (
+           UPDATE scheduled_jobs SET status = 'cancelled'
+            WHERE task_id = $4 AND status IN ('pending', 'running')
+         )
+         SELECT * FROM updated_task`,
+        [JSON.stringify(options.circuitState), JSON.stringify(notes), mergedTags, taskId],
+      );
+      row = rows[0] as DbTaskRow | undefined;
+      if (!row) {
+        // The row flipped to a terminal status (or vanished) between getTask and
+        // this UPDATE. Unlike completeTask we return current truth rather than
+        // throwing — failResumableTask is idempotent terminalization (the top
+        // guard already treats an already-terminal task as a no-op success).
+        await client.query('ROLLBACK');
+        return await this.getTask(taskId);
+      }
+      reconciledChildren = await this.runReconcileChildrenQuery(client, taskId, reconcileReason);
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
 
     const updated = mapTaskRow(row);
     try {
@@ -983,6 +1013,12 @@ export class TaskRepo {
     } catch (busErr) {
       this.logger.error({ busErr, taskId }, 'task-repo: bus publish failed after failResumableTask');
     }
+
+    // System-triggered failure has no caller agent (matches the null agentId above).
+    if (reconciledChildren.length > 0) {
+      await this.publishReconcileChildEvents(reconciledChildren, reconcileReason, undefined, taskId);
+    }
+
     this.logger.warn({ taskId }, 'task-repo: resumable task failed by circuit breaker');
     return updated;
   }

--- a/tests/integration/plan-completion-reconciliation.test.ts
+++ b/tests/integration/plan-completion-reconciliation.test.ts
@@ -313,6 +313,103 @@ describeIf('Plan completion reconciliation (#1239)', () => {
     expect(reloaded?.tags).toContain('needs-attention');
   });
 
+  it('reconciles open children when the circuit-breaker fails a planned parent', async () => {
+    // Regression for the gap closing out #1177: when the progress circuit-breaker
+    // fails a stalled planned parent, its open children must be reconciled
+    // (cancelled) rather than left for the BacklogHeartbeat to re-poke forever —
+    // the exact orphaned-subtask futility loop (gap #6) Phase 2 exists to close.
+    const ceilings = { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 2 };
+    const subscriber = new PlanFrontierSubscriber({
+      pool,
+      bus,
+      logger,
+      schedulerService,
+      taskRepo: repo,
+      eligibleAgents: new Set(['coordinator']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: ceilings,
+    });
+    subscriber.start();
+
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} breaker-fail parent`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+    });
+    const child = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} breaker-fail child`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+      parentTaskId: parent.id,
+    });
+    // A pending wake on the still-open child — reconciliation must cancel it too.
+    await schedulerService.enqueueTaskWake({
+      taskId: child.id,
+      agentId: 'coordinator',
+      runAt: new Date(Date.now() + 60_000),
+      createdBy: 'test',
+    });
+
+    await repo.setPlanBlock(parent.id, {
+      steps: [{ id: 'only', taskId: child.id }],
+      deliverableStepId: 'only',
+      done: 0,
+      total: 1,
+      next: 'Waiting on child',
+    }, 'coordinator');
+
+    // One stall short of the ceiling so this wake (no frontier progress) trips it.
+    await repo.persistResumableCircuitState(parent.id, {
+      stallCount: 1,
+      iterationCount: 3,
+      startedAt: new Date().toISOString(),
+      totalCostUsd: 0,
+      lastProgress: { done: 0, cursor: { terminalChildren: 0 } },
+    });
+
+    const parentWake = await schedulerService.enqueueTaskWake({
+      taskId: parent.id,
+      agentId: 'coordinator',
+      runAt: new Date(),
+      createdBy: 'test',
+    });
+
+    await bus.publish('system', createScheduleFired({
+      jobId: parentWake.jobId,
+      agentId: 'coordinator',
+      agentTaskId: parent.id,
+      parentEventId: 'breaker-fail-wake',
+    }));
+
+    const reloadedParent = await repo.getTask(parent.id);
+    expect(reloadedParent?.status).toBe('failed');
+
+    // The open child must be reconciled (cancelled), not left orphaned.
+    const reloadedChild = await repo.getTask(child.id);
+    expect(reloadedChild?.status).toBe('cancelled');
+
+    const openChildren = await pool.query<{ count: string }>(
+      `WITH RECURSIVE descendants AS (
+         SELECT id, status FROM tasks WHERE parent_task_id = $1
+         UNION ALL
+         SELECT t.id, t.status FROM tasks t
+         INNER JOIN descendants d ON t.parent_task_id = d.id
+       )
+       SELECT COUNT(*)::text AS count FROM descendants WHERE status NOT IN ('done', 'cancelled', 'failed')`,
+      [parent.id],
+    );
+    expect(openChildren.rows[0]!.count).toBe('0');
+
+    // The child's pending wake must be cancelled by reconciliation.
+    const pendingWakes = await pool.query(
+      `SELECT id FROM scheduled_jobs WHERE task_id = $1 AND status IN ('pending', 'running')`,
+      [child.id],
+    );
+    expect(pendingWakes.rows).toHaveLength(0);
+  });
+
   it('does not trip the breaker when the frontier advances between wakes', async () => {
     const ceilings = { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 2 };
 

--- a/tests/integration/plan-lifecycle-e2e.test.ts
+++ b/tests/integration/plan-lifecycle-e2e.test.ts
@@ -146,14 +146,28 @@ describeIf('Plan primitive end-to-end (#1177)', () => {
     );
     expect(synthDispatch.rows).toHaveLength(1);
 
+    // Mark the already-fired gather wake completed (as the scheduler would after a
+    // run), so the one-active-wake-per-task dedup frees. This lets us prove synth
+    // completion schedules a *fresh* parent wake rather than recycling the gather one.
+    await schedulerService.completeJobRun(parentWakeId, true);
+
     // 5. The deliverable child produces its output and completes.
     const deliverable = `${PREFIX} kickoff plan: agenda, sessions, owners`;
     await repo.updateTask(synthId, { progressNote: deliverable }, 'coordinator');
     await repo.updateTask(synthId, { status: 'done' }, 'coordinator');
 
-    // 6. Fire the parent wake again → subtree resolved → parent auto-completes.
+    // Synth completion must enqueue a brand-new parent wake (not the gather one).
+    const wakeAfterSynth = await pool.query<{ id: string }>(
+      `SELECT id FROM scheduled_jobs WHERE task_id = $1 AND status = 'pending'`,
+      [parent.id],
+    );
+    expect(wakeAfterSynth.rows).toHaveLength(1);
+    const completionWakeId = wakeAfterSynth.rows[0]!.id;
+    expect(completionWakeId).not.toBe(parentWakeId);
+
+    // 6. Fire the fresh wake → subtree resolved → parent auto-completes.
     await bus.publish('system', createScheduleFired({
-      jobId: parentWakeId,
+      jobId: completionWakeId,
       agentId: 'coordinator',
       agentTaskId: parent.id,
       parentEventId: 'e2e-wake-2',

--- a/tests/integration/plan-lifecycle-e2e.test.ts
+++ b/tests/integration/plan-lifecycle-e2e.test.ts
@@ -1,0 +1,182 @@
+// plan-lifecycle-e2e.test.ts — end-to-end "plan primitive" loop (Phase 2 / #1177 closeout).
+//
+// The per-PR suites cover each mechanism in isolation (plan block #1236, plan skill
+// #1237, frontier #1238, reconciliation/auto-complete #1239, deliverable #1240,
+// KG promotion #1241). This is the single test the design memo's "Verification"
+// section asks for: a multi-step goal that materializes child rows via the real
+// `plan()` skill, advances its frontier as children complete, and auto-completes
+// when the subtree resolves — surfacing the deliverable step's output as the
+// parent's result, with no orphaned open subtasks left behind.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { EventBus } from '../../src/bus/bus.js';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+import { PlanFrontierSubscriber } from '../../src/agents/plan-frontier-subscriber.js';
+import { createScheduleFired } from '../../src/bus/events.js';
+import { DEFAULT_RESUMABLE_CEILINGS } from '../../src/config.js';
+import { PlanHandler } from '../../skills/plan/handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'PlanE2E Test';
+const logger = pino({ level: 'silent' });
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  const titleLike = `${PREFIX}%`;
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [titleLike],
+  );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [titleLike]);
+}
+
+describeIf('Plan primitive end-to-end (#1177)', () => {
+  let pool: pg.Pool;
+  let bus: EventBus;
+  let repo: TaskRepo;
+  let schedulerService: SchedulerService;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+  });
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    bus = new EventBus(logger as never);
+    repo = new TaskRepo(pool, bus, logger as never, 'UTC');
+    schedulerService = new SchedulerService(pool, bus, logger as never, 'UTC');
+  });
+
+  function planCtx(input: Record<string, unknown>): SkillContext {
+    return {
+      input,
+      secret: () => 'unused',
+      log: logger,
+      agentId: 'coordinator',
+      taskRepo: repo,
+      // The handler only calls agentRegistry.has() to validate target agents.
+      agentRegistry: { has: () => true } as unknown as SkillContext['agentRegistry'],
+    } as unknown as SkillContext;
+  }
+
+  it('materializes a plan, advances the frontier, and auto-completes with the deliverable', async () => {
+    const subscriber = new PlanFrontierSubscriber({
+      pool,
+      bus,
+      logger: logger as never,
+      schedulerService,
+      taskRepo: repo,
+      eligibleAgents: new Set(['coordinator']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+    subscriber.start();
+
+    // 1. A goal the LLM judges complex enough to plan.
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} design the kickoff`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+    });
+
+    // 2. The real plan() skill materializes child rows directly (rows-direct) and
+    //    writes the progress.plan block: gather (atomic) → synth (deliverable).
+    const planResult = await new PlanHandler().execute(planCtx({
+      task_id: parent.id,
+      steps: [
+        { id: 'gather', title: `${PREFIX} gather input`, target_agent_id: 'coordinator' },
+        {
+          id: 'synth',
+          title: `${PREFIX} synthesize the kickoff plan`,
+          target_agent_id: 'coordinator',
+          blocked_by_step_id: 'gather',
+        },
+      ],
+      deliverable_step_id: 'synth',
+      next: 'Gather input first',
+    }));
+    expect(planResult.success).toBe(true);
+
+    const plan = await repo.getPlanBlock(parent.id);
+    expect(plan).toMatchObject({ total: 2, deliverableStepId: 'synth' });
+    const gatherId = plan!.steps.find((s) => s.id === 'gather')!.taskId!;
+    const synthId = plan!.steps.find((s) => s.id === 'synth')!.taskId!;
+    expect(gatherId).toBeTruthy();
+    expect(synthId).toBeTruthy();
+
+    // Two real child rows materialized under the parent.
+    const childCount = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM tasks WHERE parent_task_id = $1`,
+      [parent.id],
+    );
+    expect(childCount.rows[0]!.count).toBe('2');
+
+    // 3. Complete the first child → frontier wakes the parent.
+    await repo.updateTask(gatherId, { status: 'done' }, 'coordinator');
+    const wakeAfterGather = await pool.query<{ id: string }>(
+      `SELECT id FROM scheduled_jobs WHERE task_id = $1 AND status = 'pending'`,
+      [parent.id],
+    );
+    expect(wakeAfterGather.rows).toHaveLength(1);
+    const parentWakeId = wakeAfterGather.rows[0]!.id;
+
+    // 4. Fire the wake → frontier dispatches the now-unblocked deliverable child.
+    await bus.publish('system', createScheduleFired({
+      jobId: parentWakeId,
+      agentId: 'coordinator',
+      agentTaskId: parent.id,
+      parentEventId: 'e2e-wake-1',
+    }));
+    expect(await repo.getPlanBlock(parent.id)).toMatchObject({ done: 1, total: 2 });
+    const synthDispatch = await pool.query(
+      `SELECT id FROM scheduled_jobs WHERE task_id = $1 AND status = 'pending'`,
+      [synthId],
+    );
+    expect(synthDispatch.rows).toHaveLength(1);
+
+    // 5. The deliverable child produces its output and completes.
+    const deliverable = `${PREFIX} kickoff plan: agenda, sessions, owners`;
+    await repo.updateTask(synthId, { progressNote: deliverable }, 'coordinator');
+    await repo.updateTask(synthId, { status: 'done' }, 'coordinator');
+
+    // 6. Fire the parent wake again → subtree resolved → parent auto-completes.
+    await bus.publish('system', createScheduleFired({
+      jobId: parentWakeId,
+      agentId: 'coordinator',
+      agentTaskId: parent.id,
+      parentEventId: 'e2e-wake-2',
+    }));
+
+    const reloadedParent = await repo.getTask(parent.id);
+    expect(reloadedParent?.status).toBe('done');
+
+    // The deliverable step's output surfaces as the parent's result.
+    const notes = reloadedParent?.progress.notes as Array<{ note: string }> | undefined;
+    expect(notes?.some((n) => n.note === deliverable)).toBe(true);
+
+    // No orphaned open subtasks remain (the memo's verification).
+    const openDescendants = await pool.query<{ count: string }>(
+      `WITH RECURSIVE descendants AS (
+         SELECT id, status FROM tasks WHERE parent_task_id = $1
+         UNION ALL
+         SELECT t.id, t.status FROM tasks t
+         INNER JOIN descendants d ON t.parent_task_id = d.id
+       )
+       SELECT COUNT(*)::text AS count FROM descendants WHERE status NOT IN ('done', 'cancelled', 'failed')`,
+      [parent.id],
+    );
+    expect(openDescendants.rows[0]!.count).toBe('0');
+  });
+});


### PR DESCRIPTION
## Summary

Closes out **Phase 2 — the `plan` primitive** of the Resumable Tasks & Projects epic. A review of the six merged sub-issues (#1236–#1241) found the mechanics solid and well-wired, with three gaps left to address before the umbrella could close:

1. **🔴 Orphaned children on circuit-breaker failure (the real one).** Reconciliation fired only on `done`/`cancelled` (`TERMINAL_STATUSES`), but `failResumableTask()` — the path the progress circuit-breaker takes when a planned parent stalls — set the parent to `failed` and cancelled only its *own* wake, never its open descendant children. A stalled-out plan therefore left its children behind for the `BacklogHeartbeat` to re-poke forever: the exact orphaned-subtask futility loop (memo gap #6) the plan primitive exists to close. `failResumableTask()` now reconciles descendant children in one transaction, mirroring `completeTask()`.
2. **🟡 No end-to-end test.** Each mechanism was unit-tested in isolation but nothing exercised the whole loop. Added an integration test driving the real `plan()` skill → frontier advance → child dispatch → auto-complete → deliverable surfacing (the design memo's "Verification" scenario).
3. **⚪ Spec not promoted.** The design lived only in the WIP memo. Promoted it to **`docs/specs/20-resumable-tasks-and-projects.md`** (as-built, Phases 0–2) and cross-referenced it from spec 19.

Closes #1177 

## Changes

- **`src/db/task-repo.ts`** — `failResumableTask()` refactored to a client transaction that also runs `runReconcileChildrenQuery()`, so a `failed` terminal transition reconciles open children all-or-nothing (no `failed` parent ever observed with open children). Bus publishes stay post-commit, matching `completeTask()`.
- **`tests/integration/plan-completion-reconciliation.test.ts`** — new test: circuit-breaker failure of a planned parent cancels its open child + the child's pending wake, leaving zero open descendants (red before the fix, green after).
- **`tests/integration/plan-lifecycle-e2e.test.ts`** — new end-to-end lifecycle test.
- **`docs/specs/20-...`** (new), **`docs/specs/19-...`** (cross-ref), **WIP memo** status updated, **CHANGELOG**.

## Test plan

- `plan-completion-reconciliation` (6) + `plan-frontier` + `plan-lifecycle-e2e` + `task-resumable-progress` + `task-plan-progress` + `resumable-circuit-breaker` + `resumable-continuation` + `scheduler-task-dispatch` + `task-repo-originator` + `woken-task-authorization` — all green against the test DB.
- `pnpm run typecheck` clean; eslint clean on changed files.
- code-reviewer + silent-failure-hunter: clean (transaction correctness, error propagation, post-commit bus publishes all verified).

## Out of scope (flagged, not done)

- The three `failResumableTask`/`completeTask`/`updateTask` transaction blocks now share a near-identical connect→BEGIN→reconcile→COMMIT shape; a private `withReconcilingTransaction()` helper would remove the copy-paste drift risk. Left as tech debt.
- A few unrelated `[Unreleased]` CHANGELOG entries from other epics (document workspace #1207, calendar #1223) remain verbose; only the resumable/plan epic entries were tightened here.
