### PR TITLE
feat(console): improve /jobs filters, schedules, and linked task titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Jobs console** — schedule-type and agent filters, human-readable schedule summaries, and linked task titles with `/tasks?task=` deep links. (#1304)
 - **Calendar principal-grant design** — memo for operating the calendar as the CEO (bind the calendar client to `ceo_nylas_grant_id`), fixing RSVP `omittedAttendeesSpecified`; implementation tracked in #1217.
 
 ### Changed

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -18,5 +18,8 @@
     "react-dom": "^19.2.7",
     "typescript": "^6.0.3",
     "vite": "^8.1.0"
+  },
+  "dependencies": {
+    "cronstrue": "^3.24.0"
   }
 }

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Link } from '@tanstack/react-router';
+import cronstrue from 'cronstrue';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
@@ -25,6 +27,7 @@ interface Job {
   createdAt: string;
   timezone: string;
   agentTaskId: string | null;
+  taskTitle: string | null;
   intentAnchor: string | null;
   progress: Record<string, unknown> | null;
   runStartedAt: string | null;
@@ -59,6 +62,76 @@ function formatSchedule(job: Job): string {
   if (job.cronExpr) return job.cronExpr;
   if (job.runAt) return formatDate(job.runAt);
   return '—';
+}
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function formatClockTime(hour: number, minute: number): string {
+  const period = hour >= 12 ? 'pm' : 'am';
+  const h12 = hour % 12 || 12;
+  if (minute === 0) return `${h12}${period}`;
+  return `${h12}:${minute.toString().padStart(2, '0')}${period}`;
+}
+
+function parseCronNumber(value: string): number | null {
+  return /^\d+$/.test(value) ? parseInt(value, 10) : null;
+}
+
+function weeklyDayLabel(dayOfWeek: string): string | null {
+  const dow = parseCronNumber(dayOfWeek);
+  if (dow === null || dow < 0 || dow > 7) return null;
+  const index = dow === 7 ? 0 : dow;
+  if (index < 0 || index > 6) return null;
+  return `${DAY_NAMES[index]}s`;
+}
+
+function humanizeSchedule(job: Job): string {
+  if (job.runAt) return formatDate(job.runAt);
+  if (!job.cronExpr) return '—';
+
+  const expr = job.cronExpr.trim();
+  const parts = expr.split(/\s+/);
+  if (parts.length !== 5) {
+    try {
+      return cronstrue.toString(expr, { use24HourTimeFormat: false });
+    } catch {
+      return expr;
+    }
+  }
+
+  const [minField, hourField, domField, monthField, dowField] = parts as [string, string, string, string, string];
+
+  const everyMinMatch = minField.match(/^\*\/(\d+)$/);
+  if (everyMinMatch && hourField === '*' && domField === '*' && monthField === '*' && dowField === '*') {
+    const n = parseInt(everyMinMatch[1]!, 10);
+    return n === 1 ? 'Every minute' : `Every ${n} minutes`;
+  }
+
+  const minute = parseCronNumber(minField);
+  const hour = parseCronNumber(hourField);
+
+  if (minute !== null && hourField === '*' && domField === '*' && monthField === '*' && dowField === '*') {
+    return minute === 0 ? 'Hourly' : `Hourly at :${minute.toString().padStart(2, '0')}`;
+  }
+
+  if (minute !== null && hour !== null && domField === '*' && monthField === '*') {
+    const time = formatClockTime(hour, minute);
+
+    if (dowField === '1-5' || dowField.toUpperCase() === 'MON-FRI') {
+      return `Weekdays at ${time}`;
+    }
+
+    const weeklyDay = weeklyDayLabel(dowField);
+    if (weeklyDay) return `Weekly on ${weeklyDay}`;
+
+    if (dowField === '*') return `Daily at ${time}`;
+  }
+
+  try {
+    return cronstrue.toString(expr, { use24HourTimeFormat: false });
+  } catch {
+    return expr;
+  }
 }
 
 async function errorMessage(res: Response): Promise<string> {
@@ -453,8 +526,10 @@ function JobEditDrawer({ job, creating, onClose, onSaved, onDeleted }: DrawerPro
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 type StatusFilter = 'all' | JobStatus;
+type ScheduleTypeFilter = 'all' | 'recurring' | 'one_time';
 
 const ALL_STATUSES: JobStatus[] = ['pending', 'running', 'suspended', 'paused', 'completed', 'cancelled', 'failed'];
+const SCHEDULE_TYPE_FILTERS: ScheduleTypeFilter[] = ['all', 'recurring', 'one_time'];
 
 export default function JobsPage() {
   const [theme, setTheme] = useTheme();
@@ -464,6 +539,8 @@ export default function JobsPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending');
+  const [scheduleTypeFilter, setScheduleTypeFilter] = useState<ScheduleTypeFilter>('all');
+  const [agentFilter, setAgentFilter] = useState('all');
   const [sort, setSort] = useState<{ key: keyof Job; dir: 'asc' | 'desc' }>({ key: 'createdAt', dir: 'desc' });
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
@@ -499,9 +576,23 @@ export default function JobsPage() {
     return c;
   }, [jobs]);
 
+  const scheduleTypeCounts = useMemo(() => ({
+    all: jobs.length,
+    recurring: jobs.filter(j => j.cronExpr != null).length,
+    one_time: jobs.filter(j => j.runAt != null).length,
+  }), [jobs]);
+
+  const agentIds = useMemo(() => {
+    const ids = new Set(jobs.map(j => j.agentId));
+    return [...ids].sort();
+  }, [jobs]);
+
   const filtered = useMemo(() => {
     let rows = jobs;
     if (statusFilter !== 'all') rows = rows.filter(j => j.status === statusFilter);
+    if (scheduleTypeFilter === 'recurring') rows = rows.filter(j => j.cronExpr != null);
+    if (scheduleTypeFilter === 'one_time') rows = rows.filter(j => j.runAt != null);
+    if (agentFilter !== 'all') rows = rows.filter(j => j.agentId === agentFilter);
     if (search) {
       const q = search.toLowerCase();
       rows = rows.filter(j =>
@@ -523,7 +614,7 @@ export default function JobsPage() {
       return 0;
     });
     return rows;
-  }, [jobs, statusFilter, search, sort]);
+  }, [jobs, statusFilter, scheduleTypeFilter, agentFilter, search, sort]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const safePage = Math.min(page, totalPages);
@@ -628,6 +719,39 @@ export default function JobsPage() {
                 </div>
               </div>
 
+              <div className="records-toolbar">
+                <div className="records-toolbar-left">
+                  {SCHEDULE_TYPE_FILTERS.map(v => (
+                    <button
+                      key={v}
+                      className={`records-filter-chip${scheduleTypeFilter === v ? ' active' : ''}`}
+                      onClick={() => { setScheduleTypeFilter(v); setPage(1); }}
+                    >
+                      {v === 'all' ? 'All' : v === 'recurring' ? 'Recurring' : 'One-time'}
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+                        {scheduleTypeCounts[v]}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <div className="records-toolbar-right">
+                  <label htmlFor="jobs-agent-filter" style={{ fontSize: 12, color: 'var(--app-fg-muted)' }}>
+                    Agent
+                  </label>
+                  <select
+                    id="jobs-agent-filter"
+                    className="records-filter-select"
+                    value={agentFilter}
+                    onChange={e => { setAgentFilter(e.target.value); setPage(1); }}
+                  >
+                    <option value="all">All agents</option>
+                    {agentIds.map(id => (
+                      <option key={id} value={id}>{id}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
               <div className="records-layout">
                 <div className="records-main">
                   <div className="records-table-wrap">
@@ -664,7 +788,7 @@ export default function JobsPage() {
                               Created <span className="sort-arrow">{sortArrow('createdAt')}</span>
                             </button>
                           </th>
-                          <th>Task ID</th>
+                          <th>Task</th>
                           <th style={{ textAlign: 'right' }}>Actions</th>
                         </tr>
                       </thead>
@@ -681,7 +805,7 @@ export default function JobsPage() {
                             <td>
                               <span className={`status-pill ${j.status}`}>{j.status}</span>
                             </td>
-                            <td className="cell-mono">{formatSchedule(j)}</td>
+                            <td title={j.cronExpr ?? undefined}>{humanizeSchedule(j)}</td>
                             <td className="cell-mono col-updated">{formatDate(j.nextRunAt)}</td>
                             <td>
                               {j.lastRunOutcome
@@ -690,8 +814,20 @@ export default function JobsPage() {
                               }
                             </td>
                             <td className="cell-mono col-updated">{formatDate(j.createdAt)}</td>
-                            <td className="cell-mono" style={{ fontSize: 11 }}>
-                              {j.agentTaskId ? j.agentTaskId.slice(0, 8) + '…' : <span className="cell-muted">—</span>}
+                            <td>
+                              {j.agentTaskId && j.taskTitle ? (
+                                <Link
+                                  to="/tasks"
+                                  search={{ task: j.agentTaskId }}
+                                  className="job-task-link"
+                                  title={j.taskTitle}
+                                  onClick={e => e.stopPropagation()}
+                                >
+                                  {j.taskTitle}
+                                </Link>
+                              ) : (
+                                <span className="cell-muted">—</span>
+                              )}
                             </td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
@@ -509,6 +509,7 @@ export default function TasksPage() {
   const [pageSize, setPageSize] = useState(10);
   const [editing, setEditing] = useState<Task | null>(null);
   const [creating, setCreating] = useState(false);
+  const appliedUrlTaskRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
@@ -531,8 +532,10 @@ export default function TasksPage() {
 
   useEffect(() => {
     if (!taskIdFromUrl || tasks.length === 0) return;
+    if (appliedUrlTaskRef.current === taskIdFromUrl) return;
     const target = tasks.find(t => t.id === taskIdFromUrl);
     if (target) {
+      appliedUrlTaskRef.current = taskIdFromUrl;
       setCreating(false);
       setEditing(target);
     }
@@ -630,6 +633,7 @@ export default function TasksPage() {
     setEditing(null);
     setCreating(false);
     if (taskIdFromUrl) {
+      appliedUrlTaskRef.current = undefined;
       void navigate({ to: '/tasks', search: { task: undefined }, replace: true });
     }
   }

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
@@ -492,6 +493,8 @@ type StatusFilter = typeof STATUS_FILTERS[number];
 type OwnerFilter = 'all' | TaskOwner;
 
 export default function TasksPage() {
+  const navigate = useNavigate();
+  const { task: taskIdFromUrl } = useSearch({ strict: false }) as { task?: string };
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -525,6 +528,15 @@ export default function TasksPage() {
   }, []);
 
   useEffect(() => { void load(); }, [load]);
+
+  useEffect(() => {
+    if (!taskIdFromUrl || tasks.length === 0) return;
+    const target = tasks.find(t => t.id === taskIdFromUrl);
+    if (target) {
+      setCreating(false);
+      setEditing(target);
+    }
+  }, [taskIdFromUrl, tasks]);
 
   const counts = useMemo(() => {
     const c: Record<string, number> = { all: tasks.length };
@@ -611,6 +623,14 @@ export default function TasksPage() {
     if (target) {
       setCreating(false);
       setEditing(target);
+    }
+  }
+
+  function handleCloseDrawer() {
+    setEditing(null);
+    setCreating(false);
+    if (taskIdFromUrl) {
+      void navigate({ to: '/tasks', search: { task: undefined }, replace: true });
     }
   }
 
@@ -791,7 +811,7 @@ export default function TasksPage() {
                     key={editing ? `${editing.id}-${editing.updatedAt}` : 'new'}
                     task={editing}
                     creating={creating}
-                    onClose={() => { setEditing(null); setCreating(false); }}
+                    onClose={handleCloseDrawer}
                     onSaved={handleSaved}
                     onDeleted={handleDeleted}
                     lookupTask={lookupTask}

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -158,6 +158,9 @@ const jobsRoute = createRoute({
 const tasksRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: '/tasks',
+  validateSearch: (search: Record<string, unknown>) => ({
+    task: typeof search['task'] === 'string' ? search['task'] : undefined,
+  }),
   component: TasksPage,
 });
 

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1181,6 +1181,20 @@ table.records-table tbody tr.active td { background: transparent; }
    Use --app-fg instead to meet WCAG AA at 13px. */
 [data-theme="dark"] .task-related-link { color: var(--app-fg); }
 
+/* Linked task title in the jobs table */
+.job-task-link {
+  display: block;
+  max-width: 220px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--app-teal);
+  text-decoration: none;
+  font-size: 13px;
+}
+.job-task-link:hover { text-decoration: underline; }
+[data-theme="dark"] .job-task-link { color: var(--app-fg); }
+
 /* Responsive adjustments for records views */
 @media (max-width: 768px) {
   .drawer {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/console:
+    dependencies:
+      cronstrue:
+        specifier: ^3.24.0
+        version: 3.24.0
     devDependencies:
       '@tanstack/react-router':
         specifier: ^1.170.16
@@ -2608,6 +2612,10 @@ packages:
   cron-parser@5.6.1:
     resolution: {integrity: sha512-QBm4o1PwZiuY7KFbVvW7FLC8bozy7YWzv+Fz6KRS7sQghzcbDZCGxr/Bc5b6TQreAoSwuWVP491dIcK0THCX6A==}
     engines: {node: '>=18'}
+
+  cronstrue@3.24.0:
+    resolution: {integrity: sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==}
+    hasBin: true
 
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
@@ -7999,6 +8007,8 @@ snapshots:
   cron-parser@5.6.1:
     dependencies:
       luxon: 3.7.2
+
+  cronstrue@3.24.0: {}
 
   cross-fetch@4.1.0:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the `/jobs` console page easier to scan and filter: schedule-type and agent filters, human-readable schedule summaries in the table, and linked task titles with deep-link support on `/tasks`.

Closes #1304

## Changes

- **Schedule-type filter** — chip row (All / Recurring / One-time) composes with existing status and search filters
- **Agent filter** — dropdown populated from distinct `agentId` values in loaded jobs
- **Human-readable schedules** — pattern-matcher for common cron shapes (`Daily at 8am`, `Weekly on Tuesdays`, `Hourly`, etc.) with `cronstrue` fallback; raw cron shown on hover via `title`
- **Task column** — shows linked, truncated `taskTitle` instead of truncated UUID; navigates to `/tasks?task=<id>`
- **Task deep links** — `/tasks` route accepts optional `task` search param; `TasksPage` opens `TaskEditDrawer` on load and clears the param when the drawer closes

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] CHANGELOG updated
- [ ] CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d98da10f-6301-45ae-8dd6-6f4204708c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d98da10f-6301-45ae-8dd6-6f4204708c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

