### PR TITLE
feat(learning): surface digest items event-driven after digest removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Learning-item surfacing** — voice-guide proposals and sent-mail task completions now notify the CEO when produced, not via a digest. (#1466)
+- **Learning-item surfacing** — voice-guide proposals and sent-mail task completions now notify the CEO directly, not via a digest. (#1466)
 - **`outbound.notification`** — new `learning_proposal` `notificationType` on the bus event (public API). (#1466)
 - **`web-browser`** — optional egress proxy (`browser.proxy`) routes browsing through a residential exit, plus a WebRTC-leak guard.
 - **`web-browser`** — stable per-element refs let the agent disambiguate duplicate labels (e.g. survey radios).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Learning-item surfacing** — voice-guide proposals and sent-mail task completions now notify the CEO when produced, not via a digest. (#1466)
+- **`outbound.notification`** — new `learning_proposal` `notificationType` on the bus event (public API). (#1466)
 - **`web-browser`** — optional egress proxy (`browser.proxy`) routes browsing through a residential exit, plus a WebRTC-leak guard.
 - **`web-browser`** — stable per-element refs let the agent disambiguate duplicate labels (e.g. survey radios).
 - **`web-browser`** — circuit-breaker halts interaction after 4 consecutive failures to curb futile retry loops.

--- a/skills/_shared/learning-digest.test.ts
+++ b/skills/_shared/learning-digest.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { renderVoiceGuideSection, renderCompletionSection } from './learning-digest.js';
+import {
+  renderVoiceGuideSection,
+  renderCompletionSection,
+  buildVoiceProposalNotification,
+  buildCompletionDigestNotification,
+} from './learning-digest.js';
 import type { CompletionDigestItem } from './learning-state.js';
 
 const COMPLETION_ITEMS: CompletionDigestItem[] = [
@@ -32,5 +37,32 @@ describe('learning digest renderers', () => {
       2. Did emailing board@example.com complete *Plan AGM*? Reply \`confirm completion bbb\` or \`dismiss completion bbb\`.
       "
     `);
+  });
+});
+
+describe('event-driven learning notification bodies (#1466)', () => {
+  it('voice proposal notification inlines the guide and the approve/dismiss reply commands', () => {
+    const { subject, body } = buildVoiceProposalNotification('- Writes short.\n- Dry humour.');
+    expect(subject).toBe('Writing-voice guide update to review');
+    // The reviewable content is inlined verbatim...
+    expect(body).toContain('- Writes short.');
+    expect(body).toContain('- Dry humour.');
+    // ...along with the section heading and the reply instructions the CEO acts on.
+    expect(body).toContain('### Proposed writing-voice update');
+    expect(body).toContain('Reply `approve voice` or `dismiss voice`.');
+  });
+
+  it('completion notification inlines each undo/confirm item with its reply commands and pluralizes the subject', () => {
+    const { subject, body } = buildCompletionDigestNotification(COMPLETION_ITEMS);
+    expect(subject).toBe('2 task updates from your sent mail');
+    expect(body).toContain('### Task completion from sent mail');
+    // undo item carries its `undo completion <id>` command; confirm item carries confirm/dismiss.
+    expect(body).toContain('Reply `undo completion aaa`.');
+    expect(body).toContain('Reply `confirm completion bbb` or `dismiss completion bbb`.');
+  });
+
+  it('completion notification subject is singular for one item', () => {
+    const { subject } = buildCompletionDigestNotification([COMPLETION_ITEMS[0]!]);
+    expect(subject).toBe('1 task update from your sent mail');
   });
 });

--- a/skills/_shared/learning-digest.ts
+++ b/skills/_shared/learning-digest.ts
@@ -34,3 +34,43 @@ export function renderCompletionSection(items: CompletionDigestItem[]): string {
   ];
   return lines.join('\n');
 }
+
+// ---------------------------------------------------------------------------
+// Event-driven notification bodies (#1466)
+//
+// After #1464 removed the scheduled daily digest, these standalone builders let a generator
+// surface a learning item the moment it's produced — the only path that now reaches the CEO for
+// approve/dismiss/undo/confirm. They wrap the render* helpers above (which already inline both the
+// reviewable content AND the reply commands) with a short preamble, so the CEO can act directly
+// from the notification. The CEO's reply still resolves via resolve-learning-digest, unchanged.
+// ---------------------------------------------------------------------------
+
+/** Notification for a freshly-produced writing-voice guide proposal (voice-learn). */
+export function buildVoiceProposalNotification(guide: string): { subject: string; body: string } {
+  return {
+    subject: 'Writing-voice guide update to review',
+    body: [
+      'I drafted an update to your writing-voice guide from your recent email edits.',
+      '',
+      // trimEnd drops the trailing blank line renderVoiceGuideSection appends for digest spacing.
+      renderVoiceGuideSection(guide).trimEnd(),
+    ].join('\n'),
+  };
+}
+
+/** Notification for freshly-produced sent-mail task-completion items (task-completion-from-sent).
+ *  `items` are this run's new undo/confirm entries — the caller must not pass an empty array
+ *  (renderCompletionSection would omit the section, leaving a bare preamble). */
+export function buildCompletionDigestNotification(
+  items: CompletionDigestItem[],
+): { subject: string; body: string } {
+  const plural = items.length === 1 ? '' : 's';
+  return {
+    subject: `${items.length} task update${plural} from your sent mail`,
+    body: [
+      'I matched some of your sent mail to open tasks. Please review:',
+      '',
+      renderCompletionSection(items).trimEnd(),
+    ].join('\n'),
+  };
+}

--- a/skills/_shared/learning-notify.test.ts
+++ b/skills/_shared/learning-notify.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import { notifyLearningProposal, resolvePrincipalEmail } from './learning-notify.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { OutboundGateway } from '../../src/skills/outbound-gateway.js';
+
+interface CtxOpts {
+  withoutGateway?: boolean;
+  withoutContactService?: boolean;
+  /** Principal email; '' → findContactBySystemRole returns null (no principal). */
+  ceoEmail?: string;
+  emailVerified?: boolean;
+  emailStatus?: string;
+  sendResult?: boolean;
+  /** Make the contacts lookup throw, to exercise the best-effort catch. */
+  lookupThrows?: boolean;
+}
+
+function makeCtx(opts: CtxOpts = {}) {
+  const {
+    withoutGateway = false,
+    withoutContactService = false,
+    ceoEmail = 'ceo@example.com',
+    emailVerified = true,
+    emailStatus = 'active',
+    sendResult = true,
+    lookupThrows = false,
+  } = opts;
+
+  const sendNotificationMock = vi.fn().mockResolvedValue(sendResult);
+
+  // findContactBySystemRole('principal') → getContactWithIdentities(id) → verified+active email.
+  // An empty ceoEmail models "no principal on file" (returns null).
+  const findContactBySystemRoleMock = lookupThrows
+    ? vi.fn().mockRejectedValue(new Error('DB read error'))
+    : vi.fn().mockResolvedValue(ceoEmail ? { id: 'principal-1' } : null);
+  const getContactWithIdentitiesMock = vi.fn().mockResolvedValue(
+    ceoEmail
+      ? {
+          identities: [
+            {
+              channel: 'email',
+              verified: emailVerified,
+              status: emailStatus,
+              channelIdentifier: ceoEmail,
+            },
+          ],
+        }
+      : { identities: [] },
+  );
+
+  const logWarnMock = vi.fn();
+
+  const ctx = {
+    log: { info: vi.fn(), warn: logWarnMock, error: vi.fn(), debug: vi.fn() },
+    contactService: withoutContactService
+      ? undefined
+      : ({
+          findContactBySystemRole: findContactBySystemRoleMock,
+          getContactWithIdentities: getContactWithIdentitiesMock,
+        } as unknown as SkillContext['contactService']),
+    outboundGateway: withoutGateway
+      ? undefined
+      : ({ sendNotification: sendNotificationMock } as unknown as OutboundGateway),
+  } as unknown as SkillContext;
+
+  return { ctx, sendNotificationMock, findContactBySystemRoleMock, logWarnMock };
+}
+
+const NOTIFICATION = { subject: 'Subject', body: 'Body' };
+
+describe('resolvePrincipalEmail', () => {
+  it('returns the verified + active email', async () => {
+    const { ctx } = makeCtx({ ceoEmail: 'ceo@example.com' });
+    expect(await resolvePrincipalEmail(ctx)).toBe('ceo@example.com');
+  });
+
+  it('returns null when contactService is absent', async () => {
+    const { ctx, logWarnMock } = makeCtx({ withoutContactService: true });
+    expect(await resolvePrincipalEmail(ctx)).toBeNull();
+    expect(logWarnMock).toHaveBeenCalled();
+  });
+
+  it('returns null when there is no principal', async () => {
+    const { ctx } = makeCtx({ ceoEmail: '' });
+    expect(await resolvePrincipalEmail(ctx)).toBeNull();
+  });
+
+  it('returns null when the email is not verified+active (bounced/unverified)', async () => {
+    const { ctx } = makeCtx({ emailStatus: 'bounced' });
+    expect(await resolvePrincipalEmail(ctx)).toBeNull();
+  });
+
+  it('never throws — a contacts-layer error resolves to null', async () => {
+    const { ctx, logWarnMock } = makeCtx({ lookupThrows: true });
+    expect(await resolvePrincipalEmail(ctx)).toBeNull();
+    expect(logWarnMock).toHaveBeenCalled();
+  });
+});
+
+describe('notifyLearningProposal', () => {
+  it('sends a learning_proposal notification with the resolved email + provided subject/body', async () => {
+    const { ctx, sendNotificationMock } = makeCtx();
+    const result = await notifyLearningProposal(ctx, NOTIFICATION);
+    expect(result).toBe(true);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    expect(sendNotificationMock.mock.calls[0]![0]).toEqual({
+      notificationType: 'learning_proposal',
+      ceoEmail: 'ceo@example.com',
+      subject: 'Subject',
+      body: 'Body',
+    });
+  });
+
+  it('skips (no send) and returns false when outboundGateway is absent', async () => {
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({ withoutGateway: true });
+    expect(await notifyLearningProposal(ctx, NOTIFICATION)).toBe(false);
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalled();
+  });
+
+  it('skips (no send) and returns false when no principal email is on file', async () => {
+    const { ctx, sendNotificationMock } = makeCtx({ ceoEmail: '' });
+    expect(await notifyLearningProposal(ctx, NOTIFICATION)).toBe(false);
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false (non-fatal) when sendNotification reports a failed send', async () => {
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({ sendResult: false });
+    expect(await notifyLearningProposal(ctx, NOTIFICATION)).toBe(false);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    expect(logWarnMock).toHaveBeenCalled();
+  });
+});

--- a/skills/_shared/learning-notify.test.ts
+++ b/skills/_shared/learning-notify.test.ts
@@ -130,4 +130,11 @@ describe('notifyLearningProposal', () => {
     expect(sendNotificationMock).toHaveBeenCalledTimes(1);
     expect(logWarnMock).toHaveBeenCalled();
   });
+
+  it('never throws — an unexpected sendNotification throw resolves to false (non-fatal)', async () => {
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx();
+    sendNotificationMock.mockRejectedValue(new Error('bus exploded'));
+    await expect(notifyLearningProposal(ctx, NOTIFICATION)).resolves.toBe(false);
+    expect(logWarnMock).toHaveBeenCalled();
+  });
 });

