### PR TITLE
fix(sent-observe): drain >SENT_MAX_SCAN Sent backlogs oldest-first (#1431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Learning-subsystem config writes** — soft-rejected `ConfigStore` writes now hold state instead of silently advancing. (#1438)
 - **`resolve-learning-digest`** undo now guards on task status, so a failed clear can't wedge the item. (#1432)
 - **`sent-observe`** shadow reconciliation now dedups on a DB unique index; a failed marker write can't double-score. (#1432)
+- **`ceo-inbox-sent-observe`** — drains Sent backlogs over `SENT_MAX_SCAN` oldest-first; first run stays forward-only. (#1431)
 
 ### Added
 

--- a/docs/wip/2026-07-19-sent-observe-backfill-design.md
+++ b/docs/wip/2026-07-19-sent-observe-backfill-design.md
@@ -73,6 +73,14 @@ window is re-observed next run.
   the next `[watermark, minDate]` scan yields a strictly older `minDate` (and thus
   a strictly lower ceiling) — unless ≥500 sends share the exact same Unix second,
   which is impossible for one CEO's Sent folder. Documented as a non-issue.
+- **Soft-reject safety:** `ConfigStore.set` can soft-reject (`stored:false`) without
+  throwing on a dedup conflict, so every backfill write checks `stored` (the `#1438`
+  discipline the rest of the handler already follows). Entry writes `backfill_target`
+  first and only sets `backfill_before` once the target lands, so the drain can never
+  become active with a missing target. Completion floor-guards the jump with
+  `max(watermark, backfill_target) + 1`, so a lost/desynced target advances to the
+  pinned floor + 1 (a fresh, idempotent forward re-scan) rather than resetting the
+  watermark to epoch. A lost descend or clear simply reconciles on the next run.
 
 ### Worked example (1200 messages `d1 … d1200`, floor `F > 0`, ceiling 500)
 

--- a/docs/wip/2026-07-19-sent-observe-backfill-design.md
+++ b/docs/wip/2026-07-19-sent-observe-backfill-design.md
@@ -1,0 +1,128 @@
+# sent-observe: drain `>SENT_MAX_SCAN` Sent backlogs oldest-first
+
+**Issue:** curia#1431 (part of #1419). **Date:** 2026-07-19.
+
+## Problem
+
+`ceo-inbox-sent-observe` polls the CEO's Sent folder via a single forward
+`received_after` watermark floor. Nylas returns messages **newest-first**, so a
+window with more than `SENT_MAX_SCAN` (500) unobserved messages yields only the
+newest 500. The current, deliberate policy advances the watermark to the newest
+message seen and warns that the older tail was skipped — permanently. That is
+acceptable at steady state (a day never approaches 500 sends) but means a
+**first-run / post-downtime backfill against a large existing mailbox** never
+observes the historical tail below the newest 500.
+
+A single forward floor cannot express "drain the oldest messages first," so
+draining the tail requires a second, descending bound.
+
+## Decision: forward-only on the first-ever run
+
+On the **first-ever run** (watermark `0`, empty state) the observer does **not**
+backfill historical Sent mail. A normal run already advances the watermark to the
+newest message seen; on a fresh install there are no draft snapshots, open tasks,
+or shadow docs to match, so matching is a near-noop and the watermark simply lands
+at the newest existing send — the true forward frontier. We therefore only need to
+**not initiate a backfill when `watermark === 0`**. Backfill applies solely to the
+**post-downtime** case (a non-zero watermark with a large gap above it).
+
+Rationale: draining the entire Sent history would run many rounds of LLM
+shadow-judging against stale mail that has no live drafts/tasks/shadows to match —
+wasted work for a forward-looking observer. (Confirmed with the CEO.)
+
+## Mechanism: pinned floor + descending ceiling
+
+Two new `ceo_inbox` config keys (plain integer seconds stored as strings, like the
+watermark):
+
+- **`sent_observe.backfill_before`** — a `received_before` ceiling. Its *presence*
+  (a finite value) means "a backfill drain is in progress." Descends each run.
+- **`sent_observe.backfill_target`** — the newest message date seen when the backlog
+  was detected. The watermark jumps to `target + 1` only when the drain completes.
+
+The main watermark (`sent_observe.last_seen_at`) stays **pinned at its original
+floor** for the entire drain and doubles as the `received_after` floor for every
+backfill scan, so no separate "backfill floor" key is needed.
+
+### Run logic
+
+`advanceOk` gating is unchanged: any evidence-persist / guard-write / shadow-batch
+failure still HOLDS all state (no watermark move, no backfill-key move) so the same
+window is re-observed next run.
+
+| Mode | Scan window | Truncated | Not truncated (drained) |
+|---|---|---|---|
+| **Normal** (`backfill_before` unset) | `[watermark, ∞)` | `watermark === 0` → forward-only: advance `watermark = maxDate+1`, **no backfill**. `watermark > 0` → enter backfill: set `target = maxDate`, `backfill_before = minDate`; **do not advance watermark** | advance `watermark = maxDate+1` (unchanged behavior) |
+| **Backfill** (`backfill_before` set) | `[watermark, backfill_before]` | descend: `backfill_before = minDate` | drain complete: `watermark = target + 1`, clear both backfill keys |
+
+### Why this is correct
+
+- **No message permanently skipped** (criterion 1): the descending ceiling walks
+  the window oldest-ward until a sub-window fits under the ceiling, draining the
+  whole `[watermark, target]` range across successive runs.
+- **Watermark never advances past an unobserved message** (criterion 2, literal):
+  during a drain the watermark stays at the original floor and only jumps to
+  `target + 1` once the final (non-truncated) backfill run has observed the oldest
+  sub-window. It never sits above an un-drained message.
+- **Idempotent re-processing** (criterion 3): `backfill_before = minDate` is
+  *inclusive* (Nylas `received_before` is inclusive), so the boundary second is
+  re-scanned next run — guaranteeing a same-second group split by the 500 ceiling
+  is never lost. The already-matched-draft, asked-task, and shadow `reconciled_at`
+  guards make the re-processed boundary (and any held-window retry) a no-op.
+- **Progress guarantee:** truncation means messages older than `minDate` exist, so
+  the next `[watermark, minDate]` scan yields a strictly older `minDate` (and thus
+  a strictly lower ceiling) — unless ≥500 sends share the exact same Unix second,
+  which is impossible for one CEO's Sent folder. Documented as a non-issue.
+
+### Worked example (1200 messages `d1 … d1200`, floor `F > 0`, ceiling 500)
+
+1. Normal run, `[F, ∞)` → newest 500 `d701…d1200`, truncated. `target = d1200`,
+   `backfill_before = d701`. Watermark stays `F`.
+2. Backfill run, `[F, d701]` → `d201…d700`, truncated. `backfill_before = d201`.
+3. Backfill run, `[F, d201]` → `d1…d200`, not truncated → drained.
+   `watermark = d1200 + 1`, clear both keys.
+
+Every message observed once; watermark jumps only after the entire range is drained.
+
+## Client change
+
+Add `receivedBefore?: number` to `ListMessagesOptions` in `ceo-nylas-client.ts`,
+wired into `listMessages` and `listAllMessages`. As with `receivedAfter`, it is sent
+only on the first request; Nylas's `next_cursor` carries the filter on later pages.
+
+## Truncation warning (criterion 3 wording)
+
+The warning fires every truncated run until the backlog is drained, reworded so it
+no longer claims the tail "will not be revisited":
+
+- `watermark > 0` (backfill active): "backfill in progress — draining oldest-first
+  across successive runs," with the current ceiling and remaining floor.
+- `watermark === 0` (first run): a distinct notice that historical mail is
+  intentionally not backfilled (forward-only observer).
+
+## New mail during a drain
+
+While a multi-run drain is active the ceiling caps scanning below `target`, so mail
+sent *after* the backlog was detected is not observed until the drain finishes and
+the normal forward poll resumes. This is acceptable for a rare first-run /
+post-downtime event and is documented in the handler.
+
+## Testing (TDD)
+
+- Multi-page backlog drains to completion over ≥2 runs with **no** message skipped
+  (assert every id is observed across runs).
+- Watermark stays pinned during the drain, then jumps to `target + 1` on completion;
+  backfill keys cleared.
+- Watermark-0 first run: forward-only, advances to newest, **no** backfill keys set.
+- A backfill run whose evidence-persist fails holds its window (no key moves).
+- Idempotent re-processing across a held-window retry (boundary second re-scan does
+  not double-append a diff / double-queue a candidate).
+- Client: `receivedBefore` is sent on the first request and not re-sent on cursor
+  pages.
+
+## Versioning & changelog
+
+- Patch bump `skills/ceo-inbox-sent-observe/skill.json` (infrastructure resilience
+  fix, no new user-facing capability).
+- CHANGELOG under **Fixed**.
+- No ADR: this refines an existing mechanism within ADR-029, not a new decision.

--- a/docs/wip/2026-07-19-sent-observe-backfill.md
+++ b/docs/wip/2026-07-19-sent-observe-backfill.md
@@ -1,0 +1,430 @@
+# sent-observe Oldest-First Backlog Drain — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drain `>SENT_MAX_SCAN` Sent-folder backlogs oldest-first across successive runs so no message is permanently skipped, while keeping the first-ever run forward-only.
+
+**Architecture:** Add a `receivedBefore` filter to the CEO Nylas client, then replace the sent-observe watermark-advance block with a small state machine over two new `ceo_inbox` config keys (`backfill_before` = descending `received_before` ceiling, `backfill_target` = the newest date to jump the watermark to on completion). The main watermark stays pinned to its floor during a drain.
+
+**Tech Stack:** TypeScript (ESM, Node 24+), Vitest, Nylas v3 REST, KG-backed `ConfigStore`.
+
+## Global Constraints
+
+- ESM only; `.js` extensions on all relative imports; no `any`.
+- Skills never throw — return `{ success: true, data }` / `{ success: false, error }`.
+- pino logging only; no `console.log`.
+- Typecheck with `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill run typecheck` before every `.ts` commit.
+- Run tests with `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill test <path>`.
+- Nylas `received_before` and `received_after` are **inclusive** Unix-second bounds.
+- Commit style: conventional (`fix:` / `test:`), sign off with `-s`, no Co-Authored-By / no AI attribution.
+- Config sentinel: `'0'` (`EPOCH`) means "backfill key unset"; a real ceiling/target is always a Unix-second value `> 0`.
+
+---
+
+### Task 1: Add `receivedBefore` to the CEO Nylas client
+
+**Files:**
+- Modify: `skills/_shared/ceo-nylas-client.ts` (`ListMessagesOptions`, `listMessages`, `listAllMessages`)
+- Test: `skills/_shared/ceo-nylas-client.test.ts` (create if absent, else append)
+
+**Interfaces:**
+- Produces: `ListMessagesOptions.receivedBefore?: number`; `listAllMessages({ folder, receivedAfter?, receivedBefore?, maxScan? })` sends `received_before` on the **first** request only (cursor carries it thereafter).
+
+- [ ] **Step 1: Write the failing test.** Confirm `received_before` is sent on the first page and NOT re-sent once a `page_token` is present.
+
+```ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { CeoNylasClient } from './ceo-nylas-client.js';
+
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe('CeoNylasClient.listAllMessages received_before', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('sends received_before on page 1 and not on cursor pages', async () => {
+    const urls: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      urls.push(String(url));
+      // Page 1 → one message + a cursor; page 2 → empty, no cursor.
+      if (String(url).includes('page_token')) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ data: [{ id: 'm1', date: 100, folders: ['SENT'] }], next_cursor: 'CUR' }),
+        { status: 200 },
+      );
+    });
+
+    const client = new CeoNylasClient('key', 'grant', log);
+    const { messages } = await client.listAllMessages({
+      folder: 'SENT',
+      receivedAfter: 50,
+      receivedBefore: 200,
+      maxScan: 500,
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(urls[0]).toContain('received_before=200');
+    expect(urls[0]).toContain('received_after=50');
+    expect(urls[1]).toContain('page_token=CUR');
+    expect(urls[1]).not.toContain('received_before');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — expect FAIL** (`received_before` not in URL).
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill test skills/_shared/ceo-nylas-client.test.ts`
+Expected: FAIL on `urls[0]` assertion.
+
+- [ ] **Step 3: Implement.** In `ceo-nylas-client.ts`:
+
+Add to `ListMessagesOptions` (after `receivedAfter?: number;`):
+```ts
+  /** Inclusive upper bound (Unix seconds). Nylas returns messages with date <= this. */
+  receivedBefore?: number;
+```
+
+In `listMessages`, in the non-`query` branch after the `receivedAfter` line:
+```ts
+      if (options.receivedBefore !== undefined) params.set('received_before', String(options.receivedBefore));
+```
+
+In `listMessages`, extend the `query`-suppression warning object to include `receivedBefore` alongside `receivedAfter` so a caller combining search + `received_before` is still warned:
+```ts
+      if (options.folder || options.unread !== undefined || options.receivedAfter !== undefined || options.receivedBefore !== undefined) {
+        this.log.warn(
+          { suppressedOptions: { folder: options.folder, unread: options.unread, receivedAfter: options.receivedAfter, receivedBefore: options.receivedBefore } },
+          'nylas: listMessages — folder/unread/receivedAfter/receivedBefore ignored because search_query_native is set (Nylas v3 limitation)',
+        );
+      }
+```
+
+In `listAllMessages`, inside the first-page `else` block (where `receivedAfter` is set), after the `receivedAfter` block:
+```ts
+        if (options.receivedBefore !== undefined) {
+          params.set('received_before', String(options.receivedBefore));
+        }
+```
+Also update the method's doc comment: filters now read `(in/received_after/received_before)`.
+
+- [ ] **Step 4: Run the test — expect PASS.**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill test skills/_shared/ceo-nylas-client.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit.**
+
+```bash
+pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill run typecheck
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill add skills/_shared/ceo-nylas-client.ts skills/_shared/ceo-nylas-client.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill commit -s -m "feat(ceo-nylas-client): add received_before filter for oldest-first paging (#1431)"
+```
+
+---
+
+### Task 2: Backfill state machine in the sent-observe handler
+
+**Files:**
+- Modify: `skills/ceo-inbox-sent-observe/handler.ts`
+- Test: `skills/ceo-inbox-sent-observe/handler.test.ts`
+
+**Interfaces:**
+- Produces (exported constants, for tests): `BACKFILL_BEFORE_KEY = 'sent_observe.backfill_before'`, `BACKFILL_TARGET_KEY = 'sent_observe.backfill_target'`.
+- Consumes: `ConfigStore.get/set` (Task-0 existing), `CeoNylasClient.listAllMessages({ receivedBefore })` (Task 1).
+
+**Behavior contract (implement exactly):**
+- Read `watermark` (existing), `backfillBefore = Number(get(BACKFILL_BEFORE_KEY)) || 0`, `backfillTarget = Number(get(BACKFILL_TARGET_KEY)) || 0`. `backfillMode = backfillBefore > 0`.
+- Scan: `listAllMessages({ folder:'SENT', ...(watermark>0?{receivedAfter:watermark}:{}), ...(backfillMode?{receivedBefore:backfillBefore}:{}), maxScan:SENT_MAX_SCAN })`.
+- After processing + `advanceOk` computed, replace the watermark-advance block:
+  - If `advanceOk`:
+    - **Backfill mode:** if `messages.length > 0 && truncated` → `set(BACKFILL_BEFORE_KEY, String(minDate))` (descend; watermark pinned). Else (drained / empty window) → `set(WATERMARK_KEY, String(backfillTarget + 1))`, `set(BACKFILL_BEFORE_KEY, EPOCH)`, `set(BACKFILL_TARGET_KEY, EPOCH)`; `watermarkAdvancedTo = backfillTarget + 1`.
+    - **Normal mode** and `messages.length > 0`: if `truncated && watermark > 0` → enter backfill: `set(BACKFILL_TARGET_KEY, String(maxDate))`, `set(BACKFILL_BEFORE_KEY, String(minDate))` (watermark pinned). Else → `set(WATERMARK_KEY, String(maxDate + 1))`; `watermarkAdvancedTo = maxDate + 1`.
+  - Else (`!advanceOk` and `messages.length > 0`): existing hold-warn (unchanged).
+- Truncation warning: keep firing when `truncated`, reworded (see Step 3).
+- Idle backoff: set `IDLE_BACKOFF_KEY = nowMs` only when `messages.length === 0 && !backfillMode` (a mid-drain empty window completes the drain, it is not idle). Otherwise `set(IDLE_BACKOFF_KEY, EPOCH)`.
+- Result `data` gains `backfill_active: boolean` (true when `backfillBefore > 0` after this run's writes, i.e. a drain is still in progress).
+
+- [ ] **Step 1: Write the failing tests.** Append to `handler.test.ts`. Uses a `fetch` mock that returns pages by `received_before` window. Helper to build N summary messages:
+
+```ts
+// --- #1431 backfill drain ---
+function sentMsg(id: string, date: number) {
+  return { id, thread_id: '', subject: `s-${id}`, from: [{ email: 'ceo@x.com' }],
+    to: [{ email: 'a@x.com' }], cc: [], snippet: '', date, unread: false, folders: ['SENT'], attachments: [] };
+}
+
+// Serve a fixed corpus newest-first, honoring received_after / received_before / limit / page_token.
+// Cursor is the numeric index of the next message to return, encoded in the token.
+function serveCorpus(mockFetch: ReturnType<typeof vi.spyOn>, corpus: Array<{ id: string; date: number }>) {
+  const sorted = [...corpus].sort((a, b) => b.date - a.date); // newest-first
+  mockFetch.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+    const u = new URL(String(url));
+    if (u.pathname.includes('/messages/')) {
+      // getMessage — not needed for these no-match tests, but answer safely.
+      return new Response(JSON.stringify({ data: { id: 'x', date: 0, body: '', folders: ['SENT'] } }), { status: 200 });
+    }
+    const after = u.searchParams.get('received_after');
+    const before = u.searchParams.get('received_before');
+    const limit = Number(u.searchParams.get('limit') ?? '20');
+    const token = u.searchParams.get('page_token');
+    // Filter once; the cursor walks the filtered list.
+    const filtered = sorted.filter((m) =>
+      (after === null || m.date >= Number(after)) && (before === null || m.date <= Number(before)));
+    const start = token ? Number(token) : 0;
+    const slice = filtered.slice(start, start + limit);
+    const nextStart = start + limit;
+    const body: Record<string, unknown> = { data: slice.map((m) => sentMsg(m.id, m.date)) };
+    if (nextStart < filtered.length) body.next_cursor = String(nextStart);
+    return new Response(JSON.stringify(body), { status: 200 });
+  });
+}
+
+describe('#1431 oldest-first backlog drain', () => {
+  const BACKFILL_BEFORE_KEY = 'sent_observe.backfill_before';
+  const BACKFILL_TARGET_KEY = 'sent_observe.backfill_target';
+
+  it('drains a >SENT_MAX_SCAN backlog across runs with no message skipped', async () => {
+    // 1100 messages, dates 1000..2099 (unique seconds), floor watermark = 999.
+    const corpus = Array.from({ length: 1100 }, (_, i) => ({ id: `m${i}`, date: 1000 + i }));
+    const handler = new CeoInboxSentObserveHandler();
+    const mockFetch = vi.spyOn(globalThis, 'fetch');
+    serveCorpus(mockFetch, corpus);
+
+    const seed: Record<string, string> = { [WATERMARK_KEY]: '999' };
+    const observedDates = new Set<number>();
+    // Wrap serveCorpus to record which dates were returned in list responses.
+    const origFetch = mockFetch.getMockImplementation()!;
+    mockFetch.mockImplementation(async (url) => {
+      const res = await origFetch(url);
+      const clone = res.clone();
+      const j = await clone.json().catch(() => null);
+      if (j && Array.isArray(j.data)) for (const m of j.data) observedDates.add(m.date);
+      return res;
+    });
+
+    // Run until backfill clears (guard against runaway).
+    for (let run = 0; run < 10; run++) {
+      const ctx = buildCtx({ seed, force: true, nowMs: 9_000_000_000_000, tasks: [] });
+      // Carry config forward between runs.
+      for (const [k, v] of Object.entries(seed)) ctx.__mem.__values.set(k, v);
+      const result = await handler.execute(ctx);
+      expect(result.success).toBe(true);
+      for (const [k, v] of ctx.__mem.__values.entries()) seed[k] = v; // persist state
+      if (!(Number(seed[BACKFILL_BEFORE_KEY] ?? '0') > 0)) break;
+    }
+
+    // Every message date must have been observed at least once.
+    for (let d = 1000; d <= 2099; d++) expect(observedDates.has(d)).toBe(true);
+    // Watermark ends past the newest; backfill keys cleared.
+    expect(seed[WATERMARK_KEY]).toBe(String(2099 + 1));
+    expect(Number(seed[BACKFILL_BEFORE_KEY] ?? '0')).toBe(0);
+    expect(Number(seed[BACKFILL_TARGET_KEY] ?? '0')).toBe(0);
+  });
+
+  it('first-ever run (watermark 0) is forward-only — no backfill initiated', async () => {
+    const corpus = Array.from({ length: 1100 }, (_, i) => ({ id: `m${i}`, date: 1000 + i }));
+    const handler = new CeoInboxSentObserveHandler();
+    const mockFetch = vi.spyOn(globalThis, 'fetch');
+    serveCorpus(mockFetch, corpus);
+
+    const ctx = buildCtx({ force: true, nowMs: 9_000_000_000_000, tasks: [] }); // no watermark seed → 0
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    // Advanced to the newest seen, NO backfill state written.
+    expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe(String(2099 + 1));
+    expect(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY)).toBeUndefined();
+    expect(ctx.__mem.__values.get(BACKFILL_TARGET_KEY)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — expect FAIL** (backfill never initiated; drain test sees skipped dates / wrong watermark).
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill test skills/ceo-inbox-sent-observe/handler.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement in `handler.ts`.**
+
+Add exported constants near `WATERMARK_KEY`:
+```ts
+/** Descending `received_before` ceiling for an in-progress oldest-first backlog drain (#1431).
+ *  Presence (a value > EPOCH) means a drain is underway; it walks toward WATERMARK across runs. */
+export const BACKFILL_BEFORE_KEY = 'sent_observe.backfill_before';
+/** Newest message date captured when a >SENT_MAX_SCAN backlog was detected (#1431). The watermark
+ *  jumps to backfill_target + 1 only once the drain reaches the oldest sub-window. */
+export const BACKFILL_TARGET_KEY = 'sent_observe.backfill_target';
+```
+
+Read backfill state right after `watermark` is computed:
+```ts
+    const backfillBeforeRaw = await store.get(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY);
+    const backfillBefore = backfillBeforeRaw && Number.isFinite(Number(backfillBeforeRaw)) ? Number(backfillBeforeRaw) : 0;
+    const backfillTargetRaw = await store.get(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY);
+    const backfillTarget = backfillTargetRaw && Number.isFinite(Number(backfillTargetRaw)) ? Number(backfillTargetRaw) : 0;
+    // A drain is in progress iff a finite ceiling is stored. During a drain the watermark stays
+    // pinned to its floor (the received_after bound) and only jumps to backfillTarget+1 on completion.
+    const backfillActive = backfillBefore > 0;
+```
+
+Change the `listAllMessages` call to add the ceiling:
+```ts
+    const { messages, truncated } = await client.listAllMessages({
+      folder: 'SENT',
+      ...(watermark > 0 ? { receivedAfter: watermark } : {}),
+      ...(backfillActive ? { receivedBefore: backfillBefore } : {}),
+      maxScan: SENT_MAX_SCAN,
+    });
+```
+
+Replace the watermark-advance block (the `if (messages.length > 0 && maxDate >= watermark && advanceOk) { ... } else if (...) { warn }` block) with:
+```ts
+    // Watermark / backfill state transition (#1431). advanceOk still gates everything: any
+    // evidence-persist / guard / shadow failure holds ALL state (no watermark move, no backfill
+    // move) so the same window is re-observed next run.
+    let watermarkAdvancedTo: number | null = null;
+    if (advanceOk) {
+      if (backfillActive) {
+        if (messages.length > 0 && truncated) {
+          // Still an older tail below minDate — descend the ceiling; watermark stays pinned.
+          // minDate (inclusive) re-scans the boundary second next run so a same-second group
+          // split by the SENT_MAX_SCAN ceiling is never lost (re-processing is idempotent via
+          // the matched/asked/reconciled guards).
+          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, String(minDate));
+        } else {
+          // Drain complete (window fully scanned, or emptied). Jump the watermark past the newest
+          // date captured when the backlog was detected, then clear the backfill keys.
+          watermarkAdvancedTo = backfillTarget + 1;
+          await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
+          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, EPOCH);
+          await store.set(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY, EPOCH);
+        }
+      } else if (messages.length > 0) {
+        if (truncated && watermark > 0) {
+          // A real gap above a known floor exceeded the scan ceiling: begin an oldest-first drain.
+          // Record the newest date (watermark jumps here on completion) and set the first ceiling
+          // to this batch's oldest. The watermark is NOT advanced — it stays the drain's floor, so
+          // it never sits above an un-drained message.
+          await store.set(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY, String(maxDate));
+          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, String(minDate));
+        } else {
+          // Normal forward advance. Covers the non-truncated case AND the first-ever run
+          // (watermark 0): forward-only observation, historical tail intentionally not backfilled.
+          watermarkAdvancedTo = maxDate + 1;
+          await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
+        }
+      }
+    } else if (messages.length > 0) {
+      const holdReason = !evidencePersisted
+        ? 'ceo-inbox-sent-observe: evidence persistence failed — holding watermark for retry'
+        : !draftEvidenceComplete
+          ? 'ceo-inbox-sent-observe: draft body fetch failed — holding watermark for retry'
+          : !shadowReconcileOk
+            ? 'ceo-inbox-sent-observe: shadow reconcile failed — holding watermark for retry'
+            : 'ceo-inbox-sent-observe: guard write failed — holding watermark for retry';
+      ctx.log.warn(
+        { path: PENDING_DIFFS_PATH, evidencePersisted, shadowReconcileOk, draftEvidenceComplete, matchedGuardPersisted, askedGuardPersisted },
+        holdReason,
+      );
+    }
+    // True when a drain is still underway after this run's writes (fed back to the caller/logs).
+    const backfillStillActive = backfillActive
+      ? watermarkAdvancedTo === null // descended (not completed)
+      : (truncated && watermark > 0 && messages.length > 0); // just initiated
+```
+
+Reword the truncation warning block:
+```ts
+    if (truncated) {
+      if (watermark > 0) {
+        ctx.log.warn(
+          { scanned: messages.length, maxScan: SENT_MAX_SCAN, floor: watermark,
+            ceiling: backfillActive ? backfillBefore : null, nextCeiling: Number.isFinite(minDate) ? minDate : null,
+            backfillTarget: backfillActive ? backfillTarget : maxDate },
+          `ceo-inbox-sent-observe: Sent window exceeded the ${SENT_MAX_SCAN}-message scan ceiling — ` +
+            'draining the older tail oldest-first across successive runs (backfill in progress).',
+        );
+      } else {
+        ctx.log.warn(
+          { scanned: messages.length, maxScan: SENT_MAX_SCAN, advancedTo: watermarkAdvancedTo },
+          `ceo-inbox-sent-observe: first run against a large mailbox exceeded the ${SENT_MAX_SCAN}-message ` +
+            'scan ceiling — observing forward-only; historical mail is intentionally not backfilled.',
+        );
+      }
+    }
+```
+
+Change the idle-backoff block so a mid-drain empty window does not register as idle:
+```ts
+    if (messages.length === 0 && !backfillActive) {
+      await store.set(CONFIG_NAMESPACE, IDLE_BACKOFF_KEY, String(nowMs));
+    } else {
+      await store.set(CONFIG_NAMESPACE, IDLE_BACKOFF_KEY, EPOCH);
+    }
+```
+
+Add `backfill_active: backfillStillActive` to BOTH the early idle-backoff-skip `data` object and the final `data` object (the early skip is never mid-drain, so pass `false` there).
+
+Update the `run complete` info log to include `backfillStillActive`.
+
+- [ ] **Step 4: Run the tests — expect PASS** (both new tests).
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill test skills/ceo-inbox-sent-observe/handler.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Fix the pre-existing truncation test.** The test `on truncation advances forward and warns` runs at watermark 0 and asserts a forward advance + a warn. Under the new wording it still advances forward and still warns (the watermark-0 branch), so confirm it passes; if its warn-message assertion is substring-specific, update the substring to match the new watermark-0 message. Do NOT weaken its watermark-advance assertion. Add one assertion: `expect(ctx.__mem.__values.get('sent_observe.backfill_before')).toBeUndefined();`
+
+- [ ] **Step 6: Run the whole sent-observe suite + typecheck.**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill test skills/ceo-inbox-sent-observe/`
+Then: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill run typecheck`
+Expected: all PASS, no type errors.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill add skills/ceo-inbox-sent-observe/handler.ts skills/ceo-inbox-sent-observe/handler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill commit -s -m "fix(sent-observe): drain >SENT_MAX_SCAN Sent backlogs oldest-first (#1431)"
+```
+
+---
+
+### Task 3: Version bump, changelog, doc note, PR
+
+**Files:**
+- Modify: `skills/ceo-inbox-sent-observe/skill.json` (patch `version` bump)
+- Modify: `CHANGELOG.md` (under `## [Unreleased]` → `### Fixed`)
+- Modify: `docs/adr/029-passive-email-observation-and-counterfactual-competence.md` (one line noting the oldest-first drain + forward-only first run), if it describes the truncation policy.
+
+- [ ] **Step 1: Bump `skill.json` version** by one patch (e.g. `0.x.Y` → `0.x.(Y+1)`). Read the current value first.
+
+- [ ] **Step 2: Add CHANGELOG entry** under `### Fixed` (≤15 words after the em-dash equivalent — use a period, no em dash):
+
+```md
+- **`ceo-inbox-sent-observe`** — drains Sent backlogs over `SENT_MAX_SCAN` oldest-first; first run stays forward-only. (#1431)
+```
+
+- [ ] **Step 3: ADR note.** If ADR-029 documents the "advance past the tail and warn" truncation policy, add a short note that a `>SENT_MAX_SCAN` post-downtime backlog is now drained oldest-first (`received_before` descending ceiling) while the first-ever run remains forward-only. Skip if ADR-029 does not mention the policy.
+
+- [ ] **Step 4: Full targeted test + typecheck.**
+
+Run: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill test skills/ceo-inbox-sent-observe/ skills/_shared/ceo-nylas-client.test.ts`
+Then: `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill run typecheck`
+
+- [ ] **Step 5: Commit + run auto-review subagents (code-reviewer + silent-failure-hunter) before opening the PR.**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill add -A
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sent-observe-backfill commit -s -m "chore(sent-observe): version bump + changelog for oldest-first drain (#1431)"
+```
+
+- [ ] **Step 6: Push + open PR** with `Closes #1431` in the Summary, describing the pinned-floor/descending-ceiling drain and the forward-only first-run decision. Confirm CI started.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Task 1 = `receivedBefore` client filter. Task 2 = the drain state machine (criteria 1, 2, 3, first-run). Task 2 tests cover the ≥2-run drain and the watermark-0 first run. Task 3 = version/changelog/docs. All spec sections mapped.
+- **Placeholders:** none — every code step shows exact code.
+- **Type consistency:** `BACKFILL_BEFORE_KEY` / `BACKFILL_TARGET_KEY` used identically in handler and tests; `receivedBefore` matches the client option name; `EPOCH` (`'0'`) is the existing handler constant.
+- **Idempotency:** re-processing across the inclusive boundary and held-window retries is covered by the existing matched-draft / asked-task / shadow `reconciled_at` guards — no new idempotency surface introduced.

