### PR TITLE
fix(postgres): initialize fresh volumes by waiting for the real server (#1350)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,15 @@ jobs:
 
       - name: Shell setup/install tests
         run: pnpm run test:shell
+
+  postgres-image:
+    # Builds the real curia-postgres image and boots it on fresh volumes to guard
+    # against curia#1350 (fresh-init crash-loop in verify-pgaudit.sh). The `ci` job's
+    # postgres service uses the stock pgvector image, so the custom image is
+    # otherwise never exercised on PRs — which is exactly how #1350 shipped.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build + boot curia-postgres (fresh-init regression)
+        run: bash tests/docker/test-postgres-init.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`curia-postgres` fresh-init crash-loop** — `verify-pgaudit.sh` probed the socket-only temporary init server, racing `CREATE DATABASE` and hanging its shutdown so a fresh volume never created the `curia` DB and crash-looped. It now waits for the real server over TCP (never the temp server), and `CMD ["postgres"]` is restored so the image is self-sufficient. Fixes #1350.
 - **CI Node version drift** — `ci.yml` and `dast.yml` now read `node-version-file: .nvmrc` instead of a hardcoded `"22"`, so CI runs on Node 24 in lockstep with `engines` (`>=24`) and the `node:24` Docker image. Previously CI validated on a version that did not satisfy the project's own engines constraint.
 - **Ant Farm** — code review follow-ups: fail-closed session check, conductor live/scrub fixes, incremental live merge, per-agent overlay context, timeline cursor paging, safe `busEventToAuditRow` payload guard, `schedule.fired` task_id normalization.
 - **Ant Farm** — fix playback flicker: stable desk roster + conductor snapshot refs so Phaser scene is not restarted every animation frame.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`curia-postgres` fresh-init crash-loop** — `verify-pgaudit.sh` probed the socket-only temporary init server, racing `CREATE DATABASE` and hanging its shutdown so a fresh volume never created the `curia` DB and crash-looped. It now waits for the real server over TCP (never the temp server), and `CMD ["postgres"]` is restored so the image is self-sufficient. Fixes #1350.
+- **`curia-postgres` fresh-init** — probe the real server over TCP so fresh volumes create `curia` instead of crash-looping. (#1350)
 - **CI Node version drift** — `ci.yml` and `dast.yml` now read `node-version-file: .nvmrc` instead of a hardcoded `"22"`, so CI runs on Node 24 in lockstep with `engines` (`>=24`) and the `node:24` Docker image. Previously CI validated on a version that did not satisfy the project's own engines constraint.
 - **Ant Farm** — code review follow-ups: fail-closed session check, conductor live/scrub fixes, incremental live merge, per-agent overlay context, timeline cursor paging, safe `busEventToAuditRow` payload guard, `schedule.fired` task_id normalization.
 - **Ant Farm** — fix playback flicker: stable desk roster + conductor snapshot refs so Phaser scene is not restarted every animation frame.

--- a/docker/postgres-verify-pgaudit.sh
+++ b/docker/postgres-verify-pgaudit.sh
@@ -15,21 +15,37 @@ PG_PID=$!
 trap 'kill -TERM "$PG_PID"' TERM INT
 trap 'kill -QUIT "$PG_PID"' QUIT
 
-# Wait for Postgres to be ready (up to 30s)
-for i in $(seq 1 30); do
-  if pg_isready -U "${POSTGRES_USER:-curia}" -q 2>/dev/null; then
+# Wait for the REAL server over TCP — never the temporary init server (curia#1350).
+#
+# On a fresh volume the standard entrypoint first runs a *temporary* server that
+# is socket-only (listen_addresses='') to run initdb, CREATE DATABASE, and the
+# initdb.d scripts, then stops it and starts the real server. Probing that temp
+# server over the local socket (as this script used to) is broken two ways: it
+# races CREATE DATABASE (connecting to a DB that does not exist yet), and its
+# connections interfere with the temp server's shutdown so the real server never
+# starts — leaving the container dead mid-init with `curia` never created.
+#
+# The real server listens on TCP; the socket-only temp server does not. So a TCP
+# probe (-h 127.0.0.1) only succeeds once the real server is up — by which point
+# initdb has finished and "$POSTGRES_DB" exists — and never touches the temp
+# server. pg_isready only pings (no auth), so no password is needed here.
+PGHOST=127.0.0.1
+for i in $(seq 1 60); do
+  if pg_isready -h "$PGHOST" -U "${POSTGRES_USER:-curia}" -q 2>/dev/null; then
     break
   fi
   sleep 1
 done
 
-if ! pg_isready -U "${POSTGRES_USER:-curia}" -q 2>/dev/null; then
-  echo "ERROR: Postgres did not become ready in 30s" >&2
+if ! pg_isready -h "$PGHOST" -U "${POSTGRES_USER:-curia}" -q 2>/dev/null; then
+  echo "ERROR: Postgres did not become ready in 60s" >&2
   exit 1
 fi
 
 # Verify pgAudit setup. If anything is missing, create it (idempotent).
 # This handles the existing-volume case where initdb.d scripts were skipped.
+# Connect over the local socket (trust auth) — the real server is up on both the
+# socket and TCP by now, and the socket path needs no password.
 psql -U "${POSTGRES_USER:-curia}" -d "${POSTGRES_DB:-curia}" -v ON_ERROR_STOP=1 <<'SQL'
   -- Ensure extension exists (safe to run repeatedly)
   CREATE EXTENSION IF NOT EXISTS pgaudit;

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -29,4 +29,12 @@ COPY docker/postgres-init-pgaudit.sql /docker-entrypoint-initdb.d/10-pgaudit.sql
 # own `command:` (which starts with `postgres`), it replaces this CMD entirely and
 # the wrapper receives `postgres -c ...` either way.
 ENTRYPOINT ["verify-pgaudit.sh"]
+# No `USER` instruction is intentional. The Postgres entrypoint must start as root
+# to run initdb and chown a fresh (root-owned) data volume on first boot, then it
+# drops to the non-root `postgres` user via `gosu` to run the server itself
+# (docker-entrypoint.sh: `exec gosu postgres ...`). Adding `USER postgres` here
+# breaks first-time init on a fresh volume — the very failure #1350 fixes. So the
+# running server is non-root despite the absence of a USER instruction; Semgrep's
+# generic missing-user heuristic can't see the runtime gosu drop.
+# nosemgrep: dockerfile.security.missing-user.missing-user
 CMD ["postgres"]

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -23,4 +23,10 @@ COPY docker/postgres-verify-pgaudit.sh /usr/local/bin/verify-pgaudit.sh
 # volume mount is removed in lockstep (see docker-compose.yml).
 COPY docker/postgres-init-pgaudit.sql /docker-entrypoint-initdb.d/10-pgaudit.sql
 
+# Setting ENTRYPOINT above resets the base image's `CMD ["postgres"]` to null, so
+# without this the image would run `verify-pgaudit.sh` with no server command and
+# never start Postgres. Restore the default. When the compose files provide their
+# own `command:` (which starts with `postgres`), it replaces this CMD entirely and
+# the wrapper receives `postgres -c ...` either way.
 ENTRYPOINT ["verify-pgaudit.sh"]
+CMD ["postgres"]

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:shell": "bash tests/setup/test-setup-functions.sh",
+    "test:postgres-image": "bash tests/docker/test-postgres-init.sh",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json && tsc --noEmit -p tsconfig.tests.json && pnpm --filter @curia/antfarm run typecheck",
     "lint": "eslint src/ tests/",

--- a/tests/docker/test-postgres-init.sh
+++ b/tests/docker/test-postgres-init.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Regression test for curia#1350.
+#
+# The curia-postgres image must initialize a FRESH data volume cleanly: create
+# the `curia` database, load pgAudit, and stay up. The prior bug lived in the
+# verify-pgaudit.sh entrypoint: it backgrounded the stock Postgres entrypoint and
+# polled `pg_isready`/`psql` over the local socket. On first init the stock
+# entrypoint runs a *temporary, socket-only* server to create the DB and run
+# initdb scripts, then stops it and starts the real server. The wrapper's socket
+# probes latched onto (and interfered with) that temp server — hanging its
+# shutdown so the real server never started, or racing `CREATE DATABASE curia`
+# — leaving the container dead and the `curia` DB never created. Existing
+# (already-initialized) volumes were unaffected, which is why it shipped.
+#
+# The failure is a timing race, so this test runs the fresh-init path several
+# times: the fix (probe the real server over TCP, never the socket-only temp
+# server) is deterministic, while the buggy wrapper fails a fraction of the time.
+# Looping makes a regression reliably visible.
+#
+# Requires Docker. Run: bash tests/docker/test-postgres-init.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="curia-postgres-test:ci-$$"
+# Number of fresh-init attempts. Each is deterministic under the fix; a reverted
+# fix loses the race in at least one attempt with high probability.
+FRESH_ITERS="${FRESH_ITERS:-5}"
+# The exact pgAudit command the compose files pass. Must match them: the heavier
+# audit settings (log_relation/log_parameter) shape init timing, and reproducing
+# the bug depends on using the real command, not a reduced one.
+PGAUDIT_CMD=(postgres
+  -c shared_preload_libraries=pgaudit
+  -c pgaudit.log=write,ddl
+  -c pgaudit.log_parameter=on
+  -c pgaudit.log_relation=on
+  -c pgaudit.role=pgaudit_role)
+
+# Track resources for cleanup.
+CONTAINERS=()
+VOLUMES=()
+
+pass() { echo "  PASS: $*"; }
+fail() {
+  local container="$1"; shift
+  echo "  FAIL: $*" >&2
+  echo "  --- last 30 log lines ($container) ---" >&2
+  docker logs "$container" 2>&1 | tail -30 >&2 || true
+  exit 1
+}
+
+cleanup() {
+  local c v
+  for c in "${CONTAINERS[@]:-}"; do [ -n "$c" ] && docker rm -f "$c" >/dev/null 2>&1 || true; done
+  for v in "${VOLUMES[@]:-}"; do [ -n "$v" ] && docker volume rm "$v" >/dev/null 2>&1 || true; done
+  docker rmi "$IMAGE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+status_of() { docker inspect -f '{{.State.Status}}' "$1" 2>/dev/null || echo missing; }
+verified_count() { docker logs "$1" 2>&1 | grep -c 'pgAudit verification passed' || true; }
+
+# wait_for_verified <container> <want_count> <timeout>: poll until the wrapper has
+# reported "pgAudit verification passed" at least <want_count> times (once per
+# boot). Fails fast if the container exits or crash-loops (the #1350 signature).
+# The wrapper only reaches that line after the REAL server is up and the pgAudit
+# verification query succeeds, so it is the authoritative "healthy boot" signal.
+wait_for_verified() {
+  local container="$1" want="$2" timeout="$3" i status
+  for ((i = 1; i <= timeout; i++)); do
+    status="$(status_of "$container")"
+    if [[ "$status" == "exited" || "$status" == "restarting" ]]; then
+      fail "$container" "container entered '$status' during init (curia#1350 regression)"
+    fi
+    if [ "$(verified_count "$container")" -ge "$want" ]; then return 0; fi
+    sleep 1
+  done
+  fail "$container" "wrapper did not report 'pgAudit verification passed' x$want within ${timeout}s (curia#1350)"
+}
+
+# assert_pgaudit <container>: curia reachable, pgAudit loaded, audit role present.
+assert_pgaudit() {
+  local container="$1"
+  if ! docker exec "$container" psql -U curia -d curia -tAc 'select 1' >/dev/null 2>&1; then
+    fail "$container" "curia database not reachable"
+  fi
+  if ! docker exec "$container" psql -U curia -d curia -tAc "select current_setting('pgaudit.log', true)" | grep -q .; then
+    fail "$container" "pgAudit not loaded (pgaudit.log GUC absent)"
+  fi
+  if ! docker exec "$container" psql -U curia -d curia -tAc "select 1 from pg_roles where rolname='pgaudit_role'" | grep -q 1; then
+    fail "$container" "pgaudit_role missing"
+  fi
+}
+
+echo "==> Building curia-postgres image (context: repo root)..."
+docker build -f "$REPO_ROOT/docker/postgres.Dockerfile" -t "$IMAGE" "$REPO_ROOT" >/dev/null
+
+echo "==> [fresh volume] booting $FRESH_ITERS times (init is a timing race in the buggy build)..."
+for ((n = 1; n <= FRESH_ITERS; n++)); do
+  container="curia-pg-inittest-$$-$n"
+  volume="curia-pg-inittest-vol-$$-$n"
+  CONTAINERS+=("$container"); VOLUMES+=("$volume")
+  docker run -d --name "$container" -v "$volume:/var/lib/postgresql/data" \
+    -e POSTGRES_DB=curia -e POSTGRES_USER=curia -e POSTGRES_PASSWORD=inittest \
+    "$IMAGE" "${PGAUDIT_CMD[@]}" >/dev/null
+  wait_for_verified "$container" 1 60
+  assert_pgaudit "$container"
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  docker volume rm "$volume" >/dev/null 2>&1 || true
+  pass "fresh init #$n: curia created, pgAudit loaded, verification passed"
+done
+
+echo "==> [existing volume] restart must re-run verification and stay healthy..."
+container="curia-pg-existing-$$"
+volume="curia-pg-existing-vol-$$"
+CONTAINERS+=("$container"); VOLUMES+=("$volume")
+docker run -d --name "$container" -v "$volume:/var/lib/postgresql/data" \
+  -e POSTGRES_DB=curia -e POSTGRES_USER=curia -e POSTGRES_PASSWORD=inittest \
+  "$IMAGE" "${PGAUDIT_CMD[@]}" >/dev/null
+wait_for_verified "$container" 1 60
+assert_pgaudit "$container"
+docker restart "$container" >/dev/null            # boot onto the now-initialized volume (init skipped)
+wait_for_verified "$container" 2 45               # verification must run again after restart
+assert_pgaudit "$container"
+pass "existing volume: healthy after restart, pgAudit re-verified"
+
+echo "ALL POSTGRES IMAGE TESTS PASSED"


### PR DESCRIPTION
## Summary

Fixes #1350 — the published `curia-postgres` image crash-looped on a **fresh** data volume, so the `curia` database was never created and every fresh install broke (the `install.sh` operator quickstart, the `docker-compose.yml` quickstart, and any brand-new deploy from #1343 / epic #1281). Existing, already-initialized volumes — including production — were unaffected, which is why it shipped undetected.

## Root cause

The image's entrypoint, `docker/postgres-verify-pgaudit.sh`, backgrounds the stock Postgres `docker-entrypoint.sh` and probes for readiness before running its pgAudit verification. On a fresh volume the stock entrypoint first spins up a **temporary, socket-only** server (`listen_addresses=''`) to run `initdb`, `CREATE DATABASE curia`, and the initdb.d scripts, then stops it and starts the real server.

The old probe used the local **socket** (`pg_isready -U curia` / `psql`), which latched onto that temporary server. That broke init two ways: it raced `CREATE DATABASE` (connecting to a DB that doesn't exist yet), and its connections interfered with the temp server's shutdown so the real server never started — leaving the container dead mid-init with `curia` uncreated. It's a timing race, so it failed a fraction of the time on first init and then permanently bricked the volume (a populated data dir skips init forever).

## The fix

`docker/postgres-verify-pgaudit.sh` now probes the **real server over TCP** (`-h 127.0.0.1`). The temporary init server is socket-only, so a TCP probe:
- only succeeds once the real server is up — by which point `initdb` has finished and `curia` exists, and
- never touches the temp server, so it can't interfere with its shutdown.

`pg_isready` only pings (no auth), so no password is needed for the probe; the subsequent pgAudit verification uses the local socket (trust auth), which is up on the real server by then. The readiness timeout is bumped 30s → 60s for headroom.

Also restores `CMD ["postgres"]` in `docker/postgres.Dockerfile`: setting `ENTRYPOINT` had reset the base image's default `CMD` to null, so the image was only runnable because the compose files always pass an explicit `command:`.

## Testing

- **New regression test** `tests/docker/test-postgres-init.sh` (+ `pnpm test:postgres-image`): builds the real image and boots it on fresh volumes **5×** (the buggy failure is a timing race, so it loops to expose a regression reliably) using the exact compose pgAudit command, then covers the existing-volume restart path. Verified **red on the buggy code** (caught the crash within a few iterations) and **deterministically green on the fix** (5/5 fresh inits + restart).
- **New CI job** `postgres-image` in `ci.yml`: CI's `postgres` service uses the stock `pgvector` image, so the custom image was never exercised on PRs — which is exactly how #1350 shipped. This job builds and boots the real image on every PR.
- **Full-stack manual smoke** (isolated throwaway project): fixed postgres → 71 migrations → vault seed/verify → curia core `:edge` boots healthy, `GET /api/health` → `{"status":"ok","checks":{"db":"ok",...}}`.

## Impact / scope

- Unblocks every fresh install of the self-host packaging (epic #1281). Existing volumes (incl. production) were never affected and remain unaffected.
- Change is confined to the postgres image entrypoint + Dockerfile, plus test/CI. No application code.
- The `:edge` `curia-postgres` image needs a rebuild (a normal `main` push after merge) before a fresh deploy can rely on it.
