### PR TITLE
fix(docker): make runtime stage work as a pnpm workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Ant Farm** — code review follow-ups: fail-closed session check, conductor live/scrub fixes, incremental live merge, per-agent overlay context, timeline cursor paging, safe `busEventToAuditRow` payload guard, `schedule.fired` task_id normalization.
 - **Ant Farm** — fix playback flicker: stable desk roster + conductor snapshot refs so Phaser scene is not restarted every animation frame.
+- **Runtime image pnpm workspace** — the Dockerfile runtime stage now copies the `@curia/shared-types` member and runs `pnpm add -w --save-prod --prod tsx`, fixing a latent build-break chain (ADDING_TO_ROOT → WORKSPACE_PKG_NOT_FOUND → INCLUDED_DEPS_CONFLICT) that surfaces once curia is a real pnpm workspace.
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,13 +80,36 @@ RUN npm install -g npm@11.17.0
 
 # Copy manifest and lockfile, then install production deps only
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# Copy the @curia/shared-types workspace package (source-only: package.json +
+# index.ts) so the workspace graph is internally consistent. The root package.json
+# declares `@curia/shared-types: "workspace:*"` as a prod dependency and
+# pnpm-workspace.yaml declares `packages: [apps/*, packages/*]`; the `pnpm add tsx`
+# below re-resolves the FULL workspace and aborts with ERR_PNPM_WORKSPACE_PKG_NOT_FOUND
+# if the member isn't on disk. (--frozen-lockfile tolerates a dangling link; `pnpm add`
+# does a strict re-resolution.) shared-types is imported type-only (erased at build), so
+# it isn't required at runtime, but shipping the member keeps the manifest honest.
+COPY --from=build /app/packages/shared-types ./packages/shared-types
 RUN pnpm install --frozen-lockfile --prod
 
 # tsx is needed at runtime: skill handlers are .ts files loaded via dynamic
 # import(), and they use ESM .js extension mapping (e.g., import from './foo.js'
 # resolving to foo.ts). Node's --experimental-strip-types doesn't handle this;
 # tsx does, and it's already used for dev (pnpm dev).
-RUN pnpm add tsx
+#
+# Three flags are load-bearing (verified against pnpm 11.7.0, the pinned pkg mgr).
+# Since packages/shared-types made this a real workspace, this dir is now a workspace
+# ROOT and a bare `pnpm add tsx` fails a chain of guards:
+#   -w: without it, a `pnpm add` at a workspace root is rejected with
+#     ERR_PNPM_ADDING_TO_ROOT. tsx is a genuine root-level runtime dep, so the root is
+#     the correct target (the shared-types member copied above lets it re-resolve).
+#   --prod: the frozen install above ran with --prod, so node_modules/.modules.yaml
+#     records a prod-only include set; a bare `pnpm add` also wants devDependencies,
+#     which pnpm 11 rejects with ERR_PNPM_INCLUDED_DEPS_CONFLICT. --prod keeps the add
+#     prod-only so the include sets match.
+#   --save-prod: tsx is declared as a *devDependency* in package.json, so --prod alone
+#     would leave it there and never install it — no ./node_modules/.bin/tsx, which the
+#     CMD below invokes. --save-prod promotes tsx into `dependencies` so it installs.
+RUN pnpm add -w --save-prod --prod tsx
 
 # Remove corepack's cached pnpm tarballs. Node 24's bundled corepack pre-caches
 # pnpm@11.0.8 (the version shipped with Node 24) during `corepack enable`, even


### PR DESCRIPTION
## Summary

Once the Ant Farm work added `@curia/shared-types` (`workspace:*`) as a **prod dependency**, curia became a real pnpm workspace. The `Dockerfile` runtime stage copies only the root manifest + lockfile + `pnpm-workspace.yaml` and then runs `pnpm add tsx` — which now fails a chain of three pnpm guards:

1. **`ERR_PNPM_ADDING_TO_ROOT`** — a bare `pnpm add` at a workspace root is rejected.
2. **`ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`** — the `workspace:*` member `@curia/shared-types` isn't on disk, and `pnpm add` does a strict full-workspace re-resolution. (`--frozen-lockfile` survives it by laying down a *dangling* symlink; `pnpm add` won't.)
3. **`ERR_PNPM_INCLUDED_DEPS_CONFLICT`** — the `--prod` frozen install marks `node_modules` prod-only; a bare `pnpm add` wants devDependencies too.

The runtime stage **hasn't rebuilt since shared-types landed**, so this is latent here — but `curia-deploy`'s mirror of these exact steps hit all three in production and was fixed there first (curia-deploy #157 / #158 / #159, now deployed and green).

## Fix

- **COPY the source-only `@curia/shared-types` member** (package.json + index.ts) from the build stage *before* the frozen install, so the workspace graph resolves.
- **`pnpm add -w --save-prod --prod tsx`:**
  - `-w` — target the workspace root (avoids ADDING_TO_ROOT).
  - `--prod` — keep the add prod-only so the include set matches the frozen `--prod` install.
  - `--save-prod` — tsx is a **devDependency** in `package.json`, so `--prod` alone would leave it there and never install it (no `./node_modules/.bin/tsx`, which the `CMD` invokes → crash-loop). `--save-prod` promotes it into `dependencies`.

## Verification

The identical fix is running in production via the `curia-deploy` mirror Dockerfile. The flag behavior was verified against **pnpm 11.7.0** (the pinned `packageManager`) with faithful workspace repros: each error reproduced, and `--save-prod --prod` shown to be the only combination that clears the conflict *and* installs a pre-existing devDependency (`.bin/tsx` present, tsx promoted to `dependencies`). `NODE_ENV=production` and `--config.dev=false` do **not** work.

Not built as a full image in this PR — CI / the next image build is the final gate.

## Notes

- The two extra `pnpm add` calls in the deploy mirror (`atproto-mcp`, `@atproto/api`) are Bluesky-specific deploy-only deps and correctly stay out of the core image.
- This runtime stage intentionally omits `--ignore-scripts` (it relies on the existing `allowBuilds: esbuild: true` path); that divergence from the mirror is pre-existing and out of scope.