### PR TITLE
chore: add 7-day Dependabot cooldown to all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # Quarantine newly-published versions for 7 days before proposing a bump.
+    # A compromised package version is most often caught and yanked within days of
+    # publish; waiting 7 days lets Dependabot skip that window. We rely on this
+    # PR-proposal-layer gate rather than pnpm's install-time `minimumReleaseAge`,
+    # which would retroactively reject the existing lockfile and break CI.
+    # NOTE: cooldown applies to version updates only — Dependabot *security*
+    # updates (CVE fixes from alerts) bypass it, so CVE patches are not delayed.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       dev-dependencies:
@@ -22,6 +31,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # 7-day quarantine on newly-published action versions (see npm block above).
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:
@@ -36,6 +48,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # 7-day quarantine on newly-published image digests (see npm block above).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     ignore:
       # node 24 is the Active LTS. Do NOT auto-bump the major: the next even
@@ -53,6 +68,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # 7-day quarantine on newly-published image digests (see npm block above).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "pgvector/pgvector"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`ceo-inbox` scheduling consults** — a message parked for a calendar consult is no longer labeled "✍️ Drafted" before a draft exists, and the consult-timeout wake now keys off actual draft existence; parked scheduling replies get drafted instead of stranding the email as "In Progress + Drafted" with no draft. (#1215)
 - **Bullpen `close_after`** — closed-thread replies deliver to mentioned participants via read-and-act wakes; `close_after` with no mentions auto-mentions the thread opener; `ceo-inbox` loads the full thread before Branch A. (#1256)
 
+### Security
+
+- **Dependabot cooldown** — all four ecosystems (npm, github-actions, docker ×2) now wait 7 days before proposing a bump, quarantining freshly-published (potentially compromised) versions at the PR-proposal layer. Clears Semgrep `dependabot-missing-cooldown` alerts.
+
 ## [0.38.0] — 2026-06-26 — "Deckard"
 
 > **Rick Deckard** *(Blade Runner, 1982, Ridley Scott — from Philip K. Dick's "Do Androids Dream of Electric Sheep?", 1968)* — a blade runner whose whole craft is telling a genuinely living person from a replicant that only wears the appearance of one. This release teaches Curia the same distinction: authority now answers solely to the principal who is actually, presently live — never to a woken task that merely carries their lineage.


### PR DESCRIPTION
## Summary

Adds a 7-day `cooldown` to all four Dependabot ecosystems (npm, github-actions, docker `/`, docker `/docker`) in `.github/dependabot.yml`, so freshly-published package versions are quarantined for a week before Dependabot proposes a bump. This clears the Semgrep `dependabot-missing-cooldown` code-scanning alerts (4 of them).

Cooldown applies to **version updates only** — Dependabot **security** updates (CVE fixes from alerts) bypass it, so this does **not** delay vulnerability patches (per [GitHub's Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)).

## Why not the pnpm settings Semgrep also recommends?

Semgrep flagged two companion `pnpm-workspace.yaml` settings (`minimumReleaseAge`, `trustPolicy: no-downgrade`). Both are **intentionally omitted** — verified locally that each one retroactively fails `pnpm install --frozen-lockfile` against the **current** lockfile, which is exactly what CI runs:

- `minimumReleaseAge: 10080` → 42 lockfile entries are younger than 7 days (recent Dependabot merges, `@anthropic-ai/sdk@0.107.0`, etc.). Adopting it would require regenerating the lockfile to downgrade ~42 packages and would structurally fight the weekly Dependabot freshness flow.
- `trustPolicy: no-downgrade` → pnpm flags `chokidar@4.0.3` as a "high-risk trust downgrade (possible package takeover)" — almost certainly a pnpm trust-DB false positive (chokidar is paulmillr's; the tree also resolves `chokidar@5.0.0`), but `no-downgrade` blocks the install regardless.

The Dependabot 7-day cooldown gives us the same quarantine benefit at the PR-proposal layer without the brittle install-time gate. The two pnpm code-scanning alerts are being **dismissed** with this rationale.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts` passes (config back to baseline; no lockfile churn).
- `.github/dependabot.yml` parses; all four ecosystems carry `cooldown.default-days: 7`.
- Dependabot `cooldown` / `default-days` schema confirmed valid for all four ecosystems against GitHub's spec.

## Out of scope

- Scorecard `FuzzingID` alert (no fuzzing harness) — not a Semgrep finding; being dismissed separately (low value for this codebase).