### PR TITLE
docs: install from releases/latest/download + document CURIA_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Install docs** — README points to `releases/latest/download/install.sh` and documents `CURIA_VERSION`.
+
 ## [0.40.1] — 2026-07-09 — "Voltron"
 
 > **Voltron** *(Voltron: Defender of the Universe, 1984, World Events Productions)* — five lion ships that pilot independently until they combine into a single giant defender. This patch does the same to the installer: two drifting version knobs, a config ref and an image tag, unite into one `CURIA_VERSION`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,14 +396,17 @@ Tagging stays `git tag -a` (annotated, **unsigned**) — releases are signed at 
 
 **8. Verify release artifacts (SBOM + signatures)**
 
-Publishing the release triggers `release.yml`, which generates an SPDX SBOM and a source tarball, signs both with cosign (keyless, via GitHub OIDC), and attaches all four files to the release. This step is **not optional and not silent** — the workflow fails loudly if anything is missing or a signature fails to verify (this is the fix for v0.34.0, which shipped with no SBOM because the old auto-attach skipped silently).
+Publishing the release triggers `release.yml`, which generates an SPDX SBOM, a source tarball, and the operator install bundle (`install.sh` + `docker-compose.yml` + `docker-compose.tls.yml` + `env.example` + `Caddyfile` + `setup-common.sh`), signs the SBOM, tarball, and a `SHA256SUMS` manifest with cosign (keyless, via GitHub OIDC), and attaches all **twelve** files to the release. This step is **not optional and not silent** — the workflow fails loudly if anything is missing or a signature fails to verify (this is the fix for v0.34.0, which shipped with no SBOM because the old auto-attach skipped silently).
 
-Confirm the workflow succeeded and the four assets are present:
+Confirm the workflow succeeded and all twelve assets are present:
 
 ```bash
 gh run list --workflow=release.yml --limit 1   # must be green
 gh release view vX.Y.Z --json assets --jq '.assets[].name'
-# expect: sbom.spdx.json, sbom.spdx.json.sigstore, curia-vX.Y.Z.tar.gz, curia-vX.Y.Z.tar.gz.sigstore
+# expect (12): sbom.spdx.json, sbom.spdx.json.sigstore, curia-vX.Y.Z.tar.gz,
+#   curia-vX.Y.Z.tar.gz.sigstore, install.sh, docker-compose.yml,
+#   docker-compose.tls.yml, env.example, Caddyfile, setup-common.sh,
+#   SHA256SUMS, SHA256SUMS.sigstore
 ```
 
 If the run failed or assets are missing, re-run it (do **not** consider the release done until they are present):

--- a/README.md
+++ b/README.md
@@ -101,12 +101,18 @@ Skills come in two flavours (local handlers and MCP servers) behind a single int
 
 ```bash
 mkdir curia && cd curia
-curl -fsSL https://raw.githubusercontent.com/josephfung/curia/<vX.Y.Z>/install.sh -o install.sh
+curl -fsSL https://github.com/josephfung/curia/releases/latest/download/install.sh -o install.sh
 # Review the script, then:
 bash install.sh
 ```
 
-Replace `<vX.Y.Z>` with the latest release tag (check [releases](https://github.com/josephfung/curia/releases)). The installer pulls the published image, generates secrets, runs migrations inside the container, and prints your bootstrap secret. Curia will be running at `http://localhost:3000`.
+The installer pulls the published image, generates secrets, runs migrations inside the container, and prints your bootstrap secret. Curia will be running at `http://localhost:3000`.
+
+By default it installs the **latest release** — both the config files and the image come from it. To pin a specific version, prefix the run with `CURIA_VERSION` (this pins the config *and* the image together):
+
+```bash
+CURIA_VERSION=v0.40.1 bash install.sh
+```
 
 Save the bootstrap secret to a password manager and use it on the login page to create your account.
 


### PR DESCRIPTION
## Summary

Final step of the installer version-unification work (follows #1371 + #1373, now live in v0.40.1). Now that each release ships a **signed install bundle**, flips the README download URL from a raw git ref to the immutable latest-release asset and documents the `CURIA_VERSION` knob.

- **README** — `curl … releases/latest/download/install.sh` (was `raw.../<vX.Y.Z>/…`); documents `CURIA_VERSION` (default `latest`; `v0.40.1` to pin; `edge` for main).
- **CLAUDE.md** — release runbook step 8 now expects **12** assets (was 4), listing the install bundle + `SHA256SUMS(.sigstore)`.

Verified live before flipping: `releases/latest/download/{install.sh,env.example,…}` all resolve 200 on v0.40.1.