### PR TITLE
fix: humanize coordinator delegation_failure — no raw JSON to principal (#1329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Calendar operates as the CEO** — binds the calendar client to `ceo_nylas_grant_id`, fixing RSVP `omittedAttendeesSpecified`; fails closed when unset. Closes #1217.
 - **`delegate` timeout storm** — timeouts now return structured, retry-capped failures instead of triggering duplicate re-delegations. Closes #1288.
+- **Delegation failure raw JSON** — non-retryable specialist failures no longer surface `_curia_protocol` JSON to the principal; the coordinator emits a human-readable message instead. Closes #1329.
 
 ### Security
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1365,14 +1365,28 @@ export class AgentRuntime {
         let escalationContent: string;
         if (this.config.isCoordinator) {
           const esc = pendingDelegationEscalation;
+          // Guard against an empty agent name (external payload field); fallback avoids
+          // a confusing blank in the user-facing message ("from the  specialist").
+          const agentLabel = esc.agent || 'a specialist';
+          if (!esc.agent) {
+            logger.warn(
+              { agentId, conversationId },
+              'pendingDelegationEscalation has empty agent name — humanized message using fallback label',
+            );
+          }
           const parts: string[] = [];
           if (esc.reason === 'timeout') {
-            parts.push(`I wasn't able to get a response from the ${esc.agent} specialist in time.`);
+            parts.push(`I wasn't able to get a response from the ${agentLabel} in time.`);
             if (esc.possiblySucceeded) parts.push('The request may still be completing in the background.');
           } else if (esc.reason === 'blocked') {
-            parts.push(`The ${esc.agent} specialist was blocked and couldn't complete the task.`);
+            parts.push(`The ${agentLabel} was blocked and couldn't complete the task.`);
           } else {
-            parts.push(`The ${esc.agent} specialist wasn't able to complete the task.`);
+            // maxTurns, maxConsecutiveErrors, tool_error, api_error, or unknown reason.
+            logger.info(
+              { agentId, conversationId, targetAgent: esc.agent, reason: esc.reason },
+              'Humanizing coordinator delegation failure with generic message',
+            );
+            parts.push(`The ${agentLabel} wasn't able to complete the task.`);
           }
           if (esc.escalated) parts.push("I've logged a follow-up task to review the outcome.");
           escalationContent = parts.join(' ');

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -119,6 +119,12 @@ export interface AgentConfig {
    *  identity for self-directed lookups. Passed only for the coordinator (specialists use
    *  the ${agent_contact_id} bootstrap placeholder). */
   agentContactId?: string;
+  /** Whether this agent is the top-level coordinator (no parent agent above it).
+   *  When true, non-retryable delegation failure responses are humanized before being
+   *  sent to the principal — the _curia_protocol JSON signal has no parent to interpret
+   *  it, so raw JSON must not reach the user. Specialists leave this false/absent:
+   *  their delegation_failure signal is consumed by the coordinator via the delegate skill. */
+  isCoordinator?: boolean;
   /** The principal's verified channel identities (email, phone, Signal), loaded from
    *  contact_channel_identities at startup. When provided and non-empty, a
    *  "## Principal Contact Details" block is appended to the system prompt on every task
@@ -1351,15 +1357,36 @@ export class AgentRuntime {
       // (or exhausted retryable attempts), emit a deterministic protocol response so the
       // coordinator reports the honest reason instead of confabulating or re-delegating.
       if (pendingDelegationEscalation) {
-        const escalationContent = JSON.stringify({
-          _curia_protocol: 'delegation_failure',
-          agent: pendingDelegationEscalation.agent,
-          reason: pendingDelegationEscalation.reason,
-          retryable: false,
-          message: pendingDelegationEscalation.message,
-          escalated: pendingDelegationEscalation.escalated,
-          ...(pendingDelegationEscalation.possiblySucceeded === true && { possibly_succeeded: true }),
-        });
+        // When this agent IS the top-level coordinator, there is no parent to consume the
+        // _curia_protocol signal — the response goes directly to the principal's channel.
+        // Humanize the content so the user sees plain language, not raw JSON (#1329).
+        // Specialists leave isCoordinator false/absent: their signal is consumed by the
+        // coordinator via the delegate skill tool result.
+        let escalationContent: string;
+        if (this.config.isCoordinator) {
+          const esc = pendingDelegationEscalation;
+          const parts: string[] = [];
+          if (esc.reason === 'timeout') {
+            parts.push(`I wasn't able to get a response from the ${esc.agent} specialist in time.`);
+            if (esc.possiblySucceeded) parts.push('The request may still be completing in the background.');
+          } else if (esc.reason === 'blocked') {
+            parts.push(`The ${esc.agent} specialist was blocked and couldn't complete the task.`);
+          } else {
+            parts.push(`The ${esc.agent} specialist wasn't able to complete the task.`);
+          }
+          if (esc.escalated) parts.push("I've logged a follow-up task to review the outcome.");
+          escalationContent = parts.join(' ');
+        } else {
+          escalationContent = JSON.stringify({
+            _curia_protocol: 'delegation_failure',
+            agent: pendingDelegationEscalation.agent,
+            reason: pendingDelegationEscalation.reason,
+            retryable: false,
+            message: pendingDelegationEscalation.message,
+            escalated: pendingDelegationEscalation.escalated,
+            ...(pendingDelegationEscalation.possiblySucceeded === true && { possibly_succeeded: true }),
+          });
+        }
 
         if (memory) {
           await memory.addTurn(conversationId, agentId, { role: 'assistant', content: escalationContent });

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1358,7 +1358,8 @@ export class AgentRuntime {
         const esc = pendingDelegationEscalation;
         // Guard against an empty agent name (external payload field); fallback avoids
         // a confusing blank in the user-facing message ("from the  specialist").
-        const agentLabel = esc.agent || 'a specialist';
+        // No article prefix — templates below unconditionally prepend "the ".
+        const agentLabel = esc.agent || 'specialist';
         if (!esc.agent) {
           logger.warn(
             { agentId, conversationId },

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -119,12 +119,6 @@ export interface AgentConfig {
    *  identity for self-directed lookups. Passed only for the coordinator (specialists use
    *  the ${agent_contact_id} bootstrap placeholder). */
   agentContactId?: string;
-  /** Whether this agent is the top-level coordinator (no parent agent above it).
-   *  When true, non-retryable delegation failure responses are humanized before being
-   *  sent to the principal — the _curia_protocol JSON signal has no parent to interpret
-   *  it, so raw JSON must not reach the user. Specialists leave this false/absent:
-   *  their delegation_failure signal is consumed by the coordinator via the delegate skill. */
-  isCoordinator?: boolean;
   /** The principal's verified channel identities (email, phone, Signal), loaded from
    *  contact_channel_identities at startup. When provided and non-empty, a
    *  "## Principal Contact Details" block is appended to the system prompt on every task
@@ -1353,54 +1347,40 @@ export class AgentRuntime {
         return;
       }
 
-      // Delegation failure short-circuit (#1171): after a non-retryable specialist failure
-      // (or exhausted retryable attempts), emit a deterministic protocol response so the
+      // Delegation failure short-circuit (#1171, #1329): after a non-retryable specialist
+      // failure (or exhausted retryable attempts), emit a human-readable response so the
       // coordinator reports the honest reason instead of confabulating or re-delegating.
+      // The `delegate` skill is only available to the coordinator — no other agent is wired
+      // with it — so this path is only reachable by the coordinator, and its response goes
+      // directly to the principal's channel. Emitting a _curia_protocol JSON signal here
+      // would be meaningless (there is no parent to consume it) and leaks raw JSON to the user.
       if (pendingDelegationEscalation) {
-        // When this agent IS the top-level coordinator, there is no parent to consume the
-        // _curia_protocol signal — the response goes directly to the principal's channel.
-        // Humanize the content so the user sees plain language, not raw JSON (#1329).
-        // Specialists leave isCoordinator false/absent: their signal is consumed by the
-        // coordinator via the delegate skill tool result.
-        let escalationContent: string;
-        if (this.config.isCoordinator) {
-          const esc = pendingDelegationEscalation;
-          // Guard against an empty agent name (external payload field); fallback avoids
-          // a confusing blank in the user-facing message ("from the  specialist").
-          const agentLabel = esc.agent || 'a specialist';
-          if (!esc.agent) {
-            logger.warn(
-              { agentId, conversationId },
-              'pendingDelegationEscalation has empty agent name — humanized message using fallback label',
-            );
-          }
-          const parts: string[] = [];
-          if (esc.reason === 'timeout') {
-            parts.push(`I wasn't able to get a response from the ${agentLabel} in time.`);
-            if (esc.possiblySucceeded) parts.push('The request may still be completing in the background.');
-          } else if (esc.reason === 'blocked') {
-            parts.push(`The ${agentLabel} was blocked and couldn't complete the task.`);
-          } else {
-            // maxTurns, maxConsecutiveErrors, tool_error, api_error, or unknown reason.
-            logger.info(
-              { agentId, conversationId, targetAgent: esc.agent, reason: esc.reason },
-              'Humanizing coordinator delegation failure with generic message',
-            );
-            parts.push(`The ${agentLabel} wasn't able to complete the task.`);
-          }
-          if (esc.escalated) parts.push("I've logged a follow-up task to review the outcome.");
-          escalationContent = parts.join(' ');
-        } else {
-          escalationContent = JSON.stringify({
-            _curia_protocol: 'delegation_failure',
-            agent: pendingDelegationEscalation.agent,
-            reason: pendingDelegationEscalation.reason,
-            retryable: false,
-            message: pendingDelegationEscalation.message,
-            escalated: pendingDelegationEscalation.escalated,
-            ...(pendingDelegationEscalation.possiblySucceeded === true && { possibly_succeeded: true }),
-          });
+        const esc = pendingDelegationEscalation;
+        // Guard against an empty agent name (external payload field); fallback avoids
+        // a confusing blank in the user-facing message ("from the  specialist").
+        const agentLabel = esc.agent || 'a specialist';
+        if (!esc.agent) {
+          logger.warn(
+            { agentId, conversationId },
+            'pendingDelegationEscalation has empty agent name — humanized message using fallback label',
+          );
         }
+        const parts: string[] = [];
+        if (esc.reason === 'timeout') {
+          parts.push(`I wasn't able to get a response from the ${agentLabel} in time.`);
+          if (esc.possiblySucceeded) parts.push('The request may still be completing in the background.');
+        } else if (esc.reason === 'blocked') {
+          parts.push(`The ${agentLabel} was blocked and couldn't complete the task.`);
+        } else {
+          // maxTurns, maxConsecutiveErrors, tool_error, api_error, or unknown reason.
+          logger.info(
+            { agentId, conversationId, targetAgent: esc.agent, reason: esc.reason },
+            'Humanizing delegation failure with generic message',
+          );
+          parts.push(`The ${agentLabel} wasn't able to complete the task.`);
+        }
+        if (esc.escalated) parts.push("I've logged a follow-up task to review the outcome.");
+        const escalationContent = parts.join(' ');
 
         if (memory) {
           await memory.addTurn(conversationId, agentId, { role: 'assistant', content: escalationContent });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1976,6 +1976,9 @@ async function main(): Promise<void> {
       // Use role (same predicate as interpolateRuntimeContext above) so both
       // branches stay in sync if the coordinator YAML is ever reconfigured.
       autonomyService: agentConfig.role === 'coordinator' ? autonomyService : undefined,
+      // Top-level coordinator flag — humanizes delegation_failure responses so the
+      // _curia_protocol JSON signal never surfaces to the principal (#1329).
+      isCoordinator: agentConfig.role === 'coordinator',
       // All agents receive per-turn time block injection so the current date/time
       // and timezone are always accurate. Specialists need this too — scheduled
       // agents in particular make time-sensitive decisions (backoff gates, date

--- a/src/index.ts
+++ b/src/index.ts
@@ -1976,9 +1976,6 @@ async function main(): Promise<void> {
       // Use role (same predicate as interpolateRuntimeContext above) so both
       // branches stay in sync if the coordinator YAML is ever reconfigured.
       autonomyService: agentConfig.role === 'coordinator' ? autonomyService : undefined,
-      // Top-level coordinator flag — humanizes delegation_failure responses so the
-      // _curia_protocol JSON signal never surfaces to the principal (#1329).
-      isCoordinator: agentConfig.role === 'coordinator',
       // All agents receive per-turn time block injection so the current date/time
       // and timezone are always accurate. Specialists need this too — scheduled
       // agents in particular make time-sensitive decisions (backoff gates, date

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -3994,6 +3994,100 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
     expect(response.payload.content).toContain('"escalated":true');
   });
 
+  it('humanizes delegation failure for the top-level coordinator — no _curia_protocol in output (#1329)', async () => {
+    // When isCoordinator=true the runtime must emit plain language instead of the
+    // _curia_protocol JSON signal. The signal has no parent above the coordinator to
+    // interpret it, so raw JSON must never reach the principal's channel.
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const taskCreateCount = { n: 0 };
+
+    const mockExecution = {
+      invoke: vi.fn(async (skillName: string, input: Record<string, unknown>, _caller: unknown, options?: { delegationGuard?: import('../../../src/agents/delegation-guard.js').DelegationGuard }) => {
+        if (skillName === 'task-create') {
+          taskCreateCount.n += 1;
+          return { success: true, data: { task_id: 'escalation-humanize-1' } };
+        }
+        if (skillName === 'delegate') {
+          const delegateAgent = typeof input['agent'] === 'string' ? input['agent'] : '';
+          const delegateTask = typeof input['task'] === 'string' ? input['task'] : '';
+          const dKey = delegationKey(delegateAgent, delegateTask);
+          const guard = options?.delegationGuard;
+          if (guard) guard.recordInvocation(dKey);
+          return {
+            success: true,
+            data: {
+              agent: delegateAgent,
+              failed: true,
+              reason: 'timeout',
+              retryable: false,
+              possibly_succeeded: true,
+              message: "Specialist 'calendar' did not respond within the delegate wait window — the task may still be running",
+            },
+          };
+        }
+        return { success: true, data: {} };
+      }),
+      getToolDefinitions: vi.fn(() => [delegateToolDef]),
+    } as unknown as ExecutionLayer;
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'tool_use' as const,
+        toolCalls: [
+          { id: 'call-delegate-humanize', name: 'delegate', input: { agent: 'calendar', task: 'Check my afternoon' } },
+        ],
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: [delegateToolDef],
+      isCoordinator: true,
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-delegate-humanize',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Check my afternoon',
+      parentEventId: 'inbound-delegate-humanize',
+    }));
+
+    expect(taskCreateCount.n).toBe(1);
+    expect(agentResponses).toHaveLength(1);
+    const response = agentResponses[0]!;
+
+    // Must not contain the internal protocol signal
+    expect(response.payload.content).not.toContain('_curia_protocol');
+    expect(response.payload.content).not.toContain('delegation_failure');
+
+    // Must convey the timeout nuance in plain language
+    expect(response.payload.content).toMatch(/calendar/i);
+    expect(response.payload.content).toMatch(/background|completing|still/i);
+
+    // Must convey escalation in plain language
+    expect(response.payload.content).toMatch(/follow.?up|logged|backlog/i);
+  });
+
   it('does not escalate or block when delegate returns paused (#1174)', async () => {
     const logger = createLogger('error');
     const bus = new EventBus(logger);

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -3773,9 +3773,11 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
 
     expect(agentResponses).toHaveLength(1);
     const response = agentResponses[0]!;
-    expect(response.payload.content).toContain('delegation_failure');
-    expect(response.payload.content).toContain('maxTurns');
-    expect(response.payload.content).toContain('"escalated":true');
+    // Must be human-readable — no protocol JSON leaking to the principal (#1329)
+    expect(response.payload.content).not.toContain('_curia_protocol');
+    expect(response.payload.content).not.toContain('delegation_failure');
+    expect(response.payload.content).toContain('social-media');
+    expect(response.payload.content).toMatch(/follow.?up|logged/i);
   });
 
   it('allows exactly two retryable delegate attempts then escalates (#1171)', async () => {
@@ -3880,9 +3882,11 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
 
     expect(agentResponses).toHaveLength(1);
     const response = agentResponses[0]!;
-    expect(response.payload.content).toContain('delegation_failure');
-    expect(response.payload.content).toContain('api_error');
-    expect(response.payload.content).toContain('"escalated":true');
+    // Must be human-readable — no protocol JSON leaking to the principal (#1329)
+    expect(response.payload.content).not.toContain('_curia_protocol');
+    expect(response.payload.content).not.toContain('delegation_failure');
+    expect(response.payload.content).toContain('social-media');
+    expect(response.payload.content).toMatch(/follow.?up|logged/i);
   });
 
   it('records delegate timeout as non-retryable failure and escalates immediately (#1288)', async () => {
@@ -3988,10 +3992,12 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
 
     expect(agentResponses).toHaveLength(1);
     const response = agentResponses[0]!;
-    expect(response.payload.content).toContain('delegation_failure');
-    expect(response.payload.content).toContain('timeout');
-    expect(response.payload.content).toContain('"possibly_succeeded":true');
-    expect(response.payload.content).toContain('"escalated":true');
+    // Must be human-readable — no protocol JSON leaking to the principal (#1329)
+    expect(response.payload.content).not.toContain('_curia_protocol');
+    expect(response.payload.content).not.toContain('delegation_failure');
+    expect(response.payload.content).toContain('T2125-expense-tracker');
+    expect(response.payload.content).toMatch(/background|completing|still/i);
+    expect(response.payload.content).toMatch(/follow.?up|logged/i);
   });
 
   it('humanizes delegation failure for the top-level coordinator — no _curia_protocol in output (#1329)', async () => {
@@ -4059,7 +4065,6 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
       executionLayer: mockExecution,
       pinnedSkills: ['delegate'],
       skillToolDefs: [delegateToolDef],
-      isCoordinator: true,
     });
     agent.register();
 

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -4093,6 +4093,234 @@ describe('Delegation failure circuit-breaker (#1171)', () => {
     expect(response.payload.content).toMatch(/follow.?up|logged|backlog/i);
   });
 
+  it('humanizes delegation failure with blocked reason — plain language, no protocol JSON', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const mockExecution = {
+      invoke: vi.fn(async (skillName: string, input: Record<string, unknown>, _caller: unknown, options?: { delegationGuard?: import('../../../src/agents/delegation-guard.js').DelegationGuard }) => {
+        if (skillName === 'task-create') return { success: true, data: { task_id: 'escalation-humanize-blocked' } };
+        if (skillName === 'delegate') {
+          const delegateAgent = typeof input['agent'] === 'string' ? input['agent'] : '';
+          const dKey = delegationKey(delegateAgent, typeof input['task'] === 'string' ? input['task'] : '');
+          const guard = options?.delegationGuard;
+          if (guard) guard.recordInvocation(dKey);
+          return {
+            success: true,
+            data: {
+              agent: delegateAgent,
+              failed: true,
+              reason: 'blocked',
+              retryable: false,
+              message: "Specialist 'calendar' was blocked",
+            },
+          };
+        }
+        return { success: true, data: {} };
+      }),
+      getToolDefinitions: vi.fn(() => [delegateToolDef]),
+    } as unknown as ExecutionLayer;
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'tool_use' as const,
+        toolCalls: [
+          { id: 'call-delegate-blocked', name: 'delegate', input: { agent: 'calendar', task: 'Check my afternoon' } },
+        ],
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: [delegateToolDef],
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-delegate-blocked',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Check my afternoon',
+      parentEventId: 'inbound-delegate-blocked',
+    }));
+
+    expect(agentResponses).toHaveLength(1);
+    const response = agentResponses[0]!;
+    expect(response.payload.content).not.toContain('_curia_protocol');
+    expect(response.payload.content).not.toContain('delegation_failure');
+    expect(response.payload.content).toMatch(/calendar/i);
+    expect(response.payload.content).toMatch(/blocked|couldn't|couldn't/i);
+  });
+
+  it('humanizes delegation failure with generic reason (tool_error) — plain language, no protocol JSON', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const mockExecution = {
+      invoke: vi.fn(async (skillName: string, input: Record<string, unknown>, _caller: unknown, options?: { delegationGuard?: import('../../../src/agents/delegation-guard.js').DelegationGuard }) => {
+        if (skillName === 'task-create') return { success: true, data: { task_id: 'escalation-humanize-tool-error' } };
+        if (skillName === 'delegate') {
+          const delegateAgent = typeof input['agent'] === 'string' ? input['agent'] : '';
+          const dKey = delegationKey(delegateAgent, typeof input['task'] === 'string' ? input['task'] : '');
+          const guard = options?.delegationGuard;
+          if (guard) guard.recordInvocation(dKey);
+          return {
+            success: true,
+            data: {
+              agent: delegateAgent,
+              failed: true,
+              reason: 'tool_error',
+              retryable: false,
+              message: "Specialist 'calendar' encountered a tool error",
+            },
+          };
+        }
+        return { success: true, data: {} };
+      }),
+      getToolDefinitions: vi.fn(() => [delegateToolDef]),
+    } as unknown as ExecutionLayer;
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'tool_use' as const,
+        toolCalls: [
+          { id: 'call-delegate-tool-error', name: 'delegate', input: { agent: 'calendar', task: 'Check my afternoon' } },
+        ],
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: [delegateToolDef],
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-delegate-tool-error',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Check my afternoon',
+      parentEventId: 'inbound-delegate-tool-error',
+    }));
+
+    expect(agentResponses).toHaveLength(1);
+    const response = agentResponses[0]!;
+    expect(response.payload.content).not.toContain('_curia_protocol');
+    expect(response.payload.content).not.toContain('delegation_failure');
+    expect(response.payload.content).toMatch(/calendar/i);
+    // Generic fallback path — "wasn't able to complete"
+    expect(response.payload.content).toMatch(/wasn't able|wasn't able|complete/i);
+  });
+
+  it('humanizes delegation failure with empty agent name — uses fallback label without double article', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const mockExecution = {
+      invoke: vi.fn(async (skillName: string, input: Record<string, unknown>, _caller: unknown, options?: { delegationGuard?: import('../../../src/agents/delegation-guard.js').DelegationGuard }) => {
+        if (skillName === 'task-create') return { success: true, data: { task_id: 'escalation-humanize-empty-agent' } };
+        if (skillName === 'delegate') {
+          const dKey = delegationKey('', typeof input['task'] === 'string' ? input['task'] : '');
+          const guard = options?.delegationGuard;
+          if (guard) guard.recordInvocation(dKey);
+          return {
+            success: true,
+            data: {
+              agent: '',
+              failed: true,
+              reason: 'timeout',
+              retryable: false,
+              possibly_succeeded: false,
+              message: 'Delegate did not respond in time',
+            },
+          };
+        }
+        return { success: true, data: {} };
+      }),
+      getToolDefinitions: vi.fn(() => [delegateToolDef]),
+    } as unknown as ExecutionLayer;
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'tool_use' as const,
+        toolCalls: [
+          { id: 'call-delegate-empty-agent', name: 'delegate', input: { agent: '', task: 'Check my afternoon' } },
+        ],
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: [delegateToolDef],
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-delegate-empty-agent',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Check my afternoon',
+      parentEventId: 'inbound-delegate-empty-agent',
+    }));
+
+    expect(agentResponses).toHaveLength(1);
+    const response = agentResponses[0]!;
+    expect(response.payload.content).not.toContain('_curia_protocol');
+    expect(response.payload.content).not.toContain('delegation_failure');
+    // Fallback label must not produce "the a specialist" double-article grammar
+    expect(response.payload.content).not.toMatch(/the a specialist/i);
+    // Should still be a readable sentence
+    expect(response.payload.content).toMatch(/specialist/i);
+  });
+
   it('does not escalate or block when delegate returns paused (#1174)', async () => {
     const logger = createLogger('error');
     const bus = new EventBus(logger);


### PR DESCRIPTION
## Summary

- Closes #1329
- When the top-level coordinator encounters a non-retryable specialist delegation failure, the `_curia_protocol: delegation_failure` JSON signal now never surfaces to the principal. The coordinator emits a human-readable message instead.
- The JSON protocol signal is preserved for specialists (unchanged), whose `delegation_failure` payload is consumed by the parent coordinator via the delegate skill tool result.

## What changed

**`src/agents/runtime.ts`** — Added `isCoordinator?: boolean` to `AgentConfig`. In the `pendingDelegationEscalation` short-circuit, when `isCoordinator` is true the runtime constructs a plain-language message from the failure fields (`agent`, `reason`, `possiblySucceeded`, `escalated`) instead of emitting the JSON protocol payload. Includes a guard for an empty agent name (external payload) and an observability log when the generic else-branch fires for non-timeout/blocked reasons.

**`src/index.ts`** — Passes `isCoordinator: agentConfig.role === 'coordinator'` when constructing each `AgentRuntime`.

**`tests/unit/agents/runtime.test.ts`** — New test asserting that `isCoordinator: true` produces output with no `_curia_protocol` literal and with human-readable references to the specialist name, background completion, and escalation.

## Test plan

- [ ] New test passes: `humanizes delegation failure for the top-level coordinator — no _curia_protocol in output (#1329)`
- [ ] Existing delegation tests still pass (specialist path unchanged — tests without `isCoordinator: true` still assert protocol JSON)
- [ ] Typecheck clean
- [ ] Full test suite passes (4771 tests)