### PR TITLE
feat(browser): optional residential egress proxy for the web-browser skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`web-browser`** — optional egress proxy (`browser.proxy`) routes browsing through a residential exit, plus a WebRTC-leak guard.
 - **`TaskRepo.reopenTask` tests** — cover non-`done` rejection, `progress.notes` audit note, and `task.updated` emission. (#1434)
 
 ### Security

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -38,6 +38,10 @@ browser:
   # Browser channel: "chrome" for real Chrome (must be installed in the image),
   # empty for the bundled Playwright Chromium.
   channel: ""
+  # Optional egress proxy for browser traffic. Full URL or bare host:port
+  # (e.g. "http://browser-proxy:8888"). Empty → direct egress. Set this per-deployment
+  # to route the browser through a residential exit and avoid a datacenter-IP bot signal.
+  proxy: ""
   # Context locale (BCP 47).
   locale: "en-US"
 

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -47,6 +47,7 @@
         "sweepIntervalMs": { "type": "integer", "minimum": 1 },
         "profileDir": { "type": "string" },
         "channel": { "type": "string" },
+        "proxy": { "type": "string" },
         "locale": { "type": "string" }
       }
     },

--- a/src/browser/browser-service.test.ts
+++ b/src/browser/browser-service.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, symlinkSync, lstatSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { BrowserService, clearStaleX11Lock, clearStaleSingletonLock, isXServerBinary } from './browser-service.js';
+import { BrowserService, clearStaleX11Lock, clearStaleSingletonLock, isXServerBinary, parseProxyConfig } from './browser-service.js';
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
@@ -201,6 +201,48 @@ describe('BrowserService (unit — mocked browser)', () => {
 
   it('reports channel fallback inactive by default', () => {
     expect(service.isChannelFallbackActive()).toBe(false);
+  });
+
+  // Proxy propagation: the incognito path calls browser.newContext(buildContextOptions()),
+  // which is the same fingerprint-options builder the persistent launch uses. Asserting the
+  // options here proves the configured proxy reaches BOTH context types (real
+  // launchPersistentContext takes the same object). No proxy configured on the outer
+  // `service`, so these tests spin up dedicated instances.
+  it('propagates a configured proxy (with credentials) into context options', async () => {
+    const page = makeMockPage();
+    const browser = makeMockBrowser();
+    const ctx = makeMockContext(page, browser);
+    const incognitoCtx = { newPage: vi.fn().mockResolvedValue(makeMockPage()), close: vi.fn().mockResolvedValue(undefined), browser: vi.fn().mockReturnValue(browser), on: vi.fn() };
+    browser.newContext.mockResolvedValue(incognitoCtx as never);
+
+    const svc = new BrowserService({
+      logger,
+      sessionTtlMs: 1000,
+      sweepIntervalMs: 60000,
+      proxy: 'http://wguser:wgpass@browser-proxy:8888',
+      contextFactory: async () => ctx as never,
+    });
+    await svc.start();
+    await svc.getOrCreateSession(undefined, { incognito: true });
+
+    expect(browser.newContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: { server: 'http://browser-proxy:8888', username: 'wguser', password: 'wgpass' },
+      }),
+    );
+    await svc.stop();
+  });
+
+  it('sets no proxy in context options when none is configured', async () => {
+    // The outer `service` has no proxy. Exercise the same incognito seam and assert absence.
+    const incognitoPage = makeMockPage();
+    const incognitoContext = { newPage: vi.fn().mockResolvedValue(incognitoPage), close: vi.fn().mockResolvedValue(undefined), browser: vi.fn().mockReturnValue(mockBrowser), on: vi.fn() };
+    mockBrowser.newContext.mockResolvedValue(incognitoContext as never);
+
+    await service.getOrCreateSession(undefined, { incognito: true });
+
+    const opts = mockBrowser.newContext.mock.calls[0]![0] as { proxy?: unknown };
+    expect(opts.proxy).toBeUndefined();
   });
 
   it('does not restart the browser when a disconnect fires after stop()', async () => {
@@ -453,6 +495,45 @@ describe('isXServerBinary', () => {
     for (const binary of ['node', 'bash', 'xterm', 'Xfce4-session', 'chrome']) {
       expect(isXServerBinary(binary)).toBe(false);
     }
+  });
+});
+
+// --- parseProxyConfig (proxy URL → Playwright ProxySettings) ---
+
+describe('parseProxyConfig', () => {
+  it('returns undefined for empty/absent input (direct egress)', () => {
+    expect(parseProxyConfig(undefined)).toBeUndefined();
+    expect(parseProxyConfig('')).toBeUndefined();
+    expect(parseProxyConfig('   ')).toBeUndefined();
+  });
+
+  it('parses a bare scheme://host:port with no credentials', () => {
+    expect(parseProxyConfig('http://browser-proxy:8888')).toEqual({ server: 'http://browser-proxy:8888' });
+  });
+
+  it('splits embedded credentials out of the server field', () => {
+    // Playwright wants `server` credential-free and username/password separate.
+    expect(parseProxyConfig('http://user:pass@10.0.0.5:3128')).toEqual({
+      server: 'http://10.0.0.5:3128',
+      username: 'user',
+      password: 'pass',
+    });
+  });
+
+  it('URL-decodes percent-encoded credentials', () => {
+    expect(parseProxyConfig('http://us%40er:p%3Ass@host:8888')).toEqual({
+      server: 'http://host:8888',
+      username: 'us@er',
+      password: 'p:ss',
+    });
+  });
+
+  it('supports socks5 proxies (no auth field)', () => {
+    expect(parseProxyConfig('socks5://host:1080')).toEqual({ server: 'socks5://host:1080' });
+  });
+
+  it('treats a bare host:port as http (normalizes to a scheme)', () => {
+    expect(parseProxyConfig('browser-proxy:8888')).toEqual({ server: 'http://browser-proxy:8888' });
   });
 });
 

