### PR TITLE
chore(coordinator): remove built-in 8am digest, fold into on-demand briefing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`web-browser`** — circuit-breaker halts interaction after 4 consecutive failures to curb futile retry loops.
 - **`TaskRepo.reopenTask` tests** — cover non-`done` rejection, `progress.notes` audit note, and `task.updated` emission. (#1434)
 
+### Changed
+
+- **Daily digest** — the built-in 8am digest is now an on-demand, chat-editable morning-briefing example.
+
 ### Security
 
 - **Evidence-doc retention** — anchor `## Diff —` boundaries to the metadata envelope so an email-body heading can't dodge the purge. (#1444)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.13.0"
+version: "0.14.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -718,24 +718,4 @@ error_budget:
 schedule:
   - cron: "0 * * * *"
     task: "Run the approval expiry sweep — find and expire any pending approval requests that have passed their expiry time."
-    expectedDurationSeconds: 360
-
-  - cron: "0 8 * * *"
-    task: >
-      Send the CEO a daily digest. Steps: (1) Use list-pending-actions to get
-      all open approval requests. (2) Use task-list three times: owner "ceo"
-      with no date filter (all open CEO tasks); owner "ceo" with due_before set
-      to end of today (overdue or due today); owner "external" with no date
-      filter (waiting-on-others tasks). (3) Use list-learning-digest for the proposed
-      writing-voice guide update and sent-mail task-completion undo/confirm items — include its
-      sections_markdown only when non-empty. (4) Compose a clear summary. Lead with
-      any overdue or due-today CEO tasks — flag these prominently. Follow with
-      the full open-task counts, pending approvals, then any learning-digest
-      sections. Send via email using the CEO's address from the Principal Contact
-      Details block. Skip sending entirely if all three task-list calls return
-      empty, list-pending-actions returns no pending approvals, and
-      list-learning-digest has no items. If list-pending-actions returns an error,
-      include a brief note that pending approvals could not be retrieved, then
-      send anyway. When the CEO later replies approve/dismiss/undo/confirm for a
-      learning item, call resolve-learning-digest with the matching action.
     expectedDurationSeconds: 360


### PR DESCRIPTION
## Summary

Removes the declarative `0 8 * * *` daily-digest `schedule:` entry from `agents/coordinator.yaml`. Its content is re-homed as an on-demand, ad-hoc **morning briefing** that the user sets up and personalizes via chat — documented in curia-docs (Examples → daily morning briefing, separate PR).

**Why:** declarative jobs are reasserted from YAML on every restart — a manual cancel is revived `cancelled`→`pending` (`src/scheduler/scheduler-service.ts:675-677`) and a chat edit is wiped + cancel-swept (`scheduler.ts:833-836`, `scheduler-service.ts:906-915`). So a declarative digest can't be personalized. An ad-hoc job (`created_by='coordinator'`) can, durably, via the existing `scheduler-update` skill.

## Changes

- Delete the digest schedule entry. The hourly approval-expiry sweep (`0 * * * *`) is unchanged.
- Bump `coordinator.yaml` version `0.13.0` → `0.14.0` (behavior change).
- CHANGELOG `Changed` entry.

The `list-learning-digest` / `resolve-learning-digest` / `list-pending-actions` / `task-list` skills are retained — only the scheduled delivery job is removed.

## Consequence to review

Fresh installs no longer get an automatic 8am digest. We audited what the digest was surfacing; only two things were digest-dependent, and both are tracked for a follow-up so the guarantee doesn't rely on the (opt-in, personalizable) briefing:

- **Pending approvals** — not affected. Notified directly at creation (`sendNotification('approval_requested')`) plus an expiry email on the hourly sweep.
- **Stuck-task escalations** — not affected. An event-driven coordinator poke fires at escalation time (LLM-mediated; chose to leave as-is).
- **Learning-digest items** (voice-guide proposal + sent-mail undo/confirm) — **digest was the only surfacing path.** Fix tracked in #1466 (event-driven, surface-when-produced).
- **Overdue / due-today CEO tasks** — **no proactive push outside the digest** (heartbeat is `owner='curia'` only). Fix tracked in #1467 (declarative backstop sweep).

Stale prose to reconcile separately (out of scope here): `agents/ceo-inbox.yaml:76-82` and a few mentions in `core-concepts/scheduling.mdx` still name "the daily digest." The learning proposal still lands in the config-store; only the surfacing changes. Can open a small docs/prose-sync pass if desired.

## Verification

- `coordinator.yaml` parses; `schedule` now has a single entry (the sweep).
- No test asserts the coordinator's real schedule count — the `0 8 * * *` / "daily digest" hits in `tests/` are self-contained scheduler fixtures (`daily-brief`), and `tests/unit/agents/loader.test.ts` only checks name/role/model/prompt.
