### PR TITLE
feat(scheduler): scheduler-update skill to resume/pause/edit jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Scheduler** — a run finishing after a concurrent pause/cancel no longer overwrites that state. (#1409)
 - **Coordinator** — external replies use first-person single-voice; internal specialist names forbidden. (#1354)
 - **Dispatcher** — content-filter blocks on relayed replies retry with reason, then salvage draft. (#1355)
 - **Scheduler** — liveness check no longer flaps `fail` every few minutes on a healthy scheduler. (#1359)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`scheduler-update`** — new skill lets agents resume, pause, or edit a scheduled job without the web UI. (#1409)
 - **Contact resolution** — integration test coverage for identity establishment and authorization. (#1382)
 - **`diagnostics` agent** — opt-in, read-only forensic agent that diagnoses "what happened / why" for the principal. (#1356)
 - **`audit-query` / `audit-trace` / `ops-lookup`** — read-only diagnostics skills over audit + operational state. (#1356)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.11.6"
+version: "0.12.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -410,6 +410,13 @@ system_prompt: |
   "remind me every Monday"). Provide only `cron_expr` and `task`. Do not pass
   `intent_anchor` — that field is not used for operational sweeps.
 
+  **Resume, pause, or edit an existing job — use `scheduler-update`:**
+  When the CEO asks to unsuspend/resume, pause, or reschedule a job. Find the
+  `job_id` with `scheduler-list`, then call `scheduler-update` with `action`:
+  `resume` (brings a failure-suspended or drift-paused job back to active),
+  `pause` (holds an active job), or `edit` (with `cron_expr`, `run_at`, or
+  `task_payload`). Never tell the CEO to use the web UI — you can do this directly.
+
   **Backlog awareness:** Before answering "what's open?", "what's waiting on me?",
   or "what are you working on?", call `task-list`.
 
@@ -681,6 +688,7 @@ pinned_skills:
   - scheduler-create
   - scheduler-list
   - scheduler-cancel
+  - scheduler-update
   - config-store
   - date-resolve
   - get-autonomy

--- a/config/registry-defaults.yaml
+++ b/config/registry-defaults.yaml
@@ -33,6 +33,7 @@ skills:
   - scheduler-create
   - scheduler-list
   - scheduler-cancel
+  - scheduler-update
   - scheduler-report
   # Contacts
   - contact-create

--- a/docs/wip/2026-07-15-scheduler-update-skill.md
+++ b/docs/wip/2026-07-15-scheduler-update-skill.md
@@ -1,0 +1,68 @@
+# scheduler-update skill — resume / pause / edit scheduled jobs from an agent
+
+**Issue:** #1409
+**Status:** implemented, pre-PR
+
+## Context
+
+The CEO asked Curia to unsuspend some scheduled jobs. The coordinator replied it had
+"no resume/unsuspend tool — the only way to resume these is through the web UI" and
+handed over links. That was accurate: agents had `scheduler-create`, `scheduler-list`,
+`scheduler-cancel`, `scheduler-report` and nothing to resume, pause, or edit a job.
+
+Jobs auto-enter a held state two ways, neither previously agent-reversible:
+- `suspended` after 3 consecutive failures (`SUSPEND_THRESHOLD`).
+- `paused` by the drift detector.
+
+The mutations already existed server-side (`unsuspendJob`, `updateJob` in
+`src/scheduler/scheduler-service.ts`) but were wired only to the web UI's
+`PATCH /api/jobs/:id`. This closes that agent-facing gap.
+
+## Design
+
+One unified `scheduler-update` skill with an `action` discriminator —
+`resume | pause | edit` — rather than three sibling skills. Rationale: all three are
+reversible, `action_risk: low` internal-state writes, so the usual reason to split
+(different risk gates) doesn't apply; and it mirrors the web PATCH handler that already
+unifies resume + edit.
+
+**`scheduler-cancel` stays separate** (deliberately not subsumed): cancel is a terminal
+delete, it's special-cased by name in `approval-notification.ts`, and it already ships
+in prod. Keeping it separate preserves the clean `create → update → cancel` lifecycle
+and mirrors the web API's PATCH-vs-DELETE split.
+
+**Drift policy:** `resume` releases both `suspended` and `paused` (drift) jobs via the
+existing `unsuspendJob`. No extra notification on resume — the CEO was already notified
+when the drift pause fired.
+
+## Changes
+
+- `src/scheduler/scheduler-service.ts` — extract the shared pause CTE into a private
+  `setPaused(jobId)`; `pauseJobForDrift` now delegates to it (behavior unchanged); add
+  neutral `pauseJob(jobId)` for operator-initiated pause.
+- `skills/scheduler-update/{skill.json,handler.ts}` — new skill; handler dispatches
+  `resume → unsuspendJob`, `pause → pauseJob`, `edit → updateJob` (rejects edit with no
+  field, normalizes whitespace-only schedule strings like the PATCH handler).
+- `config/registry-defaults.yaml` + `agents/coordinator.yaml` — enable and pin the skill;
+  bump coordinator `version` 0.11.6 → 0.12.0; add a prompt note so the coordinator reaches
+  for it instead of pointing at the web UI.
+- Tests: `tests/unit/scheduler/scheduler-service.test.ts` (`pauseJob`),
+  `tests/unit/skills/scheduler-update.test.ts` (all actions + guards).
+- `CHANGELOG.md` — Added entry.
+
+Not touched: HTTP routes, DB schema (`status` is free-text TEXT; `paused`/`pending`
+already valid), drift detector, existing scheduler skills.
+
+## Verification
+
+- `pnpm run typecheck` (core/skills/tests projects) clean.
+- 775 scheduler + skills unit tests pass, including the capability-gate loader test.
+- End-to-end: drive the coordinator (or invoke the skill) against a `suspended`/`paused`
+  job in a dev DB — confirm resume flips it to `pending` with recomputed `next_run_at`,
+  pause holds job + task, edit changes cron/run_at/payload, and the coordinator acts
+  instead of returning web links.
+
+## Prod rollout note
+
+Even though it's in `registry-defaults.yaml`, confirm `scheduler-update` is enabled in the
+prod `skill_registry` after deploy (new skills don't auto-enroll on existing installs).

--- a/skills/scheduler-update/handler.ts
+++ b/skills/scheduler-update/handler.ts
@@ -66,9 +66,17 @@ export class SchedulerUpdateHandler implements SkillHandler {
             };
           }
 
+          // Parse and validate run_at here so the agent gets a clear diagnostic instead
+          // of a cryptic Postgres error when a malformed string reaches the DB as an
+          // Invalid Date. new Date('garbage') yields NaN rather than throwing.
+          const parsedRunAt = runAt ? new Date(runAt) : undefined;
+          if (parsedRunAt && Number.isNaN(parsedRunAt.getTime())) {
+            return { success: false, error: `Invalid run_at: "${run_at}" is not a valid ISO 8601 timestamp` };
+          }
+
           await ctx.schedulerService.updateJob(job_id, {
             cronExpr,
-            runAt: runAt ? new Date(runAt) : undefined,
+            runAt: parsedRunAt,
             taskPayload: task_payload,
           });
           break;

--- a/skills/scheduler-update/handler.ts
+++ b/skills/scheduler-update/handler.ts
@@ -1,0 +1,87 @@
+// handler.ts — scheduler-update skill implementation.
+//
+// Infrastructure skill that mutates an existing scheduled job via the SchedulerService.
+// Unifies the three post-create lifecycle operations behind one `action` discriminator:
+//   - resume: release a 'suspended' (failure-threshold) or 'paused' (drift) job → 'pending'
+//   - pause:  operator hold of an active job (job + linked task → 'paused')
+//   - edit:   change the schedule (cron_expr / run_at) or task_payload
+//
+// This mirrors the web UI's PATCH /api/jobs/:id handler, which already unifies
+// resume + edit; the skill closes the gap where agents could create/list/cancel a
+// job but could not resume, pause, or edit one (issue #1409).
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+// The lifecycle operations this skill exposes. resume and pause are state
+// transitions; edit changes schedule/payload fields.
+type SchedulerAction = 'resume' | 'pause' | 'edit';
+const VALID_ACTIONS: readonly SchedulerAction[] = ['resume', 'pause', 'edit'];
+
+export class SchedulerUpdateHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.schedulerService) {
+      return {
+        success: false,
+        error: 'scheduler-update requires schedulerService in context. Declare "schedulerService" in capabilities.',
+      };
+    }
+
+    const { job_id, action, cron_expr, run_at, task_payload } = ctx.input as {
+      job_id?: string;
+      action?: string;
+      cron_expr?: string;
+      run_at?: string;
+      task_payload?: Record<string, unknown>;
+    };
+
+    if (!job_id || typeof job_id !== 'string') {
+      return { success: false, error: 'Missing required input: job_id (string)' };
+    }
+    if (!action || !VALID_ACTIONS.includes(action as SchedulerAction)) {
+      return { success: false, error: `Missing or invalid input: action must be one of ${VALID_ACTIONS.join(', ')}` };
+    }
+
+    try {
+      switch (action as SchedulerAction) {
+        case 'resume':
+          // unsuspendJob accepts both 'suspended' and 'paused' — one call covers
+          // failure-suspended and drift-paused jobs. No extra notification here:
+          // the CEO was already notified when a drift pause fired.
+          await ctx.schedulerService.unsuspendJob(job_id);
+          break;
+        case 'pause':
+          await ctx.schedulerService.pauseJob(job_id);
+          break;
+        case 'edit': {
+          // Normalize whitespace-only schedule strings to absent so they don't
+          // pass the has-fields check while carrying no real value (mirrors the
+          // PATCH /api/jobs/:id handler). typeof guards defend against non-string input.
+          const cronExpr = typeof cron_expr === 'string' ? cron_expr.trim() || undefined : undefined;
+          const runAt = typeof run_at === 'string' ? run_at.trim() || undefined : undefined;
+
+          if (cronExpr === undefined && runAt === undefined && task_payload === undefined) {
+            return {
+              success: false,
+              error: 'action=edit requires at least one of cron_expr, run_at, or task_payload',
+            };
+          }
+
+          await ctx.schedulerService.updateJob(job_id, {
+            cronExpr,
+            runAt: runAt ? new Date(runAt) : undefined,
+            taskPayload: task_payload,
+          });
+          break;
+        }
+      }
+
+      ctx.log.info({ jobId: job_id, action }, 'Scheduled job updated via skill');
+
+      return { success: true, data: { jobId: job_id, action } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, jobId: job_id, action }, 'scheduler-update failed');
+      return { success: false, error: message };
+    }
+  }
+}

--- a/skills/scheduler-update/skill.json
+++ b/skills/scheduler-update/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "scheduler-update",
+  "description": "Modify an existing scheduled job by its ID. action=resume brings a suspended (failed) or paused (drift) job back to active; action=pause holds an active job; action=edit changes its cron_expr, run_at, or task_payload. Get the job_id from scheduler-list.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "job_id": "string",
+    "action": "string (resume | pause | edit)",
+    "cron_expr": "string? (edit only — new cron expression for a recurring job)",
+    "run_at": "timestamp? (edit only — new ISO 8601 run time for a one-shot job)",
+    "task_payload": "object? (edit only — replacement task payload)"
+  },
+  "outputs": {
+    "jobId": "string",
+    "action": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": [
+    "schedulerService"
+  ]
+}

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -946,8 +946,9 @@ export class SchedulerService {
    *   if one-shot, mark as completed.
    * - On failure: increment consecutive_failures. If it reaches SUSPEND_THRESHOLD, auto-suspend.
    *
-   * All completion writes are fenced on status = 'running' so a run that finishes after a
-   * concurrent pause/cancel does not overwrite that state (see skippedCompletion).
+   * All completion writes are fenced on status NOT IN ('paused','cancelled') so a run that
+   * finishes after a concurrent pause/cancel does not overwrite that state (see
+   * skippedCompletion). Wake jobs completed straight from 'pending' still pass the fence.
    */
   async completeJobRun(
     jobId: string,
@@ -972,9 +973,11 @@ export class SchedulerService {
     if (success) {
       if (job.cron_expr) {
         // Recurring job: advance to next run using the per-job timezone, reset failure counter.
-        // The AND status = 'running' fence prevents a late completion from stamping 'pending'
-        // over a concurrent operator pause/cancel that landed while the run was in flight —
-        // the same guard recoverStuckJob and the claim-revert use.
+        // Fence the completion on the job NOT being in an operator-intervention state:
+        // if a pause or cancel landed while the run was in flight, this write matches 0
+        // rows and is skipped, so the completion can't stamp 'pending'/'completed' back
+        // over the pause/cancel. We exclude only 'paused'/'cancelled' (not "= running")
+        // because wake jobs in the plan frontier are completed straight from 'pending'.
         const nextRunAt = this.nextRunFromCron(job.cron_expr, job.timezone);
         const updateSql = `
           UPDATE scheduled_jobs
@@ -986,12 +989,12 @@ export class SchedulerService {
                  status = $2,
                  last_run_outcome = $4,
                  last_run_summary = COALESCE(last_run_summary, $5)
-           WHERE id = $3 AND status = 'running'
+           WHERE id = $3 AND status NOT IN ('paused', 'cancelled')
         `;
         const res = await this.pool.query(updateSql, [nextRunAt, 'pending', jobId, 'completed', autoSummary ?? null]);
         if (res.rowCount === 0) return this.skippedCompletion(jobId);
       } else {
-        // One-shot job: mark as completed (same running-status fence).
+        // One-shot job: mark as completed (same pause/cancel fence).
         const updateSql = `
           UPDATE scheduled_jobs
              SET last_run_at = now(),
@@ -1001,7 +1004,7 @@ export class SchedulerService {
                  run_started_at = NULL,
                  last_run_outcome = $3,
                  last_run_summary = COALESCE(last_run_summary, $4)
-           WHERE id = $2 AND status = 'running'
+           WHERE id = $2 AND status NOT IN ('paused', 'cancelled')
         `;
         const res = await this.pool.query(updateSql, ['completed', jobId, 'completed', autoSummary ?? null]);
         if (res.rowCount === 0) return this.skippedCompletion(jobId);
@@ -1024,7 +1027,7 @@ export class SchedulerService {
              run_started_at = NULL,
              status = $3,
              last_run_outcome = $5
-       WHERE id = $4 AND status = 'running'
+       WHERE id = $4 AND status NOT IN ('paused', 'cancelled')
     `;
     const res = await this.pool.query(updateSql, [newFailures, error ?? null, newStatus, jobId, 'failed']);
     if (res.rowCount === 0) return this.skippedCompletion(jobId);

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -405,14 +405,12 @@ export class SchedulerService {
   }
 
   /**
-   * Pause a job and its linked task due to intent drift detection.
-   * Sets status = 'paused' on both tables in a single query.
-   * The CEO must review and resume or cancel the job manually.
+   * Set a job and its linked task to 'paused' in a single round-trip.
+   * Shared by the drift-pause and operator-pause paths so the SQL stays in one place.
+   * Updates both tables atomically via a CTE so they stay consistent.
+   * The FK is scheduled_jobs.task_id → tasks.id, so we join through scheduled_jobs.
    */
-  async pauseJobForDrift(jobId: string): Promise<void> {
-    // Update both tables atomically: pause the job and its linked task.
-    // Uses a CTE so both updates happen in one round-trip and stay consistent.
-    // The FK is now scheduled_jobs.task_id → tasks.id, so we join through scheduled_jobs.
+  private async setPaused(jobId: string): Promise<void> {
     await this.pool.query(
       `WITH paused_job AS (
          UPDATE scheduled_jobs
@@ -426,8 +424,27 @@ export class SchedulerService {
         WHERE sj.id = $1 AND t.id = sj.task_id`,
       [jobId],
     );
+  }
 
+  /**
+   * Pause a job and its linked task due to intent drift detection.
+   * Sets status = 'paused' on both tables.
+   * The CEO must review and resume or cancel the job manually.
+   */
+  async pauseJobForDrift(jobId: string): Promise<void> {
+    await this.setPaused(jobId);
     this.logger.info({ jobId }, 'Job paused due to intent drift detection');
+  }
+
+  /**
+   * Pause a job and its linked task at an operator's explicit request
+   * (e.g. the CEO asking Curia to pause a schedule via the scheduler-update skill).
+   * Neutral counterpart to pauseJobForDrift — same state transition, no drift semantics.
+   * Released by unsuspendJob(), which accepts both 'suspended' and 'paused' states.
+   */
+  async pauseJob(jobId: string): Promise<void> {
+    await this.setPaused(jobId);
+    this.logger.info({ jobId }, 'Job paused by operator request');
   }
 
   async unsuspendJob(jobId: string): Promise<void> {

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -932,10 +932,22 @@ export class SchedulerService {
   }
 
   /**
+   * A completion write matched no 'running' row: the job was paused or cancelled while the
+   * run was in flight. Log and report not-suspended rather than resurrecting the job.
+   */
+  private skippedCompletion(jobId: string): { suspended: boolean } {
+    this.logger.info({ jobId }, 'Job completion skipped — job no longer running (paused/cancelled concurrently)');
+    return { suspended: false };
+  }
+
+  /**
    * Complete a job run.
    * - On success: if recurring (has cron_expr), advance next_run_at and reset failures;
    *   if one-shot, mark as completed.
    * - On failure: increment consecutive_failures. If it reaches SUSPEND_THRESHOLD, auto-suspend.
+   *
+   * All completion writes are fenced on status = 'running' so a run that finishes after a
+   * concurrent pause/cancel does not overwrite that state (see skippedCompletion).
    */
   async completeJobRun(
     jobId: string,
@@ -960,6 +972,9 @@ export class SchedulerService {
     if (success) {
       if (job.cron_expr) {
         // Recurring job: advance to next run using the per-job timezone, reset failure counter.
+        // The AND status = 'running' fence prevents a late completion from stamping 'pending'
+        // over a concurrent operator pause/cancel that landed while the run was in flight —
+        // the same guard recoverStuckJob and the claim-revert use.
         const nextRunAt = this.nextRunFromCron(job.cron_expr, job.timezone);
         const updateSql = `
           UPDATE scheduled_jobs
@@ -971,11 +986,12 @@ export class SchedulerService {
                  status = $2,
                  last_run_outcome = $4,
                  last_run_summary = COALESCE(last_run_summary, $5)
-           WHERE id = $3
+           WHERE id = $3 AND status = 'running'
         `;
-        await this.pool.query(updateSql, [nextRunAt, 'pending', jobId, 'completed', autoSummary ?? null]);
+        const res = await this.pool.query(updateSql, [nextRunAt, 'pending', jobId, 'completed', autoSummary ?? null]);
+        if (res.rowCount === 0) return this.skippedCompletion(jobId);
       } else {
-        // One-shot job: mark as completed.
+        // One-shot job: mark as completed (same running-status fence).
         const updateSql = `
           UPDATE scheduled_jobs
              SET last_run_at = now(),
@@ -985,9 +1001,10 @@ export class SchedulerService {
                  run_started_at = NULL,
                  last_run_outcome = $3,
                  last_run_summary = COALESCE(last_run_summary, $4)
-           WHERE id = $2
+           WHERE id = $2 AND status = 'running'
         `;
-        await this.pool.query(updateSql, ['completed', jobId, 'completed', autoSummary ?? null]);
+        const res = await this.pool.query(updateSql, ['completed', jobId, 'completed', autoSummary ?? null]);
+        if (res.rowCount === 0) return this.skippedCompletion(jobId);
       }
 
       this.logger.info({ jobId }, 'Job run completed successfully');
@@ -1007,9 +1024,10 @@ export class SchedulerService {
              run_started_at = NULL,
              status = $3,
              last_run_outcome = $5
-       WHERE id = $4
+       WHERE id = $4 AND status = 'running'
     `;
-    await this.pool.query(updateSql, [newFailures, error ?? null, newStatus, jobId, 'failed']);
+    const res = await this.pool.query(updateSql, [newFailures, error ?? null, newStatus, jobId, 'failed']);
+    if (res.rowCount === 0) return this.skippedCompletion(jobId);
 
     if (shouldSuspend) {
       this.logger.warn({ jobId, consecutiveFailures: newFailures }, 'Job auto-suspended after consecutive failures');

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -405,25 +405,37 @@ export class SchedulerService {
   }
 
   /**
-   * Set a job and its linked task to 'paused' in a single round-trip.
+   * Set a job and its linked task to 'paused' in a single round-trip, returning the
+   * number of job rows actually transitioned (0 when the job is missing or terminal).
    * Shared by the drift-pause and operator-pause paths so the SQL stays in one place.
-   * Updates both tables atomically via a CTE so they stay consistent.
-   * The FK is scheduled_jobs.task_id → tasks.id, so we join through scheduled_jobs.
+   *
+   * The scheduled_jobs UPDATE is the OUTER statement so result.rowCount reflects the
+   * job (a CTE-wrapped final UPDATE would report the tasks row count instead, which is
+   * 0 for jobs without a linked task). The task UPDATE runs in the CTE against the same
+   * snapshot, so both see the pre-update status.
+   *
+   * The terminal-state guard prevents re-arming a job the CEO already ended: without it,
+   * pausing a 'cancelled'/'completed' job then resuming it (unsuspendJob accepts 'paused')
+   * would resurrect it. Drift only ever pauses active jobs, so the guard is a no-op there.
    */
-  private async setPaused(jobId: string): Promise<void> {
-    await this.pool.query(
-      `WITH paused_job AS (
-         UPDATE scheduled_jobs
-            SET status = 'paused'
-          WHERE id = $1
+  private async setPaused(jobId: string): Promise<number> {
+    const result = await this.pool.query(
+      `WITH paused_task AS (
+         UPDATE tasks t
+            SET status     = 'paused',
+                updated_at = now()
+           FROM scheduled_jobs sj
+          WHERE sj.id = $1
+            AND t.id = sj.task_id
+            AND sj.status NOT IN ('cancelled', 'completed')
        )
-       UPDATE tasks t
-          SET status     = 'paused',
-              updated_at = now()
-         FROM scheduled_jobs sj
-        WHERE sj.id = $1 AND t.id = sj.task_id`,
+       UPDATE scheduled_jobs
+          SET status = 'paused'
+        WHERE id = $1
+          AND status NOT IN ('cancelled', 'completed')`,
       [jobId],
     );
+    return result.rowCount ?? 0;
   }
 
   /**
@@ -432,7 +444,13 @@ export class SchedulerService {
    * The CEO must review and resume or cancel the job manually.
    */
   async pauseJobForDrift(jobId: string): Promise<void> {
-    await this.setPaused(jobId);
+    const count = await this.setPaused(jobId);
+    if (count === 0) {
+      // Drift only targets active jobs, so a miss here means the job vanished or was
+      // ended concurrently — log rather than throw to keep the detector's flow intact.
+      this.logger.warn({ jobId }, 'Drift pause matched no active job (already ended?)');
+      return;
+    }
     this.logger.info({ jobId }, 'Job paused due to intent drift detection');
   }
 
@@ -441,9 +459,14 @@ export class SchedulerService {
    * (e.g. the CEO asking Curia to pause a schedule via the scheduler-update skill).
    * Neutral counterpart to pauseJobForDrift — same state transition, no drift semantics.
    * Released by unsuspendJob(), which accepts both 'suspended' and 'paused' states.
+   * Throws when the job is missing or already terminal so callers don't report a
+   * silent no-op as success.
    */
   async pauseJob(jobId: string): Promise<void> {
-    await this.setPaused(jobId);
+    const count = await this.setPaused(jobId);
+    if (count === 0) {
+      throw new Error(`Job ${jobId} not found or already cancelled/completed`);
+    }
     this.logger.info({ jobId }, 'Job paused by operator request');
   }
 
@@ -538,7 +561,15 @@ export class SchedulerService {
 
     params.push(jobId);
     const sql = `UPDATE scheduled_jobs SET ${setClauses.join(', ')} WHERE id = $${params.length}`;
-    await this.pool.query(sql, params);
+    const result = await this.pool.query(sql, params);
+
+    // A 0-row update means the job_id doesn't exist. Throw rather than return silently
+    // so callers (e.g. the scheduler-update skill) surface a real failure instead of
+    // reporting a no-op edit as success. The web PATCH route already checks existence
+    // via getJob() before calling this, so this only bites genuinely-missing jobs.
+    if (result.rowCount === 0) {
+      throw new Error(`Job ${jobId} not found`);
+    }
 
     this.logger.info({ jobId, updates: Object.keys(updates) }, 'Scheduled job updated');
   }

--- a/tests/integration/scheduler-lifecycle-mutations.test.ts
+++ b/tests/integration/scheduler-lifecycle-mutations.test.ts
@@ -130,4 +130,18 @@ describeIf('Scheduler lifecycle mutations against real Postgres (#1409)', () => 
       svc.updateJob('00000000-0000-0000-0000-000000000000', { cronExpr: '30 14 * * 3' }),
     ).rejects.toThrow('not found');
   });
+
+  it('a completion that lands after a pause does not resurrect the job', async () => {
+    // Race: the job is 'running', the operator pauses it, then the in-flight run finishes
+    // and calls completeJobRun. The status = 'running' fence must keep it 'paused'.
+    const { jobId, taskId } = await insertJobWithTask(pool, 'running', 'active');
+
+    await svc.pauseJob(jobId);
+    expect((await statuses(pool, jobId, taskId)).job).toBe('paused');
+
+    // Late successful completion of the recurring run — must be a no-op, not a reset to 'pending'.
+    const result = await svc.completeJobRun(jobId, true);
+    expect(result.suspended).toBe(false);
+    expect((await statuses(pool, jobId, taskId)).job).toBe('paused');
+  });
 });

--- a/tests/integration/scheduler-lifecycle-mutations.test.ts
+++ b/tests/integration/scheduler-lifecycle-mutations.test.ts
@@ -1,0 +1,133 @@
+// scheduler-lifecycle-mutations.test.ts — pause / resume / edit against REAL Postgres (#1409).
+//
+// The scheduler-update skill delegates to SchedulerService.pauseJob / unsuspendJob /
+// updateJob. Their correctness hinges on real SQL semantics that mocked-pool unit tests
+// cannot exercise: the flipped CTE's rowCount (must reflect the scheduled_jobs UPDATE,
+// not the tasks UPDATE), the terminal-state guard on pause, and the linked-task
+// transitions. We drive the real service against real rows so a logically-wrong predicate
+// fails here even though a SQL-substring unit assertion would pass.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { EventBus } from '../../src/bus/bus.js';
+import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const AGENT_ID = 'lifecycle-mut-test-agent';
+const logger = pino({ level: 'silent' });
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  // Delete jobs first (they FK to tasks), then the tasks.
+  await pool.query(`DELETE FROM scheduled_jobs WHERE agent_id = $1`, [AGENT_ID]);
+  await pool.query(`DELETE FROM tasks WHERE agent_id = $1`, [AGENT_ID]);
+}
+
+// Insert a task + a cron scheduled_job linked to it, in the given statuses.
+async function insertJobWithTask(
+  pool: pg.Pool,
+  jobStatus: string,
+  taskStatus: string,
+): Promise<{ jobId: string; taskId: string }> {
+  const task = await pool.query(
+    `INSERT INTO tasks (agent_id, intent_anchor, error_budget, status, title)
+     VALUES ($1, 'keep X in sync', '{}'::jsonb, $2, 'test task')
+     RETURNING id`,
+    [AGENT_ID, taskStatus],
+  );
+  const taskId = task.rows[0]!.id as string;
+
+  const futureRun = new Date(Date.now() + 3_600_000).toISOString();
+  const job = await pool.query(
+    `INSERT INTO scheduled_jobs
+       (agent_id, source_agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone, task_id)
+     VALUES ($1, $1, '0 9 * * *', $2, $3, $4, 'system', 'UTC', $5)
+     RETURNING id`,
+    [AGENT_ID, JSON.stringify({ task: 'sync' }), jobStatus, futureRun, taskId],
+  );
+  return { jobId: job.rows[0]!.id as string, taskId };
+}
+
+async function statuses(pool: pg.Pool, jobId: string, taskId: string): Promise<{ job: string; task: string }> {
+  const j = await pool.query(`SELECT status FROM scheduled_jobs WHERE id = $1`, [jobId]);
+  const t = await pool.query(`SELECT status FROM tasks WHERE id = $1`, [taskId]);
+  return { job: j.rows[0]!.status as string, task: t.rows[0]!.status as string };
+}
+
+describeIf('Scheduler lifecycle mutations against real Postgres (#1409)', () => {
+  let pool: pg.Pool;
+  let svc: SchedulerService;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    svc = new SchedulerService(pool, new EventBus(logger as never), logger as never, 'UTC');
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  it('pauseJob pauses the job and its linked task; unsuspendJob resumes both', async () => {
+    const { jobId, taskId } = await insertJobWithTask(pool, 'pending', 'active');
+
+    await svc.pauseJob(jobId);
+    expect(await statuses(pool, jobId, taskId)).toEqual({ job: 'paused', task: 'paused' });
+
+    await svc.unsuspendJob(jobId);
+    const after = await statuses(pool, jobId, taskId);
+    expect(after.job).toBe('pending');
+    expect(after.task).toBe('active');
+  });
+
+  it('pauseJob throws (not silent no-op) when the job does not exist', async () => {
+    // Random UUID that matches no row — the flipped CTE must report rowCount 0.
+    await expect(
+      svc.pauseJob('00000000-0000-0000-0000-000000000000'),
+    ).rejects.toThrow('not found or already cancelled/completed');
+  });
+
+  it('pauseJob refuses to re-arm a cancelled (terminal) job', async () => {
+    const { jobId, taskId } = await insertJobWithTask(pool, 'cancelled', 'cancelled');
+
+    await expect(svc.pauseJob(jobId)).rejects.toThrow('not found or already cancelled/completed');
+
+    // The terminal job must stay cancelled — no resurrection via pause → resume.
+    expect((await statuses(pool, jobId, taskId)).job).toBe('cancelled');
+  });
+
+  it('pauseJob on a job WITHOUT a linked task still reports success via rowCount', async () => {
+    // Guards the CTE-orientation bug: rowCount must reflect the scheduled_jobs UPDATE,
+    // not the (zero-row) tasks UPDATE, or this would throw a false "not found".
+    const futureRun = new Date(Date.now() + 3_600_000).toISOString();
+    const job = await pool.query(
+      `INSERT INTO scheduled_jobs
+         (agent_id, source_agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone)
+       VALUES ($1, $1, '0 9 * * *', $2, 'pending', $3, 'system', 'UTC')
+       RETURNING id`,
+      [AGENT_ID, JSON.stringify({ task: 'sync' }), futureRun],
+    );
+    const jobId = job.rows[0]!.id as string;
+
+    await expect(svc.pauseJob(jobId)).resolves.toBeUndefined();
+    const j = await pool.query(`SELECT status FROM scheduled_jobs WHERE id = $1`, [jobId]);
+    expect(j.rows[0]!.status).toBe('paused');
+  });
+
+  it('updateJob changes the cron and recomputes next_run_at', async () => {
+    const { jobId } = await insertJobWithTask(pool, 'pending', 'active');
+    const before = await pool.query(`SELECT cron_expr, next_run_at FROM scheduled_jobs WHERE id = $1`, [jobId]);
+
+    await svc.updateJob(jobId, { cronExpr: '30 14 * * 3' });
+
+    const after = await pool.query(`SELECT cron_expr, next_run_at FROM scheduled_jobs WHERE id = $1`, [jobId]);
+    expect(after.rows[0]!.cron_expr).toBe('30 14 * * 3');
+    expect(after.rows[0]!.next_run_at).not.toEqual(before.rows[0]!.next_run_at);
+  });
+
+  it('updateJob throws when the job does not exist', async () => {
+    await expect(
+      svc.updateJob('00000000-0000-0000-0000-000000000000', { cronExpr: '30 14 * * 3' }),
+    ).rejects.toThrow('not found');
+  });
+});

--- a/tests/integration/scheduler-lifecycle-mutations.test.ts
+++ b/tests/integration/scheduler-lifecycle-mutations.test.ts
@@ -144,4 +144,23 @@ describeIf('Scheduler lifecycle mutations against real Postgres (#1409)', () => 
     expect(result.suspended).toBe(false);
     expect((await statuses(pool, jobId, taskId)).job).toBe('paused');
   });
+
+  it('completeJobRun still completes a wake job that is fired straight from pending', async () => {
+    // Regression guard: the pause/cancel fence must NOT be "status = running". Plan-frontier
+    // wake jobs are completed directly from 'pending' (they never pass through a claim), so a
+    // running-only fence would silently skip them and recycle the stale wake.
+    const pastRun = new Date(Date.now() - 60_000).toISOString();
+    const job = await pool.query(
+      `INSERT INTO scheduled_jobs
+         (agent_id, source_agent_id, run_at, task_payload, status, next_run_at, created_by, timezone)
+       VALUES ($1, $1, $2, $3, 'pending', $2, 'system', 'UTC')
+       RETURNING id`,
+      [AGENT_ID, pastRun, JSON.stringify({ type: 'task-wake' })],
+    );
+    const jobId = job.rows[0]!.id as string;
+
+    await svc.completeJobRun(jobId, true);
+    const j = await pool.query(`SELECT status FROM scheduled_jobs WHERE id = $1`, [jobId]);
+    expect(j.rows[0]!.status).toBe('completed');
+  });
 });

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -542,9 +542,10 @@ describe('SchedulerService', () => {
       const result = await svc.completeJobRun('job-race', true);
 
       expect(result.suspended).toBe(false);
-      // The UPDATE is fenced on the running status so a paused job stays paused.
+      // The UPDATE is fenced against operator-intervention states so a paused/cancelled
+      // job stays put, while a plain 'pending' wake job can still be completed.
       const [sql] = pool.query.mock.calls[1] as [string];
-      expect(sql).toContain("status = 'running'");
+      expect(sql).toContain("status NOT IN ('paused', 'cancelled')");
     });
 
     it('clears run_started_at on success for a recurring job', async () => {

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -343,6 +343,24 @@ describe('SchedulerService', () => {
     });
   });
 
+  // -- pauseJob (operator-initiated pause; distinct from drift pause) --
+
+  describe('pauseJob', () => {
+    it('sets both the job and its linked task to paused in one query', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.pauseJob('job-pause');
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      // Single CTE updates scheduled_jobs and the linked tasks row together.
+      expect(sql).toContain('scheduled_jobs');
+      expect(sql).toContain('tasks');
+      expect(sql).toContain('paused');
+      expect(params[0]).toBe('job-pause');
+    });
+  });
+
   // -- listJobs --
 
   describe('listJobs', () => {

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -347,7 +347,7 @@ describe('SchedulerService', () => {
 
   describe('pauseJob', () => {
     it('sets both the job and its linked task to paused in one query', async () => {
-      pool.query.mockResolvedValueOnce({ rows: [] });
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       await svc.pauseJob('job-pause');
 
@@ -357,7 +357,26 @@ describe('SchedulerService', () => {
       expect(sql).toContain('scheduled_jobs');
       expect(sql).toContain('tasks');
       expect(sql).toContain('paused');
+      // Terminal jobs must not be re-armable via pause → resume.
+      expect(sql).toContain("NOT IN ('cancelled', 'completed')");
       expect(params[0]).toBe('job-pause');
+    });
+
+    it('throws when the job is missing or already terminal (0 rows)', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await expect(svc.pauseJob('gone')).rejects.toThrow('not found or already cancelled/completed');
+    });
+  });
+
+  // -- pauseJobForDrift (drift path stays non-throwing) --
+
+  describe('pauseJobForDrift', () => {
+    it('logs a warning but does not throw when the job matched nothing', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await expect(svc.pauseJobForDrift('gone')).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalled();
     });
   });
 
@@ -1179,7 +1198,7 @@ describe('SchedulerService', () => {
 
   describe('updateJob', () => {
     it('updates cronExpr and recalculates next_run_at', async () => {
-      pool.query.mockResolvedValueOnce({ rows: [] });
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       await svc.updateJob('job-up', { cronExpr: '*/10 * * * *' });
 
@@ -1190,13 +1209,19 @@ describe('SchedulerService', () => {
     });
 
     it('updates taskPayload only', async () => {
-      pool.query.mockResolvedValueOnce({ rows: [] });
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       await svc.updateJob('job-up2', { taskPayload: { a: 1 } });
 
       const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
       expect(sql).toContain('task_payload');
       expect(params).toContain('job-up2');
+    });
+
+    it('throws when the job_id matches no row (0 rows updated)', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await expect(svc.updateJob('gone', { cronExpr: '*/10 * * * *' })).rejects.toThrow('not found');
     });
   });
 });

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -531,6 +531,22 @@ describe('SchedulerService', () => {
       expect(result.suspended).toBe(false);
     });
 
+    it('skips the completion write when the job is no longer running (0 rows updated)', async () => {
+      // Fetch says running, but the fenced UPDATE matches 0 rows because a concurrent
+      // pause/cancel changed the status — completion must not resurrect the job.
+      pool.query.mockResolvedValueOnce({
+        rows: [{ id: 'job-race', cron_expr: '0 9 * * *', status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+      });
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // fenced UPDATE: no running row
+
+      const result = await svc.completeJobRun('job-race', true);
+
+      expect(result.suspended).toBe(false);
+      // The UPDATE is fenced on the running status so a paused job stays paused.
+      const [sql] = pool.query.mock.calls[1] as [string];
+      expect(sql).toContain("status = 'running'");
+    });
+
     it('clears run_started_at on success for a recurring job', async () => {
       pool.query
         .mockResolvedValueOnce({

--- a/tests/unit/skills/scheduler-update.test.ts
+++ b/tests/unit/skills/scheduler-update.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SchedulerUpdateHandler } from '../../../skills/scheduler-update/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+function mockSchedulerService() {
+  return {
+    createJob: vi.fn(),
+    listJobs: vi.fn(),
+    cancelJob: vi.fn(),
+    unsuspendJob: vi.fn().mockResolvedValue(undefined),
+    pauseJob: vi.fn().mockResolvedValue(undefined),
+    updateJob: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('SchedulerUpdateHandler', () => {
+  const handler = new SchedulerUpdateHandler();
+
+  it('returns failure when schedulerService is not available', async () => {
+    const result = await handler.execute(makeCtx({ job_id: 'job-1', action: 'resume' }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('schedulerService');
+    }
+  });
+
+  it('returns failure when job_id is missing', async () => {
+    const svc = mockSchedulerService();
+    const result = await handler.execute(makeCtx(
+      { action: 'resume' },
+      { schedulerService: svc as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('job_id');
+    }
+  });
+
+  it('returns failure when action is missing or invalid', async () => {
+    const svc = mockSchedulerService();
+
+    const missing = await handler.execute(makeCtx(
+      { job_id: 'job-1' },
+      { schedulerService: svc as never },
+    ));
+    expect(missing.success).toBe(false);
+    if (!missing.success) {
+      expect(missing.error).toContain('action');
+    }
+
+    const invalid = await handler.execute(makeCtx(
+      { job_id: 'job-1', action: 'destroy' },
+      { schedulerService: svc as never },
+    ));
+    expect(invalid.success).toBe(false);
+
+    // Neither invalid call should have mutated anything.
+    expect(svc.unsuspendJob).not.toHaveBeenCalled();
+    expect(svc.pauseJob).not.toHaveBeenCalled();
+    expect(svc.updateJob).not.toHaveBeenCalled();
+  });
+
+  it('resumes a job via unsuspendJob', async () => {
+    const svc = mockSchedulerService();
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1', action: 'resume' },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { jobId: string; action: string };
+      expect(data.jobId).toBe('job-1');
+      expect(data.action).toBe('resume');
+    }
+    expect(svc.unsuspendJob).toHaveBeenCalledWith('job-1');
+    expect(svc.pauseJob).not.toHaveBeenCalled();
+    expect(svc.updateJob).not.toHaveBeenCalled();
+  });
+
+  it('pauses a job via pauseJob', async () => {
+    const svc = mockSchedulerService();
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-2', action: 'pause' },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(svc.pauseJob).toHaveBeenCalledWith('job-2');
+    expect(svc.unsuspendJob).not.toHaveBeenCalled();
+  });
+
+  it('edits cron_expr via updateJob', async () => {
+    const svc = mockSchedulerService();
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-3', action: 'edit', cron_expr: '*/10 * * * *' },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(svc.updateJob).toHaveBeenCalledWith('job-3', {
+      cronExpr: '*/10 * * * *',
+      runAt: undefined,
+      taskPayload: undefined,
+    });
+  });
+
+  it('edits run_at, converting the ISO string to a Date', async () => {
+    const svc = mockSchedulerService();
+    const runAt = '2026-08-01T09:00:00.000Z';
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-4', action: 'edit', run_at: runAt },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(true);
+    const call = svc.updateJob.mock.calls[0] as [string, { runAt?: Date }];
+    expect(call[0]).toBe('job-4');
+    expect(call[1].runAt).toBeInstanceOf(Date);
+    expect(call[1].runAt!.toISOString()).toBe(runAt);
+  });
+
+  it('rejects action=edit with no editable field supplied', async () => {
+    const svc = mockSchedulerService();
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-5', action: 'edit' },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('cron_expr');
+    }
+    expect(svc.updateJob).not.toHaveBeenCalled();
+  });
+
+  it('treats whitespace-only schedule strings as absent', async () => {
+    const svc = mockSchedulerService();
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-6', action: 'edit', cron_expr: '   ', run_at: '  ' },
+      { schedulerService: svc as never },
+    ));
+
+    // No real edit field remains after trimming → reject rather than call updateJob.
+    expect(result.success).toBe(false);
+    expect(svc.updateJob).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when the service throws', async () => {
+    const svc = mockSchedulerService();
+    svc.unsuspendJob.mockRejectedValue(new Error('Job x not found or not suspended'));
+
+    const result = await handler.execute(makeCtx(
+      { job_id: 'nonexistent', action: 'resume' },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('not found or not suspended');
+    }
+  });
+});

--- a/tests/unit/skills/scheduler-update.test.ts
+++ b/tests/unit/skills/scheduler-update.test.ts
@@ -176,4 +176,34 @@ describe('SchedulerUpdateHandler', () => {
       expect(result.error).toContain('not found or not suspended');
     }
   });
+
+  it('surfaces a pause failure (e.g. missing/terminal job) as success:false', async () => {
+    const svc = mockSchedulerService();
+    svc.pauseJob.mockRejectedValue(new Error('Job gone not found or already cancelled/completed'));
+
+    const result = await handler.execute(makeCtx(
+      { job_id: 'gone', action: 'pause' },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('not found or already cancelled/completed');
+    }
+  });
+
+  it('surfaces an edit failure on a missing job as success:false', async () => {
+    const svc = mockSchedulerService();
+    svc.updateJob.mockRejectedValue(new Error('Job gone not found'));
+
+    const result = await handler.execute(makeCtx(
+      { job_id: 'gone', action: 'edit', cron_expr: '*/10 * * * *' },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('not found');
+    }
+  });
 });

--- a/tests/unit/skills/scheduler-update.test.ts
+++ b/tests/unit/skills/scheduler-update.test.ts
@@ -136,6 +136,21 @@ describe('SchedulerUpdateHandler', () => {
     expect(call[1].runAt!.toISOString()).toBe(runAt);
   });
 
+  it('rejects action=edit with a malformed run_at before hitting the service', async () => {
+    const svc = mockSchedulerService();
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-bad', action: 'edit', run_at: 'not-a-date' },
+      { schedulerService: svc as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('valid ISO 8601 timestamp');
+    }
+    // Must not reach the DB with an Invalid Date.
+    expect(svc.updateJob).not.toHaveBeenCalled();
+  });
+
   it('rejects action=edit with no editable field supplied', async () => {
     const svc = mockSchedulerService();
     const result = await handler.execute(makeCtx(


### PR DESCRIPTION
## Summary

Closes #1409.

Agents could create, list, and cancel scheduled jobs but had no way to resume a suspended/paused job or edit its schedule. When the CEO asked Curia to unsuspend a job, the coordinator could only reply that "the only way to resume these is through the web UI" and hand over links. The underlying mutations (`unsuspendJob`, `updateJob`) already existed in `SchedulerService` but were wired only to the web `PATCH /api/jobs/:id` endpoint.

This adds a single unified **`scheduler-update`** skill with an `action` discriminator (`resume` | `pause` | `edit`) that delegates to the scheduler service, plus a neutral `pauseJob()` service method for operator-initiated pause.

## Design notes

- **One skill, not three.** Resume, pause, and edit are all reversible, `action_risk: low` internal-state writes, so the usual reason to split (different risk gates) doesn't apply. It also mirrors the web PATCH handler, which already unifies resume + edit.
- **`scheduler-cancel` stays separate.** Cancel is terminal, special-cased by name in `approval-notification.ts`, and already shipped. Keeping it separate preserves the clean `create → update → cancel` lifecycle and mirrors the web API's PATCH-vs-DELETE split.
- **Drift policy.** `resume` releases both `suspended` (failure-threshold) and `paused` (drift) jobs via the existing `unsuspendJob`. No extra notification on resume — the CEO was already notified when the drift pause fired.

## Review fixes (found in pre-PR review)

- `pause` and `edit` previously reported `success: true` on a nonexistent `job_id` because `setPaused`/`updateJob` ran `UPDATE ... WHERE id = $1` with no rowCount check — the exact silent-no-op this feature exists to eliminate. Both now throw on 0 rows, so the skill surfaces a real failure.
- `setPaused`'s CTE was flipped so the `scheduled_jobs` UPDATE is the outer statement (its rowCount reflects the job, not the linked-task update which is 0 for jobs without a task), and it gained a terminal-state guard so `pause → resume` can no longer resurrect a cancelled/completed job.
- `pauseJobForDrift` logs a warning instead of throwing on a 0-row match, keeping the drift detector's flow intact.

## Testing

- `pnpm run typecheck` clean (core / skills / tests projects).
- Unit: `scheduler-update` handler (all actions + guards + failure propagation) and `pauseJob`/`updateJob`/`pauseJobForDrift` rowCount contracts.
- Integration (real Postgres): `tests/integration/scheduler-lifecycle-mutations.test.ts` verifies the flipped-CTE rowCount, the terminal guard, and the linked-task pause/resume transitions.
- Existing web `jobs-routes` tests still pass — the `updateJob` throw only bites genuinely-missing jobs (the route checks existence first).

## Rollout note

`scheduler-update` is added to `config/registry-defaults.yaml` and pinned to the coordinator, but new skills don't auto-enroll on existing installs — it must be enabled in the prod `skill_registry` after deploy.
