### PR TITLE
Ant Farm AF-1: audit-log timeline query (findTimeline + index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **Ant Farm AF-1** — `AuditLogRepo.findTimeline` and timeline indexes on `payload->>'taskId'` and `(conversation_id, timestamp)` for replay queries. Closes #1314.
+
 ### Fixed
 
 - **`delegate` timeout storm** — timeouts now return structured, retry-capped failures instead of triggering duplicate re-delegations. Closes #1288.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Ant Farm AF-1** — `AuditLogRepo.findTimeline` returns paginated `TimelinePage` (`hasMore`, keyset `after` cursor) with scoped-query guard; timeline indexes on task id and `(conversation_id, timestamp)`. Closes #1314.
+- **Ant Farm AF-1** — `AuditLogRepo.findTimeline` / `findByEventTypes` return paginated `TimelinePage` (`hasMore`, keyset `after` cursor) with scoped-query guard; task filter uses `payload->>'taskId'` (index-aligned). Closes #1314.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Ant Farm AF-1** — `AuditLogRepo.findTimeline` and timeline indexes on `payload->>'taskId'` and `(conversation_id, timestamp)` for replay queries. Closes #1314.
+- **Ant Farm AF-1** — `AuditLogRepo.findTimeline` returns paginated `TimelinePage` (`hasMore`, keyset `after` cursor) with scoped-query guard; timeline indexes on task id and `(conversation_id, timestamp)`. Closes #1314.
 
 ### Fixed
 

--- a/src/audit/audit-log-repo.ts
+++ b/src/audit/audit-log-repo.ts
@@ -30,18 +30,35 @@ export interface TimelineAuditQuery {
   conversationId?: string;
   taskId?: string;
   limit?: number;
+  /** Keyset cursor — fetch rows strictly after this (timestamp, id) pair. */
+  after?: { timestamp: Date; id: string };
 }
 
-export interface EventTypesAuditQuery {
-  from?: Date;
-  to?: Date;
-  conversationId?: string;
-  taskId?: string;
-  limit?: number;
+/** Same filter shape as {@link TimelineAuditQuery}. */
+export type EventTypesAuditQuery = TimelineAuditQuery;
+
+export interface TimelinePage {
+  rows: AuditLogRow[];
+  hasMore: boolean;
+  /** Set when {@link TimelinePage.hasMore} is true — pass as `after` for the next page. */
+  nextCursor?: { timestamp: Date; id: string };
 }
 
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
+
+function assertTimelineScope(query: TimelineAuditQuery): void {
+  if (!query.from && !query.to && !query.conversationId && !query.taskId) {
+    throw new Error(
+      'findTimeline requires at least one scope filter: from, to, conversationId, or taskId',
+    );
+  }
+}
+
+/** Match task id on the indexed column when populated, else payload (historical rows). */
+function taskIdCondition(paramIndex: number): string {
+  return `COALESCE(task_id, payload->>'taskId') = $${paramIndex}`;
+}
 
 export class AuditLogRepo {
   constructor(
@@ -92,9 +109,12 @@ export class AuditLogRepo {
 
   /**
    * Return audit rows in a time window, optionally filtered by conversation or task.
-   * Task filtering uses payload->>'taskId' because the task_id column is often NULL.
+   * Requires at least one scope filter. Returns a page with {@link TimelinePage.hasMore}
+   * so callers know when the cap truncated results; use {@link TimelineAuditQuery.after}
+   * for keyset pagination on `(timestamp, id)`.
    */
-  async findTimeline(query: TimelineAuditQuery): Promise<AuditLogRow[]> {
+  async findTimeline(query: TimelineAuditQuery): Promise<TimelinePage> {
+    assertTimelineScope(query);
     const limit = Math.min(Math.max(query.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
     const params: unknown[] = [];
     const conditions: string[] = [];
@@ -113,28 +133,46 @@ export class AuditLogRepo {
     }
     if (query.taskId) {
       params.push(query.taskId);
-      conditions.push(`payload->>'taskId' = $${params.length}`);
+      conditions.push(taskIdCondition(params.length));
+    }
+    if (query.after) {
+      params.push(query.after.timestamp);
+      const tsParam = params.length;
+      params.push(query.after.id);
+      conditions.push(`(timestamp, id) > ($${tsParam}, $${params.length})`);
     }
 
-    params.push(limit);
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    // Fetch one extra row to detect truncation without a separate COUNT query.
+    params.push(limit + 1);
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
 
     const result = await this.pool.query(
       `SELECT id, timestamp, event_type, source_layer, source_id,
               conversation_id, parent_event_id, payload
        FROM audit_log
        ${whereClause}
-       ORDER BY timestamp ASC
+       ORDER BY timestamp ASC, id ASC
        LIMIT $${params.length}`,
       params,
     );
 
-    const rows = result.rows.map(mapRow);
+    const mapped = result.rows.map(mapRow);
+    const hasMore = mapped.length > limit;
+    const rows = hasMore ? mapped.slice(0, limit) : mapped;
+    const last = rows[rows.length - 1];
+
     this.logger.debug(
-      { count: rows.length, from: query.from, to: query.to },
+      { count: rows.length, hasMore, from: query.from, to: query.to },
       'audit-log-repo: findTimeline',
     );
-    return rows;
+
+    return {
+      rows,
+      hasMore,
+      nextCursor: hasMore && last !== undefined
+        ? { timestamp: last.timestamp, id: last.id }
+        : undefined,
+    };
   }
 
   /**
@@ -166,7 +204,7 @@ export class AuditLogRepo {
     }
     if (query.taskId) {
       params.push(query.taskId);
-      conditions.push(`payload->>'taskId' = $${params.length}`);
+      conditions.push(taskIdCondition(params.length));
     }
 
     params.push(limit);
@@ -176,7 +214,7 @@ export class AuditLogRepo {
               conversation_id, parent_event_id, payload
        FROM audit_log
        WHERE ${conditions.join(' AND ')}
-       ORDER BY timestamp ASC
+       ORDER BY timestamp ASC, id ASC
        LIMIT $${params.length}`,
       params,
     );

--- a/src/audit/audit-log-repo.ts
+++ b/src/audit/audit-log-repo.ts
@@ -24,6 +24,22 @@ export interface SkillResultAuditQuery {
   limit?: number;
 }
 
+export interface TimelineAuditQuery {
+  from?: Date;
+  to?: Date;
+  conversationId?: string;
+  taskId?: string;
+  limit?: number;
+}
+
+export interface EventTypesAuditQuery {
+  from?: Date;
+  to?: Date;
+  conversationId?: string;
+  taskId?: string;
+  limit?: number;
+}
+
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
 
@@ -70,6 +86,105 @@ export class AuditLogRepo {
     this.logger.debug(
       { count: rows.length, since: query.since, until: query.until },
       'audit-log-repo: findSkillResults',
+    );
+    return rows;
+  }
+
+  /**
+   * Return audit rows in a time window, optionally filtered by conversation or task.
+   * Task filtering uses payload->>'taskId' because the task_id column is often NULL.
+   */
+  async findTimeline(query: TimelineAuditQuery): Promise<AuditLogRow[]> {
+    const limit = Math.min(Math.max(query.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+    const params: unknown[] = [];
+    const conditions: string[] = [];
+
+    if (query.from) {
+      params.push(query.from);
+      conditions.push(`timestamp >= $${params.length}`);
+    }
+    if (query.to) {
+      params.push(query.to);
+      conditions.push(`timestamp < $${params.length}`);
+    }
+    if (query.conversationId) {
+      params.push(query.conversationId);
+      conditions.push(`conversation_id = $${params.length}`);
+    }
+    if (query.taskId) {
+      params.push(query.taskId);
+      conditions.push(`payload->>'taskId' = $${params.length}`);
+    }
+
+    params.push(limit);
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const result = await this.pool.query(
+      `SELECT id, timestamp, event_type, source_layer, source_id,
+              conversation_id, parent_event_id, payload
+       FROM audit_log
+       ${whereClause}
+       ORDER BY timestamp ASC
+       LIMIT $${params.length}`,
+      params,
+    );
+
+    const rows = result.rows.map(mapRow);
+    this.logger.debug(
+      { count: rows.length, from: query.from, to: query.to },
+      'audit-log-repo: findTimeline',
+    );
+    return rows;
+  }
+
+  /**
+   * Return audit rows matching any of the given event types within an optional window.
+   */
+  async findByEventTypes(
+    eventTypes: string[],
+    query: EventTypesAuditQuery = {},
+  ): Promise<AuditLogRow[]> {
+    if (eventTypes.length === 0) {
+      return [];
+    }
+
+    const limit = Math.min(Math.max(query.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+    const params: unknown[] = [eventTypes];
+    const conditions: string[] = [`event_type = ANY($1::text[])`];
+
+    if (query.from) {
+      params.push(query.from);
+      conditions.push(`timestamp >= $${params.length}`);
+    }
+    if (query.to) {
+      params.push(query.to);
+      conditions.push(`timestamp < $${params.length}`);
+    }
+    if (query.conversationId) {
+      params.push(query.conversationId);
+      conditions.push(`conversation_id = $${params.length}`);
+    }
+    if (query.taskId) {
+      params.push(query.taskId);
+      conditions.push(`payload->>'taskId' = $${params.length}`);
+    }
+
+    params.push(limit);
+
+    const result = await this.pool.query(
+      `SELECT id, timestamp, event_type, source_layer, source_id,
+              conversation_id, parent_event_id, payload
+       FROM audit_log
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY timestamp ASC
+       LIMIT $${params.length}`,
+      params,
+    );
+
+    const rows = result.rows.map(mapRow);
+    this.logger.debug(
+      { count: rows.length, eventTypes },
+      'audit-log-repo: findByEventTypes',
     );
     return rows;
   }

--- a/src/audit/audit-log-repo.ts
+++ b/src/audit/audit-log-repo.ts
@@ -30,7 +30,13 @@ export interface TimelineAuditQuery {
   conversationId?: string;
   taskId?: string;
   limit?: number;
-  /** Keyset cursor — fetch rows strictly after this (timestamp, id) pair. */
+  /**
+   * Keyset cursor — fetch rows strictly after this (timestamp, id) pair.
+   * Timestamps are compared at millisecond precision: all current audit writers
+   * insert ms-aligned `Date` values. Sub-ms rows (e.g. from `now()` default on
+   * a raw INSERT) could duplicate or skip at page boundaries until write-side
+   * truncation is enforced.
+   */
   after?: { timestamp: Date; id: string };
 }
 
@@ -55,9 +61,51 @@ function assertTimelineScope(query: TimelineAuditQuery): void {
   }
 }
 
-/** Match task id on the indexed column when populated, else payload (historical rows). */
-function taskIdCondition(paramIndex: number): string {
-  return `COALESCE(task_id, payload->>'taskId') = $${paramIndex}`;
+/** Uses idx_audit_log_payload_task_id — expression must match the migration exactly. */
+function payloadTaskIdCondition(paramIndex: number): string {
+  return `payload->>'taskId' = $${paramIndex}`;
+}
+
+function applyTimelineFilters(
+  query: TimelineAuditQuery,
+  params: unknown[],
+  conditions: string[],
+): void {
+  if (query.from) {
+    params.push(query.from);
+    conditions.push(`timestamp >= $${params.length}`);
+  }
+  if (query.to) {
+    params.push(query.to);
+    conditions.push(`timestamp < $${params.length}`);
+  }
+  if (query.conversationId) {
+    params.push(query.conversationId);
+    conditions.push(`conversation_id = $${params.length}`);
+  }
+  if (query.taskId) {
+    params.push(query.taskId);
+    conditions.push(payloadTaskIdCondition(params.length));
+  }
+  if (query.after) {
+    params.push(query.after.timestamp);
+    const tsParam = params.length;
+    params.push(query.after.id);
+    conditions.push(`(timestamp, id) > ($${tsParam}, $${params.length})`);
+  }
+}
+
+function pageFromRows(mapped: AuditLogRow[], limit: number): TimelinePage {
+  const hasMore = mapped.length > limit;
+  const rows = hasMore ? mapped.slice(0, limit) : mapped;
+  const last = rows[rows.length - 1];
+  return {
+    rows,
+    hasMore,
+    nextCursor: hasMore && last !== undefined
+      ? { timestamp: last.timestamp, id: last.id }
+      : undefined,
+  };
 }
 
 export class AuditLogRepo {
@@ -119,30 +167,8 @@ export class AuditLogRepo {
     const params: unknown[] = [];
     const conditions: string[] = [];
 
-    if (query.from) {
-      params.push(query.from);
-      conditions.push(`timestamp >= $${params.length}`);
-    }
-    if (query.to) {
-      params.push(query.to);
-      conditions.push(`timestamp < $${params.length}`);
-    }
-    if (query.conversationId) {
-      params.push(query.conversationId);
-      conditions.push(`conversation_id = $${params.length}`);
-    }
-    if (query.taskId) {
-      params.push(query.taskId);
-      conditions.push(taskIdCondition(params.length));
-    }
-    if (query.after) {
-      params.push(query.after.timestamp);
-      const tsParam = params.length;
-      params.push(query.after.id);
-      conditions.push(`(timestamp, id) > ($${tsParam}, $${params.length})`);
-    }
+    applyTimelineFilters(query, params, conditions);
 
-    // Fetch one extra row to detect truncation without a separate COUNT query.
     params.push(limit + 1);
     const whereClause = `WHERE ${conditions.join(' AND ')}`;
 
@@ -156,58 +182,35 @@ export class AuditLogRepo {
       params,
     );
 
-    const mapped = result.rows.map(mapRow);
-    const hasMore = mapped.length > limit;
-    const rows = hasMore ? mapped.slice(0, limit) : mapped;
-    const last = rows[rows.length - 1];
+    const page = pageFromRows(result.rows.map(mapRow), limit);
 
     this.logger.debug(
-      { count: rows.length, hasMore, from: query.from, to: query.to },
+      { count: page.rows.length, hasMore: page.hasMore, from: query.from, to: query.to },
       'audit-log-repo: findTimeline',
     );
 
-    return {
-      rows,
-      hasMore,
-      nextCursor: hasMore && last !== undefined
-        ? { timestamp: last.timestamp, id: last.id }
-        : undefined,
-    };
+    return page;
   }
 
   /**
    * Return audit rows matching any of the given event types within an optional window.
+   * Same pagination contract as {@link findTimeline}; scoped by the event-type list.
    */
   async findByEventTypes(
     eventTypes: string[],
     query: EventTypesAuditQuery = {},
-  ): Promise<AuditLogRow[]> {
+  ): Promise<TimelinePage> {
     if (eventTypes.length === 0) {
-      return [];
+      return { rows: [], hasMore: false };
     }
 
     const limit = Math.min(Math.max(query.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
     const params: unknown[] = [eventTypes];
     const conditions: string[] = [`event_type = ANY($1::text[])`];
 
-    if (query.from) {
-      params.push(query.from);
-      conditions.push(`timestamp >= $${params.length}`);
-    }
-    if (query.to) {
-      params.push(query.to);
-      conditions.push(`timestamp < $${params.length}`);
-    }
-    if (query.conversationId) {
-      params.push(query.conversationId);
-      conditions.push(`conversation_id = $${params.length}`);
-    }
-    if (query.taskId) {
-      params.push(query.taskId);
-      conditions.push(taskIdCondition(params.length));
-    }
+    applyTimelineFilters(query, params, conditions);
 
-    params.push(limit);
+    params.push(limit + 1);
 
     const result = await this.pool.query(
       `SELECT id, timestamp, event_type, source_layer, source_id,
@@ -219,12 +222,13 @@ export class AuditLogRepo {
       params,
     );
 
-    const rows = result.rows.map(mapRow);
+    const page = pageFromRows(result.rows.map(mapRow), limit);
+
     this.logger.debug(
-      { count: rows.length, eventTypes },
+      { count: page.rows.length, hasMore: page.hasMore, eventTypes },
       'audit-log-repo: findByEventTypes',
     );
-    return rows;
+    return page;
   }
 }
 

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -78,6 +78,9 @@ export class AuditLogger {
     const conversationId =
       typeof payload.conversationId === 'string' ? payload.conversationId : null;
 
+    // Populate task_id when present in payload (additive — no backfill of historical rows).
+    const taskId = typeof payload.taskId === 'string' ? payload.taskId : null;
+
     // Sanitize before the DB write in a separate try/catch so a sanitization
     // failure is logged with its own distinct message — not conflated with a
     // DB connectivity or schema error from the INSERT below.
@@ -94,10 +97,9 @@ export class AuditLogger {
     try {
       await this.pool.query(
         // All columns are explicitly listed so schema additions don't silently
-        // shift positional parameters. task_id is omitted here (Phase 1 has no
-        // task concept yet) and will default to NULL.
-        `INSERT INTO audit_log (id, timestamp, event_type, source_layer, source_id, payload, conversation_id, parent_event_id)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        // shift positional parameters.
+        `INSERT INTO audit_log (id, timestamp, event_type, source_layer, source_id, payload, conversation_id, task_id, parent_event_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
         [
           event.id,
           event.timestamp,
@@ -106,6 +108,7 @@ export class AuditLogger {
           sourceId,
           serializedPayload,
           conversationId,
+          taskId,
           event.parentEventId ?? null,
         ],
       );

--- a/src/db/migrations/071_audit_log_timeline_indexes.sql
+++ b/src/db/migrations/071_audit_log_timeline_indexes.sql
@@ -1,0 +1,18 @@
+-- Up Migration
+--
+-- Indexes to support Ant Farm timeline queries (AF-1):
+--   - payload->>'taskId' for task-scoped replay (task_id column is often NULL)
+--   - (conversation_id, timestamp) for conversation-scoped time windows
+
+CREATE INDEX idx_audit_log_payload_task_id
+  ON audit_log ((payload->>'taskId'))
+  WHERE payload->>'taskId' IS NOT NULL;
+
+CREATE INDEX idx_audit_log_conversation_timestamp
+  ON audit_log (conversation_id, timestamp)
+  WHERE conversation_id IS NOT NULL;
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_audit_log_conversation_timestamp;
+DROP INDEX IF EXISTS idx_audit_log_payload_task_id;

--- a/tests/integration/audit-log-timeline.test.ts
+++ b/tests/integration/audit-log-timeline.test.ts
@@ -53,6 +53,10 @@ describeIf('audit-log timeline query', () => {
     return result.rows[0]!.id;
   }
 
+  it('rejects unscoped queries', async () => {
+    await expect(repo.findTimeline({})).rejects.toThrow(/requires at least one scope filter/);
+  });
+
   it('returns events ordered by timestamp ASC', async () => {
     const t1 = '2026-07-01T10:00:00.000Z';
     const t2 = '2026-07-01T10:01:00.000Z';
@@ -61,12 +65,12 @@ describeIf('audit-log timeline query', () => {
     await seedRow({ timestamp: t1 });
     await seedRow({ timestamp: t2 });
 
-    const rows = await repo.findTimeline({
+    const page = await repo.findTimeline({
       from: new Date('2026-07-01T09:59:00.000Z'),
       to: new Date('2026-07-01T10:03:00.000Z'),
     });
 
-    const ours = rows.filter((r) => r.sourceLayer === sourceLayer);
+    const ours = page.rows.filter((r) => r.sourceLayer === sourceLayer);
     expect(ours.length).toBeGreaterThanOrEqual(3);
     const timestamps = ours.map((r) => r.timestamp.toISOString());
     const sorted = [...timestamps].sort();
@@ -79,15 +83,15 @@ describeIf('audit-log timeline query', () => {
     await seedRow({ timestamp: inside, conversationId: 'conv-window' });
     await seedRow({ timestamp: outside, conversationId: 'conv-window' });
 
-    const rows = await repo.findTimeline({
+    const page = await repo.findTimeline({
       from: new Date('2026-07-01T10:59:00.000Z'),
       to: new Date('2026-07-01T11:01:00.000Z'),
       conversationId: 'conv-window',
     });
 
-    expect(rows.every((r) => r.timestamp >= new Date('2026-07-01T10:59:00.000Z'))).toBe(true);
-    expect(rows.every((r) => r.timestamp < new Date('2026-07-01T11:01:00.000Z'))).toBe(true);
-    expect(rows.some((r) => r.timestamp.toISOString() === new Date(outside).toISOString())).toBe(false);
+    expect(page.rows.every((r) => r.timestamp >= new Date('2026-07-01T10:59:00.000Z'))).toBe(true);
+    expect(page.rows.every((r) => r.timestamp < new Date('2026-07-01T11:01:00.000Z'))).toBe(true);
+    expect(page.rows.some((r) => r.timestamp.toISOString() === new Date(outside).toISOString())).toBe(false);
   });
 
   it('filters by conversationId', async () => {
@@ -96,14 +100,14 @@ describeIf('audit-log timeline query', () => {
     await seedRow({ timestamp: '2026-07-01T12:00:00.000Z', conversationId: convA });
     await seedRow({ timestamp: '2026-07-01T12:01:00.000Z', conversationId: convB });
 
-    const rows = await repo.findTimeline({
+    const page = await repo.findTimeline({
       from: new Date('2026-07-01T11:59:00.000Z'),
       to: new Date('2026-07-01T12:02:00.000Z'),
       conversationId: convA,
     });
 
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    expect(rows.every((r) => r.conversationId === convA)).toBe(true);
+    expect(page.rows.length).toBeGreaterThanOrEqual(1);
+    expect(page.rows.every((r) => r.conversationId === convA)).toBe(true);
   });
 
   it('filters by taskId via payload->taskId when task_id column is NULL', async () => {
@@ -127,35 +131,63 @@ describeIf('audit-log timeline query', () => {
     );
     expect(colCheck.rows[0]!.task_id).toBeNull();
 
-    const rows = await repo.findTimeline({
+    const page = await repo.findTimeline({
       from: new Date('2026-07-01T12:59:00.000Z'),
       to: new Date('2026-07-01T13:02:00.000Z'),
       taskId,
     });
 
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    expect(rows.every((r) => r.payload.taskId === taskId)).toBe(true);
+    expect(page.rows.length).toBeGreaterThanOrEqual(1);
+    expect(page.rows.every((r) => r.payload.taskId === taskId)).toBe(true);
   });
 
-  it('includes parentEventId and clamps limit', async () => {
-    const parentId = await seedRow({ timestamp: '2026-07-01T14:00:00.000Z' });
+  it('includes parentEventId on child rows', async () => {
+    const conv = `conv-parent-${Date.now()}`;
+    const parentId = await seedRow({ timestamp: '2026-07-01T14:00:00.000Z', conversationId: conv });
     await seedRow({
       timestamp: '2026-07-01T14:01:00.000Z',
       parentEventId: parentId,
-      conversationId: 'conv-parent',
+      conversationId: conv,
     });
 
-    const rows = await repo.findTimeline({
+    const page = await repo.findTimeline({
       from: new Date('2026-07-01T13:59:00.000Z'),
       to: new Date('2026-07-01T14:02:00.000Z'),
-      conversationId: 'conv-parent',
+      conversationId: conv,
+    });
+
+    const child = page.rows.find((r) => r.parentEventId === parentId);
+    expect(child).toBeDefined();
+    expect(child!.parentEventId).toBe(parentId);
+  });
+
+  it('signals hasMore and paginates with keyset cursor', async () => {
+    const conv = `conv-page-${Date.now()}`;
+    await seedRow({ timestamp: '2026-07-01T16:00:00.000Z', conversationId: conv });
+    await seedRow({ timestamp: '2026-07-01T16:01:00.000Z', conversationId: conv });
+    await seedRow({ timestamp: '2026-07-01T16:02:00.000Z', conversationId: conv });
+
+    const page = await repo.findTimeline({
+      from: new Date('2026-07-01T15:59:00.000Z'),
+      to: new Date('2026-07-01T16:03:00.000Z'),
+      conversationId: conv,
       limit: 1,
     });
 
-    expect(rows).toHaveLength(1);
-    const child = rows.find((r) => r.parentEventId === parentId);
-    expect(child).toBeDefined();
-    expect(child!.parentEventId).toBe(parentId);
+    expect(page.rows).toHaveLength(1);
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).toBeDefined();
+
+    const page2 = await repo.findTimeline({
+      from: new Date('2026-07-01T15:59:00.000Z'),
+      to: new Date('2026-07-01T16:03:00.000Z'),
+      conversationId: conv,
+      limit: 1,
+      after: page.nextCursor,
+    });
+
+    expect(page2.rows).toHaveLength(1);
+    expect(page2.rows[0]!.id).not.toBe(page.rows[0]!.id);
   });
 
   it('findByEventTypes filters by event type list', async () => {

--- a/tests/integration/audit-log-timeline.test.ts
+++ b/tests/integration/audit-log-timeline.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { AuditLogRepo } from '../../src/audit/audit-log-repo.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('audit-log timeline query', () => {
+  let pool: pg.Pool;
+  let repo: AuditLogRepo;
+  const logger = createSilentLogger();
+  const sourceLayer = 'test-audit-timeline';
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    repo = new AuditLogRepo(pool, logger);
+    await pool.query('SELECT 1 FROM audit_log LIMIT 0');
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function seedRow(opts: {
+    timestamp: string;
+    eventType?: string;
+    conversationId?: string | null;
+    taskId?: string;
+    parentEventId?: string | null;
+  }): Promise<string> {
+    const payload: Record<string, unknown> = {};
+    if (opts.taskId) {
+      payload.taskId = opts.taskId;
+    }
+    const result = await pool.query<{ id: string }>(
+      `INSERT INTO audit_log (
+         timestamp, event_type, source_layer, source_id, payload,
+         conversation_id, parent_event_id
+       )
+       VALUES ($1, $2, $3, 'test-agent', $4::jsonb, $5, $6)
+       RETURNING id`,
+      [
+        new Date(opts.timestamp),
+        opts.eventType ?? 'agent.task',
+        sourceLayer,
+        JSON.stringify(payload),
+        opts.conversationId ?? null,
+        opts.parentEventId ?? null,
+      ],
+    );
+    return result.rows[0]!.id;
+  }
+
+  it('returns events ordered by timestamp ASC', async () => {
+    const t1 = '2026-07-01T10:00:00.000Z';
+    const t2 = '2026-07-01T10:01:00.000Z';
+    const t3 = '2026-07-01T10:02:00.000Z';
+    await seedRow({ timestamp: t3 });
+    await seedRow({ timestamp: t1 });
+    await seedRow({ timestamp: t2 });
+
+    const rows = await repo.findTimeline({
+      from: new Date('2026-07-01T09:59:00.000Z'),
+      to: new Date('2026-07-01T10:03:00.000Z'),
+    });
+
+    const ours = rows.filter((r) => r.sourceLayer === sourceLayer);
+    expect(ours.length).toBeGreaterThanOrEqual(3);
+    const timestamps = ours.map((r) => r.timestamp.toISOString());
+    const sorted = [...timestamps].sort();
+    expect(timestamps).toEqual(sorted);
+  });
+
+  it('filters by from/to window', async () => {
+    const inside = '2026-07-01T11:00:00.000Z';
+    const outside = '2026-07-01T11:05:00.000Z';
+    await seedRow({ timestamp: inside, conversationId: 'conv-window' });
+    await seedRow({ timestamp: outside, conversationId: 'conv-window' });
+
+    const rows = await repo.findTimeline({
+      from: new Date('2026-07-01T10:59:00.000Z'),
+      to: new Date('2026-07-01T11:01:00.000Z'),
+      conversationId: 'conv-window',
+    });
+
+    expect(rows.every((r) => r.timestamp >= new Date('2026-07-01T10:59:00.000Z'))).toBe(true);
+    expect(rows.every((r) => r.timestamp < new Date('2026-07-01T11:01:00.000Z'))).toBe(true);
+    expect(rows.some((r) => r.timestamp.toISOString() === new Date(outside).toISOString())).toBe(false);
+  });
+
+  it('filters by conversationId', async () => {
+    const convA = 'conv-timeline-a';
+    const convB = 'conv-timeline-b';
+    await seedRow({ timestamp: '2026-07-01T12:00:00.000Z', conversationId: convA });
+    await seedRow({ timestamp: '2026-07-01T12:01:00.000Z', conversationId: convB });
+
+    const rows = await repo.findTimeline({
+      from: new Date('2026-07-01T11:59:00.000Z'),
+      to: new Date('2026-07-01T12:02:00.000Z'),
+      conversationId: convA,
+    });
+
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows.every((r) => r.conversationId === convA)).toBe(true);
+  });
+
+  it('filters by taskId via payload->taskId when task_id column is NULL', async () => {
+    const taskId = 'task-timeline-filter-1314';
+    await seedRow({
+      timestamp: '2026-07-01T13:00:00.000Z',
+      conversationId: 'conv-task',
+      taskId,
+    });
+    await seedRow({
+      timestamp: '2026-07-01T13:01:00.000Z',
+      conversationId: 'conv-task',
+      taskId: 'other-task',
+    });
+
+    const colCheck = await pool.query<{ task_id: string | null }>(
+      `SELECT task_id FROM audit_log
+       WHERE source_layer = $1 AND payload->>'taskId' = $2
+       LIMIT 1`,
+      [sourceLayer, taskId],
+    );
+    expect(colCheck.rows[0]!.task_id).toBeNull();
+
+    const rows = await repo.findTimeline({
+      from: new Date('2026-07-01T12:59:00.000Z'),
+      to: new Date('2026-07-01T13:02:00.000Z'),
+      taskId,
+    });
+
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows.every((r) => r.payload.taskId === taskId)).toBe(true);
+  });
+
+  it('includes parentEventId and clamps limit', async () => {
+    const parentId = await seedRow({ timestamp: '2026-07-01T14:00:00.000Z' });
+    await seedRow({
+      timestamp: '2026-07-01T14:01:00.000Z',
+      parentEventId: parentId,
+      conversationId: 'conv-parent',
+    });
+
+    const rows = await repo.findTimeline({
+      from: new Date('2026-07-01T13:59:00.000Z'),
+      to: new Date('2026-07-01T14:02:00.000Z'),
+      conversationId: 'conv-parent',
+      limit: 1,
+    });
+
+    expect(rows).toHaveLength(1);
+    const child = rows.find((r) => r.parentEventId === parentId);
+    expect(child).toBeDefined();
+    expect(child!.parentEventId).toBe(parentId);
+  });
+
+  it('findByEventTypes filters by event type list', async () => {
+    await seedRow({ timestamp: '2026-07-01T15:00:00.000Z', eventType: 'task.created', conversationId: 'conv-types' });
+    await seedRow({ timestamp: '2026-07-01T15:01:00.000Z', eventType: 'task.completed', conversationId: 'conv-types' });
+    await seedRow({ timestamp: '2026-07-01T15:02:00.000Z', eventType: 'agent.task', conversationId: 'conv-types' });
+
+    const rows = await repo.findByEventTypes(
+      ['task.created', 'task.completed'],
+      {
+        from: new Date('2026-07-01T14:59:00.000Z'),
+        to: new Date('2026-07-01T15:03:00.000Z'),
+        conversationId: 'conv-types',
+      },
+    );
+
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    expect(rows.every((r) => r.eventType === 'task.created' || r.eventType === 'task.completed')).toBe(true);
+  });
+});

--- a/tests/integration/audit-log-timeline.test.ts
+++ b/tests/integration/audit-log-timeline.test.ts
@@ -195,7 +195,7 @@ describeIf('audit-log timeline query', () => {
     await seedRow({ timestamp: '2026-07-01T15:01:00.000Z', eventType: 'task.completed', conversationId: 'conv-types' });
     await seedRow({ timestamp: '2026-07-01T15:02:00.000Z', eventType: 'agent.task', conversationId: 'conv-types' });
 
-    const rows = await repo.findByEventTypes(
+    const page = await repo.findByEventTypes(
       ['task.created', 'task.completed'],
       {
         from: new Date('2026-07-01T14:59:00.000Z'),
@@ -204,7 +204,7 @@ describeIf('audit-log timeline query', () => {
       },
     );
 
-    expect(rows.length).toBeGreaterThanOrEqual(2);
-    expect(rows.every((r) => r.eventType === 'task.created' || r.eventType === 'task.completed')).toBe(true);
+    expect(page.rows.length).toBeGreaterThanOrEqual(2);
+    expect(page.rows.every((r) => r.eventType === 'task.created' || r.eventType === 'task.completed')).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1314

Adds the Ant Farm data-layer foundation: `AuditLogRepo.findTimeline` for ordered audit-log replay windows, optional `findByEventTypes`, migration 071 indexes for task and conversation queries, and forward-population of the `task_id` column in `AuditLogger.log()`.

## Changes

- **`findTimeline`** — optional `from`/`to`/`conversationId`/`taskId`/`limit` filters; `taskId` matches `payload->>'taskId'` (not the column); returns `parentEventId`.
- **`findByEventTypes`** — optional event-type list filter using the existing `ANY($n::text[])` idiom.
- **Migration 071** — expression index on `(payload->>'taskId')` and composite `(conversation_id, timestamp)`.
- **`AuditLogger.log()`** — writes `task_id` from payload when present (additive, no backfill).

## Testing

- Integration test `tests/integration/audit-log-timeline.test.ts` (gated on `DATABASE_URL`) covers ordering, each filter, `parentEventId`, limit clamping, and `findByEventTypes`.
- `pnpm run typecheck` passes.
- Existing audit logger unit/integration tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23eb8ec6-bb59-47f3-9938-c70e8617f2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23eb8ec6-bb59-47f3-9938-c70e8617f2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

