### PR TITLE
feat(audit): Phase 1 hardening — structured columns, hash chain, LLM archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Audit log Phase 1** — structured columns, `seq`-ordered hash chain, `llm_call_archive` (kill-switch + TTL), `pnpm audit:verify`. (#1383)
 - **DB outage resilience** — `DATABASE_UNAVAILABLE` errors, pool timeouts, skill retry, CEO alert after 5 min. (#1381)
 - **Operator home** — console `/` shows health, attention and activity cards plus a chat CTA. (#1375)
 - **`authorization.decision`** — audit-logs Gate-1/authz and Gate C allow/deny/escalate. (#1379)
@@ -35,6 +36,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Audit hash chain** — order by monotonic `seq`; `timestamp` stays factual; Phase 1 integrity scope documented. (#1383, #1540)
 - **`ToolResult` / `ErrorType`** — optional failure `errorType`; new `DATABASE_UNAVAILABLE` (public API). (#1381)
 - **Spec 05** — documents in-operation DB handling; removes that Known Deficiency (#1381).
 - **Scheduled pin gaps** — unresolved pins log at error so monitoring catches blind runs. (#1501)
@@ -51,6 +53,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Audit migration 080** — empty `audit_log` no longer fails `setval` during migrate. (#1540)
+- **`audit` config schema** — `llmCallArchive` keys allowed in `default-config.schema.json`. (#1540)
+- **Audit hash chain** — `canonicalJson` round-trips Dates so verify matches write-time hashes. (#1540)
 - **Docs** — correct the setup-status catalog path to `skills/setup/tools/setup-status/catalog.yaml` (moved by skills-as-bundles).
 - **Bundling review fixes** — calendar risk/docs, manifest & registry-install correctness, skill-md booleans, tool-input shorthand (`string|null` + polymorphic `string|object|null`/`object[]|object` unions), and manifest output/description contracts synced to handlers. (#1489, #1499)
 - **Smoke harness** — expands `pinned_skills` bundles via `resolvePinnedSkills` like production. (#1489)

--- a/agents/diagnostics.yaml
+++ b/agents/diagnostics.yaml
@@ -1,5 +1,5 @@
 name: diagnostics
-version: "0.2.0"
+version: "0.3.0"
 role: specialist
 description: >-
   Read-only forensic investigator for the PRINCIPAL. Diagnoses "what happened /
@@ -37,11 +37,15 @@ system_prompt: |
     whenever the question is time-anchored rather than ID-anchored.
   - **audit-query** — read the append-only `audit_log`. Anchor on an `event_id`,
     a blocked-message `block_id`, a `conversation_id`, a `task_id`, one or more
-    `event_types`, and/or a `since`/`until` window. This is your primary lens on
-    "what events fired." Prefer current names (`tool.invoke`, `tool.result`,
-    `autonomy.tool_blocked`); the repo also matches pre-rename aliases
-    (`skill.invoke`, `skill.result`, `autonomy.skill_blocked`) so older audit
-    rows remain visible.
+    `event_types`, structured dimensions (`outcome`, `target_type`/`target_id`,
+    `initiator_type`/`initiator_id`), and/or a `since`/`until` window. This is
+    your primary lens on "what events fired." Prefer current names
+    (`tool.invoke`, `tool.result`, `autonomy.tool_blocked`); the repo also
+    matches pre-rename aliases (`skill.invoke`, `skill.result`,
+    `autonomy.skill_blocked`) so older audit rows remain visible. Returned
+    records expose first-class `action` / `outcome` / `target` / `initiator`
+    fields when present (null on pre-hardening history — fall back to the
+    scrubbed payload summary).
   - **audit-trace** — from one event (or a `block_id`), reconstruct the causal
     chain: it walks `parent_event_id` UP to the root cause and children DOWN to
     the consequences. Use this once you have an anchor event and need the story

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -268,6 +268,17 @@ escalation:
     model: claude-haiku-4-5
     timeout_ms: 5000
 
+# Audit log hardening (spec 10 / #1383).
+# llm_call_archive stores redacted full prompts/responses keyed to llm.call rows.
+# Kill-switch (`enabled: false`) stops new archive writes immediately; hot
+# retention TTL is enforced by DreamEngine's nightly decay pass (DELETE older rows).
+# Encryption-at-rest for this table is a tracked follow-up — treat the store as
+# plaintext JSONB with best-effort redaction until then.
+audit:
+  llmCallArchive:
+    enabled: true
+    hotRetentionDays: 90
+
 # Dream engine — background knowledge graph maintenance (issue #27).
 # The decay pass runs on a configurable interval and reduces the confidence of
 # slow_decay and fast_decay nodes/edges using an exponential half-life model.

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -309,6 +309,27 @@ Restart Curia, then **install and enable the Signal channel** in the console (**
 
 ---
 
+## Audit log integrity check
+
+Phase 1 hardening (spec 10 / #1383) maintains a SHA-256 hash chain on `audit_log`,
+ordered by the monotonic `seq` column (not wall-clock timestamp). Phase 1 detects
+accidental corruption and naive tampering — not a knowledgeable insider with DB
+write access (HMAC + external anchoring are a later phase). Verify offline with:
+
+```bash
+# Local / developer DB
+pnpm audit:verify
+
+# Deployed instance (example path)
+pnpm --prefix /opt/curia tsx --env-file=.env scripts/audit-verify.ts
+```
+
+Exits `0` when the chain is intact (or the log is empty / only unhashed rows),
+`1` on the first broken link, and `2` on configuration/DB errors. Pre-hardening
+rows with NULL `entry_hash` are skipped.
+
+---
+
 ## What's Next
 
 If you walked through Tier 1, you've already configured the office identity

--- a/docs/specs/10-audit-log-hardening.md
+++ b/docs/specs/10-audit-log-hardening.md
@@ -162,7 +162,11 @@ CREATE TABLE llm_call_archive (
 
 **Redaction:** The existing redaction layer processes prompts and responses before archive write. Secrets and PII patterns are stripped per the same rules used for audit log payloads. **If redaction fails** (malformed content, unexpected binary data), the archive write is skipped — never fall back to writing unredacted content. The `audit_log` row for the `llm.call` event is still written (it contains hashes, not raw content). A high-severity error is logged via pino with the event ID and redaction failure reason.
 
-**Retention:** The `llm_call_archive` is large (prompts and responses can be several KB each). Retention policy: 90 days hot (in Postgres), then archived to compressed JSONL on disk. The `audit_log` row (with hashes) is retained per the standard audit retention schedule.
+**Config kill-switch:** `audit.llmCallArchive.enabled` in `config/default.yaml` (default `true`). When `false`, `AuditLogger` skips archive writes even if the `llm.call` event carries archive content — operators can kill the store fast if redaction misses something. Provenance hashes on the `llm.call` audit row still write.
+
+**Retention:** The `llm_call_archive` is large (prompts and responses can be several KB each). Hot retention is `audit.llmCallArchive.hotRetentionDays` (default 90); DreamEngine's decay pass DELETEs older rows. Cold archive to compressed JSONL on disk remains a later-phase job. The `audit_log` row (with hashes) is retained per the standard audit retention schedule.
+
+**Encryption-at-rest:** Phase 1 stores redacted JSONB in Postgres plaintext (same class as other sensitive tables). Application-level or column encryption for the archive is an explicit follow-up — until then treat the table as a plaintext concentration of conversational content with best-effort redaction.
 
 **Why separate tables:** The audit log is optimized for fast, indexed queries ("show me all actions by agent X on contact Y"). Storing multi-KB prompts inline would bloat the table and slow scans. The archive is optimized for replay ("show me exactly what the LLM saw when it made decision Z"). Different access patterns, different tables.
 
@@ -217,11 +221,11 @@ This is a convention, not a type enforcement — skills are responsible for popu
 
 ## Tamper Evidence
 
-*Required by NIST SP 800-92, SOC 2 CC7.2, recommended by AuditableLLM (2024).*
+*Informs NIST SP 800-92 / SOC 2 CC7.2 integrity controls. Phase 1 is an honesty-scoped foundation — see "What Phase 1 detects" below.*
 
 ### Hash Chain
 
-Each audit log entry includes a SHA-256 hash computed over its content and the previous entry's hash, forming a verifiable chain. Any modification to a historical record invalidates every subsequent hash.
+Each hashed audit log entry includes a SHA-256 hash computed over its content and the previous hashed entry's hash, forming a verifiable chain. Chain order is the monotonic `seq` BIGSERIAL column — **not** wall-clock `timestamp`. `timestamp` always stores the factual `event.timestamp` verbatim.
 
 **Computation:**
 
@@ -234,23 +238,29 @@ entry_hash = SHA-256(canonical_json({
 }) + previous_entry_hash)
 ```
 
-- The first entry chains from a fixed genesis constant: `SHA-256("curia-audit-genesis-v1")`
-- `canonical_json` sorts keys alphabetically and uses deterministic formatting (no whitespace) to prevent false positive tampering alerts from JSON key-ordering variations
-- The `entry_hash` column stores the computed hash of the current record. To chain, the audit logger reads the most recent `entry_hash` value before computing the new one. This means each record's hash incorporates the entire history of the chain — modifying any past record invalidates every hash after it
+- The first hashed entry chains from a fixed public genesis constant: `SHA-256("curia-audit-genesis-v1")`
+- `canonical_json` sorts keys alphabetically and uses deterministic formatting (no whitespace) to prevent false positive alerts from JSON key-ordering variations
+- `seq` is **not** part of the hashed field set (ordering key only)
+- Pre-hardening rows with NULL `entry_hash` are skipped by verify; the chain is defined only over hashed rows
+- Head select / verify walk: `ORDER BY seq` (ASC for verify, DESC LIMIT 1 for head)
 
-**Serialization:** All audit writes are serialized through a single writer (the `AuditLogger` instance). This is already the case — the bus's write-ahead hook calls `AuditLogger.log()` sequentially before delivering each event. The hash chain computation reads the previous `entry_hash` and writes the new one in the same INSERT. At current throughput (~425 events/day), serialization has negligible performance impact. If throughput ever becomes a concern, the INSERT can use an advisory lock or CTE to atomically read-then-write without external serialization.
+**What Phase 1 detects (and what it does not):** The public genesis + public SHA-256 algorithm detect **accidental corruption and naive / unsophisticated tampering** (e.g. flipping a column without recomputing hashes). They do **not** stop a knowledgeable insider with DB write access: that actor can disable the append-only trigger, edit a row, and recompute every subsequent `entry_hash` into a chain that verifies clean. Truncation is also invisible today — deleting all hashed rows makes verify pass vacuously; deleting a contiguous recent suffix leaves a shorter but internally consistent chain. Phase 1 therefore must **not** be claimed as SOC 2 CC7.2 / NIST 800-92 "tamper evidence" on its own.
 
-**Bootstrapping:** On startup, the audit logger queries `SELECT entry_hash FROM audit_log ORDER BY timestamp DESC LIMIT 1` to seed the chain. If the table is empty (fresh deployment), the genesis constant is used. This query runs once at boot, before the bus starts accepting events.
+**Next phase (genuine tamper evidence) — not in Phase 1:**
+1. **HMAC-SHA256** with a key held outside the DB (vault/KMS), so re-deriving the chain requires stealing the key too
+2. **External head-hash anchoring** — periodically publish `(head_hash, count)` to an append-only out-of-band store (object-lock/WORM, transparency log, or signed daily artifact) so truncation and wholesale rewrite are detectable
 
-**Implementation:** ~30 lines in the audit logger using Node.js native `crypto.createHash('sha256')`. Zero external dependencies.
+**Serialization ceiling:** Every bus event's write-ahead path does `pool.connect()` → `BEGIN` → `pg_advisory_xact_lock(global)` → head SELECT → INSERT → COMMIT before subscriber delivery. At ~425 events/day this is fine; the lock is a known global-serialization ceiling if throughput grows by orders of magnitude. **Invariant:** never publish a bus event from inside the audit write transaction — that re-enters `log()` on another pooled client and deadlocks on the same advisory lock. `AuditLogger` asserts this with `AsyncLocalStorage` depth tracking. Chain head is always re-read under the lock; there is no in-memory previous-hash cache.
 
-**Verification:** A CLI command `curia audit verify` walks the chain from genesis, recomputing hashes and reporting the first broken link (if any). This is O(n) over the full audit log — acceptable for periodic verification runs, not for real-time checking.
+**Bootstrapping:** On startup, `seedHashChain()` confirms the schema and logs the current head (`ORDER BY seq DESC LIMIT 1`). It does not cache chain state — every write re-reads under the lock. Empty table → genesis.
+
+**Verification:** `pnpm audit:verify` (`scripts/audit-verify.ts`) walks hashed rows `ORDER BY seq ASC`, recomputing hashes and reporting the first broken link (if any). O(n) over the full audit log — periodic runs only. Run locally with `pnpm audit:verify`, or against a deployed instance with `pnpm --prefix /opt/curia tsx --env-file=.env scripts/audit-verify.ts`.
 
 ### Merkle Checkpoints (Future)
 
 For efficient single-entry verification without walking the full chain, periodically compute Merkle tree roots over batches of entries (e.g., every 1000 records or every hour). Store roots in a separate `audit_checkpoints` table. This enables O(log n) verification of any individual entry via a Merkle proof.
 
-For launch, the linear hash chain is sufficient. Merkle checkpoints become valuable when the audit log grows past ~1M entries (~6 years at current rates).
+Merkle checkpoints complement (they do not replace) HMAC + external anchoring for insider-resistant integrity.
 
 ---
 
@@ -376,7 +386,7 @@ This table maps each change in this spec to the standards that require or recomm
 | LLM call provenance (model, tokens, cost, provider ID) | AI 600-1 | Art. 12 | LLM10 | -- | -- |
 | Prompt/response archive | AI 600-1 | Art. 12 | LLM01, LLM09 | -- | -- |
 | Source attribution (resultIds on memory queries) | -- | Art. 12 | LLM08 | -- | -- |
-| Hash-chain tamper evidence | -- | -- | -- | CC7.2 | Yes |
+| Hash-chain integrity check (Phase 1: accidental/naive tampering only; HMAC + external anchor required for CC7.2 / 800-92-grade evidence) | -- | -- | -- | Partial* | Partial* |
 | HITL decision records | -- | Art. 14 | LLM06 | CC7.2 | -- |
 | Agent config change tracking | -- | Art. 19 | LLM03 | CC7.2 | Yes |
 | Retention tiers | -- | Art. 19 | -- | 12-month | Yes |
@@ -402,11 +412,11 @@ This spec is designed to be implemented incrementally. Each phase is independent
 
 6. Migration: add `entry_hash` column to `audit_log`
 7. Hash chain computation in `AuditLogger.log()` (~30 lines)
-8. `curia audit verify` CLI command
+8. `pnpm audit:verify` maintenance script (`scripts/audit-verify.ts`)
 9. Extend `MemoryQueryPayload` with `results` array (id + optional score)
 10. `sourcesAccessed` convention for skill results
 
-**Validates:** NIST 800-92 integrity, SOC 2 CC7.2 tamper detection, EU AI Act Article 12 reference data tracking.
+**Validates (Phase 1 scope):** accidental/naive chain breakage detection + EU AI Act Article 12 reference data tracking. Full NIST 800-92 / SOC 2 CC7.2 tamper evidence waits on HMAC + external head-hash anchoring (next phase).
 
 ### Phase C: HITL Records + Config Tracking
 
@@ -427,26 +437,31 @@ This spec is designed to be implemented incrementally. Each phase is independent
 
 ## Status
 
-This spec describes a largely unimplemented hardening backlog for the audit log subsystem. Most items below have not yet been built. No single tracking issue covers this backlog as a whole; the **Phase 1** subset marked below is v1.0-blocking and tracked in [#1383](https://github.com/josephfung/curia/issues/1383). Remaining items should be filed as GitHub issues (labeled `audit`) as they're prioritized, rather than tracked in this doc.
+Phase 1 of this spec (#1383) — structured columns, field extraction, hash chain,
+`llm_call_archive`, and `pnpm audit:verify` — has shipped. Remaining items below
+are later phases and should be filed as GitHub issues (labeled `audit`) as they're
+prioritized.
 
-### Outstanding work
+### Shipped — Phase 1 ([#1383](https://github.com/josephfung/curia/issues/1383))
 
-**Phase 1 — v1.0-blocking ([#1383](https://github.com/josephfung/curia/issues/1383)):**
+- Migration: structured columns on `audit_log` (`action`, `outcome`, `target_type`, `target_id`, `initiator_type`, `initiator_id`) plus `entry_hash`
+- Migration: monotonic `seq` BIGSERIAL for chain/verify order (timestamp stays factual)
+- Field extraction logic in `AuditLogger.log()` (spec mapping + `[EXTRACTION_FAILED]` sentinel)
+- `llm.call` event emission with provenance fields (already present before #1383; typed non-persisted `archive` field)
+- `llm_call_archive` table + redacted atomic write; config kill-switch + hot TTL purge via DreamEngine
+- Hash chain on every write (`ORDER BY seq`); advisory-lock serialization; nested-publish deadlock assertion
+- Offline verify via `pnpm audit:verify` (`scripts/audit-verify.ts`) — not a `curia` CLI (no CLI harness exists)
+- Consumer adoption: `AuditLogRepo`, activity-log, diagnostics audit-query/audit-trace, trust-gate, antfarm interpreter, diagnostics agent prompt
 
-- Migration: structured columns on `audit_log` (`action`, `outcome`, `target_type`, `target_id`, `initiator_type`, `initiator_id`)
-- Field extraction logic in `AuditLogger.log()`
-- LLM providers emitting `llm.call` events with provenance fields
-- `llm_call_archive` table (creation and population) (also [#665](https://github.com/josephfung/curia/issues/665))
-- Redaction applied to prompt/response archive writes
-- `entry_hash` column and hash chain computed on every write
-- `curia audit verify` CLI command
-- Test coverage for the above (event types + hash chain verify: insert, verify, detect tamper)
+### Outstanding work — later phases
 
-**Later phases — not yet scheduled:**
-
+- **HMAC-SHA256 + external head-hash anchoring** (upgrade Phase 1 chain to genuine tamper evidence)
+- Encryption-at-rest for `llm_call_archive`
+- Cold archive of purged archive rows to compressed JSONL
 - `MemoryQueryPayload` extended with `results` array (id + optional score)
 - `sourcesAccessed` convention documented and adopted in existing skills
-- `human.decision` event type emitted from approval gates
-- Retention tiers defined in `config/default.yaml`
+- `human.decision` event type emitted from approval gates (event type exists; emission coverage may still be incomplete)
+- `config.change` event type + startup detection
 - Monitoring query: detect `[EXTRACTION_FAILED]` values in structured columns
 - Monitoring query: detect `llm.call` audit rows with no corresponding `llm_call_archive` row
+- Merkle checkpoints / CloudEvents export / partitioning (Phase D)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "backfill:contact-attributes": "tsx --env-file=.env scripts/backfill-contact-attributes.ts",
     "rederive:contact-tiers": "tsx --env-file=.env scripts/rederive-contact-tiers.ts",
     "dedup:contacts": "tsx --env-file=.env scripts/dedup-contacts.ts",
-    "seed-vault": "tsx --env-file=.env scripts/seed-vault.ts"
+    "seed-vault": "tsx --env-file=.env scripts/seed-vault.ts",
+    "audit:verify": "tsx --env-file=.env scripts/audit-verify.ts"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/shared-types/index.ts
+++ b/packages/shared-types/index.ts
@@ -97,6 +97,10 @@ export interface AuditEventRow {
   conversationId: string | null;
   parentEventId: string | null;
   payload: Record<string, unknown>;
+  /** Structured action (Phase 1) — optional; null/absent on pre-hardening rows. */
+  action?: string | null;
+  /** Structured initiator id (Phase 1) — optional; null/absent on pre-hardening rows. */
+  initiatorId?: string | null;
 }
 
 /** SSE envelope for live Ant Farm directive streaming. */

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -224,6 +224,20 @@
         }
       }
     },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "llmCallArchive": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "hotRetentionDays": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
     "dreaming": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/audit-verify.ts
+++ b/scripts/audit-verify.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env tsx
+// scripts/audit-verify.ts
+//
+// Walk the audit_log hash chain from genesis and report the first broken link.
+// Spec 10 / #1383 — offline integrity check (Phase 1: detects accidental /
+// naive tampering; see docs/specs/10-audit-log-hardening.md Tamper Evidence).
+//
+// Run locally:  pnpm audit:verify
+// Run on prod:  pnpm --prefix /opt/curia tsx --env-file=.env scripts/audit-verify.ts
+//
+// Exit codes: 0 = intact (or empty log), 1 = broken link / hash gap, 2 = usage/DB error.
+//
+// Pre-hardening rows (NULL entry_hash) cannot be backfilled — migration 021's
+// append-only trigger blocks UPDATEs. NULL rows are skipped entirely; the hash
+// chain is defined only over rows that have entry_hash. Order is the monotonic
+// `seq` column (migration 080), not wall-clock timestamp.
+
+import pg from 'pg';
+import {
+  GENESIS_HASH,
+  computeEntryHash,
+  toHashTimestamp,
+  type HashChainFields,
+} from '../src/audit/hash-chain.js';
+
+const { Pool } = pg;
+
+const PAGE_SIZE = 1000;
+
+interface AuditVerifyRow {
+  id: string;
+  timestamp: Date;
+  event_type: string;
+  source_layer: string;
+  source_id: string;
+  payload: unknown;
+  conversation_id: string | null;
+  task_id: string | null;
+  parent_event_id: string | null;
+  action: string | null;
+  outcome: string | null;
+  target_type: string | null;
+  target_id: string | null;
+  initiator_type: string | null;
+  initiator_id: string | null;
+  entry_hash: string | null;
+  seq: string;
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    process.stderr.write('DATABASE_URL is required. Add it to .env or set it in the environment.\n');
+    process.exit(2);
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl });
+  let previousHash = GENESIS_HASH;
+  let checked = 0;
+  let skippedNull = 0;
+  let lastSeq = '0';
+
+  try {
+    const colCheck = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'audit_log' AND column_name = 'seq'
+       ) AS exists`,
+    );
+    if (!colCheck.rows[0]?.exists) {
+      process.stderr.write(
+        'audit_log.seq column missing — run migrations (080_audit_log_chain_seq) first.\n',
+      );
+      process.exit(2);
+    }
+
+    for (;;) {
+      // Keyset on seq — matches AuditLogger head SELECT / write order.
+      const result = await pool.query<AuditVerifyRow>(
+        `SELECT id, timestamp, event_type, source_layer, source_id, payload,
+                conversation_id, task_id, parent_event_id,
+                action, outcome, target_type, target_id,
+                initiator_type, initiator_id, entry_hash, seq::text AS seq
+         FROM audit_log
+         WHERE seq > $1::bigint
+         ORDER BY seq ASC
+         LIMIT $2`,
+        [lastSeq, PAGE_SIZE],
+      );
+
+      if (result.rows.length === 0) break;
+
+      for (const row of result.rows) {
+        lastSeq = row.seq;
+
+        if (row.entry_hash === null || row.entry_hash === '') {
+          skippedNull += 1;
+          continue;
+        }
+
+        checked += 1;
+
+        const fields: HashChainFields = {
+          id: row.id,
+          timestamp: toHashTimestamp(row.timestamp),
+          event_type: row.event_type,
+          source_layer: row.source_layer,
+          source_id: row.source_id,
+          payload: row.payload,
+          conversation_id: row.conversation_id,
+          task_id: row.task_id,
+          parent_event_id: row.parent_event_id,
+          action: row.action,
+          outcome: row.outcome,
+          target_type: row.target_type,
+          target_id: row.target_id,
+          initiator_type: row.initiator_type,
+          initiator_id: row.initiator_id,
+        };
+
+        const expected = computeEntryHash(fields, previousHash);
+        if (expected !== row.entry_hash) {
+          process.stderr.write(
+            `BROKEN at hashed-row ${checked} id=${row.id} seq=${row.seq} timestamp=${toHashTimestamp(row.timestamp)}\n` +
+              `  expected: ${expected}\n` +
+              `  stored:   ${row.entry_hash}\n` +
+              `  previous: ${previousHash}\n`,
+          );
+          process.exit(1);
+        }
+
+        previousHash = row.entry_hash;
+      }
+
+      if (result.rows.length < PAGE_SIZE) break;
+    }
+
+    if (checked === 0 && skippedNull === 0) {
+      process.stdout.write('OK — audit_log is empty (genesis intact)\n');
+    } else if (checked === 0) {
+      process.stdout.write(
+        `OK — no hashed rows yet (${skippedNull} unhashed row(s) skipped)\n`,
+      );
+    } else {
+      process.stdout.write(
+        `OK — verified ${checked} hashed row(s)` +
+          (skippedNull > 0 ? `; skipped ${skippedNull} unhashed row(s)` : '') +
+          '; chain intact\n',
+      );
+    }
+    process.exit(0);
+  } catch (err) {
+    process.stderr.write(
+      `audit-verify failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(2);
+  } finally {
+    await pool.end();
+  }
+}
+
+void main();

--- a/skills/activity-log/handler.test.ts
+++ b/skills/activity-log/handler.test.ts
@@ -28,6 +28,7 @@ function makeAuditRow(overrides?: Partial<AuditLogRow>): AuditLogRow {
     sourceLayer: 'execution',
     sourceId: 'calendar',
     conversationId: 'conv-1',
+    taskId: null,
     parentEventId: null,
     payload: {
       toolName: 'calendar-respond-to-invite',
@@ -40,6 +41,13 @@ function makeAuditRow(overrides?: Partial<AuditLogRow>): AuditLogRow {
         },
       },
     },
+    action: null,
+    outcome: null,
+    targetType: null,
+    targetId: null,
+    initiatorType: null,
+    initiatorId: null,
+    entryHash: null,
     ...overrides,
   };
 }
@@ -103,6 +111,69 @@ describe('ActivityLogHandler', () => {
     expect(auditLogRepo.findToolResults).toHaveBeenCalledWith(expect.objectContaining({
       toolNames: ['calendar-respond-to-invite'],
     }));
+  });
+
+  it('prefers structured columns when present, falls back to payload when NULL', async () => {
+    const auditLogRepo = {
+      findToolResults: vi.fn().mockResolvedValue([
+        makeAuditRow({
+          action: 'execute',
+          outcome: 'success',
+          targetType: 'skill',
+          targetId: 'calendar-respond-to-invite',
+          initiatorType: 'agent',
+          initiatorId: 'calendar',
+          // payload toolName deliberately different — column should win
+          payload: {
+            toolName: 'wrong-from-payload',
+            result: {
+              success: true,
+              data: { response: 'accept', event: { title: 'From Columns' } },
+            },
+          },
+        }),
+        makeAuditRow({
+          id: 'audit-legacy',
+          action: null,
+          outcome: null,
+          targetType: null,
+          targetId: null,
+          initiatorType: null,
+          initiatorId: null,
+          payload: {
+            toolName: 'calendar-respond-to-invite',
+            result: {
+              success: true,
+              data: { response: 'decline', event: { title: 'From Payload' } },
+            },
+          },
+        }),
+      ]),
+    } as unknown as AuditLogRepo;
+
+    const handler = new ActivityLogHandler();
+    const result = await handler.execute(makeCtx({
+      auditLogRepo,
+      input: {
+        since: '2026-06-25T00:00:00.000Z',
+        tool_name: 'calendar-respond-to-invite',
+      },
+    }));
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { actions: Array<Record<string, unknown>> } }).data;
+    expect(data.actions).toHaveLength(2);
+    expect(data.actions[0]).toMatchObject({
+      tool: 'calendar-respond-to-invite',
+      target: 'accept — From Columns',
+      outcome: 'completed',
+      agent_id: 'calendar',
+    });
+    expect(data.actions[1]).toMatchObject({
+      tool: 'calendar-respond-to-invite',
+      target: 'decline — From Payload',
+      outcome: 'completed',
+    });
   });
 
   it('excludes non-recap skills by default', async () => {

--- a/skills/activity-log/handler.ts
+++ b/skills/activity-log/handler.ts
@@ -95,18 +95,36 @@ function summarizeToolResult(
   detail: string | null;
   autonomy: 'autonomous' | 'approved' | 'unknown';
 } | null {
-  const toolName = readAuditToolName(row.payload) ?? null;
+  const toolName = readAuditToolName(row.payload, {
+    action: row.action,
+    targetType: row.targetType,
+    targetId: row.targetId,
+  }) ?? null;
   if (!toolName) return null;
 
   const result = row.payload.result as { success?: boolean; data?: unknown; error?: string } | undefined;
-  const success = result?.success === true;
+  // Prefer structured outcome column; fall back to payload for pre-hardening rows.
+  const success = row.outcome === 'success'
+    ? true
+    : row.outcome === 'failure' || row.outcome === 'error' || row.outcome === 'denied'
+      ? false
+      : result?.success === true;
   const autonomy = matchAutonomyOutcome(toolName, row.timestamp, row.conversationId, autonomyRows);
+
+  // Human-readable target still comes from result data when available; fall back
+  // to structured target_id (tool name) for rows where payload detail is thin.
+  const targetFromPayload = extractTarget(toolName, result);
+  const target = targetFromPayload !== toolName
+    ? targetFromPayload
+    : (row.targetId && row.targetId !== '[EXTRACTION_FAILED]' ? row.targetId : targetFromPayload);
 
   return {
     timestamp: toLocalIso(Math.floor(row.timestamp.getTime() / 1000), tz) ?? row.timestamp.toISOString(),
     tool: toolName,
-    agent_id: row.sourceId,
-    target: extractTarget(toolName, result),
+    agent_id: row.initiatorId && row.initiatorType === 'agent'
+      ? row.initiatorId
+      : row.sourceId,
+    target,
     outcome: success ? 'completed' : 'failed',
     detail: success ? extractSuccessDetail(toolName, result?.data) : (result?.error ?? null),
     autonomy,

--- a/skills/diagnostics/tools/audit-query/handler.test.ts
+++ b/skills/diagnostics/tools/audit-query/handler.test.ts
@@ -24,8 +24,16 @@ function auditRow(overrides?: Partial<AuditLogRow>): AuditLogRow {
     sourceLayer: 'execution',
     sourceId: 'coordinator',
     conversationId: 'conv-1',
+    taskId: null,
     parentEventId: 'evt-0',
     payload: { toolName: 'email-send' },
+    action: null,
+    outcome: null,
+    targetType: null,
+    targetId: null,
+    initiatorType: null,
+    initiatorId: null,
+    entryHash: null,
     ...overrides,
   };
 }

--- a/skills/diagnostics/tools/audit-query/handler.ts
+++ b/skills/diagnostics/tools/audit-query/handler.ts
@@ -17,6 +17,11 @@ interface AuditQueryInput {
   conversation_id?: string;
   task_id?: string;
   event_types?: string[] | string;
+  outcome?: string;
+  target_type?: string;
+  target_id?: string;
+  initiator_type?: string;
+  initiator_id?: string;
   since?: string;
   until?: string;
   limit?: number;
@@ -41,6 +46,11 @@ export class AuditQueryHandler implements ToolHandler {
     const blockId = typeof input.block_id === 'string' ? input.block_id.trim() : undefined;
     const conversationId = typeof input.conversation_id === 'string' ? input.conversation_id.trim() : undefined;
     const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : undefined;
+    const outcome = typeof input.outcome === 'string' ? input.outcome.trim() : undefined;
+    const targetType = typeof input.target_type === 'string' ? input.target_type.trim() : undefined;
+    const targetId = typeof input.target_id === 'string' ? input.target_id.trim() : undefined;
+    const initiatorType = typeof input.initiator_type === 'string' ? input.initiator_type.trim() : undefined;
+    const initiatorId = typeof input.initiator_id === 'string' ? input.initiator_id.trim() : undefined;
     const eventTypes = Array.isArray(input.event_types)
       ? input.event_types.filter((t): t is string => typeof t === 'string' && t.trim().length > 0).map((t) => t.trim())
       : typeof input.event_types === 'string' && input.event_types.trim().length > 0
@@ -74,16 +84,29 @@ export class AuditQueryHandler implements ToolHandler {
           to: until.date,
           conversationId,
           taskId,
+          outcome,
+          targetType,
+          targetId,
+          initiatorType,
+          initiatorId,
           limit,
         });
         rows = page.rows;
         hasMore = page.hasMore;
-      } else if (since.date || until.date || conversationId || taskId) {
+      } else if (
+        since.date || until.date || conversationId || taskId
+        || outcome || targetType || targetId || initiatorType || initiatorId
+      ) {
         const page = await ctx.auditLogRepo.findTimeline({
           from: since.date,
           to: until.date,
           conversationId,
           taskId,
+          outcome,
+          targetType,
+          targetId,
+          initiatorType,
+          initiatorId,
           limit,
         });
         rows = page.rows;
@@ -91,7 +114,7 @@ export class AuditQueryHandler implements ToolHandler {
       } else {
         return {
           success: false,
-          error: 'audit-query needs at least one anchor: event_id, block_id, conversation_id, task_id, event_types, or a since/until window',
+          error: 'audit-query needs at least one anchor: event_id, block_id, conversation_id, task_id, event_types, outcome, target_type/target_id, initiator_type/initiator_id, or a since/until window',
         };
       }
 

--- a/skills/diagnostics/tools/audit-query/tool.json
+++ b/skills/diagnostics/tools/audit-query/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "audit-query",
-  "description": "Read the audit_log for forensic investigation. Anchor on an event ID, a blocked-message ID (block_…), a conversation ID, a task ID, one or more event types, and/or a time window. Returns bounded, PII-scrubbed event records (id, type, source, parent_event_id, payload summary). Read-only; principal-facing diagnostics only.",
-  "version": "0.1.0",
+  "description": "Read the audit_log for forensic investigation. Anchor on an event ID, a blocked-message ID (block_…), a conversation ID, a task ID, one or more event types, structured dimensions (outcome, target_type/target_id, initiator_type/initiator_id), and/or a time window. Returns bounded, PII-scrubbed event records with first-class action/outcome/target/initiator fields. Read-only; principal-facing diagnostics only.",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -10,6 +10,11 @@
     "conversation_id": "string?",
     "task_id": "string?",
     "event_types": "string[]?",
+    "outcome": "string?",
+    "target_type": "string?",
+    "target_id": "string?",
+    "initiator_type": "string?",
+    "initiator_id": "string?",
     "since": "timestamp?",
     "until": "timestamp?",
     "limit": "number?"

--- a/skills/diagnostics/tools/audit-trace/handler.test.ts
+++ b/skills/diagnostics/tools/audit-trace/handler.test.ts
@@ -24,8 +24,16 @@ function row(id: string, parentEventId: string | null, tsIso: string, overrides?
     sourceLayer: 'agent',
     sourceId: 'coordinator',
     conversationId: 'conv-1',
+    taskId: null,
     parentEventId,
     payload: {},
+    action: null,
+    outcome: null,
+    targetType: null,
+    targetId: null,
+    initiatorType: null,
+    initiatorId: null,
+    entryHash: null,
     ...overrides,
   };
 }

--- a/skills/diagnostics/tools/audit-trace/tool.json
+++ b/skills/diagnostics/tools/audit-trace/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "audit-trace",
-  "description": "Reconstruct the causal chain around an audit event. Given an event ID or a blocked-message ID (block_…), walks parent_event_id upward to the root cause and children downward to consequences, returning the ordered, PII-scrubbed event chain. Read-only; principal-facing diagnostics only.",
-  "version": "0.1.0",
+  "description": "Reconstruct the causal chain around an audit event. Given an event ID or a blocked-message ID (block_…), walks parent_event_id upward to the root cause and children downward to consequences, returning the ordered, PII-scrubbed event chain with first-class action/outcome/target/initiator fields. Read-only; principal-facing diagnostics only.",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/src/agents/llm/telemetry-provider.ts
+++ b/src/agents/llm/telemetry-provider.ts
@@ -108,6 +108,16 @@ export class TelemetryLlmProvider implements LLMProvider {
           promptHash,
           responseHash,
           parentEventId: 'system',
+          archive: {
+            prompt: {
+              messages: params.messages,
+              toolResults: params.toolResults ?? [],
+            },
+            response: response.type === 'text'
+              ? { type: 'text', content: response.content }
+              : { type: 'tool_use', toolCalls: response.toolCalls },
+            toolDefinitions: params.tools ?? [],
+          },
         });
 
         await this.bus.publish('agent', event);

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1917,6 +1917,14 @@ export class AgentRuntime {
           promptHash,
           responseHash,
           parentEventId: taskEvent.id,
+          // Typed non-persisted archive — AuditLogger writes llm_call_archive atomically.
+          archive: {
+            prompt: { messages: params.messages },
+            response: response.type === 'text'
+              ? { type: 'text', content: response.content }
+              : { type: 'tool_use', toolCalls: response.toolCalls },
+            toolDefinitions: params.tools ?? [],
+          },
         });
         const estimatedCostUsd = event.payload.estimatedCostUsd;
         if (budgetHandoff?.sliceCostTracker && Number.isFinite(estimatedCostUsd) && estimatedCostUsd > 0) {

--- a/src/antfarm/interpreter.ts
+++ b/src/antfarm/interpreter.ts
@@ -53,7 +53,11 @@ export function interpretEvent(row: AuditEventRow): SceneDirective | SceneDirect
     case 'tool.invoke':
     case 'skill.invoke': {
       const toolName = readAuditToolName(payload) ?? '';
-      const agentId = payloadString(payload, 'agentId') ?? row.sourceId;
+      const agentId = payloadString(payload, 'agentId')
+        ?? (typeof row.initiatorId === 'string' && row.initiatorId.length > 0
+          ? row.initiatorId
+          : undefined)
+        ?? row.sourceId;
       if (toolName === 'delegate') {
         const input = payload.input;
         const targetAgentId =
@@ -96,7 +100,11 @@ export function interpretEvent(row: AuditEventRow): SceneDirective | SceneDirect
       return {
         ...base,
         kind: 'agent.think',
-        agentId: payloadString(payload, 'agentId') ?? row.sourceId,
+        agentId: payloadString(payload, 'agentId')
+          ?? (typeof row.initiatorId === 'string' && row.initiatorId.length > 0
+            ? row.initiatorId
+            : undefined)
+          ?? row.sourceId,
         phase: 'stop',
         toolName: readAuditToolName(payload),
       };

--- a/src/audit/audit-log-repo.ts
+++ b/src/audit/audit-log-repo.ts
@@ -1,6 +1,8 @@
 // audit-log-repo.ts — read-only queries against the append-only audit_log table.
 //
 // Skills must not access the pool directly; this repo is the sanctioned read path.
+// Phase 1 (#1383): exposes structured columns and filter dimensions; historical
+// rows have NULL columns and readers must fall back to payload.
 
 import type { Pool } from 'pg';
 import type { Logger } from '../logger.js';
@@ -13,8 +15,18 @@ export interface AuditLogRow {
   sourceLayer: string;
   sourceId: string;
   conversationId: string | null;
+  /** Populated when the writer set the task_id column; null on legacy rows. */
+  taskId: string | null;
   parentEventId: string | null;
   payload: Record<string, unknown>;
+  /** Structured columns — null on pre-hardening rows (migration 078). */
+  action: string | null;
+  outcome: string | null;
+  targetType: string | null;
+  targetId: string | null;
+  initiatorType: string | null;
+  initiatorId: string | null;
+  entryHash: string | null;
 }
 
 export interface ToolResultAuditQuery {
@@ -30,6 +42,11 @@ export interface TimelineAuditQuery {
   to?: Date;
   conversationId?: string;
   taskId?: string;
+  outcome?: string;
+  targetType?: string;
+  targetId?: string;
+  initiatorType?: string;
+  initiatorId?: string;
   limit?: number;
   /**
    * Keyset cursor — fetch rows strictly after this (timestamp, id) pair.
@@ -54,17 +71,30 @@ export interface TimelinePage {
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
 
+/** Columns selected by every read path — keep in sync with {@link mapRow}. */
+const SELECT_COLUMNS = `id, timestamp, event_type, source_layer, source_id,
+              conversation_id, task_id, parent_event_id, payload,
+              action, outcome, target_type, target_id,
+              initiator_type, initiator_id, entry_hash`;
+
 function assertTimelineScope(query: TimelineAuditQuery): void {
-  if (!query.from && !query.to && !query.conversationId && !query.taskId) {
+  if (
+    !query.from && !query.to && !query.conversationId && !query.taskId
+    && !query.outcome && !query.targetType && !query.targetId
+    && !query.initiatorType && !query.initiatorId
+  ) {
     throw new Error(
-      'findTimeline requires at least one scope filter: from, to, conversationId, or taskId',
+      'findTimeline requires at least one scope filter: from, to, conversationId, taskId, outcome, targetType/targetId, or initiatorType/initiatorId',
     );
   }
 }
 
-/** Uses idx_audit_log_payload_task_id — expression must match the migration exactly. */
-function payloadTaskIdCondition(paramIndex: number): string {
-  return `payload->>'taskId' = $${paramIndex}`;
+/**
+ * Match task_id column when populated; fall back to payload->>'taskId' for
+ * legacy rows that never got the column filled (index 071 still covers those).
+ */
+function taskIdCondition(paramIndex: number): string {
+  return `(task_id = $${paramIndex} OR (task_id IS NULL AND payload->>'taskId' = $${paramIndex}))`;
 }
 
 function applyTimelineFilters(
@@ -86,7 +116,27 @@ function applyTimelineFilters(
   }
   if (query.taskId) {
     params.push(query.taskId);
-    conditions.push(payloadTaskIdCondition(params.length));
+    conditions.push(taskIdCondition(params.length));
+  }
+  if (query.outcome) {
+    params.push(query.outcome);
+    conditions.push(`outcome = $${params.length}`);
+  }
+  if (query.targetType) {
+    params.push(query.targetType);
+    conditions.push(`target_type = $${params.length}`);
+  }
+  if (query.targetId) {
+    params.push(query.targetId);
+    conditions.push(`target_id = $${params.length}`);
+  }
+  if (query.initiatorType) {
+    params.push(query.initiatorType);
+    conditions.push(`initiator_type = $${params.length}`);
+  }
+  if (query.initiatorId) {
+    params.push(query.initiatorId);
+    conditions.push(`initiator_id = $${params.length}`);
   }
   if (query.after) {
     params.push(query.after.timestamp);
@@ -128,8 +178,11 @@ export class AuditLogRepo {
     let skillFilter = '';
     if (query.toolNames && query.toolNames.length > 0) {
       params.push(query.toolNames);
-      // Historical rows store the atom name as skillName; post-rename as toolName.
-      skillFilter = `AND COALESCE(payload->>'toolName', payload->>'skillName') = ANY($${params.length}::text[])`;
+      // Prefer structured target_id (Phase 1); fall back to payload dual vocabulary.
+      skillFilter = `AND (
+        (target_type = 'skill' AND target_id = ANY($${params.length}::text[]))
+        OR (target_id IS NULL AND COALESCE(payload->>'toolName', payload->>'skillName') = ANY($${params.length}::text[]))
+      )`;
     }
     let agentFilter = '';
     if (query.agentId) {
@@ -139,8 +192,7 @@ export class AuditLogRepo {
     params.push(limit);
 
     const result = await this.pool.query(
-      `SELECT id, timestamp, event_type, source_layer, source_id,
-              conversation_id, parent_event_id, payload
+      `SELECT ${SELECT_COLUMNS}
        FROM audit_log
        WHERE timestamp >= $1
          AND timestamp < $2
@@ -178,8 +230,7 @@ export class AuditLogRepo {
     const whereClause = `WHERE ${conditions.join(' AND ')}`;
 
     const result = await this.pool.query(
-      `SELECT id, timestamp, event_type, source_layer, source_id,
-              conversation_id, parent_event_id, payload
+      `SELECT ${SELECT_COLUMNS}
        FROM audit_log
        ${whereClause}
        ORDER BY timestamp ASC, id ASC
@@ -220,8 +271,7 @@ export class AuditLogRepo {
     params.push(limit + 1);
 
     const result = await this.pool.query(
-      `SELECT id, timestamp, event_type, source_layer, source_id,
-              conversation_id, parent_event_id, payload
+      `SELECT ${SELECT_COLUMNS}
        FROM audit_log
        WHERE ${conditions.join(' AND ')}
        ORDER BY timestamp ASC, id ASC
@@ -244,8 +294,7 @@ export class AuditLogRepo {
    */
   async findById(id: string): Promise<AuditLogRow | null> {
     const result = await this.pool.query(
-      `SELECT id, timestamp, event_type, source_layer, source_id,
-              conversation_id, parent_event_id, payload
+      `SELECT ${SELECT_COLUMNS}
        FROM audit_log
        WHERE id = $1`,
       [id],
@@ -263,8 +312,7 @@ export class AuditLogRepo {
   async findChildren(parentEventId: string, options: { limit?: number } = {}): Promise<AuditLogRow[]> {
     const limit = Math.min(Math.max(options.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
     const result = await this.pool.query(
-      `SELECT id, timestamp, event_type, source_layer, source_id,
-              conversation_id, parent_event_id, payload
+      `SELECT ${SELECT_COLUMNS}
        FROM audit_log
        WHERE parent_event_id = $1
        ORDER BY timestamp ASC, id ASC
@@ -297,8 +345,7 @@ export class AuditLogRepo {
     params.push(limit);
 
     const result = await this.pool.query(
-      `SELECT id, timestamp, event_type, source_layer, source_id,
-              conversation_id, parent_event_id, payload
+      `SELECT ${SELECT_COLUMNS}
        FROM audit_log
        WHERE ${conditions.join(' AND ')}
        ORDER BY timestamp ASC, id ASC
@@ -318,9 +365,17 @@ function mapRow(row: Record<string, unknown>): AuditLogRow {
     sourceLayer: row.source_layer as string,
     sourceId: row.source_id as string,
     conversationId: (row.conversation_id as string | null) ?? null,
+    taskId: (row.task_id as string | null) ?? null,
     parentEventId: (row.parent_event_id as string | null) ?? null,
     payload: typeof payload === 'object' && payload !== null && !Array.isArray(payload)
       ? payload as Record<string, unknown>
       : {},
+    action: (row.action as string | null) ?? null,
+    outcome: (row.outcome as string | null) ?? null,
+    targetType: (row.target_type as string | null) ?? null,
+    targetId: (row.target_id as string | null) ?? null,
+    initiatorType: (row.initiator_type as string | null) ?? null,
+    initiatorId: (row.initiator_id as string | null) ?? null,
+    entryHash: (row.entry_hash as string | null) ?? null,
   };
 }

--- a/src/audit/field-extraction.ts
+++ b/src/audit/field-extraction.ts
@@ -1,0 +1,242 @@
+// field-extraction.ts — deterministic structured-field extraction for audit_log
+// (spec 10 §Field Extraction). Runs inside AuditLogger before INSERT.
+//
+// Extraction Failure Policy: missing/mistyped mapped fields become the sentinel
+// '[EXTRACTION_FAILED]' (not NULL — NULL means pre-migration). Unmapped event
+// types leave all structured columns NULL.
+
+import type { Logger } from '../logger.js';
+
+/** Sentinel written when a mapped field is missing or mistyped. */
+export const EXTRACTION_FAILED = '[EXTRACTION_FAILED]';
+
+/** Shared initiator literals for system/dispatch-originated events (queryable dimension). */
+export const INITIATOR_TYPE_SYSTEM = 'system';
+export const INITIATOR_ID_DISPATCH = 'dispatch';
+
+export interface StructuredAuditFields {
+  action: string | null;
+  outcome: string | null;
+  target_type: string | null;
+  target_id: string | null;
+  initiator_type: string | null;
+  initiator_id: string | null;
+}
+
+const ALL_NULL: StructuredAuditFields = {
+  action: null,
+  outcome: null,
+  target_type: null,
+  target_id: null,
+  initiator_type: null,
+  initiator_id: null,
+};
+
+type Extractor = (
+  payload: Record<string, unknown>,
+  fail: (field: string) => string,
+) => StructuredAuditFields;
+
+function str(
+  payload: Record<string, unknown>,
+  field: string,
+  fail: (field: string) => string,
+): string {
+  const v = payload[field];
+  return typeof v === 'string' && v.length > 0 ? v : fail(field);
+}
+
+/** toolName with legacy skillName fallback (pre-ADR-031 rows / dual vocabulary). */
+function toolName(
+  payload: Record<string, unknown>,
+  fail: (field: string) => string,
+): string {
+  if (typeof payload.toolName === 'string' && payload.toolName.length > 0) {
+    return payload.toolName;
+  }
+  if (typeof payload.skillName === 'string' && payload.skillName.length > 0) {
+    return payload.skillName;
+  }
+  return fail('toolName');
+}
+
+function toolResultOutcome(
+  payload: Record<string, unknown>,
+  fail: (field: string) => string,
+): string {
+  const result = payload.result;
+  if (typeof result !== 'object' || result === null || Array.isArray(result)) {
+    return fail('result.success');
+  }
+  const success = (result as Record<string, unknown>).success;
+  if (typeof success !== 'boolean') {
+    return fail('result.success');
+  }
+  return success ? 'success' : 'failure';
+}
+
+const extractToolInvoke: Extractor = (p, fail) => ({
+  action: 'execute',
+  outcome: 'pending',
+  target_type: 'skill',
+  target_id: toolName(p, fail),
+  initiator_type: 'agent',
+  initiator_id: str(p, 'agentId', fail),
+});
+
+const extractToolResult: Extractor = (p, fail) => ({
+  action: 'execute',
+  outcome: toolResultOutcome(p, fail),
+  target_type: 'skill',
+  target_id: toolName(p, fail),
+  initiator_type: 'agent',
+  initiator_id: str(p, 'agentId', fail),
+});
+
+/**
+ * Mapping table from spec 10. Also covers pre-ADR-031 `skill.*` aliases so any
+ * residual dual-vocabulary emitters still get structured columns.
+ */
+const EXTRACTORS: Readonly<Record<string, Extractor>> = {
+  'inbound.message': (p, fail) => ({
+    action: 'receive',
+    outcome: 'success',
+    target_type: 'conversation',
+    target_id: str(p, 'conversationId', fail),
+    initiator_type: 'human',
+    initiator_id: str(p, 'senderId', fail),
+  }),
+
+  // Spec 10 maps agent.task → system/dispatch. Originator (human vs principal
+  // vs scheduler) lives in payload.metadata.originator for trust-gate / Gate C;
+  // it is intentionally NOT mirrored into initiator_* (keeps extraction parent-
+  // lookup-free). trust-gate must not assume initiator_type = 'human' here.
+  'agent.task': (p, fail) => ({
+    action: 'delegate',
+    outcome: 'pending',
+    target_type: 'agent',
+    target_id: str(p, 'agentId', fail),
+    initiator_type: INITIATOR_TYPE_SYSTEM,
+    initiator_id: INITIATOR_ID_DISPATCH,
+  }),
+
+  'agent.response': (p, fail) => ({
+    action: 'respond',
+    outcome: 'success',
+    target_type: 'conversation',
+    target_id: str(p, 'conversationId', fail),
+    initiator_type: 'agent',
+    initiator_id: str(p, 'agentId', fail),
+  }),
+
+  'outbound.message': (p, fail) => ({
+    action: 'send',
+    outcome: 'success',
+    target_type: 'conversation',
+    target_id: str(p, 'conversationId', fail),
+    initiator_type: INITIATOR_TYPE_SYSTEM,
+    initiator_id: INITIATOR_ID_DISPATCH,
+  }),
+
+  // Spec maps initiator to channel / channelId; outbound.delivered payload uses `channel`.
+  'outbound.delivered': (p, fail) => ({
+    action: 'deliver',
+    outcome: 'success',
+    target_type: 'conversation',
+    target_id: typeof p.conversationId === 'string' && p.conversationId.length > 0
+      ? p.conversationId
+      : fail('conversationId'),
+    initiator_type: 'channel',
+    initiator_id: str(p, 'channel', fail),
+  }),
+
+  'tool.invoke': extractToolInvoke,
+  'skill.invoke': extractToolInvoke,
+
+  'tool.result': extractToolResult,
+  'skill.result': extractToolResult,
+
+  'memory.store': (p, fail) => ({
+    action: 'create',
+    outcome: 'success',
+    target_type: 'kg_node',
+    target_id: str(p, 'nodeId', fail),
+    initiator_type: 'agent',
+    initiator_id: str(p, 'agentId', fail),
+  }),
+
+  'memory.query': (p, fail) => ({
+    action: 'read',
+    outcome: 'success',
+    target_type: 'knowledge_graph',
+    target_id: str(p, 'queryType', fail),
+    initiator_type: 'agent',
+    initiator_id: str(p, 'agentId', fail),
+  }),
+
+  'contact.resolved': (p, fail) => ({
+    action: 'resolve',
+    outcome: 'success',
+    target_type: 'contact',
+    target_id: str(p, 'contactId', fail),
+    initiator_type: INITIATOR_TYPE_SYSTEM,
+    initiator_id: INITIATOR_ID_DISPATCH,
+  }),
+
+  'contact.unknown': (p, fail) => ({
+    action: 'resolve',
+    outcome: 'failure',
+    target_type: 'contact',
+    target_id: str(p, 'senderId', fail),
+    initiator_type: INITIATOR_TYPE_SYSTEM,
+    initiator_id: INITIATOR_ID_DISPATCH,
+  }),
+
+  // Spec lists message.held; the event type is reserved but not yet emitted.
+  // Keep the mapping ready so structured columns populate the day it ships.
+  'message.held': (p, fail) => ({
+    action: 'hold',
+    outcome: 'pending',
+    target_type: 'message',
+    target_id: str(p, 'heldMessageId', fail),
+    initiator_type: INITIATOR_TYPE_SYSTEM,
+    initiator_id: INITIATOR_ID_DISPATCH,
+  }),
+};
+
+/**
+ * Extract structured audit columns for an event. Never throws — failures become
+ * the EXTRACTION_FAILED sentinel and a warning log.
+ */
+export function extractStructuredFields(
+  eventType: string,
+  payload: Record<string, unknown>,
+  eventId: string,
+  logger: Logger,
+): StructuredAuditFields {
+  const extractor = EXTRACTORS[eventType];
+  if (!extractor) {
+    logger.debug(
+      { eventId, eventType },
+      'Audit field extraction: unmapped event type — structured columns left NULL',
+    );
+    return { ...ALL_NULL };
+  }
+
+  const failedFields: string[] = [];
+  const fail = (field: string): string => {
+    failedFields.push(field);
+    return EXTRACTION_FAILED;
+  };
+
+  const fields = extractor(payload, fail);
+
+  if (failedFields.length > 0) {
+    logger.warn(
+      { eventId, eventType, failedFields },
+      'Audit field extraction failed for one or more mapped fields — wrote [EXTRACTION_FAILED] sentinel',
+    );
+  }
+
+  return fields;
+}

--- a/src/audit/hash-chain.ts
+++ b/src/audit/hash-chain.ts
@@ -1,0 +1,77 @@
+// hash-chain.ts — SHA-256 hash chain for audit_log tamper evidence (spec 10).
+//
+// entry_hash = SHA-256(canonical_json(fields) + previous_entry_hash)
+// First row chains from GENESIS_HASH = SHA-256("curia-audit-genesis-v1").
+
+import { createHash } from 'node:crypto';
+
+/** Fixed genesis constant — first audit row chains from this value. */
+export const AUDIT_GENESIS_SEED = 'curia-audit-genesis-v1';
+
+export const GENESIS_HASH = createHash('sha256').update(AUDIT_GENESIS_SEED).digest('hex');
+
+/** Fields hashed into each entry (excludes entry_hash itself and acknowledged). */
+export interface HashChainFields {
+  id: string;
+  timestamp: string; // ISO-8601
+  event_type: string;
+  source_layer: string;
+  source_id: string;
+  payload: unknown;
+  conversation_id: string | null;
+  task_id: string | null;
+  parent_event_id: string | null;
+  action: string | null;
+  outcome: string | null;
+  target_type: string | null;
+  target_id: string | null;
+  initiator_type: string | null;
+  initiator_id: string | null;
+}
+
+/**
+ * Deterministic JSON: object keys sorted alphabetically at every level, no
+ * whitespace. Arrays keep order.
+ *
+ * Round-trips through JSON.stringify/parse first so Date/Buffer/toJSON values
+ * collapse exactly the way the persisted JSONB column will — otherwise
+ * write-time hashes (which may see live Date objects from stripNullBytes) and
+ * verify-time hashes (which see ISO strings from jsonb) diverge.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortKeys(JSON.parse(JSON.stringify(value)) as unknown));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  const obj = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) {
+    sorted[key] = sortKeys(obj[key]);
+  }
+  return sorted;
+}
+
+/** Compute entry_hash for the given fields chained from previousEntryHash. */
+export function computeEntryHash(fields: HashChainFields, previousEntryHash: string): string {
+  return createHash('sha256')
+    .update(canonicalJson(fields) + previousEntryHash)
+    .digest('hex');
+}
+
+/** Normalize a Date (or Date-like) to the ISO string used in the hash input. */
+export function toHashTimestamp(timestamp: Date | string): string {
+  if (timestamp instanceof Date) {
+    return timestamp.toISOString();
+  }
+  const d = new Date(timestamp);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid audit timestamp for hash chain: ${String(timestamp)}`);
+  }
+  return d.toISOString();
+}

--- a/src/audit/legacy-tool-events.ts
+++ b/src/audit/legacy-tool-events.ts
@@ -49,10 +49,28 @@ export function isToolInvokeEventType(eventType: string): boolean {
 }
 
 /**
- * Read the atom name from an audit payload that may use either field name.
- * Prefers the current `toolName` when both are present.
+ * Read the atom name from an audit row that may use structured columns (Phase 1)
+ * or either payload field name (pre-ADR-031 dual vocabulary).
+ *
+ * Prefer `target_id` when `target_type === 'skill'` — the structured `action`
+ * column is the taxonomy verb (`execute`), not the tool name.
  */
-export function readAuditToolName(payload: Record<string, unknown>): string | undefined {
+export function readAuditToolName(
+  payload: Record<string, unknown>,
+  structured?: {
+    action?: string | null;
+    targetType?: string | null;
+    targetId?: string | null;
+  },
+): string | undefined {
+  if (
+    structured?.targetType === 'skill'
+    && typeof structured.targetId === 'string'
+    && structured.targetId.length > 0
+    && structured.targetId !== '[EXTRACTION_FAILED]'
+  ) {
+    return structured.targetId;
+  }
   if (typeof payload['toolName'] === 'string') return payload['toolName'];
   if (typeof payload['skillName'] === 'string') return payload['skillName'];
   return undefined;

--- a/src/audit/llm-call-archive.ts
+++ b/src/audit/llm-call-archive.ts
@@ -1,0 +1,169 @@
+// llm-call-archive.ts — redact + persist full llm.call prompts/responses.
+//
+// Spec 10: archive rows are written in the SAME transaction as the audit_log
+// INSERT for the llm.call event. Emitters attach content via the typed
+// `archive` field on LlmCallEvent (never in payload / never hashed).
+//
+// Redaction policy: if redaction throws, skip the archive write (never store
+// unredacted content) but still write the audit_log row (hashes only).
+
+import type { Pool, PoolClient } from 'pg';
+import type { LlmCallArchiveContent } from '../bus/events.js';
+import type { Logger } from '../logger.js';
+import { scrubPii } from '../pii/scrubber.js';
+import { createSecretPatterns } from '../security/secret-patterns.js';
+
+export type { LlmCallArchiveContent };
+
+/** Sensitive JSON key names (case-insensitive) whose values become [REDACTED]. */
+const SENSITIVE_KEY_RE =
+  /^(password|passwd|token|secret|api_key|apikey|authorization|auth|credential|private_key)$/i;
+
+/**
+ * Redact secrets + PII from archive JSON. Throws on failure so the caller can
+ * skip the archive write rather than store unredacted content.
+ *
+ * Note: the shared long-hex pattern is deliberately aggressive — it redacts any
+ * 32+ lowercase-hex run (dash-less UUIDs, git SHAs, pasted hashes). Acceptable
+ * for a lossy provenance archive; do not narrow without an allowlist strategy.
+ */
+export function redactArchiveContent(value: unknown): unknown {
+  return walkRedact(value, createSecretPatterns());
+}
+
+function walkRedact(node: unknown, secretPatterns: RegExp[]): unknown {
+  if (typeof node === 'string') {
+    return redactString(node, secretPatterns);
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => walkRedact(item, secretPatterns));
+  }
+  if (node !== null && typeof node === 'object') {
+    // Reject non-plain objects (Buffer, Date, circular class instances) — they
+    // are not valid archive JSON and indicate malformed content.
+    if (Object.getPrototypeOf(node) !== Object.prototype) {
+      throw new Error(
+        `llm_call_archive redaction: non-plain object (${Object.prototype.toString.call(node)})`,
+      );
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(node as Record<string, unknown>)) {
+      if (SENSITIVE_KEY_RE.test(key)) {
+        out[key] = '[REDACTED]';
+      } else {
+        out[key] = walkRedact(val, secretPatterns);
+      }
+    }
+    return out;
+  }
+  // numbers, booleans, null
+  return node;
+}
+
+function redactString(text: string, secretPatterns: RegExp[]): string {
+  let result = text;
+  for (const pattern of secretPatterns) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, '[REDACTED]');
+  }
+  return scrubPii(result);
+}
+
+/**
+ * INSERT a redacted archive row on the given client (must be inside the caller's
+ * transaction with the matching audit_log INSERT). Returns false when redaction
+ * failed and the archive write was skipped.
+ */
+export async function writeLlmCallArchive(
+  client: PoolClient,
+  auditEventId: string,
+  content: LlmCallArchiveContent,
+  logger: Logger,
+): Promise<boolean> {
+  let prompt: unknown;
+  let response: unknown;
+  let toolDefinitions: unknown = null;
+
+  try {
+    prompt = redactArchiveContent(content.prompt);
+    response = redactArchiveContent(content.response);
+    if (content.toolDefinitions !== undefined) {
+      toolDefinitions = redactArchiveContent(content.toolDefinitions);
+    }
+  } catch (err) {
+    logger.error(
+      { err, eventId: auditEventId },
+      'llm_call_archive redaction failed — skipping archive write (audit row still written)',
+    );
+    return false;
+  }
+
+  // JSON.stringify(undefined) is JS undefined → node-pg binds SQL NULL, which
+  // violates prompt/response NOT NULL and would roll back the audit_log row too.
+  // Skip the archive (same fail-closed posture as redaction failure) instead.
+  if (prompt === undefined || response === undefined) {
+    logger.error(
+      { eventId: auditEventId, promptDefined: prompt !== undefined, responseDefined: response !== undefined },
+      'llm_call_archive missing prompt/response after redaction — skipping archive write (audit row still written)',
+    );
+    return false;
+  }
+
+  try {
+    await client.query(
+      `INSERT INTO llm_call_archive (audit_event_id, prompt, response, tool_definitions)
+       VALUES ($1, $2::jsonb, $3::jsonb, $4::jsonb)`,
+      [
+        auditEventId,
+        JSON.stringify(prompt),
+        JSON.stringify(response),
+        toolDefinitions === null ? null : JSON.stringify(toolDefinitions),
+      ],
+    );
+    return true;
+  } catch (err) {
+    // Let the caller roll back the whole transaction — orphaned audit without
+    // archive (or vice versa) violates the atomicity guarantee.
+    logger.error({ err, eventId: auditEventId }, 'llm_call_archive INSERT failed');
+    throw err;
+  }
+}
+
+/**
+ * Delete archive rows older than `retentionDays`. Bound the plaintext store —
+ * data never written (or already purged) cannot leak. Called from DreamEngine.
+ *
+ * Deletes in batches of 1000 so a large backlog cannot lock `llm_call_archive`
+ * (and bloat WAL) for one enormous transaction.
+ */
+export async function purgeExpiredLlmCallArchive(
+  pool: Pool,
+  retentionDays: number,
+  logger: Logger,
+): Promise<number> {
+  if (!Number.isInteger(retentionDays) || retentionDays < 1) {
+    throw new Error(`purgeExpiredLlmCallArchive: retentionDays must be a positive integer, got ${retentionDays}`);
+  }
+  const BATCH = 1000;
+  let total = 0;
+  try {
+    for (;;) {
+      const result = await pool.query(
+        `DELETE FROM llm_call_archive
+         WHERE audit_event_id IN (
+           SELECT audit_event_id FROM llm_call_archive
+           WHERE created_at < now() - ($1::text || ' days')::interval
+           LIMIT $2
+         )`,
+        [String(retentionDays), BATCH],
+      );
+      const n = result.rowCount ?? 0;
+      total += n;
+      if (n < BATCH) break;
+    }
+    return total;
+  } catch (err) {
+    logger.error({ err, retentionDays, purgedSoFar: total }, 'llm_call_archive purge failed');
+    throw err;
+  }
+}

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -1,11 +1,20 @@
-import type { DbPool } from '../db/connection.js';
-import type { BusEvent } from '../bus/events.js';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Pool, PoolClient } from 'pg';
+import type { BusEvent, LlmCallArchiveContent } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import {
   createDbUnavailableAgentError,
   isDbUnavailableError,
   withDbRetry,
 } from '../db/resilience.js';
+import { extractStructuredFields } from './field-extraction.js';
+import {
+  GENESIS_HASH,
+  computeEntryHash,
+  toHashTimestamp,
+  type HashChainFields,
+} from './hash-chain.js';
+import { writeLlmCallArchive } from './llm-call-archive.js';
 
 /**
  * Recursively strip null bytes (U+0000) from all string values in an object.
@@ -42,19 +51,85 @@ function stripNullBytes(value: unknown): unknown {
 }
 
 /**
+ * True while {@link AuditLogger} holds the hash-chain write transaction.
+ * Nested `log()` (e.g. publishing a bus event from inside the write path)
+ * would deadlock on the advisory lock — fail loudly instead.
+ */
+const auditWriteDepth = new AsyncLocalStorage<true>();
+
+export interface AuditLoggerOptions {
+  /** When false, skip llm_call_archive writes even if the event carries archive content. Default true. */
+  llmCallArchiveEnabled?: boolean;
+}
+
+/**
  * Write-ahead audit logger. Persists every bus event to the audit_log table
  * BEFORE the event is delivered to other subscribers. This ensures audit
  * completeness even if the process crashes mid-delivery.
+ *
+ * Phase 1 hardening (#1383 / spec 10): also extracts structured columns,
+ * maintains a SHA-256 hash chain (entry_hash), and atomically writes
+ * llm_call_archive rows for llm.call events.
+ *
+ * Hash-chain writes are serialized with a transaction-scoped advisory lock
+ * and ordered by the monotonic `seq` column (not wall-clock timestamp).
+ * Chain head is always re-read under the lock — there is no in-memory
+ * previous-hash cache (single source of truth in the DB).
+ *
+ * INVARIANT: never publish a bus event from inside the audit write
+ * transaction. Doing so re-enters `log()` on another pooled client and
+ * deadlocks on {@link AuditLogger.HASH_CHAIN_LOCK_KEY}.
  *
  * The audit log is append-only — no UPDATE or DELETE operations, with the
  * single exception of flipping `acknowledged` from false to true after
  * delivery has been attempted for all subscribers.
  */
 export class AuditLogger {
+  /**
+   * Advisory-lock key for the global audit hash chain.
+   * Stable across processes; chosen to avoid colliding with other Curia locks.
+   */
+  static readonly HASH_CHAIN_LOCK_KEY = 0x43555249; // 'CURI'
+
+  private readonly llmCallArchiveEnabled: boolean;
+
   constructor(
-    private pool: DbPool,
+    /** Real pg Pool — `.connect()` is required for the hash-chain transaction. */
+    private pool: Pool,
     private logger: Logger,
-  ) {}
+    options: AuditLoggerOptions = {},
+  ) {
+    this.llmCallArchiveEnabled = options.llmCallArchiveEnabled !== false;
+  }
+
+  /**
+   * Startup readiness check: confirm the hash-chain schema is present and log
+   * the current head. Does not cache chain state — every write re-reads under
+   * the advisory lock.
+   */
+  async seedHashChain(): Promise<void> {
+    try {
+      const result = await this.pool.query<{ entry_hash: string | null; seq: string }>(
+        `SELECT entry_hash, seq::text AS seq FROM audit_log
+         WHERE entry_hash IS NOT NULL
+         ORDER BY seq DESC
+         LIMIT 1`,
+      );
+      const latest = result.rows[0];
+      this.logger.debug(
+        {
+          seededFrom: latest?.entry_hash ? 'latest_row' : 'genesis',
+          headSeq: latest?.seq ?? null,
+          hashPrefix: (latest?.entry_hash ?? GENESIS_HASH).slice(0, 12),
+        },
+        'Audit hash chain ready',
+      );
+    } catch (err) {
+      // Fail closed — missing seq/entry_hash columns mean migrations have not run.
+      this.logger.error({ err }, 'Audit hash chain seed failed');
+      throw err;
+    }
+  }
 
   /**
    * Log a bus event to the audit_log table.
@@ -92,40 +167,107 @@ export class AuditLogger {
           ? payload.agentTaskId
           : null;
 
+    const parentEventId = event.parentEventId ?? null;
+
+    // Structured columns — extraction failures become '[EXTRACTION_FAILED]'.
+    const structured = extractStructuredFields(event.type, payload, event.id, this.logger);
+
     // Sanitize before the DB write in a separate try/catch so a sanitization
     // failure is logged with its own distinct message — not conflated with a
     // DB connectivity or schema error from the INSERT below.
     // TODO: JSON.stringify can also throw on circular references (pre-existing,
     // not introduced here). If that becomes a live issue, wrap it separately too.
+    let sanitizedPayload: unknown;
     let serializedPayload: string;
     try {
-      serializedPayload = JSON.stringify(stripNullBytes(event.payload));
+      sanitizedPayload = stripNullBytes(event.payload);
+      serializedPayload = JSON.stringify(sanitizedPayload);
     } catch (err) {
       this.logger.error({ err, eventId: event.id, eventType: event.type }, 'Audit log payload sanitization failed — event not written');
       throw err;
     }
 
+    // Typed, non-persisted archive on llm.call — never part of payload / hash.
+    const archiveContent: LlmCallArchiveContent | undefined =
+      event.type === 'llm.call' && this.llmCallArchiveEnabled
+        ? event.archive
+        : undefined;
+
     try {
       // Critical path: fail fast on DB unavailability (no long retry loop).
       // Spec 05 / #1381 — audit is write-ahead; an outage must surface as a
       // classified error to publishers rather than hang or swallow.
-      await this.pool.query(
-        // All columns are explicitly listed so schema additions don't silently
-        // shift positional parameters.
-        `INSERT INTO audit_log (id, timestamp, event_type, source_layer, source_id, payload, conversation_id, task_id, parent_event_id)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-        [
-          event.id,
-          event.timestamp,
-          event.type,
-          event.sourceLayer,
-          sourceId,
-          serializedPayload,
-          conversationId,
-          taskId,
-          event.parentEventId ?? null,
-        ],
-      );
+      await this.withTransaction(async (client) => {
+        // Serialize hash-chain appends across processes / parallel test workers.
+        await client.query('SELECT pg_advisory_xact_lock($1)', [AuditLogger.HASH_CHAIN_LOCK_KEY]);
+
+        const head = await client.query<{ entry_hash: string | null }>(
+          `SELECT entry_hash FROM audit_log
+           WHERE entry_hash IS NOT NULL
+           ORDER BY seq DESC
+           LIMIT 1`,
+        );
+        const previousHash = typeof head.rows[0]?.entry_hash === 'string' && head.rows[0].entry_hash.length > 0
+          ? head.rows[0].entry_hash
+          : GENESIS_HASH;
+
+        // timestamp is the factual event time — never mutated for chain ordering.
+        // Chain/verify order is the BIGSERIAL `seq` column (migration 080).
+        const hashFields: HashChainFields = {
+          id: event.id,
+          timestamp: toHashTimestamp(event.timestamp),
+          event_type: event.type,
+          source_layer: event.sourceLayer,
+          source_id: sourceId,
+          payload: sanitizedPayload,
+          conversation_id: conversationId,
+          task_id: taskId,
+          parent_event_id: parentEventId,
+          action: structured.action,
+          outcome: structured.outcome,
+          target_type: structured.target_type,
+          target_id: structured.target_id,
+          initiator_type: structured.initiator_type,
+          initiator_id: structured.initiator_id,
+        };
+        const entryHash = computeEntryHash(hashFields, previousHash);
+
+        await client.query(
+          `INSERT INTO audit_log (
+             id, timestamp, event_type, source_layer, source_id, payload,
+             conversation_id, task_id, parent_event_id,
+             action, outcome, target_type, target_id,
+             initiator_type, initiator_id, entry_hash
+           ) VALUES (
+             $1, $2, $3, $4, $5, $6,
+             $7, $8, $9,
+             $10, $11, $12, $13,
+             $14, $15, $16
+           )`,
+          [
+            event.id,
+            event.timestamp,
+            event.type,
+            event.sourceLayer,
+            sourceId,
+            serializedPayload,
+            conversationId,
+            taskId,
+            parentEventId,
+            structured.action,
+            structured.outcome,
+            structured.target_type,
+            structured.target_id,
+            structured.initiator_type,
+            structured.initiator_id,
+            entryHash,
+          ],
+        );
+
+        if (archiveContent !== undefined) {
+          await writeLlmCallArchive(client, event.id, archiveContent, this.logger);
+        }
+      });
     } catch (err) {
       // Audit failures must not be silent — log and re-throw so the bus can
       // decide whether to halt delivery or enter a degraded mode.
@@ -146,9 +288,41 @@ export class AuditLogger {
   }
 
   /**
+   * Run `fn` inside BEGIN/COMMIT with the audit-write depth flag set.
+   * Nested entry (bus publish → log → withTransaction) throws instead of
+   * deadlocking on the advisory lock.
+   */
+  private async withTransaction(fn: (client: PoolClient) => Promise<void>): Promise<void> {
+    if (auditWriteDepth.getStore()) {
+      throw new Error(
+        'BUG: nested AuditLogger.log() inside the audit write transaction — ' +
+          'never publish a bus event from within the hash-chain write path',
+      );
+    }
+
+    await auditWriteDepth.run(true, async () => {
+      const client = await this.pool.connect();
+      try {
+        await client.query('BEGIN');
+        await fn(client);
+        await client.query('COMMIT');
+      } catch (err) {
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackErr) {
+          this.logger.error({ err: rollbackErr }, 'Audit log transaction rollback failed');
+        }
+        throw err;
+      } finally {
+        client.release();
+      }
+    });
+  }
+
+  /**
    * Mark an audit_log row as acknowledged after delivery has been attempted.
    * This is the ONLY permitted UPDATE on audit_log — enforced by a database
-   * trigger (migration 021) that rejects all other mutations.
+   * trigger (migration 021, extended in 078/080) that rejects all other mutations.
    *
    * Called as the onDelivered hook in EventBus after all subscribers have been
    * attempted. Delivery is "attempted", not "succeeded" — per-subscriber errors

--- a/src/autonomy/escalation-judge.ts
+++ b/src/autonomy/escalation-judge.ts
@@ -291,6 +291,13 @@ export class EscalationJudge {
         promptHash: createHash('sha256').update(userPrompt).digest('hex'),
         responseHash: createHash('sha256').update(result.content).digest('hex'),
         parentEventId: 'system',
+        archive: {
+          prompt: {
+            system: kind === 'disclosure' ? DISCLOSURE_SYSTEM_PROMPT : ACTION_SYSTEM_PROMPT,
+            user: userPrompt,
+          },
+          response: { type: 'text', content: result.content },
+        },
       });
       await this.bus.publish('agent', event);
     } catch (err) {

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -940,12 +940,28 @@ export interface ConfigChangeEvent extends BaseEvent {
   payload: ConfigChangePayload;
 }
 
+/**
+ * Full redacted LLM I/O for the `llm_call_archive` table. Carried on
+ * `llm.call` as a non-persisted top-level field — AuditLogger omits it from
+ * `audit_log.payload` while still writing the side table (spec 10).
+ */
+export interface LlmCallArchiveContent {
+  prompt: unknown;
+  response: unknown;
+  toolDefinitions?: unknown;
+}
+
 // LlmCallEvent — published by the agent layer after every LLM API call.
 // parentEventId references the agent.task that triggered it.
 export interface LlmCallEvent extends BaseEvent {
   type: 'llm.call';
   sourceLayer: 'agent';
   payload: LlmCallPayload;
+  /**
+   * Non-persisted archive payload. Not part of `payload` so AuditLogger can
+   * omit it from the bus/`audit_log` JSON while still writing the side table.
+   */
+  archive?: LlmCallArchiveContent;
 }
 
 // LlmErrorEvent — published by TelemetryLlmProvider and AgentRuntime on every
@@ -1745,9 +1761,10 @@ export function createCheckpointExtractionSkipped(
 
 export function createLlmCall(
   // parentEventId is required — every LLM call must trace back to the agent.task that triggered it.
-  payload: LlmCallPayload & { parentEventId: string },
+  // archive is optional and never persists into audit_log.payload.
+  payload: LlmCallPayload & { parentEventId: string; archive?: LlmCallArchiveContent },
 ): LlmCallEvent {
-  const { parentEventId, ...rest } = payload;
+  const { parentEventId, archive, ...rest } = payload;
   return {
     id: randomUUID(),
     timestamp: new Date(),
@@ -1755,6 +1772,7 @@ export function createLlmCall(
     sourceLayer: 'agent',
     payload: rest,
     parentEventId,
+    ...(archive !== undefined ? { archive } : {}),
   };
 }
 

--- a/src/channels/http/routes/antfarm.ts
+++ b/src/channels/http/routes/antfarm.ts
@@ -33,6 +33,8 @@ function auditLogRowToEventRow(row: {
   conversationId: string | null;
   parentEventId: string | null;
   payload: Record<string, unknown>;
+  action?: string | null;
+  initiatorId?: string | null;
 }): AuditEventRow {
   return {
     id: row.id,
@@ -43,6 +45,8 @@ function auditLogRowToEventRow(row: {
     conversationId: row.conversationId,
     parentEventId: row.parentEventId,
     payload: row.payload,
+    action: row.action ?? null,
+    initiatorId: row.initiatorId ?? null,
   };
 }
 

--- a/src/checkpoint/trust-gate.ts
+++ b/src/checkpoint/trust-gate.ts
@@ -29,6 +29,11 @@ export type NoExternalOriginator = 'none';
 /**
  * Load the tier of the first external contact who originated an agent.task in this
  * conversation. Returns 'none' when every task is principal/system/agent-originated.
+ *
+ * Spec 10 maps every `agent.task` row's structured initiator to `system`/`dispatch`
+ * (originator detail stays in `payload.metadata.originator`). So this query always
+ * uses the payload path for Phase 1 + pre-hardening rows — there is no structured
+ * `initiator_type = 'human'` shortcut for agent.task. Uses idx_audit_conversation.
  */
 export async function loadFirstExternalOriginatorTier(
   pool: DbPool,

--- a/src/config.ts
+++ b/src/config.ts
@@ -470,6 +470,18 @@ export interface YamlConfig {
       errorRateThreshold?: number;
     };
   };
+  /**
+   * Audit log hardening (spec 10 / #1383). Controls the llm_call_archive side
+   * table — kill-switch + hot retention TTL for the plaintext prompt store.
+   */
+  audit?: {
+    llmCallArchive?: {
+      /** When false, skip archive writes even if llm.call carries archive content. Default true. */
+      enabled?: boolean;
+      /** Delete archive rows older than this many days (DreamEngine decay pass). Default 90. */
+      hotRetentionDays?: number;
+    };
+  };
   contact_creation_limits?: {
     /** Maximum new contacts created from a single email's participant list. Default: 10. */
     max_per_message?: number;
@@ -988,6 +1000,30 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       }
       if (autonomyScoring.errorRateThreshold !== undefined && (typeof autonomyScoring.errorRateThreshold !== 'number' || autonomyScoring.errorRateThreshold < 0 || autonomyScoring.errorRateThreshold > 1)) {
         throw new Error(`dreaming.autonomy_scoring.errorRateThreshold must be a number between 0 and 1, got: ${autonomyScoring.errorRateThreshold}`);
+      }
+    }
+  }
+
+  const audit = config.audit;
+  if (audit !== undefined) {
+    if (typeof audit !== 'object' || audit === null || Array.isArray(audit)) {
+      throw new Error('audit must be a YAML mapping');
+    }
+    const llmCallArchive = audit.llmCallArchive;
+    if (llmCallArchive !== undefined) {
+      if (typeof llmCallArchive !== 'object' || llmCallArchive === null || Array.isArray(llmCallArchive)) {
+        throw new Error('audit.llmCallArchive must be a YAML mapping');
+      }
+      if (llmCallArchive.enabled !== undefined && typeof llmCallArchive.enabled !== 'boolean') {
+        throw new Error(`audit.llmCallArchive.enabled must be a boolean, got: ${String(llmCallArchive.enabled)}`);
+      }
+      if (
+        llmCallArchive.hotRetentionDays !== undefined &&
+        (!Number.isInteger(llmCallArchive.hotRetentionDays) || llmCallArchive.hotRetentionDays < 1)
+      ) {
+        throw new Error(
+          `audit.llmCallArchive.hotRetentionDays must be a positive integer, got: ${llmCallArchive.hotRetentionDays}`,
+        );
       }
     }
   }

--- a/src/db/migrations/078_audit_log_structured_columns.sql
+++ b/src/db/migrations/078_audit_log_structured_columns.sql
@@ -1,0 +1,99 @@
+-- Up Migration
+--
+-- Phase 1 audit log hardening (#1383 / spec 10):
+--   - Structured query columns (action, outcome, target_*, initiator_*)
+--   - entry_hash for SHA-256 hash-chain tamper evidence
+--   - Extend the append-only trigger so acknowledgement flips still require
+--     all immutable columns (including the new ones) to be unchanged
+--
+-- All new columns are nullable. Historical rows stay NULL — migration 021's
+-- trigger blocks UPDATEs, so backfill is impossible. Readers must fall back
+-- to the JSONB payload for pre-hardening rows.
+
+ALTER TABLE audit_log
+  ADD COLUMN IF NOT EXISTS action         TEXT,
+  ADD COLUMN IF NOT EXISTS outcome        TEXT,
+  ADD COLUMN IF NOT EXISTS target_type    TEXT,
+  ADD COLUMN IF NOT EXISTS target_id      TEXT,
+  ADD COLUMN IF NOT EXISTS initiator_type TEXT,
+  ADD COLUMN IF NOT EXISTS initiator_id   TEXT,
+  ADD COLUMN IF NOT EXISTS entry_hash     TEXT;
+
+-- Indexes for the new columns (and task_id) live in 081_audit_log_structured_indexes.js
+-- so they can be built CONCURRENTLY outside a transaction (node-pg-migrate wraps
+-- plain .sql files in a single transaction, which forbids CONCURRENTLY).
+-- The .js wrapper (not .sql/.ts) is loadable by every migrate entry point via
+-- dynamic import; --migration-file-language sql only affects `create`, not `up`.
+
+-- Rebuild the immutability trigger so acknowledged false→true still requires every
+-- column — including the new structured/hash fields — to be bitwise identical.
+CREATE OR REPLACE FUNCTION audit_log_immutable()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND OLD.acknowledged = false
+    AND NEW.acknowledged = true
+    AND OLD.id                = NEW.id
+    AND OLD.timestamp         = NEW.timestamp
+    AND OLD.event_type        = NEW.event_type
+    AND OLD.source_layer      = NEW.source_layer
+    AND OLD.source_id         = NEW.source_id
+    AND OLD.payload           = NEW.payload
+    AND (OLD.conversation_id  IS NOT DISTINCT FROM NEW.conversation_id)
+    AND (OLD.task_id          IS NOT DISTINCT FROM NEW.task_id)
+    AND (OLD.parent_event_id  IS NOT DISTINCT FROM NEW.parent_event_id)
+    AND (OLD.action           IS NOT DISTINCT FROM NEW.action)
+    AND (OLD.outcome          IS NOT DISTINCT FROM NEW.outcome)
+    AND (OLD.target_type      IS NOT DISTINCT FROM NEW.target_type)
+    AND (OLD.target_id        IS NOT DISTINCT FROM NEW.target_id)
+    AND (OLD.initiator_type   IS NOT DISTINCT FROM NEW.initiator_type)
+    AND (OLD.initiator_id     IS NOT DISTINCT FROM NEW.initiator_id)
+    AND (OLD.entry_hash       IS NOT DISTINCT FROM NEW.entry_hash)
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'audit_log is append-only: % operations are not permitted (only acknowledged false→true is allowed)', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Down Migration
+--
+-- NOTE: Recreates the pre-078 trigger body by hand. If a later migration edits
+-- audit_log_immutable (e.g. 080 adds seq) without updating this down path,
+-- rolling back past that later migration first is required — otherwise this
+-- down path silently reintroduces trigger drift.
+-- Indexes are dropped in 081's down path (CREATE INDEX CONCURRENTLY lives there).
+
+ALTER TABLE audit_log
+  DROP COLUMN IF EXISTS entry_hash,
+  DROP COLUMN IF EXISTS initiator_id,
+  DROP COLUMN IF EXISTS initiator_type,
+  DROP COLUMN IF EXISTS target_id,
+  DROP COLUMN IF EXISTS target_type,
+  DROP COLUMN IF EXISTS outcome,
+  DROP COLUMN IF EXISTS action;
+
+-- Restore the pre-078 trigger body (columns above are gone).
+CREATE OR REPLACE FUNCTION audit_log_immutable()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND OLD.acknowledged = false
+    AND NEW.acknowledged = true
+    AND OLD.id                = NEW.id
+    AND OLD.timestamp         = NEW.timestamp
+    AND OLD.event_type        = NEW.event_type
+    AND OLD.source_layer      = NEW.source_layer
+    AND OLD.source_id         = NEW.source_id
+    AND OLD.payload           = NEW.payload
+    AND (OLD.conversation_id  IS NOT DISTINCT FROM NEW.conversation_id)
+    AND (OLD.task_id          IS NOT DISTINCT FROM NEW.task_id)
+    AND (OLD.parent_event_id  IS NOT DISTINCT FROM NEW.parent_event_id)
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'audit_log is append-only: % operations are not permitted (only acknowledged false→true is allowed)', TG_OP;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/db/migrations/079_llm_call_archive.sql
+++ b/src/db/migrations/079_llm_call_archive.sql
@@ -1,0 +1,21 @@
+-- Up Migration
+--
+-- Phase 1 audit log hardening (#1383 / spec 10): full prompt/response archive
+-- for llm.call provenance. Kept separate from audit_log so scans stay fast;
+-- keyed by audit_event_id so the audit row outlives archive retention purges.
+
+CREATE TABLE IF NOT EXISTS llm_call_archive (
+  audit_event_id    UUID PRIMARY KEY REFERENCES audit_log(id),
+  prompt            JSONB NOT NULL,
+  response          JSONB NOT NULL,
+  tool_definitions  JSONB,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_archive_created_at
+  ON llm_call_archive (created_at);
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_llm_call_archive_created_at;
+DROP TABLE IF EXISTS llm_call_archive;

--- a/src/db/migrations/080_audit_log_chain_seq.sql
+++ b/src/db/migrations/080_audit_log_chain_seq.sql
@@ -1,0 +1,139 @@
+-- Up Migration
+--
+-- Decouple hash-chain order from wall-clock timestamp (#1540 review).
+-- `timestamp` stays the factual event time; `seq` is the monotonic chain key.
+--
+-- Temporarily disables the append-only trigger for a one-time backfill of seq
+-- on existing rows (ordered by timestamp, id — the previous verify walk order).
+-- Re-enables the trigger before commit and extends it to treat seq as immutable.
+
+ALTER TABLE audit_log DISABLE TRIGGER audit_log_immutable_trigger;
+
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS seq BIGINT;
+
+-- Backfill in the order the Phase-1 verify tool previously walked. For rows
+-- written under the (now-removed) timestamp-bump logic this matches write order.
+UPDATE audit_log AS a
+SET seq = o.rn
+FROM (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY timestamp ASC, id ASC) AS rn
+  FROM audit_log
+) AS o
+WHERE a.id = o.id
+  AND a.seq IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'S' AND c.relname = 'audit_log_seq_seq' AND n.nspname = 'public'
+  ) THEN
+    CREATE SEQUENCE public.audit_log_seq_seq;
+  END IF;
+END $$;
+
+-- Align the sequence with the highest backfilled seq. On an empty table,
+-- leave the sequence at its default (next nextval → 1): setval(..., 0) fails
+-- with 22003 because ascending sequences have minvalue 1.
+DO $$
+DECLARE
+  max_seq bigint;
+BEGIN
+  SELECT MAX(seq) INTO max_seq FROM audit_log;
+  IF max_seq IS NOT NULL THEN
+    PERFORM setval('public.audit_log_seq_seq', max_seq, true);
+  END IF;
+END $$;
+
+ALTER TABLE audit_log ALTER COLUMN seq SET DEFAULT nextval('public.audit_log_seq_seq');
+ALTER TABLE audit_log ALTER COLUMN seq SET NOT NULL;
+ALTER SEQUENCE public.audit_log_seq_seq OWNED BY audit_log.seq;
+
+-- Unique index on seq is created CONCURRENTLY in 081_audit_log_structured_indexes.js
+-- (cannot run inside this transactional SQL migration). Application writes are still
+-- serialized by the advisory lock; uniqueness is enforced once 081 lands.
+
+-- seq is immutable once written (same rules as every other audit column).
+CREATE OR REPLACE FUNCTION audit_log_immutable()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND OLD.acknowledged = false
+    AND NEW.acknowledged = true
+    AND OLD.id                = NEW.id
+    AND OLD.timestamp         = NEW.timestamp
+    AND OLD.event_type        = NEW.event_type
+    AND OLD.source_layer      = NEW.source_layer
+    AND OLD.source_id         = NEW.source_id
+    AND OLD.payload           = NEW.payload
+    AND (OLD.conversation_id  IS NOT DISTINCT FROM NEW.conversation_id)
+    AND (OLD.task_id          IS NOT DISTINCT FROM NEW.task_id)
+    AND (OLD.parent_event_id  IS NOT DISTINCT FROM NEW.parent_event_id)
+    AND (OLD.action           IS NOT DISTINCT FROM NEW.action)
+    AND (OLD.outcome          IS NOT DISTINCT FROM NEW.outcome)
+    AND (OLD.target_type      IS NOT DISTINCT FROM NEW.target_type)
+    AND (OLD.target_id        IS NOT DISTINCT FROM NEW.target_id)
+    AND (OLD.initiator_type   IS NOT DISTINCT FROM NEW.initiator_type)
+    AND (OLD.initiator_id     IS NOT DISTINCT FROM NEW.initiator_id)
+    AND (OLD.entry_hash       IS NOT DISTINCT FROM NEW.entry_hash)
+    AND (OLD.seq              IS NOT DISTINCT FROM NEW.seq)
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'audit_log is append-only: % operations are not permitted (only acknowledged false→true is allowed)', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE audit_log ENABLE TRIGGER audit_log_immutable_trigger;
+
+-- NOTE on lock window: DISABLE TRIGGER … ENABLE TRIGGER requires ACCESS EXCLUSIVE
+-- for the backfill of an otherwise-immutable table. At current throughput
+-- (~425 events/day) the window is short. Splitting into a noTransaction migration
+-- would leave a partially backfilled seq on failure — worse than a brief exclusive
+-- lock. Do not remove the surrounding transaction.
+
+-- Down Migration
+--
+-- NOTE: This restores the post-078 / pre-080 trigger body (seq absent). If a
+-- later migration edits audit_log_immutable without updating this down path,
+-- rollback will silently reintroduce drift — keep them in sync.
+-- idx_audit_log_seq is dropped in 081's down path.
+
+ALTER TABLE audit_log DISABLE TRIGGER audit_log_immutable_trigger;
+
+ALTER TABLE audit_log DROP COLUMN IF EXISTS seq;
+DROP SEQUENCE IF EXISTS public.audit_log_seq_seq;
+
+CREATE OR REPLACE FUNCTION audit_log_immutable()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND OLD.acknowledged = false
+    AND NEW.acknowledged = true
+    AND OLD.id                = NEW.id
+    AND OLD.timestamp         = NEW.timestamp
+    AND OLD.event_type        = NEW.event_type
+    AND OLD.source_layer      = NEW.source_layer
+    AND OLD.source_id         = NEW.source_id
+    AND OLD.payload           = NEW.payload
+    AND (OLD.conversation_id  IS NOT DISTINCT FROM NEW.conversation_id)
+    AND (OLD.task_id          IS NOT DISTINCT FROM NEW.task_id)
+    AND (OLD.parent_event_id  IS NOT DISTINCT FROM NEW.parent_event_id)
+    AND (OLD.action           IS NOT DISTINCT FROM NEW.action)
+    AND (OLD.outcome          IS NOT DISTINCT FROM NEW.outcome)
+    AND (OLD.target_type      IS NOT DISTINCT FROM NEW.target_type)
+    AND (OLD.target_id        IS NOT DISTINCT FROM NEW.target_id)
+    AND (OLD.initiator_type   IS NOT DISTINCT FROM NEW.initiator_type)
+    AND (OLD.initiator_id     IS NOT DISTINCT FROM NEW.initiator_id)
+    AND (OLD.entry_hash       IS NOT DISTINCT FROM NEW.entry_hash)
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'audit_log is append-only: % operations are not permitted (only acknowledged false→true is allowed)', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE audit_log ENABLE TRIGGER audit_log_immutable_trigger;

--- a/src/db/migrations/081_audit_log_structured_indexes.js
+++ b/src/db/migrations/081_audit_log_structured_indexes.js
@@ -1,0 +1,67 @@
+/**
+ * 081 — Concurrent indexes for Phase 1 audit hardening columns + seq.
+ *
+ * Plain JS (not SQL/TS) on purpose:
+ * - node-pg-migrate wraps `.sql` files in a transaction → forbids
+ *   `CREATE INDEX CONCURRENTLY`
+ * - A `.js` wrapper can call `pgm.noTransaction()` and is loadable via
+ *   dynamic `import()` under both `tsx` (CLI migrate / install.sh / CI) and
+ *   the boot-time programmatic runner — without needing TypeScript compilation
+ *
+ * Migration name recorded in pgmigrations is the basename without extension
+ * (`081_audit_log_structured_indexes`), so renaming from `.ts` → `.js` does
+ * not re-apply on DBs that already ran the TypeScript version.
+ *
+ * Safe against DBs that built these indexes under the original transactional
+ * CREATE INDEX in 078/080 (`IF NOT EXISTS`).
+ */
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+export function up(pgm) {
+  pgm.noTransaction();
+
+  pgm.sql(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_action
+      ON audit_log (action)
+      WHERE action IS NOT NULL
+  `);
+  pgm.sql(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_outcome
+      ON audit_log (outcome)
+      WHERE outcome IS NOT NULL
+  `);
+  pgm.sql(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_target
+      ON audit_log (target_type, target_id)
+      WHERE target_type IS NOT NULL
+  `);
+  pgm.sql(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_initiator
+      ON audit_log (initiator_type, initiator_id)
+      WHERE initiator_type IS NOT NULL
+  `);
+  // task_id already exists (migration 001) but was under-indexed; readers historically
+  // filtered via payload->>'taskId' (idx from 071). Index the column for new rows that
+  // populate it, while keeping the payload expression index for legacy rows.
+  pgm.sql(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_task_id
+      ON audit_log (task_id)
+      WHERE task_id IS NOT NULL
+  `);
+  pgm.sql(`
+    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_log_seq
+      ON audit_log (seq)
+  `);
+}
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+export function down(pgm) {
+  pgm.noTransaction();
+
+  pgm.sql(`DROP INDEX CONCURRENTLY IF EXISTS idx_audit_log_seq`);
+  pgm.sql(`DROP INDEX CONCURRENTLY IF EXISTS idx_audit_task_id`);
+  pgm.sql(`DROP INDEX CONCURRENTLY IF EXISTS idx_audit_initiator`);
+  pgm.sql(`DROP INDEX CONCURRENTLY IF EXISTS idx_audit_target`);
+  pgm.sql(`DROP INDEX CONCURRENTLY IF EXISTS idx_audit_outcome`);
+  pgm.sql(`DROP INDEX CONCURRENTLY IF EXISTS idx_audit_action`);
+}

--- a/src/diagnostics/event-record.ts
+++ b/src/diagnostics/event-record.ts
@@ -1,7 +1,7 @@
 // event-record.ts — shared shape for audit events returned by the diagnostics
 // skills (audit-query, audit-trace). Keeps the structural fields an investigator
-// cites (id, parent_event_id, type) while replacing the raw payload with a
-// bounded, PII-scrubbed summary (see redact.ts).
+// cites (id, parent_event_id, type, action/outcome/target/initiator) while
+// replacing the raw payload with a bounded, PII-scrubbed summary (see redact.ts).
 
 import type { AuditLogRow } from '../audit/audit-log-repo.js';
 import { toLocalIso } from '../time/timestamp.js';
@@ -18,10 +18,20 @@ export interface DiagnosticEventRecord {
   sourceId: string;
   conversationId: string | null;
   parentEventId: string | null;
+  /** Structured action taxonomy verb — null on pre-hardening rows. */
+  action: string | null;
+  /** Structured outcome — null on pre-hardening rows. */
+  outcome: string | null;
+  /** `{ type, id }` when either structured target column is present. */
+  target: { type: string | null; id: string | null } | null;
+  /** `{ type, id }` when either structured initiator column is present. */
+  initiator: { type: string | null; id: string | null } | null;
   payloadSummary: unknown;
 }
 
 export function toEventRecord(row: AuditLogRow, tz?: string): DiagnosticEventRecord {
+  const hasTarget = row.targetType !== null || row.targetId !== null;
+  const hasInitiator = row.initiatorType !== null || row.initiatorId !== null;
   return {
     id: row.id,
     // toLocalIso returns null ONLY when the timestamp is corrupt (non-finite/≤0).
@@ -34,6 +44,10 @@ export function toEventRecord(row: AuditLogRow, tz?: string): DiagnosticEventRec
     sourceId: row.sourceId,
     conversationId: row.conversationId,
     parentEventId: row.parentEventId,
+    action: row.action,
+    outcome: row.outcome,
+    target: hasTarget ? { type: row.targetType, id: row.targetId } : null,
+    initiator: hasInitiator ? { type: row.initiatorType, id: row.initiatorId } : null,
     payloadSummary: summarizePayload(row.payload),
   };
 }

--- a/src/dispatch/outbound-judge.ts
+++ b/src/dispatch/outbound-judge.ts
@@ -211,6 +211,13 @@ export class OutboundLlmJudge implements OutboundJudge {
         promptHash,
         responseHash,
         parentEventId: 'system',
+        archive: {
+          prompt: {
+            system: JUDGE_SYSTEM_PROMPT,
+            user: prompt,
+          },
+          response: { type: 'text', content: responseText },
+        },
       });
       await this.bus.publish('agent', event);
     } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -307,9 +307,13 @@ async function main(): Promise<void> {
   // Uses node-pg-migrate's programmatic runner with the same DATABASE_URL.
   // This is safe for single-process deployments; node-pg-migrate acquires an
   // advisory lock to prevent concurrent migration runs.
+  //
+  // Migrations are mostly plain .sql; rare .js wrappers (e.g. 081) exist when
+  // pgm.noTransaction() is required (CREATE INDEX CONCURRENTLY). The runner
+  // loads every file in the directory — it does not filter by language.
   try {
     // Resolve from the project root (one level up from src/ or dist/) so the
-    // path works both in dev (tsx src/index.ts) and production (node dist/index.js).
+    // path works both in dev (tsx src/index.ts) and production (tsx dist/index.js).
     const migrationsDir = path.resolve(import.meta.dirname, '..', 'src', 'db', 'migrations');
     const applied = await runner({
       databaseUrl: config.databaseUrl,
@@ -359,7 +363,14 @@ async function main(): Promise<void> {
   // 3. Audit logger — must be ready before the bus starts accepting events.
   // The bus's write-ahead hook calls auditLogger.log() synchronously before
   // delivering to any subscriber, so this must exist when the bus is constructed.
-  const auditLogger = new AuditLogger(pool, logger);
+  const llmCallArchiveCfg = yamlConfig.audit?.llmCallArchive;
+  const auditLogger = new AuditLogger(pool, logger, {
+    llmCallArchiveEnabled: llmCallArchiveCfg?.enabled !== false,
+  });
+
+  // 3a. Confirm hash-chain schema + log head (spec 10). Chain state lives in the
+  // DB only — every write re-reads the head under the advisory lock.
+  await auditLogger.seedHashChain();
 
   // 3b. Startup scan — flag any events that were written but never acknowledged.
   // These indicate the process crashed between write-ahead and delivery on a
@@ -1810,6 +1821,7 @@ async function main(): Promise<void> {
   const scoringPass = new AutonomyScoringPass(actionLogRepo, autonomyService, scoringProvider, logger, scoringPassConfig);
   logger.info({ scoringPassConfig }, 'AutonomyScoringPass configured');
 
+  const llmCallArchiveRetentionDays = llmCallArchiveCfg?.hotRetentionDays ?? 90;
   const dreamEngine = new DreamEngine(
     pool,
     bus,
@@ -1819,12 +1831,15 @@ async function main(): Promise<void> {
     memory,
     workingDocsRepo,
     yamlConfig.documentWorkspace?.scratchTtlDays ?? DEFAULT_SCRATCH_DOC_TTL_DAYS,
+    llmCallArchiveRetentionDays,
   );
   logger.info(
     {
       decayConfig,
       scratchTtlDays: yamlConfig.documentWorkspace?.scratchTtlDays ?? DEFAULT_SCRATCH_DOC_TTL_DAYS,
       scratchTtlFromConfig: yamlConfig.documentWorkspace?.scratchTtlDays !== undefined,
+      llmCallArchiveEnabled: llmCallArchiveCfg?.enabled !== false,
+      llmCallArchiveRetentionDays,
     },
     'DreamEngine configured',
   );

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolClient } from 'pg';
+import { purgeExpiredLlmCallArchive } from '../audit/llm-call-archive.js';
 import type { EventBus } from '../bus/bus.js';
 import { createMemoryDecayWarning } from '../bus/events.js';
 import type { MemoryDecayWarningPayload } from '../bus/events.js';
@@ -68,6 +69,7 @@ export class DreamEngine {
   private scoringPassInFlight = false;
   private workingDocsRepo?: WorkingDocsRepo;
   private scratchTtlDays?: number;
+  private llmCallArchiveRetentionDays?: number;
 
   constructor(
     pool: Pool,
@@ -78,6 +80,8 @@ export class DreamEngine {
     workingMemory?: WorkingMemory,
     workingDocsRepo?: WorkingDocsRepo,
     scratchTtlDays?: number,
+    /** When set, purge llm_call_archive rows older than this many days each decay pass. */
+    llmCallArchiveRetentionDays?: number,
   ) {
     this.pool = pool;
     this.bus = bus;
@@ -87,6 +91,7 @@ export class DreamEngine {
     this.workingMemory = workingMemory;
     this.workingDocsRepo = workingDocsRepo;
     this.scratchTtlDays = scratchTtlDays;
+    this.llmCallArchiveRetentionDays = llmCallArchiveRetentionDays;
   }
 
   /**
@@ -224,6 +229,30 @@ export class DreamEngine {
             { err: purgeErr, scratchTtlDays: this.scratchTtlDays },
             'DreamEngine: scratch document purge failed — will retry on next pass. ' +
             'To check backlog: SELECT COUNT(*) FROM working_documents WHERE path LIKE \'/scratch/%\' AND archived_at IS NULL',
+          );
+        }
+      }
+
+      // Bound the plaintext llm_call_archive store (spec 10). Best-effort: a purge
+      // failure must not roll back committed decay state.
+      if (this.llmCallArchiveRetentionDays != null) {
+        try {
+          const purgedArchiveRows = await purgeExpiredLlmCallArchive(
+            this.pool,
+            this.llmCallArchiveRetentionDays,
+            this.logger,
+          );
+          this.logger.info(
+            {
+              purgedArchiveRows,
+              llmCallArchiveRetentionDays: this.llmCallArchiveRetentionDays,
+            },
+            'DreamEngine: llm_call_archive purge complete',
+          );
+        } catch (purgeErr) {
+          this.logger.error(
+            { err: purgeErr, llmCallArchiveRetentionDays: this.llmCallArchiveRetentionDays },
+            'DreamEngine: llm_call_archive purge failed — will retry on next pass',
           );
         }
       }

--- a/src/security/secret-patterns.ts
+++ b/src/security/secret-patterns.ts
@@ -1,0 +1,36 @@
+// secret-patterns.ts — shared credential-shape regexes for redaction / blocking.
+//
+// Single source of truth for patterns that match known secret *formats*
+// (Anthropic/OpenAI keys, AWS access keys, Bearer JWTs, long hex tokens).
+// Callers that need mutable /g regexes should use {@link createSecretPatterns}
+// so concurrent scans do not share lastIndex state.
+//
+// Policy for what to *do* with a match (block vs redact vs skip) stays at the
+// call site — outbound-filter blocks, sanitize/archive redact.
+
+/** Broad catch for 32+ lowercase-hex runs. Over-matches dash-less UUIDs, git
+ *  blob SHAs, and other high-entropy hex the user may legitimately paste —
+ *  accepted for lossy redaction paths; do not "tighten" without an explicit
+ *  allowlist strategy. */
+export const GENERIC_LONG_HEX_PATTERN_SOURCE =
+  '(?<![a-zA-Z0-9])[a-f0-9]{32,}(?![a-zA-Z0-9])';
+
+/** Pattern sources in match-precedence order (more specific first). */
+export const SECRET_PATTERN_SOURCES: readonly string[] = [
+  'sk-ant-[a-zA-Z0-9\\-_]{20,}',
+  'sk-[a-zA-Z0-9]{20,}',
+  'AKIA[0-9A-Z]{16}',
+  'Bearer\\s+[A-Za-z0-9\\-_=]+\\.[A-Za-z0-9\\-_=]+\\.[A-Za-z0-9\\-_.+/=]*',
+  GENERIC_LONG_HEX_PATTERN_SOURCE,
+];
+
+/** Fresh `/g` RegExp instances — safe to reuse within a single synchronous scan. */
+export function createSecretPatterns(options?: {
+  /** When true, omit the broad long-hex catch (capability-token opt-out). */
+  skipGenericLongHex?: boolean;
+}): RegExp[] {
+  const sources = options?.skipGenericLongHex
+    ? SECRET_PATTERN_SOURCES.filter((s) => s !== GENERIC_LONG_HEX_PATTERN_SOURCE)
+    : SECRET_PATTERN_SOURCES;
+  return sources.map((source) => new RegExp(source, 'g'));
+}

--- a/src/skills/infra-llm.ts
+++ b/src/skills/infra-llm.ts
@@ -206,6 +206,12 @@ export class InfraLlmService {
         promptHash,
         responseHash,
         parentEventId: scope.taskEventId ?? 'system',
+        archive: {
+          prompt: image
+            ? { text: prompt, image: { mediaType: image.mediaType, base64: '[omitted from archive — binary]' } }
+            : { text: prompt },
+          response: { type: 'text', content: responseText },
+        },
       });
 
       await this.bus.publish('agent', event);

--- a/src/skills/sanitize.ts
+++ b/src/skills/sanitize.ts
@@ -8,6 +8,7 @@
 // Lesson from Zora: tool outputs without sanitization are a prompt injection vector.
 
 import sanitizeHtml from 'sanitize-html';
+import { createSecretPatterns } from '../security/secret-patterns.js';
 
 export interface SanitizeOptions {
   /** Max output length in characters. Default: Infinity (no truncation). */
@@ -24,29 +25,6 @@ export interface SanitizeOptions {
    *  that must survive to reach the LLM. Default false. */
   skipSecretRedaction?: boolean;
 }
-
-// Heuristic that flags any 32+ char lowercase-hex run as a possible secret. This is the
-// ONLY pattern a skipSecretRedaction skill bypasses: it's a broad, format-agnostic catch
-// that also matches legitimate high-entropy capability tokens (e.g. the secret-capture
-// one-time link, randomBytes(32).toString('hex')). The structured credential patterns
-// below stay active even for opted-out skills, so a real API key / JWT / AWS key is still
-// scrubbed regardless of the flag.
-const GENERIC_LONG_HEX_PATTERN = /(?<![a-zA-Z0-9])[a-f0-9]{32,}(?![a-zA-Z0-9])/g;
-
-// Patterns matching common secret formats — these are redacted from all skill output.
-// Order matters: more specific patterns first to avoid partial matches.
-const SECRET_PATTERNS: RegExp[] = [
-  // Anthropic API keys
-  /sk-ant-[a-zA-Z0-9\-_]{20,}/g,
-  // OpenAI API keys
-  /sk-[a-zA-Z0-9]{20,}/g,
-  // AWS access keys
-  /AKIA[0-9A-Z]{16}/g,
-  // Bearer tokens (JWT or opaque)
-  /Bearer\s+[A-Za-z0-9\-_=]+\.[A-Za-z0-9\-_=]+\.[A-Za-z0-9\-_.+/=]*/g,
-  // Generic long hex tokens (32+ chars) — the only pattern skipSecretRedaction bypasses.
-  GENERIC_LONG_HEX_PATTERN,
-];
 
 // Tags whose content must be stripped entirely (not just the tag delimiters).
 // sanitize-html's nonTextTags option removes these elements AND all their descendants.
@@ -151,19 +129,16 @@ export function sanitizeOutput(
   //   - js/polynomial-redos: no catastrophic backtracking — parser runs in linear time
   text = stripDangerousTags(text);
 
-  // 3. Redact known secret patterns.
+  // 3. Redact known secret patterns (shared with llm_call_archive via secret-patterns.ts).
   // When the caller opts out (skill declares skip_secret_redaction), we skip ONLY the broad
-  // GENERIC_LONG_HEX_PATTERN — the rule that falsely scrubs a capability token in that skill's
+  // long-hex catch — the rule that falsely scrubs a capability token in that skill's
   // output. The structured credential patterns (API keys, JWT/Bearer, AWS) stay active, so an
   // opted-out skill still can't leak a real credential format. Caller-supplied
   // extraRedactPatterns always apply regardless.
-  const builtInPatterns = skipSecretRedaction
-    ? SECRET_PATTERNS.filter(p => p !== GENERIC_LONG_HEX_PATTERN)
-    : SECRET_PATTERNS;
+  // Fresh RegExp instances each call — /g lastIndex must not be shared across concurrent scans.
+  const builtInPatterns = createSecretPatterns({ skipGenericLongHex: skipSecretRedaction });
   const allPatterns = [...builtInPatterns, ...extraRedactPatterns];
   for (const pattern of allPatterns) {
-    // Reset lastIndex for global patterns since we reuse them across calls
-    pattern.lastIndex = 0;
     text = text.replace(pattern, '[REDACTED]');
   }
 

--- a/tests/integration/audit-log-hardening.test.ts
+++ b/tests/integration/audit-log-hardening.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { AuditLogger } from '../../src/audit/logger.js';
+import { AuditLogRepo } from '../../src/audit/audit-log-repo.js';
+import { EventBus } from '../../src/bus/bus.js';
+import {
+  createInboundMessage,
+  createToolResult,
+  createLlmCall,
+} from '../../src/bus/events.js';
+import {
+  GENESIS_HASH,
+  computeEntryHash,
+  toHashTimestamp,
+} from '../../src/audit/hash-chain.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { ActivityLogHandler } from '../../skills/activity-log/handler.js';
+import type { ToolContext } from '../../src/skills/types.js';
+import { requireCuriaTestDatabase } from './require-test-db.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('audit log Phase 1 hardening (#1383)', () => {
+  let pool: pg.Pool;
+  let auditLogger: AuditLogger;
+  let repo: AuditLogRepo;
+  const logger = createSilentLogger();
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    // Destructive suite (DISABLE TRIGGER + UPDATE on append-only audit_log).
+    await requireCuriaTestDatabase(pool);
+    auditLogger = new AuditLogger(pool, logger);
+    await auditLogger.seedHashChain();
+    repo = new AuditLogRepo(pool, logger);
+
+    // Require migrations 078/079/080.
+    const cols = await pool.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'audit_log'
+         AND column_name IN ('action', 'entry_hash', 'seq')`,
+    );
+    if (cols.rows.length < 3) {
+      throw new Error('migrations 078/080 not applied — run pnpm migrate before this suite');
+    }
+    const archive = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables WHERE table_name = 'llm_call_archive'
+       ) AS exists`,
+    );
+    if (!archive.rows[0]?.exists) {
+      throw new Error('migration 079 not applied — run pnpm migrate before this suite');
+    }
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('writes structured columns + entry_hash; verify recomputes; tamper is detected', async () => {
+    const bus = new EventBus(
+      logger,
+      (event) => auditLogger.log(event),
+      (eventId) => auditLogger.markAcknowledged(eventId),
+    );
+
+    const event = createInboundMessage({
+      conversationId: `conv-harden-${Date.now()}`,
+      channelId: 'test-channel',
+      senderId: 'sender-harden',
+      content: 'phase1',
+    });
+    await bus.publish('channel', event);
+
+    const row = await pool.query<{
+      action: string;
+      outcome: string;
+      target_type: string;
+      target_id: string;
+      initiator_type: string;
+      initiator_id: string;
+      entry_hash: string;
+      payload: unknown;
+      source_id: string;
+      conversation_id: string | null;
+      task_id: string | null;
+      parent_event_id: string | null;
+      timestamp: Date;
+      event_type: string;
+      source_layer: string;
+      seq: string;
+    }>(
+      `SELECT action, outcome, target_type, target_id, initiator_type, initiator_id,
+              entry_hash, payload, source_id, conversation_id, task_id, parent_event_id,
+              timestamp, event_type, source_layer, seq::text AS seq
+       FROM audit_log WHERE id = $1`,
+      [event.id],
+    );
+    expect(row.rows).toHaveLength(1);
+    const r = row.rows[0]!;
+    expect(r.action).toBe('receive');
+    expect(r.outcome).toBe('success');
+    expect(r.target_type).toBe('conversation');
+    expect(r.target_id).toBe(event.payload.conversationId);
+    expect(r.initiator_type).toBe('human');
+    expect(r.initiator_id).toBe('sender-harden');
+    expect(r.entry_hash).toMatch(/^[a-f0-9]{64}$/);
+    // timestamp is factual event time — never mutated for chain order
+    expect(r.timestamp.toISOString()).toBe(event.timestamp.toISOString());
+
+    // Predecessor by seq (chain order), not wall-clock timestamp.
+    const prev = await pool.query<{ entry_hash: string | null }>(
+      `SELECT entry_hash FROM audit_log
+       WHERE seq < $1::bigint
+         AND entry_hash IS NOT NULL
+       ORDER BY seq DESC
+       LIMIT 1`,
+      [r.seq],
+    );
+    const previousHash = prev.rows[0]?.entry_hash ?? GENESIS_HASH;
+    const expected = computeEntryHash(
+      {
+        id: event.id,
+        timestamp: toHashTimestamp(r.timestamp),
+        event_type: r.event_type,
+        source_layer: r.source_layer,
+        source_id: r.source_id,
+        payload: r.payload,
+        conversation_id: r.conversation_id,
+        task_id: r.task_id,
+        parent_event_id: r.parent_event_id,
+        action: r.action,
+        outcome: r.outcome,
+        target_type: r.target_type,
+        target_id: r.target_id,
+        initiator_type: r.initiator_type,
+        initiator_id: r.initiator_id,
+      },
+      previousHash,
+    );
+    expect(r.entry_hash).toBe(expected);
+
+    // Tamper detection: flip a column with the immutability trigger briefly
+    // disabled. The DISABLE/UPDATE/ENABLE runs in one transaction so a crash
+    // mid-step rolls back and restores the trigger automatically.
+    {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query('ALTER TABLE audit_log DISABLE TRIGGER audit_log_immutable_trigger');
+        await client.query(
+          `UPDATE audit_log SET action = 'tampered' WHERE id = $1`,
+          [event.id],
+        );
+        await client.query('ALTER TABLE audit_log ENABLE TRIGGER audit_log_immutable_trigger');
+        await client.query('COMMIT');
+      } catch (err) {
+        try {
+          await client.query('ROLLBACK');
+        } catch {
+          // ignore rollback errors — connection may already be aborted
+        }
+        throw err;
+      } finally {
+        client.release();
+      }
+    }
+
+    const tampered = await pool.query<{ action: string; entry_hash: string; payload: unknown }>(
+      `SELECT action, entry_hash, payload, source_id, conversation_id, task_id,
+              parent_event_id, timestamp, event_type, source_layer,
+              outcome, target_type, target_id, initiator_type, initiator_id
+       FROM audit_log WHERE id = $1`,
+      [event.id],
+    );
+    const t = tampered.rows[0]!;
+    expect(t.action).toBe('tampered');
+    const afterTamper = computeEntryHash(
+      {
+        id: event.id,
+        timestamp: toHashTimestamp(r.timestamp),
+        event_type: r.event_type,
+        source_layer: r.source_layer,
+        source_id: r.source_id,
+        payload: t.payload,
+        conversation_id: r.conversation_id,
+        task_id: r.task_id,
+        parent_event_id: r.parent_event_id,
+        action: t.action,
+        outcome: r.outcome,
+        target_type: r.target_type,
+        target_id: r.target_id,
+        initiator_type: r.initiator_type,
+        initiator_id: r.initiator_id,
+      },
+      previousHash,
+    );
+    expect(afterTamper).not.toBe(t.entry_hash);
+
+    // Restore the row so subsequent verify / tests see an intact chain.
+    {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query('ALTER TABLE audit_log DISABLE TRIGGER audit_log_immutable_trigger');
+        await client.query(
+          `UPDATE audit_log SET action = 'receive' WHERE id = $1`,
+          [event.id],
+        );
+        await client.query('ALTER TABLE audit_log ENABLE TRIGGER audit_log_immutable_trigger');
+        await client.query('COMMIT');
+      } catch (err) {
+        try {
+          await client.query('ROLLBACK');
+        } catch {
+          // ignore rollback errors
+        }
+        throw err;
+      } finally {
+        client.release();
+      }
+    }
+  });
+
+  it('writes a redacted llm_call_archive row keyed to the audit event', async () => {
+    const bus = new EventBus(
+      logger,
+      (event) => auditLogger.log(event),
+      (eventId) => auditLogger.markAcknowledged(eventId),
+    );
+
+    const event = createLlmCall({
+      agentId: 'coordinator',
+      conversationId: `conv-archive-${Date.now()}`,
+      requestedModel: 'claude-sonnet-4-6',
+      actualModel: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      estimatedCostUsd: 0,
+      latencyMs: 1,
+      providerRequestId: 'req-archive',
+      promptHash: 'c'.repeat(64),
+      responseHash: 'd'.repeat(64),
+      parentEventId: 'system',
+      archive: {
+        prompt: {
+          messages: [{ role: 'user', content: 'secret sk-ant-abcdefghijklmnopqrstuvwxyz012345' }],
+          api_key: 'should-be-redacted',
+        },
+        response: { type: 'text', content: 'ok' },
+        toolDefinitions: [{ name: 'noop' }],
+      },
+    });
+
+    await bus.publish('agent', event);
+
+    const archive = await pool.query<{
+      prompt: Record<string, unknown>;
+      response: Record<string, unknown>;
+      tool_definitions: unknown;
+    }>(
+      `SELECT prompt, response, tool_definitions FROM llm_call_archive WHERE audit_event_id = $1`,
+      [event.id],
+    );
+    expect(archive.rows).toHaveLength(1);
+    const a = archive.rows[0]!;
+    expect(a.prompt.api_key).toBe('[REDACTED]');
+    const msg = (a.prompt.messages as Array<{ content: string }>)[0]!;
+    expect(msg.content).toContain('[REDACTED]');
+    expect(msg.content).not.toContain('sk-ant-');
+    expect(a.response).toMatchObject({ type: 'text', content: 'ok' });
+  });
+
+  it('activity-log returns structured-column data for new hashed rows', async () => {
+    const bus = new EventBus(
+      logger,
+      (event) => auditLogger.log(event),
+      (eventId) => auditLogger.markAcknowledged(eventId),
+    );
+
+    const since = new Date();
+    const toolEvent = createToolResult({
+      agentId: 'calendar',
+      conversationId: `conv-activity-${Date.now()}`,
+      toolName: 'calendar-respond-to-invite',
+      result: {
+        success: true,
+        data: {
+          response: 'accept',
+          event: { title: 'Board Sync' },
+          releasedHolds: [],
+        },
+      },
+      durationMs: 12,
+      parentEventId: 'task-activity',
+    });
+    await bus.publish('execution', toolEvent);
+
+    const until = new Date(Date.now() + 1000);
+    const handler = new ActivityLogHandler();
+    const result = await handler.execute({
+      input: {
+        since: since.toISOString(),
+        until: until.toISOString(),
+        tool_name: 'calendar-respond-to-invite',
+      },
+      secret: () => { throw new Error('no'); },
+      log: logger,
+      timezone: 'UTC',
+      auditLogRepo: repo,
+    } as unknown as ToolContext);
+
+    expect(result.success).toBe(true);
+    const actions = (result as { success: true; data: { actions: Array<{
+      tool: string;
+      outcome: string;
+      target: string;
+      agent_id: string;
+    }> } }).data.actions;
+
+    const fromColumns = actions.find((a) => a.target.includes('Board Sync'));
+    expect(fromColumns).toMatchObject({
+      tool: 'calendar-respond-to-invite',
+      outcome: 'completed',
+      agent_id: 'calendar',
+    });
+
+    const structured = await repo.findById(toolEvent.id);
+    expect(structured?.action).toBe('execute');
+    expect(structured?.outcome).toBe('success');
+    expect(structured?.targetType).toBe('skill');
+    expect(structured?.targetId).toBe('calendar-respond-to-invite');
+    expect(structured?.initiatorType).toBe('agent');
+    expect(structured?.initiatorId).toBe('calendar');
+    expect(structured?.entryHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/tests/unit/audit/field-extraction.test.ts
+++ b/tests/unit/audit/field-extraction.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  EXTRACTION_FAILED,
+  extractStructuredFields,
+} from '../../../src/audit/field-extraction.js';
+import { createSilentLogger } from '../../../src/logger.js';
+
+const logger = createSilentLogger();
+
+describe('extractStructuredFields', () => {
+  it('maps inbound.message per spec 10', () => {
+    expect(extractStructuredFields(
+      'inbound.message',
+      { conversationId: 'c1', senderId: 's1', channelId: 'email', content: 'hi' },
+      'evt-1',
+      logger,
+    )).toEqual({
+      action: 'receive',
+      outcome: 'success',
+      target_type: 'conversation',
+      target_id: 'c1',
+      initiator_type: 'human',
+      initiator_id: 's1',
+    });
+  });
+
+  it('maps tool.result outcome from result.success', () => {
+    expect(extractStructuredFields(
+      'tool.result',
+      {
+        agentId: 'calendar',
+        conversationId: 'c1',
+        toolName: 'calendar-create',
+        result: { success: false, error: 'nope' },
+        durationMs: 1,
+      },
+      'evt-2',
+      logger,
+    )).toMatchObject({
+      action: 'execute',
+      outcome: 'failure',
+      target_type: 'skill',
+      target_id: 'calendar-create',
+      initiator_type: 'agent',
+      initiator_id: 'calendar',
+    });
+  });
+
+  it('writes EXTRACTION_FAILED sentinel and warns on missing mapped fields', () => {
+    const warn = vi.spyOn(logger, 'warn');
+    const fields = extractStructuredFields(
+      'inbound.message',
+      { channelId: 'email', content: 'hi' }, // missing conversationId + senderId
+      'evt-3',
+      logger,
+    );
+    expect(fields.target_id).toBe(EXTRACTION_FAILED);
+    expect(fields.initiator_id).toBe(EXTRACTION_FAILED);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('leaves structured columns NULL for unmapped event types', () => {
+    const debug = vi.spyOn(logger, 'debug');
+    expect(extractStructuredFields('llm.call', { agentId: 'a' }, 'evt-4', logger)).toEqual({
+      action: null,
+      outcome: null,
+      target_type: null,
+      target_id: null,
+      initiator_type: null,
+      initiator_id: null,
+    });
+    expect(debug).toHaveBeenCalled();
+  });
+
+  it('accepts legacy skillName on tool.result', () => {
+    expect(extractStructuredFields(
+      'skill.result',
+      {
+        agentId: 'a',
+        conversationId: 'c',
+        skillName: 'email-send',
+        result: { success: true, data: {} },
+        durationMs: 1,
+      },
+      'evt-5',
+      logger,
+    ).target_id).toBe('email-send');
+  });
+});

--- a/tests/unit/audit/hash-chain.test.ts
+++ b/tests/unit/audit/hash-chain.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  AUDIT_GENESIS_SEED,
+  GENESIS_HASH,
+  canonicalJson,
+  computeEntryHash,
+} from '../../../src/audit/hash-chain.js';
+
+describe('hash-chain', () => {
+  it('genesis hash is SHA-256 of the fixed seed', () => {
+    expect(GENESIS_HASH).toBe(
+      createHash('sha256').update(AUDIT_GENESIS_SEED).digest('hex'),
+    );
+  });
+
+  it('canonicalJson sorts object keys and omits whitespace', () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: 3 } })).toBe(
+      '{"a":{"c":3,"d":2},"b":1}',
+    );
+  });
+
+  it('canonicalJson round-trips Date to the same ISO string JSONB will store', () => {
+    const ts = new Date('2026-04-10T08:30:00.000Z');
+    // Live Date objects must hash identically to the ISO string that ends up
+    // in audit_log.payload — otherwise verify recomputes a different hash.
+    expect(canonicalJson({ mergedAt: ts })).toBe(
+      canonicalJson({ mergedAt: '2026-04-10T08:30:00.000Z' }),
+    );
+    expect(canonicalJson({ mergedAt: ts })).toBe(
+      '{"mergedAt":"2026-04-10T08:30:00.000Z"}',
+    );
+  });
+
+  it('computeEntryHash is deterministic and changes when previous hash changes', () => {
+    const fields = {
+      id: '00000000-0000-4000-8000-000000000001',
+      timestamp: '2026-07-24T12:00:00.000Z',
+      event_type: 'inbound.message',
+      source_layer: 'channel',
+      source_id: 'email',
+      payload: { conversationId: 'c1', content: 'hi' },
+      conversation_id: 'c1',
+      task_id: null,
+      parent_event_id: null,
+      action: 'receive',
+      outcome: 'success',
+      target_type: 'conversation',
+      target_id: 'c1',
+      initiator_type: 'human',
+      initiator_id: 'u1',
+    };
+
+    const h1 = computeEntryHash(fields, GENESIS_HASH);
+    const h2 = computeEntryHash(fields, GENESIS_HASH);
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[a-f0-9]{64}$/);
+
+    const h3 = computeEntryHash(fields, h1);
+    expect(h3).not.toBe(h1);
+  });
+});

--- a/tests/unit/audit/legacy-tool-events.test.ts
+++ b/tests/unit/audit/legacy-tool-events.test.ts
@@ -62,4 +62,18 @@ describe('readAuditToolName', () => {
   it('returns undefined when neither is present', () => {
     expect(readAuditToolName({})).toBeUndefined();
   });
+
+  it('prefers structured target_id when target_type is skill', () => {
+    expect(readAuditToolName(
+      { toolName: 'payload-name' },
+      { targetType: 'skill', targetId: 'column-name' },
+    )).toBe('column-name');
+  });
+
+  it('ignores EXTRACTION_FAILED sentinel and falls back to payload', () => {
+    expect(readAuditToolName(
+      { toolName: 'email-send' },
+      { targetType: 'skill', targetId: '[EXTRACTION_FAILED]' },
+    )).toBe('email-send');
+  });
 });

--- a/tests/unit/audit/llm-call-archive.test.ts
+++ b/tests/unit/audit/llm-call-archive.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { redactArchiveContent } from '../../../src/audit/llm-call-archive.js';
+
+describe('redactArchiveContent', () => {
+  it('redacts sensitive keys and secret-shaped strings', () => {
+    const redacted = redactArchiveContent({
+      messages: [
+        { role: 'user', content: 'my key is sk-ant-abcdefghijklmnopqrstuvwxyz012345' },
+      ],
+      api_key: 'should-not-appear',
+      nested: { token: 'secret-token-value' },
+    }) as Record<string, unknown>;
+
+    expect(redacted.api_key).toBe('[REDACTED]');
+    expect((redacted.nested as Record<string, unknown>).token).toBe('[REDACTED]');
+    const content = ((redacted.messages as Array<{ content: string }>)[0]!).content;
+    expect(content).toContain('[REDACTED]');
+    expect(content).not.toContain('sk-ant-');
+  });
+
+  it('throws on non-plain objects rather than writing them', () => {
+    expect(() => redactArchiveContent({ buf: Buffer.from('x') })).toThrow(/non-plain/);
+  });
+});

--- a/tests/unit/audit/logger-db-unavailable.test.ts
+++ b/tests/unit/audit/logger-db-unavailable.test.ts
@@ -8,8 +8,10 @@ import { isDbUnavailableError } from '../../../src/db/resilience.js';
 describe('AuditLogger — database unavailable (#1381)', () => {
   it('fails fast on log() with classified DB outage (critical path)', async () => {
     const dbErr = Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+    // Phase 1 hash-chain writes go through pool.connect() → transaction, not pool.query.
     const pool = {
-      query: vi.fn().mockRejectedValue(dbErr),
+      query: vi.fn(),
+      connect: vi.fn().mockRejectedValue(dbErr),
     } as unknown as DbPool;
 
     const logger = new AuditLogger(pool, createLogger('error'));
@@ -27,7 +29,8 @@ describe('AuditLogger — database unavailable (#1381)', () => {
       expect((err as { agentError?: { type: string } }).agentError?.type).toBe('DATABASE_UNAVAILABLE');
       return true;
     });
-    expect(pool.query).toHaveBeenCalledTimes(1);
+    expect(pool.connect).toHaveBeenCalledTimes(1);
+    expect(pool.query).not.toHaveBeenCalled();
   });
 
   it('retries markAcknowledged on transient DB blip (non-critical path)', async () => {

--- a/tests/unit/audit/logger.test.ts
+++ b/tests/unit/audit/logger.test.ts
@@ -1,18 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AuditLogger } from '../../../src/audit/logger.js';
 import { createSilentLogger } from '../../../src/logger.js';
-import { createInboundMessage } from '../../../src/bus/events.js';
-import type { DbPool } from '../../../src/db/connection.js';
+import { createInboundMessage, createLlmCall } from '../../../src/bus/events.js';
+import { GENESIS_HASH, computeEntryHash, toHashTimestamp } from '../../../src/audit/hash-chain.js';
+import type { Pool } from 'pg';
 
 // Minimal mock pool that captures what gets written to the DB.
 function makeMockPool() {
   const written: unknown[] = [];
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
   const pool = {
-    query: vi.fn(async (_sql: string, params?: unknown[]) => {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      // Hash-chain seed SELECT
+      if (sql.includes('SELECT entry_hash FROM audit_log')) {
+        return { rows: [], rowCount: 0 };
+      }
       if (params) written.push(...params);
       return { rows: [], rowCount: 1 };
     }),
+    connect: vi.fn(async () => {
+      const client = {
+        query: vi.fn(async (sql: string, params?: unknown[]) => {
+          queries.push({ sql, params });
+          if (params) written.push(...params);
+          return { rows: [], rowCount: 1 };
+        }),
+        release: vi.fn(),
+      };
+      return client;
+    }),
     written,
+    queries,
   };
   return pool;
 }
@@ -21,9 +40,10 @@ describe('AuditLogger.log — null byte sanitization', () => {
   let pool: ReturnType<typeof makeMockPool>;
   let logger: AuditLogger;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     pool = makeMockPool();
-    logger = new AuditLogger(pool as unknown as DbPool, createSilentLogger());
+    logger = new AuditLogger(pool as unknown as Pool, createSilentLogger());
+    await logger.seedHashChain();
   });
 
   it('strips null bytes from a string field in the payload', async () => {
@@ -37,7 +57,7 @@ describe('AuditLogger.log — null byte sanitization', () => {
 
     await logger.log(event);
 
-    // The $6 parameter is the JSON.stringify'd payload written to audit_log.payload
+    // The payload parameter is the JSON.stringify'd payload written to audit_log.payload
     const serialized = pool.written.find(
       (p) => typeof p === 'string' && p.includes('before') && p.includes('after'),
     ) as string;
@@ -132,5 +152,173 @@ describe('AuditLogger.log — null byte sanitization', () => {
     const parsed = JSON.parse(payloadParam);
     // Must serialize as ISO string, not {}
     expect(parsed.mergedAt).toBe('2026-04-10T08:30:00.000Z');
+  });
+});
+
+describe('AuditLogger.log — structured columns + hash chain', () => {
+  let pool: ReturnType<typeof makeMockPool>;
+  let logger: AuditLogger;
+
+  beforeEach(async () => {
+    pool = makeMockPool();
+    logger = new AuditLogger(pool as unknown as Pool, createSilentLogger());
+    await logger.seedHashChain();
+  });
+
+  it('populates structured columns for inbound.message and chains from genesis', async () => {
+    const event = createInboundMessage({
+      conversationId: 'conv-hash',
+      channelId: 'email',
+      senderId: 'ceo@example.com',
+      content: 'hello',
+    });
+
+    await logger.log(event);
+
+    const insert = pool.queries.find((q) => q.sql.includes('INSERT INTO audit_log'));
+    expect(insert).toBeDefined();
+    const params = insert!.params!;
+    // Positional: action, outcome, target_type, target_id, initiator_type, initiator_id, entry_hash
+    // are the last 7 params ($10..$16); $2 is event.timestamp (verbatim — never bumped)
+    expect(params[1]).toBe(event.timestamp);
+    expect(params[9]).toBe('receive');
+    expect(params[10]).toBe('success');
+    expect(params[11]).toBe('conversation');
+    expect(params[12]).toBe('conv-hash');
+    expect(params[13]).toBe('human');
+    expect(params[14]).toBe('ceo@example.com');
+
+    const entryHash = params[15] as string;
+    expect(entryHash).toMatch(/^[a-f0-9]{64}$/);
+
+    const expected = computeEntryHash(
+      {
+        id: event.id,
+        timestamp: toHashTimestamp(event.timestamp),
+        event_type: event.type,
+        source_layer: event.sourceLayer,
+        source_id: 'email',
+        payload: event.payload,
+        conversation_id: 'conv-hash',
+        task_id: null,
+        parent_event_id: null,
+        action: 'receive',
+        outcome: 'success',
+        target_type: 'conversation',
+        target_id: 'conv-hash',
+        initiator_type: 'human',
+        initiator_id: 'ceo@example.com',
+      },
+      GENESIS_HASH,
+    );
+    expect(entryHash).toBe(expected);
+  });
+
+  it('writes llm_call_archive in a transaction when event.archive is set', async () => {
+    const event = createLlmCall({
+      agentId: 'coordinator',
+      conversationId: 'conv-llm',
+      requestedModel: 'claude-sonnet-4-6',
+      actualModel: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      estimatedCostUsd: 0.001,
+      latencyMs: 100,
+      providerRequestId: 'req-1',
+      promptHash: 'a'.repeat(64),
+      responseHash: 'b'.repeat(64),
+      parentEventId: 'task-1',
+      archive: {
+        prompt: { messages: [{ role: 'user', content: 'hi' }] },
+        response: { type: 'text', content: 'hello' },
+        toolDefinitions: [],
+      },
+    });
+
+    await logger.log(event);
+
+    expect(pool.connect).toHaveBeenCalled();
+    const archiveInsert = pool.queries.find((q) => q.sql.includes('INSERT INTO llm_call_archive'));
+    expect(archiveInsert).toBeDefined();
+    // archive must not leak into audit_log.payload
+    const auditInsert = pool.queries.find((q) => q.sql.includes('INSERT INTO audit_log'));
+    const payloadJson = auditInsert!.params![5] as string;
+    expect(payloadJson).not.toContain('"archive"');
+    expect(payloadJson).not.toContain('hello');
+  });
+
+  it('skips llm_call_archive when llmCallArchiveEnabled is false', async () => {
+    logger = new AuditLogger(pool as unknown as Pool, createSilentLogger(), {
+      llmCallArchiveEnabled: false,
+    });
+    const event = createLlmCall({
+      agentId: 'coordinator',
+      conversationId: 'conv-llm-off',
+      requestedModel: 'claude-sonnet-4-6',
+      actualModel: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      estimatedCostUsd: 0,
+      latencyMs: 1,
+      providerRequestId: 'req-off',
+      promptHash: 'a'.repeat(64),
+      responseHash: 'b'.repeat(64),
+      parentEventId: 'task-off',
+      archive: {
+        prompt: { messages: [{ role: 'user', content: 'secret' }] },
+        response: { type: 'text', content: 'x' },
+      },
+    });
+
+    await logger.log(event);
+
+    const archiveInsert = pool.queries.find((q) => q.sql.includes('INSERT INTO llm_call_archive'));
+    expect(archiveInsert).toBeUndefined();
+    expect(pool.queries.some((q) => q.sql.includes('INSERT INTO audit_log'))).toBe(true);
+  });
+
+  it('rejects nested log() inside the audit write transaction', async () => {
+    const nestedPool = makeMockPool();
+    const nestedLogger = new AuditLogger(nestedPool as unknown as Pool, createSilentLogger());
+    // Make the head SELECT invoke a nested log — simulates publishing a bus event
+    // from inside the write path (deadlock landmine).
+    nestedPool.connect.mockImplementation(async () => {
+      const client = {
+        query: vi.fn(async (sql: string, params?: unknown[]) => {
+          nestedPool.queries.push({ sql, params });
+          if (sql.includes('pg_advisory_xact_lock') || sql.includes('BEGIN') || sql.includes('ROLLBACK')) {
+            return { rows: [], rowCount: 0 };
+          }
+          if (sql.includes('ORDER BY seq DESC')) {
+            await nestedLogger.log(createInboundMessage({
+              conversationId: 'nested',
+              channelId: 'test',
+              senderId: 'x',
+              content: 'should-fail',
+            }));
+            return { rows: [], rowCount: 0 };
+          }
+          if (params) nestedPool.written.push(...params);
+          return { rows: [], rowCount: 1 };
+        }),
+        release: vi.fn(),
+      };
+      return client;
+    });
+
+    await expect(
+      nestedLogger.log(createInboundMessage({
+        conversationId: 'outer',
+        channelId: 'test',
+        senderId: 'x',
+        content: 'outer',
+      })),
+    ).rejects.toThrow(/nested AuditLogger\.log/);
   });
 });


### PR DESCRIPTION
## Summary

Implements **spec 10 Phase 1** audit log hardening ([#1383](https://github.com/josephfung/curia/issues/1383)). Treated carefully as audit/security surface: append-only trigger extended, extraction failures use the `[EXTRACTION_FAILED]` sentinel (never NULL for mapped fields), archive redaction fails closed (skip archive, never write unredacted), and hash-chain writes are advisory-locked so concurrent writers cannot fork the chain.

Addresses the [design review on this PR](https://github.com/josephfung/curia/pull/1540#issuecomment-5075104560): monotonic `seq` for chain order (no timestamp mutation), honesty-scoped Phase 1 integrity claims, archive kill-switch + TTL, typed `event.archive`, shared redaction patterns, nested-publish deadlock assertion.

Closes #1383

### Part A — foundation
- Migrations `078` (structured columns + `entry_hash`), `079` (`llm_call_archive`), `080` (monotonic `seq` + trigger immutability)
- `AuditLogger` field extraction per spec 10 mapping; unmapped types leave columns NULL + debug log
- SHA-256 hash chain with public genesis; head/verify ordered by `seq`; `timestamp` is factual `event.timestamp` verbatim
- `pg_advisory_xact_lock` + re-read head under lock (no in-memory chain cache); nested `log()` fails loudly
- Typed non-persisted `archive` on `llm.call` (not WeakMap); redacted archive write atomic with audit row
- Config kill-switch + hot TTL: `audit.llmCallArchive.{enabled,hotRetentionDays}`; DreamEngine purges expired rows
- Shared `src/security/secret-patterns.ts` used by sanitize + archive redaction
- `pnpm audit:verify` walks hashed rows by `seq`, skips unhashed/pre-hardening rows

### Part B — consumer adoption
- `AuditLogRepo` exposes new columns + filters; `task_id` column preferred with payload fallback
- `activity-log`, diagnostics `audit-query`/`audit-trace` (+ `event-record`), `trust-gate`, antfarm interpreter adopt columns with payload fallback
- `readAuditToolName` prefers `target_id` when `target_type === 'skill'`
- `agents/diagnostics.yaml` prompt + version bump; coordinator unchanged

### Honesty of guarantee (Phase 1)
- Detects accidental corruption and naive tampering only
- HMAC-SHA256 (vault/KMS key) + external head-hash anchoring filed as next phase — not built here
- Spec 10 Tamper Evidence + standards table scoped accordingly

### Docs
- Spec 10 updated (seq, serialization ceiling, archive retention/gate, encryption-at-rest follow-up)
- `docs/dev/setup.md` + CHANGELOG

### Test plan
- [x] Unit: hash-chain, field-extraction, archive redaction, logger (verbatim timestamp, archive kill-switch, nested-log assertion)
- [x] Integration: structured columns + archive write + tamper detection + activity-log column path
- [x] `pnpm audit:verify` intact after suite (`ORDER BY seq`)
- [x] `pnpm run typecheck`

