### PR TITLE
chore: add 24h pnpm minimumReleaseAge supply-chain floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 
 - **Dependabot cooldown** — all four ecosystems (npm, github-actions, docker ×2) now wait 7 days before proposing a bump, quarantining freshly-published (potentially compromised) versions at the PR-proposal layer. Clears Semgrep `dependabot-missing-cooldown` alerts.
+- **pnpm `minimumReleaseAge`** — `pnpm-workspace.yaml` now sets a 24h floor (1440 min), an in-tree backstop to the Dependabot cooldown that blocks installs of just-published versions across CI, local, and the prod image build. (Semgrep's `pnpm-minimum-release-age` rule wants 7 days/10080, which fails the current lockfile's frozen-install check; 24h is the build-compatible floor.)
 
 ## [0.38.0] — 2026-06-26 — "Deckard"
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,27 @@ packages:
 # pnpm default changes.
 blockExoticSubdeps: true
 
+# Supply-chain hardening: quarantine newly-published package versions. pnpm refuses
+# to resolve/verify any version published less than this many minutes ago, blunting
+# the "publish a malicious patch, install it within minutes" attack class.
+#
+# 1440 minutes = 24h. This is a deliberate floor, NOT the primary quarantine:
+#   - The primary 7-day quarantine lives in .github/dependabot.yml (`cooldown`),
+#     which stops Dependabot from ever PROPOSING a version younger than 7 days.
+#   - This 24h pnpm gate is the in-tree backstop that catches anything the cooldown
+#     doesn't cover (e.g. a manual `pnpm add` of a brand-new package), and declares
+#     the policy where it's visible (and where Semgrep checks for it).
+#
+# Why 24h and not 7 days here: this value is verified against the COMMITTED lockfile
+# on every `pnpm install --frozen-lockfile` — CI, local installs, AND the production
+# image build (curia-deploy/deploy/compose/Dockerfile.curia copies this file and runs
+# frozen installs at both stages). A 7-day floor (10080) fails today's lockfile (it
+# holds entries <7 days old) and would block builds/deploys; 24h is satisfied by the
+# current lockfile. With the 7-day Dependabot cooldown upstream, lockfile entries are
+# effectively always far older than 24h by the time they're merged, so this rarely
+# bites in practice. Requires pnpm >=10.16.0. Ref: https://pnpm.io/settings#minimumreleaseage
+minimumReleaseAge: 1440
+
 # Dependency version overrides. pnpm v10+ reads `overrides` ONLY from this file —
 # a `pnpm.overrides` block in package.json is silently ignored. These pins force
 # transitive deps onto patched versions to clear known CVEs.


### PR DESCRIPTION
## Summary

Adds `minimumReleaseAge: 1440` (24h) to `pnpm-workspace.yaml` — an in-tree supply-chain floor that makes pnpm refuse to install any package version published within the last 24 hours.

This is the in-tree **backstop** to the 7-day Dependabot `cooldown` shipped in #1272:
- The **Dependabot cooldown** stops Dependabot from *proposing* a version younger than 7 days (the primary quarantine).
- This **24h pnpm floor** catches anything the cooldown doesn't cover — e.g. a manual `pnpm add` of a brand-new package — and declares the policy in-tree.

## Why 24h, not the 7 days Semgrep wants

The Semgrep `pnpm-minimum-release-age` rule wants `10080` (7 days) and will keep flagging a lower value — so this PR does **not** clear that alert; the alert is **dismissed with rationale** instead (see the reply on the bot's review comment). Reason: the value is verified against the **committed lockfile** on every `pnpm install --frozen-lockfile` — CI, local installs, **and the production image build** (`curia-deploy/deploy/compose/Dockerfile.curia` copies this file and runs frozen installs at both stages). A 7-day floor (`10080`) fails today's lockfile (42 entries are <7 days old) and would block builds and deploys. 24h is satisfied by the current lockfile, and with the 7-day Dependabot cooldown upstream, merged lockfile entries are effectively always far older than 24h.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts` **passes** against the current lockfile with the 24h floor active (for contrast, `10080` fails with 42 `MINIMUM_RELEASE_AGE_VIOLATION` entries, and baseline does no age check — so 24h is genuinely enforced *and* satisfied).
- No lockfile churn; `allowBuilds` untouched. Both Semgrep checks pass (the finding is an informational annotation, not a blocking failure).

## Deploy / curia-deploy note

No curia-deploy change is required for this setting: the prod image build consumes **curia's** `pnpm-workspace.yaml` directly (copies it at both build stages), so the policy propagates automatically. The 24h gate now also guards the prod image build's frozen installs — well-contained, since the 7-day cooldown keeps deployable lockfile entries far older than 24h.