### PR TITLE
fix: durable idempotency for shadow reconciliation + replay coverage (#1432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Voice-learning capture** — a body-only draft edit refreshes the snapshot in place, preserving its original `created_at`. (#1419)
 - **`voice-learn`** — voice-guide approval loop no longer breaks after one cycle; honors dismiss cooldown. (#1419)
 - **Learning-subsystem config writes** — soft-rejected `ConfigStore` writes now hold state instead of silently advancing. (#1438)
+- **`sent-observe`** shadow reconciliation now dedups on a DB unique index; a failed marker write can't double-score. (#1432)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Voice-learning capture** — a body-only draft edit refreshes the snapshot in place, preserving its original `created_at`. (#1419)
 - **`voice-learn`** — voice-guide approval loop no longer breaks after one cycle; honors dismiss cooldown. (#1419)
 - **Learning-subsystem config writes** — soft-rejected `ConfigStore` writes now hold state instead of silently advancing. (#1438)
+- **`resolve-learning-digest`** undo now guards on task status, so a failed clear can't wedge the item. (#1432)
 - **`sent-observe`** shadow reconciliation now dedups on a DB unique index; a failed marker write can't double-score. (#1432)
 
 ### Added

--- a/docs/wip/2026-07-18-shadow-eval-idempotency-design.md
+++ b/docs/wip/2026-07-18-shadow-eval-idempotency-design.md
@@ -1,0 +1,138 @@
+# Durable idempotency for shadow reconciliation + replay coverage (#1432)
+
+Status: design approved 2026-07-18
+Issue: #1432 (part of #1419). Re-scoped after #1438 landed.
+
+## Problem
+
+Three email-observation write paths were flagged in the #1429 review as non-atomic,
+not-durably-idempotent multi-store updates. #1438 subsequently restructured two of them
+(the resolve/completion sagas) to be self-healing via idempotent ordering. The remaining
+live hazard is the shadow-reconciliation path.
+
+### Item 1 — shadow reconciliation (live at-least-once hazard)
+
+`skills/ceo-inbox-sent-observe/handler.ts` scores each shadow/sent pair by:
+
+1. `actionLogRepo.insert(...)` — a pre-scored `shadow_evaluated` row into `autonomy_action_log`.
+2. `workingDocs.update(...)` — a `reconciled_at` marker on the shadow doc.
+
+If step 1 lands but step 2 fails (shadow doc missing at mark time, or a version conflict),
+`shadowReconcileOk` flips false, which **holds the watermark**. The carrying Sent message is
+therefore re-observed next run; `parseShadowDoc` still returns the shadow (its `reconciled_at`
+is unset), so it is **re-judged and re-inserted** — a duplicate `shadow_evaluated` row. The
+durable marker is the only idempotency record and it is written *after* the insert, so nothing
+guards cross-run replay. The watermark-hold actually *guarantees* the re-run.
+
+### Items 2-3 — already addressed by #1438
+
+- `task-completion-from-sent` — #1438 moved to **digest-first ordering**: undo notes are written
+  durably *before* `completeTask`; a second pass completes tasks only after the digest write is
+  confirmed; candidate consume-by-delete is gated on that write. A partial failure self-heals
+  (task stays active, re-completes idempotently, note overwrites identically).
+- `resolve-learning-digest` — mutations are content-idempotent (re-approve writes the identical
+  guide, `completeTask` guarded by `status !== 'done'`, `reopenTask` fails loud) and soft-rejects
+  are surfaced (`success:false`) so a failed clear leaves the item actionable for retry.
+
+These need **replay tests that prove the acceptance criteria hold**, not new machinery. The
+issue's own sequencing note anticipated this re-scope.
+
+## Design
+
+### Part 1 — shadow-reconciliation durable dedup
+
+**Migration `074_shadow_eval_idempotency.sql`**
+
+- **Dedup first, then constrain.** Prod may already hold duplicate `shadow_evaluated` rows
+  produced by this bug. A bare `CREATE UNIQUE INDEX` would abort on them (the migration-070
+  "detonates only on prod data" hazard). So the Up path first deletes all but the lowest-`id`
+  row per `source_message_id`, then creates the index:
+
+  ```sql
+  DELETE FROM autonomy_action_log a
+  USING autonomy_action_log b
+  WHERE a.outcome = 'shadow_evaluated'
+    AND b.outcome = 'shadow_evaluated'
+    AND a.payload->>'source_message_id' = b.payload->>'source_message_id'
+    AND a.payload->>'source_message_id' IS NOT NULL
+    AND a.id > b.id;
+
+  CREATE UNIQUE INDEX idx_aal_shadow_source
+    ON autonomy_action_log ((payload->>'source_message_id'))
+    WHERE outcome = 'shadow_evaluated';
+  ```
+
+  - `payload->>'source_message_id'` is immutable, so it is legal in an index expression.
+  - The partial predicate scopes the index to shadow rows only — no other outcome/caller can
+    ever collide with it.
+  - NULL `source_message_id` values are naturally distinct in a Postgres unique index, so the
+    dedup DELETE guards `IS NOT NULL` only to avoid collapsing unrelated null-keyed rows (there
+    should be none in practice, but the guard is defensive).
+
+- **Down:** `DROP INDEX IF EXISTS idx_aal_shadow_source;` — symmetric, non-aborting (AC #4). The
+  dedup DELETE is deliberately not reversed; the deleted rows were erroneous duplicates.
+
+- Mirror migration 073's in-transaction lock note: node-pg-migrate wraps the file in one
+  transaction, so no `CREATE INDEX CONCURRENTLY`; the brief lock/scan is acceptable at the
+  current single-tenant table size.
+
+**Repo — `src/autonomy/action-log-repo.ts`**
+
+Add `insertShadowEvaluated(row: ActionLogInsert): Promise<number | null>`:
+
+- Same column list as `insert()` but with
+  `ON CONFLICT ((payload->>'source_message_id')) WHERE outcome = 'shadow_evaluated' DO NOTHING
+  RETURNING id`.
+- Returns the new `id`, or `null` when the row already existed (conflict).
+- Factor the shared INSERT column list / VALUES tuple into a private helper so the two insert
+  paths cannot drift.
+- `insert()` keeps its `Promise<number>` signature and current behavior — no non-shadow caller
+  is affected.
+
+**Handler — `skills/ceo-inbox-sent-observe/handler.ts`**
+
+- Swap `ctx.actionLogRepo.insert(...)` → `ctx.actionLogRepo.insertShadowEvaluated(...)` in the
+  per-pair reconcile loop.
+- A `null` return means "already scored on a prior run" — **not** an error. Proceed to mark
+  `reconciled_at` so the re-run converges and stops re-observing. Only a thrown error flips
+  `shadowReconcileOk` false / holds the watermark, as today.
+- `reconciled_at` + the watermark-hold remain the **efficiency** guard (skip re-judging, avoid
+  LLM cost); the DB constraint is the new **correctness** backstop.
+- Count `shadowReconciled` on a successful `reconciled_at` mark (covers both fresh-insert and
+  converging-after-a-prior-partial-failure), so the stat reflects "reconciled this run".
+- Update the loop comments to state the constraint is now the durable idempotency record.
+
+### Part 2 — resolve & completion replay coverage
+
+Audit both `handler.test.ts` files, then add the missing replay tests:
+
+- **`resolve-learning-digest`** — for each action (`approve_voice`, `dismiss_voice`,
+  `undo_completion`, `confirm_completion`, `dismiss_completion`): the clear write
+  (`writeVoiceProposal` / `writeCompletionDigest`) soft-rejects (`false`) on the first attempt,
+  then the action is replayed. Assert: the primary mutation is not harmfully double-applied and
+  the state converges on retry.
+- **`task-completion-from-sent`** —
+  (a) digest write soft-rejects → nothing completed, nothing consumed, all candidates retry;
+  (b) `completeTask` throws after the digest write lands → candidate retained, undo note durable,
+      self-heals on the next run (re-complete is idempotent);
+  (c) a clean replay after a successful run → candidates consumed, no re-completion.
+
+If any test surfaces a genuine residual gap, fix it minimally (and version-bump that skill).
+The expectation is that most pass, demonstrating #1438 closed items 2-3.
+
+## Housekeeping
+
+- Patch-bump `skills/ceo-inbox-sent-observe/skill.json` (fix that adds infrastructure).
+- No version bump for the two verification-only skills unless a residual fix lands.
+- `CHANGELOG.md` → `Fixed` entry.
+- No ADR (bug fix under existing ADR-029; existing-pattern migration).
+
+## Acceptance criteria (from #1432)
+
+- [ ] Re-running shadow reconciliation after a marker-write failure does not create a second
+      `shadow_evaluated` row for the same shadow.
+- [ ] Replaying a `resolve-learning-digest` action after a mid-saga failure does not double-apply
+      the profile/config/task mutation.
+- [ ] Replaying `task-completion-from-sent` after a partial write reconciles to a consistent state.
+- [ ] Migration has a symmetric, non-aborting down path.
+- [ ] Unit/integration tests cover each replay scenario.

--- a/docs/wip/2026-07-18-shadow-eval-idempotency.md
+++ b/docs/wip/2026-07-18-shadow-eval-idempotency.md
@@ -1,0 +1,794 @@
+# Shadow-eval idempotency + replay coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make shadow reconciliation durably idempotent with a DB unique constraint so a marker-write failure can't double-score, and lock in items 2–3's already-shipped self-healing with replay tests (#1432).
+
+**Architecture:** A partial unique index on `autonomy_action_log((payload->>'source_message_id')) WHERE outcome='shadow_evaluated'` becomes the correctness backstop; a new `insertShadowEvaluated()` repo method uses `ON CONFLICT DO NOTHING`; the sent-observe handler swaps to it and treats a conflict as "already recorded." The `reconciled_at` marker + watermark-hold stay as the efficiency guard. Items 2–3 get replay tests only (fix minimally if one surfaces a real gap).
+
+**Tech Stack:** TypeScript (ESM, Node 24), Postgres 16 (node-pg-migrate, plain SQL), Vitest, pino.
+
+## Global Constraints
+
+- ESM only; `.js` extensions on all relative imports; no `any`. (curia CLAUDE.md)
+- Parameterized SQL only — never interpolate variables into SQL strings.
+- Skills return `{ success: true, data }` / `{ success: false, error }` — never throw.
+- Migrations: node-pg-migrate plain SQL, `-- Up Migration` / `-- Down Migration` sections; next free prefix is **074** (073 is highest — verify with `ls src/db/migrations/ | sort | tail -3` before writing).
+- Type-check with `pnpm -C <worktree> run typecheck` before every commit touching `.ts`.
+- Array element access on `rows[0]`/`mock.calls[0]` is `T | undefined` under strict null — use `!` when guaranteed.
+- Commits: conventional (`fix:`/`test:`/`docs:`), signed off (`-s`), no Co-Authored-By, no Claude credit.
+- Worktree: `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-shadow-idempotency-1432`. Run all `pnpm`/`git` via `-C <worktree>`.
+- Integration tests are `DATABASE_URL`-gated (skip locally without it). Throwaway Postgres = container `curia-test-pg` on port **5433** (never prod's 5432).
+
+## File map
+
+- Create: `src/db/migrations/074_shadow_eval_idempotency.sql` — dedup + partial unique index (Up) / drop index (Down).
+- Create: `tests/integration/migrate-shadow-eval-idempotency.test.ts` — runs the Up SQL against live PG; asserts dedup + conflict.
+- Modify: `src/autonomy/action-log-repo.ts` — extract shared INSERT builder; add `insertShadowEvaluated()`.
+- Modify: `src/autonomy/action-log-repo.test.ts` — unit tests for `insertShadowEvaluated` (mock pool).
+- Modify: `skills/ceo-inbox-sent-observe/handler.ts` — swap `insert` → `insertShadowEvaluated`; comment update.
+- Modify: `skills/ceo-inbox-sent-observe/handler.test.ts` — dedup mock + cross-run replay test.
+- Modify: `skills/ceo-inbox-sent-observe/skill.json` — patch version bump.
+- Modify: `skills/resolve-learning-digest/handler.test.ts` — replay tests (soft-reject on clear).
+- Modify: `skills/task-completion-from-sent/handler.test.ts` — replay tests (digest soft-reject; completeTask throw; clean replay).
+- Modify: `CHANGELOG.md` — one `Fixed` bullet.
+
+---
+
+## Task 1: Migration 074 — dedup existing shadow rows, then add the partial unique index
+
+**Files:**
+- Create: `src/db/migrations/074_shadow_eval_idempotency.sql`
+- Test: `tests/integration/migrate-shadow-eval-idempotency.test.ts`
+
+**Interfaces:**
+- Produces: unique index `idx_aal_shadow_source` on `autonomy_action_log ((payload->>'source_message_id')) WHERE outcome = 'shadow_evaluated'`. Consumed by Task 2's `ON CONFLICT` clause.
+
+- [ ] **Step 1: Confirm the next migration number**
+
+Run: `ls src/db/migrations/ | sort | tail -3`
+Expected: highest is `073_shadow_evaluated_outcome.sql` → use prefix `074`. (If something else landed, bump to the next free slot and use it everywhere below.)
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `tests/integration/migrate-shadow-eval-idempotency.test.ts`. It runs ONLY the Up half of the migration (split on `-- Down Migration`, so the Down's `DROP INDEX` doesn't undo the Up), against a live PG. Uses a unique `source_message_id` prefix so it only ever touches its own rows, and drops its own index in cleanup. Mirrors the DATABASE_URL gating of `tests/integration/migrate-signal-phone-consolidation.test.ts`.
+
+```typescript
+// Integration test — runs migration 074's Up SQL against a live Postgres and asserts the
+// shadow-eval dedup + partial-unique-index idempotency guard. Skips without DATABASE_URL.
+// Scopes every mutation to a test-only source_message_id prefix and drops its own index, so a
+// mispointed DATABASE_URL cannot corrupt real shadow rows or a real production index.
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import pg from 'pg';
+import { readFile } from 'node:fs/promises';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const MIGRATION_SQL_URL = new URL(
+  '../../src/db/migrations/074_shadow_eval_idempotency.sql',
+  import.meta.url,
+);
+const INDEX = 'idx_aal_shadow_source';
+// Test rows use source_message_id values under this prefix so cleanup never deletes real rows.
+const PFX = 'itest-shadow-idem-';
+
+/** Insert a pre-scored shadow row directly (bypassing the repo) with a scoped source id. */
+async function insertShadow(pool: pg.Pool, src: string): Promise<number> {
+  const { rows } = await pool.query<{ id: number }>(
+    `INSERT INTO autonomy_action_log
+       (task_id, skill_name, action_risk, outcome, payload, competence_flag, scored_by)
+     VALUES ($1, 'shadow-draft-eval', 'none', 'shadow_evaluated', $2::jsonb, 1, 'shadow-reconciler')
+     RETURNING id`,
+    [`shadow:${src}`, JSON.stringify({ shadow: true, source_message_id: src })],
+  );
+  return rows[0]!.id;
+}
+
+describeIf('migration 074: shadow-eval idempotency', () => {
+  let pool: pg.Pool;
+  let upSql: string;
+
+  beforeAll(async () => {
+    pool = new pg.Pool({ connectionString: DATABASE_URL });
+    const full = await readFile(MIGRATION_SQL_URL, 'utf8');
+    // Run only the Up half — the Down's DROP INDEX would otherwise remove what we assert.
+    upSql = full.split('-- Down Migration')[0]!;
+  });
+
+  // Clean slate: drop the index and delete only our scoped rows before each case.
+  beforeEach(async () => {
+    await pool.query(`DROP INDEX IF EXISTS ${INDEX}`);
+    await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
+  });
+
+  afterAll(async () => {
+    await pool.query(`DROP INDEX IF EXISTS ${INDEX}`);
+    await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
+    await pool.end();
+  });
+
+  it('deletes duplicate shadow rows (keeping the lowest id) before creating the index', async () => {
+    const src = `${PFX}dup`;
+    const id1 = await insertShadow(pool, src);
+    const id2 = await insertShadow(pool, src);
+    expect(id2).toBeGreaterThan(id1);
+
+    await pool.query(upSql); // dedup + CREATE UNIQUE INDEX; must not abort on the pre-existing dup
+
+    const { rows } = await pool.query<{ id: number }>(
+      `SELECT id FROM autonomy_action_log WHERE payload->>'source_message_id' = $1`,
+      [src],
+    );
+    expect(rows.map((r) => r.id)).toEqual([id1]); // only the lowest-id row survives
+  });
+
+  it('rejects a duplicate shadow insert once the index exists', async () => {
+    await pool.query(upSql);
+    const src = `${PFX}unique`;
+    await insertShadow(pool, src);
+    await expect(insertShadow(pool, src)).rejects.toThrow(/duplicate key|unique/i);
+  });
+
+  it('allows two shadow rows with different source ids', async () => {
+    await pool.query(upSql);
+    const a = await insertShadow(pool, `${PFX}a`);
+    const b = await insertShadow(pool, `${PFX}b`);
+    expect(a).not.toBe(b); // no false conflict across distinct source ids
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `DATABASE_URL=postgres://curia:curia@localhost:5433/curia_test pnpm -C <worktree> exec vitest run tests/integration/migrate-shadow-eval-idempotency.test.ts`
+Expected: FAIL — the migration file does not exist yet (`ENOENT` on readFile), or all three cases error. (Without DATABASE_URL the suite SKIPS — that is not a pass; set the URL for the throwaway container.)
+
+- [ ] **Step 4: Write the migration**
+
+Create `src/db/migrations/074_shadow_eval_idempotency.sql`:
+
+```sql
+-- Up Migration
+
+-- 074_shadow_eval_idempotency.sql
+--
+-- #1432: durable idempotency for shadow-draft competence reconciliation.
+-- sent-observe inserts a pre-scored 'shadow_evaluated' row and THEN marks the shadow doc
+-- reconciled_at. If the mark fails after the insert, the watermark is held and the next run
+-- re-judges and re-inserts a DUPLICATE row (the marker was the only idempotency record, written
+-- after the insert). This adds a DB-level backstop: one 'shadow_evaluated' row per
+-- source_message_id, enforced by a partial unique index. The insert path uses ON CONFLICT DO
+-- NOTHING (see ActionLogRepo.insertShadowEvaluated), so a re-run is a no-op.
+--
+-- Prod may already hold duplicates produced by the bug this fixes, so we DEDUP FIRST — otherwise
+-- CREATE UNIQUE INDEX would abort on the pre-existing violating rows (the same class of failure
+-- as migration 070, which only detonated against prod data).
+
+-- NOTE ON LOCKING (mirrors migrations 044 / 073): node-pg-migrate wraps each SQL file in a single
+-- transaction, so CREATE INDEX CONCURRENTLY is unavailable here. Building this partial index takes
+-- a brief lock/scan on autonomy_action_log during deploy — acceptable at the current single-tenant
+-- table size. If the table grows large enough that this stalls writes, split into a
+-- non-transactional migration using CREATE INDEX CONCURRENTLY.
+
+-- Remove all but the lowest-id row per source_message_id among existing shadow rows.
+DELETE FROM autonomy_action_log a
+USING autonomy_action_log b
+WHERE a.outcome = 'shadow_evaluated'
+  AND b.outcome = 'shadow_evaluated'
+  AND a.payload->>'source_message_id' = b.payload->>'source_message_id'
+  AND a.payload->>'source_message_id' IS NOT NULL
+  AND a.id > b.id;
+
+-- One shadow_evaluated row per source_message_id. `payload->>'source_message_id'` is immutable, so
+-- it is legal in an index expression; the partial predicate scopes the constraint to shadow rows
+-- only, so no other outcome/caller can ever collide with it. NULL source ids are naturally distinct
+-- in a unique index and are not constrained (there should be none — the writer always sets it).
+CREATE UNIQUE INDEX idx_aal_shadow_source
+  ON autonomy_action_log ((payload->>'source_message_id'))
+  WHERE outcome = 'shadow_evaluated';
+
+-- Down Migration
+
+-- Symmetric, non-aborting: just drop the index. The dedup DELETE above is deliberately NOT
+-- reversed — the rows it removed were erroneous duplicates with no meaning to restore.
+DROP INDEX IF EXISTS idx_aal_shadow_source;
+```
+
+- [ ] **Step 5: Run the integration test to verify it passes**
+
+Run: `DATABASE_URL=postgres://curia:curia@localhost:5433/curia_test pnpm -C <worktree> exec vitest run tests/integration/migrate-shadow-eval-idempotency.test.ts`
+Expected: PASS (3 tests). If the throwaway container isn't running, start it per the `curia-test-pg` reference (port 5433, run migrations), then re-run.
+
+- [ ] **Step 6: Verify migration prefixes are unique**
+
+Run: `ls src/db/migrations/ | sort | tail -3`
+Expected: `074_shadow_eval_idempotency.sql` present, no duplicate `074` prefix.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C <worktree> add src/db/migrations/074_shadow_eval_idempotency.sql tests/integration/migrate-shadow-eval-idempotency.test.ts
+git -C <worktree> commit -s -m "fix(autonomy): partial unique index dedups shadow_evaluated rows (#1432)"
+```
+
+---
+
+## Task 2: `insertShadowEvaluated()` repo method
+
+**Files:**
+- Modify: `src/autonomy/action-log-repo.ts`
+- Test: `src/autonomy/action-log-repo.test.ts`
+
+**Interfaces:**
+- Consumes: the `idx_aal_shadow_source` partial unique index from Task 1 (as the `ON CONFLICT` inference target).
+- Produces: `insertShadowEvaluated(row: ActionLogInsert): Promise<number | null>` on `ActionLogRepo` — returns the new row id, or `null` when a row for that `source_message_id` already exists. Consumed by Task 3.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Add to `src/autonomy/action-log-repo.test.ts`, inside the top-level `describe('ActionLogRepo', ...)`:
+
+```typescript
+describe('insertShadowEvaluated', () => {
+  it('inserts with ON CONFLICT DO NOTHING and returns the id', async () => {
+    const { pool, queries } = makePool([{ id: 7 }]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const id = await repo.insertShadowEvaluated({
+      taskId: 'shadow:src-1',
+      skillName: 'shadow-draft-eval',
+      actionRisk: 'none',
+      outcome: 'shadow_evaluated',
+      payload: { shadow: true, source_message_id: 'src-1' },
+      competenceFlag: 1,
+      scoredBy: 'shadow-reconciler',
+    });
+    expect(id).toBe(7);
+    expect(queries).toHaveLength(1);
+    expect(queries[0]!.sql).toContain('ON CONFLICT');
+    expect(queries[0]!.sql).toContain("payload->>'source_message_id'");
+    expect(queries[0]!.sql).toContain('DO NOTHING');
+  });
+
+  it('returns null when the insert is a no-op (conflict — row already exists)', async () => {
+    // ON CONFLICT DO NOTHING returns zero rows when the row already exists.
+    const { pool } = makePool([], 0);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const id = await repo.insertShadowEvaluated({
+      taskId: 'shadow:src-1',
+      skillName: 'shadow-draft-eval',
+      actionRisk: 'none',
+      outcome: 'shadow_evaluated',
+      payload: { shadow: true, source_message_id: 'src-1' },
+      competenceFlag: 1,
+      scoredBy: 'shadow-reconciler',
+    });
+    expect(id).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm -C <worktree> exec vitest run src/autonomy/action-log-repo.test.ts -t insertShadowEvaluated`
+Expected: FAIL — `repo.insertShadowEvaluated is not a function`.
+
+- [ ] **Step 3: Refactor the shared INSERT and add the method**
+
+In `src/autonomy/action-log-repo.ts`, replace the existing `insert()` method (lines ~23-54) with a shared column/values builder plus the two public methods. Keep `insert()`'s external signature (`Promise<number>`) unchanged.
+
+```typescript
+  /** Column list + positional VALUES tuple shared by insert() and insertShadowEvaluated().
+   *  Kept in one place so the two insert paths cannot drift. */
+  private insertColumnsAndParams(row: ActionLogInsert): { columns: string; values: string; params: unknown[] } {
+    return {
+      columns:
+        '(task_id, conversation_id, skill_name, action_risk, outcome, task_summary, ' +
+        'payload, expires_at, short_ref, description, parent_action_id, ' +
+        'competence_flag, commitment_flag, compatibility, scored_by)',
+      values: 'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)',
+      params: [
+        row.taskId,
+        row.conversationId ?? null,
+        row.skillName,
+        row.actionRisk,
+        row.outcome,
+        row.taskSummary ?? null,
+        row.payload ? JSON.stringify(row.payload) : null,
+        row.expiresAt ?? null,
+        row.shortRef ?? null,
+        row.description ?? null,
+        row.parentActionId ?? null,
+        row.competenceFlag ?? null,
+        // commitment_flag / compatibility are never set at insert time — the Phase 3
+        // scoring-pass update populates them later. Pre-scored shadow rows leave them null.
+        null,
+        null,
+        row.scoredBy ?? null,
+      ],
+    };
+  }
+
+  /** Insert a new row and return the generated id. */
+  async insert(row: ActionLogInsert): Promise<number> {
+    const { columns, values, params } = this.insertColumnsAndParams(row);
+    const result = await this.pool.query<{ id: number }>(
+      `INSERT INTO autonomy_action_log ${columns} ${values} RETURNING id`,
+      params,
+    );
+    this.logger.debug({ id: result.rows[0]!.id, skillName: row.skillName, outcome: row.outcome }, 'action-log-repo: inserted row');
+    return result.rows[0]!.id;
+  }
+
+  /**
+   * Insert a pre-scored shadow-eval row idempotently (#1432). The partial unique index
+   * idx_aal_shadow_source (migration 074) enforces one 'shadow_evaluated' row per
+   * source_message_id, so ON CONFLICT DO NOTHING makes a re-run a no-op instead of a duplicate.
+   * Returns the new id, or `null` when a row for this source_message_id already exists — the
+   * caller treats null as "already durably recorded", NOT an error.
+   */
+  async insertShadowEvaluated(row: ActionLogInsert): Promise<number | null> {
+    const { columns, values, params } = this.insertColumnsAndParams(row);
+    const result = await this.pool.query<{ id: number }>(
+      `INSERT INTO autonomy_action_log ${columns} ${values}
+       ON CONFLICT ((payload->>'source_message_id')) WHERE outcome = 'shadow_evaluated'
+       DO NOTHING
+       RETURNING id`,
+      params,
+    );
+    const id = result.rows[0]?.id ?? null;
+    this.logger.debug({ id, skillName: row.skillName, deduped: id === null }, 'action-log-repo: shadow insert');
+    return id;
+  }
+```
+
+- [ ] **Step 4: Run the repo tests to verify they pass**
+
+Run: `pnpm -C <worktree> exec vitest run src/autonomy/action-log-repo.test.ts`
+Expected: PASS — the new `insertShadowEvaluated` cases plus all pre-existing `insert` cases (the refactor is behavior-preserving).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm -C <worktree> run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C <worktree> add src/autonomy/action-log-repo.ts src/autonomy/action-log-repo.test.ts
+git -C <worktree> commit -s -m "fix(autonomy): insertShadowEvaluated does idempotent ON CONFLICT insert (#1432)"
+```
+
+---
+
+## Task 3: Wire the handler to the idempotent insert + cross-run replay test
+
+**Files:**
+- Modify: `skills/ceo-inbox-sent-observe/handler.ts:494-541`
+- Modify: `skills/ceo-inbox-sent-observe/handler.test.ts`
+- Modify: `skills/ceo-inbox-sent-observe/skill.json`
+
+**Interfaces:**
+- Consumes: `ActionLogRepo.insertShadowEvaluated(row): Promise<number | null>` (Task 2).
+
+- [ ] **Step 1: Add a deduping mock + write the failing replay test**
+
+In `skills/ceo-inbox-sent-observe/handler.test.ts`, first extend the `actionLogRepo` mock (currently at ~line 189) so it models the DB dedup. Replace the `insert`-only mock with both methods sharing the `actionLog` array:
+
+```typescript
+    ...(overrides.withActionLogRepo
+      ? {
+          actionLogRepo: {
+            insert: vi.fn(async (row: ActionLogInsert) => {
+              actionLog.push(row);
+              return actionLog.length;
+            }),
+            // Mirror the migration-074 partial unique index: one row per source_message_id.
+            // Returns null on a duplicate (ON CONFLICT DO NOTHING), just like the real method.
+            insertShadowEvaluated: vi.fn(async (row: ActionLogInsert) => {
+              const src = (row.payload as { source_message_id?: string } | undefined)?.source_message_id;
+              if (src !== undefined && actionLog.some(
+                (r) => (r.payload as { source_message_id?: string } | undefined)?.source_message_id === src,
+              )) {
+                return null; // already recorded — dedup
+              }
+              actionLog.push(row);
+              return actionLog.length;
+            }),
+          },
+        }
+      : {}),
+```
+
+Then add the replay test (place it after the "holds the watermark when the shadow-judge LLM batch fails (F2)" test). It runs the handler twice on the SAME ctx: run 1's reconciled_at mark is forced to fail (holding the watermark), run 2 re-observes and must NOT create a second row.
+
+```typescript
+  it('does not double-insert a shadow row when the reconciled_at mark fails, then re-runs (#1432)', async () => {
+    // Run 1: judge succeeds, insert lands, but the reconciled_at mark FAILS → watermark held.
+    // Run 2: the same Sent message is re-observed and re-judged, but insertShadowEvaluated dedups
+    // on source_message_id, so exactly one shadow row exists across both runs.
+    const listResponse = {
+      data: [
+        {
+          id: 'msg-sent-1',
+          thread_id: 'thread-1',
+          subject: 'Re: Hello',
+          from: [{ email: 'ceo@example.com' }],
+          to: [{ email: 'alice@example.com' }],
+          cc: [],
+          snippet: 'Thanks Alice',
+          date: 1_720_000_500,
+          unread: false,
+          folders: ['SENT'],
+          attachments: [],
+        },
+      ],
+    };
+    const fullResponse = {
+      data: { ...listResponse.data[0], body: '<p>Thanks Alice, Tuesday works.</p>', bcc: [], labels: [] },
+    };
+    mockFetch.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u.includes('/messages/msg-sent-1')) return new Response(JSON.stringify(fullResponse), { status: 200 });
+      if (u.includes('/messages?')) return new Response(JSON.stringify(listResponse), { status: 200 });
+      throw new Error(`unexpected ${u}`);
+    });
+    const extract = vi.fn(async () => ({
+      ok: true as const,
+      text: '[{"source_message_id":"src-1","same_decision":true,"reason":"same"}]',
+    }));
+
+    const ctx = buildCtx({
+      force: true,
+      nowMs: 1_720_100_000_000,
+      infraLlm: { extract, classify: vi.fn() },
+      withActionLogRepo: true,
+      snapshots: [
+        {
+          path: shadowDraftPath('src-1'),
+          type: SHADOW_DOC_TYPE,
+          frontmatter: {
+            source_message_id: 'src-1',
+            thread_id: 'thread-1',
+            subject: 'Re: Hello',
+            recipients: ['alice@example.com'],
+            created_at: '2024-07-03T00:00:00.000Z',
+          },
+          body: 'Thanks Alice, how about Wednesday?',
+        },
+      ],
+      tasks: [],
+    });
+
+    // Force the reconciled_at mark to fail on run 1 only (shadow-doc path), then restore.
+    const realUpdate = ctx.workingDocs!.update;
+    let failMark = true;
+    ctx.workingDocs!.update = vi.fn(async (path: string, params: { frontmatter?: Record<string, unknown>; body?: string; expectedVersion: number }) => {
+      if (failMark && path.startsWith(`${SHADOW_SCRATCH_PREFIX}/`)) {
+        const cur = ctx.__docs.get(path)!;
+        return { ok: false as const, conflict: true as const, document: cur };
+      }
+      return realUpdate(path, params);
+    }) as typeof realUpdate;
+
+    // Run 1 — insert lands, mark fails, watermark held.
+    const r1 = await handler.execute(ctx);
+    expect(r1.success).toBe(true);
+    expect((r1 as { data: { watermark_advanced_to: number | null } }).data.watermark_advanced_to).toBeNull();
+    expect(ctx.__actionLog).toHaveLength(1);
+    expect(ctx.__docs.get(shadowDraftPath('src-1'))?.frontmatter.reconciled_at).toBeUndefined();
+
+    // Run 2 — mark now succeeds; the re-judged shadow must NOT create a second row.
+    failMark = false;
+    const r2 = await handler.execute(ctx);
+    expect(r2.success).toBe(true);
+    expect(ctx.__actionLog).toHaveLength(1); // deduped — no double-score
+    expect(ctx.__docs.get(shadowDraftPath('src-1'))?.frontmatter.reconciled_at).toBeTruthy();
+    expect((r2 as { data: { watermark_advanced_to: number | null } }).data.watermark_advanced_to).toBe(1_720_000_501);
+  });
+```
+
+Confirm the imports at the top of the test file include `SHADOW_SCRATCH_PREFIX` (from `../_shared/shadow-draft.js`) and the existing `shadowDraftPath` / `SHADOW_DOC_TYPE` helpers; add `SHADOW_SCRATCH_PREFIX` to the import if it is missing.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C <worktree> exec vitest run skills/ceo-inbox-sent-observe/handler.test.ts -t "double-insert"`
+Expected: FAIL — the handler still calls `insert` (not `insertShadowEvaluated`), so the mock's dedup never triggers and run 2 pushes a 2nd row → `expect(ctx.__actionLog).toHaveLength(1)` fails with length 2.
+
+- [ ] **Step 3: Swap the handler to the idempotent insert**
+
+In `skills/ceo-inbox-sent-observe/handler.ts`, in the per-pair loop (~lines 494-515), replace the `ctx.actionLogRepo.insert({...})` call with `insertShadowEvaluated`, and update the surrounding comment. The `try/catch` stays — a THROWN error still holds the watermark; a `null` return (dedup) is not an error and falls through to the reconciled_at mark.
+
+Replace:
+
+```typescript
+          try {
+            await ctx.actionLogRepo.insert({
+              taskId: ctx.taskEventId ?? `shadow:${j.sourceMessageId}`,
+```
+
+with:
+
+```typescript
+          try {
+            // Idempotent insert (#1432): the migration-074 partial unique index guarantees one
+            // 'shadow_evaluated' row per source_message_id, so a re-run after a failed mark can't
+            // double-score. A null return means the row already exists (recorded on a prior run) —
+            // that's not an error; we still fall through to mark reconciled_at so the re-run
+            // converges. Only a THROW holds the watermark.
+            await ctx.actionLogRepo.insertShadowEvaluated({
+              taskId: ctx.taskEventId ?? `shadow:${j.sourceMessageId}`,
+```
+
+The rest of the `insert({...})` argument object and the `catch` block are unchanged.
+
+Also update the comment block just above the per-pair loop (~lines 490-493) that says "per-pair insert + durable reconciled_at mark" to note the DB constraint is now the durable idempotency record and reconciled_at is the efficiency guard:
+
+```typescript
+        // Clean response — per-pair idempotent insert (#1432: migration-074 unique index is the
+        // durable dedup) + reconciled_at mark (the efficiency guard that lets the watermark advance
+        // and skips re-judging next run). A per-pair insert/mark failure holds the watermark for
+        // that pair (it re-judges next run) without discarding the pairs that did land.
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C <worktree> exec vitest run skills/ceo-inbox-sent-observe/handler.test.ts`
+Expected: PASS — the new replay test plus all pre-existing sent-observe tests (the happy-path shadow test still asserts `__actionLog` length 1 and reconciled_at truthy; behavior is unchanged on the success path).
+
+- [ ] **Step 5: Patch-bump the skill version**
+
+In `skills/ceo-inbox-sent-observe/skill.json`, bump the `version` patch field (e.g. `0.x.Y` → `0.x.(Y+1)`). Read the current value first.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm -C <worktree> run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C <worktree> add skills/ceo-inbox-sent-observe/handler.ts skills/ceo-inbox-sent-observe/handler.test.ts skills/ceo-inbox-sent-observe/skill.json
+git -C <worktree> commit -s -m "fix(sent-observe): idempotent shadow insert so a failed mark can't double-score (#1432)"
+```
+
+---
+
+## Task 4: resolve-learning-digest replay tests
+
+**Files:**
+- Modify: `skills/resolve-learning-digest/handler.test.ts`
+
+**Interfaces:** none new — this task only adds tests proving AC #2 holds post-#1438.
+
+- [ ] **Step 1: Read the existing test file to find the mock harness and avoid duplicating coverage**
+
+Read `skills/resolve-learning-digest/handler.test.ts` in full. Identify: how `ctx` / `ConfigStore` / `executiveProfileService` / `taskRepo` are mocked, and whether a `writeVoiceProposal`/`writeCompletionDigest` soft-reject (`stored:false`) replay case already exists for each action. Only add the cases below that are missing.
+
+- [ ] **Step 2: Write the failing replay tests**
+
+Add tests covering the mid-saga failure for each action. The mechanism: the config-store `set` returns `{ stored: false }` on the FIRST call (so the clear soft-rejects), then `{ stored: true }` on replay. Assert: (a) the primary mutation still happened, (b) run 1 returns `success:false` (item still actionable), (c) the replay converges (`success:true`, item cleared) and the mutation is not harmfully re-applied. Use the file's existing mock style; illustrative shape:
+
+```typescript
+  it('approve_voice: a soft-rejected clear surfaces failure, replay converges without re-corrupting the profile (#1432)', async () => {
+    // First clear soft-rejects (stored:false), second succeeds.
+    const setResults = [{ stored: false }, { stored: true }];
+    const ctx = makeResolveCtx({
+      voiceProposal: { status: 'pending', generatedAt: '2026-07-18T00:00:00.000Z', guide: 'Be concise.' },
+      setImpl: () => setResults.shift() ?? { stored: true },
+    });
+    const profileUpdate = ctx.executiveProfileService.update as ReturnType<typeof vi.fn>;
+
+    // Run 1 — profile updated, but the clear soft-rejects → success:false, proposal still pending.
+    const r1 = await handler.execute({ ...ctx, input: { action: 'approve_voice' } });
+    expect(r1.success).toBe(false);
+    expect(profileUpdate).toHaveBeenCalledTimes(1);
+
+    // Run 2 (replay) — clear now lands → success:true; the guide write is identical (content-
+    // idempotent), so no harmful double-apply even though update() runs again.
+    const r2 = await handler.execute({ ...ctx, input: { action: 'approve_voice' } });
+    expect(r2.success).toBe(true);
+    expect((r2 as { data: { resolved: boolean } }).data.resolved).toBe(true);
+    // The guide written on replay equals the guide written on run 1 — content-idempotent.
+    const firstGuide = profileUpdate.mock.calls[0]![0].writingVoice.guide;
+    const secondGuide = profileUpdate.mock.calls[1]![0].writingVoice.guide;
+    expect(secondGuide).toBe(firstGuide);
+  });
+
+  it('confirm_completion: soft-rejected clear surfaces failure, replay does not re-complete an already-done task (#1432)', async () => {
+    const setResults = [{ stored: false }, { stored: true }];
+    // getTask returns status 'open' on run 1, then 'done' after the first completeTask.
+    const ctx = makeResolveCtx({
+      digest: { 't1': { kind: 'confirm', taskId: 't1', taskTitle: 'Ship it', note: 'n' } },
+      taskStatusSequence: ['open', 'done'],
+      setImpl: () => setResults.shift() ?? { stored: true },
+    });
+    const completeTask = ctx.taskRepo.completeTask as ReturnType<typeof vi.fn>;
+
+    const r1 = await handler.execute({ ...ctx, input: { action: 'confirm_completion', task_id: 't1' } });
+    expect(r1.success).toBe(false);
+    expect(completeTask).toHaveBeenCalledTimes(1);
+
+    const r2 = await handler.execute({ ...ctx, input: { action: 'confirm_completion', task_id: 't1' } });
+    expect(r2.success).toBe(true);
+    // Task was already 'done' on replay → the status guard skips completeTask; no double-complete.
+    expect(completeTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('undo_completion: soft-rejected clear surfaces failure, replay reopens idempotently (#1432)', async () => {
+    const setResults = [{ stored: false }, { stored: true }];
+    const ctx = makeResolveCtx({
+      digest: { 't1': { kind: 'undo', taskId: 't1', taskTitle: 'Ship it', note: 'n' } },
+      reopenReturns: { id: 't1' }, // non-null → reopen succeeded
+      setImpl: () => setResults.shift() ?? { stored: true },
+    });
+    const r1 = await handler.execute({ ...ctx, input: { action: 'undo_completion', task_id: 't1' } });
+    expect(r1.success).toBe(false);
+    const r2 = await handler.execute({ ...ctx, input: { action: 'undo_completion', task_id: 't1' } });
+    expect(r2.success).toBe(true);
+    expect((r2 as { data: { resolved: boolean } }).data.resolved).toBe(true);
+  });
+```
+
+Adapt `makeResolveCtx` / option names to the file's actual harness (Step 1). If the harness lacks a `setImpl` / `taskStatusSequence` seam, extend it minimally — a per-call queue for `store.set` results and a status sequence for `getTask` — following the existing mock shape rather than rewriting it.
+
+- [ ] **Step 3: Run to verify they fail (or reveal the harness gap)**
+
+Run: `pnpm -C <worktree> exec vitest run skills/resolve-learning-digest/handler.test.ts -t "#1432"`
+Expected: FAIL — either an assertion fails (revealing a genuine residual gap to fix minimally in `handler.ts`, then version-bump that skill), or the harness lacks the seam (extend it, then the tests should pass, proving #1438 already closed the gap). Most likely: they pass once the harness supports soft-reject sequencing.
+
+- [ ] **Step 4: Run the full file to confirm no regressions**
+
+Run: `pnpm -C <worktree> exec vitest run skills/resolve-learning-digest/handler.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm -C <worktree> run typecheck
+git -C <worktree> add skills/resolve-learning-digest/handler.test.ts
+git -C <worktree> commit -s -m "test(resolve-learning-digest): replay coverage for mid-saga clear failures (#1432)"
+```
+
+(If Step 3 surfaced a real gap and you edited `handler.ts` + `skill.json`, add those to the commit.)
+
+---
+
+## Task 5: task-completion-from-sent replay tests
+
+**Files:**
+- Modify: `skills/task-completion-from-sent/handler.test.ts`
+
+**Interfaces:** none new — tests proving AC #3 holds post-#1438.
+
+- [ ] **Step 1: Read the existing test file**
+
+Read `skills/task-completion-from-sent/handler.test.ts` in full. #1438 already added some coverage (e.g. "assert candidate survives a completeTask failure for retry"). Identify the mock harness (`readCompletionCandidates`/`writeCompletionDigest`/`writeCompletionCandidates`/`completeTask` mocking) and which of the three scenarios below already exist. Only add the missing ones.
+
+- [ ] **Step 2: Write the failing/verification replay tests**
+
+Cover the three partial-failure shapes. Adapt to the file's harness:
+
+```typescript
+  it('digest write soft-rejects → nothing completed, nothing consumed, all retry next run (#1432)', async () => {
+    const ctx = makeCompletionCtx({
+      candidates: { 't1': highConfidenceCandidate('t1') }, // resolves to auto_complete
+      task: { id: 't1', owner: 'ceo', status: 'open', title: 'Ship it' },
+      writeDigestReturns: false, // soft-reject
+    });
+    const completeTask = ctx.taskRepo.completeTask as ReturnType<typeof vi.fn>;
+    const writeCandidates = getWriteCandidatesSpy(ctx);
+
+    const r = await handler.execute(ctx);
+    expect(r.success).toBe(true);
+    expect((r as { data: { auto_completed: number } }).data.auto_completed).toBe(0);
+    expect(completeTask).not.toHaveBeenCalled();       // no completion without a durable undo note
+    expect(writeCandidates).not.toHaveBeenCalled();    // candidate queue untouched → full retry
+  });
+
+  it('completeTask throws after the digest write lands → candidate retained, note durable, self-heals (#1432)', async () => {
+    const ctx = makeCompletionCtx({
+      candidates: { 't1': highConfidenceCandidate('t1') },
+      task: { id: 't1', owner: 'ceo', status: 'open', title: 'Ship it' },
+      writeDigestReturns: true,
+      completeTaskThrows: true,
+    });
+    const writeDigest = getWriteDigestSpy(ctx);
+    const writeCandidates = getWriteCandidatesSpy(ctx);
+
+    const r = await handler.execute(ctx);
+    expect(r.success).toBe(true);
+    // Undo note was written durably BEFORE the (failed) completion.
+    const digestArg = writeDigest.mock.calls.at(-1)![1];
+    expect(digestArg['t1']).toMatchObject({ kind: 'undo', taskId: 't1' });
+    // Candidate 't1' is retained (not consumed) so it retries next run.
+    if (writeCandidates.mock.calls.length > 0) {
+      const remaining = writeCandidates.mock.calls.at(-1)![1];
+      expect(remaining['t1']).toBeDefined();
+    }
+  });
+
+  it('clean replay after a successful run consumes candidates and does not re-complete (#1432)', async () => {
+    // Run 1 completes t1 and consumes the candidate; run 2 sees an empty candidate map.
+    const state = mutableCandidateState({ 't1': highConfidenceCandidate('t1') });
+    const ctx = makeCompletionCtx({
+      candidateState: state, // read/write against a shared, mutating map
+      task: { id: 't1', owner: 'ceo', status: 'open', title: 'Ship it' },
+      writeDigestReturns: true,
+    });
+    const completeTask = ctx.taskRepo.completeTask as ReturnType<typeof vi.fn>;
+
+    const r1 = await handler.execute(ctx);
+    expect((r1 as { data: { auto_completed: number } }).data.auto_completed).toBe(1);
+    expect(completeTask).toHaveBeenCalledTimes(1);
+
+    const r2 = await handler.execute(ctx); // candidate map now empty
+    expect((r2 as { data: { auto_completed: number } }).data.auto_completed).toBe(0);
+    expect(completeTask).toHaveBeenCalledTimes(1); // no re-completion
+  });
+```
+
+`highConfidenceCandidate(taskId)` returns a `CompletionCandidate` whose risk classification yields `auto_complete` (high confidence, no subtasks, low-risk title) — reuse the file's existing fixture if one exists; otherwise build one matching the `CompletionCandidate` shape in `skills/_shared/learning-state.ts`. Adapt `makeCompletionCtx` / helper names to the file's real harness; extend the harness minimally (a `writeDigestReturns` boolean, a `completeTaskThrows` flag, and a shared mutable candidate map) only if the seams don't already exist.
+
+- [ ] **Step 3: Run to verify behavior**
+
+Run: `pnpm -C <worktree> exec vitest run skills/task-completion-from-sent/handler.test.ts -t "#1432"`
+Expected: PASS (proving #1438's digest-first ordering satisfies AC #3), or a genuine failure to fix minimally in `handler.ts` (+ version bump) if one surfaces.
+
+- [ ] **Step 4: Run the full file + typecheck**
+
+Run: `pnpm -C <worktree> exec vitest run skills/task-completion-from-sent/handler.test.ts`
+Then: `pnpm -C <worktree> run typecheck`
+Expected: PASS / no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C <worktree> add skills/task-completion-from-sent/handler.test.ts
+git -C <worktree> commit -s -m "test(task-completion-from-sent): replay coverage for partial-write scenarios (#1432)"
+```
+
+---
+
+## Task 6: CHANGELOG + full verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Under `## [Unreleased]` → `### Fixed` (create the section if absent), add ONE bullet (≤15 words after the em-dash — but no em-dash in body per house style; use a period):
+
+```markdown
+- **`sent-observe`** — shadow reconciliation now dedups on a DB unique index, so a failed marker write can't double-score. (#1432)
+```
+
+- [ ] **Step 2: Run the full affected test set**
+
+Run: `pnpm -C <worktree> exec vitest run skills/ceo-inbox-sent-observe skills/resolve-learning-digest skills/task-completion-from-sent src/autonomy/action-log-repo.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 3: Run the migration integration test (throwaway DB)**
+
+Run: `DATABASE_URL=postgres://curia:curia@localhost:5433/curia_test pnpm -C <worktree> exec vitest run tests/integration/migrate-shadow-eval-idempotency.test.ts`
+Expected: PASS (3). Start `curia-test-pg` first if needed.
+
+- [ ] **Step 4: Full typecheck + verify migration ordering**
+
+Run: `pnpm -C <worktree> run typecheck`
+Run: `ls src/db/migrations/ | sort | tail -3`
+Expected: no type errors; `074_` prefix unique.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C <worktree> add CHANGELOG.md
+git -C <worktree> commit -s -m "docs(changelog): shadow-eval idempotency fix (#1432)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** AC#1 → Task 1 (integration) + Task 3 (handler replay). AC#2 → Task 4. AC#3 → Task 5. AC#4 (symmetric down) → Task 1 Step 4 Down section + comment. AC#5 (unit/integration tests per scenario) → Tasks 1,3,4,5.
+- **Type consistency:** `insertShadowEvaluated(row: ActionLogInsert): Promise<number | null>` is used identically in Tasks 2 and 3; the mock in Task 3 matches the same signature. `ActionLogInsert` fields used (`payload.source_message_id`, `competenceFlag`, `scoredBy`, `outcome: 'shadow_evaluated'`) match `action-log-types.ts` and the existing insert call.
+- **Verification is real:** DB-level idempotency is proven against live Postgres (mocks can't validate SQL); handler-level and repo-level via unit tests. This is deliberate — raw SQL only fails in CI/real-DB.

--- a/skills/ceo-inbox-sent-observe/handler.test.ts
+++ b/skills/ceo-inbox-sent-observe/handler.test.ts
@@ -9,7 +9,7 @@ import {
 import type { SkillContext } from '../../src/skills/types.js';
 import type { EntityMemory } from '../../src/memory/entity-memory.js';
 import { VOICE_LEARNING_DOC_TYPE } from '../_shared/voice-learning-capture.js';
-import { SHADOW_DOC_TYPE, shadowDraftPath } from '../_shared/shadow-draft.js';
+import { SHADOW_DOC_TYPE, shadowDraftPath, SHADOW_SCRATCH_PREFIX } from '../_shared/shadow-draft.js';
 import type { ActionLogInsert } from '../../src/autonomy/action-log-types.js';
 import type { InfraLlm } from '../../src/skills/infra-llm.js';
 import { COMPLETION_CANDIDATES_KEY, ASKED_TASK_IDS_KEY, MATCHED_DRAFT_IDS_KEY } from '../_shared/learning-state.js';
@@ -188,6 +188,18 @@ function buildCtx(overrides: {
       ? {
           actionLogRepo: {
             insert: vi.fn(async (row: ActionLogInsert) => {
+              actionLog.push(row);
+              return actionLog.length;
+            }),
+            // Mirror the migration-074 partial unique index: one row per source_message_id.
+            // Returns null on a duplicate (ON CONFLICT DO NOTHING), just like the real method.
+            insertShadowEvaluated: vi.fn(async (row: ActionLogInsert) => {
+              const src = (row.payload as { source_message_id?: string } | undefined)?.source_message_id;
+              if (src !== undefined && actionLog.some(
+                (r) => (r.payload as { source_message_id?: string } | undefined)?.source_message_id === src,
+              )) {
+                return null; // already recorded — dedup
+              }
               actionLog.push(row);
               return actionLog.length;
             }),
@@ -989,6 +1001,90 @@ describe('CeoInboxSentObserveHandler', () => {
     expect(data.shadow_reconciled).toBe(0);
     const shadowDoc = ctx.__docs.get(shadowDraftPath('src-1'));
     expect(shadowDoc?.frontmatter.reconciled_at).toBeUndefined();
+  });
+
+  it('does not double-insert a shadow row when the reconciled_at mark fails, then re-runs (#1432)', async () => {
+    // Run 1: judge succeeds, insert lands, but the reconciled_at mark FAILS → watermark held.
+    // Run 2: the same Sent message is re-observed and re-judged, but insertShadowEvaluated dedups
+    // on source_message_id, so exactly one shadow row exists across both runs.
+    const listResponse = {
+      data: [
+        {
+          id: 'msg-sent-1',
+          thread_id: 'thread-1',
+          subject: 'Re: Hello',
+          from: [{ email: 'ceo@example.com' }],
+          to: [{ email: 'alice@example.com' }],
+          cc: [],
+          snippet: 'Thanks Alice',
+          date: 1_720_000_500,
+          unread: false,
+          folders: ['SENT'],
+          attachments: [],
+        },
+      ],
+    };
+    const fullResponse = {
+      data: { ...listResponse.data[0], body: '<p>Thanks Alice, Tuesday works.</p>', bcc: [], labels: [] },
+    };
+    mockFetch.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u.includes('/messages/msg-sent-1')) return new Response(JSON.stringify(fullResponse), { status: 200 });
+      if (u.includes('/messages?')) return new Response(JSON.stringify(listResponse), { status: 200 });
+      throw new Error(`unexpected ${u}`);
+    });
+    const extract = vi.fn(async () => ({
+      ok: true as const,
+      text: '[{"source_message_id":"src-1","same_decision":true,"reason":"same"}]',
+    }));
+
+    const ctx = buildCtx({
+      force: true,
+      nowMs: 1_720_100_000_000,
+      infraLlm: { extract, classify: vi.fn() },
+      withActionLogRepo: true,
+      snapshots: [
+        {
+          path: shadowDraftPath('src-1'),
+          type: SHADOW_DOC_TYPE,
+          frontmatter: {
+            source_message_id: 'src-1',
+            thread_id: 'thread-1',
+            subject: 'Re: Hello',
+            recipients: ['alice@example.com'],
+            created_at: '2024-07-03T00:00:00.000Z',
+          },
+          body: 'Thanks Alice, how about Wednesday?',
+        },
+      ],
+      tasks: [],
+    });
+
+    // Force the reconciled_at mark to fail on run 1 only (shadow-doc path), then restore.
+    const realUpdate = ctx.workingDocs!.update;
+    let failMark = true;
+    ctx.workingDocs!.update = vi.fn(async (path: string, params: { frontmatter?: Record<string, unknown>; body?: string; expectedVersion: number }) => {
+      if (failMark && path.startsWith(`${SHADOW_SCRATCH_PREFIX}/`)) {
+        const cur = ctx.__docs.get(path)!;
+        return { ok: false as const, conflict: true as const, document: cur };
+      }
+      return realUpdate(path, params);
+    }) as typeof realUpdate;
+
+    // Run 1 — insert lands, mark fails, watermark held.
+    const r1 = await handler.execute(ctx);
+    expect(r1.success).toBe(true);
+    expect((r1 as { data: { watermark_advanced_to: number | null } }).data.watermark_advanced_to).toBeNull();
+    expect(ctx.__actionLog).toHaveLength(1);
+    expect(ctx.__docs.get(shadowDraftPath('src-1'))?.frontmatter.reconciled_at).toBeUndefined();
+
+    // Run 2 — mark now succeeds; the re-judged shadow must NOT create a second row.
+    failMark = false;
+    const r2 = await handler.execute(ctx);
+    expect(r2.success).toBe(true);
+    expect(ctx.__actionLog).toHaveLength(1); // deduped — no double-score
+    expect(ctx.__docs.get(shadowDraftPath('src-1'))?.frontmatter.reconciled_at).toBeTruthy();
+    expect((r2 as { data: { watermark_advanced_to: number | null } }).data.watermark_advanced_to).toBe(1_720_000_501);
   });
 
   it('matches a shadow to the nearest eligible send, not a later unrelated one (F6)', async () => {

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -488,13 +488,19 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
           'sent-observe: shadow judge failed or returned an unusable response — holding watermark',
         );
       } else {
-        // Clean response — per-pair insert + durable reconciled_at mark. A per-pair insert/mark
-        // failure holds the watermark for that pair (it re-judges next run) without discarding
-        // the pairs that did land.
+        // Clean response — per-pair idempotent insert (#1432: migration-074 unique index is the
+        // durable dedup) + reconciled_at mark (the efficiency guard that lets the watermark advance
+        // and skips re-judging next run). A per-pair insert/mark failure holds the watermark for
+        // that pair (it re-judges next run) without discarding the pairs that did land.
         for (const pair of batch) {
           const j = judged.get(pair.sourceMessageId)!; // strict parse guarantees exact coverage
           try {
-            await ctx.actionLogRepo.insert({
+            // Idempotent insert (#1432): the migration-074 partial unique index guarantees one
+            // 'shadow_evaluated' row per source_message_id, so a re-run after a failed mark can't
+            // double-score. A null return means the row already exists (recorded on a prior run) —
+            // that's not an error; we still fall through to mark reconciled_at so the re-run
+            // converges. Only a THROW holds the watermark.
+            await ctx.actionLogRepo.insertShadowEvaluated({
               taskId: ctx.taskEventId ?? `shadow:${j.sourceMessageId}`,
               conversationId: ctx.conversationId,
               skillName: 'shadow-draft-eval',

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -531,6 +531,10 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
             );
             continue;
           }
+          // The autonomy_action_log row inserted above is the authoritative competence signal
+          // for scoring (dedup'd by the #1432 unique index). This frontmatter competence_flag
+          // is informational only — it may reflect a later re-judge that a deduped (ON CONFLICT
+          // DO NOTHING) DB row never recorded, so don't treat it as a source of truth.
           const upd = await ctx.workingDocs.update(path, {
             frontmatter: { ...doc.frontmatter, reconciled_at: new Date().toISOString(), competence_flag: j.sameDecision ? 1 : 0 },
             expectedVersion: doc.version,

--- a/skills/ceo-inbox-sent-observe/skill.json
+++ b/skills/ceo-inbox-sent-observe/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "ceo-inbox-sent-observe",
   "description": "Poll the CEO's Sent folder since a stored watermark, match new sends to Curia draft snapshots and open owner=ceo tasks, append evidence to OKF, and advance the watermark. Read-only against Nylas; never drafts, archives, or sends. Intended for the daily ceo-inbox sent-observe cron — do not fold into triage.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/skills/resolve-learning-digest/handler.test.ts
+++ b/skills/resolve-learning-digest/handler.test.ts
@@ -130,6 +130,69 @@ describe('ResolveLearningDigestHandler', () => {
     expect(update).toHaveBeenCalled();
   });
 
+  it('approve_voice: replay after a soft-rejected clear converges without re-corrupting the profile (#1432)', async () => {
+    // Proves AC #2: replaying the action after a mid-saga failure (the clear soft-rejects)
+    // does not double-apply the profile mutation. Run 1's profile write is the primary side
+    // effect; the clear soft-rejects so the proposal survives for a retry. Run 2 (the replay)
+    // re-applies the identical guide (content-idempotent) and the clear now lands.
+    const mem = makeMem();
+    mem.__values.set(VOICE_PROPOSAL_KEY, GUIDE_PROPOSAL);
+    const update = vi.fn();
+    const ctx = {
+      input: { action: 'approve_voice' },
+      workingDocs: { read: vi.fn(), update: vi.fn() },
+      entityMemory: mem,
+      executiveProfileService: {
+        get: () => ({
+          writingVoice: {
+            tone: [],
+            formality: 50,
+            patterns: [],
+            vocabulary: { prefer: [], avoid: [] },
+            signOff: '',
+            guide: '',
+          },
+        }),
+        update,
+      },
+      taskRepo: { reopenTask: vi.fn(), completeTask: vi.fn(), getTask: vi.fn() },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as SkillContext;
+
+    // The proposal clear soft-rejects on the first write, then lands on the second (replay).
+    let clearCallCount = 0;
+    (mem.storeFact as ReturnType<typeof vi.fn>).mockImplementation(
+      async (p: { label: string; properties?: Record<string, unknown> }) => {
+        if (p.label === VOICE_PROPOSAL_KEY) {
+          clearCallCount += 1;
+          if (clearCallCount === 1) return { stored: false, action: 'conflict' as const };
+        }
+        mem.__values.set(p.label, String(p.properties?.value ?? ''));
+        return { stored: true, action: 'created' as const };
+      },
+    );
+
+    const handler = new ResolveLearningDigestHandler();
+
+    // Run 1 — profile updated, but the clear soft-rejects → success:false, proposal still pending.
+    const r1 = await handler.execute(ctx);
+    expect(r1.success).toBe(false);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(mem.__values.get(VOICE_PROPOSAL_KEY)).toBe(GUIDE_PROPOSAL);
+
+    // Run 2 (replay) — the proposal is still pending so it re-applies; the clear now lands.
+    const r2 = await handler.execute(ctx);
+    expect(r2.success).toBe(true);
+    expect((r2 as { data: { resolved: boolean } }).data.resolved).toBe(true);
+    expect(update).toHaveBeenCalledTimes(2);
+    // The guide written on replay equals the guide written on run 1 — content-idempotent, so
+    // the double `update()` call doesn't corrupt the profile with a different value.
+    const firstGuide = (update.mock.calls[0]![0] as { writingVoice: { guide: string } }).writingVoice.guide;
+    const secondGuide = (update.mock.calls[1]![0] as { writingVoice: { guide: string } }).writingVoice.guide;
+    expect(secondGuide).toBe(firstGuide);
+    expect(mem.__values.get(VOICE_PROPOSAL_KEY)).toBe('null');
+  });
+
   it('dismisses a voice guide proposal and writes dismissal guard', async () => {
     const mem = makeMem();
     mem.__values.set(VOICE_PROPOSAL_KEY, GUIDE_PROPOSAL);
@@ -218,6 +281,59 @@ describe('ResolveLearningDigestHandler', () => {
     expect(reopenTask).toHaveBeenCalledWith('t1', expect.any(String), 'coordinator');
   });
 
+  it('undo_completion: replay after a soft-rejected clear reopens idempotently and clears the digest item (#1432)', async () => {
+    // Proves AC #2 for undo_completion: run 1's reopenTask (the primary side effect) succeeds,
+    // but the digest clear soft-rejects, so the item survives for a retry. Run 2 (the replay)
+    // reopens again with the identical args — a no-op at the taskRepo level for an already-open
+    // task, out of scope for this handler test — and the clear now lands.
+    const mem = makeMem();
+    const digestMap: CompletionDigestMap = {
+      t1: { kind: 'undo', taskId: 't1', taskTitle: 'Follow up', note: 'Undo?' },
+    };
+    mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
+    const reopenTask = vi.fn(async () => ({ id: 't1', status: 'open' }));
+    const ctx = {
+      input: { action: 'undo_completion', task_id: 't1' },
+      workingDocs: { read: vi.fn(), update: vi.fn() },
+      entityMemory: mem,
+      executiveProfileService: { get: vi.fn(), update: vi.fn() },
+      taskRepo: { reopenTask, completeTask: vi.fn(), getTask: vi.fn() },
+      agentId: 'coordinator',
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as SkillContext;
+
+    // The digest clear soft-rejects on the first write, then lands on the second (replay).
+    let clearCallCount = 0;
+    (mem.storeFact as ReturnType<typeof vi.fn>).mockImplementation(
+      async (p: { label: string; properties?: Record<string, unknown> }) => {
+        if (p.label === COMPLETION_DIGEST_KEY) {
+          clearCallCount += 1;
+          if (clearCallCount === 1) return { stored: false, action: 'conflict' as const };
+        }
+        mem.__values.set(p.label, String(p.properties?.value ?? ''));
+        return { stored: true, action: 'created' as const };
+      },
+    );
+
+    const handler = new ResolveLearningDigestHandler();
+
+    const r1 = await handler.execute(ctx);
+    expect(r1.success).toBe(false);
+    expect(reopenTask).toHaveBeenCalledTimes(1);
+    const afterR1 = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+    expect(afterR1.t1).toEqual(digestMap.t1);
+
+    const r2 = await handler.execute(ctx);
+    expect(r2.success).toBe(true);
+    expect((r2 as { data: { resolved: boolean } }).data.resolved).toBe(true);
+    // reopenTask fires again on replay with the identical args — the handler has no status
+    // guard for undo (unlike confirm_completion below), so it re-issues the same reopen call.
+    expect(reopenTask).toHaveBeenCalledTimes(2);
+    expect(reopenTask).toHaveBeenNthCalledWith(2, 't1', expect.any(String), 'coordinator');
+    const afterR2 = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+    expect(afterR2.t1).toBeUndefined();
+  });
+
   it('fails and keeps the undo item when the task no longer exists (reopenTask returns null)', async () => {
     const mem = makeMem();
     const digestMap: CompletionDigestMap = {
@@ -295,6 +411,65 @@ describe('ResolveLearningDigestHandler', () => {
     // writeCompletionDigest was never called — the item is preserved for a retry.
     const updated = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
     expect(updated.t1).toEqual(digestMap.t1);
+  });
+
+  it('confirm_completion: replay after a soft-rejected clear does not re-complete an already-done task (#1432)', async () => {
+    // Proves AC #2 for confirm_completion: run 1's completeTask (the primary side effect)
+    // fires because the task is 'open', but the digest clear soft-rejects, so the item
+    // survives for a retry. Run 2 (the replay) sees the task is now 'done' — the
+    // `task.status !== 'done'` guard in handler.ts skips a second completeTask call — and the
+    // clear now lands.
+    const mem = makeMem();
+    const digestMap: CompletionDigestMap = {
+      t1: { kind: 'confirm', taskId: 't1', taskTitle: 'Follow up', note: 'Did emailing them complete it?' },
+    };
+    mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
+    // getTask returns 'open' on run 1 (so completeTask fires), then 'done' on the replay —
+    // reflecting that run 1's completeTask call already landed even though the overall result
+    // reported failure.
+    const getTask = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 't1', status: 'open' })
+      .mockResolvedValueOnce({ id: 't1', status: 'done' });
+    const completeTask = vi.fn(async () => undefined);
+    const ctx = {
+      input: { action: 'confirm_completion', task_id: 't1' },
+      workingDocs: { read: vi.fn(), update: vi.fn() },
+      entityMemory: mem,
+      executiveProfileService: { get: vi.fn(), update: vi.fn() },
+      taskRepo: { reopenTask: vi.fn(), completeTask, getTask },
+      agentId: 'coordinator',
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as SkillContext;
+
+    // The digest clear soft-rejects on the first write, then lands on the second (replay).
+    let clearCallCount = 0;
+    (mem.storeFact as ReturnType<typeof vi.fn>).mockImplementation(
+      async (p: { label: string; properties?: Record<string, unknown> }) => {
+        if (p.label === COMPLETION_DIGEST_KEY) {
+          clearCallCount += 1;
+          if (clearCallCount === 1) return { stored: false, action: 'conflict' as const };
+        }
+        mem.__values.set(p.label, String(p.properties?.value ?? ''));
+        return { stored: true, action: 'created' as const };
+      },
+    );
+
+    const handler = new ResolveLearningDigestHandler();
+
+    const r1 = await handler.execute(ctx);
+    expect(r1.success).toBe(false);
+    expect(completeTask).toHaveBeenCalledTimes(1);
+    const afterR1 = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+    expect(afterR1.t1).toEqual(digestMap.t1);
+
+    const r2 = await handler.execute(ctx);
+    expect(r2.success).toBe(true);
+    expect((r2 as { data: { resolved: boolean } }).data.resolved).toBe(true);
+    // Task was already 'done' on replay → the status guard skips completeTask; no double-complete.
+    expect(completeTask).toHaveBeenCalledTimes(1);
+    const afterR2 = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+    expect(afterR2.t1).toBeUndefined();
   });
 
   it('dismisses a queued confirm item without touching the task', async () => {

--- a/skills/resolve-learning-digest/handler.test.ts
+++ b/skills/resolve-learning-digest/handler.test.ts
@@ -226,6 +226,9 @@ describe('ResolveLearningDigestHandler', () => {
     };
     mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
     const reopenTask = vi.fn(async () => ({ id: 't1', status: 'open' }));
+    // getTask must return the task in 'done' status — the handler's idempotency guard
+    // (#1432) only calls reopenTask when the task is currently 'done'.
+    const getTask = vi.fn(async () => ({ id: 't1', status: 'done' }));
     const ctx = {
       input: { action: 'undo_completion', task_id: 't1' },
       // Not read/written for completion actions any more (config-store only, #1438) — a
@@ -233,7 +236,7 @@ describe('ResolveLearningDigestHandler', () => {
       workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
-      taskRepo: { reopenTask, completeTask: vi.fn(), getTask: vi.fn() },
+      taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
       agentId: 'coordinator',
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     } as unknown as SkillContext;
@@ -256,12 +259,14 @@ describe('ResolveLearningDigestHandler', () => {
     };
     mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
     const reopenTask = vi.fn(async () => ({ id: 't1', status: 'open' }));
+    // getTask must return 'done' so the idempotency guard (#1432) lets reopenTask fire.
+    const getTask = vi.fn(async () => ({ id: 't1', status: 'done' }));
     const ctx = {
       input: { action: 'undo_completion', task_id: 't1' },
       workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
-      taskRepo: { reopenTask, completeTask: vi.fn(), getTask: vi.fn() },
+      taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
       agentId: 'coordinator',
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     } as unknown as SkillContext;
@@ -284,20 +289,28 @@ describe('ResolveLearningDigestHandler', () => {
   it('undo_completion: replay after a soft-rejected clear reopens idempotently and clears the digest item (#1432)', async () => {
     // Proves AC #2 for undo_completion: run 1's reopenTask (the primary side effect) succeeds,
     // but the digest clear soft-rejects, so the item survives for a retry. Run 2 (the replay)
-    // reopens again with the identical args — a no-op at the taskRepo level for an already-open
-    // task, out of scope for this handler test — and the clear now lands.
+    // sees the task is now 'open' — the handler's status guard (mirrors confirm_completion)
+    // skips a second reopenTask call, since calling it again would THROW (task-repo.ts only
+    // allows reopening a 'done' task) and wedge the digest item forever — and the clear lands.
     const mem = makeMem();
     const digestMap: CompletionDigestMap = {
       t1: { kind: 'undo', taskId: 't1', taskTitle: 'Follow up', note: 'Undo?' },
     };
     mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
     const reopenTask = vi.fn(async () => ({ id: 't1', status: 'open' }));
+    // getTask returns 'done' on run 1 (so reopenTask fires), then 'open' on the replay —
+    // reflecting that run 1's reopenTask call already landed even though the overall result
+    // reported failure.
+    const getTask = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 't1', status: 'done' })
+      .mockResolvedValueOnce({ id: 't1', status: 'open' });
     const ctx = {
       input: { action: 'undo_completion', task_id: 't1' },
       workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
-      taskRepo: { reopenTask, completeTask: vi.fn(), getTask: vi.fn() },
+      taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
       agentId: 'coordinator',
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     } as unknown as SkillContext;
@@ -326,35 +339,36 @@ describe('ResolveLearningDigestHandler', () => {
     const r2 = await handler.execute(ctx);
     expect(r2.success).toBe(true);
     expect((r2 as { data: { resolved: boolean } }).data.resolved).toBe(true);
-    // reopenTask fires again on replay with the identical args — the handler has no status
-    // guard for undo (unlike confirm_completion below), so it re-issues the same reopen call.
-    expect(reopenTask).toHaveBeenCalledTimes(2);
-    expect(reopenTask).toHaveBeenNthCalledWith(2, 't1', expect.any(String), 'coordinator');
+    // Task was already 'open' on replay → the status guard skips reopenTask; no second (throwing) call.
+    expect(reopenTask).toHaveBeenCalledTimes(1);
     const afterR2 = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
     expect(afterR2.t1).toBeUndefined();
   });
 
-  it('fails and keeps the undo item when the task no longer exists (reopenTask returns null)', async () => {
+  it('fails and keeps the undo item when the task no longer exists (getTask returns null)', async () => {
     const mem = makeMem();
     const digestMap: CompletionDigestMap = {
       t1: { kind: 'undo', taskId: 't1', taskTitle: 'Follow up', note: 'Undo?' },
     };
     mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
-    // reopenTask returns null when the task is gone — the digest item must survive so the user
-    // still sees the undo affordance, and the result must report failure (not a silent success).
-    const reopenTask = vi.fn(async () => null);
+    // getTask returns null when the task is gone — the guard (#1432) fails loud before ever
+    // calling reopenTask, and the digest item must survive so the user still sees the undo
+    // affordance.
+    const getTask = vi.fn(async () => null);
+    const reopenTask = vi.fn(async () => ({ id: 't1', status: 'open' }));
     const ctx = {
       input: { action: 'undo_completion', task_id: 't1' },
       workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
-      taskRepo: { reopenTask, completeTask: vi.fn(), getTask: vi.fn() },
+      taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
       agentId: 'coordinator',
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     } as unknown as SkillContext;
 
     const result = await new ResolveLearningDigestHandler().execute(ctx);
     expect(result.success).toBe(false);
+    expect(reopenTask).not.toHaveBeenCalled();
     // writeCompletionDigest was never called — the item is preserved for a retry.
     expect(mem.storeFact).not.toHaveBeenCalled();
     const updated = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;

--- a/skills/resolve-learning-digest/handler.test.ts
+++ b/skills/resolve-learning-digest/handler.test.ts
@@ -375,6 +375,36 @@ describe('ResolveLearningDigestHandler', () => {
     expect(updated.t1).toEqual(digestMap.t1);
   });
 
+  it('fails without clearing (or falsely reporting a reopen) when the task is in a non-open terminal state (#1432)', async () => {
+    // A task that moved to 'cancelled' (or 'failed', etc.) between auto-complete and undo is neither
+    // 'done' (reopenable) nor 'open' (already reopened). The guard must NOT call reopenTask (it would
+    // throw), must NOT clear the digest item, and must NOT report a phantom "Reopened". The user can
+    // still drop the stale item via dismiss_completion.
+    const mem = makeMem();
+    const digestMap: CompletionDigestMap = {
+      t1: { kind: 'undo', taskId: 't1', taskTitle: 'Follow up', note: 'Undo?' },
+    };
+    mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
+    const getTask = vi.fn(async () => ({ id: 't1', status: 'cancelled' }));
+    const reopenTask = vi.fn(async () => ({ id: 't1', status: 'open' }));
+    const ctx = {
+      input: { action: 'undo_completion', task_id: 't1' },
+      workingDocs: { read: vi.fn(), update: vi.fn() },
+      entityMemory: mem,
+      executiveProfileService: { get: vi.fn(), update: vi.fn() },
+      taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
+      agentId: 'coordinator',
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as SkillContext;
+
+    const result = await new ResolveLearningDigestHandler().execute(ctx);
+    expect(result.success).toBe(false);
+    expect(reopenTask).not.toHaveBeenCalled(); // never call the throwing reopen on a non-done task
+    expect(mem.storeFact).not.toHaveBeenCalled(); // digest item NOT cleared
+    const updated = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+    expect(updated.t1).toEqual(digestMap.t1);
+  });
+
   it('confirms completion via completeTask and removes the digest item', async () => {
     const mem = makeMem();
     const digestMap: CompletionDigestMap = {

--- a/skills/resolve-learning-digest/handler.ts
+++ b/skills/resolve-learning-digest/handler.ts
@@ -135,9 +135,13 @@ export class ResolveLearningDigestHandler implements SkillHandler {
       // Idempotency guard (mirrors confirm_completion below): reopenTask THROWS on any status other
       // than 'done' (src/db/task-repo.ts). On a replay after a soft-rejected clear, run 1 already
       // reopened the task (done -> open), so calling reopenTask again would throw and wedge the
-      // digest item forever. Reopen only when the task is still 'done'; an already-open task means
-      // run 1's reopen landed, so fall through to clear the item. A missing task fails loud (the
-      // item is kept so the user can see it didn't apply), same as the confirm path.
+      // digest item forever. Branch precisely on the status so we never falsely report "Reopened":
+      //   - 'done'  : reopen it (the normal path), then clear the item.
+      //   - 'open'  : run 1's reopen already landed — converge by clearing the item.
+      //   - other   : the task moved on independently (cancelled / failed / in_progress / ...).
+      //               Reopening doesn't apply and reporting "Reopened" would be a lie, so fail loud
+      //               and KEEP the item (the user can drop it via dismiss_completion).
+      // A missing task also fails loud with the item kept, same as the confirm path.
       const task = await ctx.taskRepo.getTask(taskId);
       if (!task) {
         return { success: false, error: `Task ${taskId} not found; cannot undo completion` };
@@ -153,10 +157,17 @@ export class ResolveLearningDigestHandler implements SkillHandler {
         if (!reopened) {
           return { success: false, error: `Task ${taskId} could not be reopened (it may have changed); retry` };
         }
+      } else if (task.status !== 'open') {
+        // Not 'done' (reopenable) and not 'open' (already reopened by a prior run's undo) — the task
+        // is in some other state we didn't cause. Don't clear the item and don't claim a reopen.
+        return {
+          success: false,
+          error: `Task ${taskId} is '${task.status}', not done; cannot undo completion`,
+        };
       }
-      // Remove the actioned item from the config map so resolved items don't accumulate. The task is
-      // reopened (or already open) by this point, so a soft-reject on the clear only means the digest
-      // item may reappear — a retry re-checks status and clears idempotently.
+      // status is 'done' (just reopened) or 'open' (already reopened) — clear the digest item. A
+      // soft-reject on the clear only means the item may reappear; a retry re-checks status and
+      // clears idempotently.
       const { [taskId]: _removed, ...rest } = digestMap;
       void _removed;
       const cleared = await writeCompletionDigest(store, rest);

--- a/skills/resolve-learning-digest/handler.ts
+++ b/skills/resolve-learning-digest/handler.ts
@@ -132,20 +132,31 @@ export class ResolveLearningDigestHandler implements SkillHandler {
     }
 
     if (action === 'undo_completion') {
-      // reopenTask returns null when the task no longer exists. Fail loudly and DON'T consume the
-      // digest item in that case — mirrors the confirm path's not-found guard below. Otherwise
-      // we'd drop the undo affordance and report success while having reopened nothing.
-      const reopened = await ctx.taskRepo.reopenTask(
-        taskId,
-        'Undo auto-complete from sent mail',
-        ctx.agentId,
-      );
-      if (!reopened) {
+      // Idempotency guard (mirrors confirm_completion below): reopenTask THROWS on any status other
+      // than 'done' (src/db/task-repo.ts). On a replay after a soft-rejected clear, run 1 already
+      // reopened the task (done -> open), so calling reopenTask again would throw and wedge the
+      // digest item forever. Reopen only when the task is still 'done'; an already-open task means
+      // run 1's reopen landed, so fall through to clear the item. A missing task fails loud (the
+      // item is kept so the user can see it didn't apply), same as the confirm path.
+      const task = await ctx.taskRepo.getTask(taskId);
+      if (!task) {
         return { success: false, error: `Task ${taskId} not found; cannot undo completion` };
       }
-      // Remove the actioned item from the config map so resolved items don't accumulate. The
-      // task is already reopened by this point, so a soft-reject on the clear only means the
-      // digest item may reappear — reopening an already-open task next retry is a no-op.
+      if (task.status === 'done') {
+        const reopened = await ctx.taskRepo.reopenTask(
+          taskId,
+          'Undo auto-complete from sent mail',
+          ctx.agentId,
+        );
+        // reopenTask returns null when the row vanished / raced to non-done between the read and
+        // the UPDATE — fail loud and DON'T consume the digest item, so the undo affordance survives.
+        if (!reopened) {
+          return { success: false, error: `Task ${taskId} could not be reopened (it may have changed); retry` };
+        }
+      }
+      // Remove the actioned item from the config map so resolved items don't accumulate. The task is
+      // reopened (or already open) by this point, so a soft-reject on the clear only means the digest
+      // item may reappear — a retry re-checks status and clears idempotently.
       const { [taskId]: _removed, ...rest } = digestMap;
       void _removed;
       const cleared = await writeCompletionDigest(store, rest);

--- a/skills/resolve-learning-digest/skill.json
+++ b/skills/resolve-learning-digest/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "resolve-learning-digest",
   "description": "Resolve a learning-digest item: approve/dismiss a voice proposal, undo an auto-completed task, or confirm/dismiss a task-completion candidate.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {

--- a/skills/task-completion-from-sent/handler.test.ts
+++ b/skills/task-completion-from-sent/handler.test.ts
@@ -361,4 +361,78 @@ describe('TaskCompletionFromSentHandler', () => {
     const remaining2 = JSON.parse(ctx2.__mem.__values.get(COMPLETION_CANDIDATES_KEY)!) as CompletionCandidateMap;
     expect(remaining2['11111111-1111-4111-8111-111111111111']).toBeUndefined();
   });
+
+  it('completeTask throws after the digest write lands → undo note durable in digest before the failure, candidate retained for retry (#1432)', async () => {
+    // Distinct from the CRITICAL test above: that test proves the candidate survives a
+    // completeTask failure but never inspects the digest. This test proves the actual
+    // digest-first *ordering* guarantee — the undo note is durably recorded in the digest
+    // even though the completion that note describes never actually happened, which is
+    // exactly the "transient wart" the handler's own comment (above the digest write) calls
+    // out as self-healing on the next run.
+    const ctx = makeCtx();
+    ctx.__mem.__values.set(
+      COMPLETION_CANDIDATES_KEY,
+      JSON.stringify({
+        '11111111-1111-4111-8111-111111111111': CANDIDATE_MAP['11111111-1111-4111-8111-111111111111'],
+      }),
+    );
+    // Digest write succeeds normally this time (unlike the DOUBLE-RUN soft-reject case) —
+    // only completeTask fails, after the digest write has already landed.
+    (ctx.taskRepo as unknown as { completeTask: (...args: unknown[]) => Promise<unknown> }).completeTask =
+      vi.fn(async () => {
+        throw new Error('db hiccup after digest write');
+      });
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const data = (result as { data: { auto_completed: number; skipped: number } }).data;
+    expect(data.auto_completed).toBe(0);
+    expect(data.skipped).toBe(1);
+
+    // The undo note is durable in the digest despite the completion failing — proof that the
+    // write happened BEFORE completeTask ran, not after.
+    const digest = JSON.parse(ctx.__mem.__values.get(COMPLETION_DIGEST_KEY)!);
+    expect(digest['11111111-1111-4111-8111-111111111111']).toMatchObject({
+      kind: 'undo',
+      taskId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    // The candidate is retained (not consumed) so it retries next run — the note is already
+    // durable and will be overwritten identically on retry (composeUndoNote is pure).
+    const remaining = JSON.parse(ctx.__mem.__values.get(COMPLETION_CANDIDATES_KEY)!) as CompletionCandidateMap;
+    expect(remaining['11111111-1111-4111-8111-111111111111']).toEqual(
+      CANDIDATE_MAP['11111111-1111-4111-8111-111111111111'],
+    );
+  });
+
+  it('clean replay after a successful run consumes the candidate; a second run on the same state sees an empty queue and does not re-complete (#1432)', async () => {
+    // Unlike the DOUBLE-RUN test above (which replays across two fresh ctx objects to prove
+    // self-healing after a soft-reject), this replays the SAME ctx/config-store state twice —
+    // the shape of an idempotent re-run of the same job with no partial failure involved.
+    const ctx = makeCtx();
+    ctx.__mem.__values.set(
+      COMPLETION_CANDIDATES_KEY,
+      JSON.stringify({
+        '11111111-1111-4111-8111-111111111111': CANDIDATE_MAP['11111111-1111-4111-8111-111111111111'],
+      }),
+    );
+
+    const result1 = await handler.execute(ctx);
+    expect(result1.success).toBe(true);
+    const data1 = (result1 as { data: { auto_completed: number } }).data;
+    expect(data1.auto_completed).toBe(1);
+    expect(ctx.__completed).toEqual(['11111111-1111-4111-8111-111111111111']);
+    const remaining1 = JSON.parse(ctx.__mem.__values.get(COMPLETION_CANDIDATES_KEY)!) as CompletionCandidateMap;
+    expect(remaining1['11111111-1111-4111-8111-111111111111']).toBeUndefined();
+
+    // Run 2 against the same underlying config-store map: run 1 already consumed the candidate,
+    // so this must be a no-op rather than re-completing the (now already-done) task.
+    const result2 = await handler.execute(ctx);
+    expect(result2.success).toBe(true);
+    const data2 = (result2 as { data: { auto_completed: number } }).data;
+    expect(data2.auto_completed).toBe(0);
+    // completeTask must not have been called again — exactly one call total across both runs.
+    expect(ctx.__completed).toEqual(['11111111-1111-4111-8111-111111111111']);
+    expect((ctx.taskRepo!.completeTask as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
 });

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -42,8 +42,9 @@ function makeSequentialPool(
 
 describe('ActionLogRepo', () => {
   describe('insert', () => {
-    it('inserts a row and returns the id', async () => {
-      const { pool, queries } = makePool([{ id: 42 }]);
+    it('inserts a row and returns the id coerced from pg\'s int8 string', async () => {
+      // pg returns the BIGSERIAL id as a string; the repo coerces it to a number at the boundary.
+      const { pool, queries } = makePool([{ id: '42' }]);
       const repo = new ActionLogRepo(pool, createSilentLogger());
       const id = await repo.insert({
         taskId: 'task-1',
@@ -77,8 +78,10 @@ describe('ActionLogRepo', () => {
   });
 
   describe('insertShadowEvaluated', () => {
-    it('inserts with ON CONFLICT DO NOTHING and returns the id', async () => {
-      const { pool, queries } = makePool([{ id: 7 }]);
+    it('inserts with ON CONFLICT DO NOTHING and returns the id coerced from pg\'s int8 string', async () => {
+      // node-postgres returns BIGSERIAL/int8 as a STRING; the fixture mirrors that so the assertion
+      // proves the repo coerces it to a number at the boundary (id === 7, not '7').
+      const { pool, queries } = makePool([{ id: '7' }]);
       const repo = new ActionLogRepo(pool, createSilentLogger());
       const id = await repo.insertShadowEvaluated({
         taskId: 'shadow:src-1',

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -76,6 +76,43 @@ describe('ActionLogRepo', () => {
     });
   });
 
+  describe('insertShadowEvaluated', () => {
+    it('inserts with ON CONFLICT DO NOTHING and returns the id', async () => {
+      const { pool, queries } = makePool([{ id: 7 }]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const id = await repo.insertShadowEvaluated({
+        taskId: 'shadow:src-1',
+        skillName: 'shadow-draft-eval',
+        actionRisk: 'none',
+        outcome: 'shadow_evaluated',
+        payload: { shadow: true, source_message_id: 'src-1' },
+        competenceFlag: 1,
+        scoredBy: 'shadow-reconciler',
+      });
+      expect(id).toBe(7);
+      expect(queries).toHaveLength(1);
+      expect(queries[0]!.sql).toContain('ON CONFLICT');
+      expect(queries[0]!.sql).toContain("payload->>'source_message_id'");
+      expect(queries[0]!.sql).toContain('DO NOTHING');
+    });
+
+    it('returns null when the insert is a no-op (conflict — row already exists)', async () => {
+      // ON CONFLICT DO NOTHING returns zero rows when the row already exists.
+      const { pool } = makePool([], 0);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const id = await repo.insertShadowEvaluated({
+        taskId: 'shadow:src-1',
+        skillName: 'shadow-draft-eval',
+        actionRisk: 'none',
+        outcome: 'shadow_evaluated',
+        payload: { shadow: true, source_message_id: 'src-1' },
+        competenceFlag: 1,
+        scoredBy: 'shadow-reconciler',
+      });
+      expect(id).toBeNull();
+    });
+  });
+
   describe('findUnscoredTerminal', () => {
     it('returns rows ordered by created_at asc with limit', async () => {
       const now = new Date();

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -54,12 +54,16 @@ export class ActionLogRepo {
   /** Insert a new row and return the generated id. */
   async insert(row: ActionLogInsert): Promise<number> {
     const { columns, values, params } = this.insertColumnsAndParams(row);
-    const result = await this.pool.query<{ id: number }>(
+    // `id` is BIGSERIAL; node-postgres returns int8 as a STRING (no global bigint type-parser is
+    // registered), so coerce to number at the repository boundary to honor the declared return
+    // type. autonomy_action_log ids never approach Number.MAX_SAFE_INTEGER at single-tenant scale.
+    const result = await this.pool.query<{ id: string }>(
       `INSERT INTO autonomy_action_log ${columns} ${values} RETURNING id`,
       params,
     );
-    this.logger.debug({ id: result.rows[0]!.id, skillName: row.skillName, outcome: row.outcome }, 'action-log-repo: inserted row');
-    return result.rows[0]!.id;
+    const id = Number(result.rows[0]!.id);
+    this.logger.debug({ id, skillName: row.skillName, outcome: row.outcome }, 'action-log-repo: inserted row');
+    return id;
   }
 
   /**
@@ -71,14 +75,16 @@ export class ActionLogRepo {
    */
   async insertShadowEvaluated(row: ActionLogInsert): Promise<number | null> {
     const { columns, values, params } = this.insertColumnsAndParams(row);
-    const result = await this.pool.query<{ id: number }>(
+    const result = await this.pool.query<{ id: string }>(
       `INSERT INTO autonomy_action_log ${columns} ${values}
        ON CONFLICT ((payload->>'source_message_id')) WHERE outcome = 'shadow_evaluated'
        DO NOTHING
        RETURNING id`,
       params,
     );
-    const id = result.rows[0]?.id ?? null;
+    // int8 -> number at the boundary (see insert()); a dedup no-op returns no row, preserved as null.
+    const raw = result.rows[0]?.id;
+    const id = raw === undefined ? null : Number(raw);
     this.logger.debug({ id, skillName: row.skillName, deduped: id === null }, 'action-log-repo: shadow insert');
     return id;
   }

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -20,16 +20,16 @@ export class ActionLogRepo {
     private readonly logger: Logger,
   ) {}
 
-  /** Insert a new row and return the generated id. */
-  async insert(row: ActionLogInsert): Promise<number> {
-    const result = await this.pool.query<{ id: number }>(
-      `INSERT INTO autonomy_action_log
-         (task_id, conversation_id, skill_name, action_risk, outcome, task_summary,
-          payload, expires_at, short_ref, description, parent_action_id,
-          competence_flag, commitment_flag, compatibility, scored_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-       RETURNING id`,
-      [
+  /** Column list + positional VALUES tuple shared by insert() and insertShadowEvaluated().
+   *  Kept in one place so the two insert paths cannot drift. */
+  private insertColumnsAndParams(row: ActionLogInsert): { columns: string; values: string; params: unknown[] } {
+    return {
+      columns:
+        '(task_id, conversation_id, skill_name, action_risk, outcome, task_summary, ' +
+        'payload, expires_at, short_ref, description, parent_action_id, ' +
+        'competence_flag, commitment_flag, compatibility, scored_by)',
+      values: 'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)',
+      params: [
         row.taskId,
         row.conversationId ?? null,
         row.skillName,
@@ -48,9 +48,39 @@ export class ActionLogRepo {
         null,
         row.scoredBy ?? null,
       ],
+    };
+  }
+
+  /** Insert a new row and return the generated id. */
+  async insert(row: ActionLogInsert): Promise<number> {
+    const { columns, values, params } = this.insertColumnsAndParams(row);
+    const result = await this.pool.query<{ id: number }>(
+      `INSERT INTO autonomy_action_log ${columns} ${values} RETURNING id`,
+      params,
     );
     this.logger.debug({ id: result.rows[0]!.id, skillName: row.skillName, outcome: row.outcome }, 'action-log-repo: inserted row');
     return result.rows[0]!.id;
+  }
+
+  /**
+   * Insert a pre-scored shadow-eval row idempotently (#1432). The partial unique index
+   * idx_aal_shadow_source (migration 074) enforces one 'shadow_evaluated' row per
+   * source_message_id, so ON CONFLICT DO NOTHING makes a re-run a no-op instead of a duplicate.
+   * Returns the new id, or `null` when a row for this source_message_id already exists — the
+   * caller treats null as "already durably recorded", NOT an error.
+   */
+  async insertShadowEvaluated(row: ActionLogInsert): Promise<number | null> {
+    const { columns, values, params } = this.insertColumnsAndParams(row);
+    const result = await this.pool.query<{ id: number }>(
+      `INSERT INTO autonomy_action_log ${columns} ${values}
+       ON CONFLICT ((payload->>'source_message_id')) WHERE outcome = 'shadow_evaluated'
+       DO NOTHING
+       RETURNING id`,
+      params,
+    );
+    const id = result.rows[0]?.id ?? null;
+    this.logger.debug({ id, skillName: row.skillName, deduped: id === null }, 'action-log-repo: shadow insert');
+    return id;
   }
 
   /**

--- a/src/db/migrations/074_shadow_eval_idempotency.sql
+++ b/src/db/migrations/074_shadow_eval_idempotency.sql
@@ -1,0 +1,44 @@
+-- Up Migration
+
+-- 074_shadow_eval_idempotency.sql
+--
+-- #1432: durable idempotency for shadow-draft competence reconciliation.
+-- sent-observe inserts a pre-scored 'shadow_evaluated' row and THEN marks the shadow doc
+-- reconciled_at. If the mark fails after the insert, the watermark is held and the next run
+-- re-judges and re-inserts a DUPLICATE row (the marker was the only idempotency record, written
+-- after the insert). This adds a DB-level backstop: one 'shadow_evaluated' row per
+-- source_message_id, enforced by a partial unique index. The insert path uses ON CONFLICT DO
+-- NOTHING (see ActionLogRepo.insertShadowEvaluated), so a re-run is a no-op.
+--
+-- Prod may already hold duplicates produced by the bug this fixes, so we DEDUP FIRST — otherwise
+-- CREATE UNIQUE INDEX would abort on the pre-existing violating rows (the same class of failure
+-- as migration 070, which only detonated against prod data).
+
+-- NOTE ON LOCKING (mirrors migrations 044 / 073): node-pg-migrate wraps each SQL file in a single
+-- transaction, so CREATE INDEX CONCURRENTLY is unavailable here. Building this partial index takes
+-- a brief lock/scan on autonomy_action_log during deploy — acceptable at the current single-tenant
+-- table size. If the table grows large enough that this stalls writes, split into a
+-- non-transactional migration using CREATE INDEX CONCURRENTLY.
+
+-- Remove all but the lowest-id row per source_message_id among existing shadow rows.
+DELETE FROM autonomy_action_log a
+USING autonomy_action_log b
+WHERE a.outcome = 'shadow_evaluated'
+  AND b.outcome = 'shadow_evaluated'
+  AND a.payload->>'source_message_id' = b.payload->>'source_message_id'
+  AND a.payload->>'source_message_id' IS NOT NULL
+  AND a.id > b.id;
+
+-- One shadow_evaluated row per source_message_id. `payload->>'source_message_id'` is immutable, so
+-- it is legal in an index expression; the partial predicate scopes the constraint to shadow rows
+-- only, so no other outcome/caller can ever collide with it. NULL source ids are naturally distinct
+-- in a unique index and are not constrained (there should be none — the writer always sets it).
+CREATE UNIQUE INDEX idx_aal_shadow_source
+  ON autonomy_action_log ((payload->>'source_message_id'))
+  WHERE outcome = 'shadow_evaluated';
+
+-- Down Migration
+
+-- Symmetric, non-aborting: just drop the index. The dedup DELETE above is deliberately NOT
+-- reversed — the rows it removed were erroneous duplicates with no meaning to restore.
+DROP INDEX IF EXISTS idx_aal_shadow_source;

--- a/src/db/migrations/074_shadow_eval_idempotency.sql
+++ b/src/db/migrations/074_shadow_eval_idempotency.sql
@@ -21,6 +21,9 @@
 -- non-transactional migration using CREATE INDEX CONCURRENTLY.
 
 -- Remove all but the lowest-id row per source_message_id among existing shadow rows.
+-- This self-join runs before any index on payload->>'source_message_id' exists (the unique
+-- index below is created after), so it is a sequential self-join; acceptable at the current
+-- single-tenant table size, but worth watching if this table grows large.
 DELETE FROM autonomy_action_log a
 USING autonomy_action_log b
 WHERE a.outcome = 'shadow_evaluated'

--- a/tests/integration/migrate-shadow-eval-idempotency.test.ts
+++ b/tests/integration/migrate-shadow-eval-idempotency.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import pg from 'pg';
 import { readFile } from 'node:fs/promises';
+import { requireCuriaTestDatabase } from './require-test-db.js';
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIf = DATABASE_URL ? describe : describe.skip;
@@ -34,22 +35,19 @@ async function insertShadow(pool: pg.Pool, src: string): Promise<number> {
 describeIf('migration 074: shadow-eval idempotency', () => {
   let pool: pg.Pool;
   let upSql: string;
+  // Set true only after requireCuriaTestDatabase confirms we're on curia_test. beforeEach/afterAll
+  // gate their destructive DDL on this: vitest still fires afterAll after a FAILED beforeAll, so
+  // without this flag a guard abort against a mispointed DB would still run `DROP INDEX` — and drop
+  // the real production index. With it, no destructive statement runs unless the guard passed.
+  let onTestDb = false;
 
   beforeAll(async () => {
     pool = new pg.Pool({ connectionString: DATABASE_URL });
     // Safety rail: this suite runs the migration's UNSCOPED, table-wide dedup DELETE + CREATE INDEX,
-    // so it must never touch a real database. Refuse to run unless connected to a *test* database —
-    // a mispointed DATABASE_URL (e.g. prod) fails loudly HERE, before any DDL executes. (No shared
-    // curia_test fixture exists in the repo yet; this in-file guard is the minimal safeguard.)
-    const { rows } = await pool.query<{ db: string }>('SELECT current_database() AS db');
-    const dbName = rows[0]!.db;
-    if (!/test/i.test(dbName)) {
-      await pool.end();
-      throw new Error(
-        `Refusing to run the destructive migration-074 integration test against database "${dbName}". ` +
-          'Point DATABASE_URL at a test database (its name must contain "test").',
-      );
-    }
+    // so it must never touch a real database. The shared guard throws HERE (before onTestDb is set,
+    // and before any DDL) if DATABASE_URL points anywhere but the canonical isolated `curia_test`.
+    await requireCuriaTestDatabase(pool);
+    onTestDb = true;
     const full = await readFile(MIGRATION_SQL_URL, 'utf8');
     // Run only the Up half — the Down's DROP INDEX would otherwise remove what we assert.
     upSql = full.split('-- Down Migration')[0]!;
@@ -58,14 +56,19 @@ describeIf('migration 074: shadow-eval idempotency', () => {
   // Clean slate: drop the index and delete only our scoped rows before each case. The index name is
   // a fixed literal (not interpolated) to keep the DDL out of the parameterized-query lint's sights.
   beforeEach(async () => {
+    if (!onTestDb) return;
     await pool.query('DROP INDEX IF EXISTS idx_aal_shadow_source');
     await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
   });
 
   afterAll(async () => {
-    await pool.query('DROP INDEX IF EXISTS idx_aal_shadow_source');
-    await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
-    await pool.end();
+    // Only clean up (destructive DDL) when the guard confirmed the test database; always close the
+    // pool if it was opened, even on the guard-abort path, so a failed run leaks no connection.
+    if (onTestDb) {
+      await pool.query('DROP INDEX IF EXISTS idx_aal_shadow_source');
+      await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
+    }
+    if (pool) await pool.end();
   });
 
   it('deletes duplicate shadow rows (keeping the lowest id) before creating the index', async () => {

--- a/tests/integration/migrate-shadow-eval-idempotency.test.ts
+++ b/tests/integration/migrate-shadow-eval-idempotency.test.ts
@@ -1,0 +1,86 @@
+// Integration test — runs migration 074's Up SQL against a live Postgres and asserts the
+// shadow-eval dedup + partial-unique-index idempotency guard. Skips without DATABASE_URL.
+// Scopes every mutation to a test-only source_message_id prefix and drops its own index, so a
+// mispointed DATABASE_URL cannot corrupt real shadow rows or a real production index.
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import pg from 'pg';
+import { readFile } from 'node:fs/promises';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const MIGRATION_SQL_URL = new URL(
+  '../../src/db/migrations/074_shadow_eval_idempotency.sql',
+  import.meta.url,
+);
+const INDEX = 'idx_aal_shadow_source';
+// Test rows use source_message_id values under this prefix so cleanup never deletes real rows.
+const PFX = 'itest-shadow-idem-';
+
+/** Insert a pre-scored shadow row directly (bypassing the repo) with a scoped source id. */
+async function insertShadow(pool: pg.Pool, src: string): Promise<number> {
+  // `id` is BIGSERIAL; node-postgres returns int8 columns as strings (no global bigint
+  // type-parser is registered in this codebase) to avoid silent precision loss on values
+  // beyond Number.MAX_SAFE_INTEGER. Test ids never approach that range, so Number() is safe here.
+  const { rows } = await pool.query<{ id: string }>(
+    `INSERT INTO autonomy_action_log
+       (task_id, skill_name, action_risk, outcome, payload, competence_flag, scored_by)
+     VALUES ($1, 'shadow-draft-eval', 'none', 'shadow_evaluated', $2::jsonb, 1, 'shadow-reconciler')
+     RETURNING id`,
+    [`shadow:${src}`, JSON.stringify({ shadow: true, source_message_id: src })],
+  );
+  return Number(rows[0]!.id);
+}
+
+describeIf('migration 074: shadow-eval idempotency', () => {
+  let pool: pg.Pool;
+  let upSql: string;
+
+  beforeAll(async () => {
+    pool = new pg.Pool({ connectionString: DATABASE_URL });
+    const full = await readFile(MIGRATION_SQL_URL, 'utf8');
+    // Run only the Up half — the Down's DROP INDEX would otherwise remove what we assert.
+    upSql = full.split('-- Down Migration')[0]!;
+  });
+
+  // Clean slate: drop the index and delete only our scoped rows before each case.
+  beforeEach(async () => {
+    await pool.query(`DROP INDEX IF EXISTS ${INDEX}`);
+    await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
+  });
+
+  afterAll(async () => {
+    await pool.query(`DROP INDEX IF EXISTS ${INDEX}`);
+    await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
+    await pool.end();
+  });
+
+  it('deletes duplicate shadow rows (keeping the lowest id) before creating the index', async () => {
+    const src = `${PFX}dup`;
+    const id1 = await insertShadow(pool, src);
+    const id2 = await insertShadow(pool, src);
+    expect(id2).toBeGreaterThan(id1);
+
+    await pool.query(upSql); // dedup + CREATE UNIQUE INDEX; must not abort on the pre-existing dup
+
+    const { rows } = await pool.query<{ id: string }>(
+      `SELECT id FROM autonomy_action_log WHERE payload->>'source_message_id' = $1`,
+      [src],
+    );
+    expect(rows.map((r) => Number(r.id))).toEqual([id1]); // only the lowest-id row survives
+  });
+
+  it('rejects a duplicate shadow insert once the index exists', async () => {
+    await pool.query(upSql);
+    const src = `${PFX}unique`;
+    await insertShadow(pool, src);
+    await expect(insertShadow(pool, src)).rejects.toThrow(/duplicate key|unique/i);
+  });
+
+  it('allows two shadow rows with different source ids', async () => {
+    await pool.query(upSql);
+    const a = await insertShadow(pool, `${PFX}a`);
+    const b = await insertShadow(pool, `${PFX}b`);
+    expect(a).not.toBe(b); // no false conflict across distinct source ids
+  });
+});

--- a/tests/integration/migrate-shadow-eval-idempotency.test.ts
+++ b/tests/integration/migrate-shadow-eval-idempotency.test.ts
@@ -13,7 +13,6 @@ const MIGRATION_SQL_URL = new URL(
   '../../src/db/migrations/074_shadow_eval_idempotency.sql',
   import.meta.url,
 );
-const INDEX = 'idx_aal_shadow_source';
 // Test rows use source_message_id values under this prefix so cleanup never deletes real rows.
 const PFX = 'itest-shadow-idem-';
 
@@ -38,19 +37,33 @@ describeIf('migration 074: shadow-eval idempotency', () => {
 
   beforeAll(async () => {
     pool = new pg.Pool({ connectionString: DATABASE_URL });
+    // Safety rail: this suite runs the migration's UNSCOPED, table-wide dedup DELETE + CREATE INDEX,
+    // so it must never touch a real database. Refuse to run unless connected to a *test* database —
+    // a mispointed DATABASE_URL (e.g. prod) fails loudly HERE, before any DDL executes. (No shared
+    // curia_test fixture exists in the repo yet; this in-file guard is the minimal safeguard.)
+    const { rows } = await pool.query<{ db: string }>('SELECT current_database() AS db');
+    const dbName = rows[0]!.db;
+    if (!/test/i.test(dbName)) {
+      await pool.end();
+      throw new Error(
+        `Refusing to run the destructive migration-074 integration test against database "${dbName}". ` +
+          'Point DATABASE_URL at a test database (its name must contain "test").',
+      );
+    }
     const full = await readFile(MIGRATION_SQL_URL, 'utf8');
     // Run only the Up half — the Down's DROP INDEX would otherwise remove what we assert.
     upSql = full.split('-- Down Migration')[0]!;
   });
 
-  // Clean slate: drop the index and delete only our scoped rows before each case.
+  // Clean slate: drop the index and delete only our scoped rows before each case. The index name is
+  // a fixed literal (not interpolated) to keep the DDL out of the parameterized-query lint's sights.
   beforeEach(async () => {
-    await pool.query(`DROP INDEX IF EXISTS ${INDEX}`);
+    await pool.query('DROP INDEX IF EXISTS idx_aal_shadow_source');
     await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
   });
 
   afterAll(async () => {
-    await pool.query(`DROP INDEX IF EXISTS ${INDEX}`);
+    await pool.query('DROP INDEX IF EXISTS idx_aal_shadow_source');
     await pool.query(`DELETE FROM autonomy_action_log WHERE payload->>'source_message_id' LIKE $1`, [`${PFX}%`]);
     await pool.end();
   });

--- a/tests/integration/require-test-db.ts
+++ b/tests/integration/require-test-db.ts
@@ -1,0 +1,36 @@
+// Shared safety guard for destructive integration suites.
+//
+// Some integration tests run UNSCOPED, table-wide DDL/DML — e.g. the migration-074 idempotency
+// suite executes the migration's own dedup `DELETE` and `CREATE UNIQUE INDEX` against the whole
+// `autonomy_action_log` table. A mispointed `DATABASE_URL` (staging, prod, a personal DB) must fail
+// LOUDLY before any such statement runs, never silently mutate real data.
+//
+// Per the repo convention (learning from #1429): `DATABASE_URL` presence stays the execution GATE
+// (`describeIf` / `describe.skip`); database-NAME enforcement, when a destructive suite needs it,
+// lives here in ONE shared helper rather than as a one-off guard copied into each test file. The
+// match is EXACT — a substring/regex check (e.g. `/test/i`) would wave through databases like
+// `production_test`, `contest`, or `customer-testing`.
+import type pg from 'pg';
+
+/**
+ * The canonical isolated integration-test database name. CI's Postgres service (`.github/workflows/
+ * ci.yml`, `dast.yml`) and the local `curia-test-pg` container both provision exactly this name.
+ */
+export const CURIA_TEST_DB = 'curia_test';
+
+/**
+ * Throw unless `pool` is connected to the canonical `curia_test` database. Call this in `beforeAll`,
+ * before any destructive statement. Uses `current_database()` (the database actually connected to)
+ * rather than parsing `DATABASE_URL`, so it reflects the real target even if the connection string
+ * resolves somewhere unexpected.
+ */
+export async function requireCuriaTestDatabase(pool: pg.Pool): Promise<void> {
+  const { rows } = await pool.query<{ db: string }>('SELECT current_database() AS db');
+  const dbName = rows[0]?.db;
+  if (dbName !== CURIA_TEST_DB) {
+    throw new Error(
+      `Refusing to run a destructive integration test against database "${dbName ?? '<unknown>'}". ` +
+        `Point DATABASE_URL at the isolated "${CURIA_TEST_DB}" database.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes #1432. Re-scoped after #1438 landed (which already made the resolve/completion sagas self-healing).

Three email-observation write paths were flagged as non-atomic, not-durably-idempotent. This PR:

- **Item 1 (real fix): shadow reconciliation double-scoring.** `ceo-inbox-sent-observe` inserted a pre-scored `shadow_evaluated` row into `autonomy_action_log`, then marked the shadow doc `reconciled_at`. If the mark failed after the insert, the watermark was held and the next run re-judged and re-inserted a **duplicate** row (the marker was the only idempotency record, written *after* the insert). Now a partial unique index is the durable backstop:
  - **Migration 074** — dedups existing `shadow_evaluated` rows (keep lowest id per `source_message_id`) **before** creating a partial unique index `((payload->>'source_message_id')) WHERE outcome = 'shadow_evaluated'`. Dedup-first avoids aborting on pre-existing prod duplicates. Down path is symmetric and non-aborting (`DROP INDEX IF EXISTS`).
  - **`ActionLogRepo.insertShadowEvaluated()`** — `ON CONFLICT DO NOTHING`, returns `null` when the row already exists (not an error).
  - **Handler** — swaps to the idempotent insert; a `null` return falls through to the `reconciled_at` mark so the re-run converges. `reconciled_at` + watermark-hold remain the efficiency guard; the DB constraint is the correctness backstop.

- **Items 2–3 (verification): resolve/completion replay coverage.** #1438 already restructured both sagas to be self-healing (digest-first ordering; content-idempotent mutations; surfaced soft-rejects). Added replay tests proving it. Verification surfaced one genuine latent bug in the **undo path** and fixed it (see below).

## Notable fix surfaced by review

`resolve-learning-digest`'s `undo_completion` called `reopenTask` unconditionally, but `reopenTask` **throws** on any non-`done` task. On a replay after a soft-rejected digest clear, the second call threw → was swallowed by the handler's outer catch → the digest item **wedged permanently**. Added a status guard mirroring the existing `confirm_completion` path (reopen only when still `done`; an already-open task falls through to clear; missing/raced task fails loud and keeps the item). This is a behavior change to a #1438-owned saga, included because it directly serves AC#2.

## Test plan

- `migrate-shadow-eval-idempotency.test.ts` (live Postgres): dedup keeps lowest id; duplicate insert rejected once indexed; distinct source ids coexist. **3/3 pass.**
- `ceo-inbox-sent-observe` handler: cross-run replay — failed mark on run 1 (watermark held) → run 2 re-observes → **no second row**. AC#1.
- `resolve-learning-digest`: mid-saga clear soft-reject replay for approve/undo/confirm; undo now converges idempotently. AC#2.
- `task-completion-from-sent`: digest soft-reject → nothing completed/consumed; completeTask throws after digest lands → candidate retained + undo note durable; clean replay → no re-completion. AC#3.
- Full: **77 unit + 3 integration pass, typecheck clean.**

## Acceptance criteria

- [x] Re-running shadow reconciliation after a marker-write failure creates no second `shadow_evaluated` row.
- [x] Replaying `resolve-learning-digest` after a mid-saga failure does not double-apply (undo path fixed).
- [x] Replaying `task-completion-from-sent` after a partial write reconciles to a consistent state.
- [x] Migration has a symmetric, non-aborting down path.
- [x] Unit/integration tests cover each replay scenario.

Part of #1419.