### PR TITLE
Ant Farm AF-3: shared contract + event-to-directive interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Ant Farm AF-1** — `AuditLogRepo.findTimeline` / `findByEventTypes` return paginated `TimelinePage` (`hasMore`, keyset `after` cursor) with scoped-query guard; task filter uses `payload->>'taskId'` (index-aligned). Closes #1314.
+- **Ant Farm AF-3** — `@curia/shared-types` contract package and server-side event→directive interpreter for the pixel-art office visualization. Closes #1316.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.107.0",
+    "@curia/shared-types": "workspace:*",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^11.1.0",

--- a/packages/shared-types/index.ts
+++ b/packages/shared-types/index.ts
@@ -1,0 +1,107 @@
+/** Shared Ant Farm contract — dependency-free types for producer and consumer. */
+
+export interface SceneDirectiveBase {
+  /** Source audit_log row id (dedupe key). */
+  id: string;
+  /** Logical time in epoch milliseconds. */
+  logicalTs: number;
+  /** Causal parent audit row id, when present. */
+  causedBy: string | null;
+}
+
+export interface ClawDeliverDirective extends SceneDirectiveBase {
+  kind: 'claw.deliver';
+  jobId: string;
+  agentId: string;
+  taskId?: string | null;
+}
+
+export interface AgentStateDirective extends SceneDirectiveBase {
+  kind: 'agent.state';
+  agentId: string;
+  state: 'active' | 'error';
+}
+
+export interface AgentWalkDirective extends SceneDirectiveBase {
+  kind: 'agent.walk';
+  agentId: string;
+  targetAgentId: string;
+}
+
+export interface AgentSpeakDirective extends SceneDirectiveBase {
+  kind: 'agent.speak';
+  agentId: string;
+  threadId?: string;
+  content?: string;
+}
+
+export interface AgentThinkDirective extends SceneDirectiveBase {
+  kind: 'agent.think';
+  agentId: string;
+  phase: 'start' | 'stop';
+  skillName?: string;
+}
+
+export interface TubeInDirective extends SceneDirectiveBase {
+  kind: 'tube.in';
+  conversationId?: string;
+  channelId?: string;
+}
+
+export interface TubeOutDirective extends SceneDirectiveBase {
+  kind: 'tube.out';
+  conversationId?: string;
+  agentId?: string;
+}
+
+export interface TaskAppearDirective extends SceneDirectiveBase {
+  kind: 'task.appear';
+  taskId: string;
+  title?: string;
+}
+
+export interface TaskTrashDirective extends SceneDirectiveBase {
+  kind: 'task.trash';
+  taskId: string;
+}
+
+export interface BadgeDirective extends SceneDirectiveBase {
+  kind: 'badge';
+  badgeKind: 'human.decision' | 'autonomy.blocked';
+  label: string;
+}
+
+export type SceneDirective =
+  | ClawDeliverDirective
+  | AgentStateDirective
+  | AgentWalkDirective
+  | AgentSpeakDirective
+  | AgentThinkDirective
+  | TubeInDirective
+  | TubeOutDirective
+  | TaskAppearDirective
+  | TaskTrashDirective
+  | BadgeDirective;
+
+export interface ActivityScript {
+  directives: SceneDirective[];
+}
+
+/** Minimal audit row shape consumed by the interpreter (no backend imports). */
+export interface AuditEventRow {
+  id: string;
+  timestamp: Date | string;
+  eventType: string;
+  sourceLayer: string;
+  sourceId: string;
+  conversationId: string | null;
+  parentEventId: string | null;
+  payload: Record<string, unknown>;
+}
+
+/** SSE envelope for live Ant Farm directive streaming. */
+export interface AntFarmSseEnvelope {
+  type: 'directive' | 'heartbeat';
+  directive?: SceneDirective;
+  ts?: string;
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@curia/shared-types",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.107.0
         version: 0.107.0(zod@4.4.3)
+      '@curia/shared-types':
+        specifier: workspace:*
+        version: link:packages/shared-types
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
@@ -207,6 +210,8 @@ importers:
       vite:
         specifier: '>=8.0.5'
         version: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+
+  packages/shared-types: {}
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@
 # deps of each app are installed by the root pnpm install.
 packages:
   - 'apps/*'
+  - 'packages/*'
 
 # Explicitly declare pnpm v11 default: prevent transitive (indirect) dependencies
 # from being resolved via exotic sources (git repos, direct tarball URLs).

--- a/src/antfarm/interpreter.test.ts
+++ b/src/antfarm/interpreter.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import type { AuditEventRow } from '@curia/shared-types';
+import { buildScript, interpretEvent } from './interpreter.js';
+
+function row(overrides: Partial<AuditEventRow> & Pick<AuditEventRow, 'eventType'>): AuditEventRow {
+  return {
+    id: overrides.id ?? 'evt-1',
+    timestamp: overrides.timestamp ?? '2026-07-02T12:00:00.000Z',
+    eventType: overrides.eventType,
+    sourceLayer: overrides.sourceLayer ?? 'agent',
+    sourceId: overrides.sourceId ?? 'coordinator',
+    conversationId: overrides.conversationId ?? 'conv-1',
+    parentEventId: overrides.parentEventId ?? 'parent-1',
+    payload: overrides.payload ?? {},
+  };
+}
+
+describe('interpretEvent', () => {
+  it('maps schedule.fired to claw.deliver', () => {
+    const result = interpretEvent(row({
+      eventType: 'schedule.fired',
+      sourceLayer: 'system',
+      payload: { jobId: 'job-1', agentId: 'calendar', agentTaskId: 'task-9' },
+    }));
+    expect(result).toMatchObject({
+      kind: 'claw.deliver',
+      id: 'evt-1',
+      causedBy: 'parent-1',
+      jobId: 'job-1',
+      agentId: 'calendar',
+      taskId: 'task-9',
+    });
+  });
+
+  it('maps agent.task to agent.state active', () => {
+    const result = interpretEvent(row({
+      eventType: 'agent.task',
+      payload: { agentId: 'research' },
+    }));
+    expect(result).toMatchObject({
+      kind: 'agent.state',
+      agentId: 'research',
+      state: 'active',
+    });
+  });
+
+  it('maps delegate skill.invoke to agent.walk and agent.speak', () => {
+    const result = interpretEvent(row({
+      eventType: 'skill.invoke',
+      payload: {
+        agentId: 'coordinator',
+        skillName: 'delegate',
+        input: { agent: 'research', task: 'Find the Q2 report' },
+      },
+    }));
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([
+      expect.objectContaining({
+        kind: 'agent.walk',
+        agentId: 'coordinator',
+        targetAgentId: 'research',
+        id: 'evt-1',
+        causedBy: 'parent-1',
+      }),
+      expect.objectContaining({
+        kind: 'agent.speak',
+        agentId: 'coordinator',
+        content: 'Find the Q2 report',
+      }),
+    ]);
+  });
+
+  it('maps non-delegate skill.invoke to agent.think start', () => {
+    const result = interpretEvent(row({
+      eventType: 'skill.invoke',
+      payload: { agentId: 'calendar', skillName: 'calendar-list-events', input: {} },
+    }));
+    expect(result).toMatchObject({
+      kind: 'agent.think',
+      agentId: 'calendar',
+      phase: 'start',
+      skillName: 'calendar-list-events',
+    });
+  });
+
+  it('maps skill.result to agent.think stop', () => {
+    const result = interpretEvent(row({
+      eventType: 'skill.result',
+      sourceLayer: 'execution',
+      payload: { agentId: 'calendar', skillName: 'calendar-list-events' },
+    }));
+    expect(result).toMatchObject({
+      kind: 'agent.think',
+      phase: 'stop',
+      skillName: 'calendar-list-events',
+    });
+  });
+
+  it('maps agent.discuss to agent.speak with threadId', () => {
+    const result = interpretEvent(row({
+      eventType: 'agent.discuss',
+      payload: {
+        senderAgentId: 'coordinator',
+        threadId: 'thread-42',
+        content: 'What do you think?',
+      },
+    }));
+    expect(result).toMatchObject({
+      kind: 'agent.speak',
+      agentId: 'coordinator',
+      threadId: 'thread-42',
+      content: 'What do you think?',
+    });
+  });
+
+  it('maps inbound.message to tube.in', () => {
+    const result = interpretEvent(row({
+      eventType: 'inbound.message',
+      sourceLayer: 'channel',
+      payload: { conversationId: 'conv-in', channelId: 'email' },
+    }));
+    expect(result).toMatchObject({ kind: 'tube.in', conversationId: 'conv-in', channelId: 'email' });
+  });
+
+  it('maps outbound.message and outbound.delivered to tube.out', () => {
+    for (const eventType of ['outbound.message', 'outbound.delivered'] as const) {
+      const result = interpretEvent(row({
+        eventType,
+        sourceLayer: 'dispatch',
+        payload: { conversationId: 'conv-out', agentId: 'coordinator' },
+      }));
+      expect(result).toMatchObject({ kind: 'tube.out', conversationId: 'conv-out', agentId: 'coordinator' });
+    }
+  });
+
+  it('maps task.created to task.appear', () => {
+    const result = interpretEvent(row({
+      eventType: 'task.created',
+      sourceLayer: 'execution',
+      payload: { taskId: 'task-1', title: 'Review deck' },
+    }));
+    expect(result).toMatchObject({ kind: 'task.appear', taskId: 'task-1', title: 'Review deck' });
+  });
+
+  it('maps task.completed to task.trash', () => {
+    const result = interpretEvent(row({
+      eventType: 'task.completed',
+      sourceLayer: 'execution',
+      payload: { taskId: 'task-1' },
+    }));
+    expect(result).toMatchObject({ kind: 'task.trash', taskId: 'task-1' });
+  });
+
+  it('maps agent.error to agent.state error', () => {
+    const result = interpretEvent(row({
+      eventType: 'agent.error',
+      payload: { agentId: 'research', message: 'Budget exceeded' },
+    }));
+    expect(result).toMatchObject({ kind: 'agent.state', agentId: 'research', state: 'error' });
+  });
+
+  it('maps human.decision to badge', () => {
+    const result = interpretEvent(row({
+      eventType: 'human.decision',
+      sourceLayer: 'dispatch',
+      payload: { subjectSummary: 'Approve outbound email' },
+    }));
+    expect(result).toMatchObject({
+      kind: 'badge',
+      badgeKind: 'human.decision',
+      label: 'Approve outbound email',
+    });
+  });
+
+  it('maps autonomy.*_blocked events to badge', () => {
+    for (const eventType of ['autonomy.skill_blocked', 'autonomy.send_blocked'] as const) {
+      const result = interpretEvent(row({
+        eventType,
+        payload: { skillName: 'send-email', reason: 'score too low' },
+      }));
+      expect(result).toMatchObject({
+        kind: 'badge',
+        badgeKind: 'autonomy.blocked',
+      });
+    }
+  });
+
+  it('returns null for unmapped event types', () => {
+    expect(interpretEvent(row({ eventType: 'memory.store', payload: {} }))).toBeNull();
+    expect(interpretEvent(row({ eventType: 'llm.call', payload: {} }))).toBeNull();
+  });
+
+  it('includes logicalTs from row timestamp', () => {
+    const ts = '2026-07-02T15:30:00.000Z';
+    const result = interpretEvent(row({
+      eventType: 'agent.task',
+      timestamp: ts,
+      payload: { agentId: 'coordinator' },
+    }));
+    expect(result).toMatchObject({
+      logicalTs: new Date(ts).getTime(),
+    });
+  });
+});
+
+describe('buildScript', () => {
+  it('produces ordered directives skipping unmapped rows', () => {
+    const script = buildScript([
+      row({ id: 'a', eventType: 'task.created', payload: { taskId: 't1', title: 'A' } }),
+      row({ id: 'b', eventType: 'memory.store', payload: {} }),
+      row({ id: 'c', eventType: 'task.completed', payload: { taskId: 't1' } }),
+    ]);
+
+    expect(script.directives).toHaveLength(2);
+    expect(script.directives[0]).toMatchObject({ kind: 'task.appear', id: 'a' });
+    expect(script.directives[1]).toMatchObject({ kind: 'task.trash', id: 'c' });
+  });
+
+  it('expands multi-directive events in order', () => {
+    const script = buildScript([
+      row({
+        id: 'd',
+        eventType: 'skill.invoke',
+        payload: {
+          agentId: 'coordinator',
+          skillName: 'delegate',
+          input: { agent: 'research', task: 'Go' },
+        },
+      }),
+    ]);
+
+    expect(script.directives).toHaveLength(2);
+    expect(script.directives[0]!.kind).toBe('agent.walk');
+    expect(script.directives[1]!.kind).toBe('agent.speak');
+  });
+});

--- a/src/antfarm/interpreter.ts
+++ b/src/antfarm/interpreter.ts
@@ -1,0 +1,186 @@
+import type {
+  ActivityScript,
+  AuditEventRow,
+  SceneDirective,
+} from '@curia/shared-types';
+
+function baseFields(row: AuditEventRow): Pick<SceneDirective, 'id' | 'logicalTs' | 'causedBy'> {
+  return {
+    id: row.id,
+    logicalTs: new Date(row.timestamp).getTime(),
+    causedBy: row.parentEventId,
+  };
+}
+
+function payloadString(payload: Record<string, unknown>, key: string): string | undefined {
+  const value = payload[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function isAutonomyBlockedEvent(eventType: string): boolean {
+  return eventType.startsWith('autonomy.') && eventType.endsWith('_blocked');
+}
+
+/**
+ * Map one audit_log row to zero or more scene directives.
+ * Unmapped event types return null.
+ */
+export function interpretEvent(row: AuditEventRow): SceneDirective | SceneDirective[] | null {
+  const base = baseFields(row);
+  const payload = row.payload;
+
+  switch (row.eventType) {
+    case 'schedule.fired':
+      return {
+        ...base,
+        kind: 'claw.deliver',
+        jobId: payloadString(payload, 'jobId') ?? '',
+        agentId: payloadString(payload, 'agentId') ?? row.sourceId,
+        taskId: payloadString(payload, 'agentTaskId') ?? null,
+      };
+
+    case 'agent.task':
+      return {
+        ...base,
+        kind: 'agent.state',
+        agentId: payloadString(payload, 'agentId') ?? row.sourceId,
+        state: 'active',
+      };
+
+    case 'skill.invoke': {
+      const skillName = payloadString(payload, 'skillName') ?? '';
+      const agentId = payloadString(payload, 'agentId') ?? row.sourceId;
+      if (skillName === 'delegate') {
+        const input = payload.input;
+        const targetAgentId =
+          typeof input === 'object' && input !== null && !Array.isArray(input)
+            ? payloadString(input as Record<string, unknown>, 'agent')
+            : undefined;
+        const taskContent =
+          typeof input === 'object' && input !== null && !Array.isArray(input)
+            ? payloadString(input as Record<string, unknown>, 'task')
+            : undefined;
+        if (!targetAgentId) {
+          return null;
+        }
+        return [
+          {
+            ...base,
+            kind: 'agent.walk',
+            agentId,
+            targetAgentId,
+          },
+          {
+            ...base,
+            kind: 'agent.speak',
+            agentId,
+            content: taskContent,
+          },
+        ];
+      }
+      return {
+        ...base,
+        kind: 'agent.think',
+        agentId,
+        phase: 'start',
+        skillName,
+      };
+    }
+
+    case 'skill.result':
+      return {
+        ...base,
+        kind: 'agent.think',
+        agentId: payloadString(payload, 'agentId') ?? row.sourceId,
+        phase: 'stop',
+        skillName: payloadString(payload, 'skillName'),
+      };
+
+    case 'agent.discuss':
+      return {
+        ...base,
+        kind: 'agent.speak',
+        agentId: payloadString(payload, 'senderAgentId') ?? row.sourceId,
+        threadId: payloadString(payload, 'threadId'),
+        content: payloadString(payload, 'content'),
+      };
+
+    case 'inbound.message':
+      return {
+        ...base,
+        kind: 'tube.in',
+        conversationId: payloadString(payload, 'conversationId') ?? row.conversationId ?? undefined,
+        channelId: payloadString(payload, 'channelId'),
+      };
+
+    case 'outbound.message':
+    case 'outbound.delivered':
+      return {
+        ...base,
+        kind: 'tube.out',
+        conversationId: payloadString(payload, 'conversationId') ?? row.conversationId ?? undefined,
+        agentId: payloadString(payload, 'agentId'),
+      };
+
+    case 'task.created':
+      return {
+        ...base,
+        kind: 'task.appear',
+        taskId: payloadString(payload, 'taskId') ?? '',
+        title: payloadString(payload, 'title'),
+      };
+
+    case 'task.completed':
+      return {
+        ...base,
+        kind: 'task.trash',
+        taskId: payloadString(payload, 'taskId') ?? '',
+      };
+
+    case 'agent.error':
+      return {
+        ...base,
+        kind: 'agent.state',
+        agentId: payloadString(payload, 'agentId') ?? row.sourceId,
+        state: 'error',
+      };
+
+    case 'human.decision':
+      return {
+        ...base,
+        kind: 'badge',
+        badgeKind: 'human.decision',
+        label: payloadString(payload, 'subjectSummary') ?? 'Human decision',
+      };
+
+    default:
+      if (isAutonomyBlockedEvent(row.eventType)) {
+        return {
+          ...base,
+          kind: 'badge',
+          badgeKind: 'autonomy.blocked',
+          label: payloadString(payload, 'skillName')
+            ?? payloadString(payload, 'reason')
+            ?? row.eventType,
+        };
+      }
+      return null;
+  }
+}
+
+/** Flatten interpretEvent results into an ordered activity script. */
+export function buildScript(rows: AuditEventRow[]): ActivityScript {
+  const directives: SceneDirective[] = [];
+  for (const row of rows) {
+    const mapped = interpretEvent(row);
+    if (mapped === null) {
+      continue;
+    }
+    if (Array.isArray(mapped)) {
+      directives.push(...mapped);
+    } else {
+      directives.push(mapped);
+    }
+  }
+  return { directives };
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -27,6 +27,6 @@
   },
   // Covers all test source files. Test handlers import from ../../src (or ../src),
   // so tsc follows those references automatically.
-  "include": ["tests/**/*.ts"],
+  "include": ["tests/**/*.ts", "packages/**/*.ts", "src/**/*.test.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'skills/**/*.test.ts',
       'apps/**/*.test.ts',
       'scripts/**/*.test.ts',
+      'packages/**/*.test.ts',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

Closes #1316

Adds the Ant Farm shared contract and server-side interpreter: a dependency-free `@curia/shared-types` package and `src/antfarm/interpreter.ts` that maps audit events to the small `SceneDirective` choreography vocabulary.

## Changes

- **`@curia/shared-types`** — `SceneDirective` discriminated union, `ActivityScript`, `AuditEventRow`, and `AntFarmSseEnvelope` types; shipped as `.ts` source.
- **`interpretEvent` / `buildScript`** — maps the full v1 catalog (schedule.fired, agent.task, delegate vs non-delegate skill.invoke, skill.result, agent.discuss, inbound/outbound messages, task lifecycle, agent.error, human.decision, autonomy.*_blocked).
- **Workspace** — `packages/*` added to `pnpm-workspace.yaml`; vitest `include` extended.

## Testing

- Unit tests in `src/antfarm/interpreter.test.ts` (17 cases) cover the full directive catalog including delegate walk+speak vs non-delegate think.
- `pnpm run typecheck` passes.
