### PR TITLE
fix: email-observation review fixes (pin skills, paginate Sent poll, dedup voice proposals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Backlog heartbeat** — stops re-poking parked-open parents whose subtasks are already scheduled; reuses one wake row per task. (#1410)
 - **Dedup sweep** — stamps structured `dedup-pair` tags so repeat runs skip pending pairs. (#1416)
 - **`task-update` wake reschedule** — updates the pending wake row in place instead of cancel+insert. (#1415)
+- **Email-observation skills** — pin `voice-learn`/`task-completion-from-sent`/`ceo-inbox-shadow-draft` to ceo-inbox so their crons work. (#1419)
+- **`ceo-inbox-sent-observe`** — paginate the Sent poll so busy days don't drop unobserved messages past the first page. (#1419)
+- **`voice-learn`** — dedup proposals so weekly reruns stop appending duplicate voice-diff blocks. (#1419)
 
 ### Added
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.17.0"
+version: "0.18.0"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -32,6 +32,11 @@ pinned_skills:
   - ceo-inbox-mark-read
   - ceo-inbox-mark-starred
   - ceo-inbox-sent-observe
+  # Email-observation learning (#1419): the daily/weekly crons and the shadow-draft
+  # triage step call these — they must be pinned or the agent cannot see them.
+  - ceo-inbox-shadow-draft
+  - task-completion-from-sent
+  - voice-learn
   - config-store
   - bullpen
   - entity-context

--- a/config/registry-defaults.yaml
+++ b/config/registry-defaults.yaml
@@ -94,7 +94,11 @@ skills:
   #        Stays admin-enabled: an operator provisions the Tavily key in the console
   #        (Settings → Skills → web-search), which lifts the gate and lets them install/enable it.
   # NOTE: calendar-* excluded — require Google Calendar credentials; enable after calendar setup
-  # NOTE: ceo-inbox-* excluded — companion to the ceo-inbox agent; enable alongside it
+  # NOTE: ceo-inbox-* excluded — companion to the ceo-inbox agent; enable alongside it.
+  #        The email-observation-learning companions (voice-learn, task-completion-from-sent,
+  #        list-learning-digest, resolve-learning-digest) are likewise excluded and must be
+  #        enabled alongside ceo-inbox — even though list/resolve are pinned to the coordinator,
+  #        they only produce output once the ceo-inbox observer subsystem is running.
   # NOTE: KG skills (extract-facts, extract-relationships, query-relationships, delete-relationship)
   #        excluded — require OpenAI embeddings
 agents:

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -207,6 +207,65 @@ export class CeoNylasClient {
     return data.map(normalizeMessageSummary);
   }
 
+  // Exhaustively list messages by following Nylas's `next_cursor`, up to `maxScan`
+  // total messages. Nylas returns messages newest-first, so a single fixed-limit
+  // listMessages() call silently drops everything past the first page — on a busy
+  // Sent folder that means lost observations (issue: #1429 review). This walks all
+  // pages so a watermark-scoped poll actually sees every message in the window.
+  //
+  // Filters (in/received_after) are only sent on the first request; Nylas's cursor
+  // encodes the original query, so subsequent pages carry the filter automatically
+  // (same contract listAllDrafts relies on). `truncated` is true when the maxScan
+  // ceiling was hit with more pages still available — callers must NOT treat the
+  // window as fully drained in that case.
+  async listAllMessages(
+    options: ListMessagesOptions & { maxScan?: number } = {},
+  ): Promise<{ messages: NylasMessageSummary[]; truncated: boolean }> {
+    const maxScan = options.maxScan ?? 500;
+    const pageSize = Math.min(options.limit ?? NYLAS_MAX_LIST_LIMIT, NYLAS_MAX_LIST_LIMIT);
+
+    const messages: NylasMessageSummary[] = [];
+    let pageToken: string | undefined;
+    let truncated = false;
+
+    for (;;) {
+      const params = new URLSearchParams();
+      params.set('limit', String(pageSize));
+      if (pageToken) {
+        // Cursor carries the original filter — do not re-send in/received_after.
+        params.set('page_token', pageToken);
+      } else {
+        if (options.folder) {
+          const normalized = GMAIL_FOLDER_ALIASES[options.folder] ?? options.folder;
+          params.set('in', normalized);
+        }
+        if (options.unread !== undefined) params.set('unread', String(options.unread));
+        if (options.receivedAfter !== undefined) {
+          params.set('received_after', String(options.receivedAfter));
+        }
+      }
+      const url = `${this.baseUrl}/messages?${params}`;
+
+      const { data, nextCursor } = await this.requestWithCursor<NylasApiMessage[]>(
+        'GET',
+        url,
+        'listAllMessages',
+      );
+      messages.push(...data.map(normalizeMessageSummary));
+
+      // An empty page with a cursor would otherwise spin forever — bail out.
+      if (data.length === 0) break;
+      if (messages.length >= maxScan) {
+        truncated = Boolean(nextCursor);
+        break;
+      }
+      if (!nextCursor) break;
+      pageToken = nextCursor;
+    }
+
+    return { messages: messages.slice(0, maxScan), truncated };
+  }
+
   async getMessage(messageId: string): Promise<NylasMessageFull> {
     const url = `${this.baseUrl}/messages/${encodeURIComponent(messageId)}`;
     const data = await this.request<NylasApiMessage>('GET', url, 'getMessage');

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -263,7 +263,11 @@ export class CeoNylasClient {
       pageToken = nextCursor;
     }
 
-    return { messages: messages.slice(0, maxScan), truncated };
+    // slice() defends against a final page overshooting maxScan when maxScan is not a
+    // multiple of pageSize; if it actually trims anything, that's a truncation too even
+    // if the last page carried no cursor.
+    const capped = messages.slice(0, maxScan);
+    return { messages: capped, truncated: truncated || capped.length < messages.length };
   }
 
   async getMessage(messageId: string): Promise<NylasMessageFull> {

--- a/skills/ceo-inbox-sent-observe/handler.test.ts
+++ b/skills/ceo-inbox-sent-observe/handler.test.ts
@@ -398,6 +398,54 @@ describe('CeoInboxSentObserveHandler', () => {
     expect(data.messages_scanned).toBe(3);
     expect(data.watermark_advanced_to).toBe(1_720_000_401);
     // Second fetch carried the cursor, proving pagination happened.
-    expect(mockFetch.mock.calls.some((c) => String(c[0]).includes('page_token=CURSOR1'))).toBe(true);
+    expect(
+      mockFetch.mock.calls.some((c: unknown[]) => String(c[0]).includes('page_token=CURSOR1')),
+    ).toBe(true);
+  });
+
+  it('on truncation advances forward and warns (never re-scans or strands via a held watermark)', async () => {
+    const mkMsg = (id: string, date: number) => ({
+      id,
+      thread_id: `t-${id}`,
+      subject: 'Note',
+      from: [{ email: 'ceo@example.com' }],
+      to: [{ email: 'x@example.com' }],
+      cc: [],
+      snippet: 'body',
+      date,
+      unread: false,
+      folders: ['SENT'],
+      attachments: [],
+    });
+
+    // Every page returns a full batch AND a cursor → listAllMessages hits the maxScan
+    // ceiling and reports truncated=true. Newest message date = 1_720_009_999.
+    let n = 0;
+    mockFetch.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u.includes('/messages?')) {
+        // 20 messages per page, always with a next_cursor.
+        const data = Array.from({ length: 20 }, (_v, i) => {
+          const date = 1_720_009_999 - (n * 20 + i);
+          return mkMsg(`m-${n}-${i}`, date);
+        });
+        n += 1;
+        return new Response(JSON.stringify({ data, next_cursor: `c${n}` }), { status: 200 });
+      }
+      throw new Error(`unexpected ${u}`);
+    });
+
+    const ctx = buildCtx({ force: true, nowMs: 1_720_100_000_000, tasks: [] });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const data = (result as { data: { messages_scanned: number; watermark_advanced_to: number } }).data;
+    // Advanced forward to newest+1 (no held-watermark re-scan loop).
+    expect(data.watermark_advanced_to).toBe(1_720_010_000);
+    expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe('1720010000');
+    // A truncation warning was emitted (loss is loud, not silent).
+    const warnMsgs = (ctx.log.warn as unknown as { mock: { calls: unknown[][] } }).mock.calls.map(
+      (c) => String(c[1]),
+    );
+    expect(warnMsgs.some((m) => /scan ceiling/i.test(m))).toBe(true);
   });
 });

--- a/skills/ceo-inbox-sent-observe/handler.test.ts
+++ b/skills/ceo-inbox-sent-observe/handler.test.ts
@@ -356,4 +356,48 @@ describe('CeoInboxSentObserveHandler', () => {
     expect((result as { data: { skipped_backoff: boolean } }).data.skipped_backoff).toBe(true);
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it('follows next_cursor to scan every message in the window (no page-1 drop)', async () => {
+    const mkMsg = (id: string, date: number) => ({
+      id,
+      thread_id: `t-${id}`,
+      subject: 'Note',
+      from: [{ email: 'ceo@example.com' }],
+      to: [{ email: 'x@example.com' }],
+      cc: [],
+      snippet: 'body',
+      date,
+      unread: false,
+      folders: ['SENT'],
+      attachments: [],
+    });
+
+    // Page 1 carries a cursor; page 2 (fetched via page_token) has no cursor → done.
+    mockFetch.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u.includes('page_token=CURSOR1')) {
+        return new Response(JSON.stringify({ data: [mkMsg('m3', 1_720_000_400)] }), { status: 200 });
+      }
+      if (u.includes('/messages?')) {
+        return new Response(
+          JSON.stringify({
+            data: [mkMsg('m1', 1_720_000_200), mkMsg('m2', 1_720_000_300)],
+            next_cursor: 'CURSOR1',
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected ${u}`);
+    });
+
+    const ctx = buildCtx({ force: true, nowMs: 1_720_100_000_000, tasks: [] });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const data = (result as { data: { messages_scanned: number; watermark_advanced_to: number } }).data;
+    // All three messages across both pages were scanned — page 2 not dropped.
+    expect(data.messages_scanned).toBe(3);
+    expect(data.watermark_advanced_to).toBe(1_720_000_401);
+    // Second fetch carried the cursor, proving pagination happened.
+    expect(mockFetch.mock.calls.some((c) => String(c[0]).includes('page_token=CURSOR1'))).toBe(true);
+  });
 });

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -35,6 +35,11 @@ export const PENDING_COMPLETIONS_TYPE = 'voice-pending-completions';
 /** Idle backoff when a run finds nothing — 2 hours (t2125 pattern). */
 const IDLE_BACKOFF_MS = 2 * 60 * 60 * 1000;
 
+/** Safety ceiling on messages scanned per run — a daily Sent volume never reaches
+ *  this, but it bounds a runaway mailbox. Truncation is handled by holding the
+ *  watermark (see watermark-advance below), not by silently dropping the tail. */
+const SENT_MAX_SCAN = 500;
+
 const EPOCH = '0';
 
 function parseSnapshot(doc: {
@@ -87,13 +92,11 @@ function extractMatchedDraftIds(pendingDiffsBody: string): Set<string> {
 }
 
 function extractAskedTaskIds(pendingCompletionsBody: string): Set<string> {
+  // Every candidate (including ones later stamped with a `completion_asked` marker)
+  // keeps its `## Candidate — task <id>` header, so this single pass covers them all.
   const ids = new Set<string>();
   for (const m of pendingCompletionsBody.matchAll(/## Candidate — task\s+(\S+)/g)) {
     if (m[1]) ids.add(m[1]);
-  }
-  // Also honor in-band completion_asked markers written by later jobs.
-  for (const m of pendingCompletionsBody.matchAll(/completion_asked:\s*\{[^}]*\}[^\n]*task[_\s-]?id[:\s]+(\S+)/gi)) {
-    if (m[1]) ids.add(m[1].replace(/[.,;]/g, ''));
   }
   return ids;
 }
@@ -210,10 +213,13 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
       : 0;
 
     const client = new CeoNylasClient(apiKey, grantId, ctx.log);
-    const messages = await client.listMessages({
+    // Paginate the whole watermark window — a single fixed-limit page silently drops
+    // everything past the newest 20 on a busy Sent folder (#1429 review). `truncated`
+    // means the maxScan ceiling was hit and older sends remain unseen this run.
+    const { messages, truncated } = await client.listAllMessages({
       folder: 'SENT',
       ...(watermark > 0 ? { receivedAfter: watermark } : {}),
-      limit: 20,
+      maxScan: SENT_MAX_SCAN,
     });
 
     // Load draft snapshots + pending evidence.
@@ -242,6 +248,9 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
     let taskCandidates = 0;
     let shadowReconciled = 0;
     let maxDate = watermark;
+    // Oldest message actually processed this run — used to keep the watermark below
+    // the un-fetched tail when a run is truncated, so nothing is skipped for good.
+    let minDate = Number.POSITIVE_INFINITY;
     const diffChunks: string[] = [];
     const completionChunks: string[] = [];
 
@@ -252,6 +261,7 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
 
     for (const msg of messages) {
       if (msg.date > maxDate) maxDate = msg.date;
+      if (msg.date < minDate) minDate = msg.date;
 
       let sentBody = msg.snippet ?? '';
       let fetchedBody = false;
@@ -354,11 +364,29 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
       completionChunks.join(''),
     );
 
-    // Advance watermark past the newest message seen (exclusive next poll).
+    // Advance the watermark. When the run drained the window (not truncated), jump
+    // past the newest message seen (exclusive next poll). When truncated, older sends
+    // below `minDate` were NOT fetched (Nylas returns newest-first), so advancing past
+    // the newest would strand them — instead hold the watermark just below the oldest
+    // message we processed so the next run re-covers the tail. Re-processing the newer
+    // messages is safe: draft/task/shadow writes are all idempotent (already-matched
+    // ids + shadow reconciled_at markers).
     let watermarkAdvancedTo: number | null = null;
-    if (messages.length > 0 && maxDate >= watermark) {
-      watermarkAdvancedTo = maxDate + 1;
-      await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
+    if (messages.length > 0) {
+      if (truncated && Number.isFinite(minDate)) {
+        const held = Math.max(watermark, minDate - 1);
+        if (held > watermark) {
+          watermarkAdvancedTo = held;
+          await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(held));
+        }
+        ctx.log.warn(
+          { scanned: messages.length, maxScan: SENT_MAX_SCAN, heldWatermarkAt: held },
+          'ceo-inbox-sent-observe: scan ceiling hit — older sends deferred to next run',
+        );
+      } else if (maxDate >= watermark) {
+        watermarkAdvancedTo = maxDate + 1;
+        await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
+      }
     }
 
     if (messages.length === 0) {

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -364,29 +364,36 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
       completionChunks.join(''),
     );
 
-    // Advance the watermark. When the run drained the window (not truncated), jump
-    // past the newest message seen (exclusive next poll). When truncated, older sends
-    // below `minDate` were NOT fetched (Nylas returns newest-first), so advancing past
-    // the newest would strand them — instead hold the watermark just below the oldest
-    // message we processed so the next run re-covers the tail. Re-processing the newer
-    // messages is safe: draft/task/shadow writes are all idempotent (already-matched
-    // ids + shadow reconciled_at markers).
+    // Advance the watermark past the newest message seen (exclusive next poll).
+    //
+    // Nylas returns newest-first and `received_after` is an exclusive lower bound, so
+    // a single-floor poll can only ever walk *forward*. On truncation the un-fetched
+    // messages are the OLDEST in the window (date < minDate); there is no lower-bound
+    // value that both advances and re-includes them, so we do not attempt a partial
+    // hold (an earlier version did and simply stranded the tail while re-scanning the
+    // newest 500 forever). Instead we advance to the newest seen and log — loudly and
+    // accurately — that older messages were skipped. This is realistically only a
+    // first-run/backfill event against a large existing mailbox; day-to-day Sent volume
+    // never approaches SENT_MAX_SCAN, and back-mining old history is not a goal of a
+    // forward-looking observer. Draining a true >ceiling backlog would need oldest-first
+    // paging (received_before), deliberately out of scope here.
     let watermarkAdvancedTo: number | null = null;
-    if (messages.length > 0) {
-      if (truncated && Number.isFinite(minDate)) {
-        const held = Math.max(watermark, minDate - 1);
-        if (held > watermark) {
-          watermarkAdvancedTo = held;
-          await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(held));
-        }
-        ctx.log.warn(
-          { scanned: messages.length, maxScan: SENT_MAX_SCAN, heldWatermarkAt: held },
-          'ceo-inbox-sent-observe: scan ceiling hit — older sends deferred to next run',
-        );
-      } else if (maxDate >= watermark) {
-        watermarkAdvancedTo = maxDate + 1;
-        await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
-      }
+    if (messages.length > 0 && maxDate >= watermark) {
+      watermarkAdvancedTo = maxDate + 1;
+      await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
+    }
+    if (truncated) {
+      ctx.log.warn(
+        {
+          scanned: messages.length,
+          maxScan: SENT_MAX_SCAN,
+          oldestScannedAt: Number.isFinite(minDate) ? minDate : null,
+          advancedTo: watermarkAdvancedTo,
+        },
+        `ceo-inbox-sent-observe: Sent window exceeded the ${SENT_MAX_SCAN}-message scan ceiling — ` +
+          'messages older than the newest batch were NOT observed and will not be revisited ' +
+          '(expected only on first run against a large mailbox).',
+      );
     }
 
     if (messages.length === 0) {

--- a/skills/ceo-inbox-sent-observe/skill.json
+++ b/skills/ceo-inbox-sent-observe/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "ceo-inbox-sent-observe",
   "description": "Poll the CEO's Sent folder since a stored watermark, match new sends to Curia draft snapshots and open owner=ceo tasks, append evidence to OKF, emit ceo.sent_observed, and advance the watermark. Read-only against Nylas; never drafts, archives, or sends. Intended for the daily ceo-inbox sent-observe cron — do not fold into triage.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/skills/voice-learn/handler.test.ts
+++ b/skills/voice-learn/handler.test.ts
@@ -167,4 +167,30 @@ describe('VoiceLearnHandler', () => {
     expect((result as { data: { pairs_considered: number } }).data.pairs_considered).toBe(0);
     expect(ctx.__updates).toHaveLength(0);
   });
+
+  it('does not re-propose a field that already has an open proposal (dedup)', async () => {
+    const ctx = makeCtx({ voice: { signOff: 'Cheers' } });
+    const mem = ctx.entityMemory as EntityMemory & { __values: Map<string, string> };
+    // operator-set → signOff takes the propose lane (never auto).
+    mem.__values.set(
+      PROVENANCE_KEY,
+      JSON.stringify({ ...DEFAULT_PROVENANCE, signOff: 'operator-set' }),
+    );
+    // Pre-seed an existing pending signOff proposal (as a prior week would have left).
+    ctx.__docs.set(PENDING_PROPOSALS_PATH, {
+      path: PENDING_PROPOSALS_PATH,
+      type: 'voice-pending-proposals',
+      frontmatter: {},
+      body: `# Pending voice proposals\n\n## Proposal — signOff\n- status: pending\n- description: Prefer Thanks\n- sample_count: 3\n- consistency: 1.00\n- patch: {"sign_off":"Thanks"}\n---\n`,
+      version: 1,
+    });
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+
+    // Still exactly one signOff proposal block — not duplicated.
+    const body = ctx.__docs.get(PENDING_PROPOSALS_PATH)?.body ?? '';
+    const count = (body.match(/## Proposal — signOff/g) ?? []).length;
+    expect(count).toBe(1);
+  });
 });

--- a/skills/voice-learn/handler.ts
+++ b/skills/voice-learn/handler.ts
@@ -51,6 +51,26 @@ function parseDismissed(raw: string | null): Set<string> {
   }
 }
 
+/**
+ * Fields that already have an open proposal in the pending-proposals doc and so
+ * must not be re-proposed. Because voice-learn re-reads the whole (never-consumed)
+ * diff doc every run, a field that stays above threshold would otherwise get a
+ * fresh `## Proposal — <field>` block appended each week — duplicates the digest
+ * shows and that the non-global status-marker can't all clear. `pending` = still
+ * awaiting the CEO; `approved` = already applied, don't nag again. `dismissed` is
+ * intentionally NOT blocked here — its cooldown is enforced via dismissedDimensions.
+ */
+function blockedProposalFields(body: string): Set<string> {
+  const blocked = new Set<string>();
+  for (const section of body.split(/^## Proposal — /m).slice(1)) {
+    const field = (section.split('\n')[0] ?? '').trim();
+    if (!field) continue;
+    const status = (section.match(/- status:\s*(\S+)/)?.[1] ?? 'pending').trim();
+    if (status === 'pending' || status === 'approved') blocked.add(field);
+  }
+  return blocked;
+}
+
 export class VoiceLearnHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.executiveProfileService || !ctx.workingDocs || !ctx.entityMemory) {
@@ -88,6 +108,11 @@ export class VoiceLearnHandler implements SkillHandler {
     const voice = profile.writingVoice;
     const bootstrap = isNearDefaultProfile(voice);
 
+    // Read the existing proposals once so we can dedup: the diff doc is never
+    // consumed, so without this a still-above-threshold field re-proposes weekly.
+    const existingProposalsDoc = await ctx.workingDocs.read(PENDING_PROPOSALS_PATH);
+    const blockedFields = blockedProposalFields(existingProposalsDoc?.body ?? '');
+
     const deltas = proposeDeltasFromPairs(pairs);
     let autoApplied = 0;
     let proposed = 0;
@@ -109,6 +134,12 @@ export class VoiceLearnHandler implements SkillHandler {
       }
 
       if (decision.action === 'propose' || decision.delta.magnitude === 'high') {
+        // Don't re-append a proposal for a field that already has one open.
+        if (blockedFields.has(delta.field)) {
+          skipped += 1;
+          continue;
+        }
+        blockedFields.add(delta.field);
         proposed += 1;
         proposalChunks.push(formatProposalBlock({ ...decision, action: 'propose' }));
         continue;
@@ -156,8 +187,14 @@ export class VoiceLearnHandler implements SkillHandler {
         autoApplied += 1;
       } catch (err) {
         ctx.log.error({ err, field: decision.delta.field }, 'voice-learn: auto-apply failed');
-        proposed += 1;
-        proposalChunks.push(formatProposalBlock({ ...decision, action: 'propose' }));
+        // Fall back to a proposal, but still dedup against any open one.
+        if (!blockedFields.has(decision.delta.field)) {
+          blockedFields.add(decision.delta.field);
+          proposed += 1;
+          proposalChunks.push(formatProposalBlock({ ...decision, action: 'propose' }));
+        } else {
+          skipped += 1;
+        }
       }
     }
 
@@ -170,7 +207,8 @@ export class VoiceLearnHandler implements SkillHandler {
     }
 
     if (!dryRun && proposalChunks.length > 0) {
-      const existing = await ctx.workingDocs.read(PENDING_PROPOSALS_PATH);
+      // Reuse the doc read at the top of the run (single-threaded weekly job).
+      const existing = existingProposalsDoc;
       if (!existing) {
         await ctx.workingDocs.create({
           path: PENDING_PROPOSALS_PATH,

--- a/skills/voice-learn/skill.json
+++ b/skills/voice-learn/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-learn",
   "description": "Weekly job: read accumulated (draft, sent) diffs from OKF, propose WritingVoice deltas, auto-apply high-confidence low-magnitude changes (and seeded empty fills), and queue the rest as digest proposals. Never fabricates on zero data. Intended for the ceo-inbox weekly voice-learn cron.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {


### PR DESCRIPTION
## Summary

Follow-up fixes for the three runtime deficiencies found reviewing #1419 / PR #1429. Targets the feature branch so it folds into that PR before merge. Part of the email-observation epic (#1419).

Every issue here only manifests at runtime and was missed by the original tests.

### 1. Skills weren't pinned to `ceo-inbox` — the flows couldn't run
Only `ceo-inbox-sent-observe` was pinned. The daily/weekly crons and the shadow-draft triage step call `voice-learn`, `task-completion-from-sent`, and `ceo-inbox-shadow-draft` too, but an unpinned skill is invisible to the agent. Pinned all three; documented the manual-enable requirement for the learning-digest companions in `registry-defaults.yaml`.

### 2. `ceo-inbox-sent-observe` dropped messages on busy days
`listMessages({ limit: 20 })` returns only the newest 20 (Nylas is newest-first), so >20 sends between runs silently lost the older ones — lost voice diffs and completion candidates. Added `CeoNylasClient.listAllMessages()` (cursor pagination, `maxScan` ceiling) and switched the observer to it. On truncation the poll advances forward and logs *accurately* that older messages were skipped (a single newest-first floor can't drain a >ceiling backlog, and back-mining old history isn't a goal — realistically only a first-run/backfill event).

### 3. `voice-learn` re-proposed the same diffs every week
The pending-diffs doc is never consumed, so a still-above-threshold field appended a fresh `## Proposal — <field>` block each run; the digest showed duplicates and the non-global status marker couldn't clear them all. Now reads existing proposals once per run and skips any field with an open (pending/approved) proposal; dismissed fields keep their cooldown path.

Also removed a dead regex in `extractAskedTaskIds` that never matched the written format.

## Review notes

Both `code-reviewer` and `silent-failure-hunter` ran on these changes. They caught that my *first* truncation attempt (holding the watermark at `minDate-1`) was inverted — it would strand the older tail and re-scan forever. That's fixed in the final commit (advance forward + honest warning) with a regression test.

## Test plan

- [x] New pagination test — follows `next_cursor` across pages, no page-1 drop
- [x] New truncation test — advances forward + warns, no held-watermark loop
- [x] New voice-learn dedup test — rerun doesn't duplicate an open proposal
- [x] `pnpm run typecheck` clean (all four projects)
- [x] 133 tests pass across all affected skills + shared helpers

Part of #1419
