### PR TITLE
fix(delegate): record timeout in DelegationGuard and widen wait headroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`delegate` timeout storm** — delegate wait timeouts now return a structured `failed{reason:timeout,retryable:true,possibly_succeeded:true}` result so `DelegationGuard` caps identical re-delegations; runtime injects headroom when computing `timeout_ms` from `expected_duration_seconds`; delegate skill outer timeout raised to 15 min. Closes #1288.
+- **`delegate` timeout storm** — timeouts now return structured, retry-capped failures instead of triggering duplicate re-delegations. Closes #1288.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`delegate` timeout storm** — delegate wait timeouts now return a structured `failed{reason:timeout,retryable:true,possibly_succeeded:true}` result so `DelegationGuard` caps identical re-delegations; runtime injects headroom when computing `timeout_ms` from `expected_duration_seconds`; delegate skill outer timeout raised to 15 min. Closes #1288.
+
 ### Security
 
 - **Console CSP (#130)** — strict `Content-Security-Policy` and `X-Frame-Options: DENY` on HTML responses; scripts locked to same-origin bundles (legacy KG Tailwind CDN removed with the React console).

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.11.4"
+version: "0.11.5"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -306,17 +306,11 @@ system_prompt: |
      (API timeout, service outage) when the reason is budget exhaustion with progress.
 
   ### Handling delegate wait timeouts (possibly still running)
-  When delegate returns with `failed: true` and `reason: "timeout"`, the specialist did
-  not respond before the delegate wait window expired. **`possibly_succeeded: true` means
-  the specialist may still be running and may complete side effects on its own.**
-
-  1. **Do not re-delegate the same work** in this turn. The platform blocks and escalates
-     on the first timeout — there is no automatic retry.
-  2. Do not tell the CEO the task "failed" or "timed out" as if it definitely did not run.
-     Say you are waiting on the specialist or that it is still working, unless you have
-     evidence it finished.
-  3. Do not queue a duplicate retry via task-create for the same reconciliation — check
-     whether the specialist already delivered before taking further action.
+  Delegate wait timeouts are non-retryable: the platform blocks, escalates, and short-circuits
+  your turn immediately — you do not get a follow-up round to re-delegate or message the CEO
+  about the timeout yourself. When the outbound `agent.response` carries
+  `delegation_failure` with `possibly_succeeded: true`, the specialist may still be running;
+  the `message` field has the principal-facing wording to use.
 
   ## What I Do Directly
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.11.3"
+version: "0.11.4"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -310,8 +310,8 @@ system_prompt: |
   not respond before the delegate wait window expired. **`possibly_succeeded: true` means
   the specialist may still be running and may complete side effects on its own.**
 
-  1. **Do not re-delegate the same work** in this turn. The platform caps identical
-     re-delegations; a third attempt is blocked and escalated.
+  1. **Do not re-delegate the same work** in this turn. The platform blocks and escalates
+     on the first timeout — there is no automatic retry.
   2. Do not tell the CEO the task "failed" or "timed out" as if it definitely did not run.
      Say you are waiting on the specialist or that it is still working, unless you have
      evidence it finished.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.11.2"
+version: "0.11.3"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -304,6 +304,19 @@ system_prompt: |
      on synchronous channels.
   3. Treat `paused` differently from `failed` — never confabulate an external cause
      (API timeout, service outage) when the reason is budget exhaustion with progress.
+
+  ### Handling delegate wait timeouts (possibly still running)
+  When delegate returns with `failed: true` and `reason: "timeout"`, the specialist did
+  not respond before the delegate wait window expired. **`possibly_succeeded: true` means
+  the specialist may still be running and may complete side effects on its own.**
+
+  1. **Do not re-delegate the same work** in this turn. The platform caps identical
+     re-delegations; a third attempt is blocked and escalated.
+  2. Do not tell the CEO the task "failed" or "timed out" as if it definitely did not run.
+     Say you are waiting on the specialist or that it is still working, unless you have
+     evidence it finished.
+  3. Do not queue a duplicate retry via task-create for the same reconciliation — check
+     whether the specialist already delivered before taking further action.
 
   ## What I Do Directly
 

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -67,6 +67,8 @@ function formatStructuredFailureMessage(agent: string, reason: AgentResponseFail
       return `Specialist '${agent}' failed due to an API error`;
     case 'blocked':
       return `Specialist '${agent}' was blocked from completing the task`;
+    case 'timeout':
+      return `Specialist '${agent}' did not respond within the delegate wait window — the task may still be running`;
     default:
       return `Specialist '${agent}' could not complete the task`;
   }
@@ -306,7 +308,12 @@ export class DelegateHandler implements SkillHandler {
       timeoutHandle = setTimeout(() => {
         if (!settled) {
           settled = true;
-          reject(new Error(`Specialist '${agent}' did not respond within ${specialistTimeoutMs}ms`));
+          reject({
+            __structuredDelegateFailure: true,
+            agent,
+            reason: 'timeout',
+            retryable: true,
+          } satisfies StructuredDelegateFailure);
         }
       }, specialistTimeoutMs);
 
@@ -493,6 +500,7 @@ export class DelegateHandler implements SkillHandler {
             retryable: err.retryable,
             ...(err.errorType !== undefined && { errorType: err.errorType }),
             message,
+            ...(err.reason === 'timeout' && { possibly_succeeded: true }),
           },
         };
       }

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -26,6 +26,7 @@ import { createAgentTask, type AgentResponseEvent, type AgentResponseFailureReas
 // future format change can't silently desync this handler from runtime.ts and the resume subscriber.
 import { decodeResumeToken, RESUME_TOKEN_VERSION } from '../../src/agents/resume-token.js';
 import { delegationKey } from '../../src/agents/delegation-guard.js';
+import { clampDelegateWaitTimeoutMs } from '../../src/agents/delegate-timeout.js';
 import {
   EXECUTION_PAUSED_PROTOCOL,
   formatPausedProgressMessage,
@@ -101,7 +102,9 @@ export class DelegateHandler implements SkillHandler {
       Number.isInteger(timeout_ms) &&
       timeout_ms > 0 &&
       Number.isFinite(timeout_ms);
-    const specialistTimeoutMs = isValidTimeout ? (timeout_ms as number) : (ctx.defaultDelegateTimeoutMs ?? DEFAULT_SPECIALIST_TIMEOUT_MS);
+    const specialistTimeoutMs = clampDelegateWaitTimeoutMs(
+      isValidTimeout ? (timeout_ms as number) : (ctx.defaultDelegateTimeoutMs ?? DEFAULT_SPECIALIST_TIMEOUT_MS),
+    );
 
     if (timeout_ms !== undefined && !isValidTimeout) {
       ctx.log.warn(
@@ -312,7 +315,11 @@ export class DelegateHandler implements SkillHandler {
             __structuredDelegateFailure: true,
             agent,
             reason: 'timeout',
-            retryable: true,
+            // Non-retryable: the specialist may still be running (possibly_succeeded below).
+            // A second delegation risks concurrent duplicate side effects — worse than
+            // escalating a task that turned out dead. Auto-retry would only help the rare
+            // "specialist actually died" case at the cost of duplicate emails in prod.
+            retryable: false,
           } satisfies StructuredDelegateFailure);
         }
       }, specialistTimeoutMs);

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "delegate",
   "description": "Delegate a task to a specialist agent. Use this when the user's request requires specialized expertise (research, expense tracking, etc.). Provide the specialist's name and a clear task description.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -24,11 +24,12 @@
     "retryable": "boolean?",
     "errorType": "string?",
     "message": "string?",
+    "possibly_succeeded": "boolean?",
     "escalated": "boolean?"
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 660000,
+  "timeout": 900000,
   "capabilities": [
     "bus",
     "agentRegistry"

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "delegate",
   "description": "Delegate a task to a specialist agent. Use this when the user's request requires specialized expertise (research, expense tracking, etc.). Provide the specialist's name and a clear task description.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/src/agents/delegate-timeout.test.ts
+++ b/src/agents/delegate-timeout.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { computeDelegateTimeoutMs } from './delegate-timeout.js';
+
+describe('computeDelegateTimeoutMs', () => {
+  it('adds 25% headroom capped at three minutes', () => {
+    expect(computeDelegateTimeoutMs(600)).toBe(750_000);
+    expect(computeDelegateTimeoutMs(360)).toBe(450_000);
+    expect(computeDelegateTimeoutMs(120)).toBe(150_000);
+  });
+
+  it('covers representative reconciliation duration with a 10-minute expected hint', () => {
+    const nineMinutesMs = 9 * 60 * 1000;
+    expect(computeDelegateTimeoutMs(600)).toBeGreaterThanOrEqual(nineMinutesMs);
+  });
+
+  it('rejects invalid duration hints', () => {
+    expect(() => computeDelegateTimeoutMs(0)).toThrow(RangeError);
+    expect(() => computeDelegateTimeoutMs(-1)).toThrow(RangeError);
+    expect(() => computeDelegateTimeoutMs(Number.NaN)).toThrow(RangeError);
+  });
+});

--- a/src/agents/delegate-timeout.test.ts
+++ b/src/agents/delegate-timeout.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { computeDelegateTimeoutMs } from './delegate-timeout.js';
+import {
+  computeDelegateTimeoutMs,
+  clampDelegateWaitTimeoutMs,
+  DELEGATE_SKILL_OUTER_TIMEOUT_MS,
+} from './delegate-timeout.js';
 
 describe('computeDelegateTimeoutMs', () => {
   it('adds 25% headroom capped at three minutes', () => {
@@ -10,7 +14,14 @@ describe('computeDelegateTimeoutMs', () => {
 
   it('caps headroom at three minutes for long expected durations', () => {
     // 0.25 * 3000 = 750s of headroom, which exceeds the 180s cap.
-    expect(computeDelegateTimeoutMs(3000)).toBe((3000 + 180) * 1000);
+    expect(computeDelegateTimeoutMs(3000)).toBe(DELEGATE_SKILL_OUTER_TIMEOUT_MS - 1);
+  });
+
+  it('clamps wait timeout strictly below delegate skill outer timeout', () => {
+    // 800 + 180 = 980s would exceed the 900s outer skill budget.
+    expect(computeDelegateTimeoutMs(800)).toBe(DELEGATE_SKILL_OUTER_TIMEOUT_MS - 1);
+    // 720 + 180 = 900s exactly — must still stay below the outer timeout.
+    expect(computeDelegateTimeoutMs(720)).toBe(DELEGATE_SKILL_OUTER_TIMEOUT_MS - 1);
   });
 
   it('covers representative reconciliation duration with a 10-minute expected hint', () => {
@@ -22,5 +33,15 @@ describe('computeDelegateTimeoutMs', () => {
     expect(() => computeDelegateTimeoutMs(0)).toThrow(RangeError);
     expect(() => computeDelegateTimeoutMs(-1)).toThrow(RangeError);
     expect(() => computeDelegateTimeoutMs(Number.NaN)).toThrow(RangeError);
+  });
+});
+
+describe('clampDelegateWaitTimeoutMs', () => {
+  it('passes through values below the outer timeout', () => {
+    expect(clampDelegateWaitTimeoutMs(750_000)).toBe(750_000);
+  });
+
+  it('rejects non-positive values', () => {
+    expect(() => clampDelegateWaitTimeoutMs(0)).toThrow(RangeError);
   });
 });

--- a/src/agents/delegate-timeout.test.ts
+++ b/src/agents/delegate-timeout.test.ts
@@ -8,6 +8,11 @@ describe('computeDelegateTimeoutMs', () => {
     expect(computeDelegateTimeoutMs(120)).toBe(150_000);
   });
 
+  it('caps headroom at three minutes for long expected durations', () => {
+    // 0.25 * 3000 = 750s of headroom, which exceeds the 180s cap.
+    expect(computeDelegateTimeoutMs(3000)).toBe((3000 + 180) * 1000);
+  });
+
   it('covers representative reconciliation duration with a 10-minute expected hint', () => {
     const nineMinutesMs = 9 * 60 * 1000;
     expect(computeDelegateTimeoutMs(600)).toBeGreaterThanOrEqual(nineMinutesMs);

--- a/src/agents/delegate-timeout.test.ts
+++ b/src/agents/delegate-timeout.test.ts
@@ -1,11 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import {
   computeDelegateTimeoutMs,
   clampDelegateWaitTimeoutMs,
   DELEGATE_SKILL_OUTER_TIMEOUT_MS,
+  DELEGATE_SKILL_OUTER_TIMEOUT_MARGIN_MS,
 } from './delegate-timeout.js';
 
 describe('computeDelegateTimeoutMs', () => {
+  it('matches skills/delegate/skill.json outer timeout', () => {
+    const manifestPath = join(import.meta.dirname, '../../skills/delegate/skill.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { timeout: number };
+    expect(DELEGATE_SKILL_OUTER_TIMEOUT_MS).toBe(manifest.timeout);
+  });
+
   it('adds 25% headroom capped at three minutes', () => {
     expect(computeDelegateTimeoutMs(600)).toBe(750_000);
     expect(computeDelegateTimeoutMs(360)).toBe(450_000);
@@ -14,14 +23,15 @@ describe('computeDelegateTimeoutMs', () => {
 
   it('caps headroom at three minutes for long expected durations', () => {
     // 0.25 * 3000 = 750s of headroom, which exceeds the 180s cap.
-    expect(computeDelegateTimeoutMs(3000)).toBe(DELEGATE_SKILL_OUTER_TIMEOUT_MS - 1);
+    expect(computeDelegateTimeoutMs(3000)).toBe(DELEGATE_SKILL_OUTER_TIMEOUT_MS - DELEGATE_SKILL_OUTER_TIMEOUT_MARGIN_MS);
   });
 
-  it('clamps wait timeout strictly below delegate skill outer timeout', () => {
+  it('clamps wait timeout below delegate skill outer timeout with margin', () => {
+    const clamped = DELEGATE_SKILL_OUTER_TIMEOUT_MS - DELEGATE_SKILL_OUTER_TIMEOUT_MARGIN_MS;
     // 800 + 180 = 980s would exceed the 900s outer skill budget.
-    expect(computeDelegateTimeoutMs(800)).toBe(DELEGATE_SKILL_OUTER_TIMEOUT_MS - 1);
+    expect(computeDelegateTimeoutMs(800)).toBe(clamped);
     // 720 + 180 = 900s exactly — must still stay below the outer timeout.
-    expect(computeDelegateTimeoutMs(720)).toBe(DELEGATE_SKILL_OUTER_TIMEOUT_MS - 1);
+    expect(computeDelegateTimeoutMs(720)).toBe(clamped);
   });
 
   it('covers representative reconciliation duration with a 10-minute expected hint', () => {
@@ -37,7 +47,7 @@ describe('computeDelegateTimeoutMs', () => {
 });
 
 describe('clampDelegateWaitTimeoutMs', () => {
-  it('passes through values below the outer timeout', () => {
+  it('passes through values below the outer timeout margin', () => {
     expect(clampDelegateWaitTimeoutMs(750_000)).toBe(750_000);
   });
 

--- a/src/agents/delegate-timeout.ts
+++ b/src/agents/delegate-timeout.ts
@@ -8,8 +8,11 @@
 // (skills/delegate/skill.json "timeout") so the handler can emit a structured failure
 // before the execution layer kills the invocation.
 
-/** Must stay in sync with skills/delegate/skill.json "timeout". */
+/** Must stay in sync with skills/delegate/skill.json "timeout" — enforced by test. */
 export const DELEGATE_SKILL_OUTER_TIMEOUT_MS = 900_000;
+
+/** Margin below the outer skill timeout so the inner wait resolves first under load. */
+export const DELEGATE_SKILL_OUTER_TIMEOUT_MARGIN_MS = 5_000;
 
 /** Maximum extra wait beyond expected_duration_seconds. */
 const DELEGATE_TIMEOUT_HEADROOM_CAP_SECONDS = 180;
@@ -21,11 +24,15 @@ const DELEGATE_TIMEOUT_HEADROOM_CAP_SECONDS = 180;
 export function clampDelegateWaitTimeoutMs(
   timeoutMs: number,
   outerTimeoutMs: number = DELEGATE_SKILL_OUTER_TIMEOUT_MS,
+  marginMs: number = DELEGATE_SKILL_OUTER_TIMEOUT_MARGIN_MS,
 ): number {
   if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
     throw new RangeError('timeoutMs must be a positive integer');
   }
-  return Math.min(timeoutMs, outerTimeoutMs - 1);
+  if (!Number.isInteger(marginMs) || marginMs <= 0 || marginMs >= outerTimeoutMs) {
+    throw new RangeError('marginMs must be a positive integer less than outerTimeoutMs');
+  }
+  return Math.min(timeoutMs, outerTimeoutMs - marginMs);
 }
 
 /**

--- a/src/agents/delegate-timeout.ts
+++ b/src/agents/delegate-timeout.ts
@@ -1,0 +1,28 @@
+// delegate-timeout.ts — compute delegate wait timeout from expected duration (#1288).
+//
+// Specialists can exceed their nominal expected_duration_seconds (e.g. reconciliation
+// runs 5–9 min against a 4–10 min hint). Add bounded headroom so the coordinator
+// does not time out a healthy in-flight delegation.
+
+/** Maximum extra wait beyond expected_duration_seconds. */
+const DELEGATE_TIMEOUT_HEADROOM_CAP_SECONDS = 180;
+
+/**
+ * Compute delegate wait timeout in milliseconds from an expected duration in seconds.
+ * Adds up to 25% headroom, capped at three minutes.
+ */
+export function computeDelegateTimeoutMs(expectedDurationSeconds: number): number {
+  if (!Number.isFinite(expectedDurationSeconds) || expectedDurationSeconds <= 0) {
+    throw new RangeError('expectedDurationSeconds must be a positive finite number');
+  }
+  const headroomSeconds = Math.min(
+    Math.ceil(expectedDurationSeconds * 0.25),
+    DELEGATE_TIMEOUT_HEADROOM_CAP_SECONDS,
+  );
+  const totalSeconds = expectedDurationSeconds + headroomSeconds;
+  const timeoutMs = totalSeconds * 1000;
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError('computed delegate timeout is not a valid positive integer');
+  }
+  return timeoutMs;
+}

--- a/src/agents/delegate-timeout.ts
+++ b/src/agents/delegate-timeout.ts
@@ -3,13 +3,34 @@
 // Specialists can exceed their nominal expected_duration_seconds (e.g. reconciliation
 // runs 5–9 min against a 4–10 min hint). Add bounded headroom so the coordinator
 // does not time out a healthy in-flight delegation.
+//
+// The wait timeout must resolve inside the delegate skill's outer execution timeout
+// (skills/delegate/skill.json "timeout") so the handler can emit a structured failure
+// before the execution layer kills the invocation.
+
+/** Must stay in sync with skills/delegate/skill.json "timeout". */
+export const DELEGATE_SKILL_OUTER_TIMEOUT_MS = 900_000;
 
 /** Maximum extra wait beyond expected_duration_seconds. */
 const DELEGATE_TIMEOUT_HEADROOM_CAP_SECONDS = 180;
 
 /**
+ * Clamp a delegate wait timeout so the handler's structured timeout fires before the
+ * execution layer's outer skill timeout.
+ */
+export function clampDelegateWaitTimeoutMs(
+  timeoutMs: number,
+  outerTimeoutMs: number = DELEGATE_SKILL_OUTER_TIMEOUT_MS,
+): number {
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError('timeoutMs must be a positive integer');
+  }
+  return Math.min(timeoutMs, outerTimeoutMs - 1);
+}
+
+/**
  * Compute delegate wait timeout in milliseconds from an expected duration in seconds.
- * Adds up to 25% headroom, capped at three minutes.
+ * Adds up to 25% headroom, capped at three minutes, then clamped below the skill outer timeout.
  */
 export function computeDelegateTimeoutMs(expectedDurationSeconds: number): number {
   if (!Number.isFinite(expectedDurationSeconds) || expectedDurationSeconds <= 0) {
@@ -24,5 +45,5 @@ export function computeDelegateTimeoutMs(expectedDurationSeconds: number): numbe
   if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
     throw new RangeError('computed delegate timeout is not a valid positive integer');
   }
-  return timeoutMs;
+  return clampDelegateWaitTimeoutMs(timeoutMs);
 }

--- a/src/agents/delegation-guard.test.ts
+++ b/src/agents/delegation-guard.test.ts
@@ -17,24 +17,14 @@ describe('DelegationGuard', () => {
     expect(guard.shouldEscalate(key)).toBe(true);
   });
 
-  it('allows one retry for timeout failures then blocks', () => {
+  it('blocks immediately after a timeout failure', () => {
     const guard = new DelegationGuard();
     guard.recordInvocation(key);
     guard.recordFailure(key, {
       agent: 'social-media',
       reason: 'timeout',
-      retryable: true,
+      retryable: false,
       message: 'delegate wait timed out',
-    });
-    expect(guard.canAttempt(key)).toBe(true);
-    expect(guard.shouldEscalate(key)).toBe(false);
-
-    guard.recordInvocation(key);
-    guard.recordFailure(key, {
-      agent: 'social-media',
-      reason: 'timeout',
-      retryable: true,
-      message: 'delegate wait timed out again',
     });
     expect(guard.canAttempt(key)).toBe(false);
     expect(guard.shouldEscalate(key)).toBe(true);

--- a/src/agents/delegation-guard.test.ts
+++ b/src/agents/delegation-guard.test.ts
@@ -17,6 +17,29 @@ describe('DelegationGuard', () => {
     expect(guard.shouldEscalate(key)).toBe(true);
   });
 
+  it('allows one retry for timeout failures then blocks', () => {
+    const guard = new DelegationGuard();
+    guard.recordInvocation(key);
+    guard.recordFailure(key, {
+      agent: 'social-media',
+      reason: 'timeout',
+      retryable: true,
+      message: 'delegate wait timed out',
+    });
+    expect(guard.canAttempt(key)).toBe(true);
+    expect(guard.shouldEscalate(key)).toBe(false);
+
+    guard.recordInvocation(key);
+    guard.recordFailure(key, {
+      agent: 'social-media',
+      reason: 'timeout',
+      retryable: true,
+      message: 'delegate wait timed out again',
+    });
+    expect(guard.canAttempt(key)).toBe(false);
+    expect(guard.shouldEscalate(key)).toBe(true);
+  });
+
   it('allows one retry for retryable failures then blocks', () => {
     const guard = new DelegationGuard();
     guard.recordInvocation(key);

--- a/src/agents/delegation-guard.ts
+++ b/src/agents/delegation-guard.ts
@@ -18,6 +18,8 @@ export interface DelegationFailureInfo {
   reason: AgentResponseFailureReason | string;
   retryable: boolean;
   message: string;
+  /** Set when a delegate wait timed out but the specialist may still be running (#1288). */
+  possiblySucceeded?: boolean;
 }
 
 interface DelegationEntry {
@@ -115,6 +117,7 @@ export function parseDelegateFailureData(data: unknown, logger?: Logger): Delega
     message: record['message'],
     ...(record['blocked'] === true && { blocked: true }),
     ...(record['escalated'] === true && { escalated: true }),
+    ...(record['possibly_succeeded'] === true && { possiblySucceeded: true }),
   };
 }
 
@@ -135,6 +138,7 @@ export async function escalateDelegationFailure(
     retryable: failure.retryable,
     message: failure.message,
     task: failure.task,
+    ...(failure.possiblySucceeded === true && { possiblySucceeded: true }),
   });
   const rendered = renderEscalation(escalation);
   const title = escalation.failureMode === 'blocked_on_human'

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1049,25 +1049,13 @@ export class AgentRuntime {
               }
 
               if (durationSeconds !== undefined) {
-                let timeoutMs: number;
                 try {
-                  timeoutMs = computeDelegateTimeoutMs(durationSeconds);
+                  const timeoutMs = computeDelegateTimeoutMs(durationSeconds);
+                  skillInput = { ...inputRecord, timeout_ms: timeoutMs };
                 } catch (err) {
                   logger.warn(
                     { err, agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds },
                     'Could not compute delegate timeout from expectedDurationSeconds — skipping injection; delegate will use default timeout',
-                  );
-                  timeoutMs = NaN;
-                }
-                // Guard against non-integer results from floating-point expectedDurationSeconds
-                // stored via out-of-band DB writes — the delegate handler would silently fall back,
-                // but we log here so the root cause is visible in audit logs.
-                if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
-                  skillInput = { ...inputRecord, timeout_ms: timeoutMs };
-                } else if (Number.isFinite(timeoutMs)) {
-                  logger.warn(
-                    { agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds, computedTimeoutMs: timeoutMs },
-                    'Computed timeout_ms from expectedDurationSeconds is not a valid positive integer — skipping injection; delegate will use default timeout',
                   );
                 }
               }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -50,6 +50,7 @@ import {
   parseDelegateFailureData,
   type DelegationFailureInfo,
 } from './delegation-guard.js';
+import { computeDelegateTimeoutMs } from './delegate-timeout.js';
 import type { WorkingDocsRepo } from '../db/working-docs-repo.js';
 import type { TaskRepo } from '../db/task-repo.js';
 import {
@@ -1048,13 +1049,22 @@ export class AgentRuntime {
               }
 
               if (durationSeconds !== undefined) {
-                const timeoutMs = durationSeconds * 1000;
+                let timeoutMs: number;
+                try {
+                  timeoutMs = computeDelegateTimeoutMs(durationSeconds);
+                } catch (err) {
+                  logger.warn(
+                    { err, agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds },
+                    'Could not compute delegate timeout from expectedDurationSeconds — skipping injection; delegate will use default timeout',
+                  );
+                  timeoutMs = NaN;
+                }
                 // Guard against non-integer results from floating-point expectedDurationSeconds
                 // stored via out-of-band DB writes — the delegate handler would silently fall back,
                 // but we log here so the root cause is visible in audit logs.
                 if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
                   skillInput = { ...inputRecord, timeout_ms: timeoutMs };
-                } else {
+                } else if (Number.isFinite(timeoutMs)) {
                   logger.warn(
                     { agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds, computedTimeoutMs: timeoutMs },
                     'Computed timeout_ms from expectedDurationSeconds is not a valid positive integer — skipping injection; delegate will use default timeout',

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1358,6 +1358,7 @@ export class AgentRuntime {
           retryable: false,
           message: pendingDelegationEscalation.message,
           escalated: pendingDelegationEscalation.escalated,
+          ...(pendingDelegationEscalation.possiblySucceeded === true && { possibly_succeeded: true }),
         });
 
         if (memory) {

--- a/src/agents/task-escalation.test.ts
+++ b/src/agents/task-escalation.test.ts
@@ -148,6 +148,23 @@ describe('buildDelegationEscalation (#1267)', () => {
     expect(e.reason).toBe('maxTurns');
     expect(e.blocker).toBe('research');
   });
+
+  it('uses the delegate message and cautious actions when timeout possibly succeeded (#1288)', () => {
+    const message = "Specialist 'T2125-expense-tracker' did not respond within the delegate wait window — the task may still be running";
+    const e = buildDelegationEscalation({
+      agent: 'T2125-expense-tracker',
+      reason: 'timeout',
+      retryable: false,
+      message,
+      task: 'Run June reconciliation',
+      possiblySucceeded: true,
+    });
+
+    expect(e.failureMode).toBe('agent_incomplete');
+    expect(e.headline).toBe(message);
+    expect(e.suggestedActions.join(' ')).toContain('may still be running');
+    expect(e.suggestedActions.join(' ')).toContain('Do not re-delegate');
+  });
 });
 
 describe('renderEscalation (#1267)', () => {

--- a/src/agents/task-escalation.ts
+++ b/src/agents/task-escalation.ts
@@ -85,6 +85,8 @@ export interface DelegationEscalationInput {
   message: string;
   /** The original delegated task text. */
   task: string;
+  /** Delegate wait timed out but the specialist may still be running (#1288). */
+  possiblySucceeded?: boolean;
 }
 
 function ceilingFailureMode(reason: CircuitBreachReason): EscalationFailureMode {
@@ -234,7 +236,16 @@ export function buildDelegationEscalation(input: DelegationEscalationInput): Tas
 
   const headline = failureMode === 'blocked_on_human'
     ? `Blocked on a person: ${input.agent} cannot proceed without input — ${input.message}`
-    : `${input.agent} could not finish the delegated work (${input.reason}).`;
+    : input.reason === 'timeout' && input.possiblySucceeded
+      ? input.message
+      : `${input.agent} could not finish the delegated work (${input.reason}).`;
+
+  const suggested = input.reason === 'timeout' && input.possiblySucceeded
+    ? [
+      'The specialist may still be running — check whether it already delivered before taking further action.',
+      'Do not re-delegate the same work; the original run may still be in flight.',
+    ]
+    : suggestedActions(failureMode, input.reason, { agent: input.agent });
 
   return {
     failureMode,
@@ -243,7 +254,7 @@ export function buildDelegationEscalation(input: DelegationEscalationInput): Tas
     headline,
     // The agent is the "blocker" for an incomplete; a human-block has no structured "who".
     blocker: failureMode === 'agent_incomplete' ? input.agent : undefined,
-    suggestedActions: suggestedActions(failureMode, input.reason, { agent: input.agent }),
+    suggestedActions: suggested,
   };
 }
 

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -75,7 +75,8 @@ export type AgentResponseFailureReason =
   | 'maxConsecutiveErrors'
   | 'tool_error'
   | 'api_error'
-  | 'blocked';
+  | 'blocked'
+  | 'timeout';
 
 interface AgentResponsePayload {
   agentId: string;

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -2938,6 +2938,65 @@ describe('AgentRuntime chatWithRetry', () => {
       );
     });
 
+    it('clamps injected timeout_ms below delegate skill outer timeout (#1288)', async () => {
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+
+      let callCount = 0;
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{ id: 'call-delegate-clamp', name: 'delegate', input: { agent: 'essay-editor', task: 'long job' } }],
+              usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+          }
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
+        }),
+      };
+
+      const { AgentRegistry } = await import('../../../src/agents/agent-registry.js');
+      const agentRegistry = new AgentRegistry();
+      agentRegistry.register('essay-editor', { role: 'specialist', description: 'Essay editor', expectedDurationSeconds: 800 });
+
+      const mockExecution = {
+        invoke: vi.fn().mockResolvedValue({ success: true, data: { response: 'Done', agent: 'essay-editor' } }),
+      } as unknown as ExecutionLayer;
+
+      const agent = new AgentRuntime({
+        agentId: 'coordinator',
+        systemPrompt: 'You are an assistant.',
+        provider,
+        resolvedModel: 'mock-model',
+        bus,
+        logger,
+        executionLayer: mockExecution,
+        skillToolDefs: [{ name: 'delegate', description: 'Delegate', input_schema: { type: 'object' as const, properties: { agent: { type: 'string' }, task: { type: 'string' } }, required: ['agent', 'task'] } }],
+        agentRegistry,
+      });
+      agent.register();
+
+      await bus.publish('dispatch', createAgentTask({
+        agentId: 'coordinator',
+        conversationId: 'conv-timeout-clamp',
+        channelId: 'cli',
+        senderId: 'user',
+        content: 'Run long job',
+        parentEventId: 'parent-timeout-clamp',
+      }));
+
+      expect(mockExecution.invoke).toHaveBeenCalledWith(
+        'delegate',
+        expect.objectContaining({ timeout_ms: 899_999 }),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
     it('falls back to default when agent has no expectedDurationSeconds', async () => {
       const logger = createLogger('error');
       const bus = new EventBus(logger);
@@ -3826,7 +3885,7 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
     expect(response.payload.content).toContain('"escalated":true');
   });
 
-  it('records delegate timeout as retryable failure and escalates after two attempts (#1288)', async () => {
+  it('records delegate timeout as non-retryable failure and escalates immediately (#1288)', async () => {
     const logger = createLogger('error');
     const bus = new EventBus(logger);
 
@@ -3869,7 +3928,7 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
               agent: delegateAgent,
               failed: true,
               reason: 'timeout',
-              retryable: true,
+              retryable: false,
               possibly_succeeded: true,
               message: "Specialist 'T2125-expense-tracker' did not respond within the delegate wait window — the task may still be running",
             },
@@ -3923,9 +3982,9 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
       parentEventId: 'inbound-delegate-timeout',
     }));
 
-    expect(delegateInvokeCount.n).toBe(2);
+    expect(delegateInvokeCount.n).toBe(1);
     expect(taskCreateCount.n).toBe(1);
-    expect(provider.chat).toHaveBeenCalledTimes(2);
+    expect(provider.chat).toHaveBeenCalledTimes(1);
 
     expect(agentResponses).toHaveLength(1);
     const response = agentResponses[0]!;

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -2804,7 +2804,7 @@ describe('AgentRuntime chatWithRetry', () => {
       // Verify the execution layer received the injected timeout_ms
       expect(mockExecution.invoke).toHaveBeenCalledWith(
         'delegate',
-        expect.objectContaining({ timeout_ms: 600000 }),
+        expect.objectContaining({ timeout_ms: 750_000 }),
         undefined,
         expect.any(Object),
       );
@@ -2929,10 +2929,10 @@ describe('AgentRuntime chatWithRetry', () => {
       });
       await bus.publish('dispatch', task);
 
-      // Scheduler's 120s (120000ms) must win over agent YAML's 600s (600000ms)
+      // Scheduler's 120s (+25% headroom = 150s) must win over agent YAML's 600s
       expect(mockExecution.invoke).toHaveBeenCalledWith(
         'delegate',
-        expect.objectContaining({ timeout_ms: 120000 }),
+        expect.objectContaining({ timeout_ms: 150_000 }),
         undefined,
         expect.any(Object),
       );
@@ -3054,7 +3054,7 @@ describe('AgentRuntime chatWithRetry', () => {
       // AND the injected timeout_ms (proving registry lookup worked after stripping @)
       expect(mockExecution.invoke).toHaveBeenCalledWith(
         'delegate',
-        expect.objectContaining({ agent: 'essay-editor', timeout_ms: 600000 }),
+        expect.objectContaining({ agent: 'essay-editor', timeout_ms: 750_000 }),
         undefined,
         expect.any(Object),
       );
@@ -3823,6 +3823,114 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
     const response = agentResponses[0]!;
     expect(response.payload.content).toContain('delegation_failure');
     expect(response.payload.content).toContain('api_error');
+    expect(response.payload.content).toContain('"escalated":true');
+  });
+
+  it('records delegate timeout as retryable failure and escalates after two attempts (#1288)', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const delegateInvokeCount = { n: 0 };
+    const taskCreateCount = { n: 0 };
+
+    const mockExecution = {
+      invoke: vi.fn(async (skillName: string, input: Record<string, unknown>, _caller: unknown, options?: { delegationGuard?: import('../../../src/agents/delegation-guard.js').DelegationGuard }) => {
+        if (skillName === 'task-create') {
+          taskCreateCount.n += 1;
+          return { success: true, data: { task_id: 'escalation-task-timeout' } };
+        }
+        if (skillName === 'delegate') {
+          const delegateAgent = typeof input['agent'] === 'string' ? input['agent'] : '';
+          const delegateTask = typeof input['task'] === 'string' ? input['task'] : '';
+          const dKey = delegationKey(delegateAgent, delegateTask);
+          const guard = options?.delegationGuard;
+          if (guard && !guard.canAttempt(dKey)) {
+            const prior = guard.getFailure(dKey);
+            return {
+              success: true,
+              data: {
+                agent: delegateAgent,
+                failed: true,
+                blocked: true,
+                reason: prior?.reason ?? 'blocked',
+                retryable: false,
+                message: prior?.message ?? `Re-delegation to '${delegateAgent}' is blocked for this task.`,
+                escalated: guard.isEscalated(dKey),
+              },
+            };
+          }
+          if (guard) {
+            guard.recordInvocation(dKey);
+          }
+          delegateInvokeCount.n += 1;
+          return {
+            success: true,
+            data: {
+              agent: delegateAgent,
+              failed: true,
+              reason: 'timeout',
+              retryable: true,
+              possibly_succeeded: true,
+              message: "Specialist 'T2125-expense-tracker' did not respond within the delegate wait window — the task may still be running",
+            },
+          };
+        }
+        return { success: true, data: {} };
+      }),
+      getToolDefinitions: vi.fn(() => [delegateToolDef]),
+    } as unknown as ExecutionLayer;
+
+    let chatRound = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async () => {
+        chatRound += 1;
+        return {
+          type: 'tool_use' as const,
+          toolCalls: [
+            { id: `call-delegate-timeout-${chatRound}`, name: 'delegate', input: { agent: 'T2125-expense-tracker', task: 'Run June reconciliation' } },
+          ],
+          usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      }),
+    };
+
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: [delegateToolDef],
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-delegate-timeout',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Run June reconciliation',
+      parentEventId: 'inbound-delegate-timeout',
+    }));
+
+    expect(delegateInvokeCount.n).toBe(2);
+    expect(taskCreateCount.n).toBe(1);
+    expect(provider.chat).toHaveBeenCalledTimes(2);
+
+    expect(agentResponses).toHaveLength(1);
+    const response = agentResponses[0]!;
+    expect(response.payload.content).toContain('delegation_failure');
+    expect(response.payload.content).toContain('timeout');
     expect(response.payload.content).toContain('"escalated":true');
   });
 

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -2991,7 +2991,7 @@ describe('AgentRuntime chatWithRetry', () => {
 
       expect(mockExecution.invoke).toHaveBeenCalledWith(
         'delegate',
-        expect.objectContaining({ timeout_ms: 899_999 }),
+        expect.objectContaining({ timeout_ms: 895_000 }),
         undefined,
         expect.any(Object),
       );
@@ -3990,6 +3990,7 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
     const response = agentResponses[0]!;
     expect(response.payload.content).toContain('delegation_failure');
     expect(response.payload.content).toContain('timeout');
+    expect(response.payload.content).toContain('"possibly_succeeded":true');
     expect(response.payload.content).toContain('"escalated":true');
   });
 

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -23,6 +23,56 @@ function makeCtx(
 describe('DelegateHandler', () => {
   const handler = new DelegateHandler();
 
+  it('returns structured retryable failure when specialist wait times out (#1288)', async () => {
+    const { vi } = await import('vitest');
+    vi.useFakeTimers();
+
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+    agentRegistry.register('slow-specialist', { role: 'specialist', description: 'Slow' });
+    const bus = new EventBus(logger);
+
+    bus.subscribe('agent.task', 'agent', async (event) => {
+      if (event.type === 'agent.task' && event.payload.agentId === 'slow-specialist') {
+        await new Promise((resolve) => setTimeout(resolve, 60_000));
+        const { createAgentResponse } = await import('../../../src/bus/events.js');
+        await bus.publish('agent', createAgentResponse({
+          agentId: 'slow-specialist',
+          conversationId: event.payload.conversationId,
+          content: 'Done after delay',
+          parentEventId: event.id,
+        }));
+      }
+    });
+
+    const executePromise = handler.execute(makeCtx(
+      { agent: 'slow-specialist', task: 'Long reconciliation', timeout_ms: 1000 },
+      { bus, agentRegistry },
+    ));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await executePromise;
+    vi.useRealTimers();
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        agent: string;
+        failed: boolean;
+        reason: string;
+        retryable: boolean;
+        possibly_succeeded?: boolean;
+        message: string;
+      };
+      expect(data.failed).toBe(true);
+      expect(data.agent).toBe('slow-specialist');
+      expect(data.reason).toBe('timeout');
+      expect(data.retryable).toBe(true);
+      expect(data.possibly_succeeded).toBe(true);
+      expect(data.message).toContain('did not respond');
+    }
+  });
+
   it('returns failure when bus is not available', async () => {
     const result = await handler.execute(makeCtx({ agent: 'research-analyst', task: 'do something' }));
     expect(result.success).toBe(false);

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -67,7 +67,7 @@ describe('DelegateHandler', () => {
       expect(data.failed).toBe(true);
       expect(data.agent).toBe('slow-specialist');
       expect(data.reason).toBe('timeout');
-      expect(data.retryable).toBe(true);
+      expect(data.retryable).toBe(false);
       expect(data.possibly_succeeded).toBe(true);
       expect(data.message).toContain('did not respond');
     }


### PR DESCRIPTION
## Summary

Closes #1288.

When a delegate wait times out, the in-flight specialist keeps running but the coordinator previously received an unstructured `{ success: false, error }` result. That bypassed `DelegationGuard`, so the LLM could re-delegate the same side-effecting task indefinitely — producing duplicate reconciliation emails in prod.

This PR adds defense in depth:

1. **Structured timeout failure** — the delegate handler now returns `failed{reason:timeout, retryable:true, possibly_succeeded:true}` so `DelegationGuard` records the outcome and caps identical re-delegations at 2 attempts before escalating.
2. **Wider effective timeout** — `computeDelegateTimeoutMs()` adds up to 25% headroom (capped at 3 min) when injecting `timeout_ms` from `expected_duration_seconds`, so a 10-minute specialist hint yields a 12.5-minute wait (covers observed 9-minute reconciliation runs).
3. **Delegate skill outer timeout** raised to 15 min so the execution layer does not kill the delegate skill before the widened wait completes.
4. **Coordinator prompt** guidance for `possibly_succeeded` timeouts — do not re-delegate or claim definite failure while the specialist may still be running.

## Acceptance criteria

- [x] Delegate timeout records a failure in `DelegationGuard`; a 3rd identical re-delegation within one coordinator turn is blocked and escalated
- [x] Long-running specialists receive a timeout derived from `expected_duration_seconds` with headroom (600s → 750s wait, ≥ 9 min)
- [x] Regression tests for structured timeout failure and guard escalation after two timeout attempts
- [ ] (Stretch) Cancel timed-out specialist work or make reconciliation idempotent — not in this PR; requires bus unsubscribe/abort (#1288 deeper fix)

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/agents/delegate-timeout.test.ts src/agents/delegation-guard.test.ts tests/unit/skills/delegate.test.ts`
- [x] `pnpm exec vitest run tests/unit/agents/runtime.test.ts -t "delegation|1288|delegate timeout injection"`
