### PR TITLE
fix(deps): clear MED/LOW Dependabot CVEs (body-parser, @hono/node-server, js-yaml)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`sharp`** — pinned ≥0.35.0 to clear GHSA-f88m-g3jw-g9cj (libvips CVEs).
 - **`find-my-way`** — pinned ≥9.7.0 to clear GHSA-c96f-x56v-gq3h (HTTP/2 DoS).
 - **`shell-quote`** — pinned ≥1.9.0 to clear GHSA-395f-4hp3-45gv (quadratic DoS).
+- **`body-parser`** — pinned ≥2.3.0 to clear GHSA-v422-hmwv-36x6 (limit DoS). (#1518)
+- **`@hono/node-server`** — pinned ≥2.0.5 to clear GHSA-frvp-7c67-39w9 (Windows path traversal). (#1518)
+- **`js-yaml`** — targeted `promptfoo>js-yaml` ≥5.2.1 clears GHSA-724g-mxrg-4qvm. (#1518)
 
 ## [0.41.0] — 2026-07-21 — "Data"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ overrides:
   sharp: '>=0.35.0'
   find-my-way: '>=9.7.0'
   shell-quote: '>=1.9.0'
+  body-parser: '>=2.3.0'
+  '@hono/node-server': '>=2.0.5'
+  promptfoo>js-yaml: '>=5.2.1'
 
 importers:
 
@@ -838,9 +841,9 @@ packages:
     resolution: {integrity: sha512-b1tBlMcfvNEziM4DZCikLOc9iqSlgCK1e5bMKtNQIADRXr1CQmbkHV3ZBVvTsFsjLErgihqO58Itn/kzCnSZ0A==}
     engines: {node: '>=12.0.0'}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: '>=4.12.27'
 
@@ -2392,8 +2395,8 @@ packages:
     resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
     engines: {node: '>=4'}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   boolbase@1.0.0:
@@ -3644,10 +3647,6 @@ packages:
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
-  js-yaml@5.2.0:
-    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
     hasBin: true
 
   js-yaml@5.2.1:
@@ -6276,7 +6275,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.12.31)':
     dependencies:
       hono: 4.12.31
 
@@ -6612,7 +6611,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -7737,15 +7736,15 @@ snapshots:
     dependencies:
       editions: 6.22.0
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.15.3
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -8413,7 +8412,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -9091,10 +9090,6 @@ snapshots:
   js-rouge@3.2.0: {}
 
   js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@5.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -10043,7 +10038,7 @@ snapshots:
       http-z: 8.1.1
       istextorbinary: 9.5.0
       js-rouge: 3.2.0
-      js-yaml: 5.2.0
+      js-yaml: 5.2.1
       json5: 2.2.3
       keyv: 5.6.0
       keyv-file: 5.3.5
@@ -10235,7 +10230,6 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
-    optional: true
 
   querystringify@2.2.0:
     optional: true
@@ -10567,7 +10561,6 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-    optional: true
 
   sift@17.1.3:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,10 @@ overrides:
   sharp: '>=0.35.0'                         # GHSA-f88m-g3jw-g9cj (libvips CVEs); allowBuilds stays false (prebuilt binary)
   find-my-way: '>=9.7.0'                    # GHSA-c96f-x56v-gq3h (HTTP/2 DoS)
   shell-quote: '>=1.9.0'                    # GHSA-395f-4hp3-45gv (quadratic-complexity DoS)
+  # MED/LOW CVEs from Dependabot, 2026-07-24 (#1518):
+  body-parser: '>=2.3.0'                    # GHSA-v422-hmwv-36x6 (invalid limit disables size enforcement DoS)
+  '@hono/node-server': '>=2.0.5'            # GHSA-frvp-7c67-39w9 (Windows serve-static path traversal via %5C); consumer is @modelcontextprotocol/sdk (^1.19.9)
+  'promptfoo>js-yaml': '>=5.2.1'            # GHSA-724g-mxrg-4qvm (!!omap quadratic DoS); targeted — js-yaml@4.x via @apidevtools/json-schema-ref-parser stays on 4.x
 
 # esbuild requires a postinstall step to download the platform binary.
 # Both versions (used by vite and tsup) are approved here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1518

## Summary

Follow-up to the HIGH CVE batch. Pins the remaining medium/low Dependabot alerts in `pnpm-workspace.yaml` `overrides:` (the only place pnpm v10+ reads them).

### 1. `body-parser` ≥2.3.0 (GHSA-v422-hmwv-36x6)
Straightforward floor. Was `2.2.2` via `express@5.2.1` (MCP SDK / promptfoo). Now resolves only `2.3.0`.

### 2. `@hono/node-server` ≥2.0.5 (GHSA-frvp-7c67-39w9)
Consumer is `@modelcontextprotocol/sdk@1.29.0` (`^1.19.9`). Forced major to `2.0.11`.

- Install + lockfile regen clean.
- Smoke-checked `getRequestListener` / `serve` still export and construct (the only MCP SDK usage).
- Advisory is **Windows-only** `serve-static` path traversal via `%5C`; prod runs Linux. Pin kept because 2.x did not break the consumer.

Note: `1.19.15` backports the same regex fix but GHSA still lists vulnerable as `< 2.0.5`, so a 1.x pin would not clear Dependabot.

### 3. `js-yaml` — targeted, not blanket (GHSA-724g-mxrg-4qvm)

`pnpm why js-yaml` before:

| Version | Parent | Status |
|---|---|---|
| `5.2.1` | direct (`package.json ^5.2.1`) | already patched |
| `5.2.0` | `promptfoo` | vulnerable (`!!omap` DoS) |
| `4.3.0` | `@apidevtools/json-schema-ref-parser` ← promptfoo | **not in alert range** (`>=5.0.0 <=5.2.0`) |

Override: `'promptfoo>js-yaml': '>=5.2.1'`. After install: only `5.2.1` (direct + promptfoo) and `4.3.0` (json-schema-ref-parser). No blanket pin that would force 4.x → 5.x.

## Verification

- `pnpm why body-parser` → only `2.3.0`
- `pnpm why @hono/node-server` → only `2.0.11`
- `pnpm why js-yaml` → `4.3.0` + `5.2.1` (no `5.2.0`)
- Lockfile retains top-level `overrides:`
- `pnpm run typecheck` + console typecheck — pass
- `DATABASE_URL=…/curia_test pnpm test` — 476 files / 5694 tests passed

## Out of scope

Docker-image `node-tar` / `brace-expansion` hits (Trivy base image) — separate task per issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac9184bc-9085-41fd-9bb6-1e37ef88fe97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac9184bc-9085-41fd-9bb6-1e37ef88fe97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

