### PR TITLE
docs: backup-before-update step for the auto-migrating update path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Ant Farm AF-5** — Phaser `OfficeScene` rendering all AF-3 directive metaphors, React-DOM detail overlays (pause on open), deterministic per-agent character variants, CC0 placeholder art + LimeZu credits. Closes #1318.
 - **Ant Farm AF-6** — Docker image builds both SPAs; `antfarm-static` route serves `/antfarm/*` before the console wildcard. Closes #1319.
 - **Ant Farm real art** — the office renders licensed LimeZu tiles/furniture and animated premade character sprites when present, served only behind session auth (`/api/antfarm/assets/*`); falls back to procedural placeholders when absent. (#1335)
+- **Backup-before-update docs** — README now documents a pg_dump backup + rollback step for the auto-migrating update path. Closes #1344.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,25 @@ Replace `<vX.Y.Z>` with the latest release tag (check [releases](https://github.
 
 Save the bootstrap secret to a password manager and use it on the login page to create your account.
 
-**To update:** `docker compose pull && docker compose up -d`
+**To update:** Back up your database first, then pull and restart. Migrations apply
+automatically on boot; re-running when already up to date is a safe no-op.
+
+```bash
+# 1. Back up the database (custom-format dump, restorable with pg_restore)
+docker compose exec -T postgres pg_dump -U curia -Fc curia > curia-backup-$(date +%Y%m%d).dump
+
+# 2. Pull new images and restart — the app migrates the schema on startup
+docker compose pull && docker compose up -d
+```
+
+If an update misbehaves, restore the backup: stop the app, restore in place
+(`--clean --if-exists` drops and recreates objects), then bring the stack back up.
+
+```bash
+docker compose stop curia
+docker compose exec -T postgres pg_restore -U curia -d curia --clean --if-exists < curia-backup-YYYYMMDD.dump
+docker compose up -d
+```
 
 ### Developer install (source)
 


### PR DESCRIPTION
## Summary

Closes #1344.

Item 2 of the self-host epic (#1281) asked for auto-migrate-on-boot, idempotently, with a documented backup step. The migrate mechanism was **already shipped** — `src/index.ts` runs `node-pg-migrate` `up` on every startup under an advisory lock, skipping already-applied migrations (confirmed live during the recent prod cutover: 70→70, clean no-op). So acceptance criteria 1 and 2 (unattended schema-changing update; idempotent re-run) were already met.

The one gap was criterion 3: **the docs didn't pair the update flow with a backup step.** The README simply said `docker compose pull && docker compose up -d`.

## Changes

- **`README.md`** — the update section now walks through a `pg_dump -Fc` backup, the pull/restart flow (noting migrations are automatic and idempotent), and a `pg_restore --clean --if-exists` in-place rollback.
- **`CHANGELOG.md`** — one `Added` bullet under `[Unreleased]`.

Docs-only; no code changed. A companion PR adds a matching "Updating Curia" section to curia-docs.

## Acceptance criteria

- [x] `docker compose pull && docker compose up -d` across a schema-changing bump migrates unattended — already true (boot-time runner).
- [x] Running it twice is idempotent — already true (node-pg-migrate skip + advisory lock).
- [x] Docs include a backup-before-update step — added here.