--- a/src/browser/browser-service.test.ts
+++ b/src/browser/browser-service.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, symlinkSync, lstatSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { BrowserService, clearStaleX11Lock, clearStaleSingletonLock, isXServerBinary, parseProxyConfig } from './browser-service.js';
+import { BrowserService, clearStaleX11Lock, clearStaleSingletonLock, isXServerBinary } from './browser-service.js';
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
@@ -495,45 +495,6 @@ describe('isXServerBinary', () => {
     for (const binary of ['node', 'bash', 'xterm', 'Xfce4-session', 'chrome']) {
       expect(isXServerBinary(binary)).toBe(false);
     }
-  });
-});
-
-// --- parseProxyConfig (proxy URL → Playwright ProxySettings) ---
-
-describe('parseProxyConfig', () => {
-  it('returns undefined for empty/absent input (direct egress)', () => {
-    expect(parseProxyConfig(undefined)).toBeUndefined();
-    expect(parseProxyConfig('')).toBeUndefined();
-    expect(parseProxyConfig('   ')).toBeUndefined();
-  });
-
-  it('parses a bare scheme://host:port with no credentials', () => {
-    expect(parseProxyConfig('http://browser-proxy:8888')).toEqual({ server: 'http://browser-proxy:8888' });
-  });
-
-  it('splits embedded credentials out of the server field', () => {
-    // Playwright wants `server` credential-free and username/password separate.
-    expect(parseProxyConfig('http://user:pass@10.0.0.5:3128')).toEqual({
-      server: 'http://10.0.0.5:3128',
-      username: 'user',
-      password: 'pass',
-    });
-  });
-
-  it('URL-decodes percent-encoded credentials', () => {
-    expect(parseProxyConfig('http://us%40er:p%3Ass@host:8888')).toEqual({
-      server: 'http://host:8888',
-      username: 'us@er',
-      password: 'p:ss',
-    });
-  });
-
-  it('supports socks5 proxies (no auth field)', () => {
-    expect(parseProxyConfig('socks5://host:1080')).toEqual({ server: 'socks5://host:1080' });
-  });
-
-  it('treats a bare host:port as http (normalizes to a scheme)', () => {
-    expect(parseProxyConfig('browser-proxy:8888')).toEqual({ server: 'http://browser-proxy:8888' });
   });
 });
 

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -44,6 +44,42 @@ import type { Logger } from '../logger.js';
 import { BrowserSession } from './browser-session.js';
 import type { SessionId } from './types.js';
 
