### PR TITLE
fix: dedup sweep no longer re-creates review tasks for pending pairs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,9 @@ caveats; standard commands live in `package.json` scripts and `scripts/setup.sh`
   migrations; they `describe.skip` when it is unset. Mirror CI by using a separate
   `curia_test` DB: create it, migrate it, then
   `DATABASE_URL=postgres://curia:<pw>@localhost:5432/curia_test LOG_LEVEL=error pnpm test`.
+
+### Git commits (DCO)
+- Every commit must include a DCO `Signed-off-by:` trailer — CI blocks PRs without it.
+  Always commit with `git commit -s` (or `git commit --signoff`). See `CONTRIBUTING.md`.
+- If an already-pushed commit is missing sign-off, amend or `git rebase --signoff main`
+  and force-push (fine when no review threads are in flight).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,17 @@ When addressing review feedback (CodeRabbit, humans, Bugbot, etc.) on a PR this 
    allow resolving fully-addressed threads.
 5. If a comment needs human judgment: reply on the thread saying so — do not
    leave a "please paste this" draft in chat.
+
+### Pull request bodies (no Cursor chrome)
+When creating or updating a PR via **ManagePullRequest**, pass **only** the
+human-readable description. Never include any of the following in `body`:
+
+- `<!-- CURSOR_AGENT_PR_BODY_BEGIN -->` / `<!-- CURSOR_AGENT_PR_BODY_END -->`
+- "Open in Web" / "Open in Cursor" buttons, badges, or image links
+- `cursor.com/agents/...` run links or other cloud-agent deep links meant as PR chrome
+
+If the platform re-injects those wrappers or footers after the call, do not add
+a second copy, and do not ask the user to scrub them as part of the happy path.
+There is currently **no** AGENTS.md or dashboard toggle that disables
+server-side injection (Cursor staff confirmed; Attribution settings only cover
+the separate "Made with Cursor" trailer).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,25 @@ caveats; standard commands live in `package.json` scripts and `scripts/setup.sh`
   Always commit with `git commit -s` (or `git commit --signoff`). See `CONTRIBUTING.md`.
 - If an already-pushed commit is missing sign-off, amend or `git rebase --signoff main`
   and force-push (fine when no review threads are in flight).
