### PR TITLE
fix: hard-block outbound email to all-no-reply recipients (#1302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Gate C principal carve-out (#1301)** — outbound actions whose recipient set is exclusively the structurally-verified principal no longer escalate on the third-party-facing axis; irreversible actions and mixed recipient sets still escalate. Parser is allowlisted to `email-send`/`signal-send` and fails closed on unknown recipient shapes. Spam backpressure deferred to #1320.
-
+- **Outbound gateway** — email sends whose recipients are all no-reply/automated addresses are now hard-blocked with an audit note instead of dispatched to a dead-end address. (#1302)
 - **Task-wake CEO questions** — task-wake sends register durable bindings (7-day TTL); the coordinator persists answers via `context-bridge-release` with `reply` after judging relevance (not structural auto-bind). When several asks are outstanding, the coordinator must match by content. (#1299)
 - **Past-due milestone subtasks** — past-due tasks wake immediately instead of being auto-completed. (#1299)
 - **Migration 070** — now a no-op; the `UPDATE audit_log` data-fix tripped the append-only trigger and crash-looped boot on prod. (#453)

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -24,6 +24,7 @@ import type { NylasClient, NylasMessage, NylasFolder, ListMessagesOptions, SendE
 import { readAttachmentFiles, MAX_ATTACHMENT_BYTES, type OutboundAttachmentInput } from './_shared/read-attachments.js';
 import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
 import type { ContactService } from '../contacts/contact-service.js';
+import { classifyEmailSender } from '../contacts/contact-service.js';
 import type { ContactTier, ChannelIdentity } from '../contacts/types.js';
 import {
   isPrincipalEmail as checkPrincipalEmail,
@@ -574,6 +575,63 @@ export class OutboundGateway {
 
     // The message body field differs between channel types.
     const messageBody = request.channel === 'email' ? request.body : request.message;
+
+    // ------------------------------------------------------------------
+    // Step 0.5: No-reply / automated recipient guard (email only, #1302)
+    // ------------------------------------------------------------------
+    // A no-reply address is a dead end: replying there is undeliverable, and it was a
+    // recurring source of mis-addressed sends — the coordinator narrating principal-
+    // directed status ("pending approval on your end") back down an automated-
+    // notification thread, auto-routed to the noreply@ sender (#1302).
+    //
+    // This is a *recipient* problem, not a *content* problem: the address cannot be
+    // fixed by rewriting, so we hard-block (like the Step-1 blocked-contact check
+    // below) rather than returning a rewrite-and-retry reason to the agent — which
+    // would only invite futile retries against an immutable recipient. We still record
+    // an outbound.blocked audit event so the suppression is visible, but we deliberately
+    // do NOT send the CEO an FYI (these automated notifications are routine; a per-drop
+    // alert would be noise — the audit log is the record).
+    //
+    // Predicate: block only when EVERY recipient classifies as automated (no deliverable
+    // human anywhere on the envelope). A normal send that merely CCs a noreply address
+    // still reaches its human recipients and is not blocked. Signal is exempt —
+    // recipients are phone numbers / group IDs, where "no-reply" has no meaning.
+    if (request.channel === 'email') {
+      const emailRecipients = this.buildFilterRecipients(request).recipients;
+      if (
+        emailRecipients.length > 0 &&
+        emailRecipients.every((r) => classifyEmailSender(r.email) === 'automated')
+      ) {
+        this.log.warn(
+          { channel: request.channel, recipientId: redactId(recipientId), rule: 'no-reply-recipient' },
+          'outbound-gateway: send blocked — all recipients are no-reply/automated addresses',
+        );
+        const blockId = `block_${randomUUID()}`;
+        try {
+          // scrubPii() because we run before Step 1.5 PII redaction — the audit event
+          // must never carry raw PII, matching the fail-closed redactor-error path below.
+          await this.bus.publish('dispatch', createOutboundBlocked({
+            blockId,
+            conversationId: '',
+            channelId: request.channel,
+            content: scrubPii(messageBody),
+            recipientId,
+            reason: 'no_reply_recipient',
+            findings: [{ rule: 'no-reply-recipient', detail: 'All recipients classify as automated/no-reply; message not deliverable' }],
+            parentEventId: '',
+          }));
+        } catch (publishErr) {
+          this.log.warn(
+            { publishErr, blockId },
+            'outbound-gateway: failed to publish outbound.blocked event for no-reply recipient — message is still blocked',
+          );
+        }
+        // Terse, terminal result — no blockedRules (that field is the content filter's
+        // "here is what to rewrite" affordance; omitting it signals a non-fixable
+        // recipient problem, discouraging retry loops).
+        return { success: false, blockedReason: 'Recipient is a no-reply/automated address; message not deliverable' };
+      }
+    }
 
     // ------------------------------------------------------------------
     // Step 1: Contact blocked check + trust level capture

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -355,6 +355,125 @@ describe('OutboundGateway', () => {
     expect(delivered!.parentEventId).toBe('outbound-msg-1');
   });
 
+  // ------------------------------------------------------------------
+  // No-reply / automated recipient guard (#1302)
+  // ------------------------------------------------------------------
+  // Regression: the coordinator's implicit reply to an inbound automated
+  // notification was auto-addressed back to the noreply@ sender, carrying
+  // principal-directed status ("pending approval on your end"). A no-reply
+  // address is a dead-end *recipient* problem — the gateway hard-blocks the send
+  // (like a blocked contact) instead of delivering to a dead address, and does so
+  // before the (expensive) content-filter LLM call.
+  describe('no-reply / automated recipient guard (#1302)', () => {
+    function makeGateway() {
+      return new OutboundGateway({
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
+        contactService: mocks.contactService,
+        contentFilter: mocks.contentFilter,
+        bus: mocks.bus,
+        principalIdentities: [makePrincipalIdentity('ceo@example.com')],
+        logger: mocks.logger,
+      });
+    }
+
+    it('blocks an email whose sole recipient is a no-reply address, without hitting Nylas or the filter', async () => {
+      const gateway = makeGateway();
+
+      const result = await gateway.send({
+        channel: 'email',
+        to: 'noreply@external-service.com',
+        subject: 'Re: your account',
+        body: 'The system put a hold on that. Pending approval on your end.',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.blockedReason).toBe(
+        'Recipient is a no-reply/automated address; message not deliverable',
+      );
+      // Hard block, not a content-rewrite affordance: no blockedRules for the agent
+      // to retry against (the recipient is immutable — retrying would be futile).
+      expect(result.blockedRules).toBeUndefined();
+      // Dropped before the transport and before the content-filter LLM call.
+      expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
+      expect(mocks.contentFilter.check).not.toHaveBeenCalled();
+    });
+
+    it('records an outbound.blocked audit event but does NOT send the CEO an FYI notification', async () => {
+      const gateway = makeGateway();
+
+      await gateway.send({
+        channel: 'email',
+        to: 'noreply@external-service.com',
+        subject: 'Re: your account',
+        body: 'principal-directed status narration',
+      });
+
+      const publishedTypes = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c) => (c[1] as BusEvent).type,
+      );
+      // Audit note required by the #1302 acceptance criteria.
+      expect(publishedTypes).toContain('outbound.blocked');
+      // Routine automated notifications: a per-drop CEO alert would be noise. No FYI.
+      expect(publishedTypes).not.toContain('outbound.notification');
+
+      const blocked = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls
+        .map((c) => c[1] as BusEvent)
+        .find((e) => e.type === 'outbound.blocked');
+      expect(blocked).toBeDefined();
+      if (blocked && blocked.type === 'outbound.blocked') {
+        expect(blocked.payload.reason).toBe('no_reply_recipient');
+        expect(blocked.payload.findings[0]!.rule).toBe('no-reply-recipient');
+      }
+    });
+
+    it.each([
+      'donotreply@service.com',
+      'do-not-reply@service.com',
+      'mailer-daemon@service.com',
+      'notifications@service.com',
+      'alerts@service.com',
+      'updates@service.com',
+      'bounces@service.com',
+    ])('blocks the full automated-classifier breadth: %s', async (address) => {
+      const gateway = makeGateway();
+
+      const result = await gateway.send({ channel: 'email', to: address, subject: 'x', body: 'y' });
+
+      expect(result.success).toBe(false);
+      expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('does NOT block a normal human recipient (falls through to filter + dispatch)', async () => {
+      const gateway = makeGateway();
+
+      const result = await gateway.send({
+        channel: 'email',
+        to: 'jane.doe@example.com',
+        subject: 'Hello',
+        body: 'Hi there',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mocks.contentFilter.check).toHaveBeenCalledOnce();
+      expect(mocks.nylasClient.sendMessage).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT block a mixed send that merely CCs a no-reply address (a human is still on it)', async () => {
+      const gateway = makeGateway();
+
+      const result = await gateway.send({
+        channel: 'email',
+        to: 'jane.doe@example.com',
+        cc: ['noreply@external-service.com'],
+        subject: 'Hello',
+        body: 'Hi there',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mocks.nylasClient.sendMessage).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('content filter', () => {
     it('blocks when filter rejects and does not call nylasClient for the original message', async () => {
       // The filter returns a blocked result — the gateway must stop here


### PR DESCRIPTION
## Summary

Closes #1302.

Processing an inbound automated notification from an external `noreply@…` sender, the coordinator's implicit reply was auto-addressed back to that no-reply address and carried principal-directed status ("pending approval on *your* end", "once *you* approve it I'll send the heads-up"). The Stage-2 LLM judge (`llm-judge-audience-leak`) blocked the send, so nothing leaked, but the mis-addressed reply should never have been produced.

**Root cause:** the coordinator's only implicit output for an inbound-email task is a threaded reply to the sender (`dispatcher.ts` auto-addresses it to the inbound `From`). There is no "nobody to reply to / notify the principal instead" path. When the inbound is an automated notification, the coordinator still emits reply text, and a downstream approval-hold status it was holding (a separate held Signal heads-up) leaked into that reply and auto-routed to `noreply@`. The codebase already classifies these senders (`classifyEmailSender` / `AUTOMATED_LOCAL_RE`) on the **inbound** side, but nothing applied it to the **outbound** reply.

## Fix

A single recipient guard at the outbound-gateway choke point (`src/skills/outbound-gateway.ts` `send()`, new "Step 0.5"), so it covers every send path (the implicit dispatcher reply and explicit `email-reply` / `email-send` calls):

- **Blocks an email send when every recipient classifies `automated`** via the existing `classifyEmailSender`, reusing `buildFilterRecipients`. Email-only (Signal recipients are phone numbers). A send that merely CCs a no-reply address still reaches its human recipients.
- **Hard block, not return-to-reconsider.** A no-reply address is an immutable *recipient* problem, so this mirrors the existing blocked-contact check rather than the content filter's rewrite-and-retry affordance (returning it to the agent would invite futile retries). Terse `{ success: false, blockedReason }`, no `blockedRules`.
- **Records an `outbound.blocked` audit event** (with `scrubPii`'d content, matching the sibling pre-redaction path) but deliberately sends **no** principal FYI — these automated notifications are routine and a per-drop CEO alert would be noise. The audit log is the record.
- Short-circuits **before** PII redaction and the content-filter LLM call, since the message is being dropped.

No new regex, classifier, or event type. Content filter unchanged as defense-in-depth for human recipients (the LLM judge continues to own narrative-audience leakage).

## Acceptance criteria (#1302)

- [x] Replies to recognized no-reply addresses are suppressed, with an audit note.
- [x] Regression test: an automated alert from a `noreply@…` sender produces no outbound reply to that sender.
- [x] The audience-leak content filter remains in place as defense-in-depth (unchanged).
- Internal status narration routing to the principal for *real human* external senders stays owned by the content filter (agreed scope — the LLM judge owns narrative content, not a deterministic classifier).

## Tests

11 new tests (TDD, written failing first): sole no-reply blocked (no Nylas/filter call), full classifier breadth, audit-event-emitted-but-no-CEO-FYI, normal human recipient passes through, mixed To=human/CC=noreply passes through.

- Gateway file: 106/106 pass. Full unit suite: 4699 passed, 0 failures. Typecheck clean. (Integration tests run in CI.)
- Reviewed by code-review, silent-failure, and security passes — all clean.

## Notes (out of scope, not changed)

- The block-and-publish boilerplate (`blockId` + try/publish `createOutboundBlocked`/catch-warn + terse return) is now repeated 3× in `send()`. Extracting a small `publishBlockedAndReturn(...)` helper would keep them in sync — flagged as tech debt, not touched here.
- The guard sits just after the autonomy gate, so a no-reply reply from a low-autonomy state could be held for approval before it reaches the drop (harmless — it drops on approval). Moving it earlier would mean relocating recipient derivation above the gate; more churn than it's worth.