### PR TITLE
docs: OpenSSF Baseline governance & supply-chain docs (#930, #931, #932)

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,26 @@
+# Developer Certificate of Origin (DCO) enforcement.
+#
+# Read by the DCO GitHub App (https://github.com/apps/dco), which runs as a
+# required status check on pull requests. Every commit must carry a valid
+# `Signed-off-by:` trailer (add one with `git commit -s`) asserting the author is
+# legally authorized to make the contribution. This satisfies OpenSSF Baseline
+# criterion OSPS-LE-01.01 ("all code contributors assert authorization on every
+# commit").
+#
+# `require.members` is intentionally left at its default (true): sign-off is
+# enforced for EVERYONE, including org members and agent-authored PRs. Exempting
+# members would fail OSPS-LE-01.01, which requires *all* code contributors to
+# assert.
+require:
+  members: true
+
+# Remediation lets an already-open branch satisfy the check WITHOUT a force-push /
+# history rewrite (which would invalidate review threads).
+allowRemediationCommits:
+  # The original author retroactively signs off their OWN past commits by adding a
+  # follow-up commit that enumerates the earlier hashes. The assertion is still
+  # made by the contributor, so this still meets OSPS-LE-01.01.
+  individual: true
+  # Keep OFF: third-party remediation would let someone OTHER than the author
+  # certify a commit, which breaks "require all code contributors to assert."
+  thirdParty: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`audit-query` / `audit-trace` / `ops-lookup`** — read-only diagnostics skills over audit + operational state. (#1356)
 - **`diagnosticsRepo` capability** — read-only reads of the ops + agent-state tables for diagnostics skills. (#1356)
 - **ADR-027** — structured secrets with schema-tagged sub-field addressing (`credit_card` first).
+- **`docs/dev/dependencies.md`** — dependency management policy (selection, pnpm lockfile, Dependabot, overrides, SBOM). (#930)
+- **`GOVERNANCE.md`** — maintainers, roles, and access to sensitive resources. (#931)
+- **DCO sign-off** — `.github/dco.yml` requires `Signed-off-by` on all commits; documented in CONTRIBUTING. (#932)
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ git commit -s -m "fix: prevent infinite retry loop in scheduler"
 
 This appends a trailer with your name and email:
 
-```
+```text
 Signed-off-by: Your Name <you@example.com>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,7 @@ Thank you for your interest in contributing to Curia. This document explains how
 
 ## Development Setup
 
-```bash
-git clone https://github.com/YOUR_USERNAME/curia.git
-cd curia
-cp .env.example .env
-# Edit .env with your API keys
-docker compose up
-```
-
-Requires: Node.js 22+, Docker, PostgreSQL 16+ (via Docker Compose).
+Follow the **Developer Install (Source)** path in the **[Development Setup guide](docs/dev/setup.md#developer-install-source)** — it is the single source of truth for prerequisites (Node, pnpm, Docker versions) and the full step-by-step. Version numbers are deliberately not repeated here so there is only one place to update.
 
 ## Making Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,29 @@ fix: prevent infinite retry loop in scheduler
 chore: update pgvector to 0.8.0
 ```
 
+### Sign-off (DCO)
+
+Every commit must be signed off under the [Developer Certificate of Origin](https://developercertificate.org/) (DCO). The sign-off is your assertion that you wrote the change (or otherwise have the right to submit it) under the project's open-source license. This is enforced by the DCO status check on every pull request — a PR with any unsigned commit is blocked until it is remediated.
+
+Add the sign-off automatically with the `-s` flag:
+
+```bash
+git commit -s -m "fix: prevent infinite retry loop in scheduler"
+```
+
+This appends a trailer with your name and email:
+
+```
+Signed-off-by: Your Name <you@example.com>
+```
+
+The name and email must match your `git config user.name` / `user.email`.
+
+**Already-open branch missing sign-offs?** You have two options:
+
+- **Rewrite (simple, but changes SHAs):** `git rebase --signoff main` re-writes each commit with a sign-off, then force-push. This invalidates existing review threads, so prefer it only on branches without review in progress.
+- **Individual remediation (preferred, no force-push):** add a single new commit that retroactively signs off your earlier commits, keeping history and review threads intact. The DCO app accepts this because you — the original author — are still the one making the assertion. See the [DCO app remediation docs](https://github.com/dcoapp/app#how-it-works) for the exact commit-message format.
+
 ### Code Standards
 
 - **TypeScript ESM** — `"type": "module"`, `.js` extensions on imports
@@ -53,6 +76,10 @@ chore: update pgvector to 0.8.0
 - Write tests for new features and bug fixes
 - Run the full test suite before submitting: `pnpm test`
 - Integration tests should use real Postgres (via Docker), not mocks
+
+### Dependencies
+
+Before adding, updating, or pinning a dependency, read the [Dependency Management Policy](docs/dev/dependencies.md). It covers how to evaluate a new dependency, why the committed `pnpm-lock.yaml` is authoritative, how Dependabot and the 7-day cooldown work, and how to pin a transitive dependency for a CVE via the `overrides:` block in `pnpm-workspace.yaml`. Always commit `package.json` and `pnpm-lock.yaml` together.
 
 ### Pull Requests
 
@@ -123,6 +150,10 @@ AI-assisted contributions (Claude Code, Copilot, Codex, etc.) are welcome. We ev
 - **Bugs**: Use the bug report issue template
 - **Features**: Use the feature request issue template
 - **Security vulnerabilities**: See [SECURITY.md](SECURITY.md) — do NOT file a public issue
+
+## Governance
+
+Curia's roles (maintainer, contributor), who holds access to sensitive project resources, and how maintainers are added are documented in [GOVERNANCE.md](GOVERNANCE.md).
 
 ## Code of Conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,93 @@
+# Governance
+
+This document describes how Curia is governed: who maintains it, what roles exist,
+who holds access to sensitive project resources, and how those roles change. It
+satisfies OpenSSF Baseline criteria **OSPS-GV-01.01** (members with access to
+sensitive resources) and **OSPS-GV-01.02** (roles and responsibilities).
+
+Curia is currently a **single-maintainer project**. This document is deliberately
+lightweight and will grow as the maintainer base does.
+
+## Roles
+
+### Maintainer
+
+Maintainers are responsible for the direction and health of the project. Their
+responsibilities include:
+
+- Reviewing and merging pull requests
+- Triaging issues and setting priorities and milestones
+- Cutting and publishing releases
+- Responding to security reports (see [SECURITY.md](SECURITY.md))
+- Administering the repository, CI, and project infrastructure
+- Upholding and enforcing the [Code of Conduct](CODE_OF_CONDUCT.md)
+
+**Current maintainers:**
+
+| Name | GitHub | Role |
+|---|---|---|
+| Joseph Fung | [@josephfung](https://github.com/josephfung) | Lead maintainer |
+
+### Contributor
+
+Anyone who submits an issue, a pull request, or otherwise participates is a
+contributor. Contributors are not required to hold any special access. Their
+responsibilities are limited to following the [Contributing Guide](CONTRIBUTING.md)
+and the [Code of Conduct](CODE_OF_CONDUCT.md), and to certifying the origin of
+their contributions via the DCO sign-off (see *Sign-off* in
+[CONTRIBUTING.md](CONTRIBUTING.md)).
+
+## Access to sensitive resources
+
+The following sensitive resources exist for this project, and access to each is
+held by the maintainer(s) listed. This inventory is kept current as access
+changes.
+
+| Resource | Description | Access held by |
+|---|---|---|
+| **Repository administration** | Admin rights on `github.com/josephfung/curia` — branch protection, settings, collaborator management | Joseph Fung |
+| **GitHub Actions secrets** | CI/CD secrets used by workflows (image registry credentials, signing/OIDC configuration, deploy credentials) | Joseph Fung |
+| **Release & registry credentials** | Publishing releases and container images (GitHub Releases, GHCR) | Joseph Fung |
+| **meetcuria.com infrastructure** | Website hosting (Cloudflare Pages), DNS, and the production deployment host | Joseph Fung |
+| **Security contact** | Intake for private vulnerability reports (see [SECURITY.md](SECURITY.md)) | Joseph Fung |
+
+Curia does not publish to the public npm registry; it is distributed as signed
+container images and source tarballs attached to GitHub releases.
+
+## Becoming a maintainer
+
+As the project grows, new maintainers may be added. The process:
+
+1. A prospective maintainer demonstrates sustained, high-quality contribution and
+   good judgment over time — meaningful PRs, thoughtful reviews, and reliable
+   participation.
+2. An existing maintainer nominates them.
+3. The current maintainers reach consensus to add them.
+4. On agreement, the new maintainer is granted the appropriate access (repository
+   permissions and any relevant secrets), this document's maintainer and access
+   tables are updated in the same change, and the addition is recorded in the
+   project history.
+
+While Curia has a single maintainer, that maintainer makes these decisions. As the
+maintainer base grows, decisions move to maintainer consensus.
+
+## Removing access
+
+Maintainer access is revoked when a maintainer steps down, becomes inactive for an
+extended period, or violates the [Code of Conduct](CODE_OF_CONDUCT.md). When access
+is revoked, the relevant credentials are rotated and the tables above are updated
+in the same change.
+
+## Decision making
+
+While Curia is single-maintainer, the maintainer is the final decision maker on
+technical direction, releases, and contribution acceptance, guided by the project's
+[architecture principles](docs/specs/00-overview.md) and
+[ADRs](docs/adr/). Significant architectural decisions are recorded as ADRs so the
+reasoning is durable and reviewable. As the maintainer base grows, this section
+will be updated to describe consensus-based decision making.
+
+## Changes to this document
+
+Changes to governance — roles, access, or process — are made via pull request and
+recorded in the project history like any other change.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -78,14 +78,14 @@ extended period, or violates the [Code of Conduct](CODE_OF_CONDUCT.md). When acc
 is revoked, the relevant credentials are rotated and the tables above are updated
 in the same change.
 
-## Decision making
+## Decision-making
 
 While Curia is single-maintainer, the maintainer is the final decision maker on
 technical direction, releases, and contribution acceptance, guided by the project's
 [architecture principles](docs/specs/00-overview.md) and
 [ADRs](docs/adr/). Significant architectural decisions are recorded as ADRs so the
 reasoning is durable and reviewable. As the maintainer base grows, this section
-will be updated to describe consensus-based decision making.
+will be updated to describe consensus-based decision-making.
 
 ## Changes to this document
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Curia is in early development and welcomes contributions — including AI-assist
 
 - Read the **[Contributing Guide](CONTRIBUTING.md)** for dev setup, code standards, and how to add channels, skills, and agents
 - Read **[CLAUDE.md](CLAUDE.md)** for repo-level conventions (if you're using Claude Code, these load automatically)
+- See **[GOVERNANCE.md](GOVERNANCE.md)** for project roles, maintainers, and how decisions are made
 - Check **[open issues](https://github.com/josephfung/curia/issues)** — look for `good first issue` labels
 - Report security vulnerabilities via **[SECURITY.md](SECURITY.md)** — not public issues
 

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -1,0 +1,144 @@
+# Dependency Management Policy
+
+This document describes how Curia selects, obtains, and tracks its third-party
+dependencies. It exists both as a contributor guide and as the project's stated
+policy for supply-chain hygiene (OpenSSF Baseline **OSPS-DO-06.01**).
+
+The practices here are not aspirational — they are already enforced by CI, the
+lockfile, and automated tooling. This page documents what the machinery does and
+why.
+
+## Selecting a new dependency
+
+Adding a dependency is a long-term commitment: every package we pull in becomes
+part of our attack surface and our maintenance burden. Before adding one, weigh:
+
+- **Is it necessary?** Prefer the standard library or a few lines of our own code
+  over a dependency for trivial functionality. A small, well-understood
+  implementation we own is often cheaper than a dependency we have to track,
+  update, and audit forever.
+- **Is it maintained?** Look at recent release cadence, open-issue responsiveness,
+  and whether the project is actively developed or effectively abandoned.
+- **Is it healthy?** Consider the size of the maintainer base (bus factor),
+  download counts, and whether it has a history of security advisories and how
+  quickly they were addressed.
+- **What does it drag in?** A package with a deep transitive tree multiplies the
+  surface we have to track. Fewer, shallower dependency trees are preferable.
+- **Is the license compatible?** Curia is MIT-licensed. New dependencies must
+  carry a permissive, compatible license (MIT, BSD, Apache-2.0, ISC, etc.).
+  Copyleft licenses (GPL/AGPL) are not compatible and must not be introduced.
+
+A dependency that fundamentally shapes the system (a new database engine, a core
+framework, a new external API the architecture depends on) also warrants an
+[Architecture Decision Record](../adr/) documenting why it was chosen over the
+alternatives.
+
+## Obtaining dependencies
+
+- **Package manager: pnpm.** Curia uses pnpm exclusively. Do not use `npm` or
+  `yarn` to install — they will not respect the workspace configuration or the
+  overrides described below.
+- **Lockfile is authoritative.** `pnpm-lock.yaml` pins the exact resolved version
+  and integrity hash of every dependency, direct and transitive. It is committed
+  to the repo and is the source of truth for what actually gets installed.
+- **CI installs are frozen.** Continuous integration runs `pnpm install
+  --frozen-lockfile`, which fails the build if `package.json` and
+  `pnpm-lock.yaml` disagree. This guarantees CI, and by extension production,
+  installs exactly the reviewed set of versions — a PR cannot silently pull in an
+  unpinned or drifted dependency.
+- **New-version quarantine.** Newly published package versions are held for a
+  cooldown window before they are proposed (see Dependabot below), reducing the
+  risk of installing a freshly compromised release before it is caught and yanked.
+
+When you add or update a dependency locally, run `pnpm install` to regenerate the
+lockfile and commit **both** `package.json` and `pnpm-lock.yaml` together in the
+same change.
+
+## Tracking and updating dependencies
+
+### Automated updates — Dependabot
+
+`.github/dependabot.yml` configures weekly Dependabot runs across four ecosystems:
+
+- **npm** — production dependencies get individual PRs; dev dependencies are
+  grouped into a single PR to reduce noise.
+- **GitHub Actions** — action versions (`checkout`, `setup-node`, etc.) are kept
+  fresh and grouped.
+- **Docker** — the root `Dockerfile` base image (`node:24-slim`) and
+  `docker/postgres.Dockerfile` (`pgvector/pgvector:pg16`) are digest-pinned and
+  kept current within their pinned major.
+
+Key policies encoded there:
+
+- **7-day cooldown** on version updates, so a freshly published (and possibly
+  compromised) release is skipped until it has survived a week in the wild.
+  **Security updates from Dependabot alerts bypass the cooldown** — CVE patches
+  are never delayed.
+- **Major-version pins** where a major bump requires a deliberate migration rather
+  than an automatic update: `node` (stays on Active LTS 24), `pgvector/pgvector`
+  (pg16 → pg17 needs a DB upgrade), `@types/node` (tracks the Node runtime line),
+  and `nylas` (an anomalous higher-numbered publish that is not the maintained
+  `latest` line).
+
+### Security pins — the `overrides` block
+
+When a transitive dependency carries a CVE but the direct dependency that pulls it
+in has not yet released a fix, we force a patched version using the `overrides:`
+block in **`pnpm-workspace.yaml`** (not `package.json` — pnpm v10+ ignores
+`package.json#pnpm.overrides` entirely).
+
+Each override pins a minimum safe floor and carries an inline comment citing the
+CVE or advisory it resolves. After editing an override:
+
+1. Run `pnpm install` and confirm the regenerated `pnpm-lock.yaml` contains a
+   top-level `overrides:` section.
+2. Confirm the pin took effect with `pnpm why <pkg>` (it must show the forced
+   version).
+
+If `pnpm install` reports "Already up to date" after editing an override, pnpm did
+not see the change — verify you edited `pnpm-workspace.yaml` and not
+`package.json`.
+
+### Build-script approvals — the `allowBuilds` block
+
+pnpm blocks dependency postinstall/build scripts by default. Packages that
+genuinely need to run a build step (e.g. `esbuild` downloading its platform
+binary) are explicitly allowed in the `allowBuilds:` block of
+`pnpm-workspace.yaml`. Values must be booleans; a pre-commit hook rejects any
+placeholder text. Use `pnpm approve-builds` to review and approve new build
+scripts interactively rather than hand-editing the file.
+
+### Software Bill of Materials (SBOM)
+
+Every push to `main` generates an SPDX-format SBOM via
+`.github/workflows/sbom.yml`, giving supply-chain visibility into exactly which
+components ship in a build. Release builds additionally generate a signed SBOM
+that is attached to the GitHub release (see `.github/workflows/release.yml`), so
+downstream consumers can verify the exact component set of any tagged version.
+
+### Continuous scanning
+
+Dependency and code scanning run on every push and pull request:
+
+- **Trivy** — filesystem and container-image CVE scanning.
+- **Semgrep** — static analysis for insecure patterns.
+- **Gitleaks** — secret scanning.
+- **CodeQL** — deep security analysis (`security-extended`).
+- **OpenSSF Scorecard** — repository-level supply-chain posture.
+
+Results surface under **GitHub → Security → Code Scanning**. Unresolved CRITICAL
+findings block a release; HIGH findings are a documented judgment call. The full
+pre-release security gate is described in [CLAUDE.md](../../CLAUDE.md) under
+*Preparing a release*.
+
+## Summary
+
+| Concern | Mechanism |
+|---|---|
+| Selection | Necessity / maintenance / health / license review; ADR for shaping deps |
+| Obtaining | pnpm + committed `pnpm-lock.yaml`; `--frozen-lockfile` in CI |
+| Updating | Weekly Dependabot (npm, Actions, Docker) with 7-day cooldown |
+| CVE pins | `overrides:` block in `pnpm-workspace.yaml`, one comment per CVE |
+| Build scripts | `allowBuilds:` block, boolean-enforced by pre-commit hook |
+| Inventory | SPDX SBOM on every `main` push; signed SBOM per release |
+| Scanning | Trivy, Semgrep, Gitleaks, CodeQL, Scorecard on push/PR |


### PR DESCRIPTION
## Summary

Batches three OpenSSF Baseline Level 2 criteria currently marked **Unmet** on the [project's bestpractices.dev entry](https://www.bestpractices.dev/en/projects/13136/baseline-2). All three are documentation/config, no code changes.

Closes #930
Closes #931
Closes #932

### #930 — Dependency management policy (OSPS-DO-06.01)
- New `docs/dev/dependencies.md`: how deps are **selected** (necessity/maintenance/health/license), **obtained** (pnpm + committed `pnpm-lock.yaml`, `--frozen-lockfile` in CI), and **tracked/updated** (weekly Dependabot with 7-day cooldown, `overrides:` block for CVE pins, `allowBuilds`, SBOM, continuous scanning).
- Linked from CONTRIBUTING.md (new *Dependencies* subsection).

### #931 — Governance (OSPS-GV-01.01 / GV-01.02)
- New root `GOVERNANCE.md`: names the maintainer, enumerates access to sensitive resources (repo admin, Actions secrets, release/registry creds, meetcuria.com infra, security contact), describes maintainer/contributor roles, and how new maintainers are added.
- Linked from README.md (Contributing section) and CONTRIBUTING.md (new *Governance* section).

### #932 — DCO sign-off (OSPS-LE-01.01)
- New `.github/dco.yml`: `require.members` left at default (**everyone** signs off, incl. org members/agent PRs), `allowRemediationCommits.individual: true`, `thirdParty: false` — per the issue's implementation notes.
- CONTRIBUTING.md documents `git commit -s` and the individual-remediation escape hatch for already-open branches.
- This PR's own commit is signed off, leading by example.

## Manual steps required (cannot be automated from here)

For #932 to be fully Met, you'll need to:
1. Install the [DCO GitHub App](https://github.com/apps/dco) on `josephfung/curia`.
2. Add **DCO** as a **required status check** on `main` in branch protection.
3. Remediate any in-flight PR whose commits lack sign-off before the check is required (per the issue: **#1349** is known to carry `Co-Authored-By` but no `Signed-off-by`).

After merge + those steps, all three criteria can be flipped to **Met** on bestpractices.dev.

## Notes
- No test/CI impact — docs and one config file only.
- CHANGELOG updated under **Added**.