### PR TITLE
feat: throughput-informed slice sizing for resumable tasks (#1265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Resumable throughput-informed slice sizing** — advisory target slice size from measured units/slice in resume guidance; throughput-aware budget nudge with cold-start fallback to the fixed turn fraction. (#1265)
 - **Resumable throughput telemetry** — derived units/slice, cost/unit, and ETA surfaced on resume and emitted to logs/audit on each pause. (#1264)
 - **Spec 20 — Resumable Tasks & Projects** — as-built design promoted to a permanent spec. (#1177)
 - **Plan frontier advancement** — child completion wakes the parent, dispatches unblocked siblings. (#1238)

--- a/src/agents/resumable-task.test.ts
+++ b/src/agents/resumable-task.test.ts
@@ -16,6 +16,8 @@ import {
 } from './resumable-task.js';
 import type { ResumableProgressBlock } from '../db/resumable-progress.js';
 import { readResumableBlock } from '../db/resumable-progress.js';
+import { computeResumableThroughput } from './resumable-throughput.js';
+import type { ResumableCircuitState } from './resumable-circuit-breaker.js';
 
 describe('isResumableTask', () => {
   it('returns true when error_budget.resumable is set', () => {
@@ -56,6 +58,37 @@ describe('checkpoint budget nudge', () => {
     expect(shouldSendCheckpointBudgetNudge(17, 20, false)).toBe(true);
     expect(shouldSendCheckpointBudgetNudge(16, 20, false)).toBe(false);
     expect(shouldSendCheckpointBudgetNudge(17, 20, true)).toBe(false);
+  });
+
+  const warmCircuit: ResumableCircuitState = {
+    stallCount: 0,
+    iterationCount: 5,
+    startedAt: '2026-06-01T00:00:00.000Z',
+    totalCostUsd: 0.5,
+    lastProgress: { done: 60, cursor: 'page:5' },
+  };
+
+  it('falls back to turn fraction on cold start (no throughput context)', () => {
+    expect(shouldSendCheckpointBudgetNudge(17, 20, false, null)).toBe(true);
+    expect(shouldSendCheckpointBudgetNudge(16, 20, false, null)).toBe(false);
+  });
+
+  it('fires throughput-aware nudge before turn fraction when last slice overshot avg', () => {
+    const ctx = {
+      resumable: { done: 60, total: 1300, lastSliceUnits: 100 },
+      circuit: warmCircuit,
+    };
+    expect(shouldSendCheckpointBudgetNudge(3, 20, false, ctx)).toBe(true);
+    expect(shouldSendCheckpointBudgetNudge(2, 20, false, ctx)).toBe(false);
+  });
+
+  it('uses turn fraction when throughput estimate unavailable', () => {
+    const ctx = {
+      resumable: { done: 0, total: 1300, lastSliceUnits: 0 },
+      circuit: warmCircuit,
+    };
+    expect(shouldSendCheckpointBudgetNudge(17, 20, false, ctx)).toBe(true);
+    expect(shouldSendCheckpointBudgetNudge(16, 20, false, ctx)).toBe(false);
   });
 });
 
@@ -118,6 +151,29 @@ describe('guidance blocks', () => {
     });
     expect(text).toContain('units/slice avg');
     expect(text).toContain('ETA');
+    expect(text).toContain('Suggested slice');
+  });
+
+  it('includes advisory slice sizing in guidance when throughput is warm', () => {
+    const metrics = computeResumableThroughput(
+      { done: 60, total: 1300, lastSliceUnits: 12 },
+      {
+        stallCount: 0,
+        iterationCount: 5,
+        startedAt: '2026-06-01T00:00:00.000Z',
+        totalCostUsd: 0.5,
+        lastProgress: { done: 60, cursor: 'page:5' },
+      },
+      new Date('2026-06-01T01:00:00.000Z'),
+    );
+    const block = buildResumableTaskGuidanceBlock({ throughputMetrics: metrics });
+    expect(block).toContain('Right-sizing (advisory)');
+    expect(block).toContain('aim for ~12 this slice');
+  });
+
+  it('omits advisory slice sizing on cold start', () => {
+    const block = buildResumableTaskGuidanceBlock();
+    expect(block).not.toContain('Right-sizing (advisory)');
   });
 });
 
@@ -155,6 +211,22 @@ describe('buildCheckpointBudgetNudgeMessage', () => {
     const msg = buildCheckpointBudgetNudgeMessage(3, 20);
     expect(msg).toContain('3 of 20');
     expect(msg).toContain('checkpoint');
+  });
+
+  it('includes throughput advisory when metrics are warm', () => {
+    const metrics = computeResumableThroughput(
+      { done: 60, total: 1300, lastSliceUnits: 12 },
+      {
+        stallCount: 0,
+        iterationCount: 5,
+        startedAt: '2026-06-01T00:00:00.000Z',
+        totalCostUsd: 0.5,
+        lastProgress: { done: 60, cursor: 'page:5' },
+      },
+    );
+    const msg = buildCheckpointBudgetNudgeMessage(3, 20, metrics);
+    expect(msg).toContain('units/slice');
+    expect(msg).toContain('aim for ~12');
   });
 });
 

