### PR TITLE
fix: make migration 070 a no-op to keep audit_log append-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
-- **`outbound.pii_redacted`** — audit event type renamed from `outbound.pii-redacted` to underscore form; existing audit rows migrated. (#453)
+- **`outbound.pii_redacted`** — audit event type standardized to the underscore form in code; legacy hyphen-form rows preserved as immutable audit history, not rewritten. (#453)
 - **`contact_auth_overrides`** — partial unique index preserves grant→revoke→re-grant history instead of reactivating revoked rows. (#45)
 - **Per-task `error_budget.kg_promotion`** — validator now accepts the documented per-task KG-promotion opt-out. (#1286)
 - **`@types/node`** — pinned to the Node 24 type surface to match the runtime; Dependabot ignores major bumps. (#1258)
+
+### Fixed
+
+- **Migration 070** — now a no-op; the `UPDATE audit_log` data-fix tripped the append-only trigger and crash-looped boot on prod. (#453)
 
 ## [0.39.0] — 2026-07-01 — "Watney"
 

--- a/src/db/migrations/070_audit_pii_redacted_event_type.sql
+++ b/src/db/migrations/070_audit_pii_redacted_event_type.sql
@@ -1,6 +1,25 @@
--- #453: standardize PII redaction audit event type to underscore form.
--- Pre-fix rows used outbound.pii-redacted (hyphen).
-
-UPDATE audit_log
-SET event_type = 'outbound.pii_redacted'
-WHERE event_type = 'outbound.pii-redacted';
+-- #453: application code standardized the PII-redaction audit event type to the
+-- underscore form (outbound.pii_redacted). A handful of historical rows predate
+-- that fix and still carry the legacy hyphen form (outbound.pii-redacted).
+--
+-- An earlier revision of this migration rewrote those historical rows with
+-- `UPDATE audit_log SET event_type = 'outbound.pii_redacted' WHERE event_type =
+-- 'outbound.pii-redacted'`. That is intentionally reverted:
+--
+--   * audit_log is append-only by design. Migration 021 installs a BEFORE UPDATE
+--     OR DELETE trigger (audit_log_immutable) that RAISEs on any mutation except
+--     an acknowledged false->true flip. The UPDATE therefore throws P0001 during
+--     migration and crash-loops the container on boot -- but only on a database
+--     that actually holds legacy rows (the trigger is FOR EACH ROW, so it never
+--     fires when zero rows match). It passed CI on an empty DB and took down prod.
+--   * Rewriting historical audit rows to match a later naming convention would
+--     falsify the record of what the system actually emitted at the time. The
+--     legacy rows are deliberately preserved as immutable history.
+--
+-- No reader filters audit_log on the legacy hyphen value (application code emits
+-- and matches only the underscore form), so mixed historical spellings are safe.
+--
+-- This migration is kept in sequence as an intentional no-op so the migration
+-- history stays contiguous and the decision is recorded where the next engineer
+-- will look. Do NOT reintroduce the UPDATE.
+SELECT 1;


### PR DESCRIPTION
## Summary

Migration `070` (added in #453) ran `UPDATE audit_log SET event_type='outbound.pii_redacted' WHERE event_type='outbound.pii-redacted'` to normalize legacy event-type labels. But migration `021` makes `audit_log` append-only via a `BEFORE UPDATE OR DELETE` trigger (`audit_log_immutable`) that `RAISE`s on any audit_log UPDATE except an `acknowledged` false→true flip.

Migrations run at boot **before** the HTTP server binds, so the throw kills `main()` → Docker `restart: unless-stopped` loops the container → healthcheck never passes → deploy aborts with `dependency failed to start: container curia-curia-1 is unhealthy`.

**Why CI was green and prod went down:** the trigger is `FOR EACH ROW`, so it only fires when the UPDATE actually matches rows. Empty CI/local DBs had zero legacy rows → the UPDATE was a silent no-op → migration "succeeded". Prod had 8 real `outbound.pii-redacted` rows → P0001 → crash loop.

Per the append-only design, the legacy hyphen-form rows are **preserved as immutable audit history** rather than rewritten (rewriting them would falsify the record of what the system actually emitted). Migration 070 is now a documented no-op. Application code already emits the underscore form, and no reader filters `audit_log` on the legacy value, so mixed historical spellings are safe.

## Prod restore

Prod was restored out-of-band by recording 070 in `pgmigrations` (skipping the UPDATE) and restarting the app container — no audit_log mutation. `pgmigrations` tracks migrations by name only (no content checksum), so this branch's no-op 070 stays recorded and will not re-run. No drift between prod and this change.

## Testing

- Ran the full `001`→`070` migration chain against a fresh throwaway Postgres → `Migrations complete!`.
- Verified migration prefixes remain unique.

Refs #453