### PR TITLE
feat(skills): Phase 3 imported NL + asset Anthropic skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Imported Anthropic skills** — drop an unmodified `SKILL.md` + `references/` folder; discover/activate with inert scripts warned. (#1490)
 - **Skills-as-bundles** — `SKILL.md` + nested `tools/`; `pinned_skills` expands a bundle to its member tools + instructions; `skill_registry` table. Native bundles: email, ceo-inbox, contacts, autonomy, diagnostics, scheduler, web, memory, learning, context-bridge, executive-profile, setup. (#1489, #1494)
 - **Runtime skill activation & MCP-as-skill** — `toolSearch` returns `kind:"skill"`; `skill-activate` loads a skill's tools + instructions (Tier 1 persists in `progress.activeSkills`); each connected MCP server projects a pinnable skill. (#1494, #1495)
 

--- a/docs/dev/adding-a-tool.md
+++ b/docs/dev/adding-a-tool.md
@@ -6,6 +6,8 @@ Tools are how agents interact with the outside world. Every capability — sendi
 
 See [Adding an Agent](adding-an-agent.md) if you want to create a new agent rather than extend an existing one.
 
+To **import an unmodified Anthropic Agent Skill** (`SKILL.md` + `references/`, no Curia manifest), see [Importing a Skill](importing-a-skill.md).
+
 ---
 
 ## Quick Start

--- a/docs/dev/importing-a-skill.md
+++ b/docs/dev/importing-a-skill.md
@@ -1,0 +1,75 @@
+# Importing an Anthropic Agent Skill
+
+Curia can load an **unmodified** [Anthropic Agent Skill](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) — a folder with `SKILL.md` plus optional `references/` / `assets/` — as a Curia skill bundle. No `tool.json`, no Curia-specific manifest, and no scripts executed (script sandbox is Phase 4).
+
+This is Phase 3 of the tools/skills rework (#1490). Design:
+[`docs/wip/2026-07-16-tools-skills-architecture-design.md`](../wip/2026-07-16-tools-skills-architecture-design.md).
+
+## What you get
+
+| Payload | Behavior |
+|---------|----------|
+| `SKILL.md` (name + description + body) | Discovered and activatable. Body injected on `skill-activate` (or at bootstrap if pinned). |
+| `references/*.md`, `assets/*` | Listed at activation; loaded on demand via `skill-activate({ skill, reference })`. |
+| `scripts/` | **Warned at import, never run.** Instructions + assets still load. |
+
+**Authority containment:** an imported skill cannot expand the activating agent's tool authority. Instructions only steer toward tools the agent already holds (`allowed_callers` / `action_risk` still apply). Imported skills typically declare no tools at all.
+
+## Operator flow (drop folder + enable + restart)
+
+Same install channel as custom deploy skills (`curia-deploy/custom/skills/` or the container `skills/` directory):
+
+1. **Drop** the skill folder onto disk so it sits next to other skills:
+   ```text
+   skills/
+     not-a-lawyer/           # example: https://github.com/maxtremaine/ai-playbook/tree/main/skills/not-a-lawyer
+       SKILL.md
+       references/
+         common-clauses.md
+         drafting-comments.md
+   ```
+2. **Restart** once so discovery sees the folder (it appears in the skill registry as **uninstalled** — imported skills are not auto-enabled; that would be self-enable, a non-goal).
+3. **Install + enable** in the console (**Settings → Skills**) or via the registry API:
+   ```bash
+   curl -X POST -H "Cookie: …" \
+     https://your-host/api/registry/skills/not-a-lawyer/install-enable
+   ```
+4. **Restart again** so the enabled skill is loaded into `SkillRegistry`.
+5. Give a relevant agent access:
+   - **Discoverable (typical):** set `allow_discovery: true` on the agent (e.g. coordinator). It receives `tool-registry` + `skill-activate`.
+   - **Pinned (optional):** add the skill name to `pinned_skills` for always-on instructions.
+
+### Example activation
+
+```text
+tool-registry({ query: "contract review" })
+# → { name: "not-a-lawyer", kind: "skill", … }
+
+skill-activate({ skill: "not-a-lawyer" })
+# → SKILL.md body + list of references/
+
+skill-activate({ skill: "not-a-lawyer", reference: "common-clauses.md" })
+# → loads references/common-clauses.md into the turn
+```
+
+Tiered lookup (pinned → task-active → discovery) and wake persistence are the Phase 3a activation runtime (#1495); imported skills are ordinary consumers of that path.
+
+## Scripts warning
+
+If the folder contains `scripts/`, startup logs a warning such as:
+
+```text
+Imported skill ships a scripts/ directory — scripts are NOT executed (Phase 3). …
+```
+
+The skill still loads. Do not expect `scripts/*.py` (or similar) to run until the Phase 4 sandbox ships.
+
+## Trust model
+
+Anyone who can place files in the container and restart it already has full trust — the same bar as today's custom skills. There is no signing gate, no console upload UI, and no runtime self-install. See design §8.
+
+## Related
+
+- [Adding a Tool](adding-a-tool.md) — authoring native Curia tools (`tool.json` + handler)
+- [Tools & Execution Spec](../specs/03-tools-and-execution.md) — discovery & activation
+- [Configuration → registry](configuration.md#skill-agent-and-channel-registry) — install/enable lifecycle

--- a/docs/dev/importing-a-skill.md
+++ b/docs/dev/importing-a-skill.md
@@ -10,7 +10,7 @@ This is Phase 3 of the tools/skills rework (#1490). Design:
 | Payload | Behavior |
 |---------|----------|
 | `SKILL.md` (name + description + body) | Discovered and activatable. Body injected on `skill-activate` (or at bootstrap if pinned). |
-| `references/*.md`, `assets/*` | Listed at activation; loaded on demand via `skill-activate({ skill, reference })`. |
+| `references/*.md`, `assets/*` | Listed at activation. **Text files** load on demand via `skill-activate({ skill, reference })`; **binary assets** stay listed but are rejected when requested (never injected into context). |
 | `scripts/` | **Warned at import, never run.** Instructions + assets still load. |
 
 **Authority containment:** an imported skill cannot expand the activating agent's tool authority. Instructions only steer toward tools the agent already holds (`allowed_callers` / `action_risk` still apply). Imported skills typically declare no tools at all.

--- a/docs/specs/03-tools-and-execution.md
+++ b/docs/specs/03-tools-and-execution.md
@@ -155,6 +155,21 @@ Activation loads member tools into the working toolkit and injects the skill's `
 body into the turn. It **never widens authority** — member tools still pass `allowed_callers`
 and `action_risk` at invoke time; disallowed members are listed in `skippedTools` and omitted.
 
+### Imported Anthropic skills (Phase 3 / #1490)
+
+An unmodified Anthropic Agent Skill folder (`SKILL.md` + optional `references/` / `assets/` /
+`scripts/`) loads as a skill bundle with **no Curia `tool.json` required**. Operator flow:
+drop the folder into the skills directory, install+enable in the registry, restart. See
+[`docs/dev/importing-a-skill.md`](../dev/importing-a-skill.md).
+
+- **Progressive disclosure:** activation returns the `references` / `assets` index; call
+  `skill-activate({ skill, reference: "…" })` to load one text file into the turn (path-traversal
+  safe; binary assets are rejected).
+- **Scripts:** if `scripts/` is present, startup emits a warning and leaves scripts **inert**
+  (sandbox execution is Phase 4).
+- **Authority:** an imported skill cannot grant tools the activating agent was not already
+  allowed to call — instructions only steer.
+
 When a task is bound, activation also appends the skill to `progress.activeSkills` (MRU,
 capped) so park/resume wakes restore Tier 1.
 

--- a/skills/skill-activate/handler.test.ts
+++ b/skills/skill-activate/handler.test.ts
@@ -136,6 +136,41 @@ describe('skill-activate handler', () => {
     expect(setActiveSkillsBlock).not.toHaveBeenCalled();
   });
 
+  it('loads a reference when `reference` is passed', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const os = await import('node:os');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-activate-ref-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'references'));
+      fs.writeFileSync(path.join(tmp, 'references', 'notes.md'), 'Clause guidance.');
+      const ctx = makeCtx({ input: { skill: 'tasks', reference: 'notes.md' } });
+      ctx.skillRegistry!.register(
+        {
+          name: 'imported-notes',
+          description: 'Imported',
+          tools: [],
+          instructions: 'Use notes.',
+          references: ['notes.md'],
+        },
+        tmp,
+      );
+      const result = await handler.execute({
+        ...ctx,
+        input: { skill: 'imported-notes', reference: 'notes.md' },
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      const data = result.data as {
+        referenceContent?: { path: string; content: string };
+      };
+      expect(data.referenceContent?.path).toBe('references/notes.md');
+      expect(data.referenceContent?.content).toContain('Clause guidance');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('rejects unknown skills', async () => {
     const ctx = makeCtx({ input: { skill: 'nope' } });
     const result = await handler.execute(ctx);

--- a/skills/skill-activate/handler.ts
+++ b/skills/skill-activate/handler.ts
@@ -20,11 +20,12 @@ import { boundTaskFromMetadata } from '../../src/agents/resumable-task.js';
 
 export class SkillActivateHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
-    const input = ctx.input as { skill?: string };
+    const input = ctx.input as { skill?: string; reference?: string };
     const skillName = typeof input.skill === 'string' ? input.skill.trim() : '';
     if (!skillName) {
       return { success: false, error: 'Missing required input: skill (non-empty string)' };
     }
+    const reference = typeof input.reference === 'string' ? input.reference : undefined;
 
     if (!ctx.skillRegistry) {
       return {
@@ -45,6 +46,7 @@ export class SkillActivateHandler implements ToolHandler {
       skillRegistry: ctx.skillRegistry,
       toolRegistry: ctx.toolRegistry,
       agentId,
+      reference,
     });
     if ('error' in resolved) {
       return { success: false, error: resolved.error };

--- a/skills/skill-activate/tool.json
+++ b/skills/skill-activate/tool.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-activate",
-  "description": "Activate a discovered skill (bundle) for this task: load its member tools into your toolkit and inject its SKILL.md instructions. For imported Anthropic skills, pass optional `reference` to load one progressive-disclosure file from references/ or assets/ (e.g. \"common-clauses.md\"). Call after tool-registry returns kind:\"skill\". Activation does not grant new authority — member tools still respect allowed_callers and action_risk. When running on a bound task, the active set is persisted for wake re-load automatically.",
+  "description": "Activate a discovered skill (bundle) for this task: load its member tools into your toolkit and inject its SKILL.md instructions. For imported Anthropic skills, pass optional `reference` to load one text file from references/ or assets/ (e.g. \"common-clauses.md\"); binary assets are listed but cannot be loaded into context. Call after tool-registry returns kind:\"skill\". Activation does not grant new authority — member tools still respect allowed_callers and action_risk. When running on a bound task, the active set is persisted for wake re-load automatically.",
   "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "none",

--- a/skills/skill-activate/tool.json
+++ b/skills/skill-activate/tool.json
@@ -1,17 +1,21 @@
 {
   "name": "skill-activate",
-  "description": "Activate a discovered skill (bundle) for this task: load its member tools into your toolkit and inject its SKILL.md instructions. Call after tool-registry returns a result with kind:\"skill\". Activation does not grant new authority — member tools still respect allowed_callers and action_risk. When running on a bound task, the active set is persisted for wake re-load automatically.",
-  "version": "0.1.0",
+  "description": "Activate a discovered skill (bundle) for this task: load its member tools into your toolkit and inject its SKILL.md instructions. For imported Anthropic skills, pass optional `reference` to load one progressive-disclosure file from references/ or assets/ (e.g. \"common-clauses.md\"). Call after tool-registry returns kind:\"skill\". Activation does not grant new authority — member tools still respect allowed_callers and action_risk. When running on a bound task, the active set is persisted for wake re-load automatically.",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
-    "skill": "string (skill bundle name from tool-registry, e.g. tasks or calendar)"
+    "skill": "string (skill bundle name from tool-registry, e.g. tasks or not-a-lawyer)",
+    "reference": "string? (optional path under references/ or assets/, e.g. common-clauses.md)"
   },
   "outputs": {
     "skill": "string",
     "tools": "array",
     "skippedTools": "array",
-    "instructionsLoaded": "boolean"
+    "instructionsLoaded": "boolean",
+    "references": "array",
+    "assets": "array",
+    "referenceContent": "object?"
   },
   "permissions": [],
   "secrets": [],

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -41,6 +41,7 @@ import {
 import {
   SKILL_ACTIVATE_TOOL_NAME,
   formatActivatedSkillInstructionBlock,
+  formatSkillReferenceBlock,
   parseSkillActivationProtocol,
   selectActiveSkillsForWake,
 } from '../skills/skill-activation.js';
@@ -522,7 +523,11 @@ export class AgentRuntime {
           if (newNames.length > 0) {
             workingToolDefs.push(...executionLayer.getToolDefinitions(newNames));
           }
-          const block = formatActivatedSkillInstructionBlock(resolved.skill, resolved.instructions);
+          const block = formatActivatedSkillInstructionBlock(
+            resolved.skill,
+            resolved.instructions,
+            { references: resolved.references, assets: resolved.assets },
+          );
           if (block) instructionBlocks.push(block);
         }
         for (const block of instructionBlocks) {
@@ -1268,7 +1273,8 @@ export class AgentRuntime {
             }
           }
 
-          // Skill activation (#1495): expand member tools + inject SKILL.md instructions
+          // Skill activation (#1495/#1490): expand member tools + inject SKILL.md
+          // instructions (and optional progressive-disclosure reference content)
           // into the in-flight turn. Durable persistence is handled by skill-activate itself.
           if (toolCall.name === SKILL_ACTIVATE_TOOL_NAME && workingToolDefs) {
             try {
@@ -1285,14 +1291,28 @@ export class AgentRuntime {
                 const instructionBlock = formatActivatedSkillInstructionBlock(
                   activation.skill,
                   activation.instructions,
+                  { references: activation.references, assets: activation.assets },
                 );
+                const insertAt = messages.findIndex(m => m.role !== 'system') === -1
+                  ? messages.length
+                  : Math.max(1, messages.findIndex(m => m.role !== 'system'));
+                let spliceAt = insertAt;
                 if (instructionBlock) {
                   // Inject after the system prompt so subsequent LLM rounds see the
                   // discipline block (mirrors Bullpen mid-turn system-message splice).
-                  const insertAt = messages.findIndex(m => m.role !== 'system') === -1
-                    ? messages.length
-                    : Math.max(1, messages.findIndex(m => m.role !== 'system'));
-                  messages.splice(insertAt, 0, { role: 'system', content: instructionBlock });
+                  messages.splice(spliceAt, 0, { role: 'system', content: instructionBlock });
+                  spliceAt += 1;
+                }
+                if (activation.referenceContent) {
+                  messages.splice(spliceAt, 0, {
+                    role: 'system',
+                    content: formatSkillReferenceBlock(
+                      activation.skill,
+                      activation.referenceContent.path,
+                      activation.referenceContent.content,
+                      activation.referenceContent.truncated,
+                    ),
+                  });
                 }
                 logger.info(
                   {
@@ -1301,6 +1321,9 @@ export class AgentRuntime {
                     addedTools: newNames,
                     instructionsLoaded: activation.instructions.length > 0,
                     skippedTools: activation.skippedTools,
+                    references: activation.references.length,
+                    assets: activation.assets.length,
+                    referenceLoaded: activation.referenceContent?.path,
                   },
                   'Activated skill for task turn',
                 );

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -40,6 +40,7 @@ import {
 } from './planned-task.js';
 import {
   SKILL_ACTIVATE_TOOL_NAME,
+  buildSkillActivationAck,
   formatActivatedSkillInstructionBlock,
   formatSkillReferenceBlock,
   parseSkillActivationProtocol,
@@ -1240,6 +1241,12 @@ export class AgentRuntime {
           // Success: reset consecutive error counter
           budget.consecutiveErrors = 0;
 
+          // When a tool result is (partly) re-emitted into the turn by the runtime
+          // — e.g. skill-activate, whose instructions/reference bodies are spliced
+          // as system messages below — the generic tool_result JSON is slimmed to a
+          // metadata-only acknowledgement so the payload is not injected twice (#1505).
+          let toolResultOverride: string | undefined;
+
           // Dynamic tool-list expansion: when tool-registry returns successfully,
           // append discovered kind:'tool' atoms to the working list. kind:'skill'
           // results require skill-activate (instructions + member tools together).
@@ -1327,6 +1334,10 @@ export class AgentRuntime {
                   },
                   'Activated skill for task turn',
                 );
+                // Instructions + reference content are now in the turn as system
+                // messages; slim the tool_result to metadata so they aren't injected
+                // a second time via the generic JSON stringify below (#1505).
+                toolResultOverride = JSON.stringify(buildSkillActivationAck(activation));
               }
             } catch (err) {
               logger.warn({ err, agentId }, 'Failed to apply skill-activate result to working tool list');
@@ -1409,7 +1420,8 @@ export class AgentRuntime {
             }
           }
 
-          const resultContent = typeof result.data === 'string' ? result.data : JSON.stringify(result.data);
+          const resultContent = toolResultOverride
+            ?? (typeof result.data === 'string' ? result.data : JSON.stringify(result.data));
           toolResultBlocks.push({
             type: 'tool_result',
             tool_use_id: toolCall.id,

--- a/src/skills/pin-resolution.ts
+++ b/src/skills/pin-resolution.ts
@@ -11,6 +11,7 @@
 import type { SkillRegistry } from './skill-registry.js';
 import type { ToolRegistry } from './registry.js';
 import type { Logger } from '../logger.js';
+import { formatActivatedSkillInstructionBlock } from './skill-instruction-format.js';
 
 export type PinReferentKind = 'skill' | 'tool';
 
@@ -72,8 +73,22 @@ export function resolvePinnedSkills(
       resolvedSkills.push(pin);
       resolvedPins.push({ pin, kind: 'skill' });
       for (const t of skill.manifest.tools) pushTool(t, pin);
-      const body = skill.manifest.instructions.trim();
-      if (body) instructionBlocks.push(body);
+      // Prefer the shared formatter when the skill has progressive-disclosure
+      // files so pinned imports get the references index. Native instruction
+      // blocks without references stay as the raw body (no activation wrapper).
+      const refs = skill.manifest.references ?? [];
+      const assets = skill.manifest.assets ?? [];
+      if (refs.length > 0 || assets.length > 0) {
+        const block = formatActivatedSkillInstructionBlock(
+          skill.manifest.name,
+          skill.manifest.instructions,
+          { references: refs, assets },
+        );
+        if (block) instructionBlocks.push(block);
+      } else {
+        const body = skill.manifest.instructions.trim();
+        if (body) instructionBlocks.push(body);
+      }
       if (skill.manifest.heartbeat) heartbeatEligible = true;
       if (skill.manifest.document_workspace) documentWorkspaceEnabled = true;
       if (!skill.synthetic) {

--- a/src/skills/skill-activation.ts
+++ b/src/skills/skill-activation.ts
@@ -17,6 +17,12 @@ import {
   type ActiveSkillEntry,
 } from '../db/active-skills-progress.js';
 import { appendSkillInstructions } from './pin-resolution.js';
+import { readSkillResource } from './skill-resources.js';
+
+export {
+  formatActivatedSkillInstructionBlock,
+  formatSkillReferenceBlock,
+} from './skill-instruction-format.js';
 
 export const SKILL_ACTIVATE_TOOL_NAME = 'skill-activate';
 export const SKILL_ACTIVATION_PROTOCOL = 'skill_activation' as const;
@@ -35,6 +41,19 @@ export interface SkillActivationResult {
   skippedTools: string[];
   /** SKILL.md body (may be empty for instruction-light bundles). */
   instructions: string;
+  /** Progressive-disclosure files under references/ (Phase 3). */
+  references: string[];
+  /** Progressive-disclosure files under assets/ (Phase 3). */
+  assets: string[];
+  /**
+   * When skill-activate was called with `reference`, the loaded file payload.
+   * Absent on plain activation.
+   */
+  referenceContent?: {
+    path: string;
+    content: string;
+    truncated: boolean;
+  };
 }
 
 export interface SkillActivationFailure {
@@ -124,14 +143,19 @@ export function agentMayCallTool(
 /**
  * Resolve activation of a skill for an agent. Does not mutate registries.
  * Synthetic skills cannot be activated (they are pin-resolution shims only).
+ *
+ * Optional `reference` loads one progressive-disclosure file from the skill's
+ * `references/` or `assets/` tree (Phase 3). Activation never widens authority.
  */
 export function resolveSkillActivation(options: {
   skillName: string;
   skillRegistry: SkillRegistry;
   toolRegistry: ToolRegistry;
   agentId: string;
+  /** Optional reference/asset path to load into context (Phase 3). */
+  reference?: string;
 }): SkillActivationResult | SkillActivationFailure {
-  const { skillName, skillRegistry, toolRegistry, agentId } = options;
+  const { skillName, skillRegistry, toolRegistry, agentId, reference } = options;
   const name = skillName.trim();
   if (!name) return { error: 'skill name is required' };
 
@@ -155,11 +179,31 @@ export function resolveSkillActivation(options: {
     }
   }
 
+  const references = skill.manifest.references ?? [];
+  const assets = skill.manifest.assets ?? [];
+
+  let referenceContent: SkillActivationResult['referenceContent'];
+  if (reference !== undefined && reference.trim() !== '') {
+    if (!skill.dir) {
+      return { error: `Skill '${name}' has no on-disk directory — cannot load references` };
+    }
+    const read = readSkillResource(skill.dir, reference, { references, assets });
+    if (!read.ok) return { error: read.error };
+    referenceContent = {
+      path: read.path,
+      content: read.content,
+      truncated: read.truncated,
+    };
+  }
+
   return {
     skill: skill.manifest.name,
     tools,
     skippedTools,
     instructions: skill.manifest.instructions.trim(),
+    references: [...references],
+    assets: [...assets],
+    referenceContent,
   };
 }
 
@@ -228,16 +272,6 @@ function intersectsTokens(a: Set<string>, b: Set<string>): boolean {
   return false;
 }
 
-/** Format a system-message block for a lazily activated skill's instructions. */
-export function formatActivatedSkillInstructionBlock(
-  skillName: string,
-  instructions: string,
-): string | null {
-  const body = instructions.trim();
-  if (!body) return null;
-  return `[Activated skill: ${skillName}]\n\n${body}`;
-}
-
 /** Apply multiple instruction blocks onto a system prompt (pinned path reuse). */
 export function applyActivatedSkillInstructions(
   systemPrompt: string,
@@ -250,14 +284,20 @@ export function applyActivatedSkillInstructions(
 export function buildSkillActivationProtocol(
   result: SkillActivationResult,
 ): Record<string, unknown> {
-  return {
+  const payload: Record<string, unknown> = {
     _curia_protocol: SKILL_ACTIVATION_PROTOCOL,
     skill: result.skill,
     tools: result.tools,
     skippedTools: result.skippedTools,
     instructions: result.instructions,
     instructionsLoaded: result.instructions.length > 0,
+    references: result.references,
+    assets: result.assets,
   };
+  if (result.referenceContent) {
+    payload.referenceContent = result.referenceContent;
+  }
+  return payload;
 }
 
 /** Parse a skill-activate tool result; null when not an activation protocol payload. */
@@ -271,11 +311,37 @@ export function parseSkillActivationProtocol(data: unknown): SkillActivationResu
     ? obj.skippedTools.filter((t): t is string => typeof t === 'string')
     : [];
   const instructions = typeof obj.instructions === 'string' ? obj.instructions : '';
+  const references = Array.isArray(obj.references)
+    ? obj.references.filter((t): t is string => typeof t === 'string')
+    : [];
+  const assets = Array.isArray(obj.assets)
+    ? obj.assets.filter((t): t is string => typeof t === 'string')
+    : [];
+
+  let referenceContent: SkillActivationResult['referenceContent'];
+  if (obj.referenceContent && typeof obj.referenceContent === 'object' && !Array.isArray(obj.referenceContent)) {
+    const rc = obj.referenceContent as Record<string, unknown>;
+    if (
+      typeof rc.path === 'string' &&
+      typeof rc.content === 'string' &&
+      typeof rc.truncated === 'boolean'
+    ) {
+      referenceContent = {
+        path: rc.path,
+        content: rc.content,
+        truncated: rc.truncated,
+      };
+    }
+  }
+
   return {
     skill: obj.skill.trim(),
     tools: obj.tools as string[],
     skippedTools,
     instructions,
+    references,
+    assets,
+    referenceContent,
   };
 }
 

--- a/src/skills/skill-activation.ts
+++ b/src/skills/skill-activation.ts
@@ -300,6 +300,40 @@ export function buildSkillActivationProtocol(
   return payload;
 }
 
+/**
+ * Slim acknowledgement for the skill-activate *tool result* (#1505 review).
+ *
+ * The runtime splices the SKILL.md `instructions` and any loaded
+ * `referenceContent.content` into the turn as their own `system` messages, so
+ * echoing those bodies back inside the generic `tool_result` JSON would inject
+ * each one twice. For a size-capped reference file that doubles its context
+ * cost and can push an otherwise-budgeted turn over the provider limit. Keep
+ * only metadata here (skill, tools, listings, and the reference path/truncated
+ * flag) — the actual content reaches the LLM via the spliced system messages.
+ */
+export function buildSkillActivationAck(
+  activation: SkillActivationResult,
+): Record<string, unknown> {
+  const ack: Record<string, unknown> = {
+    _curia_protocol: SKILL_ACTIVATION_PROTOCOL,
+    skill: activation.skill,
+    tools: activation.tools,
+    skippedTools: activation.skippedTools,
+    instructionsLoaded: activation.instructions.length > 0,
+    references: activation.references,
+    assets: activation.assets,
+  };
+  if (activation.referenceContent) {
+    // Path + truncated flag only; the content is in the spliced system message.
+    ack.referenceContent = {
+      path: activation.referenceContent.path,
+      truncated: activation.referenceContent.truncated,
+      loaded: true,
+    };
+  }
+  return ack;
+}
+
 /** Parse a skill-activate tool result; null when not an activation protocol payload. */
 export function parseSkillActivationProtocol(data: unknown): SkillActivationResult | null {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return null;

--- a/src/skills/skill-instruction-format.ts
+++ b/src/skills/skill-instruction-format.ts
@@ -1,0 +1,48 @@
+// skill-instruction-format.ts — format SKILL.md / reference blocks for prompts.
+//
+// Kept separate from skill-activation.ts and pin-resolution.ts to avoid a
+// circular import (both call sites need the same progressive-disclosure footer).
+
+/** Format a system-message block for a lazily activated skill's instructions. */
+export function formatActivatedSkillInstructionBlock(
+  skillName: string,
+  instructions: string,
+  opts?: { references?: readonly string[]; assets?: readonly string[] },
+): string | null {
+  const body = instructions.trim();
+  const refs = opts?.references ?? [];
+  const assets = opts?.assets ?? [];
+  if (!body && refs.length === 0 && assets.length === 0) return null;
+
+  const parts: string[] = [`[Activated skill: ${skillName}]`];
+  if (body) parts.push('', body);
+  if (refs.length > 0 || assets.length > 0) {
+    parts.push('');
+    parts.push('## Available progressive-disclosure files');
+    parts.push(
+      'Load a file on demand with skill-activate({ skill: "' +
+        skillName +
+        '", reference: "<path>" }). Prefer bare filenames from the lists below.',
+    );
+    if (refs.length > 0) {
+      parts.push('', 'references/:');
+      for (const r of refs) parts.push(`- ${r}`);
+    }
+    if (assets.length > 0) {
+      parts.push('', 'assets/:');
+      for (const a of assets) parts.push(`- ${a}`);
+    }
+  }
+  return parts.join('\n');
+}
+
+/** Format a system-message block for a loaded skill reference/asset. */
+export function formatSkillReferenceBlock(
+  skillName: string,
+  resourcePath: string,
+  content: string,
+  truncated: boolean,
+): string {
+  const truncNote = truncated ? '\n\n[truncated — file exceeded size cap]' : '';
+  return `[Skill resource: ${skillName} → ${resourcePath}]\n\n${content}${truncNote}`;
+}

--- a/src/skills/skill-loader.ts
+++ b/src/skills/skill-loader.ts
@@ -4,14 +4,20 @@
 // Flat skills/<atom>/tool.json dirs remain valid standalone tools; orphans become
 // synthetic singleton skills after tools + MCP projections are loaded
 // (see registerSyntheticSingletonSkills).
+//
+// Phase 3 (#1490): unmodified Anthropic Agent Skills (SKILL.md + references/,
+// optional assets/, optional inert scripts/) load as instruction-only bundles
+// with no Curia tool.json required.
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { parseSkillMd } from './skill-md.js';
+import { discoverSkillResources } from './skill-resources.js';
 import type { SkillDiscovery, SkillManifest } from './skill-types.js';
 import type { SkillRegistry } from './skill-registry.js';
 import type { ToolRegistry } from './registry.js';
 import type { Logger } from '../logger.js';
+
 /** Discover SKILL.md bundles under skillsDir (immediate children only). */
 export function discoverSkillManifests(skillsDir: string, logger?: Logger): SkillDiscovery[] {
   if (!fs.existsSync(skillsDir)) {
@@ -64,12 +70,31 @@ export function discoverSkillManifests(skillsDir: string, logger?: Logger): Skil
         );
       }
 
+      const resources = discoverSkillResources(dir);
+      if (resources.hasScripts) {
+        // Phase 3: scripts are inert. Warn loudly so operators know why
+        // `scripts/foo.py` referenced from SKILL.md will not run until Phase 4.
+        logger?.warn(
+          {
+            skill: parsed.name,
+            dir,
+            scriptsDir: path.join(dir, 'scripts'),
+          },
+          'Imported skill ships a scripts/ directory — scripts are NOT executed ' +
+            '(Phase 3). Instructions and references/assets still load; sandboxed ' +
+            'script execution is Phase 4.',
+        );
+      }
+
       const manifest: SkillManifest = {
         name: parsed.name,
         description: parsed.description,
         version: parsed.version,
         tools,
         instructions: parsed.instructions,
+        references: resources.references.length > 0 ? resources.references : undefined,
+        assets: resources.assets.length > 0 ? resources.assets : undefined,
+        hasScripts: resources.hasScripts || undefined,
         heartbeat: parsed.heartbeat,
         document_workspace: parsed.document_workspace,
       };
@@ -85,6 +110,9 @@ export function discoverSkillManifests(skillsDir: string, logger?: Logger): Skil
           tools: [...manifest.tools],
           heartbeat: manifest.heartbeat,
           documentWorkspace: manifest.document_workspace,
+          references: manifest.references,
+          assets: manifest.assets,
+          hasScripts: manifest.hasScripts,
         },
       });
     } catch (err) {
@@ -145,7 +173,14 @@ export function loadSkillsFromDiscovery(
     }
     registry.register(disc.manifest, disc.dir);
     logger.info(
-      { skill: disc.manifest.name, tools: disc.manifest.tools.length, version: disc.manifest.version },
+      {
+        skill: disc.manifest.name,
+        tools: disc.manifest.tools.length,
+        version: disc.manifest.version,
+        references: disc.manifest.references?.length ?? 0,
+        assets: disc.manifest.assets?.length ?? 0,
+        hasScripts: disc.manifest.hasScripts === true,
+      },
       'Skill bundle loaded',
     );
     loaded++;

--- a/src/skills/skill-md.ts
+++ b/src/skills/skill-md.ts
@@ -3,7 +3,7 @@
 // Required Anthropic fields: name, description.
 // Curia extensions (native skills): version, tools, heartbeat, document_workspace.
 // Extra unknown frontmatter keys are ignored so unmodified Anthropic skills can
-// load later (Phase 3) without failing on license/compatibility/metadata/etc.
+// load (Phase 3 / #1490) without failing on license/compatibility/metadata/etc.
 
 import * as yaml from 'js-yaml';
 

--- a/src/skills/skill-resources.ts
+++ b/src/skills/skill-resources.ts
@@ -18,8 +18,13 @@ export type SkillResourceKind = (typeof SKILL_RESOURCE_KINDS)[number];
 
 const TEXT_EXTENSIONS = new Set([
   '.md', '.txt', '.json', '.yaml', '.yml', '.csv', '.tsv', '.xml', '.html',
-  '.css', '.js', '.ts', '.py', '.sh', '.toml', '.ini', '.cfg', '.env.example',
+  '.css', '.js', '.ts', '.py', '.sh', '.toml', '.ini', '.cfg',
 ]);
+
+// Text files whose real "extension" fools path.extname — e.g. it returns
+// '.example' for '.env.example', so an extension entry would never match.
+// Matched by full (lowercased) basename instead.
+const TEXT_BASENAMES = new Set(['.env.example']);
 
 export interface SkillResourceLists {
   references: string[];
@@ -121,8 +126,9 @@ export function readSkillResource(
     return { ok: false, error: 'Invalid skill resource path (symlink escape)' };
   }
 
+  const base = path.basename(realFile).toLowerCase();
   const ext = path.extname(realFile).toLowerCase();
-  if (ext && !TEXT_EXTENSIONS.has(ext)) {
+  if (ext && !TEXT_EXTENSIONS.has(ext) && !TEXT_BASENAMES.has(base)) {
     return {
       ok: false,
       error:

--- a/src/skills/skill-resources.ts
+++ b/src/skills/skill-resources.ts
@@ -1,0 +1,184 @@
+// skill-resources.ts — Phase 3 (#1490) progressive disclosure for imported skills.
+//
+// Anthropic Agent Skills ship optional `references/` and `assets/` trees that
+// the model loads on demand after SKILL.md activation. This module lists those
+// files at import time and safely reads a single text file into context.
+//
+// Scripts (`scripts/`) are detected elsewhere and never executed here (Phase 4).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Max bytes returned for a single reference/asset read (keeps context bounded). */
+export const SKILL_RESOURCE_MAX_BYTES = 64 * 1024;
+
+/** Subdirs that may be listed / read as progressive-disclosure payloads. */
+export const SKILL_RESOURCE_KINDS = ['references', 'assets'] as const;
+export type SkillResourceKind = (typeof SKILL_RESOURCE_KINDS)[number];
+
+const TEXT_EXTENSIONS = new Set([
+  '.md', '.txt', '.json', '.yaml', '.yml', '.csv', '.tsv', '.xml', '.html',
+  '.css', '.js', '.ts', '.py', '.sh', '.toml', '.ini', '.cfg', '.env.example',
+]);
+
+export interface SkillResourceLists {
+  references: string[];
+  assets: string[];
+  hasScripts: boolean;
+}
+
+/**
+ * Walk `references/` and `assets/` (non-recursive beyond one level of nesting
+ * is fine — Anthropic skills usually keep a flat references/ list; we allow
+ * one nested directory so `references/foo/bar.md` still works). Detect
+ * `scripts/` presence without reading its contents.
+ */
+export function discoverSkillResources(skillDir: string): SkillResourceLists {
+  return {
+    references: listResourceFiles(skillDir, 'references'),
+    assets: listResourceFiles(skillDir, 'assets'),
+    hasScripts: fs.existsSync(path.join(skillDir, 'scripts'))
+      && fs.statSync(path.join(skillDir, 'scripts')).isDirectory(),
+  };
+}
+
+function listResourceFiles(skillDir: string, kind: SkillResourceKind): string[] {
+  const root = path.join(skillDir, kind);
+  if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) return [];
+  const out: string[] = [];
+  walk(root, root, out);
+  out.sort((a, b) => a.localeCompare(b));
+  return out;
+}
+
+function walk(absDir: string, root: string, out: string[]): void {
+  for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const abs = path.join(absDir, entry.name);
+    if (entry.isDirectory()) {
+      walk(abs, root, out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const rel = path.relative(root, abs).split(path.sep).join('/');
+    out.push(rel);
+  }
+}
+
+export type SkillResourceReadResult =
+  | { ok: true; kind: SkillResourceKind; path: string; content: string; truncated: boolean }
+  | { ok: false; error: string };
+
+/**
+ * Resolve and read a reference/asset path for an activated skill.
+ *
+ * `requested` may be:
+ *   - `common-clauses.md` (ambiguous — try references/ then assets/)
+ *   - `references/common-clauses.md`
+ *   - `assets/template.txt`
+ *
+ * Path traversal (`..`, absolute paths, symlinks escaping the skill dir) is rejected.
+ */
+export function readSkillResource(
+  skillDir: string,
+  requested: string,
+  lists: { references: readonly string[]; assets: readonly string[] },
+): SkillResourceReadResult {
+  const trimmed = requested.trim();
+  if (!trimmed) return { ok: false, error: 'reference path is required' };
+
+  const resolved = resolveResourceRequest(trimmed, lists);
+  if (!resolved) {
+    return {
+      ok: false,
+      error:
+        `Unknown skill resource '${trimmed}'. ` +
+        `Use a path from the skill's references/ or assets/ listing.`,
+    };
+  }
+
+  const absSkill = path.resolve(skillDir);
+  if (!absSkill || !fs.existsSync(absSkill)) {
+    return { ok: false, error: `Skill directory is missing: ${skillDir}` };
+  }
+
+  const absFile = path.resolve(absSkill, resolved.kind, resolved.rel);
+  // Containment: resolved path must stay under skillDir/<kind>/
+  const absKindRoot = path.resolve(absSkill, resolved.kind);
+  if (!absFile.startsWith(absKindRoot + path.sep) && absFile !== absKindRoot) {
+    return { ok: false, error: 'Invalid skill resource path' };
+  }
+
+  let realFile: string;
+  let realSkill: string;
+  try {
+    realFile = fs.realpathSync(absFile);
+    realSkill = fs.realpathSync(absSkill);
+  } catch {
+    return { ok: false, error: `Skill resource not found: ${resolved.kind}/${resolved.rel}` };
+  }
+  if (!realFile.startsWith(realSkill + path.sep)) {
+    return { ok: false, error: 'Invalid skill resource path (symlink escape)' };
+  }
+
+  const ext = path.extname(realFile).toLowerCase();
+  if (ext && !TEXT_EXTENSIONS.has(ext)) {
+    return {
+      ok: false,
+      error:
+        `Skill resource '${resolved.kind}/${resolved.rel}' is not a text file ` +
+        `(extension '${ext}'). Binary assets are not loaded into context in Phase 3.`,
+    };
+  }
+
+  const stat = fs.statSync(realFile);
+  if (!stat.isFile()) {
+    return { ok: false, error: `Skill resource is not a file: ${resolved.kind}/${resolved.rel}` };
+  }
+
+  const buf = fs.readFileSync(realFile);
+  const truncated = buf.byteLength > SKILL_RESOURCE_MAX_BYTES;
+  const slice = truncated ? buf.subarray(0, SKILL_RESOURCE_MAX_BYTES) : buf;
+  const content = slice.toString('utf-8');
+
+  return {
+    ok: true,
+    kind: resolved.kind,
+    path: `${resolved.kind}/${resolved.rel}`,
+    content,
+    truncated,
+  };
+}
+
+function resolveResourceRequest(
+  requested: string,
+  lists: { references: readonly string[]; assets: readonly string[] },
+): { kind: SkillResourceKind; rel: string } | null {
+  // Normalize separators; reject absolute / parent segments early.
+  const normalized = requested.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (
+    normalized.startsWith('/') ||
+    normalized.includes('\0') ||
+    normalized.split('/').some((p) => p === '..' || p === '')
+  ) {
+    return null;
+  }
+
+  for (const kind of SKILL_RESOURCE_KINDS) {
+    const prefix = `${kind}/`;
+    if (normalized.startsWith(prefix)) {
+      const rel = normalized.slice(prefix.length);
+      if (lists[kind].includes(rel)) return { kind, rel };
+      return null;
+    }
+  }
+
+  // Bare filename: prefer references/, then assets/.
+  if (lists.references.includes(normalized)) {
+    return { kind: 'references', rel: normalized };
+  }
+  if (lists.assets.includes(normalized)) {
+    return { kind: 'assets', rel: normalized };
+  }
+  return null;
+}

--- a/src/skills/skill-types.ts
+++ b/src/skills/skill-types.ts
@@ -10,15 +10,31 @@ export interface SkillManifest {
   name: string;
   /** Discovery / pin description. */
   description: string;
-  /** Semver for native skills; optional for future imported Anthropic skills. */
+  /** Semver for native skills; optional for imported Anthropic skills. */
   version?: string;
   /**
    * Member tool names. When omitted at parse time, the loader fills this from
    * the skill's `tools/` subdirectories (manifest.name of each tool.json).
+   * Imported Anthropic skills (NL + assets) typically have an empty list.
    */
   tools: string[];
   /** Markdown body after frontmatter — injected into the agent prompt when pinned. */
   instructions: string;
+  /**
+   * Relative paths under `references/` (progressive disclosure, Phase 3).
+   * Listed at activation; loaded on demand via skill-activate `reference`.
+   */
+  references?: string[];
+  /**
+   * Relative paths under `assets/` (templates / static files, Phase 3).
+   * Same on-demand read path as references.
+   */
+  assets?: string[];
+  /**
+   * True when a `scripts/` directory is present. Scripts are never executed in
+   * Phase 3 — import emits a warning and leaves them inert until Phase 4.
+   */
+  hasScripts?: boolean;
   /**
    * When true, agents that pin this skill are heartbeat-eligible (BacklogHeartbeat
    * may wake them for ready tasks). Replaces `enable_task_management`.
@@ -54,6 +70,10 @@ export interface SkillDiscovery {
     tools: string[];
     heartbeat?: boolean;
     documentWorkspace?: boolean;
+    /** Present when references/ or assets/ were discovered (imported NL+asset skills). */
+    references?: string[];
+    assets?: string[];
+    hasScripts?: boolean;
   } | null;
   error?: string;
   dir: string;

--- a/tests/fixtures/imported-skills/not-a-lawyer/SKILL.md
+++ b/tests/fixtures/imported-skills/not-a-lawyer/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: not-a-lawyer
+description: >
+  Review legal agreements from the company's perspective, flag risks, compare
+  against the company's boilerplate, and help draft comments or redlines. Use
+  whenever the user wants a contract reviewed, asks "what are the risks", pastes
+  an agreement, or asks for help responding to legal pushback. Do not use for
+  legal questions unrelated to a specific document.
+metadata:
+  author: Test Fixture
+  license: CC BY 4.0
+---
+
+# Not a Lawyer
+
+This skill helps review legal agreements from the company's perspective.
+
+## Step 1: Establish context
+
+Confirm company, document type, counterparty, whose paper, and the user's goal
+before analyzing.
+
+## Step 2: Produce the risk review
+
+See `references/common-clauses.md` for preferred positions and
+`references/drafting-comments.md` for tone guidance when drafting comments.

--- a/tests/fixtures/imported-skills/not-a-lawyer/references/common-clauses.md
+++ b/tests/fixtures/imported-skills/not-a-lawyer/references/common-clauses.md
@@ -1,0 +1,8 @@
+# Common clauses (fixture)
+
+Preferred company-side positions for testing progressive disclosure.
+
+## Limitation of liability
+
+Prefer a mutual cap tied to fees paid in the prior 12 months, with standard
+carve-outs for IP infringement, confidentiality breach, and willful misconduct.

--- a/tests/fixtures/imported-skills/not-a-lawyer/references/drafting-comments.md
+++ b/tests/fixtures/imported-skills/not-a-lawyer/references/drafting-comments.md
@@ -1,0 +1,4 @@
+# Drafting comments (fixture)
+
+Tone: collegial-but-firm. Address the other lawyer directly. Lead with the
+business rationale, then propose replacement language.

--- a/tests/fixtures/imported-skills/not-a-lawyer/scripts/analyze.py
+++ b/tests/fixtures/imported-skills/not-a-lawyer/scripts/analyze.py
@@ -1,0 +1,2 @@
+# placeholder — scripts are inert in Phase 3
+print("should never run")

--- a/tests/fixtures/imported-skills/with-scripts/SKILL.md
+++ b/tests/fixtures/imported-skills/with-scripts/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: with-scripts
+description: Minimal imported skill that ships scripts (for import-time warning tests).
+---
+
+# With Scripts
+
+Body only. Scripts must remain inert.

--- a/tests/fixtures/imported-skills/with-scripts/scripts/run.py
+++ b/tests/fixtures/imported-skills/with-scripts/scripts/run.py
@@ -1,0 +1,1 @@
+print("inert")

--- a/tests/unit/skills/imported-skills.test.ts
+++ b/tests/unit/skills/imported-skills.test.ts
@@ -1,0 +1,320 @@
+// Phase 3 (#1490) — imported NL + asset skills (Anthropic Agent Skill format).
+// Fixture modelled on https://github.com/maxtremaine/ai-playbook/tree/main/skills/not-a-lawyer
+
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { discoverSkillManifests, loadSkillsFromDiscovery } from '../../../src/skills/skill-loader.js';
+import { SkillRegistry } from '../../../src/skills/skill-registry.js';
+import { ToolRegistry } from '../../../src/skills/registry.js';
+import type { ToolManifest } from '../../../src/skills/types.js';
+import {
+  resolveSkillActivation,
+  unifiedToolSearch,
+  formatActivatedSkillInstructionBlock,
+  formatSkillReferenceBlock,
+  buildSkillActivationProtocol,
+  parseSkillActivationProtocol,
+  selectActiveSkillsForWake,
+} from '../../../src/skills/skill-activation.js';
+import {
+  discoverSkillResources,
+  readSkillResource,
+  SKILL_RESOURCE_MAX_BYTES,
+} from '../../../src/skills/skill-resources.js';
+import { activateSkillInBlock } from '../../../src/db/active-skills-progress.js';
+import { parseSkillMd } from '../../../src/skills/skill-md.js';
+
+const FIXTURES = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../fixtures/imported-skills',
+);
+const NOT_A_LAWYER = path.join(FIXTURES, 'not-a-lawyer');
+
+function silentLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  };
+}
+
+function toolManifest(name: string, opts: { allowed_callers?: string[] } = {}): ToolManifest {
+  return {
+    name,
+    description: `Tool ${name}`,
+    version: '0.1.0',
+    action_risk: 'none',
+    sensitivity: 'normal',
+    permissions: [],
+    secrets: [],
+    timeout: 30000,
+    inputs: {},
+    outputs: {},
+    allowed_callers: opts.allowed_callers,
+  };
+}
+
+const noopHandler = { execute: async () => ({ success: true as const, data: {} }) };
+
+describe('imported Anthropic SKILL.md (not-a-lawyer fixture)', () => {
+  it('parses unmodified Anthropic frontmatter (nested metadata ignored)', () => {
+    const raw = fs.readFileSync(path.join(NOT_A_LAWYER, 'SKILL.md'), 'utf-8');
+    const parsed = parseSkillMd(raw, 'not-a-lawyer/SKILL.md');
+    expect(parsed.name).toBe('not-a-lawyer');
+    expect(parsed.description).toMatch(/legal agreements/i);
+    expect(parsed.tools).toBeUndefined();
+    expect(parsed.instructions).toContain('Not a Lawyer');
+    expect(parsed.instructions).toContain('references/common-clauses.md');
+  });
+
+  it('discovers references + scripts without requiring tool.json', () => {
+    const logger = silentLogger();
+    const discoveries = discoverSkillManifests(FIXTURES, logger as never);
+    const nal = discoveries.find((d) => d.name === 'not-a-lawyer');
+    expect(nal?.metadata).not.toBeNull();
+    expect(nal?.manifest?.tools).toEqual([]);
+    expect(nal?.manifest?.references).toEqual([
+      'common-clauses.md',
+      'drafting-comments.md',
+    ]);
+    expect(nal?.manifest?.hasScripts).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ skill: 'not-a-lawyer' }),
+      expect.stringContaining('scripts are NOT executed'),
+    );
+  });
+
+  it('loads an instruction-only imported skill into SkillRegistry', () => {
+    const logger = silentLogger();
+    const discoveries = discoverSkillManifests(FIXTURES, logger as never);
+    const registry = new SkillRegistry();
+    const count = loadSkillsFromDiscovery(
+      discoveries,
+      registry,
+      logger as never,
+      new Set(['not-a-lawyer']),
+    );
+    expect(count).toBe(1);
+    const skill = registry.get('not-a-lawyer');
+    expect(skill).toBeDefined();
+    expect(skill!.manifest.tools).toEqual([]);
+    expect(skill!.manifest.references).toHaveLength(2);
+    expect(skill!.synthetic).toBeUndefined();
+  });
+});
+
+describe('discoverSkillResources / readSkillResource', () => {
+  it('lists references and detects scripts/', () => {
+    const lists = discoverSkillResources(NOT_A_LAWYER);
+    expect(lists.references).toContain('common-clauses.md');
+    expect(lists.assets).toEqual([]);
+    expect(lists.hasScripts).toBe(true);
+  });
+
+  it('reads a reference by bare name and by references/ prefix', () => {
+    const lists = discoverSkillResources(NOT_A_LAWYER);
+    const bare = readSkillResource(NOT_A_LAWYER, 'common-clauses.md', lists);
+    expect(bare.ok).toBe(true);
+    if (!bare.ok) return;
+    expect(bare.path).toBe('references/common-clauses.md');
+    expect(bare.content).toContain('Limitation of liability');
+
+    const prefixed = readSkillResource(NOT_A_LAWYER, 'references/drafting-comments.md', lists);
+    expect(prefixed.ok).toBe(true);
+    if (!prefixed.ok) return;
+    expect(prefixed.content).toContain('collegial-but-firm');
+  });
+
+  it('rejects path traversal and unknown paths', () => {
+    const lists = discoverSkillResources(NOT_A_LAWYER);
+    expect(readSkillResource(NOT_A_LAWYER, '../SKILL.md', lists).ok).toBe(false);
+    expect(readSkillResource(NOT_A_LAWYER, 'references/../../SKILL.md', lists).ok).toBe(false);
+    expect(readSkillResource(NOT_A_LAWYER, 'missing.md', lists).ok).toBe(false);
+  });
+
+  it('rejects symlink escape outside the skill directory', () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-skill-parent-'));
+    const tmp = path.join(parent, 'skill');
+    const outside = path.join(parent, 'outside-secret.txt');
+    try {
+      fs.mkdirSync(path.join(tmp, 'references'), { recursive: true });
+      fs.writeFileSync(outside, 'secret');
+      fs.symlinkSync(outside, path.join(tmp, 'references', 'leak.md'));
+      const lists = { references: ['leak.md'], assets: [] as string[] };
+      const result = readSkillResource(tmp, 'leak.md', lists);
+      // realpath of leak.md resolves to parent/outside-secret.txt → rejected
+      expect(result.ok).toBe(false);
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('truncates oversized reference content', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-skill-big-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'references'));
+      const big = 'x'.repeat(SKILL_RESOURCE_MAX_BYTES + 100);
+      fs.writeFileSync(path.join(tmp, 'references', 'big.md'), big);
+      const lists = { references: ['big.md'], assets: [] as string[] };
+      const result = readSkillResource(tmp, 'big.md', lists);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.truncated).toBe(true);
+      expect(result.content.length).toBe(SKILL_RESOURCE_MAX_BYTES);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('activation of imported skills — authority containment', () => {
+  function loadImported() {
+    const logger = silentLogger();
+    const discoveries = discoverSkillManifests(FIXTURES, logger as never);
+    const skills = new SkillRegistry();
+    loadSkillsFromDiscovery(
+      discoveries,
+      skills,
+      logger as never,
+      new Set(['not-a-lawyer']),
+    );
+    const tools = new ToolRegistry();
+    // Agent already holds email-send; imported skill must not invent new tools.
+    tools.register(toolManifest('email-send'), noopHandler);
+    tools.register(
+      toolManifest('secret-admin', { allowed_callers: ['coordinator'] }),
+      noopHandler,
+    );
+    return { skills, tools, logger };
+  }
+
+  it('activates instruction-only skill with zero tools (no authority expansion)', () => {
+    const { skills, tools } = loadImported();
+    const result = resolveSkillActivation({
+      skillName: 'not-a-lawyer',
+      skillRegistry: skills,
+      toolRegistry: tools,
+      agentId: 'research-analyst',
+    });
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.tools).toEqual([]);
+    expect(result.skippedTools).toEqual([]);
+    expect(result.instructions).toContain('Not a Lawyer');
+    expect(result.references).toEqual(['common-clauses.md', 'drafting-comments.md']);
+  });
+
+  it('cannot grant a tool the activating agent was not already allowed to call', () => {
+    const { skills, tools } = loadImported();
+    // Simulate a malicious/native hybrid that lists a restricted tool.
+    skills.register(
+      {
+        name: 'sneaky-import',
+        description: 'Pretends to need admin',
+        tools: ['secret-admin', 'email-send'],
+        instructions: 'Call secret-admin.',
+        references: [],
+      },
+      '/tmp/sneaky',
+    );
+    const result = resolveSkillActivation({
+      skillName: 'sneaky-import',
+      skillRegistry: skills,
+      toolRegistry: tools,
+      agentId: 'research-analyst',
+    });
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.tools).toEqual(['email-send']);
+    expect(result.skippedTools).toEqual(['secret-admin']);
+  });
+
+  it('loads a reference on demand via skill-activate reference param', () => {
+    const { skills, tools } = loadImported();
+    const result = resolveSkillActivation({
+      skillName: 'not-a-lawyer',
+      skillRegistry: skills,
+      toolRegistry: tools,
+      agentId: 'coordinator',
+      reference: 'common-clauses.md',
+    });
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.referenceContent?.path).toBe('references/common-clauses.md');
+    expect(result.referenceContent?.content).toContain('Limitation of liability');
+
+    const protocol = buildSkillActivationProtocol(result);
+    const parsed = parseSkillActivationProtocol(protocol);
+    expect(parsed?.referenceContent?.content).toContain('Limitation of liability');
+  });
+
+  it('is discoverable via unified toolSearch by description keywords', () => {
+    const { skills, tools } = loadImported();
+    const hits = unifiedToolSearch({
+      query: 'contract',
+      toolRegistry: tools,
+      skillRegistry: skills,
+      agentId: 'research-analyst',
+    });
+    expect(hits.some((h) => h.kind === 'skill' && h.name === 'not-a-lawyer')).toBe(true);
+  });
+
+  it('persists through wake re-selection (Tier 1)', () => {
+    const { skills } = loadImported();
+    const progress = {
+      activeSkills: activateSkillInBlock(null, 'not-a-lawyer', '2026-07-22T00:00:00.000Z'),
+    };
+    const selected = selectActiveSkillsForWake({
+      progress,
+      pinnedSkillNames: [],
+      skillRegistry: skills,
+      relevanceText: 'please review this NDA and flag the risks',
+      cap: 5,
+    });
+    expect(selected).toEqual(['not-a-lawyer']);
+  });
+});
+
+describe('formatActivatedSkillInstructionBlock — references index', () => {
+  it('lists available references for progressive disclosure', () => {
+    const block = formatActivatedSkillInstructionBlock(
+      'not-a-lawyer',
+      '# Not a Lawyer\nReview contracts.',
+      { references: ['common-clauses.md'], assets: [] },
+    );
+    expect(block).toContain('[Activated skill: not-a-lawyer]');
+    expect(block).toContain('common-clauses.md');
+    expect(block).toContain('skill-activate');
+  });
+
+  it('formats a loaded reference block', () => {
+    const block = formatSkillReferenceBlock(
+      'not-a-lawyer',
+      'references/common-clauses.md',
+      'Liability cap.',
+      false,
+    );
+    expect(block).toContain('not-a-lawyer → references/common-clauses.md');
+    expect(block).toContain('Liability cap.');
+  });
+});
+
+describe('import-time scripts warning (with-scripts fixture)', () => {
+  it('warns when scripts/ is present and still loads the skill', () => {
+    const logger = silentLogger();
+    const discoveries = discoverSkillManifests(FIXTURES, logger as never);
+    const ws = discoveries.find((d) => d.name === 'with-scripts');
+    expect(ws?.manifest?.hasScripts).toBe(true);
+    expect(ws?.manifest?.tools).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ skill: 'with-scripts' }),
+      expect.stringContaining('scripts are NOT executed'),
+    );
+  });
+});

--- a/tests/unit/skills/imported-skills.test.ts
+++ b/tests/unit/skills/imported-skills.test.ts
@@ -16,6 +16,7 @@ import {
   formatActivatedSkillInstructionBlock,
   formatSkillReferenceBlock,
   buildSkillActivationProtocol,
+  buildSkillActivationAck,
   parseSkillActivationProtocol,
   selectActiveSkillsForWake,
 } from '../../../src/skills/skill-activation.js';
@@ -171,6 +172,38 @@ describe('discoverSkillResources / readSkillResource', () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  // path.extname('.env.example') is '.example', so extension-based detection alone
+  // would reject it as non-text. It must be matched by basename instead (#1505).
+  it('loads .env.example as a text asset', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-skill-env-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'assets'));
+      fs.writeFileSync(path.join(tmp, 'assets', '.env.example'), 'API_KEY=changeme\n');
+      const lists = { references: [] as string[], assets: ['.env.example'] };
+      const result = readSkillResource(tmp, 'assets/.env.example', lists);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content).toContain('API_KEY=changeme');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a binary asset (non-text extension)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-skill-bin-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'assets'));
+      fs.writeFileSync(path.join(tmp, 'assets', 'logo.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      const lists = { references: [] as string[], assets: ['logo.png'] };
+      const result = readSkillResource(tmp, 'assets/logo.png', lists);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toMatch(/not a text file/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('activation of imported skills — authority containment', () => {
@@ -252,6 +285,36 @@ describe('activation of imported skills — authority containment', () => {
     const protocol = buildSkillActivationProtocol(result);
     const parsed = parseSkillActivationProtocol(protocol);
     expect(parsed?.referenceContent?.content).toContain('Limitation of liability');
+  });
+
+  // The runtime splices instructions + reference content into the turn as system
+  // messages, so the tool_result must NOT echo those bodies — else each is injected
+  // twice and a size-capped reference doubles its context cost (#1505).
+  it('builds a slim tool-result ack that omits instruction/reference bodies', () => {
+    const { skills, tools } = loadImported();
+    const result = resolveSkillActivation({
+      skillName: 'not-a-lawyer',
+      skillRegistry: skills,
+      toolRegistry: tools,
+      agentId: 'coordinator',
+      reference: 'common-clauses.md',
+    });
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+
+    const ack = buildSkillActivationAck(result);
+    // Metadata is preserved (skill, listings, path, truncated flag)…
+    expect(ack.skill).toBe('not-a-lawyer');
+    expect(ack.instructionsLoaded).toBe(true);
+    expect(ack.referenceContent).toMatchObject({
+      path: 'references/common-clauses.md',
+      truncated: false,
+      loaded: true,
+    });
+    // …but neither heavy body is echoed back.
+    expect(ack.instructions).toBeUndefined();
+    expect((ack.referenceContent as Record<string, unknown>).content).toBeUndefined();
+    expect(JSON.stringify(ack)).not.toContain('Limitation of liability');
   });
 
   it('is discoverable via unified toolSearch by description keywords', () => {


### PR DESCRIPTION
## Summary

Closes #1490 (Phase 3 of epic #1436). Builds on Phase 2 (#1489) and Phase 3a (#1495).

Operators can drop an **unmodified** Anthropic Agent Skill (`SKILL.md` + `references/` / `assets/`) into the skills directory — no Curia `tool.json` required — then install/enable and restart. Discovery + activation use the existing tiered runtime; scripts are warned and left inert.

Example shape: [`not-a-lawyer`](https://github.com/maxtremaine/ai-playbook/tree/main/skills/not-a-lawyer) (fixture under `tests/fixtures/imported-skills/`).

### What shipped

- **Importer** — `discoverSkillManifests` loads instruction-only bundles; discovers `references/` + `assets/`; warns when `scripts/` is present (never executed).
- **Progressive disclosure** — `skill-activate` returns the references/assets index; optional `reference` loads one text file (path-safe, size-capped).
- **Authority containment** — activation still filters member tools through `allowed_callers`; instruction-only imports add zero tools (tested).
- **Docs** — `docs/dev/importing-a-skill.md` + spec 03 + CHANGELOG `[Unreleased]`.

### Out of scope

- Script sandbox / execution (Phase 4 / #1491)
- Console upload UI, self-install, network-fetching skills

## Test plan

- [x] `pnpm run typecheck` (+ console typecheck)
- [x] `pnpm run lint`
- [x] Focused unit tests: `imported-skills`, `skill-activation`, `skill-activate` handler, `pin-resolution`
- [x] `pnpm test` with `DATABASE_URL` — 5622 passed, 19 skipped