+
+### GitHub PR review replies
+When addressing review feedback (CodeRabbit, humans, Bugbot, etc.) on a PR this run owns:
+
+1. **Post replies yourself** on the GitHub review thread. Never ask the user to
+   copy-paste a reply into GitHub — that is an anti-pattern for this environment.
+2. Use the Cursor **ManagePullRequest** tool (`action: post_comment`):
+   - Inline thread reply: set `in_reply_to` to the numeric review-comment id
+     (from `gh api repos/.../pulls/<n>/comments` or a permalink ending in
+     `#discussion_r<id>`).
+   - File/line note when there is no discussion id (e.g. a review-body nitpick):
+     set `path` + `line` (and optional `side`).
+   - Top-level note only when neither applies: `body` alone.
+3. Do **not** use `gh pr comment`, `gh api` POST to review comments, or raw
+   GraphQL — the cloud sandbox GitHub App token can push git but **lacks**
+   issues/PR comment write scopes (`Resource not accessible by integration`).
+4. After a confident fix: commit with `-s`, push the existing PR branch, then
+   reply on the same thread citing the fix SHA. Use `resolve_comment` only when
+   the user asks you to resolve, or when instructions for this run explicitly
+   allow resolving fully-addressed threads.
+5. If a comment needs human judgment: reply on the thread saying so — do not
+   leave a "please paste this" draft in chat.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Scheduler** — liveness check no longer flaps `fail` every few minutes on a healthy scheduler. (#1359)
 - **`sensitivity_rules`** — now read from the merged config, so `local.yaml` overrides actually take effect. (#1369)
 - **`security.extra_injection_patterns`** — same fix: now parsed from the merged config instead of `default.yaml` directly. (#1397)
+- **Backlog heartbeat** — stops re-poking parked-open parents whose subtasks are already scheduled; reuses one wake row per task. (#1410)
 - **Dedup sweep** — stamps structured `dedup-pair` tags so repeat runs skip pending pairs. (#1416)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Scheduler** — liveness check no longer flaps `fail` every few minutes on a healthy scheduler. (#1359)
 - **`sensitivity_rules`** — now read from the merged config, so `local.yaml` overrides actually take effect. (#1369)
 - **`security.extra_injection_patterns`** — same fix: now parsed from the merged config instead of `default.yaml` directly. (#1397)
-- **Backlog heartbeat** — stops re-poking parked-open parents whose subtasks are already scheduled; reuses one wake row per task. (#1410)
+- **Dedup sweep** — stamps structured `dedup-pair` tags so repeat runs skip pending pairs. (#1416)
 
 ### Added
 

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -20,6 +20,7 @@ import {
   parseNumericFlag,
   type DedupRunOptions,
 } from './dedup-contacts.js';
+import { dedupPairTag } from '../src/contacts/dedup-pair-key.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -207,6 +208,27 @@ describe('runDedup — unit', () => {
     const description = taskArgs.description as string;
     expect(description).toContain('c1');
     expect(description).toContain('c2');
+  });
+
+  it('skips fuzzy pairs that already have an open dedup review task', async () => {
+    const uuidA = '11111111-1111-1111-1111-111111111111';
+    const uuidB = '22222222-2222-2222-2222-222222222222';
+    const contacts: Contact[] = [
+      makeContact({ id: uuidA, displayName: 'Mikael Sorensen' }),
+      makeContact({ id: uuidB, displayName: 'Michael Sorenson' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, {
+      ...opts,
+      listOpenDedupTasks: async () => [{
+        tags: ['dedup', dedupPairTag(uuidA, uuidB)],
+      }],
+    });
+
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(result.taskCount).toBe(0);
+    expect(result.skippedExistingCount).toBe(1);
   });
 
   // -------------------------------------------------------------------------

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -25,6 +25,11 @@ import {
   type WriteExclusionOptions,
   type HasExclusionOptions,
 } from '../src/contacts/dedup-exclusions.js';
+import {
+  canonicalPairKey,
+  dedupPairTag,
+  pairKeyFromDedupTask,
+} from '../src/contacts/dedup-pair-key.js';
 import { ModelRegistry } from '../src/agents/llm/model-registry.js';
 import { EventBus } from '../src/bus/bus.js';
 import { AuditLogger } from '../src/audit/logger.js';
@@ -56,6 +61,8 @@ export interface DedupRunResult {
   taskCount: number;
   /** Number of pairs skipped due to dedup_exclusion facts. */
   skippedExcludedCount: number;
+  /** Number of pairs skipped because an open dedup review task already exists. */
+  skippedExistingCount: number;
   /** Number of structural pairs involving the principal (routed to task instead of merge). */
   principalSkippedCount: number;
   /** Number of pairs that would have been merged (dry-run report). */
@@ -87,8 +94,7 @@ export interface DedupRunOptions {
    * (counted in skippedAboveMaxScoreCount). Pairs with `minScore ≤ score < maxScore` are
    * acted on. Used for incremental band runs: a later, lower `--min-score` pass sets
    * `--max-score` to the previous run's `--min-score` so it doesn't re-create tasks for
-   * pairs the earlier run already surfaced (the sweep is not task-idempotent). Undefined =
-   * no upper bound.
+   * pairs the earlier run already surfaced. Undefined = no upper bound.
    */
   maxScore?: number;
   /**
@@ -113,6 +119,8 @@ export interface DedupRunOptions {
     sourceAgentId: string;
     tags: string[];
   }) => Promise<unknown>;
+  /** Open dedup review tasks for idempotency checks. Omit in unit tests that don't need it. */
+  listOpenDedupTasks?: () => Promise<Array<{ tags?: string[]; description?: string | null }>>;
   // storeFact is NOT included here: the sweep never writes exclusion facts.
   // Decline→exclusion writes go through the contacts agent calling contact-dedup-exclude.
   /** Calls EntityMemory.getFacts for a KG node — returns fact nodes. */
@@ -142,7 +150,7 @@ export async function runDedup(
   identityMap: Map<string, ChannelIdentity[]>,
   opts: DedupRunOptions,
 ): Promise<DedupRunResult> {
-  const { dryRun, mergeContacts, createTask, getFacts, minScore, maxScore, maxTasks, noTasks } = opts;
+  const { dryRun, mergeContacts, createTask, getFacts, minScore, maxScore, maxTasks, noTasks, listOpenDedupTasks } = opts;
 
   // Memoize getFacts per KG node for the duration of the sweep. The exclusion check
   // runs inside the O(n²) pair loop, and a contact that appears in many candidate
@@ -163,6 +171,7 @@ export async function runDedup(
     mergedCount: 0,
     taskCount: 0,
     skippedExcludedCount: 0,
+    skippedExistingCount: 0,
     principalSkippedCount: 0,
     wouldMergeCount: 0,
     wouldCreateTaskCount: 0,
@@ -174,6 +183,15 @@ export async function runDedup(
 
   if (contacts.length < 2) return result;
 
+  const existingPairKeys = new Set<string>();
+  if (listOpenDedupTasks) {
+    const existingTasks = await listOpenDedupTasks();
+    for (const task of existingTasks) {
+      const key = pairKeyFromDedupTask(task);
+      if (key) existingPairKeys.add(key);
+    }
+  }
+
   // Track pairs we've already handled to avoid double-processing (A,B) and (B,A).
   const processedPairs = new Set<string>();
 
@@ -184,7 +202,7 @@ export async function runDedup(
 
   // We need a canonical ordering for pair keys
   function pairKey(aId: string, bId: string): string {
-    return aId < bId ? `${aId}:${bId}` : `${bId}:${aId}`;
+    return canonicalPairKey(aId, bId);
   }
 
   for (let i = 0; i < contacts.length; i++) {
@@ -330,6 +348,11 @@ export async function runDedup(
           result.principalSkippedCount++;
         }
 
+        if (existingPairKeys.has(key)) {
+          result.skippedExistingCount++;
+          continue;
+        }
+
         // --no-tasks (merge-only) or the --max-tasks cap: suppress task creation. Compare
         // against tasks already acted on (real run: taskCount; dry-run: wouldCreateTaskCount)
         // so the cap behaves identically in both modes and the dry-run preview reflects
@@ -381,9 +404,10 @@ export async function runDedup(
             owner: 'curia',
             source: 'agent',
             sourceAgentId: 'contacts',
-            tags: ['dedup', 'contacts'],
+            tags: ['dedup', 'contacts', dedupPairTag(a.id, b.id)],
           });
           result.taskCount++;
+          existingPairKeys.add(key);
         } catch (err) {
           logger.error({ err, contactAId: a.id, contactBId: b.id }, 'dedup: task creation failed — continuing');
           result.errorCount++;
@@ -737,6 +761,12 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
 
         // TaskRepo.createTask publishes task.created and handles progress/error_budget cols.
         createTask: (params) => taskRepo.createTask(params),
+
+        listOpenDedupTasks: () => taskRepo.listTasks({
+          statuses: ['open', 'in_progress', 'waiting', 'blocked'],
+          tag: 'dedup',
+          limit: 1000,
+        }),
 
         // storeFact is NOT included in DedupRunOptions — the sweep never writes exclusion
         // facts directly. See writeExclusion() and its doc comment for the intended call site.

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -762,11 +762,24 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
         // TaskRepo.createTask publishes task.created and handles progress/error_budget cols.
         createTask: (params) => taskRepo.createTask(params),
 
-        listOpenDedupTasks: () => taskRepo.listTasks({
-          statuses: ['open', 'in_progress', 'waiting', 'blocked'],
-          tag: 'dedup',
-          limit: 1000,
-        }),
+        listOpenDedupTasks: async () => {
+          const limit = 1000;
+          const tasks = await taskRepo.listTasks({
+            statuses: ['open', 'in_progress', 'waiting', 'blocked'],
+            tag: 'dedup',
+            limit,
+          });
+          // Hitting the ceiling means the idempotency set is truncated — pairs beyond
+          // this page may be re-filed. Mirror the warning already documented on the
+          // skill's EXISTING_TASK_FETCH_LIMIT.
+          if (tasks.length >= limit) {
+            logger.warn(
+              { count: tasks.length, limit },
+              'dedup: open-task fetch hit limit — idempotency guard may miss older pairs',
+            );
+          }
+          return tasks;
+        },
 
         // storeFact is NOT included in DedupRunOptions — the sweep never writes exclusion
         // facts directly. See writeExclusion() and its doc comment for the intended call site.

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -14,6 +14,11 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 import type { DuplicatePair, TaskOriginator } from '../../src/contacts/types.js';
 import type { KgNode } from '../../src/memory/types.js';
 import { hasExclusion } from '../../src/contacts/dedup-exclusions.js';
+import {
+  canonicalPairKey,
+  dedupPairTag,
+  pairKeyFromDedupTask,
+} from '../../src/contacts/dedup-pair-key.js';
 
 // Default minimum Jaro-Winkler score — chosen empirically as the precision sweet
 // spot on the production contact set (0.95 is very clean, 0.90 starts to pick up
@@ -30,28 +35,6 @@ const OPEN_STATUSES = ['open', 'in_progress', 'waiting', 'blocked'];
 // schema change; document this as an accepted ceiling. If it ever becomes an
 // issue, adding offset to ListTasksFilters and paginating here is the right fix.
 const EXISTING_TASK_FETCH_LIMIT = 1000;
-
-// Regex to extract contact IDs from task descriptions filed by this skill or
-// by the dedup-contacts maintenance script, both of which use the same format:
-//   "Contact A ID: <uuid>  (Display Name)"
-//   "Contact B ID: <uuid>  (Display Name)"
-const CONTACT_ID_LINE_RE = /Contact ([AB]) ID: ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gi;
-
-/** Canonical (order-independent) key for a contact pair. */
-function pairKey(aId: string, bId: string): string {
-  return aId < bId ? `${aId}:${bId}` : `${bId}:${aId}`;
-}
-
-/** Extract contact A and B IDs from a dedup task description. Returns null if not found. */
-function extractPairIds(description: string | null | undefined): { aId: string; bId: string } | null {
-  if (!description) return null;
-  const found: Record<string, string> = {};
-  for (const match of description.matchAll(CONTACT_ID_LINE_RE)) {
-    found[match[1]!.toUpperCase()] = match[2]!;
-  }
-  if (found['A'] && found['B']) return { aId: found['A'], bId: found['B'] };
-  return null;
-}
 
 export class ContactFindDuplicatesHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -122,9 +105,9 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
       existingPairKeys = new Set<string>();
       let unparseable = 0;
       for (const task of existingTasks) {
-        const ids = extractPairIds(task.description ?? null);
-        if (ids) {
-          existingPairKeys.add(pairKey(ids.aId, ids.bId));
+        const key = pairKeyFromDedupTask(task);
+        if (key) {
+          existingPairKeys.add(key);
         } else {
           unparseable++;
         }
@@ -165,7 +148,7 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
 
     // -- Per-pair processing: errors are isolated so one failing pair doesn't abort the scan --
     for (const pair of pairs) {
-      const key = pairKey(pair.contactA.id, pair.contactB.id);
+      const key = canonicalPairKey(pair.contactA.id, pair.contactB.id);
 
       if (existingPairKeys.has(key)) {
         skippedExisting++;
@@ -224,7 +207,7 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
           owner: 'curia',
           source: 'agent',
           sourceAgentId: 'contacts',
-          tags: ['dedup', 'contacts'],
+          tags: ['dedup', 'contacts', dedupPairTag(pair.contactA.id, pair.contactB.id)],
           // Copy the cron run's lineage (system) onto the review task (#1125). As a source='agent'
           // task it is a DERIVED child, so when the heartbeat wakes it the bypass ladder requires
           // posture D (score >= 90) to retain system standing — below that it is propose-only and
@@ -237,6 +220,7 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
           'contact-find-duplicates: filed review task',
         );
         filed++;
+        existingPairKeys.add(key);
       } catch (taskErr) {
         // Fail open: log and continue so one pair error doesn't abort the entire scan.
         // The pair is not counted as filed, so the idempotency check will attempt it again

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -101,6 +101,12 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
         tag: 'dedup',
         limit: EXISTING_TASK_FETCH_LIMIT,
       });
+      if (existingTasks.length >= EXISTING_TASK_FETCH_LIMIT) {
+        ctx.log.warn(
+          { count: existingTasks.length, limit: EXISTING_TASK_FETCH_LIMIT },
+          'contact-find-duplicates: open-task fetch hit limit — idempotency guard may miss older pairs',
+        );
+      }
 
       existingPairKeys = new Set<string>();
       let unparseable = 0;

--- a/skills/contact-find-duplicates/skill.json
+++ b/skills/contact-find-duplicates/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "contact-find-duplicates",
-  "description": "Scan all contacts for duplicate pairs above a score threshold, file Curia-owned review tasks for new pairs, and return a summary. Idempotent: pairs that already have an open 'dedup' task or a dedup_exclusion KG fact are skipped. Use this for the weekly scheduled scan — it files tasks rather than returning a raw list, so it never floods the agent context.",
-  "version": "2.0.0",
+  "description": "Scan all contacts for duplicate pairs above a score threshold, file Curia-owned review tasks for new pairs, and return a summary. Idempotent: pairs that already have an open 'dedup' task (matched by structured dedup-pair tag or description IDs) or a dedup_exclusion KG fact are skipped. Use this for the weekly scheduled scan — it files tasks rather than returning a raw list, so it never floods the agent context.",
+  "version": "2.1.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/src/contacts/dedup-pair-key.test.ts
+++ b/src/contacts/dedup-pair-key.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalPairKey,
+  dedupPairTag,
+  extractPairKeyFromDescription,
+  extractPairKeyFromTags,
+  pairKeyFromDedupTask,
+} from './dedup-pair-key.js';
+
+const UUID_A = '11111111-1111-1111-1111-111111111111';
+const UUID_B = '22222222-2222-2222-2222-222222222222';
+
+describe('dedup-pair-key', () => {
+  it('canonicalPairKey is order-independent and lowercase', () => {
+    expect(canonicalPairKey(UUID_A, UUID_B)).toBe(`${UUID_A}:${UUID_B}`);
+    expect(canonicalPairKey(UUID_B, UUID_A)).toBe(`${UUID_A}:${UUID_B}`);
+    expect(canonicalPairKey(UUID_A.toUpperCase(), UUID_B)).toBe(`${UUID_A}:${UUID_B}`);
+  });
+
+  it('dedupPairTag encodes the canonical pair key', () => {
+    expect(dedupPairTag(UUID_B, UUID_A)).toBe(`dedup-pair:${UUID_A}:${UUID_B}`);
+  });
+
+  it('extractPairKeyFromTags reads structured dedup-pair tags', () => {
+    expect(extractPairKeyFromTags(['dedup', `dedup-pair:${UUID_B}:${UUID_A}`])).toBe(`${UUID_A}:${UUID_B}`);
+  });
+
+  it('extractPairKeyFromDescription parses legacy description lines case-insensitively', () => {
+    const description = [
+      'Contact A ID: 11111111-1111-1111-1111-111111111111  (Alice)',
+      'Contact B ID: 22222222-2222-2222-2222-222222222222  (Bob)',
+    ].join('\n');
+    expect(extractPairKeyFromDescription(description)).toBe(`${UUID_A}:${UUID_B}`);
+  });
+
+  it('pairKeyFromDedupTask prefers tags over description', () => {
+    const task = {
+      tags: [`dedup-pair:${UUID_A}:${UUID_B}`],
+      description: `Contact A ID: ${UUID_B}\nContact B ID: ${UUID_A}`,
+    };
+    expect(pairKeyFromDedupTask(task)).toBe(`${UUID_A}:${UUID_B}`);
+  });
+});

--- a/src/contacts/dedup-pair-key.ts
+++ b/src/contacts/dedup-pair-key.ts
@@ -1,0 +1,59 @@
+/** Prefix for structured, order-independent dedup-pair tags on review tasks. */
+export const DEDUP_PAIR_TAG_PREFIX = 'dedup-pair:';
+
+const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+const CANONICAL_PAIR_KEY_RE = new RegExp(`^(${UUID_PATTERN}):(${UUID_PATTERN})$`, 'i');
+
+// Regex to extract contact IDs from task descriptions filed by contact-find-duplicates
+// or the dedup-contacts maintenance script:
+//   "Contact A ID: <uuid>  (Display Name)"
+//   "Contact B ID: <uuid>  (Display Name)"
+const CONTACT_ID_LINE_RE = new RegExp(
+  `Contact ([AB]) ID: (${UUID_PATTERN})`,
+  'gi',
+);
+
+/** Canonical (order-independent, lowercase) key for a contact pair. */
+export function canonicalPairKey(aId: string, bId: string): string {
+  const a = aId.toLowerCase();
+  const b = bId.toLowerCase();
+  return a < b ? `${a}:${b}` : `${b}:${a}`;
+}
+
+/** Structured dedup-pair tag stamped on review tasks at creation time. */
+export function dedupPairTag(aId: string, bId: string): string {
+  return `${DEDUP_PAIR_TAG_PREFIX}${canonicalPairKey(aId, bId)}`;
+}
+
+/** Extract a canonical pair key from structured dedup-pair tags. */
+export function extractPairKeyFromTags(tags: string[] | null | undefined): string | null {
+  if (!tags) return null;
+  for (const tag of tags) {
+    if (!tag.startsWith(DEDUP_PAIR_TAG_PREFIX)) continue;
+    const raw = tag.slice(DEDUP_PAIR_TAG_PREFIX.length);
+    const match = raw.match(CANONICAL_PAIR_KEY_RE);
+    if (!match) continue;
+    return canonicalPairKey(match[1]!, match[2]!);
+  }
+  return null;
+}
+
+/** Extract a canonical pair key from a dedup task description (legacy fallback). */
+export function extractPairKeyFromDescription(description: string | null | undefined): string | null {
+  if (!description) return null;
+  const found: Record<string, string> = {};
+  for (const match of description.matchAll(CONTACT_ID_LINE_RE)) {
+    found[match[1]!.toUpperCase()] = match[2]!.toLowerCase();
+  }
+  if (!found['A'] || !found['B']) return null;
+  return canonicalPairKey(found['A'], found['B']);
+}
+
+/** Resolve a canonical pair key from tags first, then description. */
+export function pairKeyFromDedupTask(task: {
+  tags?: string[];
+  description?: string | null;
+}): string | null {
+  return extractPairKeyFromTags(task.tags) ?? extractPairKeyFromDescription(task.description);
+}

--- a/src/contacts/dedup-pair-key.ts
+++ b/src/contacts/dedup-pair-key.ts
@@ -46,8 +46,10 @@ export function extractPairKeyFromDescription(description: string | null | undef
   for (const match of description.matchAll(CONTACT_ID_LINE_RE)) {
     found[match[1]!.toUpperCase()] = match[2]!.toLowerCase();
   }
-  if (!found['A'] || !found['B']) return null;
-  return canonicalPairKey(found['A'], found['B']);
+  const a = found['A'];
+  const b = found['B'];
+  if (!a || !b) return null;
+  return canonicalPairKey(a, b);
 }
 
 /** Resolve a canonical pair key from tags first, then description. */

--- a/tests/unit/skills/contact-find-duplicates.test.ts
+++ b/tests/unit/skills/contact-find-duplicates.test.ts
@@ -3,6 +3,7 @@ import { ContactFindDuplicatesHandler } from '../../../skills/contact-find-dupli
 import type { SkillContext } from '../../../src/skills/types.js';
 import type { DuplicatePair } from '../../../src/contacts/types.js';
 import type { TaskRow } from '../../../src/db/queries/tasks.js';
+import { dedupPairTag } from '../../../src/contacts/dedup-pair-key.js';
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
@@ -274,38 +275,52 @@ describe('ContactFindDuplicatesHandler', () => {
     }
   });
 
+  it('skips pairs when an open dedup task has a structured dedup-pair tag', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = {
+      listTasks: async () => [{ id: 'task-tagged', tags: ['dedup', dedupPairTag(UUID_A, UUID_B)] }],
+      createTask,
+    };
+
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; skipped_existing: number };
+      expect(data.skipped_existing).toBe(1);
+      expect(createTask).not.toHaveBeenCalled();
+    }
+  });
+
+  it('does not file a second task for the same pair within one run', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.94),
+    ];
+    const contactService = { findDuplicates: async () => pairs };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { filed: number; total_scanned: number };
+      expect(data.total_scanned).toBe(2);
+      expect(data.filed).toBe(1);
+      expect(createTask).toHaveBeenCalledOnce();
+    }
+  });
+
   // ---------------------------------------------------------------------------
   // Idempotency: dedup_exclusion KG fact
   // ---------------------------------------------------------------------------
 
   it('skips pairs that have a dedup_exclusion fact on contact A naming contact B', async () => {
-    const pairs = [
-      makePair(UUID_A, 'Alice', 'kg-node-a', UUID_B, 'Bob', null, 0.95),
-    ];
-    const contactService = { findDuplicates: async () => pairs };
-    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
-    const taskRepo = { listTasks: async () => [], createTask };
-    const entityMemory = {
-      getFacts: async (nodeId: string) => {
-        if (nodeId === 'kg-node-a') {
-          return [{ properties: { attribute: 'dedup_exclusion', value: UUID_B } }];
-        }
-        return [];
-      },
-    };
-
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      const data = result.data as { filed: number; skipped_excluded: number };
-      expect(data.filed).toBe(0);
-      expect(data.skipped_excluded).toBe(1);
-      expect(createTask).not.toHaveBeenCalled();
-    }
-  });
-
-  it('skips pairs that have a dedup_exclusion fact on contact B naming contact A', async () => {
     const pairs = [
       makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', 'kg-node-b', 0.95),
     ];
@@ -476,9 +491,10 @@ describe('ContactFindDuplicatesHandler', () => {
     await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
 
     expect(createTask).toHaveBeenCalledOnce();
-    const callArg = createTask.mock.calls[0]![0] as { description: string };
+    const callArg = createTask.mock.calls[0]![0] as { description: string; tags: string[] };
     expect(callArg.description).toContain(`Contact A ID: ${UUID_A}`);
     expect(callArg.description).toContain(`Contact B ID: ${UUID_B}`);
     expect(callArg.description).toContain('Score:');
+    expect(callArg.tags).toContain(dedupPairTag(UUID_A, UUID_B));
   });
 });


### PR DESCRIPTION
## Summary

Closes #1416.

The weekly `contact-find-duplicates` sweep was filing a new "Review possible duplicate" task on every run for the same unresolved pair. This hardens the idempotency guard so a pending pair creates at most one open review task.

## Changes

- Add shared `src/contacts/dedup-pair-key.ts` helpers for canonical (order-independent) pair keys and structured `dedup-pair:<uuid>:<uuid>` task tags.
- **`contact-find-duplicates`**: resolve existing open dedup tasks by structured tag first, with description parsing as a legacy fallback; stamp the tag on newly filed tasks; track filed pairs within the same run; warn when the open-task fetch hits its 1000-row ceiling.
- **`dedup-contacts` maintenance script**: apply the same open-task guard and tag stamping; report `skippedExistingCount`; warn at the fetch ceiling.
- Tests cover tag-based matching, reversed pair order, within-run deduplication, and maintenance-script idempotency.

## Acceptance criteria

- [x] Running the dedup sweep twice against the same unresolved pair creates **at most one** open review task.
- [x] Pairs with a `dedup_exclusion` fact (or a completed/dismissed decision that wrote one) are still skipped via existing `hasExclusion` behaviour.
- [x] Pair match is order-independent (A/B == B/A).
- [x] Existing multiplied review-task rows for a pair are not further multiplied once any open task is recognized.
- [x] Test coverage for the idempotency guard.

## Notes

Legacy tasks without a `dedup-pair` tag remain matchable via the existing `Contact A/B ID:` description lines. New tasks always carry the structured tag for robust matching.

## Review follow-ups

- Destructured `found['A']`/`found['B']` locals for strict-null narrowing.
- Added ceiling warnings in both the skill and the maintenance script when open-task fetch returns ≥ 1000 rows.