--- a/skills/_shared/ceo-nylas-client.test.ts
+++ b/skills/_shared/ceo-nylas-client.test.ts
@@ -382,3 +382,52 @@ describe('CeoNylasClient — list limit clamping (≤ 20)', () => {
     expect(calledUrl.searchParams.get('limit')).toBe('20');
   });
 });
+
+// ── received_before (oldest-first paging, #1431) ────────────────────────────
+describe('CeoNylasClient — received_before filter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends received_before on listMessages', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    await client.listMessages({ folder: 'SENT', receivedAfter: 50, receivedBefore: 200 });
+
+    const calledUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(calledUrl.searchParams.get('received_before')).toBe('200');
+    expect(calledUrl.searchParams.get('received_after')).toBe('50');
+  });
+
+  it('listAllMessages sends received_before on page 1 and not on cursor pages', async () => {
+    // Page 1: one message + a cursor. Page 2 (page_token present): empty, no cursor → loop exits.
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes('page_token')) {
+        return makeResponse(200, { data: [] });
+      }
+      return makeResponse(200, {
+        data: [{ id: 'm1', date: 100, folders: ['SENT'] }],
+        next_cursor: 'CUR',
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    const { messages } = await client.listAllMessages({
+      folder: 'SENT',
+      receivedAfter: 50,
+      receivedBefore: 200,
+      maxScan: 500,
+    });
+
+    expect(messages).toHaveLength(1);
+    const page1 = new URL(fetchMock.mock.calls[0]![0] as string);
+    const page2 = new URL(fetchMock.mock.calls[1]![0] as string);
+    expect(page1.searchParams.get('received_before')).toBe('200');
+    expect(page1.searchParams.get('received_after')).toBe('50');
+    expect(page2.searchParams.get('page_token')).toBe('CUR');
+    expect(page2.searchParams.has('received_before')).toBe(false);
+  });
+});

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -120,6 +120,9 @@ export interface ListMessagesOptions {
   unread?: boolean;
   query?: string;
   receivedAfter?: number;
+  /** Inclusive upper bound (Unix seconds). Nylas returns messages with date <= this. Paired with
+   *  receivedAfter, this bounds a sub-window for oldest-first backlog draining (#1431). */
+  receivedBefore?: number;
 }
 
 // Gmail system labels use specific IDs that don't always match the display