--- a/src/agents/resumable-task.ts
+++ b/src/agents/resumable-task.ts
@@ -13,6 +13,9 @@ import type { ResumableCircuitState } from './resumable-circuit-breaker.js';
 import {
   computeResumableThroughput,
   formatResumableThroughputForResume,
+  shouldNudgeFromThroughput,
+  suggestedSliceSize,
+  type ResumableThroughputMetrics,
 } from './resumable-throughput.js';
 import {
   indexPathForDirectory,
@@ -59,20 +62,47 @@ export function checkpointNudgeThreshold(maxTurns: number): number {
   return Math.max(1, Math.floor(maxTurns * CHECKPOINT_BUDGET_NUDGE_FRACTION));
 }
 
+/** Context for throughput-aware budget nudge (#1265). */
+export interface CheckpointBudgetNudgeContext {
+  resumable: Pick<ResumableProgressBlock, 'done' | 'total' | 'lastSliceUnits'>;
+  circuit: ResumableCircuitState;
+}
+
 export function shouldSendCheckpointBudgetNudge(
   turnsUsed: number,
   maxTurns: number,
   alreadySent: boolean,
+  throughputCtx?: CheckpointBudgetNudgeContext | null,
 ): boolean {
   if (alreadySent || maxTurns <= 0) return false;
   const remaining = maxTurns - turnsUsed;
-  return remaining > 0 && remaining <= checkpointNudgeThreshold(maxTurns);
+  const turnFractionNudge = remaining > 0 && remaining <= checkpointNudgeThreshold(maxTurns);
+
+  if (!throughputCtx) {
+    return turnFractionNudge;
+  }
+
+  const metrics = computeResumableThroughput(throughputCtx.resumable, throughputCtx.circuit);
+  if (!metrics.estimateAvailable || metrics.unitsPerSlice === null || metrics.unitsPerSlice <= 0) {
+    return turnFractionNudge;
+  }
+
+  const throughputNudge = shouldNudgeFromThroughput({
+    turnsUsed,
+    maxTurns,
+    unitsPerSlice: metrics.unitsPerSlice,
+    lastSliceUnits: throughputCtx.resumable.lastSliceUnits,
+  });
+
+  return turnFractionNudge || throughputNudge;
 }
 
 export function buildResumableTaskGuidanceBlock(options?: {
   workspaceManifestPath?: string;
   /** True when #1209 appended a ## Workspace Manifest block to the task message tail. */
   workspaceManifestInjected?: boolean;
+  /** Warm-path throughput metrics for advisory slice sizing (#1265). */
+  throughputMetrics?: ResumableThroughputMetrics | null;
 }): string {
   const lines = [
     '## Resumable Task',
@@ -84,6 +114,16 @@ export function buildResumableTaskGuidanceBlock(options?: {
     '(or a document pointer after spill), last_slice_units, and a one-line `next` describing',
     'what to do on the next slice.',
   ];
+
+  const suggested = options?.throughputMetrics ? suggestedSliceSize(options.throughputMetrics) : null;
+  const avgUnits = options?.throughputMetrics?.unitsPerSlice;
+  if (suggested !== null && avgUnits !== null && avgUnits !== undefined) {
+    lines.push(
+      '',
+      `Right-sizing (advisory): you've averaged ~${avgUnits.toFixed(1)} units/slice —`,
+      `aim for ~${suggested} this slice and checkpoint before budget. You decide the exact batch.`,
+    );
+  }
 
   if (options?.workspaceManifestInjected) {
     lines.push(
@@ -132,13 +172,31 @@ export function buildResumableCheckpointResumeBlock(
   ].filter(Boolean).join('\n');
 }
 
-export function buildCheckpointBudgetNudgeMessage(remainingTurns: number, maxTurns: number): string {
-  return [
+export function buildCheckpointBudgetNudgeMessage(
+  remainingTurns: number,
+  maxTurns: number,
+  throughputMetrics?: ResumableThroughputMetrics | null,
+): string {
+  const lines = [
     '[Platform — resumable task budget nudge]',
     `You have ${remainingTurns} of ${maxTurns} turns remaining on this resumable task.`,
+  ];
+
+  const suggested = throughputMetrics ? suggestedSliceSize(throughputMetrics) : null;
+  const avgUnits = throughputMetrics?.unitsPerSlice;
+  if (suggested !== null && avgUnits !== null && avgUnits !== undefined) {
+    lines.push(
+      `You've averaged ~${avgUnits.toFixed(1)} units/slice —`,
+      `aim for ~${suggested} this slice (advisory).`,
+    );
+  }
+
+  lines.push(
     'Call `checkpoint` with your current progress now, then pause — do not keep iterating.',
     'A partial checkpoint is success; the platform will resume you on the next slice.',
-  ].join(' ');
+  );
+
+  return lines.join(' ');
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/src/agents/resumable-throughput.test.ts
+++ b/src/agents/resumable-throughput.test.ts
@@ -3,6 +3,11 @@ import {
   computeResumableThroughput,
   emitResumableThroughputTelemetry,
   formatResumableThroughputForResume,
+  projectedSliceUnits,
+  shouldNudgeFromThroughput,
+  suggestedSliceSize,
+  SUGGESTED_SLICE_TOLERANCE_FRACTION,
+  THROUGHPUT_SLICE_NUDGE_FRACTION,
 } from './resumable-throughput.js';
 import type { ResumableCircuitState } from './resumable-circuit-breaker.js';
 
@@ -62,6 +67,71 @@ describe('computeResumableThroughput (#1264)', () => {
     expect(line).toContain('units/min wallclock');
     expect(line).toContain('/unit');
     expect(line).toContain('ETA');
+    expect(line).toContain('Suggested slice');
+  });
+});
+
+describe('throughput-informed slice sizing (#1265)', () => {
+  const warmMetrics = computeResumableThroughput(
+    { done: 60, total: 1300, lastSliceUnits: 12 },
+    baseCircuit,
+    new Date('2026-06-01T01:00:00.000Z'),
+  );
+
+  it('suggests slice size within tolerance of measured units/slice', () => {
+    const suggested = suggestedSliceSize(warmMetrics);
+    expect(suggested).toBe(12);
+    expect(warmMetrics.unitsPerSlice).not.toBeNull();
+    const delta = Math.abs(suggested! - warmMetrics.unitsPerSlice!) / warmMetrics.unitsPerSlice!;
+    expect(delta).toBeLessThanOrEqual(SUGGESTED_SLICE_TOLERANCE_FRACTION);
+  });
+
+  it('returns null suggested size on cold start', () => {
+    const cold = computeResumableThroughput({ done: 0, total: 1300, lastSliceUnits: 0 }, baseCircuit);
+    expect(suggestedSliceSize(cold)).toBeNull();
+  });
+
+  it('nudges early when last slice pace overshoots measured avg', () => {
+    const maxTurns = 20;
+    expect(shouldNudgeFromThroughput({
+      turnsUsed: 3,
+      maxTurns,
+      unitsPerSlice: 12,
+      lastSliceUnits: 100,
+    })).toBe(true);
+    expect(shouldNudgeFromThroughput({
+      turnsUsed: 2,
+      maxTurns,
+      unitsPerSlice: 12,
+      lastSliceUnits: 100,
+    })).toBe(false);
+  });
+
+  it('projects slice units linearly from last-slice pace', () => {
+    expect(projectedSliceUnits(10, 20, 12, 12)).toBe(6);
+    expect(projectedSliceUnits(17, 20, 12, 12)).toBeCloseTo(12 * 17 / 20);
+  });
+
+  it('fires throughput nudge at configured fraction of suggested size', () => {
+    const maxTurns = 20;
+    const unitsPerSlice = 12;
+    const lastSliceUnits = 12;
+    const suggested = Math.round(unitsPerSlice);
+    const nudgeTurn = Math.ceil(
+      (suggested * THROUGHPUT_SLICE_NUDGE_FRACTION / lastSliceUnits) * maxTurns,
+    );
+    expect(shouldNudgeFromThroughput({
+      turnsUsed: nudgeTurn,
+      maxTurns,
+      unitsPerSlice,
+      lastSliceUnits,
+    })).toBe(true);
+    expect(shouldNudgeFromThroughput({
+      turnsUsed: nudgeTurn - 1,
+      maxTurns,
+      unitsPerSlice,
+      lastSliceUnits,
+    })).toBe(false);
   });
 });
 

--- a/src/agents/resumable-throughput.ts
+++ b/src/agents/resumable-throughput.ts
@@ -17,6 +17,15 @@ export interface ResumableThroughputMetrics {
   etaWallclockMinutes: number | null;
 }
 
+/** Nudge when projected slice units reach this fraction of the suggested size (#1265). */
+export const THROUGHPUT_SLICE_NUDGE_FRACTION = 0.85;
+
+/**
+ * Advisory slice target lands within ±this fraction of measured units/slice (#1265).
+ * Calibrated against the first #1264 telemetry baseline (~12 units/slice vs. fictional 100).
+ */
+export const SUGGESTED_SLICE_TOLERANCE_FRACTION = 0.2;
+
 export interface EmitResumableThroughputOptions {
   logger: Logger;
   bus: EventBus;
@@ -78,6 +87,55 @@ function formatRate(value: number, decimals = 1): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(decimals);
 }
 
+/** Advisory target slice size from measured units/slice; null on cold start. */
+export function suggestedSliceSize(metrics: ResumableThroughputMetrics): number | null {
+  if (!metrics.estimateAvailable || metrics.unitsPerSlice === null || metrics.unitsPerSlice <= 0) {
+    return null;
+  }
+  return Math.max(1, Math.round(metrics.unitsPerSlice));
+}
+
+/** Linear projection of units processed this slice using last-slice pace as proxy. */
+export function projectedSliceUnits(
+  turnsUsed: number,
+  maxTurns: number,
+  lastSliceUnits: number,
+  suggestedSize: number,
+): number {
+  if (maxTurns <= 0) return 0;
+  const paceUnits = lastSliceUnits > 0 ? lastSliceUnits : suggestedSize;
+  return (turnsUsed / maxTurns) * paceUnits;
+}
+
+/** Throughput-aware nudge: projected slice units approach measured avg (#1265). */
+export function shouldNudgeFromThroughput(options: {
+  turnsUsed: number;
+  maxTurns: number;
+  unitsPerSlice: number;
+  lastSliceUnits: number;
+}): boolean {
+  const { turnsUsed, maxTurns, unitsPerSlice, lastSliceUnits } = options;
+  if (maxTurns <= 0 || unitsPerSlice <= 0) return false;
+
+  const suggested = Math.max(1, Math.round(unitsPerSlice));
+  const nudgeAtUnits = suggested * THROUGHPUT_SLICE_NUDGE_FRACTION;
+  const projected = projectedSliceUnits(turnsUsed, maxTurns, lastSliceUnits, suggested);
+  return projected >= nudgeAtUnits;
+}
+
+/** Advisory right-sizing line for resume/plan guidance (#1265). */
+export function formatSuggestedSliceSizeAdvice(metrics: ResumableThroughputMetrics): string | null {
+  const suggested = suggestedSliceSize(metrics);
+  if (suggested === null || metrics.unitsPerSlice === null) return null;
+
+  const avg = formatRate(metrics.unitsPerSlice);
+  const tolerancePct = Math.round(SUGGESTED_SLICE_TOLERANCE_FRACTION * 100);
+  return (
+    `Suggested slice: ~${suggested} units (based on your ~${avg} units/slice avg, `
+    + `±${tolerancePct}% advisory — you decide). Aim for ~${suggested} this slice and checkpoint before budget.`
+  );
+}
+
 /** Human-readable throughput line for resume guidance injected into the system prompt. */
 export function formatResumableThroughputForResume(metrics: ResumableThroughputMetrics): string {
   if (!metrics.estimateAvailable) {
@@ -106,7 +164,9 @@ export function formatResumableThroughputForResume(metrics: ResumableThroughputM
     parts.push(`ETA ${etaParts.join(' / ')}`);
   }
 
-  return `Throughput: ${parts.join(', ')}.`;
+  const throughputLine = `Throughput: ${parts.join(', ')}.`;
+  const sliceAdvice = formatSuggestedSliceSizeAdvice(metrics);
+  return sliceAdvice ? `${throughputLine} ${sliceAdvice}` : throughputLine;
 }
 
 /** Structured log + audit event for each paused slice (#1264). */

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -32,7 +32,8 @@ import {
   shouldSendCheckpointBudgetNudge,
   type BoundTaskContext,
 } from './resumable-task.js';
-import { readCircuitState } from './resumable-circuit-breaker.js';
+import { readCircuitState, type ResumableCircuitState } from './resumable-circuit-breaker.js';
+import { computeResumableThroughput } from './resumable-throughput.js';
 import {
   applyPlanHarness,
   shouldOfferPlanSkill,
@@ -471,14 +472,22 @@ export class AgentRuntime {
     }
 
     const resumableActive = boundTaskCtx !== null && isResumableTask(boundTaskCtx);
+    let resumableNudgeCtx: { resumable: ResumableProgressBlock; circuit: ResumableCircuitState } | null = null;
     if (resumableActive && boundTaskCtx) {
+      const existingCheckpoint = readResumableBlock(boundTaskCtx.progress ?? {});
+      const circuit = readCircuitState(boundTaskCtx.progress ?? {});
+      const throughputMetrics = existingCheckpoint
+        ? computeResumableThroughput(existingCheckpoint, circuit)
+        : null;
+      if (existingCheckpoint && circuit) {
+        resumableNudgeCtx = { resumable: existingCheckpoint, circuit };
+      }
       effectiveSystemPrompt += '\n\n' + buildResumableTaskGuidanceBlock({
         workspaceManifestPath: boundTaskCtx.workspaceManifestPath,
         workspaceManifestInjected,
+        throughputMetrics,
       });
-      const existingCheckpoint = readResumableBlock(boundTaskCtx.progress ?? {});
       if (existingCheckpoint) {
-        const circuit = readCircuitState(boundTaskCtx.progress ?? {});
         effectiveSystemPrompt += '\n\n' + buildResumableCheckpointResumeBlock(existingCheckpoint, { circuit });
       }
     }
@@ -835,16 +844,27 @@ export class AgentRuntime {
 
     const maybeAppendCheckpointBudgetNudge = (): void => {
       if (!resumableActive || checkpointBudgetNudgeSent) return;
-      if (!shouldSendCheckpointBudgetNudge(budget.turnsUsed, budget.maxTurns, checkpointBudgetNudgeSent)) {
+      if (!shouldSendCheckpointBudgetNudge(
+        budget.turnsUsed,
+        budget.maxTurns,
+        checkpointBudgetNudgeSent,
+        resumableNudgeCtx,
+      )) {
         return;
       }
       const remaining = budget.maxTurns - budget.turnsUsed;
+      const throughputMetrics = resumableNudgeCtx
+        ? computeResumableThroughput(resumableNudgeCtx.resumable, resumableNudgeCtx.circuit)
+        : null;
       messages.push({
         role: 'user',
-        content: buildCheckpointBudgetNudgeMessage(remaining, budget.maxTurns),
+        content: buildCheckpointBudgetNudgeMessage(remaining, budget.maxTurns, throughputMetrics),
       });
       checkpointBudgetNudgeSent = true;
-      logger.info({ agentId, remaining, maxTurns: budget.maxTurns }, 'Appended resumable-task checkpoint budget nudge');
+      logger.info(
+        { agentId, remaining, maxTurns: budget.maxTurns, throughputAware: throughputMetrics?.estimateAvailable ?? false },
+        'Appended resumable-task checkpoint budget nudge',
+      );
     };
 
     logger.info({ agentId, conversationId, historyLength: history.length }, 'Agent processing task');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements throughput-informed slice right-sizing for resumable tasks (#1265), building on the throughput telemetry from #1264.

Closes #1265

## Changes

- Add advisory slice-sizing helpers (`suggestedSliceSize`, `shouldNudgeFromThroughput`, `formatSuggestedSliceSizeAdvice`) derived from measured units/slice
- Surface suggested target slice size in resume guidance (`buildResumableCheckpointResumeBlock`) and resumable task guidance (`buildResumableTaskGuidanceBlock`)
- Make the budget nudge throughput-aware: fires when projected slice units (linear pace from last slice) approach measured avg, **in addition to** the fixed ~15% turn fraction
- Cold-start falls back to turn-fraction-only nudge; deterministic pause safety-net unchanged
- Tolerance constant (`SUGGESTED_SLICE_TOLERANCE_FRACTION = 0.2`) calibrated against #1264 baseline (~12 units/slice vs. fictional 100)

## Acceptance criteria

- [x] Platform surfaces throughput-derived **suggested** slice size in resume/plan guidance (advisory; LLM decides)
- [x] Budget nudge is throughput-aware (fires relative to measured rate vs. remaining budget), not only the fixed turn fraction
- [x] Cold-start falls back to current behavior; deterministic pause safety-net unchanged
- [x] Suggested slice within ±20% of measured throughput (from #1264 baseline)
- [x] Tests cover advisory sizing, throughput-aware nudge, and cold-start fallback

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] CHANGELOG updated
- [x] CI passes (typecheck + targeted unit tests run locally)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8556fbf-488c-4795-893c-8cb1a0bdb34b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8556fbf-488c-4795-893c-8cb1a0bdb34b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

