### PR TITLE
docs: explicit SCA remediation threshold & pre-release policy (OSPS-VM-05.01/05.02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`docs/dev/dependencies.md`** — adds explicit SCA remediation threshold and pre-release policy (OSPS-VM-05.01/05.02).
 - **Install docs** — README points to `releases/latest/download/install.sh` and documents `CURIA_VERSION`.
 - **`00-overview.md` Spec Index** — dropped the `Status` column and "N of M Done" counts. (#1282)
 - **Spec audit fixes** — corrected stale claims: Node 24, console UI, secrets vault, setup story, fallback-provider prose. (#1282)

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -126,10 +126,62 @@ Dependency and code scanning run on every push and pull request:
 - **CodeQL** — deep security analysis (`security-extended`).
 - **OpenSSF Scorecard** — repository-level supply-chain posture.
 
-Results surface under **GitHub → Security → Code Scanning**. Unresolved CRITICAL
-findings block a release; HIGH findings are a documented judgment call. The full
-pre-release security gate is described in [CLAUDE.md](../../CLAUDE.md) under
-*Preparing a release*.
+Results surface under **GitHub → Security → Code Scanning**. How
+dependency-vulnerability and license findings are triaged — and the threshold that
+blocks a release — is defined once in
+[SCA remediation threshold and pre-release policy](#sca-remediation-threshold-and-pre-release-policy)
+below.
+
+## SCA remediation threshold and pre-release policy
+
+*This section states the project's Software Composition Analysis (SCA) policy: the
+remediation threshold for dependency vulnerability and license findings, and the
+requirement to clear them before a release. It satisfies OpenSSF Baseline
+**OSPS-VM-05.01** and **OSPS-VM-05.02**.*
+
+**Software Composition Analysis** — scanning the resolved dependency tree for known
+vulnerabilities and for license violations — runs continuously:
+
+- **Trivy** scans the filesystem (the resolved dependency tree) and the release
+  container image for CVEs on every push and pull request, and again on demand as
+  part of the release gate.
+- **Dependabot** raises security alerts and opens fix PRs for vulnerable
+  dependencies; security updates bypass the 7-day cooldown so CVE patches are not
+  delayed.
+- **License compatibility** is reviewed when a dependency is added (see
+  [Selecting a new dependency](#selecting-a-new-dependency)).
+
+### Remediation threshold
+
+Findings are triaged by severity, and the threshold that must be cleared before a
+release is:
+
+- **CRITICAL** — must be remediated before release. Remediation means upgrading the
+  dependency, pinning a patched transitive version via the `overrides:` block,
+  removing the dependency, or — only if the finding is genuinely unreachable or
+  unfixable — recording a written, reviewed exception. A release is **blocked**
+  while any CRITICAL SCA finding is unresolved.
+- **HIGH** — must be fixed, or explicitly accepted with a documented rationale
+  (e.g. unreachable code path, no fix available) before the release proceeds.
+- **MEDIUM / LOW** — tracked and addressed in the normal Dependabot update cadence;
+  they do not block a release.
+
+**License findings** follow a zero-tolerance threshold: only permissive licenses
+(MIT, BSD, Apache-2.0, ISC, and similar) are permitted. A dependency under a
+copyleft license (GPL/AGPL) or another incompatible license is a violation that
+must be resolved — replaced or removed — before it can be merged or released. It is
+never shipped.
+
+### Addressing findings prior to a release
+
+Clearing the threshold above is a required step of cutting a release, not an
+afterthought. Before a release is tagged, the **pre-release security gate** runs the
+on-demand scans (the Trivy image scan, a fresh CodeQL pass, Scorecard, and DAST)
+against the exact commit to be tagged; the release is blocked on any unresolved
+CRITICAL finding, with HIGH findings either fixed or documented as accepted. Because
+the release commit is code-identical to the scanned commit, clearing the gate clears
+it for the tag. The full step-by-step gate is described in
+[CLAUDE.md](../../CLAUDE.md) under *Preparing a release → Pre-release security gate*.
 
 ## Summary
 
@@ -142,3 +194,4 @@ pre-release security gate is described in [CLAUDE.md](../../CLAUDE.md) under
 | Build scripts | `allowBuilds:` block, boolean-enforced by pre-commit hook |
 | Inventory | SPDX SBOM on every `main` push; signed SBOM per release |
 | Scanning | Trivy, Semgrep, Gitleaks, CodeQL, Scorecard on push/PR |
+| SCA policy | CRITICAL blocks a release; permissive licenses only; cleared at the pre-release gate |


### PR DESCRIPTION
## Summary

Consolidates the project's Software Composition Analysis (SCA) policy into one explicit section of `docs/dev/dependencies.md`, so two OpenSSF Baseline Level 3 criteria currently marked **Unmet** can be flipped to **Met**. Docs-only, no code.

- **OSPS-VM-05.01** — threshold for remediation of SCA findings (vulnerabilities **and** licenses)
- **OSPS-VM-05.02** — policy to address SCA violations prior to any release

The substance already existed (Trivy + Dependabot scanning, the CRITICAL-blocks-release gate in CLAUDE.md, permissive-license-only selection) but was split across files and framed implicitly. This makes it a single, citable policy.

## What changed

New **"SCA remediation threshold and pre-release policy"** section in `docs/dev/dependencies.md`:
- Names the SCA mechanisms (Trivy filesystem + image scans, Dependabot alerts/updates, license review at selection).
- **Vulnerability threshold:** CRITICAL must be remediated (upgrade / `overrides:` pin / remove / reviewed exception) and **blocks a release** while unresolved; HIGH must be fixed or documented-accepted; MED/LOW tracked via Dependabot, non-blocking.
- **License threshold:** zero-tolerance — permissive licenses only; copyleft/incompatible is a violation resolved before merge/release.
- **Pre-release policy:** the pre-release security gate clears findings against the exact commit to be tagged (cross-referenced to CLAUDE.md).

To avoid duplication (and the drift it invites), the existing "Continuous scanning" paragraph now **points to** the new section instead of restating the threshold.

## Not in scope

Leaving the other 8 unmet L3 criteria for later, per discussion. Notably **VM-05.03** (auto-*block* vulnerable deps on every change) stays unmet — Trivy currently runs with `exit-code: 0` (SARIF-only) and isn't a required check, so it evaluates but does not block. That needs a fail-on-severity gate, not just docs.

## After merge

`docs/dev/dependencies.md#sca-remediation-threshold-and-pre-release-policy` can be cited as evidence to flip **OSPS-VM-05.01** and **OSPS-VM-05.02** to Met on bestpractices.dev.