### PR TITLE
fix(web-browser): survive frame.evaluate serialization (restore all page reads)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`web-browser`** — fix a regression that broke every browser page read after the element-refs change.
 - **Scheduler** — a run finishing after a concurrent pause/cancel no longer overwrites that state. (#1409)
 - **Coordinator** — external replies use first-person single-voice; internal specialist names forbidden. (#1354)
 - **Dispatcher** — content-filter blocks on relayed replies retry with reason, then salvage draft. (#1355)

--- a/skills/web-browser/dom-extract.test.ts
+++ b/skills/web-browser/dom-extract.test.ts
@@ -5,6 +5,9 @@
 // exist — this function was previously only exercised in a real browser via
 // frame.evaluate(), so these are its first direct tests.
 import { describe, it, expect, beforeEach } from 'vitest';
+import { transformWithEsbuild } from 'vite';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { extractFrameContent } from './dom-extract.js';
 
 const OPTS = { frameIndex: 0, maxRefs: 200, generation: 1 };
@@ -91,5 +94,34 @@ describe('extractFrameContent — interactable refs', () => {
     expect(document.querySelector('[data-curia-ref="g1f0e1"]')).toBeNull();
     // New refs carry generation 2; e1 is the newly-prepended Z, not A.
     expect(document.querySelector('[data-curia-ref="g2f0e1"]')!.textContent).toBe('Z');
+  });
+
+  // Regression: extractFrameContent is shipped to the browser via Playwright's
+  // frame.evaluate(), which serializes it with .toString() and re-parses it in the page's
+  // scope. Prod loads skills via tsx (esbuild keepNames: true), which wraps named inner
+  // functions in __name(...) — a module-scope helper that does NOT exist in the page, so a
+  // named inner function throws `__name is not defined` on every frame. vitest's own
+  // transpile has keepNames OFF, so a plain import can't catch this; we transpile the source
+  // the way prod does, then run the function in a fresh scope like frame.evaluate.
+  it('stays self-contained when serialized into a page after a keepNames transpile (prod pipeline)', async () => {
+    // Resolve via cwd (worktree root under `pnpm -C`, repo root in CI) rather than
+    // import.meta.url — happy-dom gives a non-file: import.meta.url here.
+    const srcPath = resolve(process.cwd(), 'skills/web-browser/dom-extract.ts');
+    const { code } = await transformWithEsbuild(readFileSync(srcPath, 'utf8'), srcPath, {
+      keepNames: true, loader: 'ts', format: 'cjs',
+    });
+    // Execute the transpiled CJS to get the keepNames-wrapped function. Its own module scope
+    // defines __name, so it works when called normally here.
+    const shim: { exports: Record<string, unknown> } = { exports: {} };
+    new Function('module', 'exports', code)(shim, shim.exports);
+    const transpiled = shim.exports.extractFrameContent as typeof extractFrameContent;
+    // Rehydrate exactly as frame.evaluate does: serialize -> re-parse in a fresh scope with
+    // no access to the module's __name helper. A named inner function throws `__name is not
+    // defined` here.
+    const rehydrated = new Function(`return (${transpiled.toString()})`)() as typeof extractFrameContent;
+    document.body.innerHTML = '<button>Go</button>';
+    let out = '';
+    expect(() => { out = rehydrated({ frameIndex: 0, maxRefs: 200, generation: 1 }); }).not.toThrow();
+    expect(out).toContain('[g1f0e1] button "Go"');
   });
 });

--- a/skills/web-browser/dom-extract.ts
+++ b/skills/web-browser/dom-extract.ts
@@ -67,44 +67,14 @@ export function extractFrameContent(opts: ExtractOpts): string {
     '[role="switch"]',
   ].join(',');
 
-  // ARIA role for display: explicit role attribute wins, else derive from the tag.
-  const roleOf = (el: Element): string => {
-    const explicit = el.getAttribute('role');
-    if (explicit) return explicit;
-    const tag = el.tagName.toLowerCase();
-    if (tag === 'a') return 'link';
-    if (tag === 'button') return 'button';
-    if (tag === 'select') return 'combobox';
-    if (tag === 'textarea') return 'textbox';
-    if (tag === 'input') {
-      const t = (el.getAttribute('type') ?? 'text').toLowerCase();
-      if (t === 'radio') return 'radio';
-      if (t === 'checkbox') return 'checkbox';
-      if (t === 'button' || t === 'submit' || t === 'reset') return 'button';
-      return 'textbox';
-    }
-    return 'element';
-  };
-
-  // Accessible name, same precedence the old form-fields list used, extended to buttons/
-  // links (their visible text). Empty is acceptable — ref + role still address the element.
-  const nameOf = (el: Element): string => {
-    const aria = el.getAttribute('aria-label');
-    if (aria && aria.trim()) return aria.trim();
-    const id = (el as HTMLElement).id;
-    if (id) {
-      const lbl = document.querySelector(`label[for="${CSS.escape(id)}"]`);
-      const lblText = lbl?.textContent?.trim();
-      if (lblText) return lblText;
-    }
-    const text = (el.textContent ?? '').trim();
-    if (text) return text;
-    return el.getAttribute('placeholder')
-      ?? el.getAttribute('value')
-      ?? el.getAttribute('name')
-      ?? el.getAttribute('title')
-      ?? '';
-  };
+  // Role and accessible-name are computed INLINE below, deliberately NOT via named helper
+  // functions. Playwright serializes this function into the browser page via
+  // frame.evaluate(); the tsx/esbuild `keepNames` transform wraps any named inner function
+  // in a module-scope `__name(...)` helper that does NOT exist in the page, so a named inner
+  // function throws `ReferenceError: __name is not defined` on every frame (this took down
+  // all browser page-reads in prod once). Keep this function free of named inner functions;
+  // the keepNames regression test in dom-extract.test.ts guards it. Anonymous forEach/arrow
+  // callbacks are fine — keepNames only wraps functions bound to a name.
 
   const interactables = Array.from(document.querySelectorAll(INTERACTABLE_SELECTOR));
   const shown = Math.min(interactables.length, maxRefs);
@@ -113,10 +83,50 @@ export function extractFrameContent(opts: ExtractOpts): string {
     const el = interactables[i]!;
     const ref = `g${generation}f${frameIndex}e${i + 1}`;
     el.setAttribute('data-curia-ref', ref);
-    const name = nameOf(el).replace(/\s+/g, ' ').slice(0, 100);
+
+    // ARIA role for display: explicit role attribute wins, else derive from the tag.
+    let role = el.getAttribute('role') ?? '';
+    if (!role) {
+      const tag = el.tagName.toLowerCase();
+      if (tag === 'a') role = 'link';
+      else if (tag === 'button') role = 'button';
+      else if (tag === 'select') role = 'combobox';
+      else if (tag === 'textarea') role = 'textbox';
+      else if (tag === 'input') {
+        const t = (el.getAttribute('type') ?? 'text').toLowerCase();
+        role = t === 'radio' ? 'radio'
+          : t === 'checkbox' ? 'checkbox'
+          : (t === 'button' || t === 'submit' || t === 'reset') ? 'button'
+          : 'textbox';
+      } else {
+        role = 'element';
+      }
+    }
+
+    // Accessible name, same precedence as before: aria-label, <label for>, visible text,
+    // then placeholder/value/name/title. Empty is acceptable — ref + role still address it.
+    let name = '';
+    const aria = el.getAttribute('aria-label');
+    if (aria && aria.trim()) {
+      name = aria.trim();
+    } else {
+      const id = (el as HTMLElement).id;
+      const lbl = id ? document.querySelector(`label[for="${CSS.escape(id)}"]`) : null;
+      const lblText = lbl?.textContent?.trim();
+      const text = (el.textContent ?? '').trim();
+      if (lblText) name = lblText;
+      else if (text) name = text;
+      else name = el.getAttribute('placeholder')
+        ?? el.getAttribute('value')
+        ?? el.getAttribute('name')
+        ?? el.getAttribute('title')
+        ?? '';
+    }
+    name = name.replace(/\s+/g, ' ').slice(0, 100);
+
     const legend = el.closest('fieldset')?.querySelector('legend')?.textContent?.trim();
     const group = legend ? ` (group: "${legend.slice(0, 120)}")` : '';
-    refLines.push(`[${ref}] ${roleOf(el)} "${name}"${group}`);
+    refLines.push(`[${ref}] ${role} "${name}"${group}`);
   }
   const overflow = interactables.length > maxRefs
     ? `\n(${interactables.length - maxRefs} more interactable elements not shown; scroll or refine)`


### PR DESCRIPTION
## Summary

Hotfix: the `web-browser` skill has been failing **every** page read in production since the element-refs deploy (`c40d6c4a`). The agent's self-diagnosis ("can't load the page") was wrong — navigation succeeds; content extraction throws.

## Root cause

The element-refs change refactored `extractFrameContent` to use two **named inner arrow helpers** (`roleOf`, `nameOf`). Prod loads skills via `tsx` (esbuild with `keepNames: true`), which wraps every named inner function in a module-scope `__name(...)` helper. Playwright ships `extractFrameContent` into the browser page by serializing it with `.toString()` (`frame.evaluate`), but `__name` doesn't exist in the page context, so **every** `frame.evaluate` threw `ReferenceError: __name is not defined`. `getCleanedContent` then saw all frames fail and threw `Failed to read page content: all frames errored during extraction`.

Verified in prod: the transpiled function contained `const roleOf=__name(el=>{…})`. The tunnel/proxy path and today's resolver/generation changes are fine — this broke all sites, not just the survey.

Why tests missed it: happy-dom tests call the function directly in Node (where `__name` exists), and vitest's own esbuild has `keepNames` **off**, so nothing exercised the serialize-into-browser path.

## Fix

Inline the role/name computation into the loop — no named inner functions — so the function stays self-contained when serialized. Behavior is unchanged (same role/name precedence). Anonymous `forEach` callbacks are fine (`keepNames` only wraps named bindings), which is why the original pre-refs extractor worked.

## Test

New regression test transpiles `dom-extract.ts` with `keepNames: true` (the prod `tsx` pipeline) and runs `extractFrameContent` in a fresh scope like `frame.evaluate` does. It fails with `ReferenceError: __name is not defined` before this fix and passes after. This is the first test to exercise the real serialization path.

48/48 `skills/web-browser/` tests pass; `pnpm run typecheck` clean.

## Deploy

Prod is currently degraded (all browser reads fail). Once CI is green, redeploy `:edge` to pick this up.
