### PR TITLE
feat(task-repo): keyset pagination to remove the 100-task match cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`resolve-learning-digest`** undo now guards on task status, so a failed clear can't wedge the item. (#1432)
 - **`sent-observe`** shadow reconciliation now dedups on a DB unique index; a failed marker write can't double-score. (#1432)
 - **`ceo-inbox-sent-observe`** — drains Sent backlogs over `SENT_MAX_SCAN` oldest-first; first run stays forward-only. (#1431)
+- **`ceo-inbox-sent-observe`** — completion matching walks all open CEO tasks via keyset paging instead of capping at 100. (#1433)
 
 ### Added
 

--- a/skills/ceo-inbox-sent-observe/handler.test.ts
+++ b/skills/ceo-inbox-sent-observe/handler.test.ts
@@ -172,7 +172,10 @@ function buildCtx(overrides: {
     entityMemory: mem as unknown as EntityMemory,
     workingDocs,
     taskRepo: {
-      listTasks: vi.fn(async () => overrides.tasks ?? []),
+      // The handler now walks the full open-task set via listAllTasks (#1433). The mock returns
+      // every provided task in one shot — the DB-level keyset paging is exercised in the
+      // task-repo integration test, not here.
+      listAllTasks: vi.fn(async () => overrides.tasks ?? []),
     },
     bus: {
       publish: vi.fn(async (_layer: string, event: { type: string; payload: Record<string, unknown> }) => {
@@ -622,6 +625,92 @@ describe('CeoInboxSentObserveHandler', () => {
     expect(stored['task-ceo-1'].confidence).toBe('high');
     const asked = JSON.parse(ctx.__mem.__values.get(ASKED_TASK_IDS_KEY)!);
     expect(asked).toContain('task-ceo-1');
+  });
+
+  it('matches a task beyond the old 100-task cap (>100 open tasks, #1433)', async () => {
+    // Regression guard for the pre-#1433 truncation: the handler capped the open-task fetch at
+    // 100, so a matching task past that index was silently never considered. It now walks the
+    // full set via listAllTasks, so a match at index 130 of 150 must still produce a candidate.
+    mockFetch.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u.includes('/messages/msg-sent-2')) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 'msg-sent-2',
+              thread_id: 't2',
+              subject: 'Follow up',
+              from: [{ email: 'ceo@example.com' }],
+              to: [{ email: 'alice@example.com' }],
+              cc: [],
+              body: '<p>Following up on our chat</p>',
+              snippet: 'Following up',
+              date: 1_720_000_300,
+              unread: false,
+              folders: ['SENT'],
+              bcc: [],
+              labels: [],
+              attachments: [],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (u.includes('/messages?')) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'msg-sent-2',
+                thread_id: 't2',
+                subject: 'Follow up',
+                from: [{ email: 'ceo@example.com' }],
+                to: [{ email: 'alice@example.com' }],
+                cc: [],
+                snippet: 'Following up on our chat with Alice',
+                date: 1_720_000_300,
+                unread: false,
+                folders: ['SENT'],
+                attachments: [],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected ${u}`);
+    });
+
+    // 149 unrelated filler tasks (no recipient/token overlap with the Alice send) plus the real
+    // match dropped in at index 130 — well past the old 100 cap.
+    const filler = Array.from({ length: 149 }, (_, i) => ({
+      id: `filler-${i}`,
+      title: `Quarterly budget review section ${i}`,
+      description: 'Unrelated internal planning item',
+      tags: [],
+      priority: 30,
+    }));
+    const tasks = [
+      ...filler.slice(0, 130),
+      {
+        id: 'task-ceo-1',
+        title: 'Follow up with Alice',
+        description: 'Email alice@example.com about the chat',
+        tags: [],
+        priority: 40,
+      },
+      ...filler.slice(130),
+    ];
+
+    const ctx = buildCtx({ force: true, nowMs: 1_720_100_000_000, tasks });
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect((result as { data: { task_candidates: number } }).data.task_candidates).toBe(1);
+
+    const stored = JSON.parse(ctx.__mem.__values.get(COMPLETION_CANDIDATES_KEY)!);
+    expect(stored['task-ceo-1']).toBeDefined();
+    expect(stored['task-ceo-1'].confidence).toBe('high');
   });
 
   it('does not persist the asked-guard when the candidate write is held (no candidate lost)', async () => {

--- a/skills/ceo-inbox-sent-observe/handler.test.ts
+++ b/skills/ceo-inbox-sent-observe/handler.test.ts
@@ -83,6 +83,8 @@ function buildCtx(overrides: {
     tags: string[];
     priority: number;
   }>;
+  /** Simulate listAllTasks hitting its pagination safety ceiling (#1433). */
+  tasksTruncated?: boolean;
   force?: boolean;
   nowMs?: number;
   infraLlm?: InfraLlm;
@@ -174,8 +176,11 @@ function buildCtx(overrides: {
     taskRepo: {
       // The handler now walks the full open-task set via listAllTasks (#1433). The mock returns
       // every provided task in one shot — the DB-level keyset paging is exercised in the
-      // task-repo integration test, not here.
-      listAllTasks: vi.fn(async () => overrides.tasks ?? []),
+      // task-repo integration test, not here. `truncated` mirrors the real result shape.
+      listAllTasks: vi.fn(async () => ({
+        tasks: overrides.tasks ?? [],
+        truncated: overrides.tasksTruncated ?? false,
+      })),
     },
     bus: {
       publish: vi.fn(async (_layer: string, event: { type: string; payload: Record<string, unknown> }) => {
@@ -711,6 +716,27 @@ describe('CeoInboxSentObserveHandler', () => {
     const stored = JSON.parse(ctx.__mem.__values.get(COMPLETION_CANDIDATES_KEY)!);
     expect(stored['task-ceo-1']).toBeDefined();
     expect(stored['task-ceo-1'].confidence).toBe('high');
+  });
+
+  it('surfaces tasks_truncated and warns when the open-task set hits the pagination ceiling (#1433)', async () => {
+    // When listAllTasks reports truncated, the run must not present a partial task set as full
+    // coverage: it logs a warning and threads tasks_truncated into its result data.
+    mockFetch.mockImplementation(async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u.includes('/messages?')) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      throw new Error(`unexpected ${u}`);
+    });
+
+    const ctx = buildCtx({ force: true, nowMs: 1_720_100_000_000, tasks: [], tasksTruncated: true });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect((result as { data: { tasks_truncated: boolean } }).data.tasks_truncated).toBe(true);
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ openTasksConsidered: expect.any(Number) }),
+      expect.stringContaining('pagination safety ceiling'),
+    );
   });
 
   it('does not persist the asked-guard when the candidate write is held (no candidate lost)', async () => {

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -340,21 +340,13 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
     // Seed the asked-guard from config (replaces the doc-derived extractAskedTaskIds scan).
     const alreadyAskedTaskIds = await readIdSet(store, ASKED_TASK_IDS_KEY, ctx.log);
 
-    const OPEN_TASK_LIMIT = 100;
-    const openTasks = await ctx.taskRepo.listTasks({
+    // Consider every open/in-progress CEO task for completion matching. listAllTasks walks
+    // keyset pages so we no longer silently truncate at the old 100-task cap (#1433); its own
+    // safety ceiling logs a warning if a pathological task volume is ever reached.
+    const openTasks = await ctx.taskRepo.listAllTasks({
       owner: 'ceo',
       statuses: ['open', 'in_progress'],
-      limit: OPEN_TASK_LIMIT,
     });
-    // taskRepo.listTasks has no keyset/pagination, so completion matching considers at
-    // most OPEN_TASK_LIMIT tasks. Log when the cap is hit so a silently-partial match set
-    // is visible rather than mistaken for full coverage (keyset paging tracked separately).
-    if (openTasks.length >= OPEN_TASK_LIMIT) {
-      ctx.log.warn(
-        { openTaskLimit: OPEN_TASK_LIMIT },
-        'ceo-inbox-sent-observe: open CEO task list hit the fetch cap — some tasks were not considered for completion',
-      );
-    }
 
     let draftMatches = 0;
     // Cleared to false if any draft's full Sent body can't be fetched. Holds the watermark (see

--- a/skills/ceo-inbox-sent-observe/handler.ts
+++ b/skills/ceo-inbox-sent-observe/handler.ts
@@ -341,12 +341,20 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
     const alreadyAskedTaskIds = await readIdSet(store, ASKED_TASK_IDS_KEY, ctx.log);
 
     // Consider every open/in-progress CEO task for completion matching. listAllTasks walks
-    // keyset pages so we no longer silently truncate at the old 100-task cap (#1433); its own
-    // safety ceiling logs a warning if a pathological task volume is ever reached.
-    const openTasks = await ctx.taskRepo.listAllTasks({
+    // keyset pages so we no longer silently truncate at the old 100-task cap (#1433). If its
+    // safety ceiling is hit, `truncated` is true — surface it here (and in the result) so a
+    // partial task set is visible rather than mistaken for full coverage.
+    const { tasks: openTasks, truncated: openTasksTruncated } = await ctx.taskRepo.listAllTasks({
       owner: 'ceo',
       statuses: ['open', 'in_progress'],
     });
+    if (openTasksTruncated) {
+      ctx.log.warn(
+        { openTasksConsidered: openTasks.length },
+        'ceo-inbox-sent-observe: open CEO task set hit the pagination safety ceiling — ' +
+          'completion matching ran against a partial set; lowest-priority tasks past the ceiling were not considered',
+      );
+    }
 
     let draftMatches = 0;
     // Cleared to false if any draft's full Sent body can't be fetched. Holds the watermark (see
@@ -872,6 +880,9 @@ export class CeoInboxSentObserveHandler implements SkillHandler {
         shadow_reconciled: shadowReconciled,
         watermark_advanced_to: watermarkAdvancedTo,
         backfill_active: backfillStillActive,
+        // True when the open-task set exceeded the pagination safety ceiling, so task-completion
+        // matching this run considered only a partial set (#1433).
+        tasks_truncated: openTasksTruncated,
         skipped_backoff: false,
       },
     };

--- a/skills/ceo-inbox-sent-observe/skill.json
+++ b/skills/ceo-inbox-sent-observe/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "ceo-inbox-sent-observe",
   "description": "Poll the CEO's Sent folder since a stored watermark, match new sends to Curia draft snapshots and open owner=ceo tasks, append evidence to OKF, and advance the watermark. Read-only against Nylas; never drafts, archives, or sends. Intended for the daily ceo-inbox sent-observe cron — do not fold into triage.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -117,6 +117,31 @@ export interface ListTasksFilters {
   parentTaskId?: string;
   dueBefore?: Date;
   limit?: number;
+  /** Keyset pagination cursor (#1433). When set, only rows strictly *after* this row in the
+   *  (priority DESC, due_at ASC NULLS LAST, id ASC) ordering are returned. Build it from the
+   *  last row of the previous page. */
+  cursor?: TaskListCursor;
+}
+
+/**
+ * Opaque keyset-pagination cursor for {@link TaskRepo.listTasks} (#1433). Encodes the sort key of
+ * the last row returned — (priority, due_at, id) — so the next page can resume without skipping or
+ * duplicating rows. `id` is the total-ordering tiebreaker that makes the sort deterministic even
+ * when priority and due_at tie.
+ */
+export interface TaskListCursor {
+  priority: number;
+  dueAt: string | null;
+  id: string;
+}
+
+/** Options for {@link TaskRepo.listAllTasks} (#1433). */
+export interface ListAllTasksOptions {
+  /** Rows fetched per keyset page. Default 500. */
+  pageSize?: number;
+  /** Hard ceiling on the total rows returned across all pages — a safety valve against
+   *  pathological task volumes. When reached, iteration stops and a warning is logged. Default 5000. */
+  maxTasks?: number;
 }
 
 // Extended row returned by list — includes the next pending wake-up time if any.
@@ -322,11 +347,14 @@ export class TaskRepo {
   }
 
   /**
-   * List tasks with optional filters. Returns rows ordered by priority DESC, due_at ASC NULLS LAST.
+   * List tasks with optional filters. Returns rows in a deterministic total order:
+   * priority DESC, due_at ASC NULLS LAST, id ASC. The id tiebreaker makes the ordering stable so
+   * a `cursor` (#1433) can page through the full result set without skipping or duplicating rows —
+   * see {@link listAllTasks} for the paging loop.
    * Joins with scheduled_jobs to include the next pending wake-up time.
    */
   async listTasks(filters: ListTasksFilters = {}): Promise<TaskListRow[]> {
-    const { statuses, owner, tag, parentTaskId, dueBefore, limit = 25 } = filters;
+    const { statuses, owner, tag, parentTaskId, dueBefore, cursor, limit = 25 } = filters;
 
     const conditions: string[] = [];
     const queryParams: unknown[] = [];
@@ -352,6 +380,30 @@ export class TaskRepo {
       conditions.push(`t.due_at < $${idx++}`);
       queryParams.push(dueBefore);
     }
+    if (cursor) {
+      // Keyset predicate: keep only rows strictly *after* the cursor row in the
+      // (priority DESC, due_at ASC NULLS LAST, id ASC) ordering. Placeholders are reused for
+      // the same value (Postgres allows referencing $N multiple times).
+      const pIdx = idx++;
+      queryParams.push(cursor.priority);
+      const iIdx = idx++;
+      queryParams.push(cursor.id);
+      if (cursor.dueAt === null) {
+        // Cursor sits in the NULLS-LAST tail: the only later rows are lower-priority rows, or
+        // same-priority rows that are also null-due with a greater id (any non-null due_at sorts
+        // *before* the nulls, so it's already been paged past).
+        conditions.push(
+          `(t.priority < $${pIdx} OR (t.priority = $${pIdx} AND t.due_at IS NULL AND t.id > $${iIdx}))`,
+        );
+      } else {
+        const dIdx = idx++;
+        queryParams.push(cursor.dueAt);
+        conditions.push(
+          `(t.priority < $${pIdx} OR (t.priority = $${pIdx} AND ` +
+            `(t.due_at IS NULL OR t.due_at > $${dIdx} OR (t.due_at = $${dIdx} AND t.id > $${iIdx}))))`,
+        );
+      }
+    }
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
@@ -370,7 +422,7 @@ export class TaskRepo {
         ) AS next_wake_at
       FROM tasks t
       ${whereClause}
-      ORDER BY t.priority DESC, t.due_at ASC NULLS LAST
+      ORDER BY t.priority DESC, t.due_at ASC NULLS LAST, t.id ASC
       LIMIT $${idx}
     `;
 
@@ -379,6 +431,57 @@ export class TaskRepo {
       ...mapTaskRow(r),
       nextWakeAt: r.next_wake_at,
     }));
+  }
+
+  /**
+   * Fetch ALL tasks matching the filters by walking keyset pages (#1433). Callers that must
+   * consider every eligible task — e.g. sent-observe completion matching, which previously capped
+   * at 100 and silently ignored the rest — should use this instead of {@link listTasks}, whose
+   * single page is bounded by `limit`.
+   *
+   * Ordering is the deterministic total order from listTasks (priority DESC, due_at ASC NULLS LAST,
+   * id ASC), so no row is skipped or duplicated across pages. `maxTasks` is a safety ceiling
+   * against pathological volumes: when reached, iteration stops and a warning is logged rather than
+   * looping unboundedly.
+   */
+  async listAllTasks(
+    filters: Omit<ListTasksFilters, 'limit' | 'cursor'> = {},
+    options: ListAllTasksOptions = {},
+  ): Promise<TaskListRow[]> {
+    const pageSize = options.pageSize ?? 500;
+    const maxTasks = options.maxTasks ?? 5000;
+    const all: TaskListRow[] = [];
+    let cursor: TaskListCursor | undefined;
+
+    // Bound the loop by the ceiling so a bug in cursor advancement can never spin forever.
+    // +1 slack lets a full final page (rows.length === pageSize) still terminate via its short
+    // successor before the ceiling logic fires.
+    const maxPages = Math.ceil(maxTasks / pageSize) + 1;
+    for (let page = 0; page < maxPages; page++) {
+      const rows = await this.listTasks({ ...filters, limit: pageSize, cursor });
+      all.push(...rows);
+
+      // A short page means the result set is drained — this is the last page.
+      if (rows.length < pageSize) return all;
+
+      if (all.length >= maxTasks) {
+        this.logger.warn(
+          { maxTasks, fetched: all.length, filters },
+          'task-repo: listAllTasks hit the safety ceiling — remaining tasks were not fetched',
+        );
+        return all.slice(0, maxTasks);
+      }
+
+      const last = rows[rows.length - 1]!;
+      cursor = { priority: last.priority, dueAt: last.dueAt, id: last.id };
+    }
+
+    // Exhausted the page budget without a short page — treat as the ceiling being hit.
+    this.logger.warn(
+      { maxTasks, fetched: all.length, filters },
+      'task-repo: listAllTasks exhausted its page budget — remaining tasks were not fetched',
+    );
+    return all.slice(0, maxTasks);
   }
 
   /**

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -458,7 +458,9 @@ export class TaskRepo {
     filters: Omit<ListTasksFilters, 'limit' | 'cursor'> = {},
     options: ListAllTasksOptions = {},
   ): Promise<ListAllTasksResult> {
-    const pageSize = options.pageSize ?? 500;
+    // Normalize pageSize to >= 1: a LIMIT 0 page is always short-but-nonempty in the loop's eyes
+    // (0 < 0 is false), so it would fall through to the cursor build and crash on rows[-1].
+    const pageSize = Math.max(1, options.pageSize ?? 500);
     const maxTasks = options.maxTasks ?? 5000;
     const all: TaskListRow[] = [];
     let cursor: TaskListCursor | undefined;
@@ -474,7 +476,10 @@ export class TaskRepo {
       // A short page means the result set is drained — this is the last page, nothing truncated.
       if (rows.length < pageSize) return { tasks: all, truncated: false };
 
-      if (all.length >= maxTasks) {
+      // Strict `>`, not `>=`: a full page landing *exactly* on the ceiling might be the last page
+      // that exists. Let the slack iteration fetch its (short/empty) successor to confirm drainage,
+      // so an exact-boundary dataset reports truncated:false instead of a spurious ceiling hit.
+      if (all.length > maxTasks) {
         this.logger.warn(
           { maxTasks, fetched: all.length, filters },
           'task-repo: listAllTasks hit the safety ceiling — remaining tasks were not fetched',

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -139,9 +139,19 @@ export interface TaskListCursor {
 export interface ListAllTasksOptions {
   /** Rows fetched per keyset page. Default 500. */
   pageSize?: number;
-  /** Hard ceiling on the total rows returned across all pages — a safety valve against
-   *  pathological task volumes. When reached, iteration stops and a warning is logged. Default 5000. */
+  /** Hard ceiling on the total rows returned across all pages — a safety valve so a runaway task
+   *  volume can't turn one poll into an unbounded scan. When reached, iteration stops, a warning is
+   *  logged, and the result's `truncated` flag is set. Default 5000. */
   maxTasks?: number;
+}
+
+/** Result of {@link TaskRepo.listAllTasks} (#1433). `truncated` is true when the safety ceiling was
+ *  hit before the result set was exhausted, so `tasks` is a partial view and the caller should treat
+ *  its answer as incomplete (mirrors the `{ messages, truncated }` shape sent-observe already
+ *  consumes from listAllMessages). */
+export interface ListAllTasksResult {
+  tasks: TaskListRow[];
+  truncated: boolean;
 }
 
 // Extended row returned by list — includes the next pending wake-up time if any.
@@ -440,14 +450,14 @@ export class TaskRepo {
    * single page is bounded by `limit`.
    *
    * Ordering is the deterministic total order from listTasks (priority DESC, due_at ASC NULLS LAST,
-   * id ASC), so no row is skipped or duplicated across pages. `maxTasks` is a safety ceiling
-   * against pathological volumes: when reached, iteration stops and a warning is logged rather than
-   * looping unboundedly.
+   * id ASC), so no row is skipped or duplicated across pages. `maxTasks` is a safety ceiling: when
+   * reached, iteration stops, a warning is logged, and the result's `truncated` flag is set so the
+   * caller can react rather than silently trusting a partial view.
    */
   async listAllTasks(
     filters: Omit<ListTasksFilters, 'limit' | 'cursor'> = {},
     options: ListAllTasksOptions = {},
-  ): Promise<TaskListRow[]> {
+  ): Promise<ListAllTasksResult> {
     const pageSize = options.pageSize ?? 500;
     const maxTasks = options.maxTasks ?? 5000;
     const all: TaskListRow[] = [];
@@ -461,15 +471,15 @@ export class TaskRepo {
       const rows = await this.listTasks({ ...filters, limit: pageSize, cursor });
       all.push(...rows);
 
-      // A short page means the result set is drained — this is the last page.
-      if (rows.length < pageSize) return all;
+      // A short page means the result set is drained — this is the last page, nothing truncated.
+      if (rows.length < pageSize) return { tasks: all, truncated: false };
 
       if (all.length >= maxTasks) {
         this.logger.warn(
           { maxTasks, fetched: all.length, filters },
           'task-repo: listAllTasks hit the safety ceiling — remaining tasks were not fetched',
         );
-        return all.slice(0, maxTasks);
+        return { tasks: all.slice(0, maxTasks), truncated: true };
       }
 
       const last = rows[rows.length - 1]!;
@@ -481,7 +491,7 @@ export class TaskRepo {
       { maxTasks, fetched: all.length, filters },
       'task-repo: listAllTasks exhausted its page budget — remaining tasks were not fetched',
     );
-    return all.slice(0, maxTasks);
+    return { tasks: all.slice(0, maxTasks), truncated: true };
   }
 
   /**

--- a/tests/integration/task-repo-list-pagination.test.ts
+++ b/tests/integration/task-repo-list-pagination.test.ts
@@ -1,0 +1,124 @@
+// task-repo-list-pagination.test.ts — keyset pagination for TaskRepo.listTasks / listAllTasks
+// against real Postgres (#1433). Verifies that paging through a >100-task dataset is
+// deterministic (no skipped or duplicated rows), order-equivalent to a single unbounded fetch,
+// and that the listAllTasks safety ceiling caps the total with a logged warning.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { TaskRepo } from '../../src/db/task-repo.js';
+import type { EventBus } from '../../src/bus/bus.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const PREFIX = 'TaskRepoPage Test';
+const logger = pino({ level: 'silent' });
+const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  await pool.query(`DELETE FROM tasks WHERE title LIKE $1`, [`${PREFIX}%`]);
+}
+
+describeIf('TaskRepo keyset pagination (#1433)', () => {
+  let pool: pg.Pool;
+  let repo: TaskRepo;
+  const TOTAL = 250;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    repo = new TaskRepo(pool, noopBus, logger as never, 'UTC');
+    await cleanup(pool);
+    // Seed a dataset with heavy ties in the sort key so the id tiebreaker is genuinely exercised:
+    // priorities repeat across a small set, and roughly a third of rows have a null due_at (the
+    // NULLS-LAST tail). i drives all three so the mix is deterministic.
+    for (let i = 0; i < TOTAL; i++) {
+      const priority = 10 + (i % 5) * 10; // 10,20,30,40,50 repeating
+      const dueAt = i % 3 === 0 ? undefined : new Date(1_720_000_000_000 + (i % 7) * 86_400_000);
+      await repo.createTask({
+        agentId: 'coordinator',
+        title: `${PREFIX} ${String(i).padStart(4, '0')}`,
+        owner: 'ceo',
+        source: 'coordinator',
+        priority,
+        dueAt,
+      });
+    }
+  });
+  afterAll(async () => { await cleanup(pool); await pool.end(); });
+
+  it('listAllTasks returns every matching row with no skips or duplicates', async () => {
+    const all = await repo.listAllTasks(
+      { owner: 'ceo', statuses: ['open'] },
+      { pageSize: 40 },
+    );
+    // Restrict to this test's rows (the shared DB may hold unrelated ceo tasks).
+    const mine = all.filter((t) => t.title.startsWith(PREFIX));
+    expect(mine).toHaveLength(TOTAL);
+    const ids = new Set(mine.map((t) => t.id));
+    expect(ids.size).toBe(TOTAL); // no duplicates
+  });
+
+  it('paged traversal is order-equivalent to a single unbounded fetch', async () => {
+    // Ground truth: one big page (limit above TOTAL) in the same deterministic order.
+    const single = (await repo.listTasks({ owner: 'ceo', statuses: ['open'], limit: 10_000 }))
+      .filter((t) => t.title.startsWith(PREFIX));
+    const paged = (await repo.listAllTasks({ owner: 'ceo', statuses: ['open'] }, { pageSize: 37 }))
+      .filter((t) => t.title.startsWith(PREFIX));
+    expect(paged.map((t) => t.id)).toEqual(single.map((t) => t.id));
+
+    // And the order actually honors priority DESC, due_at ASC NULLS LAST, id ASC.
+    for (let i = 1; i < single.length; i++) {
+      const prev = single[i - 1]!;
+      const cur = single[i]!;
+      if (prev.priority !== cur.priority) {
+        expect(prev.priority).toBeGreaterThan(cur.priority);
+        continue;
+      }
+      // Same priority → due_at ascending with nulls last, id ascending on ties.
+      const prevNull = prev.dueAt === null;
+      const curNull = cur.dueAt === null;
+      if (prevNull || curNull) {
+        // A non-null must never come after a null (nulls sort last).
+        if (prevNull && !curNull) throw new Error('null due_at sorted before a non-null');
+        if (prevNull && curNull) expect(prev.id < cur.id).toBe(true);
+        continue;
+      }
+      if (prev.dueAt !== cur.dueAt) {
+        expect(prev.dueAt! <= cur.dueAt!).toBe(true);
+      } else {
+        expect(prev.id < cur.id).toBe(true);
+      }
+    }
+  });
+
+  it('a single explicit cursor page resumes exactly after the prior page', async () => {
+    const page1 = await repo.listTasks({ owner: 'ceo', statuses: ['open'], limit: 50 });
+    const last = page1[page1.length - 1]!;
+    const page2 = await repo.listTasks({
+      owner: 'ceo',
+      statuses: ['open'],
+      limit: 50,
+      cursor: { priority: last.priority, dueAt: last.dueAt, id: last.id },
+    });
+    const page1Ids = new Set(page1.map((t) => t.id));
+    // No overlap between the two pages.
+    expect(page2.some((t) => page1Ids.has(t.id))).toBe(false);
+  });
+
+  it('listAllTasks enforces the safety ceiling and logs a warning', async () => {
+    const warnings: unknown[] = [];
+    const capLogger = pino(
+      { level: 'warn' },
+      { write: (msg: string) => warnings.push(JSON.parse(msg)) },
+    );
+    const capRepo = new TaskRepo(pool, noopBus, capLogger as never, 'UTC');
+    const capped = await capRepo.listAllTasks(
+      { owner: 'ceo', statuses: ['open'] },
+      { pageSize: 40, maxTasks: 100 },
+    );
+    expect(capped).toHaveLength(100);
+    expect(warnings.some((w) => JSON.stringify(w).includes('safety ceiling'))).toBe(true);
+  });
+});

--- a/tests/integration/task-repo-list-pagination.test.ts
+++ b/tests/integration/task-repo-list-pagination.test.ts
@@ -3,7 +3,7 @@
 // deterministic (no skipped or duplicated rows), order-equivalent to a single unbounded fetch,
 // and that the listAllTasks safety ceiling caps the total with a logged warning.
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import pg from 'pg';
 import pino from 'pino';
 import { TaskRepo } from '../../src/db/task-repo.js';

--- a/tests/integration/task-repo-list-pagination.test.ts
+++ b/tests/integration/task-repo-list-pagination.test.ts
@@ -14,6 +14,9 @@ const DATABASE_URL = process.env.DATABASE_URL;
 const describeIf = DATABASE_URL ? describe : describe.skip;
 
 const PREFIX = 'TaskRepoPage Test';
+// Unique tag on every seeded row so a filter can isolate exactly this suite's tasks (the shared DB
+// may hold unrelated ceo/open rows), which the exact-boundary test needs for a deterministic count.
+const TAG = 'taskrepo-page-test';
 const logger = pino({ level: 'silent' });
 const noopBus = { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
 
@@ -43,6 +46,7 @@ describeIf('TaskRepo keyset pagination (#1433)', () => {
         source: 'coordinator',
         priority,
         dueAt,
+        tags: [TAG],
       });
     }
   });
@@ -122,5 +126,25 @@ describeIf('TaskRepo keyset pagination (#1433)', () => {
     expect(capped.tasks).toHaveLength(100);
     expect(capped.truncated).toBe(true);
     expect(warnings.some((w) => JSON.stringify(w).includes('safety ceiling'))).toBe(true);
+  });
+
+  it('does not report truncated when the full set lands exactly on the ceiling boundary', async () => {
+    // Exact-boundary regression (CodeRabbit): TOTAL rows, pageSize divides TOTAL, and maxTasks ===
+    // TOTAL. The last full page brings the count to exactly maxTasks — with a `>=` check that would
+    // falsely warn + report truncated:true. The tag filter isolates precisely this suite's rows so
+    // the count is deterministic on the shared DB.
+    const warnings: unknown[] = [];
+    const boundaryLogger = pino(
+      { level: 'warn' },
+      { write: (msg: string) => warnings.push(JSON.parse(msg)) },
+    );
+    const boundaryRepo = new TaskRepo(pool, noopBus, boundaryLogger as never, 'UTC');
+    const result = await boundaryRepo.listAllTasks(
+      { tag: TAG, statuses: ['open'] },
+      { pageSize: 50, maxTasks: TOTAL }, // 250 / 50 = 5 exact pages, ceiling === full-set size
+    );
+    expect(result.tasks).toHaveLength(TOTAL);
+    expect(result.truncated).toBe(false);
+    expect(warnings).toHaveLength(0); // no spurious "safety ceiling" warning
   });
 });

--- a/tests/integration/task-repo-list-pagination.test.ts
+++ b/tests/integration/task-repo-list-pagination.test.ts
@@ -49,12 +49,13 @@ describeIf('TaskRepo keyset pagination (#1433)', () => {
   afterAll(async () => { await cleanup(pool); await pool.end(); });
 
   it('listAllTasks returns every matching row with no skips or duplicates', async () => {
-    const all = await repo.listAllTasks(
+    const { tasks, truncated } = await repo.listAllTasks(
       { owner: 'ceo', statuses: ['open'] },
       { pageSize: 40 },
     );
+    expect(truncated).toBe(false); // drained fully, well under the default ceiling
     // Restrict to this test's rows (the shared DB may hold unrelated ceo tasks).
-    const mine = all.filter((t) => t.title.startsWith(PREFIX));
+    const mine = tasks.filter((t) => t.title.startsWith(PREFIX));
     expect(mine).toHaveLength(TOTAL);
     const ids = new Set(mine.map((t) => t.id));
     expect(ids.size).toBe(TOTAL); // no duplicates
@@ -65,7 +66,7 @@ describeIf('TaskRepo keyset pagination (#1433)', () => {
     const single = (await repo.listTasks({ owner: 'ceo', statuses: ['open'], limit: 10_000 }))
       .filter((t) => t.title.startsWith(PREFIX));
     const paged = (await repo.listAllTasks({ owner: 'ceo', statuses: ['open'] }, { pageSize: 37 }))
-      .filter((t) => t.title.startsWith(PREFIX));
+      .tasks.filter((t) => t.title.startsWith(PREFIX));
     expect(paged.map((t) => t.id)).toEqual(single.map((t) => t.id));
 
     // And the order actually honors priority DESC, due_at ASC NULLS LAST, id ASC.
@@ -118,7 +119,8 @@ describeIf('TaskRepo keyset pagination (#1433)', () => {
       { owner: 'ceo', statuses: ['open'] },
       { pageSize: 40, maxTasks: 100 },
     );
-    expect(capped).toHaveLength(100);
+    expect(capped.tasks).toHaveLength(100);
+    expect(capped.truncated).toBe(true);
     expect(warnings.some((w) => JSON.stringify(w).includes('safety ceiling'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`ceo-inbox-sent-observe` matched sent mail against open CEO tasks with `listTasks({ limit: 100 })`, so beyond 100 open tasks completion matching silently failed — a warning logged but the tasks were never considered. This adds keyset pagination so the handler evaluates **all** eligible open/in-progress CEO tasks.

- **`TaskRepo.listTasks`** — added a `TaskListCursor` and `cursor` filter, and a deterministic total order (`priority DESC, due_at ASC NULLS LAST, id ASC`). The `id` tiebreaker makes the sort stable so paging never skips or duplicates a row, including the NULL-`due_at` tail.
- **`TaskRepo.listAllTasks`** — new helper that walks keyset pages and returns `{ tasks, truncated }`. A safety ceiling (default 5000) caps pathological volumes, logs a warning, and sets `truncated` so the caller can react (mirrors the `{ messages, truncated }` shape the handler already consumes from `listAllMessages`).
- **`ceo-inbox-sent-observe`** — completion matching now uses `listAllTasks`; if the ceiling is hit it logs a warning and surfaces `tasks_truncated` in the result data instead of presenting a partial set as full coverage.

Closes #1433

## Testing

- New integration test (`tests/integration/task-repo-list-pagination.test.ts`, real Postgres): 250-row dataset with heavy sort-key ties + ~1/3 null `due_at`; verifies full-set traversal, order-equivalence to a single unbounded fetch, no skips/dupes, single-cursor resume, and the ceiling cap + `truncated` flag + warning.
- Handler unit tests: a match at index 130 of 150 open tasks still produces a candidate (old-cap regression); `tasks_truncated` propagation + warning on ceiling hit.
- `pnpm run typecheck` clean; 26 handler unit tests + 4 integration tests pass.

## Notes / follow-up

The ceiling truncation is currently non-recoverable (same first 5000 rows every run, lowest-priority tail dropped). Building an oldest-first drain like the Sent-scan path is deliberately out of scope for this issue (which asks for a logged safety ceiling); the `truncated` signal now makes a ceiling hit visible if it ever happens.