### PR TITLE
feat(deploy): curia-deploy Ant Farm companion patch bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Ant Farm AF-4** — `@curia/antfarm` scaffold with Conductor (playback, velocity, scrub, replay↔live merge), transport bar, bookmarks, and dynamic desk layout. Closes #1317.
 - **Ant Farm AF-5** — Phaser `OfficeScene` rendering all AF-3 directive metaphors, React-DOM detail overlays (pause on open), deterministic per-agent character variants, CC0 placeholder art + LimeZu credits. Closes #1318.
 - **Ant Farm AF-6** — Docker image builds both SPAs; `antfarm-static` route serves `/antfarm/*` before the console wildcard. Closes #1319.
+- **Ant Farm deploy companion** — `deploy/curia-deploy/` patch bundle + `docs/dev/antfarm-deploy.md` for the private `curia-deploy` production image (`Dockerfile.curia` + `custom/assets/antfarm/`).
 
 ### Fixed
 

--- a/deploy/curia-deploy/README.md
+++ b/deploy/curia-deploy/README.md
@@ -1,0 +1,27 @@
+# curia-deploy — Ant Farm companion changes
+
+Production builds use `curia-deploy/deploy/compose/Dockerfile.curia`, not `curia/Dockerfile`.
+These files are the **curia-deploy half** of Ant Farm AF-6 (#1319).
+
+## Apply
+
+1. Copy `custom/assets/antfarm/` into your `curia-deploy` checkout.
+2. Apply `patches/Dockerfile.curia.antfarm.patch` to `deploy/compose/Dockerfile.curia`:
+   ```bash
+   cd /path/to/curia-deploy
+   patch -p1 < /path/to/curia/deploy/curia-deploy/patches/Dockerfile.curia.antfarm.patch
+   ```
+   If hunks fail (path prefix differs), follow the manual steps in `docs/dev/antfarm-deploy.md`.
+3. Drop licensed LimeZu sprite sheets into `custom/assets/antfarm/limezu/` (see `SOURCE.md`).
+4. Rebuild and deploy as usual (`deploy.sh` / `docker compose build curia`).
+
+## No compose / Caddy changes expected
+
+Ant Farm is served by the existing `curia` container on `:3000` under `/antfarm/`.
+The reverse proxy should already forward all paths to Curia; no new service or route is required.
+
+## Verify
+
+- `GET https://<host>/antfarm/` returns the SPA (session cookie from console login).
+- `GET https://<host>/api/antfarm/timeline?from=...&to=...` returns JSON after auth.
+- Browser network tab shows assets under `/antfarm/assets/...` (Vite base path).

--- a/deploy/curia-deploy/custom/assets/antfarm/README.md
+++ b/deploy/curia-deploy/custom/assets/antfarm/README.md
@@ -1,0 +1,6 @@
+# Licensed Ant Farm assets
+
+Place LimeZu sprite sheets here. See `SOURCE.md` for pack URLs, layout, and license notes.
+
+The build copies this directory to `apps/antfarm/public/assets/limezu/` inside the image.
+Until files are added, production runs with CC0 placeholders from the public `curia` repo.

--- a/deploy/curia-deploy/custom/assets/antfarm/SOURCE.md
+++ b/deploy/curia-deploy/custom/assets/antfarm/SOURCE.md
@@ -1,0 +1,40 @@
+# Ant Farm — licensed LimeZu assets (private)
+
+**Do not commit raw LimeZu files to the public `curia` repo.** This directory is the
+canonical home for production sprite sheets, layered into the Docker image at build time.
+
+## Packs
+
+| Pack | URL | Use in Ant Farm |
+|------|-----|-----------------|
+| Modern Office - Revamped (16×16) | https://limezu.itch.io/modernoffice | Office tiles, furniture, props |
+| Modern Interiors | https://limezu.itch.io/moderninteriors | Top-down character generator sheets |
+
+Record the **purchase date**, **itch.io version/build**, and **license confirmation**
+when you add or refresh files.
+
+## Layout
+
+Copy extracted PNG/sheets into subfolders that mirror the in-app loader paths:
+
+```
+custom/assets/antfarm/
+  SOURCE.md          ← this file
+  limezu/
+    office/          ← Modern Office sheets (tiles, furniture)
+    characters/      ← Modern Interiors character parts / walk cycles
+```
+
+At image build, `Dockerfile.curia` copies this tree to
+`apps/antfarm/public/assets/limezu/` **before** `pnpm --filter @curia/antfarm run build`.
+
+If the directory is empty, the build still succeeds — the app uses in-repo CC0
+placeholders and procedural textures until licensed art is present.
+
+## License
+
+LimeZu assets are **not redistributable** in the public open-core image. They are
+for private/hosted production builds only, until owned/commissioned art replaces them
+(see Ant Farm epic #1313).
+
+Attribution is required and is surfaced in-app via `CREDITS.md` / the credits footer.

--- a/deploy/curia-deploy/patches/Dockerfile.curia.antfarm.patch
+++ b/deploy/curia-deploy/patches/Dockerfile.curia.antfarm.patch
@@ -1,6 +1,6 @@
---- a/deploy/compose/Dockerfile.curia
-+++ b/deploy/compose/Dockerfile.curia
-@@ -16,6 +16,8 @@ RUN corepack enable
+--- a/deploy/compose/Dockerfile.curia	2026-07-03 17:07:30.612210697 +0000
++++ b/deploy/compose/Dockerfile.curia	2026-07-03 17:07:30.636210648 +0000
+@@ -17,11 +17,14 @@
  # Copy all workspace manifests so pnpm installs the full workspace in one shot.
  COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
  COPY apps/console/package.json ./apps/console/
@@ -15,7 +15,7 @@
  # Skip --dts: type declarations are for library consumers, not the runtime image.
  # tsup's DTS build also trips a TS 6.0 deprecation error on any tsconfig with baseUrl.
  RUN pnpm exec tsup src/index.ts --format esm --no-dts
-@@ -28,6 +30,13 @@ RUN pnpm exec tsup src/index.ts --format esm --no-dts
+@@ -30,6 +33,12 @@
  COPY apps/console/ ./apps/console/
  RUN pnpm --filter @curia/console run build
  
@@ -28,7 +28,7 @@
  # Production stage: minimal runtime image.
  # Same node:24-slim digest pin as the build stage above (see that comment for the
  # Scorecard / Dependabot rationale). Both stages must stay on the same digest.
-@@ -98,6 +107,9 @@ RUN rm -rf /root/.cache/node/corepack /root/.cache/corepack
+@@ -100,6 +109,9 @@
  # Copy console static bundle — served by Fastify at runtime
  COPY --from=build /app/apps/console/dist ./apps/console/dist
  

--- a/deploy/curia-deploy/patches/Dockerfile.curia.antfarm.patch
+++ b/deploy/curia-deploy/patches/Dockerfile.curia.antfarm.patch
@@ -1,0 +1,40 @@
+--- a/deploy/compose/Dockerfile.curia
++++ b/deploy/compose/Dockerfile.curia
+@@ -16,6 +16,8 @@ RUN corepack enable
+ # Copy all workspace manifests so pnpm installs the full workspace in one shot.
+ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+ COPY apps/console/package.json ./apps/console/
++COPY apps/antfarm/package.json ./apps/antfarm/
++COPY packages/shared-types/package.json ./packages/shared-types/
+ RUN pnpm install --frozen-lockfile
+ 
+ # Build backend
+ COPY src/ ./src/
+ COPY tsconfig.json ./
++COPY packages/ ./packages/
+ # Skip --dts: type declarations are for library consumers, not the runtime image.
+ # tsup's DTS build also trips a TS 6.0 deprecation error on any tsconfig with baseUrl.
+ RUN pnpm exec tsup src/index.ts --format esm --no-dts
+@@ -28,6 +30,13 @@ RUN pnpm exec tsup src/index.ts --format esm --no-dts
+ COPY apps/console/ ./apps/console/
+ RUN pnpm --filter @curia/console run build
+ 
++# Build Ant Farm frontend — output lands in apps/antfarm/dist/
++# Licensed LimeZu art from curia-deploy (optional; CC0 placeholders if directory empty)
++COPY custom/assets/antfarm/ ./apps/antfarm/public/assets/limezu/
++COPY apps/antfarm/ ./apps/antfarm/
++RUN pnpm --filter @curia/antfarm run build
++
+ # Production stage: minimal runtime image.
+ # Same node:24-slim digest pin as the build stage above (see that comment for the
+ # Scorecard / Dependabot rationale). Both stages must stay on the same digest.
+@@ -98,6 +107,9 @@ RUN rm -rf /root/.cache/node/corepack /root/.cache/corepack
+ # Copy console static bundle — served by Fastify at runtime
+ COPY --from=build /app/apps/console/dist ./apps/console/dist
+ 
++# Copy Ant Farm static bundle — served under /antfarm/
++COPY --from=build /app/apps/antfarm/dist ./apps/antfarm/dist
++
+ # Copy runtime data files loaded at startup
+ # Full src/ is needed because skill handlers import from src/ (e.g., bus/events.ts)
+ # and tsx resolves these at runtime

--- a/docs/dev/antfarm-deploy.md
+++ b/docs/dev/antfarm-deploy.md
@@ -1,0 +1,91 @@
+# Ant Farm — production deploy (`curia-deploy`)
+
+Ant Farm ships in the **public `curia` repo** (AF-6: Dockerfile + `antfarm-static` route).
+Production VPS builds use the **private [`curia-deploy`](https://github.com/josephfung/curia-deploy)**
+image (`deploy/compose/Dockerfile.curia`), which must mirror the same build steps.
+
+Ready-to-copy companion files live in [`deploy/curia-deploy/`](../../deploy/curia-deploy/).
+
+## What to change in `curia-deploy`
+
+### 1. `deploy/compose/Dockerfile.curia`
+
+Mirror the Ant Farm steps from [`curia/Dockerfile`](../../Dockerfile) (build stage + runtime copy).
+
+**Dependency install** — add workspace manifests before `pnpm install --frozen-lockfile`:
+
+```dockerfile
+COPY apps/antfarm/package.json ./apps/antfarm/
+COPY packages/shared-types/package.json ./packages/shared-types/
+```
+
+**Backend build** — copy shared-types source (interpreter + API depend on it):
+
+```dockerfile
+COPY packages/ ./packages/
+```
+
+**Ant Farm build** — layer licensed art, then Vite build:
+
+```dockerfile
+# Licensed LimeZu art from curia-deploy (optional; CC0 placeholders if empty)
+COPY custom/assets/antfarm/ ./apps/antfarm/public/assets/limezu/
+COPY apps/antfarm/ ./apps/antfarm/
+RUN pnpm --filter @curia/antfarm run build
+```
+
+Place the `COPY custom/assets/antfarm/` line **after** `apps/antfarm/package.json` is
+on disk but **before** `pnpm --filter @curia/antfarm run build` so Vite bundles the sheets.
+
+**Runtime stage** — copy the static bundle (after the console dist copy):
+
+```dockerfile
+COPY --from=build /app/apps/antfarm/dist ./apps/antfarm/dist
+```
+
+Apply the unified patch from `deploy/curia-deploy/patches/Dockerfile.curia.antfarm.patch`
+if your `Dockerfile.curia` still matches the `curia/Dockerfile` layout. If your deploy
+Dockerfile prefixes paths with `curia/` (some `deploy.sh` layouts do), adjust:
+
+| Patch path | With `curia/` prefix |
+|------------|----------------------|
+| `COPY apps/antfarm/...` | `COPY curia/apps/antfarm/...` |
+| `COPY packages/...` | `COPY curia/packages/...` |
+| `COPY custom/assets/antfarm/` | unchanged (always from deploy repo) |
+
+### 2. `custom/assets/antfarm/`
+
+Add the directory from `deploy/curia-deploy/custom/assets/antfarm/`:
+
+- `SOURCE.md` — pack URLs, layout, license notes
+- `limezu/` — drop licensed sprite sheets here (gitignored in public curia)
+
+See [`apps/antfarm/public/assets/README.md`](../../apps/antfarm/public/assets/README.md)
+and [`apps/antfarm/CREDITS.md`](../../apps/antfarm/CREDITS.md).
+
+### 3. No compose / proxy changes
+
+Ant Farm is served by the existing `curia` service on port 3000:
+
+- SPA: `/antfarm/`
+- API: `/api/antfarm/timeline`, `/api/antfarm/stream`
+
+Caddy (or your reverse proxy) should already forward all paths to Curia. No new container
+or route block is required unless you intentionally restrict paths.
+
+### 4. `deploy.sh`
+
+No change expected if it already runs `docker compose build` against `Dockerfile.curia`
+with the deploy repo as build context (including `custom/`).
+
+## Verify after deploy
+
+1. Sign in via the console (session cookie).
+2. Open `https://<host>/antfarm/` — SPA loads, no 404 from console wildcard.
+3. Scrub/play a window or switch to live mode — timeline API and SSE connect.
+4. DevTools → Network: assets load under `/antfarm/assets/...` (Vite `base: '/antfarm/'`).
+
+## Curia version pin
+
+Deploy the Ant Farm-capable Curia release (epic #1313 / AF-1–AF-6 merged). The production
+image must include `src/channels/http/routes/antfarm-static.ts` and the antfarm API routes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **curia-deploy companion** for Ant Farm production deploys. The public `curia` repo already ships AF-6 (`Dockerfile` + `antfarm-static` route); production VPS builds use the private `curia-deploy/deploy/compose/Dockerfile.curia`, which needs the same Ant Farm build steps and licensed-asset layering.

Companion to Ant Farm epic #1313 / AF-6 #1319.

## What's included

| Path | Purpose |
|------|---------|
| `deploy/curia-deploy/patches/Dockerfile.curia.antfarm.patch` | Unified diff: antfarm workspace manifests, `@curia/shared-types`, Vite build, runtime dist copy, LimeZu asset `COPY` |
| `deploy/curia-deploy/custom/assets/antfarm/` | `SOURCE.md`, README, `limezu/.gitkeep` scaffold for licensed sprite sheets |
| `docs/dev/antfarm-deploy.md` | Apply instructions, path-prefix notes, verification checklist |

## Apply to curia-deploy

1. Copy `deploy/curia-deploy/custom/assets/antfarm/` → `curia-deploy/custom/assets/antfarm/`
2. Patch `deploy/compose/Dockerfile.curia` (see `docs/dev/antfarm-deploy.md` if paths use a `curia/` prefix)
3. Drop LimeZu sheets into `custom/assets/antfarm/limezu/` when ready
4. Rebuild production image

No compose/Caddy changes expected — Ant Farm is served by the existing `curia` container on `:3000`.

## Checklist

- [x] Patch mirrors `curia/Dockerfile` AF-6 steps
- [x] Licensed-asset layout documented (`SOURCE.md`)
- [x] CHANGELOG updated
- [ ] Applied and verified in `curia-deploy` (requires private repo access)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23eb8ec6-bb59-47f3-9938-c70e8617f2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23eb8ec6-bb59-47f3-9938-c70e8617f2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

