### PR TITLE
fix(docker): bump baked npm to 11.18.0 to clear new tar + brace-expansion CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`body-parser`** — pinned ≥2.3.0 to clear GHSA-v422-hmwv-36x6 (limit DoS). (#1518)
 - **`@hono/node-server`** — pinned ≥2.0.5 to clear GHSA-frvp-7c67-39w9 (Windows path traversal). (#1518)
 - **`js-yaml`** — targeted `promptfoo>js-yaml` ≥5.2.1 clears GHSA-724g-mxrg-4qvm. (#1518)
+- **Baked npm** — bumped 11.17.0→11.18.0 (tar 7.5.19, brace-expansion 5.0.7); refreshed node:24-slim digest. (#1521)
 
 ## [0.41.0] — 2026-07-21 — "Data"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,8 @@ RUN corepack enable
 #   - CVE-2026-59871: node-tar <= 7.5.17 (crash via PAX numeric path type confusion)
 #   - CVE-2026-59875: node-tar <= 7.5.16 (uncaught exception on NUL byte in PAX records)
 #   - CVE-2026-13149: brace-expansion < 5.0.7 (exponential-time expansion DoS)
-# 11.17.0's bundled tar@7.5.16 / brace-expansion@5.0.6 predate these fixes (disclosed
-# 2026-07-21). 11.18.0 is the lowest npm release whose bundled deps clear all five above:
+# 11.17.0's bundled tar@7.5.16 / brace-expansion@5.0.6 predate these fixes.
+# 11.18.0 is the lowest npm release whose bundled deps clear all five above:
 # it bundles tar@7.5.19 (>= the 7.5.19 floor CVE-2026-59873 requires) and
 # brace-expansion@5.0.7, and still ships ip-address@10.2.0 (clears the earlier
 # CVE-2026-42338 that motivated the previous bump). Staying on the npm 11 major avoids

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # version and apply the "don't chase Current majors" ignore rule in
 # .github/dependabot.yml — a bare `node@sha256:…` pin would otherwise track `latest`.
 # Node 24 "Krypton" is the Active LTS (node 22 is Maintenance, node 26 is Current).
-FROM node:24-slim@sha256:cb4e8f7c443347358b7875e717c29e27bf9befc8f5a26cf18af3c3dec80e58c5 AS build
+FROM node:24-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS build
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN pnpm --filter @curia/antfarm run build
 # Production stage: minimal runtime image.
 # Same node:24-slim digest pin as the build stage above (see that comment for the
 # Scorecard / Dependabot rationale). Both stages must stay on the same digest.
-FROM node:24-slim@sha256:cb4e8f7c443347358b7875e717c29e27bf9befc8f5a26cf18af3c3dec80e58c5
+FROM node:24-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d
 
 # curl is needed for the HEALTHCHECK command
 # Copy uv/uvx binaries from the official signed image (Astral's recommended
@@ -69,14 +69,21 @@ WORKDIR /app
 
 RUN corepack enable
 
-# Upgrade npm to 11.17.0 to clear CVEs in npm's own bundled packages:
-#   - CVE-2026-53655: node-tar < 7.5.14 (PAX size override / file smuggling)
-#   - CVE-2026-45149: brace-expansion < 5.0.6 (arbitrary string generation)
-#   - CVE-2026-42338: ip-address < 10.1.1 (XSS via improper HTML escaping)
-# npm@11.17.0 bundles tar@7.5.16, brace-expansion@5.0.6, ip-address@10.2.0.
+# Upgrade npm to 11.18.0 to clear CVEs in npm's own bundled packages:
+#   - CVE-2026-59873: node-tar <= 7.5.18 (decompression/parse DoS via unlimited input)
+#   - CVE-2026-59874: node-tar <= 7.5.17 (infinite loop on negative-size entry in replace)
+#   - CVE-2026-59871: node-tar <= 7.5.17 (crash via PAX numeric path type confusion)
+#   - CVE-2026-59875: node-tar <= 7.5.16 (uncaught exception on NUL byte in PAX records)
+#   - CVE-2026-13149: brace-expansion < 5.0.7 (exponential-time expansion DoS)
+# 11.17.0's bundled tar@7.5.16 / brace-expansion@5.0.6 predate these fixes (disclosed
+# 2026-07-21). 11.18.0 is the lowest npm release whose bundled deps clear all five above:
+# it bundles tar@7.5.19 (>= the 7.5.19 floor CVE-2026-59873 requires) and
+# brace-expansion@5.0.7, and still ships ip-address@10.2.0 (clears the earlier
+# CVE-2026-42338 that motivated the previous bump). Staying on the npm 11 major avoids
+# npm 12's breaking changes for a build/CLI-only tool not on the runtime request path.
 # TODO: Dependabot does not track RUN-instruction version pins — bump this
 # manually when npm publishes a patch that addresses new bundled CVEs.
-RUN npm install -g npm@11.17.0
+RUN npm install -g npm@11.18.0
 
 # Copy manifest and lockfile, then install production deps only
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
## Summary

Trivy's image scan flags 5 CVEs in the **npm bundled into the production Docker image** (`usr/local/lib/node_modules/npm/node_modules/`) — four node-tar DoS advisories and one brace-expansion exponential-time DoS, all disclosed **2026-07-21**, after the previous `npm@11.17.0` pin (commit `449073ec`). These live at the image layer, not in `pnpm-lock.yaml`, so the Dependabot dep PRs (#1518) don't touch them.

`npm@11.18.0` is the **lowest** npm release whose bundled deps clear all five, and it keeps us on the npm 11 major (no npm 12 breaking changes for a build/CLI-only tool that isn't on the runtime request path):

| Bundled dep | 11.18.0 ships | Clears |
|---|---|---|
| tar | **7.5.19** | CVE-2026-59873 (≥7.5.19), -59874/-59871 (≥7.5.18), -59875 (≥7.5.17) |
| brace-expansion | **5.0.7** | CVE-2026-13149 (≥5.0.7) |
| ip-address | **10.2.0** | still clears the earlier CVE-2026-42338 (≥10.1.1) |

## Changes

- **`Dockerfile:79`** — npm pin `11.17.0 → 11.18.0`; rewrote the `Dockerfile:72-78` comment block to list the 5 new CVEs and the new bundled versions.
- **`Dockerfile:9` & `:43`** — refreshed the `node:24-slim` digest to the current multi-arch manifest-list digest (`sha256:6f7b03f7…`), identical on both build stages.
- **`CHANGELOG.md`** — one `### Security` bullet under `[Unreleased]` (no version bump).

The corepack-cached-pnpm cleanup (`rm -rf .cache/node/corepack`) already wipes the whole cache dir, so it stays correct regardless of the pnpm version Node 24's corepack bundles — no change needed there.

**curia-deploy:** no change required. `deploy/compose/Dockerfile.curia` is a thin downstream image (`FROM ghcr.io/josephfung/curia:${CURIA_IMAGE_TAG}`) that inherits npm and the base image from core — it picks up this fix automatically once the `edge` image rebuilds.

## Verification

Built a throwaway image from the **new** digest, installed `npm@11.18.0`, and confirmed **inside the image**: `npm 11.18.0`, a single `tar@7.5.19`, a single `brace-expansion@5.0.7`. A parallel security review independently confirmed the bundled versions, digest legitimacy (current multi-arch OCI index, amd64+arm64+ppc64le children, NODE_VERSION=24.18.0), and no regression on the previously-cleared CVEs.

Remaining (maintainer to run): `gh workflow run trivy.yml` to confirm alerts #205-#209 clear, then `gh workflow run scorecard.yml`.

Closes #1521