### PR TITLE
fix(task-update): reuse pending wake row on reschedule (#1415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`security.extra_injection_patterns`** — same fix: now parsed from the merged config instead of `default.yaml` directly. (#1397)
 - **Backlog heartbeat** — stops re-poking parked-open parents whose subtasks are already scheduled; reuses one wake row per task. (#1410)
 - **Dedup sweep** — stamps structured `dedup-pair` tags so repeat runs skip pending pairs. (#1416)
+- **`task-update` wake reschedule** — updates the pending wake row in place instead of cancel+insert. (#1415)
 
 ### Added
 

--- a/skills/task-update/skill.json
+++ b/skills/task-update/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "task-update",
   "description": "Update an existing task's fields. Can change status, priority, owner, due date, tags, progress note, or blocked-by dependency. Status transitions from 'done' or 'cancelled' are rejected. When wake_at is set, an existing pending wake row is rescheduled in place (or revived/inserted if none is pending). Setting status='cancelled' auto-cancels pending wake-ups.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/task-update/skill.json
+++ b/skills/task-update/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "task-update",
-  "description": "Update an existing task's fields. Can change status, priority, owner, due date, tags, progress note, or blocked-by dependency. Status transitions from 'done' or 'cancelled' are rejected. When wake_at is set, any existing pending wake-up for this task is cancelled and a new one is scheduled. Setting status='cancelled' auto-cancels pending wake-ups.",
+  "description": "Update an existing task's fields. Can change status, priority, owner, due date, tags, progress note, or blocked-by dependency. Status transitions from 'done' or 'cancelled' are rejected. When wake_at is set, an existing pending wake row is rescheduled in place (or revived/inserted if none is pending). Setting status='cancelled' auto-cancels pending wake-ups.",
   "version": "0.1.0",
   "sensitivity": "normal",
   "action_risk": "low",

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -460,25 +460,28 @@ export class TaskRepo {
       RETURNING ${TASK_COLUMNS}
     `;
 
-    // Terminal-status transitions (cancelled / done) always cancel pending wake-up jobs.
-    // The _cancel_wake arm handles the bare status-only path; wakeAt reschedules update
-    // the pending row in place (or revive/insert) instead of cancel+insert (#1415).
-    const cancelOnTerminal = (updates.status === 'cancelled' || updates.status === 'done')
-      && !updates.wakeAt;
+    // Terminal-status transitions (cancelled / done) always cancel pending wake-up jobs,
+    // even when wakeAt is also supplied — terminal wins over reschedule (#1415 review).
+    // Otherwise wakeAt updates the pending row in place (or revive/insert) instead of
+    // cancel+insert.
+    const cancelOnTerminal = updates.status === 'cancelled' || updates.status === 'done';
+    const rescheduleWake = updates.wakeAt !== undefined && !cancelOnTerminal;
 
     const transitioningToTerminal = updates.status !== undefined
       && updates.status !== current.status
       && (updates.status === 'done' || updates.status === 'cancelled');
 
     const executeUpdate = async (executor: DbQueryable): Promise<DbTaskRow | null> => {
-      if (updates.wakeAt || cancelOnTerminal) {
+      if (rescheduleWake || cancelOnTerminal) {
         const wakeAgentIdx = whereIdx + 1;
-        const wakeRunAtIdx = updates.wakeAt ? whereIdx + 2 : null;
-        const wakeCreatedByIdx = updates.wakeAt ? whereIdx + 3 : null;
-        const wakeTzIdx = updates.wakeAt ? whereIdx + 4 : null;
-        const wakeOriginatorIdx = updates.wakeAt ? whereIdx + 5 : null;
+        const wakeRunAtIdx = rescheduleWake ? whereIdx + 2 : null;
+        const wakeCreatedByIdx = rescheduleWake ? whereIdx + 3 : null;
+        const wakeTzIdx = rescheduleWake ? whereIdx + 4 : null;
+        const wakeOriginatorIdx = rescheduleWake ? whereIdx + 5 : null;
 
-        const cteSql = updates.wakeAt ? `
+        // Every wake mutation is gated on updated_task so a concurrent terminal
+        // transition cannot revive/insert a pending wake after the task UPDATE matched 0 rows.
+        const cteSql = rescheduleWake ? `
         WITH updated_task AS (
           ${updateSql}
         ),
@@ -486,8 +489,13 @@ export class TaskRepo {
           UPDATE scheduled_jobs
              SET run_at = $${wakeRunAtIdx}, next_run_at = $${wakeRunAtIdx},
                  agent_id = $${wakeAgentIdx}, created_by = $${wakeCreatedByIdx},
-                 timezone = $${wakeTzIdx}, originator = $${wakeOriginatorIdx}::jsonb
-           WHERE task_id = $${whereIdx} AND status = 'pending'
+                 timezone = $${wakeTzIdx},
+                 task_payload = '{"type":"task-wake"}'::jsonb,
+                 originator = $${wakeOriginatorIdx}::jsonb
+           WHERE task_id = $${whereIdx}
+             AND task_payload->>'type' = 'task-wake'
+             AND status = 'pending'
+             AND EXISTS (SELECT 1 FROM updated_task)
           RETURNING id
         ),
         _revive_wake AS (
@@ -509,6 +517,7 @@ export class TaskRepo {
            )
              AND status IN ('completed', 'failed', 'suspended', 'cancelled')
              AND NOT EXISTS (SELECT 1 FROM _update_pending_wake)
+             AND EXISTS (SELECT 1 FROM updated_task)
           RETURNING id
         ),
         _insert_wake AS (
@@ -517,6 +526,7 @@ export class TaskRepo {
                  $${wakeRunAtIdx}, $${wakeCreatedByIdx}, $${wakeTzIdx}, $${whereIdx}, $${wakeOriginatorIdx}::jsonb
            WHERE NOT EXISTS (SELECT 1 FROM _update_pending_wake)
              AND NOT EXISTS (SELECT 1 FROM _revive_wake)
+             AND EXISTS (SELECT 1 FROM updated_task)
           RETURNING id
         )
         SELECT * FROM updated_task
@@ -531,7 +541,7 @@ export class TaskRepo {
         SELECT * FROM updated_task
       `;
         const allParams: unknown[] = [...updateParams];
-        if (updates.wakeAt) {
+        if (rescheduleWake) {
           allParams.push(
             current.sourceAgentId ?? current.agentId ?? callerAgentId,
             updates.wakeAt,

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -383,8 +383,9 @@ export class TaskRepo {
 
   /**
    * Update a task's fields. Validates status transitions: done and cancelled are terminal.
-   * When `wakeAt` is provided, existing pending wake-up jobs are cancelled and a new one
-   * is created — all in a single CTE for atomicity.
+   * When `wakeAt` is provided, an existing pending wake row is updated in place (run_at /
+   * next_run_at); otherwise the most recent terminal wake row is revived or a new row is
+   * inserted — all in a single CTE for atomicity (#1415, mirrors enqueueTaskWake).
    *
    * Returns the updated task row, or null if the task was not found.
    */
@@ -460,8 +461,8 @@ export class TaskRepo {
     `;
 
     // Terminal-status transitions (cancelled / done) always cancel pending wake-up jobs.
-    // When wakeAt is also provided the cancel+create is already atomic; the extra
-    // _cancel_wake arm here handles the bare status-only path.
+    // The _cancel_wake arm handles the bare status-only path; wakeAt reschedules update
+    // the pending row in place (or revive/insert) instead of cancel+insert (#1415).
     const cancelOnTerminal = (updates.status === 'cancelled' || updates.status === 'done')
       && !updates.wakeAt;
 
@@ -477,19 +478,56 @@ export class TaskRepo {
         const wakeTzIdx = updates.wakeAt ? whereIdx + 4 : null;
         const wakeOriginatorIdx = updates.wakeAt ? whereIdx + 5 : null;
 
-        const cteSql = `
+        const cteSql = updates.wakeAt ? `
+        WITH updated_task AS (
+          ${updateSql}
+        ),
+        _update_pending_wake AS (
+          UPDATE scheduled_jobs
+             SET run_at = $${wakeRunAtIdx}, next_run_at = $${wakeRunAtIdx},
+                 agent_id = $${wakeAgentIdx}, created_by = $${wakeCreatedByIdx},
+                 timezone = $${wakeTzIdx}, originator = $${wakeOriginatorIdx}::jsonb
+           WHERE task_id = $${whereIdx} AND status = 'pending'
+          RETURNING id
+        ),
+        _revive_wake AS (
+          UPDATE scheduled_jobs
+             SET status = 'pending', run_at = $${wakeRunAtIdx}, next_run_at = $${wakeRunAtIdx},
+                 run_started_at = NULL,
+                 consecutive_failures = CASE WHEN status IN ('failed','suspended') THEN consecutive_failures ELSE 0 END,
+                 last_error = CASE WHEN status IN ('failed','suspended') THEN last_error ELSE NULL END,
+                 last_run_outcome = CASE WHEN status IN ('failed','suspended') THEN last_run_outcome ELSE NULL END,
+                 agent_id = $${wakeAgentIdx}, created_by = $${wakeCreatedByIdx},
+                 timezone = $${wakeTzIdx}, task_payload = '{"type":"task-wake"}'::jsonb,
+                 originator = $${wakeOriginatorIdx}::jsonb
+           WHERE id = (
+             SELECT id FROM scheduled_jobs
+              WHERE task_id = $${whereIdx} AND task_payload->>'type' = 'task-wake'
+                AND status IN ('completed', 'failed', 'suspended', 'cancelled')
+              ORDER BY created_at DESC
+              LIMIT 1
+           )
+             AND status IN ('completed', 'failed', 'suspended', 'cancelled')
+             AND NOT EXISTS (SELECT 1 FROM _update_pending_wake)
+          RETURNING id
+        ),
+        _insert_wake AS (
+          INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id, originator)
+          SELECT $${wakeAgentIdx}, $${wakeRunAtIdx}, '{"type":"task-wake"}'::jsonb, 'pending',
+                 $${wakeRunAtIdx}, $${wakeCreatedByIdx}, $${wakeTzIdx}, $${whereIdx}, $${wakeOriginatorIdx}::jsonb
+           WHERE NOT EXISTS (SELECT 1 FROM _update_pending_wake)
+             AND NOT EXISTS (SELECT 1 FROM _revive_wake)
+          RETURNING id
+        )
+        SELECT * FROM updated_task
+      ` : `
         WITH updated_task AS (
           ${updateSql}
         ),
         _cancel_wake AS (
           UPDATE scheduled_jobs SET status = 'cancelled'
           WHERE task_id = $${whereIdx} AND status = 'pending'
-        )${updates.wakeAt ? `,
-        _new_wake AS (
-          INSERT INTO scheduled_jobs (agent_id, run_at, task_payload, status, next_run_at, created_by, timezone, task_id, originator)
-          VALUES ($${wakeAgentIdx}, $${wakeRunAtIdx}, '{"type":"task-wake"}'::jsonb, 'pending',
-                  $${wakeRunAtIdx}, $${wakeCreatedByIdx}, $${wakeTzIdx}, $${whereIdx}, $${wakeOriginatorIdx}::jsonb)
-        )` : ''}
+        )
         SELECT * FROM updated_task
       `;
         const allParams: unknown[] = [...updateParams];

--- a/tests/integration/task-update-wake-reuse.test.ts
+++ b/tests/integration/task-update-wake-reuse.test.ts
@@ -27,8 +27,10 @@ async function wakeRowsFor(pool: pg.Pool, taskId: string) {
     id: string;
     status: string;
     run_at: Date;
+    next_run_at: Date;
+    task_payload: Record<string, unknown>;
   }>(
-    `SELECT id, status, run_at FROM scheduled_jobs WHERE task_id = $1 ORDER BY created_at`,
+    `SELECT id, status, run_at, next_run_at, task_payload FROM scheduled_jobs WHERE task_id = $1 ORDER BY created_at`,
     [taskId],
   );
   return rows;
@@ -63,6 +65,8 @@ describeIf('TaskRepo.updateTask wake row reuse (#1415)', () => {
     expect(rows[0]!.id).toBe(initial!.id);
     expect(rows[0]!.status).toBe('pending');
     expect(new Date(rows[0]!.run_at).getTime()).toBe(newWakeAt.getTime());
+    expect(new Date(rows[0]!.next_run_at).getTime()).toBe(newWakeAt.getTime());
+    expect(rows[0]!.task_payload).toEqual({ type: 'task-wake' });
     expect(rows.some((r) => r.status === 'cancelled')).toBe(false);
   });
 
@@ -81,6 +85,52 @@ describeIf('TaskRepo.updateTask wake row reuse (#1415)', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]!.status).toBe('pending');
     expect(new Date(rows[0]!.run_at).getTime()).toBe(wakeAt.getTime());
+    expect(new Date(rows[0]!.next_run_at).getTime()).toBe(wakeAt.getTime());
+  });
+
+  it('revives a terminal wake row instead of inserting a new one', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} revive`,
+      source: 'coordinator',
+      wakeAt: new Date(Date.now() + 3_600_000),
+    });
+    const [initial] = await wakeRowsFor(pool, task.id);
+    expect(initial).toBeDefined();
+    await pool.query(`UPDATE scheduled_jobs SET status = 'completed' WHERE id = $1`, [initial!.id]);
+
+    const newWakeAt = new Date(Date.now() + 7_200_000);
+    await repo.updateTask(task.id, { wakeAt: newWakeAt }, 'coordinator');
+
+    const rows = await wakeRowsFor(pool, task.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(initial!.id);
+    expect(rows[0]!.status).toBe('pending');
+    expect(new Date(rows[0]!.run_at).getTime()).toBe(newWakeAt.getTime());
+    expect(new Date(rows[0]!.next_run_at).getTime()).toBe(newWakeAt.getTime());
+    expect(rows[0]!.task_payload).toEqual({ type: 'task-wake' });
+  });
+
+  it('resets a heartbeat standing envelope when updating a pending wake in place', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} standing-reset`,
+      source: 'coordinator',
+      wakeAt: new Date(Date.now() + 3_600_000),
+    });
+    const [initial] = await wakeRowsFor(pool, task.id);
+    await pool.query(
+      `UPDATE scheduled_jobs SET task_payload = $2::jsonb WHERE id = $1`,
+      [initial!.id, JSON.stringify({ type: 'task-wake', standing: { derived: true } })],
+    );
+
+    const newWakeAt = new Date(Date.now() + 7_200_000);
+    await repo.updateTask(task.id, { wakeAt: newWakeAt }, 'coordinator');
+
+    const rows = await wakeRowsFor(pool, task.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(initial!.id);
+    expect(rows[0]!.task_payload).toEqual({ type: 'task-wake' });
   });
 
   it('cancels the pending wake when the task transitions to done', async () => {
@@ -105,6 +155,24 @@ describeIf('TaskRepo.updateTask wake row reuse (#1415)', () => {
       wakeAt: new Date(Date.now() + 3_600_000),
     });
     await repo.updateTask(task.id, { status: 'cancelled' }, 'coordinator');
+
+    const rows = await wakeRowsFor(pool, task.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe('cancelled');
+  });
+
+  it('cancels the pending wake when done and wakeAt are supplied together', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} done-with-wake`,
+      source: 'coordinator',
+      wakeAt: new Date(Date.now() + 3_600_000),
+    });
+    await repo.updateTask(
+      task.id,
+      { status: 'done', wakeAt: new Date(Date.now() + 7_200_000) },
+      'coordinator',
+    );
 
     const rows = await wakeRowsFor(pool, task.id);
     expect(rows).toHaveLength(1);

--- a/tests/integration/task-update-wake-reuse.test.ts
+++ b/tests/integration/task-update-wake-reuse.test.ts
@@ -1,0 +1,136 @@
+// task-update-wake-reuse.test.ts — TaskRepo.updateTask wake row reuse (#1415).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import type { EventBus } from '../../src/bus/bus.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'TaskUpdateWake Test';
+const logger = pino({ level: 'silent' });
+const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(
+    `DELETE FROM scheduled_jobs WHERE task_id IN (SELECT id FROM tasks WHERE title LIKE $1)`,
+    [`${PREFIX}%`],
+  );
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+async function wakeRowsFor(pool: pg.Pool, taskId: string) {
+  const { rows } = await pool.query<{
+    id: string;
+    status: string;
+    run_at: Date;
+  }>(
+    `SELECT id, status, run_at FROM scheduled_jobs WHERE task_id = $1 ORDER BY created_at`,
+    [taskId],
+  );
+  return rows;
+}
+
+describeIf('TaskRepo.updateTask wake row reuse (#1415)', () => {
+  let pool: pg.Pool;
+  let repo: TaskRepo;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { await cleanup(pool); });
+
+  it('updates an existing pending wake in place on reschedule', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} reschedule`,
+      source: 'coordinator',
+      wakeAt: new Date(Date.now() + 3_600_000),
+    });
+    const [initial] = await wakeRowsFor(pool, task.id);
+    expect(initial).toBeDefined();
+
+    const newWakeAt = new Date(Date.now() + 7_200_000);
+    await repo.updateTask(task.id, { wakeAt: newWakeAt }, 'coordinator');
+
+    const rows = await wakeRowsFor(pool, task.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(initial!.id);
+    expect(rows[0]!.status).toBe('pending');
+    expect(new Date(rows[0]!.run_at).getTime()).toBe(newWakeAt.getTime());
+    expect(rows.some((r) => r.status === 'cancelled')).toBe(false);
+  });
+
+  it('inserts a wake row when updateTask is the first wake for the task', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} first-wake`,
+      source: 'coordinator',
+    });
+    expect(await wakeRowsFor(pool, task.id)).toHaveLength(0);
+
+    const wakeAt = new Date(Date.now() + 3_600_000);
+    await repo.updateTask(task.id, { wakeAt }, 'coordinator');
+
+    const rows = await wakeRowsFor(pool, task.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe('pending');
+    expect(new Date(rows[0]!.run_at).getTime()).toBe(wakeAt.getTime());
+  });
+
+  it('cancels the pending wake when the task transitions to done', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} done-cancel`,
+      source: 'coordinator',
+      wakeAt: new Date(Date.now() + 3_600_000),
+    });
+    await repo.updateTask(task.id, { status: 'done' }, 'coordinator');
+
+    const rows = await wakeRowsFor(pool, task.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe('cancelled');
+  });
+
+  it('cancels the pending wake when the task transitions to cancelled', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} cancelled-cancel`,
+      source: 'coordinator',
+      wakeAt: new Date(Date.now() + 3_600_000),
+    });
+    await repo.updateTask(task.id, { status: 'cancelled' }, 'coordinator');
+
+    const rows = await wakeRowsFor(pool, task.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe('cancelled');
+  });
+
+  it('keeps exactly one wake row after repeated reschedules', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} repeated`,
+      source: 'coordinator',
+      wakeAt: new Date(Date.now() + 3_600_000),
+    });
+    const [initial] = await wakeRowsFor(pool, task.id);
+
+    for (let i = 1; i <= 5; i++) {
+      await repo.updateTask(
+        task.id,
+        { wakeAt: new Date(Date.now() + i * 3_600_000) },
+        'coordinator',
+      );
+    }
+
+    const rows = await wakeRowsFor(pool, task.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(initial!.id);
+    expect(rows[0]!.status).toBe('pending');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1415

Follow-up to #1410 / #1413. `TaskRepo.updateTask` no longer cancels and re-inserts a wake row on every `wake_at` reschedule. It now:

1. **Updates the existing pending wake in place** (`run_at` / `next_run_at`, plus agent/originator metadata)
2. **Revives the most recent terminal wake row** when no pending wake exists (mirrors `enqueueTaskWake`)
3. **Inserts a new row** only on the true first-wake path
4. **Still cancels pending wakes** on `done` / `cancelled` transitions (unchanged)

This keeps the `task-update` / ceo-inbox / meeting-debrief wake path tidy — one `scheduled_jobs` row per task instead of accumulating `cancelled` rows on each reschedule.

## Changes

- `src/db/task-repo.ts` — reworked the `updateTask` wake CTE from `_cancel_wake` + `_new_wake` to `_update_pending_wake` / `_revive_wake` / `_insert_wake`
- `tests/integration/task-update-wake-reuse.test.ts` — integration coverage for reschedule-in-place, first-wake insert, terminal cancellation, and repeated reschedules
- `skills/task-update/skill.json` — updated description to match new behavior

## Test plan

- [x] `pnpm run typecheck`
- [x] `DATABASE_URL=…/curia_test pnpm test tests/integration/task-update-wake-reuse.test.ts tests/integration/task-repo-originator.test.ts` (12/12 pass)
