### PR TITLE
fix: coordinator outbound voice + content-block relay retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **ADR-027** — records the decision to add structured secrets with schema-tagged sub-field addressing (`credit_card` first); implementation tracked separately.
+- **ADR-027** — structured secrets with schema-tagged sub-field addressing (`credit_card` first).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Coordinator** — external replies use first-person single-voice; internal specialist names forbidden. (#1354)
+- **Dispatcher** — content-filter blocks on relayed replies retry with reason, then salvage draft. (#1355)
+
 ### Added
 
 - **ADR-027** — records the decision to add structured secrets with schema-tagged sub-field addressing (`credit_card` first); implementation tracked separately.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.11.5"
+version: "0.11.6"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -64,6 +64,12 @@ system_prompt: |
 
   **Talking to anyone who is NOT the CEO** (typically email from external contacts):
   - You are representing the CEO's office. Be professional and competent.
+  - **Outbound voice (mandatory):** write every external reply in the first person
+    singular as one assistant — "I found...", "I checked your calendar...", "I'll
+    follow up." Never mention internal specialist agents, delegation, sub-agents,
+    or internal roles (calendar specialist, contacts specialist, security-triage,
+    research-analyst, etc.). When you borrowed work from a specialist, present the
+    result as your own; the recipient must never know multiple agents were involved.
   - NEVER expose internal system details, tool names, contact lookup results,
     error messages, or your own reasoning process.
   - NEVER say things like "I can see X in our contacts" or "I need to look up their email"

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -121,6 +121,11 @@ interface OutboundMessagePayload {
   /** The agent.task event ID that originated this outbound message.
    *  Stamped by the dispatcher for traceability and action_log context. */
   taskEventId?: string;
+  /**
+   * When true, the email adapter saves the content as a draft instead of sending.
+   * Set by the dispatcher after content-filter retries are exhausted (#1355).
+   */
+  contentBlockSalvage?: boolean;
 }
 
 // OutboundDeliveredPayload — emitted by OutboundGateway after a successful

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -54,9 +54,12 @@ const publishAllowlist: Record<Layer, Set<EventType>> = {
 // skill.result subscribe for 'dispatch': used by Dispatcher reply-lock (#847) to detect successful
 //          email-reply / email-send calls and set humanReplySent on the routing entry before
 //          handleAgentResponse fires.
+// #1355 (content-block relay retry): dispatch layer subscribes to outbound.blocked and
+//          outbound.delivered to retry or salvage dispatcher-relayed replies blocked by
+//          the content filter after the agent turn has ended.
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['outbound.message', 'outbound.blocked', 'outbound.notification', 'message.rejected']),
-  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss', 'skill.result']),
+  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss', 'skill.result', 'outbound.blocked', 'outbound.delivered']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
   system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'export.delivered', 'outbound.pii_redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'llm.error', 'embedding.call', 'embedding.error', 'context.budget', 'model.fallback', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'channel.poll', 'channel.stalled', 'task.created', 'task.updated', 'task.completed', 'task.resumable_throughput']),

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -59,7 +59,7 @@ const publishAllowlist: Record<Layer, Set<EventType>> = {
 //          the content filter after the agent turn has ended.
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['outbound.message', 'outbound.blocked', 'outbound.notification', 'message.rejected']),
-  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss', 'skill.result', 'outbound.blocked', 'outbound.delivered']),
+  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss', 'skill.result', 'outbound.blocked', 'outbound.delivered', 'autonomy.send_blocked']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
   system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.delivered', 'export.delivered', 'outbound.pii_redacted', 'outbound.suppressed_duplicate', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'memory.decay_warning', 'contact.resolved', 'contact.unknown', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'contact.elevated', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'llm.error', 'embedding.call', 'embedding.error', 'context.budget', 'model.fallback', 'human.decision', 'secret.accessed', 'secret.captured', 'autonomy.skill_blocked', 'autonomy.send_blocked', 'channel.poll', 'channel.stalled', 'task.created', 'task.updated', 'task.completed', 'task.resumable_throughput']),

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -718,6 +718,14 @@ export class EmailAdapter implements Channel {
         ...(ccAddresses.length > 0 ? { cc: ccAddresses } : {}),
       };
 
+      if (outbound.payload.contentBlockSalvage) {
+        await this.saveContentBlockSalvageDraft(sendRequest, {
+          conversationId: outbound.payload.conversationId,
+          taskEventId: outbound.payload.taskEventId,
+        });
+        return;
+      }
+
       await this.sendWithGatedDraftFallback(sendRequest, {
         taskEventId: outbound.payload.taskEventId,
         conversationId: outbound.payload.conversationId,
@@ -828,6 +836,39 @@ export class EmailAdapter implements Channel {
     }
 
     // Non-gated failure (blocked contact, content filter, etc.) — already logged by gateway
+  }
+
+  /**
+   * Save a blocked dispatcher-relayed reply as a draft after rewrite retries are exhausted (#1355).
+   * Skips the send path entirely — createEmailDraft still runs blocked-contact and content-filter checks.
+   */
+  private async saveContentBlockSalvageDraft(
+    sendRequest: EmailSendRequest,
+    context: { taskEventId?: string; conversationId?: string },
+  ): Promise<void> {
+    const { outboundGateway, logger, accountId } = this.config;
+    let draftResult: Awaited<ReturnType<typeof outboundGateway.createEmailDraft>> | undefined;
+    try {
+      draftResult = await outboundGateway.createEmailDraft(sendRequest);
+    } catch (err) {
+      logger.error(
+        { err, accountId, conversationId: context.conversationId },
+        'email-adapter: unexpected error creating content-block salvage draft',
+      );
+      return;
+    }
+
+    if (draftResult?.success && draftResult.draftId) {
+      logger.info(
+        { accountId, draftId: draftResult.draftId, conversationId: context.conversationId },
+        'email-adapter: content-block salvage draft created',
+      );
+    } else if (draftResult && !draftResult.success) {
+      logger.error(
+        { accountId, conversationId: context.conversationId, reason: draftResult.blockedReason },
+        'email-adapter: content-block salvage draft creation failed',
+      );
+    }
   }
 
   /**

--- a/src/dispatch/content-block-relay.ts
+++ b/src/dispatch/content-block-relay.ts
@@ -1,0 +1,68 @@
+/**
+ * Helpers for dispatcher-relayed outbound replies blocked by the content filter (#1355).
+ * When an agent.response is auto-sent via outbound.message and the gateway blocks it,
+ * the agent turn is already over — these utilities support a bounded rewrite retry
+ * and a salvage-draft fallback on final failure.
+ */
+
+/** Maximum rewrite retries after the first content-filter block (2 retries → 3 send attempts). */
+export const CONTENT_BLOCK_MAX_RETRIES = 2;
+
+/** Rules that indicate a recipient/config problem — rewriting the body cannot fix these. */
+const TERMINAL_BLOCK_RULES = new Set(['no-reply-recipient', 'filter-error']);
+
+export interface RelayOutboundContext {
+  agentId: string;
+  conversationId: string;
+  channelId: string;
+  senderId: string;
+  accountId?: string;
+  taskEventId: string;
+  content: string;
+  contentBlockRetryAttempt: number;
+}
+
+/** Whether the block reason is fixable by rewriting the message body. */
+export function isContentFilterRewriteable(findings: Array<{ rule: string; detail: string }>): boolean {
+  if (findings.length === 0) return false;
+  return findings.some((f) => !TERMINAL_BLOCK_RULES.has(f.rule));
+}
+
+/** Principal-safe summary for the rewrite task — mirrors outbound-gateway policy. */
+export function summarizeBlockFindings(findings: Array<{ rule: string; detail: string }>): string {
+  if (findings.length === 0) return 'Content filter (no rule detail available)';
+  return findings
+    .map((f) => {
+      const showDetail = (f.rule.startsWith('llm-judge-') || f.rule === 'disclosure-tier-gate') && f.detail;
+      return showDetail ? `${f.rule}: ${f.detail}` : f.rule;
+    })
+    .join('\n');
+}
+
+/** Task body instructing the agent to rewrite a blocked dispatcher-relayed reply. */
+export function buildContentBlockRewriteTask(
+  blockedContent: string,
+  findings: Array<{ rule: string; detail: string }>,
+): string {
+  const reasonSummary = summarizeBlockFindings(findings);
+  const ruleNames = findings.map((f) => f.rule).join(', ');
+  return [
+    '[OUTBOUND CONTENT FILTER — REWRITE REQUIRED]',
+    '',
+    'Your previous reply to this conversation was blocked by the outbound content filter before delivery.',
+    'Rewrite it and return ONLY the corrected reply text — no preamble, no explanation of the block.',
+    '',
+    `Block reason: ${reasonSummary}`,
+    `Rules triggered: ${ruleNames}`,
+    '',
+    'Blocked draft:',
+    '---',
+    blockedContent,
+    '---',
+    '',
+    'Requirements:',
+    '- Speak in first person as a single assistant ("I found...", "I checked...").',
+    '- Never mention internal specialists, agents, delegation, sub-agents, or internal roles.',
+    '- Fix only what caused the block; preserve the intent of the original message.',
+  ].join('\n');
+}

--- a/src/dispatch/content-block-relay.ts
+++ b/src/dispatch/content-block-relay.ts
@@ -49,8 +49,9 @@ export function buildContentBlockRewriteTask(
   return [
     '[OUTBOUND CONTENT FILTER — REWRITE REQUIRED]',
     '',
-    'Your previous reply to this conversation was blocked by the outbound content filter before delivery.',
-    'Rewrite it and return ONLY the corrected reply text — no preamble, no explanation of the block.',
+    'Your previous reply was blocked before delivery. Rewrite it to satisfy the findings below,',
+    'applying your normal audience and voice rules. Return ONLY the corrected reply text —',
+    'no preamble about the block.',
     '',
     `Block reason: ${reasonSummary}`,
     `Rules triggered: ${ruleNames}`,
@@ -59,10 +60,5 @@ export function buildContentBlockRewriteTask(
     '---',
     blockedContent,
     '---',
-    '',
-    'Requirements:',
-    '- Speak in first person as a single assistant ("I found...", "I checked...").',
-    '- Never mention internal specialists, agents, delegation, sub-agents, or internal roles.',
-    '- Fix only what caused the block; preserve the intent of the original message.',
   ].join('\n');
 }

--- a/src/dispatch/content-block-relay.ts
+++ b/src/dispatch/content-block-relay.ts
@@ -9,7 +9,7 @@
 export const CONTENT_BLOCK_MAX_RETRIES = 2;
 
 /** Rules that indicate a recipient/config problem — rewriting the body cannot fix these. */
-const TERMINAL_BLOCK_RULES = new Set(['no-reply-recipient', 'filter-error']);
+const TERMINAL_BLOCK_RULES = new Set(['no-reply-recipient', 'filter-error', 'pii_redactor_error']);
 
 export interface RelayOutboundContext {
   agentId: string;
@@ -25,7 +25,7 @@ export interface RelayOutboundContext {
 /** Whether the block reason is fixable by rewriting the message body. */
 export function isContentFilterRewriteable(findings: Array<{ rule: string; detail: string }>): boolean {
   if (findings.length === 0) return false;
-  return findings.some((f) => !TERMINAL_BLOCK_RULES.has(f.rule));
+  return findings.every((f) => !TERMINAL_BLOCK_RULES.has(f.rule));
 }
 
 /** Principal-safe summary for the rewrite task — mirrors outbound-gateway policy. */

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -1,5 +1,5 @@
 import type { EventBus } from '../bus/bus.js';
-import type { InboundMessageEvent, AgentResponseEvent, AgentErrorEvent, SkillResultEvent } from '../bus/events.js';
+import type { InboundMessageEvent, AgentResponseEvent, AgentErrorEvent, SkillResultEvent, OutboundBlockedEvent } from '../bus/events.js';
 import { createAgentTask, createOutboundMessage, createOutboundSuppressedDuplicate, createContactResolved, createContactUnknown, createMessageRejected, createConversationCheckpoint } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
@@ -12,6 +12,12 @@ import type { DbPool } from '../db/connection.js';
 import { computeTrustScore, DEFAULT_TRUST_WEIGHTS } from './trust-scorer.js';
 import type { TrustScorerWeights } from './trust-scorer.js';
 import { parseEmailMetadata, sanitizeNylasMessageId, buildCcPreamble, buildThreadParticipantsBlock } from './email-metadata.js';
+import {
+  CONTENT_BLOCK_MAX_RETRIES,
+  buildContentBlockRewriteTask,
+  isContentFilterRewriteable,
+  type RelayOutboundContext,
+} from './content-block-relay.js';
 
 /** Redact a channel identifier (email address or phone number) for safe log output. */
 function redactSenderId(value: string): string {
@@ -115,8 +121,17 @@ export class Dispatcher {
       /** Set to true when a human-facing reply skill (email-reply, email-send) succeeds
        *  during this task. handleAgentResponse suppresses outbound.message when true. */
       humanReplySent: boolean;
+      /** Rewrite attempts for dispatcher-relayed replies blocked by the content filter (#1355). */
+      contentBlockRetryAttempt?: number;
+      /** Salvage-only publish — save as draft instead of sending (#1355). */
+      contentBlockSalvage?: boolean;
     }
   >();
+  /**
+   * Tracks dispatcher-relayed outbound.message events awaiting delivery outcome.
+   * Keyed by outbound.message event ID; cleared on outbound.delivered or outbound.blocked.
+   */
+  private relayOutbound = new Map<string, RelayOutboundContext>();
   /** Key: `${conversationId}:${agentId}` — reset on every agent.response */
   private checkpointTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private pool: DbPool | undefined;
@@ -199,6 +214,18 @@ export class Dispatcher {
     // handleAgentResponse can suppress the duplicate outbound.message. See #847.
     this.bus.subscribe('skill.result', 'dispatch', async (event) => {
       await this.handleSkillResult(event as SkillResultEvent);
+    });
+
+    // outbound.blocked → bounded rewrite retry or salvage draft for dispatcher-relayed replies (#1355)
+    this.bus.subscribe('outbound.blocked', 'dispatch', async (event) => {
+      await this.handleOutboundBlocked(event as OutboundBlockedEvent);
+    });
+
+    // outbound.delivered → clear pending relay tracking on successful delivery
+    this.bus.subscribe('outbound.delivered', 'dispatch', async (event) => {
+      if (event.parentEventId) {
+        this.relayOutbound.delete(event.parentEventId);
+      }
     });
 
     this.logger.info(
@@ -910,12 +937,116 @@ export class Dispatcher {
       // The agent.response's parentEventId is the agent.task that triggered it — thread
       // this through so the email adapter can pass it to gateway.send() for action_log context.
       taskEventId: event.parentEventId ?? undefined,
+      contentBlockSalvage: routing.contentBlockSalvage,
     });
+
+    // Track for content-filter block handling (#1355) — cleared on delivery or block.
+    if (!routing.contentBlockSalvage) {
+      this.relayOutbound.set(outbound.id, {
+        agentId: event.payload.agentId,
+        conversationId: routing.conversationId,
+        channelId: routing.channelId,
+        senderId: routing.senderId,
+        accountId: routing.accountId,
+        taskEventId: event.parentEventId!,
+        content: event.payload.content,
+        contentBlockRetryAttempt: routing.contentBlockRetryAttempt ?? 0,
+      });
+    }
+
     await this.bus.publish('dispatch', outbound);
 
     // Schedule a checkpoint for this conversation — resets the debounce timer if
     // already running, so only fires after a full window of inactivity.
     this.scheduleCheckpoint(routing.conversationId, event.payload.agentId, routing.channelId);
+  }
+
+  /**
+   * Handle content-filter blocks on dispatcher-relayed outbound replies (#1355).
+   * Skill-invoked sends self-correct mid-turn; relayed agent.response replies do not —
+   * retry with the block reason, then salvage a draft on final failure (email only).
+   */
+  private async handleOutboundBlocked(event: OutboundBlockedEvent): Promise<void> {
+    const parentOutboundId = event.parentEventId;
+    if (!parentOutboundId) return;
+
+    const ctx = this.relayOutbound.get(parentOutboundId);
+    if (!ctx) return;
+    this.relayOutbound.delete(parentOutboundId);
+
+    const { findings } = event.payload;
+    const rewriteable = isContentFilterRewriteable(findings);
+    const attemptsRemaining = CONTENT_BLOCK_MAX_RETRIES - ctx.contentBlockRetryAttempt;
+
+    if (rewriteable && attemptsRemaining > 0) {
+      const nextAttempt = ctx.contentBlockRetryAttempt + 1;
+      this.logger.info(
+        {
+          agentId: ctx.agentId,
+          conversationId: ctx.conversationId,
+          attempt: nextAttempt,
+          maxRetries: CONTENT_BLOCK_MAX_RETRIES,
+          rules: findings.map((f) => f.rule),
+        },
+        'Dispatcher content-block relay: scheduling bounded rewrite retry',
+      );
+
+      const taskEvent = createAgentTask({
+        agentId: ctx.agentId,
+        conversationId: ctx.conversationId,
+        channelId: ctx.channelId,
+        senderId: ctx.senderId,
+        accountId: ctx.accountId,
+        content: buildContentBlockRewriteTask(ctx.content, findings),
+        metadata: { contentBlockRewrite: true, contentBlockRetryAttempt: nextAttempt },
+        parentEventId: event.id,
+      });
+      this.taskRouting.set(taskEvent.id, {
+        channelId: ctx.channelId,
+        conversationId: ctx.conversationId,
+        senderId: ctx.senderId,
+        accountId: ctx.accountId,
+        humanReplySent: false,
+        contentBlockRetryAttempt: nextAttempt,
+      });
+      await this.bus.publish('dispatch', taskEvent);
+      return;
+    }
+
+    this.logger.warn(
+      {
+        agentId: ctx.agentId,
+        conversationId: ctx.conversationId,
+        rewriteable,
+        attempt: ctx.contentBlockRetryAttempt,
+        rules: findings.map((f) => f.rule),
+      },
+      'Dispatcher content-block relay: retries exhausted or block not rewriteable — salvaging draft',
+    );
+    await this.publishContentBlockSalvage(ctx, event.id);
+  }
+
+  /** Publish a salvage outbound.message that the email adapter saves as a draft (#1355). */
+  private async publishContentBlockSalvage(ctx: RelayOutboundContext, parentEventId: string): Promise<void> {
+    if (ctx.channelId !== 'email') {
+      this.logger.warn(
+        { channelId: ctx.channelId, conversationId: ctx.conversationId },
+        'Dispatcher content-block relay: salvage draft not supported for this channel — reply lost',
+      );
+      return;
+    }
+
+    const outbound = createOutboundMessage({
+      conversationId: ctx.conversationId,
+      channelId: ctx.channelId,
+      accountId: ctx.accountId,
+      content: ctx.content,
+      recipientId: ctx.senderId,
+      parentEventId,
+      taskEventId: ctx.taskEventId,
+      contentBlockSalvage: true,
+    });
+    await this.bus.publish('dispatch', outbound);
   }
 
   private scheduleCheckpoint(conversationId: string, agentId: string, channelId: string): void {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -228,6 +228,13 @@ export class Dispatcher {
       }
     });
 
+    // autonomy.send_blocked → clear relay tracking when the autonomy gate blocks a relayed send
+    this.bus.subscribe('autonomy.send_blocked', 'dispatch', async (event) => {
+      if (event.parentEventId) {
+        this.relayOutbound.delete(event.parentEventId);
+      }
+    });
+
     this.logger.info(
       { outboundContextBridge: this._outboundContextService != null },
       'Dispatcher registered',

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -462,7 +462,7 @@ export class OutboundGateway {
           channel: request.channel,
           currentScore: autonomyConfig.score,
           requiredScore: sendThreshold,
-        })).catch((err) => {
+        }, options?.parentEventId)).catch((err) => {
           this.log.warn(
             { err, channel: request.channel },
             'outbound-gateway: failed to publish autonomy.send_blocked event',
@@ -854,7 +854,7 @@ export class OutboundGateway {
         try {
           await this.bus.publish('dispatch', createOutboundBlocked({
             blockId,
-            conversationId: '',
+            conversationId: options?.conversationId ?? '',
             channelId: request.channel,
             // scrubPii() as a safety fallback — the redactor itself failed, so we apply
             // a best-effort scrub before writing anything to the audit log. This ensures
@@ -863,7 +863,7 @@ export class OutboundGateway {
             recipientId,
             reason: 'pii_redactor_error',
             findings: [{ rule: 'pii_redactor_error', detail: 'PiiRedactor threw an unexpected error' }],
-            parentEventId: '',
+            parentEventId: options?.parentEventId ?? '',
           }));
         } catch (publishErr) {
           this.log.warn(
@@ -1589,7 +1589,7 @@ export class OutboundGateway {
             channel: 'email',
             currentScore: autonomyConfig.score,
             requiredScore: sendThreshold,
-          })).catch((err) => {
+          }, options?.parentEventId)).catch((err) => {
             this.log.warn(
               { err, draftId },
               'outbound-gateway: failed to publish autonomy.send_blocked event',
@@ -1697,13 +1697,13 @@ export class OutboundGateway {
 
       const blockedEvent = createOutboundBlocked({
         blockId,
-        conversationId: '',
+        conversationId: options?.conversationId ?? '',
         channelId: 'email',
         content: body,
         recipientId: recipientEmail,
         reason: fullReason,
         findings: filterFindings,
-        parentEventId: '',
+        parentEventId: options?.parentEventId ?? '',
       });
       try {
         await this.bus.publish('dispatch', blockedEvent);

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -633,13 +633,13 @@ export class OutboundGateway {
           // must never carry raw PII, matching the fail-closed redactor-error path below.
           await this.bus.publish('dispatch', createOutboundBlocked({
             blockId,
-            conversationId: '',
+            conversationId: options?.conversationId ?? '',
             channelId: request.channel,
             content: scrubPii(messageBody),
             recipientId,
             reason: 'no_reply_recipient',
             findings: [{ rule: 'no-reply-recipient', detail: 'All recipients classify as automated/no-reply; message not deliverable' }],
-            parentEventId: '',
+            parentEventId: options?.parentEventId ?? '',
           }));
         } catch (publishErr) {
           this.log.warn(
@@ -937,13 +937,13 @@ export class OutboundGateway {
       // Use redactedBody so the audit event itself does not contain unredacted PII.
       const blockedEvent = createOutboundBlocked({
         blockId,
-        conversationId: '',
+        conversationId: options?.conversationId ?? '',
         channelId: request.channel,
         content: redactedBody,
         recipientId,
         reason: fullReason,
         findings: filterFindings,
-        parentEventId: '',
+        parentEventId: options?.parentEventId ?? '',
       });
       try {
         await this.bus.publish('dispatch', blockedEvent);

--- a/tests/unit/bus/outbound-blocked-event.test.ts
+++ b/tests/unit/bus/outbound-blocked-event.test.ts
@@ -49,5 +49,6 @@ describe('outbound.blocked event', () => {
   it('dispatch layer can subscribe to outbound.blocked and outbound.delivered (#1355)', () => {
     expect(canSubscribe('dispatch', 'outbound.blocked')).toBe(true);
     expect(canSubscribe('dispatch', 'outbound.delivered')).toBe(true);
+    expect(canSubscribe('dispatch', 'autonomy.send_blocked')).toBe(true);
   });
 });

--- a/tests/unit/bus/outbound-blocked-event.test.ts
+++ b/tests/unit/bus/outbound-blocked-event.test.ts
@@ -45,4 +45,9 @@ describe('outbound.blocked event', () => {
   it('agent layer cannot publish outbound.blocked', () => {
     expect(canPublish('agent', 'outbound.blocked')).toBe(false);
   });
+
+  it('dispatch layer can subscribe to outbound.blocked and outbound.delivered (#1355)', () => {
+    expect(canSubscribe('dispatch', 'outbound.blocked')).toBe(true);
+    expect(canSubscribe('dispatch', 'outbound.delivered')).toBe(true);
+  });
 });

--- a/tests/unit/dispatch/content-block-relay.test.ts
+++ b/tests/unit/dispatch/content-block-relay.test.ts
@@ -38,14 +38,16 @@ describe('content-block-relay', () => {
     expect(summary).toContain('calendar specialist');
   });
 
-  it('buildContentBlockRewriteTask includes blocked body and first-person guidance', () => {
+  it('buildContentBlockRewriteTask passes block findings and draft without duplicating voice policy', () => {
     const task = buildContentBlockRewriteTask('The calendar specialist found 4 events.', [
       { rule: 'llm-judge-audience-leak', detail: 'named internal agent' },
     ]);
     expect(task).toContain('[OUTBOUND CONTENT FILTER — REWRITE REQUIRED]');
     expect(task).toContain('The calendar specialist found 4 events.');
-    expect(task).toContain('first person');
     expect(task).toContain('llm-judge-audience-leak');
+    expect(task).toContain('named internal agent');
+    expect(task).toContain('your normal audience and voice rules');
+    expect(task).not.toContain('Never mention internal specialists');
   });
 
   it('allows two retries after the first block', () => {

--- a/tests/unit/dispatch/content-block-relay.test.ts
+++ b/tests/unit/dispatch/content-block-relay.test.ts
@@ -19,6 +19,17 @@ describe('content-block-relay', () => {
     expect(isContentFilterRewriteable([{ rule: 'filter-error', detail: 'crash' }])).toBe(false);
   });
 
+  it('treats pii_redactor_error as terminal', () => {
+    expect(isContentFilterRewriteable([{ rule: 'pii_redactor_error', detail: 'crash' }])).toBe(false);
+  });
+
+  it('returns false when terminal and non-terminal findings are mixed', () => {
+    expect(isContentFilterRewriteable([
+      { rule: 'llm-judge-audience-leak', detail: 'leak' },
+      { rule: 'no-reply-recipient', detail: 'automated' },
+    ])).toBe(false);
+  });
+
   it('summarizes judge findings with detail', () => {
     const summary = summarizeBlockFindings([
       { rule: 'llm-judge-audience-leak', detail: 'named calendar specialist' },

--- a/tests/unit/dispatch/content-block-relay.test.ts
+++ b/tests/unit/dispatch/content-block-relay.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONTENT_BLOCK_MAX_RETRIES,
+  buildContentBlockRewriteTask,
+  isContentFilterRewriteable,
+  summarizeBlockFindings,
+} from '../../../src/dispatch/content-block-relay.js';
+
+describe('content-block-relay', () => {
+  it('treats content-filter findings as rewriteable', () => {
+    expect(isContentFilterRewriteable([{ rule: 'llm-judge-audience-leak', detail: 'named internal agent' }])).toBe(true);
+  });
+
+  it('treats no-reply-recipient as terminal (not rewriteable)', () => {
+    expect(isContentFilterRewriteable([{ rule: 'no-reply-recipient', detail: 'automated' }])).toBe(false);
+  });
+
+  it('treats filter-error as terminal', () => {
+    expect(isContentFilterRewriteable([{ rule: 'filter-error', detail: 'crash' }])).toBe(false);
+  });
+
+  it('summarizes judge findings with detail', () => {
+    const summary = summarizeBlockFindings([
+      { rule: 'llm-judge-audience-leak', detail: 'named calendar specialist' },
+    ]);
+    expect(summary).toContain('llm-judge-audience-leak');
+    expect(summary).toContain('calendar specialist');
+  });
+
+  it('buildContentBlockRewriteTask includes blocked body and first-person guidance', () => {
+    const task = buildContentBlockRewriteTask('The calendar specialist found 4 events.', [
+      { rule: 'llm-judge-audience-leak', detail: 'named internal agent' },
+    ]);
+    expect(task).toContain('[OUTBOUND CONTENT FILTER — REWRITE REQUIRED]');
+    expect(task).toContain('The calendar specialist found 4 events.');
+    expect(task).toContain('first person');
+    expect(task).toContain('llm-judge-audience-leak');
+  });
+
+  it('allows two retries after the first block', () => {
+    expect(CONTENT_BLOCK_MAX_RETRIES).toBe(2);
+  });
+});

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
 import { EventBus } from '../../../src/bus/bus.js';
 import { AgentRuntime } from '../../../src/agents/runtime.js';
-import { createInboundMessage, createAgentError, createAgentTask, createAgentResponse, createOutboundBlocked, createSkillResult, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type ContactUnknownEvent, type BusEvent } from '../../../src/bus/events.js';
+import { createInboundMessage, createAgentError, createAgentTask, createAgentResponse, createOutboundBlocked, createAutonomySendBlocked, createSkillResult, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type ContactUnknownEvent, type BusEvent } from '../../../src/bus/events.js';
 import { CONTENT_BLOCK_MAX_RETRIES } from '../../../src/dispatch/content-block-relay.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
@@ -2124,5 +2124,50 @@ describe('Dispatcher content-block relay (#1355)', () => {
     const salvage = outboundMessages.find((m) => m.payload.contentBlockSalvage);
     expect(salvage).toBeDefined();
     expect(salvage!.payload.content).toContain(`Rewritten attempt ${CONTENT_BLOCK_MAX_RETRIES}`);
+  });
+
+  it('clears relayOutbound when autonomy.send_blocked carries the outbound message id', async () => {
+    const { bus, dispatcher, outboundMessages, agentTasks } = buildHarness();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'email:thread-200',
+      channelId: 'email',
+      senderId: 'dana@example.com',
+      content: 'inbound',
+      parentEventId: 'inbound-4',
+    });
+    dispatcher.registerExternalTaskRouting(task.id, {
+      channelId: 'email',
+      conversationId: 'email:thread-200',
+      senderId: 'dana@example.com',
+    });
+    await bus.publish('system', createAgentResponse({
+      agentId: 'coordinator',
+      conversationId: 'email:thread-200',
+      content: 'Reply blocked by autonomy gate',
+      parentEventId: task.id,
+    }));
+
+    const outbound = outboundMessages[0]!;
+    await bus.publish('dispatch', createAutonomySendBlocked({
+      channel: 'email',
+      currentScore: 50,
+      requiredScore: 70,
+    }, outbound.id));
+
+    // A subsequent content-filter block should not find relay context or schedule a retry.
+    await bus.publish('dispatch', createOutboundBlocked({
+      blockId: 'block_orphan',
+      conversationId: 'email:thread-200',
+      channelId: 'email',
+      content: outbound.payload.content,
+      recipientId: 'dana@example.com',
+      reason: 'llm-judge-audience-leak: leak',
+      findings: [{ rule: 'llm-judge-audience-leak', detail: 'leak' }],
+      parentEventId: outbound.id,
+    }));
+
+    expect(agentTasks).toHaveLength(0);
   });
 });

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
 import { EventBus } from '../../../src/bus/bus.js';
 import { AgentRuntime } from '../../../src/agents/runtime.js';
-import { createInboundMessage, createAgentError, createAgentTask, createSkillResult, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type ContactUnknownEvent, type BusEvent } from '../../../src/bus/events.js';
+import { createInboundMessage, createAgentError, createAgentTask, createAgentResponse, createOutboundBlocked, createSkillResult, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type ContactUnknownEvent, type BusEvent } from '../../../src/bus/events.js';
+import { CONTENT_BLOCK_MAX_RETRIES } from '../../../src/dispatch/content-block-relay.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
 import type { ContactService } from '../../../src/contacts/contact-service.js';
@@ -2001,5 +2002,127 @@ describe('Dispatcher auto-elevation — Path 1 correspondence (#951)', () => {
     const { subscribeHandlers, elevateFn } = buildHarness({ withContactService: false });
     await fireSkillResult(subscribeHandlers, { skillName: 'email-reply', to: 'someone@example.com' });
     expect(elevateFn).not.toHaveBeenCalled();
+  });
+});
+
+// #1355: dispatcher-relayed replies blocked by the content filter get a bounded rewrite retry,
+// then a salvage draft on final failure.
+describe('Dispatcher content-block relay (#1355)', () => {
+  function buildHarness() {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const outboundMessages: OutboundMessageEvent[] = [];
+    const agentTasks: AgentTaskEvent[] = [];
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    bus.subscribe('outbound.message', 'channel', (event) => {
+      outboundMessages.push(event as OutboundMessageEvent);
+    });
+    bus.subscribe('agent.task', 'system', (event) => {
+      agentTasks.push(event as AgentTaskEvent);
+    });
+
+    return { bus, dispatcher, outboundMessages, agentTasks, logger };
+  }
+
+  it('re-dispatches a rewrite task when a relayed outbound is content-filter blocked', async () => {
+    const { bus, dispatcher, outboundMessages, agentTasks } = buildHarness();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'email:thread-99',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Original inbound',
+      parentEventId: 'inbound-1',
+    });
+    dispatcher.registerExternalTaskRouting(task.id, {
+      channelId: 'email',
+      conversationId: 'email:thread-99',
+      senderId: 'alice@example.com',
+    });
+
+    await bus.publish('system', createAgentResponse({
+      agentId: 'coordinator',
+      conversationId: 'email:thread-99',
+      content: 'The calendar specialist found 4 events.',
+      parentEventId: task.id,
+    }));
+
+    expect(outboundMessages).toHaveLength(1);
+    const blocked = createOutboundBlocked({
+      blockId: 'block_test',
+      conversationId: 'email:thread-99',
+      channelId: 'email',
+      content: 'The calendar specialist found 4 events.',
+      recipientId: 'alice@example.com',
+      reason: 'llm-judge-audience-leak: named internal agent',
+      findings: [{ rule: 'llm-judge-audience-leak', detail: 'named internal agent' }],
+      parentEventId: outboundMessages[0]!.id,
+    });
+    await bus.publish('dispatch', blocked);
+
+    expect(agentTasks).toHaveLength(1);
+    expect(agentTasks[0]!.payload.agentId).toBe('coordinator');
+    expect(agentTasks[0]!.payload.content).toContain('[OUTBOUND CONTENT FILTER — REWRITE REQUIRED]');
+    expect(agentTasks[0]!.payload.content).toContain('calendar specialist found 4 events');
+    expect(agentTasks[0]!.payload.metadata?.contentBlockRewrite).toBe(true);
+  });
+
+  it('publishes a salvage outbound after retries are exhausted', async () => {
+    const { bus, dispatcher, outboundMessages, agentTasks } = buildHarness();
+
+    const inboundTask = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'email:thread-101',
+      channelId: 'email',
+      senderId: 'carol@example.com',
+      content: 'inbound',
+      parentEventId: 'inbound-3',
+    });
+    dispatcher.registerExternalTaskRouting(inboundTask.id, {
+      channelId: 'email',
+      conversationId: 'email:thread-101',
+      senderId: 'carol@example.com',
+    });
+    await bus.publish('system', createAgentResponse({
+      agentId: 'coordinator',
+      conversationId: 'email:thread-101',
+      content: 'The calendar specialist found events.',
+      parentEventId: inboundTask.id,
+    }));
+
+    let currentOutbound = outboundMessages[0]!;
+    const findings = [{ rule: 'llm-judge-audience-leak', detail: 'named internal agent' }];
+
+    for (let attempt = 0; attempt <= CONTENT_BLOCK_MAX_RETRIES; attempt++) {
+      await bus.publish('dispatch', createOutboundBlocked({
+        blockId: `block_${attempt}`,
+        conversationId: 'email:thread-101',
+        channelId: 'email',
+        content: currentOutbound.payload.content,
+        recipientId: 'carol@example.com',
+        reason: 'llm-judge-audience-leak: named internal agent',
+        findings,
+        parentEventId: currentOutbound.id,
+      }));
+
+      if (attempt < CONTENT_BLOCK_MAX_RETRIES) {
+        const retryTask = agentTasks[agentTasks.length - 1]!;
+        await bus.publish('system', createAgentResponse({
+          agentId: 'coordinator',
+          conversationId: 'email:thread-101',
+          content: `Rewritten attempt ${attempt + 1}`,
+          parentEventId: retryTask.id,
+        }));
+        currentOutbound = outboundMessages[outboundMessages.length - 1]!;
+      }
+    }
+
+    const salvage = outboundMessages.find((m) => m.payload.contentBlockSalvage);
+    expect(salvage).toBeDefined();
+    expect(salvage!.payload.content).toContain(`Rewritten attempt ${CONTENT_BLOCK_MAX_RETRIES}`);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1354, #1355.

Two companion bugs from prod (2026-07-07): the coordinator narrated internal specialists in external replies (tripping `llm-judge-audience-leak`), and when the judge blocked a dispatcher-relayed reply the message was silently dropped because the agent turn had already ended.

### #1354 — Coordinator outbound voice

- Added an explicit **outbound voice (mandatory)** rule under the non-CEO audience section in `agents/coordinator.yaml`.
- External replies must be first-person singular as one assistant; internal specialist agents, delegation, and sub-agent roles must never appear in outbound copy.
- Bumped coordinator `version` to `0.11.6`.

### #1355 — Content-filter block on dispatcher-relayed replies

**Option A + B (complementary):**

1. **Bounded rewrite retry (Option A):** When `outbound.blocked` fires for a dispatcher-relayed `outbound.message`, the dispatcher re-dispatches an `agent.task` to the originating agent with the block reason, rule names, and blocked draft. Capped at 2 retries (3 send attempts total). Terminal blocks (`no-reply-recipient`, `filter-error`) skip retry.
2. **Salvage draft (Option B):** After retries are exhausted (email channel only), the dispatcher publishes an `outbound.message` with `contentBlockSalvage: true`; the email adapter saves it as a draft via `createEmailDraft` instead of attempting send.

**Supporting changes:**
- `outbound-gateway` now threads `parentEventId` and `conversationId` into `outbound.blocked` audit events (were previously empty strings).
- Dispatch layer bus permissions extended to subscribe to `outbound.blocked` and `outbound.delivered`.
- New `src/dispatch/content-block-relay.ts` module with helpers and tests.

Autonomy-gated behavior is unchanged.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `vitest run tests/unit/dispatch/content-block-relay.test.ts`
- [x] `vitest run tests/unit/dispatch/dispatcher.test.ts -t "Dispatcher content-block"`
- [x] `vitest run tests/unit/bus/outbound-blocked-event.test.ts`
