### PR TITLE
fix(scheduler): bound & trim scheduler-list; cap object skill output (#1487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`scheduler-list`** — bound and trim results so a large jobs table no longer overflows the model context. (#1487)
+- **`scheduler-list`** — return timestamps in the user's timezone instead of raw UTC. (#1487)
 - **Skill outputs** — cap total object-output size, not just per-leaf, matching the string-output path. (#1487)
 
 ## [0.41.0] — 2026-07-21 — "Data"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`scheduler-list`** — bound and trim results so a large jobs table no longer overflows the model context. (#1487)
+- **Skill outputs** — cap total object-output size, not just per-leaf, matching the string-output path. (#1487)
+
 ## [0.41.0] — 2026-07-21 — "Data"
 
 > **Data** *(Star Trek: The Next Generation, 1987, Gene Roddenberry)* — the android who grows more human by patiently observing the people around him, then refining his own conduct to match, and the crew's tireless analyst when something needs explaining. This release teaches Curia both halves: it watches what you actually send and learns your voice from the edits you make, and it can now investigate its own behavior when you ask what happened.

--- a/skills/scheduler-list/handler.ts
+++ b/skills/scheduler-list/handler.ts
@@ -81,7 +81,9 @@ function toJobSummary(job: JobRow, tz: string | undefined): JobSummary {
  *  default for missing / non-numeric / non-positive values. */
 function clampLimit(raw: unknown): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return DEFAULT_LIST_LIMIT;
-  return Math.min(Math.floor(raw), MAX_LIST_LIMIT);
+  // Math.max(1, …) so a fractional value in (0, 1) — which passes the > 0 guard but
+  // floors to 0 — yields a 1-row page rather than an always-empty, falsely-truncated one.
+  return Math.max(1, Math.min(Math.floor(raw), MAX_LIST_LIMIT));
 }
 
 export class SchedulerListHandler implements SkillHandler {

--- a/skills/scheduler-list/handler.ts
+++ b/skills/scheduler-list/handler.ts
@@ -1,9 +1,75 @@
 // handler.ts — scheduler-list skill implementation.
 //
 // Infrastructure skill that lists scheduled jobs via the SchedulerService.
-// Supports optional filtering by status and agent_id.
+// Supports optional filtering by status and agent_id, and an optional limit.
+//
+// The listing is deliberately BOUNDED and TRIMMED (#1487): it returns at most
+// `limit` jobs (most recent first) and omits the heavy per-job JSONB fields
+// (taskPayload, progress, lastRunContext, lastRunSummary, taskErrorBudget,
+// originator). A list view exists to identify and manage jobs — full detail for a
+// single job comes from getJob / scheduler-report. Without these bounds, a large
+// jobs table serialized into one tool_result overflows the model context window,
+// and the follow-up LLM call fails with a non-retryable 400 (VALIDATION_ERROR),
+// which surfaces to the user as the generic "unable to process" message.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { JobRow } from '../../src/scheduler/scheduler-service.js';
+
+/** Default number of jobs returned when the caller doesn't specify a limit. */
+const DEFAULT_LIST_LIMIT = 50;
+/** Hard ceiling on the limit, even if the caller asks for more. */
+const MAX_LIST_LIMIT = 200;
+
+/** Compact, LLM-friendly projection of a job — identification + management fields
+ *  only. Heavy JSONB fields are intentionally excluded (see file header). */
+interface JobSummary {
+  id: string;
+  agentId: string;
+  status: string;
+  cronExpr: string | null;
+  runAt: string | null;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  lastRunOutcome: JobRow['lastRunOutcome'];
+  consecutiveFailures: number;
+  lastError: string | null;
+  timezone: string;
+  taskTitle: string | null;
+  intentAnchor: string | null;
+  taskTags: string[] | null;
+  agentTaskId: string | null;
+  createdBy: string;
+  createdAt: string;
+}
+
+function toJobSummary(job: JobRow): JobSummary {
+  return {
+    id: job.id,
+    agentId: job.agentId,
+    status: job.status,
+    cronExpr: job.cronExpr,
+    runAt: job.runAt,
+    nextRunAt: job.nextRunAt,
+    lastRunAt: job.lastRunAt,
+    lastRunOutcome: job.lastRunOutcome,
+    consecutiveFailures: job.consecutiveFailures,
+    lastError: job.lastError,
+    timezone: job.timezone,
+    taskTitle: job.taskTitle,
+    intentAnchor: job.intentAnchor,
+    taskTags: job.taskTags,
+    agentTaskId: job.agentTaskId,
+    createdBy: job.createdBy,
+    createdAt: job.createdAt,
+  };
+}
+
+/** Coerce an untrusted limit input into [1, MAX_LIST_LIMIT], falling back to the
+ *  default for missing / non-numeric / non-positive values. */
+function clampLimit(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return DEFAULT_LIST_LIMIT;
+  return Math.min(Math.floor(raw), MAX_LIST_LIMIT);
+}
 
 export class SchedulerListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -14,18 +80,37 @@ export class SchedulerListHandler implements SkillHandler {
       };
     }
 
-    const { status, agent_id } = ctx.input as {
+    const { status, agent_id, limit } = ctx.input as {
       status?: string;
       agent_id?: string;
+      limit?: number;
     };
 
+    const effectiveLimit = clampLimit(limit);
+
     try {
-      const jobs = await ctx.schedulerService.listJobs({
+      // Fetch one extra row so we can report *exactly* whether more jobs exist beyond
+      // the cap, rather than guessing from a full-page result.
+      const rows = await ctx.schedulerService.listJobs({
         status,
         agentId: agent_id,
+        limit: effectiveLimit + 1,
       });
 
-      return { success: true, data: { jobs } };
+      const truncated = rows.length > effectiveLimit;
+      const jobs = (truncated ? rows.slice(0, effectiveLimit) : rows).map(toJobSummary);
+
+      return {
+        success: true,
+        data: {
+          jobs,
+          count: jobs.length,
+          // True when older jobs were omitted. The agent should tell the user it is
+          // showing the most recent N and can narrow with a status/agent filter.
+          truncated,
+          limit: effectiveLimit,
+        },
+      };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err }, 'scheduler-list failed');

--- a/skills/scheduler-list/handler.ts
+++ b/skills/scheduler-list/handler.ts
@@ -14,6 +14,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { JobRow } from '../../src/scheduler/scheduler-service.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 /** Default number of jobs returned when the caller doesn't specify a limit. */
 const DEFAULT_LIST_LIMIT = 50;
@@ -21,7 +22,12 @@ const DEFAULT_LIST_LIMIT = 50;
 const MAX_LIST_LIMIT = 200;
 
 /** Compact, LLM-friendly projection of a job — identification + management fields
- *  only. Heavy JSONB fields are intentionally excluded (see file header). */
+ *  only. Heavy JSONB fields are intentionally excluded (see file header).
+ *
+ *  Timestamp fields (runAt, nextRunAt, lastRunAt, createdAt) are converted to the
+ *  user's display timezone via toLocalIso — never returned as raw UTC Z-suffix
+ *  strings, which LLMs cannot reliably convert. `timezone` remains the job's own
+ *  IANA zone (the wall-clock basis for its cron), which is metadata, not an instant. */
 interface JobSummary {
   id: string;
   agentId: string;
@@ -39,18 +45,25 @@ interface JobSummary {
   taskTags: string[] | null;
   agentTaskId: string | null;
   createdBy: string;
-  createdAt: string;
+  createdAt: string | null;
 }
 
-function toJobSummary(job: JobRow): JobSummary {
+/** Convert a DB ISO-string instant to the user's local-timezone ISO for display.
+ *  Returns null for null/invalid inputs (toLocalIso guards non-finite seconds). */
+function toLocalDisplay(iso: string | null, tz: string | undefined): string | null {
+  if (!iso) return null;
+  return toLocalIso(Math.floor(new Date(iso).getTime() / 1000), tz);
+}
+
+function toJobSummary(job: JobRow, tz: string | undefined): JobSummary {
   return {
     id: job.id,
     agentId: job.agentId,
     status: job.status,
     cronExpr: job.cronExpr,
-    runAt: job.runAt,
-    nextRunAt: job.nextRunAt,
-    lastRunAt: job.lastRunAt,
+    runAt: toLocalDisplay(job.runAt, tz),
+    nextRunAt: toLocalDisplay(job.nextRunAt, tz),
+    lastRunAt: toLocalDisplay(job.lastRunAt, tz),
     lastRunOutcome: job.lastRunOutcome,
     consecutiveFailures: job.consecutiveFailures,
     lastError: job.lastError,
@@ -60,7 +73,7 @@ function toJobSummary(job: JobRow): JobSummary {
     taskTags: job.taskTags,
     agentTaskId: job.agentTaskId,
     createdBy: job.createdBy,
-    createdAt: job.createdAt,
+    createdAt: toLocalDisplay(job.createdAt, tz),
   };
 }
 
@@ -87,6 +100,7 @@ export class SchedulerListHandler implements SkillHandler {
     };
 
     const effectiveLimit = clampLimit(limit);
+    const tz = ctx.timezone;
 
     try {
       // Fetch one extra row so we can report *exactly* whether more jobs exist beyond
@@ -98,7 +112,7 @@ export class SchedulerListHandler implements SkillHandler {
       });
 
       const truncated = rows.length > effectiveLimit;
-      const jobs = (truncated ? rows.slice(0, effectiveLimit) : rows).map(toJobSummary);
+      const jobs = (truncated ? rows.slice(0, effectiveLimit) : rows).map(job => toJobSummary(job, tz));
 
       return {
         success: true,
@@ -109,6 +123,8 @@ export class SchedulerListHandler implements SkillHandler {
           // showing the most recent N and can narrow with a status/agent filter.
           truncated,
           limit: effectiveLimit,
+          // Timezone the displayed timestamps are in, so the agent can label them.
+          displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : 'UTC',
         },
       };
     } catch (err) {

--- a/skills/scheduler-list/skill.json
+++ b/skills/scheduler-list/skill.json
@@ -13,7 +13,8 @@
     "jobs": "array",
     "count": "number",
     "truncated": "boolean",
-    "limit": "number"
+    "limit": "number",
+    "displayTimezone": "string"
   },
   "permissions": [],
   "secrets": [],

--- a/skills/scheduler-list/skill.json
+++ b/skills/scheduler-list/skill.json
@@ -1,15 +1,19 @@
 {
   "name": "scheduler-list",
-  "description": "List scheduled jobs. Optionally filter by status (pending, running, completed, failed, suspended, cancelled) or agent_id.",
-  "version": "1.1.0",
+  "description": "List scheduled jobs (most recent first, trimmed summary view). Optionally filter by status (pending, running, completed, failed, suspended, cancelled, paused) or agent_id, and cap results with limit (default 50, max 200). For full detail on a single job, use scheduler-report.",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "status": "string?",
-    "agent_id": "string?"
+    "agent_id": "string?",
+    "limit": "number?"
   },
   "outputs": {
-    "jobs": "array"
+    "jobs": "array",
+    "count": "number",
+    "truncated": "boolean",
+    "limit": "number"
   },
   "permissions": [],
   "secrets": [],

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -75,6 +75,10 @@ export interface JobRow {
 export interface ListJobsFilters {
   status?: string;
   agentId?: string;
+  /** Cap the number of rows returned (most recent first). Omitted → no cap.
+   *  Callers that feed results to an LLM must set this — an unbounded listing over
+   *  a large jobs table overflows the model context window. (#1487) */
+  limit?: number;
 }
 
 // -- Internal DB row shape (snake_case) --
@@ -366,10 +370,20 @@ export class SchedulerService {
       paramIndex++;
     }
 
-    // Suppress unused-variable warning — paramIndex is incremented to stay ready for future filters.
-    void paramIndex;
-
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    // Optional row cap, applied in SQL so a large jobs table never loads fully into
+    // memory. Only added when the caller asks for one, so existing callers (HTTP
+    // /api/jobs, setup-status) keep their full-list behaviour unchanged. (#1487)
+    let limitClause = '';
+    if (filters?.limit !== undefined && Number.isFinite(filters.limit) && filters.limit > 0) {
+      limitClause = `LIMIT $${paramIndex}`;
+      params.push(Math.floor(filters.limit));
+      paramIndex++;
+    }
+
+    // Suppress unused-variable warning — paramIndex stays incremented for future filters.
+    void paramIndex;
 
     const sql = `
       SELECT sj.*,
@@ -383,6 +397,7 @@ export class SchedulerService {
         LEFT JOIN tasks t ON sj.task_id = t.id
        ${whereClause}
        ORDER BY sj.created_at DESC
+       ${limitClause}
     `;
     const { rows } = await this.pool.query(sql, params);
     return (rows as DbJobRow[]).map(mapJobRow);

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -378,7 +378,9 @@ export class SchedulerService {
     let limitClause = '';
     if (filters?.limit !== undefined && Number.isFinite(filters.limit) && filters.limit > 0) {
       limitClause = `LIMIT $${paramIndex}`;
-      params.push(Math.floor(filters.limit));
+      // Math.max(1, …) so a fractional limit in (0, 1) becomes LIMIT 1, not LIMIT 0
+      // (Math.floor(0.5) === 0 would silently return zero rows).
+      params.push(Math.max(1, Math.floor(filters.limit)));
       paramIndex++;
     }
 

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -195,6 +195,48 @@ describe('discover → invoke round-trip', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Object output size cap (#1487)
+// ---------------------------------------------------------------------------
+
+describe('object output size cap', () => {
+  it('collapses an oversized OBJECT output to a bounded string instead of returning it unbounded', async () => {
+    const registry = new SkillRegistry();
+    // An object whose JSON serialization far exceeds the tiny cap below. Each string
+    // leaf is small (so per-leaf truncation never fires) — the bloat is in the number
+    // of array elements, exactly the scheduler-list-over-a-large-jobs-table shape.
+    const bigData = {
+      jobs: Array.from({ length: 100 }, (_, i) => ({ id: `job-${i}`, note: 'x'.repeat(40) })),
+    };
+    registry.register(makeManifest('big-list'), makeHandler(bigData));
+
+    const maxLen = 200;
+    const layer = new ExecutionLayer(registry, logger, { skillOutputMaxLength: maxLen });
+
+    const result = await layer.invoke('big-list', { query: 'x' });
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: unknown }).data;
+    // Collapsed to a bounded string with a truncation marker — never an unbounded object.
+    expect(typeof data).toBe('string');
+    expect(data as string).toContain('truncated');
+    expect((data as string).length).toBeLessThanOrEqual(maxLen + 40);
+  });
+
+  it('leaves a small object output as a structured object', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeManifest('small-list'), makeHandler({ jobs: [{ id: 'job-1' }] }));
+
+    const layer = new ExecutionLayer(registry, logger, { skillOutputMaxLength: 200 });
+
+    const result = await layer.invoke('small-list', { query: 'x' });
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: unknown }).data;
+    expect(data).toEqual({ jobs: [{ id: 'job-1' }] });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Capability-gated service injection
 // ---------------------------------------------------------------------------
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -1541,12 +1541,27 @@ export class ExecutionLayer {
           maxLength: this.skillOutputMaxLength,
           skipSecretRedaction,
         });
-        // Rough post-sanitize size check for observability: if the sanitized object
-        // would serialize larger than the limit, at least one leaf was truncated.
-        // This is a warn-only signal — sanitizeObjectOutput already capped each leaf.
-        const sanitizedSize = JSON.stringify(sanitizedData).length;
-        if (sanitizedSize > this.skillOutputMaxLength) {
-          skillLogger.warn({ skillName, outputLength: sanitizedSize }, 'Skill output truncated to configured limit');
+        // Enforce an AGGREGATE size cap, not just per-leaf. sanitizeObjectOutput bounds
+        // every string leaf to skillOutputMaxLength, but a result with many leaves or
+        // array elements (e.g. scheduler-list over a large jobs table) can still serialize
+        // far larger than the limit. Left unbounded, that payload becomes a single oversized
+        // tool_result and overflows the next LLM call's context window — the provider rejects
+        // it with a non-retryable 400 (VALIDATION_ERROR) and the agent falls back to the
+        // generic "unable to process" message. String outputs are hard-capped above; object
+        // outputs must be too. (#1487)
+        const serialized = JSON.stringify(sanitizedData);
+        if (serialized.length > this.skillOutputMaxLength) {
+          skillLogger.warn(
+            { skillName, outputLength: serialized.length, limit: this.skillOutputMaxLength },
+            'Object skill output exceeded size limit — truncating to protect the LLM context window',
+          );
+          // Last-resort fallback: collapse to a bounded string form. Structure is lost,
+          // but a truncated, clearly-marked payload is safe to feed back to the model —
+          // an unbounded one is not. Skills that can legitimately return large results
+          // should page or trim at the source (see scheduler-list) so this never fires.
+          const truncated =
+            serialized.slice(0, this.skillOutputMaxLength) + '[truncated — output exceeded limit]';
+          return { success: true, data: truncated };
         }
         return { success: true, data: sanitizedData };
       }

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -471,6 +471,17 @@ describe('SchedulerService', () => {
       const [sql] = pool.query.mock.calls[0] as [string, unknown[]];
       expect(sql).not.toContain('LIMIT');
     });
+
+    it('floors a fractional limit in (0, 1) up to 1, not down to a zero-row LIMIT', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.listJobs({ limit: 0.5 });
+
+      const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('LIMIT');
+      expect(params).toContain(1);
+      expect(params).not.toContain(0);
+    });
   });
 
   // -- getJob --

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -433,6 +433,44 @@ describe('SchedulerService', () => {
       expect(sql).toContain('agent_id');
       expect(params).toContain('agent-x');
     });
+
+    it('applies a SQL LIMIT when a limit is provided (#1487)', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.listJobs({ limit: 50 });
+
+      const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('LIMIT');
+      expect(params).toContain(50);
+    });
+
+    it('does NOT add a LIMIT clause when no limit is provided', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.listJobs();
+
+      const [sql] = pool.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).not.toContain('LIMIT');
+    });
+
+    it('floors a fractional limit and combines it with filters at the right param index', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.listJobs({ status: 'pending', limit: 10.9 });
+
+      const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('LIMIT $2');
+      expect(params).toEqual(['pending', 10]);
+    });
+
+    it('ignores a non-positive limit (no LIMIT clause)', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.listJobs({ limit: 0 });
+
+      const [sql] = pool.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).not.toContain('LIMIT');
+    });
   });
 
   // -- getJob --

