### PR TITLE
feat: richer, principal-facing escalation UX for stuck tasks (#1267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Principal-facing escalation UX** — stalled / ceiling / blocked-on-human / agent-incomplete escalations now carry a structured `progress.escalation` block and a rendered progress note, so the daily digest surfaces real detail (progress, throughput/ETA, suggested actions) instead of a bare backlog row. Adds optional `progress_note` / `escalation_json` inputs to the `task-create` manifest. (#1267)
 - **Adaptive re-planning** — frontier wakes surface advisory divergence signals (failed/cancelled child, throughput below estimate, over-blocked step); plan depth and re-plan count are bounded with escalation on breach. (#1266)
 
 ### Fixed

--- a/docs/specs/20-resumable-tasks-and-projects.md
+++ b/docs/specs/20-resumable-tasks-and-projects.md
@@ -97,7 +97,12 @@ The circuit-breaker keys on **progress, not error count** (`src/agents/resumable
 state in `progress.resumableCircuit`). A continuation that makes no forward progress (cursor
 unchanged and done-count flat) increments a stall counter; after K stalls, or on breach of a
 hard per-task ceiling, the task is failed and escalated via the existing `needs-attention`
-backlog path. Defaults (`tasks.resumableCeilings`): `maxStalls: 3`, `maxIterations: 100`,
+backlog path. The escalation carries a structured, principal-facing payload
+(`src/agents/task-escalation.ts`, #1267) — one of four real failure modes (**stalled** /
+**hit-a-limit** / **blocked-on-a-person** / **agent-couldn't-finish**), progress, throughput +
+ETA (resumable leaves) or X-of-Y (planned parents), and suggested next actions — stored at
+`progress.escalation` and rendered into the CEO row's `last_progress_note` so the daily digest
+surfaces real detail, not a bare row. Defaults (`tasks.resumableCeilings`): `maxStalls: 3`, `maxIterations: 100`,
 `maxWallclockHours: 24`, `maxCostUsd: 10`; each is overridable per task through the
 `error_budget` keys validated in `src/tasks/task-error-budget.ts` (per #883: per-task keys
 only — per-invocation `max_turns`/`max_errors` belong to agent config and are rejected on

--- a/skills/task-create/handler.test.ts
+++ b/skills/task-create/handler.test.ts
@@ -413,6 +413,20 @@ describe('TaskCreateHandler', () => {
     );
   });
 
+  it('ignores a well-formed object that is not a valid escalation shape', async () => {
+    const createTask = vi.fn().mockResolvedValue(makeTaskRow());
+    const taskRepo = makeTaskRepo({ createTask });
+    // Valid JSON, an object, but missing the required TaskEscalation fields — must not persist.
+    const ctx = makeCtx({ input: { title: 'Review', escalation_json: JSON.stringify({ foo: 'bar' }) }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ escalation: undefined }),
+    );
+  });
+
   it('rejects a non-string progress_note', async () => {
     const taskRepo = makeTaskRepo();
     const ctx = makeCtx({ input: { title: 'Review', progress_note: 123 as unknown as string }, taskRepo });

--- a/skills/task-create/handler.test.ts
+++ b/skills/task-create/handler.test.ts
@@ -364,4 +364,62 @@ describe('TaskCreateHandler', () => {
     expect(result.success).toBe(false);
     expect((result as { success: false; error: string }).error).toMatch(/DB connection lost/);
   });
+
+  // ── Escalation seeding (#1267) ────────────────────────────────────────────
+
+  it('forwards progress_note to createTask so the row seeds a last progress note', async () => {
+    const createTask = vi.fn().mockResolvedValue(makeTaskRow());
+    const taskRepo = makeTaskRepo({ createTask });
+    const ctx = makeCtx({ input: { title: 'Review', progress_note: 'Stalled at 25 of 1300.' }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ progressNote: 'Stalled at 25 of 1300.' }),
+    );
+  });
+
+  it('parses escalation_json and forwards the structured block to createTask', async () => {
+    const createTask = vi.fn().mockResolvedValue(makeTaskRow());
+    const taskRepo = makeTaskRepo({ createTask });
+    const escalation = {
+      failureMode: 'agent_incomplete',
+      reason: 'maxTurns',
+      source: 'delegation',
+      headline: 'research could not finish',
+      suggestedActions: ['Re-scope it smaller.'],
+    };
+    const ctx = makeCtx({ input: { title: 'Review', escalation_json: JSON.stringify(escalation) }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ escalation: expect.objectContaining({ failureMode: 'agent_incomplete' }) }),
+    );
+  });
+
+  it('ignores malformed escalation_json but still creates the task', async () => {
+    const createTask = vi.fn().mockResolvedValue(makeTaskRow());
+    const taskRepo = makeTaskRepo({ createTask });
+    const ctx = makeCtx({ input: { title: 'Review', escalation_json: '{not json' }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ escalation: undefined }),
+    );
+  });
+
+  it('rejects a non-string progress_note', async () => {
+    const taskRepo = makeTaskRepo();
+    const ctx = makeCtx({ input: { title: 'Review', progress_note: 123 as unknown as string }, taskRepo });
+
+    const result = await new TaskCreateHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/progress_note/);
+  });
 });

--- a/skills/task-create/handler.ts
+++ b/skills/task-create/handler.ts
@@ -21,6 +21,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { TaskOriginator } from '../../src/contacts/types.js';
+import type { TaskEscalation } from '../../src/agents/task-escalation.js';
 import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 const VALID_OWNERS = new Set(['curia', 'ceo', 'external']);
@@ -48,6 +49,8 @@ export class TaskCreateHandler implements SkillHandler {
       source?: string;
       target_agent_id?: string;
       resumable?: boolean;
+      progress_note?: string;
+      escalation_json?: string;
     };
 
     if (!input.title || typeof input.title !== 'string' || !input.title.trim()) {
@@ -72,6 +75,29 @@ export class TaskCreateHandler implements SkillHandler {
     }
     if (input.tags && !Array.isArray(input.tags)) {
       return { success: false, error: 'tags must be an array of strings' };
+    }
+    if (input.progress_note !== undefined && typeof input.progress_note !== 'string') {
+      return { success: false, error: 'progress_note must be a string' };
+    }
+    if (input.progress_note && input.progress_note.length > 5000) {
+      return { success: false, error: 'progress_note must be 5000 characters or fewer' };
+    }
+
+    // Optional structured escalation block (#1267) — seeded onto progress.escalation. Carried
+    // as a JSON string to keep the input schema primitive. Malformed JSON is non-fatal: the
+    // task still gets created (and the progress note still surfaces), we just skip the block.
+    let escalation: TaskEscalation | undefined;
+    if (input.escalation_json) {
+      try {
+        const parsed: unknown = JSON.parse(input.escalation_json);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          escalation = parsed as TaskEscalation;
+        } else {
+          ctx.log.warn({ title: input.title }, 'task-create: escalation_json is not an object — ignoring');
+        }
+      } catch (err) {
+        ctx.log.warn({ err, title: input.title }, 'task-create: failed to parse escalation_json — ignoring');
+      }
     }
 
     if (!ctx.taskRepo) {
@@ -174,6 +200,10 @@ export class TaskCreateHandler implements SkillHandler {
         // parent's lineage when parent_task_id is set, so a child never exceeds its parent.
         originator: (ctx.taskMetadata?.originator as TaskOriginator | undefined) ?? null,
         resumable: input.resumable === true,
+        // Seed the first progress note + structured escalation block (#1267) so the row's
+        // last_progress_note is non-empty and the digest renders real content.
+        progressNote: input.progress_note,
+        escalation,
       });
 
       const tz = ctx.timezone;

--- a/skills/task-create/handler.ts
+++ b/skills/task-create/handler.ts
@@ -31,6 +31,20 @@ const VALID_SOURCES = new Set(['ceo', 'agent', 'scheduler', 'coordinator']);
 // "June 10 2026" or "2026/06/10" that new Date() would silently accept.
 const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
+// Validate the required TaskEscalation fields before trusting an escalation_json blob (#1267).
+// A bare `{}` or arbitrary object would otherwise pass an is-object check and land permanently
+// in progress.escalation, leaving downstream readers a swamp of inconsistent shapes. Optional
+// fields (progress, throughput, blocker, costUsd) are intentionally not checked.
+function isValidEscalationShape(value: unknown): value is TaskEscalation {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.failureMode === 'string'
+    && typeof v.reason === 'string'
+    && typeof v.source === 'string'
+    && typeof v.headline === 'string'
+    && Array.isArray(v.suggestedActions);
+}
+
 export class TaskCreateHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const input = ctx.input as {
@@ -90,10 +104,10 @@ export class TaskCreateHandler implements SkillHandler {
     if (input.escalation_json) {
       try {
         const parsed: unknown = JSON.parse(input.escalation_json);
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-          escalation = parsed as TaskEscalation;
+        if (isValidEscalationShape(parsed)) {
+          escalation = parsed;
         } else {
-          ctx.log.warn({ title: input.title }, 'task-create: escalation_json is not an object — ignoring');
+          ctx.log.warn({ title: input.title }, 'task-create: escalation_json missing required fields — ignoring');
         }
       } catch (err) {
         ctx.log.warn({ err, title: input.title }, 'task-create: failed to parse escalation_json — ignoring');

--- a/skills/task-create/skill.json
+++ b/skills/task-create/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "task-create",
-  "description": "Create a new task in the backlog. Provide a title and optionally description, owner (curia/ceo/external), priority (0-100), due date, tags, parent task, blocked-by task, waiting-on contact, and an intent anchor. When wake_at is set, schedules a one-shot wake-up for this task at that time. Set target_agent_id to assign the task (and its wake-up) to another agent — e.g. the coordinator scheduling a debrief task for the meeting-debrief specialist.",
-  "version": "0.3.0",
+  "description": "Create a new task in the backlog. Provide a title and optionally description, owner (curia/ceo/external), priority (0-100), due date, tags, parent task, blocked-by task, waiting-on contact, and an intent anchor. When wake_at is set, schedules a one-shot wake-up for this task at that time. Set target_agent_id to assign the task (and its wake-up) to another agent — e.g. the coordinator scheduling a debrief task for the meeting-debrief specialist. Set progress_note to seed the task's first progress note (it becomes the row's last progress note, surfaced in the digest).",
+  "version": "0.4.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -19,7 +19,9 @@
     "intent_anchor": "string?",
     "source": "string?",
     "target_agent_id": "string?",
-    "resumable": "boolean?"
+    "resumable": "boolean?",
+    "progress_note": "string?",
+    "escalation_json": "string?"
   },
   "outputs": {
     "task_id": "string",

--- a/src/agents/delegation-guard.ts
+++ b/src/agents/delegation-guard.ts
@@ -8,6 +8,7 @@ import type { AgentResponseFailureReason } from '../bus/events.js';
 import type { ExecutionLayer, InvokeOptions } from '../skills/execution.js';
 import type { CallerContext } from '../skills/types.js';
 import type { Logger } from '../logger.js';
+import { buildDelegationEscalation, renderEscalation } from './task-escalation.js';
 
 /** Total identical delegate calls allowed when the specialist failure was retryable. */
 export const MAX_RETRYABLE_IDENTICAL_DELEGATIONS = 2;
@@ -117,7 +118,7 @@ export function parseDelegateFailureData(data: unknown, logger?: Logger): Delega
   };
 }
 
-/** Surface a non-retryable delegation failure on the CEO backlog via task-create (#1171). */
+/** Surface a non-retryable delegation failure on the CEO backlog via task-create (#1171, #1267). */
 export async function escalateDelegationFailure(
   executionLayer: ExecutionLayer,
   caller: CallerContext | undefined,
@@ -125,22 +126,38 @@ export async function escalateDelegationFailure(
   failure: DelegationFailureInfo & { task: string },
   logger: Logger,
 ): Promise<boolean> {
+  // Structured, principal-facing payload (#1267): reason 'blocked' → blocked_on_human,
+  // anything else → agent_incomplete. Rendered into the CEO task's progress note (the digest's
+  // data source) + description, and stored as the structured progress.escalation block.
+  const escalation = buildDelegationEscalation({
+    agent: failure.agent,
+    reason: String(failure.reason),
+    retryable: failure.retryable,
+    message: failure.message,
+    task: failure.task,
+  });
+  const rendered = renderEscalation(escalation);
+  const title = escalation.failureMode === 'blocked_on_human'
+    ? `Review: ${failure.agent} is blocked on a person`
+    : `Review: ${failure.agent} could not complete delegated work`;
+
   try {
     const result = await executionLayer.invoke(
       'task-create',
       {
-        title: `Review: ${failure.agent} could not complete delegated work`,
+        title,
         description: [
-          failure.message,
-          '',
-          `Reason: ${failure.reason}`,
+          rendered.description,
           '',
           'Original delegated task:',
           failure.task,
         ].join('\n'),
         owner: 'ceo',
         source: 'coordinator',
-        tags: ['delegation-failure', failure.agent],
+        // The failureMode tag distinguishes blocked-on-a-person from couldn't-finish (#1267).
+        tags: ['delegation-failure', failure.agent, escalation.failureMode],
+        progress_note: rendered.progressNote,
+        escalation_json: JSON.stringify(escalation),
       },
       caller,
       options,

--- a/src/agents/resumable-circuit-breaker.ts
+++ b/src/agents/resumable-circuit-breaker.ts
@@ -17,6 +17,7 @@ import { computePlanRollup, type PlanStepDescriptor } from '../db/plan-progress.
 import { createAgentTask } from '../bus/events.js';
 import type { ExecutionPausedPayload } from './resumable-task.js';
 import { emitResumableThroughputTelemetry } from './resumable-throughput.js';
+import { buildCircuitBreachEscalation, renderEscalation } from './task-escalation.js';
 
 /** Persisted under tasks.progress.resumableCircuit — separate from the bounded resumable block. */
 export interface ResumableCircuitState {
@@ -247,14 +248,30 @@ export interface EscalateCircuitBreachOptions {
  */
 export async function escalateCircuitBreach(opts: EscalateCircuitBreachOptions): Promise<void> {
   const { task, breach, bus, taskRepo, logger, agentId } = opts;
-  const progressNote = [
-    breach.message,
-    `Progress at breach: ${breach.state.lastProgress.done} done, cursor ${JSON.stringify(breach.state.lastProgress.cursor)}.`,
-    `Iterations: ${breach.state.iterationCount}, stalls: ${breach.state.stallCount}, cost: $${breach.state.totalCostUsd.toFixed(4)}.`,
-  ].join(' ');
+
+  // Skip re-escalation of an already-terminal task (#1267). A redelivered pause/wake can
+  // re-enter here after the task was failed; `failResumableTask` is idempotent and returns the
+  // existing row, so without this guard the truthy-`updated` check below would fall through and
+  // publish a duplicate coordinator poke + create a duplicate CEO backlog row. Mirrors the guard
+  // in handlePlanFrontierWakeForCircuitBreaker / plan-adaptive-replan.
+  if (task.status === 'failed' || task.status === 'done' || task.status === 'cancelled') {
+    logger.debug({ taskId: task.id, status: task.status }, 'Circuit breach escalation: task already terminal — skipping');
+    return;
+  }
+
+  // Structured, principal-facing payload + its three renderings (#1267). Detects resumable
+  // leaf vs planned parent and attaches throughput/ETA or the X-of-Y rollup accordingly.
+  const escalation = buildCircuitBreachEscalation(task, breach);
+  const rendered = renderEscalation(escalation);
+  // Traceability footer for the CEO task view — the failed task id + which specialist owned it.
+  const description = [
+    rendered.description,
+    '',
+    `Task: ${task.id} · Specialist: ${task.sourceAgentId ?? agentId}`,
+  ].join('\n');
 
   const updated = await taskRepo.failResumableTask(task.id, {
-    progressNote,
+    progressNote: rendered.progressNote,
     circuitState: breach.state,
     tags: ['needs-attention', 'resumable-circuit-breach'],
   });
@@ -264,52 +281,57 @@ export async function escalateCircuitBreach(opts: EscalateCircuitBreachOptions):
     return;
   }
 
-  const notifyContent = [
-    'A resumable task hit its progress-based circuit breaker and needs attention.',
-    '',
-    `Task: ${task.id}`,
-    `Title: ${task.title}`,
-    `Agent: ${agentId}`,
-    `Reason: ${breach.reason}`,
-    breach.message,
-    '',
-    'Do not re-delegate or schedule continuations for this task. Let the principal know and help them decide next steps.',
-  ].join('\n');
-
   const notifyEvent = createAgentTask({
     agentId: 'coordinator',
     conversationId: `resumable-circuit:${task.id}`,
     channelId: 'scheduler',
     senderId: 'system',
-    content: notifyContent,
+    content: rendered.notifyContent,
     parentEventId: task.id,
   });
+  let notifySucceeded = false;
   try {
     await bus.publish('system', notifyEvent);
+    notifySucceeded = true;
   } catch (err) {
     logger.error({ err, taskId: task.id }, 'Failed to notify coordinator of circuit breach');
   }
 
+  // The CEO row carries the rendered summary as its first progress note (so the digest's
+  // last_progress_note has real content) plus the structured escalation block (#1267).
+  const kind = escalation.source === 'planned_parent' ? 'plan' : 'task';
+  const modeLabel = escalation.failureMode === 'stalled' ? 'stalled' : 'hit a limit';
+  let backlogSucceeded = false;
   try {
     await taskRepo.createTask({
       agentId: 'coordinator',
-      title: `Review: resumable task stalled (${task.title})`,
-      description: [
-        breach.message,
-        '',
-        `Task ID: ${task.id}`,
-        `Specialist: ${task.sourceAgentId ?? agentId}`,
-        '',
-        progressNote,
-      ].join('\n'),
+      title: `Review: ${kind} ${modeLabel} (${task.title})`,
+      description,
       owner: 'ceo',
       source: 'coordinator',
       tags: ['needs-attention', 'resumable-circuit-breach', breach.reason],
       parentTaskId: task.parentTaskId ?? undefined,
+      progressNote: rendered.progressNote,
+      escalation,
     });
-    logger.info({ taskId: task.id, reason: breach.reason }, 'Escalated resumable circuit breach to CEO backlog');
+    backlogSucceeded = true;
+    logger.info(
+      { taskId: task.id, reason: breach.reason, failureMode: escalation.failureMode, source: escalation.source },
+      'Escalated resumable circuit breach to CEO backlog',
+    );
   } catch (err) {
     logger.error({ err, taskId: task.id }, 'Failed to create CEO backlog task for circuit breach');
+  }
+
+  // The CEO backlog row is the digest carrier and the coordinator poke is the live surface; the
+  // failed task itself is owned by the specialist, not the principal, so it never surfaces. If a
+  // correlated infra outage takes out BOTH, the task is terminally failed with no path to the
+  // principal — log loudly so it is alertable rather than silently lost (#1267).
+  if (!notifySucceeded && !backlogSucceeded) {
+    logger.error(
+      { taskId: task.id, reason: breach.reason },
+      'Circuit breach escalation reached NEITHER the coordinator nor the CEO backlog — principal will not see this failure',
+    );
   }
 }
 

--- a/src/agents/task-escalation.test.ts
+++ b/src/agents/task-escalation.test.ts
@@ -212,4 +212,20 @@ describe('renderEscalation (#1267)', () => {
 
     expect(r.progressNote).not.toContain('units/slice');
   });
+
+  it('states each figure exactly once — no headline/dedicated-line duplication', () => {
+    const occurrences = (haystack: string, needle: string) => haystack.split(needle).length - 1;
+    const task = makeTask({ progress: { resumable: RESUMABLE_BLOCK } });
+
+    // max_cost is the worst case — the old headline + Cost-so-far + blocker said "$10.54" thrice.
+    const cost = renderEscalation(buildCircuitBreachEscalation(task, breach('max_cost'), NOW));
+    expect(occurrences(cost.progressNote, '$10.54')).toBe(1);
+    expect(occurrences(cost.progressNote, '25 of 1300')).toBe(1);
+    expect(occurrences(cost.description, '$10.54')).toBe(1);
+    expect(occurrences(cost.description, '25 of 1300')).toBe(1);
+
+    // Stalled leaf — the X-of-Y must not appear in both the headline and the Progress line.
+    const stalled = renderEscalation(buildCircuitBreachEscalation(task, breach('stall_limit'), NOW));
+    expect(occurrences(stalled.progressNote, '25 of 1300')).toBe(1);
+  });
 });

--- a/src/agents/task-escalation.test.ts
+++ b/src/agents/task-escalation.test.ts
@@ -1,0 +1,215 @@
+// task-escalation.test.ts — structured, principal-facing escalation payloads (#1267).
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildCircuitBreachEscalation,
+  buildDelegationEscalation,
+  renderEscalation,
+} from './task-escalation.js';
+import type { CircuitBreach } from './resumable-circuit-breaker.js';
+import type { TaskRow } from '../db/queries/tasks.js';
+
+const NOW = new Date('2026-06-01T01:00:00.000Z');
+
+function makeTask(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    id: 'task-1',
+    agentId: 'social-media',
+    intentAnchor: 'audit follows',
+    status: 'in_progress',
+    progress: {},
+    errorBudget: {},
+    conversationId: null,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+    title: 'Audit 1300 follows',
+    description: null,
+    owner: 'curia',
+    waitingOnContactId: null,
+    waitingOnText: null,
+    parentTaskId: null,
+    blockedByTaskId: null,
+    priority: 50,
+    dueAt: null,
+    source: 'coordinator',
+    sourceAgentId: 'social-media',
+    createdBy: 'coordinator',
+    tags: ['resumable'],
+    originator: null,
+    ...overrides,
+  };
+}
+
+const RESUMABLE_BLOCK = {
+  cursor: 'page:3',
+  done: 25,
+  total: 1300,
+  accumulator: [],
+  lastSliceUnits: 12,
+  next: 'Review page 4',
+};
+
+const PLAN_BLOCK = {
+  steps: [
+    { id: 's1', taskId: '11111111-1111-1111-1111-111111111111' },
+    { id: 's2', taskId: null },
+    { id: 's3', taskId: null },
+  ],
+  deliverableStepId: null,
+  done: 1,
+  total: 3,
+  next: 'kick off s2',
+};
+
+function breach(reason: CircuitBreach['reason'], overrides: Partial<CircuitBreach['state']> = {}): CircuitBreach {
+  return {
+    reason,
+    message: `circuit breach: ${reason}`,
+    state: {
+      stallCount: 3,
+      iterationCount: 8,
+      startedAt: '2026-06-01T00:00:00.000Z',
+      totalCostUsd: 10.5432,
+      lastProgress: { done: 25, cursor: 'page:3' },
+      ...overrides,
+    },
+  };
+}
+
+describe('buildCircuitBreachEscalation (#1267)', () => {
+  it('maps a resumable-leaf stall to failureMode=stalled with throughput + progress', () => {
+    const task = makeTask({ progress: { resumable: RESUMABLE_BLOCK } });
+    const e = buildCircuitBreachEscalation(task, breach('stall_limit'), NOW);
+
+    expect(e.failureMode).toBe('stalled');
+    expect(e.reason).toBe('stall_limit');
+    expect(e.source).toBe('resumable_leaf');
+    expect(e.progress).toEqual({ done: 25, total: 1300 });
+    expect(e.throughput?.estimateAvailable).toBe(true);
+    expect(e.throughput?.unitsPerSlice).toBeCloseTo(25 / 8);
+    expect(e.costUsd).toBeCloseTo(10.5432);
+    expect(e.suggestedActions.length).toBeGreaterThan(0);
+  });
+
+  it('maps any ceiling breach (cost/time/attempts) to failureMode=ceiling', () => {
+    const task = makeTask({ progress: { resumable: RESUMABLE_BLOCK } });
+    expect(buildCircuitBreachEscalation(task, breach('max_cost'), NOW).failureMode).toBe('ceiling');
+    expect(buildCircuitBreachEscalation(task, breach('max_wallclock'), NOW).failureMode).toBe('ceiling');
+    expect(buildCircuitBreachEscalation(task, breach('max_iterations'), NOW).failureMode).toBe('ceiling');
+  });
+
+  it('maps a planned parent (progress.plan present) to source=planned_parent with X-of-Y and no throughput', () => {
+    const task = makeTask({ progress: { plan: PLAN_BLOCK } });
+    const e = buildCircuitBreachEscalation(task, breach('stall_limit'), NOW);
+
+    expect(e.source).toBe('planned_parent');
+    expect(e.progress).toEqual({ done: 1, total: 3 });
+    expect(e.throughput).toBeUndefined();
+  });
+
+  it('degrades gracefully on cold start (done=0): throughput omitted, no divide-by-zero', () => {
+    const task = makeTask({
+      progress: { resumable: { ...RESUMABLE_BLOCK, done: 0, lastSliceUnits: 0 } },
+    });
+    const e = buildCircuitBreachEscalation(task, breach('stall_limit', { lastProgress: { done: 0, cursor: null } }), NOW);
+
+    expect(e.progress).toEqual({ done: 0, total: 1300 });
+    expect(e.throughput).toBeUndefined();
+  });
+});
+
+describe('buildDelegationEscalation (#1267)', () => {
+  it('maps reason=blocked to failureMode=blocked_on_human', () => {
+    const e = buildDelegationEscalation({
+      agent: 'research',
+      reason: 'blocked',
+      retryable: false,
+      message: 'needs the CEO to pick a vendor',
+      task: 'choose a CRM vendor',
+    });
+
+    expect(e.failureMode).toBe('blocked_on_human');
+    expect(e.source).toBe('delegation');
+    expect(e.progress).toBeUndefined();
+    expect(e.throughput).toBeUndefined();
+    expect(e.suggestedActions.length).toBeGreaterThan(0);
+  });
+
+  it('maps any other non-retryable reason to failureMode=agent_incomplete with the agent as blocker', () => {
+    const e = buildDelegationEscalation({
+      agent: 'research',
+      reason: 'maxTurns',
+      retryable: false,
+      message: 'ran out of turns mid-audit',
+      task: 'audit 1300 follows',
+    });
+
+    expect(e.failureMode).toBe('agent_incomplete');
+    expect(e.reason).toBe('maxTurns');
+    expect(e.blocker).toBe('research');
+  });
+});
+
+describe('renderEscalation (#1267)', () => {
+  it('renders a stalled leaf: progress note carries X-of-Y, throughput, and suggested actions', () => {
+    const task = makeTask({ progress: { resumable: RESUMABLE_BLOCK } });
+    const r = renderEscalation(buildCircuitBreachEscalation(task, breach('stall_limit'), NOW));
+
+    expect(r.progressNote).toContain('25 of 1300');
+    expect(r.progressNote.toLowerCase()).toContain('stall');
+    expect(r.progressNote).toMatch(/units\/slice|ETA/);
+    expect(r.progressNote.toLowerCase()).toContain('suggested');
+    // Coordinator poke must keep the no-blind-retry instruction.
+    expect(r.notifyContent).toContain('Do not re-delegate');
+  });
+
+  it('renders a cost-ceiling breach: mentions the cost and a resume-or-cancel action', () => {
+    const task = makeTask({ progress: { resumable: RESUMABLE_BLOCK } });
+    const r = renderEscalation(buildCircuitBreachEscalation(task, breach('max_cost'), NOW));
+
+    expect(r.progressNote.toLowerCase()).toContain('cost');
+    expect(r.progressNote).toContain('$10.54');
+    expect(r.description.toLowerCase()).toMatch(/resume|cancel/);
+  });
+
+  it('renders a blocked-on-human escalation: names the person-wait and suggests a nudge/answer', () => {
+    const r = renderEscalation(
+      buildDelegationEscalation({
+        agent: 'research',
+        reason: 'blocked',
+        retryable: false,
+        message: 'needs the CEO to pick a vendor',
+        task: 'choose a CRM vendor',
+      }),
+    );
+
+    expect(r.progressNote.toLowerCase()).toContain('blocked');
+    expect(r.description.toLowerCase()).toMatch(/nudge|answer|cancel/);
+  });
+
+  it('renders an agent-incomplete escalation: names the agent and the reason', () => {
+    const r = renderEscalation(
+      buildDelegationEscalation({
+        agent: 'research',
+        reason: 'maxTurns',
+        retryable: false,
+        message: 'ran out of turns mid-audit',
+        task: 'audit 1300 follows',
+      }),
+    );
+
+    expect(r.progressNote).toContain('research');
+    expect(r.description).toContain('maxTurns');
+  });
+
+  it('omits the throughput line when no estimate is available (cold start)', () => {
+    const task = makeTask({
+      progress: { resumable: { ...RESUMABLE_BLOCK, done: 0, lastSliceUnits: 0 } },
+    });
+    const r = renderEscalation(
+      buildCircuitBreachEscalation(task, breach('stall_limit', { lastProgress: { done: 0, cursor: null } }), NOW),
+    );
+
+    expect(r.progressNote).not.toContain('units/slice');
+  });
+});

--- a/src/agents/task-escalation.ts
+++ b/src/agents/task-escalation.ts
@@ -166,7 +166,7 @@ export function buildCircuitBreachEscalation(
     if (metrics.estimateAvailable) throughput = metrics;
   }
 
-  const headline = circuitHeadline(failureMode, breach, source, progress);
+  const headline = circuitHeadline(failureMode, breach, source);
 
   return {
     failureMode,
@@ -181,38 +181,42 @@ export function buildCircuitBreachEscalation(
   };
 }
 
+// The headline names the failure type only. Progress (X of Y) and cost ($) are NOT restated
+// here — renderEscalation's dedicated `Progress:` / `Cost so far:` lines are the single source
+// of truth for those numbers (#1267, avoids stating them twice in the principal-facing text).
 function circuitHeadline(
   mode: EscalationFailureMode,
   breach: CircuitBreach,
   source: EscalationSource,
-  progress: EscalationProgress,
 ): string {
   const what = source === 'planned_parent' ? 'the plan' : 'the task';
   if (mode === 'stalled') {
     const unit = source === 'planned_parent' ? 'wake' : 'slice';
-    return `Stalled: ${what} made no forward progress for ${breach.state.stallCount} ${unit}(s) `
-      + `at ${formatProgress(progress)}.`;
+    return `Stalled: ${what} made no forward progress for ${breach.state.stallCount} ${unit}(s).`;
   }
   switch (breach.reason) {
     case 'max_cost':
-      return `Hit the cost ceiling ($${breach.state.totalCostUsd.toFixed(2)}) at ${formatProgress(progress)}.`;
+      return 'Hit the cost ceiling.';
     case 'max_wallclock':
-      return `Hit the time ceiling at ${formatProgress(progress)}.`;
+      return 'Hit the time ceiling.';
     case 'max_iterations':
-      return `Hit the slice ceiling (${breach.state.iterationCount} continuations) at ${formatProgress(progress)}.`;
+      return `Hit the slice ceiling (${breach.state.iterationCount} continuations).`;
     default:
-      return `${what} breached a ceiling at ${formatProgress(progress)}.`;
+      return `${what} breached a ceiling.`;
   }
 }
 
+// Non-numeric constraint descriptor for the structured `blocker` field. Deliberately carries no
+// dollar / count — those live on the dedicated render lines, so the "Blocked by:" line never
+// repeats a figure already stated above it (#1267).
 function circuitBlocker(breach: CircuitBreach): string | undefined {
   switch (breach.reason) {
     case 'max_cost':
-      return `$${breach.state.totalCostUsd.toFixed(2)} cost ceiling`;
+      return 'the cost ceiling';
     case 'max_wallclock':
-      return 'wallclock ceiling';
+      return 'the wallclock ceiling';
     case 'max_iterations':
-      return `${breach.state.iterationCount}-slice ceiling`;
+      return 'the iteration ceiling';
     default:
       return undefined;
   }

--- a/src/agents/task-escalation.ts
+++ b/src/agents/task-escalation.ts
@@ -1,0 +1,275 @@
+// task-escalation.ts — structured, principal-facing escalation payloads (#1267).
+//
+// A stalled / ceiling-breached / blocked resumable, planned, or delegated task escalates
+// today as a near-bare `needs-attention` CEO backlog row: the detail lives in the task
+// `description`, but the daily digest reads `last_progress_note`, so the principal sees
+// only the title + tags. This module produces a structured `TaskEscalation` payload (stored
+// at progress.escalation for audit / a future interactive surface) and a pure renderer that
+// turns it into the CEO task's progress note — the field the digest actually reads — plus the
+// coordinator poke and the task description.
+//
+// Pure functions only — no I/O. The two escalation entry points
+// (escalateCircuitBreach, escalateDelegationFailure) build a payload, render it, and seed it
+// onto the created CEO task. Failure modes map to what the platform actually produces; see
+// the mapping table below. `needs_decision` is reserved but unwired — nothing emits it yet.
+
+import type { CircuitBreach, CircuitBreachReason } from './resumable-circuit-breaker.js';
+import type { ResumableThroughputMetrics } from './resumable-throughput.js';
+import {
+  computeResumableThroughput,
+  formatResumableThroughputForResume,
+} from './resumable-throughput.js';
+import type { TaskRow } from '../db/queries/tasks.js';
+import { readResumableBlock } from '../db/resumable-progress.js';
+import { readPlanBlock } from '../db/plan-progress.js';
+
+/**
+ * Principal-facing failure categories (#1267). Mapped from real producers:
+ *   - `stalled`          ← circuit breaker, reason `stall_limit`
+ *   - `ceiling`          ← circuit breaker, reason `max_cost` / `max_wallclock` / `max_iterations`
+ *   - `blocked_on_human` ← delegation guard, reason `blocked`
+ *   - `agent_incomplete` ← delegation guard, any other non-retryable reason (`maxTurns`, `api_error`, …)
+ * `needs_decision` is reserved as a category but never emitted — no producer exists yet.
+ */
+export type EscalationFailureMode =
+  | 'stalled'
+  | 'ceiling'
+  | 'blocked_on_human'
+  | 'agent_incomplete'
+  | 'needs_decision';
+
+export type EscalationSource = 'resumable_leaf' | 'planned_parent' | 'delegation';
+
+export interface EscalationProgress {
+  /** Units (resumable) or steps (plan) resolved so far. */
+  done: number;
+  /** Target unit / step count. */
+  total: number;
+}
+
+/** Structured escalation payload, stored at tasks.progress.escalation on the CEO row. */
+export interface TaskEscalation {
+  failureMode: EscalationFailureMode;
+  /** The specific producer sub-reason: 'stall_limit' | 'max_cost' | 'maxTurns' | 'blocked' | … */
+  reason: string;
+  source: EscalationSource;
+  /** One-line, principal-facing summary of what went wrong. */
+  headline: string;
+  /** X-of-Y progress; absent for delegation failures (no progress tracked). */
+  progress?: EscalationProgress;
+  /** Rolling pace + ETA (#1264); resumable leaves only, when an estimate is available. */
+  throughput?: ResumableThroughputMetrics;
+  /** What's holding it up: the ceiling hit, the person waited on, or the agent that failed. */
+  blocker?: string;
+  /** Aggregate LLM cost across slices so far (circuit breaches). */
+  costUsd?: number;
+  /** Templated next-action options for the principal (resume / raise ceiling / cancel / re-scope). */
+  suggestedActions: string[];
+}
+
+/** The three human-readable renderings derived from a payload. */
+export interface RenderedEscalation {
+  /** → the CEO task's last progress note: the field the daily digest reads. */
+  progressNote: string;
+  /** → the coordinator `agent.task` poke. */
+  notifyContent: string;
+  /** → the CEO task description (fuller detail for the task view). */
+  description: string;
+}
+
+/** Delegation-failure shape consumed by the delegation escalation builder. */
+export interface DelegationEscalationInput {
+  agent: string;
+  reason: string;
+  retryable: boolean;
+  message: string;
+  /** The original delegated task text. */
+  task: string;
+}
+
+function ceilingFailureMode(reason: CircuitBreachReason): EscalationFailureMode {
+  return reason === 'stall_limit' ? 'stalled' : 'ceiling';
+}
+
+function formatProgress(p: EscalationProgress): string {
+  return p.total > 0 ? `${p.done} of ${p.total}` : `${p.done} done`;
+}
+
+/** Templated next-action options keyed by failure mode (and the ceiling sub-reason). */
+function suggestedActions(
+  mode: EscalationFailureMode,
+  reason: string,
+  ctx: { agent?: string },
+): string[] {
+  switch (mode) {
+    case 'stalled':
+      return [
+        'No forward progress across the last slices — the approach likely will not converge.',
+        'Cancel it, or change the approach and re-delegate.',
+      ];
+    case 'ceiling': {
+      const knob =
+        reason === 'max_cost' ? 'error_budget.max_cost_usd'
+          : reason === 'max_wallclock' ? 'error_budget.max_wallclock_hours'
+            : 'error_budget.max_iterations';
+      return [
+        `Raise the ceiling (${knob}) and resume if the work is still worth it, or cancel.`,
+      ];
+    }
+    case 'blocked_on_human':
+      return [
+        'Answer the open question or nudge the person it is waiting on, then let it resume.',
+        'Or cancel if it is no longer needed.',
+      ];
+    case 'agent_incomplete':
+      return [
+        `${ctx.agent ?? 'The specialist'} could not finish as scoped.`,
+        'Re-scope it smaller, hand it to a different agent, or cancel.',
+      ];
+    case 'needs_decision':
+      return ['Make the call, then let it resume.'];
+  }
+}
+
+/**
+ * Build an escalation payload from a circuit-breaker breach. Detects whether the task is a
+ * resumable leaf (progress.resumable) or a planned parent (progress.plan) and shapes the
+ * payload accordingly: leaves carry throughput + ETA; planned parents carry an X-of-Y step
+ * rollup with no per-unit throughput.
+ */
+export function buildCircuitBreachEscalation(
+  task: TaskRow,
+  breach: CircuitBreach,
+  now: Date = new Date(),
+): TaskEscalation {
+  const failureMode = ceilingFailureMode(breach.reason);
+  const plan = readPlanBlock(task.progress);
+  const resumable = plan ? null : readResumableBlock(task.progress);
+  const source: EscalationSource = plan ? 'planned_parent' : 'resumable_leaf';
+
+  const progress: EscalationProgress = plan
+    ? { done: plan.done, total: plan.total }
+    : {
+      done: resumable?.done ?? breach.state.lastProgress.done,
+      total: resumable?.total ?? 0,
+    };
+
+  // Throughput is a resumable-leaf concept (units/slice, cost/unit, ETA). Planned parents
+  // advance by child completions, not units, so they carry the X-of-Y rollup only.
+  let throughput: ResumableThroughputMetrics | undefined;
+  if (resumable) {
+    const metrics = computeResumableThroughput(
+      { done: resumable.done, total: resumable.total, lastSliceUnits: resumable.lastSliceUnits },
+      breach.state,
+      now,
+    );
+    if (metrics.estimateAvailable) throughput = metrics;
+  }
+
+  const headline = circuitHeadline(failureMode, breach, source, progress);
+
+  return {
+    failureMode,
+    reason: breach.reason,
+    source,
+    headline,
+    progress,
+    throughput,
+    blocker: circuitBlocker(breach),
+    costUsd: breach.state.totalCostUsd,
+    suggestedActions: suggestedActions(failureMode, breach.reason, {}),
+  };
+}
+
+function circuitHeadline(
+  mode: EscalationFailureMode,
+  breach: CircuitBreach,
+  source: EscalationSource,
+  progress: EscalationProgress,
+): string {
+  const what = source === 'planned_parent' ? 'the plan' : 'the task';
+  if (mode === 'stalled') {
+    const unit = source === 'planned_parent' ? 'wake' : 'slice';
+    return `Stalled: ${what} made no forward progress for ${breach.state.stallCount} ${unit}(s) `
+      + `at ${formatProgress(progress)}.`;
+  }
+  switch (breach.reason) {
+    case 'max_cost':
+      return `Hit the cost ceiling ($${breach.state.totalCostUsd.toFixed(2)}) at ${formatProgress(progress)}.`;
+    case 'max_wallclock':
+      return `Hit the time ceiling at ${formatProgress(progress)}.`;
+    case 'max_iterations':
+      return `Hit the slice ceiling (${breach.state.iterationCount} continuations) at ${formatProgress(progress)}.`;
+    default:
+      return `${what} breached a ceiling at ${formatProgress(progress)}.`;
+  }
+}
+
+function circuitBlocker(breach: CircuitBreach): string | undefined {
+  switch (breach.reason) {
+    case 'max_cost':
+      return `$${breach.state.totalCostUsd.toFixed(2)} cost ceiling`;
+    case 'max_wallclock':
+      return 'wallclock ceiling';
+    case 'max_iterations':
+      return `${breach.state.iterationCount}-slice ceiling`;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Build an escalation payload from a non-retryable delegation failure. A `blocked` reason
+ * means the specialist is waiting on a human (blocked_on_human); any other reason means it
+ * could not finish the work as scoped (agent_incomplete). No progress / throughput — a
+ * delegation failure is a single attempt, not a tracked sweep.
+ */
+export function buildDelegationEscalation(input: DelegationEscalationInput): TaskEscalation {
+  const failureMode: EscalationFailureMode =
+    input.reason === 'blocked' ? 'blocked_on_human' : 'agent_incomplete';
+
+  const headline = failureMode === 'blocked_on_human'
+    ? `Blocked on a person: ${input.agent} cannot proceed without input — ${input.message}`
+    : `${input.agent} could not finish the delegated work (${input.reason}).`;
+
+  return {
+    failureMode,
+    reason: input.reason,
+    source: 'delegation',
+    headline,
+    // The agent is the "blocker" for an incomplete; a human-block has no structured "who".
+    blocker: failureMode === 'agent_incomplete' ? input.agent : undefined,
+    suggestedActions: suggestedActions(failureMode, input.reason, { agent: input.agent }),
+  };
+}
+
+/**
+ * Render a payload into the three principal-facing surfaces. The progress note is the digest
+ * carrier (kept compact, single block); the coordinator poke and description carry the same
+ * facts with the no-blind-retry instruction.
+ */
+export function renderEscalation(e: TaskEscalation): RenderedEscalation {
+  const noteParts: string[] = [e.headline];
+  if (e.progress) noteParts.push(`Progress: ${formatProgress(e.progress)}.`);
+  if (e.throughput?.estimateAvailable) noteParts.push(formatResumableThroughputForResume(e.throughput));
+  if (typeof e.costUsd === 'number' && e.costUsd > 0) noteParts.push(`Cost so far: $${e.costUsd.toFixed(2)}.`);
+  if (e.suggestedActions.length > 0) noteParts.push(`Suggested: ${e.suggestedActions.join(' ')}`);
+  const progressNote = noteParts.join(' ');
+
+  const detailLines: string[] = [e.headline, ''];
+  if (e.progress) detailLines.push(`Progress: ${formatProgress(e.progress)}.`);
+  if (e.throughput?.estimateAvailable) detailLines.push(formatResumableThroughputForResume(e.throughput));
+  if (typeof e.costUsd === 'number' && e.costUsd > 0) detailLines.push(`Cost so far: $${e.costUsd.toFixed(2)}.`);
+  if (e.blocker) detailLines.push(`Blocked by: ${e.blocker}.`);
+  detailLines.push('', 'Suggested next steps:', ...e.suggestedActions.map((a) => `- ${a}`));
+
+  const description = detailLines.join('\n');
+
+  const notifyContent = [
+    ...detailLines,
+    '',
+    'Do not re-delegate or schedule continuations for this task. Let the principal know and help them decide next steps.',
+  ].join('\n');
+
+  return { progressNote, notifyContent, description };
+}

--- a/src/db/task-repo.seed.test.ts
+++ b/src/db/task-repo.seed.test.ts
@@ -1,0 +1,35 @@
+// task-repo.seed.test.ts — initial-progress seeding for createTask (#1267).
+
+import { describe, it, expect } from 'vitest';
+import { buildInitialTaskProgress } from './task-repo.js';
+import type { TaskEscalation } from '../agents/task-escalation.js';
+
+const NOW = new Date('2026-06-01T00:00:00.000Z');
+
+const ESCALATION: TaskEscalation = {
+  failureMode: 'stalled',
+  reason: 'stall_limit',
+  source: 'resumable_leaf',
+  headline: 'Stalled at 25 of 1300.',
+  progress: { done: 25, total: 1300 },
+  suggestedActions: ['Cancel or change approach.'],
+};
+
+describe('buildInitialTaskProgress (#1267)', () => {
+  it('defaults to an empty notes array (matches the legacy {"notes":[]} seed)', () => {
+    expect(buildInitialTaskProgress({})).toEqual({ notes: [] });
+  });
+
+  it('seeds an initial progress note so the digest (last_progress_note) has content', () => {
+    const progress = buildInitialTaskProgress({ progressNote: 'breach summary', now: NOW });
+    expect(progress).toEqual({
+      notes: [{ at: NOW.toISOString(), note: 'breach summary' }],
+    });
+  });
+
+  it('attaches the structured escalation block under progress.escalation', () => {
+    const progress = buildInitialTaskProgress({ progressNote: 'breach summary', escalation: ESCALATION, now: NOW });
+    expect(progress.escalation).toEqual(ESCALATION);
+    expect((progress.notes as unknown[]).length).toBe(1);
+  });
+});

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -34,6 +34,7 @@ import { prepareResumableBlockWithSpill } from './resumable-accumulator-spill.js
 import type { WorkingDocsRepo } from './working-docs-repo.js';
 import { type ResumableCircuitState } from '../agents/resumable-circuit-breaker.js';
 import type { PlanAdaptiveState } from '../agents/plan-adaptive-replan.js';
+import type { TaskEscalation } from '../agents/task-escalation.js';
 
 // All SELECT / RETURNING clauses use this column list. Centralised so a schema
 // change only needs updating in one place.
@@ -70,6 +71,31 @@ export interface CreateTaskParams {
   originator?: TaskOriginator | null;
   /** When true, stamps error_budget.resumable so the checkpoint harness activates (#1173). */
   resumable?: boolean;
+  /** Seeds an initial progress note (#1267). Makes the new row's last_progress_note non-empty
+   *  so the daily digest renders real content, not just title + tags. */
+  progressNote?: string;
+  /** Structured escalation payload (#1267), stored at progress.escalation for audit and a
+   *  future interactive surface. Set by the circuit-breaker / delegation escalation paths. */
+  escalation?: TaskEscalation;
+}
+
+/**
+ * Build the initial tasks.progress JSON for a new row (#1267). Defaults to the legacy
+ * empty-notes seed (`{"notes":[]}`). An optional first progress note makes the row's
+ * last_progress_note non-empty — the field the daily digest reads — and an optional
+ * structured escalation block is stored under progress.escalation.
+ */
+export function buildInitialTaskProgress(opts: {
+  progressNote?: string;
+  escalation?: TaskEscalation;
+  now?: Date;
+}): Record<string, unknown> {
+  const notes = opts.progressNote
+    ? [{ at: (opts.now ?? new Date()).toISOString(), note: opts.progressNote }]
+    : [];
+  const progress: Record<string, unknown> = { notes };
+  if (opts.escalation) progress.escalation = opts.escalation;
+  return progress;
 }
 
 export interface UpdateTaskParams {
@@ -144,11 +170,15 @@ export class TaskRepo {
       wakeAt,
       originator,
       resumable,
+      progressNote,
+      escalation,
     } = params;
 
     const resolvedCreatedBy = createdBy ?? agentId;
     const resolvedIntentAnchor = intentAnchor ?? title;
     const errorBudgetJson = resumable ? JSON.stringify({ resumable: true }) : '{}';
+    // Seed the row's progress so the digest's last_progress_note has content from creation (#1267).
+    const progressJson = JSON.stringify(buildInitialTaskProgress({ progressNote, escalation }));
 
     // Resolve the lineage to stamp (#1125). For a child task, cap the creating event's
     // originator to the parent's lineage so a child can never carry standing above its parent.
@@ -167,7 +197,7 @@ export class TaskRepo {
         owner, parent_task_id, blocked_by_task_id, priority, due_at, tags,
         waiting_on_contact_id, waiting_on_text, source, source_agent_id, created_by, originator
       )
-      VALUES ($1, $2, $3, $4, 'open', '{"notes":[]}'::jsonb, $17::jsonb,
+      VALUES ($1, $2, $3, $4, 'open', $18::jsonb, $17::jsonb,
               $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::jsonb)
       RETURNING ${TASK_COLUMNS}
     `;
@@ -189,6 +219,7 @@ export class TaskRepo {
       resolvedCreatedBy,
       originatorJson,
       errorBudgetJson,
+      progressJson, // $18 — seeded progress (notes + optional escalation block)
     ];
 
     let row: DbTaskRow;
@@ -212,23 +243,23 @@ export class TaskRepo {
             owner, parent_task_id, blocked_by_task_id, priority, due_at, tags,
             waiting_on_contact_id, waiting_on_text, source, source_agent_id, created_by, originator
           )
-          VALUES ($1, $2, $3, $4, 'open', '{"notes":[]}'::jsonb, $17::jsonb,
+          VALUES ($1, $2, $3, $4, 'open', $18::jsonb, $17::jsonb,
                   $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::jsonb)
           RETURNING ${TASK_COLUMNS}
         ),
         _wake_job AS (
           INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id, originator)
-          SELECT $18, $19, '{"type":"task-wake"}'::jsonb, 'pending', $19, $20, $21, new_task.id, new_task.originator
+          SELECT $19, $20, '{"type":"task-wake"}'::jsonb, 'pending', $20, $21, $22, new_task.id, new_task.originator
           FROM new_task
         )
         SELECT * FROM new_task
       `;
       const { rows } = await this.pool.query(cteSql, [
-        ...taskParams,
-        agentId,           // $18 — scheduled_jobs.agent_id
-        wakeAt,            // $19 — run_at / next_run_at
-        resolvedCreatedBy, // $20 — created_by
-        this.timezone,     // $21 — timezone
+        ...taskParams,     // $1–$18 (taskParams[17] = $18 = seeded progress)
+        agentId,           // $19 — scheduled_jobs.agent_id
+        wakeAt,            // $20 — run_at / next_run_at
+        resolvedCreatedBy, // $21 — created_by
+        this.timezone,     // $22 — timezone
       ]);
       row = rows[0] as DbTaskRow | undefined
         ?? (() => { throw new Error('task-repo: createTask CTE returned no row'); })();

--- a/tests/integration/resumable-circuit-breaker.test.ts
+++ b/tests/integration/resumable-circuit-breaker.test.ts
@@ -21,7 +21,7 @@ async function cleanup(pool: pg.Pool): Promise<void> {
     `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
     [`${PREFIX}%`],
   );
-  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`Review: resumable task stalled (${PREFIX}%`]);
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`Review:%${PREFIX}%`]);
   await pool.query(`DELETE FROM tasks WHERE title LIKE $1 OR parent_task_id IN (
     SELECT id FROM tasks WHERE title LIKE $1
   )`, [`${PREFIX}%`]);
