### PR TITLE
fix(antfarm): scoped CSP so Phaser boot textures load in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Ant Farm** — code review follow-ups: fail-closed session check, conductor live/scrub fixes, incremental live merge, per-agent overlay context, timeline cursor paging, safe `busEventToAuditRow` payload guard, `schedule.fired` task_id normalization.
 - **Ant Farm** — fix playback flicker: stable desk roster + conductor snapshot refs so Phaser scene is not restarted every animation frame.
 - **Runtime image pnpm workspace** — the Dockerfile runtime stage now copies the `@curia/shared-types` member and runs `pnpm add -w --save-prod --prod tsx`, fixing a latent build-break chain (ADDING_TO_ROOT → WORKSPACE_PKG_NOT_FOUND → INCLUDED_DEPS_CONFLICT) that surfaces once curia is a real pnpm workspace.
+- **Ant Farm blank canvas in production** — `/antfarm/*` now gets a scoped CSP with `img-src 'self' data:` so Phaser's base64 boot textures load; the console keeps its strict `img-src 'self'`. The strict CSP was blocking them and the office rendered empty.
 
 ### Fixed
 

--- a/src/channels/http/security-headers.test.ts
+++ b/src/channels/http/security-headers.test.ts
@@ -5,7 +5,11 @@ import { describe, it, expect, afterEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
 import rateLimit from '@fastify/rate-limit';
-import { registerSecurityHeaders, CONSOLE_CONTENT_SECURITY_POLICY } from './security-headers.js';
+import {
+  registerSecurityHeaders,
+  CONSOLE_CONTENT_SECURITY_POLICY,
+  ANTFARM_CONTENT_SECURITY_POLICY,
+} from './security-headers.js';
 
 let app: FastifyInstance | undefined;
 
@@ -29,6 +33,19 @@ async function build(): Promise<FastifyInstance> {
   instance.get('/ok', async () => ({ ok: true }));
   instance.get('/html', async (_req, reply) => {
     return reply.type('text/html; charset=utf-8').send('<!doctype html><html><body>ok</body></html>');
+  });
+  // Ant Farm SPA routes (served as HTML) — deep links resolve to the same index.html.
+  instance.get('/antfarm/', async (_req, reply) => {
+    return reply.type('text/html; charset=utf-8').send('<!doctype html><html><body>antfarm</body></html>');
+  });
+  instance.get('/antfarm/deep/link', async (_req, reply) => {
+    return reply.type('text/html; charset=utf-8').send('<!doctype html><html><body>antfarm</body></html>');
+  });
+  // Bare /antfarm (no trailing slash) is NOT served by the antfarm bundle in prod — it
+  // falls through to the console wildcard and returns console HTML. Model that here so the
+  // test proves it keeps the strict console CSP, not the relaxed antfarm one.
+  instance.get('/antfarm', async (_req, reply) => {
+    return reply.type('text/html; charset=utf-8').send('<!doctype html><html><body>console</body></html>');
   });
   // A hook that 401s before the handler — proves the header lands on short-circuited
   // responses (the case that matters for the API's auth gate).
@@ -130,5 +147,50 @@ describe('registerSecurityHeaders', () => {
     expect(CONSOLE_CONTENT_SECURITY_POLICY).toContain("script-src 'self'");
     expect(CONSOLE_CONTENT_SECURITY_POLICY).not.toContain('cdn.tailwindcss.com');
     expect(CONSOLE_CONTENT_SECURITY_POLICY).toContain("frame-ancestors 'none'");
+  });
+
+  it('does not allow data: images in the strict console CSP', async () => {
+    // Regression guard: the console must not inherit the Ant Farm relaxation.
+    expect(CONSOLE_CONTENT_SECURITY_POLICY).toContain("img-src 'self'");
+    expect(CONSOLE_CONTENT_SECURITY_POLICY).not.toContain('data:');
+  });
+
+  it('serves the Ant Farm CSP (img-src data:) on /antfarm/ HTML responses', async () => {
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/antfarm/' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBe(ANTFARM_CONTENT_SECURITY_POLICY);
+    expect(res.headers['content-security-policy']).toContain("img-src 'self' data:");
+    expect(res.headers['x-frame-options']).toBe('DENY');
+  });
+
+  it('serves the Ant Farm CSP on deep-linked /antfarm/* HTML (SPA fallback)', async () => {
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/antfarm/deep/link?t=1' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBe(ANTFARM_CONTENT_SECURITY_POLICY);
+  });
+
+  it('keeps the strict console CSP on non-Ant-Farm HTML', async () => {
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/html' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBe(CONSOLE_CONTENT_SECURITY_POLICY);
+  });
+
+  it('keeps the strict console CSP on bare /antfarm (served by the console wildcard)', async () => {
+    // Regression guard: bare /antfarm (no trailing slash) resolves to console HTML in prod,
+    // so it must NOT receive the relaxed img-src data: policy.
+    app = await build();
+    const res = await app.inject({ method: 'GET', url: '/antfarm' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBe(CONSOLE_CONTENT_SECURITY_POLICY);
+    expect(res.headers['content-security-policy']).not.toContain('data:');
+  });
+
+  it('keeps script-src strict in the Ant Farm CSP (only images are relaxed)', async () => {
+    expect(ANTFARM_CONTENT_SECURITY_POLICY).toContain("script-src 'self'");
+    expect(ANTFARM_CONTENT_SECURITY_POLICY).toContain("frame-ancestors 'none'");
+    expect(ANTFARM_CONTENT_SECURITY_POLICY).toContain("img-src 'self' data:");
   });
 });

--- a/src/channels/http/security-headers.ts
+++ b/src/channels/http/security-headers.ts
@@ -25,10 +25,53 @@ export const CONSOLE_CONTENT_SECURITY_POLICY = [
   "frame-ancestors 'none'",
 ].join('; ');
 
+/**
+ * CSP for the Ant Farm page (`/antfarm/*`, served as text/html).
+ *
+ * Identical to the console policy except `img-src` also allows `data:`. The Ant Farm
+ * visualization runs Phaser, which loads its internal boot textures (`__DEFAULT`,
+ * `__MISSING`, `__WHITE`) from embedded base64 `data:` PNG URIs on startup. Under the
+ * console's `img-src 'self'` the browser blocks those and the WebGL canvas fails to
+ * render — the procedural office art (built via `textures.addCanvas`) is itself CSP-safe,
+ * but Phaser's own boot images are not, and `__WHITE` backs all tinting/graphics.
+ *
+ * `data:` in `img-src` cannot execute script, so `script-src 'self'` — the XSS mitigation
+ * that motivated #130 — is unchanged. Only image sources are relaxed, and only on this page.
+ */
+export const ANTFARM_CONTENT_SECURITY_POLICY = [
+  "default-src 'none'",
+  "script-src 'self'",
+  "style-src 'self' https://fonts.googleapis.com",
+  "style-src-attr 'unsafe-inline'",
+  "font-src https://fonts.gstatic.com",
+  "img-src 'self' data:",
+  "connect-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
 function isHtmlResponse(reply: { getHeader(name: string): unknown }): boolean {
   const raw = reply.getHeader('content-type');
   const value = Array.isArray(raw) ? raw[0] : raw;
   return typeof value === 'string' && value.toLowerCase().includes('text/html');
+}
+
+/**
+ * True when the request targets the Ant Farm SPA. Match only the `/antfarm/` prefix (with
+ * the trailing slash) — that is exactly what the antfarm-static plugin serves (`prefix:
+ * '/antfarm/'` plus the `/antfarm/*` fallback), and deep links into the SPA all carry it.
+ *
+ * Bare `/antfarm` (no slash) is deliberately NOT matched: no Ant Farm route handles it, so
+ * it falls through to the console's `/*` wildcard and is served the *console* index.html.
+ * Matching it here would hand that console page the relaxed `data:` CSP — the exact leak
+ * this scoping exists to prevent. Fastify's `request.url` is the raw, un-decoded path and
+ * includes any query string, so strip the query and compare the path only.
+ */
+function isAntfarmRequest(url: string): boolean {
+  // split always yields at least one element, so [0] is guaranteed present.
+  const path = url.split('?', 1)[0]!;
+  return path.startsWith('/antfarm/');
 }
 
 /**
@@ -48,13 +91,18 @@ function isHtmlResponse(reply: { getHeader(name: string): unknown }): boolean {
  * DAST baseline finding for rule 10021 (X-Content-Type-Options Header Missing). See #568.
  *
  * HTML document responses (the console SPA and its fallback pages) also receive a strict
- * Content-Security-Policy and `X-Frame-Options: DENY`. See #130.
+ * Content-Security-Policy and `X-Frame-Options: DENY`. See #130. The Ant Farm page gets a
+ * near-identical policy that additionally allows `img-src ... data:` for Phaser's base64
+ * boot textures; every other HTML response keeps the stricter console policy.
  */
 export function registerSecurityHeaders(app: FastifyInstance): void {
-  app.addHook('onSend', async (_request, reply, payload) => {
+  app.addHook('onSend', async (request, reply, payload) => {
     reply.header('X-Content-Type-Options', 'nosniff');
     if (isHtmlResponse(reply)) {
-      reply.header('Content-Security-Policy', CONSOLE_CONTENT_SECURITY_POLICY);
+      const csp = isAntfarmRequest(request.url)
+        ? ANTFARM_CONTENT_SECURITY_POLICY
+        : CONSOLE_CONTENT_SECURITY_POLICY;
+      reply.header('Content-Security-Policy', csp);
       reply.header('X-Frame-Options', 'DENY');
     }
     return payload;


### PR DESCRIPTION
## Summary

The Ant Farm page (`/antfarm/`) rendered a **blank office in production** — every sprite missing, devtools showing blocked `data:image/png;base64` requests initiated by the Phaser bundle.

**Root cause:** the global HTML Content-Security-Policy (#130) sets `img-src 'self'`, which blocks `data:` URIs. Phaser loads its internal boot textures (`__DEFAULT`, `__MISSING`, `__WHITE`) from embedded base64 `data:` PNGs on startup — and `__WHITE` backs all tinting/graphics, so blocking them leaves the WebGL canvas empty. The office's own procedural art is CSP-safe (built via `textures.addCanvas`, no data URI); it's Phaser's own boot images that trip the policy. It only reproduces in prod because `vite preview` doesn't emit the CSP.

## Fix

Serve a **scoped** CSP for `/antfarm/*` that adds `data:` to `img-src` only. Every other HTML response keeps the strict console policy (`img-src 'self'`).

`data:` in `img-src` cannot execute script, so `script-src 'self'` — the XSS mitigation behind #130 — is **unchanged**. Only image sources are relaxed, and only on this page (`default-src 'none'`, framing, base-uri, form-action, connect-src all identical to the console policy).

## Scoping (security-reviewed)

The match is on the `/antfarm/` prefix **with the trailing slash** — exactly what the `antfarm-static` plugin serves. Bare `/antfarm` (no slash) is deliberately **excluded**: no Ant Farm route handles it, so it falls through to the console `/*` wildcard and returns *console* HTML, which must keep the strict CSP. An initial version matched bare `/antfarm` too; a security review caught that it would hand the console page the relaxed policy, and it's now fixed with a regression test.

## Tests

`ANTFARM_CONTENT_SECURITY_POLICY` + 6 new cases (14 total, all passing), covering:
- `/antfarm/` and deep-linked `/antfarm/*?…` get the relaxed CSP.
- Non-antfarm HTML **and bare `/antfarm`** keep the strict console CSP.
- The console CSP still forbids `data:`; both variants keep `script-src 'self'`.

Typecheck clean.

## Note (not changed here)

Bare `/antfarm` currently serves the console SPA rather than redirecting to `/antfarm/`. That's pre-existing routing behavior, out of scope for this CSP fix. If you want `/antfarm` to be a real entry point, the clean follow-up is a `/antfarm → /antfarm/` redirect in `antfarm-static.ts`.