--- a/tests/unit/skills/scheduler-list.test.ts
+++ b/tests/unit/skills/scheduler-list.test.ts
@@ -12,11 +12,43 @@ function makeCtx(
 ): SkillContext {
   return {
     skillName: 'scheduler-list',
-    skillVersion: '1.1.0',
+    skillVersion: '1.2.0',
     input,
     secret: () => { throw new Error('no secrets'); },
     log: logger,
     ...overrides,
+  };
+}
+
+/** Build a job row with the heavy JSONB fields populated so tests can assert they
+ *  are excluded from the trimmed listing. */
+function makeJob(id: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    agentId: 'coordinator',
+    status: 'pending',
+    cronExpr: '0 8 * * *',
+    runAt: null,
+    nextRunAt: '2026-07-22T08:00:00.000Z',
+    lastRunAt: null,
+    lastRunOutcome: null,
+    consecutiveFailures: 0,
+    lastError: null,
+    timezone: 'America/Toronto',
+    taskTitle: 'Daily briefing',
+    intentAnchor: 'send daily briefing',
+    taskTags: ['briefing'],
+    agentTaskId: 'task-1',
+    createdBy: 'coordinator',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    // Heavy JSONB fields that must NOT appear in the trimmed summary:
+    taskPayload: { blob: 'x'.repeat(1000) },
+    progress: { step: 3, notes: 'y'.repeat(1000) },
+    lastRunContext: { ctx: 'z'.repeat(1000) },
+    lastRunSummary: 'w'.repeat(1000),
+    taskErrorBudget: { spent: 2 },
+    originator: { systemRole: 'system' },
+    ...extra,
   };
 }
 
