### PR TITLE
fix(scheduler): liveness check no longer flaps fail on a healthy scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Coordinator** — external replies use first-person single-voice; internal specialist names forbidden. (#1354)
 - **Dispatcher** — content-filter blocks on relayed replies retry with reason, then salvage draft. (#1355)
+- **Scheduler** — liveness check no longer flaps `fail` every few minutes on a healthy scheduler. (#1359)
 
 ### Added
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -136,8 +136,11 @@ export class Scheduler {
   // In-memory only — resets on process restart (a missed check is not a security failure).
   private burstCounts = new Map<string, number>();
 
-  /** Timestamp of the most recent watchdog tick. Null until the first tick runs.
-   *  Read by HealthService to detect a stalled scheduler. */
+  /** Timestamp of the most recent pollDueJobs tick. Null until the first tick runs.
+   *  Read by HealthService to detect a stalled scheduler. Stamped on the 30s poll
+   *  cadence (POLL_INTERVAL_MS), not the 5-min watchdog — the watchdog interval is
+   *  slower than scheduler_max_tick_s, which flapped the liveness check to 'fail'
+   *  for ~3 of every 5 minutes on an otherwise healthy scheduler (#1359). */
   public lastTickAt: Date | null = null;
 
   constructor(config: SchedulerConfig) {
@@ -194,8 +197,8 @@ export class Scheduler {
     }, POLL_INTERVAL_MS);
 
     // Watchdog: periodically recover jobs that got stuck in 'running' state.
+    // Liveness (lastTickAt) is stamped by pollDueJobs, not here — see its comment.
     this.watchdogHandle = setInterval(() => {
-      this.lastTickAt = new Date();
       this.recoverStuckJobs().catch((err) => {
         this.logger.error({ err }, 'Unhandled error in recoverStuckJobs watchdog');
       });
@@ -266,8 +269,14 @@ export class Scheduler {
    *
    * Uses FOR UPDATE SKIP LOCKED to safely claim jobs in a concurrent environment
    * (multiple scheduler instances won't double-fire the same job).
+   *
+   * Stamps lastTickAt on every call, before the query — this is the scheduler's actual
+   * 30s liveness cadence, read by HealthService's checkScheduler (#1359). Stamped even
+   * if the query below fails, so a transient DB hiccup doesn't itself read as a stalled
+   * scheduler — the poll loop running at all is the signal, not query success.
    */
   async pollDueJobs(): Promise<void> {
+    this.lastTickAt = new Date();
     try {
       const sql = `
         SELECT sj.*,

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -165,6 +165,19 @@ describe('Scheduler', () => {
       expect(recoverSpy).toHaveBeenCalled();
     });
 
+    it('watchdog tick alone does not stamp lastTickAt — only pollDueJobs does (#1359)', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      vi.spyOn(scheduler, 'recoverStuckJobs').mockResolvedValue();
+      // Prevent the 30s poll interval from firing so only the watchdog runs.
+      vi.spyOn(scheduler, 'pollDueJobs').mockResolvedValue();
+
+      scheduler.start();
+
+      await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+      expect(scheduler.lastTickAt).toBeNull();
+    });
+
     it('stop clears the watchdog interval', async () => {
       pool.query.mockResolvedValue({ rows: [] });
 
@@ -192,6 +205,23 @@ describe('Scheduler', () => {
       // Only the SELECT query, no UPDATEs or bus publishes
       expect(pool.query).toHaveBeenCalledOnce();
       expect(bus.publish).not.toHaveBeenCalled();
+    });
+
+    it('stamps lastTickAt on every call — this is the liveness signal checkScheduler reads (#1359)', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      expect(scheduler.lastTickAt).toBeNull();
+
+      await scheduler.pollDueJobs();
+
+      expect(scheduler.lastTickAt).toBeInstanceOf(Date);
+    });
+
+    it('stamps lastTickAt even when the due-jobs query throws', async () => {
+      pool.query.mockRejectedValueOnce(new Error('connection refused'));
+
+      await scheduler.pollDueJobs();
+
+      expect(scheduler.lastTickAt).toBeInstanceOf(Date);
     });
 
     it('claims due jobs and fires them (publishes schedule.fired + agent.task)', async () => {


### PR DESCRIPTION
## Summary

- `lastTickAt` — the timestamp `checkScheduler` reads for liveness — was stamped only by the 5-min watchdog interval, while `scheduler_max_tick_s` (120s) treats it stale after 2 minutes. That mismatch made `/api/health` report `scheduler: fail` for ~3 of every 5 minutes on a healthy, actively-polling scheduler, burning the signal value of `degraded` for anything alerting on it.
- Move the `lastTickAt` stamp to the top of `pollDueJobs` — the scheduler's real 30s liveness cadence — and leave the 5-min watchdog interval to own `recoverStuckJobs` only.

## Test plan

- [x] `pnpm run typecheck`
- [x] Full unit test suite (`vitest run`) — 4916 passed, 0 failed
- [x] Added test: `pollDueJobs` stamps `lastTickAt` on every call, including when the query throws
- [x] Added test: the watchdog interval alone (without `pollDueJobs` running) does *not* stamp `lastTickAt`
- [x] Existing `checkScheduler` unit tests (ok-within-grace, fail-past-grace, ok-when-recent, fail-when-stale) already cover the health-check logic itself — unchanged by this PR

Closes #1359