### PR TITLE
feat(install): unify installer version selection under one CURIA_VERSION knob

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,11 @@ HTTP_PORT=3000
 
 # Published image tags (Docker Compose pulls these). Pin to a vX.Y.Z for a
 # stable self-host; `latest` tracks the newest release, `edge` the newest main.
+# On a fresh install, install.sh sets CURIA_IMAGE_TAG from CURIA_VERSION so the
+# app image matches the release its config came from.
 CURIA_IMAGE_TAG=latest
+# CURIA_POSTGRES_TAG is a SEPARATE axis, keyed to the Postgres major (pg16) — the
+# curia-postgres image publishes no vX.Y.Z tags, so it is not driven by CURIA_VERSION.
 CURIA_POSTGRES_TAG=pg16
 
 # Public domain for automatic HTTPS. Only used with the TLS overlay (below).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release Artifacts
 # Builds, signs, and attaches release artifacts on every published release:
 #   - sbom.spdx.json            (SPDX SBOM for the release commit)
 #   - curia-<tag>.tar.gz        (reproducible source tarball)
+#   - the operator install bundle (install.sh, docker-compose.yml,
+#     docker-compose.tls.yml, .env.example, Caddyfile, setup-common.sh) so
+#     install.sh can fetch a release's config from releases/<ref>/download/
+#   - SHA256SUMS + SHA256SUMS.sigstore (one signed manifest over the bundle)
 #   - *.sigstore                (cosign keyless signature bundle per artifact)
 #
 # Signing is keyless via Sigstore + the GitHub OIDC token (id-token: write) —
@@ -128,6 +132,30 @@ jobs:
             exit 1
           fi
 
+      # Stage the operator install bundle with FLAT asset names — GitHub release
+      # assets cannot contain "/", so deploy/Caddyfile and scripts/setup-common.sh
+      # are flattened (install.sh maps them back to their paths). SHA256SUMS is a
+      # single manifest an operator can verify from one cosign signature, then
+      # `sha256sum -c` the whole bundle — cheaper than a signature per file.
+      - name: Stage install bundle
+        run: |
+          rm -rf bundle && mkdir bundle
+          cp install.sh                bundle/install.sh
+          cp docker-compose.yml        bundle/docker-compose.yml
+          cp docker-compose.tls.yml    bundle/docker-compose.tls.yml
+          cp .env.example              bundle/.env.example
+          cp deploy/Caddyfile          bundle/Caddyfile          # flatten dir
+          cp scripts/setup-common.sh   bundle/setup-common.sh    # flatten dir
+          for f in install.sh docker-compose.yml docker-compose.tls.yml .env.example Caddyfile setup-common.sh; do
+            if [ ! -s "bundle/$f" ]; then
+              echo "::error::bundle/$f is missing or empty" >&2
+              exit 1
+            fi
+          done
+          ( cd bundle && sha256sum \
+              install.sh docker-compose.yml docker-compose.tls.yml \
+              .env.example Caddyfile setup-common.sh > SHA256SUMS )
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -137,12 +165,17 @@ jobs:
         run: |
           cosign sign-blob --yes --bundle sbom.spdx.json.sigstore sbom.spdx.json
           cosign sign-blob --yes --bundle "curia-${TAG}.tar.gz.sigstore" "curia-${TAG}.tar.gz"
+          # One signature covers the whole install bundle via the manifest.
+          cosign sign-blob --yes --bundle bundle/SHA256SUMS.sigstore bundle/SHA256SUMS
 
       - name: Attach artifacts to release
         run: |
           gh release upload "$TAG" \
             sbom.spdx.json sbom.spdx.json.sigstore \
             "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore" \
+            bundle/install.sh bundle/docker-compose.yml bundle/docker-compose.tls.yml \
+            bundle/.env.example bundle/Caddyfile bundle/setup-common.sh \
+            bundle/SHA256SUMS bundle/SHA256SUMS.sigstore \
             --clobber
 
       # Final gate: re-download the assets FROM the release and verify the
@@ -155,11 +188,15 @@ jobs:
       - name: Verify attached + signed
         run: |
           rm -rf verify && mkdir verify
-          # We attach exactly 4 assets, well within one API page; `gh release
+          # We attach exactly 12 assets, well within one API page; `gh release
           # download` with no --pattern pulls them all. (If a release ever grows
           # past one page of assets, switch to per-name --pattern fetches.)
           gh release download "$TAG" --dir verify --clobber
