### PR TITLE
fix: bound backlog-heartbeat wake loop for parked-open tasks (#1410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Scheduler** — liveness check no longer flaps `fail` every few minutes on a healthy scheduler. (#1359)
 - **`sensitivity_rules`** — now read from the merged config, so `local.yaml` overrides actually take effect. (#1369)
 - **`security.extra_injection_patterns`** — same fix: now parsed from the merged config instead of `default.yaml` directly. (#1397)
+- **Backlog heartbeat** — stops re-poking parked-open parents whose subtasks are already scheduled; reuses one wake row per task. (#1410)
 
 ### Added
 

--- a/src/db/queries/tasks.ts
+++ b/src/db/queries/tasks.ts
@@ -159,6 +159,16 @@ export async function selectHeartbeatCandidates(
          AND NOT EXISTS (
                SELECT 1 FROM scheduled_jobs sj
                WHERE sj.task_id = t.id AND sj.status IN ('pending', 'running'))
+         -- Suppress a parent "container" task whose pending work is already covered by a
+         -- non-terminal subtask carrying its own ACTIVE (pending/running) wake (#1410). The
+         -- plan is progressing on schedule via the child; re-poking the parent every interval
+         -- just burns no-op agent turns. A completed/absent child wake does NOT shield the
+         -- parent — that's a stalled plan the heartbeat should still resurface.
+         AND NOT EXISTS (
+               SELECT 1 FROM tasks c
+               JOIN scheduled_jobs cj ON cj.task_id = c.id AND cj.status IN ('pending', 'running')
+               WHERE c.parent_task_id = t.id
+                 AND c.status IN ('open', 'in_progress', 'waiting', 'blocked'))
          AND (
                (t.owner = 'curia' AND t.status IN ('open','in_progress')
                   AND t.updated_at < now() - make_interval(hours => $2))

--- a/src/scheduler/backlog-heartbeat.ts
+++ b/src/scheduler/backlog-heartbeat.ts
@@ -92,12 +92,14 @@ export class BacklogHeartbeat {
         this.opts.logger.debug({ taskId: c.id, agentId: c.agentId, jobId }, 'BacklogHeartbeat: wake enqueued');
         enqueued += 1;
       } catch (err) {
-        const e = err as { code?: string; constraint?: string };
-        if (e.code === '23503') {
+        // Guard against a thrown null/undefined (optional chaining) so error classification
+        // can never itself throw and abort the tick mid-loop.
+        const e = err as { code?: string; constraint?: string } | null;
+        if (e?.code === '23503') {
           // foreign_key_violation: task completed/deleted between selection and enqueue — benign.
           taskGoneSkips += 1;
           this.opts.logger.debug({ taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: task gone at enqueue time — skipped');
-        } else if (e.code === '23505' && e.constraint === 'scheduled_jobs_one_active_wake_per_task_uq') {
+        } else if (e?.code === '23505' && e?.constraint === 'scheduled_jobs_one_active_wake_per_task_uq') {
           // unique_violation on the one-active-wake index: another enqueuer (plan-frontier /
           // resumable-continuation) won the race for this task's wake — benign. Tracked
           // separately (not folded into 23503) because within the heartbeat's own path this

--- a/src/scheduler/backlog-heartbeat.ts
+++ b/src/scheduler/backlog-heartbeat.ts
@@ -75,6 +75,9 @@ export class BacklogHeartbeat {
 
     const runAt = new Date();
     let enqueued = 0;
+    let taskGoneSkips = 0; // 23503 — task terminal/deleted between selection and enqueue
+    let raceSkips = 0; // 23505 — another enqueuer already holds this task's active wake
+    let hardFailures = 0; // anything else — a real problem
     for (const c of candidates) {
       try {
         const { jobId } = await this.opts.schedulerService.enqueueTaskWake({
@@ -89,18 +92,38 @@ export class BacklogHeartbeat {
         this.opts.logger.debug({ taskId: c.id, agentId: c.agentId, jobId }, 'BacklogHeartbeat: wake enqueued');
         enqueued += 1;
       } catch (err) {
-        // 23503 = foreign_key_violation: task was completed/deleted between selection and enqueue — benign race.
-        if ((err as { code?: string }).code === '23503') {
-          this.opts.logger.debug({ taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: task no longer exists at enqueue time — skipped');
+        const e = err as { code?: string; constraint?: string };
+        if (e.code === '23503') {
+          // foreign_key_violation: task completed/deleted between selection and enqueue — benign.
+          taskGoneSkips += 1;
+          this.opts.logger.debug({ taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: task gone at enqueue time — skipped');
+        } else if (e.code === '23505' && e.constraint === 'scheduled_jobs_one_active_wake_per_task_uq') {
+          // unique_violation on the one-active-wake index: another enqueuer (plan-frontier /
+          // resumable-continuation) won the race for this task's wake — benign. Tracked
+          // separately (not folded into 23503) because within the heartbeat's own path this
+          // should be near-zero: selectHeartbeatCandidates already excludes active-wake tasks.
+          // A sustained count means the suppression clause regressed and the flood (#1410) is
+          // recurring — surfaced at warn below so it is not silently swallowed.
+          raceSkips += 1;
+          this.opts.logger.debug({ taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: task already has an active wake — skipped (race)');
         } else {
+          hardFailures += 1;
           this.opts.logger.error({ err, taskId: c.id, agentId: c.agentId }, 'BacklogHeartbeat: failed to enqueue wake');
         }
       }
     }
-    this.opts.logger.info({ enqueued, considered: candidates.length }, 'BacklogHeartbeat: tick complete');
-    if (enqueued === 0 && candidates.length > 0) {
+    this.opts.logger.info({ enqueued, considered: candidates.length, taskGoneSkips, raceSkips, hardFailures }, 'BacklogHeartbeat: tick complete');
+    if (raceSkips > 0) {
+      this.opts.logger.warn(
+        { raceSkips, considered: candidates.length },
+        'BacklogHeartbeat: enqueue hit the one-active-wake index — expected near-zero; investigate candidate suppression (#1410) if sustained',
+      );
+    }
+    // Only alarm when real (non-benign) failures blocked all progress — a tick where every
+    // candidate was a benign task-gone/race skip is healthy, not a stuck scheduler.
+    if (enqueued === 0 && hardFailures > 0) {
       this.opts.logger.error(
-        { considered: candidates.length },
+        { considered: candidates.length, hardFailures },
         'BacklogHeartbeat: all wake enqueues failed — tasks will not advance until next tick',
       );
     }

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -1112,9 +1112,15 @@ export class SchedulerService {
     return { noOp: false, suspended: shouldSuspend, consecutiveFailures: newFailures };
   }
 
-  /** Enqueue a one-shot wake for an EXISTING task. Inserts a pending scheduled_jobs
-   *  row with task_id preset so the dispatcher routes it to `agentId` with full task
-   *  context. Used by the BacklogHeartbeat. Does not create a new task.
+  /** Enqueue a one-shot wake for an EXISTING task. Revives the task's most-recent terminal
+   *  wake row back to `pending` (or inserts one if none exists) with task_id preset so the
+   *  dispatcher routes it to `agentId` with full task context, and touches the task's
+   *  updated_at. Does not create a new task. See #1410 for the reuse + backoff rationale.
+   *
+   *  Three callers, all of which now get the revive + updated_at touch: the BacklogHeartbeat
+   *  (backlog-heartbeat.ts), resumable continuation (resumable-continuation.ts), and the
+   *  plan frontier (plan-frontier.ts). The continuation/frontier callers pre-guard with
+   *  taskHasPendingWake and catch 23505, so on their paths the touch is redundant-but-harmless.
    *
    *  `originator` (the task's lineage, #1125) is persisted on the wake row so the woken task
    *  fires with provenance — previously it fired with metadata: undefined and lost all
@@ -1131,20 +1137,66 @@ export class SchedulerService {
     derived?: boolean;
   }): Promise<{ jobId: string }> {
     const { taskId, agentId, runAt, createdBy = 'heartbeat', originator = null, derived = false } = params;
+    const payload = JSON.stringify({ type: 'task-wake', task_id: taskId, standing: { derived } });
+    const originatorJson = originator ? JSON.stringify(originator) : null;
+    const args = [agentId, runAt, payload, createdBy, this.timezone, taskId, originatorJson];
+
+    // Fix 3 (#1410): reuse the task's existing terminal wake row instead of inserting a fresh
+    // row every cycle. Left unbounded this accreted thousands of completed rows for a single
+    // looping task; reusing keeps one scheduled_jobs row per task so the table stays searchable.
+    // Failure bookkeeping is preserved when reviving a 'failed'/'suspended' row (mirrors
+    // upsertDeclarativeJob) so the SUSPEND_THRESHOLD circuit-breaker accumulates across reuse
+    // cycles for a persistently-failing wake; a clean 'completed'/'cancelled' row starts fresh.
+    // Fix 1 (#1410): the _touch CTE bumps the task's updated_at so an *attended* task leaves the
+    // heartbeat's idle window for a full idleThresholdHours rather than being re-selected on the
+    // next tick (a no-op wake previously never bumped updated_at, so the task looped forever).
+    // Safety rests on two invariants: the partial unique index
+    // scheduled_jobs_one_active_wake_per_task_uq (migration 067) means only terminal rows are
+    // revived and a racing insert loses with 23505; and the FK scheduled_jobs.task_id ON DELETE
+    // SET NULL (migration 049) means a deleted task nulls the link, so a revive/insert for a gone
+    // task fails with 23503 rather than ever touching a phantom task row.
+    const revive = await this.pool.query(
+      `WITH revived AS (
+         UPDATE scheduled_jobs
+            SET status = 'pending', run_at = $2, next_run_at = $2, run_started_at = NULL,
+                consecutive_failures = CASE WHEN status IN ('failed','suspended') THEN consecutive_failures ELSE 0 END,
+                last_error = CASE WHEN status IN ('failed','suspended') THEN last_error ELSE NULL END,
+                last_run_outcome = CASE WHEN status IN ('failed','suspended') THEN last_run_outcome ELSE NULL END,
+                agent_id = $1, created_by = $4, timezone = $5,
+                task_payload = $3::jsonb, originator = $7::jsonb
+          WHERE id = (
+            SELECT id FROM scheduled_jobs
+             WHERE task_id = $6 AND task_payload->>'type' = 'task-wake'
+               AND status IN ('completed', 'failed', 'suspended', 'cancelled')
+             ORDER BY created_at DESC
+             LIMIT 1
+          )
+         RETURNING id
+       ),
+       _touch AS (
+         UPDATE tasks SET updated_at = now() WHERE id = $6 AND EXISTS (SELECT 1 FROM revived)
+       )
+       SELECT id FROM revived`,
+      args,
+    );
+    if (revive.rows.length > 0) {
+      return { jobId: (revive.rows[0] as { id: string }).id };
+    }
+
+    // No terminal wake row to reuse (first wake for this task) — insert a new one, touching
+    // the task's updated_at in the same statement so the backoff applies to first wakes too.
     const { rows } = await this.pool.query(
-      `INSERT INTO scheduled_jobs
-         (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, timezone, task_id, originator)
-       VALUES ($1, NULL, $2, $3, 'pending', $2, $4, $5, $6, $7::jsonb)
-       RETURNING id`,
-      [
-        agentId,
-        runAt,
-        JSON.stringify({ type: 'task-wake', task_id: taskId, standing: { derived } }),
-        createdBy,
-        this.timezone,
-        taskId,
-        originator ? JSON.stringify(originator) : null,
-      ],
+      `WITH j AS (
+         INSERT INTO scheduled_jobs
+           (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, timezone, task_id, originator)
+         VALUES ($1, NULL, $2, $3::jsonb, 'pending', $2, $4, $5, $6, $7::jsonb)
+         RETURNING id
+       ),
+       _touch AS (
+         UPDATE tasks SET updated_at = now() WHERE id = $6
+       )
+       SELECT id FROM j`,
+      args,
     );
     return { jobId: (rows[0] as { id: string }).id };
   }

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -1171,6 +1171,12 @@ export class SchedulerService {
              ORDER BY created_at DESC
              LIMIT 1
           )
+          -- Re-check the status on the target row itself, not just its id. Under READ COMMITTED
+          -- two concurrent revives can both pick the same terminal row; without this predicate the
+          -- second UPDATE (whose qual is only id = X) still matches after the first commits and
+          -- silently re-revives the now-pending row. With it, the loser's UPDATE matches 0 rows,
+          -- falls through to the INSERT, and loses cleanly on the one-active-wake index (23505).
+          AND status IN ('completed', 'failed', 'suspended', 'cancelled')
          RETURNING id
        ),
        _touch AS (

--- a/tests/integration/enqueue-task-wake.test.ts
+++ b/tests/integration/enqueue-task-wake.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import pg from 'pg';
+import { SchedulerService } from '../../src/scheduler/scheduler-service.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+const PREFIX = 'ETW Test';
+
+// enqueueTaskWake only needs the task row to exist (FK) — status is irrelevant to it.
+// Seed as 'paused' (outside the heartbeat's open/in_progress/waiting/blocked selection
+// window) so these tasks never leak into a concurrently-running selectHeartbeatCandidates
+// test file. Our own assertions are scoped by task_id, so they're unaffected either way.
+async function seedTask(pool: pg.Pool, o: { status?: string; updatedAt: Date }): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO tasks (agent_id, title, intent_anchor, status, progress, error_budget, owner, priority, source, source_agent_id, created_by, tags, updated_at)
+     VALUES ('coordinator',$1,'seeded',$2,'{}'::jsonb,'{}'::jsonb,'curia',50,'agent','coordinator','test','{}',$3) RETURNING id`,
+    [`${PREFIX} ${o.status ?? 'paused'}`, o.status ?? 'paused', o.updatedAt],
+  );
+  const [row] = rows as Array<{ id: string }>;
+  if (!row) throw new Error('seedTask: INSERT INTO tasks returned no rows');
+  return row.id;
+}
+
+async function rowsForTask(pool: pg.Pool, taskId: string) {
+  const { rows } = await pool.query(
+    `SELECT id, status, run_at, task_payload, created_by FROM scheduled_jobs WHERE task_id = $1 ORDER BY created_at`,
+    [taskId],
+  );
+  return rows as Array<{ id: string; status: string; run_at: Date; task_payload: Record<string, unknown>; created_by: string }>;
+}
+
+async function taskUpdatedAt(pool: pg.Pool, taskId: string): Promise<Date> {
+  const { rows } = await pool.query(`SELECT updated_at FROM tasks WHERE id = $1`, [taskId]);
+  return (rows[0] as { updated_at: Date }).updated_at;
+}
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(`DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`, [`${PREFIX}%`]);
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+describeIf('SchedulerService.enqueueTaskWake (#1410 reuse + updated_at touch)', () => {
+  let pool: pg.Pool;
+  let svc: SchedulerService;
+  const logger = createSilentLogger();
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    svc = new SchedulerService(pool, { publish: vi.fn(), subscribe: vi.fn() } as never, logger, 'UTC');
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  it('inserts a single pending wake on first enqueue', async () => {
+    const taskId = await seedTask(pool, { updatedAt: new Date(Date.now() - 10 * 3600_000) });
+    await svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: new Date() });
+    const rows = await rowsForTask(pool, taskId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe('pending');
+    expect(rows[0]!.task_payload.type).toBe('task-wake');
+  });
+
+  it('revives the existing terminal wake row instead of inserting a new one', async () => {
+    const taskId = await seedTask(pool, { updatedAt: new Date(Date.now() - 10 * 3600_000) });
+    const first = await svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: new Date(Date.now() - 3600_000) });
+    // Simulate the wake firing and completing (completeJobRun marks a one-shot wake 'completed').
+    await pool.query(`UPDATE scheduled_jobs SET status = 'completed' WHERE id = $1`, [first.jobId]);
+
+    const newRunAt = new Date(Date.now() + 600_000);
+    const second = await svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: newRunAt });
+
+    const rows = await rowsForTask(pool, taskId);
+    expect(rows).toHaveLength(1); // reused, not accumulated
+    expect(second.jobId).toBe(first.jobId); // same row id
+    expect(rows[0]!.status).toBe('pending');
+    expect(new Date(rows[0]!.run_at).getTime()).toBe(newRunAt.getTime());
+  });
+
+  it('bumps the task updated_at when enqueuing (no-op backoff)', async () => {
+    const stale = new Date(Date.now() - 10 * 3600_000);
+    const taskId = await seedTask(pool, { updatedAt: stale });
+    await svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: new Date() });
+    const after = await taskUpdatedAt(pool, taskId);
+    expect(after.getTime()).toBeGreaterThan(stale.getTime());
+    // touched to ~now, well within the idle threshold window
+    expect(Date.now() - after.getTime()).toBeLessThan(60_000);
+  });
+
+  it('keeps at most one wake row under a concurrent double-enqueue from a terminal state', async () => {
+    const taskId = await seedTask(pool, { updatedAt: new Date(Date.now() - 10 * 3600_000) });
+    const first = await svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: new Date(Date.now() - 3600_000) });
+    await pool.query(`UPDATE scheduled_jobs SET status = 'completed' WHERE id = $1`, [first.jobId]);
+
+    const results = await Promise.allSettled([
+      svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: new Date() }),
+      svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: new Date() }),
+    ]);
+    // At least one must succeed; a racing loser fails on the partial unique index (23505).
+    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+    for (const r of results) {
+      if (r.status === 'rejected') expect((r.reason as { code?: string }).code).toBe('23505');
+    }
+    // Invariant: exactly one row for the task, and exactly one active wake.
+    const rows = await rowsForTask(pool, taskId);
+    expect(rows).toHaveLength(1);
+    expect(rows.filter((x) => x.status === 'pending' || x.status === 'running')).toHaveLength(1);
+  });
+});

--- a/tests/integration/enqueue-task-wake.test.ts
+++ b/tests/integration/enqueue-task-wake.test.ts
@@ -96,11 +96,15 @@ describeIf('SchedulerService.enqueueTaskWake (#1410 reuse + updated_at touch)', 
       svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: new Date() }),
       svc.enqueueTaskWake({ taskId, agentId: 'coordinator', runAt: new Date() }),
     ]);
-    // At least one must succeed; a racing loser fails on the partial unique index (23505).
-    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
-    for (const r of results) {
-      if (r.status === 'rejected') expect((r.reason as { code?: string }).code).toBe('23505');
-    }
+    // Deterministic: the revive UPDATE's terminal-status guard means exactly one caller revives
+    // the row; the loser matches 0 rows, inserts, and loses on the partial unique index (23505).
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const reason = (rejected[0] as PromiseRejectedResult).reason as { code?: string; constraint?: string };
+    expect(reason.code).toBe('23505');
+    expect(reason.constraint).toBe('scheduled_jobs_one_active_wake_per_task_uq');
     // Invariant: exactly one row for the task, and exactly one active wake.
     const rows = await rowsForTask(pool, taskId);
     expect(rows).toHaveLength(1);

--- a/tests/integration/heartbeat-selection.test.ts
+++ b/tests/integration/heartbeat-selection.test.ts
@@ -17,6 +17,7 @@ async function seedTask(
     owner?: string;
     sourceAgentId?: string | null;
     blockedBy?: string | null;
+    parentTaskId?: string | null;
     updatedAt: Date;
     /** Task source — drives the `derived` computation (source='agent' → derived). Default 'agent'. */
     source?: 'ceo' | 'agent' | 'scheduler' | 'coordinator';
@@ -27,8 +28,8 @@ async function seedTask(
   const { rows } = await pool.query(
     `INSERT INTO tasks
        (agent_id, title, intent_anchor, status, progress, error_budget, owner,
-        blocked_by_task_id, priority, source, source_agent_id, created_by, tags, updated_at, originator)
-     VALUES ($1,$2,$3,$4,'{}'::jsonb,'{}'::jsonb,$5,$6,50,$9,$7,'test','{}',$8,$10::jsonb)
+        blocked_by_task_id, parent_task_id, priority, source, source_agent_id, created_by, tags, updated_at, originator)
+     VALUES ($1,$2,$3,$4,'{}'::jsonb,'{}'::jsonb,$5,$6,$11,50,$9,$7,'test','{}',$8,$10::jsonb)
      RETURNING id`,
     [
       opts.sourceAgentId ?? 'coordinator',
@@ -41,6 +42,7 @@ async function seedTask(
       opts.updatedAt,
       opts.source ?? 'agent',
       opts.originator ? JSON.stringify(opts.originator) : null,
+      opts.parentTaskId ?? null,
     ],
   );
   const [row] = rows as Array<{ id: string }>;
@@ -163,6 +165,61 @@ describeIf('selectHeartbeatCandidates', () => {
     await pool.query(`UPDATE tasks SET waiting_on_contact_id = $1 WHERE id = $2`, [contactId, id]);
     const got = await selectHeartbeatCandidates(pool, opts);
     expect(got.map((c) => c.id)).not.toContain(id);
+  });
+
+  // -- parent-with-scheduled-children suppression (#1410) --
+  // A parent "container" task whose real work lives in subtasks that already carry
+  // their own future wakes has nothing to do until then; the heartbeat should not
+  // re-poke it every interval. Suppression is scoped to children with an ACTIVE
+  // (pending/running) wake — a covered plan, not a stalled one.
+
+  const seedChildWake = async (childId: string, status = 'pending') =>
+    pool.query(
+      `INSERT INTO scheduled_jobs (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, task_id)
+       VALUES ('coordinator', NULL, now() + interval '2 days', '{"type":"task-wake"}'::jsonb, $2, now() + interval '2 days', 'test', $1)`,
+      [childId, status],
+    );
+
+  it('suppresses an idle parent whose non-terminal child already has a pending wake', async () => {
+    const parent = await seedTask(pool, { title: 'parent', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    const child = await seedTask(pool, { title: 'child', status: 'open', sourceAgentId: 'ceo-inbox', parentTaskId: parent, updatedAt: hoursAgo(10) });
+    await seedChildWake(child, 'pending');
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).not.toContain(parent);
+  });
+
+  it('suppresses an idle parent whose child has a running wake', async () => {
+    const parent = await seedTask(pool, { title: 'parent-run', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    const child = await seedTask(pool, { title: 'child-run', status: 'in_progress', sourceAgentId: 'ceo-inbox', parentTaskId: parent, updatedAt: hoursAgo(10) });
+    await seedChildWake(child, 'running');
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).not.toContain(parent);
+  });
+
+  it('still selects a parent whose child wake is already terminal (completed)', async () => {
+    // A completed child wake does not "cover" the parent — the plan is not progressing on
+    // schedule, so the parent remains a legitimate heartbeat candidate.
+    const parent = await seedTask(pool, { title: 'parent-done-child', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    const child = await seedTask(pool, { title: 'child-done', status: 'open', sourceAgentId: 'ceo-inbox', parentTaskId: parent, updatedAt: hoursAgo(1) });
+    await seedChildWake(child, 'completed');
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).toContain(parent);
+  });
+
+  it('still selects a parent whose non-terminal child has no wake at all', async () => {
+    const parent = await seedTask(pool, { title: 'parent-nowake-child', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    await seedTask(pool, { title: 'child-nowake', status: 'open', sourceAgentId: 'ceo-inbox', parentTaskId: parent, updatedAt: hoursAgo(1) });
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).toContain(parent);
+  });
+
+  it('does not suppress a parent when only a terminal (done) child holds the wake', async () => {
+    // A done child is terminal — its wake, even if somehow pending, must not shield the parent.
+    const parent = await seedTask(pool, { title: 'parent-terminal-child', status: 'open', sourceAgentId: 'ceo-inbox', updatedAt: hoursAgo(10) });
+    const child = await seedTask(pool, { title: 'child-terminal', status: 'done', sourceAgentId: 'ceo-inbox', parentTaskId: parent, updatedAt: hoursAgo(1) });
+    await seedChildWake(child, 'pending');
+    const got = await selectHeartbeatCandidates(pool, opts);
+    expect(got.map((c) => c.id)).toContain(parent);
   });
 
   // -- lineage + derived threading (#1125) --

--- a/tests/integration/plan-lifecycle-e2e.test.ts
+++ b/tests/integration/plan-lifecycle-e2e.test.ts
@@ -146,9 +146,8 @@ describeIf('Plan primitive end-to-end (#1177)', () => {
     );
     expect(synthDispatch.rows).toHaveLength(1);
 
-    // Mark the already-fired gather wake completed (as the scheduler would after a
-    // run), so the one-active-wake-per-task dedup frees. This lets us prove synth
-    // completion schedules a *fresh* parent wake rather than recycling the gather one.
+    // Mark the already-fired parent wake completed (as the scheduler would after a
+    // run), so the one-active-wake-per-task dedup frees for the next enqueue.
     await schedulerService.completeJobRun(parentWakeId, true);
 
     // 5. The deliverable child produces its output and completes.
@@ -156,14 +155,16 @@ describeIf('Plan primitive end-to-end (#1177)', () => {
     await repo.updateTask(synthId, { progressNote: deliverable }, 'coordinator');
     await repo.updateTask(synthId, { status: 'done' }, 'coordinator');
 
-    // Synth completion must enqueue a brand-new parent wake (not the gather one).
+    // Synth completion enqueues the parent wake again. Per #1410, enqueueTaskWake now
+    // REVIVES the task's terminal wake row rather than inserting a new one, so the
+    // frontier keeps exactly one scheduled_jobs row per task and recycles its id.
     const wakeAfterSynth = await pool.query<{ id: string }>(
       `SELECT id FROM scheduled_jobs WHERE task_id = $1 AND status = 'pending'`,
       [parent.id],
     );
     expect(wakeAfterSynth.rows).toHaveLength(1);
     const completionWakeId = wakeAfterSynth.rows[0]!.id;
-    expect(completionWakeId).not.toBe(parentWakeId);
+    expect(completionWakeId).toBe(parentWakeId); // reused row, not a fresh insert (#1410)
 
     // 6. Fire the fresh wake → subtree resolved → parent auto-completes.
     await bus.publish('system', createScheduleFired({

--- a/tests/unit/scheduler/backlog-heartbeat.test.ts
+++ b/tests/unit/scheduler/backlog-heartbeat.test.ts
@@ -71,6 +71,55 @@ describe('BacklogHeartbeat.tick', () => {
     expect(count).toBe(1); // second succeeds despite first failing
     expect(enqueueTaskWake).toHaveBeenCalledTimes(2);
   });
+
+  it('logs an error only when a real (non-benign) failure blocks all progress', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([
+      { id: 't1', agentId: 'ceo-inbox', originator: null, derived: false },
+    ]);
+    const logger = mockLogger();
+    const { hb, enqueueTaskWake } = makeHeartbeat({ logger: logger as never });
+    enqueueTaskWake.mockRejectedValueOnce(new Error('db blip')); // no pg code → hard failure
+    expect(await hb.tick()).toBe(0);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('treats a one-active-wake unique violation (23505) as a benign race: no error, but warns (#1410)', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([
+      { id: 't1', agentId: 'ceo-inbox', originator: null, derived: false },
+    ]);
+    const logger = mockLogger();
+    const { hb, enqueueTaskWake } = makeHeartbeat({ logger: logger as never });
+    enqueueTaskWake.mockRejectedValueOnce(
+      Object.assign(new Error('dup'), { code: '23505', constraint: 'scheduled_jobs_one_active_wake_per_task_uq' }),
+    );
+    expect(await hb.tick()).toBe(0);
+    expect(logger.error).not.toHaveBeenCalled(); // benign — must not alarm
+    expect(logger.warn).toHaveBeenCalled(); // but surfaced so a suppression regression is visible
+  });
+
+  it('treats a task-gone FK violation (23503) as benign: no error and no warn', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([
+      { id: 't1', agentId: 'ceo-inbox', originator: null, derived: false },
+    ]);
+    const logger = mockLogger();
+    const { hb, enqueueTaskWake } = makeHeartbeat({ logger: logger as never });
+    enqueueTaskWake.mockRejectedValueOnce(Object.assign(new Error('fk'), { code: '23503' }));
+    expect(await hb.tick()).toBe(0);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled(); // task-gone is routine, not a regression signal
+  });
+
+  it('does not raise an unexpected unique violation on a different constraint as benign', async () => {
+    vi.spyOn(tasksQueries, 'selectHeartbeatCandidates').mockResolvedValue([
+      { id: 't1', agentId: 'ceo-inbox', originator: null, derived: false },
+    ]);
+    const logger = mockLogger();
+    const { hb, enqueueTaskWake } = makeHeartbeat({ logger: logger as never });
+    // A 23505 on some OTHER constraint is not the one-active-wake race — it must surface as error.
+    enqueueTaskWake.mockRejectedValueOnce(Object.assign(new Error('dup'), { code: '23505', constraint: 'some_other_uq' }));
+    expect(await hb.tick()).toBe(0);
+    expect(logger.error).toHaveBeenCalled();
+  });
 });
 
 describe('BacklogHeartbeat start/stop', () => {

--- a/tests/unit/scheduler/enqueue-task-wake.test.ts
+++ b/tests/unit/scheduler/enqueue-task-wake.test.ts
@@ -6,7 +6,8 @@ function mockLogger() {
 }
 
 describe('SchedulerService.enqueueTaskWake', () => {
-  it('inserts a one-shot pending scheduled_jobs row carrying the existing task_id', async () => {
+  it('revives the task\'s existing terminal wake row when one exists (#1410)', async () => {
+    // First query (the revive UPDATE) returns a row → short-circuit, no INSERT.
     const pool = { query: vi.fn().mockResolvedValue({ rows: [{ id: 'job-9' }] }) };
     const bus = { publish: vi.fn(), subscribe: vi.fn() };
     const svc = new SchedulerService(
@@ -20,10 +21,38 @@ describe('SchedulerService.enqueueTaskWake', () => {
     const result = await svc.enqueueTaskWake({ taskId: 'task-7', agentId: 'ceo-inbox', runAt });
 
     expect(result.jobId).toBe('job-9');
-    expect(pool.query).toHaveBeenCalledTimes(1);
+    expect(pool.query).toHaveBeenCalledTimes(1); // reuse short-circuits before the insert
     const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
-    expect(sql).toMatch(/INSERT INTO scheduled_jobs/i);
+    expect(sql).toMatch(/UPDATE scheduled_jobs/i); // revives the row, not a fresh insert
     expect(sql).toMatch(/task_id/);
+    expect(params).toContain('task-7');
+    expect(params).toContain('ceo-inbox');
+    expect(params).toContain(runAt);
+  });
+
+  it('inserts a one-shot pending row when there is no terminal wake to reuse (#1410)', async () => {
+    // Revive returns no row → fall through to the INSERT path.
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [] })              // revive: nothing to reuse
+        .mockResolvedValueOnce({ rows: [{ id: 'job-new' }] }), // insert
+    };
+    const bus = { publish: vi.fn(), subscribe: vi.fn() };
+    const svc = new SchedulerService(
+      pool as unknown as import('pg').Pool,
+      bus as never,
+      mockLogger() as never,
+      'America/Toronto',
+    );
+
+    const runAt = new Date('2026-06-04T12:00:00Z');
+    const result = await svc.enqueueTaskWake({ taskId: 'task-7', agentId: 'ceo-inbox', runAt });
+
+    expect(result.jobId).toBe('job-new');
+    expect(pool.query).toHaveBeenCalledTimes(2);
+    const [insertSql, params] = pool.query.mock.calls[1] as [string, unknown[]];
+    expect(insertSql).toMatch(/INSERT INTO scheduled_jobs/i);
+    expect(insertSql).toMatch(/task_id/);
     // status pending, one-shot (cron NULL), task_id = the EXISTING task
     expect(params).toContain('task-7');
     expect(params).toContain('ceo-inbox');


### PR DESCRIPTION
## Summary

Closes #1410.

Prod had accumulated ~3,200 `scheduled_jobs` — 3,146 task-wakes, 3,074 `completed`, **91% created by the BacklogHeartbeat** — with single tasks (e.g. `Trip: … Camp … drop-off`) spawning a new completed wake every ~10 min indefinitely. Each fire is a full coordinator LLM turn that concludes "No work to advance": ~150–320/day of pure token/compute burn, no task progress.

**Root cause:** a parent "container" task parked `open` with no executable work (its real work lives in future subtasks that carry their own wakes) is idle > `idleThresholdHours`, so `selectHeartbeatCandidates` re-selects it every tick. The no-op wake writes its summary to the *job's* `last_run_summary` but never bumps the *task's* `updated_at`, so the task stays permanently inside the idle window — and each cycle inserts a fresh row, so completed wakes pile up. There is no per-task cap.

## Changes (three structural, non-LLM fixes)

- **Parent-with-scheduled-children suppression** (`selectHeartbeatCandidates`, `src/db/queries/tasks.ts`) — don't re-poke a parent whose non-terminal child already holds an active (pending/running) wake. The plan is progressing on schedule via the child. A completed/absent child wake still resurfaces a genuinely stalled parent.
- **No-op backoff** (`enqueueTaskWake`, `src/scheduler/scheduler-service.ts`) — touch the owning task's `updated_at` when a wake is enqueued, so an *attended* task leaves the idle window for a full `idleThresholdHours` instead of being re-selected on the very next tick.
- **Reuse the wake row** (`enqueueTaskWake`) — revive the task's most-recent terminal wake row back to `pending` instead of inserting a new row each cycle, keeping one `scheduled_jobs` row per task so the table stays searchable. Guarded by the migration-067 one-active-wake-per-task partial unique index; a racing enqueue loses benignly with `23505`. Failure bookkeeping is preserved when reviving a `failed`/`suspended` row (mirrors `upsertDeclarativeJob`) so the suspend circuit-breaker accumulates across reuse cycles.

The prod heartbeat interval (10 min, a `local.yaml` override vs the 60 min default) is intentionally left unchanged — the loop is now bounded structurally instead.

## Observability (from code review)

The heartbeat now accounts for benign `23503` (task gone) and `23505` (one-active-wake race) skips separately, tightens the `23505` swallow to the specific constraint name (`scheduled_jobs_one_active_wake_per_task_uq`), **warns** when the race count is non-zero (near-zero is expected — a sustained count means the suppression clause regressed and the flood is recurring), and only raises the "all enqueues failed" error on real (non-benign) failures.

## Tests

- `tests/integration/heartbeat-selection.test.ts` — parent suppression: suppressed when a child holds a pending/running wake; still selected when the child wake is completed/absent or the child is terminal.
- `tests/integration/enqueue-task-wake.test.ts` (new) — revive-vs-insert, `updated_at` touch, and the concurrent double-enqueue invariant (one row, one active wake).
- `tests/unit/scheduler/{enqueue-task-wake,backlog-heartbeat}.test.ts` — revive-or-insert contract and the benign-swallow / warn / gated-error logging paths.

All scheduler + heartbeat suites green (`--no-file-parallelism` for the destructive DB integration tests), typecheck and lint clean.

## Follow-ups (not in this PR)

- Prod mitigation: park the currently-looping camp parent tasks (give each a single future wake) so the bleed stops before this deploys; optionally prune historical completed task-wake rows.
- The `task-update` skill's wake path (`src/db/task-repo.ts`) still inserts rather than reuses — fold into this reuse pattern.
- The dedup detector re-creates the same `Review possible duplicate` pair as many separate task rows — a contacts/dedup idempotency issue tracked separately.
