### PR TITLE
docs: reconcile spec 20 §1 + design memo failed-reason enum with shipped code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Spec 20 §1 failed-reason enum** — reconciled with shipped code: documents the executor-contract `ExecutorFailureReason` (`budget_max_turns`) vs the coordinator-facing `AgentResponseFailureReason` (`maxTurns`/`maxConsecutiveErrors`) and their mapping; design memo marked superseded. Doc-only. (#1277)
 - **Slice-sizing tolerance comment** — corrected to note it's an uncalibrated provisional default; real calibration deferred to #1275. (#1178)
 - **Adaptive re-planning** — sanitize divergence prompt text; idempotent breach escalation; honor configured ceilings and per-task overrides in the plan handler; count failed children in plan rollup so parents can auto-complete. (#1266)
 - **Resumable throughput-informed slice sizing** — advisory target slice size from measured units/slice in resume guidance; throughput-aware budget nudge with cold-start fallback to the fixed turn fraction. (#1265)

--- a/docs/specs/20-resumable-tasks-and-projects.md
+++ b/docs/specs/20-resumable-tasks-and-projects.md
@@ -47,7 +47,7 @@ An executor invocation returns one of three outcomes (`src/agents/resumable-task
 |---|---|---|
 | `done` | Work complete | Task → `done`; carries the final summary/deliverable |
 | `paused` | Real progress made, more remains | Task stays `in_progress`; checkpoint persisted; continuation scheduled. **Success at the delegation layer, not a timeout.** |
-| `failed` | Genuine error | Carries a structured `reason` (`budget_max_turns`, `tool_error`, `api_error`, `blocked`) and `retryable: bool`, propagated honestly upward |
+| `failed` | Genuine error | Carries a structured `reason` (the executor-contract `ExecutorFailureReason`: `budget_max_turns`, `tool_error`, `api_error`, `blocked`) and `retryable: bool`, propagated honestly upward |
 
 `paused` **reuses the existing `in_progress` status** — no new task status, no schema churn.
 It is signalled through the `EXECUTION_PAUSED_PROTOCOL` marker on the `agent.response`
@@ -55,7 +55,20 @@ It is signalled through the `EXECUTION_PAUSED_PROTOCOL` marker on the `agent.res
 `paused` as success (no re-delegation); `failed{retryable:false}` escalates without blind
 retry; `failed{retryable:true}` gets a bounded retry then escalates (`DelegationGuard`,
 `src/agents/delegation-guard.ts`). This ends the confabulation: the coordinator now receives
-`failed{reason: budget_max_turns}` and reports the truth.
+a real failure `reason` (e.g. `maxTurns` for turn-budget exhaustion) and reports the truth.
+
+> **Two `reason` vocabularies — mind which surface you're reading.** The `failed`
+> reason is spelled differently on the two surfaces it crosses, and the coordinator
+> sees the second one:
+>
+> - **Executor contract** — `ExecutorFailureReason` = `budget_max_turns | tool_error | api_error | blocked` (`src/agents/resumable-task.ts`). The outcome-contract token on `ExecutorOutcome.failed`.
+> - **Coordinator-facing** — `AgentResponseFailureReason` = `maxTurns | maxConsecutiveErrors | tool_error | api_error | blocked` (`src/bus/events.ts`). What actually rides the `agent.response` event to the coordinator / delegate skill; the runtime derives it from the classified `AgentError` (`mapAgentErrorToResponseFields`, #1170).
+>
+> Mapping between them: the executor's `budget_max_turns` corresponds to the
+> coordinator-facing `maxTurns` (turn-budget exhaustion); `tool_error`, `api_error`,
+> and `blocked` are shared verbatim. `maxConsecutiveErrors` is an *additional*
+> coordinator-facing reason (the consecutive-error ceiling was hit) with no distinct
+> executor-contract token.
 
 ## 2. Resumable state — the `progress.resumable` block
 

--- a/docs/wip/2026-06-23-resumable-tasks-and-projects-design.md
+++ b/docs/wip/2026-06-23-resumable-tasks-and-projects-design.md
@@ -223,8 +223,15 @@ respond":
 - `failed{retryable:false}` → honor it; escalate honestly; **no blind re-delegation.**
 - `failed{retryable:true}` → bounded retry.
 
-This ends the confabulation: the coordinator now receives `failed{reason:
-budget_max_turns}` and reports the truth.
+This ends the confabulation: the coordinator now receives a real `failed` reason and
+reports the truth.
+
+> **Reason-enum spelling superseded by [spec 20 §1](../specs/20-resumable-tasks-and-projects.md).**
+> This memo's `budget_max_turns` is the executor-contract token (`ExecutorFailureReason`,
+> `src/agents/resumable-task.ts`). The reason the coordinator actually sees on the
+> `agent.response` event is `AgentResponseFailureReason` (`src/bus/events.ts`):
+> `maxTurns` for turn-budget exhaustion, plus `maxConsecutiveErrors`, `tool_error`,
+> `api_error`, `blocked`. See spec 20 §1 for the authoritative enums and their mapping.
 
 ### Completion & reconciliation
 


### PR DESCRIPTION
## Summary

Doc-only correction from the #1150 closeout audit. Spec 20 §1 and the resumable-tasks design memo described the executor `failed` reason only as `budget_max_turns` and both claimed the coordinator receives `failed{reason: budget_max_turns}`. The shipped code (from #1170 / #1171) actually surfaces two parallel reason vocabularies:

- **`ExecutorFailureReason`** = `budget_max_turns | tool_error | api_error | blocked` — the executor-contract token on `ExecutorOutcome.failed` (`src/agents/resumable-task.ts`).
- **`AgentResponseFailureReason`** = `maxTurns | maxConsecutiveErrors | tool_error | api_error | blocked` — what actually rides the `agent.response` event to the coordinator / delegate skill, derived from the classified `AgentError` via `mapAgentErrorToResponseFields` (`src/bus/events.ts`, #1170).

The code is correct and self-consistent; the docs were stale.

## Changes

- **Spec 20 §1** — the `failed` table row now names the executor-contract `ExecutorFailureReason`; the paragraph's coordinator-facing claim is corrected to a real reason (`maxTurns`), and a note documents **both enums, which surface uses which token, and the `budget_max_turns` → `maxTurns` mapping** (with `maxConsecutiveErrors` as an additional coordinator-facing reason having no distinct executor-contract token).
- **Design memo** (`docs/wip/2026-06-23-…-design.md`) — the honest-status-propagation section is corrected and explicitly **marked superseded by spec 20 §1** for the reason-enum spelling.
- **CHANGELOG** — one `Fixed` entry.

No code change — the code is authoritative and unchanged.

## Verification

Factual-accuracy review confirmed every enum spelling, ordering, field name, source citation, and mapping rule in the doc text matches current source (both enum definitions plus the `mapAgentErrorToResponseFields` branches). `budget_max_turns` is defined but not wired anywhere in `src/`, so the doc correctly frames the executor↔coordinator relationship as a semantic correspondence between two independent enums, not a code-level translation.

Closes #1277