### PR TITLE
chore(deps): block TypeScript 7.x majors in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,15 @@ updates:
       # (engines + node:24-slim); block major bumps until Node itself is bumped.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # TypeScript 7.x is the native (Go) compiler rewrite with breaking internal
+      # API changes. typescript-eslint doesn't support it yet — even the latest
+      # (8.65.0) peer-caps at typescript '>=4.8.4 <6.1.0', so bumping TS to 7
+      # leaves no compatible linter version and crashes CI lint
+      # ("Cannot read properties of undefined (reading 'Cjs')", curia#1454).
+      # Stay on 6.x; bump to 7 by hand once typescript-eslint supports it. 6.x
+      # minor/patch updates still flow normally.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions versions (checkout, setup-node, etc.)
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,10 +32,12 @@ updates:
       # in disguise" onto stale, divergent SDK code (curia#1273). Block nylas
       # majors; a genuine future major (a real 9.x) gets reviewed and bumped by
       # hand. 8.x minor/patch updates still flow normally.
+      # UNBLOCK-WHEN: `npm view nylas dist-tags.latest` resolves to a real >=9.x (not the stray 17.13.1).
       - dependency-name: "nylas"
         update-types: ["version-update:semver-major"]
       # @types/node major tracks the Node.js release line. Runtime is Node 24
       # (engines + node:24-slim); block major bumps until Node itself is bumped.
+      # UNBLOCK-WHEN: package.json `engines.node` is bumped past 24 (moves in lockstep with the `node` docker ignore below).
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
       # TypeScript 7.x is the native (Go) compiler rewrite with breaking internal
@@ -45,6 +47,7 @@ updates:
       # ("Cannot read properties of undefined (reading 'Cjs')", curia#1454).
       # Stay on 6.x; bump to 7 by hand once typescript-eslint supports it. 6.x
       # minor/patch updates still flow normally.
+      # UNBLOCK-WHEN: `npm view typescript-eslint peerDependencies.typescript` allows >=7.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
 
@@ -80,6 +83,7 @@ updates:
       # release (26) is Current/unstable until it reaches LTS (~Oct 2026), and
       # Node.js says production should run only Active/Maintenance LTS. Digest +
       # minor/patch updates still flow; bump the major by hand when 26 goes LTS.
+      # UNBLOCK-WHEN: Node 26 reaches Active LTS (~2026-10) per https://nodejs.org/en/about/previous-releases.
       - dependency-name: "node"
         update-types: ["version-update:semver-major"]
 
@@ -96,5 +100,6 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
     ignore:
+      # UNBLOCK-WHEN: a deliberate pg16->pg17 database upgrade is scheduled (human decision, not automatable).
       - dependency-name: "pgvector/pgvector"
         update-types: ["version-update:semver-major"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Daily digest** — the built-in 8am digest is now an on-demand, chat-editable morning-briefing example.
 - **`ceo-inbox`** — voice-learn queues its guide proposal as a pending learning item, not the removed digest.
+- **Dependabot** — block TypeScript 7.x majors until typescript-eslint supports the native compiler. (#1454)
 
 ### Security
 


### PR DESCRIPTION
## Summary

Dependabot proposed bumping TypeScript 6.0.3 → 7.0.2 (#1454), which failed CI. TypeScript 7.x is the native (Go) compiler rewrite with breaking internal API changes, and **typescript-eslint doesn't support it yet** — even the latest `8.65.0` peer-caps at `typescript '>=4.8.4 <6.1.0'`. Bumping TS to 7 leaves no compatible linter to bump alongside it, so the lint step crashes:

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
  at @typescript-eslint/typescript-estree@8.64.0.../create-program/shared.js:59
```

This adds a Dependabot `ignore` for the `typescript` semver-major so it stops re-proposing the 7.x jump weekly (same pattern as the existing `nylas` / `@types/node` / `node` major blocks). 6.x minor/patch updates still flow normally. We'll bump to 7 deliberately, by hand, once typescript-eslint ships TS 7 support.

PR #1454 has been closed.

## Testing

- `dependabot.yml` validated as well-formed YAML.

No runtime code changes.