-          for f in sbom.spdx.json sbom.spdx.json.sigstore "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore"; do
+          for f in sbom.spdx.json sbom.spdx.json.sigstore \
+                   "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore" \
+                   install.sh docker-compose.yml docker-compose.tls.yml \
+                   .env.example Caddyfile setup-common.sh \
+                   SHA256SUMS SHA256SUMS.sigstore; do
             if [ ! -s "verify/$f" ]; then
               echo "::error::expected release asset '$f' is missing from $TAG" >&2
               exit 1
@@ -179,3 +216,11 @@ jobs:
             --certificate-identity-regexp "$IDENTITY_REGEXP" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             "verify/curia-${TAG}.tar.gz"
+          # Verify the install bundle: the manifest signature is authentic, and
+          # every downloaded bundle file matches the signed manifest.
+          cosign verify-blob \
+            --bundle verify/SHA256SUMS.sigstore \
+            --certificate-identity-regexp "$IDENTITY_REGEXP" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            verify/SHA256SUMS
+          ( cd verify && sha256sum -c SHA256SUMS )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **`install.sh` version** — one `CURIA_VERSION` knob (default `latest`) selects config files and image from the same release.
+- **Release assets** — each release now ships a signed `install.sh` + config bundle (`SHA256SUMS`).
+
 ## [0.40.0] — 2026-07-09 — "The Watcher"
 
 > **The Watcher (Uatu)** *(Marvel Comics, 1963, Stan Lee & Jack Kirby)* — a cosmic observer who witnesses and records every event in his domain, sworn never to interfere. This release gives Curia its own watcher: Ant Farm, a read-only pixel-art office that replays the audit log as living animation and never touches the work it depicts.

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,13 @@
 #
 # Usage:
 #   # Download first, then review, then run:
-#   curl -fsSL https://raw.githubusercontent.com/josephfung/curia/main/install.sh -o install.sh
+#   curl -fsSL https://github.com/josephfung/curia/releases/latest/download/install.sh -o install.sh
 #   bash install.sh
+#
+#   # Pin a specific release (config files AND image both come from it):
+#   CURIA_VERSION=v0.41.0 bash install.sh
+#   # Track the bleeding edge (main-branch config + :edge image; advanced/testing):
+#   CURIA_VERSION=edge bash install.sh
 #
 # Note: piping curl directly to bash (curl … | bash) does NOT work — this
 # script uses interactive `read` prompts that require a real TTY, not piped
@@ -16,8 +21,8 @@
 #
 # What this script does:
 #   1. Checks for Docker + compose + curl.
-#   2. Fetches docker-compose.yml, the TLS overlay, .env.example, and the
-#      Caddyfile next to install.sh (if not already present).
+#   2. Fetches the matching release's docker-compose.yml, TLS overlay,
+#      .env.example, and Caddyfile next to install.sh (if not already present).
 #   3. Creates .env from the example, generating secrets for any placeholder values.
 #   4. Prompts for an Anthropic API key (format-validated, 3 retries).
 #   5. Asks about deployment topology (local / public HTTPS / behind-proxy).