--- a/skills/_shared/learning-notify.ts
+++ b/skills/_shared/learning-notify.ts
@@ -1,0 +1,79 @@
+// learning-notify.ts — event-driven surfacing of learning-digest items (#1466).
+//
+// After #1464 removed the scheduled daily digest, the learning-item generators (voice-learn and
+// task-completion-from-sent) wrote proposals/undo-confirm items to the config store with no reader
+// left to surface them. Rather than re-add a scheduled recap, each generator calls
+// notifyLearningProposal the moment it produces a reviewable item — so the CEO reviews it fresh,
+// in context, and only when there's something to review. The CEO's approve/dismiss/undo/confirm
+// reply still resolves via resolve-learning-digest; this only adds the outbound surface.
+//
+// Everything here is best-effort and non-fatal: it runs AFTER the durable proposal/digest write,
+// so a missing gateway, missing principal email, or a failed send must never fail the generator's
+// run (which would falsely signal failure and churn the scheduler). All such cases log and return.
+
+import type { SkillContext } from '../../src/skills/types.js';
+
+/**
+ * Resolve the principal's verified + ACTIVE email address, or null (a silent skip).
+ *
+ * Mirrors approval-expiry-sweep's resolvePrincipalEmail: findContactBySystemRole('principal') is
+ * the single source of truth for principal identity, and delivery is restricted to a verified +
+ * active email (a defunct/bounced address may be reassigned, so we don't route CEO notifications
+ * to it). Never throws — a contacts-layer error on this notification path is treated as "no email".
+ */
+export async function resolvePrincipalEmail(ctx: SkillContext): Promise<string | null> {
+  if (!ctx.contactService) {
+    // Capability-wiring problem (contactService is universal, so this is unexpected) rather than a
+    // benign first-run data state — log the cause; the caller logs the consequence (skip).
+    ctx.log.warn('learning-notify: contactService unavailable — cannot resolve principal email');
+    return null;
+  }
+  try {
+    const principal = await ctx.contactService.findContactBySystemRole('principal');
+    if (!principal) return null;
+    const withIdentities = await ctx.contactService.getContactWithIdentities(principal.id);
+    const identities = withIdentities?.identities ?? [];
+    const email = identities.find(
+      (id) => id.channel === 'email' && id.verified && id.status === 'active',
+    );
+    return email?.channelIdentifier ?? null;
+  } catch (err) {
+    ctx.log.warn({ err }, 'learning-notify: failed to resolve principal email — skipping notification');
+    return null;
+  }
+}
+
+/**
+ * Fire a `learning_proposal` CEO notification with a pre-built subject + body.
+ *
+ * Best-effort and non-fatal: a missing outboundGateway, an unresolvable principal email, or a
+ * false send result is logged and swallowed so the generator's primary work (the durable
+ * proposal/digest write, already committed) never fails over a notification. Returns true only
+ * when sendNotification confirmed the notification event was published.
+ */
+export async function notifyLearningProposal(
+  ctx: SkillContext,
+  notification: { subject: string; body: string },
+): Promise<boolean> {
+  if (!ctx.outboundGateway) {
+    ctx.log.warn('learning-notify: outboundGateway unavailable — skipping learning-proposal notification');
+    return false;
+  }
+  const ceoEmail = await resolvePrincipalEmail(ctx);
+  if (!ceoEmail) {
+    ctx.log.warn('learning-notify: no principal email on file — skipping learning-proposal notification');
+    return false;
+  }
+  // sendNotification catches its own errors and returns a boolean (never throws), so this call
+  // cannot escape into the generator's outer try/catch and fail the run.
+  const sent = await ctx.outboundGateway.sendNotification({
+    notificationType: 'learning_proposal',
+    ceoEmail,
+    subject: notification.subject,
+    body: notification.body,
+  });
+  if (!sent) {
+    ctx.log.warn('learning-notify: sendNotification returned false — CEO notification not delivered this run');
+  }
+  return sent;
+}

