### PR TITLE
Improve stuck-job recovery notification: add job context and console deep-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Stuck-job recovery notifications** — recovery and suspension emails now include job objective, recurrence, and a console deep-link; `/jobs/:jobId` opens the job drawer directly. Closes #1332.
 - **Ant Farm AF-1** — `AuditLogRepo.findTimeline` / `findByEventTypes` return paginated `TimelinePage` (`hasMore`, keyset `after` cursor) with scoped-query guard; task filter uses `payload->>'taskId'` (index-aligned). Closes #1314.
 - **Ant Farm AF-3** — `@curia/shared-types` contract package and server-side event→directive interpreter for the pixel-art office visualization. Closes #1316.
 - **Ant Farm AF-2** — `GET /api/antfarm/timeline` replay endpoint and `GET /api/antfarm/stream` live SSE fan-out with separate Ant Farm client set. Closes #1315.

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
-import { Link } from '@tanstack/react-router';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import cronstrue from 'cronstrue';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
@@ -532,6 +532,8 @@ const ALL_STATUSES: JobStatus[] = ['pending', 'running', 'suspended', 'paused', 
 const SCHEDULE_TYPE_FILTERS: ScheduleTypeFilter[] = ['all', 'recurring', 'one_time'];
 
 export default function JobsPage() {
+  const navigate = useNavigate();
+  const { jobId: jobIdFromUrl } = useParams({ strict: false }) as { jobId?: string };
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -546,6 +548,8 @@ export default function JobsPage() {
   const [pageSize, setPageSize] = useState(10);
   const [editing, setEditing] = useState<Job | null>(null);
   const [creating, setCreating] = useState(false);
+  const appliedUrlJobRef = useRef<string | undefined>(undefined);
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
@@ -567,6 +571,49 @@ export default function JobsPage() {
   }, []);
 
   useEffect(() => { void load(); }, [load]);
+
+  useEffect(() => {
+    if (!jobIdFromUrl) return;
+
+    const openFromUrl = async () => {
+      let target = jobs.find(j => j.id === jobIdFromUrl);
+      if (!target) {
+        try {
+          const res = await apiFetch(`/api/jobs/${jobIdFromUrl}`);
+          if (!res.ok) return;
+          const data = await res.json() as { job: Job };
+          target = data.job;
+          setJobs(prev => {
+            const idx = prev.findIndex(j => j.id === target!.id);
+            if (idx >= 0) {
+              const next = [...prev];
+              next[idx] = target!;
+              return next;
+            }
+            return [...prev, target!];
+          });
+          setStatusFilter('all');
+          setScheduleTypeFilter('all');
+          setAgentFilter('all');
+          setSearch('');
+        } catch (err) {
+          console.error('[JobsPage] failed to load job from URL:', err);
+          return;
+        }
+      }
+
+      if (appliedUrlJobRef.current === jobIdFromUrl && editing?.id === jobIdFromUrl) return;
+      appliedUrlJobRef.current = jobIdFromUrl;
+      setStatusFilter('all');
+      setScheduleTypeFilter('all');
+      setAgentFilter('all');
+      setSearch('');
+      setCreating(false);
+      setEditing(target);
+    };
+
+    void openFromUrl();
+  }, [jobIdFromUrl, jobs, editing?.id]);
 
   const counts = useMemo(() => {
     const c: Record<string, number> = { all: jobs.length };
@@ -620,6 +667,29 @@ export default function JobsPage() {
   const safePage = Math.min(page, totalPages);
   const pageRows = filtered.slice((safePage - 1) * pageSize, safePage * pageSize);
 
+  useEffect(() => {
+    if (!jobIdFromUrl || !editing || editing.id !== jobIdFromUrl) return;
+    const idx = filtered.findIndex(j => j.id === editing.id);
+    if (idx >= 0) {
+      const targetPage = Math.floor(idx / pageSize) + 1;
+      if (targetPage !== safePage) setPage(targetPage);
+    }
+  }, [jobIdFromUrl, editing, filtered, pageSize, safePage]);
+
+  useEffect(() => {
+    if (!jobIdFromUrl || !editing || editing.id !== jobIdFromUrl) return;
+    rowRefs.current.get(editing.id)?.scrollIntoView({ block: 'nearest' });
+  }, [editing, jobIdFromUrl, safePage, pageRows.length]);
+
+  function handleCloseDrawer() {
+    setEditing(null);
+    setCreating(false);
+    if (jobIdFromUrl) {
+      appliedUrlJobRef.current = undefined;
+      void navigate({ to: '/jobs', replace: true });
+    }
+  }
+
   function toggleSort(key: keyof Job) {
     setSort(s => s.key === key
       ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
@@ -645,8 +715,7 @@ export default function JobsPage() {
 
   function handleDeleted(id: string) {
     setJobs(prev => prev.filter(j => j.id !== id));
-    setEditing(null);
-    setCreating(false);
+    handleCloseDrawer();
   }
 
   return (
@@ -796,6 +865,10 @@ export default function JobsPage() {
                         {pageRows.map(j => (
                           <tr
                             key={j.id}
+                            ref={(el) => {
+                              if (el) rowRefs.current.set(j.id, el);
+                              else rowRefs.current.delete(j.id);
+                            }}
                             className={editing?.id === j.id ? 'active' : ''}
                             onClick={() => { setCreating(false); setEditing(j); }}
                           >
@@ -869,7 +942,7 @@ export default function JobsPage() {
                     key={editing?.id ?? 'new'}
                     job={editing}
                     creating={creating}
-                    onClose={() => { setEditing(null); setCreating(false); }}
+                    onClose={handleCloseDrawer}
                     onSaved={handleSaved}
                     onDeleted={handleDeleted}
                   />

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -574,6 +574,7 @@ export default function JobsPage() {
 
   useEffect(() => {
     if (!jobIdFromUrl) return;
+    if (appliedUrlJobRef.current === jobIdFromUrl) return;
 
     const openFromUrl = async () => {
       let target = jobs.find(j => j.id === jobIdFromUrl);
@@ -602,7 +603,6 @@ export default function JobsPage() {
         }
       }
 
-      if (appliedUrlJobRef.current === jobIdFromUrl && editing?.id === jobIdFromUrl) return;
       appliedUrlJobRef.current = jobIdFromUrl;
       setStatusFilter('all');
       setScheduleTypeFilter('all');
@@ -613,7 +613,7 @@ export default function JobsPage() {
     };
 
     void openFromUrl();
-  }, [jobIdFromUrl, jobs, editing?.id]);
+  }, [jobIdFromUrl, jobs]);
 
   const counts = useMemo(() => {
     const c: Record<string, number> = { all: jobs.length };

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -155,6 +155,12 @@ const jobsRoute = createRoute({
   component: JobsPage,
 });
 
+const jobDetailRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/jobs/$jobId',
+  component: JobsPage,
+});
+
 const tasksRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: '/tasks',
@@ -205,6 +211,7 @@ const routeTree = rootRoute.addChildren([
     setupRoute,
     contactsRoute,
     jobsRoute,
+    jobDetailRoute,
     tasksRoute,
     skillsRoute,
     agentsRoute,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1633,8 +1633,11 @@ async function main(): Promise<void> {
     const suspensionNotifier = new SuspensionNotifier({
       bus,
       outboundGateway,
+      schedulerService,
       ceoEmail: principalEmail,
       logger,
+      appOrigin: config.appOrigin,
+      httpPort: config.httpPort,
     });
     suspensionNotifier.register();
   } else {
@@ -1652,8 +1655,11 @@ async function main(): Promise<void> {
     const recoveryNotifier = new RecoveryNotifier({
       bus,
       outboundGateway,
+      schedulerService,
       ceoEmail: principalEmail,
       logger,
+      appOrigin: config.appOrigin,
+      httpPort: config.httpPort,
     });
     recoveryNotifier.register();
   } else {

--- a/src/scheduler/job-notification-context.ts
+++ b/src/scheduler/job-notification-context.ts
@@ -3,7 +3,11 @@
 // RecoveryNotifier and SuspensionNotifier bypass the LLM pipeline; this module supplies
 // human-readable job objective, recurrence, and console deep-link fields from scheduled_jobs.
 
-import type { JobRow } from './scheduler-service.js';
+import type { Logger } from '../logger.js';
+import { classifyError } from '../errors/classify.js';
+import type { JobRow, SchedulerService } from './scheduler-service.js';
+
+const MAX_OBJECTIVE_LENGTH = 200;
 
 /** Format an ISO timestamp as a UTC wall-clock string for notification bodies. */
 export function formatUtcTimestamp(iso: string): string {
@@ -16,21 +20,27 @@ export function formatUtcTimestamp(iso: string): string {
   return `${y}-${mo}-${day} ${h}:${min} UTC`;
 }
 
+function truncateObjective(text: string): string {
+  return text.length > MAX_OBJECTIVE_LENGTH
+    ? `${text.slice(0, MAX_OBJECTIVE_LENGTH - 1)}…`
+    : text;
+}
+
 /**
  * Derive a short human-readable objective for a scheduled job.
  * Prefers last_run_summary; otherwise intent_anchor / task title / task_payload fields.
  */
 export function deriveJobObjective(job: JobRow): string {
   const summary = job.lastRunSummary?.trim();
-  if (summary) return summary;
+  if (summary) return truncateObjective(summary);
 
   const anchor = job.intentAnchor?.trim();
-  if (anchor) return anchor;
+  if (anchor) return truncateObjective(anchor);
 
   const title = job.taskTitle?.trim();
-  if (title) return title;
+  if (title) return truncateObjective(title);
 
-  return deriveObjectiveFromPayload(job.taskPayload);
+  return truncateObjective(deriveObjectiveFromPayload(job.taskPayload));
 }
 
 /** Parse task_payload defensively for a human-readable intent string. */
@@ -84,7 +94,7 @@ export function buildJobConsoleUrl(
   httpPort: number,
   jobId: string,
 ): string {
-  const origin = (appOrigin ?? `http://localhost:${httpPort}`).replace(/\/+$/, '');
+  const origin = (appOrigin?.trim() ? appOrigin : `http://localhost:${httpPort}`).replace(/\/+$/, '');
   return `${origin}/jobs/${jobId}`;
 }
 
@@ -105,4 +115,30 @@ export function buildJobNotificationContext(
     recurrence: formatJobRecurrence(job),
     consoleUrl: buildJobConsoleUrl(appOrigin, httpPort, job.id),
   };
+}
+
+/**
+ * Load job context for CEO notification emails. Fail-open: a lookup error must not
+ * block the underlying recovery/suspension notification from reaching the CEO.
+ */
+export async function loadJobNotificationContext(
+  schedulerService: Pick<SchedulerService, 'getJob'>,
+  appOrigin: string | undefined,
+  httpPort: number,
+  jobId: string,
+  logger: Logger,
+  source: string,
+): Promise<JobNotificationContext> {
+  const consoleUrl = buildJobConsoleUrl(appOrigin, httpPort, jobId);
+  try {
+    const job = await schedulerService.getJob(jobId);
+    if (!job) {
+      return { objective: '(job not found)', recurrence: '(unknown)', consoleUrl };
+    }
+    return buildJobNotificationContext(job, appOrigin, httpPort);
+  } catch (err: unknown) {
+    const agentErr = classifyError(err, source);
+    logger.warn({ err: agentErr, jobId }, `${source}: failed to load job context for notification`);
+    return { objective: '(unavailable)', recurrence: '(unknown)', consoleUrl };
+  }
 }

--- a/src/scheduler/job-notification-context.ts
+++ b/src/scheduler/job-notification-context.ts
@@ -1,0 +1,108 @@
+// job-notification-context.ts — lightweight DB-backed context for scheduler CEO emails.
+//
+// RecoveryNotifier and SuspensionNotifier bypass the LLM pipeline; this module supplies
+// human-readable job objective, recurrence, and console deep-link fields from scheduled_jobs.
+
+import type { JobRow } from './scheduler-service.js';
+
+/** Format an ISO timestamp as a UTC wall-clock string for notification bodies. */
+export function formatUtcTimestamp(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  const min = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${y}-${mo}-${day} ${h}:${min} UTC`;
+}
+
+/**
+ * Derive a short human-readable objective for a scheduled job.
+ * Prefers last_run_summary; otherwise intent_anchor / task title / task_payload fields.
+ */
+export function deriveJobObjective(job: JobRow): string {
+  const summary = job.lastRunSummary?.trim();
+  if (summary) return summary;
+
+  const anchor = job.intentAnchor?.trim();
+  if (anchor) return anchor;
+
+  const title = job.taskTitle?.trim();
+  if (title) return title;
+
+  return deriveObjectiveFromPayload(job.taskPayload);
+}
+
+/** Parse task_payload defensively for a human-readable intent string. */
+export function deriveObjectiveFromPayload(payload: Record<string, unknown>): string {
+  const intent = readNonEmptyString(payload['intent']);
+  if (intent) return intent;
+
+  const task = readNonEmptyString(payload['task']);
+  if (task) return task;
+
+  const description = readNonEmptyString(payload['description']);
+  if (description) return description;
+
+  const summary = readNonEmptyString(payload['summary']);
+  if (summary) return summary;
+
+  const skill = readNonEmptyString(payload['skill']);
+  if (skill) {
+    const query = readNonEmptyString(payload['query']);
+    return query ? `${skill}: ${query}` : skill;
+  }
+
+  const type = readNonEmptyString(payload['type']);
+  if (type === 'task-wake') return 'Task wake-up';
+
+  if (type) return type;
+
+  return '(no objective recorded)';
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Format recurrence type for notification bodies. */
+export function formatJobRecurrence(job: JobRow): string {
+  if (job.cronExpr) {
+    return `Recurring (cron: \`${job.cronExpr}\`)`;
+  }
+  if (job.runAt) {
+    return `One-shot (was due: \`${formatUtcTimestamp(job.runAt)}\`)`;
+  }
+  return 'Unknown schedule';
+}
+
+/** Build a console deep-link URL for a scheduled job. */
+export function buildJobConsoleUrl(
+  appOrigin: string | undefined,
+  httpPort: number,
+  jobId: string,
+): string {
+  const origin = (appOrigin ?? `http://localhost:${httpPort}`).replace(/\/+$/, '');
+  return `${origin}/jobs/${jobId}`;
+}
+
+export interface JobNotificationContext {
+  objective: string;
+  recurrence: string;
+  consoleUrl: string;
+}
+
+/** Assemble notification context fields from a loaded job row. */
+export function buildJobNotificationContext(
+  job: JobRow,
+  appOrigin: string | undefined,
+  httpPort: number,
+): JobNotificationContext {
+  return {
+    objective: deriveJobObjective(job),
+    recurrence: formatJobRecurrence(job),
+    consoleUrl: buildJobConsoleUrl(appOrigin, httpPort, job.id),
+  };
+}

--- a/src/scheduler/recovery-notifier.ts
+++ b/src/scheduler/recovery-notifier.ts
@@ -23,8 +23,7 @@ import type { ScheduleRecoveredEvent, BusEvent } from '../bus/events.js';
 import { classifyError } from '../errors/classify.js';
 import type { SchedulerService } from './scheduler-service.js';
 import {
-  buildJobNotificationContext,
-  buildJobConsoleUrl,
+  loadJobNotificationContext,
 } from './job-notification-context.js';
 
 export interface RecoveryNotifierConfig {
@@ -74,7 +73,14 @@ export class RecoveryNotifier {
       ? formatStuckDuration(event.timestamp, new Date(runStartedAt))
       : `at least ${formatMinutes(timeoutSeconds)} (start time unknown — pre-migration row)`;
 
-    const jobContext = await this.loadJobContext(jobId);
+    const jobContext = await loadJobNotificationContext(
+      this.config.schedulerService,
+      this.config.appOrigin,
+      this.config.httpPort,
+      jobId,
+      this.log,
+      'recovery-notifier',
+    );
 
     const subject = `Scheduled job recovered from stuck state: ${agentId}`;
     const body = [
@@ -107,34 +113,6 @@ export class RecoveryNotifier {
         { jobId, agentId, consecutiveFailures, stuckDescription },
         'RecoveryNotifier: failed to publish notification — recovery already recorded in audit log',
       );
-    }
-  }
-
-  /** Lightweight DB lookup for notification context; falls back gracefully on missing rows. */
-  private async loadJobContext(jobId: string): Promise<{
-    objective: string;
-    recurrence: string;
-    consoleUrl: string;
-  }> {
-    const consoleUrl = buildJobConsoleUrl(this.config.appOrigin, this.config.httpPort, jobId);
-    try {
-      const job = await this.config.schedulerService.getJob(jobId);
-      if (!job) {
-        return {
-          objective: '(job not found)',
-          recurrence: '(unknown)',
-          consoleUrl,
-        };
-      }
-      return buildJobNotificationContext(job, this.config.appOrigin, this.config.httpPort);
-    } catch (err: unknown) {
-      const agentErr = classifyError(err, 'recovery-notifier');
-      this.log.warn({ err: agentErr, jobId }, 'RecoveryNotifier: failed to load job context for notification');
-      return {
-        objective: '(unavailable)',
-        recurrence: '(unknown)',
-        consoleUrl,
-      };
     }
   }
 }

--- a/src/scheduler/recovery-notifier.ts
+++ b/src/scheduler/recovery-notifier.ts
@@ -21,12 +21,20 @@ import type { Logger } from '../logger.js';
 import type { OutboundGateway } from '../skills/outbound-gateway.js';
 import type { ScheduleRecoveredEvent, BusEvent } from '../bus/events.js';
 import { classifyError } from '../errors/classify.js';
+import type { SchedulerService } from './scheduler-service.js';
+import {
+  buildJobNotificationContext,
+  buildJobConsoleUrl,
+} from './job-notification-context.js';
 
 export interface RecoveryNotifierConfig {
   bus: EventBus;
   outboundGateway: OutboundGateway;
+  schedulerService: SchedulerService;
   ceoEmail: string;
   logger: Logger;
+  appOrigin?: string;
+  httpPort: number;
 }
 
 export class RecoveryNotifier {
@@ -66,16 +74,20 @@ export class RecoveryNotifier {
       ? formatStuckDuration(event.timestamp, new Date(runStartedAt))
       : `at least ${formatMinutes(timeoutSeconds)} (start time unknown — pre-migration row)`;
 
+    const jobContext = await this.loadJobContext(jobId);
+
     const subject = `Scheduled job recovered from stuck state: ${agentId}`;
     const body = [
       'Scheduled job was stuck and has been auto-recovered (reset to pending).',
       '',
-      `Agent:     ${agentId}`,
-      `Stuck for: ${stuckDescription}`,
-      `Timeout:   ${formatMinutes(timeoutSeconds)}`,
-      `Failures:  ${consecutiveFailures} consecutive`,
+      `Agent:      ${agentId}`,
+      `Objective:  ${jobContext.objective}`,
+      `Recurrence: ${jobContext.recurrence}`,
+      `Stuck for:  ${stuckDescription}`,
+      `Timeout:    ${formatMinutes(timeoutSeconds)}`,
+      `Failures:   ${consecutiveFailures} consecutive`,
       '',
-      `Job ID: ${jobId}`,
+      `View job: ${jobContext.consoleUrl}`,
       '',
       'The job has been rescheduled automatically and will run again on its next trigger.',
     ].join('\n');
@@ -95,6 +107,34 @@ export class RecoveryNotifier {
         { jobId, agentId, consecutiveFailures, stuckDescription },
         'RecoveryNotifier: failed to publish notification — recovery already recorded in audit log',
       );
+    }
+  }
+
+  /** Lightweight DB lookup for notification context; falls back gracefully on missing rows. */
+  private async loadJobContext(jobId: string): Promise<{
+    objective: string;
+    recurrence: string;
+    consoleUrl: string;
+  }> {
+    const consoleUrl = buildJobConsoleUrl(this.config.appOrigin, this.config.httpPort, jobId);
+    try {
+      const job = await this.config.schedulerService.getJob(jobId);
+      if (!job) {
+        return {
+          objective: '(job not found)',
+          recurrence: '(unknown)',
+          consoleUrl,
+        };
+      }
+      return buildJobNotificationContext(job, this.config.appOrigin, this.config.httpPort);
+    } catch (err: unknown) {
+      const agentErr = classifyError(err, 'recovery-notifier');
+      this.log.warn({ err: agentErr, jobId }, 'RecoveryNotifier: failed to load job context for notification');
+      return {
+        objective: '(unavailable)',
+        recurrence: '(unknown)',
+        consoleUrl,
+      };
     }
   }
 }

--- a/src/scheduler/suspension-notifier.ts
+++ b/src/scheduler/suspension-notifier.ts
@@ -14,12 +14,20 @@ import type { Logger } from '../logger.js';
 import type { OutboundGateway } from '../skills/outbound-gateway.js';
 import type { ScheduleSuspendedEvent, BusEvent } from '../bus/events.js';
 import { classifyError } from '../errors/classify.js';
+import type { SchedulerService } from './scheduler-service.js';
+import {
+  buildJobNotificationContext,
+  buildJobConsoleUrl,
+} from './job-notification-context.js';
 
 export interface SuspensionNotifierConfig {
   bus: EventBus;
   outboundGateway: OutboundGateway;
+  schedulerService: SchedulerService;
   ceoEmail: string;
   logger: Logger;
+  appOrigin?: string;
+  httpPort: number;
 }
 
 export class SuspensionNotifier {
@@ -49,17 +57,21 @@ export class SuspensionNotifier {
   private async handle(event: ScheduleSuspendedEvent): Promise<void> {
     const { jobId, agentId, lastError, consecutiveFailures } = event.payload;
 
+    const jobContext = await this.loadJobContext(jobId);
+
     const subject = `Scheduled job suspended: ${agentId}`;
     const body = [
       'Scheduled job suspended.',
       '',
-      `Agent:    ${agentId}`,
-      `Failures: ${consecutiveFailures}`,
-      `Error:    ${lastError}`,
+      `Agent:      ${agentId}`,
+      `Objective:  ${jobContext.objective}`,
+      `Recurrence: ${jobContext.recurrence}`,
+      `Failures:   ${consecutiveFailures}`,
+      `Error:      ${lastError}`,
       '',
-      `Job ID: ${jobId}`,
+      `View job: ${jobContext.consoleUrl}`,
       '',
-      'To resume this job, open the web app and navigate to Scheduler → Jobs.',
+      'To resume this job, open the link above and click Resume.',
     ].join('\n');
 
     // sendNotification() catches its own errors and returns false on failure —
@@ -77,6 +89,34 @@ export class SuspensionNotifier {
         { jobId, agentId, consecutiveFailures, lastError },
         'SuspensionNotifier: failed to publish notification — suspension already recorded in audit log',
       );
+    }
+  }
+
+  /** Lightweight DB lookup for notification context; falls back gracefully on missing rows. */
+  private async loadJobContext(jobId: string): Promise<{
+    objective: string;
+    recurrence: string;
+    consoleUrl: string;
+  }> {
+    const consoleUrl = buildJobConsoleUrl(this.config.appOrigin, this.config.httpPort, jobId);
+    try {
+      const job = await this.config.schedulerService.getJob(jobId);
+      if (!job) {
+        return {
+          objective: '(job not found)',
+          recurrence: '(unknown)',
+          consoleUrl,
+        };
+      }
+      return buildJobNotificationContext(job, this.config.appOrigin, this.config.httpPort);
+    } catch (err: unknown) {
+      const agentErr = classifyError(err, 'suspension-notifier');
+      this.log.warn({ err: agentErr, jobId }, 'SuspensionNotifier: failed to load job context for notification');
+      return {
+        objective: '(unavailable)',
+        recurrence: '(unknown)',
+        consoleUrl,
+      };
     }
   }
 }

--- a/src/scheduler/suspension-notifier.ts
+++ b/src/scheduler/suspension-notifier.ts
@@ -16,8 +16,7 @@ import type { ScheduleSuspendedEvent, BusEvent } from '../bus/events.js';
 import { classifyError } from '../errors/classify.js';
 import type { SchedulerService } from './scheduler-service.js';
 import {
-  buildJobNotificationContext,
-  buildJobConsoleUrl,
+  loadJobNotificationContext,
 } from './job-notification-context.js';
 
 export interface SuspensionNotifierConfig {
@@ -57,7 +56,14 @@ export class SuspensionNotifier {
   private async handle(event: ScheduleSuspendedEvent): Promise<void> {
     const { jobId, agentId, lastError, consecutiveFailures } = event.payload;
 
-    const jobContext = await this.loadJobContext(jobId);
+    const jobContext = await loadJobNotificationContext(
+      this.config.schedulerService,
+      this.config.appOrigin,
+      this.config.httpPort,
+      jobId,
+      this.log,
+      'suspension-notifier',
+    );
 
     const subject = `Scheduled job suspended: ${agentId}`;
     const body = [
@@ -89,34 +95,6 @@ export class SuspensionNotifier {
         { jobId, agentId, consecutiveFailures, lastError },
         'SuspensionNotifier: failed to publish notification — suspension already recorded in audit log',
       );
-    }
-  }
-
-  /** Lightweight DB lookup for notification context; falls back gracefully on missing rows. */
-  private async loadJobContext(jobId: string): Promise<{
-    objective: string;
-    recurrence: string;
-    consoleUrl: string;
-  }> {
-    const consoleUrl = buildJobConsoleUrl(this.config.appOrigin, this.config.httpPort, jobId);
-    try {
-      const job = await this.config.schedulerService.getJob(jobId);
-      if (!job) {
-        return {
-          objective: '(job not found)',
-          recurrence: '(unknown)',
-          consoleUrl,
-        };
-      }
-      return buildJobNotificationContext(job, this.config.appOrigin, this.config.httpPort);
-    } catch (err: unknown) {
-      const agentErr = classifyError(err, 'suspension-notifier');
-      this.log.warn({ err: agentErr, jobId }, 'SuspensionNotifier: failed to load job context for notification');
-      return {
-        objective: '(unavailable)',
-        recurrence: '(unknown)',
-        consoleUrl,
-      };
     }
   }
 }

--- a/tests/unit/scheduler/job-notification-context.test.ts
+++ b/tests/unit/scheduler/job-notification-context.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import type { JobRow } from '../../../src/scheduler/scheduler-service.js';
+import {
+  buildJobConsoleUrl,
+  buildJobNotificationContext,
+  deriveJobObjective,
+  deriveObjectiveFromPayload,
+  formatJobRecurrence,
+  formatUtcTimestamp,
+} from '../../../src/scheduler/job-notification-context.js';
+
+function makeJob(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-abc123',
+    agentId: 'coordinator',
+    cronExpr: null,
+    runAt: '2026-07-03T08:00:00.000Z',
+    taskPayload: { task: 'Send daily digest' },
+    status: 'pending',
+    lastRunAt: null,
+    nextRunAt: null,
+    lastError: null,
+    consecutiveFailures: 0,
+    createdBy: 'system',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    timezone: 'UTC',
+    agentTaskId: null,
+    intentAnchor: null,
+    progress: null,
+    taskErrorBudget: null,
+    taskTags: null,
+    taskTitle: null,
+    runStartedAt: null,
+    expectedDurationSeconds: null,
+    lastRunOutcome: null,
+    lastRunSummary: null,
+    lastRunContext: null,
+    originator: null,
+    ...overrides,
+  };
+}
+
+describe('formatUtcTimestamp', () => {
+  it('formats an ISO timestamp in UTC', () => {
+    expect(formatUtcTimestamp('2026-07-03T08:00:00.000Z')).toBe('2026-07-03 08:00 UTC');
+  });
+});
+
+describe('deriveObjectiveFromPayload', () => {
+  it('prefers intent over task', () => {
+    expect(deriveObjectiveFromPayload({ intent: 'Check inbox', task: 'other' })).toBe('Check inbox');
+  });
+
+  it('falls back to task field', () => {
+    expect(deriveObjectiveFromPayload({ task: 'Send daily digest' })).toBe('Send daily digest');
+  });
+
+  it('combines skill and query', () => {
+    expect(deriveObjectiveFromPayload({ skill: 'web-search', query: 'AI safety' })).toBe('web-search: AI safety');
+  });
+
+  it('handles task-wake envelopes', () => {
+    expect(deriveObjectiveFromPayload({ type: 'task-wake', task_id: 't1' })).toBe('Task wake-up');
+  });
+
+  it('returns a fallback when payload has no recognizable fields', () => {
+    expect(deriveObjectiveFromPayload({ foo: 1 })).toBe('(no objective recorded)');
+  });
+});
+
+describe('deriveJobObjective', () => {
+  it('prefers last_run_summary', () => {
+    const job = makeJob({
+      lastRunSummary: 'Compiled the daily digest.',
+      intentAnchor: 'Daily digest',
+      taskPayload: { task: 'ignored' },
+    });
+    expect(deriveJobObjective(job)).toBe('Compiled the daily digest.');
+  });
+
+  it('falls back to intent_anchor', () => {
+    const job = makeJob({ intentAnchor: 'Weekly metrics summary' });
+    expect(deriveJobObjective(job)).toBe('Weekly metrics summary');
+  });
+
+  it('falls back to task_payload', () => {
+    const job = makeJob({ taskPayload: { task: 'Morning brief' } });
+    expect(deriveJobObjective(job)).toBe('Morning brief');
+  });
+});
+
+describe('formatJobRecurrence', () => {
+  it('formats recurring cron jobs', () => {
+    const job = makeJob({ cronExpr: '0 8 * * *', runAt: null });
+    expect(formatJobRecurrence(job)).toBe('Recurring (cron: `0 8 * * *`)');
+  });
+
+  it('formats one-shot jobs', () => {
+    const job = makeJob({ cronExpr: null, runAt: '2026-07-03T08:00:00.000Z' });
+    expect(formatJobRecurrence(job)).toBe('One-shot (was due: `2026-07-03 08:00 UTC`)');
+  });
+});
+
+describe('buildJobConsoleUrl', () => {
+  it('uses appOrigin when configured', () => {
+    expect(buildJobConsoleUrl('https://curia.example.com', 3000, 'job-1')).toBe(
+      'https://curia.example.com/jobs/job-1',
+    );
+  });
+
+  it('trims trailing slash on appOrigin', () => {
+    expect(buildJobConsoleUrl('https://curia.example.com/', 3000, 'job-1')).toBe(
+      'https://curia.example.com/jobs/job-1',
+    );
+  });
+
+  it('falls back to localhost when appOrigin is unset', () => {
+    expect(buildJobConsoleUrl(undefined, 4521, 'job-1')).toBe('http://localhost:4521/jobs/job-1');
+  });
+});
+
+describe('buildJobNotificationContext', () => {
+  it('assembles all context fields', () => {
+    const job = makeJob({
+      cronExpr: '0 8 * * *',
+      runAt: null,
+      lastRunSummary: 'Sent digest to CEO.',
+    });
+    expect(buildJobNotificationContext(job, 'https://curia.example.com', 3000)).toEqual({
+      objective: 'Sent digest to CEO.',
+      recurrence: 'Recurring (cron: `0 8 * * *`)',
+      consoleUrl: 'https://curia.example.com/jobs/job-abc123',
+    });
+  });
+});

--- a/tests/unit/scheduler/job-notification-context.test.ts
+++ b/tests/unit/scheduler/job-notification-context.test.ts
@@ -87,6 +87,14 @@ describe('deriveJobObjective', () => {
     const job = makeJob({ taskPayload: { task: 'Morning brief' } });
     expect(deriveJobObjective(job)).toBe('Morning brief');
   });
+
+  it('truncates long objectives', () => {
+    const longSummary = 'x'.repeat(250);
+    const job = makeJob({ lastRunSummary: longSummary });
+    const objective = deriveJobObjective(job);
+    expect(objective.length).toBe(200);
+    expect(objective.endsWith('…')).toBe(true);
+  });
 });
 
 describe('formatJobRecurrence', () => {
@@ -116,6 +124,11 @@ describe('buildJobConsoleUrl', () => {
 
   it('falls back to localhost when appOrigin is unset', () => {
     expect(buildJobConsoleUrl(undefined, 4521, 'job-1')).toBe('http://localhost:4521/jobs/job-1');
+  });
+
+  it('falls back to localhost when appOrigin is blank', () => {
+    expect(buildJobConsoleUrl('', 4521, 'job-1')).toBe('http://localhost:4521/jobs/job-1');
+    expect(buildJobConsoleUrl('   ', 4521, 'job-1')).toBe('http://localhost:4521/jobs/job-1');
   });
 });
 

--- a/tests/unit/scheduler/notifier-fixtures.ts
+++ b/tests/unit/scheduler/notifier-fixtures.ts
@@ -1,0 +1,39 @@
+import { vi } from 'vitest';
+import type { JobRow } from '../../../src/scheduler/scheduler-service.js';
+
+export function mockSchedulerService(job: JobRow | null = null) {
+  return {
+    getJob: vi.fn().mockResolvedValue(job),
+  };
+}
+
+export function makeJob(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-abc123',
+    agentId: 'coordinator',
+    cronExpr: null,
+    runAt: '2026-07-03T08:00:00.000Z',
+    taskPayload: { task: 'Send daily digest' },
+    status: 'pending',
+    lastRunAt: null,
+    nextRunAt: null,
+    lastError: null,
+    consecutiveFailures: 0,
+    createdBy: 'system',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    timezone: 'UTC',
+    agentTaskId: null,
+    intentAnchor: null,
+    progress: null,
+    taskErrorBudget: null,
+    taskTags: null,
+    taskTitle: null,
+    runStartedAt: null,
+    expectedDurationSeconds: null,
+    lastRunOutcome: null,
+    lastRunSummary: null,
+    lastRunContext: null,
+    originator: null,
+    ...overrides,
+  };
+}

--- a/tests/unit/scheduler/recovery-notifier.test.ts
+++ b/tests/unit/scheduler/recovery-notifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RecoveryNotifier } from '../../../src/scheduler/recovery-notifier.js';
 import type { ScheduleRecoveredEvent } from '../../../src/bus/events.js';
+import type { JobRow } from '../../../src/scheduler/scheduler-service.js';
 
 // -- Mock helpers --
 
@@ -24,6 +25,43 @@ function mockLogger() {
 function mockOutboundGateway() {
   return {
     sendNotification: vi.fn(),
+  };
+}
+
+function mockSchedulerService(job: JobRow | null = null) {
+  return {
+    getJob: vi.fn().mockResolvedValue(job),
+  };
+}
+
+function makeJob(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-abc123',
+    agentId: 'coordinator',
+    cronExpr: '0 8 * * *',
+    runAt: null,
+    taskPayload: { task: 'Send daily digest' },
+    status: 'pending',
+    lastRunAt: null,
+    nextRunAt: null,
+    lastError: null,
+    consecutiveFailures: 0,
+    createdBy: 'system',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    timezone: 'UTC',
+    agentTaskId: null,
+    intentAnchor: null,
+    progress: null,
+    taskErrorBudget: null,
+    taskTags: null,
+    taskTitle: null,
+    runStartedAt: null,
+    expectedDurationSeconds: null,
+    lastRunOutcome: null,
+    lastRunSummary: 'Compiled the daily digest.',
+    lastRunContext: null,
+    originator: null,
+    ...overrides,
   };
 }
 
@@ -53,18 +91,23 @@ function makeEvent(overrides: Partial<ScheduleRecoveredEvent['payload']> = {}): 
 describe('RecoveryNotifier', () => {
   let bus: ReturnType<typeof mockBus>;
   let gateway: ReturnType<typeof mockOutboundGateway>;
+  let schedulerService: ReturnType<typeof mockSchedulerService>;
   let logger: ReturnType<typeof mockLogger>;
   let notifier: RecoveryNotifier;
 
   beforeEach(() => {
     bus = mockBus();
     gateway = mockOutboundGateway();
+    schedulerService = mockSchedulerService(makeJob());
     logger = mockLogger();
     notifier = new RecoveryNotifier({
       bus: bus as never,
       outboundGateway: gateway as never,
+      schedulerService: schedulerService as never,
       ceoEmail: 'ceo@example.com',
       logger: logger as never,
+      appOrigin: 'https://curia.example.com',
+      httpPort: 3000,
     });
   });
 
@@ -90,15 +133,18 @@ describe('RecoveryNotifier', () => {
     await (notifier as never as { handle(e: ScheduleRecoveredEvent): Promise<void> })
       .handle(makeEvent());
 
+    expect(schedulerService.getJob).toHaveBeenCalledWith('job-abc123');
     expect(gateway.sendNotification).toHaveBeenCalledOnce();
     const call = gateway.sendNotification.mock.calls[0][0];
     expect(call.notificationType).toBe('schedule_recovered');
     expect(call.ceoEmail).toBe('ceo@example.com');
     expect(call.subject).toContain('coordinator');        // agentId in subject
     expect(call.body).toContain('coordinator');           // agentId in body
-    expect(call.body).toContain('job-abc123');            // jobId
+    expect(call.body).toContain('Compiled the daily digest.'); // objective from last_run_summary
+    expect(call.body).toContain('Recurring (cron: `0 8 * * *`)');
     expect(call.body).toContain('~20 min');              // stuck duration (now - runStartedAt)
     expect(call.body).toContain('15 min');               // timeout threshold (900s)
+    expect(call.body).toContain('https://curia.example.com/jobs/job-abc123');
     expect(call.body).toContain('rescheduled automatically'); // outcome
   });
 
@@ -145,5 +191,17 @@ describe('RecoveryNotifier', () => {
     ).resolves.toBeUndefined();
 
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('falls back gracefully when the job row is missing', async () => {
+    schedulerService.getJob.mockResolvedValue(null);
+    gateway.sendNotification.mockResolvedValue(true);
+
+    await (notifier as never as { handle(e: ScheduleRecoveredEvent): Promise<void> })
+      .handle(makeEvent());
+
+    const call = gateway.sendNotification.mock.calls[0][0];
+    expect(call.body).toContain('(job not found)');
+    expect(call.body).toContain('https://curia.example.com/jobs/job-abc123');
   });
 });

--- a/tests/unit/scheduler/recovery-notifier.test.ts
+++ b/tests/unit/scheduler/recovery-notifier.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RecoveryNotifier } from '../../../src/scheduler/recovery-notifier.js';
 import type { ScheduleRecoveredEvent } from '../../../src/bus/events.js';
-import type { JobRow } from '../../../src/scheduler/scheduler-service.js';
+import { makeJob, mockSchedulerService } from './notifier-fixtures.js';
 
 // -- Mock helpers --
 
@@ -25,43 +25,6 @@ function mockLogger() {
 function mockOutboundGateway() {
   return {
     sendNotification: vi.fn(),
-  };
-}
-
-function mockSchedulerService(job: JobRow | null = null) {
-  return {
-    getJob: vi.fn().mockResolvedValue(job),
-  };
-}
-
-function makeJob(overrides: Partial<JobRow> = {}): JobRow {
-  return {
-    id: 'job-abc123',
-    agentId: 'coordinator',
-    cronExpr: '0 8 * * *',
-    runAt: null,
-    taskPayload: { task: 'Send daily digest' },
-    status: 'pending',
-    lastRunAt: null,
-    nextRunAt: null,
-    lastError: null,
-    consecutiveFailures: 0,
-    createdBy: 'system',
-    createdAt: '2026-06-01T00:00:00.000Z',
-    timezone: 'UTC',
-    agentTaskId: null,
-    intentAnchor: null,
-    progress: null,
-    taskErrorBudget: null,
-    taskTags: null,
-    taskTitle: null,
-    runStartedAt: null,
-    expectedDurationSeconds: null,
-    lastRunOutcome: null,
-    lastRunSummary: 'Compiled the daily digest.',
-    lastRunContext: null,
-    originator: null,
-    ...overrides,
   };
 }
 
@@ -98,7 +61,11 @@ describe('RecoveryNotifier', () => {
   beforeEach(() => {
     bus = mockBus();
     gateway = mockOutboundGateway();
-    schedulerService = mockSchedulerService(makeJob());
+    schedulerService = mockSchedulerService(makeJob({
+      cronExpr: '0 8 * * *',
+      runAt: null,
+      lastRunSummary: 'Compiled the daily digest.',
+    }));
     logger = mockLogger();
     notifier = new RecoveryNotifier({
       bus: bus as never,

--- a/tests/unit/scheduler/suspension-notifier.test.ts
+++ b/tests/unit/scheduler/suspension-notifier.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SuspensionNotifier } from '../../../src/scheduler/suspension-notifier.js';
 import type { ScheduleSuspendedEvent } from '../../../src/bus/events.js';
-import type { JobRow } from '../../../src/scheduler/scheduler-service.js';
+import { makeJob, mockSchedulerService } from './notifier-fixtures.js';
 
 // -- Mock helpers --
 
@@ -25,43 +25,6 @@ function mockLogger() {
 function mockOutboundGateway() {
   return {
     sendNotification: vi.fn(),
-  };
-}
-
-function mockSchedulerService(job: JobRow | null = null) {
-  return {
-    getJob: vi.fn().mockResolvedValue(job),
-  };
-}
-
-function makeJob(overrides: Partial<JobRow> = {}): JobRow {
-  return {
-    id: 'job-abc123',
-    agentId: 'ceo-inbox',
-    cronExpr: null,
-    runAt: '2026-07-03T08:00:00.000Z',
-    taskPayload: { task: 'Process inbox' },
-    status: 'suspended',
-    lastRunAt: null,
-    nextRunAt: null,
-    lastError: null,
-    consecutiveFailures: 3,
-    createdBy: 'system',
-    createdAt: '2026-06-01T00:00:00.000Z',
-    timezone: 'UTC',
-    agentTaskId: null,
-    intentAnchor: 'Process inbox daily',
-    progress: null,
-    taskErrorBudget: null,
-    taskTags: null,
-    taskTitle: null,
-    runStartedAt: null,
-    expectedDurationSeconds: null,
-    lastRunOutcome: null,
-    lastRunSummary: null,
-    lastRunContext: null,
-    originator: null,
-    ...overrides,
   };
 }
 
@@ -91,7 +54,12 @@ describe('SuspensionNotifier', () => {
   beforeEach(() => {
     bus = mockBus();
     gateway = mockOutboundGateway();
-    schedulerService = mockSchedulerService(makeJob());
+    schedulerService = mockSchedulerService(makeJob({
+      agentId: 'ceo-inbox',
+      status: 'suspended',
+      intentAnchor: 'Process inbox daily',
+      consecutiveFailures: 3,
+    }));
     logger = mockLogger();
     notifier = new SuspensionNotifier({
       bus: bus as never,

--- a/tests/unit/scheduler/suspension-notifier.test.ts
+++ b/tests/unit/scheduler/suspension-notifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SuspensionNotifier } from '../../../src/scheduler/suspension-notifier.js';
 import type { ScheduleSuspendedEvent } from '../../../src/bus/events.js';
+import type { JobRow } from '../../../src/scheduler/scheduler-service.js';
 
 // -- Mock helpers --
 
@@ -27,6 +28,43 @@ function mockOutboundGateway() {
   };
 }
 
+function mockSchedulerService(job: JobRow | null = null) {
+  return {
+    getJob: vi.fn().mockResolvedValue(job),
+  };
+}
+
+function makeJob(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-abc123',
+    agentId: 'ceo-inbox',
+    cronExpr: null,
+    runAt: '2026-07-03T08:00:00.000Z',
+    taskPayload: { task: 'Process inbox' },
+    status: 'suspended',
+    lastRunAt: null,
+    nextRunAt: null,
+    lastError: null,
+    consecutiveFailures: 3,
+    createdBy: 'system',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    timezone: 'UTC',
+    agentTaskId: null,
+    intentAnchor: 'Process inbox daily',
+    progress: null,
+    taskErrorBudget: null,
+    taskTags: null,
+    taskTitle: null,
+    runStartedAt: null,
+    expectedDurationSeconds: null,
+    lastRunOutcome: null,
+    lastRunSummary: null,
+    lastRunContext: null,
+    originator: null,
+    ...overrides,
+  };
+}
+
 function makeEvent(overrides: Partial<ScheduleSuspendedEvent['payload']> = {}): ScheduleSuspendedEvent {
   return {
     id: 'evt-1',
@@ -46,18 +84,23 @@ function makeEvent(overrides: Partial<ScheduleSuspendedEvent['payload']> = {}): 
 describe('SuspensionNotifier', () => {
   let bus: ReturnType<typeof mockBus>;
   let gateway: ReturnType<typeof mockOutboundGateway>;
+  let schedulerService: ReturnType<typeof mockSchedulerService>;
   let logger: ReturnType<typeof mockLogger>;
   let notifier: SuspensionNotifier;
 
   beforeEach(() => {
     bus = mockBus();
     gateway = mockOutboundGateway();
+    schedulerService = mockSchedulerService(makeJob());
     logger = mockLogger();
     notifier = new SuspensionNotifier({
       bus: bus as never,
       outboundGateway: gateway as never,
+      schedulerService: schedulerService as never,
       ceoEmail: 'ceo@example.com',
       logger: logger as never,
+      appOrigin: 'https://curia.example.com',
+      httpPort: 3000,
     });
   });
 
@@ -78,16 +121,19 @@ describe('SuspensionNotifier', () => {
     await (notifier as never as { handle(e: ScheduleSuspendedEvent): Promise<void> })
       .handle(makeEvent());
 
+    expect(schedulerService.getJob).toHaveBeenCalledWith('job-abc123');
     expect(gateway.sendNotification).toHaveBeenCalledOnce();
     const call = gateway.sendNotification.mock.calls[0][0];
     expect(call.notificationType).toBe('schedule_suspended');
     expect(call.ceoEmail).toBe('ceo@example.com');
     expect(call.subject).toContain('ceo-inbox');
     expect(call.body).toContain('ceo-inbox');       // agentId
+    expect(call.body).toContain('Process inbox daily'); // objective from intent_anchor
+    expect(call.body).toContain('One-shot (was due: `2026-07-03 08:00 UTC`)');
     expect(call.body).toContain('3');               // consecutiveFailures
     expect(call.body).toContain('400 — credit balance is too low to access the Anthropic API'); // lastError
-    expect(call.body).toContain('job-abc123');      // jobId
-    expect(call.body).toContain('web app');         // resume instructions
+    expect(call.body).toContain('https://curia.example.com/jobs/job-abc123');
+    expect(call.body).toContain('Resume');
   });
 
   it('logs an error and resolves when sendNotification returns false', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1332

Stuck-job recovery and suspension emails now include enough context to assess severity and take action without hunting through the console.

**Backend (`RecoveryNotifier` / `SuspensionNotifier`)**
- Lightweight `scheduled_jobs` lookup via `SchedulerService.getJob()` (no LLM pipeline)
- Notification body includes:
  - **Objective** — prefers `last_run_summary`, then `intent_anchor` / task title, then `task_payload` fields (`intent`, `task`, `skill`, etc.)
  - **Recurrence** — `Recurring (cron: \`0 8 * * *\`)` or `One-shot (was due: \`2026-07-03 08:00 UTC\`)`
  - **Console URL** — `https://<instance>/jobs/<jobId>` built from `APP_ORIGIN` (falls back to `http://localhost:{httpPort}`)

**Console**
- New `/jobs/$jobId` route opens the jobs page with the edit drawer for that job
- Clears filters, paginates to the target row, and scrolls it into view
- Closing the drawer navigates back to `/jobs`

Shared helpers live in `src/scheduler/job-notification-context.ts` with unit tests.

## Test plan

- [x] `pnpm exec vitest run tests/unit/scheduler/job-notification-context.test.ts tests/unit/scheduler/recovery-notifier.test.ts tests/unit/scheduler/suspension-notifier.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm --filter @curia/console run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8d66bc7-b22a-4dc7-a0c2-1816b5054973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8d66bc7-b22a-4dc7-a0c2-1816b5054973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