@@ -31,14 +63,10 @@ describe('SchedulerListHandler', () => {
     }
   });
 
-  it('lists all jobs when no filters provided', async () => {
-    const mockJobs = [
-      { id: 'job-1', agentId: 'coordinator', status: 'pending' },
-      { id: 'job-2', agentId: 'research-analyst', status: 'completed' },
-    ];
+  it('returns a bounded, trimmed listing and requests one extra row to detect truncation', async () => {
     const schedulerService = {
       createJob: vi.fn(),
-      listJobs: vi.fn().mockResolvedValue(mockJobs),
+      listJobs: vi.fn().mockResolvedValue([makeJob('job-1'), makeJob('job-2')]),
       cancelJob: vi.fn(),
     };
 
@@ -47,15 +75,102 @@ describe('SchedulerListHandler', () => {
       { schedulerService: schedulerService as never },
     ));
 
+    // Default limit is 50; the handler fetches limit + 1 to know if more exist.
+    expect(schedulerService.listJobs).toHaveBeenCalledWith({
+      status: undefined,
+      agentId: undefined,
+      limit: 51,
+    });
+
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { jobs: unknown[] };
-      expect(data.jobs).toEqual(mockJobs);
+      const data = result.data as {
+        jobs: Array<Record<string, unknown>>;
+        count: number;
+        truncated: boolean;
+        limit: number;
+      };
+      expect(data.count).toBe(2);
+      expect(data.truncated).toBe(false);
+      expect(data.limit).toBe(50);
+
+      // Heavy JSONB fields are stripped from the list view.
+      const job = data.jobs[0]!;
+      expect(job['id']).toBe('job-1');
+      expect(job['taskTitle']).toBe('Daily briefing');
+      expect(job).not.toHaveProperty('taskPayload');
+      expect(job).not.toHaveProperty('progress');
+      expect(job).not.toHaveProperty('lastRunContext');
+      expect(job).not.toHaveProperty('lastRunSummary');
+      expect(job).not.toHaveProperty('taskErrorBudget');
+      expect(job).not.toHaveProperty('originator');
     }
+  });
+
+  it('marks the listing truncated and trims the extra row when more jobs exist than the limit', async () => {
+    // Caller asks for limit 2 → handler fetches 3 → 3 returned → truncated, sliced to 2.
+    const schedulerService = {
+      createJob: vi.fn(),
+      listJobs: vi.fn().mockResolvedValue([makeJob('job-1'), makeJob('job-2'), makeJob('job-3')]),
+      cancelJob: vi.fn(),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { limit: 2 },
+      { schedulerService: schedulerService as never },
+    ));
 
     expect(schedulerService.listJobs).toHaveBeenCalledWith({
       status: undefined,
       agentId: undefined,
+      limit: 3,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { jobs: unknown[]; count: number; truncated: boolean; limit: number };
+      expect(data.count).toBe(2);
+      expect(data.truncated).toBe(true);
+      expect(data.limit).toBe(2);
+    }
+  });
+
+  it('clamps an over-large limit to the maximum', async () => {
+    const schedulerService = {
+      createJob: vi.fn(),
+      listJobs: vi.fn().mockResolvedValue([]),
+      cancelJob: vi.fn(),
+    };
+
+    await handler.execute(makeCtx(
+      { limit: 100000 },
+      { schedulerService: schedulerService as never },
+    ));
+
+    // Max limit is 200 → fetch 201.
+    expect(schedulerService.listJobs).toHaveBeenCalledWith({
+      status: undefined,
+      agentId: undefined,
+      limit: 201,
+    });
+  });
+
+  it('falls back to the default limit for a non-positive or non-numeric limit', async () => {
+    const schedulerService = {
+      createJob: vi.fn(),
+      listJobs: vi.fn().mockResolvedValue([]),
+      cancelJob: vi.fn(),
+    };
+
+    await handler.execute(makeCtx(
+      { limit: -5 },
+      { schedulerService: schedulerService as never },
+    ));
+
+    expect(schedulerService.listJobs).toHaveBeenCalledWith({
+      status: undefined,
+      agentId: undefined,
+      limit: 51,
     });
   });
 
@@ -74,6 +189,7 @@ describe('SchedulerListHandler', () => {
     expect(schedulerService.listJobs).toHaveBeenCalledWith({
       status: 'pending',
       agentId: 'coordinator',
+      limit: 51,
     });
   });
 

--- a/tests/unit/skills/scheduler-list.test.ts
+++ b/tests/unit/skills/scheduler-list.test.ts
@@ -89,10 +89,13 @@ describe('SchedulerListHandler', () => {
         count: number;
         truncated: boolean;
         limit: number;
+        displayTimezone: string;
       };
       expect(data.count).toBe(2);
       expect(data.truncated).toBe(false);
       expect(data.limit).toBe(50);
+      // With no ctx.timezone the handler falls back to UTC and leaves Z-suffix strings.
+      expect(data.displayTimezone).toBe('UTC');
 
       // Heavy JSONB fields are stripped from the list view.
       const job = data.jobs[0]!;
@@ -104,6 +107,40 @@ describe('SchedulerListHandler', () => {
       expect(job).not.toHaveProperty('lastRunSummary');
       expect(job).not.toHaveProperty('taskErrorBudget');
       expect(job).not.toHaveProperty('originator');
+    }
+  });
+
+  it('converts timestamps to the user timezone and reports displayTimezone (#1487)', async () => {
+    const schedulerService = {
+      createJob: vi.fn(),
+      listJobs: vi.fn().mockResolvedValue([makeJob('job-1')]),
+      cancelJob: vi.fn(),
+    };
+
+    const result = await handler.execute(makeCtx(
+      {},
+      { schedulerService: schedulerService as never, timezone: 'America/Toronto' },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        jobs: Array<Record<string, unknown>>;
+        displayTimezone: string;
+      };
+      const job = data.jobs[0]!;
+      // These are fixed July instants → always EDT (UTC-04:00), regardless of when the
+      // test runs. Crucially, NOT a raw Z-suffix string the LLM would misread.
+      expect(job['nextRunAt']).toBe('2026-07-22T04:00:00.000-04:00');
+      expect(job['createdAt']).toBe('2026-06-30T20:00:00.000-04:00');
+      expect(job['nextRunAt']).not.toMatch(/Z$/);
+      // Null instants stay null.
+      expect(job['runAt']).toBeNull();
+      expect(job['lastRunAt']).toBeNull();
+      // The job's own cron zone is preserved as metadata (not an instant).
+      expect(job['timezone']).toBe('America/Toronto');
+      // displayTimezone depends on the real "now" for DST, so match either EST/EDT.
+      expect(data.displayTimezone).toMatch(/UTC-0[45]:00/);
     }
   });
 

--- a/tests/unit/skills/scheduler-list.test.ts
+++ b/tests/unit/skills/scheduler-list.test.ts
@@ -192,6 +192,34 @@ describe('SchedulerListHandler', () => {
     });
   });
 
