### PR TITLE
chore(tests): cover reopenTask rejection, audit note, and event emission (#1434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **`TaskRepo.reopenTask` tests** — cover non-`done` rejection, `progress.notes` audit note, and `task.updated` emission. (#1434)
+
 ### Security
 
 - **KG trust gates** — checkpoint extraction and `memory-store` block untrusted inbound senders. (#1290)

--- a/tests/integration/task-reopen-wake-revive.test.ts
+++ b/tests/integration/task-reopen-wake-revive.test.ts
@@ -10,6 +10,7 @@ import pino from 'pino';
 import { TaskRepo } from '../../src/db/task-repo.js';
 import type { EventBus } from '../../src/bus/bus.js';
 import type { BusEvent, TaskUpdatedEvent } from '../../src/bus/events.js';
+import { requireCuriaTestDatabase } from './require-test-db.js';
 
 const { Pool } = pg;
 const DATABASE_URL = process.env.DATABASE_URL;
@@ -54,13 +55,22 @@ async function wakeRowsFor(pool: pg.Pool, taskId: string) {
 describeIf('TaskRepo.reopenTask wake revival', () => {
   let pool: pg.Pool;
   let repo: TaskRepo;
+  // Set true only after requireCuriaTestDatabase confirms we're on curia_test. cleanup()'s
+  // DELETEs are PREFIX-scoped, but vitest still fires afterAll after a FAILED beforeAll, so
+  // without this flag a guard abort against a mispointed DATABASE_URL would still run the
+  // teardown DELETEs against whatever database it found. With it, no DELETE runs unguarded.
+  let onTestDb = false;
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
+    // Throws HERE (before onTestDb is set, before any DELETE) if DATABASE_URL points anywhere
+    // but the canonical isolated curia_test database.
+    await requireCuriaTestDatabase(pool);
+    onTestDb = true;
     repo = new TaskRepo(pool, capturingBus, logger as never, 'UTC');
   });
-  afterAll(async () => { await cleanup(pool); await pool.end(); });
-  beforeEach(async () => { await cleanup(pool); published.length = 0; });
+  afterAll(async () => { if (onTestDb) await cleanup(pool); await pool.end(); });
+  beforeEach(async () => { if (!onTestDb) return; await cleanup(pool); published.length = 0; });
 
   it('revives the wake that completeTask cancelled, preserving its original schedule', async () => {
     const wakeAt = new Date(Date.now() + 3_600_000);

--- a/tests/integration/task-reopen-wake-revive.test.ts
+++ b/tests/integration/task-reopen-wake-revive.test.ts
@@ -9,6 +9,7 @@ import pg from 'pg';
 import pino from 'pino';
 import { TaskRepo } from '../../src/db/task-repo.js';
 import type { EventBus } from '../../src/bus/bus.js';
+import type { BusEvent, TaskUpdatedEvent } from '../../src/bus/events.js';
 
 const { Pool } = pg;
 const DATABASE_URL = process.env.DATABASE_URL;
@@ -16,7 +17,17 @@ const describeIf = DATABASE_URL ? describe : describe.skip;
 
 const PREFIX = 'TaskReopenWake Test';
 const logger = pino({ level: 'silent' });
-const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+
+// Capturing bus stub — collects every published event so the event-emission case
+// can assert reopenTask emits task.updated. The wake-revival / rejection cases
+// ignore it. Reset per-test in beforeEach so each case sees only its own events.
+const published: BusEvent[] = [];
+const capturingBus = {
+  publish: async (_layer: string, event: BusEvent) => {
+    published.push(event);
+  },
+  subscribe: () => {},
+} as unknown as EventBus;
 
 async function cleanup(pool: pg.Pool): Promise<void> {
   await pool.query(
@@ -46,10 +57,10 @@ describeIf('TaskRepo.reopenTask wake revival', () => {
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
-    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+    repo = new TaskRepo(pool, capturingBus, logger as never, 'UTC');
   });
   afterAll(async () => { await cleanup(pool); await pool.end(); });
-  beforeEach(async () => { await cleanup(pool); });
+  beforeEach(async () => { await cleanup(pool); published.length = 0; });
 
   it('revives the wake that completeTask cancelled, preserving its original schedule', async () => {
     const wakeAt = new Date(Date.now() + 3_600_000);
@@ -97,5 +108,72 @@ describeIf('TaskRepo.reopenTask wake revival', () => {
     expect(reopened).not.toBeNull();
     expect(reopened!.status).toBe('open');
     expect(await wakeRowsFor(pool, task.id)).toHaveLength(0);
+  });
+
+  // Only a 'done' task can be reopened — every other status is rejected. createTask
+  // always inserts 'open', so the cancelled / in_progress cases are forced via SQL.
+  it('rejects reopening a task that is not done', async () => {
+    for (const status of ['cancelled', 'open', 'in_progress'] as const) {
+      const task = await repo.createTask({
+        agentId: 'coordinator',
+        title: `${PREFIX} reject ${status}`,
+        source: 'coordinator',
+      });
+      if (status !== 'open') {
+        await pool.query(`UPDATE tasks SET status = $1 WHERE id = $2`, [status, task.id]);
+      }
+
+      await expect(repo.reopenTask(task.id, 'undo', 'coordinator')).rejects.toThrow(
+        /only 'done' can be reopened/,
+      );
+
+      // The guard throws before any UPDATE, so the status is left untouched.
+      const after = await repo.getTask(task.id);
+      expect(after!.status).toBe(status);
+    }
+  });
+
+  it('persists the audit note under progress.notes', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} audit note`,
+      source: 'coordinator',
+    });
+    await repo.completeTask(task.id, undefined, 'coordinator');
+
+    const auditNote = 'undo: reopened for follow-up';
+    const reopened = await repo.reopenTask(task.id, auditNote, 'coordinator');
+    expect(reopened).not.toBeNull();
+
+    // The RETURNING row carries the appended note as the newest progress.notes entry.
+    const returnedNotes = (reopened!.progress.notes ?? []) as Array<{ note: string }>;
+    expect(returnedNotes.at(-1)?.note).toBe(auditNote);
+
+    // ...and it is durably persisted — re-read straight from Postgres, not the
+    // RETURNING row, to prove the jsonb_set append committed.
+    const persisted = await repo.getTask(task.id);
+    const persistedNotes = (persisted!.progress.notes ?? []) as Array<{ note: string }>;
+    expect(persistedNotes.at(-1)?.note).toBe(auditNote);
+  });
+
+  it('emits a task.updated event (previousStatus done → newStatus open)', async () => {
+    const task = await repo.createTask({
+      agentId: 'coordinator',
+      title: `${PREFIX} event`,
+      source: 'coordinator',
+    });
+    await repo.completeTask(task.id, undefined, 'coordinator');
+    // Drop the create/complete events so only the reopen's emission remains.
+    published.length = 0;
+
+    await repo.reopenTask(task.id, 'undo', 'coordinator');
+
+    const updates = published.filter((e) => e.type === 'task.updated') as TaskUpdatedEvent[];
+    expect(updates).toHaveLength(1);
+    const { payload } = updates[0]!;
+    expect(payload.taskId).toBe(task.id);
+    expect(payload.previousStatus).toBe('done');
+    expect(payload.newStatus).toBe('open');
+    expect(payload.agentId).toBe('coordinator');
   });
 });


### PR DESCRIPTION
## Summary

Extends the existing `TaskRepo.reopenTask` integration suite (`tests/integration/task-reopen-wake-revive.test.ts`) with the three cases left uncovered after #1429. All run against real Postgres via the existing Docker harness.

- **Rejects reopening a non-`done` task** — `cancelled`, `open`, `in_progress` all throw `only 'done' can be reopened`; asserts the status is left untouched (the guard precedes any UPDATE).
- **Persists the audit note under `progress.notes`** — asserted on both the RETURNING row and an independent `getTask` re-read, so it proves durable persistence, not just the in-memory return.
- **Emits `task.updated` (previousStatus `done` → newStatus `open`)** — the noop bus is swapped for a small capturing stub that collects published events; asserts type + previous/new status + `agentId`.

The capturing bus is reset per-test (`beforeEach`), and again before the reopen in the event case so `toHaveLength(1)` is meaningful.

## Testing

- `vitest run tests/integration/task-reopen-wake-revive.test.ts` → 5 passed (against `curia_test` Postgres).
- `pnpm run typecheck` → clean.

Closes #1434