@@ -179,10 +182,10 @@ export class CeoNylasClient {
       // Nylas v3: search_query_native cannot be combined with any other filter
       // param except limit and page_token — sending in/unread/received_after
       // alongside it returns HTTP 400 "invalid_request_error".
-      if (options.folder || options.unread !== undefined || options.receivedAfter !== undefined) {
+      if (options.folder || options.unread !== undefined || options.receivedAfter !== undefined || options.receivedBefore !== undefined) {
         this.log.warn(
-          { suppressedOptions: { folder: options.folder, unread: options.unread, receivedAfter: options.receivedAfter } },
-          'nylas: listMessages — folder/unread/receivedAfter ignored because search_query_native is set (Nylas v3 limitation)',
+          { suppressedOptions: { folder: options.folder, unread: options.unread, receivedAfter: options.receivedAfter, receivedBefore: options.receivedBefore } },
+          'nylas: listMessages — folder/unread/receivedAfter/receivedBefore ignored because search_query_native is set (Nylas v3 limitation)',
         );
       }
       params.set('search_query_native', options.query);
@@ -199,6 +202,7 @@ export class CeoNylasClient {
       }
       if (options.unread !== undefined) params.set('unread', String(options.unread));
       if (options.receivedAfter !== undefined) params.set('received_after', String(options.receivedAfter));
+      if (options.receivedBefore !== undefined) params.set('received_before', String(options.receivedBefore));
     }
 
     const url = `${this.baseUrl}/messages?${params}`;
@@ -213,7 +217,7 @@ export class CeoNylasClient {
   // Sent folder that means lost observations (issue: #1429 review). This walks all
   // pages so a watermark-scoped poll actually sees every message in the window.
   //
-  // Filters (in/received_after) are only sent on the first request; Nylas's cursor
+  // Filters (in/received_after/received_before) are only sent on the first request; Nylas's cursor
   // encodes the original query, so subsequent pages carry the filter automatically
   // (same contract listAllDrafts relies on). `truncated` is true when the maxScan
   // ceiling was hit with more pages still available — callers must NOT treat the
@@ -242,6 +246,9 @@ export class CeoNylasClient {
         if (options.unread !== undefined) params.set('unread', String(options.unread));
         if (options.receivedAfter !== undefined) {
           params.set('received_after', String(options.receivedAfter));
+        }
+        if (options.receivedBefore !== undefined) {
+          params.set('received_before', String(options.receivedBefore));
         }
       }
       const url = `${this.baseUrl}/messages?${params}`;

--- a/skills/ceo-inbox-sent-observe/handler.test.ts
+++ b/skills/ceo-inbox-sent-observe/handler.test.ts
@@ -5,6 +5,8 @@ import {
   WATERMARK_KEY,
   IDLE_BACKOFF_KEY,
   PENDING_DIFFS_PATH,
+  BACKFILL_BEFORE_KEY,
+  BACKFILL_TARGET_KEY,
 } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 import type { EntityMemory } from '../../src/memory/entity-memory.js';
@@ -1431,5 +1433,172 @@ describe('CeoInboxSentObserveHandler', () => {
       (c) => String(c[1]),
     );
     expect(warnMsgs.some((m) => /scan ceiling/i.test(m))).toBe(true);
+    // First-ever run (watermark 0) is forward-only: NO backfill drain is initiated (#1431).
+    expect(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY)).toBeUndefined();
+    expect(ctx.__mem.__values.get(BACKFILL_TARGET_KEY)).toBeUndefined();
+  });
+
+  // ── #1431: oldest-first backlog drain ──────────────────────────────────────
+  describe('#1431 oldest-first backlog drain', () => {
+    // A Sent message summary (matches nothing — no snapshots/tasks/shadows in these tests, so the
+    // matching pipeline is a no-op and only the watermark/backfill state machine is exercised).
+    function sentMsg(id: string, date: number) {
+      return {
+        id,
+        thread_id: '',
+        subject: `s-${id}`,
+        from: [{ email: 'ceo@example.com' }],
+        to: [{ email: 'a@example.com' }],
+        cc: [],
+        snippet: '',
+        date,
+        unread: false,
+        folders: ['SENT'],
+        attachments: [],
+      };
+    }
+
+    // Serve a fixed corpus newest-first, honoring received_after (>=), received_before (<=), limit,
+    // and page_token. The cursor encodes `${nextOffset}:${after}:${before}` so a page_token request
+    // (which omits the filters — Nylas carries them on the cursor) still filters correctly. When
+    // `observed` is supplied, every date served in a list page is recorded, so a test can assert no
+    // message was ever skipped across the drain.
+    function serveSentCorpus(
+      fetchSpy: ReturnType<typeof vi.spyOn>,
+      corpus: Array<{ id: string; date: number }>,
+      observed?: Set<number>,
+    ): void {
+      const sorted = [...corpus].sort((a, b) => b.date - a.date);
+      fetchSpy.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+        const u = new URL(String(url));
+        // getMessage — never hit here (nothing matches), but answer with a valid envelope.
+        if (/\/messages\/[^?]+$/.test(u.pathname)) {
+          return new Response(
+            JSON.stringify({ data: { id: 'x', date: 0, body: '', bcc: [], labels: [], folders: ['SENT'] } }),
+            { status: 200 },
+          );
+        }
+        const token = u.searchParams.get('page_token');
+        let start: number;
+        let after: number | null;
+        let before: number | null;
+        if (token) {
+          const [s, a, b] = token.split(':');
+          start = Number(s);
+          after = a === '' ? null : Number(a);
+          before = b === '' ? null : Number(b);
+        } else {
+          start = 0;
+          const a = u.searchParams.get('received_after');
+          const b = u.searchParams.get('received_before');
+          after = a === null ? null : Number(a);
+          before = b === null ? null : Number(b);
+        }
+        const filtered = sorted.filter(
+          (m) => (after === null || m.date >= after) && (before === null || m.date <= before),
+        );
+        const limit = Number(u.searchParams.get('limit') ?? '20');
+        const slice = filtered.slice(start, start + limit);
+        if (observed) for (const m of slice) observed.add(m.date);
+        const nextStart = start + limit;
+        const body: Record<string, unknown> = { data: slice.map((m) => sentMsg(m.id, m.date)) };
+        if (nextStart < filtered.length) body.next_cursor = `${nextStart}:${after ?? ''}:${before ?? ''}`;
+        return new Response(JSON.stringify(body), { status: 200 });
+      });
+    }
+
+    it('drains a >SENT_MAX_SCAN backlog across runs with no message skipped', async () => {
+      // 1100 messages (dates 1000..2099, unique seconds) above a real floor watermark = 999.
+      // SENT_MAX_SCAN is 500, so this needs 3 runs: [1600..2099], [1101..1600], [1000..1101].
+      const corpus = Array.from({ length: 1100 }, (_v, i) => ({ id: `m${i}`, date: 1000 + i }));
+      const observed = new Set<number>();
+      serveSentCorpus(mockFetch, corpus, observed);
+
+      const seed: Record<string, string> = { [WATERMARK_KEY]: '999' };
+      for (let run = 0; run < 10; run++) {
+        const ctx = buildCtx({ seed: { ...seed }, force: true, nowMs: 9_000_000_000_000, tasks: [] });
+        const result = await handler.execute(ctx);
+        expect(result.success).toBe(true);
+        // Carry the resulting config state into the next run.
+        for (const [k, v] of ctx.__mem.__values.entries()) seed[k] = v;
+        if (!(Number(seed[BACKFILL_BEFORE_KEY] ?? '0') > 0)) break;
+      }
+
+      // Every message date was observed at least once — nothing permanently skipped.
+      for (let d = 1000; d <= 2099; d++) expect(observed.has(d)).toBe(true);
+      // The watermark jumps past the newest only after the whole range is drained.
+      expect(seed[WATERMARK_KEY]).toBe('2100');
+      // Backfill keys are cleared once the drain completes.
+      expect(Number(seed[BACKFILL_BEFORE_KEY] ?? '0')).toBe(0);
+      expect(Number(seed[BACKFILL_TARGET_KEY] ?? '0')).toBe(0);
+    });
+
+    it('pins the watermark during the drain and only jumps it on completion', async () => {
+      const corpus = Array.from({ length: 1100 }, (_v, i) => ({ id: `m${i}`, date: 1000 + i }));
+      serveSentCorpus(mockFetch, corpus);
+      const seed: Record<string, string> = { [WATERMARK_KEY]: '999' };
+
+      // Run 1: enters backfill. Watermark stays pinned at 999; target/ceiling recorded.
+      let ctx = buildCtx({ seed: { ...seed }, force: true, nowMs: 9_000_000_000_000, tasks: [] });
+      let result = await handler.execute(ctx);
+      expect((result as { data: { watermark_advanced_to: number | null; backfill_active: boolean } }).data.watermark_advanced_to).toBeNull();
+      expect((result as { data: { backfill_active: boolean } }).data.backfill_active).toBe(true);
+      expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe('999');
+      expect(ctx.__mem.__values.get(BACKFILL_TARGET_KEY)).toBe('2099');
+      expect(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY)).toBe('1600');
+      for (const [k, v] of ctx.__mem.__values.entries()) seed[k] = v;
+
+      // Run 2: descends the ceiling; watermark still pinned.
+      ctx = buildCtx({ seed: { ...seed }, force: true, nowMs: 9_000_000_000_000, tasks: [] });
+      await handler.execute(ctx);
+      expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe('999');
+      expect(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY)).toBe('1101');
+      for (const [k, v] of ctx.__mem.__values.entries()) seed[k] = v;
+
+      // Run 3: drains the oldest sub-window → watermark jumps to target+1, keys cleared.
+      ctx = buildCtx({ seed: { ...seed }, force: true, nowMs: 9_000_000_000_000, tasks: [] });
+      result = await handler.execute(ctx);
+      expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe('2100');
+      expect((result as { data: { backfill_active: boolean } }).data.backfill_active).toBe(false);
+      expect(Number(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY) ?? '0')).toBe(0);
+    });
+
+    it('first-ever run (watermark 0) is forward-only — no backfill initiated', async () => {
+      const corpus = Array.from({ length: 1100 }, (_v, i) => ({ id: `m${i}`, date: 1000 + i }));
+      serveSentCorpus(mockFetch, corpus);
+
+      const ctx = buildCtx({ force: true, nowMs: 9_000_000_000_000, tasks: [] }); // no seed → watermark 0
+      const result = await handler.execute(ctx);
+      expect(result.success).toBe(true);
+      // Advanced to the newest seen; NO backfill drain of history was started.
+      expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe('2100');
+      expect((result as { data: { backfill_active: boolean } }).data.backfill_active).toBe(false);
+      expect(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY)).toBeUndefined();
+      expect(ctx.__mem.__values.get(BACKFILL_TARGET_KEY)).toBeUndefined();
+    });
+
+    it('holds the drain window (no key moves) when evidence persistence fails mid-drain', async () => {
+      // Enter a drain, then on the descend run make the matched-guard write soft-reject so
+      // advanceOk is false: the ceiling must NOT descend and the watermark must stay pinned.
+      const corpus = Array.from({ length: 1100 }, (_v, i) => ({ id: `m${i}`, date: 1000 + i }));
+      serveSentCorpus(mockFetch, corpus);
+      const seed: Record<string, string> = { [WATERMARK_KEY]: '999' };
+
+      // Run 1 enters backfill (ceiling 1600).
+      let ctx = buildCtx({ seed: { ...seed }, force: true, nowMs: 9_000_000_000_000, tasks: [] });
+      await handler.execute(ctx);
+      for (const [k, v] of ctx.__mem.__values.entries()) seed[k] = v;
+      expect(seed[BACKFILL_BEFORE_KEY]).toBe('1600');
+
+      // Run 2: force every storeFact to soft-reject (stored:false) → guard writes fail → advanceOk false.
+      ctx = buildCtx({ seed: { ...seed }, force: true, nowMs: 9_000_000_000_000, tasks: [] });
+      (ctx.__mem.storeFact as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => ({ stored: false, action: 'conflict' as const }),
+      );
+      await handler.execute(ctx);
+      // Ceiling did NOT descend and the watermark stayed pinned — the window retries next run.
+      expect(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY)).toBe('1600');
+      expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe('999');
+    });
   });
 });

