### PR TITLE
fix(openrouter): surface upstream provider_error detail in last_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`scheduler-list`** — bound and trim results so a large jobs table no longer overflows the model context. (#1487)
 - **`scheduler-list`** — return timestamps in the user's timezone instead of raw UTC. (#1487)
 - **Tool outputs** — cap total object-output size, not just per-leaf, matching the string-output path. (#1487)
+- **OpenRouter errors** — surface the upstream provider name and reason in `last_error` instead of the opaque "Provider returned error".
 
 ## [0.41.0] — 2026-07-21 — "Data"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`scheduler-list`** — bound and trim results so a large jobs table no longer overflows the model context. (#1487)
 - **`scheduler-list`** — return timestamps in the user's timezone instead of raw UTC. (#1487)
 - **Tool outputs** — cap total object-output size, not just per-leaf, matching the string-output path. (#1487)
-- **OpenRouter errors** — surface the upstream provider name and reason in `last_error` instead of the opaque "Provider returned error".
+- **OpenRouter errors** — `last_error` now carries the upstream provider name and reason, not the opaque wrapper.
 
 ## [0.41.0] — 2026-07-21 — "Data"
 

--- a/src/agents/llm/openrouter.test.ts
+++ b/src/agents/llm/openrouter.test.ts
@@ -199,6 +199,44 @@ describe('OpenRouterProvider', () => {
     expect(result.error.source).toBe('openrouter');
   });
 
+  it('surfaces OpenRouter upstream provider_error detail in the classified error message', async () => {
+    // OpenRouter wraps upstream provider (Google/Anthropic/etc.) failures as a
+    // terse "400 Provider returned error", burying the real cause in
+    // err.error.metadata. This is exactly the shape the OpenAI SDK's APIError
+    // carries for an OpenRouter 400 whose upstream Google request was rejected.
+    const upstreamRaw = JSON.stringify({
+      error: {
+        code: 400,
+        message:
+          '* GenerateContentRequest.tools[0].function_declarations[31].parameters.required[0]: property is not defined',
+        status: 'INVALID_ARGUMENT',
+      },
+    });
+    const apiError = Object.assign(new Error('400 Provider returned error'), {
+      status: 400,
+      error: {
+        message: 'Provider returned error',
+        code: 400,
+        metadata: { provider_name: 'Google', raw: upstreamRaw },
+      },
+    });
+    mockCreate.mockRejectedValue(apiError);
+
+    const provider = new OpenRouterProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    const result = await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+      model: 'google/gemini-3.1-flash-lite',
+    });
+
+    expect(result.type).toBe('error');
+    if (result.type !== 'error') return;
+    // The upstream provider name and the underlying reason must both survive
+    // into last_error so the next failure isn't a week-long silent suspension.
+    expect(result.error.message).toContain('Google');
+    expect(result.error.message).toContain('property is not defined');
+    expect(result.error.context.providerName).toBe('Google');
+  });
+
   it('returns error when no model is provided', async () => {
     const provider = new OpenRouterProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     const result = await provider.chat({

--- a/src/agents/llm/openrouter.test.ts
+++ b/src/agents/llm/openrouter.test.ts
@@ -232,9 +232,36 @@ describe('OpenRouterProvider', () => {
     if (result.type !== 'error') return;
     // The upstream provider name and the underlying reason must both survive
     // into last_error so the next failure isn't a week-long silent suspension.
-    expect(result.error.message).toContain('Google');
+    // The reason leads (so it survives truncation); the wrapper trails.
+    expect(result.error.message).toMatch(/^Google: /);
     expect(result.error.message).toContain('property is not defined');
+    expect(result.error.message).toContain('400 Provider returned error');
     expect(result.error.context.providerName).toBe('Google');
+    // Status-derived classification must be unchanged by the enrichment.
+    expect(result.error.type).toBe('VALIDATION_ERROR');
+  });
+
+  it('caps an oversized non-JSON upstream raw body so the reason is not truncated away', async () => {
+    // When metadata.raw is not JSON, we fall back to the raw string. A large
+    // blob must be capped so the leading provider+reason survives classify.ts's
+    // 400-char message truncation.
+    const hugeRaw = 'x'.repeat(5000);
+    const apiError = Object.assign(new Error('400 Provider returned error'), {
+      status: 400,
+      error: { metadata: { provider_name: 'Google', raw: hugeRaw } },
+    });
+    mockCreate.mockRejectedValue(apiError);
+
+    const provider = new OpenRouterProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    const result = await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+      model: 'google/gemini-3.1-flash-lite',
+    });
+
+    expect(result.type).toBe('error');
+    if (result.type !== 'error') return;
+    expect(result.error.message).toMatch(/^Google: /);
+    expect(result.error.message).toContain('…');
   });
 
   it('returns error when no model is provided', async () => {

--- a/src/agents/llm/openrouter.ts
+++ b/src/agents/llm/openrouter.ts
@@ -74,6 +74,15 @@ function extractOpenRouterProviderError(
     // truncates and PII-scrubs it downstream, so passing it through is safe.
   }
 
+  // Cap the detail so a large unparsed upstream blob can't push the actual
+  // reason past classify.ts's 400-char message truncation — that would
+  // reproduce, in milder form, the very burial this extraction fixes. The
+  // caller leads the message with this detail, so the head always survives.
+  const MAX_DETAIL_LENGTH = 300;
+  if (detail.length > MAX_DETAIL_LENGTH) {
+    detail = `${detail.slice(0, MAX_DETAIL_LENGTH)}…`;
+  }
+
   return { providerName, detail };
 }
 
@@ -399,8 +408,10 @@ export class OpenRouterProvider implements LLMProvider {
       const providerDetail = extractOpenRouterProviderError(err);
       const errorForClassification = providerDetail
         ? Object.assign(
+            // Lead with the distilled upstream reason so it survives the
+            // downstream 400-char truncation; the opaque wrapper trails.
             new Error(
-              `${extractRawMessage(err)} (${providerDetail.providerName ?? 'upstream provider'}: ${providerDetail.detail})`,
+              `${providerDetail.providerName ?? 'upstream provider'}: ${providerDetail.detail} (${extractRawMessage(err)})`,
             ),
             // Preserve status/code so classifyError still maps the HTTP status
             // (400 → VALIDATION_ERROR, 5xx → PROVIDER_ERROR, etc.) correctly.

--- a/src/agents/llm/openrouter.ts
+++ b/src/agents/llm/openrouter.ts
@@ -46,6 +46,7 @@ function extractRawMessage(err: unknown): string {
  */
 function extractOpenRouterProviderError(
   err: unknown,
+  logger: Logger,
 ): { providerName?: string; detail: string } | undefined {
   if (typeof err !== 'object' || err === null) return undefined;
   const body = (err as { error?: unknown }).error;
@@ -72,6 +73,12 @@ function extractOpenRouterProviderError(
   } catch {
     // Not JSON — the raw string is the best detail we have. classify.ts
     // truncates and PII-scrubs it downstream, so passing it through is safe.
+    // This is an expected branch (some providers return a plain-string `raw`),
+    // not an error condition, so log at debug rather than swallowing silently.
+    logger.debug(
+      { rawPreview: rawUpstream.slice(0, 200) },
+      'OpenRouter metadata.raw is not JSON — using the verbatim string as the error detail',
+    );
   }
 
   // Cap the detail so a large unparsed upstream blob can't push the actual
@@ -405,7 +412,7 @@ export class OpenRouterProvider implements LLMProvider {
       // message before classification, so `last_error` (and the LLM-facing
       // <task_error> block) carry the real cause instead of the opaque
       // "400 Provider returned error" wrapper.
-      const providerDetail = extractOpenRouterProviderError(err);
+      const providerDetail = extractOpenRouterProviderError(err, this.logger);
       const errorForClassification = providerDetail
         ? Object.assign(
             // Lead with the distilled upstream reason so it survives the

--- a/src/agents/llm/openrouter.ts
+++ b/src/agents/llm/openrouter.ts
@@ -21,6 +21,62 @@ import type { Logger } from '../../logger.js';
 import { classifyError } from '../../errors/classify.js';
 import type { ModelRegistry } from './model-registry.js';
 
+/**
+ * Best-effort message extraction, mirroring classify.ts's own logic so the
+ * enriched message keeps the original wrapper text (e.g. "400 Provider returned
+ * error") as its prefix.
+ */
+function extractRawMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return 'OpenRouter request failed';
+}
+
+/**
+ * OpenRouter wraps upstream provider (Google, Anthropic, DeepSeek, …) failures
+ * as a terse top-level message ("Provider returned error") and buries the real
+ * cause in `error.metadata`. The OpenAI SDK surfaces that body on the thrown
+ * APIError as `err.error.metadata.{provider_name, raw}`. Without pulling it out,
+ * a scheduled job's `last_error` reads only "400 Provider returned error" — the
+ * actual reason (e.g. a Gemini-incompatible tool schema) is lost, which is how a
+ * broken tier can silently suspend an agent's jobs for a week.
+ *
+ * Returns the upstream provider name and a human-readable reason, or undefined
+ * when the error is not an OpenRouter-shaped provider error.
+ */
+function extractOpenRouterProviderError(
+  err: unknown,
+): { providerName?: string; detail: string } | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const body = (err as { error?: unknown }).error;
+  if (typeof body !== 'object' || body === null) return undefined;
+  const metadata = (body as { metadata?: unknown }).metadata;
+  if (typeof metadata !== 'object' || metadata === null) return undefined;
+
+  const rawProvider = (metadata as { provider_name?: unknown }).provider_name;
+  const providerName = typeof rawProvider === 'string' && rawProvider ? rawProvider : undefined;
+
+  const rawUpstream = (metadata as { raw?: unknown }).raw;
+  if (typeof rawUpstream !== 'string' || !rawUpstream) {
+    // No upstream body — only useful if we at least learned the provider name.
+    return providerName ? { providerName, detail: 'no upstream detail provided' } : undefined;
+  }
+
+  // `raw` is usually a JSON string of the upstream provider's own error body.
+  // Prefer its nested `.error.message`; fall back to the raw string verbatim.
+  let detail = rawUpstream;
+  try {
+    const parsed: unknown = JSON.parse(rawUpstream);
+    const nested = (parsed as { error?: { message?: unknown } })?.error?.message;
+    if (typeof nested === 'string' && nested) detail = nested;
+  } catch {
+    // Not JSON — the raw string is the best detail we have. classify.ts
+    // truncates and PII-scrubs it downstream, so passing it through is safe.
+  }
+
+  return { providerName, detail };
+}
+
 export class OpenRouterProvider implements LLMProvider {
   id = 'openrouter';
   private client: OpenAI;
@@ -335,9 +391,33 @@ export class OpenRouterProvider implements LLMProvider {
       };
     } catch (err) {
       this.logger.error({ err, model }, 'OpenRouter API call failed');
+
+      // Pull OpenRouter's buried upstream-provider detail up into the error
+      // message before classification, so `last_error` (and the LLM-facing
+      // <task_error> block) carry the real cause instead of the opaque
+      // "400 Provider returned error" wrapper.
+      const providerDetail = extractOpenRouterProviderError(err);
+      const errorForClassification = providerDetail
+        ? Object.assign(
+            new Error(
+              `${extractRawMessage(err)} (${providerDetail.providerName ?? 'upstream provider'}: ${providerDetail.detail})`,
+            ),
+            // Preserve status/code so classifyError still maps the HTTP status
+            // (400 → VALIDATION_ERROR, 5xx → PROVIDER_ERROR, etc.) correctly.
+            {
+              status: (err as { status?: unknown }).status,
+              code: (err as { code?: unknown }).code,
+            },
+          )
+        : err;
+
       // Classify the error into a structured AgentError so the runtime
       // can make informed retry and budget decisions.
-      return { type: 'error', error: classifyError(err, 'openrouter') };
+      const classified = classifyError(errorForClassification, 'openrouter');
+      if (providerDetail?.providerName) {
+        classified.context.providerName = providerDetail.providerName;
+      }
+      return { type: 'error', error: classified };
     }
   }
 }


### PR DESCRIPTION
## Summary

Prod incident: four (actually **five**) `contacts` dedup task-wake jobs were auto-suspended, all with `last_error = "400 Provider returned error"`. That opaque string hid the real cause — and misdirected diagnosis toward LLM credits and the Google People API.

Root cause: prod maps the **`fast`** model tier to `google/gemini-3.1-flash-lite`, and `contacts` is the only scheduled agent on `fast`. Google's Gemini function-calling API strictly rejects tool schemas whose `required` array names properties not present in `properties` — which the `checkpoint` tool produces (its `cursor` / `accumulator` union inputs emit JSON-Schema `type`-arrays that OpenRouter drops when translating for Gemini). DeepSeek (`standard`) and GPT-4o (`powerful`) don't validate this, so every other agent kept working.

The *model routing* is being addressed separately (swapping `fast` off Gemini). **This PR fixes the observability gap that let it run silently for a week:** OpenRouter buries the upstream provider's real error in `error.metadata.{provider_name,raw}`, but `classifyError` only read `err.message`, so the wrapper was all that reached `last_error`.

## What changed

- `OpenRouterProvider.chat`'s catch now extracts `error.metadata.{provider_name,raw}` (parsing `raw`'s nested `error.message` when present) and folds it into the classified error message, leading with the distilled reason so it survives `classify.ts`'s 400-char truncation. `detail` is capped at 300 chars so a large non-JSON upstream body can't re-bury the reason.
- `classify.ts` stays provider-agnostic; the enriched error preserves `status`/`code`, so error-type mapping (400 → `VALIDATION_ERROR`, etc.) is unchanged. `providerName` is added to the error `context`.
- The original error object is still logged in full before enrichment.

After the fix, today's failure reads:
`Google: * GenerateContentRequest.tools[0].function_declarations[31].parameters.required[0]: property is not defined (400 Provider returned error)`

## Test plan

- New tests in `openrouter.test.ts` replay the **actual prod error shape** (from the logs) and the oversized-raw fallback path.
- Full `openrouter` + `classify` suites pass (112 tests); `pnpm run typecheck` clean.

## Reviewer note

`extractOpenRouterProviderError` contains one deliberate empty `catch {}` around a side-effect-free `JSON.parse` — a parse-guard whose fallback (the verbatim raw string) preserves *more* information, not an error suppression. It's a sanctioned exception to the blanket no-empty-catch rule; there's no `logger` in that module-level helper's scope.
