### PR TITLE
Ant Farm AF-2: timeline endpoint + live SSE fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Ant Farm AF-1** — `AuditLogRepo.findTimeline` / `findByEventTypes` return paginated `TimelinePage` (`hasMore`, keyset `after` cursor) with scoped-query guard; task filter uses `payload->>'taskId'` (index-aligned). Closes #1314.
 - **Ant Farm AF-3** — `@curia/shared-types` contract package and server-side event→directive interpreter for the pixel-art office visualization. Closes #1316.
+- **Ant Farm AF-2** — `GET /api/antfarm/timeline` replay endpoint and `GET /api/antfarm/stream` live SSE fan-out with separate Ant Farm client set. Closes #1315.
 
 ### Fixed
 

--- a/src/antfarm/interpreter.ts
+++ b/src/antfarm/interpreter.ts
@@ -184,3 +184,34 @@ export function buildScript(rows: AuditEventRow[]): ActivityScript {
   }
   return { directives };
 }
+
+/** Convert a live bus event to the audit row shape the interpreter expects. */
+export function busEventToAuditRow(event: {
+  id: string;
+  timestamp: Date;
+  type: string;
+  sourceLayer: string;
+  parentEventId?: string | null;
+  payload: unknown;
+}): AuditEventRow {
+  const payload = event.payload as unknown as Record<string, unknown>;
+  const sourceId =
+    typeof payload.agentId === 'string'
+      ? payload.agentId
+      : typeof payload.channelId === 'string'
+        ? payload.channelId
+        : event.sourceLayer;
+  return {
+    id: event.id,
+    timestamp: event.timestamp,
+    eventType: event.type,
+    sourceLayer: event.sourceLayer,
+    sourceId,
+    conversationId: typeof payload.conversationId === 'string' ? payload.conversationId : null,
+    parentEventId: event.parentEventId ?? null,
+    payload:
+      typeof payload === 'object' && payload !== null && !Array.isArray(payload)
+        ? payload
+        : {},
+  };
+}

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -13,6 +13,8 @@ import type { EventBus } from '../../bus/bus.js';
 import type { BusEvent } from '../../bus/events.js';
 import type { Logger } from '../../logger.js';
 import type { ServerResponse } from 'node:http';
+import type { SceneDirective } from '@curia/shared-types';
+import { busEventToAuditRow, interpretEvent } from '../../antfarm/interpreter.js';
 import { markdownToHtml } from '../../format/markdown-to-html.js';
 
 /**
@@ -113,6 +115,36 @@ export interface SseClient {
   conversationId?: string; // Optional filter
 }
 
+/** Event types forwarded to Ant Farm live stream (interpreter catalog superset). */
+export const ANT_FARM_EVENT_TYPES = [
+  'schedule.fired',
+  'agent.task',
+  'skill.invoke',
+  'skill.result',
+  'agent.discuss',
+  'inbound.message',
+  'outbound.message',
+  'outbound.delivered',
+  'task.created',
+  'task.completed',
+  'agent.error',
+  'human.decision',
+  'autonomy.skill_blocked',
+  'autonomy.send_blocked',
+] as const;
+
+/** Per-client pending SSE frames before a slow consumer is dropped. */
+export const ANT_FARM_MAX_CLIENT_BUFFER = 50;
+/** Max interpreted directives delivered to one client per second (coalesce guard). */
+export const ANT_FARM_MAX_DIRECTIVES_PER_SECOND = 60;
+
+export interface AntfarmClient {
+  res: ServerResponse;
+  pendingWrites: number;
+  directivesThisSecond: number;
+  secondWindowStart: number;
+}
+
 /**
  * EventRouter registers shared bus subscribers and dispatches to HTTP clients.
  * Call setupSubscriptions() once at startup, then use the add/remove methods
@@ -124,6 +156,8 @@ export class EventRouter {
   private pendingResponses = new Map<string, PendingResponse>();
   /** Active SSE connections */
   private sseClients = new Set<SseClient>();
+  /** Ant Farm live-stream clients — separate from messages SSE (no cross-talk). */
+  private antfarmClients = new Set<AntfarmClient>();
 
   constructor(logger: Logger) {
     this.logger = logger;
@@ -270,6 +304,12 @@ export class EventRouter {
       this.broadcastToSseClients(sseData);
     });
 
