### PR TITLE
fix(antfarm): generic timeline 500 body and heartbeat client cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Ant Farm routes** — timeline 500s return a generic message; SSE heartbeat evicts dead clients. Closes #1365.
 - **`curia-postgres` fresh-init** — probe the real server over TCP so fresh volumes create `curia` instead of crash-looping. (#1350)
 - **CI Node version drift** — `ci.yml` and `dast.yml` now read `node-version-file: .nvmrc` instead of a hardcoded `"22"`, so CI runs on Node 24 in lockstep with `engines` (`>=24`) and the `node:24` Docker image. Previously CI validated on a version that did not satisfy the project's own engines constraint.
 - **Ant Farm** — code review follow-ups: fail-closed session check, conductor live/scrub fixes, incremental live merge, per-agent overlay context, timeline cursor paging, safe `busEventToAuditRow` payload guard, `schedule.fired` task_id normalization.

--- a/src/channels/http/routes/antfarm.ts
+++ b/src/channels/http/routes/antfarm.ts
@@ -126,8 +126,7 @@ export async function antfarmRoutes(
       });
     } catch (err) {
       logger.error({ err }, 'antfarm timeline query failed');
-      const message = err instanceof Error ? err.message : 'Failed to load timeline';
-      return reply.status(500).send({ error: message });
+      return reply.status(500).send({ error: 'Failed to load timeline' });
     }
   });
 
@@ -150,6 +149,7 @@ export async function antfarmRoutes(
         reply.raw.write(':ping\n\n');
       } catch {
         clearInterval(heartbeat);
+        cleanup();
       }
     }, 30000);
 

