### PR TITLE
refactor(channels): channel-owned outbound recipient projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Outbound recipient projection** — channels own request variants + `extractRecipients`; gateway has no projection switch. (#1513; ADR-035)
 - **Principal carve-out** — channels contribute Gate C rules via a registry; no central per-channel switch. (#1510)
 - **`ContactService.ensureChannelContact`** — shared resolve-or-create for Signal/Slack; closes 1:1 orphan leak. (#1480)
 - **Tools vs skills vocabulary** — atoms are **tools** (`tool.json`, `ToolRegistry`; audit readers dual-match legacy `skill.*`); collections are **skills**. (#1485, #1489; ADR-031)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,10 +92,11 @@ When you need to pin a transitive dependency (e.g. to clear a CVE), add it to th
 ### New Channel Adapter
 1. Create `src/channels/<name>/` implementing the `Channel` interface from `src/channels/channel.ts` (`name`, `isToggleable`, `start()`, `stop()`)
 2. Add a `ChannelDescriptor` to `src/channels/catalog.ts` (credential fields + required secret keys)
-3. Export `src/channels/<name>/principal-rules.ts` (`PrincipalChannelRules`: identity comparator + optional Gate C `carveoutSkill`) and append it to `src/contacts/principal-channel-registry.ts` — omit `carveoutSkill` to fail closed (ADR-034)
-4. Register as `layer: "channel"` with the bus
-5. Add config section to `config/default.yaml`
-6. Write tests
+3. Add `src/channels/<name>/outbound-request.ts` (the channel's `OutboundSendRequest` variant) and export `principal-rules.ts` with `PrincipalChannelRules`: identity comparator, `extractRecipients` (principal-eligible vs never-principal ids — group/conversation ids must be never-principal), and optional Gate C `carveoutSkill`. Append the contribution to `src/contacts/principal-channel-registry.ts` — omit `carveoutSkill` to fail closed for Gate C (ADR-034, ADR-035). Recipient projection for principal tagging needs **no** edit to `src/skills/outbound-gateway.ts`.
+4. Re-export the new request variant into the `OutboundSendRequest` union in `outbound-gateway.ts` and add delivery dispatch (`OutboundGatewayConfig` client + `dispatch<Channel>()` + `send()` branch) when the channel sends externally
+5. Register as `layer: "channel"` with the bus
+6. Add config section to `config/default.yaml`
+7. Write tests (include never-principal fields in `extractRecipients` tests)
 
 ### New Tool
 1. Create `skills/<name>/tool.json` (manifest) + `handler.ts`

--- a/docs/adr/034-channel-contributed-principal-carveout-registry.md
+++ b/docs/adr/034-channel-contributed-principal-carveout-registry.md
@@ -30,14 +30,15 @@ matching for the outbound gateway, no Gate C carve-out until a send skill opts i
 
 ## Consequences
 
-- Adding a channel means writing `channels/<name>/principal-rules.ts` and appending
-  one registry entry — no new branches inside `principal-recipient.ts`.
+- Adding a channel means writing `channels/<name>/principal-rules.ts` (now also
+  with `extractRecipients` per ADR-035) and appending one registry entry — no new
+  branches inside `principal-recipient.ts`.
 - Reviewers audit Gate C opt-in by reading the registry (and the derived
   `GATE_C_PRINCIPAL_CARVEOUT_SKILLS` Set), not by grepping adapters.
 - Call sites use `isPrincipalIdentity(channel, …)` instead of per-channel helpers.
 - Trade-off: the registry still imports each channel module explicitly (no
   side-effect self-registration), by design — an invisible register call would
   weaken the audit story.
-- The outbound gateway still owns request-shape → recipient projection
-  (`projectRecipients`) in one place until channels fully own that wire-shape
-  (#1513). Identity compare and Gate C skill parsing do not live there.
+- Outbound request-shape → recipient projection was deferred to #1513 and is
+  now channel-owned via `extractRecipients` on the same contributions (ADR-035).
+  Identity compare and Gate C skill parsing do not live in the gateway.

--- a/docs/adr/035-channel-owned-outbound-recipient-projection.md
+++ b/docs/adr/035-channel-owned-outbound-recipient-projection.md
@@ -1,0 +1,65 @@
+# ADR-035: Channel-owned outbound recipient projection
+
+Date: 2026-07-24
+Status: Accepted
+
+## Context
+
+ADR-034 moved principal identity comparison and Gate C skill-input parsing onto
+per-channel `PrincipalChannelRules` contributions. It deliberately left one
+concern in the outbound gateway: projecting an `OutboundSendRequest` onto the
+recipient identifiers used for principal tagging (`projectRecipients`).
+
+That projection encodes security-critical never-principal fields (Signal
+`groupId`, Slack `slackChannelId` / D…/C… conversation ids). Keeping it in the
+gateway meant every new channel still required a `switch (request.channel)` edit
+in `src/skills/outbound-gateway.ts`.
+
+The blocker in #1511 was layering: `OutboundSendRequest` lived in the skills/
+gateway layer *above* `src/channels/`. A channel module could not own projection
+over that type without inverting the dependency. Relocating the request variants
+is a public-API-surface change and needed an ADR.
+
+Alternatives considered:
+
+1. **Keep projection in the gateway** (status quo after #1511) — one function to
+   edit per channel, but not zero gateway edits.
+2. **Put `extractRecipients` on the `Channel` adapter interface** — couples the
+   lifecycle adapter (`start`/`stop`) to outbound wire shape and complicates
+   conformance tests for always-on channels that do not send externally.
+3. **Channel-owned request variants + `PrincipalChannelRules.extractRecipients`**
+   (chosen) — matches ADR-034's contribution pattern; registry stays the
+   auditable list; gateway delegates and fails closed when rules are absent.
+
+## Decision
+
+1. Move each `OutboundSendRequest` variant into its owning channel package
+   (`src/channels/<name>/outbound-request.ts`). The gateway re-exports the
+   discriminated union so existing import paths remain stable (public API).
+2. Extend `PrincipalChannelRules` with
+   `extractRecipients(request: unknown): ProjectedRecipient[] | null`. Each
+   channel narrows its own request shape and marks identifiers as
+   `principalEligible` (or not) — including the never-trust conversation/group
+   id fail-safe.
+3. `OutboundGateway.projectRecipients` becomes a thin registry lookup:
+   `findPrincipalChannelRules(request.channel)?.extractRecipients(request) ?? []`.
+   Unregistered channels and unrecognized shapes yield an empty list (no
+   principal carve-out).
+
+Delivery dispatch (`dispatchEmail` / `dispatchSignal` / `dispatchSlack`) stays
+in the gateway — that is transport wiring, not principal tagging.
+
+## Consequences
+
+- Adding a channel for principal-recipient tagging requires
+  `outbound-request.ts` + `extractRecipients` on `principal-rules.ts` and a
+  registry append — **no** recipient-projection edit in
+  `outbound-gateway.ts`.
+- Reviewers still audit Gate C opt-in and identity matching via the registry
+  (ADR-034); recipient projection is co-located with those contributions.
+- Callers may import request types from the channel package or continue
+  importing re-exports from `outbound-gateway.ts`.
+- Trade-off: the gateway still branches on `request.channel` for *delivery*
+  dispatch and a few body/subject field reads. Those are out of scope here;
+  zero gateway edits for *recipient projection* is the acceptance bar (#1513).
+- Completes the deferred consequence called out in ADR-034.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,6 +55,7 @@ Each ADR follows the [Nygard format](https://adr.github.io/):
 | [032](032-polymorphic-pins-and-mcp-as-skill.md) | Polymorphic capability pins (skill \| tool \| future MCP) + MCP servers project skills into `SkillRegistry` — prerequisites for #1494 | Accepted |
 | [033](033-slack-channel-socket-mode.md) | Slack via Socket Mode — workspace-owned app, DMs + @mentions + in-thread continuation, sender-identity trust, `inbound.reaction` | Accepted |
 | [034](034-channel-contributed-principal-carveout-registry.md) | Channel-contributed principal carve-out registry — Gate C opt-in without scattering fail-closed logic | Accepted |
+| [035](035-channel-owned-outbound-recipient-projection.md) | Channel-owned outbound recipient projection — request variants + `extractRecipients` so the gateway needs no per-channel projection edit | Accepted |
 
 ## Adding new ADRs
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -9,7 +9,8 @@
 
 import type { EventBus } from '../../bus/bus.js';
 import type { Logger } from '../../logger.js';
-import type { OutboundGateway, EmailSendRequest } from '../../skills/outbound-gateway.js';
+import type { OutboundGateway } from '../../skills/outbound-gateway.js';
+import type { EmailSendRequest } from './outbound-request.js';
 import type { ContactService } from '../../contacts/contact-service.js';
 import type { ConfigStore } from '../../memory/config-store.js';
 import { convertNylasMessage } from './message-converter.js';

--- a/src/channels/email/outbound-request.ts
+++ b/src/channels/email/outbound-request.ts
@@ -1,0 +1,38 @@
+// Email outbound send request — owned by the email channel package.
+//
+// Part of the OutboundSendRequest discriminated union re-exported from
+// outbound-gateway.ts (public API). Channel-owned so recipient projection
+// (PrincipalChannelRules.extractRecipients) can live next to the wire shape
+// without inverting the skills → channels layer dependency (ADR-035).
+
+import type { OutboundAttachmentInput } from '../../skills/_shared/read-attachments.js';
+
+export interface EmailSendRequest {
+  channel: 'email';
+  /** Which named account should send this message (e.g. "curia", "joseph").
+   *  Used by the gateway to select the right NylasClient from its map.
+   *  Defaults to the first configured account when absent. */
+  accountId?: string;
+  /** Recipient email address */
+  to: string;
+  subject?: string;
+  body: string;
+  cc?: string[];
+  /** When set, Nylas threads the outbound message as a reply */
+  replyToMessageId?: string;
+  /** Pre-formed HTML fragment appended verbatim after markdownToHtml(body, { wrap: true }).
+   *  Used for the quoted original message block: the quote is already sanitized
+   *  HTML and must remain outside the generated-body wrapper. */
+  htmlQuote?: string;
+  /** File attachments to include. Each entry must have a file:// URL pointing
+   *  to a temp file (from email-download-attachment or similar). The gateway
+   *  reads the files from disk before passing them to Nylas. */
+  attachments?: OutboundAttachmentInput[];
+}
+
+/** Type guard for email outbound requests. */
+export function isEmailSendRequest(request: unknown): request is EmailSendRequest {
+  if (typeof request !== 'object' || request === null) return false;
+  const r = request as Record<string, unknown>;
+  return r['channel'] === 'email' && typeof r['to'] === 'string' && typeof r['body'] === 'string';
+}

--- a/src/channels/email/principal-rules.test.ts
+++ b/src/channels/email/principal-rules.test.ts
@@ -23,4 +23,33 @@ describe('emailPrincipalRules.extractRecipients', () => {
       message: 'hi',
     })).toBeNull();
   });
+
+  it('returns null when cc is a string rather than an array (fail closed)', () => {
+    // A string cc would otherwise spread into char-sized "recipients".
+    expect(emailPrincipalRules.extractRecipients({
+      channel: 'email',
+      to: 'ceo@example.com',
+      body: 'hi',
+      cc: 'other@example.com',
+    })).toBeNull();
+  });
+
+  it('returns null when cc is a non-iterable value (fail closed)', () => {
+    // A non-array/non-iterable cc would otherwise throw at the spread.
+    expect(emailPrincipalRules.extractRecipients({
+      channel: 'email',
+      to: 'ceo@example.com',
+      body: 'hi',
+      cc: 42,
+    })).toBeNull();
+  });
+
+  it('returns null when cc is an array containing non-strings (fail closed)', () => {
+    expect(emailPrincipalRules.extractRecipients({
+      channel: 'email',
+      to: 'ceo@example.com',
+      body: 'hi',
+      cc: ['ok@example.com', 123],
+    })).toBeNull();
+  });
 });

--- a/src/channels/email/principal-rules.test.ts
+++ b/src/channels/email/principal-rules.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { emailPrincipalRules } from './principal-rules.js';
+import type { EmailSendRequest } from './outbound-request.js';
+
+describe('emailPrincipalRules.extractRecipients', () => {
+  it('projects to + cc as principal-eligible', () => {
+    const request: EmailSendRequest = {
+      channel: 'email',
+      to: 'ceo@example.com',
+      body: 'hi',
+      cc: ['other@example.com', ''],
+    };
+    expect(emailPrincipalRules.extractRecipients(request)).toEqual([
+      { identifier: 'ceo@example.com', principalEligible: true },
+      { identifier: 'other@example.com', principalEligible: true },
+    ]);
+  });
+
+  it('returns null for a non-email request shape (fail closed)', () => {
+    expect(emailPrincipalRules.extractRecipients({
+      channel: 'signal',
+      recipient: '+15551234567',
+      message: 'hi',
+    })).toBeNull();
+  });
+});

--- a/src/channels/email/principal-rules.ts
+++ b/src/channels/email/principal-rules.ts
@@ -40,7 +40,14 @@ function parseEmailSendRecipients(input: Record<string, unknown>): string[] | nu
  */
 function extractEmailRecipients(request: unknown): ProjectedRecipient[] | null {
   if (!isEmailSendRequest(request)) return null;
-  return [request.to, ...(request.cc ?? [])]
+  // `isEmailSendRequest` only guards `to`/`body`; `cc` is unchecked. Reject any
+  // malformed `cc` (non-array throws at the spread; a string spreads into
+  // char-sized "recipients") so projection stays fail-closed (ADR-035).
+  const cc = request.cc;
+  if (cc !== undefined && (!Array.isArray(cc) || cc.some((r) => typeof r !== 'string'))) {
+    return null;
+  }
+  return [request.to, ...(cc ?? [])]
     .filter((e) => e.length > 0)
     .map((identifier) => ({ identifier, principalEligible: true }));
 }

--- a/src/channels/email/principal-rules.ts
+++ b/src/channels/email/principal-rules.ts
@@ -1,10 +1,15 @@
-// Email channel contribution: principal identity compare + email-send carve-out.
+// Email channel contribution: principal identity compare, outbound recipient
+// projection, and email-send Gate C carve-out.
 
-import type { PrincipalChannelRules } from '../../contacts/principal-channel-rules.js';
+import type {
+  PrincipalChannelRules,
+  ProjectedRecipient,
+} from '../../contacts/principal-channel-rules.js';
 import {
   hasPresentValue,
   splitCommaSeparatedAddresses,
 } from '../../contacts/principal-carveout-parse.js';
+import { isEmailSendRequest } from './outbound-request.js';
 
 /**
  * Parse email-send recipients from skill input. Returns null when the input contains
@@ -29,11 +34,23 @@ function parseEmailSendRecipients(input: Record<string, unknown>): string[] | nu
   return emails;
 }
 
+/**
+ * Project an email outbound request onto To + CC identifiers.
+ * Every address is principal-eligible (there is no email group-id analogue).
+ */
+function extractEmailRecipients(request: unknown): ProjectedRecipient[] | null {
+  if (!isEmailSendRequest(request)) return null;
+  return [request.to, ...(request.cc ?? [])]
+    .filter((e) => e.length > 0)
+    .map((identifier) => ({ identifier, principalEligible: true }));
+}
+
 export const emailPrincipalRules: PrincipalChannelRules = {
   channel: 'email',
   identifiersEqual(a, b) {
     return a.toLowerCase() === b.toLowerCase();
   },
+  extractRecipients: extractEmailRecipients,
   carveoutSkill: {
     skillName: 'email-send',
     parseRecipients: parseEmailSendRecipients,

--- a/src/channels/signal/outbound-request.ts
+++ b/src/channels/signal/outbound-request.ts
@@ -1,0 +1,29 @@
+// Signal outbound send request — owned by the Signal channel package.
+//
+// Part of the OutboundSendRequest discriminated union re-exported from
+// outbound-gateway.ts (public API). Channel-owned so recipient projection
+// (PrincipalChannelRules.extractRecipients) can live next to the wire shape
+// without inverting the skills → channels layer dependency (ADR-035).
+
+export interface SignalOutboundRequest {
+  channel: 'signal';
+  /**
+   * E.164 phone number for 1:1 sends (e.g. "+14155552671").
+   * Mutually exclusive with groupId — set exactly one.
+   */
+  recipient?: string;
+  /**
+   * Base64-encoded group V2 ID for group sends.
+   * Mutually exclusive with recipient — set exactly one.
+   * Never principal-eligible (other members present).
+   */
+  groupId?: string;
+  message: string;
+}
+
+/** Type guard for Signal outbound requests. */
+export function isSignalOutboundRequest(request: unknown): request is SignalOutboundRequest {
+  if (typeof request !== 'object' || request === null) return false;
+  const r = request as Record<string, unknown>;
+  return r['channel'] === 'signal' && typeof r['message'] === 'string';
+}

--- a/src/channels/signal/principal-rules.test.ts
+++ b/src/channels/signal/principal-rules.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { signalPrincipalRules } from './principal-rules.js';
+import type { SignalOutboundRequest } from './outbound-request.js';
+
+describe('signalPrincipalRules.extractRecipients', () => {
+  it('projects a 1:1 recipient as principal-eligible', () => {
+    const request: SignalOutboundRequest = {
+      channel: 'signal',
+      recipient: '+15551234567',
+      message: 'hi',
+    };
+    expect(signalPrincipalRules.extractRecipients(request)).toEqual([
+      { identifier: '+15551234567', principalEligible: true },
+    ]);
+  });
+
+  it('marks groupId as never-principal', () => {
+    const request: SignalOutboundRequest = {
+      channel: 'signal',
+      groupId: 'group-base64==',
+      message: 'group ping',
+    };
+    expect(signalPrincipalRules.extractRecipients(request)).toEqual([
+      { identifier: 'group-base64==', principalEligible: false },
+    ]);
+  });
+
+  it('prefers recipient over groupId when both are present', () => {
+    const request: SignalOutboundRequest = {
+      channel: 'signal',
+      recipient: '+15551234567',
+      groupId: 'group-base64==',
+      message: 'hi',
+    };
+    expect(signalPrincipalRules.extractRecipients(request)).toEqual([
+      { identifier: '+15551234567', principalEligible: true },
+    ]);
+  });
+
+  it('returns null for a non-signal request shape (fail closed)', () => {
+    expect(signalPrincipalRules.extractRecipients({
+      channel: 'email',
+      to: 'ceo@example.com',
+      body: 'hi',
+    })).toBeNull();
+  });
+});

--- a/src/channels/signal/principal-rules.ts
+++ b/src/channels/signal/principal-rules.ts
@@ -1,7 +1,12 @@
-// Signal channel contribution: principal identity compare + signal-send carve-out.
+// Signal channel contribution: principal identity compare, outbound recipient
+// projection, and signal-send Gate C carve-out.
 
-import type { PrincipalChannelRules } from '../../contacts/principal-channel-rules.js';
+import type {
+  PrincipalChannelRules,
+  ProjectedRecipient,
+} from '../../contacts/principal-channel-rules.js';
 import { hasPresentValue } from '../../contacts/principal-carveout-parse.js';
+import { isSignalOutboundRequest } from './outbound-request.js';
 
 /**
  * Parse signal-send 1:1 recipient from skill input. Returns null for group sends or
@@ -22,11 +27,27 @@ function parseSignalSendRecipients(input: Record<string, unknown>): string[] | n
   return [(recipient as string).trim()];
 }
 
+/**
+ * Project a Signal outbound request onto its recipient identifier.
+ * 1:1 `recipient` is principal-eligible; `groupId` is never (other members present).
+ */
+function extractSignalRecipients(request: unknown): ProjectedRecipient[] | null {
+  if (!isSignalOutboundRequest(request)) return null;
+  if (request.recipient && request.recipient.length > 0) {
+    return [{ identifier: request.recipient, principalEligible: true }];
+  }
+  if (request.groupId && request.groupId.length > 0) {
+    return [{ identifier: request.groupId, principalEligible: false }];
+  }
+  return [];
+}
+
 export const signalPrincipalRules: PrincipalChannelRules = {
   channel: 'signal',
   identifiersEqual(a, b) {
     return a === b;
   },
+  extractRecipients: extractSignalRecipients,
   carveoutSkill: {
     skillName: 'signal-send',
     parseRecipients: parseSignalSendRecipients,

--- a/src/channels/slack/outbound-request.ts
+++ b/src/channels/slack/outbound-request.ts
@@ -1,0 +1,32 @@
+// Slack outbound send request — owned by the Slack channel package.
+//
+// Part of the OutboundSendRequest discriminated union re-exported from
+// outbound-gateway.ts (public API). Channel-owned so recipient projection
+// (PrincipalChannelRules.extractRecipients) can live next to the wire shape
+// without inverting the skills → channels layer dependency (ADR-035).
+
+export interface SlackOutboundRequest {
+  channel: 'slack';
+  /** Slack conversation id (D… for DM, C…/G… for channel). Never principal-eligible. */
+  slackChannelId: string;
+  /** When set, reply in this thread (channel mentions / DM threads). */
+  threadTs?: string;
+  message: string;
+  /**
+   * Slack user id (U…) of the human recipient when known (DM peer or
+   * dispatcher-stamped recipientId). Used for principal checks, blocked-contact
+   * resolution, and disclosure tier — never the D…/C… conversation id.
+   */
+  slackUserId?: string;
+}
+
+/** Type guard for Slack outbound requests. */
+export function isSlackOutboundRequest(request: unknown): request is SlackOutboundRequest {
+  if (typeof request !== 'object' || request === null) return false;
+  const r = request as Record<string, unknown>;
+  return (
+    r['channel'] === 'slack'
+    && typeof r['slackChannelId'] === 'string'
+    && typeof r['message'] === 'string'
+  );
+}

--- a/src/channels/slack/principal-rules.test.ts
+++ b/src/channels/slack/principal-rules.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { slackPrincipalRules } from './principal-rules.js';
+import type { SlackOutboundRequest } from './outbound-request.js';
+
+describe('slackPrincipalRules.extractRecipients', () => {
+  it('projects slackUserId as principal-eligible', () => {
+    const request: SlackOutboundRequest = {
+      channel: 'slack',
+      slackChannelId: 'D123',
+      slackUserId: 'U_CEO',
+      message: 'hi',
+    };
+    expect(slackPrincipalRules.extractRecipients(request)).toEqual([
+      { identifier: 'U_CEO', principalEligible: true },
+    ]);
+  });
+
+  it('marks slackChannelId (D…/C…) as never-principal when no user id', () => {
+    const dm: SlackOutboundRequest = {
+      channel: 'slack',
+      slackChannelId: 'D123',
+      message: 'hi',
+    };
+    expect(slackPrincipalRules.extractRecipients(dm)).toEqual([
+      { identifier: 'D123', principalEligible: false },
+    ]);
+
+    const channel: SlackOutboundRequest = {
+      channel: 'slack',
+      slackChannelId: 'C456',
+      message: 'hi',
+    };
+    expect(slackPrincipalRules.extractRecipients(channel)).toEqual([
+      { identifier: 'C456', principalEligible: false },
+    ]);
+  });
+
+  it('never trusts the conversation id when slackUserId is set', () => {
+    const request: SlackOutboundRequest = {
+      channel: 'slack',
+      slackChannelId: 'D123',
+      slackUserId: 'U_CEO',
+      message: 'hi',
+    };
+    const projected = slackPrincipalRules.extractRecipients(request)!;
+    expect(projected.some((r) => r.identifier === 'D123')).toBe(false);
+    expect(projected).toEqual([{ identifier: 'U_CEO', principalEligible: true }]);
+  });
+
+  it('returns null for a non-slack request shape (fail closed)', () => {
+    expect(slackPrincipalRules.extractRecipients({
+      channel: 'email',
+      to: 'ceo@example.com',
+      body: 'hi',
+    })).toBeNull();
+  });
+});

--- a/src/channels/slack/principal-rules.ts
+++ b/src/channels/slack/principal-rules.ts
@@ -1,14 +1,35 @@
-// Slack channel contribution: principal identity compare only.
+// Slack channel contribution: principal identity compare + outbound recipient
+// projection.
 //
 // No carveoutSkill — there is no slack-send skill yet, so Gate C fails closed
 // for Slack outbound (intentional; see issue #1510 / ADR-034).
 
-import type { PrincipalChannelRules } from '../../contacts/principal-channel-rules.js';
+import type {
+  PrincipalChannelRules,
+  ProjectedRecipient,
+} from '../../contacts/principal-channel-rules.js';
+import { isSlackOutboundRequest } from './outbound-request.js';
+
+/**
+ * Project a Slack outbound request onto its recipient identifier.
+ * Trust the peer U… only — never the D…/C… conversation id.
+ */
+function extractSlackRecipients(request: unknown): ProjectedRecipient[] | null {
+  if (!isSlackOutboundRequest(request)) return null;
+  if (request.slackUserId && request.slackUserId.length > 0) {
+    return [{ identifier: request.slackUserId, principalEligible: true }];
+  }
+  if (request.slackChannelId.length > 0) {
+    return [{ identifier: request.slackChannelId, principalEligible: false }];
+  }
+  return [];
+}
 
 export const slackPrincipalRules: PrincipalChannelRules = {
   channel: 'slack',
   identifiersEqual(a, b) {
     return a === b;
   },
+  extractRecipients: extractSlackRecipients,
   // carveoutSkill omitted ⇒ no Gate C principal carve-out for Slack.
 };

--- a/src/contacts/principal-channel-registry.ts
+++ b/src/contacts/principal-channel-registry.ts
@@ -1,14 +1,17 @@
 // principal-channel-registry.ts — single auditable list of channel contributions
-// for principal-identity matching and Gate C carve-out opt-in.
+// for principal-identity matching, outbound recipient projection, and Gate C
+// carve-out opt-in.
 //
 // AUDIT POINT: a skill receives the Gate C principal carve-out ONLY if it appears
 // as `carveoutSkill.skillName` on an entry below. Channels listed without
-// `carveoutSkill` (Slack today) still get identity matching for the outbound
-// gateway, but fail closed for Gate C. Unknown / unregistered channels and
-// skills also fail closed.
+// `carveoutSkill` (Slack today) still get identity matching + recipient
+// projection for the outbound gateway, but fail closed for Gate C. Unknown /
+// unregistered channels and skills also fail closed (empty projection ⇒ no
+// principal carve-out in the gateway).
 //
-// Adding a channel: export `*PrincipalRules` from the channel package and append
-// exactly one entry here. Do not add per-channel branches to principal-recipient.ts.
+// Adding a channel: export `*PrincipalRules` (with `extractRecipients`) from the
+// channel package and append exactly one entry here. Do not add per-channel
+// branches to principal-recipient.ts or outbound-gateway recipient projection.
 
 import type { PrincipalChannelRules } from './principal-channel-rules.js';
 import { emailPrincipalRules } from '../channels/email/principal-rules.js';

--- a/src/contacts/principal-channel-rules.ts
+++ b/src/contacts/principal-channel-rules.ts
@@ -1,23 +1,45 @@
 // principal-channel-rules.ts — per-channel contribution contract for principal
-// identity matching and Gate C carve-out opt-in.
+// identity matching, Gate C carve-out opt-in, and outbound recipient projection.
 //
-// Channels own comparator + send-skill recipient parsing; the central registry
-// (principal-channel-registry.ts) is the single auditable list of contributions.
-// Default is fail-closed: omit `carveoutSkill` and the skill gets no carve-out.
+// Channels own comparator + send-skill recipient parsing + request→identifier
+// projection; the central registry (principal-channel-registry.ts) is the single
+// auditable list of contributions. Default is fail-closed: omit `carveoutSkill`
+// and the skill gets no carve-out; return null from `extractRecipients` and the
+// gateway treats the request as having no principal-eligible recipients.
 
 /**
- * Channel contribution for principal-identity checks and optional Gate C carve-out.
+ * One projected recipient identifier from an outbound send request, plus whether
+ * that identifier may ever match the principal (group/conversation ids are false).
+ */
+export interface ProjectedRecipient {
+  identifier: string;
+  principalEligible: boolean;
+}
+
+/**
+ * Channel contribution for principal-identity checks, outbound recipient
+ * projection, and optional Gate C carve-out.
  *
  * - `identifiersEqual` — how this channel compares a candidate identifier to a
  *   stored verified identity (email folds case; Signal/Slack are exact).
+ * - `extractRecipients` — maps this channel's outbound request wire-shape onto
+ *   recipient identifiers for principal tagging. Returns null when the request
+ *   is not this channel's shape (fail closed).
  * - `carveoutSkill` — explicit opt-in. Absent ⇒ fail closed for Gate C (Slack
- *   today: comparator exists for the outbound gateway, but no send-skill carve-out).
+ *   today: comparator + projector exist for the outbound gateway, but no
+ *   send-skill carve-out).
  */
 export interface PrincipalChannelRules {
   /** Stable channel id: 'email' | 'signal' | 'slack' | … */
   readonly channel: string;
   /** True when `a` and `b` refer to the same identity on this channel. */
   identifiersEqual(a: string, b: string): boolean;
+  /**
+   * Project an outbound send request onto recipient identifiers.
+   * Returns null when `request` is not this channel's wire shape (fail closed —
+   * the gateway yields an empty recipient set / no principal carve-out).
+   */
+  extractRecipients(request: unknown): ProjectedRecipient[] | null;
   /**
    * When set, `skillName` is opted into Gate C's principal-only carve-out and
    * `parseRecipients` fully models that skill's recipient-shaped input.

--- a/src/contacts/principal-recipient.test.ts
+++ b/src/contacts/principal-recipient.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   PRINCIPAL_CHANNEL_RULES,
   assertPrincipalChannelRegistryUnique,
+  findPrincipalChannelRules,
 } from './principal-channel-registry.js';
 import type { PrincipalChannelRules } from './principal-channel-rules.js';
 
@@ -49,6 +50,7 @@ describe('principal-recipient', () => {
       const dupChannel: PrincipalChannelRules = {
         channel: 'email',
         identifiersEqual: (a, b) => a === b,
+        extractRecipients: () => null,
       };
       expect(() =>
         assertPrincipalChannelRegistryUnique([...PRINCIPAL_CHANNEL_RULES, dupChannel]),
@@ -57,6 +59,7 @@ describe('principal-recipient', () => {
       const dupSkill: PrincipalChannelRules = {
         channel: 'other',
         identifiersEqual: (a, b) => a === b,
+        extractRecipients: () => null,
         carveoutSkill: {
           skillName: 'email-send',
           parseRecipients: () => [],
@@ -100,6 +103,18 @@ describe('principal-recipient', () => {
 
     it('fails closed for an unregistered channel', () => {
       expect(isPrincipalIdentity('telegram', 'ceo@example.com', PRINCIPAL_IDENTITIES)).toBe(false);
+    });
+  });
+
+  describe('extractRecipients registry fail-closed', () => {
+    it('returns undefined rules for an unregistered channel (no gateway carve-out)', () => {
+      expect(findPrincipalChannelRules('telegram')).toBeUndefined();
+    });
+
+    it('every registered channel contributes extractRecipients', () => {
+      for (const rules of PRINCIPAL_CHANNEL_RULES) {
+        expect(typeof rules.extractRecipients).toBe('function');
+      }
     });
   });
 

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -12,16 +12,22 @@
 // blocked-contact check.
 //
 // Adding a new channel:
-//   1. Add a new variant to OutboundSendRequest (discriminated union by `channel`)
-//   2. Add the channel client to OutboundGatewayConfig
-//   3. Add a private dispatch<Channel>() method
-//   4. Add a branch in send() to call it
+//   1. Add `src/channels/<name>/outbound-request.ts` and contribute
+//      `extractRecipients` on that channel's `principal-rules.ts` (ADR-035) —
+//      recipient projection for principal tagging needs no gateway edit.
+//   2. Re-export the new request variant into OutboundSendRequest below
+//      (public API union) and add the channel client to OutboundGatewayConfig.
+//   3. Add a private dispatch<Channel>() method and a branch in send() to call it.
 //   The blocked-contact check and content filter in send() are channel-agnostic and
-//   run for all channels before dispatch.
+//   run for all channels before dispatch. Principal identity compare + Gate C
+//   carve-out live on PrincipalChannelRules (ADR-034).
 
 import { randomUUID } from 'node:crypto';
 import type { NylasClient, NylasMessage, NylasFolder, ListMessagesOptions, SendEmailOptions, AttachmentContent } from '../channels/email/nylas-client.js';
 import { readAttachmentFiles, MAX_ATTACHMENT_BYTES, type OutboundAttachmentInput } from './_shared/read-attachments.js';
+import type { EmailSendRequest } from '../channels/email/outbound-request.js';
+import type { SignalOutboundRequest } from '../channels/signal/outbound-request.js';
+import type { SlackOutboundRequest } from '../channels/slack/outbound-request.js';
 import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
 import type { SlackClient } from '../channels/slack/slack-client.js';
 import type { ContactService } from '../contacts/contact-service.js';
@@ -31,6 +37,8 @@ import {
   isPrincipalIdentity,
   computePrincipalIsSoleRecipient,
 } from '../contacts/principal-recipient.js';
+import { findPrincipalChannelRules } from '../contacts/principal-channel-registry.js';
+import type { ProjectedRecipient } from '../contacts/principal-channel-rules.js';
 import type { OutboundContentFilter, FilterRecipient } from '../dispatch/outbound-filter.js';
 import type { PiiRedactor } from '../dispatch/pii-redactor.js';
 import type { EventBus } from '../bus/bus.js';
@@ -57,68 +65,22 @@ import {
 import type { ExportItem } from '../security/export-controls.js';
 
 // ---------------------------------------------------------------------------
-// Public types
+// Public types — request variants owned by channel packages; re-exported here
+// so existing callers keep a stable import path (public API surface).
 // ---------------------------------------------------------------------------
 
-export interface EmailSendRequest {
-  channel: 'email';
-  /** Which named account should send this message (e.g. "curia", "joseph").
-   *  Used by the gateway to select the right NylasClient from its map.
-   *  Defaults to the first configured account when absent. */
-  accountId?: string;
-  /** Recipient email address */
-  to: string;
-  subject?: string;
-  body: string;
-  cc?: string[];
-  /** When set, Nylas threads the outbound message as a reply */
-  replyToMessageId?: string;
-  /** Pre-formed HTML fragment appended verbatim after markdownToHtml(body, { wrap: true }).
-   *  Used for the quoted original message block: the quote is already sanitized
-   *  HTML and must remain outside the generated-body wrapper. */
-  htmlQuote?: string;
-  /** File attachments to include. Each entry must have a file:// URL pointing
-   *  to a temp file (from email-download-attachment or similar). The gateway
-   *  reads the files from disk before passing them to Nylas. */
-  attachments?: OutboundAttachmentInput[];
-}
+export type { EmailSendRequest } from '../channels/email/outbound-request.js';
+export type { SignalOutboundRequest } from '../channels/signal/outbound-request.js';
+export type { SlackOutboundRequest } from '../channels/slack/outbound-request.js';
 
 // Re-export so callers can construct attachment lists without importing from read-attachments directly.
 export type { OutboundAttachmentInput };
 
-export interface SignalOutboundRequest {
-  channel: 'signal';
-  /**
-   * E.164 phone number for 1:1 sends (e.g. "+14155552671").
-   * Mutually exclusive with groupId — set exactly one.
-   */
-  recipient?: string;
-  /**
-   * Base64-encoded group V2 ID for group sends.
-   * Mutually exclusive with recipient — set exactly one.
-   */
-  groupId?: string;
-  message: string;
-}
-
-export interface SlackOutboundRequest {
-  channel: 'slack';
-  /** Slack conversation id (D… for DM, C…/G… for channel). */
-  slackChannelId: string;
-  /** When set, reply in this thread (channel mentions / DM threads). */
-  threadTs?: string;
-  message: string;
-  /**
-   * Slack user id (U…) of the human recipient when known (DM peer or
-   * dispatcher-stamped recipientId). Used for principal checks, blocked-contact
-   * resolution, and disclosure tier — never the D…/C… conversation id.
-   */
-  slackUserId?: string;
-}
-
 /**
  * Discriminated union of all supported outbound send requests.
- * Add a new variant here when adding a new channel.
+ * Variants live in `src/channels/<name>/outbound-request.ts`; re-export the new
+ * variant into this union when adding a channel (delivery dispatch still needs
+ * a gateway branch — recipient projection for principal tagging does not).
  *
  * Note: OutboundSendRequest is a public API surface — adding a new variant is
  * backwards-compatible, but changing existing field names or types is a breaking
@@ -1228,43 +1190,14 @@ export class OutboundGateway {
   /**
    * Project an outbound request onto recipient identifiers for principal checks.
    *
-   * Single place that knows request wire-shape → identifiers, including which
-   * fields are never-principal (Signal `groupId`, Slack `slackChannelId`). Adding
-   * a channel touches this method once; `isPrincipalRecipient` and
-   * `buildFilterRecipients` both derive from it. Deeper ownership by channel
-   * packages is tracked in #1513.
+   * Delegates to the channel's `PrincipalChannelRules.extractRecipients` (ADR-035).
+   * Unregistered channels / unrecognized shapes fail closed (empty list ⇒ no
+   * principal carve-out). `isPrincipalRecipient` and `buildFilterRecipients`
+   * both derive from this.
    */
-  private projectRecipients(
-    request: OutboundSendRequest,
-  ): { identifier: string; principalEligible: boolean }[] {
-    if (request.channel === 'email') {
-      return [request.to, ...(request.cc ?? [])]
-        .filter((e) => e.length > 0)
-        .map((identifier) => ({ identifier, principalEligible: true }));
-    }
-    if (request.channel === 'signal') {
-      if (request.recipient && request.recipient.length > 0) {
-        return [{ identifier: request.recipient, principalEligible: true }];
-      }
-      if (request.groupId && request.groupId.length > 0) {
-        // Group sends are never principal-eligible (other members present).
-        return [{ identifier: request.groupId, principalEligible: false }];
-      }
-      return [];
-    }
-    if (request.channel === 'slack') {
-      // Trust the peer U… only — never the D…/C… conversation id.
-      if (request.slackUserId && request.slackUserId.length > 0) {
-        return [{ identifier: request.slackUserId, principalEligible: true }];
-      }
-      if (request.slackChannelId.length > 0) {
-        return [{ identifier: request.slackChannelId, principalEligible: false }];
-      }
-      return [];
-    }
-    // Exhaustiveness: a new OutboundSendRequest variant must project recipients here.
-    const _exhaustive: never = request;
-    return _exhaustive;
+  private projectRecipients(request: OutboundSendRequest): ProjectedRecipient[] {
+    const rules = findPrincipalChannelRules(request.channel);
+    return rules?.extractRecipients(request) ?? [];
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1513.

Completes the ADR-034 follow-up: each channel owns its `OutboundSendRequest` variant and projects recipients for principal tagging via `PrincipalChannelRules.extractRecipients`. `OutboundGateway.projectRecipients` is a thin registry lookup with fail-closed empty results for unregistered channels — no per-channel projection switch remains in the gateway.

## Changes

- Move `EmailSendRequest` / `SignalOutboundRequest` / `SlackOutboundRequest` into `src/channels/<name>/outbound-request.ts`; gateway re-exports the union (stable public API import path).
- Add `extractRecipients` to `PrincipalChannelRules`; email/signal/slack projectors encode principal-eligible vs never-principal ids (Signal `groupId`, Slack `slackChannelId`).
- Delegate gateway projection to `findPrincipalChannelRules(…).extractRecipients`; document in ADR-035; update CLAUDE.md channel-adapter checklist and CHANGELOG.

## Related Issues

Closes #1513

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes (ADR-035)
- [x] CI passes

## Test plan

- [x] Unit tests for each channel projector (eligible + never-principal + wrong-shape fail-closed)
- [x] Registry fail-closed coverage for unregistered channels
- [x] `pnpm run typecheck`
- [x] Targeted vitest: principal-rules + principal-recipient + outbound-gateway (142 passed)
- [x] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0f6bc23-90f7-464e-9f9f-566048517e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0f6bc23-90f7-464e-9f9f-566048517e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

