### PR TITLE
chore: close out resumable Phase 3 (#1178) — escalation e2e + child_cancelled coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Principal-facing escalation UX** — stalled / ceiling / blocked-on-human / agent-incomplete escalations now carry a structured `progress.escalation` block and a rendered progress note, so the daily digest surfaces real detail (progress, throughput/ETA, suggested actions) instead of a bare backlog row. Adds optional `progress_note` / `escalation_json` inputs to the `task-create` manifest. (#1267)
 - **Adaptive re-planning** — frontier wakes surface advisory divergence signals (failed/cancelled child, throughput below estimate, over-blocked step); plan depth and re-plan count are bounded with escalation on breach. (#1266)
+- **Resumable Phase 3 test coverage** — planned-parent + delegation escalation e2e tests, plus a `child_cancelled` divergence test. (#1178)
 
 ### Fixed
 
+- **Slice-sizing tolerance comment** — corrected to note it's an uncalibrated provisional default; real calibration deferred to #1275. (#1178)
 - **Adaptive re-planning** — sanitize divergence prompt text; idempotent breach escalation; honor configured ceilings and per-task overrides in the plan handler; count failed children in plan rollup so parents can auto-complete. (#1266)
 - **Resumable throughput-informed slice sizing** — advisory target slice size from measured units/slice in resume guidance; throughput-aware budget nudge with cold-start fallback to the fixed turn fraction. (#1265)
 - **Resumable throughput telemetry** — derived units/slice, cost/unit, and ETA surfaced on resume and emitted to logs/audit on each pause. (#1264)

--- a/src/agents/resumable-throughput.ts
+++ b/src/agents/resumable-throughput.ts
@@ -22,7 +22,9 @@ export const THROUGHPUT_SLICE_NUDGE_FRACTION = 0.85;
 
 /**
  * Advisory slice target lands within ±this fraction of measured units/slice (#1265).
- * Calibrated against the first #1264 telemetry baseline (~12 units/slice vs. fictional 100).
+ * Provisional default — NOT yet calibrated against real telemetry: no planned/resumable goal has
+ * run in prod, so #1264's throughput trail has no baseline to set this from. Re-calibrate from the
+ * first real prod baseline (and replace the tautological tolerance test) in #1275.
  */
 export const SUGGESTED_SLICE_TOLERANCE_FRACTION = 0.2;
 

--- a/tests/integration/escalation-ux.test.ts
+++ b/tests/integration/escalation-ux.test.ts
@@ -1,0 +1,193 @@
+// escalation-ux.test.ts — richer escalation UX end-to-end for the planned-parent and delegation
+// sources (#1267). The resumable-leaf source is covered by resumable-circuit-breaker.test.ts; this
+// file closes the OTHER TWO producers so all three have a DB-level assertion that the escalated CEO
+// row carries the structured progress.escalation block AND a non-empty last progress note — the
+// field the daily digest reads, which was the whole point of #1267 (detail reaching the principal,
+// not a bare backlog row).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { EventBus } from '../../src/bus/bus.js';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import {
+  escalateCircuitBreach,
+  type ResumableCircuitState,
+} from '../../src/agents/resumable-circuit-breaker.js';
+import { buildDelegationEscalation, renderEscalation } from '../../src/agents/task-escalation.js';
+import { TaskCreateHandler } from '../../skills/task-create/handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'EscalationUX Test';
+const logger = pino({ level: 'silent' });
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [`%${PREFIX}%`],
+  );
+  // Both the seed tasks and their escalated "Review:" CEO rows carry the prefix (the planned-parent
+  // Review title embeds the parent title; the delegation Review title is seeded with the prefix).
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`%${PREFIX}%`]);
+}
+
+describeIf('Escalation UX — planned-parent + delegation (#1267)', () => {
+  let pool: pg.Pool;
+  let repo: TaskRepo;
+  let bus: EventBus;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+  });
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    bus = new EventBus(logger as never);
+    repo = new TaskRepo(pool, bus, logger as never, 'UTC');
+  });
+
+  it('planned-parent circuit breach: CEO row carries a planned_parent escalation (X-of-Y, no throughput) + non-empty note', async () => {
+    const parent = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} quarterly rollup plan`,
+      source: 'coordinator',
+      sourceAgentId: 'coordinator',
+    });
+    await repo.updateTask(parent.id, { status: 'in_progress' }, 'coordinator');
+
+    // A planned parent advances by child completions, not resumable units. total must equal
+    // steps.length (plan-progress validation); done < total leaves it mid-flight.
+    const planResult = await repo.setPlanBlock(parent.id, {
+      steps: [
+        { id: 'step-1', taskId: null },
+        { id: 'step-2', taskId: null },
+        { id: 'step-3', taskId: null },
+        { id: 'step-4', taskId: null },
+        { id: 'step-5', taskId: null },
+      ],
+      deliverableStepId: null,
+      done: 2,
+      total: 5,
+      next: 'Advance the frontier',
+    }, 'coordinator');
+    expect('task' in planResult).toBe(true);
+
+    const reloaded = await repo.getTask(parent.id);
+    expect(reloaded).toBeTruthy();
+
+    // The planned-parent frontier circuit breaker calls escalateCircuitBreach with the parent row;
+    // driving it directly here is the same seam (handlePlanFrontierWakeForCircuitBreaker).
+    const breachState: ResumableCircuitState = {
+      stallCount: 3,
+      iterationCount: 6,
+      startedAt: new Date().toISOString(),
+      totalCostUsd: 4.2,
+      lastProgress: { done: 2, cursor: null },
+    };
+    await escalateCircuitBreach({
+      pool,
+      bus,
+      taskRepo: repo,
+      logger: logger as never,
+      task: reloaded!,
+      breach: { reason: 'stall_limit', message: 'no progress across 3 frontier wakes', state: breachState },
+      agentId: 'coordinator',
+    });
+
+    // The parent itself is failed and owned by the specialist — it is NOT the principal's carrier.
+    const afterParent = await repo.getTask(parent.id);
+    expect(afterParent?.status).toBe('failed');
+
+    // The CEO backlog row is the digest carrier.
+    const { rows: ceoRows } = await pool.query<{ progress: Record<string, unknown> }>(
+      `SELECT progress FROM tasks
+         WHERE owner = 'ceo' AND tags @> ARRAY['resumable-circuit-breach']::text[]
+           AND title LIKE $1`,
+      [`Review:%${PREFIX}%`],
+    );
+    expect(ceoRows).toHaveLength(1);
+
+    const progress = ceoRows[0]!.progress;
+    const escalation = progress.escalation as Record<string, unknown> | undefined;
+    expect(escalation).toBeTruthy();
+    expect(escalation!.source).toBe('planned_parent');
+    expect(escalation!.failureMode).toBe('stalled');
+    // X-of-Y comes from the plan rollup; planned parents carry no per-unit throughput/ETA.
+    expect(escalation!.progress).toEqual({ done: 2, total: 5 });
+    expect(escalation!.throughput).toBeUndefined();
+    expect(Array.isArray(escalation!.suggestedActions)).toBe(true);
+    expect((escalation!.suggestedActions as unknown[]).length).toBeGreaterThan(0);
+
+    const notes = progress.notes as Array<{ note: string }> | undefined;
+    const lastNote = notes && notes.length > 0 ? notes[notes.length - 1]!.note : '';
+    expect(lastNote.length).toBeGreaterThan(0);
+    expect(lastNote).toContain('2 of 5');
+    expect(lastNote.toLowerCase()).toContain('stall');
+  });
+
+  it('delegation failure: task-create seeds a delegation escalation + non-empty note on the CEO row', async () => {
+    // Mirror escalateDelegationFailure's payload construction, then drive the real task-create
+    // handler against the DB — the seam it invokes via executionLayer.invoke('task-create', …).
+    const escalation = buildDelegationEscalation({
+      agent: 'research-analyst',
+      reason: 'blocked',
+      retryable: false,
+      message: 'waiting on the CFO to approve the budget',
+      task: 'Compile Q3 vendor spend',
+    });
+    const rendered = renderEscalation(escalation);
+
+    const ctx = {
+      input: {
+        title: `Review: ${PREFIX} research-analyst is blocked on a person`,
+        description: [rendered.description, '', 'Original delegated task:', 'Compile Q3 vendor spend'].join('\n'),
+        owner: 'ceo',
+        source: 'coordinator',
+        tags: ['delegation-failure', 'research-analyst', escalation.failureMode],
+        progress_note: rendered.progressNote,
+        escalation_json: JSON.stringify(escalation),
+      },
+      secret: () => 'unused',
+      log: logger,
+      agentId: 'coordinator',
+      timezone: 'UTC',
+      taskRepo: repo,
+    } as unknown as SkillContext;
+
+    const result = await new TaskCreateHandler().execute(ctx);
+    expect(result.success).toBe(true);
+    const taskId = (result as { success: true; data: { task_id: string } }).data.task_id;
+
+    const { rows } = await pool.query<{ owner: string; progress: Record<string, unknown> }>(
+      `SELECT owner, progress FROM tasks WHERE id = $1`,
+      [taskId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.owner).toBe('ceo');
+
+    const progress = rows[0]!.progress;
+    const stored = progress.escalation as Record<string, unknown> | undefined;
+    expect(stored).toBeTruthy();
+    expect(stored!.source).toBe('delegation');
+    expect(stored!.failureMode).toBe('blocked_on_human');
+    // A delegation failure is a single attempt — no tracked X-of-Y progress or throughput.
+    expect(stored!.progress).toBeUndefined();
+    expect(stored!.throughput).toBeUndefined();
+    expect((stored!.suggestedActions as unknown[]).length).toBeGreaterThan(0);
+
+    const notes = progress.notes as Array<{ note: string }> | undefined;
+    const lastNote = notes && notes.length > 0 ? notes[notes.length - 1]!.note : '';
+    expect(lastNote.length).toBeGreaterThan(0);
+    expect(lastNote).toContain('Blocked on a person');
+    expect(lastNote).toContain('research-analyst');
+  });
+});

--- a/tests/unit/agents/plan-adaptive-replan.test.ts
+++ b/tests/unit/agents/plan-adaptive-replan.test.ts
@@ -31,7 +31,7 @@ function childRow(overrides: Partial<TaskRow> = {}): Pick<TaskRow, 'id' | 'statu
 describe('plan-adaptive-replan (#1266)', () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it('detects failed/cancelled children and over-blocked steps', () => {
+  it('detects failed children and over-blocked steps', () => {
     const now = new Date('2026-06-10T00:00:00Z');
     const children = new Map([
       [CHILD_1, childRow({ status: 'failed' })],
@@ -55,6 +55,28 @@ describe('plan-adaptive-replan (#1266)', () => {
 
     expect(signals.some((s) => s.reason === 'child_failed')).toBe(true);
     expect(signals.some((s) => s.reason === 'step_over_blocked')).toBe(true);
+  });
+
+  // The cancelled-child trigger (plan-adaptive-replan.ts) mirrors the failed-child branch but is
+  // a distinct divergence reason — a child cancelled out from under the plan may need a re-plan if
+  // it was unexpected. Covered separately so the trigger set in AC#1 is fully exercised (#1266).
+  it('detects a cancelled child as divergence', () => {
+    const children = new Map([
+      [CHILD_1, childRow({ status: 'cancelled', title: 'Vendor outreach' })],
+    ]);
+
+    const signals = detectPlanDivergence({
+      steps: [{ id: 'step-1', taskId: CHILD_1 }],
+      children,
+      ceilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+
+    const cancelled = signals.find((s) => s.reason === 'child_cancelled');
+    expect(cancelled).toBeDefined();
+    expect(cancelled?.childTaskId).toBe(CHILD_1);
+    expect(cancelled?.stepId).toBe('step-1');
+    // A cancelled child must not also masquerade as a failed-child signal.
+    expect(signals.some((s) => s.reason === 'child_failed')).toBe(false);
   });
 
   it('honours per-child blocked_step_hours override', () => {


### PR DESCRIPTION
## Summary

Closes out **Phase 3 — fast-follows** of the Resumable Tasks & Projects epic. A review of the four merged sub-issues found all of them genuinely meet their acceptance criteria (throughput telemetry #1264, slice right-sizing #1265, adaptive re-planning #1266, escalation UX #1267 — all merged). Three loose ends remained; this PR closes the two that are code-actionable now and files the third.

Closes #1178

### What the audit found

- **#1264 telemetry, #1266 adaptive re-planning, #1267 escalation UX** — code and tests genuinely satisfy every AC. ✅
- **#1266 gap** — the `child_cancelled` divergence trigger was implemented but **untested**, and the one test named "detects failed/cancelled children…" only asserted `failed`.
- **#1267 gap** — the end-to-end digest-reachability test covered only the **resumable-leaf** escalation source; the **planned-parent** and **delegation** sources were unit-tested but had no DB-level assertion that the CEO row carries the structured block + a non-empty last progress note.
- **#1265 gap (deferred, not fixed here)** — AC#4 ("slices land within X% of measured throughput, X set from #1264's first telemetry") shipped with the tolerance **hardcoded to 0.2** and a comment claiming it was "calibrated against the first #1264 telemetry baseline." No planned goal has run in prod, so no such baseline exists — the "~12 units/slice" figure was the anecdote from the issue body, not measured data.

### Changes

- **`tests/integration/escalation-ux.test.ts`** (new) — end-to-end DB tests for the two remaining escalation sources. The planned-parent case drives the real `escalateCircuitBreach` seam with a seeded plan block and asserts `progress.escalation` is `source: planned_parent` with an X-of-Y rollup and no throughput; the delegation case drives the real `task-create` handler with the payload `escalateDelegationFailure` builds and asserts `source: delegation`, `failureMode: blocked_on_human`. Both assert a non-empty `last_progress_note` (the digest's data source).
- **`tests/unit/agents/plan-adaptive-replan.test.ts`** — renamed the misleading test to "detects failed children and over-blocked steps" and added a dedicated `child_cancelled` divergence test (asserts the `child_cancelled` signal fires and does not masquerade as `child_failed`).
- **`src/agents/resumable-throughput.ts`** — corrected the `SUGGESTED_SLICE_TOLERANCE_FRACTION` comment: it is a **provisional default, not yet calibrated** against real telemetry; real calibration + replacing the tautological tolerance test is tracked in **#1275**.
- **`CHANGELOG.md`** — one entry under `[Unreleased]`.

### Follow-up filed

- **#1275** (milestone v0.40) — calibrate the slice-sizing tolerance from the first real prod throughput baseline once a planned/resumable goal has run, and replace the tautological tolerance test. Put on v0.40 (not v0.39) because it is blocked on prod telemetry that will not exist during this closeout, and pinning it to v0.39 would keep that milestone from closing.

## Test plan

All against the throwaway test DB (port 5433), not prod:

- `tests/integration/escalation-ux.test.ts` — 2/2 pass (planned-parent + delegation).
- `tests/integration/resumable-circuit-breaker.test.ts` — 2/2 pass (resumable-leaf source, unchanged).
- `tests/unit/agents/plan-adaptive-replan.test.ts` — 13/13 pass (incl. new `child_cancelled`).
- `resumable-throughput` / `resumable-task` / `task-escalation` unit tests — pass.
- 63/63 across the affected set; `pnpm run typecheck` clean.
- Mutation-checked all three new/renamed tests: each fails when its target branch / the escalation-seeding line is disabled, then passes on revert — confirming they are not false-greens.
- code-reviewer + silent-failure-hunter: clean, no fixes required.

## Out of scope (flagged, not done)

- The `#1265` tolerance recalibration itself (tracked in #1275) — needs prod telemetry.
- The delegation escalation test asserts payload shape (`progress`/`throughput` absent) rather than an independent storage invariant; the note-derivation path is covered by the planned-parent test. Noted by the silent-failure review as acceptable.