--- a/skills/_shared/learning-notify.ts
+++ b/skills/_shared/learning-notify.ts
@@ -55,25 +55,32 @@ export async function notifyLearningProposal(
   ctx: SkillContext,
   notification: { subject: string; body: string },
 ): Promise<boolean> {
-  if (!ctx.outboundGateway) {
-    ctx.log.warn('learning-notify: outboundGateway unavailable — skipping learning-proposal notification');
+  // Self-contained never-throw guarantee. The generators await this bare inside their outer
+  // try/catch (which converts any throw to success:false and would churn the scheduler), so the
+  // "notification never fails the run" contract must not depend on sendNotification / the contacts
+  // layer never throwing. Wrap the whole body so a future change to any of them stays non-fatal.
+  try {
+    if (!ctx.outboundGateway) {
+      ctx.log.warn('learning-notify: outboundGateway unavailable — skipping learning-proposal notification');
+      return false;
+    }
+    const ceoEmail = await resolvePrincipalEmail(ctx);
+    if (!ceoEmail) {
+      ctx.log.warn('learning-notify: no principal email on file — skipping learning-proposal notification');
+      return false;
+    }
+    const sent = await ctx.outboundGateway.sendNotification({
+      notificationType: 'learning_proposal',
+      ceoEmail,
+      subject: notification.subject,
+      body: notification.body,
+    });
+    if (!sent) {
+      ctx.log.warn('learning-notify: sendNotification returned false — CEO notification not delivered this run');
+    }
+    return sent;
+  } catch (err) {
+    ctx.log.warn({ err }, 'learning-notify: unexpected error sending learning-proposal notification — treated as non-fatal');
     return false;
   }
-  const ceoEmail = await resolvePrincipalEmail(ctx);
-  if (!ceoEmail) {
-    ctx.log.warn('learning-notify: no principal email on file — skipping learning-proposal notification');
-    return false;
-  }
-  // sendNotification catches its own errors and returns a boolean (never throws), so this call
-  // cannot escape into the generator's outer try/catch and fail the run.
-  const sent = await ctx.outboundGateway.sendNotification({
-    notificationType: 'learning_proposal',
-    ceoEmail,
-    subject: notification.subject,
-    body: notification.body,
-  });
-  if (!sent) {
-    ctx.log.warn('learning-notify: sendNotification returned false — CEO notification not delivered this run');
-  }
-  return sent;
 }

--- a/skills/task-completion-from-sent/handler.test.ts
+++ b/skills/task-completion-from-sent/handler.test.ts
@@ -83,8 +83,10 @@ function makeMem(seed: Record<string, string> = {}): EntityMemory & { __values: 
 function makeCtx(): SkillContext & {
   __completed: string[];
   __mem: ReturnType<typeof makeMem>;
+  __sendNotification: ReturnType<typeof vi.fn>;
 } {
   const completed: string[] = [];
+  const sendNotification = vi.fn().mockResolvedValue(true);
   const mem = makeMem({ [COMPLETION_CANDIDATES_KEY]: JSON.stringify(CANDIDATE_MAP) });
 
   const tasks: Record<string, {
@@ -145,11 +147,24 @@ function makeCtx(): SkillContext & {
     sensitivityClassifier: {
       classify: (text: string) => (/board|agm/i.test(text) ? 'restricted' : 'internal'),
     },
+    // Event-driven CEO notification (#1466): a mocked gateway + principal-resolving contactService,
+    // so a produced digest fires notifyLearningProposal. Exposed as __sendNotification for asserts.
+    outboundGateway: { sendNotification } as unknown as SkillContext['outboundGateway'],
+    contactService: {
+      findContactBySystemRole: vi.fn().mockResolvedValue({ id: 'principal-1' }),
+      getContactWithIdentities: vi.fn().mockResolvedValue({
+        identities: [
+          { channel: 'email', verified: true, status: 'active', channelIdentifier: 'ceo@example.com' },
+        ],
+      }),
+    } as unknown as SkillContext['contactService'],
     __completed: completed,
     __mem: mem,
+    __sendNotification: sendNotification,
   } as unknown as SkillContext & {
     __completed: string[];
     __mem: typeof mem;
+    __sendNotification: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -176,6 +191,26 @@ describe('TaskCompletionFromSentHandler', () => {
     // prevents re-surfacing now, not an in-band marker.
     const remaining = JSON.parse(ctx.__mem.__values.get(COMPLETION_CANDIDATES_KEY)!);
     expect(remaining).toEqual({});
+
+    // Event-driven surfacing (#1466): the produced undo/confirm items are pushed to the CEO
+    // inline, in one notification, the moment they're written.
+    expect(ctx.__sendNotification).toHaveBeenCalledTimes(1);
+    const payload = ctx.__sendNotification.mock.calls[0]![0];
+    expect(payload.notificationType).toBe('learning_proposal');
+    expect(payload.ceoEmail).toBe('ceo@example.com');
+    expect(payload.body).toContain('### Task completion from sent mail');
+    // Both the undo (auto-completed) and a confirm item's reply commands are inlined.
+    expect(payload.body).toContain('undo completion 11111111-1111-4111-8111-111111111111');
+    expect(payload.body).toContain('confirm completion 22222222-2222-4222-8222-222222222222');
+  });
+
+  it('does NOT notify when the run produces no digest items (empty candidate queue)', async () => {
+    const ctx = makeCtx();
+    // Drain the queue so nothing is produced this run.
+    ctx.__mem.__values.set(COMPLETION_CANDIDATES_KEY, JSON.stringify({}));
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(ctx.__sendNotification).not.toHaveBeenCalled();
   });
 
   it('a low-confidence candidate skips the subtask lookup and the sensitivity classifier (T3.1)', async () => {

--- a/skills/task-completion-from-sent/handler.test.ts
+++ b/skills/task-completion-from-sent/handler.test.ts
@@ -302,6 +302,37 @@ describe('TaskCompletionFromSentHandler', () => {
     expect(remaining['11111111-1111-4111-8111-111111111111']).toEqual(
       CANDIDATE_MAP['11111111-1111-4111-8111-111111111111'],
     );
+
+    // The CEO must NOT be told to "undo" a task whose completeTask threw — it was never marked
+    // done. This run's only item was that failed auto-complete, so no notification fires at all.
+    expect(ctx.__sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('a failed undo auto-complete is excluded from the notification but a sibling confirm item is still sent', async () => {
+    const ctx = makeCtx();
+    // Queue the auto-complete candidate (task 1) and a fuzzy/low-confidence one (task 3 → confirm).
+    ctx.__mem.__values.set(
+      COMPLETION_CANDIDATES_KEY,
+      JSON.stringify({
+        '11111111-1111-4111-8111-111111111111': CANDIDATE_MAP['11111111-1111-4111-8111-111111111111'],
+        '33333333-3333-4333-8333-333333333333': CANDIDATE_MAP['33333333-3333-4333-8333-333333333333'],
+      }),
+    );
+    // completeTask throws → the undo item for task 1 must be dropped from the notification.
+    (ctx.taskRepo as unknown as { completeTask: (...args: unknown[]) => Promise<unknown> }).completeTask =
+      vi.fn(async () => {
+        throw new Error('db hiccup');
+      });
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+
+    // A notification still fires (the confirm item is genuine and actionable)...
+    expect(ctx.__sendNotification).toHaveBeenCalledTimes(1);
+    const body = ctx.__sendNotification.mock.calls[0]![0].body as string;
+    // ...but it carries ONLY the confirm item, not the failed undo.
+    expect(body).toContain('confirm completion 33333333-3333-4333-8333-333333333333');
+    expect(body).not.toContain('undo completion 11111111-1111-4111-8111-111111111111');
   });
 
   it('DOUBLE-RUN: a digest soft-reject blocks completion entirely; a later successful run completes it with the undo note durable (Finding 6)', async () => {

--- a/skills/task-completion-from-sent/handler.ts
+++ b/skills/task-completion-from-sent/handler.ts
@@ -212,6 +212,11 @@ export class TaskCompletionFromSentHandler implements SkillHandler {
 
     // Second pass: only now that every pending auto-complete's undo note is confirmed durable is
     // it safe to actually complete the tasks.
+    // Track which auto-completes actually landed this run so the notification below only tells the
+    // CEO to "undo" tasks that were really marked done — a completeTask that threw leaves the task
+    // active, and an "undo completion <id>" line for it would be a lie (the CEO reply path would
+    // then find a non-done task and either fail loud or falsely report "already reopened").
+    const completedTaskIds = new Set<string>();
     if (digestStored) {
       for (const pending of toAutoComplete) {
         try {
@@ -221,6 +226,7 @@ export class TaskCompletionFromSentHandler implements SkillHandler {
             ctx.agentId,
           );
           delete remaining[pending.candidateTaskId];
+          completedTaskIds.add(pending.taskId);
           autoCompleted += 1;
         } catch (err) {
           ctx.log.error({ err, taskId: pending.taskId }, 'task-completion-from-sent: auto-complete failed');
@@ -236,13 +242,18 @@ export class TaskCompletionFromSentHandler implements SkillHandler {
       await writeCompletionCandidates(store, remaining);
     }
 
-    // Surface this run's newly produced undo/confirm items to the CEO the moment they're durably
-    // written (#1466). After #1464 removed the scheduled digest, this event-driven notification is
-    // the only path that reaches the CEO for undo/confirm/dismiss. Gated on digestStored (the
-    // durable digest the CEO's reply resolves against) and on there being new items, so an
-    // empty/soft-rejected run stays silent. Best-effort — notifyLearningProposal never fails the run.
-    if (digestStored && digestAdds.length > 0) {
-      await notifyLearningProposal(ctx, buildCompletionDigestNotification(digestAdds));
+    // Surface this run's newly produced items to the CEO the moment they're durably written (#1466).
+    // After #1464 removed the scheduled digest, this event-driven notification is the only proactive
+    // path that reaches the CEO for undo/confirm/dismiss. Include every confirm item (they don't
+    // depend on completeTask) but only the undo items whose auto-complete actually succeeded this
+    // run — an undo whose completeTask threw is still in `digestAdds`/the durable digest (which
+    // self-heals next run), but must NOT be announced as done. Gated on digestStored (the durable
+    // digest the reply resolves against) and non-empty. Best-effort — notify never fails the run.
+    const notifyItems = digestAdds.filter(
+      (i) => i.kind === 'confirm' || completedTaskIds.has(i.taskId),
+    );
+    if (digestStored && notifyItems.length > 0) {
+      await notifyLearningProposal(ctx, buildCompletionDigestNotification(notifyItems));
     }
 
     ctx.log.info(

--- a/skills/task-completion-from-sent/handler.ts
+++ b/skills/task-completion-from-sent/handler.ts
@@ -19,6 +19,8 @@ import {
   type CompletionDigestMap,
   type CompletionDigestItem,
 } from '../_shared/learning-state.js';
+import { buildCompletionDigestNotification } from '../_shared/learning-digest.js';
+import { notifyLearningProposal } from '../_shared/learning-notify.js';
 
 // Active (non-terminal) task statuses eligible for sent-mail completion. Mirrors the
 // active-status set used by the scheduler/backlog queries (src/db/queries/tasks.ts).
@@ -232,6 +234,15 @@ export class TaskCompletionFromSentHandler implements SkillHandler {
 
     if (digestStored && Object.keys(remaining).length !== Object.keys(candidateMap).length) {
       await writeCompletionCandidates(store, remaining);
+    }
+
+    // Surface this run's newly produced undo/confirm items to the CEO the moment they're durably
+    // written (#1466). After #1464 removed the scheduled digest, this event-driven notification is
+    // the only path that reaches the CEO for undo/confirm/dismiss. Gated on digestStored (the
+    // durable digest the CEO's reply resolves against) and on there being new items, so an
+    // empty/soft-rejected run stays silent. Best-effort — notifyLearningProposal never fails the run.
+    if (digestStored && digestAdds.length > 0) {
+      await notifyLearningProposal(ctx, buildCompletionDigestNotification(digestAdds));
     }
 
     ctx.log.info(

--- a/skills/task-completion-from-sent/skill.json
+++ b/skills/task-completion-from-sent/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "task-completion-from-sent",
-  "description": "Consume sent-mail task-completion candidates: auto-complete low-risk high-confidence matches with a reversible undo note; queue confirmations for high-risk or fuzzy matches. Writes digest surfaces to the config-store key sent_observe.completion_digest. Intended to run after ceo-inbox-sent-observe on the daily cron.",
-  "version": "0.2.1",
+  "description": "Consume sent-mail task-completion candidates: auto-complete low-risk high-confidence matches with a reversible undo note; queue confirmations for high-risk or fuzzy matches. Writes digest surfaces to the config-store key sent_observe.completion_digest and, on new items, sends the CEO a direct notification inlining them for undo/confirm/dismiss. Intended to run after ceo-inbox-sent-observe on the daily cron.",
+  "version": "0.3.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {},
@@ -13,5 +13,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 30000,
-  "capabilities": ["taskRepo", "sensitivityClassifier", "entityMemory"]
+  "capabilities": ["taskRepo", "sensitivityClassifier", "entityMemory", "outboundGateway"]
 }

--- a/skills/voice-learn/handler.test.ts
+++ b/skills/voice-learn/handler.test.ts
@@ -97,6 +97,7 @@ function makeCtx(opts: {
 }): SkillContext & {
   __updates: unknown[];
   __docs: Map<string, { body: string; version: number; type: string; path: string; frontmatter: Record<string, unknown> }>;
+  __sendNotification: ReturnType<typeof vi.fn>;
 } {
   const voice = {
     tone: ['direct', 'warm'],
@@ -109,6 +110,9 @@ function makeCtx(opts: {
   };
   const profile: ExecutiveProfile = { writingVoice: voice };
   const updates: unknown[] = [];
+  // Event-driven CEO notification (#1466): a mocked gateway + principal-resolving contactService,
+  // so a produced proposal fires notifyLearningProposal. Exposed as __sendNotification for asserts.
+  const sendNotification = vi.fn().mockResolvedValue(true);
   const docs = new Map<string, { body: string; version: number; type: string; path: string; frontmatter: Record<string, unknown> }>();
   if (opts.diffs !== '') {
     docs.set(PENDING_DIFFS_PATH, {
@@ -169,11 +173,22 @@ function makeCtx(opts: {
       }),
     },
     log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    outboundGateway: { sendNotification } as unknown as SkillContext['outboundGateway'],
+    contactService: {
+      findContactBySystemRole: vi.fn().mockResolvedValue({ id: 'principal-1' }),
+      getContactWithIdentities: vi.fn().mockResolvedValue({
+        identities: [
+          { channel: 'email', verified: true, status: 'active', channelIdentifier: 'ceo@example.com' },
+        ],
+      }),
+    } as unknown as SkillContext['contactService'],
     __updates: updates,
     __docs: docs,
+    __sendNotification: sendNotification,
   } as unknown as SkillContext & {
     __updates: unknown[];
     __docs: typeof docs;
+    __sendNotification: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -238,6 +253,57 @@ describe('VoiceLearnHandler', () => {
     expect(result.success).toBe(true);
     expect(ctx.infraLlm!.extract).not.toHaveBeenCalled();
     expect(mem.__values.has(VOICE_PROPOSAL_KEY)).toBe(false);
+  });
+
+  // Event-driven surfacing (#1466): a produced proposal notifies the CEO; a run that produces
+  // nothing stays silent (no notification).
+  it('notifies the CEO with the inlined guide when a proposal is produced', async () => {
+    const mem = makeEntityMemory();
+    const ctx = makeCtx({ entityMemory: mem });
+    (ctx.infraLlm!.extract as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: '- Writes short.\n- Dry humour.',
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(ctx.__sendNotification).toHaveBeenCalledTimes(1);
+    const payload = ctx.__sendNotification.mock.calls[0]![0];
+    expect(payload.notificationType).toBe('learning_proposal');
+    expect(payload.ceoEmail).toBe('ceo@example.com');
+    // The reviewable guide is inlined so the CEO can approve/dismiss straight from the email.
+    expect(payload.body).toContain('Dry humour');
+    expect(payload.body).toContain('Reply `approve voice` or `dismiss voice`.');
+  });
+
+  it('does NOT notify when the run produces no proposal (empty diffs)', async () => {
+    const mem = makeEntityMemory();
+    const ctx = makeCtx({ diffs: '# empty\n', entityMemory: mem });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(ctx.__sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify when the LLM fails to produce a proposal', async () => {
+    const mem = makeEntityMemory();
+    const ctx = makeCtx({ entityMemory: mem });
+    (ctx.infraLlm!.extract as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false, error: 'timeout' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(ctx.__sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fail the run when the notification send fails (best-effort)', async () => {
+    const mem = makeEntityMemory();
+    const ctx = makeCtx({ entityMemory: mem });
+    ctx.__sendNotification.mockResolvedValue(false);
+    (ctx.infraLlm!.extract as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: '- Writes short.',
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    // The proposal was still persisted despite the notification not landing.
+    expect(mem.__values.get(VOICE_PROPOSAL_KEY)).toContain('Writes short.');
   });
 
   it('LLM failure → no proposal, success result', async () => {

--- a/skills/voice-learn/handler.ts
+++ b/skills/voice-learn/handler.ts
@@ -10,6 +10,8 @@ import { ConfigStore } from '../../src/memory/config-store.js';
 import { buildVoiceGuidePrompt, parsePendingDiffs } from '../_shared/voice-learn-logic.js';
 import { PENDING_DIFFS_PATH } from '../ceo-inbox-sent-observe/handler.js';
 import { writeVoiceProposal } from '../_shared/learning-state.js';
+import { buildVoiceProposalNotification } from '../_shared/learning-digest.js';
+import { notifyLearningProposal } from '../_shared/learning-notify.js';
 
 // Kept for Task 9 (resolve-learning-digest) and cooldown bookkeeping, even though
 // this handler no longer reads/writes provenance directly.
@@ -216,6 +218,13 @@ export class VoiceLearnHandler implements SkillHandler {
         }
       }
     }
+
+    // Surface the proposal to the CEO the moment it's durably written (#1466). After #1464 removed
+    // the scheduled digest, this event-driven notification is the only path that reaches the CEO
+    // for approve/dismiss. Best-effort: notifyLearningProposal never throws and never fails the run
+    // (the proposal is already persisted above). `guide` is guaranteed non-empty here — the
+    // empty-guide case returned earlier.
+    await notifyLearningProposal(ctx, buildVoiceProposalNotification(guide));
 
     ctx.log.info({ pairs: newPairs.length }, 'voice-learn: proposed an updated guide');
     return { success: true, data: { pairs_considered: newPairs.length, proposed: true } };

--- a/skills/voice-learn/skill.json
+++ b/skills/voice-learn/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-learn",
-  "description": "Weekly job: read accumulated (draft, sent) diffs from OKF, make one batched LLM pass to produce an updated free-form voice guide, and queue it as a digest proposal. Never writes the profile directly (human-in-the-loop). Never fabricates on zero data. Intended for the ceo-inbox weekly voice-learn cron.",
-  "version": "0.1.1",
+  "description": "Weekly job: read accumulated (draft, sent) diffs from OKF, make one batched LLM pass to produce an updated free-form voice guide, and queue it as a proposal. On a new proposal, sends the CEO a direct notification inlining it for approve/dismiss. Never writes the profile directly (human-in-the-loop). Never fabricates on zero data. Intended for the ceo-inbox weekly voice-learn cron.",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {},
@@ -12,5 +12,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 60000,
-  "capabilities": ["executiveProfileService", "workingDocs", "infraLlm", "entityMemory"]
+  "capabilities": ["executiveProfileService", "workingDocs", "infraLlm", "entityMemory", "outboundGateway"]
 }

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -229,6 +229,9 @@ interface OutboundSuppressedDuplicatePayload {
 //   - 'approval_expired':     CEO alert that pending approvals expired without response (approval-expiry-sweep)
 //   - 'schedule_suspended': CEO alert that a scheduled job was auto-suspended after consecutive failures (#538)
 //   - 'schedule_recovered': CEO alert that a stuck job was auto-recovered (reset to pending or suspended) (#207)
+//   - 'learning_proposal':  CEO alert surfacing a learning-digest item (voice-guide proposal or sent-mail
+//                           task-completion undo/confirm) event-driven when produced, after #1464 removed
+//                           the scheduled digest that used to surface them (#1466)
 export interface OutboundNotificationPayload {
   notificationType:
     | 'blocked_content'
@@ -236,7 +239,8 @@ export interface OutboundNotificationPayload {
     | 'approval_requested'
     | 'approval_expired'        // batched expiry notification (approval-expiry-sweep)
     | 'schedule_suspended'      // scheduled job auto-suspended after consecutive failures (#538)
-    | 'schedule_recovered';     // stuck job auto-recovered after exceeding timeout threshold (#207)
+    | 'schedule_recovered'      // stuck job auto-recovered after exceeding timeout threshold (#207)
+    | 'learning_proposal';      // learning-digest item surfaced event-driven when produced (#1466)
   /** Recipient email for this notification (always the CEO email today). */
   ceoEmail: string;
   subject: string;


### PR DESCRIPTION
## Summary

Closes #1466.

After #1464 removed the scheduled daily digest, the learning-item generators wrote to the config store with no reader left to surface them, so proposals never reached the CEO for approve/dismiss/undo/confirm. This surfaces each item **event-driven, the moment its generator produces it**, reusing the existing `OutboundGateway.sendNotification` primitive the approval flow uses (no scheduled recap re-added).

- **`voice-learn`** — after a writing-voice guide proposal is durably written, sends the CEO a direct `learning_proposal` notification inlining the guide + `approve voice`/`dismiss voice` instructions.
- **`task-completion-from-sent`** — after the undo/confirm digest is durably written, sends a direct notification inlining that run's new items with their reply commands. Gated on `digestStored && digestAdds.length > 0`, so an empty/soft-rejected run stays silent.
- New shared helper `skills/_shared/learning-notify.ts`: resolves the principal email and sends, **best-effort and non-fatal** (mirrors `approval-expiry-sweep`); wrapped so it can never throw into the generator's run.
- New builders in `skills/_shared/learning-digest.ts` reuse the existing `render*` helpers (content + reply commands already inlined).
- The CEO's reply still resolves via `resolve-learning-digest` — **reply path unchanged**.

## Public API

- Adds `notificationType: 'learning_proposal'` to `OutboundNotificationPayload` in `src/bus/events.ts`. Additive union member; the email adapter delivers any `notificationType` generically, so no allowlist gate needed. Called out in CHANGELOG.

## Acceptance criteria

- [x] `voice-learn` proposal → direct CEO notification inlining it, no digest dependency
- [x] sent-observe → task-completion undo/confirm items → direct notification inlining them
- [x] No notification when a run produces nothing (silent when empty)
- [x] Reply still resolves via `resolve-learning-digest`
- [x] `learning_proposal` added to `events.ts` + noted in CHANGELOG as public-API
- [x] Unit tests: produced → sent with content; empty → no send; reply → resolve

## Testing

- `pnpm run typecheck` — clean
- New/updated unit tests (builders, notify helper incl. throw-safety, both handlers): green; 70 tests across affected suites pass
- Lint clean (one pre-existing unrelated warning)

## Notes

- `resolvePrincipalEmail` here is near-identical to the copy in `approval-expiry-sweep`; now that a shared home exists, that skill could later point at it. Left out of scope to avoid touching an unrelated skill.
- Skill versions bumped minor for the new `outboundGateway` capability (voice-learn 0.2.0, task-completion-from-sent 0.3.0).