+    for (const eventType of ANT_FARM_EVENT_TYPES) {
+      bus.subscribe(eventType, 'system', (event: BusEvent) => {
+        if (event.type !== eventType) return;
+        this.broadcastAntfarmFromBusEvent(event);
+      });
+    }
 
     this.logger.info('HTTP event router subscriptions registered');
   }
@@ -351,5 +391,72 @@ export class EventRouter {
       this.sseClients.delete(client);
       this.logger.debug({ conversationId: client.conversationId }, 'SSE client disconnected');
     };
+  }
+
+  /** Register an Ant Farm SSE client. Returns a cleanup function. */
+  addAntfarmClient(client: Pick<AntfarmClient, 'res'>): () => void {
+    const entry: AntfarmClient = {
+      res: client.res,
+      pendingWrites: 0,
+      directivesThisSecond: 0,
+      secondWindowStart: Date.now(),
+    };
+    this.antfarmClients.add(entry);
+    this.logger.debug('Ant Farm SSE client connected');
+    return () => {
+      this.antfarmClients.delete(entry);
+      this.logger.debug('Ant Farm SSE client disconnected');
+    };
+  }
+
+  private broadcastAntfarmFromBusEvent(event: BusEvent): void {
+    const mapped = interpretEvent(busEventToAuditRow(event));
+    if (mapped === null) {
+      return;
+    }
+    const directives = Array.isArray(mapped) ? mapped : [mapped];
+    this.broadcastToAntfarm(directives);
+  }
+
+  /**
+   * Deliver interpreted directives to Ant Farm clients. Slow clients with a full
+   * pending-write buffer are dropped so dispatch never blocks on a single consumer.
+   */
+  broadcastToAntfarm(directives: SceneDirective[]): void {
+    if (directives.length === 0 || this.antfarmClients.size === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    for (const client of [...this.antfarmClients]) {
+      for (const directive of directives) {
+        if (client.pendingWrites >= ANT_FARM_MAX_CLIENT_BUFFER) {
+          this.antfarmClients.delete(client);
+          this.logger.warn('Dropped slow Ant Farm SSE client — pending buffer full');
+          break;
+        }
+
+        if (now - client.secondWindowStart >= 1000) {
+          client.secondWindowStart = now;
+          client.directivesThisSecond = 0;
+        }
+        if (client.directivesThisSecond >= ANT_FARM_MAX_DIRECTIVES_PER_SECOND) {
+          continue;
+        }
+
+        const envelope = JSON.stringify({ type: 'directive', directive });
+        try {
+          client.pendingWrites += 1;
+          client.res.write(`data: ${envelope}\n\n`, () => {
+            client.pendingWrites = Math.max(0, client.pendingWrites - 1);
+          });
+          client.directivesThisSecond += 1;
+        } catch (err) {
+          this.antfarmClients.delete(client);
+          this.logger.debug({ err }, 'Removed dead Ant Farm SSE client');
+          break;
+        }
+      }
+    }
   }
 }

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -32,6 +32,7 @@ import { DEFAULT_HEALTH_CONFIG } from '../../config.js';
 import { healthRoutes } from './routes/health.js';
 import { agentRoutes } from './routes/agents.js';
 import { jobRoutes } from './routes/jobs.js';
+import { antfarmRoutes } from './routes/antfarm.js';
 import { messageRoutes } from './routes/messages.js';
 import { consoleRoutes } from './routes/console.js';
 import { knowledgeGraphRoutes } from './routes/kg.js';
@@ -51,6 +52,7 @@ import type { ContactService } from '../../contacts/contact-service.js';
 import type { AutonomyService } from '../../autonomy/autonomy-service.js';
 import { type SessionStore } from './session-auth.js';
 import type { Channel } from '../channel.js';
+import type { AuditLogRepo } from '../../audit/audit-log-repo.js';
 
 /**
  * Minimal HealthService for boot paths where a full HealthService wasn't provided
@@ -128,6 +130,8 @@ export interface HttpAdapterConfig {
    * (timezone/email/name writes still succeed).
    */
   entityMemory?: import('../../memory/entity-memory.js').EntityMemory;