--- a/skills/ceo-inbox-sent-observe/handler.test.ts
+++ b/skills/ceo-inbox-sent-observe/handler.test.ts
@@ -1577,6 +1577,35 @@ describe('CeoInboxSentObserveHandler', () => {
       expect(ctx.__mem.__values.get(BACKFILL_TARGET_KEY)).toBeUndefined();
     });
 
+    it('holds the drain (no completion) on an empty page with a lingering cursor (truncated, 0 messages)', async () => {
+      // listAllMessages reports truncated=true even for an empty page that still carries a cursor —
+      // an incomplete walk that must NOT be read as fully drained. A backfill run seeing that shape
+      // must hold (no watermark jump, no key clear), not declare the drain complete.
+      mockFetch.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+        const u = String(url);
+        if (/\/messages\/[^?]+$/.test(new URL(u).pathname)) {
+          return new Response(JSON.stringify({ data: { id: 'x', date: 0, body: '', bcc: [], labels: [], folders: ['SENT'] } }), { status: 200 });
+        }
+        // Empty data + a lingering next_cursor → listAllMessages returns { messages: [], truncated: true }.
+        return new Response(JSON.stringify({ data: [], next_cursor: 'LINGER' }), { status: 200 });
+      });
+
+      const ctx = buildCtx({
+        seed: { [WATERMARK_KEY]: '999', [BACKFILL_BEFORE_KEY]: '1600', [BACKFILL_TARGET_KEY]: '2099' },
+        force: true,
+        nowMs: 9_000_000_000_000,
+        tasks: [],
+      });
+      const result = await handler.execute(ctx);
+      expect(result.success).toBe(true);
+      // Everything held: watermark pinned, keys unchanged, drain still active — retries next run.
+      expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe('999');
+      expect(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY)).toBe('1600');
+      expect(ctx.__mem.__values.get(BACKFILL_TARGET_KEY)).toBe('2099');
+      expect((result as { data: { watermark_advanced_to: number | null; backfill_active: boolean } }).data.watermark_advanced_to).toBeNull();
+      expect((result as { data: { backfill_active: boolean } }).data.backfill_active).toBe(true);
+    });
+
     it('floor-guards completion: a lost backfill_target never regresses the watermark to epoch', async () => {
       // Simulate a desync (a soft-rejected target write left BACKFILL_TARGET unset while a drain is
       // active). On completion the watermark must jump to the pinned floor + 1, NOT to 1 (epoch).

--- a/skills/ceo-inbox-sent-observe/handler.test.ts
+++ b/skills/ceo-inbox-sent-observe/handler.test.ts
@@ -1577,6 +1577,28 @@ describe('CeoInboxSentObserveHandler', () => {
       expect(ctx.__mem.__values.get(BACKFILL_TARGET_KEY)).toBeUndefined();
     });
 
+    it('floor-guards completion: a lost backfill_target never regresses the watermark to epoch', async () => {
+      // Simulate a desync (a soft-rejected target write left BACKFILL_TARGET unset while a drain is
+      // active). On completion the watermark must jump to the pinned floor + 1, NOT to 1 (epoch).
+      const corpus = Array.from({ length: 101 }, (_v, i) => ({ id: `m${i}`, date: 1000 + i })); // 1000..1100
+      serveSentCorpus(mockFetch, corpus);
+
+      // Active drain (BACKFILL_BEFORE set) but NO BACKFILL_TARGET → reads as 0. Window [999, 1101]
+      // holds all 101 messages (≤ SENT_MAX_SCAN) so the run is not truncated → drain completes.
+      const ctx = buildCtx({
+        seed: { [WATERMARK_KEY]: '999', [BACKFILL_BEFORE_KEY]: '1101' },
+        force: true,
+        nowMs: 9_000_000_000_000,
+        tasks: [],
+      });
+      const result = await handler.execute(ctx);
+      expect(result.success).toBe(true);
+      // max(floor=999, target=0) + 1 = 1000 — advances forward, never resets to epoch (1).
+      expect(ctx.__mem.__values.get(WATERMARK_KEY)).toBe('1000');
+      expect((result as { data: { watermark_advanced_to: number | null } }).data.watermark_advanced_to).toBe(1000);
+      expect(Number(ctx.__mem.__values.get(BACKFILL_BEFORE_KEY) ?? '0')).toBe(0);
+    });
+
     it('holds the drain window (no key moves) when evidence persistence fails mid-drain', async () => {
       // Enter a drain, then on the descend run make the matched-guard write soft-reject so
       // advanceOk is false: the ceiling must NOT descend and the watermark must stay pinned.

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -44,6 +44,14 @@ import {
 export const CONFIG_NAMESPACE = 'ceo_inbox';
 export const WATERMARK_KEY = 'sent_observe.last_seen_at';
 export const IDLE_BACKOFF_KEY = 'sent_observe.last_run_found_nothing_at';
+/** Descending `received_before` ceiling for an in-progress oldest-first backlog drain (#1431). A
+ *  value > EPOCH means a drain is underway; it walks down toward WATERMARK across successive runs.
+ *  See the watermark/backfill state machine below and docs/wip/2026-07-19-sent-observe-backfill-design.md. */
+export const BACKFILL_BEFORE_KEY = 'sent_observe.backfill_before';
+/** Newest message date captured when a >SENT_MAX_SCAN backlog was first detected (#1431). The
+ *  watermark jumps to backfill_target + 1 only once the drain reaches its oldest sub-window, so the
+ *  watermark never sits above an un-drained message. */
+export const BACKFILL_TARGET_KEY = 'sent_observe.backfill_target';
 export const PENDING_DIFFS_PATH = `${VOICE_LEARNING_SCRATCH_PREFIX}/pending-diffs.md`;
 export const PENDING_DIFFS_TYPE = 'voice-pending-diffs';
 
@@ -268,6 +276,9 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
               task_candidates: 0,
               shadow_reconciled: 0,
               watermark_advanced_to: null,
+              // The idle-backoff skip never runs mid-drain (a drain finds messages, so it never
+              // registers the idle backoff that would gate this early return).
+              backfill_active: false,
               skipped_backoff: true,
             },
           };
@@ -280,13 +291,32 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
       ? Number(watermarkRaw)
       : 0;
 
+    // Oldest-first backlog drain state (#1431). When a forward poll finds more than SENT_MAX_SCAN
+    // messages above a real floor, we can't reach the older tail via a single newest-first floor,
+    // so we record a descending `received_before` ceiling (backfillBefore) and the newest date seen
+    // (backfillTarget). While a drain is active the watermark stays pinned to its floor and each run
+    // scans [watermark, backfillBefore], walking the ceiling down until the window fits — then the
+    // watermark jumps to backfillTarget + 1. EPOCH ('0') means the key is unset (a real ceiling /
+    // target is always a Unix-second value > 0).
+    const backfillBeforeRaw = await store.get(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY);
+    const backfillBefore = backfillBeforeRaw && Number.isFinite(Number(backfillBeforeRaw))
+      ? Number(backfillBeforeRaw)
+      : 0;
+    const backfillTargetRaw = await store.get(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY);
+    const backfillTarget = backfillTargetRaw && Number.isFinite(Number(backfillTargetRaw))
+      ? Number(backfillTargetRaw)
+      : 0;
+    const backfillActive = backfillBefore > 0;
+
     const client = new CeoNylasClient(apiKey, grantId, ctx.log);
     // Paginate the whole watermark window — a single fixed-limit page silently drops
     // everything past the newest 20 on a busy Sent folder (#1429 review). `truncated`
-    // means the maxScan ceiling was hit and older sends remain unseen this run.
+    // means the maxScan ceiling was hit and older sends remain unseen this run. During a
+    // drain (#1431) receivedBefore caps the window from the top so we work oldest-ward.
     const { messages, truncated } = await client.listAllMessages({
       folder: 'SENT',
       ...(watermark > 0 ? { receivedAfter: watermark } : {}),
+      ...(backfillActive ? { receivedBefore: backfillBefore } : {}),
       maxScan: SENT_MAX_SCAN,
     });
 
@@ -668,27 +698,61 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
     const advanceOk =
       evidencePersisted && shadowReconcileOk && draftEvidenceComplete && matchedGuardPersisted && askedGuardPersisted;
 
-    // Advance the watermark past the newest message seen (next poll starts after it).
+    // Watermark / backfill state transition (#1431).
     //
-    // Nylas `received_after` is INCLUSIVE (returns messages with date >= the floor; Nylas
-    // timestamps are Unix seconds), so we store `maxDate + 1` to make the next poll's floor
-    // exclude the newest second we just processed — identical to the inbound email adapter's
-    // convention (see src/channels/email/email-adapter.ts, `this.lastSeenTimestamp = msg.date + 1`).
-    // Nylas returns newest-first, so a single-floor poll can only ever walk *forward*. On truncation the un-fetched
-    // messages are the OLDEST in the window (date < minDate); there is no lower-bound
-    // value that both advances and re-includes them, so we do not attempt a partial
-    // hold (an earlier version did and simply stranded the tail while re-scanning the
-    // newest 500 forever). Instead we advance to the newest seen and log — loudly and
-    // accurately — that older messages were skipped. This is realistically only a
-    // first-run/backfill event against a large existing mailbox; day-to-day Sent volume
-    // never approaches SENT_MAX_SCAN, and back-mining old history is not a goal of a
-    // forward-looking observer. Draining a true >ceiling backlog would need oldest-first
-    // paging (received_before), deliberately out of scope here.
+    // Nylas `received_after`/`received_before` are INCLUSIVE Unix-second bounds, and Nylas returns
+    // newest-first — so a single forward floor can only ever walk *forward*, and on truncation the
+    // un-fetched messages are the OLDEST in the window (date < minDate). To drain a >SENT_MAX_SCAN
+    // backlog without stranding that tail we keep the watermark PINNED at its floor and walk a
+    // descending `received_before` ceiling (backfillBefore) down toward it across runs, jumping the
+    // watermark to backfillTarget + 1 only once the oldest sub-window is drained. That way the
+    // watermark never sits above an un-drained message.
+    //
+    // `advanceOk` still gates everything: any evidence-persist / shadow / guard failure holds ALL
+    // state (no watermark move, no backfill-key move) so the same window is re-observed next run
+    // (matching is idempotent via the already-matched/asked/reconciled guards).
     let watermarkAdvancedTo: number | null = null;
-    if (messages.length > 0 && maxDate >= watermark && advanceOk) {
-      watermarkAdvancedTo = maxDate + 1;
-      await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
-    } else if (messages.length > 0 && !advanceOk) {
+    // True after this run if a drain is still underway (fed to the caller/logs).
+    let backfillStillActive = backfillActive;
+    if (advanceOk) {
+      if (backfillActive) {
+        if (messages.length > 0 && truncated) {
+          // Still an older tail below minDate — descend the ceiling; watermark stays pinned.
+          // minDate is INCLUSIVE, so the boundary second is re-scanned next run; this guarantees a
+          // same-second group split by the SENT_MAX_SCAN ceiling is never lost (the re-scan is
+          // idempotent via the matched/asked/reconciled guards). Progress is guaranteed because
+          // truncation means messages strictly older than minDate exist, so the next scan yields a
+          // strictly lower minDate — barring ≥500 sends in one second, impossible for one Sent box.
+          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, String(minDate));
+          backfillStillActive = true;
+        } else {
+          // Drain complete (window fully scanned, or emptied by deletions). Jump the watermark past
+          // the newest date captured when the backlog was detected, then clear the backfill keys.
+          watermarkAdvancedTo = backfillTarget + 1;
+          await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
+          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, EPOCH);
+          await store.set(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY, EPOCH);
+          backfillStillActive = false;
+        }
+      } else if (messages.length > 0) {
+        if (truncated && watermark > 0) {
+          // A real gap above a known floor exceeded the scan ceiling: begin an oldest-first drain.
+          // Record the newest date (the watermark jumps here on completion) and set the first
+          // ceiling to this batch's oldest. The watermark is NOT advanced — it stays the drain's
+          // floor, so it never sits above an un-drained message.
+          await store.set(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY, String(maxDate));
+          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, String(minDate));
+          backfillStillActive = true;
+        } else {
+          // Normal forward advance to newest + 1 (mirrors the inbound email adapter's
+          // `this.lastSeenTimestamp = msg.date + 1`). Covers the non-truncated steady state AND the
+          // first-ever run (watermark 0): forward-only observation — historical mail is
+          // intentionally NOT backfilled (a forward-looking observer; confirmed product decision).
+          watermarkAdvancedTo = maxDate + 1;
+          await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
+        }
+      }
+    } else if (messages.length > 0) {
       const holdReason = !evidencePersisted
         ? 'ceo-inbox-sent-observe: evidence persistence failed — holding watermark for retry'
         : !draftEvidenceComplete
@@ -708,21 +772,40 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
         holdReason,
       );
     }
