### PR TITLE
fix: resolve code-scanning alerts #200-202 (Dockerfile USER suppression + CodeQL rate-limit false positives)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,6 +9,19 @@ paths-ignore:
 # invariant, so every instance is a false positive. Inline suppression comments
 # (// codeql[...]) were tried but ignored by the analyzer. Disabling the query
 # avoids permanent whack-a-mole with new alert numbers on every scan.
+#
+# js/missing-rate-limiting flags our Fastify file-serving routes (e.g.
+# antfarm-assets, antfarm-static) as un-rate-limited. They are NOT: @fastify/rate-limit
+# is registered globally at src/channels/http/http-adapter.ts (max 200/min per IP),
+# and root-level Fastify hooks propagate to every child route context. CodeQL's
+# query only models Express-family limiters (express-rate-limit/brute/limiter) — its
+# Fastify framework model (Fastify.qll) has NO rate-limit modeling at all, so it can
+# never recognize @fastify/rate-limit in any form (global or per-route config). This
+# repo is Fastify-only, so every alert this query raises here is a false positive by
+# construction and no code change can clear it. Disable it rather than dismiss each
+# new fs/db-accessing route's alert one by one.
 query-filters:
   - exclude:
       id: js/incomplete-multi-character-sanitization
+  - exclude:
+      id: js/missing-rate-limiting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
-- **`postgres.Dockerfile` missing-USER suppression** — corrected the ineffective `nosemgrep` (wrong rule id and line) so the intentional root-then-gosu design no longer trips Semgrep's `missing-user-entrypoint` rule. (alert #200)
+- **`postgres.Dockerfile` missing-USER suppression** — fix the ineffective `nosemgrep` so the intentional root-then-gosu design stops tripping Semgrep. (alert #200)
+- **CodeQL `js/missing-rate-limiting` false positives** — excluded the query; it cannot model `@fastify/rate-limit`, which already covers all routes globally. (alerts #201, #202)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Ant Farm real art** — the office renders licensed LimeZu tiles/furniture and animated premade character sprites when present, served only behind session auth (`/api/antfarm/assets/*`); falls back to procedural placeholders when absent. (#1335)
 - **Backup-before-update docs** — README now documents a pg_dump backup + rollback step for the auto-migrating update path. Closes #1344.
 
+### Security
+
+- **`postgres.Dockerfile` missing-USER suppression** — corrected the ineffective `nosemgrep` (wrong rule id and line) so the intentional root-then-gosu design no longer trips Semgrep's `missing-user-entrypoint` rule. (alert #200)
+
 ### Fixed
 
 - **`curia-postgres` fresh-init** — probe the real server over TCP so fresh volumes create `curia` instead of crash-looping. (#1350)

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -28,6 +28,13 @@ COPY docker/postgres-init-pgaudit.sql /docker-entrypoint-initdb.d/10-pgaudit.sql
 # never start Postgres. Restore the default. When the compose files provide their
 # own `command:` (which starts with `postgres`), it replaces this CMD entirely and
 # the wrapper receives `postgres -c ...` either way.
+#
+# The missing-USER finding anchors on this ENTRYPOINT line, so its suppression must
+# live here (Semgrep only honours nosemgrep on the finding's own line or the line
+# directly above). This is the intentional-root case justified below: the server
+# drops to non-root `postgres` via gosu at runtime. Note the *entrypoint* rule id —
+# distinct from the CMD-anchored `missing-user` variant suppressed further down.
+# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
 ENTRYPOINT ["verify-pgaudit.sh"]
 # No `USER` instruction is intentional. The Postgres entrypoint must start as root
 # to run initdb and chown a fresh (root-owned) data volume on first boot, then it


### PR DESCRIPTION
## Summary

Resolves three open GitHub code-scanning alerts (#200, #201, #202). All three are false positives on intentional, already-correct designs; this PR makes the scanners agree.

### Alert #200 — `docker/postgres.Dockerfile` missing `USER` (Semgrep `missing-user-entrypoint`)

The no-`USER` design is intentional and correct: the Postgres entrypoint must start as root to `initdb`/chown a fresh volume on first boot, then drops to the non-root `postgres` user via `gosu` (this is the #1350 case). A `nosemgrep` suppression already existed but was **ineffective two ways**:

1. **Wrong rule id** — it named `dockerfile.security.missing-user.missing-user` (the CMD-anchored variant), but the firing rule is `dockerfile.security.missing-user-entrypoint.missing-user-entrypoint`.
2. **Wrong line** — it sat on the CMD line, but the finding anchors on the `ENTRYPOINT`. Semgrep only honours `nosemgrep` on the finding's own line or the line directly above.

Fix: added a correctly-targeted, documented `nosemgrep` on the line directly above `ENTRYPOINT`. **Verified** with `semgrep --config p/owasp-top-ten` (the ruleset that fires it): 1 finding before, 0 after.

### Alerts #201 / #202 — CodeQL `js/missing-rate-limiting` on `antfarm-assets` / `antfarm-static`

These routes **are** rate-limited: `@fastify/rate-limit` (`^11.1.0`) is registered globally in `src/channels/http/http-adapter.ts` (`max: 200 / 1 min` per IP) **before** all route registration, and root-level Fastify hooks propagate to every child route context.

CodeQL cannot see this: its Fastify framework model (`Fastify.qll`) has **no** rate-limit modeling, and `js/missing-rate-limiting` only recognizes Express-family limiters (express-rate-limit/brute/limiter). So no code change can ever clear these alerts, and since the app is Fastify-only, every alert this query raises here is a false positive by construction.

Fix: excluded the query in `.github/codeql/codeql-config.yml`, matching the existing precedent for `js/incomplete-multi-character-sanitization`. Chosen over dismissing #201/#202 individually to avoid whack-a-mole on every future fs/db-accessing route.

**Trade-off (called out):** excluding the query repo-wide means CodeQL would no longer flag a *future* route that explicitly opts out of the global limiter (`global: false`) with no replacement. Acceptable because the global limiter is default-on for all routes, and CodeQL could never flag a real Fastify gap anyway (it doesn't model the limiter) — it would only emit noise.

## Review

Pre-PR code review + an adversarial security review both ran. Security review independently verified (a) the postgres container demonstrably runs non-root at runtime via `gosu`, and (b) the antfarm routes are genuinely covered by the global limiter (no `global: false` opt-outs). Both suppressions ruled LEGITIMATE. Code-review's one actionable item (a CHANGELOG entry over the 15-word cap) was fixed.

## Notes

- No behaviour change — config and comments only (Dockerfile comment, CodeQL config, CHANGELOG).
- No `Closes #N`: these are code-scanning alerts, not tracked issues.