### PR TITLE
feat(agents): error-log unresolved pins on scheduled agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-<<<<<<< HEAD
 - **Operator home** — console `/` shows health, attention and activity cards plus a chat CTA. (#1375)
-=======
 - **`authorization.decision`** — audit-logs Gate-1/authz and Gate C allow/deny/escalate. (#1379)
->>>>>>> b9651a35 (feat(audit): emit authorization.decision for Gate-1/authz and Gate C)
 - **`slack-send`** — coordinator-pinned skill for 1:1 Slack DMs via OutboundGateway. (#1526)
 - **SMS channel** — Telnyx office DID two-way text; medium-trust webhook inbound. (#1478)
 - **`OutboundSendRequest`** — new `sms` variant for Telnyx Messages API delivery (public API).
@@ -37,6 +34,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Scheduled pin gaps** — unresolved pins log at error so monitoring catches blind runs. (#1501)
 - **Outbound recipient projection** — channels own request variants + `extractRecipients`; gateway has no projection switch. (#1513; ADR-035)
 - **Signal outbound** — `outbound.delivered.messageId` records the signal-cli send timestamp for reaction correlation. (#1479)
 - **Signal inbound** — reaction envelopes publish `inbound.reaction` (`isRemove` in metadata). (#1479)

--- a/docs/dev/adding-an-agent.md
+++ b/docs/dev/adding-an-agent.md
@@ -144,6 +144,8 @@ Browse `skills/*/SKILL.md` (bundles) and flat `skills/<tool>/` (singleton skills
 - Don't pin skills that are rarely needed — use `allow_discovery: true` instead
 - The Coordinator should pin a broad set since it handles all inbound routing
 
+Unresolved pins are skipped at bootstrap (warn). For **scheduled** agents, unresolved pins are also logged at **error** so monitoring can catch a reduced toolset (#1501) — schedules still load and the agent may try to run; the error is the signal to investigate.
+
 **`allowed_callers` and custom tools:** If a custom tool in your deploy repo has `allowed_callers` set and your new agent needs to use it, add your agent's name to that tool's `allowed_callers` list. This only applies to custom tools in the same deploy repo — core tools should never restrict by deployment-specific agent name. See [Adding a Tool — `allowed_callers`](adding-a-tool.md#allowed_callers-optional) for the full pattern.
 
 Current built-in skills/tools include (see `skills/` for the full list):

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ import {
   loadSkillsFromDiscovery,
   registerSyntheticSingletonSkills,
 } from './skills/skill-loader.js';
-import { resolvePinnedSkills, appendSkillInstructions } from './skills/pin-resolution.js';
+import { resolvePinnedSkills, appendSkillInstructions, reportScheduledPinGaps } from './skills/pin-resolution.js';
 import { BacklogHeartbeat } from './scheduler/backlog-heartbeat.js';
 import { ResumableContinuationSubscriber } from './agents/resumable-continuation-subscriber.js';
 import { PlanFrontierSubscriber } from './agents/plan-frontier-subscriber.js';
@@ -2085,6 +2085,14 @@ async function main(): Promise<void> {
       toolRegistry,
       logger,
       agentConfig.name,
+    );
+    // Scheduled agents with unresolved pins still boot and keep their cron jobs
+    // (#1501) — error-level log only, so monitoring can catch reduced toolsets.
+    reportScheduledPinGaps(
+      agentConfig.name,
+      pinResolution,
+      (agentConfig.schedule?.length ?? 0) > 0,
+      logger,
     );
     // For the coordinator, interpolate runtime context (just the principal contact ID).
     // The specialist roster and the coordinator's own contact ID are no longer resolved

--- a/src/skills/pin-resolution.ts
+++ b/src/skills/pin-resolution.ts
@@ -7,6 +7,10 @@
 // install/enable unit; the pin is the per-agent runtime-availability unit.
 //
 // Fine-grained "pin skill but exclude tool" is intentionally unsupported (YAGNI).
+//
+// Scheduled agents (#1501): unresolved pins still skip-and-continue (the agent
+// may run with a reduced toolset), but bootstrap logs at error so monitoring
+// can catch blind cron runs.
 
 import type { SkillRegistry } from './skill-registry.js';
 import type { ToolRegistry } from './registry.js';
@@ -14,6 +18,16 @@ import type { Logger } from '../logger.js';
 import { formatActivatedSkillInstructionBlock } from './skill-instruction-format.js';
 
 export type PinReferentKind = 'skill' | 'tool';
+
+export type UnresolvedPinReason = 'not_found' | 'member_tools_missing';
+
+/** A pin that did not fully resolve against the live registries. */
+export interface UnresolvedPin {
+  pin: string;
+  reason: UnresolvedPinReason;
+  /** Present when reason is member_tools_missing — tools absent from ToolRegistry. */
+  missingTools?: string[];
+}
 
 export interface PinResolution {
   /** Deduped tool names to pass to ToolRegistry.toToolDefinitions(). */
@@ -28,6 +42,8 @@ export interface PinResolution {
   resolvedSkills: string[];
   /** Per-pin referent kind for auditability (ADR-032). */
   resolvedPins: Array<{ pin: string; kind: PinReferentKind }>;
+  /** Pins that were skipped or only partially expanded. */
+  unresolvedPins: UnresolvedPin[];
 }
 
 /**
@@ -37,7 +53,7 @@ export interface PinResolution {
  * 1. SkillRegistry hit (bundle or MCP-projected skill, including synthetic
  *    singletons) → expand members + instructions/flags.
  * 2. Else ToolRegistry hit → first-class single-tool pin (ADR-032).
- * 3. Else warn and skip.
+ * 3. Else warn and skip (recorded in unresolvedPins).
  */
 export function resolvePinnedSkills(
   pinnedSkills: string[],
@@ -51,20 +67,22 @@ export function resolvePinnedSkills(
   const instructionBlocks: string[] = [];
   const resolvedSkills: string[] = [];
   const resolvedPins: Array<{ pin: string; kind: PinReferentKind }> = [];
+  const unresolvedPins: UnresolvedPin[] = [];
   let heartbeatEligible = false;
   let documentWorkspaceEnabled = false;
 
-  const pushTool = (name: string, via: string) => {
-    if (seenTools.has(name)) return;
+  const pushTool = (name: string, via: string): boolean => {
+    if (seenTools.has(name)) return true;
     if (!toolRegistry.get(name)) {
       logger?.warn(
         { agent: agentName, tool: name, via },
         'Pinned skill expands to a tool that is not loaded; skipping tool definition',
       );
-      return;
+      return false;
     }
     seenTools.add(name);
     toolNames.push(name);
+    return true;
   };
 
   for (const pin of pinnedSkills) {
@@ -72,7 +90,13 @@ export function resolvePinnedSkills(
     if (skill) {
       resolvedSkills.push(pin);
       resolvedPins.push({ pin, kind: 'skill' });
-      for (const t of skill.manifest.tools) pushTool(t, pin);
+      const missingTools: string[] = [];
+      for (const t of skill.manifest.tools) {
+        if (!pushTool(t, pin)) missingTools.push(t);
+      }
+      if (missingTools.length > 0) {
+        unresolvedPins.push({ pin, reason: 'member_tools_missing', missingTools });
+      }
       // Prefer the shared formatter when the skill has progressive-disclosure
       // files so pinned imports get the references index. Native instruction
       // blocks without references stay as the raw body (no activation wrapper).
@@ -118,6 +142,7 @@ export function resolvePinnedSkills(
       continue;
     }
 
+    unresolvedPins.push({ pin, reason: 'not_found' });
     logger?.warn(
       { agent: agentName, pin },
       'Pinned skill not found in SkillRegistry (and not a loaded tool); skipping',
@@ -131,7 +156,34 @@ export function resolvePinnedSkills(
     documentWorkspaceEnabled,
     resolvedSkills,
     resolvedPins,
+    unresolvedPins,
   };
+}
+
+/**
+ * Emit an error-level monitoring signal when a scheduled agent boots with
+ * unresolved pinned skills. Schedules still load — the agent may try to run —
+ * but the error is visible in logs for ops (#1501 / curia-deploy#181).
+ *
+ * Non-scheduled agents keep the per-pin warn from resolvePinnedSkills only.
+ */
+export function reportScheduledPinGaps(
+  agentName: string,
+  resolution: PinResolution,
+  hasSchedule: boolean,
+  logger: Logger,
+): void {
+  if (!hasSchedule || resolution.unresolvedPins.length === 0) return;
+
+  // Error-level so log-based alerting / monitoring catches the gap — warn alone
+  // is what let deploy agents run blind for hours (#1501 / curia-deploy#181).
+  logger.error(
+    {
+      agent: agentName,
+      unresolvedPins: resolution.unresolvedPins,
+    },
+    'Scheduled agent has unresolved pinned skills — toolset is reduced vs declared pins',
+  );
 }
 
 /** Append instruction blocks to a system prompt (blank-line separated). */

--- a/tests/unit/skills/pin-resolution.test.ts
+++ b/tests/unit/skills/pin-resolution.test.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 import { parseSkillMd } from '../../../src/skills/skill-md.js';
 import { SkillRegistry } from '../../../src/skills/skill-registry.js';
 import { ToolRegistry } from '../../../src/skills/registry.js';
-import { resolvePinnedSkills, appendSkillInstructions } from '../../../src/skills/pin-resolution.js';
+import { resolvePinnedSkills, appendSkillInstructions, reportScheduledPinGaps } from '../../../src/skills/pin-resolution.js';
 import { registerSyntheticSingletonSkills } from '../../../src/skills/skill-loader.js';
 import type { ToolManifest } from '../../../src/skills/types.js';
 
@@ -184,6 +184,33 @@ describe('resolvePinnedSkills', () => {
 
     const r = resolvePinnedSkills(['calendar'], skills, tools);
     expect(r.toolNames).toEqual(['calendar-list-events']);
+    expect(r.unresolvedPins).toEqual([
+      {
+        pin: 'calendar',
+        reason: 'member_tools_missing',
+        missingTools: ['calendar-create-event'],
+      },
+    ]);
+  });
+
+  it('records not_found for pins absent from both registries', () => {
+    const tools = new ToolRegistry();
+    const skills = new SkillRegistry();
+    const r = resolvePinnedSkills(['google-workspace', 'web-fetch'], skills, tools);
+    expect(r.toolNames).toEqual([]);
+    expect(r.resolvedPins).toEqual([]);
+    expect(r.unresolvedPins).toEqual([
+      { pin: 'google-workspace', reason: 'not_found' },
+      { pin: 'web-fetch', reason: 'not_found' },
+    ]);
+  });
+
+  it('returns empty unresolvedPins when every pin resolves', () => {
+    const tools = new ToolRegistry();
+    tools.register(toolManifest('web-fetch'), noopHandler);
+    const skills = new SkillRegistry();
+    const r = resolvePinnedSkills(['web-fetch'], skills, tools);
+    expect(r.unresolvedPins).toEqual([]);
   });
 
   it('resolves a first-class tool pin when no skill name matches (ADR-032)', () => {
@@ -273,6 +300,84 @@ describe('resolvePinnedSkills', () => {
     resolvePinnedSkills(['contacts'], skills, tools);
     expect(tools.get('contact-lookup')!.manifest.action_risk).toBe('none');
     expect(tools.get('contact-grant-permission')!.manifest.action_risk).toBe('critical');
+  });
+});
+
+describe('reportScheduledPinGaps (#1501)', () => {
+  function emptyResolution(overrides: Partial<ReturnType<typeof resolvePinnedSkills>> = {}) {
+    return {
+      toolNames: [],
+      instructionBlocks: [],
+      heartbeatEligible: false,
+      documentWorkspaceEnabled: false,
+      resolvedSkills: [],
+      resolvedPins: [] as Array<{ pin: string; kind: 'skill' | 'tool' }>,
+      unresolvedPins: [] as Array<{ pin: string; reason: 'not_found' | 'member_tools_missing'; missingTools?: string[] }>,
+      ...overrides,
+    };
+  }
+
+  it('logs error when a scheduled agent has unresolved pins (schedules still allowed)', () => {
+    const errors: Array<{ msg: string; ctx: Record<string, unknown> }> = [];
+    const logger = {
+      error: (ctx: Record<string, unknown>, msg: string) => {
+        errors.push({ msg, ctx });
+      },
+      warn: () => {},
+      info: () => {},
+      debug: () => {},
+    } as unknown as import('../../../src/logger.js').Logger;
+
+    const tools = new ToolRegistry();
+    const skills = new SkillRegistry();
+    const resolution = resolvePinnedSkills(
+      ['google-workspace', 'tasks'],
+      skills,
+      tools,
+      logger,
+      'T2125-expense-tracker',
+    );
+    reportScheduledPinGaps('T2125-expense-tracker', resolution, true, logger);
+
+    expect(resolution.unresolvedPins.map((g) => g.pin)).toEqual([
+      'google-workspace',
+      'tasks',
+    ]);
+    expect(errors.some((e) => e.msg.includes('unresolved pinned skills'))).toBe(true);
+    expect(errors.some((e) => e.msg.includes('Refusing'))).toBe(false);
+  });
+
+  it('does not escalate when the agent has no schedule', () => {
+    const errors: string[] = [];
+    const logger = {
+      error: (_ctx: Record<string, unknown>, msg: string) => {
+        errors.push(msg);
+      },
+      warn: () => {},
+      info: () => {},
+      debug: () => {},
+    } as unknown as import('../../../src/logger.js').Logger;
+
+    const resolution = emptyResolution({
+      unresolvedPins: [{ pin: 'optional-mcp', reason: 'not_found' }],
+    });
+    reportScheduledPinGaps('research-analyst', resolution, false, logger);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('does not escalate when every pin resolved', () => {
+    const errors: string[] = [];
+    const logger = {
+      error: (_ctx: Record<string, unknown>, msg: string) => {
+        errors.push(msg);
+      },
+      warn: () => {},
+      info: () => {},
+      debug: () => {},
+    } as unknown as import('../../../src/logger.js').Logger;
+
+    reportScheduledPinGaps('ceo-inbox', emptyResolution(), true, logger);
+    expect(errors).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1501.

Scheduled agents whose `pinned_skills` fail to resolve used to warn-and-skip and keep firing on a silently reduced toolset (curia-deploy#181). Ops had no strong signal in the logs to correlate with bad cron output.

### Changes

- Pin resolution now records `unresolvedPins` (`not_found` or `member_tools_missing`) instead of dropping them silently.
- When a **scheduled** agent boots with any unresolved pin, bootstrap emits an **error-level** log (structured `agent` + `unresolvedPins`) so monitoring can catch it.
- Schedules still load and the agent may still run — this is observability only, not a refuse/block path. No new agent YAML fields.

### Tests

- Unit coverage for unresolved pin tracking and error escalation on scheduled agents.
- `pnpm run typecheck` and targeted vitest suites green.

### Docs

- Note in `docs/dev/adding-an-agent.md`; `CHANGELOG.md` entry under Changed.