+  it('treats a fractional limit in (0, 1) as 1, not an always-empty page', async () => {
+    const schedulerService = {
+      createJob: vi.fn(),
+      listJobs: vi.fn().mockResolvedValue([makeJob('job-1'), makeJob('job-2')]),
+      cancelJob: vi.fn(),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { limit: 0.5 },
+      { schedulerService: schedulerService as never },
+    ));
+
+    // effectiveLimit clamps to 1 → fetch 2 (1 + 1) to detect truncation.
+    expect(schedulerService.listJobs).toHaveBeenCalledWith({
+      status: undefined,
+      agentId: undefined,
+      limit: 2,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { count: number; truncated: boolean; limit: number };
+      expect(data.limit).toBe(1);
+      expect(data.count).toBe(1);
+      expect(data.truncated).toBe(true);
+    }
+  });
+
   it('falls back to the default limit for a non-positive or non-numeric limit', async () => {
     const schedulerService = {
       createJob: vi.fn(),


### PR DESCRIPTION
## Summary

Closes #1487.

Chatting with the coordinator to view or manage a scheduled job (e.g. *"can you see the job that drives my daily briefing?"*) failed with the generic **"I'm sorry, I was unable to process that request. Please try again."** — and the diagnostics/Doctor flow failed the same way. The scheduler logic was fine; the bug was a **context-window overflow** on the follow-up LLM call.

**Root cause**
- `SchedulerService.listJobs()` had no `LIMIT` and returned every row with heavy JSONB fields (`taskPayload`, `progress`, `lastRunContext`, `lastRunSummary`, `taskErrorBudget`, `originator`).
- The execution layer hard-caps **string** skill outputs to `skillOutputMaxLength`, but for **object** outputs `sanitizeObjectOutput` only truncated each *string leaf* — the aggregate was unbounded (the size check was warn-only). `scheduler-list` returns `{ jobs: [...] }`, so its result grew with the jobs table.

The oversized `tool_result` overflowed the next LLM call → provider returned HTTP 400 → `classifyError` maps it to `VALIDATION_ERROR` (non-retryable) → the runtime's `sendErrorResponse` emitted the generic message. This is **data-dependent**, which is why it only started failing after the jobs table had grown. The diagnose path hits the same wall because it invokes `scheduler-list` first.

## Changes (defense in depth)

**Execution layer** (`src/skills/execution.ts`)
- Enforce an **aggregate** size cap on object skill outputs, mirroring the string path: when the serialized object exceeds `skillOutputMaxLength`, collapse it to a bounded, clearly-marked string. No object-returning skill can overflow the model context again.

**`scheduler-list`** (`skills/scheduler-list/`, `src/scheduler/scheduler-service.ts`)
- `listJobs()` gains an optional `limit` (SQL `LIMIT`, so a large table never fully loads into memory). Existing callers (HTTP `/api/jobs`, `setup-status`) pass none and are **unchanged**.
- The skill applies a default `LIMIT` of 50 (max 200), fetches `limit + 1` to report `truncated` exactly, and returns a **trimmed summary** that drops the heavy JSONB fields. Full per-job detail remains available via `getJob` / `scheduler-report`.
- **Timestamps** (`runAt`, `nextRunAt`, `lastRunAt`, `createdAt`) are now converted to the user's timezone via `toLocalIso(ctx.timezone)` instead of raw-UTC Z-suffix strings, with a `displayTimezone` label added to the result (per the CLAUDE.md timestamp rule — LLMs can't reliably convert UTC). The job's own `timezone` field (its cron wall-clock basis) is preserved as metadata.
- Manifest: new `limit` input + `count`/`truncated`/`limit`/`displayTimezone` outputs; version 1.1.0 → **1.2.0** (new input field ⇒ minor).

## Testing
- `pnpm run typecheck` — clean
- `pnpm run lint` — clean (0 errors)
- Unit tests: `scheduler-list` handler (bounded/trimmed/truncation/clamp + timezone conversion + `displayTimezone`), `scheduler-service.listJobs` (SQL LIMIT, param indexing, no-limit default), execution-layer object size cap, plus the `listJobs` caller suites (`jobs-routes`, `setup-status`) to confirm no regression. All green.

## Notes
- The diagnostics agent (#1356) is now on `main`, so `delegate` to it should work once past this bug.

---
Two commits: the overflow fix (+ aggregate output cap) and the timezone conversion. Both carry DCO sign-off.
