### PR TITLE
docs: document release-artifact verification (OSPS-BR-06.01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 
 - **KG trust gates** — checkpoint extraction and `memory-store` block untrusted inbound senders. (#1290)
+- **Release verification docs** — README documents `cosign verify-blob` for signed release artifacts. (#929)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ The install bundle (`install.sh`, `docker-compose*.yml`, `env.example`, `Caddyfi
 cosign verify-blob --bundle SHA256SUMS.sigstore \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github.com/josephfung/curia/.github/workflows/release.yml@' \
-  SHA256SUMS
-
-sha256sum -c SHA256SUMS
+  SHA256SUMS && sha256sum -c SHA256SUMS
 ```
+
+`cosign verify-blob` prints `Verified OK` on success and exits non-zero on failure — the `&&` above ensures a failed signature check stops before `sha256sum -c` (which only checks hashes, not authenticity) can print a misleading pass. If either command fails, do not trust the downloaded assets.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ pnpm run setup
 **[→ Full installation guide](https://docs.meetcuria.com/get-started/installation)**  
 (channels, production deploy, configuration reference)
 
+### Verifying release artifacts
+
+Every published release is signed with [cosign](https://github.com/sigstore/cosign) (keyless, via GitHub OIDC — no long-lived signing key). The SBOM, source tarball, and the install bundle's `SHA256SUMS` manifest each ship with a `.sigstore` bundle, verifiable against GitHub's OIDC issuer:
+
+```bash
+gh release download vX.Y.Z --dir verify && cd verify
+
+cosign verify-blob --bundle sbom.spdx.json.sigstore \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/josephfung/curia/.github/workflows/release.yml@' \
+  sbom.spdx.json
+```
+
+The install bundle (`install.sh`, `docker-compose*.yml`, `env.example`, `Caddyfile`, `setup-common.sh`) is covered by one signed manifest — verify it, then check the files against it:
+
+```bash
+cosign verify-blob --bundle SHA256SUMS.sigstore \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/josephfung/curia/.github/workflows/release.yml@' \
+  SHA256SUMS
+
+sha256sum -c SHA256SUMS
+```
+
 ---
 
 ## Contributing


### PR DESCRIPTION
## Summary

Closes #929.

Investigation showed release-artifact signing was already implemented in `.github/workflows/release.yml` (#1011, merged 2026-06-16) — cosign keyless-signs the SBOM, source tarball, and the install bundle's `SHA256SUMS` manifest, with `id-token`/`contents` scoped to the signing job only, and a final gate that re-downloads and re-verifies from the published release before the run can go green. The bestpractices.dev entry for OSPS-BR-06.01 already reflects this ("Met").

The remaining gap was #929's third acceptance criterion: no documented verification instructions for consumers. This PR adds a "Verifying release artifacts" section to `README.md` with the exact `cosign verify-blob` invocations (identity pinned to this repo's `release.yml`, issuer pinned to GitHub's OIDC endpoint), plus a CHANGELOG entry.

A parallel silent-failure-hunter review of this diff flagged that the `SHA256SUMS` verify command and `sha256sum -c` were two separate un-chained statements — a failed cosign check wouldn't stop `sha256sum -c` from printing a misleading pass, since that command only checks hashes, not authenticity. Fixed by chaining them with `&&` and adding a one-line note on what success/failure looks like.

## Test plan

- [x] Commands cross-checked line-by-line against `release.yml`'s actual `cosign sign-blob` / `IDENTITY_REGEXP` / OIDC issuer values (code-reviewer pass)
- [x] Verified the `&&`-chaining fix addresses the silent-pass hazard (silent-failure-hunter pass)
- [ ] No CI relevant beyond markdown-lint / link-check, if configured