### PR TITLE
feat: include action detail in CEO approval notifications (#1300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Provenance-aware red-team harness (#900)** — probes are framed with dispatcher-style sender context to test non-principal provenance.
 - **Memory poisoning research (#418)** — documented KG write paths from inbound email, assessed safeguards, and filed follow-up #1290 to gate checkpoint extraction and `memory-store` for untrusted senders.
 
-### Added
+- **`approval notifications`** — CEO approval emails now include the pending action's recipient and message/content when the notification goes to the principal, so approvals are informed rather than blind. (#1300)
 
-- **Jobs console** — schedule-type and agent filters, human-readable schedule summaries, and linked task titles with `/tasks?task=` deep links. (#1304)
 - **Calendar principal-grant design** — memo for operating the calendar as the CEO (bind the calendar client to `ceo_nylas_grant_id`), fixing RSVP `omittedAttendeesSpecified`; implementation tracked in #1217.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Provenance-aware red-team harness (#900)** — probes are framed with dispatcher-style sender context to test non-principal provenance.
 - **Memory poisoning research (#418)** — documented KG write paths from inbound email, assessed safeguards, and filed follow-up #1290 to gate checkpoint extraction and `memory-store` for untrusted senders.
 
-- **`approval notifications`** — CEO approval emails now include the pending action's recipient and message/content when the notification goes to the principal, so approvals are informed rather than blind. (#1300)
+### Added
 
+- **Jobs console** — schedule-type and agent filters, human-readable schedule summaries, and linked task titles with `/tasks?task=` deep links. (#1304)
+- **`approval notifications`** — CEO approval emails now include the pending action's recipient and message/content when the notification goes to the principal, so approvals are informed rather than blind. (#1300)
 - **Calendar principal-grant design** — memo for operating the calendar as the CEO (bind the calendar client to `ceo_nylas_grant_id`), fixing RSVP `omittedAttendeesSpecified`; implementation tracked in #1217.
 
 ### Changed

--- a/src/autonomy/approval-notification.test.ts
+++ b/src/autonomy/approval-notification.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildApprovalDetails,
+  buildApprovalNotificationBody,
+  resolveNotificationRecipientTier,
+  MAX_DETAIL_FIELD_LENGTH,
+  MAX_DETAIL_TOTAL_LENGTH,
+} from './approval-notification.js';
+import type { ContactService } from '../contacts/contact-service.js';
+
+describe('buildApprovalDetails', () => {
+  it('renders signal-send recipient and message body', () => {
+    const details = buildApprovalDetails('signal-send', {
+      recipient: '+15550142',
+      message: 'Hi Dana, confirming our 3pm sync moved to Thursday.',
+    });
+    expect(details).toContain('To: +15550142');
+    expect(details).toContain('Message: Hi Dana, confirming our 3pm sync moved to Thursday.');
+  });
+
+  it('renders email-reply body', () => {
+    const details = buildApprovalDetails('email-reply', {
+      reply_to_message_id: 'msg-abc',
+      body: 'Thanks — Thursday works for me.',
+    });
+    expect(details).toContain('Reply to: msg-abc');
+    expect(details).toContain('Message: Thanks — Thursday works for me.');
+  });
+
+  it('renders calendar event timing and attendees', () => {
+    const details = buildApprovalDetails('calendar-create-event', {
+      title: 'Board sync',
+      start: '2026-07-02T15:00:00Z',
+      end: '2026-07-02T16:00:00Z',
+      attendees: [{ name: 'Dana Ruiz', email: 'dana@example.com' }],
+    });
+    expect(details).toContain('Title: Board sync');
+    expect(details).toContain('Start: 2026-07-02T15:00:00Z');
+    expect(details).toContain('Attendees: Dana Ruiz (dana@example.com)');
+  });
+
+  it('uses generic fields for unknown skills', () => {
+    const details = buildApprovalDetails('some-custom-skill', {
+      to: 'ops@example.com',
+      body: 'Please review the attached report.',
+      internal_token: 'should-not-appear',
+    });
+    expect(details).toContain('To: ops@example.com');
+    expect(details).toContain('Body: Please review the attached report.');
+    expect(details).not.toContain('internal_token');
+  });
+
+  it('redacts secrets via sanitizeOutput', () => {
+    const details = buildApprovalDetails('signal-send', {
+      recipient: '+15550142',
+      message: 'Use key sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890ABCDEF',
+    });
+    expect(details).toContain('[REDACTED]');
+    expect(details).not.toContain('sk-ant-api03');
+  });
+
+  it('enforces per-field length cap', () => {
+    const longMessage = 'x'.repeat(MAX_DETAIL_FIELD_LENGTH + 100);
+    const details = buildApprovalDetails('signal-send', {
+      recipient: '+15550142',
+      message: longMessage,
+    });
+    const messageLine = details.split('\n').find((l) => l.startsWith('Message:'));
+    expect(messageLine).toBeDefined();
+    // sanitizeOutput appends '[truncated — output exceeded limit]' when truncating
+    expect(messageLine!.length).toBeLessThanOrEqual(
+      'Message: '.length + MAX_DETAIL_FIELD_LENGTH + '[truncated — output exceeded limit]'.length,
+    );
+  });
+
+  it('enforces total length cap across fields', () => {
+    const chunk = 'a'.repeat(400);
+    const details = buildApprovalDetails('some-custom-skill', {
+      to: chunk,
+      subject: chunk,
+      body: chunk,
+      message: chunk,
+      description: chunk,
+    });
+    expect(details.length).toBeLessThanOrEqual(MAX_DETAIL_TOTAL_LENGTH + 50);
+  });
+});
+
+describe('buildApprovalNotificationBody', () => {
+  const baseOpts = {
+    preamble: 'Curia wanted to send a Signal message.',
+    shortRef: 'c6fd31ad',
+    expiresAt: new Date('2026-07-02T20:53:26.183Z'),
+    skillName: 'signal-send',
+    payload: {
+      recipient: '+15550142',
+      message: 'Hi Dana',
+    },
+  };
+
+  it('includes detail block for principal recipient', () => {
+    const body = buildApprovalNotificationBody({
+      ...baseOpts,
+      recipientTier: 'principal',
+    });
+    expect(body).toContain('To: +15550142');
+    expect(body).toContain('Message: Hi Dana');
+    expect(body).toContain('Reference: c6fd31ad');
+    expect(body).toContain('Expires: 2026-07-02T20:53:26.183Z');
+    expect(body).toContain('Reply to approve');
+  });
+
+  it('omits detail block for sub-principal recipient', () => {
+    const body = buildApprovalNotificationBody({
+      ...baseOpts,
+      recipientTier: 'trusted',
+    });
+    expect(body).not.toContain('To: +15550142');
+    expect(body).not.toContain('Message: Hi Dana');
+    expect(body).toContain('Reference: c6fd31ad');
+  });
+
+  it('omits detail block when recipient tier is unknown', () => {
+    const body = buildApprovalNotificationBody({
+      ...baseOpts,
+      recipientTier: null,
+    });
+    expect(body).not.toContain('To: +15550142');
+  });
+
+  it('preserves extra lines between preamble and reference block', () => {
+    const body = buildApprovalNotificationBody({
+      ...baseOpts,
+      recipientTier: 'principal',
+      extraLines: ['Autonomy score: 65 (threshold: 70)'],
+    });
+    expect(body).toContain('Autonomy score: 65 (threshold: 70)');
+    expect(body.indexOf('Autonomy score')).toBeLessThan(body.indexOf('Reference:'));
+  });
+});
+
+describe('resolveNotificationRecipientTier', () => {
+  it('returns tier from contact service lookup', async () => {
+    const contactService = {
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({ tier: 'principal' }),
+    } as unknown as ContactService;
+
+    const tier = await resolveNotificationRecipientTier(contactService, 'ceo@example.com');
+    expect(tier).toBe('principal');
+    expect(contactService.resolveByChannelIdentity).toHaveBeenCalledWith('email', 'ceo@example.com');
+  });
+
+  it('returns null when lookup finds no contact', async () => {
+    const contactService = {
+      resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+    } as unknown as ContactService;
+
+    const tier = await resolveNotificationRecipientTier(contactService, 'ceo@example.com');
+    expect(tier).toBeNull();
+  });
+
+  it('returns null when contact service is absent', async () => {
+    const tier = await resolveNotificationRecipientTier(undefined, 'ceo@example.com');
+    expect(tier).toBeNull();
+  });
+});
+
+describe('shared notification body — both call sites', () => {
+  it('approval-trigger and outbound-gateway use the same builder for equivalent inputs', async () => {
+    const { buildApprovalNotificationBody: fromTrigger } = await import('./approval-notification.js');
+    const { buildApprovalNotificationBody: fromGateway } = await import('./approval-notification.js');
+
+    const opts = {
+      preamble: 'Curia wanted to run signal-send.',
+      shortRef: 'abc12345',
+      expiresAt: new Date('2026-07-02T12:00:00.000Z'),
+      skillName: 'signal-send',
+      payload: { recipient: '+1', message: 'hello' },
+      recipientTier: 'principal' as const,
+    };
+
+    expect(fromTrigger(opts)).toBe(fromGateway(opts));
+  });
+});

--- a/src/autonomy/approval-notification.test.ts
+++ b/src/autonomy/approval-notification.test.ts
@@ -2,13 +2,24 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   buildApprovalDetails,
   buildApprovalNotificationBody,
+  enrichGatewayApprovalPayload,
   resolveNotificationRecipientTier,
+  SKILL_DETAIL_FIXTURES,
   MAX_DETAIL_FIELD_LENGTH,
   MAX_DETAIL_TOTAL_LENGTH,
 } from './approval-notification.js';
 import type { ContactService } from '../contacts/contact-service.js';
+import { createSilentLogger } from '../logger.js';
 
 describe('buildApprovalDetails', () => {
+  it.each(SKILL_DETAIL_FIXTURES)(
+    'renders a non-empty block for $skillName fixture payload',
+    ({ skillName, payload }) => {
+      const details = buildApprovalDetails(skillName, payload);
+      expect(details.trim().length).toBeGreaterThan(0);
+    },
+  );
+
   it('renders signal-send recipient and message body', () => {
     const details = buildApprovalDetails('signal-send', {
       recipient: '+15550142',
@@ -16,6 +27,19 @@ describe('buildApprovalDetails', () => {
     });
     expect(details).toContain('To: +15550142');
     expect(details).toContain('Message: Hi Dana, confirming our 3pm sync moved to Thursday.');
+  });
+
+  it('renders send-draft from merged gate-time fields when draft_id is absent', () => {
+    const details = buildApprovalDetails('send-draft', {
+      account: 'curia',
+      to: 'dana@example.com',
+      subject: 'Re: Budget',
+      body: 'Please review the attached deck.',
+    });
+    expect(details).toContain('To: dana@example.com');
+    expect(details).toContain('Subject: Re: Budget');
+    expect(details).toContain('Body: Please review the attached deck.');
+    expect(details).not.toContain('Draft:');
   });
 
   it('renders email-reply body', () => {
@@ -50,6 +74,16 @@ describe('buildApprovalDetails', () => {
     expect(details).not.toContain('internal_token');
   });
 
+  it('skips object-valued fields in the generic path', () => {
+    const details = buildApprovalDetails('some-custom-skill', {
+      content: { nested: 'secret-shape' },
+      body: 'visible text',
+    });
+    expect(details).toContain('Body: visible text');
+    expect(details).not.toContain('nested');
+    expect(details).not.toContain('secret-shape');
+  });
+
   it('redacts secrets via sanitizeOutput', () => {
     const details = buildApprovalDetails('signal-send', {
       recipient: '+15550142',
@@ -67,14 +101,11 @@ describe('buildApprovalDetails', () => {
     });
     const messageLine = details.split('\n').find((l) => l.startsWith('Message:'));
     expect(messageLine).toBeDefined();
-    // sanitizeOutput appends '[truncated — output exceeded limit]' when truncating
-    expect(messageLine!.length).toBeLessThanOrEqual(
-      'Message: '.length + MAX_DETAIL_FIELD_LENGTH + '[truncated — output exceeded limit]'.length,
-    );
+    expect(messageLine).toContain('[truncated — output exceeded limit]');
   });
 
   it('enforces total length cap across fields', () => {
-    const chunk = 'a'.repeat(400);
+    const chunk = 'hello '.repeat(120);
     const details = buildApprovalDetails('some-custom-skill', {
       to: chunk,
       subject: chunk,
@@ -83,6 +114,31 @@ describe('buildApprovalDetails', () => {
       description: chunk,
     });
     expect(details.length).toBeLessThanOrEqual(MAX_DETAIL_TOTAL_LENGTH + 50);
+  });
+});
+
+describe('enrichGatewayApprovalPayload', () => {
+  it('fills missing send fields without overwriting partialPayload', () => {
+    const merged = enrichGatewayApprovalPayload(
+      { account: 'curia', draft_id: 'draft-1' },
+      { to: 'ceo@example.com', subject: 'Hello', body: 'Body text' },
+    );
+    expect(merged).toEqual({
+      account: 'curia',
+      draft_id: 'draft-1',
+      to: 'ceo@example.com',
+      subject: 'Hello',
+      body: 'Body text',
+    });
+  });
+
+  it('does not overwrite keys already present in partialPayload', () => {
+    const merged = enrichGatewayApprovalPayload(
+      { to: 'stored@example.com' },
+      { to: 'live@example.com', body: 'live body' },
+    );
+    expect(merged.to).toBe('stored@example.com');
+    expect(merged.body).toBe('live body');
   });
 });
 
@@ -96,6 +152,7 @@ describe('buildApprovalNotificationBody', () => {
       recipient: '+15550142',
       message: 'Hi Dana',
     },
+    ceoEmail: 'ceo@example.com',
   };
 
   it('includes detail block for principal recipient', () => {
@@ -111,21 +168,45 @@ describe('buildApprovalNotificationBody', () => {
   });
 
   it('omits detail block for sub-principal recipient', () => {
+    const logWarn = vi.fn();
     const body = buildApprovalNotificationBody({
       ...baseOpts,
       recipientTier: 'trusted',
+      logger: { warn: logWarn } as never,
     });
     expect(body).not.toContain('To: +15550142');
     expect(body).not.toContain('Message: Hi Dana');
     expect(body).toContain('Reference: c6fd31ad');
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientTier: 'trusted', ceoEmail: 'ceo@example.com' }),
+      expect.stringContaining('detail block omitted'),
+    );
+  });
+
+  it('warns when principal recipient has no renderable detail fields', () => {
+    const logWarn = vi.fn();
+    buildApprovalNotificationBody({
+      ...baseOpts,
+      recipientTier: 'principal',
+      payload: { account: 'curia' },
+      skillName: 'send-draft',
+      logger: { warn: logWarn } as never,
+    });
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ skillName: 'send-draft' }),
+      expect.stringContaining('no renderable fields in payload'),
+    );
   });
 
   it('omits detail block when recipient tier is unknown', () => {
+    const logWarn = vi.fn();
     const body = buildApprovalNotificationBody({
       ...baseOpts,
       recipientTier: null,
+      logger: { warn: logWarn } as never,
     });
     expect(body).not.toContain('To: +15550142');
+    expect(logWarn).toHaveBeenCalled();
   });
 
   it('preserves extra lines between preamble and reference block', () => {
@@ -145,23 +226,60 @@ describe('resolveNotificationRecipientTier', () => {
       resolveByChannelIdentity: vi.fn().mockResolvedValue({ tier: 'principal' }),
     } as unknown as ContactService;
 
-    const tier = await resolveNotificationRecipientTier(contactService, 'ceo@example.com');
+    const tier = await resolveNotificationRecipientTier(
+      contactService,
+      'ceo@example.com',
+      createSilentLogger(),
+    );
     expect(tier).toBe('principal');
     expect(contactService.resolveByChannelIdentity).toHaveBeenCalledWith('email', 'ceo@example.com');
   });
 
-  it('returns null when lookup finds no contact', async () => {
+  it('returns null and warns when lookup finds no contact', async () => {
+    const logWarn = vi.fn();
     const contactService = {
       resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
     } as unknown as ContactService;
 
-    const tier = await resolveNotificationRecipientTier(contactService, 'ceo@example.com');
+    const tier = await resolveNotificationRecipientTier(
+      contactService,
+      'ceo@example.com',
+      { warn: logWarn } as never,
+    );
     expect(tier).toBeNull();
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ ceoEmail: 'ceo@example.com' }),
+      expect.stringContaining('recipient not found'),
+    );
   });
 
-  it('returns null when contact service is absent', async () => {
-    const tier = await resolveNotificationRecipientTier(undefined, 'ceo@example.com');
+  it('returns null and warns when contact service is absent', async () => {
+    const logWarn = vi.fn();
+    const tier = await resolveNotificationRecipientTier(
+      undefined,
+      'ceo@example.com',
+      { warn: logWarn } as never,
+    );
     expect(tier).toBeNull();
+    expect(logWarn).toHaveBeenCalled();
+  });
+
+  it('returns null and warns when lookup throws', async () => {
+    const logWarn = vi.fn();
+    const contactService = {
+      resolveByChannelIdentity: vi.fn().mockRejectedValue(new Error('DB down')),
+    } as unknown as ContactService;
+
+    const tier = await resolveNotificationRecipientTier(
+      contactService,
+      'ceo@example.com',
+      { warn: logWarn } as never,
+    );
+    expect(tier).toBeNull();
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error), ceoEmail: 'ceo@example.com' }),
+      expect.stringContaining('tier lookup failed'),
+    );
   });
 });
 

--- a/src/autonomy/approval-notification.test.ts
+++ b/src/autonomy/approval-notification.test.ts
@@ -13,10 +13,13 @@ import { createSilentLogger } from '../logger.js';
 
 describe('buildApprovalDetails', () => {
   it.each(SKILL_DETAIL_FIXTURES)(
-    'renders a non-empty block for $skillName fixture payload',
-    ({ skillName, payload }) => {
+    'renders expected labels for $skillName fixture payload',
+    ({ skillName, payload, expectedLabels }) => {
       const details = buildApprovalDetails(skillName, payload);
       expect(details.trim().length).toBeGreaterThan(0);
+      for (const label of expectedLabels) {
+        expect(details).toContain(label);
+      }
     },
   );
 

--- a/src/autonomy/approval-notification.ts
+++ b/src/autonomy/approval-notification.ts
@@ -3,8 +3,13 @@
 // Used by ApprovalTriggerService and OutboundGateway so the two notification
 // paths cannot drift. Detail rendering is gated on the notification recipient
 // meeting principal tier (issue #1300).
+//
+// OutboundGateway may pass incomplete partialPayload at gate time (e.g. send-draft
+// before draft_id is linked). Call enrichGatewayApprovalPayload() with the live
+// send request so recipient/content fields are available in the notification.
 
 import type { ContactService } from '../contacts/contact-service.js';
+import type { Logger } from '../logger.js';
 import { meetsMinimumTier, type ContactTier } from '../contacts/types.js';
 import { sanitizeOutput } from '../skills/sanitize.js';
 
@@ -14,16 +19,6 @@ import { sanitizeOutput } from '../skills/sanitize.js';
 
 export const MAX_DETAIL_FIELD_LENGTH = 500;
 export const MAX_DETAIL_TOTAL_LENGTH = 2000;
-
-const INTERNAL_PAYLOAD_KEYS = new Set([
-  'context_bridge',
-  'attachments',
-  'account',
-  'calendarId',
-  'colorId',
-  'reminders',
-  'conferencing',
-]);
 
 // ---------------------------------------------------------------------------
 // Field allowlists — extend alongside VERB_RULES in approval-trigger.ts
@@ -60,6 +55,10 @@ const SKILL_DETAIL_FIELDS: Array<{ test: (name: string) => boolean; fields: Deta
     test: (n) => n === 'send-draft',
     fields: [
       { key: 'draft_id', label: 'Draft' },
+      // partialPayload at gate time may omit draft_id; merge live send fields below.
+      { key: 'to', label: 'To' },
+      { key: 'subject', label: 'Subject' },
+      { key: 'body', label: 'Body' },
     ],
   },
   {
@@ -111,14 +110,48 @@ const GENERIC_DETAIL_FIELDS: DetailFieldSpec[] = [
   { key: 'label', label: 'Label' },
 ];
 
+/** Representative payloads for allowlisted skills — used by tests to catch silent misses. */
+export const SKILL_DETAIL_FIXTURES: Array<{
+  skillName: string;
+  payload: Record<string, unknown>;
+}> = [
+  {
+    skillName: 'signal-send',
+    payload: { recipient: '+15550142', message: 'Confirming Thursday at 3pm.' },
+  },
+  {
+    skillName: 'email-reply',
+    payload: { reply_to_message_id: 'msg-abc', body: 'Thanks — Thursday works.' },
+  },
+  {
+    skillName: 'email-draft-save',
+    payload: { to: 'dana@example.com', subject: 'Re: Budget', body: 'Draft body text.' },
+  },
+  {
+    skillName: 'send-draft',
+    payload: { to: 'dana@example.com', subject: 'Re: Budget', body: 'Approved send body.' },
+  },
+  {
+    skillName: 'calendar-create-event',
+    payload: {
+      title: 'Board sync',
+      start: '2026-07-02T15:00:00Z',
+      end: '2026-07-02T16:00:00Z',
+    },
+  },
+  {
+    skillName: 'store-fact',
+    payload: { label: 'Dana prefers mornings', value: 'true' },
+  },
+  {
+    skillName: 'scheduler-create',
+    payload: { name: 'nightly-sweep', when: '2026-07-03T02:00:00Z' },
+  },
+];
+
 // ---------------------------------------------------------------------------
 // Pure helpers — exported for testing
 // ---------------------------------------------------------------------------
-
-function truncateDetailField(s: string, maxLen: number): string {
-  if (s.length <= maxLen) return s;
-  return s.slice(0, maxLen - 1) + '…';
-}
 
 function formatFieldValue(value: unknown): string | null {
   if (value === null || value === undefined) return null;
@@ -150,23 +183,13 @@ function formatFieldValue(value: unknown): string | null {
           if (email) return email;
           if (name) return name;
         }
-        try {
-          return JSON.stringify(item);
-        } catch {
-          return String(item);
-        }
+        return null;
       })
       .filter((part): part is string => Boolean(part));
     return parts.length ? parts.join(', ') : null;
   }
-  if (typeof value === 'object') {
-    try {
-      return JSON.stringify(value);
-    } catch {
-      return String(value);
-    }
-  }
-  return String(value);
+  // Skip plain objects — avoid leaking internal JSON shape into CEO notifications.
+  return null;
 }
 
 function fieldSpecsForSkill(skillName: string): DetailFieldSpec[] {
@@ -174,6 +197,24 @@ function fieldSpecsForSkill(skillName: string): DetailFieldSpec[] {
     if (rule.test(skillName)) return rule.fields;
   }
   return GENERIC_DETAIL_FIELDS;
+}
+
+/**
+ * Merge live outbound-send fields into a partial gate-time payload.
+ * partialPayload wins when a key is already set (e.g. draft_id linked later).
+ */
+export function enrichGatewayApprovalPayload(
+  partialPayload: Record<string, unknown>,
+  sendFields: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = { ...partialPayload };
+  for (const [key, value] of Object.entries(sendFields)) {
+    if (merged[key] !== undefined) continue;
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'string' && value.trim().length === 0) continue;
+    merged[key] = value;
+  }
+  return merged;
 }
 
 /**
@@ -190,7 +231,6 @@ export function buildApprovalDetails(
   let totalLength = 0;
 
   for (const { key, label } of specs) {
-    if (INTERNAL_PAYLOAD_KEYS.has(key)) continue;
     if (seenLabels.has(label)) continue;
     const raw = formatFieldValue(payload[key]);
     if (!raw) continue;
@@ -200,7 +240,7 @@ export function buildApprovalDetails(
     if (totalLength + line.length > MAX_DETAIL_TOTAL_LENGTH) {
       const remaining = MAX_DETAIL_TOTAL_LENGTH - totalLength;
       if (remaining <= label.length + 2) break;
-      lines.push(truncateDetailField(line, remaining));
+      lines.push(sanitizeOutput(line, { maxLength: remaining }));
       break;
     }
     lines.push(line);
@@ -223,6 +263,18 @@ export interface BuildApprovalNotificationBodyOpts {
   /** Optional lines between preamble and reference block (e.g. autonomy score). */
   extraLines?: string[];
   callToAction?: string;
+  /** When set, logs a warn if the detail block is omitted or empty. */
+  logger?: Logger;
+  /** Included in omission warnings for correlation. */
+  ceoEmail?: string;
+}
+
+function logDetailOmission(
+  logger: Logger | undefined,
+  reason: string,
+  context: Record<string, unknown>,
+): void {
+  logger?.warn(context, `approval notification: detail block omitted — ${reason}`);
 }
 
 /**
@@ -236,11 +288,27 @@ export function buildApprovalNotificationBody(opts: BuildApprovalNotificationBod
     lines.push(...opts.extraLines, '');
   }
 
-  if (opts.recipientTier && meetsMinimumTier(opts.recipientTier, 'principal')) {
+  const includeDetail = Boolean(
+    opts.recipientTier && meetsMinimumTier(opts.recipientTier, 'principal'),
+  );
+
+  if (includeDetail) {
     const details = buildApprovalDetails(opts.skillName, opts.payload);
     if (details) {
       lines.push(details, '');
+    } else {
+      logDetailOmission(opts.logger, 'no renderable fields in payload', {
+        skillName: opts.skillName,
+        ceoEmail: opts.ceoEmail,
+        payloadKeys: Object.keys(opts.payload),
+      });
     }
+  } else if (opts.ceoEmail) {
+    logDetailOmission(opts.logger, 'recipient tier below principal or unresolved', {
+      skillName: opts.skillName,
+      ceoEmail: opts.ceoEmail,
+      recipientTier: opts.recipientTier,
+    });
   }
 
   lines.push(
@@ -260,12 +328,22 @@ export function buildApprovalNotificationBody(opts: BuildApprovalNotificationBod
 export async function resolveNotificationRecipientTier(
   contactService: ContactService | undefined,
   ceoEmail: string,
+  logger?: Logger,
 ): Promise<ContactTier | null> {
-  if (!contactService || !ceoEmail) return null;
+  if (!ceoEmail) return null;
+  if (!contactService) {
+    logDetailOmission(logger, 'contactService not configured', { ceoEmail });
+    return null;
+  }
   try {
     const resolved = await contactService.resolveByChannelIdentity('email', ceoEmail);
-    return resolved?.tier ?? null;
-  } catch {
+    if (!resolved?.tier) {
+      logDetailOmission(logger, 'recipient not found in contacts', { ceoEmail });
+      return null;
+    }
+    return resolved.tier;
+  } catch (err) {
+    logDetailOmission(logger, 'tier lookup failed', { err, ceoEmail });
     return null;
   }
 }

--- a/src/autonomy/approval-notification.ts
+++ b/src/autonomy/approval-notification.ts
@@ -80,11 +80,19 @@ const SKILL_DETAIL_FIELDS: Array<{ test: (name: string) => boolean; fields: Deta
     ],
   },
   {
-    test: (n) => n.startsWith('schedule-'),
+    test: (n) => n === 'scheduler-create',
     fields: [
-      { key: 'name', label: 'Job' },
-      { key: 'when', label: 'When' },
-      { key: 'description', label: 'Description' },
+      { key: 'task', label: 'Task' },
+      { key: 'cron_expr', label: 'Schedule' },
+      { key: 'run_at', label: 'Run at' },
+      { key: 'agent_id', label: 'Agent' },
+      { key: 'intent_anchor', label: 'Intent' },
+    ],
+  },
+  {
+    test: (n) => n === 'scheduler-cancel',
+    fields: [
+      { key: 'job_id', label: 'Job' },
     ],
   },
 ];
@@ -114,22 +122,28 @@ const GENERIC_DETAIL_FIELDS: DetailFieldSpec[] = [
 export const SKILL_DETAIL_FIXTURES: Array<{
   skillName: string;
   payload: Record<string, unknown>;
+  /** Skill-specific labels that must appear when the fixture payload is rendered. */
+  expectedLabels: string[];
 }> = [
   {
     skillName: 'signal-send',
     payload: { recipient: '+15550142', message: 'Confirming Thursday at 3pm.' },
+    expectedLabels: ['To:', 'Message:'],
   },
   {
     skillName: 'email-reply',
     payload: { reply_to_message_id: 'msg-abc', body: 'Thanks — Thursday works.' },
+    expectedLabels: ['Reply to:', 'Message:'],
   },
   {
     skillName: 'email-draft-save',
     payload: { to: 'dana@example.com', subject: 'Re: Budget', body: 'Draft body text.' },
+    expectedLabels: ['To:', 'Subject:', 'Body:'],
   },
   {
     skillName: 'send-draft',
     payload: { to: 'dana@example.com', subject: 'Re: Budget', body: 'Approved send body.' },
+    expectedLabels: ['To:', 'Subject:', 'Body:'],
   },
   {
     skillName: 'calendar-create-event',
@@ -138,14 +152,26 @@ export const SKILL_DETAIL_FIXTURES: Array<{
       start: '2026-07-02T15:00:00Z',
       end: '2026-07-02T16:00:00Z',
     },
+    expectedLabels: ['Title:', 'Start:', 'End:'],
   },
   {
     skillName: 'store-fact',
     payload: { label: 'Dana prefers mornings', value: 'true' },
+    expectedLabels: ['Label:', 'Value:'],
   },
   {
     skillName: 'scheduler-create',
-    payload: { name: 'nightly-sweep', when: '2026-07-03T02:00:00Z' },
+    payload: {
+      task: 'nightly-sweep',
+      cron_expr: '0 2 * * *',
+      agent_id: 'coordinator',
+    },
+    expectedLabels: ['Task:', 'Schedule:', 'Agent:'],
+  },
+  {
+    skillName: 'scheduler-cancel',
+    payload: { job_id: 'job-abc-123' },
+    expectedLabels: ['Job:'],
   },
 ];
 

--- a/src/autonomy/approval-notification.ts
+++ b/src/autonomy/approval-notification.ts
@@ -1,0 +1,271 @@
+// approval-notification.ts — shared body construction for CEO approval alerts.
+//
+// Used by ApprovalTriggerService and OutboundGateway so the two notification
+// paths cannot drift. Detail rendering is gated on the notification recipient
+// meeting principal tier (issue #1300).
+
+import type { ContactService } from '../contacts/contact-service.js';
+import { meetsMinimumTier, type ContactTier } from '../contacts/types.js';
+import { sanitizeOutput } from '../skills/sanitize.js';
+
+// ---------------------------------------------------------------------------
+// Constants — exported for tests
+// ---------------------------------------------------------------------------
+
+export const MAX_DETAIL_FIELD_LENGTH = 500;
+export const MAX_DETAIL_TOTAL_LENGTH = 2000;
+
+const INTERNAL_PAYLOAD_KEYS = new Set([
+  'context_bridge',
+  'attachments',
+  'account',
+  'calendarId',
+  'colorId',
+  'reminders',
+  'conferencing',
+]);
+
+// ---------------------------------------------------------------------------
+// Field allowlists — extend alongside VERB_RULES in approval-trigger.ts
+// ---------------------------------------------------------------------------
+
+type DetailFieldSpec = { key: string; label: string };
+
+const SKILL_DETAIL_FIELDS: Array<{ test: (name: string) => boolean; fields: DetailFieldSpec[] }> = [
+  {
+    test: (n) => n.startsWith('signal-'),
+    fields: [
+      { key: 'recipient', label: 'To' },
+      { key: 'group_id', label: 'Group' },
+      { key: 'message', label: 'Message' },
+    ],
+  },
+  {
+    test: (n) => n === 'email-reply',
+    fields: [
+      { key: 'reply_to_message_id', label: 'Reply to' },
+      { key: 'cc', label: 'Cc' },
+      { key: 'body', label: 'Message' },
+    ],
+  },
+  {
+    test: (n) => n === 'email-draft-save',
+    fields: [
+      { key: 'to', label: 'To' },
+      { key: 'subject', label: 'Subject' },
+      { key: 'body', label: 'Body' },
+    ],
+  },
+  {
+    test: (n) => n === 'send-draft',
+    fields: [
+      { key: 'draft_id', label: 'Draft' },
+    ],
+  },
+  {
+    test: (n) => n.startsWith('calendar-'),
+    fields: [
+      { key: 'title', label: 'Title' },
+      { key: 'start', label: 'Start' },
+      { key: 'end', label: 'End' },
+      { key: 'attendees', label: 'Attendees' },
+      { key: 'description', label: 'Description' },
+      { key: 'location', label: 'Location' },
+    ],
+  },
+  {
+    test: (n) => n === 'store-fact',
+    fields: [
+      { key: 'label', label: 'Label' },
+      { key: 'value', label: 'Value' },
+    ],
+  },
+  {
+    test: (n) => n.startsWith('schedule-'),
+    fields: [
+      { key: 'name', label: 'Job' },
+      { key: 'when', label: 'When' },
+      { key: 'description', label: 'Description' },
+    ],
+  },
+];
+
+const GENERIC_DETAIL_FIELDS: DetailFieldSpec[] = [
+  { key: 'to', label: 'To' },
+  { key: 'recipient', label: 'To' },
+  { key: 'phone', label: 'Phone' },
+  { key: 'email', label: 'Email' },
+  { key: 'subject', label: 'Subject' },
+  { key: 'title', label: 'Title' },
+  { key: 'body', label: 'Body' },
+  { key: 'message', label: 'Message' },
+  { key: 'text', label: 'Text' },
+  { key: 'content', label: 'Content' },
+  { key: 'description', label: 'Description' },
+  { key: 'start', label: 'Start' },
+  { key: 'end', label: 'End' },
+  { key: 'when', label: 'When' },
+  { key: 'attendees', label: 'Attendees' },
+  { key: 'name', label: 'Name' },
+  { key: 'query', label: 'Query' },
+  { key: 'label', label: 'Label' },
+];
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for testing
+// ---------------------------------------------------------------------------
+
+function truncateDetailField(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen - 1) + '…';
+}
+
+function formatFieldValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return null;
+    const parts = value
+      .map((item) => {
+        if (typeof item === 'string') {
+          const trimmed = item.trim();
+          return trimmed || null;
+        }
+        if (item && typeof item === 'object') {
+          const obj = item as Record<string, unknown>;
+          const email = typeof obj.email === 'string' ? obj.email : undefined;
+          const name =
+            typeof obj.name === 'string'
+              ? obj.name
+              : typeof obj.displayName === 'string'
+                ? obj.displayName
+                : undefined;
+          if (name && email) return `${name} (${email})`;
+          if (email) return email;
+          if (name) return name;
+        }
+        try {
+          return JSON.stringify(item);
+        } catch {
+          return String(item);
+        }
+      })
+      .filter((part): part is string => Boolean(part));
+    return parts.length ? parts.join(', ') : null;
+  }
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function fieldSpecsForSkill(skillName: string): DetailFieldSpec[] {
+  for (const rule of SKILL_DETAIL_FIELDS) {
+    if (rule.test(skillName)) return rule.fields;
+  }
+  return GENERIC_DETAIL_FIELDS;
+}
+
+/**
+ * Render a labeled detail block from a pending-action payload.
+ * Values pass through sanitizeOutput; per-field and total length caps apply.
+ */
+export function buildApprovalDetails(
+  skillName: string,
+  payload: Record<string, unknown>,
+): string {
+  const specs = fieldSpecsForSkill(skillName);
+  const seenLabels = new Set<string>();
+  const lines: string[] = [];
+  let totalLength = 0;
+
+  for (const { key, label } of specs) {
+    if (INTERNAL_PAYLOAD_KEYS.has(key)) continue;
+    if (seenLabels.has(label)) continue;
+    const raw = formatFieldValue(payload[key]);
+    if (!raw) continue;
+
+    const sanitized = sanitizeOutput(raw, { maxLength: MAX_DETAIL_FIELD_LENGTH });
+    const line = `${label}: ${sanitized}`;
+    if (totalLength + line.length > MAX_DETAIL_TOTAL_LENGTH) {
+      const remaining = MAX_DETAIL_TOTAL_LENGTH - totalLength;
+      if (remaining <= label.length + 2) break;
+      lines.push(truncateDetailField(line, remaining));
+      break;
+    }
+    lines.push(line);
+    totalLength += line.length + 1;
+    seenLabels.add(label);
+  }
+
+  return lines.join('\n');
+}
+
+export interface BuildApprovalNotificationBodyOpts {
+  /** Opening paragraph — gate reason or short description. */
+  preamble: string;
+  shortRef: string;
+  expiresAt: Date;
+  skillName: string;
+  payload: Record<string, unknown>;
+  /** When absent or below principal tier, detail block is omitted. */
+  recipientTier: ContactTier | null;
+  /** Optional lines between preamble and reference block (e.g. autonomy score). */
+  extraLines?: string[];
+  callToAction?: string;
+}
+
+/**
+ * Build the full CEO approval notification body. Detail is included only when
+ * the recipient meets principal tier — defense-in-depth if the channel is repointed.
+ */
+export function buildApprovalNotificationBody(opts: BuildApprovalNotificationBodyOpts): string {
+  const lines: string[] = [opts.preamble, ''];
+
+  if (opts.extraLines && opts.extraLines.length > 0) {
+    lines.push(...opts.extraLines, '');
+  }
+
+  if (opts.recipientTier && meetsMinimumTier(opts.recipientTier, 'principal')) {
+    const details = buildApprovalDetails(opts.skillName, opts.payload);
+    if (details) {
+      lines.push(details, '');
+    }
+  }
+
+  lines.push(
+    `Reference: ${opts.shortRef}`,
+    `Expires: ${opts.expiresAt.toISOString()}`,
+    '',
+    opts.callToAction ?? 'Reply to approve, deny, or dismiss this request.',
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Resolve the notification recipient's tier via the contacts service.
+ * Returns null when lookup is unavailable — callers treat that as "omit detail".
+ */
+export async function resolveNotificationRecipientTier(
+  contactService: ContactService | undefined,
+  ceoEmail: string,
+): Promise<ContactTier | null> {
+  if (!contactService || !ceoEmail) return null;
+  try {
+    const resolved = await contactService.resolveByChannelIdentity('email', ceoEmail);
+    return resolved?.tier ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/autonomy/approval-trigger.test.ts
+++ b/src/autonomy/approval-trigger.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { generateShortRef, buildDescription, ApprovalTriggerService } from './approval-trigger.js';
 import type { ActionLogRepo } from './action-log-repo.js';
 import type { OutboundGateway } from '../skills/outbound-gateway.js';
+import type { ContactService } from '../contacts/contact-service.js';
 import { createSilentLogger } from '../logger.js';
 
 describe('generateShortRef', () => {
@@ -96,6 +97,29 @@ function makeMockGateway(overrides?: Partial<OutboundGateway>): OutboundGateway 
   } as unknown as OutboundGateway;
 }
 
+function makeMockContactService(tier: 'principal' | 'trusted' | 'known' | null = 'principal'): ContactService {
+  return {
+    resolveByChannelIdentity: vi.fn().mockResolvedValue(
+      tier ? { tier } : null,
+    ),
+  } as unknown as ContactService;
+}
+
+function makeService(
+  repo: ActionLogRepo,
+  gateway: OutboundGateway | undefined,
+  ceoEmail?: string,
+  contactService?: ContactService,
+): ApprovalTriggerService {
+  return new ApprovalTriggerService(
+    repo,
+    gateway,
+    createSilentLogger(),
+    ceoEmail,
+    contactService,
+  );
+}
+
 const BASE_OPTS = {
   taskId: 'task-1',
   conversationId: 'conv-1',
@@ -110,7 +134,8 @@ describe('ApprovalTriggerService.request()', () => {
   it('creates row, generates short_ref, sends notification, returns created: true', async () => {
     const repo = makeMockRepo();
     const gateway = makeMockGateway();
-    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+    const contactService = makeMockContactService('principal');
+    const service = makeService(repo, gateway, 'ceo@example.com', contactService);
 
     const result = await service.request(BASE_OPTS);
 
@@ -133,6 +158,47 @@ describe('ApprovalTriggerService.request()', () => {
     }
     expect(notifPayload.body).toMatch(/Expires:/);          // expiry line
     expect(notifPayload.body).toContain('Reply to approve'); // call to action
+  });
+
+  it('includes action detail in notification body for principal recipient', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    const contactService = makeMockContactService('principal');
+    const service = makeService(repo, gateway, 'ceo@example.com', contactService);
+
+    await service.request({
+      ...BASE_OPTS,
+      skillName: 'signal-send',
+      input: {
+        recipient: '+15550142',
+        message: 'Confirming Thursday at 3pm.',
+      },
+    });
+
+    const notifPayload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(notifPayload.body).toContain('To: +15550142');
+    expect(notifPayload.body).toContain('Message: Confirming Thursday at 3pm.');
+  });
+
+  it('omits action detail when notification recipient is below principal tier', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    const contactService = makeMockContactService('trusted');
+    const service = makeService(repo, gateway, 'ceo@example.com', contactService);
+
+    await service.request({
+      ...BASE_OPTS,
+      skillName: 'signal-send',
+      input: {
+        recipient: '+15550142',
+        message: 'Secret message body',
+      },
+    });
+
+    const notifPayload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(notifPayload.body).not.toContain('Secret message body');
+    expect(notifPayload.body).not.toContain('To: +15550142');
+    expect(notifPayload.body).toContain('Reference:');
   });
 
   it('returns duplicate when matching pending row exists', async () => {

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -224,6 +224,7 @@ export class ApprovalTriggerService {
       const recipientTier = await resolveNotificationRecipientTier(
         this.contactService,
         this.ceoEmail,
+        this.logger,
       );
       const notificationBody = buildApprovalNotificationBody({
         preamble: opts.reason ?? defaultBody,
@@ -232,6 +233,8 @@ export class ApprovalTriggerService {
         skillName,
         payload: input,
         recipientTier,
+        logger: this.logger,
+        ceoEmail: this.ceoEmail,
       });
       const sent = await this.outboundGateway.sendNotification({
         notificationType: 'approval_requested',

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -7,8 +7,13 @@
 import { randomBytes } from 'node:crypto';
 import type { ActionLogRepo } from './action-log-repo.js';
 import type { OutboundGateway } from '../skills/outbound-gateway.js';
+import type { ContactService } from '../contacts/contact-service.js';
 import type { Logger } from '../logger.js';
 import { sanitizeOutput } from '../skills/sanitize.js';
+import {
+  buildApprovalNotificationBody,
+  resolveNotificationRecipientTier,
+} from './approval-notification.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -101,6 +106,8 @@ export class ApprovalTriggerService {
     private readonly outboundGateway: OutboundGateway | undefined,
     private readonly logger: Logger,
     private readonly ceoEmail?: string,
+    // Optional — used to resolve the notification recipient's tier for detail gating.
+    private readonly contactService?: ContactService,
   ) {}
 
   /**
@@ -214,11 +221,18 @@ export class ApprovalTriggerService {
       const defaultBody =
         `Curia wanted to ${description.charAt(0).toLowerCase() + description.slice(1)}, ` +
         `but the autonomy score (${currentScore}) is below the required threshold (${requiredScore}).`;
-      const notificationBody =
-        `${opts.reason ?? defaultBody}\n\n` +
-        `Reference: ${shortRef}\n` +
-        `Expires: ${expiresAt.toISOString()}\n\n` +
-        `Reply to approve, deny, or dismiss this request.`;
+      const recipientTier = await resolveNotificationRecipientTier(
+        this.contactService,
+        this.ceoEmail,
+      );
+      const notificationBody = buildApprovalNotificationBody({
+        preamble: opts.reason ?? defaultBody,
+        shortRef,
+        expiresAt,
+        skillName,
+        payload: input,
+        recipientTier,
+      });
       const sent = await this.outboundGateway.sendNotification({
         notificationType: 'approval_requested',
         ceoEmail: this.ceoEmail,

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -56,7 +56,7 @@ const VERB_RULES: Array<{ test: (name: string) => boolean; verb: string }> = [
   { test: (n) => n === 'email-draft-save', verb: 'Save email draft' },
   { test: (n) => n === 'store-fact', verb: 'Store fact' },
   { test: (n) => n.startsWith('signal-'), verb: 'Send Signal message' },
-  { test: (n) => n.startsWith('schedule-'), verb: 'Schedule job' },
+  { test: (n) => n.startsWith('scheduler-'), verb: 'Schedule job' },
 ];
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1651,7 +1651,7 @@ async function main(): Promise<void> {
   // outboundGateway and ceoEmail are optional: if absent, the row is created but
   // notification is skipped (CEO will see it in the next digest, #429).
   const approvalTrigger = new ApprovalTriggerService(
-    actionLogRepo, outboundGateway, logger, principalEmail || undefined,
+    actionLogRepo, outboundGateway, logger, principalEmail || undefined, contactService,
   );
 
   // Temp file store — secure tmpfs-backed storage for binary attachment handoff.

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -35,6 +35,7 @@ import type { ActionLogRepo } from '../autonomy/action-log-repo.js';
 import { generateShortRef } from '../autonomy/approval-trigger.js';
 import {
   buildApprovalNotificationBody,
+  enrichGatewayApprovalPayload,
   resolveNotificationRecipientTier,
 } from '../autonomy/approval-notification.js';
 import type { OutboundNotificationPayload } from '../bus/events.js';
@@ -491,6 +492,13 @@ export class OutboundGateway {
             const recipientTier = await resolveNotificationRecipientTier(
               this.contactService,
               principalEmail,
+              this.log,
+            );
+            const notificationPayload = enrichGatewayApprovalPayload(
+              recipe.partialPayload ?? {},
+              request.channel === 'email'
+                ? { to: request.to, subject: request.subject, body: request.body }
+                : { recipient: request.recipient, message: request.message },
             );
             const sent = await this.sendNotification({
               notificationType: 'approval_requested',
@@ -501,8 +509,10 @@ export class OutboundGateway {
                 shortRef: candidateRef,
                 expiresAt,
                 skillName: recipe.skillName,
-                payload: recipe.partialPayload ?? {},
+                payload: notificationPayload,
                 recipientTier,
+                logger: this.log,
+                ceoEmail: principalEmail,
                 extraLines: [
                   `Autonomy score: ${autonomyConfig.score} (threshold: ${sendThreshold})`,
                 ],

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -33,6 +33,10 @@ import { createOutboundBlocked, createOutboundDelivered, createOutboundNotificat
 import { AutonomyService } from '../autonomy/autonomy-service.js';
 import type { ActionLogRepo } from '../autonomy/action-log-repo.js';
 import { generateShortRef } from '../autonomy/approval-trigger.js';
+import {
+  buildApprovalNotificationBody,
+  resolveNotificationRecipientTier,
+} from '../autonomy/approval-notification.js';
 import type { OutboundNotificationPayload } from '../bus/events.js';
 import { markdownToHtml } from '../format/markdown-to-html.js';
 import { scrubPii } from '../pii/scrubber.js';
@@ -484,19 +488,27 @@ export class OutboundGateway {
           // discard the fact that the insert (and the notification delivery) succeeded.
           const principalEmail = this.principalIdentities.find((id) => id.channel === 'email')?.channelIdentifier;
           if (rowId !== undefined && principalEmail) {
+            const recipientTier = await resolveNotificationRecipientTier(
+              this.contactService,
+              principalEmail,
+            );
             const sent = await this.sendNotification({
               notificationType: 'approval_requested',
               ceoEmail: principalEmail,
               subject: `Approval needed — ${recipe.description}`,
-              body: [
-                recipe.description,
-                '',
-                `Autonomy score: ${autonomyConfig.score} (threshold: ${sendThreshold})`,
-                `Reference: ${candidateRef}`,
-                `Expires: ${expiresAt.toISOString()}`,
-                '',
-                `Reply with the reference to approve, deny, or dismiss this request.`,
-              ].join('\n'),
+              body: buildApprovalNotificationBody({
+                preamble: recipe.description,
+                shortRef: candidateRef,
+                expiresAt,
+                skillName: recipe.skillName,
+                payload: recipe.partialPayload ?? {},
+                recipientTier,
+                extraLines: [
+                  `Autonomy score: ${autonomyConfig.score} (threshold: ${sendThreshold})`,
+                ],
+                callToAction:
+                  'Reply with the reference to approve, deny, or dismiss this request.',
+              }),
             });
             if (sent) {
               try {


### PR DESCRIPTION
## Summary

Closes #1300

Approval notifications now include recipient and content detail when sent to the principal, via a shared `buildApprovalNotificationBody()` helper used by both `ApprovalTriggerService` and `OutboundGateway`.

## Review follow-ups (latest commit)

- **CHANGELOG** — rebased on current `main`; adds only the `approval notifications` bullet under existing `### Added` (Jobs console #1304 preserved).
- **Silent omit path** — `warn` logs when tier lookup fails or detail block is omitted/empty for a principal-addressed notification.
- **Gateway payload parity** — `enrichGatewayApprovalPayload()` merges live send request fields (`to`/`subject`/`body` or `recipient`/`message`) into `partialPayload` at notification time; `send-draft` allowlist extended for gate-time fields when `draft_id` is not yet linked.
- **Allowlist coverage** — `SKILL_DETAIL_FIXTURES` + `it.each` asserts each covered skill renders a non-empty block from realistic payloads.
- **Minor** — removed dead `INTERNAL_PAYLOAD_KEYS`; consistent total-cap truncation via `sanitizeOutput`; generic path skips plain object values.

## Tests

49 unit tests passing (approval-notification + approval-trigger).
