### PR TITLE
feat(contacts): edit channel identities and bind principal channels (#1514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+<<<<<<< HEAD
 - **Reaction approvals** — Slack/Signal 👍/👎 (incl. skin tones) resolve pending approvals; unrecognized principal reactions get a hint. (#1479)
+=======
+- **Contact identity editing** — console + API add/verify/remove channel identities and merge lookalikes; binds principal Slack/Signal for outbound detection. (#1514)
+>>>>>>> 2e89a69c (feat(contacts): edit channel identities and bind principal channels)
 - **Imported Anthropic skills** — drop an unmodified `SKILL.md` + `references/` folder; discover/activate with inert scripts warned. (#1490)
 - **Skills-as-bundles** — `SKILL.md` + nested `tools/`; `pinned_skills` expands a bundle to its member tools + instructions; `skill_registry` table. Native bundles: email, ceo-inbox, contacts, autonomy, diagnostics, scheduler, web, memory, learning, context-bridge, executive-profile, setup. (#1489, #1494)
 - **Runtime skill activation & MCP-as-skill** — `toolSearch` returns `kind:"skill"`; `skill-activate` loads a skill's tools + instructions (Tier 1 persists in `progress.activeSkills`); each connected MCP server projects a pinnable skill. (#1494, #1495)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-<<<<<<< HEAD
-- **Reaction approvals** — Slack/Signal 👍/👎 (incl. skin tones) resolve pending approvals; unrecognized principal reactions get a hint. (#1479)
-=======
 - **Contact identity editing** — console + API add/verify/remove channel identities and merge lookalikes; binds principal Slack/Signal for outbound detection. (#1514)
->>>>>>> 2e89a69c (feat(contacts): edit channel identities and bind principal channels)
+- **Reaction approvals** — Slack/Signal 👍/👎 (incl. skin tones) resolve pending approvals; unrecognized principal reactions get a hint. (#1479)
 - **Imported Anthropic skills** — drop an unmodified `SKILL.md` + `references/` folder; discover/activate with inert scripts warned. (#1490)
 - **Skills-as-bundles** — `SKILL.md` + nested `tools/`; `pinned_skills` expands a bundle to its member tools + instructions; `skill_registry` table. Native bundles: email, ceo-inbox, contacts, autonomy, diagnostics, scheduler, web, memory, learning, context-bridge, executive-profile, setup. (#1489, #1494)
 - **Runtime skill activation & MCP-as-skill** — `toolSearch` returns `kind:"skill"`; `skill-activate` loads a skill's tools + instructions (Tier 1 persists in `progress.activeSkills`); each connected MCP server projects a pinnable skill. (#1494, #1495)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Contact identity editing** — console + API add/verify/remove channel identities and merge lookalikes; binds principal Slack/Signal for outbound detection. (#1514)
+- **Contact identity editing** — console + API add/update/verify/remove channel identities and merge lookalikes; binds principal Slack/Signal for outbound detection. (#1514)
 - **Reaction approvals** — Slack/Signal 👍/👎 (incl. skin tones) resolve pending approvals; unrecognized principal reactions get a hint. (#1479)
 - **Imported Anthropic skills** — drop an unmodified `SKILL.md` + `references/` folder; discover/activate with inert scripts warned. (#1490)
 - **Skills-as-bundles** — `SKILL.md` + nested `tools/`; `pinned_skills` expands a bundle to its member tools + instructions; `skill_registry` table. Native bundles: email, ceo-inbox, contacts, autonomy, diagnostics, scheduler, web, memory, learning, context-bridge, executive-profile, setup. (#1489, #1494)

--- a/apps/console/src/linkable-channels.ts
+++ b/apps/console/src/linkable-channels.ts
@@ -1,0 +1,8 @@
+// Re-export the shared allowlist so console typecheck can resolve it without
+// a deprecated `baseUrl`/`paths` setup. Vite resolves `@curia/linkable-channels`
+// via alias; this file is the TypeScript entry for the same module (#1514).
+export {
+  LINKABLE_CHANNEL_IDENTITIES,
+  LINKABLE_CHANNEL_IDENTITY_SET,
+  type LinkableChannelIdentity,
+} from '../../../src/contacts/linkable-channels.js';

--- a/apps/console/src/pages/ChannelSettings.tsx
+++ b/apps/console/src/pages/ChannelSettings.tsx
@@ -235,6 +235,21 @@ function ChannelDrawer({ entry, onClose, onChanged }: {
             </div>
           )}
 
+          {/* Principal identity binding reminder (#1514) — credentials alone do not
+              bind Slack/Signal to the principal contact for outbound principal detection. */}
+          {(entry.name === 'slack' || entry.name === 'signal') && entry.state === 'enabled' && (
+            <div className="form-field">
+              <label>Principal identity</label>
+              <p className="settings-page-sub" style={{ margin: 0 }}>
+                After enabling {entry.name === 'slack' ? 'Slack' : 'Signal'}, open{' '}
+                <a href="/contacts">Contacts</a> → your principal and add your{' '}
+                {entry.name === 'slack' ? 'Slack user ID (U…)' : 'Signal phone number'}{' '}
+                as a channel identity. Without that binding, outbound messages to you on this
+                channel may be blocked by the content filter.
+              </p>
+            </div>
+          )}
+
           {/* Email accounts sub-section — only for the email channel.
               Lets the operator manage Nylas-backed mailboxes the agent uses. */}
           {entry.name === 'email' && <EmailAccountsSection />}

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -961,15 +961,20 @@ export default function ContactsPage() {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
   }, [mobileOpen]);
 
-  const load = useCallback(async () => {
+  // Returns the freshly-fetched contacts (or null on failure) so callers can
+  // reconcile drawer state against the authoritative server response, not a
+  // stale pre-fetch closure.
+  const load = useCallback(async (): Promise<Contact[] | null> => {
     try {
       const res = await apiFetch('/api/kg/contacts');
       if (!res.ok) throw new Error(await errorMessage(res));
       const data = await res.json() as { contacts: Contact[] };
       setContacts(data.contacts);
+      return data.contacts;
     } catch (err) {
       console.error('[ContactsPage] failed to load contacts:', err);
       setLoadError(err instanceof Error ? err.message : 'Failed to load contacts');
+      return null;
     }
   }, []);
 
@@ -1053,11 +1058,16 @@ export default function ContactsPage() {
   }
 
   function handleMerged(primaryId: string, secondaryId: string) {
+    // Drop the merged-away secondary immediately for responsiveness.
     setContacts(prev => prev.filter(c => c.id !== secondaryId));
-    const primary = contacts.find(c => c.id === primaryId) ?? null;
-    setSelected(primary);
-    setDrawerMode(primary ? 'view' : null);
-    void load();
+    // The merge recomputes the golden record (displayName/tier/notes) onto the
+    // primary server-side, so the pre-merge `contacts` closure is stale. Reconcile
+    // `selected` against load()'s fresh response instead of the old snapshot.
+    void load().then(fresh => {
+      const primary = fresh?.find(c => c.id === primaryId) ?? null;
+      setSelected(primary);
+      setDrawerMode(primary ? 'view' : null);
+    });
   }
 
   function openView(contact: Contact) {

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -137,9 +137,11 @@ function Pagination({ total, page, pageSize, totalPages, onPage, onPageSize }: P
 interface DrawerProps {
   contact: Contact | null;
   creating: boolean;
+  allContacts: Contact[];
   onClose: () => void;
   onSaved: (contact: Contact) => void;
   onDeleted: (id: string) => void;
+  onMerged: (primaryId: string, secondaryId: string) => void;
 }
 
 interface AuthOverride {
@@ -147,7 +149,9 @@ interface AuthOverride {
   granted: boolean;
 }
 
-function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: DrawerProps) {
+const IDENTITY_CHANNEL_OPTIONS = ['email', 'phone', 'signal', 'telegram', 'slack'] as const;
+
+function ContactEditDrawer({ contact, creating, allContacts, onClose, onSaved, onDeleted, onMerged }: DrawerProps) {
   const [displayName, setDisplayName] = useState(contact?.displayName ?? '');
   const [role, setRole] = useState(contact?.role ?? '');
   const [tier, setTier] = useState<ContactTier>(contact?.tier ?? 'unknown');
@@ -175,6 +179,32 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
   const [overridesError, setOverridesError] = useState<string | null>(null);
   const [revoking, setRevoking] = useState<string | null>(null);
 
+  // Channel identities (#1514)
+  const [identities, setIdentities] = useState<ContactIdentity[]>([]);
+  const [identitiesError, setIdentitiesError] = useState<string | null>(null);
+  const [newChannel, setNewChannel] = useState<typeof IDENTITY_CHANNEL_OPTIONS[number]>('email');
+  const [newIdentifier, setNewIdentifier] = useState('');
+  const [newLabel, setNewLabel] = useState('');
+  const [identityBusy, setIdentityBusy] = useState<string | null>(null);
+
+  // Merge lookalike into another contact (current = secondary)
+  const [mergePrimaryId, setMergePrimaryId] = useState('');
+  const [merging, setMerging] = useState(false);
+  const [mergeError, setMergeError] = useState<string | null>(null);
+
+  const reloadIdentities = useCallback(async () => {
+    if (!contact || creating) return;
+    setIdentitiesError(null);
+    try {
+      const res = await apiFetch(`/api/kg/contacts/${contact.id}/identities`);
+      if (!res.ok) { setIdentitiesError('Failed to load identities'); return; }
+      const d = await res.json() as { identities: ContactIdentity[] };
+      setIdentities(d.identities);
+    } catch (_err: unknown) {
+      setIdentitiesError('Failed to load identities');
+    }
+  }, [contact, creating]);
+
   useEffect(() => {
     if (!contact || creating) return;
     setOverridesError(null);
@@ -188,6 +218,10 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
       .catch((_err: unknown) => setOverridesError('Failed to load permissions'));
   }, [contact, creating]);
 
+  useEffect(() => {
+    void reloadIdentities();
+  }, [reloadIdentities]);
+
   async function handleRevokeOverride(permission: string) {
     if (!contact) return;
     setRevoking(permission);
@@ -199,6 +233,138 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
       setOverridesError('Failed to revoke permission');
     } finally {
       setRevoking(null);
+    }
+  }
+
+  async function handleAddIdentity() {
+    if (!contact) return;
+    const identifier = newIdentifier.trim();
+    if (!identifier) {
+      setIdentitiesError('Identifier is required.');
+      return;
+    }
+    setIdentityBusy('add');
+    setIdentitiesError(null);
+    try {
+      const res = await apiFetch(`/api/kg/contacts/${contact.id}/identities`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          channel: newChannel,
+          channelIdentifier: identifier,
+          label: newLabel.trim() || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      setNewIdentifier('');
+      setNewLabel('');
+      await reloadIdentities();
+    } catch (err) {
+      console.error('[ContactEditDrawer] add identity failed:', err);
+      setIdentitiesError(err instanceof Error ? err.message : 'Failed to add identity');
+    } finally {
+      setIdentityBusy(null);
+    }
+  }
+
+  async function handleVerifyIdentity(identityId: string) {
+    if (!contact) return;
+    setIdentityBusy(identityId);
+    setIdentitiesError(null);
+    try {
+      const res = await apiFetch(`/api/kg/contacts/${contact.id}/identities/${identityId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verified: true }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      await reloadIdentities();
+    } catch (err) {
+      console.error('[ContactEditDrawer] verify identity failed:', err);
+      setIdentitiesError(err instanceof Error ? err.message : 'Failed to verify identity');
+    } finally {
+      setIdentityBusy(null);
+    }
+  }
+
+  async function handleSetIdentityStatus(identityId: string, status: IdentityStatus) {
+    if (!contact) return;
+    setIdentityBusy(identityId);
+    setIdentitiesError(null);
+    try {
+      const res = await apiFetch(`/api/kg/contacts/${contact.id}/identities/${identityId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      await reloadIdentities();
+    } catch (err) {
+      console.error('[ContactEditDrawer] set identity status failed:', err);
+      setIdentitiesError(err instanceof Error ? err.message : 'Failed to update identity');
+    } finally {
+      setIdentityBusy(null);
+    }
+  }
+
+  async function handleRemoveIdentity(identityId: string) {
+    if (!contact) return;
+    setIdentityBusy(identityId);
+    setIdentitiesError(null);
+    try {
+      const res = await apiFetch(`/api/kg/contacts/${contact.id}/identities/${identityId}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      await reloadIdentities();
+    } catch (err) {
+      console.error('[ContactEditDrawer] remove identity failed:', err);
+      setIdentitiesError(err instanceof Error ? err.message : 'Failed to remove identity');
+    } finally {
+      setIdentityBusy(null);
+    }
+  }
+
+  async function handleMerge() {
+    if (!contact || !mergePrimaryId) return;
+    setMerging(true);
+    setMergeError(null);
+    try {
+      const preview = await apiFetch('/api/kg/contacts/merge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          primaryContactId: mergePrimaryId,
+          secondaryContactId: contact.id,
+          dryRun: true,
+        }),
+      });
+      if (!preview.ok) throw new Error(await errorMessage(preview));
+      const previewData = await preview.json() as {
+        goldenRecord: { displayName: string; identityCount: number };
+      };
+      const confirmed = window.confirm(
+        `Merge "${contact.displayName}" into "${previewData.goldenRecord.displayName}"?\n\n` +
+        `This re-points ${previewData.goldenRecord.identityCount} channel identities onto the primary and deletes this contact.`,
+      );
+      if (!confirmed) return;
+
+      const res = await apiFetch('/api/kg/contacts/merge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          primaryContactId: mergePrimaryId,
+          secondaryContactId: contact.id,
+          dryRun: false,
+        }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      onMerged(mergePrimaryId, contact.id);
+    } catch (err) {
+      console.error('[ContactEditDrawer] merge failed:', err);
+      setMergeError(err instanceof Error ? err.message : 'Merge failed');
+    } finally {
+      setMerging(false);
     }
   }
 
@@ -429,6 +595,96 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
             <textarea id="cf-notes" rows={4} value={notes} onChange={e => setNotes(e.target.value)} />
           </div>
 
+          {/* Section: Channel identities (#1514) */}
+          {!creating && (
+            <>
+              <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Channel identities</p>
+              {contact?.systemRole === 'principal' && (
+                <p style={{ color: 'var(--app-fg-muted)', fontSize: 12, margin: '0 0 8px' }}>
+                  Bind Slack / Signal / phone identities here so outbound messages to you skip the Stage-2 judge.
+                </p>
+              )}
+              {identitiesError && <p style={{ color: 'var(--app-destructive)', fontSize: 12, margin: 0 }}>{identitiesError}</p>}
+              {identities.length === 0 && !identitiesError && (
+                <p style={{ color: 'var(--app-fg-muted)', fontSize: 12, margin: 0 }}>No channel identities on file.</p>
+              )}
+              {identities.map(idn => (
+                <div key={idn.id} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginBottom: 6, flexWrap: 'wrap' }}>
+                  <span style={{ fontSize: 11, color: 'var(--app-fg-muted)', textTransform: 'uppercase', minWidth: 48 }}>{idn.channel}</span>
+                  <span style={{ flex: 1, fontFamily: 'JetBrains Mono, monospace', fontSize: 12, wordBreak: 'break-all' }}>{idn.channelIdentifier}</span>
+                  <span style={{ fontSize: 11, color: idn.verified ? 'var(--app-success, #22c55e)' : 'var(--app-fg-muted)' }}>
+                    {idn.verified ? 'verified' : 'unverified'}
+                  </span>
+                  <select
+                    value={idn.status}
+                    disabled={identityBusy === idn.id}
+                    onChange={e => void handleSetIdentityStatus(idn.id, e.target.value as IdentityStatus)}
+                    style={{ fontSize: 11, padding: '2px 4px' }}
+                    aria-label={`Status for ${idn.channelIdentifier}`}
+                  >
+                    <option value="active">active</option>
+                    <option value="defunct">defunct</option>
+                    <option value="bounced">bounced</option>
+                  </select>
+                  {!idn.verified && (
+                    <button
+                      className="btn btn-secondary btn-sm"
+                      style={{ padding: '2px 8px', fontSize: 11 }}
+                      onClick={() => void handleVerifyIdentity(idn.id)}
+                      disabled={identityBusy === idn.id}
+                    >
+                      Verify
+                    </button>
+                  )}
+                  <button
+                    className="btn btn-secondary btn-sm"
+                    style={{ padding: '2px 8px', fontSize: 11 }}
+                    onClick={() => void handleRemoveIdentity(idn.id)}
+                    disabled={identityBusy === idn.id}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <div className="form-grid" style={{ marginTop: 8 }}>
+                <div className="form-field">
+                  <label htmlFor="ci-channel">Channel</label>
+                  <select
+                    id="ci-channel"
+                    value={newChannel}
+                    onChange={e => setNewChannel(e.target.value as typeof IDENTITY_CHANNEL_OPTIONS[number])}
+                  >
+                    {IDENTITY_CHANNEL_OPTIONS.map(ch => (
+                      <option key={ch} value={ch}>{ch}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="form-field">
+                  <label htmlFor="ci-identifier">Identifier</label>
+                  <input
+                    id="ci-identifier"
+                    type="text"
+                    value={newIdentifier}
+                    onChange={e => setNewIdentifier(e.target.value)}
+                    placeholder={newChannel === 'slack' ? 'U0123ABCDEF' : newChannel === 'email' ? 'you@example.com' : '+15551234567'}
+                  />
+                </div>
+                <div className="form-field">
+                  <label htmlFor="ci-label">Label (optional)</label>
+                  <input id="ci-label" type="text" value={newLabel} onChange={e => setNewLabel(e.target.value)} placeholder="work, personal…" />
+                </div>
+              </div>
+              <button
+                className="btn btn-secondary btn-sm"
+                style={{ marginTop: 4 }}
+                onClick={() => void handleAddIdentity()}
+                disabled={identityBusy === 'add' || !newIdentifier.trim()}
+              >
+                {identityBusy === 'add' ? 'Adding…' : 'Add identity'}
+              </button>
+            </>
+          )}
+
           {/* Section: Permission grants */}
           {!creating && (
             <>
@@ -455,6 +711,42 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
                   </button>
                 </div>
               ))}
+            </>
+          )}
+
+          {/* Section: Merge lookalike (#1514) — current contact is the secondary (deleted). */}
+          {!creating && contact && contact.systemRole === null && (
+            <>
+              <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Merge into…</p>
+              <p style={{ color: 'var(--app-fg-muted)', fontSize: 12, margin: '0 0 8px' }}>
+                Re-point this contact&apos;s channel identities onto another contact and delete this one.
+                Use when inbound resolution created a lookalike of the principal.
+              </p>
+              {mergeError && <p style={{ color: 'var(--app-destructive)', fontSize: 12, margin: 0 }}>{mergeError}</p>}
+              <div className="form-field">
+                <label htmlFor="ci-merge-primary">Primary (survivor)</label>
+                <select
+                  id="ci-merge-primary"
+                  value={mergePrimaryId}
+                  onChange={e => setMergePrimaryId(e.target.value)}
+                >
+                  <option value="">Select contact…</option>
+                  {allContacts
+                    .filter(c => c.id !== contact.id)
+                    .map(c => (
+                      <option key={c.id} value={c.id}>
+                        {c.displayName}{c.systemRole === 'principal' ? ' (principal)' : ''} · {c.tier}
+                      </option>
+                    ))}
+                </select>
+              </div>
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={() => void handleMerge()}
+                disabled={merging || !mergePrimaryId}
+              >
+                {merging ? 'Merging…' : 'Preview & merge'}
+              </button>
             </>
           )}
         </div>
@@ -756,6 +1048,14 @@ export default function ContactsPage() {
     setDrawerMode(null);
   }
 
+  function handleMerged(primaryId: string, secondaryId: string) {
+    setContacts(prev => prev.filter(c => c.id !== secondaryId));
+    const primary = contacts.find(c => c.id === primaryId) ?? null;
+    setSelected(primary);
+    setDrawerMode(primary ? 'view' : null);
+    void load();
+  }
+
   function openView(contact: Contact) {
     setSelected(contact);
     setDrawerMode('view');
@@ -966,9 +1266,11 @@ export default function ContactsPage() {
                     key={drawerMode === 'edit' ? selected?.id ?? 'edit' : 'new'}
                     contact={drawerMode === 'edit' ? selected : null}
                     creating={drawerMode === 'create'}
+                    allContacts={contacts}
                     onClose={closeDrawer}
                     onSaved={handleSaved}
                     onDeleted={handleDeleted}
+                    onMerged={handleMerged}
                   />
                 )}
               </div>

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -5,6 +5,10 @@ import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
 import { apiFetch } from '../api.js';
 import { useTheme } from '../hooks/useTheme.js';
 import { buildContactViewFields, kgNodeHref, formatDateTime } from './contacts-utils.js';
+import {
+  LINKABLE_CHANNEL_IDENTITIES,
+  type LinkableChannelIdentity,
+} from '../linkable-channels.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -149,7 +153,7 @@ interface AuthOverride {
   granted: boolean;
 }
 
-const IDENTITY_CHANNEL_OPTIONS = ['email', 'phone', 'signal', 'telegram', 'slack'] as const;
+const IDENTITY_CHANNEL_OPTIONS = LINKABLE_CHANNEL_IDENTITIES;
 
 function ContactEditDrawer({ contact, creating, allContacts, onClose, onSaved, onDeleted, onMerged }: DrawerProps) {
   const [displayName, setDisplayName] = useState(contact?.displayName ?? '');
@@ -182,7 +186,7 @@ function ContactEditDrawer({ contact, creating, allContacts, onClose, onSaved, o
   // Channel identities (#1514)
   const [identities, setIdentities] = useState<ContactIdentity[]>([]);
   const [identitiesError, setIdentitiesError] = useState<string | null>(null);
-  const [newChannel, setNewChannel] = useState<typeof IDENTITY_CHANNEL_OPTIONS[number]>('email');
+  const [newChannel, setNewChannel] = useState<LinkableChannelIdentity>('email');
   const [newIdentifier, setNewIdentifier] = useState('');
   const [newLabel, setNewLabel] = useState('');
   const [identityBusy, setIdentityBusy] = useState<string | null>(null);
@@ -652,7 +656,7 @@ function ContactEditDrawer({ contact, creating, allContacts, onClose, onSaved, o
                   <select
                     id="ci-channel"
                     value={newChannel}
-                    onChange={e => setNewChannel(e.target.value as typeof IDENTITY_CHANNEL_OPTIONS[number])}
+                    onChange={e => setNewChannel(e.target.value as LinkableChannelIdentity)}
                   >
                     {IDENTITY_CHANNEL_OPTIONS.map(ch => (
                       <option key={ch} value={ch}>{ch}</option>

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-oxc';
 import { createRequire } from 'node:module';
+import path from 'node:path';
 const require = createRequire(import.meta.url);
 const pkg = require('./package.json') as { version: string };
 
@@ -19,6 +20,10 @@ export default defineConfig({
     sourcemap: process.env['NODE_ENV'] !== 'production',
   },
   server: {
+    fs: {
+      // Permit resolving the shared linkable-channels module outside apps/console (#1514).
+      allow: [path.resolve(import.meta.dirname, '../..')],
+    },
     // In dev, proxy backend-served paths to the Fastify server on :3000.
     // This mirrors the production layout where Fastify serves everything from
     // the same origin.

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -21,8 +21,17 @@ export default defineConfig({
   },
   server: {
     fs: {
-      // Permit resolving the shared linkable-channels module outside apps/console (#1514).
-      allow: [path.resolve(import.meta.dirname, '../..')],
+      // Serve only what the dev server actually needs from outside apps/console,
+      // instead of the whole monorepo root (which would expose repo-root secrets
+      // like .env via /@fs/) (#1514):
+      //   - the console project root itself (and its symlinked node_modules)
+      //   - the pnpm-hoisted dependency store at repo-root/node_modules
+      //   - the single shared module the console imports: src/contacts/linkable-channels.ts
+      allow: [
+        import.meta.dirname,
+        path.resolve(import.meta.dirname, '../../node_modules'),
+        path.resolve(import.meta.dirname, '../../src/contacts'),
+      ],
     },
     // In dev, proxy backend-served paths to the Fastify server on :3000.
     // This mirrors the production layout where Fastify serves everything from

--- a/skills/contacts/tools/contact-link-identity/handler.ts
+++ b/skills/contacts/tools/contact-link-identity/handler.ts
@@ -7,6 +7,7 @@
 // This skill uses contactService, which is a universal service.
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
+import { LINKABLE_CHANNEL_IDENTITY_SET } from '../../../../src/contacts/linkable-channels.js';
 
 export class ContactLinkIdentityHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
@@ -36,10 +37,12 @@ export class ContactLinkIdentityHandler implements ToolHandler {
       return { success: false, error: 'Label must be 200 characters or fewer' };
     }
 
-    // Channel allowlist — only accept known channel types
-    const ALLOWED_CHANNELS = ['email', 'phone', 'signal', 'telegram', 'slack'];
-    if (!ALLOWED_CHANNELS.includes(channel)) {
-      return { success: false, error: `Invalid channel '${channel}'. Allowed: ${ALLOWED_CHANNELS.join(', ')}` };
+    // Channel allowlist — single shared constant with the console HTTP API (#1514).
+    if (!LINKABLE_CHANNEL_IDENTITY_SET.has(channel)) {
+      return {
+        success: false,
+        error: `Invalid channel '${channel}'. Allowed: ${[...LINKABLE_CHANNEL_IDENTITY_SET].join(', ')}`,
+      };
     }
 
     // contactService is a universal service — always injected by ExecutionLayer

--- a/skills/contacts/tools/contact-link-identity/handler.ts
+++ b/skills/contacts/tools/contact-link-identity/handler.ts
@@ -1,6 +1,6 @@
 // handler.ts — contact-link-identity skill implementation.
 //
-// Adds a channel identity (email, phone, Signal, Telegram) to an existing
+// Adds a channel identity (email, phone, Signal, Telegram, Slack) to an existing
 // contact. Uses source 'ceo_stated' since the coordinator acts on behalf
 // of the CEO, which means the identity is auto-verified.
 //
@@ -37,7 +37,7 @@ export class ContactLinkIdentityHandler implements ToolHandler {
     }
 
     // Channel allowlist — only accept known channel types
-    const ALLOWED_CHANNELS = ['email', 'phone', 'signal', 'telegram'];
+    const ALLOWED_CHANNELS = ['email', 'phone', 'signal', 'telegram', 'slack'];
     if (!ALLOWED_CHANNELS.includes(channel)) {
       return { success: false, error: `Invalid channel '${channel}'. Allowed: ${ALLOWED_CHANNELS.join(', ')}` };
     }

--- a/skills/contacts/tools/contact-link-identity/tool.json
+++ b/skills/contacts/tools/contact-link-identity/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "contact-link-identity",
-  "description": "Add a channel identity (email, phone, Signal, Telegram) to an existing contact. To update profile attributes (title, organization, timezone, etc.), use contact-update instead.",
-  "version": "1.0.0",
+  "description": "Add a channel identity (email, phone, Signal, Telegram, Slack) to an existing contact. To update profile attributes (title, organization, timezone, etc.), use contact-update instead.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/contacts/tools/contact-merge/handler.ts
+++ b/skills/contacts/tools/contact-merge/handler.ts
@@ -18,6 +18,7 @@
 // than reintroducing a handler gate. See docs/specs/14-autonomy-engine.md.
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
+import { ContactNotFoundError } from '../../../../src/contacts/types.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -86,13 +87,13 @@ export class ContactMergeHandler implements ToolHandler {
         },
       };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('not found')) {
+      if (err instanceof ContactNotFoundError) {
         return {
           success: false,
-          error: `Contact not found: ${message}. Use contact-lookup to verify the contact IDs before retrying.`,
+          error: `Contact not found: ${err.message}. Use contact-lookup to verify the contact IDs before retrying.`,
         };
       }
+      const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err, primary_contact_id, secondary_contact_id }, 'contact-merge failed');
       return { success: false, error: `Merge failed: ${message}` };
     }

--- a/skills/setup/tools/setup-status/catalog.yaml
+++ b/skills/setup/tools/setup-status/catalog.yaml
@@ -58,7 +58,7 @@ tasks:
       keys:
         - channel.signal.socket_path
         - channel.signal.phone_number
-    credential_how_to: "Set up signal-cli (included in docker-compose.yml), then enter the socket path and your phone number in Settings → Channels → Signal."
+    credential_how_to: "Set up signal-cli (included in docker-compose.yml), then enter the socket path and your phone number in Settings → Channels → Signal. After enabling, open Contacts → your principal and add your Signal number as a channel identity so outbound principal detection works."
     docs_url: /channels/signal-setup
 
   - id: slack
@@ -72,7 +72,7 @@ tasks:
       keys:
         - channel.slack.bot_token
         - channel.slack.app_token
-    credential_how_to: "Import Curia's Slack app manifest, name the bot after your office identity, install it into your workspace, then enter the bot token and app-level token in Settings → Channels → Slack."
+    credential_how_to: "Import Curia's Slack app manifest, name the bot after your office identity, install it into your workspace, then enter the bot token and app-level token in Settings → Channels → Slack. After enabling, open Contacts → your principal and add your Slack user ID (U…) as a channel identity so DMs to you skip the outbound judge."
     docs_url: /channels/slack-setup
 
   - id: web_research

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -16,7 +16,10 @@ import {
   resolveNotificationRecipientTier,
 } from './approval-notification.js';
 import { deliverApprovalToChatChannels } from './approval-channel-notify.js';
-
+import {
+  resolvePrincipalEmail,
+  type PrincipalEmailRef,
+} from '../contacts/types.js';
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -107,7 +110,8 @@ export class ApprovalTriggerService {
     // If absent, notification is skipped (same as when ceoEmail is not configured).
     private readonly outboundGateway: OutboundGateway | undefined,
     private readonly logger: Logger,
-    private readonly ceoEmail?: string,
+    /** Plain string (tests) or live ref so post-boot email binds hot-reload (#1514). */
+    private readonly ceoEmail?: string | PrincipalEmailRef,
     // Optional — used to resolve the notification recipient's tier for detail gating.
     private readonly contactService?: ContactService,
     /** Verified principal channel identities — used for Slack/Signal approval DMs (#1479). */
@@ -225,11 +229,12 @@ export class ApprovalTriggerService {
       `Curia wanted to ${description.charAt(0).toLowerCase() + description.slice(1)}, ` +
       `but the autonomy score (${currentScore}) is below the required threshold (${requiredScore}).`;
     const preamble = opts.reason ?? defaultBody;
+    const ceoEmail = resolvePrincipalEmail(this.ceoEmail);
 
-    if (this.ceoEmail && this.outboundGateway) {
+    if (ceoEmail && this.outboundGateway) {
       const recipientTier = await resolveNotificationRecipientTier(
         this.contactService,
-        this.ceoEmail,
+        ceoEmail,
         this.logger,
       );
       const emailBody = buildApprovalNotificationBody({
@@ -240,11 +245,11 @@ export class ApprovalTriggerService {
         payload: input,
         recipientTier,
         logger: this.logger,
-        ceoEmail: this.ceoEmail,
+        ceoEmail,
       });
       const sent = await this.outboundGateway.sendNotification({
         notificationType: 'approval_requested',
-        ceoEmail: this.ceoEmail,
+        ceoEmail,
         subject: `Approval needed — ${description}`,
         body: emailBody,
       });
@@ -258,7 +263,7 @@ export class ApprovalTriggerService {
           'approval-trigger: CEO notification failed — row exists, CEO will see it in digest',
         );
       }
-    } else if (!this.ceoEmail) {
+    } else if (!ceoEmail) {
       this.logger.warn(
         { rowId, shortRef },
         'approval-trigger: ceoEmail not configured — skipping email notification',

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -12,6 +12,8 @@ import type { Logger } from '../../logger.js';
 import type { OutboundGateway } from '../../skills/outbound-gateway.js';
 import type { EmailSendRequest } from './outbound-request.js';
 import type { ContactService } from '../../contacts/contact-service.js';
+import type { PrincipalEmailRef } from '../../contacts/types.js';
+import { resolvePrincipalEmail } from '../../contacts/types.js';
 import type { ConfigStore } from '../../memory/config-store.js';
 import { convertNylasMessage } from './message-converter.js';
 import {
@@ -76,9 +78,10 @@ export interface EmailAdapterConfig {
   suppressedSenderEmails: string[];
   /**
    * CEO's email address — used as the recipient for rate-limit notification emails.
-   * When absent, rate-limit notifications are logged but not emailed.
+   * When absent/empty, rate-limit notifications are logged but not emailed.
+   * Accepts a mutable PrincipalEmailRef so post-boot binds hot-reload (#1514).
    */
-  ceoEmail?: string;
+  ceoEmail?: string | PrincipalEmailRef;
   /**
    * Maximum new contacts to auto-create from a single email's participant list.
    * Existing contacts (already in DB) don't count. Default: 10.
@@ -1047,7 +1050,8 @@ export class EmailAdapter implements Channel {
     emailSubject: string,
     emailSender: string,
   ): Promise<void> {
-    const { outboundGateway, logger, ceoEmail } = this.config;
+    const { outboundGateway, logger } = this.config;
+    const ceoEmail = resolvePrincipalEmail(this.config.ceoEmail);
     const now = Date.now();
 
     // Dedup: skip if we already sent a notification for this limit type within the last hour

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -115,6 +115,11 @@ export interface HttpAdapterConfig {
    */
   setupRequiredAtBoot: boolean;
   /**
+   * Hot-reload the startup-cached principalIdentities array after console identity
+   * mutations (#1514). Optional — omitted in tests that don't exercise principal matching.
+   */
+  onPrincipalIdentitiesChanged?: () => void | Promise<void>;
+  /**
    * ISO timestamp captured at the very start of main() so the wizard's post-
    * setup polling loop can detect a process restart (the value changes after
    * the supervisor brings the new process up). Exposed via GET /api/setup/status.
@@ -495,6 +500,7 @@ export class HttpAdapter implements Channel {
         eventRouter: this.eventRouter,
         contactService: this.config.contactService,
         sessions,
+        onPrincipalIdentitiesChanged: this.config.onPrincipalIdentitiesChanged,
       });
     }
 

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -115,11 +115,6 @@ export interface HttpAdapterConfig {
    */
   setupRequiredAtBoot: boolean;
   /**
-   * Hot-reload the startup-cached principalIdentities array after console identity
-   * mutations (#1514). Optional — omitted in tests that don't exercise principal matching.
-   */
-  onPrincipalIdentitiesChanged?: () => void | Promise<void>;
-  /**
    * ISO timestamp captured at the very start of main() so the wizard's post-
    * setup polling loop can detect a process restart (the value changes after
    * the supervisor brings the new process up). Exposed via GET /api/setup/status.
@@ -500,7 +495,6 @@ export class HttpAdapter implements Channel {
         eventRouter: this.eventRouter,
         contactService: this.config.contactService,
         sessions,
-        onPrincipalIdentitiesChanged: this.config.onPrincipalIdentitiesChanged,
       });
     }
 

--- a/src/channels/http/routes/kg.test.ts
+++ b/src/channels/http/routes/kg.test.ts
@@ -292,3 +292,244 @@ describe('GET /api/kg/contacts/:id/identities', () => {
     expect(res.statusCode).toBe(401);
   });
 });
+
+function makeIdentity(overrides: Partial<ChannelIdentity> = {}): ChannelIdentity {
+  return {
+    id: '22222222-2222-4222-8222-222222222222',
+    contactId: '11111111-1111-4111-8111-111111111111',
+    channel: 'slack',
+    channelIdentifier: 'U_CEO',
+    label: null,
+    verified: true,
+    verifiedAt: new Date('2024-01-02T00:00:00Z'),
+    status: 'active',
+    source: 'ceo_stated',
+    createdAt: new Date('2024-01-02T00:00:00Z'),
+    updatedAt: new Date('2024-01-02T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('POST /api/kg/contacts/:id/identities — link (#1514)', () => {
+  let app: FastifyInstance;
+  const CID = '11111111-1111-4111-8111-111111111111';
+  const contact = { ...BASE_CONTACT, id: CID };
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('links a verified ceo_stated identity and returns 201', async () => {
+    const linked = makeIdentity({ contactId: CID });
+    const linkIdentity = vi.fn().mockResolvedValue(linked);
+    const svc = fakeContactService({
+      linkIdentity,
+      getContact: vi.fn().mockResolvedValue(contact),
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/kg/contacts/${CID}/identities`,
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ channel: 'slack', channelIdentifier: 'U_CEO' }),
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().identity.channel).toBe('slack');
+    expect(res.json().identity.verified).toBe(true);
+    expect(linkIdentity).toHaveBeenCalledWith(expect.objectContaining({
+      contactId: CID,
+      channel: 'slack',
+      channelIdentifier: 'U_CEO',
+      source: 'ceo_stated',
+      verified: true,
+    }));
+  });
+
+  it('rejects an unknown channel with 400', async () => {
+    const svc = fakeContactService({ getContact: vi.fn().mockResolvedValue(contact) });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/kg/contacts/${CID}/identities`,
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ channel: 'discord', channelIdentifier: 'x' }),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 409 when the identity is already linked elsewhere', async () => {
+    const err = Object.assign(new Error('duplicate'), { code: '23505' });
+    const svc = fakeContactService({
+      getContact: vi.fn().mockResolvedValue(contact),
+      linkIdentity: vi.fn().mockRejectedValue(err),
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/kg/contacts/${CID}/identities`,
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ channel: 'slack', channelIdentifier: 'U_CEO' }),
+    });
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe('PATCH /api/kg/contacts/:id/identities/:identityId — verify/status (#1514)', () => {
+  let app: FastifyInstance;
+  const CID = '11111111-1111-4111-8111-111111111111';
+  const contact = { ...BASE_CONTACT, id: CID };
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('verifies an unverified identity', async () => {
+    const existing = makeIdentity({ contactId: CID, verified: false, verifiedAt: null, source: 'self_claimed' });
+    const verified = { ...existing, verified: true, verifiedAt: new Date() };
+    const svc = fakeContactService({
+      getContact: vi.fn().mockResolvedValue(contact),
+      getIdentity: vi.fn().mockResolvedValue(existing),
+      verifyIdentity: vi.fn().mockResolvedValue(verified),
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/kg/contacts/${CID}/identities/${existing.id}`,
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ verified: true }),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().identity.verified).toBe(true);
+  });
+
+  it('updates identity status', async () => {
+    const existing = makeIdentity({ contactId: CID });
+    const updated = { ...existing, status: 'defunct' as const };
+    const svc = fakeContactService({
+      getContact: vi.fn().mockResolvedValue(contact),
+      getIdentity: vi.fn().mockResolvedValue(existing),
+      setIdentityStatus: vi.fn().mockResolvedValue(updated),
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/kg/contacts/${CID}/identities/${existing.id}`,
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'defunct' }),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().identity.status).toBe('defunct');
+  });
+});
+
+describe('DELETE /api/kg/contacts/:id/identities/:identityId — unlink (#1514)', () => {
+  let app: FastifyInstance;
+  const CID = '11111111-1111-4111-8111-111111111111';
+  const contact = { ...BASE_CONTACT, id: CID };
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('unlinks an identity owned by the contact', async () => {
+    const existing = makeIdentity({ contactId: CID });
+    const unlinkIdentity = vi.fn().mockResolvedValue(true);
+    const svc = fakeContactService({
+      getContact: vi.fn().mockResolvedValue(contact),
+      getIdentity: vi.fn().mockResolvedValue(existing),
+      unlinkIdentity,
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/kg/contacts/${CID}/identities/${existing.id}`,
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(204);
+    expect(unlinkIdentity).toHaveBeenCalledWith(existing.id);
+  });
+
+  it('returns 404 when the identity belongs to another contact', async () => {
+    const existing = makeIdentity({ contactId: '33333333-3333-4333-8333-333333333333' });
+    const svc = fakeContactService({
+      getContact: vi.fn().mockResolvedValue(contact),
+      getIdentity: vi.fn().mockResolvedValue(existing),
+      unlinkIdentity: vi.fn(),
+    });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/kg/contacts/${CID}/identities/${existing.id}`,
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('POST /api/kg/contacts/merge — merge lookalikes (#1514)', () => {
+  let app: FastifyInstance;
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  const PRIMARY = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const SECONDARY = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  it('defaults to dryRun and returns a golden-record preview', async () => {
+    const mergeContacts = vi.fn().mockResolvedValue({
+      primaryContactId: PRIMARY,
+      secondaryContactId: SECONDARY,
+      dryRun: true,
+      goldenRecord: {
+        displayName: 'Principal',
+        role: null,
+        notes: null,
+        tier: 'principal',
+        identities: [makeIdentity()],
+        authOverrides: [],
+      },
+    });
+    const svc = fakeContactService({ mergeContacts });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/kg/contacts/merge',
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ primaryContactId: PRIMARY, secondaryContactId: SECONDARY }),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().dryRun).toBe(true);
+    expect(res.json().goldenRecord.identityCount).toBe(1);
+    expect(mergeContacts).toHaveBeenCalledWith(PRIMARY, SECONDARY, true);
+  });
+
+  it('commits when dryRun is false', async () => {
+    const mergeContacts = vi.fn().mockResolvedValue({
+      primaryContactId: PRIMARY,
+      secondaryContactId: SECONDARY,
+      dryRun: false,
+      mergedAt: new Date('2024-06-01T00:00:00Z'),
+      goldenRecord: {
+        displayName: 'Principal',
+        role: null,
+        notes: null,
+        tier: 'principal',
+        identities: [],
+        authOverrides: [],
+      },
+    });
+    const svc = fakeContactService({ mergeContacts });
+    app = await build(svc);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/kg/contacts/merge',
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        primaryContactId: PRIMARY,
+        secondaryContactId: SECONDARY,
+        dryRun: false,
+      }),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().dryRun).toBe(false);
+    expect(res.json().mergedAt).toBe('2024-06-01T00:00:00.000Z');
+    expect(mergeContacts).toHaveBeenCalledWith(PRIMARY, SECONDARY, false);
+  });
+});

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -6,7 +6,8 @@ import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import { ContactValidationError } from '../../../contacts/contact-service.js';
-import type { ChannelIdentity, Contact, ContactCanonicalFields, ContactKind, ContactTier } from '../../../contacts/types.js';
+import type { ChannelIdentity, Contact, ContactCanonicalFields, ContactKind, ContactTier, IdentityStatus } from '../../../contacts/types.js';
+import { IdentityNotFoundError } from '../../../contacts/types.js';
 import type { EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { resolveConsoleOriginator } from '../console-originator.js';
@@ -31,6 +32,12 @@ export interface KnowledgeGraphRouteOptions {
   // Shared session store — created in HttpAdapter, passed to both KG and identity routes
   // so both can accept the curia_session cookie for authentication.
   sessions: SessionStore;
+  /**
+   * Hot-reload the startup-cached principalIdentities array after console identity
+   * mutations (#1514). Optional so unit tests that don't care about principal matching
+   * can omit it.
+   */
+  onPrincipalIdentitiesChanged?: () => void | Promise<void>;
 }
 
 // Channel identifier used when the KG web app dispatches messages to the agent layer.
@@ -78,7 +85,16 @@ export async function knowledgeGraphRoutes(
   app: FastifyInstance,
   options: KnowledgeGraphRouteOptions,
 ): Promise<void> {
-  const { pool, logger, webAppBootstrapSecret, secureCookies, bus, eventRouter, contactService, sessions } = options;
+  const { pool, logger, webAppBootstrapSecret, secureCookies, bus, eventRouter, contactService, sessions, onPrincipalIdentitiesChanged } = options;
+
+  async function notifyPrincipalIdentitiesChanged(): Promise<void> {
+    if (!onPrincipalIdentitiesChanged) return;
+    try {
+      await onPrincipalIdentitiesChanged();
+    } catch (err) {
+      logger.warn({ err }, 'onPrincipalIdentitiesChanged failed (non-fatal)');
+    }
+  }
   // sessions is managed by HttpAdapter — no local Map creation needed here.
 
   // POST /auth — exchanges the bootstrap secret for an HttpOnly session cookie.
@@ -1157,6 +1173,203 @@ export async function knowledgeGraphRoutes(
     } catch (err) {
       logger.error({ err, contactId: id }, 'GET /api/kg/contacts/:id/identities failed');
       return reply.status(500).send({ error: 'Failed to load identities.' });
+    }
+  });
+
+  // Channels the console may bind. Matches contact-link-identity (plus slack — #1514).
+  const IDENTITY_CHANNELS = new Set(['email', 'phone', 'signal', 'telegram', 'slack']);
+  const IDENTITY_STATUSES = new Set<IdentityStatus>(['active', 'defunct', 'bounced']);
+
+  // POST /api/kg/contacts/:id/identities — link a channel identity (CEO-stated → verified).
+  // Binding a Slack/Signal/SMS identity to the principal is the durable fix for the
+  // outbound-filter principal-detection gap (#1514).
+  app.post('/api/kg/contacts/:id/identities', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+    const { id } = request.params as { id: string };
+    if (!UUID_RE.test(id)) return reply.status(400).send({ error: 'Invalid contact ID.' });
+
+    const body = (request.body ?? {}) as {
+      channel?: unknown;
+      channelIdentifier?: unknown;
+      label?: unknown;
+    };
+    const channel = typeof body.channel === 'string' ? body.channel.trim() : '';
+    const channelIdentifier = typeof body.channelIdentifier === 'string' ? body.channelIdentifier.trim() : '';
+    const label = typeof body.label === 'string' && body.label.trim().length > 0
+      ? body.label.trim()
+      : undefined;
+
+    if (!IDENTITY_CHANNELS.has(channel)) {
+      return reply.status(400).send({
+        error: `Invalid channel. Allowed: ${[...IDENTITY_CHANNELS].join(', ')}.`,
+      });
+    }
+    if (!channelIdentifier) {
+      return reply.status(400).send({ error: 'channelIdentifier is required.' });
+    }
+    if (channelIdentifier.length > 500) {
+      return reply.status(400).send({ error: 'channelIdentifier must be 500 characters or fewer.' });
+    }
+    if (label && label.length > 200) {
+      return reply.status(400).send({ error: 'label must be 200 characters or fewer.' });
+    }
+
+    try {
+      const contact = await contactService.getContact(id);
+      if (!contact) return reply.status(404).send({ error: 'Contact not found.' });
+
+      const identity = await contactService.linkIdentity({
+        contactId: id,
+        channel,
+        channelIdentifier,
+        label,
+        source: 'ceo_stated',
+        verified: true,
+      });
+      await notifyPrincipalIdentitiesChanged();
+      return reply.status(201).send({ identity: serializeIdentity(identity) });
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === '23505') {
+        return reply.status(409).send({
+          error: 'That channel identity is already linked to a contact. Merge the lookalike or unlink it first.',
+        });
+      }
+      logger.error({ err, contactId: id }, 'POST /api/kg/contacts/:id/identities failed');
+      return reply.status(500).send({ error: 'Failed to link identity.' });
+    }
+  });
+
+  // PATCH /api/kg/contacts/:id/identities/:identityId — update status and/or verify.
+  app.patch('/api/kg/contacts/:id/identities/:identityId', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+    const { id, identityId } = request.params as { id: string; identityId: string };
+    if (!UUID_RE.test(id) || !UUID_RE.test(identityId)) {
+      return reply.status(400).send({ error: 'Invalid contact or identity ID.' });
+    }
+
+    const body = (request.body ?? {}) as { status?: unknown; verified?: unknown };
+    const hasStatus = 'status' in body;
+    const hasVerified = 'verified' in body;
+    if (!hasStatus && !hasVerified) {
+      return reply.status(400).send({ error: 'Provide status and/or verified.' });
+    }
+
+    let nextStatus: IdentityStatus | undefined;
+    if (hasStatus) {
+      if (typeof body.status !== 'string' || !IDENTITY_STATUSES.has(body.status as IdentityStatus)) {
+        return reply.status(400).send({ error: "status must be 'active', 'defunct', or 'bounced'." });
+      }
+      nextStatus = body.status as IdentityStatus;
+    }
+    if (hasVerified && body.verified !== true) {
+      // Console verify is one-way: un-verifying would silently drop principal detection.
+      return reply.status(400).send({ error: 'verified may only be set to true (use status to retire an identity).' });
+    }
+
+    try {
+      const contact = await contactService.getContact(id);
+      if (!contact) return reply.status(404).send({ error: 'Contact not found.' });
+
+      const existing = await contactService.getIdentity(identityId);
+      if (!existing || existing.contactId !== id) {
+        return reply.status(404).send({ error: 'Identity not found on this contact.' });
+      }
+
+      let updated = existing;
+      if (nextStatus !== undefined) {
+        updated = await contactService.setIdentityStatus(identityId, nextStatus);
+      }
+      if (hasVerified && body.verified === true && !updated.verified) {
+        updated = await contactService.verifyIdentity(identityId);
+      }
+      await notifyPrincipalIdentitiesChanged();
+      return reply.send({ identity: serializeIdentity(updated) });
+    } catch (err) {
+      if (err instanceof IdentityNotFoundError) {
+        return reply.status(404).send({ error: 'Identity not found.' });
+      }
+      logger.error({ err, contactId: id, identityId }, 'PATCH /api/kg/contacts/:id/identities/:identityId failed');
+      return reply.status(500).send({ error: 'Failed to update identity.' });
+    }
+  });
+
+  // DELETE /api/kg/contacts/:id/identities/:identityId — unlink a channel identity.
+  app.delete('/api/kg/contacts/:id/identities/:identityId', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+    const { id, identityId } = request.params as { id: string; identityId: string };
+    if (!UUID_RE.test(id) || !UUID_RE.test(identityId)) {
+      return reply.status(400).send({ error: 'Invalid contact or identity ID.' });
+    }
+
+    try {
+      const contact = await contactService.getContact(id);
+      if (!contact) return reply.status(404).send({ error: 'Contact not found.' });
+
+      const existing = await contactService.getIdentity(identityId);
+      if (!existing || existing.contactId !== id) {
+        return reply.status(404).send({ error: 'Identity not found on this contact.' });
+      }
+
+      const removed = await contactService.unlinkIdentity(identityId);
+      if (!removed) return reply.status(404).send({ error: 'Identity not found.' });
+      await notifyPrincipalIdentitiesChanged();
+      return reply.status(204).send();
+    } catch (err) {
+      logger.error({ err, contactId: id, identityId }, 'DELETE /api/kg/contacts/:id/identities/:identityId failed');
+      return reply.status(500).send({ error: 'Failed to unlink identity.' });
+    }
+  });
+
+  // POST /api/kg/contacts/merge — merge secondary into primary (re-points identities).
+  // dryRun defaults to true so a preview is always available before commit.
+  app.post('/api/kg/contacts/merge', KG_RATE, async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+
+    const body = (request.body ?? {}) as {
+      primaryContactId?: unknown;
+      secondaryContactId?: unknown;
+      dryRun?: unknown;
+    };
+    const primaryContactId = typeof body.primaryContactId === 'string' ? body.primaryContactId : '';
+    const secondaryContactId = typeof body.secondaryContactId === 'string' ? body.secondaryContactId : '';
+    if (!UUID_RE.test(primaryContactId) || !UUID_RE.test(secondaryContactId)) {
+      return reply.status(400).send({ error: 'primaryContactId and secondaryContactId must be valid UUIDs.' });
+    }
+    if (primaryContactId === secondaryContactId) {
+      return reply.status(400).send({ error: 'primaryContactId and secondaryContactId must differ.' });
+    }
+    const dryRun = body.dryRun !== false;
+
+    try {
+      const result = await contactService.mergeContacts(primaryContactId, secondaryContactId, dryRun);
+      if (!dryRun) await notifyPrincipalIdentitiesChanged();
+      return reply.send({
+        primaryContactId: result.primaryContactId,
+        secondaryContactId: result.secondaryContactId,
+        dryRun: result.dryRun,
+        goldenRecord: {
+          displayName: result.goldenRecord.displayName,
+          role: result.goldenRecord.role,
+          notes: result.goldenRecord.notes,
+          tier: result.goldenRecord.tier,
+          identityCount: result.goldenRecord.identities.length,
+          authOverrideCount: result.goldenRecord.authOverrides.length,
+        },
+        ...('mergedAt' in result && result.mergedAt
+          ? { mergedAt: result.mergedAt.toISOString() }
+          : {}),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('not found')) {
+        return reply.status(404).send({ error: message });
+      }
+      if (message.includes('structural contact') || message.includes('must be different')) {
+        return reply.status(400).send({ error: message });
+      }
+      logger.error({ err, primaryContactId, secondaryContactId }, 'POST /api/kg/contacts/merge failed');
+      return reply.status(500).send({ error: 'Failed to merge contacts.' });
     }
   });
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -7,7 +7,12 @@ import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import { ContactValidationError } from '../../../contacts/contact-service.js';
 import type { ChannelIdentity, Contact, ContactCanonicalFields, ContactKind, ContactTier, IdentityStatus } from '../../../contacts/types.js';
-import { IdentityNotFoundError } from '../../../contacts/types.js';
+import {
+  IdentityNotFoundError,
+  ContactNotFoundError,
+  StructuralContactMergeError,
+} from '../../../contacts/types.js';
+import { LINKABLE_CHANNEL_IDENTITY_SET } from '../../../contacts/linkable-channels.js';
 import type { EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { resolveConsoleOriginator } from '../console-originator.js';
@@ -32,12 +37,6 @@ export interface KnowledgeGraphRouteOptions {
   // Shared session store — created in HttpAdapter, passed to both KG and identity routes
   // so both can accept the curia_session cookie for authentication.
   sessions: SessionStore;
-  /**
-   * Hot-reload the startup-cached principalIdentities array after console identity
-   * mutations (#1514). Optional so unit tests that don't care about principal matching
-   * can omit it.
-   */
-  onPrincipalIdentitiesChanged?: () => void | Promise<void>;
 }
 
 // Channel identifier used when the KG web app dispatches messages to the agent layer.
@@ -85,16 +84,8 @@ export async function knowledgeGraphRoutes(
   app: FastifyInstance,
   options: KnowledgeGraphRouteOptions,
 ): Promise<void> {
-  const { pool, logger, webAppBootstrapSecret, secureCookies, bus, eventRouter, contactService, sessions, onPrincipalIdentitiesChanged } = options;
-
-  async function notifyPrincipalIdentitiesChanged(): Promise<void> {
-    if (!onPrincipalIdentitiesChanged) return;
-    try {
-      await onPrincipalIdentitiesChanged();
-    } catch (err) {
-      logger.warn({ err }, 'onPrincipalIdentitiesChanged failed (non-fatal)');
-    }
-  }
+  const { pool, logger, webAppBootstrapSecret, secureCookies, bus, eventRouter, contactService, sessions } = options;
+  // sessions is managed by HttpAdapter — no local Map creation needed here.
   // sessions is managed by HttpAdapter — no local Map creation needed here.
 
   // POST /auth — exchanges the bootstrap secret for an HttpOnly session cookie.
@@ -1176,13 +1167,13 @@ export async function knowledgeGraphRoutes(
     }
   });
 
-  // Channels the console may bind. Matches contact-link-identity (plus slack — #1514).
-  const IDENTITY_CHANNELS = new Set(['email', 'phone', 'signal', 'telegram', 'slack']);
+  // Channels the console may bind — single allowlist shared with contact-link-identity (#1514).
   const IDENTITY_STATUSES = new Set<IdentityStatus>(['active', 'defunct', 'bounced']);
 
   // POST /api/kg/contacts/:id/identities — link a channel identity (CEO-stated → verified).
   // Binding a Slack/Signal/SMS identity to the principal is the durable fix for the
-  // outbound-filter principal-detection gap (#1514).
+  // outbound-filter principal-detection gap (#1514). Principal cache refresh is handled
+  // by ContactService.onIdentitiesChanged (no route-level duplicate).
   app.post('/api/kg/contacts/:id/identities', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const { id } = request.params as { id: string };
@@ -1199,9 +1190,9 @@ export async function knowledgeGraphRoutes(
       ? body.label.trim()
       : undefined;
 
-    if (!IDENTITY_CHANNELS.has(channel)) {
+    if (!LINKABLE_CHANNEL_IDENTITY_SET.has(channel)) {
       return reply.status(400).send({
-        error: `Invalid channel. Allowed: ${[...IDENTITY_CHANNELS].join(', ')}.`,
+        error: `Invalid channel. Allowed: ${[...LINKABLE_CHANNEL_IDENTITY_SET].join(', ')}.`,
       });
     }
     if (!channelIdentifier) {
@@ -1226,7 +1217,6 @@ export async function knowledgeGraphRoutes(
         source: 'ceo_stated',
         verified: true,
       });
-      await notifyPrincipalIdentitiesChanged();
       return reply.status(201).send({ identity: serializeIdentity(identity) });
     } catch (err) {
       const code = (err as { code?: string }).code;
@@ -1283,7 +1273,6 @@ export async function knowledgeGraphRoutes(
       if (hasVerified && body.verified === true && !updated.verified) {
         updated = await contactService.verifyIdentity(identityId);
       }
-      await notifyPrincipalIdentitiesChanged();
       return reply.send({ identity: serializeIdentity(updated) });
     } catch (err) {
       if (err instanceof IdentityNotFoundError) {
@@ -1313,7 +1302,6 @@ export async function knowledgeGraphRoutes(
 
       const removed = await contactService.unlinkIdentity(identityId);
       if (!removed) return reply.status(404).send({ error: 'Identity not found.' });
-      await notifyPrincipalIdentitiesChanged();
       return reply.status(204).send();
     } catch (err) {
       logger.error({ err, contactId: id, identityId }, 'DELETE /api/kg/contacts/:id/identities/:identityId failed');
@@ -1323,6 +1311,7 @@ export async function knowledgeGraphRoutes(
 
   // POST /api/kg/contacts/merge — merge secondary into primary (re-points identities).
   // dryRun defaults to true so a preview is always available before commit.
+  // Principal cache refresh (when primary is the principal) is via onIdentitiesChanged.
   app.post('/api/kg/contacts/merge', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
 
@@ -1343,7 +1332,6 @@ export async function knowledgeGraphRoutes(
 
     try {
       const result = await contactService.mergeContacts(primaryContactId, secondaryContactId, dryRun);
-      if (!dryRun) await notifyPrincipalIdentitiesChanged();
       return reply.send({
         primaryContactId: result.primaryContactId,
         secondaryContactId: result.secondaryContactId,
@@ -1361,11 +1349,14 @@ export async function knowledgeGraphRoutes(
           : {}),
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('not found')) {
-        return reply.status(404).send({ error: message });
+      if (err instanceof ContactNotFoundError) {
+        return reply.status(404).send({ error: err.message });
       }
-      if (message.includes('structural contact') || message.includes('must be different')) {
+      if (err instanceof StructuralContactMergeError) {
+        return reply.status(400).send({ error: err.message });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('must be different')) {
         return reply.status(400).send({ error: message });
       }
       logger.error({ err, primaryContactId, secondaryContactId }, 'POST /api/kg/contacts/merge failed');

--- a/src/contacts/contact-identity-binding.test.ts
+++ b/src/contacts/contact-identity-binding.test.ts
@@ -1,0 +1,147 @@
+// contact-identity-binding.test.ts — #1514
+//
+// Covers the durable principal-detection fix: bind a Slack identity onto the
+// principal contact → structural match → inbound resolves to principal (not a
+// lookalike) → Stage-2 judge skips when that identity is the sole recipient.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ContactService } from './contact-service.js';
+import { isPrincipalIdentity, computePrincipalIsSoleRecipient } from './principal-recipient.js';
+import type { ChannelIdentity } from './types.js';
+import { OutboundLlmJudge } from '../dispatch/outbound-judge.js';
+import type { JudgeConfig } from '../dispatch/outbound-judge.js';
+import type { LLMProvider } from '../agents/llm/provider.js';
+import { ModelRegistry } from '../agents/llm/model-registry.js';
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+
+const silentLogger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn(), trace: vi.fn(),
+  child: () => silentLogger,
+} as unknown as Logger;
+
+async function makePrincipal(svc: ContactService) {
+  const created = await svc.createContact({
+    displayName: 'CEO',
+    tier: 'known',
+    kind: 'person',
+    source: 'test',
+  });
+  // createContact always stores systemRole=null; promote to structural principal.
+  return svc.saveContact({
+    ...created,
+    systemRole: 'principal',
+    tier: 'principal',
+    kind: 'principal',
+  });
+}
+
+describe('principal channel-identity binding (#1514)', () => {
+  it('binding Slack to the principal makes isPrincipalIdentity match and inbound resolve', async () => {
+    const changed: string[] = [];
+    const svc = ContactService.createInMemory(undefined, {
+      onIdentitiesChanged: (contactId) => { changed.push(contactId); },
+    });
+
+    const principal = await makePrincipal(svc);
+
+    // Before binding — Slack DM from the CEO creates a lookalike via ensureChannelContact.
+    const lookalike = await svc.ensureChannelContact({
+      channel: 'slack',
+      channelIdentifier: 'U_CEO',
+      displayName: 'CEO',
+      source: 'slack_participant',
+    });
+    expect(lookalike.contactId).not.toBe(principal.id);
+    expect(lookalike.created).toBe(true);
+
+    // Merge lookalike → principal (console / agent path for the incident repair).
+    await svc.mergeContacts(principal.id, lookalike.contactId, false);
+    expect(changed).toContain(principal.id);
+
+    const identities = await svc.getIdentitiesForContact(principal.id);
+    const slack = identities.find((i) => i.channel === 'slack');
+    expect(slack).toBeDefined();
+    expect(slack!.verified).toBe(true);
+    expect(slack!.status).toBe('active');
+
+    // Structural principal match (outbound filter / Gate C input).
+    expect(isPrincipalIdentity('slack', 'U_CEO', identities)).toBe(true);
+    expect(
+      computePrincipalIsSoleRecipient([
+        { identifier: 'U_CEO', isPrincipal: true },
+      ]),
+    ).toBe(true);
+
+    // Inbound from the same Slack user now resolves to the principal — no new lookalike.
+    const resolved = await svc.resolveByChannelIdentity('slack', 'U_CEO');
+    expect(resolved?.contactId).toBe(principal.id);
+    expect(resolved?.systemRole).toBe('principal');
+
+    const again = await svc.ensureChannelContact({
+      channel: 'slack',
+      channelIdentifier: 'U_CEO',
+      displayName: 'CEO',
+      source: 'slack_participant',
+    });
+    expect(again.contactId).toBe(principal.id);
+    expect(again.created).toBe(false);
+  });
+
+  it('linking Slack directly onto the principal verifies and notifies', async () => {
+    const changed: string[] = [];
+    const svc = ContactService.createInMemory(undefined, {
+      onIdentitiesChanged: (contactId) => { changed.push(contactId); },
+    });
+
+    const principal = await makePrincipal(svc);
+
+    const identity = await svc.linkIdentity({
+      contactId: principal.id,
+      channel: 'slack',
+      channelIdentifier: 'U0123ABCDEF',
+      source: 'ceo_stated',
+      verified: true,
+    });
+    expect(identity.verified).toBe(true);
+    expect(changed).toContain(principal.id);
+
+    // Hot-reload pattern used by index.ts — mutate a shared cache in place.
+    const cache: ChannelIdentity[] = [];
+    const fresh = (await svc.getIdentitiesForContact(principal.id))
+      .filter((id) => id.verified && id.status === 'active');
+    cache.length = 0;
+    cache.push(...fresh);
+
+    expect(isPrincipalIdentity('slack', 'U0123ABCDEF', cache)).toBe(true);
+  });
+
+  it('Stage-2 judge skips when principalIsSoleRecipient is true after binding', async () => {
+    const provider = {
+      id: 'fake',
+      chat: vi.fn(async () => {
+        throw new Error('LLM should not be called for principal-only sends');
+      }),
+    } as unknown as LLMProvider;
+    const bus = { publish: vi.fn() } as unknown as EventBus;
+    const registry = new ModelRegistry(silentLogger);
+    const config: JudgeConfig = {
+      enabled: true,
+      model: 'claude-haiku-4-5',
+      timeoutMs: 5000,
+      failMode: 'split',
+    };
+    const judge = new OutboundLlmJudge(provider, config, bus, silentLogger, registry);
+
+    const findings = await judge.review({
+      content: 'Hi — your Google Docs auth failed; retry the OAuth grant.',
+      recipients: [{ email: 'U_CEO', isPrincipal: true }],
+      principalIncluded: true,
+      principalIsSoleRecipient: true,
+      conversationId: 'conv-1',
+      channelId: 'slack',
+    });
+    expect(findings).toEqual([]);
+    expect(provider.chat).not.toHaveBeenCalled();
+  });
+});

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -14,7 +14,7 @@ import type { DbPool, DbPoolClient } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import { sanitizeDisplayName } from '../skills/sanitize.js';
-import { TIER_RANK, IdentityNotFoundError } from './types.js';
+import { TIER_RANK, IdentityNotFoundError, ContactNotFoundError, StructuralContactMergeError } from './types.js';
 import type {
   AuthOverride,
   Contact,
@@ -273,19 +273,34 @@ export class ContactService {
     this.onDuplicateDetected = options?.onDuplicateDetected;
   }
 
-  /** Fire-and-forget identity-mutation notifier (#1514). Never fails the caller. */
-  private notifyIdentitiesChanged(contactId: string): void {
-    if (!this.onIdentitiesChanged) return;
+  /** Fire-and-forget maybe-async callback. Never fails the caller (#1514). */
+  private invokeNonFatalCallback(
+    label: string,
+    callback: (() => void | Promise<void>) | undefined,
+    context: Record<string, unknown>,
+  ): void {
+    if (!callback) return;
     try {
-      const maybePromise = this.onIdentitiesChanged(contactId);
+      const maybePromise = callback();
       if (maybePromise instanceof Promise) {
         maybePromise.catch(err => {
-          this.logger?.warn({ err, contactId }, 'onIdentitiesChanged callback rejected (non-fatal)');
+          this.logger?.warn({ err, ...context }, `${label} callback rejected (non-fatal)`);
         });
       }
     } catch (err) {
-      this.logger?.warn({ err, contactId }, 'onIdentitiesChanged callback threw (non-fatal)');
+      this.logger?.warn({ err, ...context }, `${label} callback threw (non-fatal)`);
     }
+  }
+
+  /** Fire-and-forget identity-mutation notifier (#1514). Never fails the caller. */
+  private notifyIdentitiesChanged(contactId: string): void {
+    this.invokeNonFatalCallback(
+      'onIdentitiesChanged',
+      this.onIdentitiesChanged
+        ? () => this.onIdentitiesChanged!(contactId)
+        : undefined,
+      { contactId },
+    );
   }
 
   /** Create a Postgres-backed instance for production use */
@@ -817,21 +832,15 @@ export class ContactService {
     await this.backend.createIdentity(identity);
 
     // Fire-and-forget: notify scoring pipeline when a verified identity is linked.
-    // The callback may return a promise (async pipeline update), so we handle both
-    // sync throws and async rejections. Scoring is non-blocking — must not fail
-    // the linkIdentity operation.
-    if (verified && this.onIdentityVerified) {
-      try {
-        const maybePromise = this.onIdentityVerified(options.contactId) as void | Promise<void>;
-        // Handle async callbacks — catch unhandled rejections
-        if (maybePromise instanceof Promise) {
-          maybePromise.catch(err => {
-            this.logger?.warn({ err, contactId: options.contactId }, 'onIdentityVerified callback rejected (non-fatal)');
-          });
-        }
-      } catch (err) {
-        this.logger?.warn({ err, contactId: options.contactId }, 'onIdentityVerified callback threw (non-fatal)');
-      }
+    // Scoring is non-blocking — must not fail the linkIdentity operation.
+    if (verified) {
+      this.invokeNonFatalCallback(
+        'onIdentityVerified',
+        this.onIdentityVerified
+          ? () => this.onIdentityVerified!(options.contactId)
+          : undefined,
+        { contactId: options.contactId },
+      );
     }
 
     this.notifyIdentitiesChanged(options.contactId);
@@ -1137,18 +1146,13 @@ export class ContactService {
    */
   async verifyIdentity(identityId: string): Promise<ChannelIdentity> {
     const updated = await this.backend.verifyIdentity(identityId);
-    if (this.onIdentityVerified) {
-      try {
-        const maybePromise = this.onIdentityVerified(updated.contactId) as void | Promise<void>;
-        if (maybePromise instanceof Promise) {
-          maybePromise.catch(err => {
-            this.logger?.warn({ err, contactId: updated.contactId }, 'onIdentityVerified callback rejected (non-fatal)');
-          });
-        }
-      } catch (err) {
-        this.logger?.warn({ err, contactId: updated.contactId }, 'onIdentityVerified callback threw (non-fatal)');
-      }
-    }
+    this.invokeNonFatalCallback(
+      'onIdentityVerified',
+      this.onIdentityVerified
+        ? () => this.onIdentityVerified!(updated.contactId)
+        : undefined,
+      { contactId: updated.contactId },
+    );
     this.notifyIdentitiesChanged(updated.contactId);
     return updated;
   }
@@ -1379,9 +1383,9 @@ export class ContactService {
     }
 
     const primary = await this.backend.getContact(primaryId);
-    if (!primary) throw new Error(`Contact not found: ${primaryId}`);
+    if (!primary) throw new ContactNotFoundError(primaryId);
     const secondary = await this.backend.getContact(secondaryId);
-    if (!secondary) throw new Error(`Contact not found: ${secondaryId}`);
+    if (!secondary) throw new ContactNotFoundError(secondaryId);
 
     // Structural-contact guard. A merge writes the golden record onto the primary and
     // deletes the secondary, but it only copies scalar fields (tier/displayName/role/
@@ -1391,11 +1395,10 @@ export class ContactService {
     // of the primary — a structural→structural merge is just as destructive as
     // structural→non-structural. If two rows really are the same structural entity, the
     // structural one must be the primary (the survivor).
+    // notifyIdentitiesChanged(primaryId) after merge relies on this: the principal can
+    // never be the deleted secondary, so refreshing the survivor is sufficient (#1514).
     if (isStructuralContact(secondary)) {
-      throw new Error(
-        `Cannot merge structural contact ${secondaryId} (principal/agent/system-role) — a merge ` +
-          `deletes the secondary, which would destroy the structural row. Make it the primary instead.`,
-      );
+      throw new StructuralContactMergeError(secondaryId);
     }
 
     const primaryIdentities = await this.backend.getIdentitiesForContact(primaryId);

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -148,10 +148,12 @@ interface ContactServiceBackend {
   listContacts(filters?: { tier?: ContactTier; kind?: ContactKind[]; limit?: number; offset?: number }): Promise<Contact[]>;
   updateContact(contact: Contact, client?: DbPoolClient): Promise<void>;
   createIdentity(identity: ChannelIdentity): Promise<void>;
+  getIdentity(identityId: string): Promise<ChannelIdentity | null>;
   getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]>;
   resolveByChannelIdentity(channel: string, channelIdentifier: string): Promise<ResolvedSender | null>;
   unlinkIdentity(identityId: string): Promise<boolean>;
   setIdentityStatus(identityId: string, status: IdentityStatus): Promise<ChannelIdentity>;
+  verifyIdentity(identityId: string): Promise<ChannelIdentity>;
 
   /**
    * Atomically elevate a contact's tier from 'unknown' to 'known'.
@@ -247,6 +249,7 @@ const AUTO_VERIFIED_SOURCES: ReadonlySet<IdentitySource> = new Set([
 export class ContactService {
   private onContactMerged?: (primaryId: string, secondaryId: string, mergedAt: Date) => void;
   private onIdentityVerified?: (contactId: string) => void;
+  private onIdentitiesChanged?: (contactId: string) => void | Promise<void>;
   private onContactElevated?: (contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment') => void;
   private dedupService?: DedupService;
   private onDuplicateDetected?: (
@@ -264,9 +267,25 @@ export class ContactService {
   ) {
     this.onContactMerged = options?.onContactMerged;
     this.onIdentityVerified = options?.onIdentityVerified;
+    this.onIdentitiesChanged = options?.onIdentitiesChanged;
     this.onContactElevated = options?.onContactElevated;
     this.dedupService = options?.dedupService;
     this.onDuplicateDetected = options?.onDuplicateDetected;
+  }
+
+  /** Fire-and-forget identity-mutation notifier (#1514). Never fails the caller. */
+  private notifyIdentitiesChanged(contactId: string): void {
+    if (!this.onIdentitiesChanged) return;
+    try {
+      const maybePromise = this.onIdentitiesChanged(contactId);
+      if (maybePromise instanceof Promise) {
+        maybePromise.catch(err => {
+          this.logger?.warn({ err, contactId }, 'onIdentitiesChanged callback rejected (non-fatal)');
+        });
+      }
+    } catch (err) {
+      this.logger?.warn({ err, contactId }, 'onIdentitiesChanged callback threw (non-fatal)');
+    }
   }
 
   /** Create a Postgres-backed instance for production use */
@@ -815,6 +834,8 @@ export class ContactService {
       }
     }
 
+    this.notifyIdentitiesChanged(options.contactId);
+
     return identity;
   }
 
@@ -1088,14 +1109,48 @@ export class ContactService {
     return this.backend.getIdentitiesForContact(contactId);
   }
 
+  /** Look up a single channel identity by ID. Returns null if not found. */
+  async getIdentity(identityId: string): Promise<ChannelIdentity | null> {
+    return this.backend.getIdentity(identityId);
+  }
+
   /** Remove a channel identity by its ID. Returns true if found and removed, false if not found. */
   async unlinkIdentity(identityId: string): Promise<boolean> {
-    return this.backend.unlinkIdentity(identityId);
+    const existing = await this.backend.getIdentity(identityId);
+    if (!existing) return false;
+    const removed = await this.backend.unlinkIdentity(identityId);
+    if (removed) this.notifyIdentitiesChanged(existing.contactId);
+    return removed;
   }
 
   /** Update the status of a channel identity (active, defunct, bounced). */
   async setIdentityStatus(identityId: string, status: IdentityStatus): Promise<ChannelIdentity> {
-    return this.backend.setIdentityStatus(identityId, status);
+    const updated = await this.backend.setIdentityStatus(identityId, status);
+    this.notifyIdentitiesChanged(updated.contactId);
+    return updated;
+  }
+
+  /**
+   * Mark a channel identity as verified (CEO confirmation). This is the console /
+   * agent path for verifying `self_claimed` identities and re-confirming any other
+   * identity so it counts toward the structural principal match (#1514).
+   */
+  async verifyIdentity(identityId: string): Promise<ChannelIdentity> {
+    const updated = await this.backend.verifyIdentity(identityId);
+    if (this.onIdentityVerified) {
+      try {
+        const maybePromise = this.onIdentityVerified(updated.contactId) as void | Promise<void>;
+        if (maybePromise instanceof Promise) {
+          maybePromise.catch(err => {
+            this.logger?.warn({ err, contactId: updated.contactId }, 'onIdentityVerified callback rejected (non-fatal)');
+          });
+        }
+      } catch (err) {
+        this.logger?.warn({ err, contactId: updated.contactId }, 'onIdentityVerified callback threw (non-fatal)');
+      }
+    }
+    this.notifyIdentitiesChanged(updated.contactId);
+    return updated;
   }
 
   /** Get active (non-revoked) auth overrides for a contact. */
@@ -1404,6 +1459,11 @@ export class ContactService {
         this.logger?.warn({ err: callbackErr }, 'onContactMerged callback threw (non-fatal, merge already committed)');
       }
     }
+
+    // Primary absorbs the secondary's identities — refresh principal cache if either side
+    // was (or is) the principal contact. Secondary is already deleted; notifying primary
+    // is enough when the principal was the survivor.
+    this.notifyIdentitiesChanged(primaryId);
 
     this.logger?.info({ primaryId, secondaryId }, 'Contacts merged');
 
@@ -1756,6 +1816,28 @@ class PostgresContactBackend implements ContactServiceBackend {
     );
   }
 
+  async getIdentity(identityId: string): Promise<ChannelIdentity | null> {
+    const result = await this.pool.query<{
+      id: string;
+      contact_id: string;
+      channel: string;
+      channel_identifier: string;
+      label: string | null;
+      verified: boolean;
+      verified_at: Date | null;
+      status: string;
+      source: string;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT id, contact_id, channel, channel_identifier, label, verified, verified_at, status, source, created_at, updated_at
+       FROM contact_channel_identities WHERE id = $1`,
+      [identityId],
+    );
+    const row = result.rows[0];
+    return row ? this.rowToIdentity(row) : null;
+  }
+
   async getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]> {
     const result = await this.pool.query<{
       id: string;
@@ -1900,6 +1982,37 @@ class PostgresContactBackend implements ContactServiceBackend {
        WHERE id = $2
        RETURNING id, contact_id, channel, channel_identifier, label, verified, verified_at, status, source, created_at, updated_at`,
       [status, identityId],
+    );
+
+    const row = result.rows[0];
+    if (!row) {
+      throw new IdentityNotFoundError(identityId);
+    }
+    return this.rowToIdentity(row);
+  }
+
+  async verifyIdentity(identityId: string): Promise<ChannelIdentity> {
+    this.logger.debug({ identityId }, 'contacts: verifying identity');
+    const result = await this.pool.query<{
+      id: string;
+      contact_id: string;
+      channel: string;
+      channel_identifier: string;
+      label: string | null;
+      verified: boolean;
+      verified_at: Date | null;
+      status: string;
+      source: string;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `UPDATE contact_channel_identities
+       SET verified = true,
+           verified_at = COALESCE(verified_at, now()),
+           updated_at = now()
+       WHERE id = $1
+       RETURNING id, contact_id, channel, channel_identifier, label, verified, verified_at, status, source, created_at, updated_at`,
+      [identityId],
     );
 
     const row = result.rows[0];
@@ -2484,6 +2597,10 @@ class InMemoryContactBackend implements ContactServiceBackend {
     this.identities.set(identity.id, identity);
   }
 
+  async getIdentity(identityId: string): Promise<ChannelIdentity | null> {
+    return this.identities.get(identityId) ?? null;
+  }
+
   async getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]> {
     const results: ChannelIdentity[] = [];
     for (const identity of this.identities.values()) {
@@ -2541,6 +2658,22 @@ class InMemoryContactBackend implements ContactServiceBackend {
       ...identity,
       status,
       updatedAt: new Date(),
+    };
+    this.identities.set(identityId, updated);
+    return updated;
+  }
+
+  async verifyIdentity(identityId: string): Promise<ChannelIdentity> {
+    const identity = this.identities.get(identityId);
+    if (!identity) {
+      throw new IdentityNotFoundError(identityId);
+    }
+    const now = new Date();
+    const updated: ChannelIdentity = {
+      ...identity,
+      verified: true,
+      verifiedAt: identity.verifiedAt ?? now,
+      updatedAt: now,
     };
     this.identities.set(identityId, updated);
     return updated;

--- a/src/contacts/linkable-channels.ts
+++ b/src/contacts/linkable-channels.ts
@@ -1,0 +1,21 @@
+// linkable-channels.ts — single allowlist for channel identities that may be
+// linked via the console HTTP API or the contact-link-identity skill (#1514).
+//
+// Keep this file free of other src/ imports so the console can import it via a
+// path alias without pulling the backend graph into the Vite bundle.
+
+/** Channels operators / agents may bind onto a contact. */
+export const LINKABLE_CHANNEL_IDENTITIES = [
+  'email',
+  'phone',
+  'signal',
+  'telegram',
+  'slack',
+] as const;
+
+export type LinkableChannelIdentity = (typeof LINKABLE_CHANNEL_IDENTITIES)[number];
+
+/** Set form for O(1) membership checks in HTTP / skill validation. */
+export const LINKABLE_CHANNEL_IDENTITY_SET: ReadonlySet<string> = new Set(
+  LINKABLE_CHANNEL_IDENTITIES,
+);

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -417,6 +417,47 @@ export class IdentityNotFoundError extends Error {
   }
 }
 
+/** Thrown when a contact id does not resolve (merge / lookup paths). */
+export class ContactNotFoundError extends Error {
+  readonly code = 'CONTACT_NOT_FOUND' as const;
+
+  constructor(contactId: string) {
+    super(`Contact not found: ${contactId}`);
+    this.name = 'ContactNotFoundError';
+  }
+}
+
+/**
+ * Thrown when mergeContacts would delete a structural contact (principal/agent).
+ * The structural row must be the primary (survivor), never the secondary.
+ */
+export class StructuralContactMergeError extends Error {
+  readonly code = 'STRUCTURAL_CONTACT_MERGE' as const;
+
+  constructor(secondaryId: string) {
+    super(
+      `Cannot merge structural contact ${secondaryId} (principal/agent/system-role) — a merge ` +
+        `deletes the secondary, which would destroy the structural row. Make it the primary instead.`,
+    );
+    this.name = 'StructuralContactMergeError';
+  }
+}
+
+/**
+ * Mutable holder for the principal's verified email so post-boot identity
+ * refreshes propagate to consumers that captured a reference at construction
+ * (#1514). Prefer this over a reassigned string primitive.
+ */
+export interface PrincipalEmailRef {
+  current: string;
+}
+
+/** Resolve a ceoEmail config that may be a plain string (tests) or a live ref. */
+export function resolvePrincipalEmail(email: string | PrincipalEmailRef | undefined): string {
+  if (email === undefined) return '';
+  return typeof email === 'string' ? email : email.current;
+}
+
 // -- Grant recommendation types (issue #952) --
 
 export type GrantRecommendationStatus = 'pending' | 'approved' | 'declined';

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -449,6 +449,10 @@ export interface ContactServiceOptions {
   /** Called when a verified identity is linked — triggers confidence recompute.
    *  May return a Promise; rejections are caught by ContactService (non-fatal). */
   onIdentityVerified?: (contactId: string) => void | Promise<void>;
+  /** Called after any channel-identity mutation (link / unlink / status / verify / merge).
+   *  Used to hot-reload the startup-cached principalIdentities array (#1514).
+   *  May return a Promise; rejections are caught by ContactService (non-fatal). */
+  onIdentitiesChanged?: (contactId: string) => void | Promise<void>;
   /** Called after a contact's tier is automatically elevated to 'known'.
    *  Fired with the reason for observability/audit trail. Non-throwing. */
   onContactElevated?: (contactId: string, reason: 'correspondence' | 'domain-validated' | 'judgment') => void;

--- a/src/dispatch/outbound-filter.ts
+++ b/src/dispatch/outbound-filter.ts
@@ -17,7 +17,7 @@
 import { createHash } from 'node:crypto';
 
 import type { ContactTier } from '../contacts/types.js';
-import { meetsMinimumTier } from '../contacts/types.js';
+import { meetsMinimumTier, resolvePrincipalEmail, type PrincipalEmailRef } from '../contacts/types.js';
 import type { Logger } from '../logger.js';
 import { normalizeFragmentText } from './prompt-exfiltration-markers.js';
 import type { OutboundJudge, JudgeInput } from './outbound-judge.js';
@@ -72,7 +72,8 @@ export interface OutboundContentFilterConfig {
   // a signal the agent accidentally echoed its own instructions.
   systemPromptMarkers: string[];
   // CEO email — allowed in outbound content (not a third-party leak).
-  ceoEmail: string;
+  // Accepts a mutable PrincipalEmailRef so post-boot identity binds hot-reload (#1514).
+  ceoEmail: string | PrincipalEmailRef;
   /** Optional Stage 2 LLM judge. When absent, Stage 2 is a no-op pass. */
   judge?: OutboundJudge;
   /**
@@ -433,12 +434,13 @@ export class OutboundContentFilter {
     recipientEmail: string,
     recipientTier: ContactTier,
   ): FilterFinding[] {
+    const ceoEmail = resolvePrincipalEmail(this.config.ceoEmail);
     // Only add ceoEmail if it is actually known — an empty string (no verified
     // principal email on file) would be a no-op entry that never matches but
     // obscures the fact that the principal identity is incomplete.
     const allowedEmails = new Set([
       recipientEmail.toLowerCase(),
-      ...(this.config.ceoEmail ? [this.config.ceoEmail.toLowerCase()] : []),
+      ...(ceoEmail ? [ceoEmail.toLowerCase()] : []),
     ]);
 
     // Recipients at 'trusted' or above may receive third-party email addresses.

--- a/src/index.ts
+++ b/src/index.ts
@@ -573,6 +573,18 @@ async function main(): Promise<void> {
   // callback references the pipeline, which depends on contactService.
   let confidencePipeline: ConfidencePipeline | undefined;
 
+  // Hot-reload holder for principal identities (#1514). Assigned after the principal
+  // contact is resolved below; ContactService callbacks close over this object so
+  // agent-skill identity writes (link/unlink/merge) refresh the shared cache without
+  // a process restart.
+  const principalIdentityHotReload: {
+    contactId: string | null;
+    refresh: () => Promise<void>;
+  } = {
+    contactId: null,
+    refresh: async () => { /* wired after principal resolution */ },
+  };
+
   // Contact system — provides identity resolution and contact management.
   // Always initialized (contacts work even without entity memory / KG).
   // DedupService is wired here so that createContact() automatically checks for
@@ -599,6 +611,14 @@ async function main(): Promise<void> {
     onIdentityVerified: (contactId: string) => {
       confidencePipeline?.incrementalUpdate(contactId, { type: 'pairing_confirmed' })
         .catch(err => logger.warn({ err, contactId }, 'pairing_confirmed pipeline update failed (non-fatal)'));
+    },
+    onIdentitiesChanged: async (contactId: string) => {
+      if (
+        principalIdentityHotReload.contactId
+        && contactId === principalIdentityHotReload.contactId
+      ) {
+        await principalIdentityHotReload.refresh();
+      }
     },
     onContactMerged: (primaryContactId, secondaryContactId, mergedAt) => {
       const event = createContactMerged({
@@ -680,12 +700,35 @@ async function main(): Promise<void> {
   // setup-required mode so the operator can finish onboarding via the web UI. That keeps
   // the env-var-unset and fresh-setup paths identical (principalEmail = '', no bypass),
   // which is exactly the dual-path inconsistency #1049 removes.
+  //
+  // principalIdentities is a shared mutable array (never reassigned) so console / agent
+  // identity writes can hot-reload it in place (#1514) — OutboundGateway, ExecutionLayer,
+  // and AgentRuntime all hold a reference to this same array.
   let principalContact: Contact | null = null;
-  let principalIdentities: ChannelIdentity[] = [];
+  const principalIdentities: ChannelIdentity[] = [];
   // Empty string when there is no principal or no verified email (fresh setup, Signal-only).
   // Downstream consumers already treat '' as "absent" — the same contract the old unset
   // CEO_PRIMARY_EMAIL had.
   let principalEmail = '';
+
+  async function refreshPrincipalIdentities(): Promise<void> {
+    if (!principalContact) {
+      principalIdentities.length = 0;
+      principalEmail = '';
+      return;
+    }
+    const withIdentities = await contactService.getContactWithIdentities(principalContact.id);
+    const allIdentities = withIdentities?.identities ?? [];
+    const next = allIdentities.filter((id) => id.verified && id.status === 'active');
+    principalIdentities.length = 0;
+    principalIdentities.push(...next);
+    principalEmail = principalIdentities.find((id) => id.channel === 'email')?.channelIdentifier ?? '';
+    logger.info(
+      { contactId: principalContact.id, identityCount: principalIdentities.length, hasEmail: !!principalEmail },
+      'Principal identities refreshed',
+    );
+  }
+
   try {
     principalContact = await contactService.findContactBySystemRole('principal');
     if (principalContact) {
@@ -696,19 +739,7 @@ async function main(): Promise<void> {
       // silently not apply, which is worse than refusing to boot.
       await repairPrincipalMetadata(principalContact.id, pool, logger);
 
-      const withIdentities = await contactService.getContactWithIdentities(principalContact.id);
-      const allIdentities = withIdentities?.identities ?? [];
-      // Only verified + active identities are authoritative for reachability — stale
-      // (defunct/bounced) addresses must not be presented to agents as live.
-      principalIdentities = allIdentities.filter((id) => id.verified && id.status === 'active');
-
-      // principalEmail: the principal's verified + ACTIVE email. Restricted to active only
-      // (#1049 review): a defunct/bounced address may have been reassigned, so routing
-      // operational alerts to it — or seeding the outbound-filter allow-list with it — is a
-      // confidentiality risk. When there is no active email, principalEmail stays '' and the
-      // dependent features degrade with their own warnings (notifiers below; the email-adapter
-      // escalation after adapter construction).
-      principalEmail = principalIdentities.find((id) => id.channel === 'email')?.channelIdentifier ?? '';
+      await refreshPrincipalIdentities();
 
       logger.info(
         { contactId: principalContact.id, kgNodeId: principalContact.kgNodeId, hasEmail: !!principalEmail },
@@ -730,6 +761,10 @@ async function main(): Promise<void> {
     );
     process.exit(1);
   }
+
+  // Wire hot-reload so post-boot identity mutations update the shared cache (#1514).
+  principalIdentityHotReload.contactId = principalContact?.id ?? null;
+  principalIdentityHotReload.refresh = refreshPrincipalIdentities;
 
   // Email channel — optional. Accounts are managed via the console (email_accounts table,
   // migration 064). Grants live in the vault under channel.email.<name>.nylas_grant_id.
@@ -2417,6 +2452,8 @@ async function main(): Promise<void> {
     secretCaptureService,
     setupRequiredAtBoot,
     bootStartedAt,
+    // Hot-reload principal identities after console link/unlink/verify/merge (#1514).
+    onPrincipalIdentitiesChanged: refreshPrincipalIdentities,
     // Powers POST /api/setup/suggest-name (wizard starter-name suggestion, #799).
     infraLlmService,
     // Powers principal profile endpoints in setup routes (#392). Undefined when

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import type { ToolDiscovery } from './skills/loader.js';
 import { loadMcpServers, loadSkillsConfig, registerMcpProjectedSkills } from './skills/mcp-loader.js';
 import type { McpSession } from './skills/mcp-client.js';
 import { ContactService } from './contacts/contact-service.js';
-import type { ChannelIdentity, Contact } from './contacts/types.js';
+import type { ChannelIdentity, Contact, PrincipalEmailRef } from './contacts/types.js';
 import { ConfidencePipeline } from './contacts/confidence-pipeline.js';
 import { DedupService } from './contacts/dedup-service.js';
 import { ContactResolver } from './contacts/contact-resolver.js';
@@ -704,17 +704,21 @@ async function main(): Promise<void> {
   // principalIdentities is a shared mutable array (never reassigned) so console / agent
   // identity writes can hot-reload it in place (#1514) — OutboundGateway, ExecutionLayer,
   // and AgentRuntime all hold a reference to this same array.
+  //
+  // principalEmail is a mutable holder (never replaced) for the same reason: OutboundContentFilter,
+  // EmailAdapter, notifiers, and ApprovalTrigger read `.current` at use time so binding an
+  // email identity post-boot updates the allow-list / notification target without restart.
   let principalContact: Contact | null = null;
   const principalIdentities: ChannelIdentity[] = [];
   // Empty string when there is no principal or no verified email (fresh setup, Signal-only).
   // Downstream consumers already treat '' as "absent" — the same contract the old unset
   // CEO_PRIMARY_EMAIL had.
-  let principalEmail = '';
+  const principalEmail: PrincipalEmailRef = { current: '' };
 
   async function refreshPrincipalIdentities(): Promise<void> {
     if (!principalContact) {
       principalIdentities.length = 0;
-      principalEmail = '';
+      principalEmail.current = '';
       return;
     }
     const withIdentities = await contactService.getContactWithIdentities(principalContact.id);
@@ -722,9 +726,14 @@ async function main(): Promise<void> {
     const next = allIdentities.filter((id) => id.verified && id.status === 'active');
     principalIdentities.length = 0;
     principalIdentities.push(...next);
-    principalEmail = principalIdentities.find((id) => id.channel === 'email')?.channelIdentifier ?? '';
+    principalEmail.current =
+      principalIdentities.find((id) => id.channel === 'email')?.channelIdentifier ?? '';
     logger.info(
-      { contactId: principalContact.id, identityCount: principalIdentities.length, hasEmail: !!principalEmail },
+      {
+        contactId: principalContact.id,
+        identityCount: principalIdentities.length,
+        hasEmail: !!principalEmail.current,
+      },
       'Principal identities refreshed',
     );
   }
@@ -742,7 +751,7 @@ async function main(): Promise<void> {
       await refreshPrincipalIdentities();
 
       logger.info(
-        { contactId: principalContact.id, kgNodeId: principalContact.kgNodeId, hasEmail: !!principalEmail },
+        { contactId: principalContact.id, kgNodeId: principalContact.kgNodeId, hasEmail: !!principalEmail.current },
         'Principal identity resolved',
       );
     } else {
@@ -1206,8 +1215,8 @@ async function main(): Promise<void> {
     // not from config. Must NOT be Curia's own Nylas address (nylasSelfEmail): using
     // Curia's address here was a bug that (a) treated the CEO's email as a third-party
     // leak and (b) routed blocked-content notifications to Curia's inbox instead of the CEO's.
-    const ceoEmail = principalEmail;
-    if (!ceoEmail) {
+    // Pass the mutable PrincipalEmailRef so post-boot identity binds update the allow-list (#1514).
+    if (!principalEmail.current) {
       logger.warn('Outbound content filter initialized without principal email (no verified principal email on file) — contact-data-leak rule may produce false positives');
     }
     // Canary: with markers now derived from the identity AND the coordinator prompt,
@@ -1270,7 +1279,7 @@ async function main(): Promise<void> {
 
     outboundFilter = new OutboundContentFilter({
       systemPromptMarkers,
-      ceoEmail,
+      ceoEmail: principalEmail,
       judge: outboundJudge,
       logger,
     });
@@ -1613,8 +1622,8 @@ async function main(): Promise<void> {
         selfEmail: account.selfEmail,
         suppressedSenderEmails: ownedMailboxAddresses,
         // Principal's email, resolved from findContactBySystemRole('principal') (#1049).
-        // undefined when unknown — EmailAdapter treats it as optional.
-        ceoEmail: principalEmail || undefined,
+        // Mutable ref so post-boot email binds update rate-limit notifications (#1514).
+        ceoEmail: principalEmail,
         contactCreationMaxPerMessage: yamlConfig.contact_creation_limits?.max_per_message ?? 10,
         contactCreationMaxPerHour: yamlConfig.contact_creation_limits?.max_per_hour ?? 100,
         timezone: config.timezone,
@@ -1638,7 +1647,7 @@ async function main(): Promise<void> {
   // to their contact and is held as provisional. Surface at error for log aggregators.
   // Lives here (not in the principal-resolution block) because adapter activeness is only
   // known after this point.
-  if (emailAdapters.length > 0 && principalContact && !principalEmail) {
+  if (emailAdapters.length > 0 && principalContact && !principalEmail.current) {
     logger.error(
       { contactId: principalContact.id },
       'Email adapter(s) active but the principal has no verified active email — inbound email from the principal WILL be held as provisional until an email identity is bound',
@@ -1783,8 +1792,10 @@ async function main(): Promise<void> {
 
   // SuspensionNotifier — emails the CEO when a scheduled job is auto-suspended.
   // Bypasses the LLM pipeline: notifies even when Anthropic is the thing that's down.
-  // Skipped (with a warning) if outboundGateway or the principal's email is absent.
-  if (outboundGateway && principalEmail) {
+  // Always registered when the gateway exists; ceoEmail is a live ref so a post-boot
+  // email bind enables notifications without restart (#1514). Sends no-op/skip when
+  // current is empty.
+  if (outboundGateway) {
     const suspensionNotifier = new SuspensionNotifier({
       bus,
       outboundGateway,
@@ -1795,18 +1806,23 @@ async function main(): Promise<void> {
       httpPort: config.httpPort,
     });
     suspensionNotifier.register();
+    if (!principalEmail.current) {
+      logger.warn(
+        'SuspensionNotifier registered without principal email yet — will notify once an email identity is bound',
+      );
+    }
   } else {
     logger.warn(
-      { hasGateway: !!outboundGateway, hasCeoEmail: !!principalEmail },
-      'SuspensionNotifier not registered — outboundGateway or principal email absent; suspended jobs will not trigger CEO email alerts',
+      { hasGateway: false, hasCeoEmail: !!principalEmail.current },
+      'SuspensionNotifier not registered — outboundGateway absent; suspended jobs will not trigger CEO email alerts',
     );
   }
 
   // RecoveryNotifier — emails the CEO when the watchdog auto-recovers a stuck job.
   // Bypasses the LLM pipeline for the same reason as SuspensionNotifier: the LLM
   // may be the reason the job is stuck in the first place.
-  // Skipped (with a warning) if outboundGateway or the principal's email is absent.
-  if (outboundGateway && principalEmail) {
+  // Same live-ref pattern as SuspensionNotifier (#1514).
+  if (outboundGateway) {
     const recoveryNotifier = new RecoveryNotifier({
       bus,
       outboundGateway,
@@ -1817,10 +1833,15 @@ async function main(): Promise<void> {
       httpPort: config.httpPort,
     });
     recoveryNotifier.register();
+    if (!principalEmail.current) {
+      logger.warn(
+        'RecoveryNotifier registered without principal email yet — will notify once an email identity is bound',
+      );
+    }
   } else {
     logger.warn(
-      { hasGateway: !!outboundGateway, hasCeoEmail: !!principalEmail },
-      'RecoveryNotifier not registered — outboundGateway or principal email absent; recovered stuck jobs will not trigger CEO email alerts',
+      { hasGateway: false, hasCeoEmail: !!principalEmail.current },
+      'RecoveryNotifier not registered — outboundGateway absent; recovered stuck jobs will not trigger CEO email alerts',
     );
   }
 
@@ -1859,7 +1880,7 @@ async function main(): Promise<void> {
     actionLogRepo,
     outboundGateway,
     logger,
-    principalEmail || undefined,
+    principalEmail,
     contactService,
     principalIdentities,
   );
@@ -2452,8 +2473,6 @@ async function main(): Promise<void> {
     secretCaptureService,
     setupRequiredAtBoot,
     bootStartedAt,
-    // Hot-reload principal identities after console link/unlink/verify/merge (#1514).
-    onPrincipalIdentitiesChanged: refreshPrincipalIdentities,
     // Powers POST /api/setup/suggest-name (wizard starter-name suggestion, #799).
     infraLlmService,
     // Powers principal profile endpoints in setup routes (#392). Undefined when

--- a/src/index.ts
+++ b/src/index.ts
@@ -715,13 +715,24 @@ async function main(): Promise<void> {
   // CEO_PRIMARY_EMAIL had.
   const principalEmail: PrincipalEmailRef = { current: '' };
 
+  // Monotonic guard against overlapping refreshes (#1514). onIdentitiesChanged is
+  // fire-and-forget, so two mutations in quick succession (e.g. add + verify, or a
+  // merge racing a direct link) can start two refreshes; if their DB reads settle out
+  // of order the stale one would clobber the fresher state. Each refresh claims a
+  // generation and discards its result if a newer refresh has since started.
+  let refreshGeneration = 0;
+
   async function refreshPrincipalIdentities(): Promise<void> {
     if (!principalContact) {
       principalIdentities.length = 0;
       principalEmail.current = '';
       return;
     }
+    const myGeneration = ++refreshGeneration;
     const withIdentities = await contactService.getContactWithIdentities(principalContact.id);
+    // A newer refresh started while this one awaited the DB — its result is fresher,
+    // so drop ours rather than overwrite the shared array/holder with a stale snapshot.
+    if (myGeneration !== refreshGeneration) return;
     const allIdentities = withIdentities?.identities ?? [];
     const next = allIdentities.filter((id) => id.verified && id.status === 'active');
     principalIdentities.length = 0;

--- a/src/scheduler/recovery-notifier.ts
+++ b/src/scheduler/recovery-notifier.ts
@@ -25,12 +25,17 @@ import type { SchedulerService } from './scheduler-service.js';
 import {
   loadJobNotificationContext,
 } from './job-notification-context.js';
+import {
+  resolvePrincipalEmail,
+  type PrincipalEmailRef,
+} from '../contacts/types.js';
 
 export interface RecoveryNotifierConfig {
   bus: EventBus;
   outboundGateway: OutboundGateway;
   schedulerService: SchedulerService;
-  ceoEmail: string;
+  /** Plain string (tests) or live ref so post-boot email binds hot-reload (#1514). */
+  ceoEmail: string | PrincipalEmailRef;
   logger: Logger;
   appOrigin?: string;
   httpPort: number;
@@ -98,12 +103,21 @@ export class RecoveryNotifier {
       'The job has been rescheduled automatically and will run again on its next trigger.',
     ].join('\n');
 
+    const ceoEmail = resolvePrincipalEmail(this.config.ceoEmail);
+    if (!ceoEmail) {
+      this.log.warn(
+        { jobId, agentId },
+        'RecoveryNotifier: principal email not bound yet — skipping notification',
+      );
+      return;
+    }
+
     // sendNotification() catches its own errors and returns false on failure —
     // it does not throw. We log at error if it returns false so the anomaly is
     // visible in alerting.
     const sent = await this.config.outboundGateway.sendNotification({
       notificationType: 'schedule_recovered',
-      ceoEmail: this.config.ceoEmail,
+      ceoEmail,
       subject,
       body,
     });

--- a/src/scheduler/suspension-notifier.ts
+++ b/src/scheduler/suspension-notifier.ts
@@ -18,12 +18,17 @@ import type { SchedulerService } from './scheduler-service.js';
 import {
   loadJobNotificationContext,
 } from './job-notification-context.js';
+import {
+  resolvePrincipalEmail,
+  type PrincipalEmailRef,
+} from '../contacts/types.js';
 
 export interface SuspensionNotifierConfig {
   bus: EventBus;
   outboundGateway: OutboundGateway;
   schedulerService: SchedulerService;
-  ceoEmail: string;
+  /** Plain string (tests) or live ref so post-boot email binds hot-reload (#1514). */
+  ceoEmail: string | PrincipalEmailRef;
   logger: Logger;
   appOrigin?: string;
   httpPort: number;
@@ -80,12 +85,21 @@ export class SuspensionNotifier {
       'To resume this job, open the link above and click Resume.',
     ].join('\n');
 
+    const ceoEmail = resolvePrincipalEmail(this.config.ceoEmail);
+    if (!ceoEmail) {
+      this.log.warn(
+        { jobId, agentId },
+        'SuspensionNotifier: principal email not bound yet — skipping notification',
+      );
+      return;
+    }
+
     // sendNotification() catches its own errors and returns false on failure —
     // it does not throw. We log at error if it returns false so the anomaly is
     // visible in alerting.
     const sent = await this.config.outboundGateway.sendNotification({
       notificationType: 'schedule_suspended',
-      ceoEmail: this.config.ceoEmail,
+      ceoEmail,
       subject,
       body,
     });

--- a/tests/unit/skills/contact-merge.test.ts
+++ b/tests/unit/skills/contact-merge.test.ts
@@ -136,8 +136,9 @@ describe('ContactMergeHandler', () => {
   });
 
   it('surfaces "not found" error with contact-lookup guidance', async () => {
+    const { ContactNotFoundError } = await import('../../../src/contacts/types.js');
     const contactService = {
-      mergeContacts: vi.fn().mockRejectedValue(new Error(`Contact not found: ${VALID_UUID_A}`)),
+      mergeContacts: vi.fn().mockRejectedValue(new ContactNotFoundError(VALID_UUID_A)),
     };
     const result = await handler.execute(makeCtx(
       { primary_contact_id: VALID_UUID_A, secondary_contact_id: VALID_UUID_B },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1514.

Adds a first-class way to **add / verify / remove** contact channel identities and **merge lookalike contacts**, so the principal’s Slack/Signal (and future SMS) identities can be bound for structural principal detection. This is the durable fix for the 2026-07-23 outbound-filter flood where Slack DMs to the principal failed `isPrincipal` and tripped Stage-2.

## What changed

- **HTTP API** (`/api/kg/contacts/...`):
  - `POST /:id/identities` — link with `ceo_stated` (verified)
  - `PATCH /:id/identities/:identityId` — set status / verify
  - `DELETE /:id/identities/:identityId` — unlink
  - `POST /merge` — merge secondary → primary (dry-run default)
- **Hot-reload** via `ContactService.onIdentitiesChanged` only (shared `principalIdentities` array + `PrincipalEmailRef` for email allow-list / notifiers) — no route-level duplicate
- **Console Contacts** edit drawer: identity CRUD + “Merge into…” for lookalikes
- **Setup surfacing**: Signal/Slack catalog how-tos + Channels settings callout pointing at Contacts → principal
- **Shared allowlist** `src/contacts/linkable-channels.ts` used by HTTP, skill, and console
- **`contact-link-identity`**: allow `slack` (v1.1.0)

## Acceptance criteria

- [x] Console contacts view can add / edit (status) / verify / remove identities
- [x] Principal bind stores verified identities used by structural match
- [x] Bound channel → `principalIsSoleRecipient` / Stage-2 skip (hot-reloaded cache)
- [x] Inbound from bound identity resolves to principal (UNIQUE + ensureChannelContact)
- [x] Merge path for lookalike → principal (console + API; same as agent skill)
- [x] Setup / channels UI points operators at principal identity binding
- [x] Tests: API identity CRUD/merge; bind → match + inbound resolve; judge skip

## Test plan

- [x] `vitest` — `kg.test.ts` identity/merge routes + `contact-identity-binding.test.ts`
- [x] `pnpm run typecheck` + console typecheck
- [ ] Manual: Contacts → principal → add Slack `U…` → send internal-language Slack DM → delivered without “outbound blocked”
- [ ] Manual: merge lookalike into principal when identity already exists elsewhere (409 on direct link → merge)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b3ad653-9a29-4c32-afca-db0e515e4a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b3ad653-9a29-4c32-afca-db0e515e4a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

