### PR TITLE
feat: graceful degradation when database unavailable mid-task (#1381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **DB outage resilience** — `DATABASE_UNAVAILABLE` errors, pool timeouts, skill retry, CEO alert after 5 min. (#1381)
 - **Operator home** — console `/` shows health, attention and activity cards plus a chat CTA. (#1375)
 - **`authorization.decision`** — audit-logs Gate-1/authz and Gate C allow/deny/escalate. (#1379)
 - **`slack-send`** — coordinator-pinned skill for 1:1 Slack DMs via OutboundGateway. (#1526)
@@ -34,6 +35,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`ToolResult` / `ErrorType`** — optional failure `errorType`; new `DATABASE_UNAVAILABLE` (public API). (#1381)
+- **Spec 05** — documents in-operation DB handling; removes that Known Deficiency (#1381).
 - **Scheduled pin gaps** — unresolved pins log at error so monitoring catches blind runs. (#1501)
 - **Outbound recipient projection** — channels own request variants + `extractRecipients`; gateway has no projection switch. (#1513; ADR-035)
 - **Signal outbound** — `outbound.delivered.messageId` records the signal-cli send timestamp for reaction correlation. (#1479)

--- a/docs/specs/05-error-recovery.md
+++ b/docs/specs/05-error-recovery.md
@@ -121,7 +121,7 @@ A `known_failures` table records tool + error-type combinations that consistentl
 - The framework requires Postgres at startup — fails fast with a clear error if unreachable
 - During operation:
   - **Critical paths** (write-ahead audit insert, working-memory load/persist, bus publish that depends on audit) fail fast with a retryable `DATABASE_UNAVAILABLE` `AgentError` — no silent hangs (`connectionTimeoutMillis` on the pool)
-  - **Non-critical paths** (audit acknowledgement, working-memory summarization, skill execution) retry with bounded exponential backoff via `withDbRetry`, then degrade (skills return `{ success: false, errorType: 'DATABASE_UNAVAILABLE' }`)
+  - **Non-critical paths** (audit acknowledgement, working-memory summary *persistence*) retry with bounded exponential backoff via `withDbRetry`. Skill handlers are **not** retried wholesale (side-effect duplication risk) — they classify the fault and return `{ success: false, errorType: 'DATABASE_UNAVAILABLE' }`
 - Task error budgets track DB failures on a separate `dbFailures` counter — temporary outages do **not** burn `consecutiveErrors`
 - The health endpoint detects DB connectivity issues immediately (`checkDb`)
 - `DbAvailabilityMonitor` probes every 30s; after **>5 minutes** of continuous unavailability it escalates to the CEO via `outbound.notification` (`database_unavailable`), retrying until delivery succeeds (typically once Postgres recovers)

--- a/docs/specs/05-error-recovery.md
+++ b/docs/specs/05-error-recovery.md
@@ -119,9 +119,12 @@ A `known_failures` table records tool + error-type combinations that consistentl
 ### Database Unavailable
 
 - The framework requires Postgres at startup — fails fast with a clear error if unreachable
-- During operation: DB failures in non-critical paths (e.g., audit write) are retried with backoff
-- DB failures in critical paths (e.g., loading agent config, reading working memory) bubble up as `agent.error`
-- The health endpoint detects DB connectivity issues immediately
+- During operation:
+  - **Critical paths** (write-ahead audit insert, working-memory load/persist, bus publish that depends on audit) fail fast with a retryable `DATABASE_UNAVAILABLE` `AgentError` — no silent hangs (`connectionTimeoutMillis` on the pool)
+  - **Non-critical paths** (audit acknowledgement, working-memory summarization, skill execution) retry with bounded exponential backoff via `withDbRetry`, then degrade (skills return `{ success: false, errorType: 'DATABASE_UNAVAILABLE' }`)
+- Task error budgets track DB failures on a separate `dbFailures` counter — temporary outages do **not** burn `consecutiveErrors`
+- The health endpoint detects DB connectivity issues immediately (`checkDb`)
+- `DbAvailabilityMonitor` probes every 30s; after **>5 minutes** of continuous unavailability it escalates to the CEO via `outbound.notification` (`database_unavailable`), retrying until delivery succeeds (typically once Postgres recovers)
 
 ---
 
@@ -214,12 +217,13 @@ type ErrorType =
   | 'NOT_FOUND'
   | 'VALIDATION_ERROR'
   | 'PROVIDER_ERROR'
+  | 'DATABASE_UNAVAILABLE'  // Postgres / pool unreachable — retryable (#1381)
   | 'SKILL_ERROR'
   | 'BUDGET_EXCEEDED'
   | 'UNKNOWN';
 ```
 
-Provider-specific errors are mapped to `ErrorType` inside the provider implementation — never leaked as raw strings to the agent runtime. This prevents the fragile string-matching pattern Zora suffered from.
+Provider-specific errors are mapped to `ErrorType` inside the provider implementation — never leaked as raw strings to the agent runtime. This prevents the fragile string-matching pattern Zora suffered from. Database connection failures (pg SQLSTATE class `08` / `57P0x`, Node `ECONNREFUSED` / `ETIMEDOUT`, pool acquire timeouts) map to `DATABASE_UNAVAILABLE` rather than `PROVIDER_ERROR`.
 
 ---
 
@@ -244,5 +248,4 @@ This is enforced by code review convention. A lint rule (`no-empty-catch` + cust
 - **Per-task error pattern detection** — sliding window of last 10 tool invocations is not yet implemented.
 - **Cross-task `known_failures` table** — data collection for future warnings is not yet implemented.
 - **Outbound message queue** — max 100 queue for disconnected channels is not yet implemented. (#1380)
-- **Database unavailable: in-operation handling** — health check detects it, but path-specific handling (retry in non-critical paths, bubble up in critical) is not verified. (#1381)
 - **`no-empty-catch` ESLint rule** — the "Never Swallow" rule is enforced by convention only; the rule is absent from `eslint.config.js`.

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -265,12 +265,21 @@ export class AgentRuntime {
       );
 
       // Best-effort: try to send an error response so the user isn't left hanging.
-      // When the outage is the audit DB itself, publish may also fail — log and move on.
-      try {
-        if (agentErr) {
+      // Isolate agent.error from agent.response — a failed audit write on the
+      // error event must not skip the user-facing response (#1381 review).
+      if (agentErr) {
+        try {
           await this.publishAgentError(agentErr, taskEvent);
+        } catch (publishErr) {
+          this.config.logger.error({ err: publishErr }, 'Failed to publish agent.error');
+        }
+        try {
           await this.sendErrorResponse(taskEvent, agentErr);
-        } else {
+        } catch (publishErr) {
+          this.config.logger.error({ err: publishErr }, 'Failed to publish error response');
+        }
+      } else {
+        try {
           const responseEvent = createAgentResponse({
             agentId: this.config.agentId,
             conversationId: taskEvent.payload.conversationId,
@@ -281,9 +290,9 @@ export class AgentRuntime {
             parentEventId: taskEvent.id,
           });
           await this.config.bus.publish('agent', responseEvent);
+        } catch (publishErr) {
+          this.config.logger.error({ err: publishErr }, 'Failed to publish error response');
         }
-      } catch (publishErr) {
-        this.config.logger.error({ err: publishErr }, 'Failed to publish error response');
       }
     } finally {
       // Clean up the rate limit entry for this task so the validator's writeCounts map

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -15,6 +15,7 @@ import type { ChannelIdentity, TaskOriginator } from '../contacts/types.js';
 import { sanitizeOutput } from '../skills/sanitize.js';
 import { classifySkillError, formatTaskError } from '../errors/classify.js';
 import { DEFAULT_ERROR_BUDGET, type AgentError, type ErrorBudget } from '../errors/types.js';
+import { createDbUnavailableAgentError, isDbUnavailableError } from '../db/resilience.js';
 // Value import (not type-only) — we call AutonomyService.formatPromptBlock() as a static method.
 import { AutonomyService } from '../autonomy/autonomy-service.js';
 import { formatTimeContextBlock } from '../time/time-context.js';
@@ -234,27 +235,53 @@ export class AgentRuntime {
   /**
    * Top-level error boundary for task processing.
    * Ensures the user always gets a response, even if something unexpected throws.
+   * Database outages are classified as retryable DATABASE_UNAVAILABLE (#1381).
    */
   private async handleTask(taskEvent: AgentTaskEvent): Promise<void> {
     try {
       await this.processTask(taskEvent);
     } catch (err) {
+      const attached =
+        err !== null && typeof err === 'object'
+          ? (err as { agentError?: AgentError }).agentError
+          : undefined;
+      const agentErr =
+        attached?.type === 'DATABASE_UNAVAILABLE'
+          ? attached
+          : isDbUnavailableError(err)
+            ? createDbUnavailableAgentError('runtime', err)
+            : null;
+
       this.config.logger.error(
-        { err, agentId: this.config.agentId, conversationId: taskEvent.payload.conversationId },
-        'Unhandled error in agent task processing',
-      );
-      // Best-effort: try to send an error response so the user isn't left hanging
-      try {
-        const responseEvent = createAgentResponse({
+        {
+          err: agentErr ?? err,
           agentId: this.config.agentId,
           conversationId: taskEvent.payload.conversationId,
-          content: "I'm sorry, an unexpected error occurred while processing your request.",
-          // Mark as an error response (same as sendErrorResponse) so delegate and other
-          // consumers don't treat this fallback message as a real agent result.
-          isError: true,
-          parentEventId: taskEvent.id,
-        });
-        await this.config.bus.publish('agent', responseEvent);
+          dbUnavailable: agentErr?.type === 'DATABASE_UNAVAILABLE',
+        },
+        agentErr?.type === 'DATABASE_UNAVAILABLE'
+          ? 'Database unavailable during agent task processing — failing with retryable error'
+          : 'Unhandled error in agent task processing',
+      );
+
+      // Best-effort: try to send an error response so the user isn't left hanging.
+      // When the outage is the audit DB itself, publish may also fail — log and move on.
+      try {
+        if (agentErr) {
+          await this.publishAgentError(agentErr, taskEvent);
+          await this.sendErrorResponse(taskEvent, agentErr);
+        } else {
+          const responseEvent = createAgentResponse({
+            agentId: this.config.agentId,
+            conversationId: taskEvent.payload.conversationId,
+            content: "I'm sorry, an unexpected error occurred while processing your request.",
+            // Mark as an error response (same as sendErrorResponse) so delegate and other
+            // consumers don't treat this fallback message as a real agent result.
+            isError: true,
+            parentEventId: taskEvent.id,
+          });
+          await this.config.bus.publish('agent', responseEvent);
+        }
       } catch (publishErr) {
         this.config.logger.error({ err: publishErr }, 'Failed to publish error response');
       }
@@ -464,6 +491,7 @@ export class AgentRuntime {
       maxConsecutiveErrors: budgetConfig?.maxConsecutiveErrors ?? DEFAULT_ERROR_BUDGET.maxConsecutiveErrors,
       turnsUsed: 0,
       consecutiveErrors: 0,
+      dbFailures: 0,
     };
 
     // Append turn budget block — tells the model the exact number of turns it has
@@ -1433,14 +1461,30 @@ export class AgentRuntime {
         } else {
           // Failure: classify the error and format as a structured <task_error> block
           // so the LLM gets machine-readable error context instead of raw strings.
-          budget.consecutiveErrors++;
-          const agentErr = classifySkillError(toolCall.name, result.error);
+          // Transient DB outages (#1381) are tracked on budget.dbFailures and do NOT
+          // burn the consecutive error budget — temporary infra must not abort the task.
+          const isDbFailure = result.errorType === 'DATABASE_UNAVAILABLE';
+          if (isDbFailure) {
+            budget.dbFailures++;
+          } else {
+            budget.consecutiveErrors++;
+          }
+          const agentErr = isDbFailure
+            ? {
+                type: 'DATABASE_UNAVAILABLE' as const,
+                source: `skill:${toolCall.name}`,
+                message: result.error,
+                retryable: true,
+                context: { toolName: toolCall.name },
+                timestamp: new Date(),
+              }
+            : classifySkillError(toolCall.name, result.error);
           const formattedError = formatTaskError(
             toolCall.name,
             agentErr.type,
             agentErr.message,
-            budget.consecutiveErrors,
-            budget.maxConsecutiveErrors,
+            isDbFailure ? budget.dbFailures : budget.consecutiveErrors,
+            isDbFailure ? budget.dbFailures : budget.maxConsecutiveErrors,
           );
           toolResultBlocks.push({
             type: 'tool_result',
@@ -2280,6 +2324,9 @@ function mapAgentErrorToResponseFields(agentErr: AgentError): {
   }
   if (agentErr.type === 'SKILL_ERROR') {
     return { errorType: agentErr.type, reason: 'tool_error', retryable: agentErr.retryable };
+  }
+  if (agentErr.type === 'DATABASE_UNAVAILABLE') {
+    return { errorType: agentErr.type, reason: 'api_error', retryable: agentErr.retryable };
   }
   if (agentErr.type === 'AUTH_FAILURE' || agentErr.type === 'VALIDATION_ERROR') {
     return { errorType: agentErr.type, reason: 'blocked', retryable: agentErr.retryable };

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -1,6 +1,11 @@
 import type { DbPool } from '../db/connection.js';
 import type { BusEvent } from '../bus/events.js';
 import type { Logger } from '../logger.js';
+import {
+  createDbUnavailableAgentError,
+  isDbUnavailableError,
+  withDbRetry,
+} from '../db/resilience.js';
 
 /**
  * Recursively strip null bytes (U+0000) from all string values in an object.
@@ -101,6 +106,9 @@ export class AuditLogger {
     }
 
     try {
+      // Critical path: fail fast on DB unavailability (no long retry loop).
+      // Spec 05 / #1381 — audit is write-ahead; an outage must surface as a
+      // classified error to publishers rather than hang or swallow.
       await this.pool.query(
         // All columns are explicitly listed so schema additions don't silently
         // shift positional parameters.
@@ -121,6 +129,17 @@ export class AuditLogger {
     } catch (err) {
       // Audit failures must not be silent — log and re-throw so the bus can
       // decide whether to halt delivery or enter a degraded mode.
+      if (isDbUnavailableError(err)) {
+        const agentErr = createDbUnavailableAgentError('audit', err);
+        this.logger.error(
+          { err: agentErr, eventId: event.id, eventType: event.type },
+          'Audit log write failed — database unavailable',
+        );
+        throw Object.assign(new Error(agentErr.message), {
+          code: agentErr.context.code,
+          agentError: agentErr,
+        });
+      }
       this.logger.error({ err, eventId: event.id, eventType: event.type }, 'Audit log write failed');
       throw err;
     }
@@ -141,12 +160,17 @@ export class AuditLogger {
    */
   async markAcknowledged(eventId: string): Promise<void> {
     try {
-      const result = await this.pool.query(
-        // The WHERE clause guards against double-acknowledgement. The DB trigger
-        // also rejects acknowledged = true → true flips, but the WHERE makes
-        // the intent explicit in the application layer.
-        `UPDATE audit_log SET acknowledged = true WHERE id = $1 AND acknowledged = false`,
-        [eventId],
+      // Non-critical path: acknowledgement can retry briefly on transient
+      // outages. Delivery already completed; a delayed ack is preferable to
+      // an immediate throw that the bus would only log anyway (#1381).
+      const result = await withDbRetry(() =>
+        this.pool.query(
+          // The WHERE clause guards against double-acknowledgement. The DB trigger
+          // also rejects acknowledged = true → true flips, but the WHERE makes
+          // the intent explicit in the application layer.
+          `UPDATE audit_log SET acknowledged = true WHERE id = $1 AND acknowledged = false`,
+          [eventId],
+        ),
       );
       if ((result.rowCount ?? 0) === 0) {
         // 0 rows updated — either the row is already acknowledged (acceptable) or
@@ -155,6 +179,17 @@ export class AuditLogger {
         this.logger.warn({ eventId }, 'markAcknowledged matched 0 rows — row may already be acknowledged or eventId not found in audit_log');
       }
     } catch (err) {
+      if (isDbUnavailableError(err)) {
+        const agentErr = createDbUnavailableAgentError('audit', err);
+        this.logger.error(
+          { err: agentErr, eventId },
+          'Failed to mark audit log row as acknowledged — database unavailable',
+        );
+        throw Object.assign(new Error(agentErr.message), {
+          code: agentErr.context.code,
+          agentError: agentErr,
+        });
+      }
       this.logger.error({ err, eventId }, 'Failed to mark audit log row as acknowledged');
       throw err;
     }

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -249,6 +249,7 @@ interface OutboundSuppressedDuplicatePayload {
 //   - 'learning_proposal':  CEO alert surfacing a learning-digest item (voice-guide proposal or sent-mail
 //                           task-completion undo/confirm) event-driven when produced, after #1464 removed
 //                           the scheduled digest that used to surface them (#1466)
+//   - 'database_unavailable': CEO alert that Postgres has been unreachable for >5 minutes (#1381)
 export interface OutboundNotificationPayload {
   notificationType:
     | 'blocked_content'
@@ -257,7 +258,8 @@ export interface OutboundNotificationPayload {
     | 'approval_expired'        // batched expiry notification (approval-expiry-sweep)
     | 'schedule_suspended'      // scheduled job auto-suspended after consecutive failures (#538)
     | 'schedule_recovered'      // stuck job auto-recovered after exceeding timeout threshold (#207)
-    | 'learning_proposal';      // learning-digest item surfaced event-driven when produced (#1466)
+    | 'learning_proposal'       // learning-digest item surfaced event-driven when produced (#1466)
+    | 'database_unavailable';  // Postgres unreachable beyond escalation threshold (#1381)
   /** Recipient email for this notification (always the CEO email today). */
   ceoEmail: string;
   subject: string;

--- a/src/db/availability-monitor.ts
+++ b/src/db/availability-monitor.ts
@@ -123,17 +123,27 @@ export class DbAvailabilityMonitor {
   async probe(): Promise<DbAvailabilitySnapshot> {
     if (this.probing) return this.getSnapshot();
     this.probing = true;
+    let probeTimer: ReturnType<typeof setTimeout> | undefined;
     try {
       try {
         await Promise.race([
           this.config.pool.query('SELECT 1'),
           new Promise<never>((_, reject) => {
-            setTimeout(() => reject(Object.assign(new Error('db probe timeout'), { code: 'ETIMEDOUT' })), 2_000);
+            probeTimer = setTimeout(
+              () => reject(Object.assign(new Error('db probe timeout'), { code: 'ETIMEDOUT' })),
+              2_000,
+            );
+            // Don't keep the process alive solely for a probe timeout.
+            if (typeof probeTimer === 'object' && probeTimer !== null && 'unref' in probeTimer) {
+              (probeTimer as NodeJS.Timeout).unref();
+            }
           }),
         ]);
         await this.onAvailable();
       } catch (err) {
         await this.onUnavailable(err);
+      } finally {
+        if (probeTimer !== undefined) clearTimeout(probeTimer);
       }
       return this.getSnapshot();
     } finally {

--- a/src/db/availability-monitor.ts
+++ b/src/db/availability-monitor.ts
@@ -1,0 +1,240 @@
+// availability-monitor.ts — probe Postgres and escalate to the CEO after a
+// sustained outage (#1381 / spec 05).
+//
+// Design:
+// - In-memory `downSince` tracker — no DB required to observe the outage.
+// - Periodic SELECT 1 probe (default 30s).
+// - After continuous unavailability ≥ 5 minutes, attempt CEO notification
+//   via OutboundGateway.sendNotification (LLM-free, same pattern as
+//   SuspensionNotifier). While the bus audit write still needs Postgres,
+//   retries continue each probe until the send succeeds (typically on
+//   recovery) so the alert is not lost.
+// - One alert per continuous outage episode.
+
+import type { Pool } from 'pg';
+import type { Logger } from '../logger.js';
+import type { OutboundGateway } from '../skills/outbound-gateway.js';
+import {
+  resolvePrincipalEmail,
+  type PrincipalEmailRef,
+} from '../contacts/types.js';
+import {
+  DEFAULT_DB_ESCALATION_MS,
+  DEFAULT_DB_PROBE_INTERVAL_MS,
+  isDbUnavailableError,
+} from './resilience.js';
+
+export interface DbAvailabilityMonitorConfig {
+  pool: Pool;
+  logger: Logger;
+  /** Optional — without a gateway the monitor still logs; it cannot email. */
+  outboundGateway?: OutboundGateway;
+  /** Plain string (tests) or live ref so post-boot email binds hot-reload (#1514). */
+  ceoEmail?: string | PrincipalEmailRef;
+  /** Probe interval. Default 30s. */
+  probeIntervalMs?: number;
+  /** Continuous-down threshold before CEO escalation. Default 5 min. */
+  escalationAfterMs?: number;
+  /** Override setInterval/clearInterval for tests. */
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+  /** Override Date.now for tests. */
+  now?: () => number;
+}
+
+export interface DbAvailabilitySnapshot {
+  available: boolean;
+  /** Epoch ms when the current continuous outage began, or null if healthy. */
+  downSince: number | null;
+  /** True once the escalation threshold was crossed for this outage episode. */
+  escalationDue: boolean;
+  /** True after a CEO notification was successfully published for this episode. */
+  escalated: boolean;
+}
+
+export class DbAvailabilityMonitor {
+  private readonly log: Logger;
+  private readonly probeIntervalMs: number;
+  private readonly escalationAfterMs: number;
+  private readonly setIntervalFn: typeof setInterval;
+  private readonly clearIntervalFn: typeof clearInterval;
+  private readonly now: () => number;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private downSince: number | null = null;
+  private escalationDue = false;
+  private escalated = false;
+  private probing = false;
+
+  constructor(private readonly config: DbAvailabilityMonitorConfig) {
+    this.log = config.logger.child({ component: 'db-availability-monitor' });
+    this.probeIntervalMs = config.probeIntervalMs ?? DEFAULT_DB_PROBE_INTERVAL_MS;
+    this.escalationAfterMs = config.escalationAfterMs ?? DEFAULT_DB_ESCALATION_MS;
+    this.setIntervalFn = config.setIntervalFn ?? setInterval;
+    this.clearIntervalFn = config.clearIntervalFn ?? clearInterval;
+    this.now = config.now ?? Date.now;
+  }
+
+  /** Start periodic probes. Idempotent. */
+  start(): void {
+    if (this.timer !== null) return;
+    this.log.info(
+      {
+        probeIntervalMs: this.probeIntervalMs,
+        escalationAfterMs: this.escalationAfterMs,
+      },
+      'DbAvailabilityMonitor started',
+    );
+    // Fire once immediately so a boot-time outage is detected without waiting
+    // a full interval; subsequent probes ride the interval timer.
+    void this.probe();
+    this.timer = this.setIntervalFn(() => {
+      void this.probe();
+    }, this.probeIntervalMs);
+    // Unref so the timer does not keep the process alive during clean shutdown
+    // in environments that support it (Node.js Timeout).
+    if (typeof this.timer === 'object' && this.timer !== null && 'unref' in this.timer) {
+      (this.timer as NodeJS.Timeout).unref();
+    }
+  }
+
+  /** Stop periodic probes. Idempotent. */
+  stop(): void {
+    if (this.timer === null) return;
+    this.clearIntervalFn(this.timer);
+    this.timer = null;
+    this.log.info('DbAvailabilityMonitor stopped');
+  }
+
+  /** Current in-memory snapshot — useful for tests and health introspection. */
+  getSnapshot(): DbAvailabilitySnapshot {
+    return {
+      available: this.downSince === null,
+      downSince: this.downSince,
+      escalationDue: this.escalationDue,
+      escalated: this.escalated,
+    };
+  }
+
+  /**
+   * Run one probe. Exposed for tests; production callers use start().
+   * Concurrent probes are coalesced — a slow SELECT 1 must not stack.
+   */
+  async probe(): Promise<DbAvailabilitySnapshot> {
+    if (this.probing) return this.getSnapshot();
+    this.probing = true;
+    try {
+      try {
+        await Promise.race([
+          this.config.pool.query('SELECT 1'),
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(Object.assign(new Error('db probe timeout'), { code: 'ETIMEDOUT' })), 2_000);
+          }),
+        ]);
+        await this.onAvailable();
+      } catch (err) {
+        await this.onUnavailable(err);
+      }
+      return this.getSnapshot();
+    } finally {
+      this.probing = false;
+    }
+  }
+
+  private async onAvailable(): Promise<void> {
+    if (this.downSince !== null) {
+      const durationMs = this.now() - this.downSince;
+      this.log.info(
+        { durationMs, escalated: this.escalated },
+        'Database connectivity restored',
+      );
+      // If we crossed the threshold but never got the email out (audit was
+      // down too), try one last time now that Postgres is back.
+      if (this.escalationDue && !this.escalated) {
+        await this.tryEscalate(durationMs);
+      }
+    }
+    this.downSince = null;
+    this.escalationDue = false;
+    this.escalated = false;
+  }
+
+  private async onUnavailable(err: unknown): Promise<void> {
+    const now = this.now();
+    if (this.downSince === null) {
+      this.downSince = now;
+      this.escalationDue = false;
+      this.escalated = false;
+      this.log.error(
+        { err, dbUnavailable: isDbUnavailableError(err) },
+        'Database probe failed — marking unavailable',
+      );
+    }
+
+    const downForMs = now - this.downSince;
+    if (downForMs >= this.escalationAfterMs) {
+      this.escalationDue = true;
+      if (!this.escalated) {
+        await this.tryEscalate(downForMs);
+      }
+    }
+  }
+
+  private async tryEscalate(downForMs: number): Promise<void> {
+    const minutes = Math.round(downForMs / 60_000);
+    this.log.error(
+      { downForMs, minutes },
+      'Database unavailable beyond escalation threshold — attempting CEO notification',
+    );
+
+    const gateway = this.config.outboundGateway;
+    if (!gateway) {
+      this.log.error(
+        { downForMs },
+        'DbAvailabilityMonitor: no outbound gateway — cannot email CEO; reliance on health endpoint / logs',
+      );
+      return;
+    }
+
+    const ceoEmail = this.config.ceoEmail
+      ? resolvePrincipalEmail(this.config.ceoEmail)
+      : '';
+    if (!ceoEmail) {
+      this.log.warn(
+        { downForMs },
+        'DbAvailabilityMonitor: principal email not bound yet — skipping notification',
+      );
+      return;
+    }
+
+    const subject = 'Curia database unavailable';
+    const body = [
+      'Curia cannot reach its Postgres database.',
+      '',
+      `Unavailable for: ~${minutes} min`,
+      '',
+      'Critical paths (audit, dispatch, working memory) are failing fast with',
+      'retryable DATABASE_UNAVAILABLE errors. Non-critical paths retry with backoff.',
+      '',
+      'Check the /api/health endpoint and Postgres / Docker host.',
+      'This alert retries until delivery succeeds (typically once connectivity returns).',
+    ].join('\n');
+
+    const sent = await gateway.sendNotification({
+      notificationType: 'database_unavailable',
+      ceoEmail,
+      subject,
+      body,
+    });
+
+    if (sent) {
+      this.escalated = true;
+      this.log.info({ downForMs, minutes }, 'DbAvailabilityMonitor: CEO notification published');
+    } else {
+      this.log.error(
+        { downForMs, minutes },
+        'DbAvailabilityMonitor: failed to publish notification (audit/bus likely also down) — will retry',
+      );
+    }
+  }
+}

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,5 +1,6 @@
 import pg from 'pg';
 import type { Logger } from '../logger.js';
+import { DEFAULT_CONNECTION_TIMEOUT_MS, isDbUnavailableError } from './resilience.js';
 
 const { Pool } = pg;
 
@@ -7,6 +8,14 @@ const { Pool } = pg;
 // This keeps the rest of the codebase decoupled from the pg driver's type surface.
 export type DbPool = pg.Pool;
 export type DbPoolClient = pg.PoolClient;
+
+export interface CreatePoolOptions {
+  /**
+   * Max ms to wait when checking out a client from the pool. Default 5000.
+   * Without this, a dead Postgres can hang callers indefinitely (#1381).
+   */
+  connectionTimeoutMillis?: number;
+}
 
 /**
  * Create a managed connection pool to Postgres.
@@ -17,14 +26,32 @@ export type DbPoolClient = pg.PoolClient;
  *
  * The 'error' handler is required: without it, an idle-client error from pg
  * would be an unhandled EventEmitter exception and crash the process.
+ *
+ * connectionTimeoutMillis ensures connection acquire failures surface to
+ * callers as rejected promises instead of silent hangs (#1381).
  */
-export function createPool(databaseUrl: string, logger: Logger): DbPool {
-  const pool = new Pool({ connectionString: databaseUrl });
+export function createPool(
+  databaseUrl: string,
+  logger: Logger,
+  options: CreatePoolOptions = {},
+): DbPool {
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    connectionTimeoutMillis:
+      options.connectionTimeoutMillis ?? DEFAULT_CONNECTION_TIMEOUT_MS,
+  });
 
   pool.on('error', (err) => {
     // Log but do not re-throw — pool errors on idle clients are not fatal
     // (e.g., Postgres server restarted). pg will reconnect on the next query.
-    logger.error({ err }, 'Unexpected database pool error');
+    // Classify so operators can grep DATABASE_UNAVAILABLE in structured logs.
+    const unavailable = isDbUnavailableError(err);
+    logger.error(
+      { err, dbUnavailable: unavailable },
+      unavailable
+        ? 'Database pool idle-client error — Postgres may be unavailable'
+        : 'Unexpected database pool error',
+    );
   });
 
   return pool;

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -29,6 +29,10 @@ export interface CreatePoolOptions {
  *
  * connectionTimeoutMillis ensures connection acquire failures surface to
  * callers as rejected promises instead of silent hangs (#1381).
+ *
+ * Note: this bounds pool checkout only — a connection that hangs mid-query
+ * (half-alive server, lock wait) still needs a future `statement_timeout` /
+ * `query_timeout` policy. Out of scope for #1381.
  */
 export function createPool(
   databaseUrl: string,

--- a/src/db/resilience.ts
+++ b/src/db/resilience.ts
@@ -1,0 +1,172 @@
+// resilience.ts — database unavailability detection and retry helpers (#1381).
+//
+// Spec 05: non-critical DB paths retry with backoff; critical paths bubble as
+// AgentError (DATABASE_UNAVAILABLE). Classification uses pg SQLSTATE codes and
+// Node system error codes — never string-matching messages.
+
+import type { AgentError } from '../errors/types.js';
+import { isRetryable } from '../errors/types.js';
+import { sanitizeOutput } from '../skills/sanitize.js';
+
+/** Default connection acquire timeout so callers fail fast instead of hanging. */
+export const DEFAULT_CONNECTION_TIMEOUT_MS = 5_000;
+
+/** Default probe interval for the availability monitor. */
+export const DEFAULT_DB_PROBE_INTERVAL_MS = 30_000;
+
+/** Escalate to the CEO after this continuous unavailability window. */
+export const DEFAULT_DB_ESCALATION_MS = 5 * 60_000;
+
+/** Bounded backoff for non-critical DB retries. */
+export const DEFAULT_DB_RETRY = {
+  maxAttempts: 3,
+  baseDelayMs: 100,
+  maxDelayMs: 1_000,
+} as const;
+
+/**
+ * Postgres SQLSTATE classes / codes that indicate the server or connection is
+ * unavailable (transient). See https://www.postgresql.org/docs/current/errcodes-appendix.html
+ *
+ * - Class 08 — Connection Exception
+ * - 57P01 — admin_shutdown
+ * - 57P02 — crash_shutdown
+ * - 57P03 — cannot_connect_now
+ * - 53300 — too_many_connections
+ */
+const PG_UNAVAILABLE_CODES = new Set([
+  '08000', // connection_exception
+  '08001', // sqlclient_unable_to_establish_sqlconnection
+  '08003', // connection_does_not_exist
+  '08004', // sqlserver_rejected_establishment_of_sqlconnection
+  '08006', // connection_failure
+  '08007', // transaction_resolution_unknown
+  '08P01', // protocol_violation
+  '57P01', // admin_shutdown
+  '57P02', // crash_shutdown
+  '57P03', // cannot_connect_now
+  '53300', // too_many_connections
+]);
+
+/** Node / libpq system codes that surface as connection failures. */
+const NODE_UNAVAILABLE_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'ESOCKETTIMEDOUT',
+  'ENOTFOUND',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+  // pg pool: no connection acquired within connectionTimeoutMillis
+  'CONNECTION_STOPPED',
+  'CONNECTION_ENDED',
+]);
+
+function extractCode(err: unknown): string | undefined {
+  if (err === null || err === undefined || typeof err !== 'object') return undefined;
+  const record = err as Record<string, unknown>;
+  if (typeof record.code === 'string') return record.code;
+  return undefined;
+}
+
+/**
+ * True when `err` indicates Postgres / the connection pool is unavailable.
+ * Does NOT treat application SQL errors (syntax, constraint, etc.) as outages.
+ */
+export function isDbUnavailableError(err: unknown): boolean {
+  const code = extractCode(err);
+  if (!code) {
+    // pg wraps some connection failures as AggregateError / nested causes.
+    if (err instanceof Error && 'cause' in err && err.cause !== undefined) {
+      return isDbUnavailableError(err.cause);
+    }
+    // Pool "timeout exceeded when trying to connect" has no code in older pg —
+    // match the well-known message only as a last resort for that specific shape.
+    if (err instanceof Error && /timeout exceeded when trying to connect/i.test(err.message)) {
+      return true;
+    }
+    return false;
+  }
+  if (NODE_UNAVAILABLE_CODES.has(code)) return true;
+  if (PG_UNAVAILABLE_CODES.has(code)) return true;
+  // Class 08xxxx — any connection_exception subclass we didn't list explicitly.
+  if (/^08/.test(code)) return true;
+  return false;
+}
+
+function extractMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  if (err === null || err === undefined) return 'Database unavailable (no details)';
+  return String(err);
+}
+
+/**
+ * Build a structured AgentError for a database outage.
+ * Always retryable — temporary infra failure, not a logic bug.
+ */
+export function createDbUnavailableAgentError(source: string, err: unknown): AgentError {
+  const code = extractCode(err);
+  const context: Record<string, unknown> = {};
+  if (code) context.code = code;
+  return {
+    type: 'DATABASE_UNAVAILABLE',
+    source,
+    message: sanitizeOutput(extractMessage(err), { maxLength: 400 }),
+    retryable: isRetryable('DATABASE_UNAVAILABLE'),
+    context,
+    timestamp: new Date(),
+  };
+}
+
+export interface WithDbRetryOptions {
+  /** Max attempts including the first try. Default 3. */
+  maxAttempts?: number;
+  /** Initial backoff delay in ms. Default 100. */
+  baseDelayMs?: number;
+  /** Cap on backoff delay. Default 1000. */
+  maxDelayMs?: number;
+  /** Optional sleep override for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Retry a DB operation on transient unavailability. Non-DB errors and
+ * exhaustion of attempts rethrow the last error unchanged.
+ *
+ * Use on non-critical paths (acknowledgement writes, telemetry, summarization).
+ * Critical paths should call the operation once and classify with
+ * `createDbUnavailableAgentError` instead.
+ */
+export async function withDbRetry<T>(
+  fn: () => Promise<T>,
+  options: WithDbRetryOptions = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_DB_RETRY.maxAttempts;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_DB_RETRY.baseDelayMs;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_DB_RETRY.maxDelayMs;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (!isDbUnavailableError(err) || attempt >= maxAttempts) {
+        throw err;
+      }
+      const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+      await sleep(delay);
+    }
+  }
+  // Unreachable — loop always returns or throws — but satisfies the type checker.
+  throw lastErr;
+}

--- a/src/db/resilience.ts
+++ b/src/db/resilience.ts
@@ -163,7 +163,10 @@ export async function withDbRetry<T>(
       if (!isDbUnavailableError(err) || attempt >= maxAttempts) {
         throw err;
       }
-      const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+      // Full-jitter exponential backoff so concurrent retryers don't stampede
+      // Postgres as it recovers (base/2 … base, doubled each attempt, capped).
+      const rawDelay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+      const delay = rawDelay / 2 + Math.random() * (rawDelay / 2);
       await sleep(delay);
     }
   }

--- a/src/errors/classify.ts
+++ b/src/errors/classify.ts
@@ -93,6 +93,11 @@ function sanitizeMessage(message: string): string {
  * 1. HTTP status code (most reliable — from API responses)
  * 2. Node.js error code (system-level failures)
  * 3. Fallback to UNKNOWN
+ *
+ * Note: Postgres outages are classified at DB call sites via
+ * `createDbUnavailableAgentError` / `isDbUnavailableError` (#1381). Generic
+ * ECONNREFUSED here remains PROVIDER_ERROR so LLM/network failures are not
+ * mislabeled as DATABASE_UNAVAILABLE.
  */
 export function classifyError(err: unknown, source: string): AgentError {
   const rawMessage = extractMessage(err);
@@ -115,6 +120,12 @@ export function classifyError(err: unknown, source: string): AgentError {
     if (type === 'UNKNOWN' && CODE_MAP[code]) {
       type = CODE_MAP[code];
     }
+  }
+
+  // 3. Prefer an AgentError already attached by a DB call site (#1381).
+  const attached = (err as { agentError?: AgentError })?.agentError;
+  if (attached && attached.type === 'DATABASE_UNAVAILABLE') {
+    return attached;
   }
 
   return {

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -4,15 +4,16 @@
 // ErrorType is a discriminated union — never match error strings.
 
 export type ErrorType =
-  | 'AUTH_FAILURE'       // 401/403 — never retry, counts double against budget
-  | 'RATE_LIMIT'         // 429 — retryable with backoff
-  | 'TIMEOUT'            // request timeout, ETIMEDOUT
-  | 'NOT_FOUND'          // 404, ENOENT
-  | 'VALIDATION_ERROR'   // malformed input, schema violation
-  | 'PROVIDER_ERROR'     // 5xx, upstream LLM failure
-  | 'SKILL_ERROR'        // skill returned { success: false }
-  | 'BUDGET_EXCEEDED'    // turn or error budget exhausted
-  | 'UNKNOWN';           // fallback — something unexpected
+  | 'AUTH_FAILURE'           // 401/403 — never retry, counts double against budget
+  | 'RATE_LIMIT'             // 429 — retryable with backoff
+  | 'TIMEOUT'                // request timeout, ETIMEDOUT
+  | 'NOT_FOUND'              // 404, ENOENT
+  | 'VALIDATION_ERROR'       // malformed input, schema violation
+  | 'PROVIDER_ERROR'         // 5xx, upstream LLM failure
+  | 'DATABASE_UNAVAILABLE'   // Postgres / pool unreachable — retryable, tracked separately (#1381)
+  | 'SKILL_ERROR'            // skill returned { success: false }
+  | 'BUDGET_EXCEEDED'        // turn or error budget exhausted
+  | 'UNKNOWN';               // fallback — something unexpected
 
 export interface AgentError {
   type: ErrorType;
@@ -28,15 +29,23 @@ export interface ErrorBudget {
   maxConsecutiveErrors: number;  // max consecutive errors before abort (default: 5)
   turnsUsed: number;
   consecutiveErrors: number;
+  /**
+   * Transient DB outage failures observed this task. Tracked for observability
+   * but do NOT increment consecutiveErrors — temporary infra blips must not
+   * burn the agent's error budget (spec 05 / #1381).
+   */
+  dbFailures: number;
 }
 
 // Retryable is deterministic from ErrorType — no per-instance overrides.
 // AUTH_FAILURE and BUDGET_EXCEEDED are never retryable.
-// RATE_LIMIT, TIMEOUT, and PROVIDER_ERROR are retryable (transient failures).
+// RATE_LIMIT, TIMEOUT, PROVIDER_ERROR, and DATABASE_UNAVAILABLE are retryable
+// (transient failures).
 const RETRYABLE_TYPES: ReadonlySet<ErrorType> = new Set([
   'RATE_LIMIT',
   'TIMEOUT',
   'PROVIDER_ERROR',
+  'DATABASE_UNAVAILABLE',
 ]);
 
 export function isRetryable(type: ErrorType): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { loadConfig, loadYamlConfig, resolveTasksConfig, resolveHealthConfig } f
 import { createLogger } from './logger.js';
 import { HttpAdapter } from './channels/http/http-adapter.js';
 import { createPool } from './db/connection.js';
+import { DbAvailabilityMonitor } from './db/availability-monitor.js';
 import { EventBus } from './bus/bus.js';
 import { AuditLogger } from './audit/logger.js';
 import { AuditLogRepo } from './audit/audit-log-repo.js';
@@ -1895,6 +1896,26 @@ async function main(): Promise<void> {
     );
   }
 
+  // DbAvailabilityMonitor — probes Postgres and emails the CEO after >5 min of
+  // continuous unavailability (#1381 / spec 05). LLM-free; retries notification
+  // until the bus/audit path can deliver (typically on recovery).
+  const dbAvailabilityMonitor = new DbAvailabilityMonitor({
+    pool,
+    logger,
+    outboundGateway,
+    ceoEmail: principalEmail,
+  });
+  dbAvailabilityMonitor.start();
+  if (!outboundGateway) {
+    logger.warn(
+      'DbAvailabilityMonitor started without outbound gateway — will log outages but cannot email CEO',
+    );
+  } else if (!principalEmail.current) {
+    logger.warn(
+      'DbAvailabilityMonitor started without principal email yet — will notify once an email identity is bound',
+    );
+  }
+
   // HealthService — observability layer for liveness probes and canary jobs (#434).
   // Requires: pool, bus, logger (always available), scheduler (just constructed),
   // mcpSessions (loaded at line 926), and modelRoutingConfig (from line 393).
@@ -2634,6 +2655,12 @@ async function main(): Promise<void> {
       dispatcher.close();
     } catch (err) {
       logger.error({ err }, 'Error clearing checkpoint timers during shutdown');
+    }
+    // Stop DB probes before closing the pool so the last SELECT 1 isn't racing end().
+    try {
+      dbAvailabilityMonitor.stop();
+    } catch (err) {
+      logger.error({ err }, 'Error stopping DB availability monitor during shutdown');
     }
     // Purge temp files and stop the sweep timer before exit.
     if (tempFileStore) {

--- a/src/memory/working-memory.ts
+++ b/src/memory/working-memory.ts
@@ -141,12 +141,11 @@ class PostgresBackend implements StorageBackend {
     // the turn has already been persisted. Catch here (not inside maybeSummarize)
     // so errors propagate cleanly out of the private method and the non-fatal
     // decision is explicit and visible at the call site.
-    // Non-critical: retry briefly on transient DB blips before giving up (#1381).
+    // DB retries for the post-LLM persistence half live inside maybeSummarize —
+    // wrapping the whole call would re-bill the summarization LLM on a DB blip.
     if (this.summarization) {
       try {
-        await withDbRetry(() =>
-          this.maybeSummarize(conversationId, agentId, this.summarization!),
-        );
+        await this.maybeSummarize(conversationId, agentId, this.summarization);
       } catch (err) {
         this.logger.error(
           { err, conversationId, agentId },
@@ -315,6 +314,31 @@ class PostgresBackend implements StorageBackend {
     }
     const summaryContent = response.content.trim();
 
+    // Persist only — retry transient DB blips here without re-running the LLM
+    // call above (#1381 review). The transaction is atomic, so a failed attempt
+    // rolls back cleanly before the next retry.
+    const archiveIds = turnsToArchive.map((t) => t.id);
+    await withDbRetry(() =>
+      this.persistSummary(
+        conversationId,
+        agentId,
+        archiveIds,
+        summaryContent,
+      ),
+    );
+  }
+
+  /**
+   * Post-LLM half of summarization: anchor timestamp + archive/insert transaction.
+   * Idempotent across retries only when the prior attempt rolled back (COMMIT
+   * success means withDbRetry does not re-enter).
+   */
+  private async persistSummary(
+    conversationId: string,
+    agentId: string,
+    archiveIds: string[],
+    summaryContent: string,
+  ): Promise<void> {
     // The synthetic summary is inserted 1ms before the oldest *kept* turn so that
     // chronological ordering places it at the head of the active window.
     const oldestKeptResult = await this.pool.query<{ created_at: Date }>(
@@ -326,7 +350,7 @@ class PostgresBackend implements StorageBackend {
          AND id != ALL($3::uuid[])
        ORDER BY created_at ASC
        LIMIT 1`,
-      [conversationId, agentId, turnsToArchive.map((t) => t.id)],
+      [conversationId, agentId, archiveIds],
     );
 
     // If toArchiveCount < activeCount, there must always be at least one kept row.
@@ -341,7 +365,6 @@ class PostgresBackend implements StorageBackend {
 
     // Atomic transaction: archive old turns + insert synthetic summary.
     // If either step fails the whole operation rolls back — no partial state.
-    const archiveIds = turnsToArchive.map((t) => t.id);
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');

--- a/src/memory/working-memory.ts
+++ b/src/memory/working-memory.ts
@@ -1,6 +1,11 @@
 import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 import type { LLMProvider } from '../agents/llm/provider.js';
+import {
+  createDbUnavailableAgentError,
+  isDbUnavailableError,
+  withDbRetry,
+} from '../db/resilience.js';
 
 export interface ConversationTurn {
   role: 'user' | 'assistant' | 'system';
@@ -107,20 +112,41 @@ class PostgresBackend implements StorageBackend {
     const expiresAt = this.ttlDays != null
       ? new Date(Date.now() + this.ttlDays * 24 * 60 * 60 * 1000)
       : null;
-    await this.pool.query(
-      `INSERT INTO working_memory (conversation_id, agent_id, role, content, expires_at)
-       VALUES ($1, $2, $3, $4, $5)`,
-      [conversationId, agentId, turn.role, turn.content, expiresAt],
-    );
+    // Critical path: reading/writing working memory must fail fast with a
+    // classified DATABASE_UNAVAILABLE error so the runtime can publish
+    // agent.error rather than hang (#1381 / spec 05).
+    try {
+      await this.pool.query(
+        `INSERT INTO working_memory (conversation_id, agent_id, role, content, expires_at)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [conversationId, agentId, turn.role, turn.content, expiresAt],
+      );
+    } catch (err) {
+      if (isDbUnavailableError(err)) {
+        const agentErr = createDbUnavailableAgentError('working-memory', err);
+        this.logger.error(
+          { err: agentErr, conversationId, agentId },
+          'working_memory: add failed — database unavailable',
+        );
+        throw Object.assign(new Error(agentErr.message), {
+          code: agentErr.context.code,
+          agentError: agentErr,
+        });
+      }
+      throw err;
+    }
 
     // After writing, check whether we've crossed the summarization threshold.
     // Summarization is best-effort — a failure must not abort the agent turn since
     // the turn has already been persisted. Catch here (not inside maybeSummarize)
     // so errors propagate cleanly out of the private method and the non-fatal
     // decision is explicit and visible at the call site.
+    // Non-critical: retry briefly on transient DB blips before giving up (#1381).
     if (this.summarization) {
       try {
-        await this.maybeSummarize(conversationId, agentId, this.summarization);
+        await withDbRetry(() =>
+          this.maybeSummarize(conversationId, agentId, this.summarization!),
+        );
       } catch (err) {
         this.logger.error(
           { err, conversationId, agentId },
@@ -133,26 +159,42 @@ class PostgresBackend implements StorageBackend {
   async get(conversationId: string, agentId: string, maxTurns?: number): Promise<ConversationTurn[]> {
     const limit = maxTurns ?? 50;
 
-    // Subquery gets the most recent N active (non-archived) rows (newest first),
-    // then the outer query reverses to chronological order for LLM context.
-    // Archived rows are excluded — they're represented by the synthetic summary turn.
-    const result = await this.pool.query<{ role: string; content: string }>(
-      `SELECT role, content FROM (
-         SELECT role, content, created_at
-         FROM working_memory
-         WHERE conversation_id = $1
-           AND agent_id = $2
-           AND archived = false
-         ORDER BY created_at DESC
-         LIMIT $3
-       ) sub ORDER BY created_at ASC`,
-      [conversationId, agentId, limit],
-    );
+    // Critical path: history load must fail fast on DB outage (#1381).
+    try {
+      // Subquery gets the most recent N active (non-archived) rows (newest first),
+      // then the outer query reverses to chronological order for LLM context.
+      // Archived rows are excluded — they're represented by the synthetic summary turn.
+      const result = await this.pool.query<{ role: string; content: string }>(
+        `SELECT role, content FROM (
+           SELECT role, content, created_at
+           FROM working_memory
+           WHERE conversation_id = $1
+             AND agent_id = $2
+             AND archived = false
+           ORDER BY created_at DESC
+           LIMIT $3
+         ) sub ORDER BY created_at ASC`,
+        [conversationId, agentId, limit],
+      );
 
-    return result.rows.map((row) => ({
-      role: row.role as ConversationTurn['role'],
-      content: row.content,
-    }));
+      return result.rows.map((row) => ({
+        role: row.role as ConversationTurn['role'],
+        content: row.content,
+      }));
+    } catch (err) {
+      if (isDbUnavailableError(err)) {
+        const agentErr = createDbUnavailableAgentError('working-memory', err);
+        this.logger.error(
+          { err: agentErr, conversationId, agentId },
+          'working_memory: get failed — database unavailable',
+        );
+        throw Object.assign(new Error(agentErr.message), {
+          code: agentErr.context.code,
+          agentError: agentErr,
+        });
+      }
+      throw err;
+    }
   }
 
   async purgeExpired(): Promise<number> {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -65,6 +65,10 @@ import {
   maxItemSensitivity,
 } from '../security/export-controls.js';
 import { createExportDelivered } from '../bus/events.js';
+import {
+  isDbUnavailableError,
+  withDbRetry,
+} from '../db/resilience.js';
 
 // Default max output length — used when no value is configured in default.yaml.
 // Skills returning more than this will have their output truncated before it
@@ -1624,8 +1628,11 @@ export class ExecutionLayer {
     });
 
     try {
+      // Non-critical path (#1381): transient DB outages during skill execution
+      // are retried with bounded backoff before surfacing to the agent. The
+      // skill timeout still races the whole retry sequence so we never hang.
       const result = await Promise.race([
-        handler.execute(ctx),
+        withDbRetry(() => handler.execute(ctx)),
         timeoutPromise,
       ]);
 
@@ -1710,6 +1717,15 @@ export class ExecutionLayer {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       skillLogger.error({ err }, 'Skill invocation failed');
+      // Classify DB outages so the runtime can track them separately from the
+      // consecutive error budget (spec 05 / #1381).
+      if (isDbUnavailableError(err)) {
+        return {
+          success: false,
+          error: this.wrapSkillError(message),
+          errorType: 'DATABASE_UNAVAILABLE',
+        };
+      }
       return { success: false, error: this.wrapSkillError(message) };
     } finally {
       // Clean up the timeout timer whether we succeeded, failed, or timed out

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -65,10 +65,7 @@ import {
   maxItemSensitivity,
 } from '../security/export-controls.js';
 import { createExportDelivered } from '../bus/events.js';
-import {
-  isDbUnavailableError,
-  withDbRetry,
-} from '../db/resilience.js';
+import { isDbUnavailableError } from '../db/resilience.js';
 
 // Default max output length — used when no value is configured in default.yaml.
 // Skills returning more than this will have their output truncated before it
@@ -1628,11 +1625,13 @@ export class ExecutionLayer {
     });
 
     try {
-      // Non-critical path (#1381): transient DB outages during skill execution
-      // are retried with bounded backoff before surfacing to the agent. The
-      // skill timeout still races the whole retry sequence so we never hang.
+      // Do NOT wrap handler.execute in withDbRetry: handlers may have already
+      // sent external messages or mutated other systems before a later DB write
+      // fails, and a full replay would duplicate side effects (#1381 review).
+      // Transient DB faults are classified below as DATABASE_UNAVAILABLE so the
+      // runtime can degrade without burning the consecutive-error budget.
       const result = await Promise.race([
-        withDbRetry(() => handler.execute(ctx)),
+        handler.execute(ctx),
         timeoutPromise,
       ]);
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -328,10 +328,20 @@ export interface ToolContext {
  * Skills NEVER throw — they return success or failure as a value.
  * This makes error handling explicit and prevents unhandled exceptions
  * from propagating through the execution layer.
+ *
+ * `errorType` is optional and additive (#1381): when the execution layer
+ * classifies a thrown failure (e.g. DATABASE_UNAVAILABLE), it attaches the
+ * type so the runtime can track DB outages separately from the consecutive
+ * error budget. Handlers may omit it — absence means a generic SKILL_ERROR.
  */
 export type ToolResult =
   | { success: true; data: unknown }
-  | { success: false; error: string };
+  | {
+      success: false;
+      error: string;
+      /** Structured classification when known (e.g. DATABASE_UNAVAILABLE). */
+      errorType?: import('../errors/types.js').ErrorType;
+    };
 
 /**
  * Interface that all skill handlers implement.

--- a/tests/integration/db-unavailable-mid-task.test.ts
+++ b/tests/integration/db-unavailable-mid-task.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration-style coverage for mid-task DB unavailability (#1381).
+ *
+ * Uses a real Postgres pool when DATABASE_URL is set, then points WorkingMemory
+ * at a sabotaged pool that rejects with ECONNREFUSED — simulating Postgres
+ * going away after dispatch. Asserts the agent fails with a retryable
+ * DATABASE_UNAVAILABLE error rather than hanging.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { EventBus } from '../../src/bus/bus.js';
+import {
+  createAgentTask,
+  type AgentResponseEvent,
+  type AgentErrorEvent,
+} from '../../src/bus/events.js';
+import type { LLMProvider } from '../../src/agents/llm/provider.js';
+import { createLogger } from '../../src/logger.js';
+import { WorkingMemory } from '../../src/memory/working-memory.js';
+import { createPool, type DbPool } from '../../src/db/connection.js';
+import { AuditLogger } from '../../src/audit/logger.js';
+
+const hasDb = !!process.env['DATABASE_URL'];
+const describeIf = hasDb ? describe : describe.skip;
+
+const MOCK_PROVENANCE = {
+  requestedModel: 'mock-model',
+  actualModel: 'mock-model',
+  providerRequestId: 'msg_mock_int',
+} as const;
+
+describeIf('integration: database unavailable mid-task (#1381)', () => {
+  let healthyPool: DbPool;
+
+  beforeAll(() => {
+    healthyPool = createPool(process.env['DATABASE_URL']!, createLogger('error'));
+  });
+
+  afterAll(async () => {
+    await healthyPool.end();
+  });
+
+  it('task fails gracefully with retryable error when DB goes down mid-task', async () => {
+    // Prove the real pool is healthy first (mirrors production boot probe).
+    await healthyPool.query('SELECT 1');
+
+    const logger = createLogger('error');
+    const auditLogger = new AuditLogger(healthyPool, logger);
+    const bus = new EventBus(
+      logger,
+      (event) => auditLogger.log(event),
+      (id) => auditLogger.markAcknowledged(id),
+    );
+
+    const responses: AgentResponseEvent[] = [];
+    const errors: AgentErrorEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (e) => {
+      responses.push(e as AgentResponseEvent);
+    });
+    bus.subscribe('agent.error', 'system', (e) => {
+      errors.push(e as AgentErrorEvent);
+    });
+
+    // Sabotaged pool: every query fails as if Postgres vanished after dispatch.
+    const deadPool = {
+      query: vi.fn().mockRejectedValue(
+        Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), {
+          code: 'ECONNREFUSED',
+        }),
+      ),
+      on: vi.fn(),
+      end: vi.fn(),
+    } as unknown as DbPool;
+
+    const memory = WorkingMemory.createWithPostgres(deadPool, logger);
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'unreachable',
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'test',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      memory,
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: `conv-db-int-${Date.now()}`,
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'ping',
+      parentEventId: 'parent-int-db',
+    });
+
+    // Dispatch still works (audit uses healthyPool). Mid-task memory hits deadPool.
+    await bus.publish('dispatch', task);
+
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(errors.some((e) => e.payload.errorType === 'DATABASE_UNAVAILABLE')).toBe(true);
+    const errEvt = errors.find((e) => e.payload.errorType === 'DATABASE_UNAVAILABLE');
+    expect(errEvt!.payload.retryable).toBe(true);
+    expect(responses.some((r) => r.payload.isError && r.payload.errorType === 'DATABASE_UNAVAILABLE')).toBe(
+      true,
+    );
+  });
+});

--- a/tests/integration/db-unavailable-mid-task.test.ts
+++ b/tests/integration/db-unavailable-mid-task.test.ts
@@ -19,6 +19,7 @@ import { createLogger } from '../../src/logger.js';
 import { WorkingMemory } from '../../src/memory/working-memory.js';
 import { createPool, type DbPool } from '../../src/db/connection.js';
 import { AuditLogger } from '../../src/audit/logger.js';
+import { requireCuriaTestDatabase } from './require-test-db.js';
 
 const hasDb = !!process.env['DATABASE_URL'];
 const describeIf = hasDb ? describe : describe.skip;
@@ -29,14 +30,27 @@ const MOCK_PROVENANCE = {
   providerRequestId: 'msg_mock_int',
 } as const;
 
+const CONV_ID_PREFIX = 'conv-db-int-';
+
 describeIf('integration: database unavailable mid-task (#1381)', () => {
   let healthyPool: DbPool;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     healthyPool = createPool(process.env['DATABASE_URL']!, createLogger('error'));
+    // Refuse to write audit_log rows against anything other than curia_test.
+    await requireCuriaTestDatabase(healthyPool);
   });
 
   afterAll(async () => {
+    try {
+      await healthyPool.query(
+        `DELETE FROM audit_log WHERE conversation_id LIKE $1`,
+        [`${CONV_ID_PREFIX}%`],
+      );
+    } catch (err) {
+      // Cleanup must not block pool shutdown.
+      createLogger('error').error({ err }, 'db-unavailable integration: audit_log cleanup failed');
+    }
     await healthyPool.end();
   });
 
@@ -96,7 +110,7 @@ describeIf('integration: database unavailable mid-task (#1381)', () => {
 
     const task = createAgentTask({
       agentId: 'coordinator',
-      conversationId: `conv-db-int-${Date.now()}`,
+      conversationId: `${CONV_ID_PREFIX}${Date.now()}`,
       channelId: 'cli',
       senderId: 'user',
       content: 'ping',

--- a/tests/unit/agents/runtime-db-unavailable.test.ts
+++ b/tests/unit/agents/runtime-db-unavailable.test.ts
@@ -169,7 +169,9 @@ describe('AgentRuntime — database unavailable mid-task (#1381)', () => {
           input_schema: { type: 'object' as const, properties: {}, required: [] },
         },
       ],
-      errorBudget: { maxTurns: 5, maxConsecutiveErrors: 2 },
+      // maxConsecutiveErrors: 1 — if a DB failure were wrongly counted against
+      // consecutiveErrors, the task would abort before the second chat call.
+      errorBudget: { maxTurns: 5, maxConsecutiveErrors: 1 },
     });
     runtime.register();
 

--- a/tests/unit/agents/runtime-db-unavailable.test.ts
+++ b/tests/unit/agents/runtime-db-unavailable.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AgentRuntime } from '../../../src/agents/runtime.js';
+import { EventBus } from '../../../src/bus/bus.js';
+import {
+  createAgentTask,
+  type AgentResponseEvent,
+  type AgentErrorEvent,
+} from '../../../src/bus/events.js';
+import type { LLMProvider } from '../../../src/agents/llm/provider.js';
+import { createLogger } from '../../../src/logger.js';
+import type { WorkingMemory } from '../../../src/memory/working-memory.js';
+import type { AgentError } from '../../../src/errors/types.js';
+import type { ExecutionLayer } from '../../../src/skills/execution.js';
+
+/**
+ * Mid-task DB unavailability (#1381).
+ *
+ * When working memory (critical path) fails with a connection error after
+ * dispatch, the runtime must fail gracefully with a retryable
+ * DATABASE_UNAVAILABLE agent.error / agent.response — not hang or swallow.
+ */
+
+const MOCK_PROVENANCE = {
+  requestedModel: 'mock-model',
+  actualModel: 'mock-model',
+  providerRequestId: 'msg_mock_000',
+} as const;
+
+const CONFIRMED_SENDER_CONTEXT = {
+  resolved: true as const,
+  contactId: 'test-contact-id',
+  displayName: 'Test User',
+  role: null,
+  systemRole: null,
+  tier: 'known' as const,
+  kind: 'person' as const,
+  verified: true,
+  kgNodeId: null,
+  knowledgeSummary: '',
+  authorization: {
+    allowed: [] as string[],
+    denied: [] as string[],
+    escalate: [] as string[],
+    channelTrust: 'high' as const,
+    trustBlocked: [] as string[],
+  },
+  contactConfidence: 1.0,
+};
+
+describe('AgentRuntime — database unavailable mid-task (#1381)', () => {
+  let bus: EventBus;
+  let responses: AgentResponseEvent[];
+  let errors: AgentErrorEvent[];
+
+  beforeEach(() => {
+    const logger = createLogger('error');
+    bus = new EventBus(logger);
+    responses = [];
+    errors = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      responses.push(event as AgentResponseEvent);
+    });
+    bus.subscribe('agent.error', 'system', (event) => {
+      errors.push(event as AgentErrorEvent);
+    });
+  });
+
+  it('fails gracefully with retryable DATABASE_UNAVAILABLE when memory.getHistory throws ECONNREFUSED', async () => {
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'should not be reached',
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const dbErr = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), {
+      code: 'ECONNREFUSED',
+    });
+    const memory = {
+      getHistory: vi.fn().mockRejectedValue(dbErr),
+      addTurn: vi.fn(),
+      purgeExpired: vi.fn(),
+    } as unknown as WorkingMemory;
+
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger: createLogger('error'),
+      memory,
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-db-down',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      senderContext: CONFIRMED_SENDER_CONTEXT,
+      parentEventId: 'parent-db',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.payload.errorType).toBe('DATABASE_UNAVAILABLE');
+    expect(errors[0]!.payload.retryable).toBe(true);
+    expect(responses).toHaveLength(1);
+    expect(responses[0]!.payload.isError).toBe(true);
+    expect(responses[0]!.payload.errorType).toBe('DATABASE_UNAVAILABLE');
+    expect(responses[0]!.payload.retryable).toBe(true);
+  });
+
+  it('does not burn consecutiveErrors when a skill returns DATABASE_UNAVAILABLE', async () => {
+    // LLM returns a tool call; skill fails with DATABASE_UNAVAILABLE; LLM then
+    // replies with text. Budget.consecutiveErrors must stay 0.
+    let chatCalls = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockImplementation(async () => {
+        chatCalls += 1;
+        if (chatCalls === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'tu_1', name: 'contact-lookup', input: { query: 'x' } }],
+            usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
+          };
+        }
+        return {
+          type: 'text' as const,
+          content: 'Recovered after DB blip',
+          usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      }),
+    };
+
+    const executionLayer = {
+      invoke: vi.fn().mockResolvedValue({
+        success: false,
+        error: 'connect ECONNREFUSED',
+        errorType: 'DATABASE_UNAVAILABLE' satisfies AgentError['type'],
+      }),
+      getToolDefinitions: vi.fn().mockReturnValue([
+        { name: 'contact-lookup', description: 'lookup', input_schema: { type: 'object', properties: {} } },
+      ]),
+    } as unknown as ExecutionLayer;
+
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger: createLogger('error'),
+      executionLayer,
+      pinnedTools: ['contact-lookup'],
+      skillToolDefs: [
+        {
+          name: 'contact-lookup',
+          description: 'lookup',
+          input_schema: { type: 'object' as const, properties: {}, required: [] },
+        },
+      ],
+      errorBudget: { maxTurns: 5, maxConsecutiveErrors: 2 },
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-skill-db',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Find Alice',
+      senderContext: CONFIRMED_SENDER_CONTEXT,
+      parentEventId: 'parent-skill-db',
+    });
+    await bus.publish('dispatch', task);
+
+    // Task completed with text — did not abort on consecutiveErrors budget.
+    expect(responses).toHaveLength(1);
+    expect(responses[0]!.payload.content).toBe('Recovered after DB blip');
+    expect(responses[0]!.payload.isError).toBeFalsy();
+    expect(chatCalls).toBe(2);
+  });
+});

--- a/tests/unit/audit/logger-db-unavailable.test.ts
+++ b/tests/unit/audit/logger-db-unavailable.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AuditLogger } from '../../../src/audit/logger.js';
+import type { DbPool } from '../../../src/db/connection.js';
+import { createLogger } from '../../../src/logger.js';
+import { createAgentTask } from '../../../src/bus/events.js';
+import { isDbUnavailableError } from '../../../src/db/resilience.js';
+
+describe('AuditLogger — database unavailable (#1381)', () => {
+  it('fails fast on log() with classified DB outage (critical path)', async () => {
+    const dbErr = Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+    const pool = {
+      query: vi.fn().mockRejectedValue(dbErr),
+    } as unknown as DbPool;
+
+    const logger = new AuditLogger(pool, createLogger('error'));
+    const event = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'c1',
+      channelId: 'cli',
+      senderId: 'u',
+      content: 'hi',
+      parentEventId: 'parent-1',
+    });
+
+    await expect(logger.log(event)).rejects.toSatisfy((err: unknown) => {
+      expect(isDbUnavailableError(err)).toBe(true);
+      expect((err as { agentError?: { type: string } }).agentError?.type).toBe('DATABASE_UNAVAILABLE');
+      return true;
+    });
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries markAcknowledged on transient DB blip (non-critical path)', async () => {
+    const blip = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+    const pool = {
+      query: vi
+        .fn()
+        .mockRejectedValueOnce(blip)
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] }),
+    } as unknown as DbPool;
+
+    const logger = new AuditLogger(pool, createLogger('error'));
+    await expect(logger.markAcknowledged('evt-1')).resolves.toBeUndefined();
+    expect(pool.query).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/db/availability-monitor.test.ts
+++ b/tests/unit/db/availability-monitor.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Pool } from 'pg';
+import { DbAvailabilityMonitor } from '../../../src/db/availability-monitor.js';
+import type { Logger } from '../../../src/logger.js';
+import type { OutboundGateway } from '../../../src/skills/outbound-gateway.js';
+
+function createLogger(): Logger {
+  return {
+    child: () => createLogger(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    silent: vi.fn(),
+    level: 'info',
+  } as unknown as Logger;
+}
+
+describe('DbAvailabilityMonitor', () => {
+  let now: number;
+  let timers: Array<{ cb: () => void; ms: number }>;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    timers = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createMonitor(overrides: {
+    queryImpl?: () => Promise<unknown>;
+    sendNotification?: ReturnType<typeof vi.fn>;
+    escalationAfterMs?: number;
+  } = {}) {
+    const sendNotification =
+      overrides.sendNotification ?? vi.fn().mockResolvedValue(true);
+    const pool = {
+      query: overrides.queryImpl ?? vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+    } as unknown as Pool;
+    const gateway = { sendNotification } as unknown as OutboundGateway;
+
+    const monitor = new DbAvailabilityMonitor({
+      pool,
+      logger: createLogger(),
+      outboundGateway: gateway,
+      ceoEmail: 'ceo@example.com',
+      probeIntervalMs: 60_000,
+      escalationAfterMs: overrides.escalationAfterMs ?? 5 * 60_000,
+      now: () => now,
+      setIntervalFn: ((cb: () => void, ms: number) => {
+        timers.push({ cb, ms });
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval,
+      clearIntervalFn: vi.fn() as unknown as typeof clearInterval,
+    });
+
+    return { monitor, pool, sendNotification };
+  }
+
+  it('stays available when probe succeeds', async () => {
+    const { monitor } = createMonitor();
+    const snap = await monitor.probe();
+    expect(snap.available).toBe(true);
+    expect(snap.downSince).toBeNull();
+    expect(snap.escalationDue).toBe(false);
+  });
+
+  it('marks unavailable on probe failure without escalating immediately', async () => {
+    const { monitor, sendNotification } = createMonitor({
+      queryImpl: () =>
+        Promise.reject(Object.assign(new Error('refused'), { code: 'ECONNREFUSED' })),
+    });
+    const snap = await monitor.probe();
+    expect(snap.available).toBe(false);
+    expect(snap.downSince).toBe(now);
+    expect(snap.escalationDue).toBe(false);
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('escalates to CEO after continuous outage exceeds threshold', async () => {
+    const sendNotification = vi.fn().mockResolvedValue(true);
+    const { monitor } = createMonitor({
+      queryImpl: () =>
+        Promise.reject(Object.assign(new Error('refused'), { code: 'ECONNREFUSED' })),
+      sendNotification,
+      escalationAfterMs: 5 * 60_000,
+    });
+
+    await monitor.probe();
+    expect(monitor.getSnapshot().escalationDue).toBe(false);
+
+    now += 5 * 60_000 + 1;
+    const snap = await monitor.probe();
+    expect(snap.escalationDue).toBe(true);
+    expect(snap.escalated).toBe(true);
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotification.mock.calls[0]![0]).toMatchObject({
+      notificationType: 'database_unavailable',
+      ceoEmail: 'ceo@example.com',
+    });
+  });
+
+  it('retries notification when send fails, then succeeds once', async () => {
+    const sendNotification = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const { monitor } = createMonitor({
+      queryImpl: () =>
+        Promise.reject(Object.assign(new Error('refused'), { code: 'ECONNREFUSED' })),
+      sendNotification,
+      escalationAfterMs: 1_000,
+    });
+
+    await monitor.probe();
+    now += 2_000;
+    await monitor.probe();
+    expect(monitor.getSnapshot().escalated).toBe(false);
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+
+    now += 2_000;
+    await monitor.probe();
+    expect(monitor.getSnapshot().escalated).toBe(true);
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('notifies on recovery if escalation was due but undelivered', async () => {
+    const sendNotification = vi
+      .fn()
+      .mockResolvedValueOnce(false) // while down
+      .mockResolvedValueOnce(true); // on recovery
+    let down = true;
+    const { monitor } = createMonitor({
+      queryImpl: () =>
+        down
+          ? Promise.reject(Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }))
+          : Promise.resolve({ rows: [] }),
+      sendNotification,
+      escalationAfterMs: 1_000,
+    });
+
+    await monitor.probe();
+    now += 2_000;
+    await monitor.probe();
+    expect(monitor.getSnapshot().escalated).toBe(false);
+
+    down = false;
+    now += 1_000;
+    await monitor.probe();
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+    expect(monitor.getSnapshot().available).toBe(true);
+  });
+});

--- a/tests/unit/db/resilience.test.ts
+++ b/tests/unit/db/resilience.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createDbUnavailableAgentError,
+  isDbUnavailableError,
+  withDbRetry,
+} from '../../../src/db/resilience.js';
+import { classifyError } from '../../../src/errors/classify.js';
+import { isRetryable } from '../../../src/errors/types.js';
+
+describe('isDbUnavailableError', () => {
+  it('detects Node connection refused', () => {
+    expect(isDbUnavailableError(Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }))).toBe(true);
+  });
+
+  it('detects pg connection_exception SQLSTATE', () => {
+    expect(isDbUnavailableError(Object.assign(new Error('db down'), { code: '08006' }))).toBe(true);
+  });
+
+  it('detects admin_shutdown', () => {
+    expect(isDbUnavailableError(Object.assign(new Error('shutdown'), { code: '57P01' }))).toBe(true);
+  });
+
+  it('detects nested cause', () => {
+    const cause = Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+    expect(isDbUnavailableError(new Error('wrapper', { cause }))).toBe(true);
+  });
+
+  it('detects pool connect timeout message', () => {
+    expect(
+      isDbUnavailableError(new Error('timeout exceeded when trying to connect')),
+    ).toBe(true);
+  });
+
+  it('does not treat constraint violations as outages', () => {
+    expect(isDbUnavailableError(Object.assign(new Error('unique'), { code: '23505' }))).toBe(false);
+  });
+
+  it('does not treat plain Error as outage', () => {
+    expect(isDbUnavailableError(new Error('something else'))).toBe(false);
+  });
+});
+
+describe('createDbUnavailableAgentError', () => {
+  it('builds a retryable DATABASE_UNAVAILABLE AgentError', () => {
+    const err = Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+    const agentErr = createDbUnavailableAgentError('audit', err);
+    expect(agentErr.type).toBe('DATABASE_UNAVAILABLE');
+    expect(agentErr.retryable).toBe(true);
+    expect(isRetryable(agentErr.type)).toBe(true);
+    expect(agentErr.source).toBe('audit');
+    expect(agentErr.context.code).toBe('ECONNREFUSED');
+  });
+});
+
+describe('classifyError DB precedence', () => {
+  it('preserves AgentError attached by a DB call site', () => {
+    const err = Object.assign(new Error('refused'), {
+      code: 'ECONNREFUSED',
+      agentError: createDbUnavailableAgentError('working-memory', Object.assign(new Error('refused'), { code: 'ECONNREFUSED' })),
+    });
+    const result = classifyError(err, 'runtime');
+    expect(result.type).toBe('DATABASE_UNAVAILABLE');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('keeps bare ECONNREFUSED as PROVIDER_ERROR (LLM/network, not DB)', () => {
+    const err = Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+    const result = classifyError(err, 'anthropic');
+    expect(result.type).toBe('PROVIDER_ERROR');
+  });
+});
+
+describe('withDbRetry', () => {
+  it('returns on first success', async () => {
+    const fn = vi.fn().mockResolvedValue(42);
+    await expect(withDbRetry(fn, { sleep: async () => undefined })).resolves.toBe(42);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient DB errors then succeeds', async () => {
+    const blip = Object.assign(new Error('blip'), { code: 'ECONNRESET' });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(blip)
+      .mockRejectedValueOnce(blip)
+      .mockResolvedValueOnce('ok');
+    const sleep = vi.fn(async () => undefined);
+    await expect(withDbRetry(fn, { sleep, baseDelayMs: 1 })).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows non-DB errors immediately', async () => {
+    const fn = vi.fn().mockRejectedValue(Object.assign(new Error('unique'), { code: '23505' }));
+    await expect(withDbRetry(fn, { sleep: async () => undefined })).rejects.toMatchObject({
+      code: '23505',
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows after exhausting attempts', async () => {
+    const blip = Object.assign(new Error('down'), { code: '57P03' });
+    const fn = vi.fn().mockRejectedValue(blip);
+    await expect(
+      withDbRetry(fn, { maxAttempts: 2, sleep: async () => undefined, baseDelayMs: 1 }),
+    ).rejects.toBe(blip);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1381. When Postgres becomes unavailable mid-task, Curia now fails fast on critical paths with a retryable `DATABASE_UNAVAILABLE` error, retries/degrades on non-critical paths, tracks DB failures separately from the consecutive-error budget, and escalates to the CEO after >5 minutes of continuous outage.

## Changes

- **`DATABASE_UNAVAILABLE` `ErrorType`** — retryable; used by audit, working memory, skills, and runtime
- **Pool `connectionTimeoutMillis` (5s)** — connection acquire failures surface instead of hanging
- **`isDbUnavailableError` / `withDbRetry`** — pg SQLSTATE + Node connection codes; bounded backoff for non-critical paths
- **Critical paths fail fast** — audit write-ahead insert, working-memory get/add classify and rethrow
- **Non-critical paths retry** — `markAcknowledged`, summarization, skill `execute` via `withDbRetry`; skills return `{ errorType: 'DATABASE_UNAVAILABLE' }`
- **`ErrorBudget.dbFailures`** — transient DB skill failures do not burn `consecutiveErrors`
- **`DbAvailabilityMonitor`** — 30s probes; CEO `outbound.notification` (`database_unavailable`) after 5 min, retrying until delivery succeeds
- **Spec 05** — documents in-operation handling; removes the Known Deficiency

## Acceptance criteria

- [x] DB pool detects connection errors and surfaces them (timeout + classified errors)
- [x] Critical operations (audit, working memory / dispatch via audit) fail with `AgentError`
- [x] Non-critical operations (skills, ack) retry or degrade
- [x] Integration test: DB down mid-task → retryable `DATABASE_UNAVAILABLE`
- [x] Escalation notifier alerts CEO if DB down >5 min
- [x] Spec 05 Known Deficiency removed; section updated

## Testing

- `pnpm run typecheck` — pass
- Unit: resilience, availability-monitor, runtime-db-unavailable, audit logger — pass
- Integration: `tests/integration/db-unavailable-mid-task.test.ts` — pass (with Postgres)