--- a/src/channels/http/routes/antfarm.ts
+++ b/src/channels/http/routes/antfarm.ts
@@ -147,7 +147,8 @@ export async function antfarmRoutes(
     const heartbeat = setInterval(() => {
       try {
         reply.raw.write(':ping\n\n');
-      } catch {
+      } catch (err) {
+        logger.warn({ err }, 'Ant Farm SSE heartbeat write failed — removing client');
         clearInterval(heartbeat);
         cleanup();
       }

--- a/tests/unit/channels/http/antfarm-routes.test.ts
+++ b/tests/unit/channels/http/antfarm-routes.test.ts
@@ -73,6 +73,7 @@ describe('antfarm routes', () => {
 
     it('removes the antfarm client when a heartbeat write fails', async () => {
       const cleanup = vi.fn();
+      const logger = createLogger();
       const eventRouter = {
         addAntfarmClient: vi.fn().mockImplementation((client: { res: { write: (...args: unknown[]) => boolean } }) => {
           const originalWrite = client.res.write.bind(client.res);
@@ -92,7 +93,7 @@ describe('antfarm routes', () => {
         eventRouter,
         webAppBootstrapSecret: TEST_SECRET,
         sessions: new Map(),
-        logger: createLogger(),
+        logger,
       });
       await app.ready();
       await app.listen({ port: 0, host: '127.0.0.1' });
@@ -117,6 +118,10 @@ describe('antfarm routes', () => {
 
       vi.advanceTimersByTime(30000);
       expect(cleanup).toHaveBeenCalledOnce();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        'Ant Farm SSE heartbeat write failed — removing client',
+      );
 
       await app.close();
     });

--- a/tests/unit/channels/http/antfarm-routes.test.ts
+++ b/tests/unit/channels/http/antfarm-routes.test.ts
@@ -1,0 +1,124 @@
+// Unit tests for Ant Farm HTTP routes — error sanitization and SSE client cleanup.
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import Fastify from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { antfarmRoutes } from '../../../../src/channels/http/routes/antfarm.js';
+import type { AuditLogRepo } from '../../../../src/audit/audit-log-repo.js';
+import type { EventRouter } from '../../../../src/channels/http/event-router.js';
+import type { Logger } from '../../../../src/logger.js';
+
+const TEST_SECRET = 'test-antfarm-secret';
+const AUTH_HEADER = { 'x-web-bootstrap-secret': TEST_SECRET };
+
+function createLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+}
+
+describe('antfarm routes', () => {
+  describe('GET /api/antfarm/timeline', () => {
+    it('returns a generic 500 body when the timeline query fails', async () => {
+      const sensitiveMessage = 'relation "audit_log" does not exist at character 42';
+      const auditLogRepo = {
+        findTimeline: vi.fn().mockRejectedValue(new Error(sensitiveMessage)),
+      } as unknown as AuditLogRepo;
+      const logger = createLogger();
+      const app = Fastify();
+
+      await app.register(antfarmRoutes, {
+        auditLogRepo,
+        eventRouter: { addAntfarmClient: vi.fn().mockReturnValue(() => {}) } as unknown as EventRouter,
+        webAppBootstrapSecret: TEST_SECRET,
+        sessions: new Map(),
+        logger,
+      });
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/antfarm/timeline?conversationId=conv-1',
+        headers: AUTH_HEADER,
+      });
+
+      expect(res.statusCode).toBe(500);
+      const body = JSON.parse(res.body) as { error: string };
+      expect(body.error).toBe('Failed to load timeline');
+      expect(body.error).not.toContain('audit_log');
+      expect(body.error).not.toContain('character 42');
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        'antfarm timeline query failed',
+      );
+
+      await app.close();
+    });
+  });
+
+  describe('GET /api/antfarm/stream heartbeat', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('removes the antfarm client when a heartbeat write fails', async () => {
+      const cleanup = vi.fn();
+      const eventRouter = {
+        addAntfarmClient: vi.fn().mockImplementation((client: { res: { write: (...args: unknown[]) => boolean } }) => {
+          const originalWrite = client.res.write.bind(client.res);
+          vi.spyOn(client.res, 'write').mockImplementation((chunk: unknown, ...args: unknown[]) => {
+            if (typeof chunk === 'string' && chunk.startsWith(':ping')) {
+              throw new Error('broken pipe');
+            }
+            return originalWrite(chunk, ...args);
+          });
+          return cleanup;
+        }),
+      } as unknown as EventRouter;
+      const app = Fastify();
+
+      await app.register(antfarmRoutes, {
+        auditLogRepo: { findTimeline: vi.fn() } as unknown as AuditLogRepo,
+        eventRouter,
+        webAppBootstrapSecret: TEST_SECRET,
+        sessions: new Map(),
+        logger: createLogger(),
+      });
+      await app.ready();
+      await app.listen({ port: 0, host: '127.0.0.1' });
+
+      const addr = app.server.address() as AddressInfo;
+      const connected = new Promise<void>((resolve) => {
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port: addr.port,
+            path: '/api/antfarm/stream',
+            headers: AUTH_HEADER,
+          },
+          () => resolve(),
+        );
+        req.on('error', () => resolve());
+        req.end();
+      });
+
+      await connected;
+      expect(eventRouter.addAntfarmClient).toHaveBeenCalledOnce();
+
+      vi.advanceTimersByTime(30000);
+      expect(cleanup).toHaveBeenCalledOnce();
+
+      await app.close();
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1365

Two small defects in `src/channels/http/routes/antfarm.ts`, flagged during the v0.40 pre-release scans:

1. **`/api/antfarm/timeline`** — 500 responses no longer echo raw `err.message` (Postgres/driver text). The handler logs the full error server-side and returns a fixed `{ error: 'Failed to load timeline' }` body, matching the pattern used elsewhere (e.g. KG routes).

2. **`/api/antfarm/stream` heartbeat** — when a heartbeat `write` fails, the handler now calls `cleanup()` in addition to `clearInterval`, so the dead client is removed from `EventRouter.antfarmClients` immediately (consistent with `broadcastToAntfarm` eviction). Heartbeat write failures are logged at `warn` before eviction.

## Tests

- Unit test confirms timeline 500 body is generic and does not contain DB/driver internals; verifies `logger.error` still receives the real error.
- Unit test confirms heartbeat write failure triggers `cleanup()` and `logger.warn` via mocked `addAntfarmClient` + fake timers.

Success paths unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37882b8d-ad1f-4fe0-92b2-0d3b554b2858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37882b8d-ad1f-4fe0-92b2-0d3b554b2858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

