### PR TITLE
test: add contact resolution integration coverage (#1382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Contact resolution** — integration test coverage for identity establishment and authorization. (#1382)
 - **`diagnostics` agent** — opt-in, read-only forensic agent that diagnoses "what happened / why" for the principal. (#1356)
 - **`audit-query` / `audit-trace` / `ops-lookup`** — read-only diagnostics skills over audit + operational state. (#1356)
 - **`diagnosticsRepo` capability** — read-only reads of the ops + agent-state tables for diagnostics skills. (#1356)

--- a/docs/specs/09-contacts-and-identity.md
+++ b/docs/specs/09-contacts-and-identity.md
@@ -662,17 +662,13 @@ The migration depends on `kg_nodes` existing (for the foreign key), so it must r
 - [ ] Unknown sender policy config and enforcement
 - [ ] Authorization check in Coordinator context assembly (role → overrides → trust)
 - [ ] Audit logging for all identity resolution and authorization decisions
-- [ ] Integration tests: proactive identity establishment
-- [ ] Integration tests: reactive identity establishment (unknown sender flow)
-- [ ] Integration tests: external source enrichment (CRM/calendar → contact)
-- [ ] Integration tests: authorization check (role defaults + overrides + trust)
+- [x] Integration tests: proactive identity establishment — covered by `tests/integration/contacts/` (#1382)
+- [x] Integration tests: reactive identity establishment (unknown sender flow) — covered by `tests/integration/contacts/` (#1382)
+- [x] Integration tests: external source enrichment (CRM/calendar → contact) — covered by `tests/integration/contacts/` (#1382)
+- [x] Integration tests: authorization check (role defaults + overrides + trust) — covered by `tests/integration/contacts/` (#1382)
 
 ---
 
 ## Known Deficiencies
 
 - **Audit logging for authorization decisions (allow/deny/escalate)** — not yet implemented; the `AuthorizationService` is a pure function with no bus or logger access. (#1379)
-- **Integration tests: proactive identity establishment** — not yet covered by an integration test. (#1382)
-- **Integration tests: reactive identity establishment (unknown sender flow)** — not yet covered by an integration test. (#1382)
-- **Integration tests: external source enrichment (CRM/calendar → contact)** — not yet covered by an integration test. (#1382)
-- **Integration tests: authorization check (role defaults + overrides + trust)** — three-layer logic is unit-tested in `authorization.test.ts`, but end-to-end integration coverage is missing. (#1382)

--- a/tests/integration/contacts/authorization-check.test.ts
+++ b/tests/integration/contacts/authorization-check.test.ts
@@ -1,0 +1,311 @@
+// Authorization check integration — service seam + dispatch audit events (#1382).
+//
+// "decision logged" here means dispatch-layer events the dispatcher actually publishes
+// (contact.resolved / contact.unknown / message.rejected). AuthorizationService.evaluate
+// is a pure function with no bus/logger — a dedicated authz-decision audit row is #1379.
+
+import { it, expect, beforeAll, afterAll } from 'vitest';
+import { EventBus } from '../../../src/bus/bus.js';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import {
+  createInboundMessage,
+  type ContactResolvedEvent,
+  type MessageRejectedEvent,
+  type AgentTaskEvent,
+} from '../../../src/bus/events.js';
+import { AuthorizationService } from '../../../src/contacts/authorization.js';
+import { loadAuthConfig } from '../../../src/contacts/config-loader.js';
+import type { AuthConfig } from '../../../src/contacts/types.js';
+import {
+  describeIf,
+  makeRunId,
+  createContactStack,
+  CONFIG_DIR,
+  type ContactTestStack,
+} from './harness.js';
+
+describeIf('Contact resolution: authorization check integration', () => {
+  let stack: ContactTestStack;
+  const runId = makeRunId();
+
+  beforeAll(async () => {
+    stack = await createContactStack();
+  });
+
+  afterAll(async () => {
+    await stack.cleanup();
+  });
+
+  it('CFO known-tier: allowed/denied/escalate/trustBlocked match three-layer config', async () => {
+    const email = `authz-cfo-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Authz CFO ${runId}`,
+      role: 'cfo',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'ceo_stated',
+    });
+
+    // Low-trust channel (email): high-sensitivity CFO grants are trust-blocked.
+    const onEmail = await stack.resolver.resolve('email', email);
+    expect(onEmail.resolved).toBe(true);
+    if (!onEmail.resolved) return;
+    expect(onEmail.authorization).not.toBeNull();
+    const emailAuth = onEmail.authorization!;
+    expect(emailAuth.allowed).toEqual(
+      expect.arrayContaining(['schedule_meetings', 'request_action_items']),
+    );
+    expect(emailAuth.denied).toEqual(
+      expect.arrayContaining(['send_on_behalf', 'see_personal_calendar']),
+    );
+    expect(emailAuth.trustBlocked).toEqual(
+      expect.arrayContaining(['view_financial_reports', 'view_board_materials']),
+    );
+    expect(emailAuth.escalate).toEqual(
+      expect.arrayContaining(['book_travel', 'manage_personal_appointments', 'access_internal_docs']),
+    );
+
+    // High-trust channel: same role grants without trust block.
+    const signalId = `+1777${String([...runId].reduce((n, c) => (n * 31 + c.charCodeAt(0)) >>> 0, 0) % 10_000_000).padStart(7, '0')}`;
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'signal',
+      channelIdentifier: signalId,
+      source: 'ceo_stated',
+    });
+    const onSignal = await stack.resolver.resolve('signal', signalId);
+    expect(onSignal.resolved).toBe(true);
+    if (!onSignal.resolved) return;
+    expect(onSignal.authorization!.allowed).toEqual(
+      expect.arrayContaining([
+        'view_financial_reports',
+        'view_board_materials',
+        'schedule_meetings',
+        'request_action_items',
+      ]),
+    );
+    expect(onSignal.authorization!.trustBlocked).not.toContain('view_financial_reports');
+  });
+
+  it('override wins: grant role-denied and deny role-granted', async () => {
+    const email = `authz-override-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Authz Override ${runId}`,
+      role: 'cfo',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'ceo_stated',
+    });
+
+    // Grant a role-denied perm; deny a role-granted perm.
+    await stack.contactService.grantPermission(contact.id, 'send_on_behalf', true, 'ceo');
+    await stack.contactService.grantPermission(contact.id, 'schedule_meetings', false, 'ceo');
+
+    // send_on_behalf is high sensitivity — use signal so override grant is not trust-blocked.
+    const signalId = `+1888${String([...runId].reduce((n, c) => (n * 31 + c.charCodeAt(0)) >>> 0, 1) % 10_000_000).padStart(7, '0')}`;
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'signal',
+      channelIdentifier: signalId,
+      source: 'ceo_stated',
+    });
+
+    const resolved = await stack.resolver.resolve('signal', signalId);
+    expect(resolved.resolved).toBe(true);
+    if (!resolved.resolved) return;
+    expect(resolved.authorization!.allowed).toContain('send_on_behalf');
+    expect(resolved.authorization!.denied).toContain('schedule_meetings');
+  });
+
+  it('free-text role falls back to tier_defaults', async () => {
+    const email = `authz-sister-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Sister ${runId}`,
+      role: 'Sister',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    await stack.contactService.setTier(contact.id, 'trusted');
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'ceo_stated',
+    });
+
+    const resolved = await stack.resolver.resolve('email', email);
+    expect(resolved.resolved).toBe(true);
+    if (!resolved.resolved) return;
+    // tier_defaults.trusted grants calendar/travel/meetings; deny financials/board/internal
+    expect(resolved.authorization!.allowed).toEqual(
+      expect.arrayContaining([
+        'see_personal_calendar',
+        'book_travel',
+        'schedule_meetings',
+        'request_action_items',
+        'request_meeting_notes',
+      ]),
+    );
+    expect(resolved.authorization!.denied).toEqual(
+      expect.arrayContaining([
+        'view_financial_reports',
+        'view_board_materials',
+        'access_internal_docs',
+      ]),
+    );
+  });
+
+  it('effective trust: trusted tier on email does not trust-block high-sensitivity grants', async () => {
+    const email = `authz-trusted-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Trusted CFO ${runId}`,
+      role: 'cfo',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    await stack.contactService.setTier(contact.id, 'trusted');
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'ceo_stated',
+    });
+
+    const resolved = await stack.resolver.resolve('email', email);
+    expect(resolved.resolved).toBe(true);
+    if (!resolved.resolved) return;
+    // effectiveTrustRank = max(email=low=0, trusted=2) = 2 >= high sensitivity → allowed
+    expect(resolved.authorization!.trustBlocked).not.toContain('view_financial_reports');
+    expect(resolved.authorization!.allowed).toContain('view_financial_reports');
+  });
+
+  it('edge: no tier_defaults entry falls through to unknown role deny-all', () => {
+    const base = loadAuthConfig(CONFIG_DIR);
+    const { known: _removed, ...rest } = base.tierDefaults ?? {};
+    void _removed;
+    const configWithoutKnown: AuthConfig = {
+      ...base,
+      tierDefaults: rest,
+    };
+    const auth = new AuthorizationService(configWithoutKnown);
+    // Free-text role → no role match → missing tierDefaults['known'] → roles.unknown → deny-all
+    const result = auth.evaluate({
+      role: 'Head Instructor',
+      tier: 'known',
+      channel: 'email',
+      overrides: [],
+    });
+    expect(result.allowed).toEqual([]);
+    expect(result.denied).toContain('*');
+  });
+
+  it('edge: Gate-1 deny-all for unknown and blocked tiers regardless of role/overrides', async () => {
+    const unknownEmail = `authz-gate-unknown-${runId}@example.com`;
+    const blockedEmail = `authz-gate-blocked-${runId}@example.com`;
+
+    const unknown = await stack.contactService.createContact({
+      displayName: `Gate Unknown ${runId}`,
+      role: 'cfo',
+      source: 'ceo_stated',
+      tier: 'unknown',
+    });
+    stack.trackContact(unknown.id, unknown.kgNodeId);
+    await stack.contactService.grantPermission(unknown.id, 'schedule_meetings', true, 'ceo');
+    await stack.contactService.linkIdentity({
+      contactId: unknown.id,
+      channel: 'email',
+      channelIdentifier: unknownEmail,
+      source: 'ceo_stated',
+    });
+
+    const blocked = await stack.contactService.createContact({
+      displayName: `Gate Blocked ${runId}`,
+      role: 'cfo',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(blocked.id, blocked.kgNodeId);
+    await stack.contactService.setTier(blocked.id, 'blocked');
+    await stack.contactService.grantPermission(blocked.id, 'schedule_meetings', true, 'ceo');
+    await stack.contactService.linkIdentity({
+      contactId: blocked.id,
+      channel: 'email',
+      channelIdentifier: blockedEmail,
+      source: 'ceo_stated',
+    });
+
+    const u = await stack.resolver.resolve('email', unknownEmail);
+    expect(u.resolved).toBe(true);
+    if (!u.resolved) return;
+    expect(u.authorization!.allowed).toEqual([]);
+    expect(u.authorization!.denied).toContain('*');
+
+    const b = await stack.resolver.resolve('email', blockedEmail);
+    expect(b.resolved).toBe(true);
+    if (!b.resolved) return;
+    expect(b.authorization!.allowed).toEqual([]);
+    expect(b.authorization!.denied).toContain('*');
+  });
+
+  it('dispatch audit: contact.resolved fires for known sender (authz-decision row is #1379)', async () => {
+    // AuthorizationService.evaluate cannot emit an audit row (#1379). The evidence
+    // we have today is the dispatch-layer contact.resolved event.
+    const email = `authz-logged-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Authz Logged ${runId}`,
+      role: 'cfo',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'ceo_stated',
+    });
+
+    const bus = new EventBus(stack.logger);
+    const dispatcher = new Dispatcher({
+      bus,
+      logger: stack.logger,
+      contactResolver: stack.resolver,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow', threaded: true } },
+    });
+    dispatcher.register();
+
+    const resolvedEvents: ContactResolvedEvent[] = [];
+    const rejectedEvents: MessageRejectedEvent[] = [];
+    const taskEvents: AgentTaskEvent[] = [];
+    bus.subscribe('contact.resolved', 'system', (e) => { resolvedEvents.push(e as ContactResolvedEvent); });
+    bus.subscribe('message.rejected', 'system', (e) => { rejectedEvents.push(e as MessageRejectedEvent); });
+    bus.subscribe('agent.task', 'agent', (e) => { taskEvents.push(e as AgentTaskEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: `email:${email}:authz`,
+      channelId: 'email',
+      senderId: email,
+      content: 'Request board pack',
+    }));
+
+    expect(resolvedEvents).toHaveLength(1);
+    expect(resolvedEvents[0]!.payload.contactId).toBe(contact.id);
+    expect(resolvedEvents[0]!.payload.role).toBe('cfo');
+    expect(rejectedEvents).toHaveLength(0);
+    expect(taskEvents).toHaveLength(1);
+  });
+});

--- a/tests/integration/contacts/authorization-check.test.ts
+++ b/tests/integration/contacts/authorization-check.test.ts
@@ -19,6 +19,7 @@ import type { AuthConfig } from '../../../src/contacts/types.js';
 import {
   describeIf,
   makeRunId,
+  signalForRun,
   createContactStack,
   CONFIG_DIR,
   type ContactTestStack,
@@ -72,7 +73,7 @@ describeIf('Contact resolution: authorization check integration', () => {
     );
 
     // High-trust channel: same role grants without trust block.
-    const signalId = `+1777${String([...runId].reduce((n, c) => (n * 31 + c.charCodeAt(0)) >>> 0, 0) % 10_000_000).padStart(7, '0')}`;
+    const signalId = signalForRun(runId, 77);
     await stack.contactService.linkIdentity({
       contactId: contact.id,
       channel: 'signal',
@@ -114,7 +115,7 @@ describeIf('Contact resolution: authorization check integration', () => {
     await stack.contactService.grantPermission(contact.id, 'schedule_meetings', false, 'ceo');
 
     // send_on_behalf is high sensitivity — use signal so override grant is not trust-blocked.
-    const signalId = `+1888${String([...runId].reduce((n, c) => (n * 31 + c.charCodeAt(0)) >>> 0, 1) % 10_000_000).padStart(7, '0')}`;
+    const signalId = signalForRun(runId, 88);
     await stack.contactService.linkIdentity({
       contactId: contact.id,
       channel: 'signal',

--- a/tests/integration/contacts/external-enrichment.test.ts
+++ b/tests/integration/contacts/external-enrichment.test.ts
@@ -4,6 +4,7 @@ import { it, expect, beforeAll, afterAll } from 'vitest';
 import {
   describeIf,
   makeRunId,
+  signalForRun,
   createContactStack,
   type ContactTestStack,
 } from './harness.js';
@@ -56,7 +57,7 @@ describeIf('Contact resolution: external source enrichment', () => {
 
   it('enrichment via crm_import Signal identity + field update is resolvable', async () => {
     const email = `crm-${runId}@example.com`;
-    const signalId = `+1666${runId.slice(0, 7).padEnd(7, '0')}`;
+    const signalId = signalForRun(runId, 66);
 
     const contact = await stack.contactService.createContact({
       displayName: `CRM Import ${runId}`,
@@ -118,11 +119,14 @@ describeIf('Contact resolution: external source enrichment', () => {
     });
 
     if (contact.kgNodeId) {
-      await stack.entityMemory.storeFact({
+      const factResult = await stack.entityMemory.storeFact({
         entityNodeId: contact.kgNodeId,
         label: `Imported from HubSpot account run ${runId}`,
         source: 'crm_import',
       });
+      if (factResult.stored && factResult.nodeId) {
+        stack.trackKgNode(factResult.nodeId);
+      }
     }
 
     const resolved = await stack.resolver.resolve('email', email);

--- a/tests/integration/contacts/external-enrichment.test.ts
+++ b/tests/integration/contacts/external-enrichment.test.ts
@@ -1,0 +1,133 @@
+// External-source enrichment (CRM/calendar → contact) — service/resolver seam (#1382).
+
+import { it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  describeIf,
+  makeRunId,
+  createContactStack,
+  type ContactTestStack,
+} from './harness.js';
+
+describeIf('Contact resolution: external source enrichment', () => {
+  let stack: ContactTestStack;
+  const runId = makeRunId();
+
+  beforeAll(async () => {
+    stack = await createContactStack();
+  });
+
+  afterAll(async () => {
+    await stack.cleanup();
+  });
+
+  it('calendar_attendee / crm_import identities auto-verify and resolve', async () => {
+    const email = `cal-attendee-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Calendar Guest ${runId}`,
+      role: 'Advisor',
+      source: 'calendar_attendee',
+      tier: 'known',
+      organization: 'Acme Corp',
+      timezone: 'America/Toronto',
+      title: 'VP Ops',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+
+    const identity = await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'calendar_attendee',
+    });
+    expect(identity.verified).toBe(true);
+
+    const resolved = await stack.resolver.resolve('email', email);
+    expect(resolved.resolved).toBe(true);
+    if (!resolved.resolved) return;
+    expect(resolved.verified).toBe(true);
+    expect(resolved.tier).toBe('known');
+
+    // Canonical fields round-trip
+    const stored = await stack.contactService.getContact(contact.id);
+    expect(stored?.organization).toBe('Acme Corp');
+    expect(stored?.timezone).toBe('America/Toronto');
+    expect(stored?.title).toBe('VP Ops');
+  });
+
+  it('enrichment via crm_import Signal identity + field update is resolvable', async () => {
+    const email = `crm-${runId}@example.com`;
+    const signalId = `+1666${runId.slice(0, 7).padEnd(7, '0')}`;
+
+    const contact = await stack.contactService.createContact({
+      displayName: `CRM Import ${runId}`,
+      source: 'crm_import',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'crm_import',
+    });
+
+    // Edge: channel not yet linked → unresolved
+    const before = await stack.resolver.resolve('signal', signalId);
+    expect(before.resolved).toBe(false);
+
+    const signalIdentity = await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'signal',
+      channelIdentifier: signalId,
+      source: 'crm_import',
+    });
+    expect(signalIdentity.verified).toBe(true);
+
+    await stack.contactService.updateContactFields(contact.id, {
+      organization: 'Globex',
+      timezone: 'America/Vancouver',
+      title: 'Partner',
+    });
+
+    const after = await stack.resolver.resolve('signal', signalId);
+    expect(after.resolved).toBe(true);
+    if (!after.resolved) return;
+    expect(after.verified).toBe(true);
+
+    const stored = await stack.contactService.getContact(contact.id);
+    expect(stored?.organization).toBe('Globex');
+    expect(stored?.timezone).toBe('America/Vancouver');
+    expect(stored?.title).toBe('Partner');
+  });
+
+  it('enriched KG facts surface in knowledgeSummary after external create', async () => {
+    const email = `crm-kg-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `CRM KG ${runId}`,
+      source: 'crm_import',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'crm_import',
+    });
+
+    if (contact.kgNodeId) {
+      await stack.entityMemory.storeFact({
+        entityNodeId: contact.kgNodeId,
+        label: `Imported from HubSpot account run ${runId}`,
+        source: 'crm_import',
+      });
+    }
+
+    const resolved = await stack.resolver.resolve('email', email);
+    expect(resolved.resolved).toBe(true);
+    if (!resolved.resolved) return;
+    expect(resolved.knowledgeSummary).toContain(`HubSpot account run ${runId}`);
+  });
+});

--- a/tests/integration/contacts/harness.ts
+++ b/tests/integration/contacts/harness.ts
@@ -1,0 +1,109 @@
+// Shared harness for contact-resolution integration tests (#1382).
+// Parallel-safe: tracks created IDs and deletes by id (never blanket DELETE).
+// Self-skips when DATABASE_URL is unset.
+
+import path from 'node:path';
+import { describe } from 'vitest';
+import pg from 'pg';
+import { ContactService } from '../../../src/contacts/contact-service.js';
+import { ContactResolver } from '../../../src/contacts/contact-resolver.js';
+import { AuthorizationService } from '../../../src/contacts/authorization.js';
+import { loadAuthConfig } from '../../../src/contacts/config-loader.js';
+import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../../src/memory/embedding.js';
+import { EntityMemory } from '../../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../../src/memory/validation.js';
+import { createLogger, createSilentLogger } from '../../../src/logger.js';
+import type { Logger } from '../../../src/logger.js';
+
+const { Pool } = pg;
+
+export const DATABASE_URL = process.env['DATABASE_URL'];
+export const describeIf = DATABASE_URL ? describe : describe.skip;
+export const CONFIG_DIR = path.join(process.cwd(), 'config');
+
+export function makeRunId(): string {
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+}
+
+export interface ContactTestStack {
+  pool: pg.Pool;
+  logger: Logger;
+  entityMemory: EntityMemory;
+  contactService: ContactService;
+  authService: AuthorizationService;
+  resolver: ContactResolver;
+  createdContactIds: string[];
+  createdKgNodeIds: string[];
+  trackContact: (contactId: string, kgNodeId?: string | null) => void;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Wire ContactService + ContactResolver + AuthorizationService against real Postgres.
+ * Same service stack as tests/integration/contacts.test.ts, with auth wired in
+ * and parallel-safe ID-scoped cleanup (dedup-contacts-merge.test.ts pattern).
+ */
+export async function createContactStack(): Promise<ContactTestStack> {
+  if (!DATABASE_URL) {
+    throw new Error('createContactStack requires DATABASE_URL');
+  }
+
+  const pool = new Pool({ connectionString: DATABASE_URL });
+  const logger = createLogger('error');
+  const embeddingService = EmbeddingService.createForTesting();
+  const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+  const validator = new MemoryValidator(kgStore, embeddingService);
+  const entityMemory = new EntityMemory(kgStore, validator, embeddingService, createSilentLogger());
+  const contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
+  const authService = new AuthorizationService(loadAuthConfig(CONFIG_DIR));
+  const resolver = new ContactResolver(contactService, entityMemory, authService, logger);
+
+  const createdContactIds: string[] = [];
+  const createdKgNodeIds: string[] = [];
+
+  const trackContact = (contactId: string, kgNodeId?: string | null): void => {
+    createdContactIds.push(contactId);
+    if (kgNodeId) createdKgNodeIds.push(kgNodeId);
+  };
+
+  const cleanup = async (): Promise<void> => {
+    // FK order: identities / overrides → contacts → kg edges → kg nodes.
+    // Never DELETE FROM audit_log — append-only trigger rejects it.
+    if (createdContactIds.length > 0) {
+      await pool.query(
+        'DELETE FROM contact_channel_identities WHERE contact_id = ANY($1)',
+        [createdContactIds],
+      );
+      await pool.query(
+        'DELETE FROM contact_auth_overrides WHERE contact_id = ANY($1)',
+        [createdContactIds],
+      );
+      await pool.query('DELETE FROM contacts WHERE id = ANY($1)', [createdContactIds]);
+    }
+    if (createdKgNodeIds.length > 0) {
+      await pool.query(
+        'DELETE FROM kg_edges WHERE source_node_id = ANY($1) OR target_node_id = ANY($1)',
+        [createdKgNodeIds],
+      );
+      // Fact nodes linked via edges are cleaned above; also remove tracked entity nodes.
+      await pool.query('DELETE FROM kg_nodes WHERE id = ANY($1)', [createdKgNodeIds]);
+    }
+    await pool.end();
+  };
+
+  await pool.query('SELECT 1 FROM contacts LIMIT 0');
+
+  return {
+    pool,
+    logger,
+    entityMemory,
+    contactService,
+    authService,
+    resolver,
+    createdContactIds,
+    createdKgNodeIds,
+    trackContact,
+    cleanup,
+  };
+}

--- a/tests/integration/contacts/harness.ts
+++ b/tests/integration/contacts/harness.ts
@@ -26,6 +26,20 @@ export function makeRunId(): string {
   return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 }
 
+/**
+ * Deterministic digit-only Signal identifier derived from runId.
+ * `salt` differentiates multiple identities within the same suite.
+ */
+export function signalForRun(runId: string, salt = 0): string {
+  let n = salt >>> 0;
+  for (let i = 0; i < runId.length; i++) {
+    n = (n * 31 + runId.charCodeAt(i)) >>> 0;
+  }
+  // Keep NPA in the 7xx range so callers can vary the area code by salt.
+  const npa = 700 + (salt % 100);
+  return `+1${npa}${String(n % 10_000_000).padStart(7, '0')}`;
+}
+
 export interface ContactTestStack {
   pool: pg.Pool;
   logger: Logger;
@@ -36,6 +50,8 @@ export interface ContactTestStack {
   createdContactIds: string[];
   createdKgNodeIds: string[];
   trackContact: (contactId: string, kgNodeId?: string | null) => void;
+  /** Track arbitrary KG nodes (e.g. fact nodes from storeFact) for teardown. */
+  trackKgNode: (kgNodeId: string) => void;
   cleanup: () => Promise<void>;
 }
 
@@ -50,60 +66,75 @@ export async function createContactStack(): Promise<ContactTestStack> {
   }
 
   const pool = new Pool({ connectionString: DATABASE_URL });
-  const logger = createLogger('error');
-  const embeddingService = EmbeddingService.createForTesting();
-  const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
-  const validator = new MemoryValidator(kgStore, embeddingService);
-  const entityMemory = new EntityMemory(kgStore, validator, embeddingService, createSilentLogger());
-  const contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
-  const authService = new AuthorizationService(loadAuthConfig(CONFIG_DIR));
-  const resolver = new ContactResolver(contactService, entityMemory, authService, logger);
 
-  const createdContactIds: string[] = [];
-  const createdKgNodeIds: string[] = [];
+  try {
+    const logger = createLogger('error');
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    const entityMemory = new EntityMemory(kgStore, validator, embeddingService, createSilentLogger());
+    const contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
+    const authService = new AuthorizationService(loadAuthConfig(CONFIG_DIR));
+    const resolver = new ContactResolver(contactService, entityMemory, authService, logger);
 
-  const trackContact = (contactId: string, kgNodeId?: string | null): void => {
-    createdContactIds.push(contactId);
-    if (kgNodeId) createdKgNodeIds.push(kgNodeId);
-  };
+    const createdContactIds: string[] = [];
+    const createdKgNodeIds: string[] = [];
 
-  const cleanup = async (): Promise<void> => {
-    // FK order: identities / overrides → contacts → kg edges → kg nodes.
-    // Never DELETE FROM audit_log — append-only trigger rejects it.
-    if (createdContactIds.length > 0) {
-      await pool.query(
-        'DELETE FROM contact_channel_identities WHERE contact_id = ANY($1)',
-        [createdContactIds],
-      );
-      await pool.query(
-        'DELETE FROM contact_auth_overrides WHERE contact_id = ANY($1)',
-        [createdContactIds],
-      );
-      await pool.query('DELETE FROM contacts WHERE id = ANY($1)', [createdContactIds]);
-    }
-    if (createdKgNodeIds.length > 0) {
-      await pool.query(
-        'DELETE FROM kg_edges WHERE source_node_id = ANY($1) OR target_node_id = ANY($1)',
-        [createdKgNodeIds],
-      );
-      // Fact nodes linked via edges are cleaned above; also remove tracked entity nodes.
-      await pool.query('DELETE FROM kg_nodes WHERE id = ANY($1)', [createdKgNodeIds]);
-    }
-    await pool.end();
-  };
+    const trackContact = (contactId: string, kgNodeId?: string | null): void => {
+      createdContactIds.push(contactId);
+      if (kgNodeId) createdKgNodeIds.push(kgNodeId);
+    };
 
-  await pool.query('SELECT 1 FROM contacts LIMIT 0');
+    const trackKgNode = (kgNodeId: string): void => {
+      createdKgNodeIds.push(kgNodeId);
+    };
 
-  return {
-    pool,
-    logger,
-    entityMemory,
-    contactService,
-    authService,
-    resolver,
-    createdContactIds,
-    createdKgNodeIds,
-    trackContact,
-    cleanup,
-  };
+    const cleanup = async (): Promise<void> => {
+      // FK order: identities / overrides → contacts → kg edges → kg nodes.
+      // Never DELETE FROM audit_log — append-only trigger rejects it.
+      try {
+        if (createdContactIds.length > 0) {
+          await pool.query(
+            'DELETE FROM contact_channel_identities WHERE contact_id = ANY($1)',
+            [createdContactIds],
+          );
+          await pool.query(
+            'DELETE FROM contact_auth_overrides WHERE contact_id = ANY($1)',
+            [createdContactIds],
+          );
+          await pool.query('DELETE FROM contacts WHERE id = ANY($1)', [createdContactIds]);
+        }
+        if (createdKgNodeIds.length > 0) {
+          await pool.query(
+            'DELETE FROM kg_edges WHERE source_node_id = ANY($1) OR target_node_id = ANY($1)',
+            [createdKgNodeIds],
+          );
+          // Delete tracked nodes (contact entity nodes and any fact nodes via trackKgNode).
+          await pool.query('DELETE FROM kg_nodes WHERE id = ANY($1)', [createdKgNodeIds]);
+        }
+      } finally {
+        await pool.end();
+      }
+    };
+
+    await pool.query('SELECT 1 FROM contacts LIMIT 0');
+
+    return {
+      pool,
+      logger,
+      entityMemory,
+      contactService,
+      authService,
+      resolver,
+      createdContactIds,
+      createdKgNodeIds,
+      trackContact,
+      trackKgNode,
+      cleanup,
+    };
+  } catch (err) {
+    // Setup failed after the pool was opened — release connections before rethrowing.
+    await pool.end().catch(() => undefined);
+    throw err;
+  }
 }

--- a/tests/integration/contacts/proactive-identity.test.ts
+++ b/tests/integration/contacts/proactive-identity.test.ts
@@ -5,15 +5,10 @@ import { it, expect, beforeAll, afterAll } from 'vitest';
 import {
   describeIf,
   makeRunId,
+  signalForRun,
   createContactStack,
   type ContactTestStack,
 } from './harness.js';
-
-function signalForRun(runId: string): string {
-  let n = 0;
-  for (let i = 0; i < runId.length; i++) n = (n * 31 + runId.charCodeAt(i)) >>> 0;
-  return `+1555${String(n % 10_000_000).padStart(7, '0')}`;
-}
 
 describeIf('Contact resolution: proactive identity establishment', () => {
   let stack: ContactTestStack;
@@ -115,11 +110,14 @@ describeIf('Contact resolution: proactive identity establishment', () => {
     });
 
     if (contact.kgNodeId) {
-      await stack.entityMemory.storeFact({
+      const factResult = await stack.entityMemory.storeFact({
         entityNodeId: contact.kgNodeId,
         label: `Manages Q3 board packet for run ${runId}`,
         source: 'integration-test',
       });
+      if (factResult.stored && factResult.nodeId) {
+        stack.trackKgNode(factResult.nodeId);
+      }
     }
 
     const resolved = await stack.resolver.resolve('email', email);

--- a/tests/integration/contacts/proactive-identity.test.ts
+++ b/tests/integration/contacts/proactive-identity.test.ts
@@ -1,0 +1,130 @@
+// Proactive identity establishment — service/resolver seam (#1382).
+// Contact already known / pre-populated; resolver returns tier, attributes, and auth.
+
+import { it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  describeIf,
+  makeRunId,
+  createContactStack,
+  type ContactTestStack,
+} from './harness.js';
+
+function signalForRun(runId: string): string {
+  let n = 0;
+  for (let i = 0; i < runId.length; i++) n = (n * 31 + runId.charCodeAt(i)) >>> 0;
+  return `+1555${String(n % 10_000_000).padStart(7, '0')}`;
+}
+
+describeIf('Contact resolution: proactive identity establishment', () => {
+  let stack: ContactTestStack;
+  const runId = makeRunId();
+
+  beforeAll(async () => {
+    stack = await createContactStack();
+  });
+
+  afterAll(async () => {
+    await stack.cleanup();
+  });
+
+  it('resolves a pre-populated CFO contact with known tier and role grants', async () => {
+    const email = `proactive-cfo-${runId}@example.com`;
+    const signalId = signalForRun(runId);
+    const contact = await stack.contactService.createContact({
+      displayName: `Proactive CFO ${runId}`,
+      role: 'CFO',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'ceo_stated',
+    });
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'signal',
+      channelIdentifier: signalId,
+      source: 'ceo_stated',
+    });
+
+    // Use signal (high trust) so CFO high-sensitivity grants land in allowed, not trustBlocked.
+    const resolved = await stack.resolver.resolve('signal', signalId);
+    expect(resolved.resolved).toBe(true);
+    if (!resolved.resolved) return;
+
+    expect(resolved.tier).toBe('known');
+    expect(resolved.verified).toBe(true);
+    expect(resolved.displayName).toBe(`Proactive CFO ${runId}`);
+    expect(resolved.role).toBe('CFO');
+    expect(resolved.authorization).not.toBeNull();
+    expect(resolved.authorization!.allowed).toEqual(
+      expect.arrayContaining([
+        'view_financial_reports',
+        'view_board_materials',
+        'request_action_items',
+        'schedule_meetings',
+      ]),
+    );
+    expect(resolved.authorization!.denied).toEqual(
+      expect.arrayContaining(['send_on_behalf', 'see_personal_calendar']),
+    );
+
+    const emailResolved = await stack.resolver.resolve('email', email);
+    expect(emailResolved.resolved).toBe(true);
+  });
+
+  it('returns resolved:false when contact has a role but no identity for that channel', async () => {
+    const contact = await stack.contactService.createContact({
+      displayName: `Partial Mention ${runId}`,
+      role: 'Advisor',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    // No linkIdentity — CEO mentioned them but no channel identity yet.
+
+    const result = await stack.resolver.resolve(
+      'email',
+      `partial-mention-${runId}@example.com`,
+    );
+    expect(result.resolved).toBe(false);
+    if (!result.resolved) {
+      expect(result.senderId).toBe(`partial-mention-${runId}@example.com`);
+    }
+  });
+
+  it('surfaces KG facts in knowledgeSummary for a known contact', async () => {
+    const email = `proactive-kg-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `KG Enrich ${runId}`,
+      role: 'CFO',
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'ceo_stated',
+    });
+
+    if (contact.kgNodeId) {
+      await stack.entityMemory.storeFact({
+        entityNodeId: contact.kgNodeId,
+        label: `Manages Q3 board packet for run ${runId}`,
+        source: 'integration-test',
+      });
+    }
+
+    const resolved = await stack.resolver.resolve('email', email);
+    expect(resolved.resolved).toBe(true);
+    if (!resolved.resolved) return;
+    expect(resolved.knowledgeSummary).toContain(`Q3 board packet for run ${runId}`);
+  });
+});

--- a/tests/integration/contacts/reactive-identity.test.ts
+++ b/tests/integration/contacts/reactive-identity.test.ts
@@ -1,0 +1,249 @@
+// Reactive identity establishment (unknown-sender flow) — real Dispatcher + bus (#1382).
+//
+// Two real steps:
+//   A) Channel adapters create tier='unknown' contacts (modeled here via ContactService
+//      with source email_participant — the dispatcher itself does NOT create contacts).
+//   B) Dispatcher routes unknown / unknown-tier senders per channelPolicies.
+
+import { it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { EventBus } from '../../../src/bus/bus.js';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import { AgentRuntime } from '../../../src/agents/runtime.js';
+import {
+  createInboundMessage,
+  type ContactUnknownEvent,
+  type ContactResolvedEvent,
+  type MessageRejectedEvent,
+  type AgentTaskEvent,
+} from '../../../src/bus/events.js';
+import type { LLMProvider } from '../../../src/agents/llm/provider.js';
+import {
+  describeIf,
+  makeRunId,
+  createContactStack,
+  type ContactTestStack,
+} from './harness.js';
+
+const MOCK_PROVENANCE = {
+  requestedModel: 'mock-model',
+  actualModel: 'mock-model',
+  providerRequestId: 'msg_mock_reactive',
+} as const;
+
+describeIf('Contact resolution: reactive identity establishment', () => {
+  let stack: ContactTestStack;
+  const runId = makeRunId();
+
+  beforeAll(async () => {
+    stack = await createContactStack();
+  });
+
+  afterAll(async () => {
+    await stack.cleanup();
+  });
+
+  function wireDispatch(policies: Record<string, { trust: 'low' | 'medium' | 'high'; unknownSender: 'allow' | 'ignore'; threaded: boolean }>) {
+    const bus = new EventBus(stack.logger);
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Acknowledged.',
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger: stack.logger,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger: stack.logger,
+      contactResolver: stack.resolver,
+      channelPolicies: policies,
+    });
+    dispatcher.register();
+
+    const unknownEvents: ContactUnknownEvent[] = [];
+    const resolvedEvents: ContactResolvedEvent[] = [];
+    const rejectedEvents: MessageRejectedEvent[] = [];
+    const taskEvents: AgentTaskEvent[] = [];
+
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+    bus.subscribe('contact.resolved', 'system', (e) => { resolvedEvents.push(e as ContactResolvedEvent); });
+    bus.subscribe('message.rejected', 'system', (e) => { rejectedEvents.push(e as MessageRejectedEvent); });
+    bus.subscribe('agent.task', 'agent', (e) => { taskEvents.push(e as AgentTaskEvent); });
+
+    return { bus, unknownEvents, resolvedEvents, rejectedEvents, taskEvents };
+  }
+
+  it('step A: unknown sender persisted as tier=unknown then resolves', async () => {
+    // Models channel-adapter auto-create (email-adapter / signal-adapter), not the dispatcher.
+    const email = `reactive-unknown-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: email,
+      source: 'email_participant',
+      tier: 'unknown',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+
+    const identity = await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'email_participant',
+    });
+    expect(identity.verified).toBe(true); // email_participant is AUTO_VERIFIED
+
+    const resolved = await stack.resolver.resolve('email', email);
+    expect(resolved.resolved).toBe(true);
+    if (!resolved.resolved) return;
+    expect(resolved.tier).toBe('unknown');
+    expect(resolved.verified).toBe(true);
+  });
+
+  it('truly-unknown sender with allow policy: contact.unknown + agent.task, no reject', async () => {
+    const email = `truly-unknown-${runId}@example.com`;
+    const { bus, unknownEvents, rejectedEvents, taskEvents } = wireDispatch({
+      email: { trust: 'low', unknownSender: 'allow', threaded: true },
+    });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: `email:${email}:1`,
+      channelId: 'email',
+      senderId: email,
+      content: 'Hello from a stranger',
+    }));
+
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('allow');
+    expect(unknownEvents[0]!.payload.senderId).toBe(email);
+    expect(taskEvents).toHaveLength(1);
+    expect(rejectedEvents).toHaveLength(0);
+  });
+
+  it('resolved tier=unknown (non-automated) routes to coordinator; contact.resolved fires', async () => {
+    const email = `unknown-tier-route-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Unknown Tier ${runId}`,
+      source: 'email_participant',
+      tier: 'unknown',
+      kind: 'person',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'email_participant',
+    });
+
+    const { bus, unknownEvents, resolvedEvents, rejectedEvents, taskEvents } = wireDispatch({
+      email: { trust: 'low', unknownSender: 'allow', threaded: true },
+    });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: `email:${email}:1`,
+      channelId: 'email',
+      senderId: email,
+      content: 'Following up',
+    }));
+
+    expect(resolvedEvents).toHaveLength(1);
+    expect(resolvedEvents[0]!.payload.contactId).toBe(contact.id);
+    expect(unknownEvents).toHaveLength(0);
+    expect(rejectedEvents).toHaveLength(0);
+    expect(taskEvents).toHaveLength(1);
+  });
+
+  it('unknownSender=ignore rejects truly-unknown with reason unknown_sender, no agent.task', async () => {
+    const email = `ignored-stranger-${runId}@example.com`;
+    const { bus, unknownEvents, rejectedEvents, taskEvents } = wireDispatch({
+      email: { trust: 'low', unknownSender: 'ignore', threaded: true },
+    });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: `email:${email}:1`,
+      channelId: 'email',
+      senderId: email,
+      content: 'Please ignore me',
+    }));
+
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('ignore');
+    expect(rejectedEvents).toHaveLength(1);
+    expect(rejectedEvents[0]!.payload.reason).toBe('unknown_sender');
+    expect(taskEvents).toHaveLength(0);
+  });
+
+  it('tier=blocked is dropped with message.rejected reason blocked_sender', async () => {
+    const email = `blocked-${runId}@example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Blocked ${runId}`,
+      source: 'email_participant',
+      tier: 'known',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    await stack.contactService.setTier(contact.id, 'blocked');
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'email_participant',
+    });
+
+    const { bus, rejectedEvents, taskEvents } = wireDispatch({
+      email: { trust: 'low', unknownSender: 'allow', threaded: true },
+    });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: `email:${email}:1`,
+      channelId: 'email',
+      senderId: email,
+      content: 'Should be dropped',
+    }));
+
+    expect(rejectedEvents).toHaveLength(1);
+    expect(rejectedEvents[0]!.payload.reason).toBe('blocked_sender');
+    expect(taskEvents).toHaveLength(0);
+  });
+
+  it('kind=automated + tier=unknown bypasses the gate and routes normally', async () => {
+    const email = `automated-${runId}@noreply.example.com`;
+    const contact = await stack.contactService.createContact({
+      displayName: `Automated ${runId}`,
+      source: 'email_participant',
+      tier: 'unknown',
+      kind: 'automated',
+    });
+    stack.trackContact(contact.id, contact.kgNodeId);
+    await stack.contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: email,
+      source: 'email_participant',
+    });
+
+    // Even with ignore policy, automated unknown-tier bypasses the gate.
+    const { bus, rejectedEvents, resolvedEvents, taskEvents } = wireDispatch({
+      email: { trust: 'low', unknownSender: 'ignore', threaded: true },
+    });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: `email:${email}:1`,
+      channelId: 'email',
+      senderId: email,
+      content: 'Calendar invite notification',
+    }));
+
+    expect(resolvedEvents).toHaveLength(1);
+    expect(rejectedEvents).toHaveLength(0);
+    expect(taskEvents).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1382.

Adds end-to-end integration coverage for the contact resolution system (spec 09) before v1.0:

1. **Proactive identity establishment** — pre-populated known contact resolves with tier, verification, and CFO role grants; partial-mention and KG enrichment edge cases.
2. **Reactive identity establishment** — channel-adapter-style `tier='unknown'` create/link, plus real `Dispatcher` + `EventBus` coverage for truly-unknown allow/ignore, unknown-tier low-trust routing, blocked drop, and automated bypass.
3. **External source enrichment** — `calendar_attendee` / `crm_import` auto-verify, field round-trip, KG summary, missing-channel → linked-channel edge.
4. **Authorization check** — real `loadAuthConfig` + DB overrides via resolver; override wins, free-text → `tier_defaults`, effective trust for `trusted` on email; Gate-1 and missing-`tier_defaults` edges; dispatch `contact.resolved` as the logged decision (authz audit row remains #1379).

Also marks the four checklist items done and removes the four integration-test Known Deficiencies from `docs/specs/09-contacts-and-identity.md` (leaves #1379).

## Changes

- Added `tests/integration/contacts/` (harness + 4 scenario suites, 19 tests)
- Updated spec 09 checklist / Known Deficiencies
- CHANGELOG `[Unreleased]` Added bullet for #1382
- Addressed CodeRabbit review: pool `try/finally`, `trackKgNode` for fact teardown, shared `signalForRun`

## Related Issues

Closes #1382

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [ ] CI passes

## Test plan

- [x] `DATABASE_URL=…/curia_test LOG_LEVEL=error npx vitest run tests/integration/contacts/` — 4 files / 19 tests pass
- [x] Unset `DATABASE_URL` — suites skip via `describeIf`
- [x] `pnpm run typecheck` passes
- [x] ESLint clean on new files
- [ ] CI Postgres job runs migrations then `pnpm test` with suites active
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55ed120e-f04d-492d-9c3f-942e15b529f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55ed120e-f04d-492d-9c3f-942e15b529f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

