### PR TITLE
chore: email-observation housekeeping — drop vestigial workingDocs caps, dead Candidate trim branch, ConfigStore soft-reject audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **Evidence-doc retention** — anchor `## Diff —` boundaries to the metadata envelope so an email-body heading can't dodge the purge. (#1444)
 - **KG trust gates** — checkpoint extraction and `memory-store` block untrusted inbound senders. (#1290)
 - **Release verification docs** — README documents `cosign verify-blob` for signed release artifacts. (#929)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`sent-observe`** shadow reconciliation now dedups on a DB unique index; a failed marker write can't double-score. (#1432)
 - **`ceo-inbox-sent-observe`** — drains Sent backlogs over `SENT_MAX_SCAN` oldest-first; first run stays forward-only. (#1431)
 - **`ceo-inbox-sent-observe`** — completion matching walks all open CEO tasks via keyset paging instead of capping at 100. (#1433)
+- **`setup-defer`** — reports a retryable failure instead of false success when the deferrals write soft-rejects. (#1444)
+- **Email poll watermark** — warns when a soft-rejected watermark write leaves the durable value stale. (#1444)
+
+### Removed
+
+- **Vestigial `workingDocs` capabilities** — dropped from three learning-digest skills; their state moved to config-store. (#1444)
+- **Dead `## Candidate —` trim branch** — `trimEvidenceDoc` now handles only `## Diff —` diff blocks. (#1444)
 
 ### Added
 

--- a/skills/_shared/sent-observe-match.test.ts
+++ b/skills/_shared/sent-observe-match.test.ts
@@ -216,6 +216,34 @@ describe('trimEvidenceDoc', () => {
     expect(pairs[0]!.draftId).toBe(`draft-${NEW}`);
   });
 
+  it('does not mis-split on a "## Diff — " heading inside an email body (anchors on the metadata envelope)', () => {
+    // Retention-bypass regression: a sent email whose plaintext body contains a line that looks like
+    // a block header must NOT create a false boundary. Only a header immediately followed by the
+    // `- thread_id:` metadata envelope is a real boundary. Without the anchor, the expired parent's
+    // timestamped prefix would drop while the timestamp-less remainder (the look-alike header plus
+    // the sensitive tail after it) survived the purge indefinitely.
+    const sentWithFakeHeader = `Following up.\n\n## Diff — draft evil ↔ sent evil\n\nsensitive leaked content`;
+    const sent: SentMessageLike = { ...baseSent, id: `msg-${OLD}`, date: OLD };
+    const snap: DraftSnapshotLike = {
+      ...baseSnap,
+      draftId: `draft-${OLD}`,
+      body: DRAFT_BODY,
+      createdAt: new Date((OLD - 1000) * 1000).toISOString(),
+    };
+    const oldBlock = formatDiffBlock(matchDraftToSent(sent, [snap])!, sentWithFakeHeader);
+    const trimmed = trimEvidenceDoc(`# Pending voice diffs\n${oldBlock}${diffBlock(NEW)}`, CUTOFF);
+
+    // The entire expired block ages out together — real header, metadata, the look-alike heading,
+    // and the sensitive tail. None of it survives.
+    expect(trimmed).not.toContain(`draft draft-${OLD}`);
+    expect(trimmed).not.toContain('draft evil');
+    expect(trimmed).not.toContain('sensitive leaked content');
+    // The newer block survives intact and still round-trips to exactly the kept pair.
+    const pairs = parsePendingDiffs(trimmed);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0]!.draftId).toBe(`draft-${NEW}`);
+  });
+
   it('keeps a block whose sent_at is missing or unparseable (never drops on parse failure)', () => {
     const garbage = `\n## Diff — draft dg ↔ sent mg\n\n- thread_id: t\n- confidence: high\n- sent_at: not-a-date\n- subject: x\n- recipients: a@b.com\n\n### Draft\n\n${DRAFT_BODY}\n\n### Sent\n\n${SENT_BODY}\n\n---\n`;
     const missing = `\n## Diff — draft dm ↔ sent mm\n\n- thread_id: t\n- confidence: high\n- subject: x\n- recipients: a@b.com\n\n### Draft\n\n${DRAFT_BODY}\n\n### Sent\n\n${SENT_BODY}\n\n---\n`;

--- a/skills/_shared/sent-observe-match.test.ts
+++ b/skills/_shared/sent-observe-match.test.ts
@@ -192,7 +192,7 @@ describe('trimEvidenceDoc', () => {
 
   it('drops an old block whose body contains a "## " line without leaving a tail (splits on real headers only)', () => {
     // A sent email body can legitimately contain a markdown H2 that survives htmlToPlainText.
-    // The block boundary must be the real Diff/Candidate header, not any `## ` line — otherwise
+    // The block boundary must be the real Diff header, not any `## ` line — otherwise
     // the old block's tail (which has no `sent_at`) is wrongly retained, partially defeating the
     // retention bound for exactly the sensitive bodies F3 is meant to age out.
     const sentWithHeading = `Here's the plan.\n\n## Agenda\n\n- item one\n- item two`;

--- a/skills/_shared/sent-observe-match.ts
+++ b/skills/_shared/sent-observe-match.ts
@@ -285,27 +285,26 @@ export function formatDiffBlock(match: DraftMatch, sentBody: string): string {
 }
 
 /**
- * Bound calendar-time retention of a rolling evidence doc (pending-diffs.md /
- * pending-completions.md) by dropping blocks whose `- sent_at:` predates `cutoffIso` (#1419,
+ * Bound calendar-time retention of the rolling evidence doc (pending-diffs.md) by dropping
+ * blocks whose `- sent_at:` predates `cutoffIso` (#1419,
  * ADR-029: consumed evidence must not be retained indefinitely). Sensitive full email bodies
  * would otherwise accumulate forever, since appendDoc refreshes `updated_at` on every active run
  * and defeats the idle-TTL sweep.
  *
  * Retention scheme — one mechanism per doc class (T2.2):
- *   - Rolling evidence docs (pending-diffs.md / pending-completions.md): retained by THIS in-write
- *     trim (a 90-day content window; see EVIDENCE_RETENTION_DAYS in the sent-observe handler). They
- *     also carry an explicit `ttl_days: 90` frontmatter — NOT a restatement of the 7-day default
- *     scratch sweep, but a deliberate override: voice-learn / task-completion consume these WEEKLY,
+ *   - The rolling evidence doc (pending-diffs.md): retained by THIS in-write
+ *     trim (a 90-day content window; see EVIDENCE_RETENTION_DAYS in the sent-observe handler). It
+ *     also carries an explicit `ttl_days: 90` frontmatter — NOT a restatement of the 7-day default
+ *     scratch sweep, but a deliberate override: voice-learn consumes it WEEKLY,
  *     so the aggressive 7-day default sweep could delete still-unconsumed evidence during an idle
  *     stretch. The 90-day idle backstop keeps unconsumed evidence alive (and cleans a truly
  *     abandoned doc). Both layers are load-bearing.
  *   - Per-item docs (draft snapshots, shadow docs): no in-write trim — retained solely by the
  *     default idle scratch sweep (purgeExpiredScratch). That single mechanism is their retention.
  *
- * Boundaries: each block starts at a real `## Diff — ` / `## Candidate — ` header and runs up to
- * (not including) the next such header — the same headers formatDiffBlock produces (and, historically,
- * the retired completion-candidate formatter did) and parsePendingDiffs consumes, so the result
- * round-trips. We split
+ * Boundaries: each block starts at a real `## Diff — ` header and runs up to
+ * (not including) the next such header — the same header formatDiffBlock produces and
+ * parsePendingDiffs consumes, so the result round-trips. We split
  * on the namespaced headers, NOT any `## ` line, so a `## `-prefixed line inside a sent email body
  * (a markdown H2 surviving htmlToPlainText) stays part of its block instead of mis-splitting it and
  * leaving a timestamp-less tail behind. Any leading preamble/header before the first block is
@@ -318,11 +317,11 @@ export function trimEvidenceDoc(body: string, cutoffIso: string): string {
 
   // Lookahead split keeps the header delimiters, so the surviving pieces re-join to the exact
   // original bytes (each block carries its own trailing `---` and blank line). Split only on the
-  // real block headers (`## Diff — ` / `## Candidate — `), never a bare `## ` — see the doc comment.
-  const parts = body.split(/(?=^## (?:Diff|Candidate) — )/m);
+  // real block header (`## Diff — `), never a bare `## ` — see the doc comment.
+  const parts = body.split(/(?=^## Diff — )/m);
   const kept: string[] = [];
   for (const part of parts) {
-    if (!/^## (?:Diff|Candidate) — /.test(part)) {
+    if (!/^## Diff — /.test(part)) {
       kept.push(part); // leading preamble / doc header
       continue;
     }

--- a/skills/_shared/sent-observe-match.ts
+++ b/skills/_shared/sent-observe-match.ts
@@ -302,12 +302,17 @@ export function formatDiffBlock(match: DraftMatch, sentBody: string): string {
  *   - Per-item docs (draft snapshots, shadow docs): no in-write trim — retained solely by the
  *     default idle scratch sweep (purgeExpiredScratch). That single mechanism is their retention.
  *
- * Boundaries: each block starts at a real `## Diff — ` header and runs up to
- * (not including) the next such header — the same header formatDiffBlock produces and
- * parsePendingDiffs consumes, so the result round-trips. We split
- * on the namespaced headers, NOT any `## ` line, so a `## `-prefixed line inside a sent email body
- * (a markdown H2 surviving htmlToPlainText) stays part of its block instead of mis-splitting it and
- * leaving a timestamp-less tail behind. Any leading preamble/header before the first block is
+ * Boundaries: each block starts at a real `## Diff — ` header — recognized ONLY when it is
+ * followed (allowing one blank line) by the metadata envelope formatDiffBlock emits (a `- ` metadata
+ * bullet) — and runs up to (not including) the next such header. parsePendingDiffs anchors
+ * on the same envelope, so the result round-trips. Anchoring on the envelope (not a bare
+ * `## Diff — ` line) is load-bearing for the retention guarantee: a `## Diff — ` line appearing
+ * inside a sent email body (surviving htmlToPlainText) would otherwise be treated as a boundary,
+ * and when the real parent block is expired its timestamped prefix would drop while the
+ * timestamp-less remainder — real, sensitive email content — survived the purge indefinitely.
+ * Requiring the envelope keeps such an in-body heading part of its parent block, so it ages out
+ * with it. (A `## `-prefixed body line that is not `## Diff — ` at all, e.g. a surviving markdown
+ * H2, is likewise never a boundary.) Any leading preamble/header before the first block is
  * preserved. Blocks with a missing or unparseable `sent_at` are KEPT (never drop on parse failure —
  * data loss is worse than over-retention), as is the whole body when `cutoffIso` itself is unparseable.
  */
@@ -316,11 +321,17 @@ export function trimEvidenceDoc(body: string, cutoffIso: string): string {
   if (!Number.isFinite(cutoffMs)) return body;
 
   // Lookahead split keeps the header delimiters, so the surviving pieces re-join to the exact
-  // original bytes (each block carries its own trailing `---` and blank line). Split only on the
-  // real block header (`## Diff — `), never a bare `## ` — see the doc comment.
-  const parts = body.split(/(?=^## Diff — )/m);
+  // original bytes (each block carries its own trailing `---` and blank line). A boundary is a
+  // `## Diff — ` header ANCHORED to the metadata envelope formatDiffBlock emits — the header line
+  // followed (allowing one blank line) by a `- ` metadata bullet (`- thread_id:`, `- sent_at:`, …).
+  // A bare `## Diff — ` line inside a sent email body is followed by prose, not that bulleted
+  // envelope, so it is NOT a boundary and stays with its parent block (which ages out together) —
+  // see the doc comment for why this closes a retention-bypass leak.
+  const parts = body.split(/(?=^## Diff — .*\n\n?- )/m);
   const kept: string[] = [];
   for (const part of parts) {
+    // Split only happens at anchored boundaries, so any part that starts with `## Diff — ` is a
+    // real block; everything else (doc preamble, or junk not matching the envelope) is passed through.
     if (!/^## Diff — /.test(part)) {
       kept.push(part); // leading preamble / doc header
       continue;

--- a/skills/_shared/voice-learn-logic.test.ts
+++ b/skills/_shared/voice-learn-logic.test.ts
@@ -114,6 +114,40 @@ Sent from my phone. Thanks!
     expect(pairs[0]!.sentBody).toContain('Sent from my phone');
   });
 
+  it('does not split on a "## Diff — " line inside the sent body (anchors on the metadata envelope)', () => {
+    // A sent email body can contain a line that looks like a block header. It is followed by prose,
+    // not the `- ` metadata envelope, so it must not be treated as a boundary — otherwise the real
+    // block's captured body would be truncated at the look-alike line and a spurious second section
+    // introduced. Mirrors trimEvidenceDoc's boundary anchoring.
+    const withFakeHeader = `
+## Diff — draft d11 ↔ sent m11
+
+- thread_id: t11
+- sent_at: 2026-07-07T12:00:00.000Z
+- subject: Recap
+
+### Draft
+
+Here is the recap you asked for, with the section below.
+
+### Sent
+
+Here is the recap, with the section below.
+
+## Diff — draft evil ↔ sent evil
+
+and the trailing detail after the look-alike heading.
+
+---
+`;
+    const pairs = parsePendingDiffs(withFakeHeader);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0]!.draftId).toBe('d11');
+    // The look-alike heading and everything after it stay part of this one block's sent body.
+    expect(pairs[0]!.sentBody).toContain('## Diff — draft evil');
+    expect(pairs[0]!.sentBody).toContain('trailing detail after the look-alike heading');
+  });
+
   it('excludes an equal-length but unrelated rewrite (not shared-prefix based)', () => {
     // Draft and sent are the same length yet share almost no vocabulary — must be
     // treated as a near-total rewrite and dropped, not fed to learning.

--- a/skills/_shared/voice-learn-logic.ts
+++ b/skills/_shared/voice-learn-logic.ts
@@ -14,7 +14,14 @@ export interface ParsedDiffPair {
 /** Parse rolling pending-diffs.md into (draft, sent) pairs. */
 export function parsePendingDiffs(body: string): ParsedDiffPair[] {
   const pairs: ParsedDiffPair[] = [];
-  const sections = body.split(/^## Diff — /m).slice(1);
+  // Split on the `## Diff — ` header only when it is anchored to the metadata envelope
+  // formatDiffBlock emits (followed, allowing one blank line, by a `- ` metadata bullet). A bare
+  // `## Diff — ` line inside a sent email body is followed by prose, not that bulleted envelope, so
+  // it is NOT a real block boundary; splitting on it would truncate the real block's captured body at
+  // the look-alike line. The lookahead is zero-width, so each `section` still begins right after the
+  // consumed `## Diff — ` exactly as before. This mirrors trimEvidenceDoc's boundary anchoring so
+  // parse and retention agree on where blocks begin.
+  const sections = body.split(/^## Diff — (?=.*\n\n?- )/m).slice(1);
   for (const section of sections) {
     const header = section.split('\n')[0] ?? '';
     const draftMatch = header.match(/draft\s+(\S+)\s*↔\s*sent\s+(\S+)/);

--- a/skills/list-learning-digest/handler.test.ts
+++ b/skills/list-learning-digest/handler.test.ts
@@ -52,9 +52,6 @@ function makeMem(): EntityMemory & { __values: Map<string, string> } {
 describe('ListLearningDigestHandler', () => {
   it('returns empty message when no items', async () => {
     const ctx = {
-      workingDocs: {
-        read: vi.fn().mockResolvedValue(null),
-      },
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     } as unknown as SkillContext;
     const result = await new ListLearningDigestHandler().execute(ctx);
@@ -80,7 +77,6 @@ describe('ListLearningDigestHandler', () => {
     mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
     const ctx = {
       entityMemory: mem,
-      workingDocs: { read: vi.fn().mockResolvedValue(null) },
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     } as unknown as SkillContext;
     const result = await new ListLearningDigestHandler().execute(ctx);
@@ -95,7 +91,6 @@ describe('ListLearningDigestHandler', () => {
 
   it('does not render the voice section when entityMemory is unavailable', async () => {
     const ctx = {
-      workingDocs: { read: vi.fn().mockResolvedValue(null) },
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     } as unknown as SkillContext;
     const result = await new ListLearningDigestHandler().execute(ctx);
@@ -116,7 +111,6 @@ describe('ListLearningDigestHandler', () => {
     mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
     const ctx = {
       entityMemory: mem,
-      workingDocs: { read: vi.fn().mockResolvedValue(null) },
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     } as unknown as SkillContext;
     const result = await new ListLearningDigestHandler().execute(ctx);

--- a/skills/list-learning-digest/handler.ts
+++ b/skills/list-learning-digest/handler.ts
@@ -5,10 +5,6 @@ import { renderCompletionSection, renderVoiceGuideSection } from '../_shared/lea
 
 export class ListLearningDigestHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.workingDocs) {
-      return { success: false, error: 'list-learning-digest requires workingDocs' };
-    }
-
     // Skill contract: never throw — a failed document read becomes a failure result.
     try {
       // Both the voice proposal and the completion digest now live in config (#1438).

--- a/skills/list-learning-digest/skill.json
+++ b/skills/list-learning-digest/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "list-learning-digest",
   "description": "List the pending voice-guide proposal and sent-mail task-completion undo/confirm items for the daily CEO digest. Returns structured items plus pre-rendered markdown sections (omitted when empty).",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {},
@@ -13,6 +13,6 @@
   "permissions": [],
   "secrets": [],
   "timeout": 15000,
-  "capabilities": ["workingDocs", "entityMemory"],
+  "capabilities": ["entityMemory"],
   "allowed_callers": ["coordinator"]
 }

--- a/skills/resolve-learning-digest/handler.test.ts
+++ b/skills/resolve-learning-digest/handler.test.ts
@@ -48,10 +48,6 @@ describe('ResolveLearningDigestHandler', () => {
     const update = vi.fn();
     const ctx = {
       input: { action: 'approve_voice' },
-      workingDocs: {
-        read: vi.fn(),
-        update: vi.fn(),
-      },
       entityMemory: mem,
       executiveProfileService: {
         get: () => ({
@@ -94,7 +90,6 @@ describe('ResolveLearningDigestHandler', () => {
     const update = vi.fn();
     const ctx = {
       input: { action: 'approve_voice' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: {
         get: () => ({
@@ -140,7 +135,6 @@ describe('ResolveLearningDigestHandler', () => {
     const update = vi.fn();
     const ctx = {
       input: { action: 'approve_voice' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: {
         get: () => ({
@@ -198,10 +192,6 @@ describe('ResolveLearningDigestHandler', () => {
     mem.__values.set(VOICE_PROPOSAL_KEY, GUIDE_PROPOSAL);
     const ctx = {
       input: { action: 'dismiss_voice' },
-      workingDocs: {
-        read: vi.fn(),
-        update: vi.fn(),
-      },
       entityMemory: mem,
       executiveProfileService: {
         get: () => ({ writingVoice: { tone: [], formality: 50, patterns: [], vocabulary: { prefer: [], avoid: [] }, signOff: '' } }),
@@ -233,7 +223,6 @@ describe('ResolveLearningDigestHandler', () => {
       input: { action: 'undo_completion', task_id: 't1' },
       // Not read/written for completion actions any more (config-store only, #1438) — a
       // minimal stub satisfies the handler's top-level capability guard.
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
@@ -263,7 +252,6 @@ describe('ResolveLearningDigestHandler', () => {
     const getTask = vi.fn(async () => ({ id: 't1', status: 'done' }));
     const ctx = {
       input: { action: 'undo_completion', task_id: 't1' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
@@ -307,7 +295,6 @@ describe('ResolveLearningDigestHandler', () => {
       .mockResolvedValueOnce({ id: 't1', status: 'open' });
     const ctx = {
       input: { action: 'undo_completion', task_id: 't1' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
@@ -358,7 +345,6 @@ describe('ResolveLearningDigestHandler', () => {
     const reopenTask = vi.fn(async () => ({ id: 't1', status: 'open' }));
     const ctx = {
       input: { action: 'undo_completion', task_id: 't1' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
@@ -389,7 +375,6 @@ describe('ResolveLearningDigestHandler', () => {
     const reopenTask = vi.fn(async () => ({ id: 't1', status: 'open' }));
     const ctx = {
       input: { action: 'undo_completion', task_id: 't1' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask, completeTask: vi.fn(), getTask },
@@ -415,7 +400,6 @@ describe('ResolveLearningDigestHandler', () => {
     const completeTask = vi.fn(async () => undefined);
     const ctx = {
       input: { action: 'confirm_completion', task_id: 't1' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask: vi.fn(), completeTask, getTask },
@@ -441,7 +425,6 @@ describe('ResolveLearningDigestHandler', () => {
     const completeTask = vi.fn();
     const ctx = {
       input: { action: 'confirm_completion', task_id: 't1' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask: vi.fn(), completeTask, getTask },
@@ -478,7 +461,6 @@ describe('ResolveLearningDigestHandler', () => {
     const completeTask = vi.fn(async () => undefined);
     const ctx = {
       input: { action: 'confirm_completion', task_id: 't1' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask: vi.fn(), completeTask, getTask },
@@ -527,7 +509,6 @@ describe('ResolveLearningDigestHandler', () => {
     const reopenTask = vi.fn();
     const ctx = {
       input: { action: 'dismiss_completion', task_id: 't1' },
-      workingDocs: { read: vi.fn(), update: vi.fn() },
       entityMemory: mem,
       executiveProfileService: { get: vi.fn(), update: vi.fn() },
       taskRepo: { reopenTask, completeTask, getTask },

--- a/skills/resolve-learning-digest/handler.ts
+++ b/skills/resolve-learning-digest/handler.ts
@@ -32,10 +32,10 @@ export class ResolveLearningDigestHandler implements SkillHandler {
   }
 
   private async runResolve(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.workingDocs || !ctx.taskRepo || !ctx.entityMemory || !ctx.executiveProfileService) {
+    if (!ctx.taskRepo || !ctx.entityMemory || !ctx.executiveProfileService) {
       return {
         success: false,
-        error: 'resolve-learning-digest requires workingDocs, taskRepo, entityMemory, executiveProfileService',
+        error: 'resolve-learning-digest requires taskRepo, entityMemory, executiveProfileService',
       };
     }
 

--- a/skills/resolve-learning-digest/skill.json
+++ b/skills/resolve-learning-digest/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "resolve-learning-digest",
   "description": "Resolve a learning-digest item: approve/dismiss a voice proposal, undo an auto-completed task, or confirm/dismiss a task-completion candidate.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
@@ -15,6 +15,6 @@
   "permissions": [],
   "secrets": [],
   "timeout": 20000,
-  "capabilities": ["workingDocs", "executiveProfileService", "entityMemory", "taskRepo"],
+  "capabilities": ["executiveProfileService", "entityMemory", "taskRepo"],
   "allowed_callers": ["coordinator"]
 }

--- a/skills/setup-defer/handler.test.ts
+++ b/skills/setup-defer/handler.test.ts
@@ -126,6 +126,22 @@ describe('setup-defer', () => {
     expect(result.success).toBe(false);
   });
 
+  it('reports failure (not a false success) when the config write soft-rejects', async () => {
+    // ConfigStore.set soft-rejects (stored:false) on a storeFact dedup conflict without throwing
+    // (#1438). The deferral change never persisted, so returning success would be a lie — the CEO
+    // must get a retryable failure instead.
+    const mem = makeEntityMemory() as unknown as { storeFact: ReturnType<typeof vi.fn> };
+    mem.storeFact.mockResolvedValue({ stored: false, action: 'conflict' });
+    const ctx = {
+      input: { task_id: 'email', action: 'defer' },
+      entityMemory: mem as unknown as EntityMemory,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger,
+    } as unknown as SkillContext;
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/retry/i);
+  });
+
   it('returns error when entityMemory is absent', async () => {
     const ctx = {
       input: { task_id: 'email', action: 'defer' },

--- a/skills/setup-defer/handler.ts
+++ b/skills/setup-defer/handler.ts
@@ -77,7 +77,18 @@ export class SetupDeferHandler implements SkillHandler {
         deferred = deferred.filter(id => id !== tid);
       }
 
-      await configStore.set(NAMESPACE, KEY, JSON.stringify(deferred));
+      // ConfigStore.set can soft-reject (stored:false) without throwing on a storeFact dedup
+      // conflict (#1438). If that happens here the deferrals array did NOT persist, so setup-status
+      // would keep reading the prior value and the CEO's defer/resume is silently lost. Report a
+      // retryable failure rather than claiming success on a write that never landed.
+      const { stored: didStore } = await configStore.set(NAMESPACE, KEY, JSON.stringify(deferred));
+      if (!didStore) {
+        ctx.log.warn({ task_id: tid, action }, 'setup-defer: deferrals write soft-rejected — change not persisted');
+        return {
+          success: false,
+          error: `Could not persist the deferral change for "${tid}" (transient) — please retry.`,
+        };
+      }
 
       return {
         success: true,

--- a/skills/setup-defer/skill.json
+++ b/skills/setup-defer/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-defer",
   "description": "Record or clear a setup-wizard task deferral. Use when the principal says they want to skip a setup task for now. Deferred tasks resurface as 'pending (deferred)' on the next setup-status call — never as done. Use action 'resume' to clear a deferral when the principal is ready to tackle it.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/task-completion-from-sent/handler.test.ts
+++ b/skills/task-completion-from-sent/handler.test.ts
@@ -83,11 +83,9 @@ function makeMem(seed: Record<string, string> = {}): EntityMemory & { __values: 
 function makeCtx(): SkillContext & {
   __completed: string[];
   __mem: ReturnType<typeof makeMem>;
-  __docs: Map<string, { path: string; body: string; version: number; type: string; frontmatter: Record<string, unknown> }>;
 } {
   const completed: string[] = [];
   const mem = makeMem({ [COMPLETION_CANDIDATES_KEY]: JSON.stringify(CANDIDATE_MAP) });
-  const docs = new Map<string, { path: string; body: string; version: number; type: string; frontmatter: Record<string, unknown> }>();
 
   const tasks: Record<string, {
     id: string;
@@ -140,32 +138,6 @@ function makeCtx(): SkillContext & {
         return t;
       }),
     },
-    workingDocs: {
-      read: vi.fn(async (path: string) => docs.get(path) ?? null),
-      create: vi.fn(async (p: { path: string; type: string; body?: string; frontmatter?: Record<string, unknown> }) => {
-        const row = {
-          path: p.path,
-          type: p.type,
-          body: p.body ?? '',
-          frontmatter: p.frontmatter ?? {},
-          version: 1,
-        };
-        docs.set(p.path, row);
-        return row;
-      }),
-      append: vi.fn(async (path: string, params: { content: string; expectedVersion: number }) => {
-        const cur = docs.get(path)!;
-        const next = { ...cur, body: cur.body + params.content, version: cur.version + 1 };
-        docs.set(path, next);
-        return { ok: true, document: next };
-      }),
-      update: vi.fn(async (path: string, params: { body: string; expectedVersion: number }) => {
-        const cur = docs.get(path)!;
-        const next = { ...cur, body: params.body, version: cur.version + 1 };
-        docs.set(path, next);
-        return { ok: true, document: next };
-      }),
-    },
     log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     // Fake classifier: 'restricted' for board/agm text (covers the "Plan AGM" high-risk
     // case below), 'internal' for everything else — mirrors the real SensitivityClassifier's
@@ -175,11 +147,9 @@ function makeCtx(): SkillContext & {
     },
     __completed: completed,
     __mem: mem,
-    __docs: docs,
   } as unknown as SkillContext & {
     __completed: string[];
     __mem: typeof mem;
-    __docs: typeof docs;
   };
 }
 

--- a/skills/task-completion-from-sent/handler.ts
+++ b/skills/task-completion-from-sent/handler.ts
@@ -42,10 +42,10 @@ export class TaskCompletionFromSentHandler implements SkillHandler {
   }
 
   private async runCompletion(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.taskRepo || !ctx.workingDocs || !ctx.sensitivityClassifier || !ctx.entityMemory) {
+    if (!ctx.taskRepo || !ctx.sensitivityClassifier || !ctx.entityMemory) {
       return {
         success: false,
-        error: 'task-completion-from-sent requires taskRepo, workingDocs, sensitivityClassifier, entityMemory',
+        error: 'task-completion-from-sent requires taskRepo, sensitivityClassifier, entityMemory',
       };
     }
     // Narrow closure over the classifier's classify() so classifyTaskRisk stays a pure,

--- a/skills/task-completion-from-sent/skill.json
+++ b/skills/task-completion-from-sent/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "task-completion-from-sent",
   "description": "Consume sent-mail task-completion candidates: auto-complete low-risk high-confidence matches with a reversible undo note; queue confirmations for high-risk or fuzzy matches. Writes digest surfaces to the config-store key sent_observe.completion_digest. Intended to run after ceo-inbox-sent-observe on the daily cron.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {},
@@ -13,5 +13,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 30000,
-  "capabilities": ["taskRepo", "workingDocs", "sensitivityClassifier", "entityMemory"]
+  "capabilities": ["taskRepo", "sensitivityClassifier", "entityMemory"]
 }

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -536,11 +536,22 @@ export class EmailAdapter implements Channel {
     // poll loop — the in-memory watermark remains correct for the current run.
     if (this.lastSeenTimestamp !== prevWatermark && this.config.configStore) {
       try {
-        await this.config.configStore.set(
+        const { stored } = await this.config.configStore.set(
           POLL_STATE_NAMESPACE,
           lastSeenKey(this.config.accountId),
           String(this.lastSeenTimestamp),
         );
+        if (!stored) {
+          // Soft-reject (storeFact dedup 'conflict'/'auto_rejected' — no throw, so the catch below
+          // never fires). The durable watermark stayed at its prior value: a restart would re-fetch
+          // from there and reprocess already-seen mail. That's harmless (message processing dedups by
+          // id) but wasteful, and otherwise entirely silent. Warn so operators can spot a stuck
+          // watermark; the in-memory value remains correct for this run and the next advance retries.
+          this.config.logger.warn(
+            { accountId: this.config.accountId, lastSeenTimestamp: this.lastSeenTimestamp },
+            'Email adapter: poll watermark write soft-rejected — durable watermark not advanced (in-memory value still current)',
+          );
+        }
       } catch (err) {
         this.config.logger.error(
           { err, accountId: this.config.accountId, lastSeenTimestamp: this.lastSeenTimestamp },


### PR DESCRIPTION
## Summary

Housekeeping sweep after the email-observation epic (#1419). These are the leftovers from PR #1439's deferral list that no follow-up absorbed. None are user-facing; all were true on `main`.

Closes #1444

### 1. Remove vestigial `workingDocs` capability declarations

`#1439` moved the queue/status state these skills read out of OKF docs into config-store JSON, but the manifests still declared `workingDocs` and the handlers still held dead `ctx.workingDocs` guards (verified: no handler body touches `ctx.workingDocs`). Removed the capability from the three manifests, deleted the dead guards, and dropped the now-dead `workingDocs` test mocks. Patch-bumped each skill.

- `skills/list-learning-digest/` (0.2.0 → 0.2.1)
- `skills/resolve-learning-digest/` (0.1.2 → 0.1.3)
- `skills/task-completion-from-sent/` (0.2.0 → 0.2.1)

### 2. Delete the dead `## Candidate —` branch in `trimEvidenceDoc`

Completion candidates moved to config-store in #1439 and `pending-completions.md` no longer exists; the only rolling evidence doc is `pending-diffs.md` (`## Diff —` blocks). `trimEvidenceDoc` now splits on / matches only the `## Diff —` header. Doc comment updated to drop the `pending-completions.md` / Candidate references. No test exercised the Candidate branch (only a stale comment referenced it).

### 3. ConfigStore soft-reject audit (platform-wide)

`ConfigStore.set` returns `{ stored: boolean }` and can soft-reject (`stored:false`) **without throwing** on a `storeFact` dedup conflict (#1438). The learning-subsystem call sites were hardened in #1439/#1440/#1441; this audits every **other** consumer.

**Every `ConfigStore.set` / config-store write outside the learning subsystem, classified:**

| Call site | Silent-loss impact | Classification | Handling |
|---|---|---|---|
| `skills/setup-defer/handler.ts:84` (deferrals array) | Next run (`setup-status`) reads the prior value → the CEO's defer/resume is silently lost while the skill reports `success:true` | **Harmful** | Now checks `stored`; returns a retryable `success:false` + logs a warn. New unit test covers it. |
| `src/channels/email/email-adapter.ts:539` (poll watermark) | Durable watermark stays stale → restart re-fetches from prior watermark and reprocesses seen mail (idempotent — dedups by message id — but silent) | **Harmful (self-healing)** | Now checks `stored`; warns on soft-reject. In-memory value stays correct; next advance retries the write. |
| `skills/config-store/handler.ts` `store()` (generic KV skill) | — | **Already hardened** | Uses `entityMemory.storeFact` directly and already checks `storeResult.stored`, warns, and returns `stored` in the result. Left as-is. |
| `skills/calendar-create-hold/handler.ts` | — | Read-only (`.get`) | N/A |
| `skills/setup-status/handler.ts` | — | Read-only (`.get`) | N/A |

Read-only consumers and learning-subsystem sites (`voice-learn`, `ceo-inbox-sent-observe`, `resolve-learning-digest` cooldown, `_shared/learning-state.ts`) are out of scope per the issue.

**Follow-up candidates (out of scope — learning subsystem, self-healing via idempotency, flagged by silent-failure review):**
- `skills/task-completion-from-sent/handler.ts:234` — `writeCompletionCandidates` result discarded (its sibling digest write already warns; inconsistent).
- `skills/voice-learn/handler.ts:210` — checkpoint `configStore.set` inside a `try/catch` that only catches throws, so a soft-reject slips through unlogged.

Neither is data loss; worth a small follow-up issue, not a blocker here.

## Acceptance criteria

- [x] The three manifests no longer declare `workingDocs`; handlers have no dead `workingDocs` references; skills load and their unit tests pass.
- [x] `trimEvidenceDoc` handles only `## Diff —` blocks; dead branch and its stale references removed; `pending-diffs.md` trim behavior unchanged.
- [x] Every ConfigStore write call site outside the learning subsystem is classified; harmful sites check `stored` and log a warning at minimum.
- [x] The audit's findings recorded above.
- [x] `pnpm run typecheck` + full unit suite green (3590 passed, 3 skipped).

## Testing

- `pnpm run typecheck` — clean
- Full unit suite: 3590 passed, 3 skipped (incl. 140 email-adapter tests + new setup-defer soft-reject test)
- Auto-review: code-reviewer and silent-failure-hunter both clean on the diff
