### PR TITLE
fix(release): publish .env.example as env.example asset; re-cut v0.40.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,10 +143,10 @@ jobs:
           cp install.sh                bundle/install.sh
           cp docker-compose.yml        bundle/docker-compose.yml
           cp docker-compose.tls.yml    bundle/docker-compose.tls.yml
-          cp .env.example              bundle/.env.example
+          cp .env.example              bundle/env.example        # no leading dot (GitHub mangles it)
           cp deploy/Caddyfile          bundle/Caddyfile          # flatten dir
           cp scripts/setup-common.sh   bundle/setup-common.sh    # flatten dir
-          for f in install.sh docker-compose.yml docker-compose.tls.yml .env.example Caddyfile setup-common.sh; do
+          for f in install.sh docker-compose.yml docker-compose.tls.yml env.example Caddyfile setup-common.sh; do
             if [ ! -s "bundle/$f" ]; then
               echo "::error::bundle/$f is missing or empty" >&2
               exit 1
@@ -154,7 +154,7 @@ jobs:
           done
           ( cd bundle && sha256sum \
               install.sh docker-compose.yml docker-compose.tls.yml \
-              .env.example Caddyfile setup-common.sh > SHA256SUMS )
+              env.example Caddyfile setup-common.sh > SHA256SUMS )
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -174,7 +174,7 @@ jobs:
             sbom.spdx.json sbom.spdx.json.sigstore \
             "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore" \
             bundle/install.sh bundle/docker-compose.yml bundle/docker-compose.tls.yml \
-            bundle/.env.example bundle/Caddyfile bundle/setup-common.sh \
+            bundle/env.example bundle/Caddyfile bundle/setup-common.sh \
             bundle/SHA256SUMS bundle/SHA256SUMS.sigstore \
             --clobber
 
@@ -195,7 +195,7 @@ jobs:
           for f in sbom.spdx.json sbom.spdx.json.sigstore \
                    "curia-${TAG}.tar.gz" "curia-${TAG}.tar.gz.sigstore" \
                    install.sh docker-compose.yml docker-compose.tls.yml \
-                   .env.example Caddyfile setup-common.sh \
+                   env.example Caddyfile setup-common.sh \
                    SHA256SUMS SHA256SUMS.sigstore; do
             if [ ! -s "verify/$f" ]; then
               echo "::error::expected release asset '$f' is missing from $TAG" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Fixed
-
-- **Release bundle** — `.env.example` publishes as the asset `env.example`; GitHub mangles leading-dot asset names.
-
 ## [0.40.1] — 2026-07-09 — "Voltron"
 
 > **Voltron** *(Voltron: Defender of the Universe, 1984, World Events Productions)* — five lion ships that pilot independently until they combine into a single giant defender. This patch does the same to the installer: two drifting version knobs, a config ref and an image tag, unite into one `CURIA_VERSION`.
@@ -25,6 +21,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **`install.sh` version** — one `CURIA_VERSION` knob (default `latest`) selects config files and image from the same release.
 - **Release assets** — each release now ships a signed `install.sh` + config bundle (`SHA256SUMS`).
+
+### Fixed
+
+- **Release bundle** — `.env.example` publishes as the asset `env.example`; GitHub mangles leading-dot asset names.
 
 ## [0.40.0] — 2026-07-09 — "The Watcher"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release bundle** — `.env.example` publishes as the asset `env.example`; GitHub mangles leading-dot asset names.
+
 ## [0.40.1] — 2026-07-09 — "Voltron"
 
 > **Voltron** *(Voltron: Defender of the Universe, 1984, World Events Productions)* — five lion ships that pilot independently until they combine into a single giant defender. This patch does the same to the installer: two drifting version knobs, a config ref and an image tag, unite into one `CURIA_VERSION`.

--- a/install.sh
+++ b/install.sh
@@ -223,13 +223,15 @@ check_prereqs() {
 # This lets an operator re-run install.sh safely without clobbering hand-edits.
 fetch_bundle() {
   # local-path : flat-release-asset-name. GitHub release assets cannot contain
-  # "/", so deploy/Caddyfile is published as the flat asset "Caddyfile"; the
-  # other three map 1:1. In raw mode the asset name is ignored (see fetch_asset).
+  # "/", so deploy/Caddyfile publishes as "Caddyfile", and cannot start with a
+  # "." (GitHub mangles a leading-dot asset name), so .env.example publishes as
+  # "env.example". docker-compose.* map 1:1. In raw mode the asset name is
+  # ignored and the local path is used verbatim (see fetch_asset).
   local pair local_path asset
   for pair in \
     "docker-compose.yml:docker-compose.yml" \
     "docker-compose.tls.yml:docker-compose.tls.yml" \
-    ".env.example:.env.example" \
+    ".env.example:env.example" \
     "deploy/Caddyfile:Caddyfile"; do
     local_path="${pair%%:*}"
     asset="${pair#*:}"


### PR DESCRIPTION
## Summary

The v0.40.1 `release.yml` run **failed** — and it caught a real bug. GitHub sanitizes release-asset names that start with a dot, so uploading `bundle/.env.example` landed on the release as **`default.env.example`**. That broke:
- the workflow's own verify gate (the presence-check + `sha256sum -c` looked for `.env.example` → went red), and
- `install.sh`, which fetches `${ASSET_BASE}/.env.example` → would 404.

The "green means present + verified" invariant did its job: the bad upload turned the run red instead of shipping a broken bundle silently.

## Fix
- **`release.yml`** — stage/sign/upload/verify the config file as the flat asset **`env.example`** (no leading dot).
- **`install.sh`** — `fetch_bundle` maps local `.env.example` → asset `env.example` (raw-mode path unchanged).

## Decision: re-cut v0.40.1 (not v0.40.2)
v0.40.1 is minutes old, its install-bundle was never referenced (docs not flipped), and its `release.yml` can't go green without moving the tag. So after this merges, we **delete + re-cut v0.40.1** on the fixed commit. The CHANGELOG entry for this fix is folded under the **v0.40.1** heading (not `[Unreleased]`) to match.

## Validation
`shellcheck` + `actionlint` clean; 66 unit tests pass. The other 5 bundle assets came through un-mangled — only the leading-dot name was affected.