### PR TITLE
chore(ceo-inbox): drop stale 'daily digest' reference in voice-learn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **Daily digest** — the built-in 8am digest is now an on-demand, chat-editable morning-briefing example.
+- **`ceo-inbox`** — voice-learn queues its guide proposal as a pending learning item, not the removed digest.
 
 ### Security
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.14.0"
+version: "0.14.1"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -76,8 +76,9 @@ schedule:
   - cron: "0 8 * * 1"  # weekly voice-learn (Monday 8am)
     task: >
       Run voice-learn only: read accumulated (draft, sent) diffs and, if there is
-      enough new signal, queue a single updated writing-voice guide proposal for the
-      daily digest (human-approved; never writes the profile directly). Call
+      enough new signal, queue a single updated writing-voice guide proposal as a
+      pending learning item for the CEO to review (human-approved; never writes the
+      profile directly). Call
       scheduler-report when done. Do NOT triage the inbox, draft, archive, label, or
       send any messages on this wake.
     expectedDurationSeconds: 180


### PR DESCRIPTION
## Summary

Follow-up prose cleanup after removing the built-in daily digest (#1464). The ceo-inbox weekly voice-learn prompt still said it queued its writing-voice guide proposal "for the daily digest." That job no longer exists.

Reworded to be mechanism-agnostic: the proposal is queued as a **pending learning item for the CEO to review** — surfaced via whatever review path is active (the on-demand morning briefing today; event-driven per #1466). No behavior change; the proposal still lands in the learning-digest store and is never applied without approval.

- `agents/ceo-inbox.yaml` — reword the voice-learn task; patch bump `0.14.0` → `0.14.1`.
- CHANGELOG entry.

## Verification
- `ceo-inbox.yaml` parses; no remaining "daily digest" reference.