+
+    // Truncation is loud until the backlog is drained (#1431). With a real floor it means a drain is
+    // in progress (older tail still to come); on the first-ever run (watermark 0) it means history
+    // is intentionally skipped.
     if (truncated) {
-      ctx.log.warn(
-        {
-          scanned: messages.length,
-          maxScan: SENT_MAX_SCAN,
-          oldestScannedAt: Number.isFinite(minDate) ? minDate : null,
-          advancedTo: watermarkAdvancedTo,
-        },
-        `ceo-inbox-sent-observe: Sent window exceeded the ${SENT_MAX_SCAN}-message scan ceiling — ` +
-          'messages older than the newest batch were NOT observed and will not be revisited ' +
-          '(expected only on first run against a large mailbox).',
-      );
+      if (watermark > 0) {
+        ctx.log.warn(
+          {
+            scanned: messages.length,
+            maxScan: SENT_MAX_SCAN,
+            floor: watermark,
+            ceiling: backfillActive ? backfillBefore : null,
+            nextCeiling: Number.isFinite(minDate) ? minDate : null,
+            backfillTarget: backfillActive ? backfillTarget : maxDate,
+          },
+          `ceo-inbox-sent-observe: Sent window exceeded the ${SENT_MAX_SCAN}-message scan ceiling — ` +
+            'draining the older tail oldest-first across successive runs (backfill in progress).',
+        );
+      } else {
+        ctx.log.warn(
+          {
+            scanned: messages.length,
+            maxScan: SENT_MAX_SCAN,
+            advancedTo: watermarkAdvancedTo,
+          },
+          `ceo-inbox-sent-observe: first run against a large mailbox exceeded the ${SENT_MAX_SCAN}-message ` +
+            'scan ceiling — observing forward-only; historical mail is intentionally not backfilled.',
+        );
+      }
     }
 
