### PR TITLE
feat(skills): Phase 3a skill activation runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Skill (bundle) model** — `SKILL.md` + nested `tools/`; `pinned_skills` expands bundles; `skill_registry` table. (#1489)
+- **Skill activation runtime** — `toolSearch` returns `kind:"skill"`; `skill-activate` loads tools + instructions; Tier 1 persists in `progress.activeSkills`. (#1495)
 
 ### Changed
 

--- a/config/registry-defaults.yaml
+++ b/config/registry-defaults.yaml
@@ -20,6 +20,7 @@ skills:
   #        the historical enable_task_management surface).
 tools:
   - tool-registry
+  - skill-activate
   # Core communication
   - email-send
   - email-reply

--- a/docs/specs/03-tools-and-execution.md
+++ b/docs/specs/03-tools-and-execution.md
@@ -109,25 +109,58 @@ At startup, the framework connects to each MCP server, discovers tools via `tool
 
 ---
 
-## Skill Discovery
+## Skill Discovery & Activation
 
-Two-tier access:
+Vocabulary (ADR-031): a **tool** is the callable atom; a **skill** is a bundle of tools +
+optional `SKILL.md` instructions. Agents pin **skills** (`pinned_skills`); discovery and
+activation also operate at the skill level.
 
-### Pinned Skills
-Explicitly listed in agent config (`pinned_skills`). Always available to the agent, always included in the LLM's tool list.
+Two orthogonal axes (design §6 / #1495):
 
-### Discoverable Skills
-All registered skills (local + MCP) are searchable via the built-in `tool-registry` skill. Agents with `allow_discovery: true` in their YAML automatically receive `tool-registry` in their tool list. When the LLM determines it needs a capability not in its pinned skills, it invokes:
+| Axis | Options |
+|------|---------|
+| **Availability** | pinned (curated, always in toolkit) vs discoverable (`allow_discovery`) |
+| **Instruction-loading** | eager (bootstrap) vs lazy (on activation). Pinned ≠ eager for future imports; today pinned skills load instructions at bootstrap. |
+
+### Tiered lookup
+
+1. **Tier 0 — pinned skills** — expanded at bootstrap via `resolvePinnedSkills` (member tools + instruction blocks). Unchanged by activation.
+2. **Tier 1 — task-active skills** — recorded in `tasks.progress.activeSkills`. On each wake, re-loaded as a strong prior, re-checked for relevance against the current step, and capped (default 5).
+3. **Tier 2 — discovery** — only when Tiers 0/1 miss and the agent has `allow_discovery: true`.
+
+### Pinned skills (Tier 0)
+Explicitly listed in agent config (`pinned_skills`). Always available to the agent, always included in the LLM's tool list; instruction bodies are appended to the system prompt at bootstrap.
+
+### Discoverable tools & skills (Tier 2)
+All registered tools and non-synthetic skills are searchable via the built-in `tool-registry` tool. Agents with `allow_discovery: true` automatically receive `tool-registry` and `skill-activate` in their tool list. When the LLM needs a capability not in its pinned set:
 
 ```text
 tool-registry({ query: "send email" })
 ```
 
-This returns a list of matching skill names and descriptions. **Discovered skills are immediately callable** — after `tool-registry` succeeds, `AgentRuntime` calls `ExecutionLayer.getToolDefinitions()` with the returned names and appends the full tool schemas to the per-task working tool list before the next LLM call. The LLM can then call any discovered skill natively, with its real input schema, in the same or subsequent turns.
+Returns matches with `kind: "tool"` (orphan / synthetic-owned atom) or `kind: "skill"` (bundle).
+Member tools of a real skill are **promoted to the owning skill** — discovering `task-create`
+returns the `tasks` skill, not the atom alone — so the discipline block cannot be skipped.
 
-Tool-list expansion is **per-task**: each task gets a local copy of the startup tool list, so concurrent tasks never see each other's discoveries. Multiple `tool-registry` calls within one task accumulate — the runtime deduplicates by name. Discovered skills flow through the same `ExecutionLayer.invoke()` path as pinned skills, including the elevation gate (`sensitivity: elevated` skills require a live principal turn — see Safety Gate below).
+**Tools** (`kind: "tool"`) are immediately callable: after `tool-registry` succeeds,
+`AgentRuntime` appends their schemas to the per-task working tool list.
 
-`tool-registry` itself is excluded from its own search results to avoid circular self-discovery.
+**Skills** (`kind: "skill"`) require activation:
+
+```text
+skill-activate({ skill: "tasks" })
+```
+
+Activation loads member tools into the working toolkit and injects the skill's `SKILL.md`
+body into the turn. It **never widens authority** — member tools still pass `allowed_callers`
+and `action_risk` at invoke time; disallowed members are listed in `skippedTools` and omitted.
+
+When a task is bound, activation also appends the skill to `progress.activeSkills` (MRU,
+capped) so park/resume wakes restore Tier 1.
+
+Tool-list expansion is **per-task**: each task gets a local copy of the startup tool list.
+`tool-registry` and `skill-activate` are excluded from search results to avoid circular
+self-discovery.
 
 ### Safety Gate for First-Time Use
 
@@ -135,6 +168,7 @@ Tool-list expansion is **per-task**: each task gets a local copy of the startup 
 - Skills tagged `sensitivity: "elevated"` (CEO-authority primitives — approve/deny/dismiss actions, set-autonomy, grant-recommendation decisions): require a **live principal turn**, enforced at the execution-layer gate (`isLivePrincipalTurn`). Not a per-agent first-use approval — every invocation must be a fresh principal turn (#1126)
 - The deferred per-agent-skill `skill_approvals` "ask once on first use by that agent" flow is a separate, still-unbuilt concern (persist-once-ask-once); it would layer on top of, not replace, the elevation gate
 - Elevation rejections and autonomy-gate blocks are audit-logged
+- **Activation ≠ authorization** — activating a skill only surfaces + instructs; it cannot grant a tool the agent was not already allowed to call
 
 ---
 

--- a/docs/specs/03-tools-and-execution.md
+++ b/docs/specs/03-tools-and-execution.md
@@ -125,7 +125,7 @@ Two orthogonal axes (design §6 / #1495):
 ### Tiered lookup
 
 1. **Tier 0 — pinned skills** — expanded at bootstrap via `resolvePinnedSkills` (member tools + instruction blocks). Unchanged by activation.
-2. **Tier 1 — task-active skills** — recorded in `tasks.progress.activeSkills`. On each wake, re-loaded as a strong prior, re-checked for relevance against the current step, and capped (default 5).
+2. **Tier 1 — task-active skills** — recorded in `tasks.progress.activeSkills`. On each wake, re-loaded as a strong prior: skills with no whole-token overlap (≥3 chars) against the current step are dropped when any other active skill still matches; if none match, MRU fills up to the cap (default 5). Unchanged sets are not re-written (no `updated_at` / bus churn).
 3. **Tier 2 — discovery** — only when Tiers 0/1 miss and the agent has `allow_discovery: true`.
 
 ### Pinned skills (Tier 0)

--- a/docs/specs/19-tasks-and-backlog.md
+++ b/docs/specs/19-tasks-and-backlog.md
@@ -114,6 +114,15 @@ Preserved verbatim from `agent_tasks`: `intent_anchor` (durable goal statement),
 `progress` JSONB (multi-burst execution state), `error_budget`, `conversation_id`,
 `agent_id`, timestamps.
 
+`progress` keys used by the platform (all optional; absent when unused):
+
+| Key | Purpose |
+|-----|---------|
+| `notes` | Human-readable progress notes (`task-update`) |
+| `resumable` | Checkpoint cursor / accumulator (spec 20) |
+| `plan` | Planned child-step descriptors (spec 20) |
+| `activeSkills` | Tier-1 skill activations for this task — MRU list of `{ name, activatedAt }`, capped; re-loaded on wake with relevance re-check (spec 03 / #1495) |
+
 ### 2.2 Status lifecycle
 
 The status `CHECK` constraint carries **both** the new task-lifecycle values and the

--- a/skills/skill-activate/handler.test.ts
+++ b/skills/skill-activate/handler.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import handler from './handler.js';
+import type { ToolContext } from '../../src/skills/types.js';
+import { SkillRegistry } from '../../src/skills/skill-registry.js';
+import { ToolRegistry } from '../../src/skills/registry.js';
+import type { ToolManifest } from '../../src/skills/types.js';
+import { SKILL_ACTIVATION_PROTOCOL } from '../../src/skills/skill-activation.js';
+import { readActiveSkillsBlock } from '../../src/db/active-skills-progress.js';
+
+function toolManifest(name: string, allowed_callers?: string[]): ToolManifest {
+  return {
+    name,
+    description: `Tool ${name}`,
+    version: '0.1.0',
+    action_risk: 'none',
+    sensitivity: 'normal',
+    permissions: [],
+    secrets: [],
+    timeout: 30000,
+    inputs: {},
+    outputs: {},
+    allowed_callers,
+  };
+}
+
+const noopHandler = { execute: async () => ({ success: true as const, data: {} }) };
+
+function makeCtx(overrides: Partial<ToolContext> = {}): ToolContext {
+  const tools = new ToolRegistry();
+  tools.register(toolManifest('task-create'), noopHandler);
+  tools.register(toolManifest('task-list'), noopHandler);
+  tools.register(toolManifest('secret-admin', ['coordinator']), noopHandler);
+
+  const skills = new SkillRegistry();
+  skills.register(
+    {
+      name: 'tasks',
+      description: 'Task management',
+      tools: ['task-create', 'task-list'],
+      instructions: '## Task Management\nOwn the how.',
+    },
+    '/tmp/tasks',
+  );
+  skills.register(
+    {
+      name: 'admin-bundle',
+      description: 'Admin',
+      tools: ['secret-admin'],
+      instructions: 'Careful.',
+    },
+    '/tmp/admin',
+  );
+
+  return {
+    input: {},
+    toolName: 'skill-activate',
+    toolVersion: '0.1.0',
+    log: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    } as unknown as ToolContext['log'],
+    secret: () => '',
+    agentId: 'research-analyst',
+    skillRegistry: skills,
+    toolRegistry: tools,
+    ...overrides,
+  };
+}
+
+describe('skill-activate handler', () => {
+  it('activates a skill and returns protocol payload with instructions', async () => {
+    const ctx = makeCtx({ input: { skill: 'tasks' } });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as Record<string, unknown>;
+    expect(data._curia_protocol).toBe(SKILL_ACTIVATION_PROTOCOL);
+    expect(data.skill).toBe('tasks');
+    expect(data.tools).toEqual(['task-create', 'task-list']);
+    expect(data.instructionsLoaded).toBe(true);
+    expect(String(data.instructions)).toContain('Task Management');
+  });
+
+  it('does not surface tools the agent is not allowed to call', async () => {
+    const ctx = makeCtx({
+      input: { skill: 'admin-bundle' },
+      agentId: 'research-analyst',
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as { tools: string[]; skippedTools: string[] };
+    expect(data.tools).toEqual([]);
+    expect(data.skippedTools).toEqual(['secret-admin']);
+  });
+
+  it('persists activeSkills on a bound task', async () => {
+    const taskId = '11111111-1111-4111-8111-111111111111';
+    const progress: Record<string, unknown> = {};
+    const setActiveSkillsBlock = vi.fn(async (_id: string, block: unknown) => {
+      progress.activeSkills = block;
+      return { task: { id: taskId, progress }, block };
+    });
+    const ctx = makeCtx({
+      input: { skill: 'tasks', task_id: taskId },
+      taskRepo: {
+        getTask: async () => ({ id: taskId, progress, status: 'open' }),
+        setActiveSkillsBlock,
+      } as unknown as ToolContext['taskRepo'],
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(setActiveSkillsBlock).toHaveBeenCalledOnce();
+    expect(readActiveSkillsBlock(progress)?.skills.map((s) => s.name)).toEqual(['tasks']);
+  });
+
+  it('rejects unknown skills', async () => {
+    const ctx = makeCtx({ input: { skill: 'nope' } });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toContain('Unknown skill');
+  });
+});

--- a/skills/skill-activate/handler.test.ts
+++ b/skills/skill-activate/handler.test.ts
@@ -54,7 +54,7 @@ function makeCtx(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
     input: {},
     toolName: 'skill-activate',
-    toolVersion: '0.1.0',
+    toolVersion: '0.1.1',
     log: {
       debug: vi.fn(),
       info: vi.fn(),
@@ -97,7 +97,7 @@ describe('skill-activate handler', () => {
     expect(data.skippedTools).toEqual(['secret-admin']);
   });
 
-  it('persists activeSkills on a bound task', async () => {
+  it('persists activeSkills only for the bound task from taskMetadata', async () => {
     const taskId = '11111111-1111-4111-8111-111111111111';
     const progress: Record<string, unknown> = {};
     const setActiveSkillsBlock = vi.fn(async (_id: string, block: unknown) => {
@@ -105,7 +105,10 @@ describe('skill-activate handler', () => {
       return { task: { id: taskId, progress }, block };
     });
     const ctx = makeCtx({
-      input: { skill: 'tasks', task_id: taskId },
+      input: { skill: 'tasks' },
+      taskMetadata: {
+        boundTask: { taskId, errorBudget: {}, progress: {} },
+      },
       taskRepo: {
         getTask: async () => ({ id: taskId, progress, status: 'open' }),
         setActiveSkillsBlock,
@@ -114,7 +117,23 @@ describe('skill-activate handler', () => {
     const result = await handler.execute(ctx);
     expect(result.success).toBe(true);
     expect(setActiveSkillsBlock).toHaveBeenCalledOnce();
+    expect(setActiveSkillsBlock.mock.calls[0]![0]).toBe(taskId);
     expect(readActiveSkillsBlock(progress)?.skills.map((s) => s.name)).toEqual(['tasks']);
+  });
+
+  it('ignores LLM-supplied task_id and does not write without a bound task', async () => {
+    const setActiveSkillsBlock = vi.fn();
+    const ctx = makeCtx({
+      // LLM might still hallucinate task_id — must be ignored.
+      input: { skill: 'tasks', task_id: '11111111-1111-4111-8111-111111111111' },
+      taskRepo: {
+        getTask: vi.fn(),
+        setActiveSkillsBlock,
+      } as unknown as ToolContext['taskRepo'],
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(setActiveSkillsBlock).not.toHaveBeenCalled();
   });
 
   it('rejects unknown skills', async () => {

--- a/skills/skill-activate/handler.ts
+++ b/skills/skill-activate/handler.ts
@@ -1,0 +1,96 @@
+// handler.ts — skill-activate (#1495 Phase 3a).
+//
+// Activates a skill (bundle) for the current task: resolves member tools the
+// calling agent may invoke and returns the SKILL.md instruction body. The
+// agent runtime expands the working tool list and injects instructions;
+// durable state is written to tasks.progress.activeSkills when a task is bound.
+
+import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
+import {
+  buildSkillActivationProtocol,
+  resolveSkillActivation,
+} from '../../src/skills/skill-activation.js';
+import {
+  activateSkillInBlock,
+  prepareActiveSkillsBlock,
+  readActiveSkillsBlock,
+} from '../../src/db/active-skills-progress.js';
+import { boundTaskFromMetadata } from '../../src/agents/resumable-task.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class SkillActivateHandler implements ToolHandler {
+  async execute(ctx: ToolContext): Promise<ToolResult> {
+    const input = ctx.input as { skill?: string; task_id?: string };
+    const skillName = typeof input.skill === 'string' ? input.skill.trim() : '';
+    if (!skillName) {
+      return { success: false, error: 'Missing required input: skill (non-empty string)' };
+    }
+
+    if (!ctx.skillRegistry) {
+      return {
+        success: false,
+        error: 'skill-activate: skillRegistry not available — check ExecutionLayer configuration.',
+      };
+    }
+    if (!ctx.toolRegistry) {
+      return {
+        success: false,
+        error: 'skill-activate: toolRegistry not available — check ExecutionLayer configuration.',
+      };
+    }
+
+    const agentId = ctx.agentId ?? 'system';
+    const resolved = resolveSkillActivation({
+      skillName,
+      skillRegistry: ctx.skillRegistry,
+      toolRegistry: ctx.toolRegistry,
+      agentId,
+    });
+    if ('error' in resolved) {
+      return { success: false, error: resolved.error };
+    }
+
+    // Persist to durable task state when we have a task id + repo.
+    const bound = boundTaskFromMetadata(ctx.taskMetadata as Record<string, unknown> | undefined);
+    const taskId = (typeof input.task_id === 'string' && input.task_id.trim())
+      ? input.task_id.trim()
+      : bound?.taskId;
+
+    if (taskId && ctx.taskRepo) {
+      if (!UUID_RE.test(taskId)) {
+        return { success: false, error: 'task_id must be a valid UUID' };
+      }
+      try {
+        const task = await ctx.taskRepo.getTask(taskId);
+        if (task) {
+          const next = activateSkillInBlock(
+            readActiveSkillsBlock(task.progress),
+            resolved.skill,
+          );
+          const prepared = prepareActiveSkillsBlock(next);
+          if (prepared.ok) {
+            await ctx.taskRepo.setActiveSkillsBlock(taskId, next, agentId);
+          } else {
+            ctx.log.warn(
+              { skill: resolved.skill, taskId, prepared },
+              'skill-activate: could not prepare activeSkills block — activation still applies in-memory',
+            );
+          }
+        }
+      } catch (err) {
+        ctx.log.warn(
+          { err, skill: resolved.skill, taskId },
+          'skill-activate: failed to persist activeSkills — activation still applies in-memory',
+        );
+      }
+    }
+
+    return {
+      success: true,
+      data: buildSkillActivationProtocol(resolved),
+    };
+  }
+}
+
+export default new SkillActivateHandler();

--- a/skills/skill-activate/handler.ts
+++ b/skills/skill-activate/handler.ts
@@ -3,7 +3,8 @@
 // Activates a skill (bundle) for the current task: resolves member tools the
 // calling agent may invoke and returns the SKILL.md instruction body. The
 // agent runtime expands the working tool list and injects instructions;
-// durable state is written to tasks.progress.activeSkills when a task is bound.
+// durable state is written to tasks.progress.activeSkills when a task is bound
+// via taskMetadata (never via an LLM-supplied task_id — cross-task write risk).
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
 import {
@@ -17,11 +18,9 @@ import {
 } from '../../src/db/active-skills-progress.js';
 import { boundTaskFromMetadata } from '../../src/agents/resumable-task.js';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 export class SkillActivateHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
-    const input = ctx.input as { skill?: string; task_id?: string };
+    const input = ctx.input as { skill?: string };
     const skillName = typeof input.skill === 'string' ? input.skill.trim() : '';
     if (!skillName) {
       return { success: false, error: 'Missing required input: skill (non-empty string)' };
@@ -51,16 +50,13 @@ export class SkillActivateHandler implements ToolHandler {
       return { success: false, error: resolved.error };
     }
 
-    // Persist to durable task state when we have a task id + repo.
+    // Persist only to the runtime-bound task (taskMetadata) — never accept an
+    // LLM-supplied task_id (would allow cross-task writes into another row's
+    // activeSkills).
     const bound = boundTaskFromMetadata(ctx.taskMetadata as Record<string, unknown> | undefined);
-    const taskId = (typeof input.task_id === 'string' && input.task_id.trim())
-      ? input.task_id.trim()
-      : bound?.taskId;
+    const taskId = bound?.taskId;
 
     if (taskId && ctx.taskRepo) {
-      if (!UUID_RE.test(taskId)) {
-        return { success: false, error: 'task_id must be a valid UUID' };
-      }
       try {
         const task = await ctx.taskRepo.getTask(taskId);
         if (task) {

--- a/skills/skill-activate/tool.json
+++ b/skills/skill-activate/tool.json
@@ -1,0 +1,24 @@
+{
+  "name": "skill-activate",
+  "description": "Activate a discovered skill (bundle) for this task: load its member tools into your toolkit and inject its SKILL.md instructions. Call after tool-registry returns a result with kind:\"skill\". Activation does not grant new authority — member tools still respect allowed_callers and action_risk.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "skill": "string (skill bundle name from tool-registry, e.g. tasks or calendar)",
+    "task_id": "string? (optional — defaults to the bound task when on a scheduler wake)"
+  },
+  "outputs": {
+    "skill": "string",
+    "tools": "array",
+    "skippedTools": "array",
+    "instructionsLoaded": "boolean"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 5000,
+  "capabilities": [
+    "skillRegistry",
+    "taskRepo"
+  ]
+}

--- a/skills/skill-activate/tool.json
+++ b/skills/skill-activate/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-activate",
   "description": "Activate a discovered skill (bundle) for this task: load its member tools into your toolkit and inject its SKILL.md instructions. Call after tool-registry returns a result with kind:\"skill\". Activation does not grant new authority — member tools still respect allowed_callers and action_risk. When running on a bound task, the active set is persisted for wake re-load automatically.",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/skills/skill-activate/tool.json
+++ b/skills/skill-activate/tool.json
@@ -1,12 +1,11 @@
 {
   "name": "skill-activate",
-  "description": "Activate a discovered skill (bundle) for this task: load its member tools into your toolkit and inject its SKILL.md instructions. Call after tool-registry returns a result with kind:\"skill\". Activation does not grant new authority — member tools still respect allowed_callers and action_risk.",
-  "version": "0.1.0",
+  "description": "Activate a discovered skill (bundle) for this task: load its member tools into your toolkit and inject its SKILL.md instructions. Call after tool-registry returns a result with kind:\"skill\". Activation does not grant new authority — member tools still respect allowed_callers and action_risk. When running on a bound task, the active set is persisted for wake re-load automatically.",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
-    "skill": "string (skill bundle name from tool-registry, e.g. tasks or calendar)",
-    "task_id": "string? (optional — defaults to the bound task when on a scheduler wake)"
+    "skill": "string (skill bundle name from tool-registry, e.g. tasks or calendar)"
   },
   "outputs": {
     "skill": "string",

--- a/skills/tool-registry/handler.ts
+++ b/skills/tool-registry/handler.ts
@@ -1,11 +1,12 @@
 // handler.ts — tool-registry built-in skill.
 //
-// Thin wrapper around ToolRegistry.search() that lets discovery-enabled agents
-// find capabilities not in their pinned skill list.
+// Thin wrapper around unified tool/skill search (ctx.toolSearch) that lets
+// discovery-enabled agents find capabilities not in their pinned skill list.
+// Results may be kind:'tool' (callable immediately) or kind:'skill' (activate
+// via skill-activate to load member tools + SKILL.md instructions).
 //
-// The registry reference is injected by the execution layer as ctx.toolSearch —
-// a closure scoped to this skill by name, following the same name-gated pattern
-// used for autonomyService and browserService. Declare "toolSearch" in capabilities.
+// The search closure is injected by the execution layer as ctx.toolSearch —
+// declare "toolSearch" in capabilities.
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
 

--- a/skills/tool-registry/tool.json
+++ b/skills/tool-registry/tool.json
@@ -1,11 +1,11 @@
 {
   "name": "tool-registry",
-  "description": "Search the tool registry to discover available capabilities by keyword. Use this when you need a tool that is not in your current tool list. Returns matching tool names and descriptions. Pass an empty string to list all available tools.",
-  "version": "1.1.0",
+  "description": "Search the registry to discover available tools and skills (bundles) by keyword. Returns matches with kind:\"tool\" (callable atom) or kind:\"skill\" (bundle — call skill-activate to load its tools + instructions). Pass an empty string to list all available entries. Member tools of a skill are returned as the skill, not as individual tools.",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
-    "query": "string (keyword to search — pass an empty string to list all available tools)"
+    "query": "string (keyword to search — pass an empty string to list all available tools and skills)"
   },
   "outputs": {
     "tools": "array"

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -38,6 +38,16 @@ import {
   applyPlanHarness,
   shouldOfferPlanSkill,
 } from './planned-task.js';
+import {
+  SKILL_ACTIVATE_TOOL_NAME,
+  formatActivatedSkillInstructionBlock,
+  parseSkillActivationProtocol,
+  selectActiveSkillsForWake,
+} from '../skills/skill-activation.js';
+import {
+  prepareActiveSkillsBlock,
+  replaceActiveSkillsBlock,
+} from '../db/active-skills-progress.js';
 import { readResumableBlock, type ResumableProgressBlock } from '../db/resumable-progress.js';
 import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js';
 import { buildRateLimitSourceKey } from '../memory/rate-limit-key.js';
@@ -92,6 +102,10 @@ export interface AgentConfig {
   executionLayer?: ExecutionLayer;
   /** Tool names to include as tools in every LLM call (after pin expansion). */
   pinnedTools?: string[];
+  /** Skill bundle names resolved from pinned_skills at bootstrap (Tier 0). */
+  pinnedSkillNames?: string[];
+  /** Skill (bundle) registry — used for Tier-1 wake re-load of active skills (#1495). */
+  skillRegistry?: import('../skills/skill-registry.js').SkillRegistry;
   /** Pre-built tool definitions for the LLM (from ToolRegistry.toToolDefinitions). */
   skillToolDefs?: ToolDefinition[];
   /** Optional autonomy service — when provided, the autonomy block is injected
@@ -469,6 +483,65 @@ export class AgentRuntime {
       const fresh = await this.config.taskRepo.getTask(boundTaskCtx.taskId);
       if (fresh) {
         boundTaskCtx = { ...boundTaskCtx, progress: fresh.progress };
+      }
+    }
+
+    // Tier 1 — re-load task-active skills from durable progress as a strong prior,
+    // re-check relevance vs the current step, and cap the set (design §6 / #1495).
+    // Pinned skills (Tier 0) stay eager in the bootstrap prompt and are skipped here.
+    const pinnedSkillNames = new Set(this.config.pinnedSkillNames ?? []);
+    if (
+      boundTaskCtx
+      && this.config.skillRegistry
+      && executionLayer
+    ) {
+      const relevanceText = [
+        typeof originalContent === 'string' ? originalContent : '',
+        typeof taskEvent.payload.intentAnchor === 'string' ? taskEvent.payload.intentAnchor : '',
+      ].join(' ');
+      const wakeSkills = selectActiveSkillsForWake({
+        progress: boundTaskCtx.progress,
+        pinnedSkillNames,
+        skillRegistry: this.config.skillRegistry,
+        relevanceText,
+      });
+      if (wakeSkills.length > 0) {
+        if (!workingToolDefs) workingToolDefs = [];
+        const instructionBlocks: string[] = [];
+        for (const skillName of wakeSkills) {
+          const resolved = executionLayer.resolveSkillActivationForAgent(skillName, agentId);
+          if ('error' in resolved) {
+            logger.warn({ agentId, skill: skillName, error: resolved.error }, 'Wake active-skill re-load skipped');
+            continue;
+          }
+          const currentNames = new Set(workingToolDefs.map((t) => t.name));
+          const newNames = resolved.tools.filter((n) => !currentNames.has(n));
+          if (newNames.length > 0) {
+            workingToolDefs.push(...executionLayer.getToolDefinitions(newNames));
+          }
+          const block = formatActivatedSkillInstructionBlock(resolved.skill, resolved.instructions);
+          if (block) instructionBlocks.push(block);
+        }
+        for (const block of instructionBlocks) {
+          effectiveSystemPrompt += `\n\n${block}`;
+        }
+        // Persist the re-selected set so dropped (irrelevant / over-cap) skills stay dropped.
+        if (this.config.taskRepo) {
+          try {
+            const next = replaceActiveSkillsBlock(wakeSkills);
+            const prepared = prepareActiveSkillsBlock(next);
+            if (prepared.ok) {
+              await this.config.taskRepo.setActiveSkillsBlock(boundTaskCtx.taskId, next, agentId);
+              boundTaskCtx = { ...boundTaskCtx, progress: { ...boundTaskCtx.progress, activeSkills: next } };
+            }
+          } catch (err) {
+            logger.warn({ err, agentId, taskId: boundTaskCtx.taskId }, 'Failed to persist re-selected activeSkills on wake');
+          }
+        }
+        logger.info(
+          { agentId, taskId: boundTaskCtx.taskId, activeSkills: wakeSkills },
+          'Re-loaded task-active skills on wake',
+        );
       }
     }
 
@@ -1152,8 +1225,8 @@ export class AgentRuntime {
           budget.consecutiveErrors = 0;
 
           // Dynamic tool-list expansion: when tool-registry returns successfully,
-          // append the discovered skills' full tool definitions to the working list
-          // so the LLM can call them in subsequent turns without pinning them upfront.
+          // append discovered kind:'tool' atoms to the working list. kind:'skill'
+          // results require skill-activate (instructions + member tools together).
           // Expansion is per-task (workingToolDefs is a local copy) — concurrent tasks
           // never see each other's discovered tools.
           if (toolCall.name === 'tool-registry' && workingToolDefs) {
@@ -1161,9 +1234,12 @@ export class AgentRuntime {
               const data = typeof result.data === 'string'
                 ? JSON.parse(result.data) as unknown
                 : result.data;
-              const discovered = (data as { tools?: Array<{ name: string }> })?.tools ?? [];
+              const discovered = (data as {
+                tools?: Array<{ name: string; kind?: 'tool' | 'skill' }>;
+              })?.tools ?? [];
               const currentNames = new Set(workingToolDefs.map(t => t.name));
               const newNames = discovered
+                .filter(s => !s.kind || s.kind === 'tool')
                 .map(s => s.name)
                 .filter(name => !currentNames.has(name));
               if (newNames.length > 0) {
@@ -1175,9 +1251,51 @@ export class AgentRuntime {
               }
             } catch (err) {
               // Non-fatal: if we can't parse the tool-registry result, the LLM simply
-              // cannot call discovered skills this turn. Log at warn and continue —
+              // cannot call discovered tools this turn. Log at warn and continue —
               // failing to expand the tool list must not abort the task.
               logger.warn({ err, agentId }, 'Failed to expand tool list from tool-registry result');
+            }
+          }
+
+          // Skill activation (#1495): expand member tools + inject SKILL.md instructions
+          // into the in-flight turn. Durable persistence is handled by skill-activate itself.
+          if (toolCall.name === SKILL_ACTIVATE_TOOL_NAME && workingToolDefs) {
+            try {
+              const data = typeof result.data === 'string'
+                ? JSON.parse(result.data) as unknown
+                : result.data;
+              const activation = parseSkillActivationProtocol(data);
+              if (activation) {
+                const currentNames = new Set(workingToolDefs.map(t => t.name));
+                const newNames = activation.tools.filter(name => !currentNames.has(name));
+                if (newNames.length > 0) {
+                  workingToolDefs.push(...executionLayer.getToolDefinitions(newNames));
+                }
+                const instructionBlock = formatActivatedSkillInstructionBlock(
+                  activation.skill,
+                  activation.instructions,
+                );
+                if (instructionBlock) {
+                  // Inject after the system prompt so subsequent LLM rounds see the
+                  // discipline block (mirrors Bullpen mid-turn system-message splice).
+                  const insertAt = messages.findIndex(m => m.role !== 'system') === -1
+                    ? messages.length
+                    : Math.max(1, messages.findIndex(m => m.role !== 'system'));
+                  messages.splice(insertAt, 0, { role: 'system', content: instructionBlock });
+                }
+                logger.info(
+                  {
+                    agentId,
+                    skill: activation.skill,
+                    addedTools: newNames,
+                    instructionsLoaded: activation.instructions.length > 0,
+                    skippedTools: activation.skippedTools,
+                  },
+                  'Activated skill for task turn',
+                );
+              }
+            } catch (err) {
+              logger.warn({ err, agentId }, 'Failed to apply skill-activate result to working tool list');
             }
           }
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -46,7 +46,10 @@ import {
 } from '../skills/skill-activation.js';
 import {
   prepareActiveSkillsBlock,
-  replaceActiveSkillsBlock,
+  readActiveSkillNames,
+  readActiveSkillsBlock,
+  reconcileActiveSkillsBlock,
+  activeSkillNameSetsEqual,
 } from '../db/active-skills-progress.js';
 import { readResumableBlock, type ResumableProgressBlock } from '../db/resumable-progress.js';
 import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js';
@@ -525,17 +528,25 @@ export class AgentRuntime {
         for (const block of instructionBlocks) {
           effectiveSystemPrompt += `\n\n${block}`;
         }
-        // Persist the re-selected set so dropped (irrelevant / over-cap) skills stay dropped.
+        // Persist only when the re-selected set actually changed — a no-op write
+        // would bump updated_at + publish task-updated on every wake (#1410/#1064).
+        // reconcileActiveSkillsBlock preserves activatedAt for survivors (prompt-cache).
         if (this.config.taskRepo) {
-          try {
-            const next = replaceActiveSkillsBlock(wakeSkills);
-            const prepared = prepareActiveSkillsBlock(next);
-            if (prepared.ok) {
-              await this.config.taskRepo.setActiveSkillsBlock(boundTaskCtx.taskId, next, agentId);
-              boundTaskCtx = { ...boundTaskCtx, progress: { ...boundTaskCtx.progress, activeSkills: next } };
+          const storedNames = readActiveSkillNames(boundTaskCtx.progress);
+          if (!activeSkillNameSetsEqual(wakeSkills, storedNames)) {
+            try {
+              const next = reconcileActiveSkillsBlock(
+                wakeSkills,
+                readActiveSkillsBlock(boundTaskCtx.progress),
+              );
+              const prepared = prepareActiveSkillsBlock(next);
+              if (prepared.ok) {
+                await this.config.taskRepo.setActiveSkillsBlock(boundTaskCtx.taskId, next, agentId);
+                boundTaskCtx = { ...boundTaskCtx, progress: { ...boundTaskCtx.progress, activeSkills: next } };
+              }
+            } catch (err) {
+              logger.warn({ err, agentId, taskId: boundTaskCtx.taskId }, 'Failed to persist re-selected activeSkills on wake');
             }
-          } catch (err) {
-            logger.warn({ err, agentId, taskId: boundTaskCtx.taskId }, 'Failed to persist re-selected activeSkills on wake');
           }
         }
         logger.info(

--- a/src/db/active-skills-progress.ts
+++ b/src/db/active-skills-progress.ts
@@ -63,6 +63,16 @@ export function readActiveSkillNames(
   return readActiveSkillsBlock(progress)?.skills.map((s) => s.name) ?? [];
 }
 
+/** True when both name lists contain the same set (order-independent). */
+export function activeSkillNameSetsEqual(
+  a: readonly string[],
+  b: readonly string[],
+): boolean {
+  if (a.length !== b.length) return false;
+  const setB = new Set(b);
+  return a.every((name) => setB.has(name));
+}
+
 /**
  * Merge `skillName` into the active set (MRU at front), capped at ACTIVE_SKILLS_CAP.
  * Drops oldest when over cap.
@@ -79,22 +89,41 @@ export function activateSkillInBlock(
   return { skills };
 }
 
-/** Replace the active set wholesale (wake re-selection). */
+/**
+ * Reconcile the wake-selected name list into a block.
+ * Preserves `activatedAt` for skills already present (stable prompt-cache prefix);
+ * only stamps `now` for newly added names. Does not restamp survivors.
+ */
+export function reconcileActiveSkillsBlock(
+  selectedNames: string[],
+  existing: ActiveSkillsBlock | null | undefined,
+  now: string = new Date().toISOString(),
+  cap: number = ACTIVE_SKILLS_CAP,
+): ActiveSkillsBlock {
+  const priorByName = new Map((existing?.skills ?? []).map((s) => [s.name, s]));
+  const seen = new Set<string>();
+  const skills: ActiveSkillEntry[] = [];
+  for (const raw of selectedNames) {
+    const name = raw.trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    const prior = priorByName.get(name);
+    skills.push({ name, activatedAt: prior?.activatedAt ?? now });
+    if (skills.length >= cap) break;
+  }
+  return { skills };
+}
+
+/**
+ * @deprecated Prefer reconcileActiveSkillsBlock — this restamps every activatedAt
+ * and should not be used on the wake path (prompt-cache / bus churn).
+ */
 export function replaceActiveSkillsBlock(
   names: string[],
   activatedAt: string = new Date().toISOString(),
   cap: number = ACTIVE_SKILLS_CAP,
 ): ActiveSkillsBlock {
-  const seen = new Set<string>();
-  const skills: ActiveSkillEntry[] = [];
-  for (const raw of names) {
-    const name = raw.trim();
-    if (!name || seen.has(name)) continue;
-    seen.add(name);
-    skills.push({ name, activatedAt });
-    if (skills.length >= cap) break;
-  }
-  return { skills };
+  return reconcileActiveSkillsBlock(names, null, activatedAt, cap);
 }
 
 export function activeSkillsBlockBytes(block: ActiveSkillsBlock): number {

--- a/src/db/active-skills-progress.ts
+++ b/src/db/active-skills-progress.ts
@@ -1,0 +1,123 @@
+// active-skills-progress.ts — typed read/write helpers for tasks.progress.activeSkills.
+//
+// Phase 3a (#1495): durable record of skills activated for a task so park/resume
+// wakes can re-load them as a Tier-1 strong prior (design §6). Persisted under
+// the existing tasks.progress JSONB — no schema migration.
+
+import { serializedUtf8Bytes } from './resumable-progress.js';
+
+/** Max skills kept active per task (≈ Anthropic's 25k / ~5k-per-skill budget). */
+export const ACTIVE_SKILLS_CAP = 5;
+
+/** Max serialized size (UTF-8 bytes) of the entire activeSkills block. */
+export const ACTIVE_SKILLS_BLOCK_MAX_BYTES = 4096;
+
+export interface ActiveSkillEntry {
+  /** Skill (bundle) name. */
+  name: string;
+  /** ISO timestamp of the most recent activation (or wake re-load). */
+  activatedAt: string;
+}
+
+export interface ActiveSkillsBlock {
+  skills: ActiveSkillEntry[];
+}
+
+export type ActiveSkillsWriteResult =
+  | { ok: true; block: ActiveSkillsBlock; progress: Record<string, unknown> }
+  | { ok: false; code: 'block_overflow'; bytes: number; maxBytes: number }
+  | { ok: false; code: 'invalid_block'; message: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseEntry(raw: unknown): ActiveSkillEntry | null {
+  if (!isPlainObject(raw)) return null;
+  if (typeof raw.name !== 'string' || !raw.name.trim()) return null;
+  if (typeof raw.activatedAt !== 'string' || !raw.activatedAt.trim()) return null;
+  return { name: raw.name.trim(), activatedAt: raw.activatedAt.trim() };
+}
+
+/** Read and validate progress.activeSkills; null when absent or malformed. */
+export function readActiveSkillsBlock(
+  progress: Record<string, unknown> | undefined | null,
+): ActiveSkillsBlock | null {
+  if (!progress) return null;
+  const raw = progress.activeSkills;
+  if (!isPlainObject(raw)) return null;
+  if (!Array.isArray(raw.skills)) return null;
+  const skills: ActiveSkillEntry[] = [];
+  for (const item of raw.skills) {
+    const entry = parseEntry(item);
+    if (!entry) return null;
+    skills.push(entry);
+  }
+  return { skills };
+}
+
+/** Skill names only (order preserved). Empty when block absent/invalid. */
+export function readActiveSkillNames(
+  progress: Record<string, unknown> | undefined | null,
+): string[] {
+  return readActiveSkillsBlock(progress)?.skills.map((s) => s.name) ?? [];
+}
+
+/**
+ * Merge `skillName` into the active set (MRU at front), capped at ACTIVE_SKILLS_CAP.
+ * Drops oldest when over cap.
+ */
+export function activateSkillInBlock(
+  existing: ActiveSkillsBlock | null | undefined,
+  skillName: string,
+  activatedAt: string = new Date().toISOString(),
+  cap: number = ACTIVE_SKILLS_CAP,
+): ActiveSkillsBlock {
+  const name = skillName.trim();
+  const prior = (existing?.skills ?? []).filter((s) => s.name !== name);
+  const skills = [{ name, activatedAt }, ...prior].slice(0, Math.max(1, cap));
+  return { skills };
+}
+
+/** Replace the active set wholesale (wake re-selection). */
+export function replaceActiveSkillsBlock(
+  names: string[],
+  activatedAt: string = new Date().toISOString(),
+  cap: number = ACTIVE_SKILLS_CAP,
+): ActiveSkillsBlock {
+  const seen = new Set<string>();
+  const skills: ActiveSkillEntry[] = [];
+  for (const raw of names) {
+    const name = raw.trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    skills.push({ name, activatedAt });
+    if (skills.length >= cap) break;
+  }
+  return { skills };
+}
+
+export function activeSkillsBlockBytes(block: ActiveSkillsBlock): number {
+  return serializedUtf8Bytes(block);
+}
+
+export function prepareActiveSkillsBlock(
+  block: ActiveSkillsBlock,
+): ActiveSkillsWriteResult {
+  if (!Array.isArray(block.skills)) {
+    return { ok: false, code: 'invalid_block', message: 'skills must be an array' };
+  }
+  for (const entry of block.skills) {
+    if (!entry || typeof entry.name !== 'string' || !entry.name.trim()) {
+      return { ok: false, code: 'invalid_block', message: 'each skill needs a non-empty name' };
+    }
+    if (typeof entry.activatedAt !== 'string' || !entry.activatedAt.trim()) {
+      return { ok: false, code: 'invalid_block', message: 'each skill needs activatedAt' };
+    }
+  }
+  const bytes = activeSkillsBlockBytes(block);
+  if (bytes > ACTIVE_SKILLS_BLOCK_MAX_BYTES) {
+    return { ok: false, code: 'block_overflow', bytes, maxBytes: ACTIVE_SKILLS_BLOCK_MAX_BYTES };
+  }
+  return { ok: true, block, progress: { activeSkills: block } };
+}

--- a/src/db/active-skills-progress.ts
+++ b/src/db/active-skills-progress.ts
@@ -63,14 +63,20 @@ export function readActiveSkillNames(
   return readActiveSkillsBlock(progress)?.skills.map((s) => s.name) ?? [];
 }
 
-/** True when both name lists contain the same set (order-independent). */
+/** True when both name lists represent the same set (order- and duplicate-independent). */
 export function activeSkillNameSetsEqual(
   a: readonly string[],
   b: readonly string[],
 ): boolean {
-  if (a.length !== b.length) return false;
+  // Compare unique membership, not array length — duplicates in one list must not
+  // make it compare equal to a differently-sized set (e.g. ['x','x'] vs ['x','y']).
+  const setA = new Set(a);
   const setB = new Set(b);
-  return a.every((name) => setB.has(name));
+  if (setA.size !== setB.size) return false;
+  for (const name of setA) {
+    if (!setB.has(name)) return false;
+  }
+  return true;
 }
 
 /**

--- a/src/db/task-repo.ts
+++ b/src/db/task-repo.ts
@@ -30,6 +30,11 @@ import {
   type ResumableProgressBlock,
   type ResumableWriteResult,
 } from './resumable-progress.js';
+import {
+  prepareActiveSkillsBlock,
+  type ActiveSkillsBlock,
+  type ActiveSkillsWriteResult,
+} from './active-skills-progress.js';
 import { prepareResumableBlockWithSpill } from './resumable-accumulator-spill.js';
 import type { WorkingDocsRepo } from './working-docs-repo.js';
 import { type ResumableCircuitState } from '../agents/resumable-circuit-breaker.js';
@@ -1199,6 +1204,62 @@ export class TaskRepo {
     this.logger.info(
       { taskId: updated.id, done: prepared.block.done, total: prepared.block.total },
       'task-repo: persisted plan block',
+    );
+    return { task: updated, block: prepared.block };
+  }
+
+  async setActiveSkillsBlock(
+    taskId: string,
+    block: ActiveSkillsBlock,
+    callerAgentId?: string,
+  ): Promise<{ task: TaskRow; block: ActiveSkillsBlock } | ActiveSkillsWriteResult> {
+    const current = await this.getTask(taskId);
+    if (!current) {
+      return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
+    }
+    if (TERMINAL_STATUSES.has(current.status)) {
+      return { ok: false, code: 'invalid_block', message: `task ${taskId} is in a terminal state` };
+    }
+
+    const prepared = prepareActiveSkillsBlock(block);
+    if (!prepared.ok) return prepared;
+
+    const { rows } = await this.pool.query(
+      `UPDATE tasks
+          SET progress = jsonb_set(COALESCE(progress, '{}'::jsonb), '{activeSkills}', $1::jsonb, true),
+              updated_at = now()
+        WHERE id = $2
+          AND status NOT IN ('done', 'cancelled')
+        RETURNING ${TASK_COLUMNS}`,
+      [JSON.stringify(prepared.block), taskId],
+    );
+    const row = rows[0] as DbTaskRow | undefined;
+    if (!row) {
+      const currentTask = await this.getTask(taskId);
+      if (!currentTask) {
+        return { ok: false, code: 'invalid_block', message: `task not found: ${taskId}` };
+      }
+      if (TERMINAL_STATUSES.has(currentTask.status)) {
+        return { ok: false, code: 'invalid_block', message: `task ${taskId} is in a terminal state` };
+      }
+      throw new Error(`task-repo: setActiveSkillsBlock update returned no row for non-terminal task ${taskId}`);
+    }
+
+    const updated = mapTaskRow(row);
+
+    try {
+      await this.bus.publish('execution', createTaskUpdated({
+        taskId: updated.id,
+        previousStatus: current.status,
+        agentId: callerAgentId ?? null,
+      }));
+    } catch (busErr) {
+      this.logger.error({ busErr, taskId: updated.id }, 'task-repo: bus publish failed after setActiveSkillsBlock');
+    }
+
+    this.logger.info(
+      { taskId: updated.id, skills: prepared.block.skills.map((s) => s.name) },
+      'task-repo: persisted activeSkills block',
     );
     return { task: updated, block: prepared.block };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1823,7 +1823,7 @@ async function main(): Promise<void> {
   // validated here (the JSON-schema startup check only covers default.yaml, not local overrides,
   // and cannot express the derived_child >= same_task invariant). Throws → boot fails loudly.
   const bypassLadder = resolveBypassLadder(yamlConfig.autonomy?.bypass_ladder);
-  const executionLayer = new ExecutionLayer(toolRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, secretsService, executiveProfileService, officeIdentityService, browserService, bullpenService, approvalTrigger, escalationJudge, actionLogRepo, auditLogRepo, diagnosticsRepo, taskRepo, workingDocsRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, exportControlService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs, appOrigin: config.appOrigin, httpPort: config.httpPort, bypassLadder, resumableCeilings: resolveTasksConfig(yamlConfig.tasks).resumableCeilings, principalIdentities, sensitivityClassifier });
+  const executionLayer = new ExecutionLayer(toolRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, secretsService, executiveProfileService, officeIdentityService, browserService, bullpenService, approvalTrigger, escalationJudge, actionLogRepo, auditLogRepo, diagnosticsRepo, taskRepo, workingDocsRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, exportControlService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs, appOrigin: config.appOrigin, httpPort: config.httpPort, bypassLadder, resumableCeilings: resolveTasksConfig(yamlConfig.tasks).resumableCeilings, principalIdentities, sensitivityClassifier, skillRegistry });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete
@@ -1983,20 +1983,22 @@ async function main(): Promise<void> {
 
     const agentToolDefs = toolRegistry.toToolDefinitions(effectivePinnedTools);
 
-    // allow_discovery: true → inject the tool-registry discovery tool into the agent's
+    // allow_discovery: true → inject tool-registry + skill-activate into the agent's
     // tool list. Skipped if already pinned to avoid duplicate tool definitions.
-    // The tool-registry handler is loaded by the standard file loader like any other
-    // tool; this only controls whether it appears in the LLM's tool list for this agent.
-    if (agentConfig.allow_discovery && !effectivePinnedTools.includes('tool-registry')) {
-      const discoveryToolDefs = toolRegistry.toToolDefinitions(['tool-registry']);
-      if (discoveryToolDefs.length === 0) {
-        // tool-registry is not in the registry — it either failed to load (bad manifest,
-        // missing handler) or was never registered. Error-level: a declared capability is
-        // unavailable for this agent's entire lifetime. Root cause will be in the earlier
-        // skill-loader error log; this connects the agent-level consequence to it.
-        logger.error({ agent: agentConfig.name }, 'allow_discovery is true but tool-registry is not registered — discovery unavailable; check startup logs for skill load errors');
-      } else {
-        agentToolDefs.push(...discoveryToolDefs);
+    // tool-registry discovers tools/skills; skill-activate loads a skill's tools +
+    // SKILL.md instructions into the turn (Phase 3a / #1495).
+    if (agentConfig.allow_discovery) {
+      for (const discoveryTool of ['tool-registry', 'skill-activate'] as const) {
+        if (effectivePinnedTools.includes(discoveryTool)) continue;
+        const discoveryToolDefs = toolRegistry.toToolDefinitions([discoveryTool]);
+        if (discoveryToolDefs.length === 0) {
+          logger.error(
+            { agent: agentConfig.name, tool: discoveryTool },
+            `allow_discovery is true but ${discoveryTool} is not registered — discovery/activation unavailable; check startup logs for skill load errors`,
+          );
+        } else {
+          agentToolDefs.push(...discoveryToolDefs);
+        }
       }
     }
 
@@ -2057,6 +2059,8 @@ async function main(): Promise<void> {
       executionLayer,
       pinnedTools: effectivePinnedTools,
       skillToolDefs: agentToolDefs,
+      pinnedSkillNames: pinResolution.resolvedSkills,
+      skillRegistry,
       // Registry-backed context window lookups and cost estimation (DI so runtime is testable).
       modelRegistry,
       estimateCostUsd,

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -2158,6 +2158,74 @@ describe('toolSearch filters by allowed_callers', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Phase 3a unified discovery (kind:skill)
+// ---------------------------------------------------------------------------
+
+describe('toolSearch unified skill discovery (#1495)', () => {
+  it('returns kind:skill for non-synthetic bundles and promotes member atoms', async () => {
+    const { SkillRegistry } = await import('./skill-registry.js');
+    const registry = new ToolRegistry();
+    const skillRegistry = new SkillRegistry();
+
+    registry.register(makeManifest('task-create'), makeHandler('ok'));
+    skillRegistry.register(
+      {
+        name: 'tasks',
+        description: 'Task management bundle',
+        tools: ['task-create'],
+        instructions: '## Tasks\nDecide.',
+      },
+      '/tmp/tasks',
+    );
+
+    const searcher = { ...makeManifest('searcher'), capabilities: ['toolSearch'] };
+    const searchResults: Array<{ name: string; kind?: string }> = [];
+    registry.register(searcher, {
+      execute: async (ctx: ToolContext) => {
+        searchResults.push(...ctx.toolSearch!('task'));
+        return { success: true, data: searchResults };
+      },
+    });
+
+    const layer = new ExecutionLayer(registry, logger, { skillRegistry });
+    await layer.invoke('searcher', {}, undefined, { agentId: 'coordinator' });
+
+    expect(searchResults).toContainEqual({
+      name: 'tasks',
+      description: 'Task management bundle',
+      kind: 'skill',
+    });
+    expect(searchResults.some((r) => r.name === 'task-create')).toBe(false);
+  });
+
+  it('resolveSkillActivationForAgent skips disallowed member tools', async () => {
+    const { SkillRegistry } = await import('./skill-registry.js');
+    const registry = new ToolRegistry();
+    const skillRegistry = new SkillRegistry();
+    registry.register(
+      { ...makeManifest('secret-admin'), allowed_callers: ['coordinator'] },
+      makeHandler('ok'),
+    );
+    skillRegistry.register(
+      {
+        name: 'admin-bundle',
+        description: 'Admin',
+        tools: ['secret-admin'],
+        instructions: 'Careful.',
+      },
+      '/tmp/admin',
+    );
+
+    const layer = new ExecutionLayer(registry, logger, { skillRegistry });
+    const result = layer.resolveSkillActivationForAgent('admin-bundle', 'research-analyst');
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.tools).toEqual([]);
+    expect(result.skippedTools).toEqual(['secret-admin']);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // secret resolution: vault-first with env fallback + audit source tag
 // ---------------------------------------------------------------------------
 describe('ctx.secret resolution', () => {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -27,6 +27,8 @@ import type { ActionConsequenceClass, EscalationDecision } from '../autonomy/esc
 import type { EscalationJudge } from '../autonomy/escalation-judge.js';
 import type { ContactTier } from '../contacts/types.js';
 import type { ToolRegistry } from './registry.js';
+import type { SkillRegistry } from './skill-registry.js';
+import { unifiedToolSearch, resolveSkillActivation } from './skill-activation.js';
 import { sanitizeOutput, sanitizeObjectOutput } from './sanitize.js';
 import { createSecretAccessed, createAutonomySkillBlocked } from '../bus/events.js';
 import type { Logger } from '../logger.js';
@@ -142,6 +144,7 @@ function buildActionDescription(
 
 export class ExecutionLayer {
   private registry: ToolRegistry;
+  private skillRegistry?: SkillRegistry;
   private logger: Logger;
   private bus?: EventBus;
   private agentRegistry?: AgentRegistry;
@@ -246,8 +249,11 @@ export class ExecutionLayer {
     exportControlService?: ExportControlService;
     /** Shared sensitivity classifier (#1419) — available to skills declaring 'sensitivityClassifier'. */
     sensitivityClassifier?: SensitivityClassifier;
+    /** Skill (bundle) registry — enables unified discovery + skill-activate (#1495). */
+    skillRegistry?: SkillRegistry;
   }) {
     this.registry = registry;
+    this.skillRegistry = options?.skillRegistry;
     this.logger = logger;
     this.bus = options?.bus;
     this.agentRegistry = options?.agentRegistry;
@@ -605,6 +611,26 @@ export class ExecutionLayer {
    */
   getToolDefinitions(toolNames: string[]): ToolDefinition[] {
     return this.registry.toToolDefinitions(toolNames);
+  }
+
+  /**
+   * Resolve a skill activation for an agent (#1495). Returns member tools the
+   * agent may call (allowed_callers) plus SKILL.md instructions — never widens
+   * authority. Requires skillRegistry on this layer.
+   */
+  resolveSkillActivationForAgent(
+    skillName: string,
+    agentId: string,
+  ): import('./skill-activation.js').SkillActivationResult | import('./skill-activation.js').SkillActivationFailure {
+    if (!this.skillRegistry) {
+      return { error: 'skillRegistry not configured on ExecutionLayer' };
+    }
+    return resolveSkillActivation({
+      skillName,
+      skillRegistry: this.skillRegistry,
+      toolRegistry: this.registry,
+      agentId,
+    });
   }
 
   /**
@@ -1285,6 +1311,7 @@ export class ExecutionLayer {
     // refuse to run the skill. This catches configuration errors at invocation time.
     const missingCaps = caps.filter(cap => {
       if (cap === 'toolSearch') return false; // toolSearch is synthesized, not a field on `this`
+      if (cap === 'skillRegistry') return this.skillRegistry === undefined;
       return capabilityServices[cap] === undefined;
     });
     if (missingCaps.length > 0) {
@@ -1315,28 +1342,41 @@ export class ExecutionLayer {
           ? buildEntityMemoryObserver(this.entityMemory!, this.bus, memAudit, skillLogger)
           : this.entityMemory;
       } else if (cap === 'toolSearch') {
-        // Special case: toolSearch is a closure over the tool registry, not a service field.
-        // Filters out tool-registry itself (circular self-discovery) and tools whose
-        // allowed_callers list does not include the calling agent (defense-in-depth —
-        // prevents LLM from discovering tools it cannot invoke).
+        // Special case: toolSearch is a closure over ToolRegistry + SkillRegistry.
+        // Filters out tool-registry / skill-activate (circular self-discovery) and
+        // tools whose allowed_callers list does not include the calling agent.
         //
-        // Phase 2: skill (bundle) results are deferred until Phase 3 lands activation
-        // (tiered lookup + task-state persistence). Returning kind:'skill' now would
-        // surface bundles the agent cannot activate, inviting hallucinated calls and
-        // duplicating member atoms already listed as tools.
-        ctx.toolSearch = (query: string) =>
-          this.registry.search(query)
-            .filter(s => s.manifest.name !== 'tool-registry')
-            .filter(s => {
-              const allowed = s.manifest.allowed_callers;
-              if (!allowed || allowed.length === 0) return true;
-              return allowed.includes(options?.agentId ?? 'system');
-            })
-            .map(s => ({
-              name: s.manifest.name,
-              description: s.manifest.description,
-              kind: 'tool' as const,
-            }));
+        // Phase 3a (#1495): returns kind:'skill' for non-synthetic bundles and
+        // promotes member-atom matches to their owning skill (lazy instruction-loading).
+        const skillRegistry = this.skillRegistry;
+        ctx.toolSearch = (query: string) => {
+          if (!skillRegistry) {
+            // Fallback: tools-only (pre-Phase-3a behaviour) when skillRegistry unset.
+            return this.registry.search(query)
+              .filter(s => s.manifest.name !== 'tool-registry' && s.manifest.name !== 'skill-activate')
+              .filter(s => {
+                const allowed = s.manifest.allowed_callers;
+                if (!allowed || allowed.length === 0) return true;
+                return allowed.includes(options?.agentId ?? 'system');
+              })
+              .map(s => ({
+                name: s.manifest.name,
+                description: s.manifest.description,
+                kind: 'tool' as const,
+              }));
+          }
+          return unifiedToolSearch({
+            query,
+            toolRegistry: this.registry,
+            skillRegistry,
+            agentId: options?.agentId ?? 'system',
+          });
+        };
+      } else if (cap === 'skillRegistry') {
+        // skill-activate needs both the bundle catalog and the atom catalog to
+        // resolve member tools under allowed_callers without widening authority.
+        ctx.skillRegistry = this.skillRegistry;
+        ctx.toolRegistry = this.registry;
       } else if (cap === 'infraLlm') {
         // Special case: infraLlm creates a scoped instance per invocation that
         // carries telemetry context (agentId, taskEventId, conversationId, toolName).

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -25,6 +25,10 @@ import type { ManifestMetadata } from '../registry/types.js';
  *
  * Services NOT in this list (contactService, entityContextAssembler, agentPersona)
  * are universal — available to every skill without declaration.
+ *
+ * Note: declaring `skillRegistry` also injects `toolRegistry` on the context
+ * (ExecutionLayer special-case) so skill-activate can resolve member tools under
+ * allowed_callers without a separate capability. `toolRegistry` is not listed here.
  */
 export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'bus', 'agentRegistry', 'outboundGateway',

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -30,6 +30,7 @@ export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'bus', 'agentRegistry', 'outboundGateway',
   'schedulerService', 'entityMemory', 'nylasCalendarClient',
   'autonomyService', 'executiveProfileService', 'officeIdentityService', 'browserService', 'bullpenService', 'toolSearch',
+  'skillRegistry',
   'actionLogRepo', 'auditLogRepo', 'executionLayer', 'confidencePipeline', 'tempFileStore',
   'infraLlm', 'outboundContext', 'taskRepo', 'workingDocs', 'secretCapture', 'secretResolver',
   'diagnosticsRepo', 'sensitivityClassifier',

--- a/src/skills/skill-activation.ts
+++ b/src/skills/skill-activation.ts
@@ -1,0 +1,269 @@
+// skill-activation.ts — Phase 3a (#1495) unified discovery + activation helpers.
+//
+// Design §6 (docs/wip/2026-07-16-tools-skills-architecture-design.md):
+//   Tier 0 — pinned (eager at bootstrap; unchanged)
+//   Tier 1 — task-active (durable progress.activeSkills; re-loaded on wake)
+//   Tier 2 — discovery (toolSearch kind:'skill' when allow_discovery)
+//
+// Activation never widens authority: member tools still pass allowed_callers /
+// action_risk at invoke time; we only surface tools the agent may already call.
+
+import type { SkillRegistry } from './skill-registry.js';
+import type { ToolRegistry } from './registry.js';
+import type { RegisteredSkill } from './skill-types.js';
+import {
+  ACTIVE_SKILLS_CAP,
+  readActiveSkillsBlock,
+  type ActiveSkillEntry,
+} from '../db/active-skills-progress.js';
+import { appendSkillInstructions } from './pin-resolution.js';
+
+export const SKILL_ACTIVATE_TOOL_NAME = 'skill-activate';
+export const SKILL_ACTIVATION_PROTOCOL = 'skill_activation' as const;
+
+export interface DiscoveryHit {
+  name: string;
+  description: string;
+  kind: 'tool' | 'skill';
+}
+
+export interface SkillActivationResult {
+  skill: string;
+  /** Member tools the calling agent is allowed to invoke (allowed_callers). */
+  tools: string[];
+  /** Member tools skipped because allowed_callers excludes the agent. */
+  skippedTools: string[];
+  /** SKILL.md body (may be empty for instruction-light bundles). */
+  instructions: string;
+}
+
+export interface SkillActivationFailure {
+  error: string;
+}
+
+/**
+ * Unified discovery: non-synthetic skills as kind:'skill', orphan/synthetic-owned
+ * tools as kind:'tool'. Matching a member atom promotes its owning skill instead
+ * of returning the atom (closes the Phase 2 gap where task-create could be
+ * invoked without the tasks discipline block).
+ */
+export function unifiedToolSearch(options: {
+  query: string;
+  toolRegistry: ToolRegistry;
+  skillRegistry: SkillRegistry;
+  agentId: string;
+  /** Tool names excluded from results (e.g. tool-registry, skill-activate). */
+  excludeToolNames?: ReadonlySet<string>;
+}): DiscoveryHit[] {
+  const {
+    query,
+    toolRegistry,
+    skillRegistry,
+    agentId,
+    excludeToolNames = new Set(['tool-registry', SKILL_ACTIVATE_TOOL_NAME]),
+  } = options;
+
+  const results: DiscoveryHit[] = [];
+  const seenSkills = new Set<string>();
+  const seenTools = new Set<string>();
+
+  const pushSkill = (skill: RegisteredSkill) => {
+    if (skill.synthetic) return;
+    if (seenSkills.has(skill.manifest.name)) return;
+    seenSkills.add(skill.manifest.name);
+    results.push({
+      name: skill.manifest.name,
+      description: skill.manifest.description,
+      kind: 'skill',
+    });
+  };
+
+  for (const skill of skillRegistry.search(query)) {
+    pushSkill(skill);
+  }
+
+  for (const tool of toolRegistry.search(query)) {
+    const name = tool.manifest.name;
+    if (excludeToolNames.has(name)) continue;
+
+    const allowed = tool.manifest.allowed_callers;
+    if (allowed && allowed.length > 0 && !allowed.includes(agentId)) continue;
+
+    const owner = skillRegistry.toolOwner(name);
+    if (owner && !owner.synthetic) {
+      // Prefer the bundle — activation loads tools + instructions together.
+      pushSkill(owner);
+      continue;
+    }
+
+    if (seenTools.has(name)) continue;
+    seenTools.add(name);
+    results.push({
+      name,
+      description: tool.manifest.description,
+      kind: 'tool',
+    });
+  }
+
+  return results;
+}
+
+/** Whether the agent may call this tool given allowed_callers. */
+export function agentMayCallTool(
+  toolRegistry: ToolRegistry,
+  toolName: string,
+  agentId: string,
+): boolean {
+  const entry = toolRegistry.get(toolName);
+  if (!entry) return false;
+  const allowed = entry.manifest.allowed_callers;
+  if (!allowed || allowed.length === 0) return true;
+  return allowed.includes(agentId);
+}
+
+/**
+ * Resolve activation of a skill for an agent. Does not mutate registries.
+ * Synthetic skills cannot be activated (they are pin-resolution shims only).
+ */
+export function resolveSkillActivation(options: {
+  skillName: string;
+  skillRegistry: SkillRegistry;
+  toolRegistry: ToolRegistry;
+  agentId: string;
+}): SkillActivationResult | SkillActivationFailure {
+  const { skillName, skillRegistry, toolRegistry, agentId } = options;
+  const name = skillName.trim();
+  if (!name) return { error: 'skill name is required' };
+
+  const skill = skillRegistry.get(name);
+  if (!skill) return { error: `Unknown skill: ${name}` };
+  if (skill.synthetic) {
+    return { error: `Cannot activate synthetic skill '${name}' — pin or discover a real bundle` };
+  }
+
+  const tools: string[] = [];
+  const skippedTools: string[] = [];
+  for (const toolName of skill.manifest.tools) {
+    if (!toolRegistry.get(toolName)) {
+      skippedTools.push(toolName);
+      continue;
+    }
+    if (agentMayCallTool(toolRegistry, toolName, agentId)) {
+      tools.push(toolName);
+    } else {
+      skippedTools.push(toolName);
+    }
+  }
+
+  return {
+    skill: skill.manifest.name,
+    tools,
+    skippedTools,
+    instructions: skill.manifest.instructions.trim(),
+  };
+}
+
+/**
+ * On wake: treat stored active skills as a strong prior, re-check relevance
+ * against the current step text, and cap the set. Pinned skills are excluded
+ * (already eager in the bootstrap prompt).
+ */
+export function selectActiveSkillsForWake(options: {
+  progress: Record<string, unknown> | undefined | null;
+  pinnedSkillNames: ReadonlySet<string> | readonly string[];
+  skillRegistry: SkillRegistry;
+  relevanceText: string;
+  cap?: number;
+}): string[] {
+  const cap = options.cap ?? ACTIVE_SKILLS_CAP;
+  const pinned = options.pinnedSkillNames instanceof Set
+    ? options.pinnedSkillNames
+    : new Set(options.pinnedSkillNames);
+
+  const stored = readActiveSkillsBlock(options.progress)?.skills ?? [];
+  if (stored.length === 0) return [];
+
+  const relevance = options.relevanceText.toLowerCase();
+  const scored: Array<{ name: string; relevant: boolean; activatedAt: string }> = [];
+
+  for (const entry of stored) {
+    if (pinned.has(entry.name)) continue;
+    const skill = options.skillRegistry.get(entry.name);
+    if (!skill || skill.synthetic) continue;
+
+    const haystack = [
+      skill.manifest.name,
+      skill.manifest.description,
+      ...skill.manifest.tools,
+    ].join(' ').toLowerCase();
+    const relevant = relevance.length === 0
+      || haystack.split(/[^a-z0-9]+/).some((token) => token.length >= 3 && relevance.includes(token))
+      || relevance.split(/[^a-z0-9]+/).some((token) => token.length >= 3 && haystack.includes(token));
+
+    scored.push({ name: entry.name, relevant, activatedAt: entry.activatedAt });
+  }
+
+  // Relevant first (strong prior that still matches), then MRU by activatedAt.
+  scored.sort((a, b) => {
+    if (a.relevant !== b.relevant) return a.relevant ? -1 : 1;
+    return b.activatedAt.localeCompare(a.activatedAt);
+  });
+
+  return scored.slice(0, cap).map((s) => s.name);
+}
+
+/** Format a system-message block for a lazily activated skill's instructions. */
+export function formatActivatedSkillInstructionBlock(
+  skillName: string,
+  instructions: string,
+): string | null {
+  const body = instructions.trim();
+  if (!body) return null;
+  return `[Activated skill: ${skillName}]\n\n${body}`;
+}
+
+/** Apply multiple instruction blocks onto a system prompt (pinned path reuse). */
+export function applyActivatedSkillInstructions(
+  systemPrompt: string,
+  blocks: string[],
+): string {
+  return appendSkillInstructions(systemPrompt, blocks);
+}
+
+/** Build the protocol payload returned by skill-activate for the runtime. */
+export function buildSkillActivationProtocol(
+  result: SkillActivationResult,
+): Record<string, unknown> {
+  return {
+    _curia_protocol: SKILL_ACTIVATION_PROTOCOL,
+    skill: result.skill,
+    tools: result.tools,
+    skippedTools: result.skippedTools,
+    instructions: result.instructions,
+    instructionsLoaded: result.instructions.length > 0,
+  };
+}
+
+/** Parse a skill-activate tool result; null when not an activation protocol payload. */
+export function parseSkillActivationProtocol(data: unknown): SkillActivationResult | null {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null;
+  const obj = data as Record<string, unknown>;
+  if (obj._curia_protocol !== SKILL_ACTIVATION_PROTOCOL) return null;
+  if (typeof obj.skill !== 'string' || !obj.skill.trim()) return null;
+  if (!Array.isArray(obj.tools) || !obj.tools.every((t) => typeof t === 'string')) return null;
+  const skippedTools = Array.isArray(obj.skippedTools)
+    ? obj.skippedTools.filter((t): t is string => typeof t === 'string')
+    : [];
+  const instructions = typeof obj.instructions === 'string' ? obj.instructions : '';
+  return {
+    skill: obj.skill.trim(),
+    tools: obj.tools as string[],
+    skippedTools,
+    instructions,
+  };
+}
+
+/** MRU order helper for tests / callers inspecting entries. */
+export function sortActiveSkillEntriesMru(entries: ActiveSkillEntry[]): ActiveSkillEntry[] {
+  return [...entries].sort((a, b) => b.activatedAt.localeCompare(a.activatedAt));
+}

--- a/src/skills/skill-activation.ts
+++ b/src/skills/skill-activation.ts
@@ -164,9 +164,11 @@ export function resolveSkillActivation(options: {
 }
 
 /**
- * On wake: treat stored active skills as a strong prior, re-check relevance
- * against the current step text, and cap the set. Pinned skills are excluded
- * (already eager in the bootstrap prompt).
+ * On wake: treat stored active skills as a strong prior, drop skills that no
+ * longer share a whole-token overlap (≥3 chars) with the current step text,
+ * and cap the set. When *no* stored skill is relevant, fall back to MRU up to
+ * cap (still a strong prior, just without a relevance signal). Pinned skills
+ * are excluded (already eager in the bootstrap prompt).
  */
 export function selectActiveSkillsForWake(options: {
   progress: Record<string, unknown> | undefined | null;
@@ -183,7 +185,7 @@ export function selectActiveSkillsForWake(options: {
   const stored = readActiveSkillsBlock(options.progress)?.skills ?? [];
   if (stored.length === 0) return [];
 
-  const relevance = options.relevanceText.toLowerCase();
+  const relevanceTokens = tokenizeForRelevance(options.relevanceText);
   const scored: Array<{ name: string; relevant: boolean; activatedAt: string }> = [];
 
   for (const entry of stored) {
@@ -191,25 +193,39 @@ export function selectActiveSkillsForWake(options: {
     const skill = options.skillRegistry.get(entry.name);
     if (!skill || skill.synthetic) continue;
 
-    const haystack = [
+    const haystackTokens = tokenizeForRelevance([
       skill.manifest.name,
       skill.manifest.description,
       ...skill.manifest.tools,
-    ].join(' ').toLowerCase();
-    const relevant = relevance.length === 0
-      || haystack.split(/[^a-z0-9]+/).some((token) => token.length >= 3 && relevance.includes(token))
-      || relevance.split(/[^a-z0-9]+/).some((token) => token.length >= 3 && haystack.includes(token));
+    ].join(' '));
+    const relevant = relevanceTokens.size === 0
+      || intersectsTokens(relevanceTokens, haystackTokens);
 
     scored.push({ name: entry.name, relevant, activatedAt: entry.activatedAt });
   }
 
-  // Relevant first (strong prior that still matches), then MRU by activatedAt.
-  scored.sort((a, b) => {
-    if (a.relevant !== b.relevant) return a.relevant ? -1 : 1;
-    return b.activatedAt.localeCompare(a.activatedAt);
-  });
+  const relevant = scored.filter((s) => s.relevant);
+  const pool = relevant.length > 0 ? relevant : scored;
 
-  return scored.slice(0, cap).map((s) => s.name);
+  // MRU within the chosen pool.
+  pool.sort((a, b) => b.activatedAt.localeCompare(a.activatedAt));
+  return pool.slice(0, cap).map((s) => s.name);
+}
+
+/** Whole tokens of length ≥ 3 — avoids "task" matching "multitask". */
+function tokenizeForRelevance(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length >= 3) tokens.add(raw);
+  }
+  return tokens;
+}
+
+function intersectsTokens(a: Set<string>, b: Set<string>): boolean {
+  for (const t of a) {
+    if (b.has(t)) return true;
+  }
+  return false;
 }
 
 /** Format a system-message block for a lazily activated skill's instructions. */

--- a/src/skills/skill-activation.ts
+++ b/src/skills/skill-activation.ts
@@ -86,8 +86,8 @@ export function unifiedToolSearch(options: {
     const name = tool.manifest.name;
     if (excludeToolNames.has(name)) continue;
 
-    const allowed = tool.manifest.allowed_callers;
-    if (allowed && allowed.length > 0 && !allowed.includes(agentId)) continue;
+    // Single source of truth for the allowed_callers rule (see agentMayCallTool).
+    if (!agentMayCallTool(toolRegistry, name, agentId)) continue;
 
     const owner = skillRegistry.toolOwner(name);
     if (owner && !owner.synthetic) {

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -227,13 +227,19 @@ export interface ToolContext {
   browserService?: import('../browser/browser-service.js').BrowserService;
   /** Skill search — available to skills declaring 'toolSearch' in capabilities.
    *  Searches all registered skills by keyword, excluding tool-registry itself. */
-  /** Search tools (and optionally skills) by keyword. Used by tool-registry. */
+  /** Search tools and skills by keyword. Used by tool-registry (Phase 3a unified discovery). */
   toolSearch?: (query: string) => Array<{
     name: string;
     description: string;
-    /** Phase 2: 'tool' (atom) or 'skill' (bundle). Omitted → treat as tool. */
+    /** 'tool' (atom) or 'skill' (bundle). Omitted → treat as tool. */
     kind?: 'tool' | 'skill';
   }>;
+  /** Skill (bundle) registry — available to tools declaring 'skillRegistry' in capabilities.
+   *  Used by skill-activate for Tier-2 activation (#1495). */
+  skillRegistry?: import('./skill-registry.js').SkillRegistry;
+  /** Atom tool catalog — injected alongside skillRegistry for activation resolution.
+   *  Not a separate capability; accompanies skillRegistry. */
+  toolRegistry?: import('./registry.js').ToolRegistry;
   /** Arbitrary task-level metadata forwarded from the agent.task event payload.
    *  Skills that do not need it can ignore this field entirely. */
   taskMetadata?: Record<string, unknown>;

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -225,8 +225,6 @@ export interface ToolContext {
    *  Provides a warm Playwright Chromium instance with session management.
    *  Skills use this to interact with JS-rendered pages and web forms. */
   browserService?: import('../browser/browser-service.js').BrowserService;
-  /** Skill search — available to skills declaring 'toolSearch' in capabilities.
-   *  Searches all registered skills by keyword, excluding tool-registry itself. */
   /** Search tools and skills by keyword. Used by tool-registry (Phase 3a unified discovery). */
   toolSearch?: (query: string) => Array<{
     name: string;

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1691,6 +1691,233 @@ describe('AgentRuntime tool-use loop', () => {
   });
 });
 
+// -- Phase 3a skill activation runtime (#1495) --
+
+describe('AgentRuntime skill-activate (#1495)', () => {
+  const skillActivateToolDef = {
+    name: 'skill-activate',
+    description: 'Activate a skill',
+    input_schema: {
+      type: 'object' as const,
+      properties: { skill: { type: 'string' } },
+      required: ['skill'],
+    },
+  };
+  const taskCreateToolDef = {
+    name: 'task-create',
+    description: 'Create a task',
+    input_schema: { type: 'object' as const, properties: {}, required: [] as string[] },
+  };
+  const taskListToolDef = {
+    name: 'task-list',
+    description: 'List tasks',
+    input_schema: { type: 'object' as const, properties: {}, required: [] as string[] },
+  };
+
+  it('splices instruction block and expands workingToolDefs after skill-activate', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    bus.subscribe('agent.response', 'dispatch', () => {});
+
+    const chatCalls: Array<{ messages: unknown[]; tools?: Array<{ name: string }> }> = [];
+    let callCount = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: async (params) => {
+        callCount++;
+        chatCalls.push({
+          messages: params.messages as unknown[],
+          tools: params.tools?.map((t) => ({ name: t.name })),
+        });
+        if (callCount === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'call-1', name: 'skill-activate', input: { skill: 'tasks' } }],
+            usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
+          };
+        }
+        return {
+          type: 'text' as const,
+          content: 'Activated and ready.',
+          usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      },
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          _curia_protocol: 'skill_activation',
+          skill: 'tasks',
+          tools: ['task-create', 'task-list'],
+          skippedTools: [],
+          instructions: '## Task Management\nDecide, don\'t drop.',
+          instructionsLoaded: true,
+        },
+      }),
+      getToolDefinitions: vi.fn((names: string[]) => {
+        const defs = [taskCreateToolDef, taskListToolDef];
+        return defs.filter((d) => names.includes(d.name));
+      }),
+    } as unknown as ExecutionLayer;
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [skillActivateToolDef],
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-activate-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Track this work',
+      senderContext: CONFIRMED_SENDER_CONTEXT,
+      parentEventId: 'parent-activate-1',
+    }));
+
+    expect(mockExecution.invoke).toHaveBeenCalledWith(
+      'skill-activate',
+      { skill: 'tasks' },
+      expect.anything(),
+      expect.objectContaining({ agentId: 'coordinator' }),
+    );
+    expect(chatCalls).toHaveLength(2);
+
+    // Second LLM round sees expanded member tools.
+    const secondTools = chatCalls[1]!.tools?.map((t) => t.name) ?? [];
+    expect(secondTools).toContain('skill-activate');
+    expect(secondTools).toContain('task-create');
+    expect(secondTools).toContain('task-list');
+
+    // Instruction block spliced as a system message.
+    const secondMessages = chatCalls[1]!.messages as Array<{ role: string; content: unknown }>;
+    const instructionMsg = secondMessages.find(
+      (m) => m.role === 'system'
+        && typeof m.content === 'string'
+        && m.content.includes('[Activated skill: tasks]')
+        && m.content.includes('Task Management'),
+    );
+    expect(instructionMsg).toBeDefined();
+  });
+
+  it('re-loads active skills on wake without rewriting when the set is unchanged', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    bus.subscribe('agent.response', 'dispatch', () => {});
+
+    const chatCalls: Array<{ tools?: Array<{ name: string }>; messages: Array<{ role: string; content: unknown }> }> = [];
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: async (params) => {
+        chatCalls.push({
+          tools: params.tools?.map((t) => ({ name: t.name })),
+          messages: params.messages as Array<{ role: string; content: unknown }>,
+        });
+        return {
+          type: 'text' as const,
+          content: 'Resumed.',
+          usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      },
+    };
+
+    const setActiveSkillsBlock = vi.fn();
+    const taskId = '22222222-2222-4222-8222-222222222222';
+    const activeSkills = {
+      skills: [{ name: 'tasks', activatedAt: '2026-07-21T00:00:00.000Z' }],
+    };
+    const mockTaskRepo = {
+      getTask: vi.fn().mockResolvedValue({
+        id: taskId,
+        status: 'open',
+        progress: { activeSkills },
+      }),
+      setActiveSkillsBlock,
+    };
+
+    const { SkillRegistry } = await import('../../../src/skills/skill-registry.js');
+    const skillRegistry = new SkillRegistry();
+    skillRegistry.register(
+      {
+        name: 'tasks',
+        description: 'Defer and track multi-step work with tasks',
+        tools: ['task-create', 'task-list'],
+        instructions: '## Task Management\nOwn the how.',
+      },
+      '/tmp/tasks',
+    );
+
+    const mockExecution = {
+      invoke: vi.fn(),
+      getToolDefinitions: vi.fn((names: string[]) => {
+        const defs = [taskCreateToolDef, taskListToolDef];
+        return defs.filter((d) => names.includes(d.name));
+      }),
+      resolveSkillActivationForAgent: vi.fn().mockReturnValue({
+        skill: 'tasks',
+        tools: ['task-create', 'task-list'],
+        skippedTools: [],
+        instructions: '## Task Management\nOwn the how.',
+      }),
+    } as unknown as ExecutionLayer;
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [skillActivateToolDef],
+      skillRegistry,
+      taskRepo: mockTaskRepo as never,
+    });
+    agent.register();
+
+    await bus.publish('dispatch', createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-wake-1',
+      channelId: 'scheduler',
+      senderId: 'scheduler',
+      content: JSON.stringify({ task_id: taskId }),
+      metadata: {
+        boundTask: {
+          taskId,
+          progress: { activeSkills },
+        },
+      },
+      parentEventId: 'parent-wake-1',
+    }));
+
+    expect(mockExecution.resolveSkillActivationForAgent).toHaveBeenCalledWith('tasks', 'coordinator');
+    expect(setActiveSkillsBlock).not.toHaveBeenCalled(); // unchanged set → no write
+
+    const tools = chatCalls[0]!.tools?.map((t) => t.name) ?? [];
+    expect(tools).toContain('task-create');
+    expect(tools).toContain('task-list');
+
+    const sys = chatCalls[0]!.messages.find(
+      (m) => m.role === 'system'
+        && typeof m.content === 'string'
+        && m.content.includes('[Activated skill: tasks]'),
+    );
+    expect(sys).toBeDefined();
+  });
+});
+
 // -- Error budget enforcement tests --
 
 describe('AgentRuntime error budget', () => {

--- a/tests/unit/skills/active-skills-progress.test.ts
+++ b/tests/unit/skills/active-skills-progress.test.ts
@@ -73,6 +73,13 @@ describe('active-skills-progress', () => {
     expect(activeSkillNameSetsEqual(['a'], ['a', 'b'])).toBe(false);
   });
 
+  it('activeSkillNameSetsEqual compares unique membership, not array length', () => {
+    // Equal length but different sets — duplicates must not mask a real difference.
+    expect(activeSkillNameSetsEqual(['x', 'x'], ['x', 'y'])).toBe(false);
+    // Same set, differing duplicate counts — still equal.
+    expect(activeSkillNameSetsEqual(['x', 'x', 'y'], ['x', 'y'])).toBe(true);
+  });
+
   it('prepareActiveSkillsBlock rejects overflow', () => {
     const huge = activateSkillInBlock(null, 'x'.repeat(5000), 't');
     const prepared = prepareActiveSkillsBlock(huge);

--- a/tests/unit/skills/active-skills-progress.test.ts
+++ b/tests/unit/skills/active-skills-progress.test.ts
@@ -5,6 +5,8 @@ import {
   readActiveSkillNames,
   readActiveSkillsBlock,
   replaceActiveSkillsBlock,
+  reconcileActiveSkillsBlock,
+  activeSkillNameSetsEqual,
   ACTIVE_SKILLS_CAP,
 } from '../../../src/db/active-skills-progress.js';
 
@@ -46,6 +48,29 @@ describe('active-skills-progress', () => {
   it('replaceActiveSkillsBlock dedupes and caps', () => {
     const block = replaceActiveSkillsBlock(['tasks', 'tasks', 'calendar', 'x', 'y', 'z'], 't', 3);
     expect(block.skills.map((s) => s.name)).toEqual(['tasks', 'calendar', 'x']);
+  });
+
+  it('reconcileActiveSkillsBlock preserves activatedAt for survivors', () => {
+    const existing = {
+      skills: [
+        { name: 'tasks', activatedAt: '2026-07-21T00:00:00.000Z' },
+        { name: 'calendar', activatedAt: '2026-07-21T01:00:00.000Z' },
+      ],
+    };
+    const next = reconcileActiveSkillsBlock(
+      ['calendar', 'email'],
+      existing,
+      '2026-07-22T12:00:00.000Z',
+    );
+    expect(next.skills).toEqual([
+      { name: 'calendar', activatedAt: '2026-07-21T01:00:00.000Z' },
+      { name: 'email', activatedAt: '2026-07-22T12:00:00.000Z' },
+    ]);
+  });
+
+  it('activeSkillNameSetsEqual is order-independent', () => {
+    expect(activeSkillNameSetsEqual(['a', 'b'], ['b', 'a'])).toBe(true);
+    expect(activeSkillNameSetsEqual(['a'], ['a', 'b'])).toBe(false);
   });
 
   it('prepareActiveSkillsBlock rejects overflow', () => {

--- a/tests/unit/skills/active-skills-progress.test.ts
+++ b/tests/unit/skills/active-skills-progress.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  activateSkillInBlock,
+  prepareActiveSkillsBlock,
+  readActiveSkillNames,
+  readActiveSkillsBlock,
+  replaceActiveSkillsBlock,
+  ACTIVE_SKILLS_CAP,
+} from '../../../src/db/active-skills-progress.js';
+
+describe('active-skills-progress', () => {
+  it('reads a valid block', () => {
+    const block = readActiveSkillsBlock({
+      activeSkills: {
+        skills: [
+          { name: 'tasks', activatedAt: '2026-07-21T00:00:00.000Z' },
+          { name: 'calendar', activatedAt: '2026-07-21T01:00:00.000Z' },
+        ],
+      },
+    });
+    expect(block?.skills.map((s) => s.name)).toEqual(['tasks', 'calendar']);
+    expect(readActiveSkillNames({ activeSkills: block })).toEqual(['tasks', 'calendar']);
+  });
+
+  it('returns null for malformed blocks', () => {
+    expect(readActiveSkillsBlock({})).toBeNull();
+    expect(readActiveSkillsBlock({ activeSkills: { skills: [{ name: 'x' }] } })).toBeNull();
+  });
+
+  it('activates MRU and caps the set', () => {
+    let block = activateSkillInBlock(null, 'a', '2026-07-21T00:00:00.000Z', 3);
+    block = activateSkillInBlock(block, 'b', '2026-07-21T01:00:00.000Z', 3);
+    block = activateSkillInBlock(block, 'c', '2026-07-21T02:00:00.000Z', 3);
+    block = activateSkillInBlock(block, 'd', '2026-07-21T03:00:00.000Z', 3);
+    expect(block.skills.map((s) => s.name)).toEqual(['d', 'c', 'b']);
+    expect(ACTIVE_SKILLS_CAP).toBe(5);
+  });
+
+  it('re-activating moves a skill to the front', () => {
+    let block = activateSkillInBlock(null, 'a', '2026-07-21T00:00:00.000Z');
+    block = activateSkillInBlock(block, 'b', '2026-07-21T01:00:00.000Z');
+    block = activateSkillInBlock(block, 'a', '2026-07-21T02:00:00.000Z');
+    expect(block.skills.map((s) => s.name)).toEqual(['a', 'b']);
+  });
+
+  it('replaceActiveSkillsBlock dedupes and caps', () => {
+    const block = replaceActiveSkillsBlock(['tasks', 'tasks', 'calendar', 'x', 'y', 'z'], 't', 3);
+    expect(block.skills.map((s) => s.name)).toEqual(['tasks', 'calendar', 'x']);
+  });
+
+  it('prepareActiveSkillsBlock rejects overflow', () => {
+    const huge = activateSkillInBlock(null, 'x'.repeat(5000), 't');
+    const prepared = prepareActiveSkillsBlock(huge);
+    expect(prepared.ok).toBe(false);
+    if (!prepared.ok) expect(prepared.code).toBe('block_overflow');
+  });
+});

--- a/tests/unit/skills/skill-activation.test.ts
+++ b/tests/unit/skills/skill-activation.test.ts
@@ -213,7 +213,7 @@ describe('selectActiveSkillsForWake', () => {
     expect(selected).toEqual(['tasks']);
   });
 
-  it('caps and prefers relevant over irrelevant', () => {
+  it('caps and drops irrelevant when any skill still matches', () => {
     const { skills } = setup();
     skills.register(
       {
@@ -243,9 +243,46 @@ describe('selectActiveSkillsForWake', () => {
       pinnedSkillNames: [],
       skillRegistry: skills,
       relevanceText: 'reschedule the calendar meeting',
-      cap: 2,
+      cap: 5,
     });
-    expect(selected[0]).toBe('calendar');
-    expect(selected).toHaveLength(2);
+    // Only calendar shares a whole token with the step — email/tasks are dropped.
+    expect(selected).toEqual(['calendar']);
+  });
+
+  it('does not match substring tokens (multitask ≠ task)', () => {
+    const { skills } = setup();
+    let block = activateSkillInBlock(null, 'tasks', '2026-07-21T00:00:00.000Z');
+    const selected = selectActiveSkillsForWake({
+      progress: { activeSkills: block },
+      pinnedSkillNames: [],
+      skillRegistry: skills,
+      relevanceText: 'finish the multitask spreadsheet review',
+      cap: 5,
+    });
+    // No whole-token overlap → fall back to MRU (tasks still returned).
+    expect(selected).toEqual(['tasks']);
+  });
+
+  it('falls back to MRU when nothing is relevant', () => {
+    const { skills } = setup();
+    skills.register(
+      {
+        name: 'calendar',
+        description: 'Google Calendar scheduling',
+        tools: [],
+        instructions: '',
+      },
+      '/tmp/calendar',
+    );
+    let block = activateSkillInBlock(null, 'tasks', '2026-07-21T00:00:00.000Z');
+    block = activateSkillInBlock(block, 'calendar', '2026-07-21T01:00:00.000Z');
+    const selected = selectActiveSkillsForWake({
+      progress: { activeSkills: block },
+      pinnedSkillNames: [],
+      skillRegistry: skills,
+      relevanceText: 'xyzzy completely unrelated',
+      cap: 1,
+    });
+    expect(selected).toEqual(['calendar']); // MRU
   });
 });

--- a/tests/unit/skills/skill-activation.test.ts
+++ b/tests/unit/skills/skill-activation.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import { SkillRegistry } from '../../../src/skills/skill-registry.js';
+import { ToolRegistry } from '../../../src/skills/registry.js';
+import type { ToolManifest } from '../../../src/skills/types.js';
+import {
+  resolveSkillActivation,
+  selectActiveSkillsForWake,
+  unifiedToolSearch,
+  buildSkillActivationProtocol,
+  parseSkillActivationProtocol,
+} from '../../../src/skills/skill-activation.js';
+import { activateSkillInBlock } from '../../../src/db/active-skills-progress.js';
+
+function toolManifest(
+  name: string,
+  opts: { allowed_callers?: string[]; description?: string } = {},
+): ToolManifest {
+  return {
+    name,
+    description: opts.description ?? `Tool ${name}`,
+    version: '0.1.0',
+    action_risk: 'none',
+    sensitivity: 'normal',
+    permissions: [],
+    secrets: [],
+    timeout: 30000,
+    inputs: {},
+    outputs: {},
+    allowed_callers: opts.allowed_callers,
+  };
+}
+
+const noopHandler = { execute: async () => ({ success: true as const, data: {} }) };
+
+function setup() {
+  const tools = new ToolRegistry();
+  const skills = new SkillRegistry();
+
+  for (const name of ['task-create', 'task-list', 'task-update', 'task-complete']) {
+    tools.register(toolManifest(name, { description: `Manage tasks via ${name}` }), noopHandler);
+  }
+  tools.register(
+    toolManifest('secret-admin', { allowed_callers: ['coordinator'], description: 'Admin only' }),
+    noopHandler,
+  );
+  tools.register(toolManifest('web-search', { description: 'Search the web' }), noopHandler);
+  tools.register(toolManifest('tool-registry', { description: 'Discover tools' }), noopHandler);
+
+  skills.register(
+    {
+      name: 'tasks',
+      description: 'Defer and track multi-step work with tasks',
+      tools: ['task-create', 'task-list', 'task-update', 'task-complete'],
+      instructions: '## Task Management\nDecide, don\'t drop.',
+    },
+    '/tmp/tasks',
+  );
+  skills.register(
+    {
+      name: 'admin-bundle',
+      description: 'Admin tools',
+      tools: ['secret-admin'],
+      instructions: 'Be careful.',
+    },
+    '/tmp/admin',
+  );
+  // Synthetic singleton for web-search (orphan flat tool)
+  skills.register(
+    {
+      name: 'web-search',
+      description: 'Search the web',
+      tools: ['web-search'],
+      instructions: '',
+    },
+    '/tmp/web-search',
+    { synthetic: true },
+  );
+
+  return { tools, skills };
+}
+
+describe('unifiedToolSearch', () => {
+  it('returns kind:skill for matching bundles and promotes member atoms', () => {
+    const { tools, skills } = setup();
+    const hits = unifiedToolSearch({
+      query: 'task-create',
+      toolRegistry: tools,
+      skillRegistry: skills,
+      agentId: 'coordinator',
+    });
+    expect(hits.some((h) => h.kind === 'skill' && h.name === 'tasks')).toBe(true);
+    expect(hits.some((h) => h.name === 'task-create')).toBe(false);
+  });
+
+  it('returns kind:tool for synthetic-owned / orphan tools', () => {
+    const { tools, skills } = setup();
+    const hits = unifiedToolSearch({
+      query: 'web',
+      toolRegistry: tools,
+      skillRegistry: skills,
+      agentId: 'coordinator',
+    });
+    expect(hits).toContainEqual({
+      name: 'web-search',
+      description: 'Search the web',
+      kind: 'tool',
+    });
+  });
+
+  it('hides tools whose allowed_callers excludes the agent', () => {
+    const { tools, skills } = setup();
+    // Promote via skill description match for admin-bundle
+    const hits = unifiedToolSearch({
+      query: 'Admin',
+      toolRegistry: tools,
+      skillRegistry: skills,
+      agentId: 'research-analyst',
+    });
+    // Skill itself may still appear (activation will skip disallowed tools)
+    expect(hits.some((h) => h.name === 'secret-admin')).toBe(false);
+  });
+
+  it('excludes tool-registry and skill-activate from results', () => {
+    const { tools, skills } = setup();
+    tools.register(toolManifest('skill-activate', { description: 'Activate a skill' }), noopHandler);
+    const hits = unifiedToolSearch({
+      query: '',
+      toolRegistry: tools,
+      skillRegistry: skills,
+      agentId: 'coordinator',
+    });
+    expect(hits.map((h) => h.name)).not.toContain('tool-registry');
+    expect(hits.map((h) => h.name)).not.toContain('skill-activate');
+  });
+});
+
+describe('resolveSkillActivation', () => {
+  it('returns tools + instructions for a real skill', () => {
+    const { tools, skills } = setup();
+    const result = resolveSkillActivation({
+      skillName: 'tasks',
+      skillRegistry: skills,
+      toolRegistry: tools,
+      agentId: 'coordinator',
+    });
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.tools).toEqual(['task-create', 'task-list', 'task-update', 'task-complete']);
+    expect(result.instructions).toContain('Task Management');
+    expect(result.skippedTools).toEqual([]);
+  });
+
+  it('does not widen authority — skips tools the agent cannot call', () => {
+    const { tools, skills } = setup();
+    const result = resolveSkillActivation({
+      skillName: 'admin-bundle',
+      skillRegistry: skills,
+      toolRegistry: tools,
+      agentId: 'research-analyst',
+    });
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.tools).toEqual([]);
+    expect(result.skippedTools).toEqual(['secret-admin']);
+  });
+
+  it('rejects synthetic skills', () => {
+    const { tools, skills } = setup();
+    const result = resolveSkillActivation({
+      skillName: 'web-search',
+      skillRegistry: skills,
+      toolRegistry: tools,
+      agentId: 'coordinator',
+    });
+    expect(result).toEqual({
+      error: expect.stringContaining('synthetic'),
+    });
+  });
+
+  it('round-trips the activation protocol payload', () => {
+    const { tools, skills } = setup();
+    const resolved = resolveSkillActivation({
+      skillName: 'tasks',
+      skillRegistry: skills,
+      toolRegistry: tools,
+      agentId: 'coordinator',
+    });
+    expect('error' in resolved).toBe(false);
+    if ('error' in resolved) return;
+    const parsed = parseSkillActivationProtocol(buildSkillActivationProtocol(resolved));
+    expect(parsed).toEqual(resolved);
+  });
+});
+
+describe('selectActiveSkillsForWake', () => {
+  it('keeps relevant skills as a strong prior and drops pinned', () => {
+    const { skills } = setup();
+    let progress: Record<string, unknown> = {};
+    const block = activateSkillInBlock(
+      activateSkillInBlock(null, 'tasks', '2026-07-21T00:00:00.000Z'),
+      'admin-bundle',
+      '2026-07-21T01:00:00.000Z',
+    );
+    progress = { activeSkills: block };
+
+    const selected = selectActiveSkillsForWake({
+      progress,
+      pinnedSkillNames: ['admin-bundle'],
+      skillRegistry: skills,
+      relevanceText: 'please create a task for the board deck',
+      cap: 5,
+    });
+    expect(selected).toEqual(['tasks']);
+  });
+
+  it('caps and prefers relevant over irrelevant', () => {
+    const { skills } = setup();
+    skills.register(
+      {
+        name: 'calendar',
+        description: 'Google Calendar scheduling',
+        tools: [],
+        instructions: '',
+      },
+      '/tmp/calendar',
+    );
+    skills.register(
+      {
+        name: 'email',
+        description: 'Send email',
+        tools: [],
+        instructions: '',
+      },
+      '/tmp/email',
+    );
+
+    let block = activateSkillInBlock(null, 'email', '2026-07-21T00:00:00.000Z');
+    block = activateSkillInBlock(block, 'calendar', '2026-07-21T01:00:00.000Z');
+    block = activateSkillInBlock(block, 'tasks', '2026-07-21T02:00:00.000Z');
+
+    const selected = selectActiveSkillsForWake({
+      progress: { activeSkills: block },
+      pinnedSkillNames: [],
+      skillRegistry: skills,
+      relevanceText: 'reschedule the calendar meeting',
+      cap: 2,
+    });
+    expect(selected[0]).toBe('calendar');
+    expect(selected).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1495 (Phase 3a of epic #1436). Builds on Phase 2 (#1489) by shipping the deferred activation runtime from design §6.

- **Unified discovery** — `toolSearch` returns `kind:"skill"` for non-synthetic bundles and promotes member-atom matches to their owning skill (so `task-create` surfaces as `tasks`, not a bare tool without instructions).
- **`skill-activate` tool** — discovery-enabled agents get it alongside `tool-registry`; activation expands member tools into the working toolkit and injects the SKILL.md body mid-turn.
- **Tiered lookup** — Tier 0 pinned (eager, unchanged) → Tier 1 `progress.activeSkills` (wake re-load with relevance filter + cap 5; no-op writes skipped) → Tier 2 discovery when `allow_discovery`.
- **Authority unchanged** — activation never widens `allowed_callers` / `action_risk`; disallowed members land in `skippedTools`. Persistence uses bound task only (no LLM `task_id`).
- Docs (spec 03 + 19) and `CHANGELOG` `[Unreleased]`.

## Design review follow-ups (ee0c0765)

- [x] Skip wake `activeSkills` write when name set unchanged; preserve `activatedAt`
- [x] Remove LLM-facing `task_id` from `skill-activate`
- [x] Runtime tests for mid-turn splice/expansion + wake no-op write
- [x] Tighten relevance to whole-token filter; align spec 03

## Test plan

- [x] `pnpm run typecheck` (+ console typecheck)
- [x] `pnpm run lint`
- [x] Focused unit/runtime tests for activation + wake short-circuit
- [x] `pnpm test` with `DATABASE_URL` on initial implementation (5579 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e0484ff-7673-4878-9b31-209f24f5acd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e0484ff-7673-4878-9b31-209f24f5acd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