@@ -34,17 +39,95 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# The Git ref (tag or branch) this installer was downloaded from. Bumped at
-# release time so that installs fetch matching compose files.
-CURIA_REF="${CURIA_REF:-main}"
-RAW_BASE="https://raw.githubusercontent.com/josephfung/curia/${CURIA_REF}"
+# CURIA_VERSION selects a release. From it we derive BOTH where the config files
+# come from AND which app image tag is written to .env — so config and image
+# always come from the same release (no per-release edits to this script).
+#   latest  (default) -> newest release assets       + image tag "latest"
+#   vX.Y.Z / X.Y.Z    -> that release's assets        + image tag "vX.Y.Z"
+#   edge              -> config from raw main branch  + image tag "edge"
+# Advanced override: CURIA_REF=<git-ref> forces the raw path for the config
+# fetch (does NOT set an image tag; .env.example's default applies).
+CURIA_VERSION="${CURIA_VERSION:-latest}"
+
+GH_RELEASES="https://github.com/josephfung/curia/releases"
+RAW_REPO="https://raw.githubusercontent.com/josephfung/curia"
+
+# Populated by resolve_version. Declared up-front for `set -u` safety.
+ASSET_MODE=""               # "release" (flat asset names) | "raw" (repo paths)
+ASSET_BASE=""               # release-asset base URL (release mode)
+RAW_BASE=""                 # raw repo base URL (raw mode)
+CURIA_IMAGE_TAG_RESOLVED="" # image tag to write on fresh install ("" = leave .env.example default)
+
+# Map CURIA_VERSION (and the CURIA_REF override) onto the config source + image
+# tag. Pure string logic — runs before setup-common.sh is sourced, so it must
+# not use the error/hint helpers; it prints its own errors inline.
+resolve_version() {
+  # Advanced escape hatch: an explicit CURIA_REF wins and forces raw mode.
+  if [[ -n "${CURIA_REF:-}" ]]; then
+    ASSET_MODE="raw"
+    RAW_BASE="${RAW_REPO}/${CURIA_REF}"
+    CURIA_IMAGE_TAG_RESOLVED=""
+    return 0
+  fi
+
+  local v="$CURIA_VERSION"
+  case "$v" in
+    latest)
+      ASSET_MODE="release"
+      ASSET_BASE="${GH_RELEASES}/latest/download"
+      CURIA_IMAGE_TAG_RESOLVED="latest"
+      ;;
+    edge)
+      ASSET_MODE="raw"
+      RAW_BASE="${RAW_REPO}/main"
+      CURIA_IMAGE_TAG_RESOLVED="edge"
+      ;;
+    v[0-9]*|[0-9]*)
+      # Normalize a bare "0.41.0" to "v0.41.0".
+      case "$v" in v*) ;; *) v="v$v" ;; esac
+      # Validate the tag shape (same regex the release workflow enforces).
+      if ! printf '%s' "$v" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$'; then
+        printf 'error: invalid CURIA_VERSION: %s\n' "$CURIA_VERSION" >&2
+        printf 'hint:  use "latest", "edge", or a release tag like v0.41.0 (see %s)\n' "$GH_RELEASES" >&2
+        exit 1
+      fi
+      ASSET_MODE="release"
+      ASSET_BASE="${GH_RELEASES}/download/${v}"
+      CURIA_IMAGE_TAG_RESOLVED="$v"
+      ;;
+    *)
+      printf 'error: invalid CURIA_VERSION: %s\n' "$CURIA_VERSION" >&2
+      printf 'hint:  use "latest", "edge", or a release tag like v0.41.0\n' >&2
+      exit 1
+      ;;
+  esac
+}
+
+resolve_version
+
+# Fetch a bundled file, mapping its local path to the flat release-asset name in
+# release mode, or using the repo-relative path in raw mode.
+#   $1 = local path (e.g. scripts/setup-common.sh), $2 = flat asset name (e.g. setup-common.sh)
+fetch_asset() {
+  local local_path="$1" asset="$2"
+  if [[ "$ASSET_MODE" == "release" ]]; then
+    curl -fsSL "${ASSET_BASE}/${asset}" -o "$INSTALL_DIR/$local_path"
+  else
+    curl -fsSL "${RAW_BASE}/${local_path}" -o "$INSTALL_DIR/$local_path"
+  fi
+}
 
 # setup-common.sh may not be present when install.sh is fetched standalone.
-# Fetch it from the same ref if missing, then source it to get the shared output
-# helpers and wait_* functions.
+# Fetch it from the matching release/ref if missing, then source it to get the
+# shared output helpers and wait_* functions. NOTE: this runs before INSTALL_DIR
+# is set below, so it targets $SCRIPT_DIR directly rather than via fetch_asset.
 if [[ ! -f "$SCRIPT_DIR/scripts/setup-common.sh" ]]; then
   mkdir -p "$SCRIPT_DIR/scripts"