+/** Playwright's proxy shape: a credential-free `server` plus optional auth. */
+type ProxyConfig = NonNullable<BrowserContextOptions['proxy']>;
+
+/**
+ * Parse a proxy config string into Playwright's ProxySettings. Accepts a full URL
+ * (`http://user:pass@host:port`, `socks5://host:1080`) or a bare `host:port` (assumed http).
+ * Credentials embedded in the URL are split out because Playwright wants `server` WITHOUT
+ * credentials and `username`/`password` as separate fields. Empty/absent → undefined
+ * (direct egress). Exported for unit testing. (residential-proxy support)
+ */
+export function parseProxyConfig(raw: string | undefined): ProxyConfig | undefined {
+  if (!raw || raw.trim().length === 0) return undefined;
+  const trimmed = raw.trim();
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+    // A bare "host:port" parses as a URL with an empty host (scheme becomes "host"),
+    // so fall through to the http:// normalization below.
+    if (!url.host) throw new Error('no host');
+  } catch {
+    try {
+      url = new URL(`http://${trimmed}`);
+    } catch {
+      return undefined;
+    }
+  }
+  const username = url.username ? decodeURIComponent(url.username) : undefined;
+  const password = url.password ? decodeURIComponent(url.password) : undefined;
+  return {
+    // url.protocol includes the trailing colon; url.host includes the port.
+    server: `${url.protocol}//${url.host}`,
+    ...(username ? { username } : {}),
+    ...(password ? { password } : {}),
+  };
+}
+
 interface BrowserServiceOptions {
   logger: Logger;
   /** Session idle TTL in ms. Default: 600_000 (10 minutes). */
@@ -54,6 +90,11 @@ interface BrowserServiceOptions {
   profileDir?: string;
   /** Browser channel, e.g. 'chrome' for real Chrome. Absent → bundled Chromium. */
   channel?: string;
+  /**
+   * Optional egress proxy for browser traffic (e.g. a residential home-network exit).
+   * Full URL or bare host:port. Absent/empty → direct egress. See parseProxyConfig.
+   */
+  proxy?: string;
   /** Context locale (BCP 47). Default 'en-US'. */
   locale?: string;
   /** IANA timezone for the context, aligned to the principal. */
@@ -71,6 +112,9 @@ export class BrowserService {
   private sweepIntervalMs: number;
   private profileDir: string;
   private channel: string | undefined;
+  // Parsed once in the constructor; spread into every context's options and used to gate
+  // the WebRTC-leak launch flag. Undefined → direct egress.
+  private proxy: ProxyConfig | undefined;
   private locale: string;
   private timezone: string | undefined;
   private contextFactory: () => Promise<BrowserContext>;
@@ -108,6 +152,7 @@ export class BrowserService {
       ? options.profileDir
       : join(homedir(), '.curia', 'browser-profile');
     this.channel = options.channel && options.channel.length > 0 ? options.channel : undefined;
+    this.proxy = parseProxyConfig(options.proxy);
     this.locale = options.locale && options.locale.length > 0 ? options.locale : 'en-US';
     this.timezone = options.timezone;
     this.contextFactory = options.contextFactory ?? (() => this.launchPersistentContext());
@@ -402,6 +447,10 @@ export class BrowserService {
    * inconsistency detection keys on — and a hardcoded UA goes stale into a bot tell (#987).
    * timezoneId is set only when a timezone is configured, aligning the context with the
    * principal. (#1053)
+   *
+   * The proxy (when configured) is spread here so it applies to BOTH the persistent context
+   * (launchPersistentContext) and any incognito context (browser.newContext) — routing all
+   * browser egress through, e.g., a residential home-network exit. (residential-proxy support)
    */
   private buildContextOptions(): BrowserContextOptions {
     return {
@@ -409,6 +458,7 @@ export class BrowserService {
       locale: this.locale,
       colorScheme: 'light',
       ...(this.timezone ? { timezoneId: this.timezone } : {}),
+      ...(this.proxy ? { proxy: this.proxy } : {}),
     };
   }
 
@@ -457,6 +507,11 @@ export class BrowserService {
         // manages is a documented anti-pattern). These two are container requirements. (#1053)
         '--no-sandbox',
         '--disable-dev-shm-usage',
+        // When egressing through a proxy, force WebRTC to only use proxied UDP so a STUN
+        // candidate can't leak the real (datacenter) IP behind the residential exit. This is
+        // a browser-process-level flag, so it also covers incognito contexts spun off this
+        // launch. Only added when a proxy is set. (residential-proxy support)
+        ...(this.proxy ? ['--force-webrtc-ip-handling-policy=disable_non_proxied_udp'] : []),
       ],
       ...this.buildContextOptions(),
     };
@@ -498,7 +553,12 @@ export class BrowserService {
   /** Log the resolved channel + real browser version for observability (UA traceability). */
   private logChannel(context: BrowserContext, channel: string | undefined): void {
     const version = context.browser()?.version();
-    this.logger.info({ channel: channel ?? 'chromium', version, profileDir: this.profileDir }, 'Persistent browser context launched');
+    // Log the proxy server (never the credentials) so the egress posture is greppable —
+    // a residential exit vs. direct datacenter egress is exactly what we want observable.
+    this.logger.info(
+      { channel: channel ?? 'chromium', version, profileDir: this.profileDir, proxy: this.proxy?.server ?? null },
+      'Persistent browser context launched',
+    );
   }
 
   /**

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -43,42 +43,7 @@ import { PlaywrightBlocker } from '@ghostery/adblocker-playwright';
 import type { Logger } from '../logger.js';
 import { BrowserSession } from './browser-session.js';
 import type { SessionId } from './types.js';
-
-/** Playwright's proxy shape: a credential-free `server` plus optional auth. */
-type ProxyConfig = NonNullable<BrowserContextOptions['proxy']>;
-
-/**
- * Parse a proxy config string into Playwright's ProxySettings. Accepts a full URL
- * (`http://user:pass@host:port`, `socks5://host:1080`) or a bare `host:port` (assumed http).
- * Credentials embedded in the URL are split out because Playwright wants `server` WITHOUT
- * credentials and `username`/`password` as separate fields. Empty/absent → undefined
- * (direct egress). Exported for unit testing. (residential-proxy support)
- */
-export function parseProxyConfig(raw: string | undefined): ProxyConfig | undefined {
-  if (!raw || raw.trim().length === 0) return undefined;
-  const trimmed = raw.trim();
-  let url: URL;
-  try {
-    url = new URL(trimmed);
-    // A bare "host:port" parses as a URL with an empty host (scheme becomes "host"),
-    // so fall through to the http:// normalization below.
-    if (!url.host) throw new Error('no host');
-  } catch {
-    try {
-      url = new URL(`http://${trimmed}`);
-    } catch {
-      return undefined;
-    }
-  }
-  const username = url.username ? decodeURIComponent(url.username) : undefined;
-  const password = url.password ? decodeURIComponent(url.password) : undefined;
-  return {
-    // url.protocol includes the trailing colon; url.host includes the port.
-    server: `${url.protocol}//${url.host}`,
-    ...(username ? { username } : {}),
-    ...(password ? { password } : {}),
-  };
-}
+import { parseProxyConfig, type ProxyConfig } from './proxy-config.js';
 
 interface BrowserServiceOptions {
   logger: Logger;

--- a/src/browser/proxy-config.test.ts
+++ b/src/browser/proxy-config.test.ts
@@ -1,0 +1,69 @@
+// src/browser/proxy-config.test.ts — parseProxyConfig unit tests.
+//
+// The security-critical contract is FAIL-CLOSED: a non-empty but unparseable value must
+// throw (abort boot) rather than resolve to `undefined` and let the browser egress directly
+// from the datacenter IP this feature exists to hide.
+
+import { describe, it, expect } from 'vitest';
+import { parseProxyConfig } from './proxy-config.js';
+
+describe('parseProxyConfig', () => {
+  // --- No proxy: the ONLY inputs that legitimately resolve to undefined ---
+  it('returns undefined for empty/absent input (intentional direct egress)', () => {
+    expect(parseProxyConfig(undefined)).toBeUndefined();
+    expect(parseProxyConfig('')).toBeUndefined();
+    expect(parseProxyConfig('   ')).toBeUndefined();
+  });
+
+  // --- Valid proxies ---
+  it('parses a scheme://host:port with no credentials', () => {
+    expect(parseProxyConfig('http://browser-wg:8888')).toEqual({ server: 'http://browser-wg:8888' });
+  });
+
+  it('splits embedded credentials out of the server field', () => {
+    // Playwright wants `server` credential-free and username/password separate.
+    expect(parseProxyConfig('http://user:pass@10.0.0.5:3128')).toEqual({
+      server: 'http://10.0.0.5:3128',
+      username: 'user',
+      password: 'pass',
+    });
+  });
+
+  it('URL-decodes percent-encoded credentials', () => {
+    expect(parseProxyConfig('http://us%40er:p%3Ass@host:8888')).toEqual({
+      server: 'http://host:8888',
+      username: 'us@er',
+      password: 'p:ss',
+    });
+  });
+
+  it('supports socks5 proxies (no auth field)', () => {
+    expect(parseProxyConfig('socks5://host:1080')).toEqual({ server: 'socks5://host:1080' });
+  });
+
+  it('treats a bare host:port as http (normalizes to a scheme)', () => {
+    expect(parseProxyConfig('browser-wg:8888')).toEqual({ server: 'http://browser-wg:8888' });
+  });
+
+  // --- Fail-closed: non-empty but invalid must THROW, never return undefined ---
+  it('throws on whitespace inside an otherwise-set value (a likely hand-edit typo)', () => {
+    // Regression for the silent-leak finding: "http://browser-wg :8888" must not degrade
+    // to direct egress.
+    expect(() => parseProxyConfig('http://browser-wg :8888')).toThrow(/browser\.proxy/);
+    expect(() => parseProxyConfig('browser wg:8888')).toThrow(/browser\.proxy/);
+  });
+
+  it('throws on an unparseable value', () => {
+    expect(() => parseProxyConfig('not a url at all')).toThrow(/browser\.proxy/);
+    expect(() => parseProxyConfig('://oops')).toThrow(/browser\.proxy/);
+  });
+
+  it('throws on a scheme with no host instead of emitting a bogus server', () => {
+    expect(() => parseProxyConfig('http://')).toThrow(/browser\.proxy/);
+  });
+
+  it('throws (does not crash with an opaque URIError) on a bare % in credentials', () => {
+    // Regression for the boot-crash finding: decodeURIComponent throws URIError on "%ss".
+    expect(() => parseProxyConfig('http://user:pa%ss@host:8888')).toThrow(/percent-encoding/);
+  });
+});

--- a/src/browser/proxy-config.test.ts
+++ b/src/browser/proxy-config.test.ts
@@ -66,4 +66,16 @@ describe('parseProxyConfig', () => {
     // Regression for the boot-crash finding: decodeURIComponent throws URIError on "%ss".
     expect(() => parseProxyConfig('http://user:pa%ss@host:8888')).toThrow(/percent-encoding/);
   });
+
+  it('never leaks the password in the error for an invalid proxy that carries credentials', () => {
+    // The thrown message is wrapped by loadYamlConfig and may be logged at startup, so a
+    // malformed value with userinfo must not echo the secret. (CodeRabbit security finding)
+    try {
+      parseProxyConfig('http://user:sup3rsecret@'); // no host → throws
+      throw new Error('expected parseProxyConfig to throw');
+    } catch (err) {
+      expect((err as Error).message).not.toContain('sup3rsecret');
+      expect((err as Error).message).not.toContain('user:');
+    }
+  });
 });

--- a/src/browser/proxy-config.ts
+++ b/src/browser/proxy-config.ts
@@ -1,0 +1,65 @@
+// src/browser/proxy-config.ts — parse the browser egress-proxy config string.
+//
+// Kept in its own module (no runtime deps beyond the URL global, and only a type-only
+// playwright import) so config.ts can validate the value at load time WITHOUT importing
+// browser-service.ts, which pulls in patchright/Chromium. (residential-proxy support)
+
+import type { BrowserContextOptions } from 'playwright';
+
+/** Playwright's proxy shape: a credential-free `server` plus optional auth. */
+export type ProxyConfig = NonNullable<BrowserContextOptions['proxy']>;
+
+/**
+ * Parse a proxy config string into Playwright's ProxySettings.
+ *
+ * Contract (deliberately FAIL-CLOSED — this feature exists to stop the browser leaking the
+ * real datacenter IP, so a misconfiguration must never silently degrade to direct egress):
+ *   - empty / whitespace / undefined → `undefined` (operator intends NO proxy, direct egress)
+ *   - a valid proxy (`http://user:pass@host:port`, `socks5://host:1080`, bare `host:port`)
+ *     → the parsed ProxyConfig
+ *   - a NON-EMPTY but unparseable value → THROWS. A typo'd proxy must abort boot loudly,
+ *     not resolve to `undefined` and egress directly.
+ *
+ * Credentials embedded in the URL are split out because Playwright wants `server` WITHOUT
+ * credentials and `username`/`password` as separate fields.
+ */
+export function parseProxyConfig(raw: string | undefined): ProxyConfig | undefined {
+  if (!raw || raw.trim().length === 0) return undefined;
+  const trimmed = raw.trim();
+
+  // Accept an explicit scheme (http/https/socks5/...); otherwise treat the value as a bare
+  // host:port and normalize to http so `server` is unambiguous. The regex requires "://"
+  // so a bare "host:port" (which has a colon but no "//") correctly falls through to http.
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    throw new Error(`browser.proxy is not a valid proxy URL: ${JSON.stringify(raw)}`);
+  }
+  // new URL('http://') succeeds with an empty host; reject it rather than emitting a bogus
+  // server like "http://http".
+  if (!url.hostname) {
+    throw new Error(`browser.proxy has no host: ${JSON.stringify(raw)}`);
+  }
+
+  // decodeURIComponent throws URIError on a bare '%' (a common char in generated passwords
+  // that new URL happily preserves). Catch it and fail closed with a clear message instead
+  // of an opaque URIError crashing boot from outside any handler. (#finding: %-in-password)
+  let username: string | undefined;
+  let password: string | undefined;
+  try {
+    username = url.username ? decodeURIComponent(url.username) : undefined;
+    password = url.password ? decodeURIComponent(url.password) : undefined;
+  } catch {
+    throw new Error('browser.proxy has malformed percent-encoding in its credentials');
+  }
+
+  return {
+    // url.protocol includes the trailing colon; url.host includes the port.
+    server: `${url.protocol}//${url.host}`,
+    ...(username ? { username } : {}),
+    ...(password ? { password } : {}),
+  };
+}

--- a/src/browser/proxy-config.ts
+++ b/src/browser/proxy-config.ts
@@ -36,12 +36,15 @@ export function parseProxyConfig(raw: string | undefined): ProxyConfig | undefin
   try {
     url = new URL(withScheme);
   } catch {
-    throw new Error(`browser.proxy is not a valid proxy URL: ${JSON.stringify(raw)}`);
+    // Never echo the raw value: a malformed proxy can still carry userinfo
+    // (http://user:secret@…), and this message is wrapped by loadYamlConfig and may be
+    // logged at startup. Keep it credential-free.
+    throw new Error('browser.proxy is not a valid proxy URL');
   }
   // new URL('http://') succeeds with an empty host; reject it rather than emitting a bogus
-  // server like "http://http".
+  // server like "http://http". Credential-free for the same reason as above.
   if (!url.hostname) {
-    throw new Error(`browser.proxy has no host: ${JSON.stringify(raw)}`);
+    throw new Error('browser.proxy has no host');
   }
 
   // decodeURIComponent throws URIError on a bare '%' (a common char in generated passwords

--- a/src/config.browser.test.ts
+++ b/src/config.browser.test.ts
@@ -42,4 +42,21 @@ describe('loadYamlConfig: browser block validation', () => {
     const dir = writeTempConfig(`browser:\n  channel: 123\n`);
     expect(() => loadYamlConfig(dir)).toThrow('browser.channel');
   });
+
+  it('accepts a valid proxy', () => {
+    const dir = writeTempConfig(`browser:\n  proxy: "http://browser-wg:8888"\n`);
+    expect(loadYamlConfig(dir).browser?.proxy).toBe('http://browser-wg:8888');
+  });
+
+  it('accepts an empty proxy (direct egress)', () => {
+    const dir = writeTempConfig(`browser:\n  proxy: ""\n`);
+    expect(() => loadYamlConfig(dir)).not.toThrow();
+  });
+
+  // Fail-closed: a set-but-unparseable proxy must abort boot rather than silently egress
+  // directly and leak the datacenter IP the proxy exists to hide.
+  it('rejects a non-empty but unparseable proxy (fail closed, no silent direct egress)', () => {
+    const dir = writeTempConfig(`browser:\n  proxy: "http://browser-wg :8888"\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('browser.proxy is set but invalid');
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import * as yaml from 'js-yaml';
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { parseSensitivityRules, type SensitivityRule } from './memory/sensitivity.js';
+import { parseProxyConfig } from './browser/proxy-config.js';
 
 // ---------------------------------------------------------------------------
 // Multi-account email config types
@@ -729,6 +730,20 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     for (const [key, value] of [['profileDir', profileDir], ['channel', channel], ['proxy', proxy], ['locale', locale]] as const) {
       if (value !== undefined && typeof value !== 'string') {
         throw new Error(`browser.${key} must be a string, got: ${typeof value}`);
+      }
+    }
+    // Fail closed on a misconfigured proxy: browser.proxy exists so the web-browser skill
+    // egresses through a residential exit instead of the datacenter IP. A non-empty but
+    // unparseable value must abort boot loudly — NOT silently resolve to "no proxy" and let
+    // the browser leak the real IP. parseProxyConfig throws on a bad non-empty value.
+    if (typeof proxy === 'string' && proxy.trim().length > 0) {
+      try {
+        parseProxyConfig(proxy);
+      } catch (err) {
+        throw new Error(
+          `browser.proxy is set but invalid — refusing to start (an unparseable proxy would ` +
+          `egress directly and leak the real IP): ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -245,6 +245,12 @@ export interface YamlConfig {
     profileDir?: string;
     /** Browser channel, e.g. "chrome" for real Chrome. Empty/absent → bundled Chromium. */
     channel?: string;
+    /**
+     * Optional egress proxy for browser traffic (full URL or bare host:port, e.g.
+     * "http://browser-proxy:8888"). Empty/absent → direct egress. Set per-deployment to
+     * route the browser through a residential exit and avoid a datacenter-IP bot signal.
+     */
+    proxy?: string;
     /** Context locale (BCP 47). Default "en-US". */
     locale?: string;
   };
@@ -713,14 +719,14 @@ export function loadYamlConfig(configDir: string): YamlConfig {
   // reach BrowserService and schedule near-continuous sweeps. Reject malformed values here.
   const browser = config.browser;
   if (browser !== undefined) {
-    const { sessionTtlMs, sweepIntervalMs, profileDir, channel, locale } = browser;
+    const { sessionTtlMs, sweepIntervalMs, profileDir, channel, proxy, locale } = browser;
     if (sessionTtlMs !== undefined && (!Number.isInteger(sessionTtlMs) || sessionTtlMs <= 0)) {
       throw new Error(`browser.sessionTtlMs must be a positive integer, got: ${sessionTtlMs}`);
     }
     if (sweepIntervalMs !== undefined && (!Number.isInteger(sweepIntervalMs) || sweepIntervalMs <= 0)) {
       throw new Error(`browser.sweepIntervalMs must be a positive integer, got: ${sweepIntervalMs}`);
     }
-    for (const [key, value] of [['profileDir', profileDir], ['channel', channel], ['locale', locale]] as const) {
+    for (const [key, value] of [['profileDir', profileDir], ['channel', channel], ['proxy', proxy], ['locale', locale]] as const) {
       if (value !== undefined && typeof value !== 'string') {
         throw new Error(`browser.${key} must be a string, got: ${typeof value}`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -840,6 +840,9 @@ async function main(): Promise<void> {
       sweepIntervalMs: browserConfig?.sweepIntervalMs ?? 120_000,
       profileDir: browserConfig?.profileDir,
       channel: browserConfig?.channel,
+      // Optional egress proxy (e.g. a residential home-network exit) so the browser doesn't
+      // present a datacenter IP to anti-bot systems. Empty in core; set per-deployment.
+      proxy: browserConfig?.proxy,
       locale: browserConfig?.locale,
       // Align the browser timezone with the principal's configured timezone.
       timezone: config.timezone,


### PR DESCRIPTION
## Summary

The `web-browser` skill keeps getting flagged as a bot (16personalities throws a Cloudflare challenge; X routes to the signup flow, not login). Investigation showed the **fingerprint is already clean** — real Google Chrome channel, patchright (patches the CDP leaks that betray Playwright/Puppeteer), Xvfb headful, persistent profile, and human-like mouse/typing. The remaining tell is the **egress IP**: prod egresses from a Hetzner datacenter IP (`AS24940`, Helsinki), which anti-bot systems flag on ASN alone — and its geo doesn't match the browser's timezone (the principal's), a second signal.

This adds an optional `browser.proxy` so the browser can egress through a residential exit. Core stays empty by default (direct egress); the deployment opts in. The paired infra (a home WireGuard tunnel) lands in curia-deploy.

## What's here

- `parseProxyConfig()` (new `src/browser/proxy-config.ts`) turns a URL / `host:port` into Playwright `ProxySettings`, splitting embedded credentials out of the `server` field.
- Proxy is spread through `buildContextOptions()`, so it covers **both** the persistent context and incognito contexts.
- When a proxy is set, a WebRTC-leak guard (`--force-webrtc-ip-handling-policy=disable_non_proxied_udp`) is added so STUN/UDP can't leak the real IP behind the exit.
- **Fail-closed:** a non-empty but unparseable `browser.proxy` throws at config load — it never silently degrades to direct (datacenter) egress. Empty means "no proxy" intentionally.
- The proxy `server` (never credentials) is logged for egress observability.

## Testing

- `src/browser/proxy-config.test.ts` — parse cases + fail-closed cases (whitespace typo, bare `%`, no-host).
- `src/browser/browser-service.test.ts` — proxy propagates into both context types; absent when unset.
- `src/config.browser.test.ts` — a misconfigured proxy aborts boot.
- `pnpm run typecheck` clean.

## Notes

No linked issue. Reviewed by the code-reviewer + silent-failure-hunter agents before opening; all findings addressed (the fail-closed behavior above is the main one).