@@ -124,13 +124,58 @@ describeIf('Resumable circuit breaker (#1176)', () => {
     );
     expect(wakes).toHaveLength(0);
 
+    // The coordinator poke carries the rendered, principal-facing summary + the no-blind-retry
+    // instruction (#1267), not the old generic "circuit breaker" line.
     expect(coordinatorTasks.length).toBeGreaterThan(0);
-    expect(coordinatorTasks[0]!.content).toContain('circuit breaker');
+    expect(coordinatorTasks[0]!.content).toContain('Do not re-delegate');
+    expect(coordinatorTasks[0]!.content).toContain('25 of 1300');
 
+    // Scope to THIS test's escalation by title — integration files run in parallel against the
+    // same DB, so an unscoped tag-only query catches other tests' circuit-breach rows.
+    const ceoRowFilter = `Review:%${PREFIX}%`;
     const { rows: ceoTasks } = await pool.query(
-      `SELECT id, owner, tags FROM tasks WHERE owner = 'ceo' AND tags @> ARRAY['resumable-circuit-breach']::text[]`,
+      `SELECT id, owner, tags, title, progress FROM tasks
+         WHERE owner = 'ceo' AND tags @> ARRAY['resumable-circuit-breach']::text[]
+           AND title LIKE $1`,
+      [ceoRowFilter],
     );
-    expect(ceoTasks.length).toBeGreaterThan(0);
+    expect(ceoTasks).toHaveLength(1);
+
+    // Richer escalation UX (#1267): the CEO row carries a structured progress.escalation block
+    // AND a non-empty last progress note — the field the daily digest reads — so the detail
+    // reaches the principal instead of being a bare backlog row.
+    const ceo = ceoTasks[0]! as { progress: Record<string, unknown> };
+    const escalation = ceo.progress.escalation as Record<string, unknown> | undefined;
+    expect(escalation).toBeTruthy();
+    expect(escalation!.failureMode).toBe('stalled');
+    expect(escalation!.source).toBe('resumable_leaf');
+    expect(escalation!.reason).toBe('stall_limit');
+    expect(escalation!.progress).toEqual({ done: 25, total: 1300 });
+    expect(Array.isArray(escalation!.suggestedActions)).toBe(true);
+    expect((escalation!.suggestedActions as unknown[]).length).toBeGreaterThan(0);
+
+    const notes = ceo.progress.notes as Array<{ note: string }> | undefined;
+    const lastNote = notes && notes.length > 0 ? notes[notes.length - 1]!.note : '';
+    expect(lastNote.length).toBeGreaterThan(0);
+    expect(lastNote).toContain('25 of 1300');
+    expect(lastNote.toLowerCase()).toContain('stall');
+
+    // Re-firing the same pause on the now-failed task must NOT create a second CEO row or
+    // a second coordinator poke — the terminal-task guard short-circuits the re-escalation (#1267).
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-stall-refire',
+      content: JSON.stringify(pausedPayload),
+      parentEventId: 'parent-stall-refire',
+    }));
+
+    const { rows: ceoTasksAfterRefire } = await pool.query(
+      `SELECT id FROM tasks WHERE owner = 'ceo' AND tags @> ARRAY['resumable-circuit-breach']::text[]
+         AND title LIKE $1`,
+      [ceoRowFilter],
+    );
+    expect(ceoTasksAfterRefire).toHaveLength(1);
+    expect(coordinatorTasks).toHaveLength(1);
   });
 
   it('schedules continuation when progress advances', async () => {


### PR DESCRIPTION
## Summary

Closes #1267. Part of #1150 (Resumable Tasks & Projects), Phase 3 (#1178).

**Targets `main`.** #1270 (#1266) is merged; this is rebased onto main and is just this feature's 12 files.

A stalled / ceiling-breached / blocked / agent-incomplete task used to escalate as a near-bare `needs-attention` CEO backlog row. Two concrete gaps: (1) the rich content went into the task `description`, but the daily digest reads `last_progress_note` (via `task-list`), and the new CEO row had empty notes, so the digest only ever saw the title + tags; (2) no structured payload, no failure-mode distinction. This makes escalations carry a structured payload and render into the field the digest actually reads.

## What changed

- **`src/agents/task-escalation.ts` (new)** — `TaskEscalation` payload + per-source builders (`buildCircuitBreachEscalation` for resumable leaves *and* planned parents, `buildDelegationEscalation`), a pure `renderEscalation`, and a templated suggested-actions table. Four real failure modes mapped from their producers: **stalled** (`stall_limit`), **ceiling** (`max_cost`/`max_wallclock`/`max_iterations`), **blocked-on-human** (`reason: blocked`), **agent-incomplete** (other non-retryable). `needs_decision` is reserved but unwired — nothing produces it.
- **Graceful degradation** — resumable leaves carry throughput + ETA (#1264) and X-of-Y; planned parents carry the X-of-Y rollup (no per-unit throughput); delegation failures carry reason-only.
- **`src/db/task-repo.ts`** — `createTask` seeds an initial progress note + a structured `progress.escalation` block (new pure `buildInitialTaskProgress` helper). No migration (`progress` is existing JSONB).
- **`escalateCircuitBreach` / `escalateDelegationFailure`** — both build → render → seed. The escalation renders into the CEO row's `last_progress_note`, so detail reaches the principal through the existing daily digest. No priority bump, no new digest section, no new notify subsystem (digest-only, no added prominence, per design).
- **`task-create` skill (v0.4.0)** — optional `progress_note` / `escalation_json` inputs (additive manifest change), so the delegation path seeds the same note + block.

## Review hardening (from silent-failure review)

- **Guard against duplicate escalation** on a re-fired breach — `failResumableTask` is idempotent and returns the existing row when already-terminal, so the truthy-`updated` check fell through and created a second CEO row + poke. Added a terminal-task guard mirroring the plan-adaptive path.
- **Loud log when neither surface reaches the principal** — if both the coordinator poke and the CEO `createTask` throw (correlated infra outage), the failed task is terminal with no path to the principal; now logged at `error` so it is alertable.

## Tests

- Unit: `renderEscalation` per failure mode + each builder (leaf-with-throughput, plan-rollup, delegation, cold-start degradation); `buildInitialTaskProgress`; `task-create` forwarding (incl. malformed `escalation_json`).
- Integration (`resumable-circuit-breaker.test.ts`): asserts the CEO row carries the structured `progress.escalation` block + a non-empty `last_progress_note`, and that a re-fire does not duplicate.
- Full suite green (4609 passed), typecheck + lint clean.

## Design

Refined design + decisions in #1267. Spec 20 §4 updated with a one-paragraph note on the structured escalation payload.
