### PR TITLE
fix(antfarm): allow blob: images in CSP so licensed art loads in prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Ant Farm** — code review follow-ups: fail-closed session check, conductor live/scrub fixes, incremental live merge, per-agent overlay context, timeline cursor paging, safe `busEventToAuditRow` payload guard, `schedule.fired` task_id normalization.
 - **Ant Farm** — fix playback flicker: stable desk roster + conductor snapshot refs so Phaser scene is not restarted every animation frame.
 - **Runtime image pnpm workspace** — the Dockerfile runtime stage now copies the `@curia/shared-types` member and runs `pnpm add -w --save-prod --prod tsx`, fixing a latent build-break chain (ADDING_TO_ROOT → WORKSPACE_PKG_NOT_FOUND → INCLUDED_DEPS_CONFLICT) that surfaces once curia is a real pnpm workspace.
+- **Ant Farm placeholder-only art in production** — the scoped `/antfarm/` CSP now allows `img-src ... blob:`. Phaser's file loader fetches the licensed art via XHR and assigns it as a `blob:` URL, which `'self' data:` didn't cover, so every real-art load was CSP-blocked and the office silently fell back to procedural placeholders. (#1335)
 - **Ant Farm blank canvas in production** — `/antfarm/*` now gets a scoped CSP with `img-src 'self' data:` so Phaser's base64 boot textures load; the console keeps its strict `img-src 'self'`. The strict CSP was blocking them and the office rendered empty.
 
 ### Fixed

--- a/src/channels/http/security-headers.test.ts
+++ b/src/channels/http/security-headers.test.ts
@@ -155,12 +155,15 @@ describe('registerSecurityHeaders', () => {
     expect(CONSOLE_CONTENT_SECURITY_POLICY).not.toContain('data:');
   });
 
-  it('serves the Ant Farm CSP (img-src data:) on /antfarm/ HTML responses', async () => {
+  it('serves the Ant Farm CSP (img-src data: blob:) on /antfarm/ HTML responses', async () => {
     app = await build();
     const res = await app.inject({ method: 'GET', url: '/antfarm/' });
     expect(res.statusCode).toBe(200);
     expect(res.headers['content-security-policy']).toBe(ANTFARM_CONTENT_SECURITY_POLICY);
-    expect(res.headers['content-security-policy']).toContain("img-src 'self' data:");
+    // Both schemes are required: data: for Phaser's base64 boot textures, blob: for the
+    // loader-fetched licensed art (XHR → URL.createObjectURL). Missing blob: silently
+    // degrades the office to placeholders even though the assets serve fine.
+    expect(res.headers['content-security-policy']).toContain("img-src 'self' data: blob:");
     expect(res.headers['x-frame-options']).toBe('DENY');
   });
 
@@ -191,6 +194,6 @@ describe('registerSecurityHeaders', () => {
   it('keeps script-src strict in the Ant Farm CSP (only images are relaxed)', async () => {
     expect(ANTFARM_CONTENT_SECURITY_POLICY).toContain("script-src 'self'");
     expect(ANTFARM_CONTENT_SECURITY_POLICY).toContain("frame-ancestors 'none'");
-    expect(ANTFARM_CONTENT_SECURITY_POLICY).toContain("img-src 'self' data:");
+    expect(ANTFARM_CONTENT_SECURITY_POLICY).toContain("img-src 'self' data: blob:");
   });
 });

--- a/src/channels/http/security-headers.ts
+++ b/src/channels/http/security-headers.ts
@@ -28,15 +28,22 @@ export const CONSOLE_CONTENT_SECURITY_POLICY = [
 /**
  * CSP for the Ant Farm page (`/antfarm/*`, served as text/html).
  *
- * Identical to the console policy except `img-src` also allows `data:`. The Ant Farm
- * visualization runs Phaser, which loads its internal boot textures (`__DEFAULT`,
- * `__MISSING`, `__WHITE`) from embedded base64 `data:` PNG URIs on startup. Under the
- * console's `img-src 'self'` the browser blocks those and the WebGL canvas fails to
- * render — the procedural office art (built via `textures.addCanvas`) is itself CSP-safe,
- * but Phaser's own boot images are not, and `__WHITE` backs all tinting/graphics.
+ * Identical to the console policy except `img-src` also allows `data:` and `blob:`. The
+ * Ant Farm visualization runs Phaser, which needs both:
+ *   - `data:` — Phaser loads its internal boot textures (`__DEFAULT`, `__MISSING`,
+ *     `__WHITE`) from embedded base64 `data:` PNG URIs on startup. `__WHITE` backs all
+ *     tinting/graphics, so without this the WebGL canvas fails to render at all.
+ *   - `blob:` — Phaser's file loader fetches real image assets (the licensed LimeZu
+ *     tilesets/singles/character sheets served from `/api/antfarm/assets/*`) via XHR and
+ *     hands the response to an `Image` element as an `URL.createObjectURL(blob)` `blob:`
+ *     URL. Same-origin `'self'` does NOT cover the `blob:` scheme, so without this every
+ *     real-art load is blocked ("Loading the image 'blob:…' violates … img-src") → the
+ *     loader errors → the office silently falls back to procedural placeholders. This is
+ *     the half the #1337 boot-texture fix missed; the office renders but stays placeholder.
  *
- * `data:` in `img-src` cannot execute script, so `script-src 'self'` — the XSS mitigation
- * that motivated #130 — is unchanged. Only image sources are relaxed, and only on this page.
+ * Neither `data:` nor `blob:` in `img-src` can execute script, so `script-src 'self'` —
+ * the XSS mitigation that motivated #130 — is unchanged. Only image sources are relaxed,
+ * and only on this page.
  */
 export const ANTFARM_CONTENT_SECURITY_POLICY = [
   "default-src 'none'",
@@ -44,7 +51,7 @@ export const ANTFARM_CONTENT_SECURITY_POLICY = [
   "style-src 'self' https://fonts.googleapis.com",
   "style-src-attr 'unsafe-inline'",
   "font-src https://fonts.gstatic.com",
-  "img-src 'self' data:",
+  "img-src 'self' data: blob:",
   "connect-src 'self'",
   "base-uri 'self'",
   "form-action 'self'",


### PR DESCRIPTION
## Summary

Production hotfix for the Ant Farm rendering **procedural placeholders** instead of the licensed LimeZu art, even though the real-art loader (#1340) shipped and the assets serve correctly at 200.

**Root cause:** Phaser's file loader fetches image assets via XHR and hands them to an `<img>` as a `URL.createObjectURL(blob)` `blob:` URL. The scoped `/antfarm/` CSP allowed `img-src 'self' data:` (`data:` added in #1337 for the base64 boot textures) but **not `blob:`**, so the browser blocked every licensed-art load:

```
Loading the image 'blob:<URL>' violates the following Content Security Policy
directive: "img-src 'self' data:". The action has been blocked.
```

Each blocked load errored, tripping the all-or-nothing `realArtReady` gate → the office fell back to placeholders. Diagnosed against the live container: assets present, route 200s with a session cookie, paths match — the failure is purely the client-side CSP block. Local dev worked because Vite doesn't emit the production CSP.

**Fix:** `img-src 'self' data: blob:`. `blob:` cannot execute script, so the #130 XSS mitigation (`script-src 'self'`) is unchanged — same rationale as `data:`.

This is the half the #1337 boot-texture fix missed. #1340 was already merged, hence a separate PR.

## Testing
- `security-headers` suite updated (asserts `img-src 'self' data: blob:`) — 14/14 pass
- Full typecheck clean

## Notes
Deploy required to take effect (the CSP string is compiled into the image; no runtime toggle).