### PR TITLE
chore: add p/dockerfile ruleset to Semgrep CI scan

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,7 @@ jobs:
             --config p/owasp-top-ten \
             --config p/command-injection \
             --config p/secrets \
+            --config p/dockerfile \
             --metrics=off \
             --sarif \
             --output semgrep.sarif \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **Semgrep Dockerfile scanning** — `semgrep.yml` adds `p/dockerfile` so Dockerfile findings surface and auto-close in CI.
 - **`postgres.Dockerfile` missing-USER suppression** — fix the ineffective `nosemgrep` so the intentional root-then-gosu design stops tripping Semgrep. (alert #200)
 - **CodeQL `js/missing-rate-limiting` false positives** — excluded the query; it cannot model `@fastify/rate-limit`, which already covers all routes globally. (alerts #201, #202)
 


### PR DESCRIPTION
## Summary

`semgrep.yml` scanned only `p/typescript`, `p/nodejs`, `p/owasp-top-ten`, `p/command-injection`, and `p/secrets` — **no Dockerfile ruleset**. So the `missing-user` Dockerfile findings (e.g. `postgres.Dockerfile` alert #200) originated from out-of-band Semgrep runs and could never be re-evaluated or auto-closed by committed CI. They lingered open indefinitely even after the in-code `nosemgrep` fix.

This adds `--config p/dockerfile` so CI is the authoritative source for Dockerfile findings — they surface *and* auto-close on push/PR like every other Semgrep rule.

## Verification

Ran `semgrep --config p/dockerfile` over the whole repo: **0 findings** across all targets. The app `Dockerfile` runs as a non-root `curia` user and `postgres.Dockerfile` is suppressed in place (intentional root-then-gosu init), so this is purely additive and introduces no new alerts.

Follow-up from the v0.40 pre-release security-gate triage (which surfaced the orphaned #200).