### PR TITLE
chore(ci): cancel superseded docker-publish runs via concurrency group

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,21 @@ on:
 permissions:
   contents: read
 
+# Only the newest run per ref needs to publish. A rapid batch of main merges
+# (e.g. several back-to-back dependency bumps) each retag `edge`, so keeping
+# every superseded ~10min build running is pure waste — cancel the in-flight
+# one when a newer commit for the same ref arrives.
+#
+# Keying on `github.ref` (not just the workflow name) keeps the trigger types
+# independent: `push` to main collapses into one group (refs/heads/main) so
+# older edge builds get cancelled, while each `release` sits in its own
+# per-tag group (refs/tags/vX.Y.Z) and is never cancelled by another release
+# or by a main push. `edge` is a mutable last-write-wins tag, so cancelling a
+# partial push just leaves the previous `edge` in place until the winner lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
 


### PR DESCRIPTION
## Summary

The `docker-publish` workflow takes ~10 minutes per run. When several PRs merge to `main` in quick succession (e.g. a batch of dependency/security bumps), each merge kicks off a full build that retags the mutable `edge` image. Only the last one matters, so the earlier builds are pure wasted CI time.

This adds a top-level `concurrency` group so a newer commit for the same ref cancels the in-flight build.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Why key on `github.ref`

Keying on `github.ref` (not just the workflow name) keeps the three trigger types independent:

- **`push` to main** → all rapid main merges share the group (`refs/heads/main`) → older edge builds get cancelled, only the newest publishes.
- **`release: published`** → each release gets its own per-tag group (`refs/tags/vX.Y.Z`) → releases never cancel each other or get cancelled by a main push.
- **`workflow_dispatch` republish** → keyed to its dispatch ref, so it won't clobber an unrelated in-flight run.

## Safety

`cancel-in-progress` can interrupt a build mid-push, but the only tag main pushes write is `edge`, which is mutable and last-write-wins. A cancelled partial push just leaves the previous `edge` in place until the winning run completes. Immutable semver tags come only from `release` events, which sit in their own per-tag group and are never cancelled.

CI-only change; no CHANGELOG entry (no user-facing behavior change).