### PR TITLE
fix: scope docker-publish GITHUB_TOKEN to build job (Scorecard #197)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,10 +14,12 @@ on:
         description: "Release tag to (re)publish, e.g. v0.40.0"
         required: false
 
+# Least privilege at the workflow level; jobs opt into the scopes they need
+# (mirrors release.yml). Only the `build` job touches GHCR / OIDC, so the
+# `packages: write` + `id-token: write` scopes live there, not here — the
+# `guard` job (which only validates a tag string) never receives them.
 permissions:
   contents: read
-  packages: write
-  id-token: write   # keyless cosign via GitHub OIDC
 
 env:
   REGISTRY: ghcr.io
@@ -44,6 +46,10 @@ jobs:
   build:
     needs: guard
     runs-on: ubuntu-latest
+    permissions:
+      contents: read    # actions/checkout
+      packages: write   # push + sign images in GHCR
+      id-token: write   # keyless cosign via GitHub OIDC
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **`docker-publish.yml` least-privilege token** — `packages:write`/`id-token:write` scoped to the `build` job. Clears alert #197.
 - **Ant Farm asset route hardening** — `/api/antfarm/assets/*` now serves a strict content-type allowlist (png/json only, 404 otherwise) and sets `X-Content-Type-Options: nosniff`, closing the MIME-sniffing/XSS class on direct file streaming. (#1335)
 - **Outbound filter** — Stage 1 fixes a signature false-positive, derives prompt-exfiltration markers from the live coordinator prompt (whitespace/markdown-robust) instead of hardcoded phrases, and adds a principal-recipient bypass for identity/structure rules. Closes #1334.
 


### PR DESCRIPTION
## Summary

Fixes Scorecard **Token-Permissions** code-scanning alert #197 (HIGH): `docker-publish.yml` granted `packages: write` and `id-token: write` at the **workflow top level**, so every job — including the `guard` job that only validates a tag string — received registry-write and OIDC scopes.

This moves both write scopes down to the `build` job (the only job that logs into GHCR, pushes images, and cosign-signs them), leaving `contents: read` at the top level. It mirrors the least-privilege pattern `release.yml` already uses and documents ("least privilege at the workflow level; jobs opt into the scopes they need").

## Why this is safe

- `build` is the only job that touches GHCR / OIDC — it keeps exactly the scopes it needs (`contents: read` for checkout, `packages: write` for push+sign, `id-token: write` for keyless cosign).
- `guard` already declares its own `contents: read` and needs nothing more.

## Bonus

Scorecard's Token-Permissions score is repo-wide, so removing this top-level write may also lift alert #196 (`release.yml` job-level `contents: write`) on the next Scorecard run — that finding only surfaces while the overall score sits at 0.

## Testing

- YAML validated (`yaml.safe_load`).
- Scope change only; no build-step or logic changes.