### PR TITLE
feat: publish GHCR images + image-based self-host install (Part A of #1281)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,19 @@ DATABASE_URL=postgres://curia:your-db-password@localhost:5432/curia
 # HTTP API
 HTTP_PORT=3000
 
+# Published image tags (Docker Compose pulls these). Pin to a vX.Y.Z for a
+# stable self-host; `latest` tracks the newest release, `edge` the newest main.
+CURIA_IMAGE_TAG=latest
+CURIA_POSTGRES_TAG=pg16
+
+# Public domain for automatic HTTPS. Only used with the TLS overlay (below).
+# DOMAIN=curia.example.com
+
+# TLS overlay selection. `install.sh` sets this automatically when you choose
+# the "public domain + HTTPS" option so every `docker compose` command applies
+# the Caddy overlay without a manual -f flag. Uncomment to enable by hand:
+# COMPOSE_FILE=docker-compose.yml:docker-compose.tls.yml
+
 # Postgres host port (Docker Compose). Override only if 5432 is already bound on
 # the host — e.g. running a parallel curia stack against a sibling clone for
 # install testing. Leave at the default for the common case.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,6 @@ jobs:
         env:
           DATABASE_URL: postgres://curia:curia_test@localhost:5432/curia_test
           LOG_LEVEL: error
+
+      - name: Shell setup/install tests
+        run: pnpm run test:shell

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,7 +64,7 @@ jobs:
               type=raw,value=latest,enable=${{ github.event_name == 'release' }}
               type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -97,7 +97,7 @@ jobs:
           sbom: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the pushed image by digest
         env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,106 @@
+name: docker-publish
+
+# Build, push, sign, and SBOM-attest the Curia app + Postgres images to GHCR.
+# - release published -> semver + latest (app), pg16 + latest (postgres)
+# - push to main      -> edge (both), for dogfood / curia-deploy pulls
+on:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re)publish, e.g. v0.40.0"
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write   # keyless cosign via GitHub OIDC
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # Validate a workflow_dispatch tag input against strict semver to avoid
+  # injection (mirrors release.yml). No-op on release/push triggers.
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate dispatch tag
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        # Pass the input through an env var so the shell never sees raw
+        # expression output — prevents injection if the value contains
+        # shell metacharacters (mirrors the pattern in release.yml).
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          printf '%s' "$INPUT_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
+            || { echo "Invalid tag format"; exit 1; }
+
+  build:
+    needs: guard
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: curia
+            image: curia
+            dockerfile: Dockerfile
+            # App tags: semver+latest on release, edge on main.
+            tags: |
+              type=semver,pattern=v{{version}}
+              type=semver,pattern=v{{major}}.{{minor}}
+              type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+              type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+          - name: curia-postgres
+            image: curia-postgres
+            dockerfile: docker/postgres.Dockerfile
+            # DB is versioned by pg major, not app semver.
+            tags: |
+              type=raw,value=pg16
+              type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+              type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: ${{ matrix.tags }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the pushed image by digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,17 +60,17 @@ jobs:
             dockerfile: docker/postgres.Dockerfile
             # DB is versioned by pg major, not app semver.
             tags: |
-              type=raw,value=pg16
+              type=raw,value=pg16,enable=${{ github.event_name == 'release' }}
               type=raw,value=latest,enable=${{ github.event_name == 'release' }}
               type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -78,14 +78,14 @@ jobs:
 
       - name: Derive tags & labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: ${{ matrix.tags }}
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -97,7 +97,7 @@ jobs:
           sbom: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Sign the pushed image by digest
         env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,6 +67,12 @@ jobs:
               type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # On a manual workflow_dispatch re-publish, check out the requested
+          # tag so the built image matches inputs.tag (validated in the guard
+          # job). For release/push triggers inputs.tag is empty, so fall back to
+          # the event ref (the release tag or the pushed branch).
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,8 @@ jobs:
   # injection (mirrors release.yml). No-op on release/push triggers.
   guard:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Validate dispatch tag
         if: github.event_name == 'workflow_dispatch' && inputs.tag != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`install.sh` operator installer** — interactive, image-based entry point for self-hosted operators; fetches the compose bundle, generates secrets, runs migrations and vault-seed inside the pulled container (tsx direct, no host pnpm), prompts for topology/TLS, and prints a bootstrap secret summary. No Node/pnpm/openssl required on the host. (#1343)
 - **Stuck-job recovery notifications** — recovery and suspension emails now include job objective, recurrence, and a console deep-link; `/jobs/:jobId` opens the job drawer directly. Closes #1332.
 - **Ant Farm AF-1** — `AuditLogRepo.findTimeline` / `findByEventTypes` return paginated `TimelinePage` (`hasMore`, keyset `after` cursor) with scoped-query guard; task filter uses `payload->>'taskId'` (index-aligned). Closes #1314.
 - **Ant Farm AF-3** — `@curia/shared-types` contract package and server-side event→directive interpreter for the pixel-art office visualization. Closes #1316.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **GHCR image publishing** — releases now push signed, multi-arch `ghcr.io/josephfung/curia` and `ghcr.io/josephfung/curia-postgres` images to the GitHub Container Registry; pushes to `main` publish the `:edge` tag for dogfood use. (#1343)
 - **`install.sh` operator installer** — interactive, image-based entry point for self-hosted operators; fetches the compose bundle, generates secrets, runs migrations and vault-seed inside the pulled container (tsx direct, no host pnpm), prompts for topology/TLS, and prints a bootstrap secret summary. No Node/pnpm/openssl required on the host. (#1343)
 - **Stuck-job recovery notifications** — recovery and suspension emails now include job objective, recurrence, and a console deep-link; `/jobs/:jobId` opens the job drawer directly. Closes #1332.
 - **Ant Farm AF-1** — `AuditLogRepo.findTimeline` / `findByEventTypes` return paginated `TimelinePage` (`hasMore`, keyset `after` cursor) with scoped-query guard; task filter uses `payload->>'taskId'` (index-aligned). Closes #1314.
@@ -59,6 +60,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`docker-compose.yml`** — references published GHCR images by default (`ghcr.io/josephfung/curia:latest`); developers who need local builds override with `docker-compose.dev.yml`. Shared installer helpers extracted to `scripts/setup-common.sh`. (#1343)
 - **Channel registry** — reconcile no longer auto-installs toggleable channels from ambient credentials; operators install and enable `email`/`signal` explicitly (parity with skills/agents), and `uninstall()` is durable across restarts. Outbound egress is gated on the same registry enabled-state as inbound adapters. (#965, #966)
 - **`outbound.pii_redacted`** — audit event type standardized to the underscore form in code; legacy hyphen-form rows preserved as immutable audit history, not rewritten. (#453)
 - **`contact_auth_overrides`** — partial unique index preserves grant→revoke→re-grant history instead of reactivating revoked rows. (#45)

--- a/README.md
+++ b/README.md
@@ -96,15 +96,32 @@ Skills come in two flavours (local handlers and MCP servers) behind a single int
 
 ## Quickstart
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/), Node >= 24, pnpm, and an [Anthropic API key](https://console.anthropic.com).
+### Operator install (image)
+
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and an [Anthropic API key](https://console.anthropic.com). No Node or pnpm required.
+
+```bash
+mkdir curia && cd curia
+curl -fsSL https://raw.githubusercontent.com/josephfung/curia/<vX.Y.Z>/install.sh -o install.sh
+# Review the script, then:
+bash install.sh
+```
+
+Replace `<vX.Y.Z>` with the latest release tag (check [releases](https://github.com/josephfung/curia/releases)). The installer pulls the published image, generates secrets, runs migrations inside the container, and prints your bootstrap secret. Curia will be running at `http://localhost:3000`.
+
+Save the bootstrap secret to a password manager and use it on the login page to create your account.
+
+**To update:** `docker compose pull && docker compose up -d`
+
+### Developer install (source)
+
+For contributing or hacking on the code. Requires Node >= 24 and pnpm.
 
 ```bash
 git clone https://github.com/josephfung/curia.git
 cd curia
 pnpm run setup
 ```
-
-Curia will be running at `http://localhost:3000`. The setup script prints your bootstrap secret — save it to a password manager and use it on the login page to create your account.
 
 **[→ Full installation guide](https://docs.meetcuria.com/get-started/installation)**  
 (channels, production deploy, configuration reference)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Skills come in two flavours (local handlers and MCP servers) behind a single int
 
 ### Operator install (image)
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and an [Anthropic API key](https://console.anthropic.com). No Node or pnpm required.
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) (with the Compose plugin), `curl`, and an [Anthropic API key](https://console.anthropic.com). No Node or pnpm required.
 
 ```bash
 mkdir curia && cd curia
@@ -115,7 +115,7 @@ Save the bootstrap secret to a password manager and use it on the login page to 
 
 ### Developer install (source)
 
-For contributing or hacking on the code. Requires Node >= 24 and pnpm.
+For contributing or hacking on the code. Requires Node >= 24, pnpm, and [Docker](https://docs.docker.com/get-docker/) (with the Compose plugin) for the Postgres container.
 
 ```bash
 git clone https://github.com/josephfung/curia.git

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,5 @@
+# Automatic HTTPS for Curia via Caddy + Let's Encrypt. DOMAIN is injected from
+# the environment. Caddy terminates TLS and reverse-proxies to the curia service.
+{$DOMAIN} {
+	reverse_proxy curia:3000
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,13 @@
+# Developer/source override: restores local image builds instead of pulling
+# published GHCR images. Used by `pnpm run setup` (scripts/setup.sh) and any
+# contributor running from a source checkout:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+services:
+  postgres:
+    build:
+      context: .
+      dockerfile: docker/postgres.Dockerfile
+  curia:
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -1,0 +1,24 @@
+# Optional HTTPS overlay. Enable by adding this file to COMPOSE_FILE in .env
+# (install.sh does this for you when you choose the public-domain option):
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.tls.yml
+# Requires DOMAIN set and an A record pointing at this host (ports 80/443 open).
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN}
+    volumes:
+      - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      curia:
+        condition: service_healthy
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   postgres:
-    build:
-      context: .
-      dockerfile: docker/postgres.Dockerfile
+    image: ghcr.io/josephfung/curia-postgres:${CURIA_POSTGRES_TAG:-pg16}
     restart: unless-stopped
     # POSTGRES_PORT is parameterized so a second stack can coexist on the same
     # host (e.g. testing a fresh `pnpm run setup` against a sibling clone while
@@ -11,8 +9,6 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
-      # pgAudit init script runs on first database creation only
-      - ./docker/postgres-init-pgaudit.sql:/docker-entrypoint-initdb.d/10-pgaudit.sql:ro
     environment:
       POSTGRES_DB: curia
       POSTGRES_USER: ${DB_USER:-your-db-user}
@@ -36,9 +32,7 @@ services:
       retries: 5
 
   curia:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG:-latest}
     # No explicit container_name — Docker Compose generates `<project>-curia-1`,
     # which is namespaced by COMPOSE_PROJECT_NAME. The previous `container_name: curia`
     # was global to the Docker daemon and made it impossible to run a second curia

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -17,4 +17,10 @@ RUN apt-get update \
 # not just on first init. Handles the existing-volume case where initdb.d scripts
 # were skipped because the data directory already existed.
 COPY docker/postgres-verify-pgaudit.sh /usr/local/bin/verify-pgaudit.sh
+
+# Bake the pgAudit init script into the image so a source-free self-host stack
+# (no repo checkout to volume-mount) still runs it on first DB init. The compose
+# volume mount is removed in lockstep (see docker-compose.yml).
+COPY docker/postgres-init-pgaudit.sql /docker-entrypoint-initdb.d/10-pgaudit.sql
+
 ENTRYPOINT ["verify-pgaudit.sh"]

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -106,9 +106,10 @@ for you:
 5. Starts the Postgres container, waits for it to be healthy, and applies
    all database migrations.
 6. **Seeds the encrypted secrets vault** from the values it just generated
-   and prompted for. Secrets resolve from the vault only (no `.env`
-   fallback; see [ADR-021](../adr/021-vault-only-secret-resolution.md)),
-   so this runs before first boot to avoid an empty-vault failure.
+   and prompted for. Most secrets resolve from the vault only (see
+   [ADR-021](../adr/021-vault-only-secret-resolution.md); `TAVILY_API_KEY` is
+   the documented env-fallback exception), so this runs before first boot to
+   avoid an empty-vault failure.
 7. Runs `pnpm install --frozen-lockfile` if `node_modules/` is missing
    (skipped on re-runs).
 8. Brings up the full stack (`docker compose up -d`) and polls Curia's
@@ -181,9 +182,11 @@ full design is documented in
 ## Adding secrets after setup
 
 Tiers 2 and 3 add credentials (Nylas, OpenAI, Tavily, Signal). These are
-**secrets**, and secrets resolve from the encrypted vault only (no `.env`
-fallback; see [ADR-021](../adr/021-vault-only-secret-resolution.md)).
-Setting a key in `.env` alone has no effect.
+**secrets**, and most of them resolve from the encrypted vault only (see
+[ADR-021](../adr/021-vault-only-secret-resolution.md)) — setting the key in
+`.env` alone has no effect. The one documented exception is `TAVILY_API_KEY`,
+which the web-search resolver reads vault-first but with an env-var fallback
+(see the Tavily section below).
 
 To add or update a secret, pass it as a transient env var to the seeder:
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -1,12 +1,69 @@
 # Development Setup
 
-This guide gets your local Curia instance running. Setup is organized into three tiers — start with the minimum and add services as needed.
+This guide covers two ways to run Curia:
+
+- **Operator install (image):** for self-hosted deployments. Docker only; no Node, pnpm, or openssl required on the host. Start here if you just want to run Curia, not develop it.
+- **Developer install (source):** for contributing to Curia or hacking on the code. Requires Node 24, pnpm, and openssl.
+
+---
+
+## Operator Install (Image)
+
+Requires Docker (with the Compose plugin) and `curl`. No other tools needed.
+
+**1. Create a working directory and download the installer:**
+
+```bash
+mkdir curia && cd curia
+curl -fsSL https://raw.githubusercontent.com/josephfung/curia/<vX.Y.Z>/install.sh -o install.sh
+```
+
+Replace `<vX.Y.Z>` with the release tag you want (e.g. `v0.40.0`). Check [releases](https://github.com/josephfung/curia/releases) for the latest.
+
+**2. Review the script before running it:**
+
+```bash
+less install.sh   # read it; it is short and well-commented
+```
+
+**3. Run the installer:**
+
+```bash
+bash install.sh
+```
+
+The installer will:
+
+1. Check for Docker, the Compose plugin, and `curl`.
+2. Fetch `docker-compose.yml`, `.env.example`, and the TLS overlay into the current directory.
+3. Generate secrets for `DB_PASSWORD`, `API_TOKEN`, and `WEB_APP_BOOTSTRAP_SECRET`.
+4. Prompt for your **Anthropic API key** (format-validated, 3 retries).
+5. Ask about deployment topology: local only, public HTTPS (Caddy), or behind an existing reverse proxy.
+6. Pull the published image, start Postgres, run migrations and vault-seed inside the container (no host `pnpm` or `openssl` required), then bring the full stack up.
+7. Print a summary box with the bootstrap secret you need to sign in.
+
+**Save the bootstrap secret to a password manager.** Use it on the login page at `http://localhost:3000` (or your configured domain) to create your account.
+
+**Updating an operator install:**
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+---
+
+## Developer Install (Source)
+
+For contributing or extending Curia. This path runs from source and requires local tooling.
+
+This guide is organized into three tiers. Start with the minimum and add services as needed.
 
 | Tier | Services | What you get |
 |---|---|---|
-| **1 — Minimum** | Anthropic + Postgres | Agents running, CLI and web app working |
-| **2 — Recommended** | + Nylas + OpenAI | Email channel active, entity memory and semantic search working |
-| **3 — Full** | + Tavily + Signal | Web research skill, encrypted Signal messaging |
+| **1 - Minimum** | Anthropic + Postgres | Agents running, CLI and web app working |
+| **2 - Recommended** | + Nylas + OpenAI | Email channel active, entity memory and semantic search working |
+| **3 - Full** | + Tavily + Signal | Web research skill, encrypted Signal messaging |
 
 Complete each tier before moving to the next.
 
@@ -16,15 +73,15 @@ Complete each tier before moving to the next.
 
 Install these before anything else:
 
-- **Node.js 24+** — check with `node --version`
-- **Docker and Docker Compose** — Postgres runs in Docker; install [Docker Desktop](https://www.docker.com/products/docker-desktop/) or the standalone CLI
-- **pnpm** — `npm install -g pnpm`
-- **openssl** — used by `pnpm run setup` to generate secrets; usually
+- **Node.js 24+:** check with `node --version`
+- **Docker and Docker Compose:** Postgres runs in Docker; install [Docker Desktop](https://www.docker.com/products/docker-desktop/) or the standalone CLI
+- **pnpm:** `npm install -g pnpm`
+- **openssl:** used by `pnpm run setup` to generate secrets; usually
   pre-installed on macOS and Linux. Verify with `openssl version`.
 
 ---
 
-## Tier 1 — Minimum
+## Tier 1 - Minimum
 
 Everything you need to run Curia and interact with it via the CLI and web app.
 
@@ -49,8 +106,8 @@ for you:
 5. Starts the Postgres container, waits for it to be healthy, and applies
    all database migrations.
 6. **Seeds the encrypted secrets vault** from the values it just generated
-   and prompted for. Secrets resolve from the vault only — there is no
-   `.env` fallback (see [ADR-021](../adr/021-vault-only-secret-resolution.md)),
+   and prompted for. Secrets resolve from the vault only (no `.env`
+   fallback; see [ADR-021](../adr/021-vault-only-secret-resolution.md)),
    so this runs before first boot to avoid an empty-vault failure.
 7. Runs `pnpm install --frozen-lockfile` if `node_modules/` is missing
    (skipped on re-runs).
@@ -60,13 +117,13 @@ for you:
 9. Appends `# SETUP_COMPLETE` to `.env` as a clean-finish marker and prints
    a summary box with `http://localhost:3000` and your bootstrap secret.
 
-**Save the bootstrap secret to a password manager** — the script will not
+**Save the bootstrap secret to a password manager.** The script will not
 show it again. If you need to recover it, it's in `.env` as
 `WEB_APP_BOOTSTRAP_SECRET=...`.
 
 > **Re-running `pnpm run setup`:** If `.env` already exists, the script
-> presents a menu — start the stack (default), resume an interrupted setup,
-> or do a full reset. See [spec 18 — Onboarding](../specs/18-onboarding.md#re-entry-path)
+> presents a menu (start the stack, resume an interrupted setup, or full
+> reset). See [spec 18 - Onboarding](../specs/18-onboarding.md#re-entry-path)
 > for what each option does.
 
 ### 2. Verify
@@ -76,7 +133,7 @@ prompted for your `WEB_APP_BOOTSTRAP_SECRET`. The next step (Tier 1, §3)
 walks through the in-app setup that finishes immediately after login.
 
 **CLI:** If you want a CLI interface alongside the web app, run `pnpm local`
-in a separate terminal — it attaches a CLI channel to the running stack.
+in a separate terminal. It attaches a CLI channel to the running stack.
 
 ### 3. Personalize your instance
 
@@ -84,10 +141,10 @@ After logging in for the first time, the app detects that the office identity
 has not been configured and redirects you to `/setup` automatically. This is
 a six-step React form wizard:
 
-1. **About you** — the CEO's name (the principal contact). This step no longer
+1. **About you:** the CEO's name (the principal contact). This step no longer
    auto-skips when a principal already exists; it pre-populates the current
    name so it can be corrected if needed.
-2. **Your details** — the principal's operational profile. Captures timezone
+2. **Your details:** the principal's operational profile. Captures timezone
    (required), email, preferred name, title, and working hours (all optional).
    The email is stored as a verified principal identity that comes online after
    the wizard's restart. The selected timezone informs agent reasoning via
@@ -95,25 +152,25 @@ a six-step React form wizard:
    environment variable `TIMEZONE`) remains env-driven separate from the wizard
    selection. Aligning the system clock to match the principal's contact
    timezone is tracked as a follow-up.
-3. **Identity** — assistant name, title, optional email signature.
-4. **Tone** — 1–3 baseline tone words + verbosity and directness sliders.
-5. **Posture** — decision-making posture + initial behavioral preferences.
-6. **Review** — confirm and save.
+3. **Identity:** assistant name, title, optional email signature.
+4. **Tone:** 1-3 baseline tone words, verbosity and directness sliders.
+5. **Posture:** decision-making posture and initial behavioral preferences.
+6. **Review:** confirm and save.
 
 When you submit step 6, the wizard saves the identity, hot reloads it, and
 (if the process booted in setup-required mode) asks the supervisor to
 restart so the email and Signal channels can come online. You'll see a
-brief "Setting up channels…" screen during the restart, then land directly
+brief "Setting up channels..." screen during the restart, then land directly
 in the chat view at `/chat`. The `setup-wizard` specialist agent
 automatically introduces itself and asks about your priorities, working
-hours, and debrief cadence. Reply to it like you'd talk to any agent —
-preferences captured here are appended to the same office identity the
+hours, and debrief cadence. Reply to it like you'd talk to any agent.
+Preferences captured here are appended to the same office identity the
 form wizard wrote.
 
 The whole personalization step takes a few minutes. You can come back to
 `/setup` directly any time you want to revise the identity by hand. The
 full design is documented in
-[spec 18 — Onboarding](../specs/18-onboarding.md).
+[spec 18 - Onboarding](../specs/18-onboarding.md).
 
 > **Checkpoint:** Curia is running, your identity is configured, and the
 > coordinator is personalized. Stop here or continue to Tier 2 for email
@@ -124,8 +181,8 @@ full design is documented in
 ## Adding secrets after setup
 
 Tiers 2 and 3 add credentials (Nylas, OpenAI, Tavily, Signal). These are
-**secrets**, and secrets resolve from the encrypted vault only — there is no
-`.env` fallback (see [ADR-021](../adr/021-vault-only-secret-resolution.md)).
+**secrets**, and secrets resolve from the encrypted vault only (no `.env`
+fallback; see [ADR-021](../adr/021-vault-only-secret-resolution.md)).
 Setting a key in `.env` alone has no effect.
 
 To add or update a secret, pass it as a transient env var to the seeder:
@@ -142,18 +199,18 @@ tiers below name the variables to seed.
 > Only the four vault-bootstrap values (`DB_USER`, `DB_PASSWORD`,
 > `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`) plus non-secret config (`TIMEZONE`,
 > etc.) belong in `.env`. Everything else goes through the vault. The principal's
-> email is not env config — it's set in the onboarding wizard and lives in the
+> email is not env config; it's set in the onboarding wizard and lives in the
 > contacts store.
 
 ---
 
-## Tier 2 — Recommended
+## Tier 2 - Recommended
 
 Adds the email channel and knowledge graph embeddings. This gives you a realistic development environment close to how Curia is actually used.
 
 ### Nylas (Email)
 
-Curia uses [Nylas](https://nylas.com) as its email layer — a unified API that handles the IMAP/SMTP complexity and provides a consistent interface across Gmail, Outlook, and other providers.
+Curia uses [Nylas](https://nylas.com) as its email layer. Nylas is a unified API that handles the IMAP/SMTP complexity and provides a consistent interface across Gmail, Outlook, and other providers.
 
 **1. Create a Nylas account**
 
@@ -161,19 +218,19 @@ Sign up at [app.nylas.com](https://app.nylas.com). The free tier is sufficient f
 
 **2. Create an application**
 
-In the Nylas dashboard, create a new application. Choose "Email" as the product. Once created, copy your **API key** — this is your `NYLAS_API_KEY`.
+In the Nylas dashboard, create a new application. Choose "Email" as the product. Once created, copy your **API key**. This is your `NYLAS_API_KEY`.
 
 **3. Connect an email account**
 
 In your application, go to **Grants** and add a new grant. This connects an email account (Gmail, Outlook, etc.) to your Nylas application via OAuth. Use the email address you want Curia to read and send from.
 
-After completing the OAuth flow, the grant appears in your dashboard. Copy the **Grant ID** — this is your `NYLAS_GRANT_ID`.
+After completing the OAuth flow, the grant appears in your dashboard. Copy the **Grant ID**. This is your `NYLAS_GRANT_ID`.
 
 > **Note:** For development, using a dedicated email account (rather than your primary inbox) is strongly recommended. Curia will read and process all incoming messages.
 
 **4. Set the email address**
 
-`NYLAS_SELF_EMAIL` is the address of the connected account — the address Curia reads and sends from:
+`NYLAS_SELF_EMAIL` is the address of the connected account (the address Curia reads and sends from).
 
 Seed all three into the vault (see [Adding secrets after setup](#adding-secrets-after-setup)):
 
@@ -184,9 +241,9 @@ NYLAS_SELF_EMAIL=curia@yourdomain.com \
 pnpm run seed-vault
 ```
 
-Restart Curia (`pnpm local`), then **install and enable the email channel** in the console (**Settings → Channels → Email**). Credentials in the vault alone do not activate the channel — the registry requires an explicit install→enable, the same as skills and agents. See [configuration.md](configuration.md#skill-agent-and-channel-registry).
+Restart Curia (`pnpm local`), then **install and enable the email channel** in the console (**Settings -> Channels -> Email**). Credentials in the vault alone do not activate the channel. The registry requires an explicit install then enable, the same as skills and agents. See [configuration.md](configuration.md#skill-agent-and-channel-registry).
 
-> **Multiple email accounts:** Additional accounts are managed from the console after first boot — go to **Settings → Channels → Email → Email accounts**. Each account stores its Nylas grant in the vault at `channel.email.<name>.nylas_grant_id`. See [configuration.md](configuration.md#email-accounts) for details.
+> **Multiple email accounts:** Additional accounts are managed from the console after first boot. Go to **Settings -> Channels -> Email -> Email accounts**. Each account stores its Nylas grant in the vault at `channel.email.<name>.nylas_grant_id`. See [configuration.md](configuration.md#email-accounts) for details.
 
 ### OpenAI (Embeddings)
 
@@ -202,7 +259,7 @@ OPENAI_API_KEY=sk-... pnpm run seed-vault
 
 ---
 
-## Tier 3 — Full
+## Tier 3 - Full
 
 Adds web research capability and (when available) Signal messaging.
 
@@ -210,14 +267,14 @@ Adds web research capability and (when available) Signal messaging.
 
 Powers the `web-search` skill, which lets agents research topics and look up current information.
 
-`web-search` is **excluded from the default core set** and is **gated by `install.requires_secrets: [tavily_api_key]`** — it cannot be installed or enabled until the Tavily key exists in the vault. This makes it the reference flow for provisioning a skill secret through the console.
+`web-search` is **excluded from the default core set** and is **gated by `install.requires_secrets: [tavily_api_key]`**. It cannot be installed or enabled until the Tavily key exists in the vault. This makes it the reference flow for provisioning a skill secret through the console.
 
 **Provision via the console (recommended):**
 
 1. Sign up at [tavily.com](https://tavily.com) and copy your API key (`tvly-...`).
-2. In the console, open **Settings → Skills → web-search → Required secrets**. `tavily_api_key` shows as **missing** and **Install & enable** is disabled.
+2. In the console, open **Settings -> Skills -> web-search -> Required secrets**. `tavily_api_key` shows as **missing** and **Install & enable** is disabled.
 3. Paste the key inline. It is stored encrypted in the vault; the status flips to **configured** and the button enables.
-4. Click **Install & enable**. Enforcement is **restart-based** — the skill registers and becomes usable on the next process restart.
+4. Click **Install & enable**. Enforcement is restart-based. The skill registers and becomes usable on the next process restart.
 
 **Alternative (dev shortcut):** seed the key into the vault directly, then enable web-search in the console:
 
@@ -225,13 +282,13 @@ Powers the `web-search` skill, which lets agents research topics and look up cur
 TAVILY_API_KEY=tvly-... pnpm run seed-vault
 ```
 
-`ctx.secret('tavily_api_key')` resolves **vault-first** with a `TAVILY_API_KEY` env-var fallback. In production the vault is the single source of truth — do **not** leave `TAVILY_API_KEY` set in the deploy environment, since a lingering env var would mask whether the vault entry is actually being used.
+`ctx.secret('tavily_api_key')` resolves vault-first with a `TAVILY_API_KEY` env-var fallback. In production the vault is the single source of truth. Do **not** leave `TAVILY_API_KEY` set in the deploy environment, since a lingering env var would mask whether the vault entry is actually being used.
 
-> **Revocation caveat:** the install/enable gate checks the **vault only**, but the runtime resolver falls back to the env var. So if `TAVILY_API_KEY` is still set, *deleting `tavily_api_key` from the vault does not revoke web-search* — the skill keeps working off the env var, and only the `secret.accessed` event (`source: env`) reveals it. Treat removing the env var as a prerequisite for vault-based key rotation/revocation, not just initial setup.
+> **Revocation caveat:** the install/enable gate checks the vault only, but the runtime resolver falls back to the env var. So if `TAVILY_API_KEY` is still set, deleting `tavily_api_key` from the vault does not revoke web-search. The skill keeps working off the env var, and only the `secret.accessed` event (`source: env`) reveals it. Treat removing the env var as a prerequisite for vault-based key rotation/revocation, not just initial setup.
 
 ### Signal
 
-Signal messaging runs via [signal-cli](https://github.com/AsamK/signal-cli). The socket path is wired up automatically by Docker Compose — the only thing you need to set is your phone number.
+Signal messaging runs via [signal-cli](https://github.com/AsamK/signal-cli). The socket path is wired up automatically by Docker Compose. The only thing you need to set is your phone number.
 
 **1. Bootstrap signal-cli**
 
@@ -243,9 +300,9 @@ Signal requires registering a phone number with signal-cli and seeding the `sign
 SIGNAL_PHONE_NUMBER=+12223334444 pnpm run seed-vault
 ```
 
-That's the E.164 number you registered via `signal-cli register` + `verify`. `SIGNAL_SOCKET_PATH` is managed by the deployment layer — do not set it in `.env`.
+That's the E.164 number you registered via `signal-cli register` + `verify`. `SIGNAL_SOCKET_PATH` is managed by the deployment layer; do not set it in `.env`.
 
-Restart Curia, then **install and enable the Signal channel** in the console (**Settings → Channels → Signal**). The phone number in the vault and a populated `signal-data` volume are prerequisites, but the channel still requires an explicit install→enable before it starts.
+Restart Curia, then **install and enable the Signal channel** in the console (**Settings -> Channels -> Signal**). The phone number in the vault and a populated `signal-data` volume are prerequisites, but the channel still requires an explicit install then enable before it starts.
 
 ---
 
@@ -256,14 +313,14 @@ and met the `setup-wizard` agent. From here:
 
 - **Use the chat view.** Open `http://localhost:3000/chat` and start
   talking to the coordinator. This is the primary surface for everyday use.
-- **Or use the CLI.** Run `pnpm local` in a terminal — it attaches a CLI
+- **Or use the CLI.** Run `pnpm local` in a terminal. It attaches a CLI
   channel to the running stack. Type a message at the prompt.
 
 If you want to dig deeper, the [architecture overview](../specs/00-overview.md)
 explains how the layers fit together, and the [agent](adding-an-agent.md)
 and [skill](adding-a-skill.md) guides cover the most common extension points.
 The end-to-end onboarding flow is documented in
-[spec 18 — Onboarding](../specs/18-onboarding.md).
+[spec 18 - Onboarding](../specs/18-onboarding.md).
 
 To enable Google Drive access (for expense trackers, job application
 trackers, and other persistent documents), see [google-drive.md](google-drive.md).
@@ -294,5 +351,5 @@ Make sure the Docker container is running (`docker compose ps`). If the containe
 
 All three Nylas vars (`NYLAS_API_KEY`, `NYLAS_GRANT_ID`, `NYLAS_SELF_EMAIL`) must be set. If any are missing, the channel disables itself at startup. Two possible log messages:
 
-- `NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled` — the API key or grant ID is missing
-- `NYLAS_SELF_EMAIL not set — email adapter disabled` — the first two vars are set but `NYLAS_SELF_EMAIL` is missing
+- `NYLAS_API_KEY/NYLAS_GRANT_ID not set: email channel disabled` (the API key or grant ID is missing)
+- `NYLAS_SELF_EMAIL not set: email adapter disabled` (the first two vars are set but `NYLAS_SELF_EMAIL` is missing)

--- a/docs/wip/2026-07-04-ghcr-publish-self-host-design.md
+++ b/docs/wip/2026-07-04-ghcr-publish-self-host-design.md
@@ -1,0 +1,130 @@
+# Publish semver-tagged images to GHCR + interactive image-based install
+
+**Issue:** [#1343](https://github.com/josephfung/curia/issues/1343)
+**Epic:** [#1281 — open-core self-hosting](https://github.com/josephfung/curia/issues/1281)
+**Date:** 2026-07-04
+**Status:** Design — awaiting review
+
+---
+
+## 1. Objective
+
+Two concrete goals, in priority order:
+
+1. **Publish each Curia release as a versioned container image** to a public registry (GHCR), so an operator can run a released Curia without a source checkout or a Node/pnpm toolchain.
+2. **Eliminate the core-Dockerfile duplication in `curia-deploy`.** Today `curia-deploy/deploy/compose/Dockerfile.curia` is a ~330-line near-copy of `curia/Dockerfile`; the two drift and have hit the same bugs independently. Publishing lets `curia-deploy` consume the core image via a thin `FROM` layer.
+
+Everyday install becomes: **download one `install.sh`, run it, answer one prompt (the Anthropic key), and a working Curia comes up from the published image.**
+
+Non-goal restatement (from the epic): this is *not* npm/brew distribution of the product. A container registry is the right channel for a stateful, Postgres-backed server app.
+
+## 2. Current state (baseline)
+
+- **Two divergent Dockerfiles.** `curia/Dockerfile` (core) is built only for local `docker-compose up` and CI security scans — **never published**. `curia-deploy/deploy/compose/Dockerfile.curia` is a near-copy that additionally layers custom agents/skills, Chrome/patchright, atproto-mcp, and licensed LimeZu art.
+- **Deploy is a source-build model.** `curia-deploy/scripts/deploy.sh` rsyncs the *local* `repos/curia` checkout to the VPS and runs `docker compose build` on the server. No registry, no pull.
+- **Migrations already auto-run on container boot** — `src/index.ts` (~L291) runs node-pg-migrate programmatically under an advisory lock before service init. (#1344's runtime half is effectively already true.)
+- **Secrets are vault-only.** `src/secrets/apply-vault-secrets.ts` resolves `anthropic_api_key`, `api_token`, `web_app_bootstrap_secret`, etc. from the encrypted `secrets` table with **no env fallback**. Boot **fatal-exits** without `api_token` (`src/index.ts:339`) or `anthropic_api_key` (`src/index.ts:418`). The vault is populated by `scripts/seed-vault.ts`, invoked by the interactive `scripts/setup.sh` **host-side** (needs source + Node + pnpm).
+- **Interactive installer exists.** `scripts/setup.sh` already prompts for the Anthropic key, generates the other secrets, writes the vault-unlock `.env`, runs migrations + seed-vault host-side, brings up the stack, and prints a summary. It is built for the **source-checkout** model.
+- **Version 0.39.0**, manual bump. `release.yml` fires on GitHub release `published` and produces a signed SBOM + source tarball — no image push.
+
+## 3. Design decisions (with rationale)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Publish `curia/Dockerfile` to GHCR as the **single source of truth**. | Kills the two-Dockerfile drift. |
+| D2 | Tags: **`vX.Y.Z` + `latest`** on release published; **`edge`** on every push to main. | `edge` preserves fast merge→deploy cadence without cutting a release; `vX.Y.Z`/`latest` are the stable self-host tags. |
+| D3 | Multi-arch **`linux/amd64` + `linux/arm64`** via buildx. | Covers cloud VPS (amd64) and Apple Silicon / ARM self-hosters. |
+| D4 | **cosign keyless-sign** the image + **SPDX SBOM attestation**. | Matches `release.yml`'s existing OIDC-identity posture; provenance for the self-host credibility goal. |
+| D5 | GHCR package is **public** (anonymous pull). | The point of the epic. One-time package-visibility setting. |
+| D6 | Everyday operator installs via an **interactive, image-based `install.sh`** (download one file, run it). | A detached `docker compose up -d` container cannot prompt (no TTY); an interactive installer can. Keeps the excellent setup.sh UX but retargets it to the pulled image. |
+| D7 | `install.sh` runs **migrate + seed-vault *inside the pulled image*** (`docker compose run --rm curia …`), not host-side. | Operator has no source/Node/pnpm. The image already contains the migration runner, `scripts/seed-vault.ts`, and `node_modules`. Invoke `tsx` directly (the runtime image deliberately avoids corepack). |
+| D8 | **No change to core secret-handling.** The vault is seeded by `install.sh` *before* boot, so the container always boots against a populated vault (as prod does today). | Smallest blast radius on core — no `bootstrapSecretsFromEnv` in `src/index.ts`. |
+| D9 | `SECRET_ENCRYPTION_KEY` is **required in `.env`**, but `install.sh` **auto-generates it** (`head -c 32 /dev/urandom | base64`) if absent, and **preserves** an existing one. | At-rest: never written to the data volume (unlike auto-gen-to-volume); a DB dump stays pure ciphertext. Key custody: operator can back it up and restore on a fresh host. Generating in the installer keeps "set one key" UX while keeping the key off the data volume. |
+| D10 | `.env` is an **optional input**: append/update if present, create from template if absent. | Operator convenience; don't clobber an existing key. |
+| D11 | Developer path unchanged: `git clone && pnpm run setup` (source build). Shared logic extracted to `scripts/setup-common.sh`. | Contributor muscle-memory preserved; DRY across the two installers. |
+| D12 | `curia-deploy/Dockerfile.curia` → `FROM ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG}` + private layers only. | Removes ~250 lines of duplicated core build. |
+| D13 | The thin downstream (custom) image is **built on the VPS**, not pushed to any registry. | Private custom code + licensed LimeZu art never enter a registry. Minimal change from today (just drops the core-source rsync). |
+| D14 | `deploy.sh` **stops rsyncing the curia source**; syncs only `curia-deploy`, pulls the base tag, rebuilds the fast thin layer, `up -d`. `CURIA_IMAGE_TAG` defaults to `edge` / pins `vX.Y.Z`. | The "curia checkout on the VPS" concept goes away. Dogfoods the published image. |
+
+### Deferred / out of scope (recorded, not built)
+
+- **Web onboarding** (boot degraded without an Anthropic key → enter it in a browser setup wizard). This is the true zero-secret-env path but belongs to #771: the app currently fatal-exits without a key and the setup wizard doesn't accept API keys. Captured as the follow-on.
+- **Volume-mount custom layering** (epic #3's alternative). We use the downstream-image path, which our Chrome/atproto *system* deps require anyway. This resolves the epic's open question: downstream-image is the blessed path.
+- **Extension-contract versioning** (#4), **docs page** (#5), migrate-idempotency hardening beyond what exists (#1344).
+
+## 4. Components & changes
+
+### 4.1 curia repo — publish workflow
+**New:** `.github/workflows/docker-publish.yml`
+
+- Triggers: `release: [published]` and `push: [main]` (and `workflow_dispatch` for manual/backfill).
+- Auth: `GITHUB_TOKEN` with `packages: write`, `id-token: write` (OIDC for cosign), `contents: read`.
+- Steps: `docker/setup-qemu-action` + `docker/setup-buildx-action` → `docker/login-action` (ghcr.io) → `docker/metadata-action` (derive tags: `vX.Y.Z`+`latest` from the release tag, or `edge` from main) → `docker/build-push-action` (`platforms: linux/amd64,linux/arm64`, `provenance: true`, `push: true`) → `cosign sign` (keyless) → `anchore/sbom-action` + `cosign attest` SBOM.
+- Tag-name validation mirrors `release.yml`'s injection guard (strict semver regex on the release tag).
+
+### 4.2 curia repo — self-host bundle (repo root)
+- **New:** `docker-compose.yml` — image-based:
+  - `curia`: `image: ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG:-latest}`, port `3000:3000`, `depends_on: postgres (healthy)`, healthcheck on `/api/health`, named volumes for runtime state, env from `.env`.
+  - `postgres`: `pgvector/pgvector:pg16`, named volume `curia-pgdata`, healthcheck `pg_isready`.
+  - No Caddy in the minimal file (TLS is a documented production add-on).
+- **New:** `.env.example` — the vault-unlock set (`DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`) + non-secret config (`DOMAIN`, `HTTP_PORT`, `TIMEZONE`, `LOG_LEVEL`, `CURIA_IMAGE_TAG`), with the encryption-key one-liner documented. This is the template `install.sh` renders and the standalone reference for hand-configurers.
+- **New:** `docker-compose.dev.yml` — a build-context override so the developer/source path builds locally instead of pulling.
+
+### 4.3 curia repo — installers
+- **New:** `install.sh` (root) — the everyday operator entry (image-based, interactive). Responsibilities:
+  1. Prereq check: **Docker + docker compose + curl** only.
+  2. Fetch version-pinned `docker-compose.yml` (+ `.env.example`) if absent.
+  3. Prompt for the Anthropic key (validated `sk-ant-…`).
+  4. Resolve `.env`: create from template if absent, else append/update; preserve an existing `SECRET_ENCRYPTION_KEY`, generate one if missing.
+  5. Generate `API_TOKEN`, `WEB_APP_BOOTSTRAP_SECRET`.
+  6. `docker compose up -d postgres` → wait healthy.
+  7. **One-shot migrate in-container:** `docker compose run --rm curia ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql` (DATABASE_URL from compose env).
+  8. **Seed vault in-container:** `docker compose run --rm -e ANTHROPIC_API_KEY -e API_TOKEN -e WEB_APP_BOOTSTRAP_SECRET -e SEED_VAULT_VERIFY=1 curia ./node_modules/.bin/tsx scripts/seed-vault.ts`.
+  9. `docker compose up -d` → poll `/api/health` → print summary box (show the web login secret once).
+- **Refactor:** `scripts/setup.sh` (dev/source) — keep behavior; its host-side migrate + seed logic stays for the source path. Extract shared prompt/gen/health-poll/summary into:
+- **New:** `scripts/setup-common.sh` — sourced by both `setup.sh` and `install.sh`.
+
+Note the chicken-and-egg the one-shot migrate solves: `seed-vault` needs the `secrets` table, but a full boot fatal-exits before healthy without `api_token`. Running migrate in a throwaway container first creates the schema without booting the app.
+
+### 4.4 curia-deploy repo — thin downstream image + pull-based deploy
+- **Rewrite:** `deploy/compose/Dockerfile.curia` → `FROM ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG}` then only: install Chrome/patchright, atproto-mcp + `@atproto/api`, `COPY custom/agents|skills|config`, LimeZu art copy, volume/dir setup unique to our instance. Drop everything the base image already provides (build stage, tsup/vite builds, base deps, uv, tsx, non-root user — inherited).
+- **Edit:** `scripts/deploy.sh` — remove the `repos/curia` rsync and the `Dockerfile` presence check; add `CURIA_IMAGE_TAG` (default `edge`) and `docker pull ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG}` before build; keep the thin-layer build on the VPS. The `curia/` sibling directory on the VPS is no longer required.
+- **Edit:** `deploy/compose/compose.production.yaml` — its `curia` service already sets `build.dockerfile: …/Dockerfile.curia` with context `/opt/curia/`; adjust so the build context is just `curia-deploy/` (custom + Dockerfile), no core source needed. Base image pinned via `CURIA_IMAGE_TAG`.
+- `Dockerfile.signal-cli` untouched (no core duplication).
+
+## 5. What belongs in core vs the downstream image
+
+| Concern | Public core image | Downstream (curia-deploy) |
+|---------|-------------------|---------------------------|
+| Backend build (tsup), console + antfarm (vite) | ✅ | inherited |
+| Base deps, uv/uvx (workspace-mcp), tsx, non-root user | ✅ | inherited |
+| Migrations, seed-vault script, scripts/ | ✅ | inherited |
+| Chrome / patchright (web-browser skill) | ❌ | ✅ |
+| atproto-mcp, `@atproto/api` (Bluesky) | ❌ | ✅ |
+| Licensed LimeZu art | ❌ (license) | ✅ (built on VPS only) |
+| Custom agents / skills / `config/skills.yaml` | ❌ | ✅ |
+
+A bare core self-hoster therefore gets a working Curia **without** the browser or Bluesky skills — acceptable for #1343 ("a working Curia"). Those are instance-specific extensions.
+
+## 6. Revised acceptance criteria
+
+1. A clean machine with **only Docker** installed can: download `install.sh`, run it, answer the Anthropic-key prompt, and reach a **healthy** Curia (`/api/health` → ok) from the **published GHCR image** — **no source checkout, no host Node/pnpm, no manual SQL**.
+2. The published image is **multi-arch** (amd64+arm64), **cosign-signed**, and carries an **SBOM attestation**; the GHCR package is publicly pullable.
+3. `docker compose pull && docker compose up -d` across a version bump brings up the new image and auto-applies migrations unattended.
+4. `curia-deploy` deploys by **pulling** `ghcr.io/josephfung/curia:<tag>` and building only the thin custom layer on the VPS — **no curia source is rsynced**; the two Dockerfiles no longer duplicate core build logic.
+5. The developer path (`git clone && pnpm run setup`) still builds and runs from source.
+6. Seeding is **idempotent**: re-running `install.sh` against an existing instance does not clobber the encryption key or rotate already-seeded secrets.
+
+## 7. Risks & mitigations
+
+- **Bad migration ships in an image that auto-migrates on boot** (harder to hot-patch than an rsync'd tree; cf. migration 070 crash-loop). *Mitigation:* migrations are advisory-locked and idempotent; docs prescribe a DB backup before `docker compose pull` (folds into #1344); `edge` catches migration breakage before a release tag.
+- **Losing the ability to deploy un-merged local HEAD to prod.** *Accepted:* `edge` (built on every main push) covers merged-but-unreleased code; truly un-merged WIP should go through a PR. (No `--local` escape hatch in this iteration.)
+- **Multi-arch CI cost (~2× via QEMU).** *Accepted* for reach; revisit if build minutes bite.
+- **Registry outage blocks deploy/pull.** *Mitigation:* pinning `CURIA_IMAGE_TAG` to a `vX.Y.Z` that's already local avoids re-pull; GHCR availability is acceptable for this stage.
+- **`.env` secret at-rest.** `SECRET_ENCRYPTION_KEY` stays out of the DB/volume; operator is advised to back it up. Full-host-compromise is out of scope (equivalent for any .env-based app).
+
+## 8. Open questions for review
+
+- Should `docker-compose.yml` include an **optional Caddy TLS overlay** now (as a separate `docker-compose.tls.yml`), or leave TLS entirely to docs?
+- Confirm the GHCR image name: `ghcr.io/josephfung/curia` (owner `josephfung`).
+- `curia-deploy` currently builds the thin layer on the VPS. Is a `docker pull`-only future (private registry) worth a follow-up, or is on-VPS build the durable answer?

--- a/docs/wip/2026-07-04-ghcr-publish-self-host-design.md
+++ b/docs/wip/2026-07-04-ghcr-publish-self-host-design.md
@@ -31,7 +31,7 @@ Non-goal restatement (from the epic): this is *not* npm/brew distribution of the
 
 | # | Decision | Rationale |
 |---|----------|-----------|
-| D1 | Publish `curia/Dockerfile` to GHCR as the **single source of truth**. | Kills the two-Dockerfile drift. |
+| D1 | Publish `curia/Dockerfile` to **GHCR** (`ghcr.io/josephfung/curia`) as the **single source of truth**. | GHCR chosen over Docker Hub: same GitHub identity → cosign keyless/OIDC "just works", no separate account, and **no anonymous pull rate limits** (Docker Hub throttles hard — a real self-host papercut). Kills the two-Dockerfile drift. |
 | D2 | Tags: **`vX.Y.Z` + `latest`** on release published; **`edge`** on every push to main. | `edge` preserves fast merge→deploy cadence without cutting a release; `vX.Y.Z`/`latest` are the stable self-host tags. |
 | D3 | Multi-arch **`linux/amd64` + `linux/arm64`** via buildx. | Covers cloud VPS (amd64) and Apple Silicon / ARM self-hosters. |
 | D4 | **cosign keyless-sign** the image + **SPDX SBOM attestation**. | Matches `release.yml`'s existing OIDC-identity posture; provenance for the self-host credibility goal. |
@@ -48,9 +48,13 @@ Non-goal restatement (from the epic): this is *not* npm/brew distribution of the
 
 ### Deferred / out of scope (recorded, not built)
 
-- **Web onboarding** (boot degraded without an Anthropic key → enter it in a browser setup wizard). This is the true zero-secret-env path but belongs to #771: the app currently fatal-exits without a key and the setup wizard doesn't accept API keys. Captured as the follow-on.
-- **Volume-mount custom layering** (epic #3's alternative). We use the downstream-image path, which our Chrome/atproto *system* deps require anyway. This resolves the epic's open question: downstream-image is the blessed path.
-- **Extension-contract versioning** (#4), **docs page** (#5), migrate-idempotency hardening beyond what exists (#1344).
+- **Browser Anthropic-key entry** (boot degraded without a key → paste it in the web wizard → seed over HTTP). This is the true zero-secret-env path. **Note:** #771 (in-app onboarding) is **already shipped (v0.32)** — it built setup-required boot mode + name-only principal + wizard, but *not* API-key entry (the key is still seeded pre-boot). Our interactive `install.sh` gives a clean key-entry path, so browser entry is a nice-to-have for shell-less installs (one-click PaaS). Filed as backlog **#1345** (P5, non-blocking).
+- **Volume-mount custom layering** (epic item 3's alternative). We use the downstream-image path, which our Chrome/atproto *system* deps require anyway. **The epic #1281 open question has been updated to record downstream-image as the blessed path.**
+- **Extension-contract versioning** (epic item 4), **docs page** (epic item 5), migrate-idempotency hardening beyond what exists (#1344).
+
+### Registry choice & OSSF Scorecard
+
+GHCR is chosen on its own merits (see D1). Note it will **not reliably satisfy the Scorecard "Packaging" check** — that check is GitHub-only, binary, and self-describes as blind to non-recognized methods ("a project that fulfills this criterion with other tools may still receive a low score"); it hunts for language-hub publish actions (npm/PyPI), not `docker/build-push-action` → GHCR. Packaging is Medium-risk and a known false-negative here; we accept it rather than reverse-engineer the registry choice around a flaky heuristic.
 
 ## 4. Components & changes
 
@@ -66,21 +70,23 @@ Non-goal restatement (from the epic): this is *not* npm/brew distribution of the
 - **New:** `docker-compose.yml` — image-based:
   - `curia`: `image: ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG:-latest}`, port `3000:3000`, `depends_on: postgres (healthy)`, healthcheck on `/api/health`, named volumes for runtime state, env from `.env`.
   - `postgres`: `pgvector/pgvector:pg16`, named volume `curia-pgdata`, healthcheck `pg_isready`.
-  - No Caddy in the minimal file (TLS is a documented production add-on).
+  - No Caddy in the **base** file — base exposes `:3000` so localhost/eval and bring-your-own-proxy (nginx/Traefik/Cloudflare Tunnel) both work.
+- **New:** `docker-compose.tls.yml` — an **optional** Caddy overlay (automatic Let's Encrypt HTTPS, `DOMAIN` env). Operators with a public domain add it: `docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d`. Generalizes the pattern already in `curia-deploy/compose.production.yaml`. TLS matters because Curia auth (bootstrap secret, API token, session cookies) must not cross the wire in cleartext on a public host.
 - **New:** `.env.example` — the vault-unlock set (`DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`) + non-secret config (`DOMAIN`, `HTTP_PORT`, `TIMEZONE`, `LOG_LEVEL`, `CURIA_IMAGE_TAG`), with the encryption-key one-liner documented. This is the template `install.sh` renders and the standalone reference for hand-configurers.
 - **New:** `docker-compose.dev.yml` — a build-context override so the developer/source path builds locally instead of pulling.
 
 ### 4.3 curia repo — installers
 - **New:** `install.sh` (root) — the everyday operator entry (image-based, interactive). Responsibilities:
   1. Prereq check: **Docker + docker compose + curl** only.
-  2. Fetch version-pinned `docker-compose.yml` (+ `.env.example`) if absent.
-  3. Prompt for the Anthropic key (validated `sk-ant-…`).
-  4. Resolve `.env`: create from template if absent, else append/update; preserve an existing `SECRET_ENCRYPTION_KEY`, generate one if missing.
-  5. Generate `API_TOKEN`, `WEB_APP_BOOTSTRAP_SECRET`.
-  6. `docker compose up -d postgres` → wait healthy.
-  7. **One-shot migrate in-container:** `docker compose run --rm curia ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql` (DATABASE_URL from compose env).
-  8. **Seed vault in-container:** `docker compose run --rm -e ANTHROPIC_API_KEY -e API_TOKEN -e WEB_APP_BOOTSTRAP_SECRET -e SEED_VAULT_VERIFY=1 curia ./node_modules/.bin/tsx scripts/seed-vault.ts`.
-  9. `docker compose up -d` → poll `/api/health` → print summary box (show the web login secret once).
+  2. **Source-checkout sanity check:** if it detects it's running inside the Curia source tree (`.git/` + `src/` + `package.json` whose `name` is `curia`), ask the operator whether they want to (a) pull & run the **published image** [continue] or (b) build & run from **this source** — for (b), point them to `pnpm run setup` and exit. Prevents a confused "I cloned the repo, why is it pulling an image?" install.
+  3. Fetch version-pinned `docker-compose.yml` (+ `.env.example` template + optional `docker-compose.tls.yml`) if absent.
+  4. Prompt for the Anthropic key (validated `sk-ant-…`).
+  5. Resolve `.env`: create from template if absent, else append/update; preserve an existing `SECRET_ENCRYPTION_KEY`, generate one if missing.
+  6. Generate `API_TOKEN`, `WEB_APP_BOOTSTRAP_SECRET`.
+  7. `docker compose up -d postgres` → wait healthy.
+  8. **One-shot migrate in-container:** `docker compose run --rm curia ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql` (DATABASE_URL from compose env).
+  9. **Seed vault in-container:** `docker compose run --rm -e ANTHROPIC_API_KEY -e API_TOKEN -e WEB_APP_BOOTSTRAP_SECRET -e SEED_VAULT_VERIFY=1 curia ./node_modules/.bin/tsx scripts/seed-vault.ts`.
+  10. `docker compose up -d` → poll `/api/health` → print summary box (show the web login secret once).
 - **Refactor:** `scripts/setup.sh` (dev/source) — keep behavior; its host-side migrate + seed logic stays for the source path. Extract shared prompt/gen/health-poll/summary into:
 - **New:** `scripts/setup-common.sh` — sourced by both `setup.sh` and `install.sh`.
 
@@ -123,8 +129,13 @@ A bare core self-hoster therefore gets a working Curia **without** the browser o
 - **Registry outage blocks deploy/pull.** *Mitigation:* pinning `CURIA_IMAGE_TAG` to a `vX.Y.Z` that's already local avoids re-pull; GHCR availability is acceptable for this stage.
 - **`.env` secret at-rest.** `SECRET_ENCRYPTION_KEY` stays out of the DB/volume; operator is advised to back it up. Full-host-compromise is out of scope (equivalent for any .env-based app).
 
-## 8. Open questions for review
+## 8. Resolved questions (from review 2026-07-04)
 
-- Should `docker-compose.yml` include an **optional Caddy TLS overlay** now (as a separate `docker-compose.tls.yml`), or leave TLS entirely to docs?
-- Confirm the GHCR image name: `ghcr.io/josephfung/curia` (owner `josephfung`).
-- `curia-deploy` currently builds the thin layer on the VPS. Is a `docker pull`-only future (private registry) worth a follow-up, or is on-VPS build the durable answer?
+- **Caddy TLS** → ship an **optional `docker-compose.tls.yml`** overlay; base stays HTTP-on-:3000. (§4.2)
+- **GHCR image name** → confirmed `ghcr.io/josephfung/curia`.
+- **Thin-layer build location** → **on the VPS** is the durable answer for now (keeps private code + licensed art off any registry). A private-registry pull future is optional, not planned.
+- **Dev script name** → keep `pnpm run setup` for the source path; `install.sh` is the operator path. No rename.
+- **`#771`** → already shipped (v0.32); browser API-key entry filed as backlog **#1345**.
+- **Epic #1281 open question (volume-mount vs downstream-image)** → resolved in the epic: downstream-image is the blessed path.
+
+No open questions remain blocking the implementation plan.

--- a/docs/wip/2026-07-04-ghcr-publish-self-host-design.md
+++ b/docs/wip/2026-07-04-ghcr-publish-self-host-design.md
@@ -71,22 +71,26 @@ GHCR is chosen on its own merits (see D1). Note it will **not reliably satisfy t
   - `curia`: `image: ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG:-latest}`, port `3000:3000`, `depends_on: postgres (healthy)`, healthcheck on `/api/health`, named volumes for runtime state, env from `.env`.
   - `postgres`: `pgvector/pgvector:pg16`, named volume `curia-pgdata`, healthcheck `pg_isready`.
   - No Caddy in the **base** file — base exposes `:3000` so localhost/eval and bring-your-own-proxy (nginx/Traefik/Cloudflare Tunnel) both work.
-- **New:** `docker-compose.tls.yml` — an **optional** Caddy overlay (automatic Let's Encrypt HTTPS, `DOMAIN` env). Operators with a public domain add it: `docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d`. Generalizes the pattern already in `curia-deploy/compose.production.yaml`. TLS matters because Curia auth (bootstrap secret, API token, session cookies) must not cross the wire in cleartext on a public host.
-- **New:** `.env.example` — the vault-unlock set (`DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`) + non-secret config (`DOMAIN`, `HTTP_PORT`, `TIMEZONE`, `LOG_LEVEL`, `CURIA_IMAGE_TAG`), with the encryption-key one-liner documented. This is the template `install.sh` renders and the standalone reference for hand-configurers.
+- **New:** `docker-compose.tls.yml` — an **optional** Caddy overlay (automatic Let's Encrypt HTTPS, `DOMAIN` env). Generalizes the pattern already in `curia-deploy/compose.production.yaml`. TLS matters because Curia auth (bootstrap secret, API token, session cookies) must not cross the wire in cleartext on a public host. The overlay is selected **durably** via the `COMPOSE_FILE` env var in `.env` (see §4.3) — not by remembering to pass `-f` each time.
+- **New:** `.env.example` — the vault-unlock set (`DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`) + non-secret config (`DOMAIN`, `HTTP_PORT`, `TIMEZONE`, `LOG_LEVEL`, `CURIA_IMAGE_TAG`, and a commented `COMPOSE_FILE` for the TLS overlay), with the encryption-key one-liner documented. This is the template `install.sh` renders and the standalone reference for hand-configurers.
 - **New:** `docker-compose.dev.yml` — a build-context override so the developer/source path builds locally instead of pulling.
 
 ### 4.3 curia repo — installers
 - **New:** `install.sh` (root) — the everyday operator entry (image-based, interactive). Responsibilities:
   1. Prereq check: **Docker + docker compose + curl** only.
   2. **Source-checkout sanity check:** if it detects it's running inside the Curia source tree (`.git/` + `src/` + `package.json` whose `name` is `curia`), ask the operator whether they want to (a) pull & run the **published image** [continue] or (b) build & run from **this source** — for (b), point them to `pnpm run setup` and exit. Prevents a confused "I cloned the repo, why is it pulling an image?" install.
-  3. Fetch version-pinned `docker-compose.yml` (+ `.env.example` template + optional `docker-compose.tls.yml`) if absent.
+  3. Fetch version-pinned `docker-compose.yml` (+ `.env.example` template + `docker-compose.tls.yml`) if absent.
   4. Prompt for the Anthropic key (validated `sk-ant-…`).
-  5. Resolve `.env`: create from template if absent, else append/update; preserve an existing `SECRET_ENCRYPTION_KEY`, generate one if missing.
-  6. Generate `API_TOKEN`, `WEB_APP_BOOTSTRAP_SECRET`.
-  7. `docker compose up -d postgres` → wait healthy.
-  8. **One-shot migrate in-container:** `docker compose run --rm curia ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql` (DATABASE_URL from compose env).
-  9. **Seed vault in-container:** `docker compose run --rm -e ANTHROPIC_API_KEY -e API_TOKEN -e WEB_APP_BOOTSTRAP_SECRET -e SEED_VAULT_VERIFY=1 curia ./node_modules/.bin/tsx scripts/seed-vault.ts`.
-  10. `docker compose up -d` → poll `/api/health` → print summary box (show the web login secret once).
+  5. **Deployment topology / TLS prompt** — ask how the operator will reach Curia:
+     - **Local / eval** → HTTP on `:3000`, no TLS.
+     - **Public domain + automatic HTTPS** → prompt for `DOMAIN`; best-effort check that it resolves (warn, don't block, if not); set `DOMAIN` and `COMPOSE_FILE=docker-compose.yml:docker-compose.tls.yml` in `.env` so **every future bare `docker compose` command includes the Caddy overlay** (durable, no `-f` to remember). Caddy binds 80/443 and issues via Let's Encrypt.
+     - **Public IP / behind my own reverse proxy** → HTTP on `:3000`, no bundled TLS; note to terminate TLS upstream.
+  6. Resolve `.env`: create from template if absent, else append/update; preserve an existing `SECRET_ENCRYPTION_KEY`, generate one if missing; write `DOMAIN`/`COMPOSE_FILE` per step 5.
+  7. Generate `API_TOKEN`, `WEB_APP_BOOTSTRAP_SECRET`.
+  8. `docker compose up -d postgres` → wait healthy.
+  9. **One-shot migrate in-container:** `docker compose run --rm curia ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql` (DATABASE_URL from compose env).
+  10. **Seed vault in-container:** `docker compose run --rm -e ANTHROPIC_API_KEY -e API_TOKEN -e WEB_APP_BOOTSTRAP_SECRET -e SEED_VAULT_VERIFY=1 curia ./node_modules/.bin/tsx scripts/seed-vault.ts`.
+  11. `docker compose up -d` → poll `/api/health` → print summary box: the correct URL (`https://$DOMAIN` or `http://localhost:3000`), the web login secret (once), and — on the TLS path — a "if the cert doesn't appear, check `docker compose logs caddy` and confirm DNS/ports 80,443" hint.
 - **Refactor:** `scripts/setup.sh` (dev/source) — keep behavior; its host-side migrate + seed logic stays for the source path. Extract shared prompt/gen/health-poll/summary into:
 - **New:** `scripts/setup-common.sh` — sourced by both `setup.sh` and `install.sh`.
 

--- a/docs/wip/2026-07-04-ghcr-publish-self-host-design.md
+++ b/docs/wip/2026-07-04-ghcr-publish-self-host-design.md
@@ -36,6 +36,7 @@ Non-goal restatement (from the epic): this is *not* npm/brew distribution of the
 | D3 | Multi-arch **`linux/amd64` + `linux/arm64`** via buildx. | Covers cloud VPS (amd64) and Apple Silicon / ARM self-hosters. |
 | D4 | **cosign keyless-sign** the image + **SPDX SBOM attestation**. | Matches `release.yml`'s existing OIDC-identity posture; provenance for the self-host credibility goal. |
 | D5 | GHCR package is **public** (anonymous pull). | The point of the epic. One-time package-visibility setting. |
+| D15 | Publish a **second image** `ghcr.io/josephfung/curia-postgres:pg16` from `docker/postgres.Dockerfile` (pgvector+pgAudit), with the init SQL **baked in** (not volume-mounted). The shared root compose references both curia + postgres by `image:`. | pgAudit (spec 10 hardening) is defense-in-depth (not a boot dep) but we want it source-free for self-hosters *and* unified with prod — publishing it keeps dev/self-host/prod on one hardened DB with no compose fork. |
 | D6 | Everyday operator installs via an **interactive, image-based `install.sh`** (download one file, run it). | A detached `docker compose up -d` container cannot prompt (no TTY); an interactive installer can. Keeps the excellent setup.sh UX but retargets it to the pulled image. |
 | D7 | `install.sh` runs **migrate + seed-vault *inside the pulled image*** (`docker compose run --rm curia …`), not host-side. | Operator has no source/Node/pnpm. The image already contains the migration runner, `scripts/seed-vault.ts`, and `node_modules`. Invoke `tsx` directly (the runtime image deliberately avoids corepack). |
 | D8 | **No change to core secret-handling.** The vault is seeded by `install.sh` *before* boot, so the container always boots against a populated vault (as prod does today). | Smallest blast radius on core — no `bootstrapSecretsFromEnv` in `src/index.ts`. |
@@ -63,17 +64,20 @@ GHCR is chosen on its own merits (see D1). Note it will **not reliably satisfy t
 
 - Triggers: `release: [published]` and `push: [main]` (and `workflow_dispatch` for manual/backfill).
 - Auth: `GITHUB_TOKEN` with `packages: write`, `id-token: write` (OIDC for cosign), `contents: read`.
-- Steps: `docker/setup-qemu-action` + `docker/setup-buildx-action` → `docker/login-action` (ghcr.io) → `docker/metadata-action` (derive tags: `vX.Y.Z`+`latest` from the release tag, or `edge` from main) → `docker/build-push-action` (`platforms: linux/amd64,linux/arm64`, `provenance: true`, `push: true`) → `cosign sign` (keyless) → `anchore/sbom-action` + `cosign attest` SBOM.
+- **Two images**, each its own build-push job (or a matrix): `ghcr.io/josephfung/curia` (from `Dockerfile`) and `ghcr.io/josephfung/curia-postgres` (from `docker/postgres.Dockerfile`). The postgres image is tagged `pg16` (+ `latest`); curia is tagged per D2.
+- Steps per image: `docker/setup-qemu-action` + `docker/setup-buildx-action` → `docker/login-action` (ghcr.io) → `docker/metadata-action` (derive tags: `vX.Y.Z`+`latest` from the release tag, or `edge` from main) → `docker/build-push-action` (`platforms: linux/amd64,linux/arm64`, `provenance: true`, `push: true`) → `cosign sign` (keyless) → `anchore/sbom-action` + `cosign attest` SBOM.
 - Tag-name validation mirrors `release.yml`'s injection guard (strict semver regex on the release tag).
 
 ### 4.2 curia repo — self-host bundle (repo root)
-- **New:** `docker-compose.yml` — image-based:
-  - `curia`: `image: ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG:-latest}`, port `3000:3000`, `depends_on: postgres (healthy)`, healthcheck on `/api/health`, named volumes for runtime state, env from `.env`.
-  - `postgres`: `pgvector/pgvector:pg16`, named volume `curia-pgdata`, healthcheck `pg_isready`.
+> **Note:** `docker-compose.yml` and `.env.example` **already exist** (build-context based) and are **modified**, not created. `docker/postgres.Dockerfile` exists and is **modified**.
+- **Modify:** `docker-compose.yml` — swap build contexts for published images:
+  - `curia`: `build:` → `image: ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG:-latest}`. Keep existing ports/env_file/DATABASE_URL override/healthcheck/volumes/tmpfs.
+  - `postgres`: `build: docker/postgres.Dockerfile` → `image: ghcr.io/josephfung/curia-postgres:${CURIA_POSTGRES_TAG:-pg16}`. Keep the `command:` (shared_preload_libraries=pgaudit …) and healthcheck. **Remove** the `./docker/postgres-init-pgaudit.sql` volume mount (now baked into the image).
   - No Caddy in the **base** file — base exposes `:3000` so localhost/eval and bring-your-own-proxy (nginx/Traefik/Cloudflare Tunnel) both work.
+- **Modify:** `docker/postgres.Dockerfile` — add `COPY docker/postgres-init-pgaudit.sql /docker-entrypoint-initdb.d/10-pgaudit.sql` so the init runs on first-boot without a source mount.
 - **New:** `docker-compose.tls.yml` — an **optional** Caddy overlay (automatic Let's Encrypt HTTPS, `DOMAIN` env). Generalizes the pattern already in `curia-deploy/compose.production.yaml`. TLS matters because Curia auth (bootstrap secret, API token, session cookies) must not cross the wire in cleartext on a public host. The overlay is selected **durably** via the `COMPOSE_FILE` env var in `.env` (see §4.3) — not by remembering to pass `-f` each time.
-- **New:** `.env.example` — the vault-unlock set (`DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`) + non-secret config (`DOMAIN`, `HTTP_PORT`, `TIMEZONE`, `LOG_LEVEL`, `CURIA_IMAGE_TAG`, and a commented `COMPOSE_FILE` for the TLS overlay), with the encryption-key one-liner documented. This is the template `install.sh` renders and the standalone reference for hand-configurers.
-- **New:** `docker-compose.dev.yml` — a build-context override so the developer/source path builds locally instead of pulling.
+- **Modify:** `.env.example` — add `CURIA_IMAGE_TAG`, `CURIA_POSTGRES_TAG`, `DOMAIN`, and a commented `COMPOSE_FILE` (TLS overlay). Existing vars (`DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `SECRET_ENCRYPTION_KEY`, `HTTP_PORT`, `POSTGRES_PORT`, `TIMEZONE`, `LOG_LEVEL`) stay. It remains the template `install.sh`/`setup.sh` render and the standalone reference.
+- **New:** `docker-compose.dev.yml` — a build-context override (restores `build:` for `curia` and `postgres`) so the developer/source path builds locally instead of pulling. `scripts/setup.sh` (dev) uses `-f docker-compose.yml -f docker-compose.dev.yml`.
 
 ### 4.3 curia repo — installers
 - **New:** `install.sh` (root) — the everyday operator entry (image-based, interactive). Responsibilities:
@@ -109,6 +113,7 @@ Note the chicken-and-egg the one-shot migrate solves: `seed-vault` needs the `se
 | Backend build (tsup), console + antfarm (vite) | ✅ | inherited |
 | Base deps, uv/uvx (workspace-mcp), tsx, non-root user | ✅ | inherited |
 | Migrations, seed-vault script, scripts/ | ✅ | inherited |
+| Postgres (pgvector + pgAudit) — separate `curia-postgres` image | ✅ (own image) | uses same image |
 | Chrome / patchright (web-browser skill) | ❌ | ✅ |
 | atproto-mcp, `@atproto/api` (Bluesky) | ❌ | ✅ |
 | Licensed LimeZu art | ❌ (license) | ✅ (built on VPS only) |

--- a/docs/wip/2026-07-04-ghcr-publish-self-host.md
+++ b/docs/wip/2026-07-04-ghcr-publish-self-host.md
@@ -1,0 +1,1038 @@
+# GHCR Image Publish + Image-Based Self-Host — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish semver-tagged, signed, multi-arch Curia images (app + Postgres) to GHCR, ship an interactive image-based `install.sh` so a Docker-only machine can run a released Curia with no source checkout, and collapse `curia-deploy`'s duplicated core Dockerfile into a thin `FROM ghcr.io/josephfung/curia` layer.
+
+**Architecture:** `curia/Dockerfile` becomes the single published source of truth (`ghcr.io/josephfung/curia`), and `docker/postgres.Dockerfile` publishes `ghcr.io/josephfung/curia-postgres`. The shared root `docker-compose.yml` switches from build-contexts to `image:` refs; developers restore local builds via a `docker-compose.dev.yml` override. A new interactive `install.sh` prompts for the Anthropic key, seeds the vault *inside the pulled image*, and brings the stack up. `curia-deploy` pulls the published core image and layers only private extensions on the VPS.
+
+**Tech Stack:** GitHub Actions, docker buildx (QEMU multi-arch), cosign (keyless OIDC), anchore/sbom-action, Docker Compose v2, Bash, node-pg-migrate, tsx, pnpm.
+
+**Spec:** `docs/wip/2026-07-04-ghcr-publish-self-host-design.md`
+
+## Global Constraints
+
+- **No `Co-Authored-By` / no Claude attribution** anywhere (commits, PRs, code, docs). Hard rule.
+- **Conventional commits** (`feat:`/`fix:`/`chore:`/`docs:`); commit early and often, one logical change per commit.
+- **Every PR updates `CHANGELOG.md`** under `## [Unreleased]` before opening; use **Added/Changed/Fixed/Removed/Security** sections, one bold-led bullet per change, reference `#1343`.
+- **Every PR body includes `Closes #1343`** (Part A) — Part B references but does not close it.
+- **No em dashes** in any prose authored for user-facing docs/README/curia-docs (repo docs allow them).
+- **Image registry/name:** `ghcr.io/josephfung/curia` (app), `ghcr.io/josephfung/curia-postgres` (db). Both **public**.
+- **Multi-arch:** `linux/amd64,linux/arm64` for both images.
+- **Supply chain:** cosign keyless-sign each pushed image by digest + buildx SBOM/provenance attestations. Mirror `release.yml`'s OIDC identity posture.
+- **Curia runtime avoids corepack** — invoke `tsx` directly (`./node_modules/.bin/tsx`), never `pnpm ...`, inside the published image.
+- **Node ≥ 24**, pnpm `11.7.0`, ESM, `.js` import extensions (unchanged; only relevant if touching TS — this plan does not).
+- **Two repos / two PRs:** Part A in worktree `worktrees/curia-ghcr-publish-1343` (branch `feat/ghcr-publish-1343`). Part B in a **new** `curia-deploy` worktree (create in Task B0).
+
+---
+
+## File Structure
+
+**Part A — curia repo** (`worktrees/curia-ghcr-publish-1343`)
+
+- Create: `.github/workflows/docker-publish.yml` — build+push+sign both images.
+- Modify: `docker/postgres.Dockerfile` — bake the pgAudit init SQL into the image.
+- Modify: `docker-compose.yml` — `build:` → `image:` for `curia` and `postgres`; drop the init-SQL volume mount.
+- Create: `docker-compose.dev.yml` — build-context override for the developer path.
+- Create: `docker-compose.tls.yml` — optional Caddy HTTPS overlay.
+- Create: `deploy/Caddyfile` — Caddyfile for the TLS overlay.
+- Modify: `.env.example` — add `CURIA_IMAGE_TAG`, `CURIA_POSTGRES_TAG`, `DOMAIN`, commented `COMPOSE_FILE`.
+- Create: `scripts/setup-common.sh` — shared prompt/secret-gen/health-poll/summary helpers.
+- Modify: `scripts/setup.sh` — source `setup-common.sh`; use `-f docker-compose.dev.yml` for local build.
+- Create: `install.sh` (repo root) — interactive image-based operator installer.
+- Modify: `tests/setup/test-setup-functions.sh` — cover `setup-common.sh` + `install.sh` pure helpers.
+- Create: `package.json` script `test:shell` + Modify `.github/workflows/ci.yml` — run the shell tests in CI.
+- Modify: `CHANGELOG.md`, `docs/dev/setup.md` (or equivalent), `README.md` — document the two install paths.
+
+**Part B — curia-deploy repo** (new worktree)
+
+- Modify: `deploy/compose/Dockerfile.curia` — `FROM ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG}` + private layers only.
+- Modify: `deploy/compose/compose.production.yaml` — image-based base; build context `curia-deploy/`; postgres image ref.
+- Modify: `scripts/deploy.sh` — drop core rsync; pull image tag; `CURIA_IMAGE_TAG` var.
+- Modify: `.github/workflows/validate.yml` — keep Dockerfile/Caddyfile lint valid against the thin file.
+- Modify: deploy runbook docs.
+
+---
+
+# PART A — curia repo
+
+## Task A1: Bake the pgAudit init SQL into the Postgres image
+
+**Files:**
+- Modify: `docker/postgres.Dockerfile`
+- Reference: `docker/postgres-init-pgaudit.sql` (baked), `docker-compose.yml:15` (current volume mount)
+
+**Interfaces:**
+- Produces: image build in which `/docker-entrypoint-initdb.d/10-pgaudit.sql` exists without a host mount. Consumed by A3 (compose drops the mount) and A2 (published).
+
+- [ ] **Step 1: Add the COPY to the Dockerfile**
+
+In `docker/postgres.Dockerfile`, after the `COPY docker/postgres-verify-pgaudit.sh ...` line and before `ENTRYPOINT`, add:
+
+```dockerfile
+# Bake the pgAudit init script into the image so a source-free self-host stack
+# (no repo checkout to volume-mount) still runs it on first DB init. The compose
+# volume mount is removed in lockstep (see docker-compose.yml).
+COPY docker/postgres-init-pgaudit.sql /docker-entrypoint-initdb.d/10-pgaudit.sql
+```
+
+- [ ] **Step 2: Build the image to verify it succeeds and the file lands**
+
+Run:
+```bash
+docker build -f docker/postgres.Dockerfile -t curia-postgres:verify .
+docker run --rm --entrypoint ls curia-postgres:verify -1 /docker-entrypoint-initdb.d/
+```
+Expected: build succeeds; `ls` output includes `10-pgaudit.sql`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/postgres.Dockerfile
+git commit -m "feat: bake pgAudit init SQL into postgres image for source-free self-host (#1343)"
+```
+
+---
+
+## Task A2: Publish workflow for both images (multi-arch, signed, SBOM)
+
+**Files:**
+- Create: `.github/workflows/docker-publish.yml`
+- Reference: `.github/workflows/release.yml` (cosign identity + tag-validation pattern), `.github/workflows/trivy.yml` (existing `docker build` usage)
+
+**Interfaces:**
+- Produces: `ghcr.io/josephfung/curia:{vX.Y.Z,latest,edge}` and `ghcr.io/josephfung/curia-postgres:{pg16,latest,edge}`, each multi-arch + cosign-signed + SBOM-attested. Consumed by A3 (compose refs) and all of Part B.
+
+- [ ] **Step 1: Write the workflow file**
+
+Create `.github/workflows/docker-publish.yml`:
+
+```yaml
+name: docker-publish
+
+# Build, push, sign, and SBOM-attest the Curia app + Postgres images to GHCR.
+# - release published -> semver + latest (app), pg16 + latest (postgres)
+# - push to main      -> edge (both), for dogfood / curia-deploy pulls
+on:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re)publish, e.g. v0.40.0"
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write   # keyless cosign via GitHub OIDC
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # Validate a workflow_dispatch tag input against strict semver to avoid
+  # injection (mirrors release.yml). No-op on release/push triggers.
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate dispatch tag
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        run: |
+          echo "${{ inputs.tag }}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
+            || { echo "Invalid tag format"; exit 1; }
+
+  build:
+    needs: guard
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: curia
+            image: curia
+            dockerfile: Dockerfile
+            # App tags: semver+latest on release, edge on main.
+            tags: |
+              type=semver,pattern=v{{version}}
+              type=semver,pattern=v{{major}}.{{minor}}
+              type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+              type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+          - name: curia-postgres
+            image: curia-postgres
+            dockerfile: docker/postgres.Dockerfile
+            # DB is versioned by pg major, not app semver.
+            tags: |
+              type=raw,value=pg16
+              type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+              type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: ${{ matrix.tags }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the pushed image by digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+```
+
+- [ ] **Step 2: Lint the workflow syntax**
+
+Run:
+```bash
+npx --yes @action-validator/cli .github/workflows/docker-publish.yml || \
+  docker run --rm -v "$PWD":/repo rhysd/actionlint:latest -color /repo/.github/workflows/docker-publish.yml
+```
+Expected: no errors. (If neither linter is available, at minimum `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/docker-publish.yml'))"` must succeed.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/docker-publish.yml
+git commit -m "feat: publish signed multi-arch curia + curia-postgres images to GHCR (#1343)"
+```
+
+- [ ] **Step 4: Post-merge verification (record, do not run now)**
+
+After this lands on main, the `push: [main]` trigger runs. Verify once available:
+```bash
+gh run list --workflow=docker-publish.yml --limit 1          # green
+docker pull ghcr.io/josephfung/curia:edge
+docker buildx imagetools inspect ghcr.io/josephfung/curia:edge | grep -E "linux/amd64|linux/arm64"
+cosign verify ghcr.io/josephfung/curia:edge \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/josephfung/curia/.github/workflows/docker-publish.yml@'
+```
+Also set both GHCR packages to **public** in repo/org package settings (one-time).
+
+---
+
+## Task A3: Convert root compose to image-based + dev override + env
+
+**Files:**
+- Modify: `docker-compose.yml`
+- Create: `docker-compose.dev.yml`
+- Modify: `.env.example`
+
+**Interfaces:**
+- Consumes: images from A2, baked init from A1.
+- Produces: `docker compose up -d` pulls published images; `-f docker-compose.dev.yml` restores local builds. `.env` keys `CURIA_IMAGE_TAG`, `CURIA_POSTGRES_TAG` consumed by compose. Consumed by A5 (setup.sh dev), A6 (install.sh).
+
+- [ ] **Step 1: Switch `postgres` to an image + drop the init mount**
+
+In `docker-compose.yml`, replace the `postgres` service's `build:` block (lines ~2-5) with an `image:` line, and remove the init-SQL volume mount (line ~15). Result:
+
+```yaml
+  postgres:
+    image: ghcr.io/josephfung/curia-postgres:${CURIA_POSTGRES_TAG:-pg16}
+    restart: unless-stopped
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: curia
+      POSTGRES_USER: ${DB_USER:-your-db-user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-your-db-password}
+    command: >
+      postgres
+      -c shared_preload_libraries=pgaudit
+      -c pgaudit.log=write,ddl
+      -c pgaudit.log_parameter=on
+      -c pgaudit.log_relation=on
+      -c pgaudit.role=pgaudit_role
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-curia}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+```
+
+- [ ] **Step 2: Switch `curia` to an image**
+
+Replace the `curia` service's `build:` block (lines ~39-41) with:
+
+```yaml
+  curia:
+    image: ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG:-latest}
+```
+Leave the rest of the `curia` service (ports, `env_file`, `DATABASE_URL` override, `depends_on`, healthcheck, volumes, tmpfs) unchanged.
+
+- [ ] **Step 3: Create the dev override**
+
+Create `docker-compose.dev.yml`:
+
+```yaml
+# Developer/source override: restores local image builds instead of pulling
+# published GHCR images. Used by `pnpm run setup` (scripts/setup.sh) and any
+# contributor running from a source checkout:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+services:
+  postgres:
+    build:
+      context: .
+      dockerfile: docker/postgres.Dockerfile
+  curia:
+    build:
+      context: .
+      dockerfile: Dockerfile
+```
+
+When both `build:` and `image:` are present, Compose builds locally and tags the
+result with the `image:` name from the base file — exactly what the dev path
+wants (build from source, no pull). No `!reset` needed.
+
+- [ ] **Step 4: Update `.env.example`**
+
+In `.env.example`, add below the `HTTP_PORT` block:
+
+```bash
+# Published image tags (Docker Compose pulls these). Pin to a vX.Y.Z for a
+# stable self-host; `latest` tracks the newest release, `edge` the newest main.
+CURIA_IMAGE_TAG=latest
+CURIA_POSTGRES_TAG=pg16
+
+# Public domain for automatic HTTPS. Only used with the TLS overlay (below).
+# DOMAIN=curia.example.com
+
+# TLS overlay selection. `install.sh` sets this automatically when you choose
+# the "public domain + HTTPS" option so every `docker compose` command applies
+# the Caddy overlay without a manual -f flag. Uncomment to enable by hand:
+# COMPOSE_FILE=docker-compose.yml:docker-compose.tls.yml
+```
+
+- [ ] **Step 5: Validate both compose configurations parse**
+
+Run:
+```bash
+CURIA_IMAGE_TAG=latest CURIA_POSTGRES_TAG=pg16 DB_PASSWORD=x docker compose -f docker-compose.yml config >/dev/null && echo OK-base
+DB_PASSWORD=x docker compose -f docker-compose.yml -f docker-compose.dev.yml config | grep -A2 "curia:" | grep -q "build:" && echo OK-dev-build
+```
+Expected: `OK-base` and `OK-dev-build`. The dev config must show a `build:` context restored; the base config must show `image: ghcr.io/josephfung/curia:latest`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker-compose.yml docker-compose.dev.yml .env.example
+git commit -m "feat: image-based compose with dev build override (#1343)"
+```
+
+---
+
+## Task A4: Optional Caddy TLS overlay
+
+**Files:**
+- Create: `docker-compose.tls.yml`
+- Create: `deploy/Caddyfile`
+- Reference: `curia-deploy/deploy/compose/compose.production.yaml` (existing Caddy pattern)
+
+**Interfaces:**
+- Consumes: `DOMAIN` env, the `curia` service from A3.
+- Produces: an overlay that fronts `curia` with Caddy on 80/443. Selected via `COMPOSE_FILE` (A6 step wiring).
+
+- [ ] **Step 1: Create the Caddyfile**
+
+Create `deploy/Caddyfile`:
+
+```
+# Automatic HTTPS for Curia via Caddy + Let's Encrypt. DOMAIN is injected from
+# the environment. Caddy terminates TLS and reverse-proxies to the curia service.
+{$DOMAIN} {
+	reverse_proxy curia:3000
+}
+```
+
+- [ ] **Step 2: Create the overlay**
+
+Create `docker-compose.tls.yml`:
+
+```yaml
+# Optional HTTPS overlay. Enable by adding this file to COMPOSE_FILE in .env
+# (install.sh does this for you when you choose the public-domain option):
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.tls.yml
+# Requires DOMAIN set and an A record pointing at this host (ports 80/443 open).
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN}
+    volumes:
+      - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      curia:
+        condition: service_healthy
+
+volumes:
+  caddy-data:
+  caddy-config:
+```
+
+- [ ] **Step 3: Validate the merged config parses**
+
+Run:
+```bash
+DOMAIN=curia.example.com DB_PASSWORD=x \
+  docker compose -f docker-compose.yml -f docker-compose.tls.yml config >/dev/null && echo OK-tls
+```
+Expected: `OK-tls`; the merged config includes a `caddy` service bound to 80/443.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.tls.yml deploy/Caddyfile
+git commit -m "feat: optional Caddy HTTPS overlay for self-host (#1343)"
+```
+
+---
+
+## Task A5: Extract `setup-common.sh` and rewire `setup.sh` for the dev override
+
+**Files:**
+- Create: `scripts/setup-common.sh`
+- Modify: `scripts/setup.sh`
+- Modify: `tests/setup/test-setup-functions.sh`
+- Reference: `scripts/setup.sh` current functions (`validate_anthropic_key`, `prompt_anthropic_key`, `generate_secrets`, `wait_for_postgres`, `wait_for_curia`, `print_summary`)
+
+**Interfaces:**
+- Produces: `scripts/setup-common.sh` exporting the shared helpers (`validate_anthropic_key`, `prompt_anthropic_key`, `gen_secret_b64`, `gen_secret_hex`, `wait_for_postgres`, `wait_for_curia`, `print_summary`). Consumed by A6 (`install.sh` sources it).
+- `setup.sh` keeps its own `main`/`run_infra`/`handle_existing_env` but sources the common helpers and adds `-f docker-compose.dev.yml` to its compose invocations.
+
+- [ ] **Step 1: Write a failing test for the extracted secret generators**
+
+In `tests/setup/test-setup-functions.sh`, after the existing `source` line add a source of the new file and a test. First, at the top near line 9, add:
+
+```bash
+source "$SCRIPT_DIR/../../scripts/setup-common.sh"
+```
+
+Then append these test invocations before the final PASS/FAIL summary:
+
+```bash
+echo "setup-common: secret generators"
+key_b64="$(gen_secret_b64)"
+# base64 of 32 bytes is 44 chars ending in '='
+if [[ "${#key_b64}" -eq 44 ]]; then echo "  ✓ gen_secret_b64 length 44"; PASS=$((PASS+1)); else echo "  ✗ gen_secret_b64 length ${#key_b64}"; FAIL=$((FAIL+1)); fi
+key_hex="$(gen_secret_hex)"
+if [[ "${#key_hex}" -eq 64 ]]; then echo "  ✓ gen_secret_hex length 64"; PASS=$((PASS+1)); else echo "  ✗ gen_secret_hex length ${#key_hex}"; FAIL=$((FAIL+1)); fi
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash tests/setup/test-setup-functions.sh`
+Expected: FAIL — `scripts/setup-common.sh` does not exist (source error) or functions undefined.
+
+- [ ] **Step 3: Create `scripts/setup-common.sh` with the shared helpers**
+
+Create `scripts/setup-common.sh`. Move `validate_anthropic_key`, `prompt_anthropic_key`, `wait_for_curia`, and `print_summary` here **verbatim** from `setup.sh`, and add two openssl-free generators (works on a Docker-only host):
+
+```bash
+#!/usr/bin/env bash
+# Shared helpers for both installers:
+#   - scripts/setup.sh  (developer / build-from-source)
+#   - install.sh        (operator / pull-published-image)
+# Sourced, never executed directly. Callers provide REPO_ROOT and any compose
+# invocation flags they need.
+
+# --- Colors / output helpers (copy from setup.sh: info/success/warn/error/hint) ---
+# [MOVE the RED/GREEN/... color block and info()/success()/warn()/error()/hint()
+#  helpers here verbatim from setup.sh, and have setup.sh rely on these.]
+
+# 32 random bytes, base64 (vault master key format). No openssl dependency.
+gen_secret_b64() { head -c 32 /dev/urandom | base64 | tr -d '\n'; }
+
+# 32 random bytes, hex (api_token / bootstrap secret format).
+gen_secret_hex() { head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n'; }
+
+# validate_anthropic_key / prompt_anthropic_key — MOVED verbatim from setup.sh.
+# wait_for_postgres / wait_for_curia / print_summary — MOVED verbatim from setup.sh.
+# These call `docker compose --project-directory "$REPO_ROOT" ...`; callers set
+# REPO_ROOT (setup.sh already does; install.sh sets REPO_ROOT="$INSTALL_DIR").
+```
+
+In `setup.sh`: remove the moved functions, and near the top (after the path vars) add `source "$SCRIPT_DIR/setup-common.sh"`. Replace `generate_secrets`' `openssl rand -base64 32` / `openssl rand -hex 32` calls with `gen_secret_b64` / `gen_secret_hex` (keeps setup.sh working if openssl is absent, and shares one implementation).
+
+- [ ] **Step 4: Point setup.sh's compose calls at the dev override**
+
+In `setup.sh`, every `docker compose --project-directory "$REPO_ROOT" <cmd>` becomes `docker compose --project-directory "$REPO_ROOT" -f docker-compose.yml -f docker-compose.dev.yml <cmd>` (so the dev path builds locally against the new image-based base). There are calls in `handle_existing_env` (option 1 up -d), `wait_for_postgres`, `wait_for_curia` (moved to common — pass a `COMPOSE_FLAGS` variable), and `run_infra` (up -d postgres, up -d). Introduce a `DEV_COMPOSE=(-f docker-compose.yml -f docker-compose.dev.yml)` array in setup.sh and pass `"${DEV_COMPOSE[@]}"`; for `wait_for_curia`/`wait_for_postgres` in common, read a caller-set `COMPOSE_FLAGS` array (default empty).
+
+- [ ] **Step 5: Run the shell tests to verify they pass**
+
+Run: `bash tests/setup/test-setup-functions.sh`
+Expected: PASS — all existing assertions plus the two new generator assertions pass.
+
+- [ ] **Step 6: Smoke-check setup.sh still parses**
+
+Run: `bash -n scripts/setup.sh && bash -n scripts/setup-common.sh && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/setup-common.sh scripts/setup.sh tests/setup/test-setup-functions.sh
+git commit -m "refactor: extract setup-common.sh shared installer helpers (#1343)"
+```
+
+---
+
+## Task A6: Interactive image-based `install.sh`
+
+**Files:**
+- Create: `install.sh` (repo root)
+- Modify: `tests/setup/test-setup-functions.sh`
+- Reference: `scripts/setup-common.sh` (A5), `docker-compose.yml`/`.env.example` (A3), `scripts/seed-vault.ts`, `package.json` migrate script
+
+**Interfaces:**
+- Consumes: `setup-common.sh` helpers; published images.
+- Produces: a source-free operator install. Pure helpers `detect_source_checkout`, `resolve_env_file`, `choose_topology` are unit-tested.
+
+- [ ] **Step 1: Write failing tests for the pure helpers**
+
+Append to `tests/setup/test-setup-functions.sh`:
+
+```bash
+source "$SCRIPT_DIR/../../install.sh"   # guarded: defines funcs, does not run main
+
+echo "install.sh: source-checkout detection"
+tmp_src=$(mktemp -d); mkdir -p "$tmp_src/src" "$tmp_src/.git"; echo '{"name":"curia"}' > "$tmp_src/package.json"
+if detect_source_checkout "$tmp_src"; then echo "  ✓ detects a curia source tree"; PASS=$((PASS+1)); else echo "  ✗ missed a curia source tree"; FAIL=$((FAIL+1)); fi
+tmp_bare=$(mktemp -d)
+if ! detect_source_checkout "$tmp_bare"; then echo "  ✓ bare dir is not a source tree"; PASS=$((PASS+1)); else echo "  ✗ false-positive on bare dir"; FAIL=$((FAIL+1)); fi
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash tests/setup/test-setup-functions.sh`
+Expected: FAIL — `install.sh` missing / `detect_source_checkout` undefined.
+
+- [ ] **Step 3: Write `install.sh`**
+
+Create `install.sh` at the repo root. Structure (fill helper bodies as shown; reuse `setup-common.sh`):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Pin to the release this installer shipped with. Bumped at release time.
+CURIA_REF="${CURIA_REF:-main}"
+RAW_BASE="https://raw.githubusercontent.com/josephfung/curia/${CURIA_REF}"
+
+# setup-common.sh may not be present when install.sh is fetched standalone; fetch
+# it if missing, then source it.
+if [[ ! -f "$SCRIPT_DIR/scripts/setup-common.sh" ]]; then
+  mkdir -p "$SCRIPT_DIR/scripts"
+  curl -fsSL "$RAW_BASE/scripts/setup-common.sh" -o "$SCRIPT_DIR/scripts/setup-common.sh"
+fi
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/scripts/setup-common.sh"
+
+INSTALL_DIR="$SCRIPT_DIR"
+REPO_ROOT="$INSTALL_DIR"   # setup-common.sh's wait_for_postgres/wait_for_curia use this
+
+# Returns 0 if $1 looks like a Curia source checkout (has .git + src + package.json name curia).
+detect_source_checkout() {
+  local d="$1"
+  [[ -d "$d/.git" && -d "$d/src" ]] || return 1
+  [[ -f "$d/package.json" ]] || return 1
+  grep -q '"name"[[:space:]]*:[[:space:]]*"curia"' "$d/package.json"
+}
+
+# Prereqs: Docker + compose + curl only.
+check_prereqs() {
+  docker info &>/dev/null || { error "Docker not found or not running."; hint "https://docs.docker.com/get-docker/"; exit 1; }
+  docker compose version &>/dev/null || { error "docker compose plugin missing."; exit 1; }
+  command -v curl &>/dev/null || { error "curl is required."; exit 1; }
+}
+
+# Fetch compose + env template + tls overlay next to install.sh if absent.
+fetch_bundle() {
+  local f
+  for f in docker-compose.yml docker-compose.tls.yml .env.example deploy/Caddyfile; do
+    if [[ ! -f "$INSTALL_DIR/$f" ]]; then
+      mkdir -p "$INSTALL_DIR/$(dirname "$f")"
+      curl -fsSL "$RAW_BASE/$f" -o "$INSTALL_DIR/$f"
+    fi
+  done
+}
+
+# Create .env from template if missing; return path. Never clobber an existing key.
+resolve_env_file() {
+  local env="$INSTALL_DIR/.env"
+  [[ -f "$env" ]] || cp "$INSTALL_DIR/.env.example" "$env"
+  printf '%s' "$env"
+}
+
+# Set KEY=VALUE in .env: replace an existing (commented or not) line, else append.
+set_env_var() {
+  local env="$1" key="$2" val="$3"
+  if grep -qE "^#?[[:space:]]*${key}=" "$env"; then
+    # portable in-place edit without sed -i portability issues
+    local tmp; tmp="$(mktemp)"
+    awk -v k="$key" -v v="$val" '
+      $0 ~ "^#?[[:space:]]*"k"=" && !done { print k"="v; done=1; next } { print }
+      END { if (!done) print k"="v }' "$env" > "$tmp"
+    mv "$tmp" "$env"
+  else
+    printf '\n%s=%s\n' "$key" "$val" >> "$env"
+  fi
+}
+
+# Ask topology; echo one of: local | domain | proxy. On domain, also sets DOMAIN.
+choose_topology() {
+  echo "" >&2
+  echo "How will you reach Curia?" >&2
+  echo "  1  Local / evaluation        (http://localhost:3000, no TLS)" >&2
+  echo "  2  Public domain + HTTPS      (automatic Let's Encrypt via Caddy)" >&2
+  echo "  3  Public IP / my own proxy   (http on :3000, terminate TLS upstream)" >&2
+  read -rp "Choice [1]: " c; c="${c:-1}"
+  case "$c" in
+    2) echo "domain" ;;
+    3) echo "proxy" ;;
+    *) echo "local" ;;
+  esac
+}
+
+main() {
+  check_prereqs
+  if detect_source_checkout "$INSTALL_DIR"; then
+    echo "" >&2
+    warn "This looks like the Curia source repo."
+    read -rp "Pull & run the published image (i), or build from this source (s)? [i]: " m
+    if [[ "${m:-i}" == "s" ]]; then
+      info "Use the developer path instead:"; hint "  pnpm run setup"; exit 0
+    fi
+  fi
+  fetch_bundle
+  local env; env="$(resolve_env_file)"
+
+  # DB creds + vault key: generate any that are still at their placeholder/missing.
+  local db_pass secret_key api_token boot_secret
+  db_pass="$(gen_secret_hex)"; secret_key="$(gen_secret_b64)"
+  api_token="$(gen_secret_hex)"; boot_secret="$(gen_secret_hex)"
+  set_env_var "$env" DB_USER curia
+  set_env_var "$env" DB_PASSWORD "$db_pass"
+  set_env_var "$env" DATABASE_URL "postgres://curia:${db_pass}@localhost:5432/curia"
+  # Preserve an existing encryption key; only set if placeholder/empty.
+  if grep -qE '^SECRET_ENCRYPTION_KEY=(replace-with|[[:space:]]*$)' "$env"; then
+    set_env_var "$env" SECRET_ENCRYPTION_KEY "$secret_key"
+  fi
+
+  local anthropic; anthropic="$(prompt_anthropic_key)"
+
+  case "$(choose_topology)" in
+    domain)
+      read -rp "Domain (e.g. curia.example.com): " dom
+      set_env_var "$env" DOMAIN "$dom"
+      set_env_var "$env" COMPOSE_FILE "docker-compose.yml:docker-compose.tls.yml"
+      # Best-effort DNS warning (never blocks).
+      getent hosts "$dom" >/dev/null 2>&1 || command -v host >/dev/null && host "$dom" >/dev/null 2>&1 || \
+        warn "Could not resolve $dom yet — Let's Encrypt needs an A record pointing here + ports 80/443 open."
+      ;;
+    *) : ;;  # local / proxy: base compose, http :3000
+  esac
+
+  info "Starting Postgres..."
+  docker compose --project-directory "$INSTALL_DIR" up -d postgres
+  wait_for_postgres   # from setup-common.sh; uses $REPO_ROOT
+
+  info "Applying migrations (in-container)..."
+  docker compose --project-directory "$INSTALL_DIR" run --rm curia \
+    ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up \
+    --migrations-dir src/db/migrations --migration-file-language sql
+
+  info "Seeding secrets vault (in-container)..."
+  docker compose --project-directory "$INSTALL_DIR" run --rm \
+    -e "ANTHROPIC_API_KEY=$anthropic" -e "API_TOKEN=$api_token" \
+    -e "WEB_APP_BOOTSTRAP_SECRET=$boot_secret" -e SEED_VAULT_VERIFY=1 \
+    curia ./node_modules/.bin/tsx scripts/seed-vault.ts
+
+  info "Starting Curia..."
+  docker compose --project-directory "$INSTALL_DIR" up -d
+  wait_for_curia    # from setup-common.sh; uses REPO_ROOT-style project dir
+  print_summary "$boot_secret"
+}
+
+# Guard: define-only when sourced (tests), run main when executed.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then main "$@"; fi
+```
+
+Note: `wait_for_curia`/`wait_for_postgres`/`print_summary` come from `setup-common.sh`; they reference the compose project dir via `$REPO_ROOT`. Set `REPO_ROOT="$INSTALL_DIR"` before calling, or adapt the common helpers to read a `PROJECT_DIR` variable (do this in A5 if cleaner). Keep the migrate/seed invocations exactly as shown (tsx direct, no pnpm).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bash tests/setup/test-setup-functions.sh`
+Expected: PASS — including `detect_source_checkout` cases.
+
+- [ ] **Step 5: Lint parse**
+
+Run: `bash -n install.sh && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add install.sh tests/setup/test-setup-functions.sh
+git commit -m "feat: interactive image-based install.sh for source-free self-host (#1343)"
+```
+
+---
+
+## Task A7: Wire shell tests into CI
+
+**Files:**
+- Modify: `package.json` (add `test:shell` script)
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Produces: CI runs the setup/install shell tests so A5/A6 assertions actually gate.
+
+- [ ] **Step 1: Add the npm script**
+
+In `package.json` scripts, add:
+```json
+"test:shell": "bash tests/setup/test-setup-functions.sh"
+```
+
+- [ ] **Step 2: Make the harness exit non-zero on failure**
+
+Confirm `tests/setup/test-setup-functions.sh` ends by exiting non-zero when `FAIL>0`. If it does not, append:
+```bash
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]
+```
+
+- [ ] **Step 3: Add a CI step**
+
+In `.github/workflows/ci.yml`, in the main test job after the existing test step, add:
+```yaml
+      - name: Shell setup/install tests
+        run: pnpm run test:shell
+```
+
+- [ ] **Step 4: Verify locally**
+
+Run: `pnpm run test:shell; echo "exit=$?"`
+Expected: `exit=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json .github/workflows/ci.yml
+git commit -m "test: run setup/install shell tests in CI (#1343)"
+```
+
+---
+
+## Task A8: Docs — two install paths + CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/dev/setup.md` (or the closest existing setup guide)
+- Modify: `README.md`
+
+**Interfaces:** documentation only.
+
+- [ ] **Step 1: CHANGELOG**
+
+Under `## [Unreleased]` in `CHANGELOG.md`, add:
+```markdown
+### Added
+- **GHCR image publishing** — releases now push signed, multi-arch `ghcr.io/josephfung/curia` and `ghcr.io/josephfung/curia-postgres` images; `main` pushes publish `:edge`. (#1343)
+- **`install.sh`** — interactive, source-free operator installer that pulls the published image, seeds the vault in-container, and can wire up automatic HTTPS. (#1343)
+
+### Changed
+- **`docker-compose.yml`** — references published images by default; developers restore local builds with `docker-compose.dev.yml`. (#1343)
+```
+
+- [ ] **Step 2: Setup docs — two paths**
+
+In the setup guide, document both quickstarts. Operator:
+```bash
+mkdir curia && cd curia
+curl -fsSL https://raw.githubusercontent.com/josephfung/curia/<vX.Y.Z>/install.sh -o install.sh
+# review it, then:
+bash install.sh
+```
+Developer (unchanged): `git clone … && cd curia && pnpm run setup`. Note `docker compose pull && docker compose up -d` as the update path. No em dashes in user-facing copy.
+
+- [ ] **Step 3: README quickstart**
+
+Update the README quickstart to lead with the operator (image) path and link the developer path. Keep the version badge as-is (bumped at release, not here).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md docs/dev/setup.md README.md
+git commit -m "docs: document image install path + update changelog (#1343)"
+```
+
+- [ ] **Step 5: curia-docs (separate repo, note only)**
+
+Record that `curia-docs` needs a "Self-hosting" quickstart page (epic #1281 item 5). Out of scope for this PR; flag it in the PR description as a follow-up.
+
+---
+
+## Part A — pre-PR review & open
+
+- [ ] Run `pnpm run typecheck` (unchanged TS, must stay green), `pnpm test`, `pnpm run test:shell`, `pnpm run lint`.
+- [ ] Run the auto-review subagents in parallel: `pr-review-toolkit:code-reviewer` and `pr-review-toolkit:silent-failure-hunter` (shell error handling — the migrate/seed steps must fail loudly). Address high-priority findings.
+- [ ] Open the PR with `Closes #1343`, CHANGELOG present, and the curia-docs follow-up noted. Confirm CI started (`gh run list --branch feat/ghcr-publish-1343 --limit 1`).
+
+---
+
+# PART B — curia-deploy repo
+
+> Executed in a **separate worktree**. Depends on Part A being merged and `:edge` published (so `FROM ghcr.io/josephfung/curia:edge` resolves). Does **not** close #1343.
+
+## Task B0: Create the curia-deploy worktree
+
+- [ ] **Step 1: Pull main and branch**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/curia-deploy pull --ff-only origin main
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/curia-deploy worktree add \
+  /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull -b feat/ghcr-pull-1343
+```
+
+- [ ] **Step 2: Symlink gitignored files the worktree needs**
+
+```bash
+MAIN=/Users/josephfung/Projects/office-of-the-ceo/repos/curia-deploy WORKTREE=/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull; for item in deploy/compose/.env; do if [ -e "$MAIN/$item" ]; then ln -sf "$MAIN/$item" "$WORKTREE/$item"; fi; done
+```
+
+---
+
+## Task B1: Thin `Dockerfile.curia` (FROM the published core image)
+
+**Files:**
+- Modify: `deploy/compose/Dockerfile.curia`
+- Reference: current `Dockerfile.curia` stage-2 custom blocks; core `curia/Dockerfile` (what is now inherited)
+
+**Interfaces:**
+- Produces: an image = published core + private layers. Consumed by B2/B3.
+
+- [ ] **Step 1: Read the current file and identify the custom-only blocks**
+
+Read `deploy/compose/Dockerfile.curia` and mark the blocks that are **NOT** in core: Chrome/patchright install, real Google Chrome install, `atproto-mcp` + `@atproto/api` pre-install, `COPY curia-deploy/custom/agents ./agents/`, `COPY curia-deploy/custom/skills ./skills/`, `COPY curia-deploy/custom/config/skills.yaml ./config/skills.yaml`, LimeZu art copy, and any instance-specific volume/dir setup. Everything else (build stage, tsup/vite builds, base deps, uv, tsx, non-root user, dist/src/scripts copies, HEALTHCHECK, CMD) is now inherited and must be deleted.
+
+- [ ] **Step 2: Rewrite as a thin downstream image**
+
+Replace the entire file with a single-stage image `FROM` the published core, keeping only the marked custom blocks:
+
+```dockerfile
+# Thin downstream image: pulls the published Curia core and layers only this
+# instance's private extensions (browser, Bluesky MCP, licensed art, custom
+# skills/agents). Core build logic now lives ONCE in curia/Dockerfile.
+ARG CURIA_IMAGE_TAG=edge
+FROM ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG}
+
+# Runs as non-root `curia` (uid 1001) inherited from core. Switch to root only
+# for system installs, then back.
+USER root
+
+# [KEEP verbatim from the old Dockerfile.curia: the RUN blocks that install
+#  patchright/Playwright Chromium, real Google Chrome, and their apt deps.]
+
+# [KEEP verbatim: the atproto-mcp + @atproto/api pre-install RUN block.]
+
+# Layer in this instance's private agents/skills/config (override core files).
+COPY curia-deploy/custom/agents/ ./agents/
+COPY curia-deploy/custom/skills/ ./skills/
+COPY curia-deploy/custom/config/skills.yaml ./config/skills.yaml
+
+# [KEEP verbatim: the licensed LimeZu art COPY block and any chown/dir setup it needs.]
+
+USER curia
+# No CMD/HEALTHCHECK/EXPOSE — inherited from the core image.
+```
+
+Fill each `[KEEP ...]` by moving the exact lines from the current file. Do not reintroduce anything core already provides.
+
+- [ ] **Step 3: Build against the published base to verify it resolves and layers apply**
+
+```bash
+docker build --build-arg CURIA_IMAGE_TAG=edge \
+  -f deploy/compose/Dockerfile.curia -t curia-office:verify \
+  /Users/josephfung/Projects/office-of-the-ceo/repos/curia-deploy/..
+# (build context must contain curia-deploy/custom/*; adjust context per compose in B2)
+docker run --rm --entrypoint ls curia-office:verify -1 ./agents ./skills | head
+```
+Expected: build pulls `ghcr.io/josephfung/curia:edge`, applies custom COPYs; `ls` shows custom agents/skills present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull add deploy/compose/Dockerfile.curia
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull commit -m "refactor: thin Dockerfile.curia FROM published core image (#1343)"
+```
+
+---
+
+## Task B2: Point compose at the published core base + shrink build context
+
+**Files:**
+- Modify: `deploy/compose/compose.production.yaml`
+
+**Interfaces:**
+- Consumes: thin Dockerfile (B1), published postgres image.
+- Produces: prod stack that pulls core + builds only the thin layer. Consumed by B3.
+
+- [ ] **Step 1: Update the `curia` service build**
+
+In `compose.production.yaml`, change the `curia` service so its build context is `curia-deploy/` (not `/opt/curia/`) and pass `CURIA_IMAGE_TAG`:
+```yaml
+  curia:
+    build:
+      context: /opt/curia/curia-deploy/
+      dockerfile: deploy/compose/Dockerfile.curia
+      args:
+        CURIA_IMAGE_TAG: ${CURIA_IMAGE_TAG:-edge}
+```
+(The `COPY curia-deploy/custom/...` paths in the Dockerfile must be adjusted to be relative to this context — i.e. `COPY custom/...`. Update B1's COPY lines to `custom/agents/` etc. to match the new context.)
+
+- [ ] **Step 2: Point `postgres` at the published image**
+
+If `compose.production.yaml` overlays the core `postgres` build, change it to `image: ghcr.io/josephfung/curia-postgres:${CURIA_POSTGRES_TAG:-pg16}` (matching Part A). If it inherits from the root compose only, ensure the deploy no longer relies on the core source `docker/postgres.Dockerfile` being on the VPS.
+
+- [ ] **Step 3: Validate the merged production config parses**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull
+DOMAIN=x DB_PASSWORD=x SECRET_ENCRYPTION_KEY=x DATABASE_URL=x \
+  docker compose -f deploy/compose/compose.production.yaml config >/dev/null && echo OK
+```
+Expected: `OK` (adjust required env stubs to whatever the file references).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull add deploy/compose/compose.production.yaml deploy/compose/Dockerfile.curia
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull commit -m "feat: production compose pulls published core, builds only thin layer (#1343)"
+```
+
+---
+
+## Task B3: `deploy.sh` — pull the image, stop rsyncing core source
+
+**Files:**
+- Modify: `scripts/deploy.sh`
+
+**Interfaces:**
+- Produces: a deploy that no longer needs the curia checkout on the VPS.
+
+- [ ] **Step 1: Remove the core-source coupling**
+
+In `scripts/deploy.sh`: delete the `CURIA_REPO`/`Dockerfile` presence checks (lines ~72-80) and the `rsync … "$CURIA_REPO/" "$SSH_HOST:$REMOTE_ROOT/curia/"` block (lines ~138-147). The `curia/` sibling on the VPS is no longer required for building.
+
+- [ ] **Step 2: Add tag selection + explicit pull**
+
+Near the top, add:
+```bash
+# Which published core image tag this deploy pulls. `edge` = newest main (dogfood);
+# pin to a vX.Y.Z for a stable/rollback deploy.
+CURIA_IMAGE_TAG="${CURIA_IMAGE_TAG:-edge}"
+```
+Before the `docker compose … build` step, add a pull so the base is fresh:
+```bash
+ssh "$SSH_HOST" "cd $REMOTE_ROOT && CURIA_IMAGE_TAG=$CURIA_IMAGE_TAG docker pull ghcr.io/josephfung/curia:$CURIA_IMAGE_TAG"
+```
+Ensure `CURIA_IMAGE_TAG` is exported into the remote compose build/up commands (it is consumed by the Dockerfile `ARG` and compose `args`).
+
+- [ ] **Step 3: Lint**
+
+Run: `bash -n scripts/deploy.sh && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull add scripts/deploy.sh
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull commit -m "feat: deploy pulls published core image instead of rsyncing source (#1343)"
+```
+
+---
+
+## Task B4: validate.yml + deploy runbook
+
+**Files:**
+- Modify: `.github/workflows/validate.yml` (if it hardcodes Dockerfile expectations)
+- Modify: the deploy runbook doc (update the "how deploy works" section)
+
+- [ ] **Step 1: Confirm validate.yml still passes against the thin Dockerfile**
+
+Run: `bash -n scripts/*.sh` and, if validate.yml lints the Dockerfile, ensure it doesn't assert on removed stages. Adjust any hardcoded expectations.
+
+- [ ] **Step 2: Update the runbook**
+
+Document the new model: deploy pulls `ghcr.io/josephfung/curia:$CURIA_IMAGE_TAG`, builds only the thin custom layer on the VPS, no core source on the box. Note pinning `CURIA_IMAGE_TAG=vX.Y.Z` for rollback.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull add .github/workflows/validate.yml docs/
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-deploy-ghcr-pull commit -m "docs: update deploy runbook + validation for pull-based model (#1343)"
+```
+
+---
+
+## Part B — pre-PR review, open, and end-to-end verification
+
+- [ ] Run `pr-review-toolkit:code-reviewer` + `silent-failure-hunter` on the branch.
+- [ ] Open the PR (references #1343, does not close it). Note the ordering dependency on Part A in the body.
+- [ ] **End-to-end acceptance (after both merge + images publish):**
+  - On a clean Docker-only VM: `curl` `install.sh`, run it, answer the Anthropic prompt, confirm `/api/health` → ok with **no source checkout**. (Acceptance 1)
+  - `docker buildx imagetools inspect` shows amd64+arm64; `cosign verify` passes. (Acceptance 2)
+  - `docker compose pull && docker compose up -d` across a version bump migrates unattended and is idempotent. (Acceptance 3)
+  - A curia-deploy deploy pulls the image and builds only the thin layer; **no curia source rsynced**. (Acceptance 4)
+  - `git clone && pnpm run setup` still builds from source. (Acceptance 5)
+  - Re-running `install.sh` on an existing instance preserves the encryption key and does not rotate seeded secrets. (Acceptance 6)
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** D1/D15 → A1,A2; D2/D3/D4/D5 → A2; D6/D7/D8/D9/D10 → A6; D11 → A5; D12/D13/D14 → B1,B2,B3; TLS (§4.2/4.3) → A4,A6; postgres image (§4.1/4.2) → A1,A2,A3.
+- **Ordering:** Part B strictly after Part A (needs `:edge`). Within Part A, A1→A2 (A2 builds A1's image), A3 needs A1's baked init, A6 needs A5's helpers.
+- **Openssl-free secrets:** A5 `gen_secret_b64/hex` use `/dev/urandom` so a Docker-only host needs no openssl.
+- **Risk — seed/migrate must fail loudly:** flagged for `silent-failure-hunter` in both PRs; the in-container migrate/seed steps run without `|| true`.

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,13 @@
 # install.sh — interactive, image-based Curia installer for operators.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/josephfung/curia/main/install.sh | bash
-#   -- or --
+#   # Download first, then review, then run:
+#   curl -fsSL https://raw.githubusercontent.com/josephfung/curia/main/install.sh -o install.sh
 #   bash install.sh
+#
+# Note: piping curl directly to bash (curl … | bash) does NOT work — this
+# script uses interactive `read` prompts that require a real TTY, not piped
+# stdin. Always download the script first, then run it.
 #
 # Requirements: Docker (with the compose plugin) + curl only.
 # No Node, pnpm, or openssl is required on the host — everything runs inside
@@ -20,19 +24,24 @@
 #   6. Starts Postgres, runs migrations and vault-seed *inside* the pulled image
 #      (tsx direct — no corepack/pnpm on the host), then brings the full stack up.
 #   7. Prints a summary box with the bootstrap secret the operator needs to sign in.
+#
+# Re-running on an existing install:
+#   The script detects a completed install (SETUP_COMPLETE marker in .env) and
+#   takes a non-rotating upgrade path: no secrets are regenerated, migrations are
+#   re-applied idempotently, and seed-vault runs in verify-only mode.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # The Git ref (tag or branch) this installer was downloaded from. Bumped at
-# release time so that curl-piped installs fetch matching compose files.
+# release time so that installs fetch matching compose files.
 CURIA_REF="${CURIA_REF:-main}"
 RAW_BASE="https://raw.githubusercontent.com/josephfung/curia/${CURIA_REF}"
 
-# setup-common.sh may not be present when install.sh is fetched standalone (the
-# operator ran `curl … | bash`). Fetch it from the same ref if missing, then
-# source it to get the shared output helpers and wait_* functions.
+# setup-common.sh may not be present when install.sh is fetched standalone.
+# Fetch it from the same ref if missing, then source it to get the shared output
+# helpers and wait_* functions.
 if [[ ! -f "$SCRIPT_DIR/scripts/setup-common.sh" ]]; then
   mkdir -p "$SCRIPT_DIR/scripts"
   curl -fsSL "$RAW_BASE/scripts/setup-common.sh" -o "$SCRIPT_DIR/scripts/setup-common.sh"
@@ -85,6 +94,38 @@ set_env_var() {
   else
     printf '\n%s=%s\n' "$key" "$val" >> "$env"
   fi
+}
+
+# Returns 0 (true) if the install at env file $1 is considered complete.
+# Detection: the SETUP_COMPLETE marker written at the end of a fresh install,
+# OR a real (non-placeholder, non-empty) DB_PASSWORD value. This covers both
+# the new-style marker and any pre-marker install where the operator re-runs
+# the script against an already-working DB volume.
+# Returns 1 (false) for a fresh/placeholder .env that hasn't been through setup.
+install_is_complete() {
+  local env="$1"
+  # Fastest check: marker line added at the end of every successful fresh install.
+  if grep -q "^# SETUP_COMPLETE" "$env" 2>/dev/null; then
+    return 0
+  fi
+  # Fallback: a real DB_PASSWORD (non-empty, non-placeholder) means Postgres was
+  # already initialised with these creds. Regenerating would break auth against
+  # the existing volume.
+  local db_pass
+  db_pass="$(grep -E "^DB_PASSWORD=" "$env" 2>/dev/null | cut -d= -f2-)"
+  if [[ -z "$db_pass" ]]; then
+    return 1
+  fi
+  # Treat any value that starts with "replace-" as a placeholder — the template
+  # ships with "replace-with-a-strong-password" style defaults.
+  case "$db_pass" in
+    replace-*|"")
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -152,6 +193,138 @@ choose_topology() {
 }
 
 # ---------------------------------------------------------------------------
+# Fresh-install path: generate secrets, prompt for keys, seed vault, mark done.
+# ---------------------------------------------------------------------------
+fresh_install() {
+  local env="$1"
+
+  # Generate all secrets for this install. None of these are written to .env
+  # in plaintext (DB creds are the exception — they must be in .env for the
+  # postgres container and migration runner to consume them). api_token and
+  # boot_secret are passed only as transient env vars to the seed-vault container.
+  local db_pass api_token boot_secret
+  db_pass="$(gen_secret_hex)"
+  api_token="$(gen_secret_hex)"
+  boot_secret="$(gen_secret_hex)"
+
+  set_env_var "$env" DB_USER curia
+  set_env_var "$env" DB_PASSWORD "$db_pass"
+  # Note: the compose `curia` service overrides DATABASE_URL in its environment:
+  # block (pointing at the internal postgres hostname). This .env value is used
+  # by the migration runner (docker compose run --rm curia), not by the app container.
+  set_env_var "$env" DATABASE_URL "postgres://curia:${db_pass}@postgres:5432/curia"
+
+  # Only generate a new encryption key if the current value is the template
+  # placeholder or entirely absent/empty. A key that already exists must be
+  # preserved — regenerating it makes any existing encrypted vault rows unreadable.
+  if grep -qE '^SECRET_ENCRYPTION_KEY=(replace-with|[[:space:]]*$)' "$env" 2>/dev/null \
+      || ! grep -qE '^SECRET_ENCRYPTION_KEY=' "$env" 2>/dev/null; then
+    local secret_key
+    secret_key="$(gen_secret_b64)"
+    set_env_var "$env" SECRET_ENCRYPTION_KEY "$secret_key"
+  fi
+
+  # Prompt for the Anthropic key (format-validated, 3 retries). Not written to
+  # .env — passed as a transient env var to the vault-seed container only.
+  local anthropic
+  anthropic="$(prompt_anthropic_key)"
+
+  # Prompt for topology only on a fresh install (no COMPOSE_FILE/DOMAIN yet).
+  local topology
+  topology="$(choose_topology)"
+  case "$topology" in
+    domain)
+      read -rp "Domain (e.g. curia.example.com): " dom
+      set_env_var "$env" DOMAIN "$dom"
+      set_env_var "$env" COMPOSE_FILE "docker-compose.yml:docker-compose.tls.yml"
+      # Best-effort DNS warning; never blocks the install.
+      if ! getent hosts "$dom" >/dev/null 2>&1; then
+        if command -v host >/dev/null 2>&1; then
+          host "$dom" >/dev/null 2>&1 || \
+            warn "Could not resolve $dom. Let's Encrypt requires a DNS A record pointing here + ports 80/443 open."
+        else
+          warn "Could not verify DNS for $dom. Make sure an A record points here and ports 80/443 are open."
+        fi
+      fi
+      ;;
+    *) : ;;  # local / proxy: base compose only, HTTP on :3000
+  esac
+
+  # Start Postgres and wait for it to be ready before running migrations.
+  info "Starting Postgres..."
+  docker compose --project-directory "$INSTALL_DIR" up -d postgres
+  wait_for_postgres  # from setup-common.sh; uses $REPO_ROOT
+
+  # Run migrations inside the pulled image (tsx direct — no host pnpm needed).
+  info "Applying database migrations (in-container)..."
+  docker compose --project-directory "$INSTALL_DIR" run --rm curia \
+    ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up \
+    --migrations-dir src/db/migrations --migration-file-language sql
+
+  # Seed the encrypted vault with the freshly generated secrets. Secrets are
+  # passed as transient env vars so they never land on disk in plaintext.
+  # SEED_VAULT_VERIFY=1 makes seed-vault confirm required rows exist and exit
+  # non-zero if any are missing — so a partial seed fails loudly here rather
+  # than booting a half-configured instance with auth disabled.
+  info "Seeding secrets vault (in-container)..."
+  docker compose --project-directory "$INSTALL_DIR" run --rm \
+    -e "ANTHROPIC_API_KEY=$anthropic" \
+    -e "API_TOKEN=$api_token" \
+    -e "WEB_APP_BOOTSTRAP_SECRET=$boot_secret" \
+    -e SEED_VAULT_VERIFY=1 \
+    curia ./node_modules/.bin/tsx scripts/seed-vault.ts
+
+  # Bring the full stack up and wait for the app to become healthy.
+  info "Starting Curia..."
+  docker compose --project-directory "$INSTALL_DIR" up -d
+  wait_for_curia  # from setup-common.sh; uses $REPO_ROOT
+
+  # Mark setup as complete. On subsequent re-runs, install_is_complete() sees
+  # this marker and takes the upgrade path instead of rotating secrets.
+  printf '\n# SETUP_COMPLETE\n' >> "$env"
+
+  print_summary "$boot_secret"
+}
+
+# ---------------------------------------------------------------------------
+# Existing-install path: upgrade / restart without rotating any secret.
+# ---------------------------------------------------------------------------
+existing_install() {
+  local env="$1"
+  info "Existing install detected — running in upgrade/restart mode."
+  info "No secrets will be regenerated."
+
+  # Re-apply migrations idempotently. node-pg-migrate skips already-applied
+  # migrations, so this is safe on every re-run.
+  info "Applying database migrations (in-container)..."
+  docker compose --project-directory "$INSTALL_DIR" up -d postgres
+  wait_for_postgres
+
+  docker compose --project-directory "$INSTALL_DIR" run --rm curia \
+    ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up \
+    --migrations-dir src/db/migrations --migration-file-language sql
+
+  # Verify-only vault seed: pass NO secret env vars so seed-vault does not
+  # rotate any existing row. SEED_VAULT_VERIFY=1 confirms the required rows
+  # (anthropic_api_key, api_token, web_app_bootstrap_secret) are present and
+  # decryptable. If any are missing the re-run fails loudly — the operator
+  # should run a fresh install from a clean install dir in that case.
+  info "Verifying secrets vault (in-container)..."
+  docker compose --project-directory "$INSTALL_DIR" run --rm \
+    -e SEED_VAULT_VERIFY=1 \
+    curia ./node_modules/.bin/tsx scripts/seed-vault.ts
+
+  info "Starting Curia..."
+  docker compose --project-directory "$INSTALL_DIR" up -d
+  wait_for_curia
+
+  # Pass empty string: print_summary then shows the "secret is stored in the
+  # vault — use the console to retrieve it" branch rather than printing a
+  # fresh secret (which we don't have on the upgrade path).
+  print_summary ""
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -178,84 +351,13 @@ main() {
   local env
   env="$(resolve_env_file)"
 
-  # ----- Generate secrets -----
-  # Always generate fresh values. set_env_var will replace placeholder lines in
-  # the template, or append if the key was somehow removed.
-  local db_pass api_token boot_secret
-  db_pass="$(gen_secret_hex)"
-  api_token="$(gen_secret_hex)"
-  boot_secret="$(gen_secret_hex)"
-
-  set_env_var "$env" DB_USER curia
-  set_env_var "$env" DB_PASSWORD "$db_pass"
-  # "postgres" here is the Docker Compose service name, not localhost — migrate/seed
-  # run inside the container on the compose network where that hostname resolves.
-  set_env_var "$env" DATABASE_URL "postgres://curia:${db_pass}@postgres:5432/curia"
-
-  # Preserve a previously-generated encryption key so that existing encrypted
-  # vault rows remain readable on re-runs. Only generate a new key if the
-  # current value is the template placeholder or entirely absent/empty.
-  if grep -qE '^SECRET_ENCRYPTION_KEY=(replace-with|[[:space:]]*$)' "$env" 2>/dev/null \
-      || ! grep -qE '^SECRET_ENCRYPTION_KEY=' "$env" 2>/dev/null; then
-    local secret_key
-    secret_key="$(gen_secret_b64)"
-    set_env_var "$env" SECRET_ENCRYPTION_KEY "$secret_key"
+  # Detect whether this is a re-run against an already-completed install.
+  # If so, take the non-rotating upgrade path; otherwise run fresh install.
+  if install_is_complete "$env"; then
+    existing_install "$env"
+  else
+    fresh_install "$env"
   fi
-
-  # ----- Anthropic key -----
-  local anthropic
-  anthropic="$(prompt_anthropic_key)"
-
-  # ----- Topology -----
-  local topology
-  topology="$(choose_topology)"
-  case "$topology" in
-    domain)
-      read -rp "Domain (e.g. curia.example.com): " dom
-      set_env_var "$env" DOMAIN "$dom"
-      set_env_var "$env" COMPOSE_FILE "docker-compose.yml:docker-compose.tls.yml"
-      # Best-effort DNS warning; never blocks the install.
-      if ! getent hosts "$dom" >/dev/null 2>&1; then
-        if command -v host >/dev/null 2>&1; then
-          host "$dom" >/dev/null 2>&1 || \
-            warn "Could not resolve $dom. Let's Encrypt requires a DNS A record pointing here + ports 80/443 open."
-        else
-          warn "Could not verify DNS for $dom. Make sure an A record points here and ports 80/443 are open."
-        fi
-      fi
-      ;;
-    *) : ;;  # local / proxy: base compose only, HTTP on :3000
-  esac
-
-  # ----- Start Postgres and wait -----
-  info "Starting Postgres..."
-  docker compose --project-directory "$INSTALL_DIR" up -d postgres
-  wait_for_postgres  # from setup-common.sh; uses $REPO_ROOT
-
-  # ----- Migrations (inside the pulled image, tsx direct — no host pnpm) -----
-  info "Applying database migrations (in-container)..."
-  docker compose --project-directory "$INSTALL_DIR" run --rm curia \
-    ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up \
-    --migrations-dir src/db/migrations --migration-file-language sql
-
-  # ----- Vault seed (inside the pulled image) -----
-  # Pass secrets as environment variables so they never touch the filesystem in
-  # plaintext. SEED_VAULT_VERIFY=1 causes seed-vault.ts to read back every
-  # secret and fail loudly if any is missing or corrupt.
-  info "Seeding secrets vault (in-container)..."
-  docker compose --project-directory "$INSTALL_DIR" run --rm \
-    -e "ANTHROPIC_API_KEY=$anthropic" \
-    -e "API_TOKEN=$api_token" \
-    -e "WEB_APP_BOOTSTRAP_SECRET=$boot_secret" \
-    -e SEED_VAULT_VERIFY=1 \
-    curia ./node_modules/.bin/tsx scripts/seed-vault.ts
-
-  # ----- Bring the full stack up -----
-  info "Starting Curia..."
-  docker compose --project-directory "$INSTALL_DIR" up -d
-  wait_for_curia  # from setup-common.sh; uses $REPO_ROOT
-
-  print_summary "$boot_secret"
 }
 
 # Guard: when sourced (e.g. by the test harness), only define functions above.

--- a/install.sh
+++ b/install.sh
@@ -96,36 +96,20 @@ set_env_var() {
   fi
 }
 
-# Returns 0 (true) if the install at env file $1 is considered complete.
-# Detection: the SETUP_COMPLETE marker written at the end of a fresh install,
-# OR a real (non-placeholder, non-empty) DB_PASSWORD value. This covers both
-# the new-style marker and any pre-marker install where the operator re-runs
-# the script against an already-working DB volume.
-# Returns 1 (false) for a fresh/placeholder .env that hasn't been through setup.
+# Returns 0 (true) only if the install at env file $1 is fully COMPLETE — i.e.
+# a prior fresh install ran all the way through migrations, vault seeding, a
+# healthy container, and wrote the SETUP_COMPLETE marker as its last step.
+#
+# A "real DB_PASSWORD but no marker" state is deliberately NOT treated as
+# complete: it means a fresh install was interrupted after writing DB creds but
+# before the vault was seeded. That state must route back through fresh_install
+# (which preserves the existing DB password so the Postgres volume still
+# authenticates) so the missing vault secrets still get generated and seeded.
+# Routing it to the verify-only upgrade path would leave it stuck with an
+# unseeded vault. See fresh_install's DB-password preservation below.
 install_is_complete() {
   local env="$1"
-  # Fastest check: marker line added at the end of every successful fresh install.
-  if grep -q "^# SETUP_COMPLETE" "$env" 2>/dev/null; then
-    return 0
-  fi
-  # Fallback: a real DB_PASSWORD (non-empty, non-placeholder) means Postgres was
-  # already initialised with these creds. Regenerating would break auth against
-  # the existing volume.
-  local db_pass
-  db_pass="$(grep -E "^DB_PASSWORD=" "$env" 2>/dev/null | cut -d= -f2-)"
-  if [[ -z "$db_pass" ]]; then
-    return 1
-  fi
-  # Treat any value that starts with "replace-" as a placeholder — the template
-  # ships with "replace-with-a-strong-password" style defaults.
-  case "$db_pass" in
-    replace-*|"")
-      return 1
-      ;;
-    *)
-      return 0
-      ;;
-  esac
+  grep -q "^# SETUP_COMPLETE" "$env" 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------
@@ -203,7 +187,15 @@ fresh_install() {
   # postgres container and migration runner to consume them). api_token and
   # boot_secret are passed only as transient env vars to the seed-vault container.
   local db_pass api_token boot_secret
-  db_pass="$(gen_secret_hex)"
+  # Preserve an existing real DB password. This path also handles a partial
+  # install (DB creds written on a prior interrupted run but the vault never
+  # seeded): the Postgres volume was already initialised with that password, so
+  # regenerating it would break authentication. Only generate when the value is
+  # absent or the shipped placeholder.
+  db_pass="$(grep -E '^DB_PASSWORD=' "$env" 2>/dev/null | cut -d= -f2-)"
+  case "$db_pass" in
+    ""|replace-*) db_pass="$(gen_secret_hex)" ;;
+  esac
   api_token="$(gen_secret_hex)"
   boot_secret="$(gen_secret_hex)"
 
@@ -234,10 +226,17 @@ fresh_install() {
   topology="$(choose_topology)"
   case "$topology" in
     domain)
-      read -rp "Domain (e.g. curia.example.com): " dom
+      # Require a non-empty domain — the TLS overlay and the summary URL are
+      # both useless without one, and Caddy cannot request a certificate.
+      local dom=""
+      while [[ -z "$dom" ]]; do
+        read -rp "Domain (e.g. curia.example.com): " dom
+        [[ -n "$dom" ]] || error "A domain is required for the HTTPS topology."
+      done
       set_env_var "$env" DOMAIN "$dom"
       set_env_var "$env" COMPOSE_FILE "docker-compose.yml:docker-compose.tls.yml"
       # Expose DOMAIN as a shell variable so print_summary can build the HTTPS URL.
+      # shellcheck disable=SC2034  # read by print_summary (sourced from setup-common.sh)
       DOMAIN="$dom"
       # Best-effort DNS warning; never blocks the install.
       if ! getent hosts "$dom" >/dev/null 2>&1; then
@@ -360,10 +359,17 @@ existing_install() {
     exit 1
   fi
 
-  # If the existing install used the domain topology, load DOMAIN into the shell
-  # so print_summary can show the correct HTTPS URL instead of localhost.
+  # Load the URL-shaping values from .env so print_summary shows the right
+  # address for this existing install: DOMAIN (HTTPS topology) and a custom
+  # HTTP_PORT (local/proxy topology). Both are read by print_summary, which is
+  # sourced from setup-common.sh — hence the shellcheck disables.
+  # shellcheck disable=SC2034
   if grep -qE '^DOMAIN=.+' "$env" 2>/dev/null; then
     DOMAIN="$(grep -E '^DOMAIN=' "$env" | cut -d= -f2-)"
+  fi
+  # shellcheck disable=SC2034
+  if grep -qE '^HTTP_PORT=.+' "$env" 2>/dev/null; then
+    HTTP_PORT="$(grep -E '^HTTP_PORT=' "$env" | cut -d= -f2-)"
   fi
 
   # Pass empty string: print_summary then shows the "secret is stored in the

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# install.sh — interactive, image-based Curia installer for operators.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/josephfung/curia/main/install.sh | bash
+#   -- or --
+#   bash install.sh
+#
+# Requirements: Docker (with the compose plugin) + curl only.
+# No Node, pnpm, or openssl is required on the host — everything runs inside
+# the published container image.
+#
+# What this script does:
+#   1. Checks for Docker + compose + curl.
+#   2. Fetches docker-compose.yml, the TLS overlay, .env.example, and the
+#      Caddyfile next to install.sh (if not already present).
+#   3. Creates .env from the example, generating secrets for any placeholder values.
+#   4. Prompts for an Anthropic API key (format-validated, 3 retries).
+#   5. Asks about deployment topology (local / public HTTPS / behind-proxy).
+#   6. Starts Postgres, runs migrations and vault-seed *inside* the pulled image
+#      (tsx direct — no corepack/pnpm on the host), then brings the full stack up.
+#   7. Prints a summary box with the bootstrap secret the operator needs to sign in.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The Git ref (tag or branch) this installer was downloaded from. Bumped at
+# release time so that curl-piped installs fetch matching compose files.
+CURIA_REF="${CURIA_REF:-main}"
+RAW_BASE="https://raw.githubusercontent.com/josephfung/curia/${CURIA_REF}"
+
+# setup-common.sh may not be present when install.sh is fetched standalone (the
+# operator ran `curl … | bash`). Fetch it from the same ref if missing, then
+# source it to get the shared output helpers and wait_* functions.
+if [[ ! -f "$SCRIPT_DIR/scripts/setup-common.sh" ]]; then
+  mkdir -p "$SCRIPT_DIR/scripts"
+  curl -fsSL "$RAW_BASE/scripts/setup-common.sh" -o "$SCRIPT_DIR/scripts/setup-common.sh"
+fi
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/scripts/setup-common.sh"
+
+# setup-common.sh's wait_for_postgres / wait_for_curia look up the compose
+# project via $REPO_ROOT. For the image-based install, the install dir IS the
+# project root (docker-compose.yml lives alongside install.sh).
+INSTALL_DIR="$SCRIPT_DIR"
+REPO_ROOT="$INSTALL_DIR"
+
+# No extra compose file flags for the operator path (the dev overlay is not
+# used here). COMPOSE_FLAGS is read by wait_for_postgres/wait_for_curia.
+COMPOSE_FLAGS=()
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested via tests/setup/test-setup-functions.sh)
+# ---------------------------------------------------------------------------
+
+# Returns 0 if $1 looks like a Curia source checkout:
+#   - has a .git directory (it's a git repo)
+#   - has a src/ directory (Curia's TypeScript sources live here)
+#   - has a package.json whose "name" field is "curia"
+# Returns 1 otherwise. Used to warn operators who accidentally ran install.sh
+# inside a developer clone and offer them the right path.
+detect_source_checkout() {
+  local d="$1"
+  [[ -d "$d/.git" && -d "$d/src" ]] || return 1
+  [[ -f "$d/package.json" ]] || return 1
+  grep -q '"name"[[:space:]]*:[[:space:]]*"curia"' "$d/package.json"
+}
+
+# Set KEY=VALUE in the .env file at path $1.
+#   - If the key already exists (commented or uncommented), replace that line.
+#   - If the key is absent, append it.
+# Uses awk for a portable in-place edit that avoids sed -i portability issues
+# between GNU and BSD sed.
+set_env_var() {
+  local env="$1" key="$2" val="$3"
+  if grep -qE "^#?[[:space:]]*${key}=" "$env"; then
+    local tmp
+    tmp="$(mktemp)"
+    awk -v k="$key" -v v="$val" '
+      $0 ~ "^#?[[:space:]]*"k"=" && !done { print k"="v; done=1; next }
+      { print }
+      END { if (!done) print k"="v }' "$env" > "$tmp"
+    mv "$tmp" "$env"
+  else
+    printf '\n%s=%s\n' "$key" "$val" >> "$env"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Non-interactive helpers (not unit-tested; rely on Docker or filesystem state)
+# ---------------------------------------------------------------------------
+
+# Validate prereqs: Docker daemon up, compose plugin present, curl available.
+# The operator path deliberately does NOT require Node, pnpm, or openssl.
+check_prereqs() {
+  docker info &>/dev/null || {
+    error "Docker not found or not running."
+    hint "Install Docker Desktop: https://docs.docker.com/get-docker/"
+    exit 1
+  }
+  docker compose version &>/dev/null || {
+    error "docker compose plugin is missing."
+    hint "Make sure you have Docker 20.10+ with the Compose plugin."
+    exit 1
+  }
+  command -v curl &>/dev/null || {
+    error "curl is required but not found."
+    exit 1
+  }
+}
+
+# Fetch the compose bundle (base compose file, TLS overlay, env template,
+# Caddyfile) into the install dir, skipping files that are already present.
+# This lets an operator re-run install.sh safely without clobbering hand-edits.
+fetch_bundle() {
+  local f
+  for f in docker-compose.yml docker-compose.tls.yml .env.example deploy/Caddyfile; do
+    if [[ ! -f "$INSTALL_DIR/$f" ]]; then
+      mkdir -p "$INSTALL_DIR/$(dirname "$f")"
+      info "Fetching $f ..."
+      curl -fsSL "$RAW_BASE/$f" -o "$INSTALL_DIR/$f"
+    fi
+  done
+}
+
+# Create .env from the template if it does not exist yet, then return its path.
+# Never overwrites an existing .env — idempotent.
+resolve_env_file() {
+  local env="$INSTALL_DIR/.env"
+  if [[ ! -f "$env" ]]; then
+    cp "$INSTALL_DIR/.env.example" "$env"
+  fi
+  printf '%s' "$env"
+}
+
+# Prompt for deployment topology. Echoes one of: local | domain | proxy.
+# Runs interactively; not unit-tested (requires a TTY and user input).
+choose_topology() {
+  echo "" >&2
+  echo "How will you reach Curia?" >&2
+  echo "  1  Local / evaluation        (http://localhost:3000, no TLS)" >&2
+  echo "  2  Public domain + HTTPS      (automatic Let's Encrypt via Caddy)" >&2
+  echo "  3  Public IP / my own proxy   (http on :3000, terminate TLS upstream)" >&2
+  read -rp "Choice [1]: " c
+  c="${c:-1}"
+  case "$c" in
+    2) echo "domain" ;;
+    3) echo "proxy" ;;
+    *) echo "local" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  check_prereqs
+
+  # If we're running from inside the Curia source tree, warn the operator and
+  # offer to proceed with the image path or redirect to the developer setup.
+  if detect_source_checkout "$INSTALL_DIR"; then
+    echo "" >&2
+    warn "This looks like the Curia source repository."
+    echo "  The image-based installer works here, but most developers prefer" >&2
+    echo "  the source build path which hot-reloads changes." >&2
+    read -rp "Pull & run the published image (i), or use source build (s)? [i]: " m
+    if [[ "${m:-i}" == "s" ]]; then
+      info "Use the developer setup instead:"
+      hint "  pnpm run setup"
+      exit 0
+    fi
+  fi
+
+  fetch_bundle
+
+  local env
+  env="$(resolve_env_file)"
+
+  # ----- Generate secrets -----
+  # Always generate fresh values. set_env_var will replace placeholder lines in
+  # the template, or append if the key was somehow removed.
+  local db_pass api_token boot_secret
+  db_pass="$(gen_secret_hex)"
+  api_token="$(gen_secret_hex)"
+  boot_secret="$(gen_secret_hex)"
+
+  set_env_var "$env" DB_USER curia
+  set_env_var "$env" DB_PASSWORD "$db_pass"
+  set_env_var "$env" DATABASE_URL "postgres://curia:${db_pass}@postgres:5432/curia"
+
+  # Preserve a previously-generated encryption key so that existing encrypted
+  # vault rows remain readable on re-runs. Only generate a new key if the
+  # current value is the template placeholder or entirely absent/empty.
+  if grep -qE '^SECRET_ENCRYPTION_KEY=(replace-with|[[:space:]]*$)' "$env" 2>/dev/null \
+      || ! grep -qE '^SECRET_ENCRYPTION_KEY=' "$env" 2>/dev/null; then
+    local secret_key
+    secret_key="$(gen_secret_b64)"
+    set_env_var "$env" SECRET_ENCRYPTION_KEY "$secret_key"
+  fi
+
+  # ----- Anthropic key -----
+  local anthropic
+  anthropic="$(prompt_anthropic_key)"
+
+  # ----- Topology -----
+  local topology
+  topology="$(choose_topology)"
+  case "$topology" in
+    domain)
+      read -rp "Domain (e.g. curia.example.com): " dom
+      set_env_var "$env" DOMAIN "$dom"
+      set_env_var "$env" COMPOSE_FILE "docker-compose.yml:docker-compose.tls.yml"
+      # Best-effort DNS warning; never blocks the install.
+      if ! getent hosts "$dom" >/dev/null 2>&1; then
+        if command -v host >/dev/null 2>&1; then
+          host "$dom" >/dev/null 2>&1 || \
+            warn "Could not resolve $dom. Let's Encrypt requires a DNS A record pointing here + ports 80/443 open."
+        else
+          warn "Could not verify DNS for $dom. Make sure an A record points here and ports 80/443 are open."
+        fi
+      fi
+      ;;
+    *) : ;;  # local / proxy: base compose only, HTTP on :3000
+  esac
+
+  # ----- Start Postgres and wait -----
+  info "Starting Postgres..."
+  docker compose --project-directory "$INSTALL_DIR" up -d postgres
+  wait_for_postgres  # from setup-common.sh; uses $REPO_ROOT
+
+  # ----- Migrations (inside the pulled image, tsx direct — no host pnpm) -----
+  info "Applying database migrations (in-container)..."
+  docker compose --project-directory "$INSTALL_DIR" run --rm curia \
+    ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up \
+    --migrations-dir src/db/migrations --migration-file-language sql
+
+  # ----- Vault seed (inside the pulled image) -----
+  # Pass secrets as environment variables so they never touch the filesystem in
+  # plaintext. SEED_VAULT_VERIFY=1 causes seed-vault.ts to read back every
+  # secret and fail loudly if any is missing or corrupt.
+  info "Seeding secrets vault (in-container)..."
+  docker compose --project-directory "$INSTALL_DIR" run --rm \
+    -e "ANTHROPIC_API_KEY=$anthropic" \
+    -e "API_TOKEN=$api_token" \
+    -e "WEB_APP_BOOTSTRAP_SECRET=$boot_secret" \
+    -e SEED_VAULT_VERIFY=1 \
+    curia ./node_modules/.bin/tsx scripts/seed-vault.ts
+
+  # ----- Bring the full stack up -----
+  info "Starting Curia..."
+  docker compose --project-directory "$INSTALL_DIR" up -d
+  wait_for_curia  # from setup-common.sh; uses $REPO_ROOT
+
+  print_summary "$boot_secret"
+}
+
+# Guard: when sourced (e.g. by the test harness), only define functions above.
+# When executed directly, run main.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/install.sh
+++ b/install.sh
@@ -237,6 +237,8 @@ fresh_install() {
       read -rp "Domain (e.g. curia.example.com): " dom
       set_env_var "$env" DOMAIN "$dom"
       set_env_var "$env" COMPOSE_FILE "docker-compose.yml:docker-compose.tls.yml"
+      # Expose DOMAIN as a shell variable so print_summary can build the HTTPS URL.
+      DOMAIN="$dom"
       # Best-effort DNS warning; never blocks the install.
       if ! getent hosts "$dom" >/dev/null 2>&1; then
         if command -v host >/dev/null 2>&1; then
@@ -252,14 +254,22 @@ fresh_install() {
 
   # Start Postgres and wait for it to be ready before running migrations.
   info "Starting Postgres..."
-  docker compose --project-directory "$INSTALL_DIR" up -d postgres
+  if ! docker compose --project-directory "$INSTALL_DIR" up -d postgres; then
+    error "Failed to start the Postgres container."
+    hint "Check Docker logs: docker compose --project-directory \"$INSTALL_DIR\" logs postgres"
+    exit 1
+  fi
   wait_for_postgres  # from setup-common.sh; uses $REPO_ROOT
 
   # Run migrations inside the pulled image (tsx direct — no host pnpm needed).
   info "Applying database migrations (in-container)..."
-  docker compose --project-directory "$INSTALL_DIR" run --rm curia \
+  if ! docker compose --project-directory "$INSTALL_DIR" run --rm curia \
     ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up \
-    --migrations-dir src/db/migrations --migration-file-language sql
+    --migrations-dir src/db/migrations --migration-file-language sql; then
+    error "Database migration failed."
+    hint "Check Docker logs: docker compose --project-directory \"$INSTALL_DIR\" logs curia"
+    exit 1
+  fi
 
   # Seed the encrypted vault with the freshly generated secrets. Secrets are
   # passed as transient env vars so they never land on disk in plaintext.
@@ -267,17 +277,29 @@ fresh_install() {
   # non-zero if any are missing — so a partial seed fails loudly here rather
   # than booting a half-configured instance with auth disabled.
   info "Seeding secrets vault (in-container)..."
-  docker compose --project-directory "$INSTALL_DIR" run --rm \
+  if ! docker compose --project-directory "$INSTALL_DIR" run --rm \
     -e "ANTHROPIC_API_KEY=$anthropic" \
     -e "API_TOKEN=$api_token" \
     -e "WEB_APP_BOOTSTRAP_SECRET=$boot_secret" \
     -e SEED_VAULT_VERIFY=1 \
-    curia ./node_modules/.bin/tsx scripts/seed-vault.ts
+    curia ./node_modules/.bin/tsx scripts/seed-vault.ts; then
+    error "Vault seeding failed."
+    hint "Check Docker logs: docker compose --project-directory \"$INSTALL_DIR\" logs curia"
+    exit 1
+  fi
 
   # Bring the full stack up and wait for the app to become healthy.
   info "Starting Curia..."
-  docker compose --project-directory "$INSTALL_DIR" up -d
-  wait_for_curia  # from setup-common.sh; uses $REPO_ROOT
+  if ! docker compose --project-directory "$INSTALL_DIR" up -d; then
+    error "Failed to start the Curia stack."
+    hint "Check Docker logs: docker compose --project-directory \"$INSTALL_DIR\" logs"
+    exit 1
+  fi
+  if ! wait_for_curia; then
+    error "Curia did not become healthy — refusing to print a success banner."
+    hint "Check logs: docker compose --project-directory \"$INSTALL_DIR\" logs curia"
+    exit 1
+  fi
 
   # Mark setup as complete. On subsequent re-runs, install_is_complete() sees
   # this marker and takes the upgrade path instead of rotating secrets.
@@ -297,12 +319,20 @@ existing_install() {
   # Re-apply migrations idempotently. node-pg-migrate skips already-applied
   # migrations, so this is safe on every re-run.
   info "Applying database migrations (in-container)..."
-  docker compose --project-directory "$INSTALL_DIR" up -d postgres
+  if ! docker compose --project-directory "$INSTALL_DIR" up -d postgres; then
+    error "Failed to start the Postgres container."
+    hint "Check Docker logs: docker compose --project-directory \"$INSTALL_DIR\" logs postgres"
+    exit 1
+  fi
   wait_for_postgres
 
-  docker compose --project-directory "$INSTALL_DIR" run --rm curia \
+  if ! docker compose --project-directory "$INSTALL_DIR" run --rm curia \
     ./node_modules/.bin/tsx node_modules/node-pg-migrate/bin/node-pg-migrate.js up \
-    --migrations-dir src/db/migrations --migration-file-language sql
+    --migrations-dir src/db/migrations --migration-file-language sql; then
+    error "Database migration failed."
+    hint "Check Docker logs: docker compose --project-directory \"$INSTALL_DIR\" logs curia"
+    exit 1
+  fi
 
   # Verify-only vault seed: pass NO secret env vars so seed-vault does not
   # rotate any existing row. SEED_VAULT_VERIFY=1 confirms the required rows
@@ -310,13 +340,31 @@ existing_install() {
   # decryptable. If any are missing the re-run fails loudly — the operator
   # should run a fresh install from a clean install dir in that case.
   info "Verifying secrets vault (in-container)..."
-  docker compose --project-directory "$INSTALL_DIR" run --rm \
+  if ! docker compose --project-directory "$INSTALL_DIR" run --rm \
     -e SEED_VAULT_VERIFY=1 \
-    curia ./node_modules/.bin/tsx scripts/seed-vault.ts
+    curia ./node_modules/.bin/tsx scripts/seed-vault.ts; then
+    error "Vault verification failed — required secrets may be missing."
+    hint "Re-run a fresh install from a clean directory if secrets were lost."
+    exit 1
+  fi
 
   info "Starting Curia..."
-  docker compose --project-directory "$INSTALL_DIR" up -d
-  wait_for_curia
+  if ! docker compose --project-directory "$INSTALL_DIR" up -d; then
+    error "Failed to start the Curia stack."
+    hint "Check Docker logs: docker compose --project-directory \"$INSTALL_DIR\" logs"
+    exit 1
+  fi
+  if ! wait_for_curia; then
+    error "Curia did not become healthy — refusing to print a success banner."
+    hint "Check logs: docker compose --project-directory \"$INSTALL_DIR\" logs curia"
+    exit 1
+  fi
+
+  # If the existing install used the domain topology, load DOMAIN into the shell
+  # so print_summary can show the correct HTTPS URL instead of localhost.
+  if grep -qE '^DOMAIN=.+' "$env" 2>/dev/null; then
+    DOMAIN="$(grep -E '^DOMAIN=' "$env" | cut -d= -f2-)"
+  fi
 
   # Pass empty string: print_summary then shows the "secret is stored in the
   # vault — use the console to retrieve it" branch rather than printing a

--- a/install.sh
+++ b/install.sh
@@ -188,6 +188,8 @@ main() {
 
   set_env_var "$env" DB_USER curia
   set_env_var "$env" DB_PASSWORD "$db_pass"
+  # "postgres" here is the Docker Compose service name, not localhost — migrate/seed
+  # run inside the container on the compose network where that hostname resolves.
   set_env_var "$env" DATABASE_URL "postgres://curia:${db_pass}@postgres:5432/curia"
 
   # Preserve a previously-generated encryption key so that existing encrypted

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "tsup src/index.ts --format esm --dts",
     "start": "node dist/index.js",
     "test": "vitest run",
+    "test:shell": "bash tests/setup/test-setup-functions.sh",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json && tsc --noEmit -p tsconfig.tests.json && pnpm --filter @curia/antfarm run typecheck",
     "lint": "eslint src/ tests/",

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Shared helpers for both installers:
+#   - scripts/setup.sh  (developer / build-from-source)
+#   - install.sh        (operator / pull-published-image)
+#
+# Sourced by each installer, never executed directly. Callers must set REPO_ROOT
+# before calling wait_for_postgres or wait_for_curia. Callers that want to pass
+# extra compose flags (e.g. -f docker-compose.dev.yml) should set COMPOSE_FLAGS
+# as an array before sourcing or before calling the wait_* functions — the helpers
+# default to an empty array (no extra flags) when COMPOSE_FLAGS is unset.
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+GREY='\033[0;37m'
+RESET='\033[0m'
+
+# --- Output helpers ---
+info()    { echo -e "${BOLD}==> $*${RESET}"; }
+success() { echo -e "${GREEN}✓${RESET}  $*"; }
+warn()    { echo -e "${YELLOW}⚠${RESET}  $*" >&2; }
+error()   { echo -e "${RED}✗${RESET}  $*" >&2; }
+hint()    { echo -e "${GREY}   $*${RESET}" >&2; }
+
+# 32 random bytes, base64-encoded (44-char string). Used for vault master key.
+# No openssl dependency — works on any POSIX host with /dev/urandom.
+gen_secret_b64() { head -c 32 /dev/urandom | base64 | tr -d '\n'; }
+
+# 32 random bytes, hex-encoded (64-char string). Used for api_token / bootstrap secret.
+# No openssl dependency.
+gen_secret_hex() { head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n'; }
+
+# Returns 0 if key matches sk-ant-... format, 1 otherwise.
+validate_anthropic_key() {
+    local key="$1"
+    [[ "$key" =~ ^sk-ant-[A-Za-z0-9_-]+$ ]]
+}
+
+# Prompts for an Anthropic API key, validates format, retries up to 3 times.
+# Prints the key to stdout on success. Exits 1 after 3 failed attempts.
+prompt_anthropic_key() {
+    local key=""
+    local attempts=0
+    local max_attempts=3
+
+    echo "" >&2
+    echo "Curia needs an Anthropic API key to run its agents." >&2
+    hint "Get one at: https://console.anthropic.com"
+    echo "" >&2
+
+    while [[ $attempts -lt $max_attempts ]]; do
+        read -rsp "Paste your key: " key || true
+        echo "" >&2
+        if validate_anthropic_key "$key"; then
+            echo "$key"
+            return 0
+        fi
+        attempts=$((attempts + 1))
+        local remaining=$((max_attempts - attempts))
+        if [[ $remaining -gt 0 ]]; then
+            error "Key must start with 'sk-ant-' followed by letters, numbers, hyphens, or underscores. Try again ($remaining attempt(s) remaining):"
+        else
+            error "Key must start with 'sk-ant-' followed by letters, numbers, hyphens, or underscores."
+        fi
+    done
+
+    error "Failed to get a valid Anthropic API key after $max_attempts attempts."
+    hint "Get your key at: https://console.anthropic.com"
+    exit 1
+}
+
+# Polls docker for Postgres healthy status every 2s, up to 60s. Exits 1 on timeout.
+# Callers may set COMPOSE_FLAGS (array) for extra compose file flags; defaults to empty.
+wait_for_postgres() {
+    local max_wait=60
+    local elapsed=0
+    # Expand caller-supplied COMPOSE_FLAGS if set; default to empty array otherwise.
+    local -a _flags=("${COMPOSE_FLAGS[@]+"${COMPOSE_FLAGS[@]}"}")
+
+    info "Waiting for Postgres to be ready..."
+    while [[ $elapsed -lt $max_wait ]]; do
+        local container_id ps_err
+        # Distinguish "container not started yet" (empty output, exit 0) from docker failures.
+        if ! ps_err=$(docker compose --project-directory "$REPO_ROOT" "${_flags[@]}" ps -q postgres 2>&1); then
+            error "docker compose ps failed: $ps_err"
+            hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs postgres"
+            exit 1
+        fi
+        container_id="$ps_err"
+        if [[ -n "$container_id" ]]; then
+            local health inspect_err
+            # Container may exit between ps and inspect — treat that as not-healthy yet.
+            if inspect_err=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>&1); then
+                health="$inspect_err"
+                if [[ "$health" == "healthy" ]]; then
+                    success "Postgres is ready"
+                    return 0
+                fi
+            fi
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+        echo -e "${GREY}   ... still waiting (${elapsed}s)${RESET}"
+    done
+
+    error "Postgres did not become healthy within ${max_wait}s."
+    hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs postgres"
+    exit 1
+}
+
+# Polls docker for Curia healthy status every 2s, up to 120s. Returns 0 on healthy,
+# 1 on timeout or detected failure. Does not exit — caller decides what to do
+# (typically: print a red failure and exit, so the operator doesn't see a green
+# success banner against a container that's actually in a restart loop).
+#
+# 120s is generous: Curia's HEALTHCHECK has start_period=60s + interval=30s, so the
+# first probe lands at ~60s and a healthy verdict needs at least one successful
+# probe. 120s = first probe + one retry window + slack for slow hosts.
+#
+# Failure detection beyond timeout:
+#  - Once the container has been observed at least once, an empty `ps -q` result
+#    means it was removed (crash without restart, or `docker rm`). Bail rather
+#    than wait the full 120s with a misleading "did not become healthy" message.
+#  - `.State.Status == exited` with a non-zero exit code or rising restart count
+#    means the container is in a fast crash-loop. Bail immediately.
+#  - `.State.Health.Status` is validated against {starting, healthy, unhealthy}.
+#    Any other value (e.g. `<no value>` when no healthcheck is defined, or the
+#    field being missing) is treated as a configuration error, not a "wait longer".
+#
+# Callers may set COMPOSE_FLAGS (array) for extra compose file flags; defaults to empty.
+wait_for_curia() {
+    local max_wait=120
+    local elapsed=0
+    local ever_seen=0   # 0 until we observe a container id at least once
+    local last_seen_id=""
+    # Expand caller-supplied COMPOSE_FLAGS if set; default to empty array otherwise.
+    local -a _flags=("${COMPOSE_FLAGS[@]+"${COMPOSE_FLAGS[@]}"}")
+
+    info "Waiting for Curia to become healthy (up to ${max_wait}s)..."
+    while [[ $elapsed -lt $max_wait ]]; do
+        local container_id ps_err
+        if ! ps_err=$(docker compose --project-directory "$REPO_ROOT" "${_flags[@]}" ps -q curia 2>&1); then
+            error "docker compose ps failed: $ps_err"
+            hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
+            return 1
+        fi
+        container_id="$ps_err"
+
+        if [[ -z "$container_id" ]]; then
+            if [[ "$ever_seen" -eq 1 ]]; then
+                # Container existed earlier in this loop and is gone now — Docker
+                # removed it (e.g. it crashed and the restart policy isn't bringing
+                # it back, or someone ran `docker rm`). Don't wait the full timeout.
+                error "Curia container disappeared (last seen: ${last_seen_id:0:12}) — likely a crash without restart."
+                hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
+                return 1
+            fi
+            # Not seen yet — keep waiting. Compose may still be creating the container.
+        else
+            ever_seen=1
+            last_seen_id="$container_id"
+
+            # Read State.Status and RestartCount alongside Health.Status so we can
+            # bail on a clear failure rather than wait the full timeout. Format
+            # uses a sentinel separator that's unlikely to appear in any value.
+            local inspect_out inspect_err
+            if ! inspect_out=$(docker inspect \
+                --format='{{.State.Status}}|{{.RestartCount}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}NO_HEALTHCHECK{{end}}' \
+                "$container_id" 2>&1); then
+                inspect_err="$inspect_out"
+                # The container may have been removed between `ps -q` and `inspect` —
+                # let the next loop iteration handle that via the empty-id branch.
+                echo -e "${GREY}   ... inspect transient error: ${inspect_err}${RESET}"
+            else
+                local state restarts health
+                state="${inspect_out%%|*}"
+                local rest="${inspect_out#*|}"
+                restarts="${rest%%|*}"
+                health="${rest#*|}"
+
+                if [[ "$state" == "exited" || "$state" == "dead" ]] && [[ "${restarts:-0}" -ge 1 ]]; then
+                    error "Curia container is in a crash loop (state=${state}, restarts=${restarts})."
+                    hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
+                    return 1
+                fi
+
+                case "$health" in
+                    healthy)
+                        success "Curia is healthy"
+                        return 0
+                        ;;
+                    starting|unhealthy)
+                        # Both are transient; keep polling. The Dockerfile's retries
+                        # let an unhealthy container recover within a probe or two.
+                        ;;
+                    NO_HEALTHCHECK)
+                        error "Curia container has no healthcheck — cannot verify install."
+                        hint "Was the Dockerfile rebuilt? Expected HEALTHCHECK on /api/health."
+                        return 1
+                        ;;
+                    *)
+                        # Unknown value — flag rather than silently keep waiting.
+                        error "Unexpected Health.Status value: '$health' (expected starting/healthy/unhealthy)."
+                        hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
+                        return 1
+                        ;;
+                esac
+            fi
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+        echo -e "${GREY}   ... still waiting (${elapsed}s)${RESET}"
+    done
+
+    error "Curia did not become healthy within ${max_wait}s."
+    hint "The container may be slow or stuck — check logs:"
+    hint "  docker compose --project-directory \"$REPO_ROOT\" logs curia"
+    return 1
+}
+
+# Prints the final summary box with login URL and bootstrap secret.
+# $1 = WEB_APP_BOOTSTRAP_SECRET (plain hex, no formatting)
+print_summary() {
+    local secret="$1"
+    local port="${HTTP_PORT:-3000}"
+    local W=70  # inner box width; wide enough for a 64-char hex secret + padding
+    local border
+    border=$(printf '═%.0s' $(seq 1 $W))
+
+    echo ""
+    printf "╔%s╗\n" "$border"
+    printf "║%-${W}s║\n" ""
+    printf "║   %-$((W-3))s║\n" "Curia is running."
+    printf "║%-${W}s║\n" ""
+    printf "║   %-$((W-3))s║\n" "Open:    http://localhost:${port}"
+    printf "║%-${W}s║\n" ""
+    if [[ -n "$secret" ]]; then
+        # Full setup — the freshly generated secret is in hand; show it once.
+        printf "║   %-$((W-3))s║\n" "Bootstrap secret (save this to a password manager):"
+        printf "║   %-$((W-3))s║\n" "${secret}"
+        printf "║%-${W}s║\n" ""
+        printf "║   %-$((W-3))s║\n" "Enter it on the login page to create your account."
+        printf "║   %-$((W-3))s║\n" "You won't be shown it again here."
+    else
+        # Resume — the secret now lives in the vault, not .env, and isn't retrievable
+        # here. It was shown during the initial setup run.
+        printf "║   %-$((W-3))s║\n" "Bootstrap secret: stored in the encrypted vault."
+        printf "║   %-$((W-3))s║\n" "(Shown once during initial setup; not retrievable here.)"
+    fi
+    printf "║%-${W}s║\n" ""
+    printf "╚%s╝\n" "$border"
+    echo ""
+}

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -229,19 +229,29 @@ wait_for_curia() {
 
 # Prints the final summary box with login URL and bootstrap secret.
 # $1 = WEB_APP_BOOTSTRAP_SECRET (plain hex, no formatting)
+# Reads DOMAIN from the environment: when set, shows https://$DOMAIN;
+# otherwise falls back to http://localhost:$HTTP_PORT.
 print_summary() {
     local secret="$1"
     local port="${HTTP_PORT:-3000}"
     local W=70  # inner box width; wide enough for a 64-char hex secret + padding
-    local border
+    local border url
     border=$(printf '═%.0s' $(seq 1 $W))
+
+    # Use the public HTTPS URL when the operator chose the domain topology;
+    # fall back to localhost for local and behind-proxy installs.
+    if [[ -n "${DOMAIN:-}" ]]; then
+        url="https://${DOMAIN}"
+    else
+        url="http://localhost:${port}"
+    fi
 
     echo ""
     printf "╔%s╗\n" "$border"
     printf "║%-${W}s║\n" ""
     printf "║   %-$((W-3))s║\n" "Curia is running."
     printf "║%-${W}s║\n" ""
-    printf "║   %-$((W-3))s║\n" "Open:    http://localhost:${port}"
+    printf "║   %-$((W-3))s║\n" "Open:    $url"
     printf "║%-${W}s║\n" ""
     if [[ -n "$secret" ]]; then
         # Full setup — the freshly generated secret is in hand; show it once.

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -73,6 +73,12 @@ prompt_anthropic_key() {
 
 # Polls docker for Postgres healthy status every 2s, up to 60s. Exits 1 on timeout.
 # Callers may set COMPOSE_FLAGS (array) for extra compose file flags; defaults to empty.
+#
+# TODO: asymmetry hazard — wait_for_postgres uses `exit 1` on failure while
+# wait_for_curia uses `return 1`. This is intentional today (wait_for_postgres is
+# always called unconditionally; wait_for_curia's return lets the caller decide),
+# but if wait_for_curia is ever called inside a conditional (which disables set -e),
+# a bare `return 1` propagates cleanly. Be mindful if you ever swap their call sites.
 wait_for_postgres() {
     local max_wait=60
     local elapsed=0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,26 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- Colors ---
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BOLD='\033[1m'
-GREY='\033[0;37m'
-RESET='\033[0m'
-
-# --- Output helpers ---
-info()    { echo -e "${BOLD}==> $*${RESET}"; }
-success() { echo -e "${GREEN}✓${RESET}  $*"; }
-warn()    { echo -e "${YELLOW}⚠${RESET}  $*" >&2; }
-error()   { echo -e "${RED}✗${RESET}  $*" >&2; }
-hint()    { echo -e "${GREY}   $*${RESET}" >&2; }
-
 # --- Paths ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENV_FILE="$REPO_ROOT/.env"
 ENV_EXAMPLE="$REPO_ROOT/.env.example"
+
+# Load shared installer helpers (colors, output, secret generators, wait_*, print_summary).
+# setup-common.sh must be sourced after REPO_ROOT is set — the wait_* helpers reference it.
+source "$SCRIPT_DIR/setup-common.sh"
+
+# Compose flags for the dev (build-from-source) path. The base docker-compose.yml
+# defines the service topology; docker-compose.dev.yml overlays the build: context so
+# the stack builds the local image rather than pulling a published one.
+DEV_COMPOSE=(-f docker-compose.yml -f docker-compose.dev.yml)
+
+# The wait_* helpers in setup-common.sh read COMPOSE_FLAGS (array) for extra compose
+# file flags. Point them at the dev override so they query the correct project.
+COMPOSE_FLAGS=("${DEV_COMPOSE[@]}")
 
 # Global: set by handle_existing_env to control main() flow
 SETUP_MODE="full"  # "full" | "resume"
@@ -31,8 +29,9 @@ PRESERVED_ENCRYPTION_KEY=""
 # seed the vault (#911). Empty on the resume path (vault already seeded on first run).
 SEED_ANTHROPIC_KEY=""
 
-# Verifies docker, docker compose, node >= 24, pnpm, and openssl are available.
+# Verifies docker, docker compose, node >= 24, and pnpm are available.
 # Exits 1 with an install link on the first missing tool.
+# (openssl check removed — secret generation now uses /dev/urandom via gen_secret_b64/hex)
 check_prerequisites() {
     if ! docker info &>/dev/null; then
         error "docker not found or not running."
@@ -64,65 +63,20 @@ check_prerequisites() {
         hint "Install at: https://pnpm.io/installation"
         exit 1
     fi
-
-    if ! command -v openssl &>/dev/null; then
-        error "openssl not found (required for secret generation)."
-        hint "Install via your system package manager (e.g. brew install openssl)"
-        exit 1
-    fi
 }
 
-# Returns 0 if key matches sk-ant-... format, 1 otherwise.
-validate_anthropic_key() {
-    local key="$1"
-    [[ "$key" =~ ^sk-ant-[A-Za-z0-9_-]+$ ]]
-}
-
-# Prompts for an Anthropic API key, validates format, retries up to 3 times.
-# Prints the key to stdout on success. Exits 1 after 3 failed attempts.
-prompt_anthropic_key() {
-    local key=""
-    local attempts=0
-    local max_attempts=3
-
-    echo "" >&2
-    echo "Curia needs an Anthropic API key to run its agents." >&2
-    hint "Get one at: https://console.anthropic.com"
-    echo "" >&2
-
-    while [[ $attempts -lt $max_attempts ]]; do
-        read -rsp "Paste your key: " key || true
-        echo "" >&2
-        if validate_anthropic_key "$key"; then
-            echo "$key"
-            return 0
-        fi
-        attempts=$((attempts + 1))
-        local remaining=$((max_attempts - attempts))
-        if [[ $remaining -gt 0 ]]; then
-            error "Key must start with 'sk-ant-' followed by letters, numbers, hyphens, or underscores. Try again ($remaining attempt(s) remaining):"
-        else
-            error "Key must start with 'sk-ant-' followed by letters, numbers, hyphens, or underscores."
-        fi
-    done
-
-    error "Failed to get a valid Anthropic API key after $max_attempts attempts."
-    hint "Get your key at: https://console.anthropic.com"
-    exit 1
-}
-
-# Populates global secret variables using openssl CSPRNG.
+# Populates global secret variables using /dev/urandom (no openssl dependency).
 generate_secrets() {
     DB_USER="curia"
-    DB_PASSWORD=$(openssl rand -hex 32)
-    API_TOKEN=$(openssl rand -hex 32)
-    WEB_APP_BOOTSTRAP_SECRET=$(openssl rand -hex 32)
+    DB_PASSWORD=$(gen_secret_hex)
+    API_TOKEN=$(gen_secret_hex)
+    WEB_APP_BOOTSTRAP_SECRET=$(gen_secret_hex)
     # Reuse a preserved key if one exists (full reset keeps Postgres data, so the
     # vault key must stay the same or existing encrypted rows become unreadable).
     if [[ -n "${PRESERVED_ENCRYPTION_KEY:-}" ]]; then
         SECRET_ENCRYPTION_KEY="$PRESERVED_ENCRYPTION_KEY"
     else
-        SECRET_ENCRYPTION_KEY=$(openssl rand -base64 32)
+        SECRET_ENCRYPTION_KEY=$(gen_secret_b64)
     fi
     # DATABASE_URL is consumed by host-side `pnpm migrate` (against the postgres
     # container's published port), so the port here must match POSTGRES_PORT.
@@ -182,7 +136,7 @@ handle_existing_env() {
             # User chose to start stack manually — exit setup
             info "Starting the stack..."
             hint "You can also run this directly: docker compose up -d"
-            docker compose --project-directory "$REPO_ROOT" up -d
+            docker compose --project-directory "$REPO_ROOT" "${DEV_COMPOSE[@]}" up -d
             success "Stack is up."
             exit 0
             ;;
@@ -213,149 +167,6 @@ handle_existing_env() {
     esac
 }
 
-# Polls docker for Postgres healthy status every 2s, up to 60s. Exits 1 on timeout.
-wait_for_postgres() {
-    local max_wait=60
-    local elapsed=0
-
-    info "Waiting for Postgres to be ready..."
-    while [[ $elapsed -lt $max_wait ]]; do
-        local container_id ps_err
-        # Distinguish "container not started yet" (empty output, exit 0) from docker failures.
-        if ! ps_err=$(docker compose --project-directory "$REPO_ROOT" ps -q postgres 2>&1); then
-            error "docker compose ps failed: $ps_err"
-            hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs postgres"
-            exit 1
-        fi
-        container_id="$ps_err"
-        if [[ -n "$container_id" ]]; then
-            local health inspect_err
-            # Container may exit between ps and inspect — treat that as not-healthy yet.
-            if inspect_err=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>&1); then
-                health="$inspect_err"
-                if [[ "$health" == "healthy" ]]; then
-                    success "Postgres is ready"
-                    return 0
-                fi
-            fi
-        fi
-        sleep 2
-        elapsed=$((elapsed + 2))
-        echo -e "${GREY}   ... still waiting (${elapsed}s)${RESET}"
-    done
-
-    error "Postgres did not become healthy within ${max_wait}s."
-    hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs postgres"
-    exit 1
-}
-
-# Polls docker for Curia healthy status every 2s, up to 120s. Returns 0 on healthy,
-# 1 on timeout or detected failure. Does not exit — caller decides what to do
-# (typically: print a red failure and exit, so the operator doesn't see a green
-# success banner against a container that's actually in a restart loop).
-#
-# 120s is generous: Curia's HEALTHCHECK has start_period=60s + interval=30s, so the
-# first probe lands at ~60s and a healthy verdict needs at least one successful
-# probe. 120s = first probe + one retry window + slack for slow hosts.
-#
-# Failure detection beyond timeout:
-#  - Once the container has been observed at least once, an empty `ps -q` result
-#    means it was removed (crash without restart, or `docker rm`). Bail rather
-#    than wait the full 120s with a misleading "did not become healthy" message.
-#  - `.State.Status == exited` with a non-zero exit code or rising restart count
-#    means the container is in a fast crash-loop. Bail immediately.
-#  - `.State.Health.Status` is validated against {starting, healthy, unhealthy}.
-#    Any other value (e.g. `<no value>` when no healthcheck is defined, or the
-#    field being missing) is treated as a configuration error, not a "wait longer".
-wait_for_curia() {
-    local max_wait=120
-    local elapsed=0
-    local ever_seen=0   # 0 until we observe a container id at least once
-    local last_seen_id=""
-
-    info "Waiting for Curia to become healthy (up to ${max_wait}s)..."
-    while [[ $elapsed -lt $max_wait ]]; do
-        local container_id ps_err
-        if ! ps_err=$(docker compose --project-directory "$REPO_ROOT" ps -q curia 2>&1); then
-            error "docker compose ps failed: $ps_err"
-            hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
-            return 1
-        fi
-        container_id="$ps_err"
-
-        if [[ -z "$container_id" ]]; then
-            if [[ "$ever_seen" -eq 1 ]]; then
-                # Container existed earlier in this loop and is gone now — Docker
-                # removed it (e.g. it crashed and the restart policy isn't bringing
-                # it back, or someone ran `docker rm`). Don't wait the full timeout.
-                error "Curia container disappeared (last seen: ${last_seen_id:0:12}) — likely a crash without restart."
-                hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
-                return 1
-            fi
-            # Not seen yet — keep waiting. Compose may still be creating the container.
-        else
-            ever_seen=1
-            last_seen_id="$container_id"
-
-            # Read State.Status and RestartCount alongside Health.Status so we can
-            # bail on a clear failure rather than wait the full timeout. Format
-            # uses a sentinel separator that's unlikely to appear in any value.
-            local inspect_out inspect_err
-            if ! inspect_out=$(docker inspect \
-                --format='{{.State.Status}}|{{.RestartCount}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}NO_HEALTHCHECK{{end}}' \
-                "$container_id" 2>&1); then
-                inspect_err="$inspect_out"
-                # The container may have been removed between `ps -q` and `inspect` —
-                # let the next loop iteration handle that via the empty-id branch.
-                echo -e "${GREY}   ... inspect transient error: ${inspect_err}${RESET}"
-            else
-                local state restarts health
-                state="${inspect_out%%|*}"
-                local rest="${inspect_out#*|}"
-                restarts="${rest%%|*}"
-                health="${rest#*|}"
-
-                if [[ "$state" == "exited" || "$state" == "dead" ]] && [[ "${restarts:-0}" -ge 1 ]]; then
-                    error "Curia container is in a crash loop (state=${state}, restarts=${restarts})."
-                    hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
-                    return 1
-                fi
-
-                case "$health" in
-                    healthy)
-                        success "Curia is healthy"
-                        return 0
-                        ;;
-                    starting|unhealthy)
-                        # Both are transient; keep polling. The Dockerfile's retries
-                        # let an unhealthy container recover within a probe or two.
-                        ;;
-                    NO_HEALTHCHECK)
-                        error "Curia container has no healthcheck — cannot verify install."
-                        hint "Was the Dockerfile rebuilt? Expected HEALTHCHECK on /api/health."
-                        return 1
-                        ;;
-                    *)
-                        # Unknown value — flag rather than silently keep waiting.
-                        error "Unexpected Health.Status value: '$health' (expected starting/healthy/unhealthy)."
-                        hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
-                        return 1
-                        ;;
-                esac
-            fi
-        fi
-
-        sleep 2
-        elapsed=$((elapsed + 2))
-        echo -e "${GREY}   ... still waiting (${elapsed}s)${RESET}"
-    done
-
-    error "Curia did not become healthy within ${max_wait}s."
-    hint "The container may be slow or stuck — check logs:"
-    hint "  docker compose --project-directory \"$REPO_ROOT\" logs curia"
-    return 1
-}
-
 # Starts Postgres, runs migrations, starts the full stack, writes SETUP_COMPLETE marker.
 # Parses .env to get DATABASE_URL and HTTP_PORT for use at runtime. The bootstrap secret
 # is no longer stored in .env (#911) — it lives in the vault; only the full-setup path
@@ -377,7 +188,7 @@ run_infra() {
     done < "$ENV_FILE"
 
     info "Starting Postgres..."
-    docker compose --project-directory "$REPO_ROOT" up -d postgres
+    docker compose --project-directory "$REPO_ROOT" "${DEV_COMPOSE[@]}" up -d postgres
 
     wait_for_postgres
 
@@ -433,7 +244,7 @@ run_infra() {
     success "Secrets vault seeded"
 
     info "Starting Curia..."
-    if ! docker compose --project-directory "$REPO_ROOT" up -d; then
+    if ! docker compose --project-directory "$REPO_ROOT" "${DEV_COMPOSE[@]}" up -d; then
         error "Failed to start Curia stack."
         hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs"
         exit 1
@@ -455,40 +266,6 @@ run_infra() {
     # On the resume path the bootstrap secret is not in-shell (not in .env anymore,
     # not regenerated), so pass it defensively — print_summary degrades gracefully.
     print_summary "${WEB_APP_BOOTSTRAP_SECRET:-}"
-}
-
-# Prints the final summary box with login URL and bootstrap secret.
-# $1 = WEB_APP_BOOTSTRAP_SECRET (plain hex, no formatting)
-print_summary() {
-    local secret="$1"
-    local port="${HTTP_PORT:-3000}"
-    local W=70  # inner box width; wide enough for a 64-char hex secret + padding
-    local border
-    border=$(printf '═%.0s' $(seq 1 $W))
-
-    echo ""
-    printf "╔%s╗\n" "$border"
-    printf "║%-${W}s║\n" ""
-    printf "║   %-$((W-3))s║\n" "Curia is running."
-    printf "║%-${W}s║\n" ""
-    printf "║   %-$((W-3))s║\n" "Open:    http://localhost:${port}"
-    printf "║%-${W}s║\n" ""
-    if [[ -n "$secret" ]]; then
-        # Full setup — the freshly generated secret is in hand; show it once.
-        printf "║   %-$((W-3))s║\n" "Bootstrap secret (save this to a password manager):"
-        printf "║   %-$((W-3))s║\n" "${secret}"
-        printf "║%-${W}s║\n" ""
-        printf "║   %-$((W-3))s║\n" "Enter it on the login page to create your account."
-        printf "║   %-$((W-3))s║\n" "You won't be shown it again here."
-    else
-        # Resume — the secret now lives in the vault, not .env, and isn't retrievable
-        # here. It was shown during the initial setup run.
-        printf "║   %-$((W-3))s║\n" "Bootstrap secret: stored in the encrypted vault."
-        printf "║   %-$((W-3))s║\n" "(Shown once during initial setup; not retrievable here.)"
-    fi
-    printf "║%-${W}s║\n" ""
-    printf "╚%s╝\n" "$border"
-    echo ""
 }
 
 main() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -135,7 +135,7 @@ handle_existing_env() {
         1)
             # User chose to start stack manually — exit setup
             info "Starting the stack..."
-            hint "You can also run this directly: docker compose up -d"
+            hint "You can also run this directly: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d"
             docker compose --project-directory "$REPO_ROOT" "${DEV_COMPOSE[@]}" up -d
             success "Stack is up."
             exit 0

--- a/tests/setup/test-setup-functions.sh
+++ b/tests/setup/test-setup-functions.sh
@@ -94,12 +94,7 @@ NODE_EOF
 exit 0
 PNPM_EOF
 
-    cat > "$tmp_bin/openssl" <<'OPENSSL_EOF'
-#!/usr/bin/env bash
-exit 0
-OPENSSL_EOF
-
-    chmod +x "$tmp_bin/docker" "$tmp_bin/node" "$tmp_bin/pnpm" "$tmp_bin/openssl"
+    chmod +x "$tmp_bin/docker" "$tmp_bin/node" "$tmp_bin/pnpm"
 
     local rc
     set +e

--- a/tests/setup/test-setup-functions.sh
+++ b/tests/setup/test-setup-functions.sh
@@ -451,13 +451,16 @@ else
     FAIL=$((FAIL+1))
 fi
 
-# Returns true (0) when .env has a real (non-placeholder, non-empty) DB_PASSWORD.
+# Returns false (1) when .env has a real DB_PASSWORD but NO marker: this is a
+# partial/interrupted install (DB creds written, vault not yet seeded). It must
+# route through fresh_install (which preserves the DB password) so the missing
+# vault secrets still get seeded — not the verify-only upgrade path.
 printf 'DB_PASSWORD=realhexvalue0011aabbccdd\n' > "$_ic_env"
-if install_is_complete "$_ic_env"; then
-    echo "  ✓ real DB_PASSWORD (no marker) → complete"
+if ! install_is_complete "$_ic_env"; then
+    echo "  ✓ real DB_PASSWORD, no marker → not complete (partial install)"
     PASS=$((PASS+1))
 else
-    echo "  ✗ real DB_PASSWORD with no marker should also return complete"
+    echo "  ✗ real DB_PASSWORD without marker should NOT be treated as complete"
     FAIL=$((FAIL+1))
 fi
 

--- a/tests/setup/test-setup-functions.sh
+++ b/tests/setup/test-setup-functions.sh
@@ -340,6 +340,106 @@ if [[ "${#key_b64}" -eq 44 ]]; then echo "  ✓ gen_secret_b64 length 44"; PASS=
 key_hex="$(gen_secret_hex)"
 if [[ "${#key_hex}" -eq 64 ]]; then echo "  ✓ gen_secret_hex length 64"; PASS=$((PASS+1)); else echo "  ✗ gen_secret_hex length ${#key_hex}"; FAIL=$((FAIL+1)); fi
 
+# --- install.sh: source-checkout detection ---
+# Source install.sh (guarded: defines functions, does not run main).
+# Suppress setup-common.sh re-sourcing output; the helpers are already loaded.
+source "$TEST_DIR/../../install.sh" 2>/dev/null
+
+echo ""
+echo "=== install.sh: detect_source_checkout ==="
+
+# A directory with .git + src/ + package.json naming the curia project.
+tmp_src=$(mktemp -d)
+mkdir -p "$tmp_src/src" "$tmp_src/.git"
+printf '{"name":"curia"}' > "$tmp_src/package.json"
+if detect_source_checkout "$tmp_src"; then
+    echo "  ✓ detects a curia source tree"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ missed a curia source tree"
+    FAIL=$((FAIL+1))
+fi
+
+# A bare directory: no .git, no src/, no package.json.
+tmp_bare=$(mktemp -d)
+if ! detect_source_checkout "$tmp_bare"; then
+    echo "  ✓ bare dir is not a source tree"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ false-positive on bare dir"
+    FAIL=$((FAIL+1))
+fi
+
+# A directory with .git + src but a different package name (not curia).
+tmp_other=$(mktemp -d)
+mkdir -p "$tmp_other/src" "$tmp_other/.git"
+printf '{"name":"other-project"}' > "$tmp_other/package.json"
+if ! detect_source_checkout "$tmp_other"; then
+    echo "  ✓ non-curia package.json is not a source tree"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ false-positive on non-curia package.json"
+    FAIL=$((FAIL+1))
+fi
+
+rm -rf "$tmp_src" "$tmp_bare" "$tmp_other"
+
+# --- install.sh: set_env_var ---
+
+echo ""
+echo "=== install.sh: set_env_var ==="
+
+# set_env_var replaces an existing uncommented key.
+_sv_env=$(mktemp)
+printf 'FOO=old\nBAR=keep\n' > "$_sv_env"
+set_env_var "$_sv_env" FOO new_value
+if grep -qF "FOO=new_value" "$_sv_env"; then
+    echo "  ✓ replaces existing key"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ did not replace existing key"
+    FAIL=$((FAIL+1))
+fi
+if grep -qF "BAR=keep" "$_sv_env"; then
+    echo "  ✓ preserves unrelated key"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ unrelated key was clobbered"
+    FAIL=$((FAIL+1))
+fi
+# Old value must not remain.
+if ! grep -qF "FOO=old" "$_sv_env"; then
+    echo "  ✓ old value removed"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ old value still present"
+    FAIL=$((FAIL+1))
+fi
+
+# set_env_var replaces a commented-out key (e.g. # FOO=placeholder).
+printf '# FOO=placeholder\nBAR=keep\n' > "$_sv_env"
+set_env_var "$_sv_env" FOO activated
+if grep -qF "FOO=activated" "$_sv_env"; then
+    echo "  ✓ activates commented key"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ did not activate commented key"
+    FAIL=$((FAIL+1))
+fi
+
+# set_env_var appends when the key is entirely absent.
+printf 'BAR=keep\n' > "$_sv_env"
+set_env_var "$_sv_env" NEWKEY newval
+if grep -qF "NEWKEY=newval" "$_sv_env"; then
+    echo "  ✓ appends missing key"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ did not append missing key"
+    FAIL=$((FAIL+1))
+fi
+
+rm -f "$_sv_env"
+
 # --- Results ---
 
 echo ""

--- a/tests/setup/test-setup-functions.sh
+++ b/tests/setup/test-setup-functions.sh
@@ -5,8 +5,14 @@ PASS=0
 FAIL=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Capture the test dir before sourcing setup.sh, which re-assigns SCRIPT_DIR to scripts/.
+TEST_DIR="$SCRIPT_DIR"
 # Source the script under test without running main (guarded by BASH_SOURCE check at script bottom)
 source "$SCRIPT_DIR/../../scripts/setup.sh"
+# Source the shared helpers explicitly so this file documents its direct dependency.
+# setup.sh already sources setup-common.sh at load time, so this is a no-op in practice;
+# we use TEST_DIR here because SCRIPT_DIR was re-assigned by setup.sh's sourcing.
+source "$TEST_DIR/../../scripts/setup-common.sh"
 
 # --- Helpers ---
 
@@ -323,6 +329,16 @@ _assert_output "contains password manager instruction"      "save this to a pass
 _assert_output "contains login instruction"                 "Enter it on the login page"
 _assert_output "contains box top-left corner"               "╔"
 _assert_output "contains box bottom-right corner"           "╝"
+
+# --- setup-common: secret generator tests ---
+
+echo ""
+echo "=== setup-common: secret generators ==="
+key_b64="$(gen_secret_b64)"
+# base64 of 32 bytes is 44 chars ending in '='
+if [[ "${#key_b64}" -eq 44 ]]; then echo "  ✓ gen_secret_b64 length 44"; PASS=$((PASS+1)); else echo "  ✗ gen_secret_b64 length ${#key_b64}"; FAIL=$((FAIL+1)); fi
+key_hex="$(gen_secret_hex)"
+if [[ "${#key_hex}" -eq 64 ]]; then echo "  ✓ gen_secret_hex length 64"; PASS=$((PASS+1)); else echo "  ✗ gen_secret_hex length ${#key_hex}"; FAIL=$((FAIL+1)); fi
 
 # --- Results ---
 

--- a/tests/setup/test-setup-functions.sh
+++ b/tests/setup/test-setup-functions.sh
@@ -435,6 +435,64 @@ fi
 
 rm -f "$_sv_env"
 
+# --- install.sh: install_is_complete ---
+
+echo ""
+echo "=== install.sh: install_is_complete ==="
+
+# Returns true (0) when .env has the SETUP_COMPLETE marker.
+_ic_env=$(mktemp)
+printf 'DB_PASSWORD=abc123\n# SETUP_COMPLETE\n' > "$_ic_env"
+if install_is_complete "$_ic_env"; then
+    echo "  ✓ SETUP_COMPLETE marker → complete"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ SETUP_COMPLETE marker should return complete"
+    FAIL=$((FAIL+1))
+fi
+
+# Returns true (0) when .env has a real (non-placeholder, non-empty) DB_PASSWORD.
+printf 'DB_PASSWORD=realhexvalue0011aabbccdd\n' > "$_ic_env"
+if install_is_complete "$_ic_env"; then
+    echo "  ✓ real DB_PASSWORD (no marker) → complete"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ real DB_PASSWORD with no marker should also return complete"
+    FAIL=$((FAIL+1))
+fi
+
+# Returns false (1) for a brand-new .env with the placeholder DB_PASSWORD.
+printf 'DB_PASSWORD=replace-with-a-strong-password\n' > "$_ic_env"
+if ! install_is_complete "$_ic_env"; then
+    echo "  ✓ placeholder DB_PASSWORD → not complete"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ placeholder DB_PASSWORD should return not complete"
+    FAIL=$((FAIL+1))
+fi
+
+# Returns false (1) when DB_PASSWORD is absent entirely.
+printf 'DB_USER=curia\n' > "$_ic_env"
+if ! install_is_complete "$_ic_env"; then
+    echo "  ✓ absent DB_PASSWORD → not complete"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ absent DB_PASSWORD should return not complete"
+    FAIL=$((FAIL+1))
+fi
+
+# Returns false (1) when DB_PASSWORD is empty (key present, value blank).
+printf 'DB_PASSWORD=\n' > "$_ic_env"
+if ! install_is_complete "$_ic_env"; then
+    echo "  ✓ empty DB_PASSWORD → not complete"
+    PASS=$((PASS+1))
+else
+    echo "  ✗ empty DB_PASSWORD should return not complete"
+    FAIL=$((FAIL+1))
+fi
+
+rm -f "$_ic_env"
+
 # --- Results ---
 
 echo ""


### PR DESCRIPTION
## Summary

Part A of the open-core self-hosting epic (#1281): make Curia runnable from a **published container image** with no source checkout, and de-duplicate the release/container story. This is the curia-repo half; the curia-deploy dogfood (pulling the published core) is a follow-up PR gated on this merging + `:edge` publishing.

Closes #1343.

**What ships:**
- **`.github/workflows/docker-publish.yml`** — publishes two signed, multi-arch (amd64+arm64) images to GHCR: `ghcr.io/josephfung/curia` (app) and `ghcr.io/josephfung/curia-postgres` (pgvector+pgAudit). Tags: `vX.Y.Z`+`latest` on release, `:edge` on every `main` push; postgres `pg16`+`latest` on release. cosign keyless sign-by-digest + buildx SBOM/provenance. Actions SHA-pinned; `workflow_dispatch` tag input injection-guarded; least-privilege permissions.
- **`docker/postgres.Dockerfile`** — bakes the pgAudit init SQL into the image so a source-free stack still runs it on first init.
- **`docker-compose.yml`** — now references the published images by default (`CURIA_IMAGE_TAG`/`CURIA_POSTGRES_TAG`); developers restore local builds via **`docker-compose.dev.yml`**. **`docker-compose.tls.yml`** adds an optional Caddy HTTPS overlay.
- **`install.sh`** — interactive, image-based operator installer (Docker + curl only). Prompts for the Anthropic key, generates the other secrets, runs migrate + vault-seed **inside the pulled image** (`tsx` directly, no pnpm), and brings the stack up. Idempotent on re-run (`install_is_complete`: preserves DB creds + encryption key, verify-only re-seed, no secret rotation). Detects a source checkout and redirects to `pnpm run setup`. Optional TLS topology writes `DOMAIN` + a durable `COMPOSE_FILE` selection.
- **`scripts/setup-common.sh`** — shared installer helpers extracted from `setup.sh` (no duplication); developer `pnpm run setup` path preserved.
- Shell tests wired into CI (`test:shell`); docs (`README.md`, `docs/dev/setup.md`) document both install paths.

## Install paths after this PR

- **Operator (new):** download `install.sh` from a release tag, review it, `bash install.sh`, answer the Anthropic prompt. No source, no Node/pnpm. Update via `docker compose pull && docker compose up -d`.
- **Developer (unchanged):** `git clone && cd curia && pnpm run setup` (builds from source via the dev override).

## Testing

- Shell suite: 51/51 pass, now gated in CI. `bash -n` clean; workflow + compose YAML validated (`docker compose config`, actionlint, yaml parse).
- No TypeScript changed; the app/typecheck suites are unaffected.
- **Post-merge verification (can't run pre-publish):** first `main` push publishes `:edge`; then confirm multi-arch `imagetools inspect`, `cosign verify` against the docker-publish OIDC identity, and an end-to-end `install.sh` on a clean Docker-only host. GHCR packages must be set **public** (one-time).

## Reviews

Ran code-reviewer + silent-failure-hunter + a security pass. Fixed: summary box now shows `https://$DOMAIN` on the HTTPS path; install.sh Docker steps get actionable failure messages; guard job scoped to `contents: read`.

Known/accepted (not blockers): compose default DB password fallback and `-e KEY=VAL` seed-window are pre-existing/v0-acceptable single-user-host trade-offs; `caddy:2-alpine` matches existing usage. **Release-checklist item:** bump `install.sh`'s `CURIA_REF` default to the release tag at release time so a tag-downloaded installer fetches matching compose/env files.