### PR TITLE
fix(registry): drop channel credential auto-enroll; gate outbound on registry state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Channel registry** — reconcile no longer auto-installs toggleable channels from ambient credentials; operators install and enable `email`/`signal` explicitly (parity with skills/agents), and `uninstall()` is durable across restarts. Outbound egress is gated on the same registry enabled-state as inbound adapters. (#965, #966)
 - **`outbound.pii_redacted`** — audit event type standardized to the underscore form in code; legacy hyphen-form rows preserved as immutable audit history, not rewritten. (#453)
 - **`contact_auth_overrides`** — partial unique index preserves grant→revoke→re-grant history instead of reactivating revoked rows. (#45)
 - **Per-task `error_budget.kg_promotion`** — validator now accepts the documented per-task KG-promotion opt-out. (#1286)

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -217,10 +217,10 @@ Changes take effect on restart.
 
 Skills, agents, and channels are not enabled simply by existing on disk — they are tracked in three registry tables (`skill_registry`, `agent_registry`, `channel_registry`) with an explicit **install → enable** lifecycle.
 
-- **Disabled by default.** A newly added skill or agent is registered at startup but starts **disabled**. It must be enabled before it can be loaded.
+- **Disabled by default.** A newly added skill or agent is registered at startup but starts **disabled**. It must be enabled before it can be loaded. Toggleable channels (`email`, `signal`) follow the same rule: seeding credentials does **not** install or enable them — use **Settings → Channels** (install, then enable, then restart).
 - **Restart-based enforcement.** Enabled items are loaded/registered at startup; disabled items are skipped. Changing enable state takes effect on the next restart.
 - **Secret gating (`install.requires_secrets`).** A skill manifest may declare `install: { requires_secrets: [...] }` — vault secret keys that must already exist before the registry will install or enable the skill. `RegistryService` rejects install/enable until every declared key is present in the vault. (`web-search` declares `["tavily_api_key"]`.)
-- **Always-on channels.** The `http` and `cli` channels have `isToggleable: false` — they always start and cannot be disabled, an operator-lockout safeguard. `email` and `signal` are toggleable.
+- **Always-on channels.** The `http` and `cli` channels have `isToggleable: false` — they always start and cannot be disabled, an operator-lockout safeguard. `email` and `signal` are toggleable and require explicit install→enable; outbound egress is gated on the same registry state as inbound adapters.
 
 Lifecycle is driven via the registry HTTP API (or the admin UI):
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -184,7 +184,7 @@ NYLAS_SELF_EMAIL=curia@yourdomain.com \
 pnpm run seed-vault
 ```
 
-Restart Curia (`pnpm local`) — the email channel activates automatically when all three Nylas secrets are in the vault.
+Restart Curia (`pnpm local`), then **install and enable the email channel** in the console (**Settings → Channels → Email**). Credentials in the vault alone do not activate the channel — the registry requires an explicit install→enable, the same as skills and agents. See [configuration.md](configuration.md#skill-agent-and-channel-registry).
 
 > **Multiple email accounts:** Additional accounts are managed from the console after first boot — go to **Settings → Channels → Email → Email accounts**. Each account stores its Nylas grant in the vault at `channel.email.<name>.nylas_grant_id`. See [configuration.md](configuration.md#email-accounts) for details.
 
@@ -245,7 +245,7 @@ SIGNAL_PHONE_NUMBER=+12223334444 pnpm run seed-vault
 
 That's the E.164 number you registered via `signal-cli register` + `verify`. `SIGNAL_SOCKET_PATH` is managed by the deployment layer — do not set it in `.env`.
 
-Restart Curia — the Signal channel activates when `SIGNAL_PHONE_NUMBER` is set and the signal-data volume is populated.
+Restart Curia, then **install and enable the Signal channel** in the console (**Settings → Channels → Signal**). The phone number in the vault and a populated `signal-data` volume are prerequisites, but the channel still requires an explicit install→enable before it starts.
 
 ---
 

--- a/docs/specs/04-channels.md
+++ b/docs/specs/04-channels.md
@@ -78,7 +78,7 @@ interface OutboundMessage {
 
 ## Launch Channels
 
-Channels are not started merely by being configured — like skills and agents, they are tracked in the `channel_registry` with an install/enable lifecycle (restart-based). The `http` and `cli` channels are non-toggleable and always start; `email` and `signal` must be enabled in the registry.
+Channels are not started merely by being configured — like skills and agents, they are tracked in the `channel_registry` with an install/enable lifecycle (restart-based). The `http` and `cli` channels are non-toggleable and always start; `email` and `signal` must be installed and enabled in the registry (via **Settings → Channels**). Seeding channel credentials alone does not enroll a toggleable channel. Inbound adapters and outbound egress both derive from the same registry gate.
 
 ### CLI
 Interactive terminal for local dev and testing. Reads from stdin, writes to stdout. Simplest adapter — useful for testing agent logic without external services. **Non-toggleable** (`isToggleable: false`): always starts, cannot be disabled.

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,7 @@ import { channelCredentialStatus } from './channels/credential-resolver.js';
 import { ChannelRegistryRepo } from './registry/channel-registry-repo.js';
 import { ChannelRegistryService } from './registry/channel-registry-service.js';
 import { reconcileChannelRegistry } from './registry/channel-reconcile.js';
+import { gateOutboundClientsForRegistry, hasRegistryGatedOutboundClient } from './registry/channel-outbound-gate.js';
 import { McpRegistryRepo } from './registry/mcp-registry-repo.js';
 import { McpRegistryService } from './registry/mcp-registry-service.js';
 import { reconcileMcpRegistry } from './registry/mcp-reconcile.js';
@@ -1281,63 +1282,9 @@ async function main(): Promise<void> {
     logger.info('All startup readiness checks passed');
   }
 
-  // Outbound gateway — single choke-point for all outbound external communication.
-  // Runs blocked-contact checks and content filtering before any message leaves Curia.
-  //
-  // Initialization guard:
-  //   Production assumption: Nylas + Signal are always configured together.
-  //   The guard initializes the gateway when either client is available + outboundFilter
-  //   is ready. This keeps the gateway functional for Signal-only setups (e.g., during
-  //   initial deployment before Nylas credentials are added) and for testing scenarios.
-  //
-  //   TODO: If the system ever runs in a Signal-only mode in production (no Nylas), the
-  //   blocked-content CEO notification path will silently degrade (no email to send it on).
-  //   In that mode, log.error is the fallback — see OutboundGateway.send() comments.
-  //   For now we assume Nylas + Signal together, so this path is only for dev flexibility.
-  let outboundGateway: OutboundGateway | undefined;
-  const hasAnyOutboundClient = nylasClientMap.size > 0 || !!signalRpcClient;
-  // Defense-in-depth for setup-required mode: even though inbound email/Signal
-  // adapters are skipped (so no inbound traffic should be triggering outbound
-  // replies), the OutboundGateway is also used by notifiers (suspension, recovery,
-  // approval) and skills that send directly. Skipping the gateway construction
-  // here closes those non-reply send paths too — there is no email/Signal
-  // egress at all until the operator completes setup and restarts.
-  if (setupRequiredAtBoot && hasAnyOutboundClient) {
-    logger.warn(
-      'SETUP-REQUIRED mode: outbound gateway NOT initialized — no email/Signal egress (notifiers, autonomy alerts) until restart',
-    );
-  }
-  if (hasAnyOutboundClient && outboundFilter && !setupRequiredAtBoot) {
-    outboundGateway = new OutboundGateway({
-      nylasClients: nylasClientMap.size > 0 ? nylasClientMap : undefined,
-      signalClient: signalRpcClient,
-      signalPhoneNumber: config.signalPhoneNumber,
-      contactService,
-      contentFilter: outboundFilter,
-      bus,
-      // principalIdentities loaded from the DB at startup — used by isPrincipalRecipient()
-      // to bypass the autonomy gate for agent-to-principal communications.
-      principalIdentities,
-      logger,
-      autonomyService,
-      piiRedactor,
-      // Wire action log repo so the gateway can write autonomy_action_log rows on
-      // gated sends and support two-step draft linkage (#435).
-      actionLogRepo,
-      confidencePipeline,
-    });
-    logger.info({
-      emailAccounts: [...nylasClientMap.keys()],
-      hasSignal: !!signalRpcClient,
-    }, 'Outbound gateway initialized');
-  } else if (nylasClientMap.size > 0 && !outboundFilter) {
-    // Nylas clients are available but outboundFilter is missing (no coordinator config found).
-    // Email skills will be unavailable because they check ctx.outboundGateway before sending.
-    logger.warn('Outbound gateway NOT initialized — outboundFilter not ready (coordinator config missing?). Outbound send skills will be unavailable.');
-  }
-
   // ── Channel registry ───────────────────────────────────────────────────────
   // Decide which channels start, from DB lifecycle state + resolvable credentials.
+  // Reconcile runs before OutboundGateway so inbound and outbound share one gate.
   // Credentials resolve vault-first, then env, then config (multi-account email).
   const channelRegistryRepo = new ChannelRegistryRepo(pool);
 
@@ -1368,7 +1315,6 @@ async function main(): Promise<void> {
     await reconcileChannelRegistry({
       repo: channelRegistryRepo,
       catalog: CHANNEL_CATALOG,
-      credentialStatus: channelCredentialStatusFn,
       logger,
     });
   } catch (err) {
@@ -1401,6 +1347,63 @@ async function main(): Promise<void> {
     secretsService,
   );
   // ───────────────────────────────────────────────────────────────────────────
+
+  // Outbound gateway — single choke-point for all outbound external communication.
+  // Runs blocked-contact checks and content filtering before any message leaves Curia.
+  // Clients are gated on channelShouldStart so disabled/uninstalled channels cannot egress.
+  let outboundGateway: OutboundGateway | undefined;
+  const registryGatedOutbound = gateOutboundClientsForRegistry(
+    channelShouldStart,
+    nylasClientMap,
+    signalRpcClient,
+    config.signalPhoneNumber,
+  );
+  const hasAnyOutboundClient = hasRegistryGatedOutboundClient(registryGatedOutbound);
+  // Defense-in-depth for setup-required mode: even though inbound email/Signal
+  // adapters are skipped (so no inbound traffic should be triggering outbound
+  // replies), the OutboundGateway is also used by notifiers (suspension, recovery,
+  // approval) and skills that send directly. Skipping the gateway construction
+  // here closes those non-reply send paths too — there is no email/Signal
+  // egress at all until the operator completes setup and restarts.
+  if (setupRequiredAtBoot && hasAnyOutboundClient) {
+    logger.warn(
+      'SETUP-REQUIRED mode: outbound gateway NOT initialized — no email/Signal egress (notifiers, autonomy alerts) until restart',
+    );
+  }
+  if (hasAnyOutboundClient && outboundFilter && !setupRequiredAtBoot) {
+    outboundGateway = new OutboundGateway({
+      nylasClients: registryGatedOutbound.nylasClients,
+      signalClient: registryGatedOutbound.signalClient,
+      signalPhoneNumber: registryGatedOutbound.signalPhoneNumber,
+      contactService,
+      contentFilter: outboundFilter,
+      bus,
+      // principalIdentities loaded from the DB at startup — used by isPrincipalRecipient()
+      // to bypass the autonomy gate for agent-to-principal communications.
+      principalIdentities,
+      logger,
+      autonomyService,
+      piiRedactor,
+      // Wire action log repo so the gateway can write autonomy_action_log rows on
+      // gated sends and support two-step draft linkage (#435).
+      actionLogRepo,
+      confidencePipeline,
+    });
+    logger.info({
+      emailAccounts: registryGatedOutbound.nylasClients ? [...registryGatedOutbound.nylasClients.keys()] : [],
+      hasSignal: !!registryGatedOutbound.signalClient,
+      channelShouldStart: [...channelShouldStart],
+    }, 'Outbound gateway initialized');
+  } else if (nylasClientMap.size > 0 && !outboundFilter) {
+    // Nylas clients are available but outboundFilter is missing (no coordinator config found).
+    // Email skills will be unavailable because they check ctx.outboundGateway before sending.
+    logger.warn('Outbound gateway NOT initialized — outboundFilter not ready (coordinator config missing?). Outbound send skills will be unavailable.');
+  } else if ((nylasClientMap.size > 0 || signalRpcClient) && !hasAnyOutboundClient) {
+    logger.info(
+      { channelShouldStart: [...channelShouldStart] },
+      'Outbound gateway NOT initialized — toggleable channels with credentials are disabled or uninstalled in the registry',
+    );
+  }
 
   // Construct one EmailAdapter per resolved account (but don't start any yet —
   // adapters must not poll until the dispatcher is registered, otherwise inbound.message

--- a/src/registry/channel-outbound-gate.test.ts
+++ b/src/registry/channel-outbound-gate.test.ts
@@ -1,0 +1,47 @@
+// src/registry/channel-outbound-gate.test.ts
+import { describe, it, expect } from 'vitest';
+import { gateOutboundClientsForRegistry, hasRegistryGatedOutboundClient } from './channel-outbound-gate.js';
+import type { NylasClient } from '../channels/email/nylas-client.js';
+import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
+
+const fakeNylasMap = () => new Map<string, NylasClient>([['curia', {} as NylasClient]]);
+const fakeSignal = {} as SignalRpcClient;
+
+describe('gateOutboundClientsForRegistry', () => {
+  it('exposes email outbound only when the registry marks email enabled', () => {
+    const gated = gateOutboundClientsForRegistry(
+      new Set(['email']),
+      fakeNylasMap(),
+      fakeSignal,
+      '+15551234567',
+    );
+    expect(gated.nylasClients?.size).toBe(1);
+    expect(gated.signalClient).toBeUndefined();
+    expect(hasRegistryGatedOutboundClient(gated)).toBe(true);
+  });
+
+  it('exposes signal outbound only when the registry marks signal enabled', () => {
+    const gated = gateOutboundClientsForRegistry(
+      new Set(['signal']),
+      fakeNylasMap(),
+      fakeSignal,
+      '+15551234567',
+    );
+    expect(gated.nylasClients).toBeUndefined();
+    expect(gated.signalClient).toBe(fakeSignal);
+    expect(gated.signalPhoneNumber).toBe('+15551234567');
+    expect(hasRegistryGatedOutboundClient(gated)).toBe(true);
+  });
+
+  it('omits outbound clients for disabled/uninstalled toggleable channels', () => {
+    const gated = gateOutboundClientsForRegistry(
+      new Set(['http', 'cli']),
+      fakeNylasMap(),
+      fakeSignal,
+      '+15551234567',
+    );
+    expect(gated.nylasClients).toBeUndefined();
+    expect(gated.signalClient).toBeUndefined();
+    expect(hasRegistryGatedOutboundClient(gated)).toBe(false);
+  });
+});

--- a/src/registry/channel-outbound-gate.ts
+++ b/src/registry/channel-outbound-gate.ts
@@ -1,0 +1,29 @@
+// src/registry/channel-outbound-gate.ts
+// Gate outbound client wiring on the same registry decision as inbound adapter start.
+import type { NylasClient } from '../channels/email/nylas-client.js';
+import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
+
+export interface RegistryGatedOutboundClients {
+  nylasClients: Map<string, NylasClient> | undefined;
+  signalClient: SignalRpcClient | undefined;
+  signalPhoneNumber: string | undefined;
+}
+
+export function gateOutboundClientsForRegistry(
+  channelShouldStart: ReadonlySet<string>,
+  nylasClientMap: Map<string, NylasClient>,
+  signalRpcClient: SignalRpcClient | undefined,
+  signalPhoneNumber: string | undefined,
+): RegistryGatedOutboundClients {
+  const emailEnabled = channelShouldStart.has('email');
+  const signalEnabled = channelShouldStart.has('signal');
+  return {
+    nylasClients: emailEnabled && nylasClientMap.size > 0 ? nylasClientMap : undefined,
+    signalClient: signalEnabled ? signalRpcClient : undefined,
+    signalPhoneNumber: signalEnabled ? signalPhoneNumber : undefined,
+  };
+}
+
+export function hasRegistryGatedOutboundClient(clients: RegistryGatedOutboundClients): boolean {
+  return (clients.nylasClients?.size ?? 0) > 0 || clients.signalClient !== undefined;
+}

--- a/src/registry/channel-reconcile.test.ts
+++ b/src/registry/channel-reconcile.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { reconcileChannelRegistry } from './channel-reconcile.js';
 import type { IChannelRegistryRepo, ChannelRegistryRow } from './channel-registry-types.js';
 import type { ChannelDescriptor } from '../channels/catalog.js';
-import type { ChannelCredentialStatus } from '../channels/credential-resolver.js';
 import { createLogger } from '../logger.js';
 
 class FakeRepo implements IChannelRegistryRepo {
@@ -29,16 +28,12 @@ const CATALOG: ChannelDescriptor[] = [
   { name: 'cli', description: '', isToggleable: false, credentialFields: [], requiredSecretKeys: [] },
 ];
 
-// resolvable: only 'email'
-const statusFn = async (d: ChannelDescriptor): Promise<ChannelCredentialStatus> =>
-  ({ requiredResolvable: d.name === 'email' || !d.isToggleable, fields: [] });
-
 describe('reconcileChannelRegistry', () => {
   let repo: FakeRepo;
   beforeEach(() => { repo = new FakeRepo(); });
 
   it('always enrolls http and cli as enabled + non-toggleable', async () => {
-    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, logger: silentLogger });
     for (const name of ['http', 'cli']) {
       const row = repo.rows.get(name)!;
       expect(row.enabled).toBe(true);
@@ -46,21 +41,37 @@ describe('reconcileChannelRegistry', () => {
     }
   });
 
-  it('enrolls a toggleable channel as enabled only when its credentials resolve', async () => {
-    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
-    expect(repo.rows.get('email')!.enabled).toBe(true);   // resolvable
-    expect(repo.rows.get('signal')).toBeUndefined();       // not resolvable → no row
+  it('leaves toggleable channels uninstalled on a fresh boot even when credentials would resolve', async () => {
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, logger: silentLogger });
+    expect(repo.rows.get('email')).toBeUndefined();
+    expect(repo.rows.get('signal')).toBeUndefined();
   });
 
   it('respects existing admin state and does not overwrite it', async () => {
     await repo.install('email', 'admin', true); // installed but deliberately left disabled
-    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, logger: silentLogger });
     expect(repo.rows.get('email')!.enabled).toBe(false);   // left as-is
+  });
+
+  it('keeps a disabled toggleable channel disabled across restarts', async () => {
+    await repo.install('email', 'admin', true);
+    await repo.enable('email', 'admin');
+    await repo.disable('email', 'admin');
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, logger: silentLogger });
+    expect(repo.rows.get('email')!.enabled).toBe(false);
+  });
+
+  it('does not re-install a toggleable channel after operator uninstall', async () => {
+    await repo.install('email', 'admin', true);
+    await repo.enable('email', 'admin');
+    await repo.uninstall('email');
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, logger: silentLogger });
+    expect(repo.rows.get('email')).toBeUndefined();
   });
 
   it('re-enables http/cli if a prior run left them disabled (safeguard)', async () => {
     await repo.install('http', 'system', false); // disabled row exists
-    await reconcileChannelRegistry({ repo, catalog: CATALOG, credentialStatus: statusFn, logger: silentLogger });
+    await reconcileChannelRegistry({ repo, catalog: CATALOG, logger: silentLogger });
     expect(repo.rows.get('http')!.enabled).toBe(true);
   });
 });

--- a/src/registry/channel-reconcile.ts
+++ b/src/registry/channel-reconcile.ts
@@ -1,22 +1,20 @@
 // src/registry/channel-reconcile.ts
 // Startup reconciliation for the channel registry:
 //   - http/cli (non-toggleable) are ALWAYS present and enabled — operator-lockout safeguard.
-//   - toggleable channels with no row whose credentials resolve are installed + enabled, so
-//     existing deployments light up unchanged. Existing admin state is never overwritten.
+//   - toggleable channels are enrolled only by an explicit operator install→enable action;
+//     reconcile never auto-installs them from ambient credentials (parity with skill/agent registries).
 import type { Logger } from '../logger.js';
 import type { ChannelDescriptor } from '../channels/catalog.js';
-import type { CredentialStatusFn } from './channel-registry-service.js';
 import type { IChannelRegistryRepo } from './channel-registry-types.js';
 
 export interface ReconcileChannelDeps {
   repo: IChannelRegistryRepo;
   catalog: ChannelDescriptor[];
-  credentialStatus: CredentialStatusFn;
   logger: Logger;
 }
 
 export async function reconcileChannelRegistry(deps: ReconcileChannelDeps): Promise<void> {
-  const { repo, catalog, credentialStatus, logger } = deps;
+  const { repo, catalog, logger } = deps;
   const existing = new Map((await repo.listRows()).map(r => [r.name, r]));
 
   for (const d of catalog) {
@@ -35,16 +33,9 @@ export async function reconcileChannelRegistry(deps: ReconcileChannelDeps): Prom
       continue;
     }
 
-    // Toggleable channels: respect any existing admin state.
-    if (row) continue;
-
-    const status = await credentialStatus(d);
-    if (status.requiredResolvable) {
-      await repo.install(d.name, 'reconciliation', true);
-      await repo.enable(d.name, 'reconciliation');
-      logger.info({ channel: d.name }, 'channel registry: enrolled channel with resolvable credentials as enabled');
-    } else {
-      logger.info({ channel: d.name }, 'channel registry: channel has no credentials; left uninstalled');
+    // Toggleable channels: respect any existing admin state; never auto-enroll.
+    if (!row) {
+      logger.info({ channel: d.name }, 'channel registry: toggleable channel not installed; left uninstalled');
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the channel registry with skill/agent registries and closes the inbound/outbound availability split. Toggleable channels (`email`, `signal`) are no longer auto-installed from ambient credentials at reconcile time, and outbound egress is gated on the same `channelShouldStart` decision as inbound adapters.

Closes #965
Closes #966

## Changes

- **`channel-reconcile.ts`** — removed credential-based auto-enroll for toggleable channels; reconcile now only guarantees always-on `http`/`cli` enrollment. Dropped `credentialStatus` from `ReconcileChannelDeps`.
- **`channel-reconcile.test.ts`** — fresh-boot leaves toggleable channels uninstalled; added post-uninstall and post-disable restart coverage.
- **`channel-outbound-gate.ts`** — pure helper gating Nylas/Signal clients on `channelShouldStart`.
- **`index.ts`** — channel registry reconcile + `channelShouldStart` computation moved before `OutboundGateway` construction; gateway receives only registry-enabled channel clients.
- **Docs** — `setup.md`, `configuration.md`, and `docs/specs/04-channels.md` updated for manual channel install→enable.
- **`CHANGELOG.md`** — Changed entry under `[Unreleased]`.

## Behavior notes

- **Existing deployments** with enabled channel rows are untouched on upgrade (reconcile never overwrites existing admin state).
- **Fresh deployments** must install + enable channels in **Settings → Channels** after seeding credentials.
- **`uninstall()`** is durable: reconcile no longer re-adds env/config-backed channels.
- **curia-docs** (public site) still needs a matching onboarding update in the separate repo — not included here.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [x] CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b19a7de-4b28-4076-bf0c-23fa42a12f0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b19a7de-4b28-4076-bf0c-23fa42a12f0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

