### PR TITLE
fix: edit recurring ad-hoc jobs in place instead of duplicating (#1465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Daily digest** — the built-in 8am digest is now an on-demand, chat-editable morning-briefing example.
 - **`ceo-inbox`** — voice-learn queues its guide proposal as a pending learning item, not the removed digest.
 
-### Fixed
-
-- **Coordinator scheduling** — changing a recurring ad-hoc job now edits it in place instead of creating a duplicate that fires twice. (#1465)
-
 ### Security
 
 - **Evidence-doc retention** — anchor `## Diff —` boundaries to the metadata envelope so an email-body heading can't dodge the purge. (#1444)
@@ -45,6 +41,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`web-browser`** — idle session TTL raised to 30 minutes so long forms aren't evicted mid-flow.
 - **Scheduler** — a run finishing after a concurrent pause/cancel no longer overwrites that state. (#1409)
 - **Coordinator** — external replies use first-person single-voice; internal specialist names forbidden. (#1354)
+- **Coordinator scheduling** — changing a recurring job now edits it in place instead of duplicating it. (#1465)
 - **Dispatcher** — content-filter blocks on relayed replies retry with reason, then salvage draft. (#1355)
 - **Scheduler** — liveness check no longer flaps `fail` every few minutes on a healthy scheduler. (#1359)
 - **`sensitivity_rules`** — now read from the merged config, so `local.yaml` overrides actually take effect. (#1369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Daily digest** — the built-in 8am digest is now an on-demand, chat-editable morning-briefing example.
 - **`ceo-inbox`** — voice-learn queues its guide proposal as a pending learning item, not the removed digest.
 
+### Fixed
+
+- **Coordinator scheduling** — changing a recurring ad-hoc job now edits it in place instead of creating a duplicate that fires twice. (#1465)
+
 ### Security
 
 - **Evidence-doc retention** — anchor `## Diff —` boundaries to the metadata envelope so an email-body heading can't dodge the purge. (#1444)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.14.0"
+version: "0.14.1"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -409,6 +409,11 @@ system_prompt: |
   When setting up something that repeats on a cron ("check X every week",
   "remind me every Monday"). Provide only `cron_expr` and `task`. Do not pass
   `intent_anchor` — that field is not used for operational sweeps.
+  Before creating, first call `scheduler-list` and scan for an active job
+  (`status` `pending`/`suspended`/`paused`) that already covers this routine —
+  same agent and effectively the same task. If one exists, this is a change to
+  that job, not a new one: edit it in place per the rule below. Only
+  `scheduler-create` when no equivalent active job is found.
 
   **Resume, pause, or edit an existing job — use `scheduler-update`:**
   When the CEO asks to unsuspend/resume, pause, or reschedule a job. Find the
@@ -416,6 +421,16 @@ system_prompt: |
   `resume` (brings a failure-suspended or drift-paused job back to active),
   `pause` (holds an active job), or `edit` (with `cron_expr`, `run_at`, or
   `task_payload`). Never tell the CEO to use the web UI — you can do this directly.
+
+  **Changing an existing routine edits it in place — never duplicate.**
+  When the CEO asks to change a recurring routine you already manage (a new time,
+  tweaked instructions, "actually make it 10am", "also cc Dana"), that is an EDIT,
+  not a fresh setup. Call `scheduler-list`, identify the matching active job by its
+  agent and task, and call `scheduler-update` with `action: edit` on that same
+  `job_id` — passing the new `cron_expr`/`run_at` and/or an updated `task_payload`.
+  Do NOT call `scheduler-create` for a change request: a second job with the same
+  cron and payload makes the task fire twice. After editing, confirm to the CEO
+  what changed on the existing schedule.
 
   **Backlog awareness:** Before answering "what's open?", "what's waiting on me?",
   or "what are you working on?", call `task-list`.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -411,8 +411,10 @@ system_prompt: |
   `intent_anchor` — that field is not used for operational sweeps.
   Before creating, call `scheduler-list` (it filters by only one `status`, so
   list without a status filter and scan the results) and look for an active job —
-  `pending`, `suspended`, or `paused` — with the same agent and effectively the
-  same task. A match matters only when the CEO is *changing* that routine: edit
+  `pending`, `running`, `suspended`, or `paused` — with the same agent and
+  effectively the same task. Include `running`: a recurring job that happens to
+  be mid-execution is still the same routine, and skipping it would let a change
+  request slip through to a duplicate `scheduler-create`. A match matters only when the CEO is *changing* that routine: edit
   it in place per the rule below. If the CEO wants an ADDITIONAL run or a variant
   ("also scan on Fridays at 4pm", "add a second check") — even one that resembles
   an existing job — that is a genuinely new job, so `scheduler-create` it. `edit`
@@ -432,7 +434,10 @@ system_prompt: |
   tweaked instructions, "actually make it 10am", "also cc Dana"), that is an EDIT,
   not a fresh setup. Call `scheduler-list`, identify the matching active job by its
   agent and task, and call `scheduler-update` with `action: edit` on that same
-  `job_id` — passing the new `cron_expr`/`run_at` and/or an updated `task_payload`.
+  `job_id`. For a recurring routine, change the cadence via `cron_expr` — `run_at`
+  is only for one-shot jobs; passing it here just overrides the next fire and
+  leaves the cron cadence unchanged, so the reschedule would not stick. Pass an
+  updated `task_payload` to reword what the job does.
   Do NOT call `scheduler-create` for a change request: a second job with the same
   cron and payload makes the task fire twice. After editing, confirm to the CEO
   what changed on the existing schedule. If more than one active job could be the

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -409,11 +409,16 @@ system_prompt: |
   When setting up something that repeats on a cron ("check X every week",
   "remind me every Monday"). Provide only `cron_expr` and `task`. Do not pass
   `intent_anchor` — that field is not used for operational sweeps.
-  Before creating, first call `scheduler-list` and scan for an active job
-  (`status` `pending`/`suspended`/`paused`) that already covers this routine —
-  same agent and effectively the same task. If one exists, this is a change to
-  that job, not a new one: edit it in place per the rule below. Only
-  `scheduler-create` when no equivalent active job is found.
+  Before creating, call `scheduler-list` (it filters by only one `status`, so
+  list without a status filter and scan the results) and look for an active job —
+  `pending`, `suspended`, or `paused` — with the same agent and effectively the
+  same task. A match matters only when the CEO is *changing* that routine: edit
+  it in place per the rule below. If the CEO wants an ADDITIONAL run or a variant
+  ("also scan on Fridays at 4pm", "add a second check") — even one that resembles
+  an existing job — that is a genuinely new job, so `scheduler-create` it. `edit`
+  overwrites the cron and payload rather than adding, so treating an additive
+  request as an edit silently destroys the original and never creates the new one.
+  When it is unclear whether the CEO means "change this" or "add another", ask.
 
   **Resume, pause, or edit an existing job — use `scheduler-update`:**
   When the CEO asks to unsuspend/resume, pause, or reschedule a job. Find the
@@ -430,7 +435,9 @@ system_prompt: |
   `job_id` — passing the new `cron_expr`/`run_at` and/or an updated `task_payload`.
   Do NOT call `scheduler-create` for a change request: a second job with the same
   cron and payload makes the task fire twice. After editing, confirm to the CEO
-  what changed on the existing schedule.
+  what changed on the existing schedule. If more than one active job could be the
+  one they mean, do not guess — the edit is destructive; ask which routine they
+  mean (cite each candidate's time/cron) before editing.
 
   **Backlog awareness:** Before answering "what's open?", "what's waiting on me?",
   or "what are you working on?", call `task-list`.

--- a/tests/smoke/cases/coordinator-edit-recurring-job.yaml
+++ b/tests/smoke/cases/coordinator-edit-recurring-job.yaml
@@ -1,0 +1,54 @@
+name: Coordinator edits an existing recurring job instead of duplicating it
+description: >
+  When the CEO sets up a recurring ad-hoc job and then, in a later turn, asks to
+  change its time, the coordinator must EDIT the existing job in place
+  (scheduler-list to find it, then scheduler-update action: edit) rather than
+  calling scheduler-create again and leaving two overlapping jobs that fire the
+  task twice. See issue #1465 — observed in prod as a cancelled + pending pair
+  with the same daily cron and payload.
+tags:
+  - scheduling
+  - scheduler-update
+  - multi-turn
+  - no-duplicate
+
+turns:
+  - role: user
+    content: |
+      Set up a recurring check every weekday morning at 9am — scan my inbox for
+      anything from investors and flag it for me.
+  - role: user
+    delay_ms: 2000
+    content: |
+      Actually, make that 10am instead of 9am. Same thing otherwise.
+
+expected_behaviors:
+  - id: edits_in_place_not_duplicate
+    description: >
+      In response to the second turn, the coordinator changes the SAME existing
+      job to 10am rather than standing up a brand-new schedule. The response
+      should read as an update to the routine already set up in turn 1 (e.g.
+      "I've moved your morning investor check to 10am"), not as creating a second
+      schedule. It must not describe now having two schedules, and must not imply
+      the 9am job still exists alongside a new 10am one.
+    weight: critical
+  - id: single_active_routine_at_new_time
+    description: >
+      After the change, the coordinator conveys that there is exactly one active
+      recurring job and it runs at 10am on weekday mornings. It does not confirm
+      or leave the impression that the task will fire twice (once at 9am and once
+      at 10am).
+    weight: critical
+  - id: confirms_the_change
+    description: >
+      The coordinator confirms to the CEO what changed on the existing schedule
+      (the new 10am time), closing the loop rather than silently editing.
+    weight: important
+
+failure_modes:
+  - Coordinator calls scheduler-create for the second turn, creating a duplicate
+    overlapping job so the investor scan runs twice each morning.
+  - Response describes two schedules (a 9am one and a 10am one) instead of one
+    edited job.
+  - Coordinator tells the CEO to change it themselves in the web UI instead of
+    editing the job directly.


### PR DESCRIPTION
## Summary

Changing an existing recurring ad-hoc scheduled job (`created_by != 'system'`) — a new time, tweaked instructions — could have the coordinator call `scheduler-create` and add a second overlapping job instead of editing the existing one, so the task runs twice. Observed in prod as a `cancelled` + `pending` pair with the same daily cron and payload.

Per the issue's prescribed low-risk approach (service-level upsert explicitly deferred), the fix is a coordinator system-prompt rule, not a schema change:

- **Before `scheduler-create`** for a recurring sweep, the coordinator lists existing jobs and, if the request is a *change* to an equivalent active job, edits that job in place.
- **A change to a routine already managed** (reword, new time) is framed as an EDIT: find the `job_id` via `scheduler-list`, then `scheduler-update` (`action: edit`) the same job, then confirm to the CEO.

Jobs stay ad-hoc (`created_by='coordinator'`); no declarative `schedule:` entry is introduced, so they survive restart unchanged.

### Guardrails (from pre-PR review)

- The dedup check is scoped to genuine change requests — an *additive* request ("also scan Fridays at 4pm", "add a second check") still `scheduler-create`s a new job even when it resembles an existing one, because `edit` overwrites cron+payload (mis-editing would silently destroy the original and drop the new job).
- When more than one active job could match, the coordinator disambiguates with the CEO before the (destructive) edit rather than guessing.

## Testing

- New two-turn smoke case `tests/smoke/cases/coordinator-edit-recurring-job.yaml` (set up a 9am routine, then "make it 10am") with critical behaviors discriminating edit-in-place from the duplicate-create failure mode.
- Note: the smoke harness is LLM-judged on the coordinator's response text (it boots a real DB and runs end-to-end, but the runner captures only the final text — it does not inspect which skill was invoked or count `scheduled_jobs` rows). A hard DB-row assertion would require extending the harness, which is out of scope for this fix; the issue prescribed an LLM-judged smoke case.
- `src/agents/loader.test.ts` and `tests/unit/smoke/loader.test.ts` pass (config + new case validate).

Closes #1465