### PR TITLE
chore: release v0.40.1 — "Voltron"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+## [0.40.1] — 2026-07-09 — "Voltron"
+
+> **Voltron** *(Voltron: Defender of the Universe, 1984, World Events Productions)* — five lion ships that pilot independently until they combine into a single giant defender. This patch does the same to the installer: two drifting version knobs, a config ref and an image tag, unite into one `CURIA_VERSION`.
+
 ### Changed
 
 - **`install.sh` version** — one `CURIA_VERSION` knob (default `latest`) selects config files and image from the same release.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.40.0-blueviolet" alt="Version: 0.40.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.40.1-blueviolet" alt="Version: 0.40.1" /></a>
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D24-brightgreen" alt="Node >= 24" />
   <img src="https://img.shields.io/badge/typescript-ESM-blue" alt="TypeScript ESM" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "packageManager": "pnpm@11.7.0",


### PR DESCRIPTION
> **Voltron** *(Voltron: Defender of the Universe, 1984, World Events Productions)* — five lion ships that pilot independently until they combine into a single giant defender. This patch does the same to the installer: two drifting version knobs, a config ref and an image tag, unite into one `CURIA_VERSION`.

Release commit for **v0.40.1** — CHANGELOG heading, `package.json` bump, README version badge. No code changes.

The substance shipped in #1371: `install.sh` now selects its config files and its app image from the same release under a single `CURIA_VERSION` (default `latest`), and each release ships a cosign-signed install bundle. This patch cuts the release that carries that bundle, so `releases/latest/download/…` starts resolving — after which a follow-up flips the README and docs download URLs.

### Changed

- **`install.sh` version** — one `CURIA_VERSION` knob (default `latest`) selects config files and image from the same release.
- **Release assets** — each release now ships a signed `install.sh` + config bundle (`SHA256SUMS`).

---

```
Two dials, one hand now.
The config and the image
answer the same call.
```