+  /** Backs GET /api/antfarm/timeline (replay window queries). */
+  auditLogRepo?: AuditLogRepo;
 }
 
 export class HttpAdapter implements Channel {
@@ -220,6 +224,7 @@ export class HttpAdapter implements Channel {
         routeUrl.startsWith('/api/identity') ||
         routeUrl.startsWith('/api/executive') ||
         routeUrl.startsWith('/api/jobs') ||
+        routeUrl.startsWith('/api/antfarm') ||
         routeUrl.startsWith('/api/autonomy') ||
         routeUrl.startsWith('/api/registry') ||
         routeUrl.startsWith('/api/vault') ||
@@ -325,6 +330,16 @@ export class HttpAdapter implements Channel {
         sessions,
         // Needed so console-created jobs carry principal lineage (#1127).
         contactService: this.config.contactService,
+        logger,
+      });
+    }
+
+    if (this.config.auditLogRepo) {
+      await this.app.register(antfarmRoutes, {
+        auditLogRepo: this.config.auditLogRepo,
+        eventRouter: this.eventRouter,
+        webAppBootstrapSecret,
+        sessions,
         logger,
       });
     }

--- a/src/channels/http/routes/antfarm.ts
+++ b/src/channels/http/routes/antfarm.ts
@@ -1,0 +1,137 @@
+// antfarm.ts — Ant Farm replay timeline and live directive stream.
+//
+// GET /api/antfarm/timeline — historical ActivityScript for a time window.
+// GET /api/antfarm/stream   — SSE of interpreted directives for live monitoring.
+//
+// Auth: session cookie or x-web-bootstrap-secret (same as jobs/KG routes).
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { AuditLogRepo } from '../../../audit/audit-log-repo.js';
+import type { Logger } from '../../../logger.js';
+import { buildScript } from '../../../antfarm/interpreter.js';
+import type { AuditEventRow } from '@curia/shared-types';
+import { assertSecret, type SessionStore } from '../session-auth.js';
+import type { EventRouter } from '../event-router.js';
+
+export interface AntfarmRouteOptions {
+  auditLogRepo: AuditLogRepo;
+  eventRouter: EventRouter;
+  webAppBootstrapSecret: string | undefined;
+  sessions: SessionStore;
+  logger: Logger;
+}
+
+const DEFAULT_TIMELINE_LIMIT = 500;
+const MAX_TIMELINE_LIMIT = 2000;
+
+function auditLogRowToEventRow(row: {
+  id: string;
+  timestamp: Date;
+  eventType: string;
+  sourceLayer: string;
+  sourceId: string;
+  conversationId: string | null;
+  parentEventId: string | null;
+  payload: Record<string, unknown>;
+}): AuditEventRow {
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    eventType: row.eventType,
+    sourceLayer: row.sourceLayer,
+    sourceId: row.sourceId,
+    conversationId: row.conversationId,
+    parentEventId: row.parentEventId,
+    payload: row.payload,
+  };
+}
+
+function parseOptionalDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed;
+}
+
+export async function antfarmRoutes(
+  app: FastifyInstance,
+  options: AntfarmRouteOptions,
+): Promise<void> {
+  const { auditLogRepo, eventRouter, webAppBootstrapSecret, sessions, logger } = options;
+
+  app.get('/api/antfarm/timeline', async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+
+    const query = request.query as {
+      from?: string;
+      to?: string;
+      conversationId?: string;
+      taskId?: string;
+      limit?: string;
+    };
+
+    const from = parseOptionalDate(query.from);
+    const to = parseOptionalDate(query.to);
+    if (query.from && !from) {
+      return reply.status(400).send({ error: 'Invalid from timestamp' });
+    }
+    if (query.to && !to) {
+      return reply.status(400).send({ error: 'Invalid to timestamp' });
+    }
+
+    const parsedLimit = query.limit ? Number.parseInt(query.limit, 10) : DEFAULT_TIMELINE_LIMIT;
+    const limit = Number.isFinite(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), MAX_TIMELINE_LIMIT)
+      : DEFAULT_TIMELINE_LIMIT;
+
+    try {
+      const page = await auditLogRepo.findTimeline({
+        from,
+        to,
+        conversationId: query.conversationId,
+        taskId: query.taskId,
+        limit,
+      });
+      const script = buildScript(page.rows.map(auditLogRowToEventRow));
+      return reply.send({
+        ...script,
+        hasMore: page.hasMore,
+        nextCursor: page.nextCursor,
+      });
+    } catch (err) {
+      logger.error({ err }, 'antfarm timeline query failed');
+      const message = err instanceof Error ? err.message : 'Failed to load timeline';
+      return reply.status(500).send({ error: message });
+    }
+  });
+
+  app.get('/api/antfarm/stream', async (request: FastifyRequest, reply: FastifyReply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+
+    reply.hijack();
+    reply.raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    reply.raw.write(':connected\n\n');
+
+    const cleanup = eventRouter.addAntfarmClient({ res: reply.raw });
+
+    const heartbeat = setInterval(() => {
+      try {
+        reply.raw.write(':ping\n\n');
+      } catch {
+        clearInterval(heartbeat);
+      }
+    }, 30000);
+
+    request.raw.on('close', () => {
+      clearInterval(heartbeat);
+      cleanup();
+    });
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2253,6 +2253,7 @@ async function main(): Promise<void> {
     entityMemory,
     // Powers GET /api/health with real probes and canary state (#434).
     healthService,
+    auditLogRepo,
   });
 
   try {

--- a/tests/integration/antfarm-routes.test.ts
+++ b/tests/integration/antfarm-routes.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Fastify from 'fastify';
+import pg from 'pg';
+import pino from 'pino';
+import { antfarmRoutes } from '../../src/channels/http/routes/antfarm.js';
+import { AuditLogRepo } from '../../src/audit/audit-log-repo.js';
+import { EventRouter } from '../../src/channels/http/event-router.js';
+
+const logger = pino({ level: 'silent' });
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('Ant Farm REST routes', () => {
+  let app: ReturnType<typeof Fastify>;
+  let pool: pg.Pool;
+  let repo: AuditLogRepo;
+  const sessions = new Map<string, number>();
+  const TEST_SECRET = 'test-antfarm-secret';
+  const AUTH_HEADER = { 'x-web-bootstrap-secret': TEST_SECRET };
+  const sourceLayer = 'test-antfarm-routes';
+
+  beforeAll(async () => {
+    app = Fastify();
+    pool = new pg.Pool({ connectionString: DATABASE_URL });
+    repo = new AuditLogRepo(pool, logger);
+    const eventRouter = new EventRouter(logger);
+
+    await pool.query('SELECT 1 FROM audit_log LIMIT 0');
+
+    await app.register(antfarmRoutes, {
+      auditLogRepo: repo,
+      eventRouter,
+      webAppBootstrapSecret: TEST_SECRET,
+      sessions,
+      logger,
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  it('rejects unauthenticated timeline requests', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/antfarm/timeline',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns interpreted directives for a seeded window', async () => {
+    const from = '2026-07-02T20:00:00.000Z';
+    const to = '2026-07-02T21:00:00.000Z';
+    await pool.query(
+      `INSERT INTO audit_log (timestamp, event_type, source_layer, source_id, payload, conversation_id)
+       VALUES ($1, 'task.created', $2, 'coordinator', $3::jsonb, 'conv-antfarm')`,
+      [
+        new Date('2026-07-02T20:30:00.000Z'),
+        sourceLayer,
+        JSON.stringify({ taskId: 'task-af2', title: 'Demo task' }),
+      ],
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/antfarm/timeline?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&conversationId=conv-antfarm`,
+      headers: AUTH_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { directives: Array<{ kind: string; taskId?: string }> };
+    expect(body.directives.some((d) => d.kind === 'task.appear' && d.taskId === 'task-af2')).toBe(true);
+  });
+
+  it('rejects unauthenticated stream requests', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/antfarm/stream',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tests/unit/channels/http/event-router.test.ts
+++ b/tests/unit/channels/http/event-router.test.ts
@@ -28,13 +28,22 @@ function createLogger(): Logger {
 // A fake bus that captures the EventRouter's subscribers so a test can emit
 // events directly into them without standing up the real EventBus.
 function createBus(): { bus: EventBus; emit: (event: BusEvent) => void } {
-  const handlers = new Map<string, (event: BusEvent) => void>();
+  const handlers = new Map<string, Array<(event: BusEvent) => void>>();
   const bus = {
     subscribe: (type: string, _layer: string, handler: (event: BusEvent) => void) => {
-      handlers.set(type, handler);
+      const list = handlers.get(type) ?? [];
+      list.push(handler);
+      handlers.set(type, list);
     },
   } as unknown as EventBus;
-  return { bus, emit: (event: BusEvent) => handlers.get(event.type)?.(event) };
+  return {
+    bus,
+    emit: (event: BusEvent) => {
+      for (const handler of handlers.get(event.type) ?? []) {
+        handler(event);
+      }
+    },
+  };
 }
 
 function makeRouter(): { router: EventRouter; emit: (event: BusEvent) => void } {
@@ -170,5 +179,60 @@ describe('EventRouter SSE — outbound.message html rendering', () => {
     expect(frame).toBeDefined();
     const payload = JSON.parse(frame!.slice('data: '.length).trim()) as { html: string | null };
     expect(payload.html).toBeNull();
+  });
+});
+
+describe('EventRouter Ant Farm SSE', () => {
+  it('delivers interpreted directives only to antfarm clients, not messages SSE clients', () => {
+    const { router, emit } = makeRouter();
+    const messageWrites: string[] = [];
+    const antfarmWrites: string[] = [];
+
+    router.addSseClient({
+      res: { write: (chunk: string) => { messageWrites.push(chunk); return true; } } as unknown as ServerResponse,
+    });
+    router.addAntfarmClient({
+      res: { write: (chunk: string) => { antfarmWrites.push(chunk); return true; } } as unknown as ServerResponse,
+    });
+
+    emit({
+      id: 'evt-task',
+      type: 'task.created',
+      sourceLayer: 'execution',
+      timestamp: new Date('2026-07-02T12:00:00.000Z'),
+      payload: { taskId: 't-live', title: 'Live' },
+    } as unknown as BusEvent);
+
+    expect(messageWrites.some((w) => w.includes('task.appear'))).toBe(false);
+    expect(antfarmWrites.some((w) => w.includes('task.appear'))).toBe(true);
+  });
+
+  it('drops a slow antfarm client when its pending buffer is full', () => {
+    const { router } = makeRouter();
+    let writeCount = 0;
+    const res = {
+      write: (_chunk: string, _cb?: () => void) => {
+        writeCount += 1;
+        return true;
+      },
+    };
+
+    router.addAntfarmClient({ res: res as unknown as ServerResponse });
+
+    const directives = Array.from({ length: 60 }, (_, i) => ({
+      id: `d-${i}`,
+      logicalTs: i,
+      causedBy: null,
+      kind: 'badge' as const,
+      badgeKind: 'human.decision' as const,
+      label: 'test',
+    }));
+
+    router.broadcastToAntfarm(directives);
+    expect(writeCount).toBeLessThanOrEqual(60);
+    const firstPassWrites = writeCount;
+
+    router.broadcastToAntfarm(directives);
+    expect(writeCount).toBe(firstPassWrites);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1315

Adds the Ant Farm backend API layer: historical replay via `GET /api/antfarm/timeline` and live monitoring via `GET /api/antfarm/stream`. Both endpoints use session auth and route audit events through the AF-3 interpreter.

**Stack note:** This branch includes AF-1 (#1314, #1322) and AF-3 (#1316, #1323) commits. Merge those first or merge this after they land.

## Changes

- **`GET /api/antfarm/timeline`** — query params `from`/`to`/`conversationId`/`taskId`/`limit`; returns `ActivityScript`.
- **`GET /api/antfarm/stream`** — SSE of `{ type: 'directive', directive }` envelopes with heartbeat.
- **`EventRouter`** — separate `antfarmClients` set; subscribes to the interpreter catalog on the `system` layer; backpressure via pending-write buffer cap and per-second directive rate limit.
- **`http-adapter`** — `/api/antfarm` auth bypass; routes registered before console catch-all; `auditLogRepo` threaded through config.

## Testing

- `tests/integration/antfarm-routes.test.ts` — auth + timeline interpretation (gated on `DATABASE_URL`).
- `tests/unit/channels/http/event-router.test.ts` — antfarm/message SSE isolation + slow-client drop.
- `pnpm run typecheck` passes.
