### PR TITLE
chore: point CI Node version at .nvmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "22"
+          # Track .nvmrc so CI, engines (>=24), and the node:24 Docker image stay in lockstep
+          node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "22"
+          # Track .nvmrc so CI, engines (>=24), and the node:24 Docker image stay in lockstep
+          node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **CI Node version drift** — `ci.yml` and `dast.yml` now read `node-version-file: .nvmrc` instead of a hardcoded `"22"`, so CI runs on Node 24 in lockstep with `engines` (`>=24`) and the `node:24` Docker image. Previously CI validated on a version that did not satisfy the project's own engines constraint.
 - **Ant Farm** — code review follow-ups: fail-closed session check, conductor live/scrub fixes, incremental live merge, per-agent overlay context, timeline cursor paging, safe `busEventToAuditRow` payload guard, `schedule.fired` task_id normalization.
 - **Ant Farm** — fix playback flicker: stable desk roster + conductor snapshot refs so Phaser scene is not restarted every animation frame.
 - **Runtime image pnpm workspace** — the Dockerfile runtime stage now copies the `@curia/shared-types` member and runs `pnpm add -w --save-prod --prod tsx`, fixing a latent build-break chain (ADDING_TO_ROOT → WORKSPACE_PKG_NOT_FOUND → INCLUDED_DEPS_CONFLICT) that surfaces once curia is a real pnpm workspace.


### PR DESCRIPTION
## Summary

CI was validating on the wrong Node version. `ci.yml` and `dast.yml` hardcoded `node-version: "22"`, but every other surface targets Node 24:

| Surface | Version |
|---|---|
| `package.json` engines | `>=24` |
| `.nvmrc` | `24` |
| Dockerfile (build + runtime) | `node:24-slim` |
| CI (`ci.yml`, `dast.yml`) — **before** | `22` ← drift |

Node 22 does not even satisfy the project's own `engines` constraint, so CI could pass on a version that never ships, and a Node 24-only API or syntax could break in prod without CI ever seeing it.

Both workflows now use `node-version-file: ".nvmrc"`, making `.nvmrc` the single source of truth. Future Node bumps only need to touch `.nvmrc` (plus the Dockerfile tag) and CI follows automatically.

## Testing

- Both workflow files parse as valid YAML.
- Green CI on this PR is the real verification — it will now run on Node 24.

## Notes

- No code changes; config + CHANGELOG only.
- The `"22"` was almost certainly stale drift rather than an intentional lower-bound check, since a valid floor for `engines: >=24` would be 24, not 22.