-    if (messages.length === 0) {
+    // A mid-drain empty window is not "idle" — it completes the drain (handled above), so only a
+    // genuinely empty forward poll registers the idle backoff.
+    if (messages.length === 0 && !backfillActive) {
       await store.set(CONFIG_NAMESPACE, IDLE_BACKOFF_KEY, String(nowMs));
     } else {
       await store.set(CONFIG_NAMESPACE, IDLE_BACKOFF_KEY, EPOCH);
@@ -735,6 +818,7 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
         taskCandidates,
         shadowReconciled,
         watermarkAdvancedTo,
+        backfillStillActive,
       },
       'ceo-inbox-sent-observe: run complete',
     );
@@ -747,6 +831,7 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
         task_candidates: taskCandidates,
         shadow_reconciled: shadowReconciled,
         watermark_advanced_to: watermarkAdvancedTo,
+        backfill_active: backfillStillActive,
         skipped_backoff: false,
       },
     };

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -734,6 +734,18 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
             );
           }
           backfillStillActive = true;
+        } else if (truncated) {
+          // Anomalous empty page carrying a lingering cursor: listAllMessages reports
+          // truncated=true with zero messages (see its "empty page with a cursor" guard), and its
+          // comment is explicit that this must NOT be read as a fully-drained window. With no
+          // messages there's no new minDate to descend to, so hold everything — no watermark jump,
+          // no key clear — and retry next run, exactly like the !advanceOk path. Completing here
+          // would strand the un-walked tail, the precise failure this drain exists to prevent.
+          ctx.log.warn(
+            { floor: watermark, ceiling: backfillBefore },
+            'ceo-inbox-sent-observe: backfill page reported truncated with zero messages — holding, retrying next run',
+          );
+          backfillStillActive = true;
         } else {
           // Drain complete (window fully scanned, or emptied by deletions). Jump the watermark past
           // the newest date captured when the backlog was detected, then clear the backfill keys.

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -723,16 +723,37 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
           // idempotent via the matched/asked/reconciled guards). Progress is guaranteed because
           // truncation means messages strictly older than minDate exist, so the next scan yields a
           // strictly lower minDate — barring ≥500 sends in one second, impossible for one Sent box.
-          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, String(minDate));
+          // ConfigStore.set can SOFT-REJECT (stored:false) without throwing (#1438); a lost descend
+          // just re-scans the same window next run (idempotent), but we log it so a stalled drain
+          // (ceiling never moving) is visible rather than silent.
+          const res = await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, String(minDate));
+          if (!res.stored) {
+            ctx.log.warn(
+              { floor: watermark, ceiling: backfillBefore, nextCeiling: minDate },
+              'ceo-inbox-sent-observe: backfill ceiling descend not persisted — re-scanning same window next run',
+            );
+          }
           backfillStillActive = true;
         } else {
           // Drain complete (window fully scanned, or emptied by deletions). Jump the watermark past
           // the newest date captured when the backlog was detected, then clear the backfill keys.
-          watermarkAdvancedTo = backfillTarget + 1;
-          await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
-          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, EPOCH);
-          await store.set(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY, EPOCH);
-          backfillStillActive = false;
+          // Math.max(watermark, backfillTarget) FLOOR-GUARDS the jump: the watermark must never move
+          // backward, so even a desynced/lost target (read as 0 after a soft-rejected write) advances
+          // to the pinned floor + 1 — triggering a fresh forward re-scan (idempotent), never a reset
+          // to epoch. Each write is checked (#1438): the drain only counts as finished once the
+          // BACKFILL_BEFORE key actually clears, so a lost clear re-completes next run (empty window,
+          // monotonically increasing watermark) instead of silently stranding an active-but-stale drain.
+          watermarkAdvancedTo = Math.max(watermark, backfillTarget) + 1;
+          const wRes = await store.set(CONFIG_NAMESPACE, WATERMARK_KEY, String(watermarkAdvancedTo));
+          const bRes = await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, EPOCH);
+          const tRes = await store.set(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY, EPOCH);
+          backfillStillActive = !bRes.stored; // still "active" next run if the ceiling didn't clear
+          if (!wRes.stored || !bRes.stored || !tRes.stored) {
+            ctx.log.warn(
+              { watermarkStored: wRes.stored, beforeCleared: bRes.stored, targetCleared: tRes.stored, watermarkAdvancedTo },
+              'ceo-inbox-sent-observe: backfill completion writes only partially persisted — will reconcile next run',
+            );
+          }
         }
       } else if (messages.length > 0) {
         if (truncated && watermark > 0) {
@@ -740,9 +761,24 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
           // Record the newest date (the watermark jumps here on completion) and set the first
           // ceiling to this batch's oldest. The watermark is NOT advanced — it stays the drain's
           // floor, so it never sits above an un-drained message.
-          await store.set(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY, String(maxDate));
-          await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, String(minDate));
-          backfillStillActive = true;
+          //
+          // Order + guard matters (#1438): the TARGET write can SOFT-REJECT (stored:false) — e.g.
+          // overwriting the EPOCH sentinel a prior drain left. We write TARGET first and only set the
+          // BEFORE ceiling once TARGET has actually landed, so the drain can never become active with
+          // a missing target (the (before>0, target=0) state that would later reset the watermark to
+          // epoch on completion). If TARGET doesn't land, we hold: the watermark is already pinned, so
+          // next run re-scans the same truncated window and retries entry.
+          const tRes = await store.set(CONFIG_NAMESPACE, BACKFILL_TARGET_KEY, String(maxDate));
+          const bRes = tRes.stored
+            ? await store.set(CONFIG_NAMESPACE, BACKFILL_BEFORE_KEY, String(minDate))
+            : { stored: false };
+          backfillStillActive = bRes.stored;
+          if (!tRes.stored || !bRes.stored) {
+            ctx.log.warn(
+              { targetStored: tRes.stored, ceilingStored: bRes.stored, maxDate, minDate },
+              'ceo-inbox-sent-observe: could not fully persist backfill entry — watermark held, retrying next run',
+            );
+          }
         } else {
           // Normal forward advance to newest + 1 (mirrors the inbound email adapter's
           // `this.lastSeenTimestamp = msg.date + 1`). Covers the non-truncated steady state AND the

--- a/skills/ceo-inbox-sent-observe/skill.json
+++ b/skills/ceo-inbox-sent-observe/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "ceo-inbox-sent-observe",
   "description": "Poll the CEO's Sent folder since a stored watermark, match new sends to Curia draft snapshots and open owner=ceo tasks, append evidence to OKF, and advance the watermark. Read-only against Nylas; never drafts, archives, or sends. Intended for the daily ceo-inbox sent-observe cron — do not fold into triage.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {


### PR DESCRIPTION
## Summary

Closes #1431 (part of #1419).

`ceo-inbox-sent-observe` polls the CEO's Sent folder via a single forward `received_after` watermark. Nylas returns newest-first, so a window with more than `SENT_MAX_SCAN` (500) unobserved messages yielded only the newest 500 and the current policy advanced the watermark to the newest, **permanently skipping the older tail**. That's fine at steady state but strands the historical tail on a first-run / post-downtime backfill against a large mailbox.

This drains a `>SENT_MAX_SCAN` backlog **oldest-first** across successive runs so no message is permanently skipped, while keeping the first-ever run forward-only.

## Approach

- **Client:** add an inclusive `receivedBefore` filter to `CeoNylasClient.listMessages` / `listAllMessages` (sent on the first page only; the cursor carries it forward).
- **Handler:** a small state machine over two new `ceo_inbox` config keys:
  - `sent_observe.backfill_before` — a descending `received_before` ceiling; its presence means a drain is in progress.
  - `sent_observe.backfill_target` — the newest date seen when the backlog was detected; the watermark jumps to `target + 1` only on completion.
- During a drain the **watermark stays pinned to its floor** and each run scans `[watermark, backfill_before]`, walking the ceiling down until the window fits — so the watermark **never advances past an unobserved message**.
- `backfill_before = minDate` is inclusive, so the boundary second is re-scanned idempotently — a same-second group split by the 500 ceiling is never lost (re-processing is a no-op via the existing matched-draft / asked-task / shadow `reconciled_at` guards).

## First-run decision (confirmed with product)

On the **first-ever run** (watermark `0`) the observer is **forward-only**: it advances to the newest existing send (the forward frontier) and does **not** backfill history. Backfill applies only to a real gap above a non-zero floor (post-downtime). Draining full history would run many rounds of LLM shadow-judging against stale mail with nothing to match.

## Correctness / hardening

Two independent PR-review passes flagged that the new backfill writes ignored `ConfigStore.set`'s soft-reject (`{stored:false}`) return — the `#1438` hazard the rest of the handler already guards. Addressed:
- **Entry** writes `backfill_target` first and only sets the ceiling once it lands, so a drain can never be active with a missing target.
- **Completion** floor-guards the jump with `max(watermark, target) + 1`, so a lost/desynced target advances to the pinned floor + 1 (a fresh idempotent forward re-scan), never a reset to epoch.
- Every backfill write now checks `stored` and warns; a lost descend/clear reconciles on the next run instead of stalling silently.

## Acceptance criteria

- [x] A Sent window with >`SENT_MAX_SCAN` unobserved messages is fully processed across successive runs, no message permanently skipped.
- [x] The watermark never advances past a message that has not been observed (pinned during the drain).
- [x] Re-processing during catch-up remains idempotent (existing matched/asked/reconciled guards).
- [x] Unit test covers a truncated multi-page backlog draining to completion over ≥2 runs.
- [x] First-ever-run (watermark 0) behaviour documented and tested (forward-only).

## Tests

New coverage in `handler.test.ts` and `ceo-nylas-client.test.ts`: the ≥3-run drain with no message skipped, watermark pinned-then-jumps, forward-only first run, evidence-persist failure holding the window mid-drain, and the floor-guard against an epoch reset. Full skills suite green (143 files / 1817 tests); typecheck clean.

Design + plan: `docs/wip/2026-07-19-sent-observe-backfill-design.md`, `docs/wip/2026-07-19-sent-observe-backfill.md`.