### PR TITLE
feat(console): add Content-Security-Policy for HTML responses (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **Console CSP (#130)** — strict `Content-Security-Policy` and `X-Frame-Options: DENY` on HTML responses; scripts locked to same-origin bundles (legacy KG Tailwind CDN removed with the React console).
 - **Coordinator provenance-aware presentation hardening (#856)** — presentation directives now follow only the principal's instructions, ignoring third-party content.
 - **Provenance-aware red-team harness (#900)** — probes are framed with dispatcher-style sender context to test non-principal provenance.
 - **Memory poisoning research (#418)** — documented KG write paths from inbound email, assessed safeguards, and filed follow-up #1290 to gate checkpoint extraction and `memory-store` for untrusted senders.

--- a/src/channels/http/routes/console.ts
+++ b/src/channels/http/routes/console.ts
@@ -27,8 +27,7 @@ export const consoleRoutes: FastifyPluginAsync = async (app) => {
         .type('text/html; charset=utf-8')
         .send(
           '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Curia</title></head>' +
-          '<body style="font-family:system-ui;padding:2rem">' +
-          '<p>Console not built. Run: <code>pnpm build:console</code></p></body></html>',
+          '<body><p>Console not built. Run: <code>pnpm build:console</code></p></body></html>',
         );
     });
     return;

--- a/src/channels/http/security-headers.test.ts
+++ b/src/channels/http/security-headers.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
 import rateLimit from '@fastify/rate-limit';
-import { registerSecurityHeaders } from './security-headers.js';
+import { registerSecurityHeaders, CONSOLE_CONTENT_SECURITY_POLICY } from './security-headers.js';
 
 let app: FastifyInstance | undefined;
 
@@ -27,6 +27,9 @@ async function build(): Promise<FastifyInstance> {
   // onRequest hook short-circuits the response (e.g. an auth 401).
   registerSecurityHeaders(instance);
   instance.get('/ok', async () => ({ ok: true }));
+  instance.get('/html', async (_req, reply) => {
+    return reply.type('text/html; charset=utf-8').send('<!doctype html><html><body>ok</body></html>');
+  });
   // A hook that 401s before the handler — proves the header lands on short-circuited
   // responses (the case that matters for the API's auth gate).
   instance.get('/blocked', {
@@ -104,5 +107,28 @@ describe('registerSecurityHeaders', () => {
     // @fastify/cors replies to the preflight directly (204 No Content).
     expect([200, 204]).toContain(res.statusCode);
     expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('does not set Content-Security-Policy on JSON responses', async () => {
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/ok' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBeUndefined();
+    expect(res.headers['x-frame-options']).toBeUndefined();
+  });
+
+  it('sets Content-Security-Policy and X-Frame-Options on HTML responses', async () => {
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/html' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBe(CONSOLE_CONTENT_SECURITY_POLICY);
+    expect(res.headers['x-frame-options']).toBe('DENY');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('locks script-src to self in the console CSP', async () => {
+    expect(CONSOLE_CONTENT_SECURITY_POLICY).toContain("script-src 'self'");
+    expect(CONSOLE_CONTENT_SECURITY_POLICY).not.toContain('cdn.tailwindcss.com');
+    expect(CONSOLE_CONTENT_SECURITY_POLICY).toContain("frame-ancestors 'none'");
   });
 });

--- a/src/channels/http/security-headers.ts
+++ b/src/channels/http/security-headers.ts
@@ -2,6 +2,36 @@
 import type { FastifyInstance } from 'fastify';
 
 /**
+ * Strict Content-Security-Policy for the console SPA (served as text/html).
+ *
+ * The legacy KG standalone HTML that loaded Tailwind from cdn.tailwindcss.com was
+ * removed when the React console shipped; Vite pre-builds CSS/JS under /assets/.
+ * This policy locks script execution to same-origin bundles and allows Google Fonts
+ * for the typefaces linked from index.html.
+ *
+ * `style-src-attr 'unsafe-inline'` is required for React's `style={{…}}` props.
+ * Scripts remain strict (`script-src 'self'`) — the main XSS mitigation goal of #130.
+ */
+export const CONSOLE_CONTENT_SECURITY_POLICY = [
+  "default-src 'none'",
+  "script-src 'self'",
+  "style-src 'self' https://fonts.googleapis.com",
+  "style-src-attr 'unsafe-inline'",
+  "font-src https://fonts.gstatic.com",
+  "img-src 'self'",
+  "connect-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
+function isHtmlResponse(reply: { getHeader(name: string): unknown }): boolean {
+  const raw = reply.getHeader('content-type');
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === 'string' && value.toLowerCase().includes('text/html');
+}
+
+/**
  * Set baseline security headers on every HTTP response.
  *
  * Uses an `onSend` hook, not `onRequest`. `onSend` runs for *every* reply that is sent —
@@ -12,14 +42,21 @@ import type { FastifyInstance } from 'fastify';
  * before headers are flushed, so `reply.header()` still applies; the payload is returned
  * unchanged.
  *
- * Currently sets `X-Content-Type-Options: nosniff`, which tells browsers not to
+ * Always sets `X-Content-Type-Options: nosniff`, which tells browsers not to
  * MIME-sniff a response away from its declared Content-Type. It's cheap and correct even
  * for a pure JSON API (it also covers the static console assets), and it clears the ZAP
  * DAST baseline finding for rule 10021 (X-Content-Type-Options Header Missing). See #568.
+ *
+ * HTML document responses (the console SPA and its fallback pages) also receive a strict
+ * Content-Security-Policy and `X-Frame-Options: DENY`. See #130.
  */
 export function registerSecurityHeaders(app: FastifyInstance): void {
   app.addHook('onSend', async (_request, reply, payload) => {
     reply.header('X-Content-Type-Options', 'nosniff');
+    if (isHtmlResponse(reply)) {
+      reply.header('Content-Security-Policy', CONSOLE_CONTENT_SECURITY_POLICY);
+      reply.header('X-Frame-Options', 'DENY');
+    }
     return payload;
   });
 }


### PR DESCRIPTION
## Summary

Closes #130

The legacy KG standalone HTML that loaded Tailwind from `cdn.tailwindcss.com` was already removed when the React console shipped (Vite pre-builds CSS/JS under `/assets/`). The remaining security gap was the missing Content-Security-Policy.

This PR adds a strict CSP (and `X-Frame-Options: DENY`) on all `text/html` responses:

- `script-src 'self'` — no CDN scripts, no inline script blocks
- `style-src 'self' https://fonts.googleapis.com` — bundled CSS + Google Fonts stylesheets
- `style-src-attr 'unsafe-inline'` — required for React `style={{…}}` props (scripts remain strict)
- `font-src https://fonts.gstatic.com`, `connect-src 'self'`, `img-src 'self'`
- `frame-ancestors 'none'` + `X-Frame-Options: DENY`

JSON API responses are unchanged (no CSP overhead on `/api/*`).

## Test plan

- [x] `pnpm exec vitest run src/channels/http/security-headers.test.ts` — 8 tests pass
- [x] `pnpm run typecheck`
- [ ] Manual: load console at `/`, confirm page renders and DevTools shows `Content-Security-Policy` header on the document response
