### PR TITLE
docs: reconcile conversation_id spec to reversible TEXT key (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`contact_auth_overrides`** — partial unique index preserves grant→revoke→re-grant history instead of reactivating revoked rows. (#45)
 - **Per-task `error_budget.kg_promotion`** — validator now accepts the documented per-task KG-promotion opt-out. (#1286)
 - **`@types/node`** — pinned to the Node 24 type surface to match the runtime; Dependabot ignores major bumps. (#1258)
+- **`conversation_id` spec** — reconciled specs 01/02/04 to the real reversible TEXT key, not UUID v5; decision recorded in ADR-025. (#16)
 
 ### Fixed
 

--- a/docs/adr/025-conversation-id-reversible-text-key.md
+++ b/docs/adr/025-conversation-id-reversible-text-key.md
@@ -1,0 +1,105 @@
+# ADR-025: conversation_id is a reversible TEXT key, not a UUID v5
+
+Date: 2026-07-01
+Status: Accepted
+
+## Context
+
+Early specs described `conversation_id` as a *"deterministic UUID v5 generated
+from `channel:user_id:thread_id`"* ([spec 02](../specs/02-agent-system.md),
+[spec 04](../specs/04-channels.md)). #16 tracked the follow-up work: add the v5
+generator and migrate the `audit_log` / `working_memory` id columns from TEXT to
+UUID (`ALTER COLUMN conversation_id TYPE UUID USING conversation_id::uuid`).
+
+When we came to do it, exploration showed the premise no longer held. During
+Phase 4 the channel adapters converged on **human-readable, reversible** keys,
+because outbound routing needs to recover the reply target *from the id itself*:
+
+| Channel | `conversation_id` | Outbound reversal |
+|---|---|---|
+| CLI | `cli:local:default` | n/a (single session) |
+| Email | `email:<nylasThreadId>` | `conversationId.slice('email:'.length)` recovers the thread id for the reply |
+| Signal | `signal:+15550001111` / `signal:group=<base64GroupId>` | split back to a phone number or group id |
+| HTTP | client-supplied, or `http-<randomUUID()>` | n/a |
+
+Three facts made the v5 migration the wrong move:
+
+1. **v5 adds no determinism we lack.** The current keys are *already*
+   deterministic (`email:<threadId>` always maps to the same id). v5 would only
+   add opacity — at the cost of reversibility.
+2. **v5 is one-way; reversibility is load-bearing.** A hash cannot be parsed back
+   into a thread id / phone / group id, so every channel's outbound path would
+   need the routing target stored elsewhere (payload metadata or a side table)
+   plus a rewrite. Pure downside for outbound reply routing.
+3. **None of the live formats cast to UUID.** `email:...`, `signal:...`,
+   `signal:group=...`, `cli:local:default`, and client-supplied HTTP strings all
+   fail `::uuid`, so the proposed one-line `ALTER` would error on essentially
+   every existing row. Rewriting `conversation_id` on historical rows also sits
+   badly against the append-only `audit_log` (trigger from migration 021;
+   migration 070 was made a no-op precisely to preserve that immutability).
+
+The spec was also **internally inconsistent**: [spec 04](../specs/04-channels.md)
+annotated the type as `// deterministic UUID v5` while its own per-channel prose
+described the reversible `email:<threadId>` / Signal / HTTP derivations that were
+actually built. The implementation followed the prose; the type comment was a
+stale aspiration from before the reversibility need surfaced.
+
+Alternatives considered:
+
+- **A. Do the migration as written (#16).** Add v5 generation, move routing
+  targets to payload/side-table, rewrite all four adapters, backfill + `ALTER`
+  both tables. Rejected: high risk/effort to *remove* a useful property
+  (reversibility) and gain only opacity.
+- **B. Keep TEXT, reconcile the spec to reality.** Chosen (below).
+- **C. Cheaper opacity without a type migration** (tokenize just the sensitive
+  segment). Deferred to #1296 — the one real benefit (PII) is pursued separately,
+  not via a TEXT→UUID type change.
+
+## Decision
+
+**Keep `conversation_id` (and `task_id`, `parent_event_id`) as TEXT, and treat
+the reversible channel-scoped key as the intended design.** #16 is resolved by
+reconciling the specs to reality rather than by migrating:
+
+- [spec 02](../specs/02-agent-system.md) and [spec 04](../specs/04-channels.md)
+  now describe `conversation_id` as a deterministic, human-readable, *reversible*
+  key stored as TEXT — not a UUID v5.
+- [spec 01](../specs/01-memory-system.md) `working_memory` is corrected from the
+  never-built `task_id UUID / key / value` shape to the real conversation-scoped
+  `conversation_id TEXT / role / content` shape.
+
+The three id columns have genuinely different natures, and TEXT is correct for
+all of them:
+
+- **`conversation_id`** — deliberately reversible; must *not* be an opaque UUID.
+- **`parent_event_id`** — happens to hold event UUIDs (`randomUUID()` bus event
+  ids), so it is UUID-castable, but stays TEXT for schema simplicity and because
+  there is no FK to enforce. Migrating it alone buys nothing.
+- **`audit_log.task_id`** — vestigial: the audit logger never writes it
+  ("Phase 1 has no task concept"), so it is an always-NULL TEXT column. No
+  migration target until it is actually populated.
+
+## Consequences
+
+**Positive**
+
+- No risky migration against the append-only `audit_log`; historical audit rows
+  keep the readable channel keys that let an operator trace a row to its channel.
+- Outbound reply routing keeps working with a zero-cost string parse instead of a
+  new lookup table or payload duplication.
+- The specs stop contradicting themselves and now match the code.
+
+**Trade-offs / accepted risks**
+
+- The schema keeps three TEXT id columns rather than uniform UUIDs — a cosmetic
+  inconsistency we accept in exchange for reversibility and zero migration risk.
+- Reversible keys embed raw identifiers (notably Signal phone numbers) into the
+  append-only `audit_log`. This is a real PII concern, tracked separately for
+  future hardening in **#1296** — to be solved without giving up reversibility
+  and without a TEXT→UUID migration.
+
+**Follow-ups**
+
+- #1296 — reduce PII in `audit_log.conversation_id` (opaque/tokenized routing).
+- If `audit_log.task_id` is ever populated, revisit whether it should be UUID +
+  FK to `tasks(id)` at that point.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,7 @@ Each ADR follows the [Nygard format](https://adr.github.io/):
 | [022](022-skill-agent-registry.md) | DB-gated skill/agent registry — install/enable lifecycle with startup reconciliation and restart-based enforcement | Accepted |
 | [023](023-bullpen-consult-and-resume.md) | Async bullpen consult-and-resume convention — tap/park/resume over existing bullpen primitives, no new event types | Accepted |
 | [024](024-plan-rows-direct.md) | Plan primitive writes child rows directly (rows-direct) — not coordinator-proposed trees | Accepted |
+| [025](025-conversation-id-reversible-text-key.md) | `conversation_id` is a reversible TEXT key, not a UUID v5 — reject the #16 migration, reconcile specs to reality | Accepted |
 
 ## Adding new ADRs
 

--- a/docs/specs/01-memory-system.md
+++ b/docs/specs/01-memory-system.md
@@ -8,18 +8,19 @@ Four memory tiers + inter-agent discussion, all backed by PostgreSQL + pgvector.
 
 ---
 
-## Tier 1: Working Memory (per-task ephemeral)
+## Tier 1: Working Memory (per-conversation ephemeral)
 
-Short-lived context for active agent tasks. Stored in `working_memory` table, scoped to a task ID. Holds conversation turns, intermediate results, tool outputs. Auto-expires on task completion (configurable TTL for reactive conversations). Lives in Postgres — survives restarts.
+Short-lived context for active agent conversations. Stored in the `working_memory` table, scoped to a `conversation_id` (the deterministic, reversible channel-scoped key described in [spec 04](04-channels.md); stored as TEXT — see ADR-025). Holds conversation turns as `role`/`content`. Auto-expires via a configurable TTL (`expires_at`); summarized turns are marked `archived` and excluded from active context loading. Lives in Postgres — survives restarts.
 
 **Table:** `working_memory`
 - `id` UUID
-- `task_id` UUID
+- `conversation_id` TEXT
 - `agent_id` TEXT
-- `key` TEXT
-- `value` JSONB
+- `role` TEXT
+- `content` TEXT
 - `created_at` TIMESTAMPTZ
 - `expires_at` TIMESTAMPTZ
+- `archived` BOOLEAN — excludes summarized turns from active context loading (migration 018)
 
 ---
 

--- a/docs/specs/02-agent-system.md
+++ b/docs/specs/02-agent-system.md
@@ -148,7 +148,7 @@ The agent runtime exposes hooks at key lifecycle points. Hooks are used by the f
 
 ## Agent State Model
 
-**Stateful per-conversation, restart-safe.** Each inbound message carries a `conversation_id` — a deterministic UUID v5 generated from `channel:user_id:thread_id` (e.g., `signal:+15550001111:thread-789` → UUID). The agent loads conversation history from working memory (Postgres) on each invocation. No in-process state — restarts lose nothing.
+**Stateful per-conversation, restart-safe.** Each inbound message carries a `conversation_id` — a deterministic, human-readable key derived from the channel and its native thread/sender identity (e.g., `signal:+15550001111`, `email:<threadId>`, `cli:local:default`). It is deliberately *reversible*: outbound adapters parse it back to recover the reply target (thread id, phone number, group id). Stored as TEXT, not a UUID. See ADR-025. The agent loads conversation history from working memory (Postgres) on each invocation. No in-process state — restarts lose nothing.
 
 ---
 

--- a/docs/specs/04-channels.md
+++ b/docs/specs/04-channels.md
@@ -56,7 +56,9 @@ interface ChannelCredentialField {
 ```typescript
 interface InboundMessage {
   id: string;                  // UUID
-  conversation_id: string;     // deterministic UUID v5 from channel:user_id:thread_id
+  conversation_id: string;     // deterministic, reversible channel-scoped key, e.g. "email:<threadId>",
+                               // "signal:+1555...", "signal:group=<id>", "cli:local:default". NOT a UUID —
+                               // outbound adapters parse it back to recover the reply target. See ADR-025.
   channel_id: string;          // e.g., "email"
   sender_id: string;           // platform-specific user ID
   content: string;             // normalized text content


### PR DESCRIPTION
## Summary

`Closes #16.`

#16 proposed migrating `audit_log` / `working_memory` id columns TEXT→UUID, per the spec's claim that `conversation_id` is a "deterministic UUID v5". On investigation the premise doesn't hold, and the migration would remove a property we rely on:

- **4 adapters, not 3** (the issue's analysis missed Signal). No live format casts to UUID: `email:<threadId>`, `signal:+1555...`, `signal:group=<id>`, `cli:local:default`, `http-<uuid>`, arbitrary client strings — `::uuid` fails on ~every row.
- **Reversibility is load-bearing** — email/Signal outbound parse `conversation_id` back to recover the reply target; a one-way v5 hash destroys that, forcing a routing side-table + adapter rewrites for no real gain (keys are already deterministic).
- **Append-only tension** — rewriting `conversation_id` on historical `audit_log` rows conflicts with its trigger (migration 021; 070 was just no-op'd to preserve this).
- **The spec contradicted itself** — spec 04 annotated `// UUID v5` while its own prose described the reversible derivations actually built.

## Decision — keep TEXT, reconcile specs to reality

- **spec 02 / 04** — `conversation_id` = deterministic, reversible channel-scoped TEXT key.
- **spec 01** — `working_memory` corrected to the real `conversation_id TEXT / role / content` (+ `archived`), from the never-built `task_id UUID / key / value` shape.
- **ADR-025** — records the decision, the rejected migration, and the three columns' real natures (`conversation_id` deliberately reversible; `parent_event_id` holds event UUIDs but stays TEXT/no-FK; `audit_log.task_id` vestigial/always-NULL).
- **CHANGELOG** — entry under `[Unreleased]`.

## Follow-up

Reversible keys embed raw identifiers (Signal phone numbers) into the append-only `audit_log` — a real PII concern, tracked for future hardening in #1296 (to be solved without giving up reversibility and without a type migration).

## Testing

Docs-only change; no code touched. No migration to test against prod (that was the point). Verified internal spec/ADR links resolve and the three specs are now internally consistent.