### PR TITLE
chore: ignore nylas semver-major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # nylas published a stray, higher-numbered release (17.13.1, 2025-09-17)
+      # that is NOT the registry `latest` tag — the maintained line is 8.x
+      # (latest 8.4.0, 2026-06-24) and Nylas kept shipping 8.x *after* 17.13.1.
+      # Dependabot sees 17.13.1 > 8.4.0 by raw semver and proposes a "downgrade
+      # in disguise" onto stale, divergent SDK code (curia#1273). Block nylas
+      # majors; a genuine future major (a real 9.x) gets reviewed and bumped by
+      # hand. 8.x minor/patch updates still flow normally.
+      - dependency-name: "nylas"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions versions (checkout, setup-node, etc.)
   - package-ecosystem: "github-actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Resumable Phase 3 test coverage** — planned-parent + delegation escalation e2e tests, plus a `child_cancelled` divergence test. (#1178)
 - **Resumable Phase 1 test hardening** — runtime harness wiring, overflow negative paths, marker parsing, steady-state circuit breaker, heartbeat backstop, and bounded-retry delegation e2e. (#1278)
 
+### Changed
+
+- **Dependabot** — ignore `nylas` semver-major bumps; a stray `17.13.1` sits above the maintained 8.x `latest`. (#1273)
+
 ### Fixed
 
 - **`execution_paused` parser** — reject blank `next` strings (empty or whitespace-only) so partial markers are not misread as paused. (#1278)


### PR DESCRIPTION
## Summary

Adds a Dependabot `ignore` rule for `nylas` semver-major bumps so it stops proposing the stray, higher-numbered release as an "upgrade."

### Why

Dependabot opened #1273 to bump `nylas` **8.4.0 → 17.13.1**. This is a downgrade-in-disguise:

- The npm registry `latest` dist-tag for `nylas` is **8.4.0** (published 2026-06-24). The maintained line is 6.x → 7.x → 8.x.
- **17.13.1** is a single stray publish from **2025-09-17** (the only stable 17.x that exists, plus a few `17.13.1-canary.N` from the same day). It has no `latest`-style dist-tag, isn't deprecated, and Nylas shipped **8.0.0 (Dec 2025)** and **8.4.0 (Jun 2026)** *after* it.
- Because `17.13.1 > 8.4.0` by raw semver and it isn't deprecated, Dependabot treats it as the newest version. Merging would run nine-month-old, divergent SDK code against the live Nylas API v3 — exactly where a subtle email/calendar break would come from.

This is **not** the Nylas API v2 → v3 migration: Curia is already on API v3 / SDK 8 (`src/channels/email/nylas-client.ts`, `src/channels/calendar/nylas-calendar-client.ts` use the v3 resource API), so the SDK v6 → v7 upgrade guide does not apply.

### Change

Ignore `version-update:semver-major` for `nylas` (same pattern already used for `node` and `pgvector`). Effect:

- Blocks the stray 17.x train and any future nylas major (a genuine `9.x` gets reviewed and bumped by hand — appropriate for an email/calendar SDK).
- `8.x` minor/patch updates still flow normally.

Once merged, Dependabot will auto-close #1273 on its next run. If it doesn't, close #1273 manually — do not merge it.

### Verification

- `yaml.safe_load` parses the file; the ignore rule resolves on the npm ecosystem block.
- No code paths touched (Dependabot config + CHANGELOG only).