### PR TITLE
feat(contacts): extract ensureChannelContact for channel auto-create (#1480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **Principal carve-out** — channels contribute Gate C rules via a registry; no central per-channel switch. (#1510)
+- **`ContactService.ensureChannelContact`** — shared resolve-or-create for Signal/Slack; closes 1:1 orphan leak. (#1480)
 - **Tools vs skills vocabulary** — atoms are **tools** (`tool.json`, `ToolRegistry`; audit readers dual-match legacy `skill.*`); collections are **skills**. (#1485, #1489; ADR-031)
 - **Polymorphic pins** — a pin resolves a skill, a single tool, or an MCP-projected skill (per-tool `action_risk` preserved); `enable_task_management` retired for pinning `tasks` + `documents`; `tasks` gains `plan`/`checkpoint`, `memory` gains `decay-warnings-list`. (#1489, #1494; ADR-032)
 - **`approve-grant-recommendation`** — `action_risk` raised low→critical, matching direct permission grants. (#1499)

--- a/docs/adr/033-slack-channel-socket-mode.md
+++ b/docs/adr/033-slack-channel-socket-mode.md
@@ -47,4 +47,5 @@ App distribution alternatives:
 - Events API remains a later alternative if a deployment prefers webhooks.
 - Meeting-debrief and other proactive flows can target `channel_id: "slack"` once the gateway path exists, without agent changes.
 - Reaction→approval wiring is intentionally a follow-up (#1479) so the bus primitive ships with Slack.
-- Contact auto-create (create → link → orphan cleanup) is duplicated with Signal’s adapter; extract into `ContactService` when a fourth channel lands.
+- Contact auto-create (create → link → orphan cleanup) is shared via
+  `ContactService.ensureChannelContact` (#1480) so Voice/SMS can call the same helper.

--- a/docs/adr/033-slack-channel-socket-mode.md
+++ b/docs/adr/033-slack-channel-socket-mode.md
@@ -49,3 +49,6 @@ App distribution alternatives:
 - Reaction→approval wiring is intentionally a follow-up (#1479) so the bus primitive ships with Slack.
 - Contact auto-create (create → link → orphan cleanup) is shared via
   `ContactService.ensureChannelContact` (#1480) so Voice/SMS can call the same helper.
+  Best-effort cleanup (not a DB transaction): neither approach closes the KG-node
+  orphan window on a raced create — `createEntity` may return a label-shared node, so
+  we intentionally leave it and only delete the orphaned contact row.

--- a/src/channels/signal/signal-adapter.ts
+++ b/src/channels/signal/signal-adapter.ts
@@ -148,7 +148,7 @@ export class SignalAdapter implements Channel {
       // Resolve-or-create via ContactService so the create→link→orphan-cleanup dance
       // is shared with Slack (and future Voice/SMS). signal_participant is auto-verified
       // inside linkIdentity. Display name stays resolved here (Signal profile / E.164).
-      const { contact, created } = await this.config.contactService.ensureChannelContact({
+      const { tier, created } = await this.config.contactService.ensureChannelContact({
         channel: 'signal',
         channelIdentifier: senderId,
         source: 'signal_participant',
@@ -161,7 +161,7 @@ export class SignalAdapter implements Channel {
       // meetsMinimumTier() (issue #945) so an unexpected tier value fails safe to
       // "not known" rather than the prior denylist (!== 'unknown' && !== 'blocked'),
       // which would have treated any unrecognized value as known.
-      isKnownSender = meetsMinimumTier(contact.tier, 'known');
+      isKnownSender = meetsMinimumTier(tier, 'known');
       if (created) {
         this.log.info({ senderId, sourceName: metadata.sourceName }, 'Auto-created contact from Signal sender');
       }

--- a/src/channels/signal/signal-adapter.ts
+++ b/src/channels/signal/signal-adapter.ts
@@ -145,32 +145,24 @@ export class SignalAdapter implements Channel {
     // so the dispatcher's contact resolver can find the record immediately.
     let isKnownSender = false;
     try {
-      const existing = await this.config.contactService.resolveByChannelIdentity('signal', senderId);
-
-      if (existing) {
-        // Known sender: tier >= 'known' counts as "known" for read-receipt purposes.
-        // The dispatcher enforces hold/block policy. Uses a positive allowlist via
-        // meetsMinimumTier() (issue #945) so an unexpected tier value fails safe to
-        // "not known" rather than the prior denylist (!== 'unknown' && !== 'blocked'),
-        // which would have treated any unrecognized value as known.
-        isKnownSender = meetsMinimumTier(existing.tier, 'known');
-      } else {
-        // New sender — auto-create a contact at tier='unknown'.
-        // signal_participant is auto-verified (per contact-service.ts) so the phone
-        // number identity gets verified:true at creation time, matching email_participant.
-        // Display name comes from Signal's profile; phone number is the E.164 fallback.
-        const contact = await this.config.contactService.createContact({
-          displayName: metadata.sourceName || senderId,
-          fallbackDisplayName: senderId,
-          source: 'signal_participant',
-          tier: 'unknown',
-        });
-        await this.config.contactService.linkIdentity({
-          contactId: contact.id,
-          channel: 'signal',
-          channelIdentifier: senderId,
-          source: 'signal_participant',
-        });
+      // Resolve-or-create via ContactService so the create→link→orphan-cleanup dance
+      // is shared with Slack (and future Voice/SMS). signal_participant is auto-verified
+      // inside linkIdentity. Display name stays resolved here (Signal profile / E.164).
+      const { contact, created } = await this.config.contactService.ensureChannelContact({
+        channel: 'signal',
+        channelIdentifier: senderId,
+        source: 'signal_participant',
+        displayName: metadata.sourceName || senderId,
+        fallbackDisplayName: senderId,
+        tier: 'unknown',
+      });
+      // Known sender: tier >= 'known' counts as "known" for read-receipt purposes.
+      // The dispatcher enforces hold/block policy. Uses a positive allowlist via
+      // meetsMinimumTier() (issue #945) so an unexpected tier value fails safe to
+      // "not known" rather than the prior denylist (!== 'unknown' && !== 'blocked'),
+      // which would have treated any unrecognized value as known.
+      isKnownSender = meetsMinimumTier(contact.tier, 'known');
+      if (created) {
         this.log.info({ senderId, sourceName: metadata.sourceName }, 'Auto-created contact from Signal sender');
       }
     } catch (err) {
@@ -340,46 +332,18 @@ export class SignalAdapter implements Channel {
       // ledger stays complete. The group message routes to the coordinator in low-trust mode
       // rather than being held — the coordinator applies read-only constraints.
       for (const phone of trust.unknownMembers) {
-        let contact: { id: string } | null = null;
         try {
-          contact = await this.config.contactService.createContact({
-            displayName: phone,
-            fallbackDisplayName: phone,
-            source: 'signal_participant',
-            tier: 'unknown',
-          });
-        } catch (err) {
-          this.log.warn({ err, phone }, 'Signal adapter: failed to create contact for unknown group member');
-          continue;
-        }
-        try {
-          await this.config.contactService.linkIdentity({
-            contactId: contact.id,
+          await this.config.contactService.ensureChannelContact({
             channel: 'signal',
             channelIdentifier: phone,
             source: 'signal_participant',
+            displayName: phone,
+            fallbackDisplayName: phone,
+            tier: 'unknown',
           });
-        } catch (linkErr) {
-          const isDuplicate = (linkErr as { code?: string }).code === '23505';
-          // Always clean up the newly created contact — linkIdentity failed regardless of reason.
-          // 23505: identity already belongs to an existing contact (prior 1:1 message from this
-          // phone). Non-23505: unexpected DB failure. In both cases the new contact row is
-          // orphaned with no identity and must be deleted.
-          try {
-            await this.config.contactService.deleteContact(contact.id);
-          } catch (cleanupErr) {
-            this.log.warn(
-              { cleanupErr, orphanId: contact.id, phone },
-              'Signal adapter: failed to clean up orphan contact after linkIdentity failure',
-            );
-          }
-          if (isDuplicate) {
-            // Expected: phone already has a signal identity from a prior 1:1 message.
-            // The existing contact will be resolved normally by the dispatcher.
-            this.log.debug({ phone }, 'Signal adapter: skipping group member create — signal identity already exists for this phone');
-          } else {
-            this.log.warn({ err: linkErr, phone }, 'Signal adapter: linkIdentity failed for unknown group member — orphan cleaned up');
-          }
+        } catch (err) {
+          // Best-effort: a failed ensure must not block the group inbound publish.
+          this.log.warn({ err, phone }, 'Signal adapter: failed to ensure contact for unknown group member');
         }
       }
 

--- a/src/channels/slack/slack-adapter.ts
+++ b/src/channels/slack/slack-adapter.ts
@@ -247,6 +247,7 @@ export class SlackAdapter implements Channel {
 
   private async ensureSlackContact(senderId: string): Promise<void> {
     try {
+      // Skip users.info when the contact already exists — avoid an API round-trip per message.
       const existing = await this.config.contactService.resolveByChannelIdentity('slack', senderId);
       if (existing) return;
 
@@ -254,43 +255,19 @@ export class SlackAdapter implements Channel {
       const userInfo = await this.config.client.lookupUser(senderId);
       if (userInfo?.displayName) displayName = userInfo.displayName;
 
-      let contact: { id: string } | null = null;
-      try {
-        contact = await this.config.contactService.createContact({
-          displayName,
-          fallbackDisplayName: senderId,
-          source: 'slack_participant',
-          tier: 'unknown',
-        });
-      } catch (err) {
-        this.log.warn({ err, senderId }, 'Failed to create contact for Slack sender');
-      }
-
-      if (contact) {
-        try {
-          await this.config.contactService.linkIdentity({
-            contactId: contact.id,
-            channel: 'slack',
-            channelIdentifier: senderId,
-            source: 'slack_participant',
-          });
-          this.log.info({ senderId, displayName }, 'Auto-created contact from Slack sender');
-        } catch (linkErr) {
-          const isDuplicate = (linkErr as { code?: string }).code === '23505';
-          try {
-            await this.config.contactService.deleteContact(contact.id);
-          } catch (cleanupErr) {
-            this.log.warn(
-              { cleanupErr, orphanId: contact.id, senderId },
-              'Slack adapter: failed to clean up orphan contact after linkIdentity failure',
-            );
-          }
-          if (!isDuplicate) {
-            this.log.warn({ err: linkErr, senderId }, 'Slack adapter: linkIdentity failed');
-          }
-        }
+      const { created } = await this.config.contactService.ensureChannelContact({
+        channel: 'slack',
+        channelIdentifier: senderId,
+        source: 'slack_participant',
+        displayName,
+        fallbackDisplayName: senderId,
+        tier: 'unknown',
+      });
+      if (created) {
+        this.log.info({ senderId, displayName }, 'Auto-created contact from Slack sender');
       }
     } catch (err) {
+      // Non-fatal: contact creation is best-effort. The inbound message is still published.
       this.log.warn({ err, senderId }, 'Failed to resolve/auto-create Slack contact');
     }
   }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -837,20 +837,29 @@ export class ContactService {
    * not re-implement the create → link → orphan-cleanup dance (#1480).
    *
    * Design: best-effort create+link with orphan cleanup — not a single DB transaction.
-   * `createContact` creates a KG entity outside Postgres before inserting the contact
-   * row, and neither `createContact` nor `createIdentity` accept a transaction client
-   * today. Wrapping only the SQL inserts would still leave the orphan window for the
-   * KG node and would require a larger backend-interface refactor. Lifting the proven
-   * adapter cleanup path keeps behavior identical while closing the Signal 1:1 leak
-   * (that path previously lacked cleanup on link race).
+   * Neither `createContact` nor `createIdentity` accept a transaction client today, so
+   * a true create+link transaction would need a backend-interface refactor. Either
+   * approach leaves a KG-node orphan on a failed/raced create: `createContact` mints a
+   * person node via `entityMemory.createEntity` before the row insert, and cleanup is
+   * just `DELETE FROM contacts` (it never touches `kg_node_id`). We intentionally do
+   * not delete that node — `createEntity` returns `created: false` when a label already
+   * exists, so the node may be shared across contacts. Lifting the proven adapter
+   * cleanup path keeps contact-row behavior identical while closing the Signal 1:1
+   * contact-row leak (that path previously lacked cleanup on link race).
+   *
+   * Returns `{ contactId, tier, created }` from fields already on `ResolvedSender` /
+   * the created contact — no extra `getContact` round-trip on the known-sender hot path.
    *
    * `23505` on link is expected (concurrent create for the same identifier): the
-   * orphan contact is deleted and the existing contact is resolved and returned with
+   * orphan contact row is deleted and the existing contact is resolved and returned with
    * `created: false`. Non-duplicate link failures clean up the orphan and rethrow.
    *
    * Display-name resolution stays in the caller (channel-specific lookups). Auto-verify
    * semantics are unchanged: `source` is passed through to `linkIdentity` so
    * `signal_participant` / `slack_participant` remain in AUTO_VERIFIED_SOURCES.
+   *
+   * Note on naming: this is resolve-or-create-once, not upsert — `displayName` / `source`
+   * / `tier` are ignored when the identity already exists.
    */
   async ensureChannelContact(params: {
     channel: string;
@@ -859,18 +868,12 @@ export class ContactService {
     displayName: string;
     fallbackDisplayName?: string;
     tier?: ContactTier;
-  }): Promise<{ contact: Contact; created: boolean }> {
+  }): Promise<{ contactId: string; tier: ContactTier; created: boolean }> {
     const existing = await this.resolveByChannelIdentity(params.channel, params.channelIdentifier);
     if (existing) {
-      const contact = await this.getContact(existing.contactId);
-      if (!contact) {
-        // Identity JOIN succeeded but the contact row is gone — impossible under the
-        // Postgres FK (ON DELETE CASCADE) and the in-memory cascade mirror. Fail loud.
-        throw new Error(
-          `ensureChannelContact: identity resolved to missing contact ${existing.contactId}`,
-        );
-      }
-      return { contact, created: false };
+      // ResolvedSender already carries contactId + tier — avoid a second getContact query
+      // on every inbound message from a known sender (the common case).
+      return { contactId: existing.contactId, tier: existing.tier, created: false };
     }
 
     const contact = await this.createContact({
@@ -887,7 +890,7 @@ export class ContactService {
         channelIdentifier: params.channelIdentifier,
         source: params.source,
       });
-      return { contact, created: true };
+      return { contactId: contact.id, tier: contact.tier, created: true };
     } catch (linkErr) {
       const isDuplicate = (linkErr as { code?: string }).code === '23505';
       // Always clean up the newly created contact — linkIdentity failed regardless of reason.
@@ -914,10 +917,7 @@ export class ContactService {
         );
         const resolved = await this.resolveByChannelIdentity(params.channel, params.channelIdentifier);
         if (resolved) {
-          const existingContact = await this.getContact(resolved.contactId);
-          if (existingContact) {
-            return { contact: existingContact, created: false };
-          }
+          return { contactId: resolved.contactId, tier: resolved.tier, created: false };
         }
         // Winner's contact vanished between link failure and re-resolve — surface original error.
         throw linkErr;

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -830,6 +830,103 @@ export class ContactService {
     return this.backend.resolveByChannelIdentity(channel, channelIdentifier);
   }
 
+  /**
+   * Resolve-or-create a contact for an inbound channel identity.
+   *
+   * Shared by Signal / Slack (and future Voice / SMS) adapters so each channel does
+   * not re-implement the create → link → orphan-cleanup dance (#1480).
+   *
+   * Design: best-effort create+link with orphan cleanup — not a single DB transaction.
+   * `createContact` creates a KG entity outside Postgres before inserting the contact
+   * row, and neither `createContact` nor `createIdentity` accept a transaction client
+   * today. Wrapping only the SQL inserts would still leave the orphan window for the
+   * KG node and would require a larger backend-interface refactor. Lifting the proven
+   * adapter cleanup path keeps behavior identical while closing the Signal 1:1 leak
+   * (that path previously lacked cleanup on link race).
+   *
+   * `23505` on link is expected (concurrent create for the same identifier): the
+   * orphan contact is deleted and the existing contact is resolved and returned with
+   * `created: false`. Non-duplicate link failures clean up the orphan and rethrow.
+   *
+   * Display-name resolution stays in the caller (channel-specific lookups). Auto-verify
+   * semantics are unchanged: `source` is passed through to `linkIdentity` so
+   * `signal_participant` / `slack_participant` remain in AUTO_VERIFIED_SOURCES.
+   */
+  async ensureChannelContact(params: {
+    channel: string;
+    channelIdentifier: string;
+    source: IdentitySource;
+    displayName: string;
+    fallbackDisplayName?: string;
+    tier?: ContactTier;
+  }): Promise<{ contact: Contact; created: boolean }> {
+    const existing = await this.resolveByChannelIdentity(params.channel, params.channelIdentifier);
+    if (existing) {
+      const contact = await this.getContact(existing.contactId);
+      if (!contact) {
+        // Identity JOIN succeeded but the contact row is gone — impossible under the
+        // Postgres FK (ON DELETE CASCADE) and the in-memory cascade mirror. Fail loud.
+        throw new Error(
+          `ensureChannelContact: identity resolved to missing contact ${existing.contactId}`,
+        );
+      }
+      return { contact, created: false };
+    }
+
+    const contact = await this.createContact({
+      displayName: params.displayName,
+      fallbackDisplayName: params.fallbackDisplayName,
+      source: params.source,
+      tier: params.tier ?? 'unknown',
+    });
+
+    try {
+      await this.linkIdentity({
+        contactId: contact.id,
+        channel: params.channel,
+        channelIdentifier: params.channelIdentifier,
+        source: params.source,
+      });
+      return { contact, created: true };
+    } catch (linkErr) {
+      const isDuplicate = (linkErr as { code?: string }).code === '23505';
+      // Always clean up the newly created contact — linkIdentity failed regardless of reason.
+      // 23505: identity already belongs to an existing contact (concurrent create).
+      // Non-23505: unexpected failure. In both cases the new contact row is orphaned.
+      try {
+        await this.deleteContact(contact.id);
+      } catch (cleanupErr) {
+        this.logger?.warn(
+          {
+            cleanupErr,
+            orphanId: contact.id,
+            channel: params.channel,
+            channelIdentifier: params.channelIdentifier,
+          },
+          'ensureChannelContact: failed to clean up orphan contact after linkIdentity failure',
+        );
+      }
+
+      if (isDuplicate) {
+        this.logger?.debug(
+          { channel: params.channel, channelIdentifier: params.channelIdentifier },
+          'ensureChannelContact: identity already exists from a prior message — resolving existing contact',
+        );
+        const resolved = await this.resolveByChannelIdentity(params.channel, params.channelIdentifier);
+        if (resolved) {
+          const existingContact = await this.getContact(resolved.contactId);
+          if (existingContact) {
+            return { contact: existingContact, created: false };
+          }
+        }
+        // Winner's contact vanished between link failure and re-resolve — surface original error.
+        throw linkErr;
+      }
+
+      throw linkErr;
+    }
+  }
+
   /** Get a contact together with all its linked channel identities. */
   async getContactWithIdentities(
     id: string,

--- a/tests/unit/channels/signal/signal-adapter.test.ts
+++ b/tests/unit/channels/signal/signal-adapter.test.ts
@@ -60,6 +60,13 @@ function makeMockGateway() {
 function makeMockContactService(resolved: { contactId: string; tier: ContactTier } | null = null) {
   return {
     resolveByChannelIdentity: vi.fn().mockResolvedValue(resolved),
+    ensureChannelContact: vi.fn().mockResolvedValue({
+      contact: {
+        id: resolved?.contactId ?? 'new-contact-id',
+        tier: resolved?.tier ?? 'unknown',
+      },
+      created: resolved == null,
+    }),
     createContact: vi.fn().mockResolvedValue({ id: 'new-contact-id' }),
     linkIdentity: vi.fn().mockResolvedValue(undefined),
   } as unknown as ContactService;
@@ -253,11 +260,13 @@ describe('SignalAdapter', () => {
     rpcClient.simulateMessage(makeEnvelope());
     await new Promise((r) => setTimeout(r, 30));
 
-    expect(unknownService.createContact).toHaveBeenCalledWith(
-      expect.objectContaining({ source: 'signal_participant', tier: 'unknown' }),
-    );
-    expect(unknownService.linkIdentity).toHaveBeenCalledWith(
-      expect.objectContaining({ channel: 'signal', channelIdentifier: '+14155551234' }),
+    expect(unknownService.ensureChannelContact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'signal',
+        channelIdentifier: '+14155551234',
+        source: 'signal_participant',
+        tier: 'unknown',
+      }),
     );
 
     await unknownAdapter.stop();
@@ -436,8 +445,13 @@ describe('SignalAdapter', () => {
       // Message should be published (not held)
       expect(published).toHaveLength(1);
       // Auto-create contact for the unknown member at tier='unknown'
-      expect(contactService.createContact).toHaveBeenCalledWith(
-        expect.objectContaining({ source: 'signal_participant', tier: 'unknown' }),
+      expect(contactService.ensureChannelContact).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'signal',
+          channelIdentifier: '+14155551234',
+          source: 'signal_participant',
+          tier: 'unknown',
+        }),
       );
       // No hold notification sent
       expect(gateway.sendNotification).not.toHaveBeenCalled();

--- a/tests/unit/channels/signal/signal-adapter.test.ts
+++ b/tests/unit/channels/signal/signal-adapter.test.ts
@@ -61,10 +61,8 @@ function makeMockContactService(resolved: { contactId: string; tier: ContactTier
   return {
     resolveByChannelIdentity: vi.fn().mockResolvedValue(resolved),
     ensureChannelContact: vi.fn().mockResolvedValue({
-      contact: {
-        id: resolved?.contactId ?? 'new-contact-id',
-        tier: resolved?.tier ?? 'unknown',
-      },
+      contactId: resolved?.contactId ?? 'new-contact-id',
+      tier: resolved?.tier ?? 'unknown',
       created: resolved == null,
     }),
     createContact: vi.fn().mockResolvedValue({ id: 'new-contact-id' }),

--- a/tests/unit/channels/slack/slack-adapter.test.ts
+++ b/tests/unit/channels/slack/slack-adapter.test.ts
@@ -48,7 +48,8 @@ function makeMockContactService(resolved: { contactId: string } | null = null) {
   return {
     resolveByChannelIdentity: vi.fn().mockResolvedValue(resolved),
     ensureChannelContact: vi.fn().mockResolvedValue({
-      contact: { id: resolved?.contactId ?? 'new-contact-id', tier: 'unknown' },
+      contactId: resolved?.contactId ?? 'new-contact-id',
+      tier: 'unknown',
       created: resolved == null,
     }),
     createContact: vi.fn().mockResolvedValue({ id: 'new-contact-id' }),

--- a/tests/unit/channels/slack/slack-adapter.test.ts
+++ b/tests/unit/channels/slack/slack-adapter.test.ts
@@ -47,6 +47,10 @@ function makeMockGateway() {
 function makeMockContactService(resolved: { contactId: string } | null = null) {
   return {
     resolveByChannelIdentity: vi.fn().mockResolvedValue(resolved),
+    ensureChannelContact: vi.fn().mockResolvedValue({
+      contact: { id: resolved?.contactId ?? 'new-contact-id', tier: 'unknown' },
+      created: resolved == null,
+    }),
     createContact: vi.fn().mockResolvedValue({ id: 'new-contact-id' }),
     linkIdentity: vi.fn().mockResolvedValue(undefined),
     deleteContact: vi.fn().mockResolvedValue(undefined),
@@ -102,12 +106,12 @@ describe('SlackAdapter', () => {
     expect(event.payload.channelId).toBe('slack');
     expect(event.payload.senderId).toBe('U_ALICE');
     expect(event.payload.conversationId).toBe('slack:D123');
-    expect(contactService.createContact).toHaveBeenCalled();
-    expect(contactService.linkIdentity).toHaveBeenCalledWith(
+    expect(contactService.ensureChannelContact).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: 'slack',
         channelIdentifier: 'U_ALICE',
         source: 'slack_participant',
+        displayName: 'Alice',
       }),
     );
   });

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -553,6 +553,119 @@ describe('ContactService', () => {
     });
   });
 
+  describe('ensureChannelContact', () => {
+    it('creates and links a contact for a new channel identity', async () => {
+      const { contact, created } = await service.ensureChannelContact({
+        channel: 'signal',
+        channelIdentifier: '+14165550199',
+        source: 'signal_participant',
+        displayName: 'New Signal User',
+        fallbackDisplayName: '+14165550199',
+        tier: 'unknown',
+      });
+
+      expect(created).toBe(true);
+      expect(contact.tier).toBe('unknown');
+      expect(contact.displayName).toBe('New Signal User');
+
+      const resolved = await service.resolveByChannelIdentity('signal', '+14165550199');
+      expect(resolved).not.toBeNull();
+      expect(resolved!.contactId).toBe(contact.id);
+      expect(resolved!.verified).toBe(true); // signal_participant is auto-verified
+    });
+
+    it('returns the existing contact without creating when identity already linked', async () => {
+      const existing = await service.createContact({
+        displayName: 'Already Known',
+        source: 'signal_participant',
+        tier: 'known',
+      });
+      await service.linkIdentity({
+        contactId: existing.id,
+        channel: 'signal',
+        channelIdentifier: '+14165550100',
+        source: 'signal_participant',
+      });
+
+      const before = await service.listContacts();
+      const { contact, created } = await service.ensureChannelContact({
+        channel: 'signal',
+        channelIdentifier: '+14165550100',
+        source: 'signal_participant',
+        displayName: 'Should Not Matter',
+        tier: 'unknown',
+      });
+
+      expect(created).toBe(false);
+      expect(contact.id).toBe(existing.id);
+      expect(contact.tier).toBe('known');
+      const after = await service.listContacts();
+      expect(after).toHaveLength(before.length);
+    });
+
+    it('on link race (23505): deletes the orphan and returns the existing contact', async () => {
+      const winner = await service.createContact({
+        displayName: 'Race Winner',
+        source: 'slack_participant',
+        tier: 'unknown',
+      });
+      await service.linkIdentity({
+        contactId: winner.id,
+        channel: 'slack',
+        channelIdentifier: 'U_RACE',
+        source: 'slack_participant',
+      });
+
+      // Identity already exists, but the first resolve inside ensureChannelContact
+      // misses it (simulating a concurrent insert between resolve and link).
+      const resolveSpy = vi.spyOn(service, 'resolveByChannelIdentity');
+      resolveSpy.mockImplementationOnce(async () => null);
+
+      const beforeIds = new Set((await service.listContacts()).map((c) => c.id));
+      const { contact, created } = await service.ensureChannelContact({
+        channel: 'slack',
+        channelIdentifier: 'U_RACE',
+        source: 'slack_participant',
+        displayName: 'Race Loser',
+        fallbackDisplayName: 'U_RACE',
+        tier: 'unknown',
+      });
+
+      expect(created).toBe(false);
+      expect(contact.id).toBe(winner.id);
+
+      const after = await service.listContacts();
+      // No orphan: contact count unchanged (loser's row deleted)
+      expect(after.map((c) => c.id).sort()).toEqual([...beforeIds].sort());
+      resolveSpy.mockRestore();
+    });
+
+    it('on non-duplicate link failure: deletes the orphan and surfaces the error', async () => {
+      const linkSpy = vi.spyOn(service, 'linkIdentity').mockRejectedValueOnce(
+        Object.assign(new Error('connection reset'), { code: 'ECONNRESET' }),
+      );
+
+      const beforeCount = (await service.listContacts()).length;
+      await expect(
+        service.ensureChannelContact({
+          channel: 'signal',
+          channelIdentifier: '+14165550999',
+          source: 'signal_participant',
+          displayName: 'Will Fail',
+          fallbackDisplayName: '+14165550999',
+          tier: 'unknown',
+        }),
+      ).rejects.toThrow(/connection reset/);
+
+      const after = await service.listContacts();
+      expect(after).toHaveLength(beforeCount); // orphan cleaned up
+      // Identity must not have been linked
+      const resolved = await service.resolveByChannelIdentity('signal', '+14165550999');
+      expect(resolved).toBeNull();
+      linkSpy.mockRestore();
+    });
+  });
+
   describe('getContactWithIdentities', () => {
     it('returns contact with all channel identities', async () => {
       const contact = await service.createContact({ displayName: 'Jenna', source: 'test' });

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -555,7 +555,7 @@ describe('ContactService', () => {
 
   describe('ensureChannelContact', () => {
     it('creates and links a contact for a new channel identity', async () => {
-      const { contact, created } = await service.ensureChannelContact({
+      const { contactId, tier, created } = await service.ensureChannelContact({
         channel: 'signal',
         channelIdentifier: '+14165550199',
         source: 'signal_participant',
@@ -565,13 +565,15 @@ describe('ContactService', () => {
       });
 
       expect(created).toBe(true);
-      expect(contact.tier).toBe('unknown');
-      expect(contact.displayName).toBe('New Signal User');
+      expect(tier).toBe('unknown');
 
       const resolved = await service.resolveByChannelIdentity('signal', '+14165550199');
       expect(resolved).not.toBeNull();
-      expect(resolved!.contactId).toBe(contact.id);
+      expect(resolved!.contactId).toBe(contactId);
       expect(resolved!.verified).toBe(true); // signal_participant is auto-verified
+
+      const contact = await service.getContact(contactId);
+      expect(contact?.displayName).toBe('New Signal User');
     });
 
     it('returns the existing contact without creating when identity already linked', async () => {
@@ -587,8 +589,12 @@ describe('ContactService', () => {
         source: 'signal_participant',
       });
 
+      const createSpy = vi.spyOn(service, 'createContact');
+      const linkSpy = vi.spyOn(service, 'linkIdentity');
+      const getSpy = vi.spyOn(service, 'getContact');
+
       const before = await service.listContacts();
-      const { contact, created } = await service.ensureChannelContact({
+      const { contactId, tier, created } = await service.ensureChannelContact({
         channel: 'signal',
         channelIdentifier: '+14165550100',
         source: 'signal_participant',
@@ -597,10 +603,18 @@ describe('ContactService', () => {
       });
 
       expect(created).toBe(false);
-      expect(contact.id).toBe(existing.id);
-      expect(contact.tier).toBe('known');
+      expect(contactId).toBe(existing.id);
+      expect(tier).toBe('known');
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(linkSpy).not.toHaveBeenCalled();
+      // Hot path: tier comes from ResolvedSender — no second getContact round-trip
+      expect(getSpy).not.toHaveBeenCalled();
       const after = await service.listContacts();
       expect(after).toHaveLength(before.length);
+
+      createSpy.mockRestore();
+      linkSpy.mockRestore();
+      getSpy.mockRestore();
     });
 
     it('on link race (23505): deletes the orphan and returns the existing contact', async () => {
@@ -622,7 +636,7 @@ describe('ContactService', () => {
       resolveSpy.mockImplementationOnce(async () => null);
 
       const beforeIds = new Set((await service.listContacts()).map((c) => c.id));
-      const { contact, created } = await service.ensureChannelContact({
+      const { contactId, created } = await service.ensureChannelContact({
         channel: 'slack',
         channelIdentifier: 'U_RACE',
         source: 'slack_participant',
@@ -632,7 +646,7 @@ describe('ContactService', () => {
       });
 
       expect(created).toBe(false);
-      expect(contact.id).toBe(winner.id);
+      expect(contactId).toBe(winner.id);
 
       const after = await service.listContacts();
       // No orphan: contact count unchanged (loser's row deleted)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts the duplicated Signal/Slack **resolve → create → link → orphan-cleanup** dance into `ContactService.ensureChannelContact`, so Voice/SMS (v0.42) can call the helper instead of pasting it again. Also fixes the Signal 1:1 path, which previously leaked an orphan contact row when `linkIdentity` lost a `23505` race.

### Design choice: best-effort cleanup (not transactional)

Preferred option in the issue was a single DB transaction. This PR uses **best-effort create+link with orphan cleanup** instead, because neither `createContact` nor `createIdentity` accept a transaction client today — a true create+link transaction needs a backend-interface refactor.

Neither approach closes the KG-node orphan window: `createContact` mints a person node via `entityMemory.createEntity` before the row insert, and cleanup is just `DELETE FROM contacts` (it never touches `kg_node_id`). We intentionally do **not** delete that node — `createEntity` returns `created: false` when a label already exists, so the node may be shared across contacts. Leaving it is the safe choice; only the orphaned contact row is reclaimed.

On `23505`, the helper deletes the orphan contact row, re-resolves, and returns `{ contactId, tier, created: false }`. Non-duplicate link failures delete the orphan and rethrow.

### Return shape

Returns `{ contactId, tier, created }` from fields already on `ResolvedSender` / the created contact — no extra `getContact` round-trip on every inbound message from a known sender.

### Call sites updated

- Signal 1:1 unknown sender (now gets orphan cleanup + tier back for read receipts)
- Signal unknown group members
- Slack `ensureSlackContact` (still skips `users.info` when the contact already exists)

## Changes

- Add `ContactService.ensureChannelContact` (resolve-or-create + link, orphan cleanup on link failure)
- Wire Signal 1:1, Signal group unknown members, and Slack `ensureSlackContact` to the helper
- Unit tests for create / resolve (no create/link/getContact) / `23505` race / non-duplicate link failure
- Note extraction + KG-orphan rationale in ADR-033; CHANGELOG under Unreleased

## Related Issues

Closes #1480

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes (ADR-033 consequence note)
- [ ] CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f89a9c1-9e98-4737-ace9-783f19965447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f89a9c1-9e98-4737-ace9-783f19965447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

