### PR TITLE
feat(skills): add ceo-backlog-sweep operational backstop for overdue CEO tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Learning-item surfacing** — voice-guide proposals and sent-mail task completions now notify the CEO directly, not via a digest. (#1466)
 - **`outbound.notification`** — new `learning_proposal` `notificationType` on the bus event (public API). (#1466)
+- **`ceo-backlog-sweep`** — declarative sweep nudges the CEO when owned tasks are overdue or due today. (#1467)
 - **`web-browser`** — optional egress proxy (`browser.proxy`) routes browsing through a residential exit, plus a WebRTC-leak guard.
 - **`web-browser`** — stable per-element refs let the agent disambiguate duplicate labels (e.g. survey radios).
 - **`web-browser`** — circuit-breaker halts interaction after 4 consecutive failures to curb futile retry loops.
@@ -26,6 +27,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Daily digest** — the built-in 8am digest is now an on-demand, chat-editable morning-briefing example.
 - **`ceo-inbox`** — voice-learn queues its guide proposal as a pending learning item, not the removed digest.
+- **`OutboundNotificationPayload`** — new `ceo_backlog_nudge` notificationType member (public bus API). (#1467)
 
 ### Security
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.14.1"
+version: "0.15.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -735,6 +735,7 @@ pinned_skills:
   - activity-log
   - task-list
   - approval-expiry-sweep
+  - ceo-backlog-sweep
   - scheduler-report
   - secret-capture-request
 allow_discovery: true
@@ -746,3 +747,6 @@ schedule:
   - cron: "0 * * * *"
     task: "Run the approval expiry sweep — find and expire any pending approval requests that have passed their expiry time."
     expectedDurationSeconds: 360
+  - cron: "0 8 * * *"
+    task: "Run the ceo-backlog-sweep skill — find CEO-owned tasks that are overdue or due today and still open, and send the CEO one terse nudge if there are any. It is silent when there are none; do not compose your own message, just invoke the skill."
+    expectedDurationSeconds: 60

--- a/config/registry-defaults.yaml
+++ b/config/registry-defaults.yaml
@@ -86,6 +86,7 @@ skills:
   - list-pending-actions
   - activity-log
   - approval-expiry-sweep
+  - ceo-backlog-sweep
   # NOTE: diagnostics skills (audit-query, audit-trace, ops-lookup) excluded — they
   #        read internal audit + operational state and are the principal-only
   #        diagnostics agent's toolset. Opt-in: enable them alongside the diagnostics

--- a/skills/ceo-backlog-sweep/handler.test.ts
+++ b/skills/ceo-backlog-sweep/handler.test.ts
@@ -67,11 +67,14 @@ function makeCtx(overrides: {
     listTasksThrows = false,
   } = overrides;
 
-  const listTasksMock = vi.fn();
+  // The handler uses listAllTasks (paginated, exact counts) — not the single-page
+  // listTasks — so the reported counts never silently cap. The mock returns the
+  // { tasks, truncated } shape listAllTasks resolves to.
+  const listAllTasksMock = vi.fn();
   if (listTasksThrows) {
-    listTasksMock.mockRejectedValue(new Error('db exploded'));
+    listAllTasksMock.mockRejectedValue(new Error('db exploded'));
   } else {
-    listTasksMock.mockResolvedValue(rows);
+    listAllTasksMock.mockResolvedValue({ tasks: rows, truncated: false });
   }
   const sendNotificationMock = vi.fn().mockResolvedValue(sendNotificationResult);
   const logInfoMock = vi.fn();
@@ -98,7 +101,7 @@ function makeCtx(overrides: {
     log: { info: logInfoMock, warn: logWarnMock, error: logErrorMock, debug: vi.fn() } as unknown as SkillContext['log'],
     taskRepo: withoutTaskRepo
       ? undefined
-      : ({ listTasks: listTasksMock } as unknown as TaskRepo),
+      : ({ listAllTasks: listAllTasksMock } as unknown as TaskRepo),
     contactService: {
       findContactBySystemRole: findContactBySystemRoleMock,
       getContactWithIdentities: getContactWithIdentitiesMock,
@@ -108,7 +111,7 @@ function makeCtx(overrides: {
       : ({ sendNotification: sendNotificationMock } as unknown as OutboundGateway),
   } as SkillContext;
 
-  return { ctx, listTasksMock, sendNotificationMock, logWarnMock, logErrorMock };
+  return { ctx, listAllTasksMock, sendNotificationMock, logWarnMock, logErrorMock };
 }
 
 describe('CeoBacklogSweepHandler', () => {
@@ -137,15 +140,33 @@ describe('CeoBacklogSweepHandler', () => {
   });
 
   it('scopes the query to owner=ceo, open statuses, and the end-of-today boundary', async () => {
-    const { ctx, listTasksMock } = makeCtx({ rows: [makeRow()] });
+    const { ctx, listAllTasksMock } = makeCtx({ rows: [makeRow()] });
     await new CeoBacklogSweepHandler().execute(ctx);
 
-    expect(listTasksMock).toHaveBeenCalledTimes(1);
-    const filters = listTasksMock.mock.calls[0]![0];
+    expect(listAllTasksMock).toHaveBeenCalledTimes(1);
+    const filters = listAllTasksMock.mock.calls[0]![0];
     expect(filters.owner).toBe('ceo');
     expect(filters.statuses).toEqual(['open', 'in_progress', 'blocked', 'waiting']);
     // start of tomorrow (local UTC midnight) — captures everything due today and earlier
     expect((filters.dueBefore as Date).toISOString()).toBe('2026-07-21T00:00:00.000Z');
+    // No single-page `limit` — listAllTasks pages through so counts stay exact.
+    expect(filters.limit).toBeUndefined();
+  });
+
+  it('reports exact counts beyond a single 100-row page (no silent cap)', async () => {
+    // 101 overdue tasks — the old single-page listTasks(limit:100) would have
+    // under-reported this as "100". listAllTasks returns them all in one { tasks }
+    // result here, so the handler must count every one.
+    const rows = Array.from({ length: 101 }, (_, i) =>
+      makeRow({ id: `overdue-${i}`, dueAt: '2026-07-19T09:00:00.000Z' }),
+    );
+    const { ctx, sendNotificationMock } = makeCtx({ rows });
+    const result = await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { overdue: 101, dueToday: 0, notified: 101 } });
+    const payload = sendNotificationMock.mock.calls[0]![0];
+    expect(payload.subject).toBe('101 CEO tasks overdue or due today');
+    expect(payload.body).toContain('101 overdue');
   });
 
   it('is silent (no send) when no CEO tasks are overdue or due today', async () => {

--- a/skills/ceo-backlog-sweep/handler.test.ts
+++ b/skills/ceo-backlog-sweep/handler.test.ts
@@ -1,0 +1,212 @@
+// handler.test.ts — unit tests for ceo-backlog-sweep skill handler.
+//
+// Covers the acceptance criteria of #1467:
+//   - overdue CEO task → nudge with correct counts
+//   - nothing overdue/due-today → silent (no send)
+//   - the query scopes to owner='ceo' + open statuses (non-CEO/curia tasks ignored)
+//   - overdue vs due-today split and body wording
+//   - non-fatal skip paths: no gateway, no principal email, sendNotification false
+//   - unexpected DB error → { success: false }
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CeoBacklogSweepHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { TaskRepo, TaskListRow } from '../../src/db/task-repo.js';
+import type { ContactService } from '../../src/contacts/contact-service.js';
+import type { OutboundGateway } from '../../src/skills/outbound-gateway.js';
+
+// Fixed "now" so overdue/due-today classification is deterministic. All fixtures
+// below are relative to this instant; ctx.timezone is 'UTC' so day boundaries are
+// simple: start of today = 2026-07-20T00:00:00Z, start of tomorrow = 2026-07-21T00:00:00Z.
+const NOW = new Date('2026-07-20T15:00:00.000Z');
+
+function makeRow(overrides: Partial<TaskListRow> = {}): TaskListRow {
+  return {
+    id: 'task-1',
+    agentId: 'coordinator',
+    intentAnchor: null,
+    title: 'Review Q3 board deck',
+    description: null,
+    status: 'open',
+    progress: { notes: [] },
+    errorBudget: {},
+    conversationId: null,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    owner: 'ceo',
+    waitingOnContactId: null,
+    waitingOnText: null,
+    parentTaskId: null,
+    blockedByTaskId: null,
+    priority: 0,
+    dueAt: '2026-07-19T09:00:00.000Z', // yesterday → overdue
+    source: null,
+    sourceAgentId: null,
+    createdBy: null,
+    tags: [],
+    originator: null,
+    nextWakeAt: null,
+    ...overrides,
+  } as unknown as TaskListRow;
+}
+
+function makeCtx(overrides: {
+  rows?: TaskListRow[];
+  sendNotificationResult?: boolean;
+  ceoEmail?: string;
+  withoutOutboundGateway?: boolean;
+  withoutTaskRepo?: boolean;
+  listTasksThrows?: boolean;
+} = {}) {
+  const {
+    rows = [],
+    sendNotificationResult = true,
+    ceoEmail = 'ceo@example.com',
+    withoutOutboundGateway = false,
+    withoutTaskRepo = false,
+    listTasksThrows = false,
+  } = overrides;
+
+  const listTasksMock = vi.fn();
+  if (listTasksThrows) {
+    listTasksMock.mockRejectedValue(new Error('db exploded'));
+  } else {
+    listTasksMock.mockResolvedValue(rows);
+  }
+  const sendNotificationMock = vi.fn().mockResolvedValue(sendNotificationResult);
+  const logInfoMock = vi.fn();
+  const logWarnMock = vi.fn();
+  const logErrorMock = vi.fn();
+
+  const findContactBySystemRoleMock = vi
+    .fn()
+    .mockResolvedValue(ceoEmail ? { id: 'principal-contact-id' } : null);
+  const getContactWithIdentitiesMock = vi.fn().mockResolvedValue(
+    ceoEmail
+      ? { identities: [{ channel: 'email', channelIdentifier: ceoEmail, verified: true, status: 'active' }] }
+      : { identities: [] },
+  );
+
+  const ctx: SkillContext = {
+    skillName: 'ceo-backlog-sweep',
+    skillVersion: '0.1.0',
+    input: {},
+    timezone: 'UTC',
+    secret: vi.fn().mockImplementation((name: string) => {
+      throw new Error(`secret ${name} not configured`);
+    }),
+    log: { info: logInfoMock, warn: logWarnMock, error: logErrorMock, debug: vi.fn() } as unknown as SkillContext['log'],
+    taskRepo: withoutTaskRepo
+      ? undefined
+      : ({ listTasks: listTasksMock } as unknown as TaskRepo),
+    contactService: {
+      findContactBySystemRole: findContactBySystemRoleMock,
+      getContactWithIdentities: getContactWithIdentitiesMock,
+    } as unknown as ContactService,
+    outboundGateway: withoutOutboundGateway
+      ? undefined
+      : ({ sendNotification: sendNotificationMock } as unknown as OutboundGateway),
+  } as SkillContext;
+
+  return { ctx, listTasksMock, sendNotificationMock, logWarnMock, logErrorMock };
+}
+
+describe('CeoBacklogSweepHandler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends a nudge with correct counts for an overdue CEO task', async () => {
+    const { ctx, sendNotificationMock } = makeCtx({ rows: [makeRow()] });
+    const handler = new CeoBacklogSweepHandler();
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { overdue: 1, dueToday: 0, notified: 1 } });
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    const payload = sendNotificationMock.mock.calls[0]![0];
+    expect(payload.notificationType).toBe('ceo_backlog_nudge');
+    expect(payload.ceoEmail).toBe('ceo@example.com');
+    expect(payload.subject).toBe('1 CEO task overdue or due today');
+    expect(payload.body).toContain('1 overdue');
+    expect(payload.body).toContain("what's open");
+  });
+
+  it('scopes the query to owner=ceo, open statuses, and the end-of-today boundary', async () => {
+    const { ctx, listTasksMock } = makeCtx({ rows: [makeRow()] });
+    await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(listTasksMock).toHaveBeenCalledTimes(1);
+    const filters = listTasksMock.mock.calls[0]![0];
+    expect(filters.owner).toBe('ceo');
+    expect(filters.statuses).toEqual(['open', 'in_progress', 'blocked', 'waiting']);
+    // start of tomorrow (local UTC midnight) — captures everything due today and earlier
+    expect((filters.dueBefore as Date).toISOString()).toBe('2026-07-21T00:00:00.000Z');
+  });
+
+  it('is silent (no send) when no CEO tasks are overdue or due today', async () => {
+    const { ctx, sendNotificationMock } = makeCtx({ rows: [] });
+    const result = await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { overdue: 0, dueToday: 0, notified: 0 } });
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('splits overdue and due-today and reports both in the body', async () => {
+    const rows = [
+      makeRow({ id: 't-overdue', dueAt: '2026-07-19T09:00:00.000Z' }), // yesterday
+      makeRow({ id: 't-today-am', dueAt: '2026-07-20T09:00:00.000Z' }), // today
+      makeRow({ id: 't-today-pm', dueAt: '2026-07-20T20:00:00.000Z' }), // today
+    ];
+    const { ctx, sendNotificationMock } = makeCtx({ rows });
+    const result = await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { overdue: 1, dueToday: 2, notified: 3 } });
+    const payload = sendNotificationMock.mock.calls[0]![0];
+    expect(payload.subject).toBe('3 CEO tasks overdue or due today');
+    expect(payload.body).toContain('1 overdue, 2 due today');
+  });
+
+  it('does not send when outboundGateway is unavailable but still reports counts', async () => {
+    const { ctx } = makeCtx({ rows: [makeRow()], withoutOutboundGateway: true });
+    const result = await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { overdue: 1, dueToday: 0, notified: 0 } });
+  });
+
+  it('does not send when no principal email is on file', async () => {
+    const { ctx, sendNotificationMock } = makeCtx({ rows: [makeRow()], ceoEmail: '' });
+    const result = await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { overdue: 1, dueToday: 0, notified: 0 } });
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('reports notified:0 when sendNotification returns false (non-fatal)', async () => {
+    const { ctx } = makeCtx({ rows: [makeRow()], sendNotificationResult: false });
+    const result = await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { overdue: 1, dueToday: 0, notified: 0 } });
+  });
+
+  it('returns failure when taskRepo capability is missing', async () => {
+    const { ctx, sendNotificationMock } = makeCtx({ withoutTaskRepo: true });
+    const result = await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('returns failure (not throw) on an unexpected DB error', async () => {
+    const { ctx, logErrorMock } = makeCtx({ listTasksThrows: true });
+    const result = await new CeoBacklogSweepHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('db exploded');
+    expect(logErrorMock).toHaveBeenCalled();
+  });
+});

--- a/skills/ceo-backlog-sweep/handler.ts
+++ b/skills/ceo-backlog-sweep/handler.ts
@@ -1,0 +1,177 @@
+// handler.ts — ceo-backlog-sweep skill implementation.
+//
+// Operational backstop sweep (#1467). Finds CEO-owned tasks that are overdue or
+// due today and still open, and sends the CEO ONE terse nudge when any exist.
+// Fires only when count > 0 — silent otherwise.
+//
+// This is the system-owned safety net that guarantees an overdue CEO task never
+// rots silently. It replaces the "lead with overdue/due-today CEO tasks" behaviour
+// that used to live only in the declarative daily digest (removed in #1464). It is
+// operational, not personalized: the body is a hardcoded template of counts plus
+// how to get detail ("reply 'what's open'"), never an LLM-generated presentation.
+// Modeled on skills/approval-expiry-sweep — same shape, same notification path.
+//
+// Non-fatal failure modes (mirror approval-expiry-sweep):
+//   - no principal email on file → nudge skipped (notified stays 0)
+//   - outboundGateway absent → nudge skipped
+//   - sendNotification() returns false → logged at warn, not propagated
+
+import { DateTime } from 'luxon';
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { TaskListRow } from '../../src/db/task-repo.js';
+
+// Non-terminal statuses: a task in any of these is still "open" and can rot.
+// Terminal statuses (done, cancelled) are excluded — a completed/cancelled task
+// with a past due date is not a backlog item.
+const OPEN_STATUSES = ['open', 'in_progress', 'blocked', 'waiting'];
+
+// Upper bound on how many candidate rows we pull for the count. A CEO with more
+// than this many overdue/due-today tasks has bigger problems than an exact count;
+// the nudge says "review for the full list" regardless, so an approximate ceiling
+// is fine. Kept well above any realistic backlog.
+const MAX_CANDIDATES = 100;
+
+/**
+ * Resolve the principal's email address from the contacts store.
+ *
+ * Identical strategy to approval-expiry-sweep: findContactBySystemRole('principal')
+ * is the single source of truth for principal identity, restricted to a verified +
+ * ACTIVE email. Returns null — a silent skip — when there is no contactService, no
+ * principal, no verified+active email, or the lookup itself fails. Never throws:
+ * a notification-path lookup failure must not fail the sweep and trigger retry churn.
+ */
+async function resolvePrincipalEmail(ctx: SkillContext): Promise<string | null> {
+  if (!ctx.contactService) {
+    ctx.log.warn('ceo-backlog-sweep: contactService capability unavailable — cannot resolve principal email');
+    return null;
+  }
+  try {
+    const principal = await ctx.contactService.findContactBySystemRole('principal');
+    if (!principal) return null;
+    const withIdentities = await ctx.contactService.getContactWithIdentities(principal.id);
+    const identities = withIdentities?.identities ?? [];
+    const email = identities.find((id) => id.channel === 'email' && id.verified && id.status === 'active');
+    return email?.channelIdentifier ?? null;
+  } catch (err) {
+    ctx.log.warn({ err }, 'ceo-backlog-sweep: failed to resolve principal email — skipping nudge');
+    return null;
+  }
+}
+
+/**
+ * Build the terse nudge subject + body from the two counts.
+ *
+ * Deliberately NOT a personalized presentation — hardcoded template of counts plus
+ * how to get detail. Three shapes: overdue only, due-today only, or both.
+ */
+function buildNudge(overdue: number, dueToday: number): { subject: string; body: string } {
+  const total = overdue + dueToday;
+  const taskWord = total === 1 ? 'task' : 'tasks';
+  const subject = `${total} CEO ${taskWord} overdue or due today`;
+
+  let counts: string;
+  if (overdue > 0 && dueToday > 0) {
+    counts = `${overdue} overdue, ${dueToday} due today`;
+  } else if (overdue > 0) {
+    counts = `${overdue} overdue`;
+  } else {
+    counts = `${dueToday} due today`;
+  }
+
+  const body = `${total} CEO ${taskWord} need attention (${counts}). Reply "what's open" for the full list.`;
+  return { subject, body };
+}
+
+export class CeoBacklogSweepHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    try {
+      if (!ctx.taskRepo) {
+        return { success: false, error: 'ceo-backlog-sweep requires taskRepo capability' };
+      }
+
+      // --- Step 1: Compute the "end of today" boundary in the CEO's timezone ---
+      // listTasks filters `due_at < dueBefore`, so passing the start of tomorrow
+      // (local midnight) captures everything due today and earlier. Day boundaries
+      // are timezone-sensitive, so we anchor on ctx.timezone (falling back to UTC).
+      const tz = ctx.timezone ?? 'UTC';
+      const now = DateTime.now().setZone(tz);
+      const startOfToday = now.startOf('day');
+      const startOfTomorrow = startOfToday.plus({ days: 1 });
+
+      // --- Step 2: Query open CEO tasks that are overdue or due today ---
+      const rows: TaskListRow[] = await ctx.taskRepo.listTasks({
+        statuses: OPEN_STATUSES,
+        owner: 'ceo',
+        dueBefore: startOfTomorrow.toJSDate(),
+        limit: MAX_CANDIDATES,
+      });
+
+      // --- Step 3: Split into overdue (before today) vs due-today ---
+      // The query already bounds due_at below start-of-tomorrow, so any row here is
+      // either overdue (before today) or due today. Rows with a null due_at are
+      // excluded by the `due_at < dueBefore` filter, so every row has a due date.
+      const startOfTodayMs = startOfToday.toMillis();
+      let overdue = 0;
+      let dueToday = 0;
+      for (const row of rows) {
+        // dueAt is guaranteed non-null here (see above), but guard defensively.
+        if (row.dueAt && new Date(row.dueAt).getTime() < startOfTodayMs) {
+          overdue += 1;
+        } else {
+          dueToday += 1;
+        }
+      }
+
+      const total = overdue + dueToday;
+
+      // --- Step 4: Silent when nothing is overdue or due today ---
+      if (total === 0) {
+        return { success: true, data: { overdue: 0, dueToday: 0, notified: 0 } };
+      }
+
+      ctx.log.info({ overdue, dueToday }, 'ceo-backlog-sweep: open CEO tasks overdue or due today');
+
+      // --- Step 5: Send the single terse nudge ---
+      let notified = 0;
+
+      if (ctx.outboundGateway === undefined) {
+        ctx.log.warn(
+          { overdue, dueToday },
+          'ceo-backlog-sweep: outboundGateway not available — skipping CEO nudge',
+        );
+      } else {
+        const ceoEmail = await resolvePrincipalEmail(ctx);
+        if (!ceoEmail) {
+          ctx.log.warn(
+            { overdue, dueToday },
+            'ceo-backlog-sweep: no principal email on file — skipping CEO nudge',
+          );
+        } else {
+          const { subject, body } = buildNudge(overdue, dueToday);
+          const sent = await ctx.outboundGateway.sendNotification({
+            notificationType: 'ceo_backlog_nudge',
+            ceoEmail,
+            subject,
+            body,
+          });
+
+          if (sent) {
+            notified = total;
+          } else {
+            // Non-fatal — the CEO won't get this cycle's nudge, but the next sweep
+            // will re-surface the same still-open tasks. Nothing is lost permanently.
+            ctx.log.warn(
+              { overdue, dueToday },
+              'ceo-backlog-sweep: sendNotification returned false — CEO nudge not delivered',
+            );
+          }
+        }
+      }
+
+      return { success: true, data: { overdue, dueToday, notified } };
+    } catch (e) {
+      ctx.log.error({ err: e }, 'ceo-backlog-sweep: unexpected error');
+      return { success: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+}

--- a/skills/ceo-backlog-sweep/handler.ts
+++ b/skills/ceo-backlog-sweep/handler.ts
@@ -18,18 +18,11 @@
 
 import { DateTime } from 'luxon';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import type { TaskListRow } from '../../src/db/task-repo.js';
 
 // Non-terminal statuses: a task in any of these is still "open" and can rot.
 // Terminal statuses (done, cancelled) are excluded — a completed/cancelled task
 // with a past due date is not a backlog item.
 const OPEN_STATUSES = ['open', 'in_progress', 'blocked', 'waiting'];
-
-// Upper bound on how many candidate rows we pull for the count. A CEO with more
-// than this many overdue/due-today tasks has bigger problems than an exact count;
-// the nudge says "review for the full list" regardless, so an approximate ceiling
-// is fine. Kept well above any realistic backlog.
-const MAX_CANDIDATES = 100;
 
 /**
  * Resolve the principal's email address from the contacts store.
@@ -94,7 +87,7 @@ export class CeoBacklogSweepHandler implements SkillHandler {
       }
 
       // --- Step 1: Compute the "end of today" boundary in the CEO's timezone ---
-      // listTasks filters `due_at < dueBefore`, so passing the start of tomorrow
+      // listAllTasks filters `due_at < dueBefore`, so passing the start of tomorrow
       // (local midnight) captures everything due today and earlier. Day boundaries
       // are timezone-sensitive, so we anchor on ctx.timezone (falling back to UTC).
       const tz = ctx.timezone ?? 'UTC';
@@ -103,11 +96,16 @@ export class CeoBacklogSweepHandler implements SkillHandler {
       const startOfTomorrow = startOfToday.plus({ days: 1 });
 
       // --- Step 2: Query open CEO tasks that are overdue or due today ---
-      const rows: TaskListRow[] = await ctx.taskRepo.listTasks({
+      // listAllTasks (not listTasks) so the reported counts are exact rather than
+      // capped at a single page — an operational backstop must not under-report a
+      // 101-task backlog as "100" (#1433 fixed the same silent-cap bug in
+      // sent-observe). It pages internally with a 5000-row safety ceiling; a CEO
+      // backlog large enough to hit that has far bigger problems, and listAllTasks
+      // logs + flags `truncated` if it ever does.
+      const { tasks: rows } = await ctx.taskRepo.listAllTasks({
         statuses: OPEN_STATUSES,
         owner: 'ceo',
         dueBefore: startOfTomorrow.toJSDate(),
-        limit: MAX_CANDIDATES,
       });
 
       // --- Step 3: Split into overdue (before today) vs due-today ---

--- a/skills/ceo-backlog-sweep/handler.ts
+++ b/skills/ceo-backlog-sweep/handler.ts
@@ -42,7 +42,11 @@ const MAX_CANDIDATES = 100;
  */
 async function resolvePrincipalEmail(ctx: SkillContext): Promise<string | null> {
   if (!ctx.contactService) {
-    ctx.log.warn('ceo-backlog-sweep: contactService capability unavailable — cannot resolve principal email');
+    // Distinct from the benign "no principal yet" case below: this is a capability-wiring
+    // fault (the skill ran without contactService injected) that does NOT heal on the next
+    // sweep — every cycle hits the same missing capability and the CEO is never nudged. Log
+    // at error so a misconfigured deployment is detectable in alerting, not just a warn stream.
+    ctx.log.error('ceo-backlog-sweep: contactService capability unavailable — cannot resolve principal email (persistent wiring fault)');
     return null;
   }
   try {
@@ -135,9 +139,12 @@ export class CeoBacklogSweepHandler implements SkillHandler {
       let notified = 0;
 
       if (ctx.outboundGateway === undefined) {
-        ctx.log.warn(
+        // Persistent wiring fault, not a transient hiccup: a missing gateway recurs every
+        // sweep, so "the next cycle re-surfaces it" does not apply and the backstop silently
+        // never fires. Log at error so it surfaces in alerting rather than a warn stream.
+        ctx.log.error(
           { overdue, dueToday },
-          'ceo-backlog-sweep: outboundGateway not available — skipping CEO nudge',
+          'ceo-backlog-sweep: outboundGateway not available — skipping CEO nudge (persistent wiring fault)',
         );
       } else {
         const ceoEmail = await resolvePrincipalEmail(ctx);

--- a/skills/ceo-backlog-sweep/skill.json
+++ b/skills/ceo-backlog-sweep/skill.json
@@ -8,7 +8,7 @@
   "outputs": {
     "overdue": "number — count of open CEO tasks whose due date is before today",
     "dueToday": "number — count of open CEO tasks due today",
-    "notified": "number — count of tasks included in the nudge (0 when nothing sent)"
+    "notified": "number — count of tasks in the nudge once handed off to the outbound pipeline (0 when nothing enqueued); reflects successful enqueue, not confirmed delivery"
   },
   "permissions": [],
   "secrets": [],

--- a/skills/ceo-backlog-sweep/skill.json
+++ b/skills/ceo-backlog-sweep/skill.json
@@ -1,0 +1,17 @@
+{
+  "name": "ceo-backlog-sweep",
+  "description": "Operational backstop sweep: find CEO-owned tasks that are overdue or due today and still open, and send the CEO one terse nudge when any exist. Silent when none. Not a personalized digest — counts plus how to get detail only. Intended to run on a low-frequency system schedule.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "overdue": "number — count of open CEO tasks whose due date is before today",
+    "dueToday": "number — count of open CEO tasks due today",
+    "notified": "number — count of tasks included in the nudge (0 when nothing sent)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["taskRepo", "outboundGateway"]
+}

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -232,6 +232,7 @@ interface OutboundSuppressedDuplicatePayload {
 //   - 'learning_proposal':  CEO alert surfacing a learning-digest item (voice-guide proposal or sent-mail
 //                           task-completion undo/confirm) event-driven when produced, after #1464 removed
 //                           the scheduled digest that used to surface them (#1466)
+//   - 'ceo_backlog_nudge': terse nudge that CEO-owned tasks are overdue or due today (ceo-backlog-sweep, #1467)
 export interface OutboundNotificationPayload {
   notificationType:
     | 'blocked_content'
@@ -240,7 +241,8 @@ export interface OutboundNotificationPayload {
     | 'approval_expired'        // batched expiry notification (approval-expiry-sweep)
     | 'schedule_suspended'      // scheduled job auto-suspended after consecutive failures (#538)
     | 'schedule_recovered'      // stuck job auto-recovered after exceeding timeout threshold (#207)
-    | 'learning_proposal';      // learning-digest item surfaced event-driven when produced (#1466)
+    | 'learning_proposal'       // learning-digest item surfaced event-driven when produced (#1466)
+    | 'ceo_backlog_nudge';      // overdue/due-today CEO tasks backstop nudge (ceo-backlog-sweep, #1467)
   /** Recipient email for this notification (always the CEO email today). */
   ceoEmail: string;
   subject: string;


### PR DESCRIPTION
## Summary

Adds `ceo-backlog-sweep`, a system-owned declarative backstop that surfaces overdue / due-today **CEO-owned** tasks. Removing the declarative daily digest (#1464) left these tasks with no proactive push — `BacklogHeartbeat` only wakes `owner='curia'` tasks and never emails the CEO, so an overdue CEO task was visible only via an on-demand "what's open?" query.

Modeled exactly on `skills/approval-expiry-sweep` (operational, not personalized), so the personalization revert-trap that motivated #1464 does not apply.

Closes #1467

## What it does

- Queries open `owner='ceo'` tasks whose `due_at` is before the start of tomorrow (in the CEO's timezone) — i.e. overdue or due today.
- Splits them into overdue vs due-today and sends **one terse nudge** (counts + `reply "what's open"` for detail), never a personalized digest.
- **Silent** when there are none.
- Sends via `OutboundGateway.sendNotification` using the same system-notification autonomy-gate bypass as the approval-expiry sweep.
- Runs on a low-frequency cron (`0 8 * * *`) on the coordinator, alongside the approval-expiry sweep.

## Changes

- **New skill** `skills/ceo-backlog-sweep/` (handler + manifest + 9 unit tests).
- **New** `ceo_backlog_nudge` member on `OutboundNotificationPayload.notificationType` (`src/bus/events.ts`, public bus API — noted in CHANGELOG). No consumer switches on the union, so the addition is purely additive; the email adapter delivers `subject`/`body` opaquely.
- Pinned to the coordinator + enrolled in `config/registry-defaults.yaml`; coordinator bumped `0.14.0 → 0.15.0`.
- `action_risk: "none"` (matches `approval-expiry-sweep`) — the nudge uses the system-notification bypass, and gating this backstop behind an autonomy score would defeat its "nothing rots" guarantee.

## Acceptance criteria

- [x] Overdue/due-today CEO task → direct nudge on the sweep's cadence, no dependency on a personalized briefing
- [x] Silent when there are no overdue/due-today CEO tasks
- [x] Nudge is terse (counts + how to get detail), not a full digest
- [x] Declarative/system-owned; no duplicate or personalizable jobs
- [x] `notificationType: 'ceo_backlog_nudge'` added to `src/bus/events.ts` + noted in CHANGELOG
- [x] Unit tests: overdue → nudge with correct counts; none → no send; non-CEO/curia tasks ignored (query scoped to `owner='ceo'` + open statuses)

## Testing

- `pnpm run typecheck` — clean
- 9 new unit tests pass; loader + registry + sibling-sweep tests green (57 total in scope)

## Review notes

Pre-PR review agents (code-reviewer + silent-failure-hunter) ran. Code-reviewer found no high-confidence issues. Silent-failure-hunter's one substantive point — persistent wiring faults (missing `outboundGateway` / `contactService`) were logged at `warn` under a "next sweep heals it" rationale that only holds for transient faults — is addressed: those two paths now log at `error` (matching the outbound-gateway precedent), while no-principal-yet and transient publish-failure stay at `warn`.
