### PR TITLE
test: harden resumable Phase 1 coverage (#1278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`execution_paused` parser** — reject empty `next` strings so partial markers are not misread as paused. (#1278)
-
-### Fixed
-
+- **`execution_paused` parser** — reject blank `next` strings (empty or whitespace-only) so partial markers are not misread as paused. (#1278)
 - **Spec 20 §1 failed-reason enum** — reconciled with shipped code: documents the executor-contract `ExecutorFailureReason` (`budget_max_turns`) vs the coordinator-facing `AgentResponseFailureReason` (`maxTurns`/`maxConsecutiveErrors`) and their mapping; design memo marked superseded. Doc-only. (#1277)
 - **Slice-sizing tolerance comment** — corrected to note it's an uncalibrated provisional default; real calibration deferred to #1275. (#1178)
 - **Adaptive re-planning** — sanitize divergence prompt text; idempotent breach escalation; honor configured ceilings and per-task overrides in the plan handler; count failed children in plan rollup so parents can auto-complete. (#1266)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Principal-facing escalation UX** — stalled / ceiling / blocked-on-human / agent-incomplete escalations now carry a structured `progress.escalation` block and a rendered progress note, so the daily digest surfaces real detail (progress, throughput/ETA, suggested actions) instead of a bare backlog row. Adds optional `progress_note` / `escalation_json` inputs to the `task-create` manifest. (#1267)
 - **Adaptive re-planning** — frontier wakes surface advisory divergence signals (failed/cancelled child, throughput below estimate, over-blocked step); plan depth and re-plan count are bounded with escalation on breach. (#1266)
 - **Resumable Phase 3 test coverage** — planned-parent + delegation escalation e2e tests, plus a `child_cancelled` divergence test. (#1178)
+- **Resumable Phase 1 test hardening** — runtime harness wiring, overflow negative paths, marker parsing, steady-state circuit breaker, heartbeat backstop, and bounded-retry delegation e2e. (#1278)
+
+### Fixed
+
+- **`execution_paused` parser** — reject empty `next` strings so partial markers are not misread as paused. (#1278)
 
 ### Fixed
 

--- a/src/agents/resumable-circuit-breaker.test.ts
+++ b/src/agents/resumable-circuit-breaker.test.ts
@@ -8,6 +8,7 @@ import {
   readCircuitState,
   resolveResumableCeilings,
   mergeCircuitState,
+  type ResumableCircuitState,
 } from './resumable-circuit-breaker.js';
 import { DEFAULT_RESUMABLE_CEILINGS } from '../config.js';
 import type { ExecutionPausedPayload } from './resumable-task.js';
@@ -229,5 +230,35 @@ describe('resumable-circuit-breaker (#1176)', () => {
       expect(result.action).toBe('continue');
       if (result.action === 'continue') expect(result.state.stallCount).toBe(0);
     });
+  });
+
+  it('never escalates across several progressing continuation slices', () => {
+    const startedAt = '2026-06-01T00:00:00.000Z';
+    let circuit: ResumableCircuitState = {
+      stallCount: 0,
+      iterationCount: 0,
+      startedAt,
+      totalCostUsd: 0,
+      lastProgress: { done: 0, cursor: null },
+    };
+
+    for (let slice = 1; slice <= 6; slice += 1) {
+      const done = slice * 25;
+      const result = processPausedSliceOutcome({
+        paused: paused({
+          done,
+          cursor: `page:${slice}`,
+          last_slice_units: 25,
+        }),
+        circuit,
+        ceilings: { ...DEFAULT_RESUMABLE_CEILINGS, maxStalls: 3 },
+        now: new Date(`2026-06-01T0${slice}:00:00.000Z`),
+      });
+      expect(result.action).toBe('continue');
+      if (result.action !== 'continue') return;
+      expect(result.state.stallCount).toBe(0);
+      expect(result.state.iterationCount).toBe(slice);
+      circuit = result.state;
+    }
   });
 });

--- a/src/agents/resumable-task.test.ts
+++ b/src/agents/resumable-task.test.ts
@@ -301,3 +301,39 @@ describe('executor outcome contract (#1174)', () => {
     expect(readResumableBlock(ctx!.progress ?? {})).not.toBeNull();
   });
 });
+
+describe('parseExecutionPausedPayload negative paths (#1174)', () => {
+  const basePayload = {
+    _curia_protocol: EXECUTION_PAUSED_PROTOCOL,
+    done: 10,
+    total: 100,
+    cursor: 'page:1',
+    last_slice_units: 10,
+    next: 'Continue',
+  };
+
+  it.each([
+    ['invalid JSON', '{not valid json'],
+    ['wrong protocol', JSON.stringify({ ...basePayload, _curia_protocol: 'clarification_request' })],
+    ['missing total', JSON.stringify({ _curia_protocol: EXECUTION_PAUSED_PROTOCOL, done: 10, cursor: null, last_slice_units: 10, next: 'go' })],
+    ['empty next', JSON.stringify({ ...basePayload, next: '' })],
+    ['non-object cursor', JSON.stringify({ ...basePayload, cursor: 42 })],
+    ['missing last_slice_units', JSON.stringify({ ...basePayload, last_slice_units: undefined })],
+  ])('returns null for %s — treated as non-paused', (_label, content) => {
+    expect(parseExecutionPausedPayload(content)).toBeNull();
+  });
+
+  it('accepts a valid payload without task_id (optional field)', () => {
+    const content = JSON.stringify({
+      _curia_protocol: EXECUTION_PAUSED_PROTOCOL,
+      done: 10,
+      total: 100,
+      cursor: null,
+      last_slice_units: 10,
+      next: 'Continue',
+    });
+    const parsed = parseExecutionPausedPayload(content);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.task_id).toBeUndefined();
+  });
+});

--- a/src/agents/resumable-task.test.ts
+++ b/src/agents/resumable-task.test.ts
@@ -317,6 +317,7 @@ describe('parseExecutionPausedPayload negative paths (#1174)', () => {
     ['wrong protocol', JSON.stringify({ ...basePayload, _curia_protocol: 'clarification_request' })],
     ['missing total', JSON.stringify({ _curia_protocol: EXECUTION_PAUSED_PROTOCOL, done: 10, cursor: null, last_slice_units: 10, next: 'go' })],
     ['empty next', JSON.stringify({ ...basePayload, next: '' })],
+    ['whitespace-only next', JSON.stringify({ ...basePayload, next: '   ' })],
     ['non-object cursor', JSON.stringify({ ...basePayload, cursor: 42 })],
     ['missing last_slice_units', JSON.stringify({ ...basePayload, last_slice_units: undefined })],
   ])('returns null for %s — treated as non-paused', (_label, content) => {

--- a/src/agents/resumable-task.ts
+++ b/src/agents/resumable-task.ts
@@ -329,7 +329,7 @@ export function parseExecutionPausedPayload(content: string, logger?: Logger): E
     const parsed = JSON.parse(content) as Record<string, unknown>;
     if (parsed['_curia_protocol'] !== EXECUTION_PAUSED_PROTOCOL) return null;
     if (typeof parsed['done'] !== 'number' || typeof parsed['total'] !== 'number') return null;
-    if (typeof parsed['next'] !== 'string') return null;
+    if (typeof parsed['next'] !== 'string' || parsed['next'].length === 0) return null;
     if (typeof parsed['last_slice_units'] !== 'number') return null;
     const cursor = parsed['cursor'];
     if (cursor !== null && typeof cursor !== 'string' && !isPlainObject(cursor)) return null;

--- a/src/agents/resumable-task.ts
+++ b/src/agents/resumable-task.ts
@@ -329,7 +329,7 @@ export function parseExecutionPausedPayload(content: string, logger?: Logger): E
     const parsed = JSON.parse(content) as Record<string, unknown>;
     if (parsed['_curia_protocol'] !== EXECUTION_PAUSED_PROTOCOL) return null;
     if (typeof parsed['done'] !== 'number' || typeof parsed['total'] !== 'number') return null;
-    if (typeof parsed['next'] !== 'string' || parsed['next'].length === 0) return null;
+    if (typeof parsed['next'] !== 'string' || parsed['next'].trim().length === 0) return null;
     if (typeof parsed['last_slice_units'] !== 'number') return null;
     const cursor = parsed['cursor'];
     if (cursor !== null && typeof cursor !== 'string' && !isPlainObject(cursor)) return null;

--- a/src/db/resumable-progress.test.ts
+++ b/src/db/resumable-progress.test.ts
@@ -144,6 +144,17 @@ describe('accumulator bounding', () => {
     expect(result.bytes).toBeGreaterThan(RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES);
   });
 
+  it('rejects block_overflow when a non-accumulator field exceeds the block cap', () => {
+    const result = prepareResumableBlock({
+      ...BASE_INPUT,
+      accumulator: ['did:plc:small'],
+      next: 'x'.repeat(RESUMABLE_BLOCK_MAX_BYTES),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok || result.code !== 'block_overflow') return;
+    expect(result.bytes).toBeGreaterThan(RESUMABLE_BLOCK_MAX_BYTES);
+  });
+
   it('allows a document pointer regardless of inline cap', () => {
     const pointer = documentAccumulatorPointer('/projects/audit/findings.md', 'flagged');
     expect(isDocumentPointer(pointer)).toBe(true);

--- a/tests/integration/backlog-heartbeat.test.ts
+++ b/tests/integration/backlog-heartbeat.test.ts
@@ -80,4 +80,50 @@ describeIf('BacklogHeartbeat end-to-end', () => {
     expect(await hb.tick()).toBe(1);
     expect(await hb.tick()).toBe(0); // already has a pending wake
   });
+
+  it('re-surfaces a lost in_progress resumable task after the idle threshold (#1176)', async () => {
+    const hoursAgo = (h: number) => new Date(Date.now() - h * 3600_000);
+    const taskId = await seedTask(pool, {
+      status: 'in_progress',
+      sourceAgentId: 'social-media',
+      updatedAt: hoursAgo(5),
+    });
+    await pool.query(
+      `UPDATE tasks
+          SET error_budget = $1::jsonb,
+              progress = $2::jsonb
+        WHERE id = $3`,
+      [
+        JSON.stringify({ resumable: true }),
+        JSON.stringify({
+          resumable: {
+            cursor: 'page:3',
+            done: 25,
+            total: 1300,
+            accumulator: [],
+            lastSliceUnits: 25,
+            next: 'Continue paging',
+          },
+        }),
+        taskId,
+      ],
+    );
+
+    const schedulerService = new SchedulerService(pool, { publish: vi.fn(), subscribe: vi.fn() } as never, logger, 'UTC');
+    const hb = new BacklogHeartbeat({
+      pool, logger, schedulerService,
+      eligibleAgents: new Set(['social-media', 'coordinator']),
+      intervalMinutes: 60, maxWakesPerTick: 5, idleThresholdHours: 4, staleWaitThresholdHours: 48,
+    });
+
+    expect(await hb.tick()).toBe(1);
+
+    const { rows } = await pool.query(
+      `SELECT task_id, agent_id, status FROM scheduled_jobs WHERE task_id = $1`,
+      [taskId],
+    );
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as { agent_id: string; status: string }).agent_id).toBe('social-media');
+    expect((rows[0] as { status: string }).status).toBe('pending');
+  });
 });

--- a/tests/integration/task-resumable-progress.test.ts
+++ b/tests/integration/task-resumable-progress.test.ts
@@ -7,6 +7,7 @@ import { TaskRepo } from '../../src/db/task-repo.js';
 import { WorkingDocsRepo } from '../../src/db/working-docs-repo.js';
 import {
   RESUMABLE_BLOCK_MAX_BYTES,
+  RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES,
   documentAccumulatorPointer,
   isDocumentPointer,
   resumableBlockBytes,
@@ -195,6 +196,48 @@ describeIf('TaskRepo resumable progress (#1172, #1210)', () => {
     }
 
     expect(spilled).toBe(true);
+  });
+
+  it('returns inline_accumulator_overflow without silent truncate when spill is unavailable (#1172)', async () => {
+    const repoNoSpill = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+    const task = await repoNoSpill.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} no-spill overflow`,
+      source: 'coordinator',
+    });
+
+    const big = 'x'.repeat(RESUMABLE_INLINE_ACCUMULATOR_MAX_BYTES + 100);
+    const result = await repoNoSpill.setResumableBlock(task.id, {
+      cursor: 'page:1',
+      done: 10,
+      total: 1300,
+      accumulator: [big],
+      lastSliceUnits: 10,
+      next: 'Continue paging',
+    });
+
+    expect(result).toMatchObject({ ok: false, code: 'inline_accumulator_overflow' });
+    expect(await repoNoSpill.getResumableBlock(task.id)).toBeNull();
+  });
+
+  it('returns block_overflow when a non-accumulator field exceeds the cap (#1172)', async () => {
+    const task = await repo.createTask({
+      agentId: 'social-media',
+      title: `${PREFIX} block overflow`,
+      source: 'coordinator',
+    });
+
+    const result = await repo.setResumableBlock(task.id, {
+      cursor: 'page:1',
+      done: 10,
+      total: 1300,
+      accumulator: ['did:plc:abc'],
+      lastSliceUnits: 10,
+      next: 'x'.repeat(RESUMABLE_BLOCK_MAX_BYTES),
+    });
+
+    expect(result).toMatchObject({ ok: false, code: 'block_overflow' });
+    expect(await repo.getResumableBlock(task.id)).toBeNull();
   });
 
   it('round-trip: child task spill, resume prefix, and continue from pointer', async () => {

--- a/tests/unit/agents/resumable-continuation-subscriber.test.ts
+++ b/tests/unit/agents/resumable-continuation-subscriber.test.ts
@@ -128,4 +128,75 @@ describe('ResumableContinuationSubscriber', () => {
 
     expect(scheduleSpy).not.toHaveBeenCalled();
   });
+
+  it('skips continuation when task_id is missing (heartbeat backstop fallback)', async () => {
+    const scheduleSpy = vi.spyOn(continuation, 'scheduleResumableContinuation')
+      .mockResolvedValue({ scheduled: true, jobId: 'job-1', agentId: 'social-media', runAt: new Date() });
+    const warn = vi.fn();
+    const logger = { ...mockLogger(), warn };
+
+    const bus = new EventBus(logger as never);
+    const subscriber = new ResumableContinuationSubscriber({
+      pool: {} as never,
+      bus,
+      logger: logger as never,
+      schedulerService: {} as never,
+      taskRepo: {} as never,
+      eligibleAgents: new Set(['social-media']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+    subscriber.start();
+
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-1',
+      content: JSON.stringify({
+        _curia_protocol: 'execution_paused',
+        done: 25,
+        total: 1300,
+        cursor: 'page:3',
+        last_slice_units: 25,
+        next: 'Review page 4',
+      }),
+      parentEventId: 'parent-1',
+    }));
+
+    expect(scheduleSpy).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'social-media' }),
+      'execution_paused response missing task_id — cannot schedule continuation',
+    );
+  });
+
+  it('ignores malformed execution_paused markers', async () => {
+    const scheduleSpy = vi.spyOn(continuation, 'scheduleResumableContinuation')
+      .mockResolvedValue({ scheduled: true, jobId: 'job-1', agentId: 'social-media', runAt: new Date() });
+
+    const bus = new EventBus(mockLogger() as never);
+    const subscriber = new ResumableContinuationSubscriber({
+      pool: {} as never,
+      bus,
+      logger: mockLogger() as never,
+      schedulerService: {} as never,
+      taskRepo: {} as never,
+      eligibleAgents: new Set(['social-media']),
+      continuationDelaySeconds: 30,
+      resumableCeilings: DEFAULT_RESUMABLE_CEILINGS,
+    });
+    subscriber.start();
+
+    await bus.publish('agent', createAgentResponse({
+      agentId: 'social-media',
+      conversationId: 'conv-1',
+      content: JSON.stringify({
+        _curia_protocol: 'execution_paused',
+        done: 25,
+        next: 'missing total and last_slice_units',
+      }),
+      parentEventId: 'parent-1',
+    }));
+
+    expect(scheduleSpy).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -8,6 +8,7 @@ import { createLogger } from '../../../src/logger.js';
 import { WorkingMemory } from '../../../src/memory/working-memory.js';
 import { BullpenService } from '../../../src/memory/bullpen.js';
 import type { AgentError } from '../../../src/errors/types.js';
+import { delegationKey } from '../../../src/agents/delegation-guard.js';
 
 // Minimal provenance block for mock LLM responses — satisfies the required field
 // without tying tests to specific model names.
@@ -2179,6 +2180,158 @@ describe('AgentRuntime resumable budget safety-net (#1174)', () => {
   });
 });
 
+describe('AgentRuntime resumable harness wiring (#1173)', () => {
+  const webFetchToolDef = {
+    name: 'web-fetch',
+    description: 'Fetch',
+    input_schema: { type: 'object' as const, properties: {}, required: [] as string[] },
+  };
+  const checkpointToolDef = {
+    name: 'checkpoint',
+    description: 'Save resumable checkpoint',
+    input_schema: { type: 'object' as const, properties: {}, required: [] as string[] },
+  };
+
+  const resumableCheckpoint = {
+    cursor: 'page-2',
+    done: 25,
+    total: 1300,
+    accumulator: [] as string[],
+    lastSliceUnits: 25,
+    next: 'Continue paging',
+  };
+
+  const NUDGE_MARKER = '[Platform — resumable task budget nudge]';
+
+  function publishResumableSchedulerTask(bus: EventBus, taskId: string): Promise<void> {
+    return bus.publish('dispatch', createAgentTask({
+      agentId: 'social-media',
+      conversationId: 'conv-resumable-harness',
+      channelId: 'scheduler',
+      senderId: 'scheduler',
+      content: JSON.stringify({ task_id: taskId }),
+      metadata: {
+        boundTask: {
+          taskId,
+          errorBudget: { resumable: true },
+          progress: { resumable: resumableCheckpoint },
+        },
+      },
+      parentEventId: 'parent-resumable-harness',
+    }));
+  }
+
+  function makeHarnessRuntime(provider: LLMProvider, maxTurns = 20) {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+      getToolDefinitions: vi.fn((names: string[]) => {
+        if (names.includes('checkpoint')) return [checkpointToolDef];
+        return [];
+      }),
+    } as unknown as ExecutionLayer;
+
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'social-media',
+      systemPrompt: 'You are a social media specialist.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [webFetchToolDef],
+      errorBudget: { maxTurns, maxConsecutiveErrors: 10 },
+    });
+    agent.register();
+
+    return { bus, provider, mockExecution, agentResponses };
+  }
+
+  it('injects guidance, checkpoint resume block, and pins checkpoint tool', async () => {
+    const provider = createMockProvider('Slice complete.');
+    const { bus, provider: chatProvider } = makeHarnessRuntime(provider);
+
+    await publishResumableSchedulerTask(bus, 'task-harness-1');
+
+    const firstCall = (chatProvider.chat as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
+      messages: Array<{ role: string; content: string }>;
+      tools?: Array<{ name: string }>;
+    };
+    const systemContent = firstCall.messages
+      .filter((m) => m.role === 'system')
+      .map((m) => m.content)
+      .join('\n');
+    expect(systemContent).toContain('## Resumable Task');
+    expect(systemContent).toContain('## Last Checkpoint (resume from here)');
+    expect(systemContent).toContain('25 / 1300');
+    expect(systemContent).not.toContain(NUDGE_MARKER);
+
+    const toolNames = (firstCall.tools ?? []).map((t) => t.name);
+    expect(toolNames).toContain('checkpoint');
+  });
+
+  it('appends budget nudge as a user tail message at most once across tool-loop turns', async () => {
+    let chatRound = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async () => {
+        chatRound += 1;
+        if (chatRound <= 17) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: `call-${chatRound}`, name: 'web-fetch', input: {} }],
+            usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
+          };
+        }
+        return {
+          type: 'text' as const,
+          content: 'Slice complete.',
+          usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      }),
+    };
+
+    const { bus, provider: chatProvider, agentResponses } = makeHarnessRuntime(provider, 20);
+    await publishResumableSchedulerTask(bus, 'task-harness-nudge');
+
+    const allCalls = (chatProvider.chat as ReturnType<typeof vi.fn>).mock.calls as Array<
+      [{ messages: Array<{ role: string; content: string }>; tools?: Array<{ name: string }> }]
+    >;
+
+    let prevNudgeCount = 0;
+    let sawNudge = false;
+    for (const [call] of allCalls) {
+      const systemBlob = call.messages
+        .filter((m) => m.role === 'system')
+        .map((m) => m.content)
+        .join('\n');
+      expect(systemBlob).not.toContain(NUDGE_MARKER);
+
+      const nudgeCount = call.messages.filter(
+        (m) => m.role === 'user' && typeof m.content === 'string' && m.content.includes(NUDGE_MARKER),
+      ).length;
+      expect(nudgeCount).toBeLessThanOrEqual(1);
+      if (nudgeCount > prevNudgeCount) {
+        expect(nudgeCount - prevNudgeCount).toBe(1);
+        sawNudge = true;
+      }
+      prevNudgeCount = nudgeCount;
+    }
+
+    expect(sawNudge).toBe(true);
+    expect(agentResponses).toHaveLength(1);
+    expect(agentResponses[0]!.payload.content).toBe('Slice complete.');
+  });
+});
+
 // -- Structured error injection test --
 
 describe('AgentRuntime structured error injection', () => {
@@ -3562,6 +3715,113 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
     const response = agentResponses[0]!;
     expect(response.payload.content).toContain('delegation_failure');
     expect(response.payload.content).toContain('maxTurns');
+    expect(response.payload.content).toContain('"escalated":true');
+  });
+
+  it('allows exactly two retryable delegate attempts then escalates (#1171)', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const delegateInvokeCount = { n: 0 };
+    const taskCreateCount = { n: 0 };
+
+    const mockExecution = {
+      invoke: vi.fn(async (skillName: string, input: Record<string, unknown>, _caller: unknown, options?: { delegationGuard?: import('../../../src/agents/delegation-guard.js').DelegationGuard }) => {
+        if (skillName === 'task-create') {
+          taskCreateCount.n += 1;
+          return { success: true, data: { task_id: 'escalation-task-retry' } };
+        }
+        if (skillName === 'delegate') {
+          const delegateAgent = typeof input['agent'] === 'string' ? input['agent'] : '';
+          const delegateTask = typeof input['task'] === 'string' ? input['task'] : '';
+          const dKey = delegationKey(delegateAgent, delegateTask);
+          const guard = options?.delegationGuard;
+          if (guard && !guard.canAttempt(dKey)) {
+            const prior = guard.getFailure(dKey);
+            return {
+              success: true,
+              data: {
+                agent: delegateAgent,
+                failed: true,
+                blocked: true,
+                reason: prior?.reason ?? 'blocked',
+                retryable: false,
+                message: prior?.message ?? `Re-delegation to '${delegateAgent}' is blocked for this task.`,
+                escalated: guard.isEscalated(dKey),
+              },
+            };
+          }
+          if (guard) {
+            guard.recordInvocation(dKey);
+          }
+          delegateInvokeCount.n += 1;
+          return {
+            success: true,
+            data: {
+              agent: delegateAgent,
+              failed: true,
+              reason: 'api_error',
+              retryable: true,
+              message: "Specialist 'social-media' timed out",
+            },
+          };
+        }
+        return { success: true, data: {} };
+      }),
+      getToolDefinitions: vi.fn(() => [delegateToolDef]),
+    } as unknown as ExecutionLayer;
+
+    let chatRound = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async () => {
+        chatRound += 1;
+        return {
+          type: 'tool_use' as const,
+          toolCalls: [
+            { id: `call-delegate-retry-${chatRound}`, name: 'delegate', input: { agent: 'social-media', task: 'Post to Bluesky' } },
+          ],
+          usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      }),
+    };
+
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: [delegateToolDef],
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-delegate-retryable',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Post this to Bluesky',
+      parentEventId: 'inbound-delegate-retryable',
+    }));
+
+    expect(delegateInvokeCount.n).toBe(2);
+    expect(taskCreateCount.n).toBe(1);
+    expect(provider.chat).toHaveBeenCalledTimes(2);
+
+    expect(agentResponses).toHaveLength(1);
+    const response = agentResponses[0]!;
+    expect(response.payload.content).toContain('delegation_failure');
+    expect(response.payload.content).toContain('api_error');
     expect(response.payload.content).toContain('"escalated":true');
   });
 

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -2278,9 +2278,13 @@ describe('AgentRuntime resumable harness wiring (#1173)', () => {
 
   it('appends budget nudge as a user tail message at most once across tool-loop turns', async () => {
     let chatRound = 0;
+    const chatSnapshots: Array<{ messages: Array<{ role: string; content: string }> }> = [];
     const provider: LLMProvider = {
       id: 'mock',
-      chat: vi.fn(async () => {
+      chat: vi.fn(async (params) => {
+        chatSnapshots.push({
+          messages: structuredClone(params.messages) as Array<{ role: string; content: string }>,
+        });
         chatRound += 1;
         if (chatRound <= 17) {
           return {
@@ -2299,16 +2303,12 @@ describe('AgentRuntime resumable harness wiring (#1173)', () => {
       }),
     };
 
-    const { bus, provider: chatProvider, agentResponses } = makeHarnessRuntime(provider, 20);
+    const { bus, agentResponses } = makeHarnessRuntime(provider, 20);
     await publishResumableSchedulerTask(bus, 'task-harness-nudge');
-
-    const allCalls = (chatProvider.chat as ReturnType<typeof vi.fn>).mock.calls as Array<
-      [{ messages: Array<{ role: string; content: string }>; tools?: Array<{ name: string }> }]
-    >;
 
     let prevNudgeCount = 0;
     let sawNudge = false;
-    for (const [call] of allCalls) {
+    for (const call of chatSnapshots) {
       const systemBlob = call.messages
         .filter((m) => m.role === 'system')
         .map((m) => m.content)
@@ -2327,6 +2327,7 @@ describe('AgentRuntime resumable harness wiring (#1173)', () => {
     }
 
     expect(sawNudge).toBe(true);
+    expect(chatSnapshots.length).toBeGreaterThan(17);
     expect(agentResponses).toHaveLength(1);
     expect(agentResponses[0]!.payload.content).toBe('Slice complete.');
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1278

Adds regression tests for the resumable Phase 0+1 closeout gaps identified in the #1150 completion audit. Coverage now guards the runtime harness wiring, prompt-cache nudge contract, overflow write paths, `execution_paused` negative parsing, circuit-breaker steady state, heartbeat backstop, and bounded-retry delegation.

## Changes

### Runtime harness (#1173)
- `tests/unit/agents/runtime.test.ts` — drives a resumable scheduler `agent.task` through `AgentRuntime` and asserts:
  - `## Resumable Task` guidance + `## Last Checkpoint (resume from here)` in the system prompt
  - `checkpoint` tool auto-pinned
  - budget nudge is a `role:'user'` tail message, not in the system prefix
  - nudge fires at most once across tool-loop turns

### Overflow paths (#1172)
- `src/db/resumable-progress.test.ts` — `block_overflow` when a non-accumulator field exceeds 8 KB with a valid inline accumulator
- `tests/integration/task-resumable-progress.test.ts` — `inline_accumulator_overflow` without `workingDocsRepo` (no silent truncate) and `block_overflow` via `TaskRepo`

### Marker negative paths (#1174)
- `src/agents/resumable-task.test.ts` — malformed/partial `execution_paused` payloads return `null`
- `tests/unit/agents/resumable-continuation-subscriber.test.ts` — missing `task_id` skips continuation (heartbeat backstop fallback); malformed markers ignored
- **Production:** `parseExecutionPausedPayload` now rejects empty `next` strings

### Steady state + backstop (#1176)
- `src/agents/resumable-circuit-breaker.test.ts` — multi-slice progressing continuations never escalate (stall counter stays 0)
- `tests/integration/backlog-heartbeat.test.ts` — idle `in_progress` resumable task re-surfaced by heartbeat when continuation is lost

### Bounded-retry delegation (#1171)
- `tests/unit/agents/runtime.test.ts` — retryable delegate failures allow exactly two invocations then escalate through the runtime tool loop

## Test plan

- [x] `pnpm exec vitest run` on touched unit test files (132 tests)
- [x] `pnpm run typecheck`
- [ ] Integration suites (`task-resumable-progress`, `backlog-heartbeat`) — require `DATABASE_URL` + healthy Postgres (skipped in this VM)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f95de1-ee9e-476b-99eb-0543dbbeebb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f95de1-ee9e-476b-99eb-0543dbbeebb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

