### PR TITLE
fix(deps): pin adm-zip to >=0.6.0 (GHSA-xcpc-8h2w-3j85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **`adm-zip`** — pin transitive dev dep to `>=0.6.0`, clearing GHSA-xcpc-8h2w-3j85 (crafted ZIP 4GB allocation, HIGH).
 - **Evidence-doc retention** — anchor `## Diff —` boundaries to the metadata envelope so an email-body heading can't dodge the purge. (#1444)
 - **KG trust gates** — checkpoint extraction and `memory-store` block untrusted inbound senders. (#1290)
 - **Release verification docs** — README documents `cosign verify-blob` for signed release artifacts. (#929)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   undici: '>=7.28.0'
   '@opentelemetry/core': '>=2.8.0'
   onnxruntime-web>protobufjs: '>=7.6.3 <8'
+  adm-zip: '>=0.6.0'
 
 importers:
 
@@ -2376,9 +2377,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.18:
-    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   afinn-165-financialmarketnews@3.0.0:
     resolution: {integrity: sha512-0g9A1S3ZomFIGDTzZ0t6xmv4AuokBvBmpes8htiyHpH7N4xDmvSQL6UxL/Zcs2ypRb3VwgCscaD8Q3zEawKYhw==}
@@ -7802,7 +7803,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  adm-zip@0.5.18:
+  adm-zip@0.6.0:
     optional: true
 
   afinn-165-financialmarketnews@3.0.0:
@@ -9836,7 +9837,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.5.18
+      adm-zip: 0.6.0
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,7 @@ overrides:
   # Scorecard vulnerability pins (GHSA alerts flagged in code-scanning #155):
   '@opentelemetry/core': '>=2.8.0'          # GHSA-8988-4f7v-96qf (unbounded baggage header memory allocation)
   'onnxruntime-web>protobufjs': '>=7.6.3 <8' # GHSA-f38q-mgvj-vph7 (schema name shadowing DoS); targeted to onnxruntime-web only — protobufjs@8.x is patched at 8.6.0; promptfoo already resolves 8.6.1 which is clean
+  adm-zip: '>=0.6.0'                        # GHSA-xcpc-8h2w-3j85 (crafted ZIP triggers 4GB allocation, HIGH); only consumer is optional onnxruntime-node; 0.6.0 is latest
 
 # esbuild requires a postinstall step to download the platform binary.
 # Both versions (used by vite and tsup) are approved here.


### PR DESCRIPTION
## Summary

Patches Dependabot alert #51. `adm-zip < 0.6.0` lets a crafted ZIP file trigger a ~4GB memory allocation (GHSA-xcpc-8h2w-3j85, **HIGH**).

It reaches us only as a **transitive dev dependency** of the optional `onnxruntime-node`:

```
adm-zip@0.6.0
└─ onnxruntime-node@1.24.3
   └─ @huggingface/transformers@4.2.0
      └─ promptfoo@0.121.18 (devDependencies)
```

## Fix

Pin `adm-zip: '>=0.6.0'` in the `overrides:` block of `pnpm-workspace.yaml` (the only place pnpm v10+ reads overrides from), then regenerate the lockfile. `0.6.0` is the current `latest`.

## Verification

- `pnpm install` applied the override (not "Already up to date").
- Lockfile now has the `overrides:` entry and resolves a **single** `adm-zip@0.6.0` (no `0.5.18` remaining).
- `pnpm why adm-zip` confirms the forced version and the dev-only consumer chain.

No source changes — dependency pin only.