### PR TITLE
docs: correct setup-status catalog path after skills-as-bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Docs** — correct the setup-status catalog path to `skills/setup/tools/setup-status/catalog.yaml` (moved by skills-as-bundles).
 - **Bundling review fixes** — calendar risk/docs, manifest & registry-install correctness, skill-md booleans, tool-input shorthand (`string|null` + polymorphic `string|object|null`/`object[]|object` unions), and manifest output/description contracts synced to handlers. (#1489, #1499)
 - **Smoke harness** — expands `pinned_skills` bundles via `resolvePinnedSkills` like production. (#1489)
 - **Email poll tests** — interval ticks after `mockResolvedValueOnce` no longer reject the suite. (#1489)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ third-party integration, a credential-requiring skill bundle, or a major skill
 that changes what a new user would want to configure — check whether the setup
 wizard catalog needs a matching entry:
 
-- The catalog lives in `skills/setup-status/catalog.yaml`. It is the canonical
+- The catalog lives in `skills/setup/tools/setup-status/catalog.yaml`. It is the canonical
   list of "what a new user sets up" and is owned by the setup-wizard agent, not
   core.
 - If your change adds a configurable capability, add a catalog entry with:

--- a/docs/dev/adding-a-channel.md
+++ b/docs/dev/adding-a-channel.md
@@ -264,7 +264,7 @@ Integration tests should run through a real bus instance so events flow the full
 - [ ] `principal-rules.ts` contributes `identifiersEqual` + `extractRecipients` (group/conversation ids `principalEligible: false`); appended to `principal-channel-registry.ts`; `carveoutSkill` omitted unless a send skill needs Gate C
 - [ ] `channels.<name>` block in `config/channel-trust.yaml` (`trust`, `unknown_sender`, `threaded`); channel-specific settings in `config/default.yaml`
 - [ ] Bootstrap wiring in `src/index.ts` (client + adapter, gated on `channelShouldStart`, adapter constructed after the gateway)
-- [ ] If the channel is something a new user would set up, a matching entry exists in `skills/setup-status/catalog.yaml` with a `docs_url`, and a setup guide exists in the `curia-docs` repo
+- [ ] If the channel is something a new user would set up, a matching entry exists in `skills/setup/tools/setup-status/catalog.yaml` with a `docs_url`, and a setup guide exists in the `curia-docs` repo
 - [ ] Tests: inbound, outbound, `extractRecipients`, catalog, conformance
 - [ ] Remember the channel starts **disabled** — enabling it is a restart-based registry action
 

--- a/docs/dev/adding-a-tool.md
+++ b/docs/dev/adding-a-tool.md
@@ -619,7 +619,7 @@ For **freeform working state that grows** — running notes, a draft, or a resea
 - [ ] Any required secrets are declared in `"secrets"` array
 - [ ] If the skill is useless without a specific credential, it declares that vault key in `install.requires_secrets` so the registry blocks install/enable until it is configured
 - [ ] If the skill sends bulk data externally (attachments, Workspace exports), it accepts `export_items` so the bulk-export gates can resolve sensitivity
-- [ ] If the skill adds a configurable capability a new user would set up (new channel, third-party integration, credential-requiring bundle), a matching entry exists in `skills/setup-status/catalog.yaml` with a `docs_url`
+- [ ] If the skill adds a configurable capability a new user would set up (new channel, third-party integration, credential-requiring bundle), a matching entry exists in `skills/setup/tools/setup-status/catalog.yaml` with a `docs_url`
 - [ ] Skill is pinned in at least one agent YAML (or documented as discoverable)
 - [ ] Remember the skill starts **disabled** in the registry — enabling it is a restart-based registry action, not just adding the directory
 

--- a/docs/specs/03-tools-and-execution.md
+++ b/docs/specs/03-tools-and-execution.md
@@ -293,7 +293,7 @@ The framework ships with these skills (in `skills/` as part of core):
 - `get-autonomy` / `set-autonomy` — read and write the global autonomy score (CEO only)
 - `bullpen` — inter-agent discussion threads; `post`/`reply` persist the thread/message synchronously and fire-and-forget the `agent.discuss` publish so a slow subscriber can't push the handler past its timeout (see *Timeout safety* above)
 - `image-generate` — generate an image from a text prompt via DALL-E 3; returns a temporary CDN URL (~1hr TTL)
-- `setup-status` — read-only (`action_risk: none`); returns the setup catalog (`skills/setup-status/catalog.yaml`) with each task's live-derived status (`done` / `pending` / `deferred`). The catalog is owned by the skill bundle, not core.
+- `setup-status` — read-only (`action_risk: none`); returns the setup catalog (`skills/setup/tools/setup-status/catalog.yaml`) with each task's live-derived status (`done` / `pending` / `deferred`). The catalog is owned by the skill bundle, not core.
 - `setup-defer` — write (`action_risk: low`); persists or clears a setup task deferral in config-store (`setup_wizard/deferrals`). Pinned to `setup-wizard`.
 - `context-bridge-clear` — write (`action_risk: low`); bulk-releases active outbound-context entries matching a list of meeting subjects across the full active window (not just the injected slice). Pinned to coordinator, contacts, ceo-inbox, and meeting-debrief.
 

--- a/docs/specs/18-onboarding.md
+++ b/docs/specs/18-onboarding.md
@@ -217,7 +217,7 @@ The v0.2.0 prompt replaces the fixed 4-turn interview script with an
    and can be deferred with `setup-defer` (`setup_wizard/deferrals` in
    config-store).
 
-The catalog of setup tasks (`skills/setup-status/catalog.yaml`) is owned
+The catalog of setup tasks (`skills/setup/tools/setup-status/catalog.yaml`) is owned
 by the skill bundle. The agent can show the full menu on request and can
 resume deferred tasks in any subsequent session.
 


### PR DESCRIPTION
## Summary

The setup-status catalog moved to `skills/setup/tools/setup-status/catalog.yaml` when it became part of the setup skill bundle (#1489), but several docs still point at the old flat `skills/setup-status/catalog.yaml`. This corrects them.

Surfaced while reviewing the SMS channel PR (#1524), which correctly edited the nested path — confirming the docs were stale. `docs/dev/adding-a-channel.md` (from #1523) carried the same wrong path; since #1523 is already merged, this is a follow-up PR.

## Changes

- `docs/dev/adding-a-channel.md` — checklist path
- `docs/dev/adding-a-tool.md` — checklist path
- `docs/specs/03-tools-and-execution.md` — `setup-status` tool description
- `docs/specs/18-onboarding.md` — setup-catalog ownership note
- `CLAUDE.md` — setup-wizard catalog path

Docs-only; no behavior change.