-  curl -fsSL "$RAW_BASE/scripts/setup-common.sh" -o "$SCRIPT_DIR/scripts/setup-common.sh"
+  if [[ "$ASSET_MODE" == "release" ]]; then
+    curl -fsSL "${ASSET_BASE}/setup-common.sh" -o "$SCRIPT_DIR/scripts/setup-common.sh"
+  else
+    curl -fsSL "${RAW_BASE}/scripts/setup-common.sh" -o "$SCRIPT_DIR/scripts/setup-common.sh"
+  fi
 fi
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/scripts/setup-common.sh"
@@ -139,12 +222,21 @@ check_prereqs() {
 # Caddyfile) into the install dir, skipping files that are already present.
 # This lets an operator re-run install.sh safely without clobbering hand-edits.
 fetch_bundle() {
-  local f
-  for f in docker-compose.yml docker-compose.tls.yml .env.example deploy/Caddyfile; do
-    if [[ ! -f "$INSTALL_DIR/$f" ]]; then
-      mkdir -p "$INSTALL_DIR/$(dirname "$f")"
-      info "Fetching $f ..."
-      curl -fsSL "$RAW_BASE/$f" -o "$INSTALL_DIR/$f"
+  # local-path : flat-release-asset-name. GitHub release assets cannot contain
+  # "/", so deploy/Caddyfile is published as the flat asset "Caddyfile"; the
+  # other three map 1:1. In raw mode the asset name is ignored (see fetch_asset).
+  local pair local_path asset
+  for pair in \
+    "docker-compose.yml:docker-compose.yml" \
+    "docker-compose.tls.yml:docker-compose.tls.yml" \
+    ".env.example:.env.example" \
+    "deploy/Caddyfile:Caddyfile"; do
+    local_path="${pair%%:*}"
+    asset="${pair#*:}"
+    if [[ ! -f "$INSTALL_DIR/$local_path" ]]; then
+      mkdir -p "$INSTALL_DIR/$(dirname "$local_path")"
+      info "Fetching $local_path ..."
+      fetch_asset "$local_path" "$asset"
     fi
   done
 }
@@ -205,6 +297,15 @@ fresh_install() {
   # block (pointing at the internal postgres hostname). This .env value is used
   # by the migration runner (docker compose run --rm curia), not by the app container.
   set_env_var "$env" DATABASE_URL "postgres://curia:${db_pass}@postgres:5432/curia"
+
+  # Pin the app image tag to the resolved CURIA_VERSION (latest / vX.Y.Z / edge),
+  # so the config files and the image both come from the same release. This runs
+  # only on fresh install, so a re-run never clobbers an operator's hand-pinned
+  # tag. CURIA_POSTGRES_TAG is intentionally left at its default (pg16) — the
+  # postgres image is versioned by PG major, not app version.
+  if [[ -n "$CURIA_IMAGE_TAG_RESOLVED" ]]; then
+    set_env_var "$env" CURIA_IMAGE_TAG "$CURIA_IMAGE_TAG_RESOLVED"
+  fi
 
   # Only generate a new encryption key if the current value is the template
   # placeholder or entirely absent/empty. A key that already exists must be

--- a/tests/setup/test-setup-functions.sh
+++ b/tests/setup/test-setup-functions.sh
@@ -496,6 +496,59 @@ fi
 
 rm -f "$_ic_env"
 
+# --- install.sh: resolve_version ---
+
+echo ""
+echo "=== install.sh: resolve_version ==="
+
+_assert_var() {
+    local desc="$1" got="$2" want="$3"
+    if [[ "$got" == "$want" ]]; then
+        echo "  ✓ $desc"; PASS=$((PASS+1))
+    else
+        echo "  ✗ $desc — got '$got' want '$want'"; FAIL=$((FAIL+1))
+    fi
+}
+
+# latest (default): release assets + image tag "latest".
+CURIA_REF=""; CURIA_VERSION="latest"; resolve_version
+_assert_var "latest → release mode" "$ASSET_MODE" "release"
+_assert_var "latest → latest/download base" "$ASSET_BASE" "https://github.com/josephfung/curia/releases/latest/download"
+_assert_var "latest → image tag latest" "$CURIA_IMAGE_TAG_RESOLVED" "latest"
+
+# vX.Y.Z: that release's assets + matching image tag.
+CURIA_REF=""; CURIA_VERSION="v0.41.0"; resolve_version
+_assert_var "v0.41.0 → release mode" "$ASSET_MODE" "release"
+_assert_var "v0.41.0 → download/<tag> base" "$ASSET_BASE" "https://github.com/josephfung/curia/releases/download/v0.41.0"
+_assert_var "v0.41.0 → image tag v0.41.0" "$CURIA_IMAGE_TAG_RESOLVED" "v0.41.0"
+
+# Bare X.Y.Z is normalized to vX.Y.Z.
+CURIA_REF=""; CURIA_VERSION="0.41.0"; resolve_version
+_assert_var "0.41.0 normalized → image tag v0.41.0" "$CURIA_IMAGE_TAG_RESOLVED" "v0.41.0"
+_assert_var "0.41.0 normalized → download/v0.41.0 base" "$ASSET_BASE" "https://github.com/josephfung/curia/releases/download/v0.41.0"
+
+# edge: config from raw main + image tag "edge".
+CURIA_REF=""; CURIA_VERSION="edge"; resolve_version
+_assert_var "edge → raw mode" "$ASSET_MODE" "raw"
+_assert_var "edge → raw main base" "$RAW_BASE" "https://raw.githubusercontent.com/josephfung/curia/main"
+_assert_var "edge → image tag edge" "$CURIA_IMAGE_TAG_RESOLVED" "edge"
+
+# CURIA_REF override: raw mode at that ref, no image-tag pin (empty).
+CURIA_REF="my-branch"; CURIA_VERSION="latest"; resolve_version
+_assert_var "CURIA_REF override → raw mode" "$ASSET_MODE" "raw"
+_assert_var "CURIA_REF override → raw base at ref" "$RAW_BASE" "https://raw.githubusercontent.com/josephfung/curia/my-branch"
+_assert_var "CURIA_REF override → no image-tag pin" "$CURIA_IMAGE_TAG_RESOLVED" ""
+
+# Invalid version errors (subshell so exit 1 doesn't kill the suite).
+if ( CURIA_REF=""; CURIA_VERSION="nope"; resolve_version ) 2>/dev/null; then
+    echo "  ✗ invalid version should error"; FAIL=$((FAIL+1))
+else
+    echo "  ✓ invalid version errors out"; PASS=$((PASS+1))
+fi
+
+# Reset globals so nothing downstream inherits test state.
+CURIA_REF=""; CURIA_VERSION="latest"; resolve_version
+
 # --- Results ---
 
 echo ""


### PR DESCRIPTION
## Summary

`install.sh` had **two uncoordinated version axes**: `CURIA_REF` (default `main`) picked the git ref for the config/compose files, while `CURIA_IMAGE_TAG` (in `.env.example`, default `latest`) picked the container image. Net effect: **config files came from `main` HEAD but images from the latest release** — they could drift. This also surfaced as a README/docs inconsistency (README said download `install.sh` from `<vX.Y.Z>/…`, docs from `main/…`), and even the README's tag URL didn't actually pin because `install.sh`'s internal `CURIA_REF` defaults to `main` regardless.

This unifies both axes under a **single `CURIA_VERSION` knob (default `latest`)** that selects a release; the config files and the app image now come from the **same** release. No per-release edits to `install.sh` ever again.

## How it works

`CURIA_VERSION` resolves to a config source + an image tag:

| `CURIA_VERSION` | config source | image tag |
|---|---|---|
| `latest` (default) | `releases/latest/download/` | `latest` |
| `vX.Y.Z` / bare `X.Y.Z` | `releases/download/vX.Y.Z/` | `vX.Y.Z` |
| `edge` | `raw.../main` | `edge` |

- `CURIA_REF=<ref>` is retained as a **hidden advanced override** (raw ref; no image-tag pin).
- `install.sh` writes `CURIA_IMAGE_TAG` on **fresh install only**, so a re-run never clobbers an operator's pinned tag.
- `curia-postgres` stays on `CURIA_POSTGRES_TAG=pg16` — it publishes no semver tags, so it's an intentionally separate axis (documented in `.env.example`).

## Changes
- **`install.sh`** — `resolve_version` (with bare-version normalization + strict validation matching `release.yml`), `ASSET_MODE`-branched fetches, flat-asset→path map (`Caddyfile`→`deploy/Caddyfile`, `setup-common.sh`→`scripts/setup-common.sh`), fresh-install image-tag pin.
- **`release.yml`** — stages the install bundle with flat asset names, signs a single `SHA256SUMS` manifest (cosign keyless), attaches all **12** assets, and extends the re-download-verify gate to cosign-verify the manifest + `sha256sum -c` the bundle.
- **`tests/`** — 15 new `resolve_version` cases (66 pass).
- **`.env.example`** — documents the postgres separate-axis.

## Sequencing (important)
The docs URL flip is **deliberately not in this PR**. `releases/latest/download/install.sh` only resolves once a release carries the bundle, so:
1. Merge this PR.
2. Cut **v0.40.1** (carries the 12-asset bundle via the updated `release.yml`).
3. Smoke-test the CDN, then a follow-up PR flips README + curia-docs to `releases/latest/download/…` + documents `CURIA_VERSION`.

Until then docs keep pointing at the working `raw.../main/install.sh`.

## Verification
- `shellcheck` + `actionlint` clean (only pre-existing SC2034 on `REPO_ROOT`/`COMPOSE_FLAGS`).
- `bash tests/setup/test-setup-functions.sh` → **66 passed, 0 failed**.
- Reviewed by code-reviewer + silent-failure-hunter: no bugs, error handling sound, "green = present + verified" release invariant preserved.

Design notes: install.sh relies on TLS + `curl -fsSL` (a 404 on a missing asset fails loudly) rather than client-side cosign verification, keeping host deps to docker + curl; the signed `SHA256SUMS` is for CI's self-check + optional operator verification.