### PR TITLE
feat(console): operator config-refinement settings pages (#1376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Settings refinement** — Assistant, Posture, and Memory pages replace the Workspace stub. (#1376)
+- **`GET /api/memory/retention`** — read-only boot-time KG/memory retention policy. (#1376)
 - **Audit log Phase 1** — structured columns, `seq`-ordered hash chain, `llm_call_archive` (kill-switch + TTL), `pnpm audit:verify`. (#1383)
 - **DB outage resilience** — `DATABASE_UNAVAILABLE` errors, pool timeouts, skill retry, CEO alert after 5 min. (#1381)
 - **Operator home** — console `/` shows health, attention and activity cards plus a chat CTA. (#1375)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Settings refinement** — Assistant, Posture, and Memory pages replace the Workspace stub. (#1376)
+- **Settings refinement** — Personality, Ghostwriting, Posture, Autonomy, Memory, and System pages replace the Workspace stub. (#1376)
 - **`GET /api/memory/retention`** — read-only boot-time KG/memory retention policy. (#1376)
+- **`GET /api/system`** — read-only version, runtime, timezone, and tier→model config for the System page. (#1376)
 - **Audit log Phase 1** — structured columns, `seq`-ordered hash chain, `llm_call_archive` (kill-switch + TTL), `pnpm audit:verify`. (#1383)
 - **DB outage resilience** — `DATABASE_UNAVAILABLE` errors, pool timeouts, skill retry, CEO alert after 5 min. (#1381)
 - **Operator home** — console `/` shows health, attention and activity cards plus a chat CTA. (#1375)

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -37,7 +37,7 @@ const ROUTES: Record<string, string> = {
   agents:   '/agents',
   channels:   '/channels',
   'mcp-skills': '/mcp-skills',
-  settings:   '/settings/workspace',
+  settings:   '/settings',
 };
 
 function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (t: Theme) => void }) {

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -81,6 +81,10 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
     activeView === 'settings' || activeView === 'tools' || activeView === 'agents' || activeView === 'channels' || activeView === 'mcp-skills',
   );
   const [principalName, setPrincipalName] = useState<string | null>(null);
+  // Real Curia release version from GET /api/system. The build-time __APP_VERSION__
+  // is the console package's own 0.0.x and does not track the app release; we only
+  // fall back to it if the fetch fails.
+  const [version, setVersion] = useState<string | null>(null);
   const { setOpen } = useMobileMenu();
   const navigate = useNavigate();
 
@@ -99,6 +103,25 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
         if (err instanceof DOMException && err.name === 'AbortError') return;
         // Non-fatal: sidebar degrades to placeholders, but log so the cause is visible.
         console.error('[Sidebar] Failed to load principal contact:', err);
+      });
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    apiFetch('/api/system', { signal: controller.signal })
+      .then(r => {
+        if (!r.ok) throw new Error(`/api/system returned ${r.status}`);
+        return r.json();
+      })
+      .then((data: { system?: { version?: string } }) => {
+        if (typeof data.system?.version === 'string') setVersion(data.system.version);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        // Non-fatal: fall back to the build-time console version so the footer isn't blank.
+        console.error('[Sidebar] Failed to load system version:', err);
+        setVersion(__APP_VERSION__);
       });
     return () => controller.abort();
   }, []);
@@ -232,7 +255,7 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
           <span className="sidebar-user-avatar">{getInitials(principalName)}</span>
           <span className="sidebar-user-meta">
             <span className="sidebar-user-name">{principalName ?? 'Setting up…'}</span>
-            <span className="sidebar-user-org">v{__APP_VERSION__}</span>
+            <span className="sidebar-user-org">{version ? `v${version}` : ''}</span>
           </span>
         </button>
       </div>

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -219,7 +219,7 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
                 onClick={() => go('settings')}
               >
                 <IconSettings />
-                Workspace
+                Assistant
               </button>
             </div>
           )}

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -219,7 +219,7 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
                 onClick={() => go('settings')}
               >
                 <IconSettings />
-                Assistant
+                Personality
               </button>
             </div>
           )}

--- a/apps/console/src/components/settings/ConfigHistory.tsx
+++ b/apps/console/src/components/settings/ConfigHistory.tsx
@@ -1,0 +1,106 @@
+export interface ConfigHistoryEntry {
+  id: number | string;
+  version?: number;
+  changedBy: string;
+  note?: string | null;
+  reason?: string | null;
+  createdAt: string;
+  summary?: string;
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+interface ConfigHistoryProps {
+  entries: ConfigHistoryEntry[];
+  loading?: boolean;
+  error?: string | null;
+  emptyLabel?: string;
+  /** Show at most this many (identity/executive return full history). */
+  limit?: number;
+}
+
+/** Version history list matching the autonomy settings pattern. */
+export function ConfigHistory({
+  entries,
+  loading = false,
+  error = null,
+  emptyLabel = 'No changes yet.',
+  limit = 10,
+}: ConfigHistoryProps) {
+  const shown = entries.slice(0, limit);
+  return (
+    <div className="autonomy-history">
+      <div className="autonomy-history-label">Recent Changes</div>
+      <div className="autonomy-history-list">
+        {shown.length === 0 && !loading && !error && (
+          <p className="settings-muted-hint">{emptyLabel}</p>
+        )}
+        {shown.map(entry => {
+          const note = entry.note ?? entry.reason ?? null;
+          return (
+            <div key={String(entry.id)} className="autonomy-history-entry">
+              <div className="autonomy-history-score">
+                {entry.version != null ? `v${entry.version}` : 'Change'}
+                {entry.summary && (
+                  <span className="settings-history-summary">{entry.summary}</span>
+                )}
+              </div>
+              <div className="autonomy-history-meta">
+                {entry.changedBy} &middot; {timeAgo(entry.createdAt)}
+              </div>
+              {note && <div className="autonomy-history-reason">{note}</div>}
+            </div>
+          );
+        })}
+        {error && <p className="autonomy-error">{error}</p>}
+        {loading && <p className="settings-muted-hint">Loading…</p>}
+      </div>
+    </div>
+  );
+}
+
+interface ChangeNoteFieldProps {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export function ChangeNoteField({ id, value, onChange }: ChangeNoteFieldProps) {
+  return (
+    <div>
+      <label className="autonomy-reason-label" htmlFor={id}>
+        Change note (optional)
+      </label>
+      <textarea
+        id={id}
+        rows={2}
+        placeholder="Reason for change (optional)"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+/** Safe error message extraction — guards against non-JSON error bodies. */
+export async function errorMessage(res: Response): Promise<string> {
+  const ct = res.headers.get('content-type') ?? '';
+  if (ct.includes('application/json')) {
+    try {
+      const d = await res.json() as { error?: string };
+      if (d.error) return d.error;
+    } catch (err) {
+      console.error('[errorMessage] failed to read JSON error body:', err);
+    }
+  }
+  return `HTTP ${res.status}`;
+}

--- a/apps/console/src/components/settings/ConfigHistory.tsx
+++ b/apps/console/src/components/settings/ConfigHistory.tsx
@@ -8,7 +8,7 @@ export interface ConfigHistoryEntry {
   summary?: string;
 }
 
-function timeAgo(iso: string): string {
+export function timeAgo(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();
   const mins = Math.floor(diff / 60_000);
   if (mins < 1) return 'just now';

--- a/apps/console/src/components/settings/PostureFields.tsx
+++ b/apps/console/src/components/settings/PostureFields.tsx
@@ -19,7 +19,11 @@ export function PostureCardGrid({ value, onChange, scopeHint }: PostureCardGridP
           </span>
         )}
       </div>
-      <div className="posture-grid" role="radiogroup" aria-label="Decision posture">
+      <div
+        className="posture-grid"
+        role="radiogroup"
+        aria-label={`Decision posture ${scopeHint ?? ''}`.trim()}
+      >
         {POSTURE_OPTIONS.map(opt => (
           <button
             key={opt.value}

--- a/apps/console/src/components/settings/PostureFields.tsx
+++ b/apps/console/src/components/settings/PostureFields.tsx
@@ -1,0 +1,39 @@
+import { POSTURE_OPTIONS, type DecisionPosture } from '../../pages/wizard-utils';
+
+interface PostureCardGridProps {
+  value: DecisionPosture;
+  onChange: (next: DecisionPosture) => void;
+  /** Optional label suffix shown after "Decision posture". */
+  scopeHint?: string;
+}
+
+/** Shared Conservative / Balanced / Proactive card picker. */
+export function PostureCardGrid({ value, onChange, scopeHint }: PostureCardGridProps) {
+  return (
+    <>
+      <div className="wizard-label">
+        Decision posture{' '}
+        {scopeHint && (
+          <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: 'var(--app-fg-muted)' }}>
+            {scopeHint}
+          </span>
+        )}
+      </div>
+      <div className="posture-grid" role="radiogroup" aria-label="Decision posture">
+        {POSTURE_OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={value === opt.value}
+            className={`posture-card${value === opt.value ? ' selected' : ''}`}
+            onClick={() => onChange(opt.value)}
+          >
+            <div className="posture-card-title">{opt.title}</div>
+            <div className="posture-card-desc">{opt.desc}</div>
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/console/src/components/settings/StringListEditor.tsx
+++ b/apps/console/src/components/settings/StringListEditor.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+
+interface StringListEditorProps {
+  id: string;
+  label: string;
+  items: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  emptyHint?: string;
+}
+
+/**
+ * Ordered string-list editor (add / remove / reorder via delete+re-add).
+ * Used for standing preferences, writing patterns, and vocabulary lists.
+ */
+export function StringListEditor({
+  id,
+  label,
+  items,
+  onChange,
+  placeholder = 'Add an item…',
+  emptyHint,
+}: StringListEditorProps) {
+  const [draft, setDraft] = useState('');
+
+  function addItem() {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    if (items.includes(trimmed)) {
+      setDraft('');
+      return;
+    }
+    onChange([...items, trimmed]);
+    setDraft('');
+  }
+
+  return (
+    <div className="string-list-editor">
+      <label className="wizard-label" htmlFor={`${id}-input`}>{label}</label>
+      {items.length === 0 && emptyHint && (
+        <p className="settings-muted-hint">{emptyHint}</p>
+      )}
+      <ul className="string-list" aria-label={label}>
+        {items.map((item, idx) => (
+          <li key={`${idx}-${item}`} className="string-list-item">
+            <span className="string-list-text">{item}</span>
+            <button
+              type="button"
+              className="btn btn-secondary string-list-remove"
+              aria-label={`Remove: ${item}`}
+              onClick={() => onChange(items.filter((_, i) => i !== idx))}
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="string-list-add-row">
+        <input
+          id={`${id}-input`}
+          type="text"
+          value={draft}
+          placeholder={placeholder}
+          onChange={e => setDraft(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              addItem();
+            }
+          }}
+        />
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={!draft.trim()}
+          onClick={addItem}
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/components/settings/ToneFields.tsx
+++ b/apps/console/src/components/settings/ToneFields.tsx
@@ -1,0 +1,139 @@
+import type { CSSProperties } from 'react';
+import {
+  TONE_OPTIONS,
+  toggleToneSelection,
+  tonePreviewText,
+  verbosityBand,
+  directnessBand,
+  formalityBand,
+} from '../../pages/wizard-utils';
+
+interface TonePillGridProps {
+  selected: string[];
+  onChange: (next: string[]) => void;
+  idPrefix?: string;
+}
+
+/** Shared 1–3 tone pill picker used by the wizard and Assistant settings. */
+export function TonePillGrid({ selected, onChange, idPrefix = 'tone' }: TonePillGridProps) {
+  const atMax = selected.length >= 3;
+  return (
+    <>
+      <div className="wizard-label" id={`${idPrefix}-label`}>
+        Tone{' '}
+        <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>
+          (pick up to 3)
+        </span>
+      </div>
+      <div className="tone-pill-grid" role="group" aria-labelledby={`${idPrefix}-label`}>
+        {TONE_OPTIONS.map(word => {
+          const isSelected = selected.includes(word);
+          const disabled = atMax && !isSelected;
+          return (
+            <button
+              key={word}
+              type="button"
+              className={`tone-pill${isSelected ? ' selected' : ''}`}
+              disabled={disabled}
+              aria-pressed={isSelected}
+              onClick={() => onChange(toggleToneSelection(selected, word))}
+            >
+              {word}
+            </button>
+          );
+        })}
+      </div>
+      <div className="wizard-preview">{tonePreviewText(selected)}</div>
+    </>
+  );
+}
+
+interface ScaleSliderProps {
+  id: string;
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  leftLabel: string;
+  rightLabel: string;
+  sample: string;
+}
+
+function ScaleSlider({ id, label, value, onChange, leftLabel, rightLabel, sample }: ScaleSliderProps) {
+  return (
+    <>
+      <label className="wizard-label" htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        type="range"
+        min={0}
+        max={100}
+        value={value}
+        style={{ width: '100%', marginBottom: 6 } as CSSProperties}
+        onChange={e => onChange(Number(e.target.value))}
+      />
+      <div className="slider-labels"><span>{leftLabel}</span><span>{rightLabel}</span></div>
+      <div className="wizard-sample">{sample}</div>
+    </>
+  );
+}
+
+interface AssistantToneSlidersProps {
+  verbosity: number;
+  directness: number;
+  onVerbosityChange: (v: number) => void;
+  onDirectnessChange: (v: number) => void;
+  idPrefix?: string;
+}
+
+/** Verbosity + directness sliders for assistant (office identity) tone. */
+export function AssistantToneSliders({
+  verbosity,
+  directness,
+  onVerbosityChange,
+  onDirectnessChange,
+  idPrefix = 'asst',
+}: AssistantToneSlidersProps) {
+  return (
+    <>
+      <ScaleSlider
+        id={`${idPrefix}-verbosity`}
+        label="Detail level"
+        value={verbosity}
+        onChange={onVerbosityChange}
+        leftLabel="Brief"
+        rightLabel="Thorough"
+        sample={verbosityBand(verbosity)}
+      />
+      <ScaleSlider
+        id={`${idPrefix}-directness`}
+        label="Directness"
+        value={directness}
+        onChange={onDirectnessChange}
+        leftLabel="Measured"
+        rightLabel="Direct"
+        sample={directnessBand(directness)}
+      />
+    </>
+  );
+}
+
+interface FormalitySliderProps {
+  value: number;
+  onChange: (v: number) => void;
+  id?: string;
+}
+
+/** Formality slider for executive writing voice. */
+export function FormalitySlider({ value, onChange, id = 'formality' }: FormalitySliderProps) {
+  return (
+    <ScaleSlider
+      id={id}
+      label="Formality"
+      value={value}
+      onChange={onChange}
+      leftLabel="Casual"
+      rightLabel="Formal"
+      sample={formalityBand(value)}
+    />
+  );
+}

--- a/apps/console/src/pages/AssistantSettingsPage.tsx
+++ b/apps/console/src/pages/AssistantSettingsPage.tsx
@@ -222,11 +222,17 @@ function AssistantSection() {
     setVoiceSaving(true);
     setVoiceStatus('Saving…');
     try {
+      // Re-fetch so the LLM-learned guide (and any other concurrent edits) are preserved.
+      const freshRes = await apiFetch('/api/executive');
+      if (!freshRes.ok) throw new Error(await errorMessage(freshRes));
+      const freshData = await freshRes.json() as { profile: ExecutiveProfile };
       const writingVoice: WritingVoice = {
-        ...profile.writingVoice,
-        // Preserve the LLM-learned guide — operator UI never edits it.
-        guide: savedVoice.guide,
+        tone: profile.writingVoice.tone,
+        formality: profile.writingVoice.formality,
+        patterns: profile.writingVoice.patterns,
+        vocabulary: profile.writingVoice.vocabulary,
         signOff: profile.writingVoice.signOff.trim(),
+        guide: freshData.profile.writingVoice.guide,
       };
       const res = await apiFetch('/api/executive', {
         method: 'PUT',

--- a/apps/console/src/pages/AssistantSettingsPage.tsx
+++ b/apps/console/src/pages/AssistantSettingsPage.tsx
@@ -312,228 +312,235 @@ function AssistantSection() {
       </div>
 
       <section className="settings-section">
-        <h3 className="settings-section-title">Persona</h3>
-        <div className="wizard-field">
-          <label htmlFor="asst-name">Assistant name *</label>
-          <input
-            id="asst-name"
-            type="text"
-            value={identity.assistant.name}
-            onChange={e => {
-              setIdentity({ ...identity, assistant: { ...identity.assistant, name: e.target.value } });
-              if (nameError) setNameError('');
-            }}
-          />
-          {nameError && <div className="wizard-step1-error">{nameError}</div>}
+        <div className="settings-section-head">
+          <h3 className="settings-section-title">Persona</h3>
         </div>
-        <div className="wizard-field">
-          <label htmlFor="asst-title">Title</label>
-          <input
-            id="asst-title"
-            type="text"
-            value={identity.assistant.title}
-            onChange={e => setIdentity({
-              ...identity,
-              assistant: { ...identity.assistant, title: e.target.value },
-            })}
-          />
-        </div>
-        <div className="wizard-field">
-          <label htmlFor="asst-signature">Email signature</label>
-          <textarea
-            id="asst-signature"
-            value={identity.assistant.emailSignature}
-            onChange={e => setIdentity({
-              ...identity,
-              assistant: { ...identity.assistant, emailSignature: e.target.value },
-            })}
-          />
-        </div>
-
-        <TonePillGrid
-          selected={identity.tone.baseline}
-          onChange={baseline => setIdentity({
-            ...identity,
-            tone: { ...identity.tone, baseline },
-          })}
-          idPrefix="asst-tone"
-        />
-        <AssistantToneSliders
-          verbosity={identity.tone.verbosity}
-          directness={identity.tone.directness}
-          onVerbosityChange={verbosity => setIdentity({
-            ...identity,
-            tone: { ...identity.tone, verbosity },
-          })}
-          onDirectnessChange={directness => setIdentity({
-            ...identity,
-            tone: { ...identity.tone, directness },
-          })}
-          idPrefix="asst"
-        />
-
-        <div className="autonomy-control" style={{ marginTop: 20 }}>
-          <ChangeNoteField id="asst-identity-note" value={identityNote} onChange={setIdentityNote} />
-          <div className="autonomy-save-row">
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={!identityDirty || identitySaving}
-              onClick={() => void saveIdentity()}
-            >
-              Save persona
-            </button>
-            {identityStatus && <span className="autonomy-save-status">{identityStatus}</span>}
+        <div className="settings-section-body">
+          <div className="wizard-field">
+            <label htmlFor="asst-name">Assistant name *</label>
+            <input
+              id="asst-name"
+              type="text"
+              value={identity.assistant.name}
+              onChange={e => {
+                setIdentity({ ...identity, assistant: { ...identity.assistant, name: e.target.value } });
+                if (nameError) setNameError('');
+              }}
+            />
+            {nameError && <div className="wizard-step1-error">{nameError}</div>}
           </div>
+          <div className="wizard-field">
+            <label htmlFor="asst-title">Title</label>
+            <input
+              id="asst-title"
+              type="text"
+              value={identity.assistant.title}
+              onChange={e => setIdentity({
+                ...identity,
+                assistant: { ...identity.assistant, title: e.target.value },
+              })}
+            />
+          </div>
+          <div className="wizard-field">
+            <label htmlFor="asst-signature">Email signature</label>
+            <textarea
+              id="asst-signature"
+              value={identity.assistant.emailSignature}
+              onChange={e => setIdentity({
+                ...identity,
+                assistant: { ...identity.assistant, emailSignature: e.target.value },
+              })}
+            />
+          </div>
+
+          <TonePillGrid
+            selected={identity.tone.baseline}
+            onChange={baseline => setIdentity({
+              ...identity,
+              tone: { ...identity.tone, baseline },
+            })}
+            idPrefix="asst-tone"
+          />
+          <AssistantToneSliders
+            verbosity={identity.tone.verbosity}
+            directness={identity.tone.directness}
+            onVerbosityChange={verbosity => setIdentity({
+              ...identity,
+              tone: { ...identity.tone, verbosity },
+            })}
+            onDirectnessChange={directness => setIdentity({
+              ...identity,
+              tone: { ...identity.tone, directness },
+            })}
+            idPrefix="asst"
+          />
+
+          <div className="autonomy-control">
+            <ChangeNoteField id="asst-identity-note" value={identityNote} onChange={setIdentityNote} />
+            <div className="autonomy-save-row">
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={!identityDirty || identitySaving}
+                onClick={() => void saveIdentity()}
+              >
+                Save persona
+              </button>
+              {identityStatus && <span className="autonomy-save-status">{identityStatus}</span>}
+            </div>
+          </div>
+          <ConfigHistory entries={identityHistory} error={identityHistoryError} />
         </div>
-        <ConfigHistory entries={identityHistory} error={identityHistoryError} />
       </section>
 
       <section className="settings-section">
-        <h3 className="settings-section-title">Writing voice</h3>
-        <p className="settings-page-sub" style={{ marginBottom: 16 }}>
-          How Curia drafts when writing as you (emails, messages). Separate from the assistant&apos;s own tone above.
-        </p>
-        {voiceMeta && (
-          <p className="settings-version-meta">
-            Voice v{voiceMeta.version} · last changed by {voiceMeta.changedBy}
+        <div className="settings-section-head">
+          <h3 className="settings-section-title">Writing voice</h3>
+          <p className="settings-section-sub">
+            How Curia drafts when writing as you (emails, messages). Separate from the assistant&apos;s own tone above.
           </p>
-        )}
-
-        <div className="wizard-label">
-          Tone descriptors{' '}
-          <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>
-            (up to 3, free-form)
-          </span>
+          {voiceMeta && (
+            <p className="settings-version-meta">
+              Voice v{voiceMeta.version} · last changed by {voiceMeta.changedBy}
+            </p>
+          )}
         </div>
-        <div className="tone-pill-grid" style={{ marginBottom: 8 }}>
-          {profile.writingVoice.tone.map(word => (
-            <button
-              key={word}
-              type="button"
-              className="tone-pill selected"
-              onClick={() => setProfile({
-                ...profile,
-                writingVoice: {
-                  ...profile.writingVoice,
-                  tone: profile.writingVoice.tone.filter(t => t !== word),
-                },
-              })}
-              title="Click to remove"
-            >
-              {word} ×
-            </button>
-          ))}
-        </div>
-        {profile.writingVoice.tone.length < 3 && (
-          <div className="string-list-add-row" style={{ marginBottom: 16 }}>
-            <input
-              type="text"
-              value={toneDraft}
-              placeholder="e.g. crisp, warm"
-              onChange={e => setToneDraft(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  addVoiceTone();
-                }
-              }}
-            />
-            <button
-              type="button"
-              className="btn btn-secondary"
-              disabled={!toneDraft.trim()}
-              onClick={addVoiceTone}
-            >
-              Add
-            </button>
+        <div className="settings-section-body">
+          <div className="wizard-label">
+            Tone descriptors{' '}
+            <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>
+              (up to 3, free-form)
+            </span>
           </div>
-        )}
+          <div className="tone-pill-grid" style={{ marginBottom: 8 }}>
+            {profile.writingVoice.tone.map(word => (
+              <button
+                key={word}
+                type="button"
+                className="tone-pill selected"
+                onClick={() => setProfile({
+                  ...profile,
+                  writingVoice: {
+                    ...profile.writingVoice,
+                    tone: profile.writingVoice.tone.filter(t => t !== word),
+                  },
+                })}
+                title="Click to remove"
+              >
+                {word} ×
+              </button>
+            ))}
+          </div>
+          {profile.writingVoice.tone.length < 3 && (
+            <div className="string-list-add-row" style={{ marginBottom: 16 }}>
+              <input
+                type="text"
+                value={toneDraft}
+                placeholder="e.g. crisp, warm"
+                onChange={e => setToneDraft(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addVoiceTone();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                className="btn btn-secondary"
+                disabled={!toneDraft.trim()}
+                onClick={addVoiceTone}
+              >
+                Add
+              </button>
+            </div>
+          )}
 
-        <FormalitySlider
-          value={profile.writingVoice.formality}
-          onChange={formality => setProfile({
-            ...profile,
-            writingVoice: { ...profile.writingVoice, formality },
-          })}
-          id="voice-formality"
-        />
-
-        <StringListEditor
-          id="voice-patterns"
-          label="Style patterns"
-          items={profile.writingVoice.patterns}
-          onChange={patterns => setProfile({
-            ...profile,
-            writingVoice: { ...profile.writingVoice, patterns },
-          })}
-          placeholder="e.g. Concise and to the point"
-          emptyHint="No patterns yet."
-        />
-
-        <StringListEditor
-          id="voice-prefer"
-          label="Prefer these words"
-          items={profile.writingVoice.vocabulary.prefer}
-          onChange={prefer => setProfile({
-            ...profile,
-            writingVoice: {
-              ...profile.writingVoice,
-              vocabulary: { ...profile.writingVoice.vocabulary, prefer },
-            },
-          })}
-          placeholder="Add a preferred word or phrase"
-        />
-
-        <StringListEditor
-          id="voice-avoid"
-          label="Avoid these words"
-          items={profile.writingVoice.vocabulary.avoid}
-          onChange={avoid => setProfile({
-            ...profile,
-            writingVoice: {
-              ...profile.writingVoice,
-              vocabulary: { ...profile.writingVoice.vocabulary, avoid },
-            },
-          })}
-          placeholder="Add a word or phrase to avoid"
-        />
-
-        <div className="wizard-field">
-          <label htmlFor="voice-signoff">Sign-off</label>
-          <input
-            id="voice-signoff"
-            type="text"
-            value={profile.writingVoice.signOff}
-            placeholder="e.g. Best, — Joseph"
-            onChange={e => setProfile({
+          <FormalitySlider
+            value={profile.writingVoice.formality}
+            onChange={formality => setProfile({
               ...profile,
-              writingVoice: { ...profile.writingVoice, signOff: e.target.value },
+              writingVoice: { ...profile.writingVoice, formality },
             })}
+            id="voice-formality"
           />
-        </div>
 
-        {savedVoice.guide && (
-          <p className="settings-muted-hint" style={{ marginTop: 8 }}>
-            A learned voice guide is active (updated by weekly voice-learn). Operator edits here keep it intact.
-          </p>
-        )}
+          <StringListEditor
+            id="voice-patterns"
+            label="Style patterns"
+            items={profile.writingVoice.patterns}
+            onChange={patterns => setProfile({
+              ...profile,
+              writingVoice: { ...profile.writingVoice, patterns },
+            })}
+            placeholder="e.g. Concise and to the point"
+            emptyHint="No patterns yet."
+          />
 
-        <div className="autonomy-control" style={{ marginTop: 20 }}>
-          <ChangeNoteField id="asst-voice-note" value={voiceNote} onChange={setVoiceNote} />
-          <div className="autonomy-save-row">
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={!voiceDirty || voiceSaving}
-              onClick={() => void saveVoice()}
-            >
-              Save writing voice
-            </button>
-            {voiceStatus && <span className="autonomy-save-status">{voiceStatus}</span>}
+          <StringListEditor
+            id="voice-prefer"
+            label="Prefer these words"
+            items={profile.writingVoice.vocabulary.prefer}
+            onChange={prefer => setProfile({
+              ...profile,
+              writingVoice: {
+                ...profile.writingVoice,
+                vocabulary: { ...profile.writingVoice.vocabulary, prefer },
+              },
+            })}
+            placeholder="Add a preferred word or phrase"
+          />
+
+          <StringListEditor
+            id="voice-avoid"
+            label="Avoid these words"
+            items={profile.writingVoice.vocabulary.avoid}
+            onChange={avoid => setProfile({
+              ...profile,
+              writingVoice: {
+                ...profile.writingVoice,
+                vocabulary: { ...profile.writingVoice.vocabulary, avoid },
+              },
+            })}
+            placeholder="Add a word or phrase to avoid"
+          />
+
+          <div className="wizard-field">
+            <label htmlFor="voice-signoff">Sign-off</label>
+            <input
+              id="voice-signoff"
+              type="text"
+              value={profile.writingVoice.signOff}
+              placeholder="e.g. Best, — Joseph"
+              onChange={e => setProfile({
+                ...profile,
+                writingVoice: { ...profile.writingVoice, signOff: e.target.value },
+              })}
+            />
           </div>
+
+          {savedVoice.guide && (
+            <p className="settings-muted-hint" style={{ marginTop: 8 }}>
+              A learned voice guide is active (updated by weekly voice-learn). Operator edits here keep it intact.
+            </p>
+          )}
+
+          <div className="autonomy-control">
+            <ChangeNoteField id="asst-voice-note" value={voiceNote} onChange={setVoiceNote} />
+            <div className="autonomy-save-row">
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={!voiceDirty || voiceSaving}
+                onClick={() => void saveVoice()}
+              >
+                Save writing voice
+              </button>
+              {voiceStatus && <span className="autonomy-save-status">{voiceStatus}</span>}
+            </div>
+          </div>
+          <ConfigHistory entries={voiceHistory} error={voiceHistoryError} />
         </div>
-        <ConfigHistory entries={voiceHistory} error={voiceHistoryError} />
       </section>
     </>
   );

--- a/apps/console/src/pages/AssistantSettingsPage.tsx
+++ b/apps/console/src/pages/AssistantSettingsPage.tsx
@@ -1,0 +1,544 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../api';
+import { SettingsLayout } from './SettingsPage';
+import { TonePillGrid, AssistantToneSliders, FormalitySlider } from '../components/settings/ToneFields';
+import { StringListEditor } from '../components/settings/StringListEditor';
+import {
+  ChangeNoteField,
+  ConfigHistory,
+  errorMessage,
+  type ConfigHistoryEntry,
+} from '../components/settings/ConfigHistory';
+import type { LocalIdentity } from './wizard-utils';
+import { validateNonEmptyName } from './wizard-utils';
+
+interface WritingVoice {
+  tone: string[];
+  formality: number;
+  patterns: string[];
+  vocabulary: { prefer: string[]; avoid: string[] };
+  signOff: string;
+  guide: string;
+}
+
+interface ExecutiveProfile {
+  writingVoice: WritingVoice;
+}
+
+interface VersionMeta {
+  version: number;
+  changedBy: string;
+  createdAt: string;
+  note?: string | null;
+}
+
+function voicesEqual(a: WritingVoice, b: WritingVoice): boolean {
+  // Ignore guide — operator edits must preserve it but it is not in the form.
+  return JSON.stringify({
+    tone: a.tone,
+    formality: a.formality,
+    patterns: a.patterns,
+    vocabulary: a.vocabulary,
+    signOff: a.signOff,
+  }) === JSON.stringify({
+    tone: b.tone,
+    formality: b.formality,
+    patterns: b.patterns,
+    vocabulary: b.vocabulary,
+    signOff: b.signOff,
+  });
+}
+
+function AssistantSection() {
+  const [identity, setIdentity] = useState<LocalIdentity | null>(null);
+  const [savedIdentity, setSavedIdentity] = useState<LocalIdentity | null>(null);
+  const [identityMeta, setIdentityMeta] = useState<VersionMeta | null>(null);
+  const [identityNote, setIdentityNote] = useState('');
+  const [identityStatus, setIdentityStatus] = useState('');
+  const [identitySaving, setIdentitySaving] = useState(false);
+  const [identityHistory, setIdentityHistory] = useState<ConfigHistoryEntry[]>([]);
+  const [identityHistoryError, setIdentityHistoryError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState('');
+
+  const [profile, setProfile] = useState<ExecutiveProfile | null>(null);
+  const [savedVoice, setSavedVoice] = useState<WritingVoice | null>(null);
+  const [voiceMeta, setVoiceMeta] = useState<VersionMeta | null>(null);
+  const [voiceNote, setVoiceNote] = useState('');
+  const [voiceStatus, setVoiceStatus] = useState('');
+  const [voiceSaving, setVoiceSaving] = useState(false);
+  const [voiceHistory, setVoiceHistory] = useState<ConfigHistoryEntry[]>([]);
+  const [voiceHistoryError, setVoiceHistoryError] = useState<string | null>(null);
+  const [toneDraft, setToneDraft] = useState('');
+
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const loadIdentityHistory = useCallback(async () => {
+    setIdentityHistoryError(null);
+    try {
+      const res = await apiFetch('/api/identity/history');
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as {
+        history: Array<{
+          id: number;
+          version: number;
+          changedBy: string;
+          note?: string | null;
+          createdAt: string;
+        }>;
+      };
+      setIdentityHistory(data.history.map(h => ({
+        id: h.id,
+        version: h.version,
+        changedBy: h.changedBy,
+        note: h.note,
+        createdAt: h.createdAt,
+      })));
+      const latest = data.history[0];
+      if (latest) {
+        setIdentityMeta({
+          version: latest.version,
+          changedBy: latest.changedBy,
+          createdAt: latest.createdAt,
+          note: latest.note,
+        });
+      }
+    } catch (err) {
+      setIdentityHistoryError(err instanceof Error ? err.message : 'Failed to load identity history');
+    }
+  }, []);
+
+  const loadVoiceHistory = useCallback(async () => {
+    setVoiceHistoryError(null);
+    try {
+      const res = await apiFetch('/api/executive/history');
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as {
+        history: Array<{
+          id: number;
+          version: number;
+          changedBy: string;
+          note?: string | null;
+          createdAt: string;
+        }>;
+      };
+      setVoiceHistory(data.history.map(h => ({
+        id: h.id,
+        version: h.version,
+        changedBy: h.changedBy,
+        note: h.note,
+        createdAt: h.createdAt,
+      })));
+      const latest = data.history[0];
+      if (latest) {
+        setVoiceMeta({
+          version: latest.version,
+          changedBy: latest.changedBy,
+          createdAt: latest.createdAt,
+          note: latest.note,
+        });
+      }
+    } catch (err) {
+      setVoiceHistoryError(err instanceof Error ? err.message : 'Failed to load writing-voice history');
+    }
+  }, []);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [idRes, exRes] = await Promise.all([
+          apiFetch('/api/identity'),
+          apiFetch('/api/executive'),
+        ]);
+        if (!idRes.ok) throw new Error(await errorMessage(idRes));
+        if (!exRes.ok) throw new Error(await errorMessage(exRes));
+        const idData = await idRes.json() as { identity: LocalIdentity };
+        const exData = await exRes.json() as { profile: ExecutiveProfile };
+        setIdentity(idData.identity);
+        setSavedIdentity(idData.identity);
+        setProfile(exData.profile);
+        setSavedVoice(exData.profile.writingVoice);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load assistant settings');
+      }
+    }
+    void load();
+    void loadIdentityHistory();
+    void loadVoiceHistory();
+  }, [loadIdentityHistory, loadVoiceHistory]);
+
+  async function saveIdentity() {
+    if (!identity || !savedIdentity) return;
+    if (!validateNonEmptyName(identity.assistant.name)) {
+      setNameError('Assistant name is required.');
+      return;
+    }
+    setNameError('');
+    setIdentitySaving(true);
+    setIdentityStatus('Saving…');
+    try {
+      // Re-fetch before write so concurrent Posture edits are not clobbered.
+      const freshRes = await apiFetch('/api/identity');
+      if (!freshRes.ok) throw new Error(await errorMessage(freshRes));
+      const freshData = await freshRes.json() as { identity: LocalIdentity };
+      const payload: LocalIdentity = {
+        ...freshData.identity,
+        assistant: {
+          name: identity.assistant.name.trim(),
+          title: identity.assistant.title.trim(),
+          emailSignature: identity.assistant.emailSignature.trim(),
+        },
+        tone: {
+          baseline: identity.tone.baseline,
+          verbosity: identity.tone.verbosity,
+          directness: identity.tone.directness,
+        },
+      };
+      const res = await apiFetch('/api/identity', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          identity: payload,
+          changedBy: 'api',
+          note: identityNote.trim() || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as { identity: LocalIdentity };
+      setIdentity(data.identity);
+      setSavedIdentity(data.identity);
+      setIdentityNote('');
+      setIdentityStatus('Saved');
+      setTimeout(() => setIdentityStatus(''), 2000);
+      void loadIdentityHistory();
+    } catch (err) {
+      setIdentityStatus(`Error: ${err instanceof Error ? err.message : 'unknown error'}`);
+    } finally {
+      setIdentitySaving(false);
+    }
+  }
+
+  async function saveVoice() {
+    if (!profile || !savedVoice) return;
+    setVoiceSaving(true);
+    setVoiceStatus('Saving…');
+    try {
+      const writingVoice: WritingVoice = {
+        ...profile.writingVoice,
+        // Preserve the LLM-learned guide — operator UI never edits it.
+        guide: savedVoice.guide,
+        signOff: profile.writingVoice.signOff.trim(),
+      };
+      const res = await apiFetch('/api/executive', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: { writingVoice },
+          changedBy: 'api',
+          note: voiceNote.trim() || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as { profile: ExecutiveProfile };
+      setProfile(data.profile);
+      setSavedVoice(data.profile.writingVoice);
+      setVoiceNote('');
+      setVoiceStatus('Saved');
+      setTimeout(() => setVoiceStatus(''), 2000);
+      void loadVoiceHistory();
+    } catch (err) {
+      setVoiceStatus(`Error: ${err instanceof Error ? err.message : 'unknown error'}`);
+    } finally {
+      setVoiceSaving(false);
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="settings-page-header">
+        <p className="autonomy-error">{loadError}</p>
+      </div>
+    );
+  }
+
+  if (!identity || !profile || !savedIdentity || !savedVoice) {
+    return (
+      <div className="settings-page-header">
+        <p className="settings-muted-hint">Loading…</p>
+      </div>
+    );
+  }
+
+  const identityDirty =
+    identity.assistant.name.trim() !== savedIdentity.assistant.name.trim()
+    || identity.assistant.title.trim() !== savedIdentity.assistant.title.trim()
+    || identity.assistant.emailSignature.trim() !== savedIdentity.assistant.emailSignature.trim()
+    || JSON.stringify(identity.tone) !== JSON.stringify(savedIdentity.tone);
+
+  const voiceDirty = !voicesEqual(profile.writingVoice, savedVoice);
+
+  function addVoiceTone() {
+    const trimmed = toneDraft.trim();
+    if (!trimmed) return;
+    const current = profile!.writingVoice.tone;
+    if (current.includes(trimmed) || current.length >= 3) {
+      setToneDraft('');
+      return;
+    }
+    setProfile({
+      ...profile!,
+      writingVoice: { ...profile!.writingVoice, tone: [...current, trimmed] },
+    });
+    setToneDraft('');
+  }
+
+  return (
+    <>
+      <div className="settings-page-header">
+        <h2 className="settings-page-title">Assistant</h2>
+        <p className="settings-page-sub">
+          Name, communication style, and how Curia drafts in your voice.
+        </p>
+        {identityMeta && (
+          <p className="settings-version-meta">
+            Identity v{identityMeta.version} · last changed by {identityMeta.changedBy}
+          </p>
+        )}
+      </div>
+
+      <section className="settings-section">
+        <h3 className="settings-section-title">Persona</h3>
+        <div className="wizard-field">
+          <label htmlFor="asst-name">Assistant name *</label>
+          <input
+            id="asst-name"
+            type="text"
+            value={identity.assistant.name}
+            onChange={e => {
+              setIdentity({ ...identity, assistant: { ...identity.assistant, name: e.target.value } });
+              if (nameError) setNameError('');
+            }}
+          />
+          {nameError && <div className="wizard-step1-error">{nameError}</div>}
+        </div>
+        <div className="wizard-field">
+          <label htmlFor="asst-title">Title</label>
+          <input
+            id="asst-title"
+            type="text"
+            value={identity.assistant.title}
+            onChange={e => setIdentity({
+              ...identity,
+              assistant: { ...identity.assistant, title: e.target.value },
+            })}
+          />
+        </div>
+        <div className="wizard-field">
+          <label htmlFor="asst-signature">Email signature</label>
+          <textarea
+            id="asst-signature"
+            value={identity.assistant.emailSignature}
+            onChange={e => setIdentity({
+              ...identity,
+              assistant: { ...identity.assistant, emailSignature: e.target.value },
+            })}
+          />
+        </div>
+
+        <TonePillGrid
+          selected={identity.tone.baseline}
+          onChange={baseline => setIdentity({
+            ...identity,
+            tone: { ...identity.tone, baseline },
+          })}
+          idPrefix="asst-tone"
+        />
+        <AssistantToneSliders
+          verbosity={identity.tone.verbosity}
+          directness={identity.tone.directness}
+          onVerbosityChange={verbosity => setIdentity({
+            ...identity,
+            tone: { ...identity.tone, verbosity },
+          })}
+          onDirectnessChange={directness => setIdentity({
+            ...identity,
+            tone: { ...identity.tone, directness },
+          })}
+          idPrefix="asst"
+        />
+
+        <div className="autonomy-control" style={{ marginTop: 20 }}>
+          <ChangeNoteField id="asst-identity-note" value={identityNote} onChange={setIdentityNote} />
+          <div className="autonomy-save-row">
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={!identityDirty || identitySaving}
+              onClick={() => void saveIdentity()}
+            >
+              Save persona
+            </button>
+            {identityStatus && <span className="autonomy-save-status">{identityStatus}</span>}
+          </div>
+        </div>
+        <ConfigHistory entries={identityHistory} error={identityHistoryError} />
+      </section>
+
+      <section className="settings-section">
+        <h3 className="settings-section-title">Writing voice</h3>
+        <p className="settings-page-sub" style={{ marginBottom: 16 }}>
+          How Curia drafts when writing as you (emails, messages). Separate from the assistant&apos;s own tone above.
+        </p>
+        {voiceMeta && (
+          <p className="settings-version-meta">
+            Voice v{voiceMeta.version} · last changed by {voiceMeta.changedBy}
+          </p>
+        )}
+
+        <div className="wizard-label">
+          Tone descriptors{' '}
+          <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>
+            (up to 3, free-form)
+          </span>
+        </div>
+        <div className="tone-pill-grid" style={{ marginBottom: 8 }}>
+          {profile.writingVoice.tone.map(word => (
+            <button
+              key={word}
+              type="button"
+              className="tone-pill selected"
+              onClick={() => setProfile({
+                ...profile,
+                writingVoice: {
+                  ...profile.writingVoice,
+                  tone: profile.writingVoice.tone.filter(t => t !== word),
+                },
+              })}
+              title="Click to remove"
+            >
+              {word} ×
+            </button>
+          ))}
+        </div>
+        {profile.writingVoice.tone.length < 3 && (
+          <div className="string-list-add-row" style={{ marginBottom: 16 }}>
+            <input
+              type="text"
+              value={toneDraft}
+              placeholder="e.g. crisp, warm"
+              onChange={e => setToneDraft(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addVoiceTone();
+                }
+              }}
+            />
+            <button
+              type="button"
+              className="btn btn-secondary"
+              disabled={!toneDraft.trim()}
+              onClick={addVoiceTone}
+            >
+              Add
+            </button>
+          </div>
+        )}
+
+        <FormalitySlider
+          value={profile.writingVoice.formality}
+          onChange={formality => setProfile({
+            ...profile,
+            writingVoice: { ...profile.writingVoice, formality },
+          })}
+          id="voice-formality"
+        />
+
+        <StringListEditor
+          id="voice-patterns"
+          label="Style patterns"
+          items={profile.writingVoice.patterns}
+          onChange={patterns => setProfile({
+            ...profile,
+            writingVoice: { ...profile.writingVoice, patterns },
+          })}
+          placeholder="e.g. Concise and to the point"
+          emptyHint="No patterns yet."
+        />
+
+        <StringListEditor
+          id="voice-prefer"
+          label="Prefer these words"
+          items={profile.writingVoice.vocabulary.prefer}
+          onChange={prefer => setProfile({
+            ...profile,
+            writingVoice: {
+              ...profile.writingVoice,
+              vocabulary: { ...profile.writingVoice.vocabulary, prefer },
+            },
+          })}
+          placeholder="Add a preferred word or phrase"
+        />
+
+        <StringListEditor
+          id="voice-avoid"
+          label="Avoid these words"
+          items={profile.writingVoice.vocabulary.avoid}
+          onChange={avoid => setProfile({
+            ...profile,
+            writingVoice: {
+              ...profile.writingVoice,
+              vocabulary: { ...profile.writingVoice.vocabulary, avoid },
+            },
+          })}
+          placeholder="Add a word or phrase to avoid"
+        />
+
+        <div className="wizard-field">
+          <label htmlFor="voice-signoff">Sign-off</label>
+          <input
+            id="voice-signoff"
+            type="text"
+            value={profile.writingVoice.signOff}
+            placeholder="e.g. Best, — Joseph"
+            onChange={e => setProfile({
+              ...profile,
+              writingVoice: { ...profile.writingVoice, signOff: e.target.value },
+            })}
+          />
+        </div>
+
+        {savedVoice.guide && (
+          <p className="settings-muted-hint" style={{ marginTop: 8 }}>
+            A learned voice guide is active (updated by weekly voice-learn). Operator edits here keep it intact.
+          </p>
+        )}
+
+        <div className="autonomy-control" style={{ marginTop: 20 }}>
+          <ChangeNoteField id="asst-voice-note" value={voiceNote} onChange={setVoiceNote} />
+          <div className="autonomy-save-row">
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={!voiceDirty || voiceSaving}
+              onClick={() => void saveVoice()}
+            >
+              Save writing voice
+            </button>
+            {voiceStatus && <span className="autonomy-save-status">{voiceStatus}</span>}
+          </div>
+        </div>
+        <ConfigHistory entries={voiceHistory} error={voiceHistoryError} />
+      </section>
+    </>
+  );
+}
+
+export function AssistantPage() {
+  return (
+    <SettingsLayout activeSection="assistant">
+      <AssistantSection />
+    </SettingsLayout>
+  );
+}
+
+export default AssistantPage;

--- a/apps/console/src/pages/GhostwritingSettingsPage.tsx
+++ b/apps/console/src/pages/GhostwritingSettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '../api';
 import { SettingsLayout } from './SettingsPage';
-import { TonePillGrid, AssistantToneSliders, FormalitySlider } from '../components/settings/ToneFields';
+import { FormalitySlider } from '../components/settings/ToneFields';
 import { StringListEditor } from '../components/settings/StringListEditor';
 import {
   ChangeNoteField,
@@ -9,8 +9,6 @@ import {
   errorMessage,
   type ConfigHistoryEntry,
 } from '../components/settings/ConfigHistory';
-import type { LocalIdentity } from './wizard-utils';
-import { validateNonEmptyName } from './wizard-utils';
 
 interface WritingVoice {
   tone: string[];
@@ -28,8 +26,6 @@ interface ExecutiveProfile {
 interface VersionMeta {
   version: number;
   changedBy: string;
-  createdAt: string;
-  note?: string | null;
 }
 
 function voicesEqual(a: WritingVoice, b: WritingVoice): boolean {
@@ -49,17 +45,9 @@ function voicesEqual(a: WritingVoice, b: WritingVoice): boolean {
   });
 }
 
-function AssistantSection() {
-  const [identity, setIdentity] = useState<LocalIdentity | null>(null);
-  const [savedIdentity, setSavedIdentity] = useState<LocalIdentity | null>(null);
-  const [identityMeta, setIdentityMeta] = useState<VersionMeta | null>(null);
-  const [identityNote, setIdentityNote] = useState('');
-  const [identityStatus, setIdentityStatus] = useState('');
-  const [identitySaving, setIdentitySaving] = useState(false);
-  const [identityHistory, setIdentityHistory] = useState<ConfigHistoryEntry[]>([]);
-  const [identityHistoryError, setIdentityHistoryError] = useState<string | null>(null);
-  const [nameError, setNameError] = useState('');
-
+// Ghostwriting = how Curia drafts when it writes *as the principal* (emails,
+// messages). Distinct from Curia's own personality (/settings/personality).
+function GhostwritingSection() {
   const [profile, setProfile] = useState<ExecutiveProfile | null>(null);
   const [savedVoice, setSavedVoice] = useState<WritingVoice | null>(null);
   const [voiceMeta, setVoiceMeta] = useState<VersionMeta | null>(null);
@@ -69,43 +57,7 @@ function AssistantSection() {
   const [voiceHistory, setVoiceHistory] = useState<ConfigHistoryEntry[]>([]);
   const [voiceHistoryError, setVoiceHistoryError] = useState<string | null>(null);
   const [toneDraft, setToneDraft] = useState('');
-
   const [loadError, setLoadError] = useState<string | null>(null);
-
-  const loadIdentityHistory = useCallback(async () => {
-    setIdentityHistoryError(null);
-    try {
-      const res = await apiFetch('/api/identity/history');
-      if (!res.ok) throw new Error(await errorMessage(res));
-      const data = await res.json() as {
-        history: Array<{
-          id: number;
-          version: number;
-          changedBy: string;
-          note?: string | null;
-          createdAt: string;
-        }>;
-      };
-      setIdentityHistory(data.history.map(h => ({
-        id: h.id,
-        version: h.version,
-        changedBy: h.changedBy,
-        note: h.note,
-        createdAt: h.createdAt,
-      })));
-      const latest = data.history[0];
-      if (latest) {
-        setIdentityMeta({
-          version: latest.version,
-          changedBy: latest.changedBy,
-          createdAt: latest.createdAt,
-          note: latest.note,
-        });
-      }
-    } catch (err) {
-      setIdentityHistoryError(err instanceof Error ? err.message : 'Failed to load identity history');
-    }
-  }, []);
 
   const loadVoiceHistory = useCallback(async () => {
     setVoiceHistoryError(null);
@@ -130,12 +82,7 @@ function AssistantSection() {
       })));
       const latest = data.history[0];
       if (latest) {
-        setVoiceMeta({
-          version: latest.version,
-          changedBy: latest.changedBy,
-          createdAt: latest.createdAt,
-          note: latest.note,
-        });
+        setVoiceMeta({ version: latest.version, changedBy: latest.changedBy });
       }
     } catch (err) {
       setVoiceHistoryError(err instanceof Error ? err.message : 'Failed to load writing-voice history');
@@ -145,77 +92,18 @@ function AssistantSection() {
   useEffect(() => {
     async function load() {
       try {
-        const [idRes, exRes] = await Promise.all([
-          apiFetch('/api/identity'),
-          apiFetch('/api/executive'),
-        ]);
-        if (!idRes.ok) throw new Error(await errorMessage(idRes));
-        if (!exRes.ok) throw new Error(await errorMessage(exRes));
-        const idData = await idRes.json() as { identity: LocalIdentity };
-        const exData = await exRes.json() as { profile: ExecutiveProfile };
-        setIdentity(idData.identity);
-        setSavedIdentity(idData.identity);
-        setProfile(exData.profile);
-        setSavedVoice(exData.profile.writingVoice);
+        const res = await apiFetch('/api/executive');
+        if (!res.ok) throw new Error(await errorMessage(res));
+        const data = await res.json() as { profile: ExecutiveProfile };
+        setProfile(data.profile);
+        setSavedVoice(data.profile.writingVoice);
       } catch (err) {
-        setLoadError(err instanceof Error ? err.message : 'Failed to load assistant settings');
+        setLoadError(err instanceof Error ? err.message : 'Failed to load ghostwriting settings');
       }
     }
     void load();
-    void loadIdentityHistory();
     void loadVoiceHistory();
-  }, [loadIdentityHistory, loadVoiceHistory]);
-
-  async function saveIdentity() {
-    if (!identity || !savedIdentity) return;
-    if (!validateNonEmptyName(identity.assistant.name)) {
-      setNameError('Assistant name is required.');
-      return;
-    }
-    setNameError('');
-    setIdentitySaving(true);
-    setIdentityStatus('Saving…');
-    try {
-      // Re-fetch before write so concurrent Posture edits are not clobbered.
-      const freshRes = await apiFetch('/api/identity');
-      if (!freshRes.ok) throw new Error(await errorMessage(freshRes));
-      const freshData = await freshRes.json() as { identity: LocalIdentity };
-      const payload: LocalIdentity = {
-        ...freshData.identity,
-        assistant: {
-          name: identity.assistant.name.trim(),
-          title: identity.assistant.title.trim(),
-          emailSignature: identity.assistant.emailSignature.trim(),
-        },
-        tone: {
-          baseline: identity.tone.baseline,
-          verbosity: identity.tone.verbosity,
-          directness: identity.tone.directness,
-        },
-      };
-      const res = await apiFetch('/api/identity', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          identity: payload,
-          changedBy: 'api',
-          note: identityNote.trim() || undefined,
-        }),
-      });
-      if (!res.ok) throw new Error(await errorMessage(res));
-      const data = await res.json() as { identity: LocalIdentity };
-      setIdentity(data.identity);
-      setSavedIdentity(data.identity);
-      setIdentityNote('');
-      setIdentityStatus('Saved');
-      setTimeout(() => setIdentityStatus(''), 2000);
-      void loadIdentityHistory();
-    } catch (err) {
-      setIdentityStatus(`Error: ${err instanceof Error ? err.message : 'unknown error'}`);
-    } finally {
-      setIdentitySaving(false);
-    }
-  }
+  }, [loadVoiceHistory]);
 
   async function saveVoice() {
     if (!profile || !savedVoice) return;
@@ -266,19 +154,13 @@ function AssistantSection() {
     );
   }
 
-  if (!identity || !profile || !savedIdentity || !savedVoice) {
+  if (!profile || !savedVoice) {
     return (
       <div className="settings-page-header">
         <p className="settings-muted-hint">Loading…</p>
       </div>
     );
   }
-
-  const identityDirty =
-    identity.assistant.name.trim() !== savedIdentity.assistant.name.trim()
-    || identity.assistant.title.trim() !== savedIdentity.assistant.title.trim()
-    || identity.assistant.emailSignature.trim() !== savedIdentity.assistant.emailSignature.trim()
-    || JSON.stringify(identity.tone) !== JSON.stringify(savedIdentity.tone);
 
   const voiceDirty = !voicesEqual(profile.writingVoice, savedVoice);
 
@@ -300,111 +182,19 @@ function AssistantSection() {
   return (
     <>
       <div className="settings-page-header">
-        <h2 className="settings-page-title">Assistant</h2>
+        <h2 className="settings-page-title">Ghostwriting</h2>
         <p className="settings-page-sub">
-          Name, communication style, and how Curia drafts in your voice.
+          How Curia drafts when it writes as you — emails and messages in your voice.
+          Separate from Curia&apos;s own personality.
         </p>
-        {identityMeta && (
+        {voiceMeta && (
           <p className="settings-version-meta">
-            Identity v{identityMeta.version} · last changed by {identityMeta.changedBy}
+            Voice v{voiceMeta.version} · last changed by {voiceMeta.changedBy}
           </p>
         )}
       </div>
 
       <section className="settings-section">
-        <div className="settings-section-head">
-          <h3 className="settings-section-title">Persona</h3>
-        </div>
-        <div className="settings-section-body">
-          <div className="wizard-field">
-            <label htmlFor="asst-name">Assistant name *</label>
-            <input
-              id="asst-name"
-              type="text"
-              value={identity.assistant.name}
-              onChange={e => {
-                setIdentity({ ...identity, assistant: { ...identity.assistant, name: e.target.value } });
-                if (nameError) setNameError('');
-              }}
-            />
-            {nameError && <div className="wizard-step1-error">{nameError}</div>}
-          </div>
-          <div className="wizard-field">
-            <label htmlFor="asst-title">Title</label>
-            <input
-              id="asst-title"
-              type="text"
-              value={identity.assistant.title}
-              onChange={e => setIdentity({
-                ...identity,
-                assistant: { ...identity.assistant, title: e.target.value },
-              })}
-            />
-          </div>
-          <div className="wizard-field">
-            <label htmlFor="asst-signature">Email signature</label>
-            <textarea
-              id="asst-signature"
-              value={identity.assistant.emailSignature}
-              onChange={e => setIdentity({
-                ...identity,
-                assistant: { ...identity.assistant, emailSignature: e.target.value },
-              })}
-            />
-          </div>
-
-          <TonePillGrid
-            selected={identity.tone.baseline}
-            onChange={baseline => setIdentity({
-              ...identity,
-              tone: { ...identity.tone, baseline },
-            })}
-            idPrefix="asst-tone"
-          />
-          <AssistantToneSliders
-            verbosity={identity.tone.verbosity}
-            directness={identity.tone.directness}
-            onVerbosityChange={verbosity => setIdentity({
-              ...identity,
-              tone: { ...identity.tone, verbosity },
-            })}
-            onDirectnessChange={directness => setIdentity({
-              ...identity,
-              tone: { ...identity.tone, directness },
-            })}
-            idPrefix="asst"
-          />
-
-          <div className="autonomy-control">
-            <ChangeNoteField id="asst-identity-note" value={identityNote} onChange={setIdentityNote} />
-            <div className="autonomy-save-row">
-              <button
-                type="button"
-                className="btn btn-primary"
-                disabled={!identityDirty || identitySaving}
-                onClick={() => void saveIdentity()}
-              >
-                Save persona
-              </button>
-              {identityStatus && <span className="autonomy-save-status">{identityStatus}</span>}
-            </div>
-          </div>
-          <ConfigHistory entries={identityHistory} error={identityHistoryError} />
-        </div>
-      </section>
-
-      <section className="settings-section">
-        <div className="settings-section-head">
-          <h3 className="settings-section-title">Writing voice</h3>
-          <p className="settings-section-sub">
-            How Curia drafts when writing as you (emails, messages). Separate from the assistant&apos;s own tone above.
-          </p>
-          {voiceMeta && (
-            <p className="settings-version-meta">
-              Voice v{voiceMeta.version} · last changed by {voiceMeta.changedBy}
-            </p>
-          )}
-        </div>
         <div className="settings-section-body">
           <div className="wizard-label">
             Tone descriptors{' '}
@@ -511,7 +301,7 @@ function AssistantSection() {
               id="voice-signoff"
               type="text"
               value={profile.writingVoice.signOff}
-              placeholder="e.g. Best, — Joseph"
+              placeholder="e.g. Best, Joseph"
               onChange={e => setProfile({
                 ...profile,
                 writingVoice: { ...profile.writingVoice, signOff: e.target.value },
@@ -546,12 +336,12 @@ function AssistantSection() {
   );
 }
 
-export function AssistantPage() {
+export function GhostwritingPage() {
   return (
-    <SettingsLayout activeSection="assistant">
-      <AssistantSection />
+    <SettingsLayout activeSection="ghostwriting">
+      <GhostwritingSection />
     </SettingsLayout>
   );
 }
 
-export default AssistantPage;
+export default GhostwritingPage;

--- a/apps/console/src/pages/MemorySettingsPage.tsx
+++ b/apps/console/src/pages/MemorySettingsPage.tsx
@@ -70,66 +70,78 @@ function MemorySection() {
       </div>
 
       <section className="settings-section">
-        <h3 className="settings-section-title">Conversation &amp; scratch</h3>
-        <dl className="retention-list">
-          <div className="retention-row">
-            <dt>Conversation turns</dt>
-            <dd>
-              Kept for <strong>{policy.workingMemoryTtlDays} days</strong>, then purged by the
-              nightly dream pass.
-            </dd>
-          </div>
-          <div className="retention-row">
-            <dt>Scratch documents</dt>
-            <dd>
-              Ephemeral scratch docs are archived after{' '}
-              <strong>{policy.scratchTtlDays} days</strong> of inactivity.
-            </dd>
-          </div>
-        </dl>
+        <div className="settings-section-head">
+          <h3 className="settings-section-title">Conversation &amp; scratch</h3>
+        </div>
+        <div className="settings-section-body">
+          <dl className="retention-list">
+            <div className="retention-row">
+              <dt>Conversation turns</dt>
+              <dd>
+                Kept for <strong>{policy.workingMemoryTtlDays} days</strong>, then purged by the
+                nightly dream pass.
+              </dd>
+            </div>
+            <div className="retention-row">
+              <dt>Scratch documents</dt>
+              <dd>
+                Ephemeral scratch docs are archived after{' '}
+                <strong>{policy.scratchTtlDays} days</strong> of inactivity.
+              </dd>
+            </div>
+          </dl>
+        </div>
       </section>
 
       <section className="settings-section">
-        <h3 className="settings-section-title">Fact decay</h3>
-        <dl className="retention-list">
-          <div className="retention-row">
-            <dt>Slow-decay facts</dt>
-            <dd>
-              Confidence halves every <strong>{policy.halfLifeDays.slowDecay} days</strong>
-              {' '}(employer, residence, and similar long-lived facts).
-            </dd>
-          </div>
-          <div className="retention-row">
-            <dt>Fast-decay facts</dt>
-            <dd>
-              Confidence halves every <strong>{policy.halfLifeDays.fastDecay} days</strong>
-              {' '}(preferences and short-lived context).
-            </dd>
-          </div>
-          <div className="retention-row">
-            <dt>Archive threshold</dt>
-            <dd>
-              Facts at or below <strong>{archivePct}% confidence</strong> are soft-deleted
-              (archived) and drop out of queries.
-            </dd>
-          </div>
-          <div className="retention-row">
-            <dt>Decay warnings</dt>
-            <dd>
-              Important nodes about to archive are held back for{' '}
-              <strong>{policy.warnHoldBackDays} days</strong> so you can re-confirm them.
-            </dd>
-          </div>
-        </dl>
+        <div className="settings-section-head">
+          <h3 className="settings-section-title">Fact decay</h3>
+        </div>
+        <div className="settings-section-body">
+          <dl className="retention-list">
+            <div className="retention-row">
+              <dt>Slow-decay facts</dt>
+              <dd>
+                Confidence halves every <strong>{policy.halfLifeDays.slowDecay} days</strong>
+                {' '}(employer, residence, and similar long-lived facts).
+              </dd>
+            </div>
+            <div className="retention-row">
+              <dt>Fast-decay facts</dt>
+              <dd>
+                Confidence halves every <strong>{policy.halfLifeDays.fastDecay} days</strong>
+                {' '}(preferences and short-lived context).
+              </dd>
+            </div>
+            <div className="retention-row">
+              <dt>Archive threshold</dt>
+              <dd>
+                Facts at or below <strong>{archivePct}% confidence</strong> are soft-deleted
+                (archived) and drop out of queries.
+              </dd>
+            </div>
+            <div className="retention-row">
+              <dt>Decay warnings</dt>
+              <dd>
+                Important nodes about to archive are held back for{' '}
+                <strong>{policy.warnHoldBackDays} days</strong> so you can re-confirm them.
+              </dd>
+            </div>
+          </dl>
+        </div>
       </section>
 
       <section className="settings-section">
-        <h3 className="settings-section-title">Review nodes</h3>
-        <p className="settings-page-sub">
-          To review knowledge-graph nodes nearing archival, ask Curia in{' '}
-          <Link to="/chat">Chat</Link>
-          {' '}to run the decay-warnings list (the <code>decay-warnings-list</code> skill).
-        </p>
+        <div className="settings-section-head">
+          <h3 className="settings-section-title">Review nodes</h3>
+        </div>
+        <div className="settings-section-body">
+          <p className="settings-muted-hint" style={{ margin: 0 }}>
+            To review knowledge-graph nodes nearing archival, ask Curia in{' '}
+            <Link to="/chat">Chat</Link>
+            {' '}to run the decay-warnings list (the <code>decay-warnings-list</code> skill).
+          </p>
+        </div>
       </section>
     </>
   );

--- a/apps/console/src/pages/MemorySettingsPage.tsx
+++ b/apps/console/src/pages/MemorySettingsPage.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { apiFetch } from '../api';
+import { SettingsLayout } from './SettingsPage';
+import { errorMessage } from '../components/settings/ConfigHistory';
+
+export interface MemoryRetentionPolicy {
+  workingMemoryTtlDays: number;
+  scratchTtlDays: number;
+  archiveThreshold: number;
+  halfLifeDays: {
+    slowDecay: number;
+    fastDecay: number;
+  };
+  warnHoldBackDays: number;
+  editable: false;
+}
+
+function MemorySection() {
+  const [policy, setPolicy] = useState<MemoryRetentionPolicy | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await apiFetch('/api/memory/retention');
+        if (!res.ok) throw new Error(await errorMessage(res));
+        const data = await res.json() as { retention: MemoryRetentionPolicy };
+        setPolicy(data.retention);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load retention policy');
+      }
+    }
+    void load();
+  }, []);
+
+  if (loadError) {
+    return (
+      <div className="settings-page-header">
+        <p className="autonomy-error">{loadError}</p>
+      </div>
+    );
+  }
+
+  if (!policy) {
+    return (
+      <div className="settings-page-header">
+        <p className="settings-muted-hint">Loading…</p>
+      </div>
+    );
+  }
+
+  const archivePct = Math.round(policy.archiveThreshold * 1000) / 10;
+
+  return (
+    <>
+      <div className="settings-page-header">
+        <h2 className="settings-page-title">Memory</h2>
+        <p className="settings-page-sub">
+          How long conversation turns and knowledge-graph facts are kept before decay or archival.
+        </p>
+      </div>
+
+      <div className="settings-callout settings-callout-readonly">
+        <p>
+          <strong>Read-only — configured at deploy time.</strong> These values are loaded from
+          server config at boot. Changing them requires a config edit and restart. In-console
+          editing is a future enhancement.
+        </p>
+      </div>
+
+      <section className="settings-section">
+        <h3 className="settings-section-title">Conversation &amp; scratch</h3>
+        <dl className="retention-list">
+          <div className="retention-row">
+            <dt>Conversation turns</dt>
+            <dd>
+              Kept for <strong>{policy.workingMemoryTtlDays} days</strong>, then purged by the
+              nightly dream pass.
+            </dd>
+          </div>
+          <div className="retention-row">
+            <dt>Scratch documents</dt>
+            <dd>
+              Ephemeral scratch docs are archived after{' '}
+              <strong>{policy.scratchTtlDays} days</strong> of inactivity.
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="settings-section">
+        <h3 className="settings-section-title">Fact decay</h3>
+        <dl className="retention-list">
+          <div className="retention-row">
+            <dt>Slow-decay facts</dt>
+            <dd>
+              Confidence halves every <strong>{policy.halfLifeDays.slowDecay} days</strong>
+              {' '}(employer, residence, and similar long-lived facts).
+            </dd>
+          </div>
+          <div className="retention-row">
+            <dt>Fast-decay facts</dt>
+            <dd>
+              Confidence halves every <strong>{policy.halfLifeDays.fastDecay} days</strong>
+              {' '}(preferences and short-lived context).
+            </dd>
+          </div>
+          <div className="retention-row">
+            <dt>Archive threshold</dt>
+            <dd>
+              Facts at or below <strong>{archivePct}% confidence</strong> are soft-deleted
+              (archived) and drop out of queries.
+            </dd>
+          </div>
+          <div className="retention-row">
+            <dt>Decay warnings</dt>
+            <dd>
+              Important nodes about to archive are held back for{' '}
+              <strong>{policy.warnHoldBackDays} days</strong> so you can re-confirm them.
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="settings-section">
+        <h3 className="settings-section-title">Review nodes</h3>
+        <p className="settings-page-sub">
+          To review knowledge-graph nodes nearing archival, ask Curia in{' '}
+          <Link to="/chat">Chat</Link>
+          {' '}to run the decay-warnings list (the <code>decay-warnings-list</code> skill).
+        </p>
+      </section>
+    </>
+  );
+}
+
+export function MemoryPage() {
+  return (
+    <SettingsLayout activeSection="memory">
+      <MemorySection />
+    </SettingsLayout>
+  );
+}
+
+export default MemoryPage;

--- a/apps/console/src/pages/MemorySettingsPage.tsx
+++ b/apps/console/src/pages/MemorySettingsPage.tsx
@@ -16,6 +16,23 @@ export interface MemoryRetentionPolicy {
   editable: false;
 }
 
+// Runtime guard for the /api/memory/retention payload. The endpoint is our own,
+// but a malformed 200 (e.g. a proxy/SPA fallback returning valid JSON of the
+// wrong shape) must not reach state and crash the render on halfLifeDays.*.
+function isMemoryRetentionPolicy(value: unknown): value is MemoryRetentionPolicy {
+  if (typeof value !== 'object' || value === null) return false;
+  const p = value as Record<string, unknown>;
+  const hl = p['halfLifeDays'];
+  if (typeof hl !== 'object' || hl === null) return false;
+  const half = hl as Record<string, unknown>;
+  return typeof p['workingMemoryTtlDays'] === 'number'
+    && typeof p['scratchTtlDays'] === 'number'
+    && typeof p['archiveThreshold'] === 'number'
+    && typeof p['warnHoldBackDays'] === 'number'
+    && typeof half['slowDecay'] === 'number'
+    && typeof half['fastDecay'] === 'number';
+}
+
 function MemorySection() {
   const [policy, setPolicy] = useState<MemoryRetentionPolicy | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -25,7 +42,10 @@ function MemorySection() {
       try {
         const res = await apiFetch('/api/memory/retention');
         if (!res.ok) throw new Error(await errorMessage(res));
-        const data = await res.json() as { retention: MemoryRetentionPolicy };
+        const data = await res.json() as { retention: unknown };
+        if (!isMemoryRetentionPolicy(data.retention)) {
+          throw new Error('Malformed retention policy response');
+        }
         setPolicy(data.retention);
       } catch (err) {
         setLoadError(err instanceof Error ? err.message : 'Failed to load retention policy');

--- a/apps/console/src/pages/PersonalitySettingsPage.tsx
+++ b/apps/console/src/pages/PersonalitySettingsPage.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../api';
+import { SettingsLayout } from './SettingsPage';
+import { TonePillGrid, AssistantToneSliders } from '../components/settings/ToneFields';
+import {
+  ChangeNoteField,
+  ConfigHistory,
+  errorMessage,
+  type ConfigHistoryEntry,
+} from '../components/settings/ConfigHistory';
+import type { LocalIdentity } from './wizard-utils';
+import { validateNonEmptyName } from './wizard-utils';
+
+interface VersionMeta {
+  version: number;
+  changedBy: string;
+  createdAt: string;
+  note?: string | null;
+}
+
+// Curia's own characteristics (name, title, signature, tone). Ghostwriting —
+// drafting *as the principal* — is a separate page (/settings/ghostwriting).
+function PersonalitySection() {
+  const [identity, setIdentity] = useState<LocalIdentity | null>(null);
+  const [savedIdentity, setSavedIdentity] = useState<LocalIdentity | null>(null);
+  const [identityMeta, setIdentityMeta] = useState<VersionMeta | null>(null);
+  const [identityNote, setIdentityNote] = useState('');
+  const [identityStatus, setIdentityStatus] = useState('');
+  const [identitySaving, setIdentitySaving] = useState(false);
+  const [identityHistory, setIdentityHistory] = useState<ConfigHistoryEntry[]>([]);
+  const [identityHistoryError, setIdentityHistoryError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState('');
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const loadIdentityHistory = useCallback(async () => {
+    setIdentityHistoryError(null);
+    try {
+      const res = await apiFetch('/api/identity/history');
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as {
+        history: Array<{
+          id: number;
+          version: number;
+          changedBy: string;
+          note?: string | null;
+          createdAt: string;
+        }>;
+      };
+      setIdentityHistory(data.history.map(h => ({
+        id: h.id,
+        version: h.version,
+        changedBy: h.changedBy,
+        note: h.note,
+        createdAt: h.createdAt,
+      })));
+      const latest = data.history[0];
+      if (latest) {
+        setIdentityMeta({
+          version: latest.version,
+          changedBy: latest.changedBy,
+          createdAt: latest.createdAt,
+          note: latest.note,
+        });
+      }
+    } catch (err) {
+      setIdentityHistoryError(err instanceof Error ? err.message : 'Failed to load identity history');
+    }
+  }, []);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await apiFetch('/api/identity');
+        if (!res.ok) throw new Error(await errorMessage(res));
+        const data = await res.json() as { identity: LocalIdentity };
+        setIdentity(data.identity);
+        setSavedIdentity(data.identity);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load personality settings');
+      }
+    }
+    void load();
+    void loadIdentityHistory();
+  }, [loadIdentityHistory]);
+
+  async function saveIdentity() {
+    if (!identity || !savedIdentity) return;
+    if (!validateNonEmptyName(identity.assistant.name)) {
+      setNameError('Assistant name is required.');
+      return;
+    }
+    setNameError('');
+    setIdentitySaving(true);
+    setIdentityStatus('Saving…');
+    try {
+      // Re-fetch before write so concurrent Posture/Ghostwriting edits are not clobbered.
+      const freshRes = await apiFetch('/api/identity');
+      if (!freshRes.ok) throw new Error(await errorMessage(freshRes));
+      const freshData = await freshRes.json() as { identity: LocalIdentity };
+      const payload: LocalIdentity = {
+        ...freshData.identity,
+        assistant: {
+          name: identity.assistant.name.trim(),
+          title: identity.assistant.title.trim(),
+          emailSignature: identity.assistant.emailSignature.trim(),
+        },
+        tone: {
+          baseline: identity.tone.baseline,
+          verbosity: identity.tone.verbosity,
+          directness: identity.tone.directness,
+        },
+      };
+      const res = await apiFetch('/api/identity', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          identity: payload,
+          changedBy: 'api',
+          note: identityNote.trim() || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as { identity: LocalIdentity };
+      setIdentity(data.identity);
+      setSavedIdentity(data.identity);
+      setIdentityNote('');
+      setIdentityStatus('Saved');
+      setTimeout(() => setIdentityStatus(''), 2000);
+      void loadIdentityHistory();
+    } catch (err) {
+      setIdentityStatus(`Error: ${err instanceof Error ? err.message : 'unknown error'}`);
+    } finally {
+      setIdentitySaving(false);
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="settings-page-header">
+        <p className="autonomy-error">{loadError}</p>
+      </div>
+    );
+  }
+
+  if (!identity || !savedIdentity) {
+    return (
+      <div className="settings-page-header">
+        <p className="settings-muted-hint">Loading…</p>
+      </div>
+    );
+  }
+
+  const identityDirty =
+    identity.assistant.name.trim() !== savedIdentity.assistant.name.trim()
+    || identity.assistant.title.trim() !== savedIdentity.assistant.title.trim()
+    || identity.assistant.emailSignature.trim() !== savedIdentity.assistant.emailSignature.trim()
+    || JSON.stringify(identity.tone) !== JSON.stringify(savedIdentity.tone);
+
+  return (
+    <>
+      <div className="settings-page-header">
+        <h2 className="settings-page-title">Personality</h2>
+        <p className="settings-page-sub">
+          How Curia presents itself — its name, communication style, and personality in its own voice.
+        </p>
+        {identityMeta && (
+          <p className="settings-version-meta">
+            Identity v{identityMeta.version} · last changed by {identityMeta.changedBy}
+          </p>
+        )}
+      </div>
+
+      <section className="settings-section">
+        <div className="settings-section-body">
+          <div className="wizard-field">
+            <label htmlFor="asst-name">Assistant name *</label>
+            <input
+              id="asst-name"
+              type="text"
+              value={identity.assistant.name}
+              onChange={e => {
+                setIdentity({ ...identity, assistant: { ...identity.assistant, name: e.target.value } });
+                if (nameError) setNameError('');
+              }}
+            />
+            {nameError && <div className="wizard-step1-error">{nameError}</div>}
+          </div>
+          <div className="wizard-field">
+            <label htmlFor="asst-title">Title</label>
+            <input
+              id="asst-title"
+              type="text"
+              value={identity.assistant.title}
+              onChange={e => setIdentity({
+                ...identity,
+                assistant: { ...identity.assistant, title: e.target.value },
+              })}
+            />
+          </div>
+          <div className="wizard-field">
+            <label htmlFor="asst-signature">Email signature</label>
+            <textarea
+              id="asst-signature"
+              value={identity.assistant.emailSignature}
+              onChange={e => setIdentity({
+                ...identity,
+                assistant: { ...identity.assistant, emailSignature: e.target.value },
+              })}
+            />
+          </div>
+
+          <TonePillGrid
+            selected={identity.tone.baseline}
+            onChange={baseline => setIdentity({
+              ...identity,
+              tone: { ...identity.tone, baseline },
+            })}
+            idPrefix="asst-tone"
+          />
+          <AssistantToneSliders
+            verbosity={identity.tone.verbosity}
+            directness={identity.tone.directness}
+            onVerbosityChange={verbosity => setIdentity({
+              ...identity,
+              tone: { ...identity.tone, verbosity },
+            })}
+            onDirectnessChange={directness => setIdentity({
+              ...identity,
+              tone: { ...identity.tone, directness },
+            })}
+            idPrefix="asst"
+          />
+
+          <div className="autonomy-control">
+            <ChangeNoteField id="asst-identity-note" value={identityNote} onChange={setIdentityNote} />
+            <div className="autonomy-save-row">
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={!identityDirty || identitySaving}
+                onClick={() => void saveIdentity()}
+              >
+                Save personality
+              </button>
+              {identityStatus && <span className="autonomy-save-status">{identityStatus}</span>}
+            </div>
+          </div>
+          <ConfigHistory entries={identityHistory} error={identityHistoryError} />
+        </div>
+      </section>
+    </>
+  );
+}
+
+export function PersonalityPage() {
+  return (
+    <SettingsLayout activeSection="personality">
+      <PersonalitySection />
+    </SettingsLayout>
+  );
+}
+
+export default PersonalityPage;

--- a/apps/console/src/pages/PostureSettingsPage.tsx
+++ b/apps/console/src/pages/PostureSettingsPage.tsx
@@ -78,14 +78,27 @@ function PostureSection() {
       const freshRes = await apiFetch('/api/identity');
       if (!freshRes.ok) throw new Error(await errorMessage(freshRes));
       const freshData = await freshRes.json() as { identity: LocalIdentity };
+      // Only overwrite the fields the operator actually changed on this page;
+      // keep the freshly-fetched values for the rest. Without this, saving a
+      // posture edit would also clobber behavioralPreferences that a background
+      // skill (e.g. preference-update) appended after this page loaded.
       const payload: LocalIdentity = {
         ...freshData.identity,
         decisionStyle: {
           ...freshData.identity.decisionStyle,
-          externalActions: identity.decisionStyle.externalActions,
-          internalAnalysis: identity.decisionStyle.internalAnalysis,
+          externalActions:
+            identity.decisionStyle.externalActions !== saved.decisionStyle.externalActions
+              ? identity.decisionStyle.externalActions
+              : freshData.identity.decisionStyle.externalActions,
+          internalAnalysis:
+            identity.decisionStyle.internalAnalysis !== saved.decisionStyle.internalAnalysis
+              ? identity.decisionStyle.internalAnalysis
+              : freshData.identity.decisionStyle.internalAnalysis,
         },
-        behavioralPreferences: identity.behavioralPreferences,
+        behavioralPreferences:
+          JSON.stringify(identity.behavioralPreferences) !== JSON.stringify(saved.behavioralPreferences)
+            ? identity.behavioralPreferences
+            : freshData.identity.behavioralPreferences,
       };
       const res = await apiFetch('/api/identity', {
         method: 'PUT',

--- a/apps/console/src/pages/PostureSettingsPage.tsx
+++ b/apps/console/src/pages/PostureSettingsPage.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { apiFetch } from '../api';
+import { SettingsLayout } from './SettingsPage';
+import { PostureCardGrid } from '../components/settings/PostureFields';
+import { StringListEditor } from '../components/settings/StringListEditor';
+import {
+  ChangeNoteField,
+  ConfigHistory,
+  errorMessage,
+  type ConfigHistoryEntry,
+} from '../components/settings/ConfigHistory';
+import type { DecisionPosture, LocalIdentity } from './wizard-utils';
+
+function PostureSection() {
+  const [identity, setIdentity] = useState<LocalIdentity | null>(null);
+  const [saved, setSaved] = useState<LocalIdentity | null>(null);
+  const [note, setNote] = useState('');
+  const [saveStatus, setSaveStatus] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [history, setHistory] = useState<ConfigHistoryEntry[]>([]);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [meta, setMeta] = useState<{ version: number; changedBy: string } | null>(null);
+
+  const loadHistory = useCallback(async () => {
+    setHistoryError(null);
+    try {
+      const res = await apiFetch('/api/identity/history');
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as {
+        history: Array<{
+          id: number;
+          version: number;
+          changedBy: string;
+          note?: string | null;
+          createdAt: string;
+        }>;
+      };
+      setHistory(data.history.map(h => ({
+        id: h.id,
+        version: h.version,
+        changedBy: h.changedBy,
+        note: h.note,
+        createdAt: h.createdAt,
+      })));
+      const latest = data.history[0];
+      if (latest) {
+        setMeta({ version: latest.version, changedBy: latest.changedBy });
+      }
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : 'Failed to load history');
+    }
+  }, []);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await apiFetch('/api/identity');
+        if (!res.ok) throw new Error(await errorMessage(res));
+        const data = await res.json() as { identity: LocalIdentity };
+        setIdentity(data.identity);
+        setSaved(data.identity);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load posture settings');
+      }
+    }
+    void load();
+    void loadHistory();
+  }, [loadHistory]);
+
+  async function handleSave() {
+    if (!identity || !saved) return;
+    setSaving(true);
+    setSaveStatus('Saving…');
+    try {
+      // Re-fetch before write so concurrent Assistant persona edits are not clobbered.
+      const freshRes = await apiFetch('/api/identity');
+      if (!freshRes.ok) throw new Error(await errorMessage(freshRes));
+      const freshData = await freshRes.json() as { identity: LocalIdentity };
+      const payload: LocalIdentity = {
+        ...freshData.identity,
+        decisionStyle: {
+          ...freshData.identity.decisionStyle,
+          externalActions: identity.decisionStyle.externalActions,
+          internalAnalysis: identity.decisionStyle.internalAnalysis,
+        },
+        behavioralPreferences: identity.behavioralPreferences,
+      };
+      const res = await apiFetch('/api/identity', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          identity: payload,
+          changedBy: 'api',
+          note: note.trim() || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as { identity: LocalIdentity };
+      setIdentity(data.identity);
+      setSaved(data.identity);
+      setNote('');
+      setSaveStatus('Saved');
+      setTimeout(() => setSaveStatus(''), 2000);
+      void loadHistory();
+    } catch (err) {
+      setSaveStatus(`Error: ${err instanceof Error ? err.message : 'unknown error'}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="settings-page-header">
+        <p className="autonomy-error">{loadError}</p>
+      </div>
+    );
+  }
+
+  if (!identity || !saved) {
+    return (
+      <div className="settings-page-header">
+        <p className="settings-muted-hint">Loading…</p>
+      </div>
+    );
+  }
+
+  const isDirty =
+    identity.decisionStyle.externalActions !== saved.decisionStyle.externalActions
+    || identity.decisionStyle.internalAnalysis !== saved.decisionStyle.internalAnalysis
+    || JSON.stringify(identity.behavioralPreferences) !== JSON.stringify(saved.behavioralPreferences);
+
+  return (
+    <>
+      <div className="settings-page-header">
+        <h2 className="settings-page-title">Posture</h2>
+        <p className="settings-page-sub">
+          Default decision style and standing preferences for your assistant.
+        </p>
+        {meta && (
+          <p className="settings-version-meta">
+            Identity v{meta.version} · last changed by {meta.changedBy}
+          </p>
+        )}
+      </div>
+
+      <div className="settings-callout">
+        <p>
+          <strong>Posture vs autonomy.</strong> Decision posture is the assistant&apos;s
+          default bias when judging external actions (verify first vs act when confident).
+          The{' '}
+          <Link to="/settings/autonomy">Autonomy score</Link>
+          {' '}is a separate knob: how far Curia may proceed before stopping for your
+          confirmation. Adjust both independently.
+        </p>
+      </div>
+
+      <section className="settings-section">
+        <PostureCardGrid
+          value={identity.decisionStyle.externalActions}
+          onChange={(externalActions: DecisionPosture) => setIdentity({
+            ...identity,
+            decisionStyle: { ...identity.decisionStyle, externalActions },
+          })}
+          scopeHint="(for external actions)"
+        />
+
+        <div style={{ marginTop: 20 }}>
+          <PostureCardGrid
+            value={identity.decisionStyle.internalAnalysis}
+            onChange={(internalAnalysis: DecisionPosture) => setIdentity({
+              ...identity,
+              decisionStyle: { ...identity.decisionStyle, internalAnalysis },
+            })}
+            scopeHint="(for internal analysis)"
+          />
+        </div>
+
+        <div style={{ marginTop: 24 }}>
+          <StringListEditor
+            id="standing-prefs"
+            label="Standing preferences"
+            items={identity.behavioralPreferences}
+            onChange={behavioralPreferences => setIdentity({
+              ...identity,
+              behavioralPreferences,
+            })}
+            placeholder="e.g. Always include agenda items in meeting requests"
+            emptyHint="No standing preferences yet."
+          />
+          <p className="settings-muted-hint">
+            Stored on the office identity (`behavioralPreferences`). Edits replace the
+            full list; the setup wizard only appends.
+          </p>
+        </div>
+
+        <div className="autonomy-control" style={{ marginTop: 20 }}>
+          <ChangeNoteField id="posture-note" value={note} onChange={setNote} />
+          <div className="autonomy-save-row">
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={!isDirty || saving}
+              onClick={() => void handleSave()}
+            >
+              Save
+            </button>
+            {saveStatus && <span className="autonomy-save-status">{saveStatus}</span>}
+          </div>
+        </div>
+
+        <ConfigHistory entries={history} error={historyError} />
+      </section>
+    </>
+  );
+}
+
+export function PosturePage() {
+  return (
+    <SettingsLayout activeSection="posture">
+      <PostureSection />
+    </SettingsLayout>
+  );
+}
+
+export default PosturePage;

--- a/apps/console/src/pages/PostureSettingsPage.tsx
+++ b/apps/console/src/pages/PostureSettingsPage.tsx
@@ -191,8 +191,8 @@ function PostureSection() {
             emptyHint="No standing preferences yet."
           />
           <p className="settings-muted-hint">
-            Stored on the office identity (`behavioralPreferences`). Edits replace the
-            full list; the setup wizard only appends.
+            Standing preferences are part of the office identity. Edits replace the full
+            list; the setup wizard only appends.
           </p>
         </div>
 

--- a/apps/console/src/pages/PostureSettingsPage.tsx
+++ b/apps/console/src/pages/PostureSettingsPage.tsx
@@ -158,60 +158,62 @@ function PostureSection() {
       </div>
 
       <section className="settings-section">
-        <PostureCardGrid
-          value={identity.decisionStyle.externalActions}
-          onChange={(externalActions: DecisionPosture) => setIdentity({
-            ...identity,
-            decisionStyle: { ...identity.decisionStyle, externalActions },
-          })}
-          scopeHint="(for external actions)"
-        />
-
-        <div style={{ marginTop: 20 }}>
+        <div className="settings-section-body">
           <PostureCardGrid
-            value={identity.decisionStyle.internalAnalysis}
-            onChange={(internalAnalysis: DecisionPosture) => setIdentity({
+            value={identity.decisionStyle.externalActions}
+            onChange={(externalActions: DecisionPosture) => setIdentity({
               ...identity,
-              decisionStyle: { ...identity.decisionStyle, internalAnalysis },
+              decisionStyle: { ...identity.decisionStyle, externalActions },
             })}
-            scopeHint="(for internal analysis)"
+            scopeHint="(for external actions)"
           />
-        </div>
 
-        <div style={{ marginTop: 24 }}>
-          <StringListEditor
-            id="standing-prefs"
-            label="Standing preferences"
-            items={identity.behavioralPreferences}
-            onChange={behavioralPreferences => setIdentity({
-              ...identity,
-              behavioralPreferences,
-            })}
-            placeholder="e.g. Always include agenda items in meeting requests"
-            emptyHint="No standing preferences yet."
-          />
-          <p className="settings-muted-hint">
-            Standing preferences are part of the office identity. Edits replace the full
-            list; the setup wizard only appends.
-          </p>
-        </div>
-
-        <div className="autonomy-control" style={{ marginTop: 20 }}>
-          <ChangeNoteField id="posture-note" value={note} onChange={setNote} />
-          <div className="autonomy-save-row">
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={!isDirty || saving}
-              onClick={() => void handleSave()}
-            >
-              Save
-            </button>
-            {saveStatus && <span className="autonomy-save-status">{saveStatus}</span>}
+          <div style={{ marginTop: 20 }}>
+            <PostureCardGrid
+              value={identity.decisionStyle.internalAnalysis}
+              onChange={(internalAnalysis: DecisionPosture) => setIdentity({
+                ...identity,
+                decisionStyle: { ...identity.decisionStyle, internalAnalysis },
+              })}
+              scopeHint="(for internal analysis)"
+            />
           </div>
-        </div>
 
-        <ConfigHistory entries={history} error={historyError} />
+          <div style={{ marginTop: 24 }}>
+            <StringListEditor
+              id="standing-prefs"
+              label="Standing preferences"
+              items={identity.behavioralPreferences}
+              onChange={behavioralPreferences => setIdentity({
+                ...identity,
+                behavioralPreferences,
+              })}
+              placeholder="e.g. Always include agenda items in meeting requests"
+              emptyHint="No standing preferences yet."
+            />
+            <p className="settings-muted-hint">
+              Standing preferences are part of the office identity. Edits replace the full
+              list; the setup wizard only appends.
+            </p>
+          </div>
+
+          <div className="autonomy-control">
+            <ChangeNoteField id="posture-note" value={note} onChange={setNote} />
+            <div className="autonomy-save-row">
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={!isDirty || saving}
+                onClick={() => void handleSave()}
+              >
+                Save
+              </button>
+              {saveStatus && <span className="autonomy-save-status">{saveStatus}</span>}
+            </div>
+          </div>
+
+          <ConfigHistory entries={history} error={historyError} />
+        </div>
       </section>
     </>
   );

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -292,13 +292,16 @@ function AutonomySection() {
 
 // ── Settings layout ───────────────────────────────────────────────────────────
 
-// In-page settings nav (#1376). Order: Assistant → Posture → Autonomy → Memory.
+// In-page settings nav (#1376). Order: Personality → Ghostwriting → Posture →
+// Autonomy → Memory → System.
 // Skills / Agents / Channels live as standalone sidebar pages outside this shell.
 const SETTINGS_SECTIONS = [
-  { id: 'assistant', label: 'Assistant', href: '/settings/assistant' },
-  { id: 'posture',   label: 'Posture',   href: '/settings/posture' },
-  { id: 'autonomy',  label: 'Autonomy',  href: '/settings/autonomy' },
-  { id: 'memory',    label: 'Memory',    href: '/settings/memory' },
+  { id: 'personality',  label: 'Personality',  href: '/settings/personality' },
+  { id: 'ghostwriting', label: 'Ghostwriting', href: '/settings/ghostwriting' },
+  { id: 'posture',      label: 'Posture',      href: '/settings/posture' },
+  { id: 'autonomy',     label: 'Autonomy',     href: '/settings/autonomy' },
+  { id: 'memory',       label: 'Memory',       href: '/settings/memory' },
+  { id: 'system',       label: 'System',       href: '/settings/system' },
 ] as const;
 
 interface SettingsLayoutProps {

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -314,15 +314,14 @@ function AutonomySection() {
 
 // ── Settings layout ───────────────────────────────────────────────────────────
 
-// The settings nav sections. Only 'autonomy' is functional; 'workspace' is a stub
-// for a future PR. Skills and Agents used to live here but are now standalone
-// top-level pages (see RegistrySettings.tsx) reachable from the sidebar directly.
-// Rendered as <Link> elements so the URL changes on click and back/forward
-// navigation works correctly within the settings shell.
+// In-page settings nav (#1376). Order: Assistant → Posture → Autonomy → Memory.
+// Skills / Agents / Channels live as standalone sidebar pages outside this shell.
 const SETTINGS_SECTIONS = [
-  { id: 'autonomy',  label: 'Autonomy',    href: '/settings/autonomy' },
-  { id: 'workspace', label: 'Workspace',   href: '/settings/workspace' },
-];
+  { id: 'assistant', label: 'Assistant', href: '/settings/assistant' },
+  { id: 'posture',   label: 'Posture',   href: '/settings/posture' },
+  { id: 'autonomy',  label: 'Autonomy',  href: '/settings/autonomy' },
+  { id: 'memory',    label: 'Memory',    href: '/settings/memory' },
+] as const;
 
 interface SettingsLayoutProps {
   activeSection: string;
@@ -337,12 +336,14 @@ export function SettingsLayout({ activeSection, children }: SettingsLayoutProps)
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
   }, [mobileOpen]);
 
+  const activeLabel = SETTINGS_SECTIONS.find(s => s.id === activeSection)?.label ?? 'Settings';
+
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
         <Sidebar activeView="settings" theme={theme} onThemeChange={setTheme} />
         <main className="main">
-          <Topbar crumb="Settings" title="Workspace" />
+          <Topbar crumb="Settings" title={activeLabel} />
           <div className="settings-shell">
             <nav className="settings-nav">
               <div className="settings-nav-title">Settings</div>
@@ -372,17 +373,6 @@ export function AutonomyPage() {
   return (
     <SettingsLayout activeSection="autonomy">
       <AutonomySection />
-    </SettingsLayout>
-  );
-}
-
-export function WorkspacePage() {
-  return (
-    <SettingsLayout activeSection="workspace">
-      <div className="settings-page-header">
-        <h2 className="settings-page-title">Workspace</h2>
-        <p className="settings-page-sub">Workspace settings — coming soon.</p>
-      </div>
     </SettingsLayout>
   );
 }

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -5,6 +5,9 @@ import { Sidebar } from '../components/Sidebar';
 import { Topbar } from '../components/Topbar';
 import { apiFetch } from '../api';
 import { useTheme } from '../hooks/useTheme';
+// Shared with the operator config-settings pages — single source of truth for
+// the relative-time and HTTP-error-body helpers (they were duplicated here).
+import { errorMessage, timeAgo } from '../components/settings/ConfigHistory';
 
 // ── Band metadata ─────────────────────────────────────────────────────────────
 
@@ -43,17 +46,6 @@ function BandBadge({ band }: { band: AutonomyBand }) {
   );
 }
 
-function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
-
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 interface AutonomyConfig {
@@ -72,20 +64,6 @@ interface HistoryEntry {
   changedBy: string;
   reason: string | null;
   changedAt: string;
-}
-
-// Safe error message extraction — guards against non-JSON error bodies (e.g. rate-limiter HTML).
-async function errorMessage(res: Response): Promise<string> {
-  const ct = res.headers.get('content-type') ?? '';
-  if (ct.includes('application/json')) {
-    try {
-      const d = await res.json() as { error?: string };
-      if (d.error) return d.error;
-    } catch (err) {
-      console.error('[errorMessage] failed to read JSON error body:', err);
-    }
-  }
-  return `HTTP ${res.status}`;
 }
 
 // ── Autonomy section ──────────────────────────────────────────────────────────

--- a/apps/console/src/pages/SystemSettingsPage.tsx
+++ b/apps/console/src/pages/SystemSettingsPage.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react';
+import { apiFetch } from '../api';
+import { SettingsLayout } from './SettingsPage';
+import { errorMessage, timeAgo } from '../components/settings/ConfigHistory';
+
+interface SystemModelTier {
+  tier: string;
+  model: string;
+}
+
+export interface SystemInfo {
+  version: string;
+  nodeVersion: string;
+  timezone: string;
+  bootedAt: string;
+  models: {
+    defaultTier: string;
+    tiers: SystemModelTier[];
+  };
+}
+
+// Runtime guard for the /api/system payload — a malformed 200 must not reach
+// state and crash the render (same defensive pattern as the Memory page).
+function isSystemInfo(value: unknown): value is SystemInfo {
+  if (typeof value !== 'object' || value === null) return false;
+  const s = value as Record<string, unknown>;
+  const models = s['models'];
+  if (typeof models !== 'object' || models === null) return false;
+  const m = models as Record<string, unknown>;
+  return typeof s['version'] === 'string'
+    && typeof s['nodeVersion'] === 'string'
+    && typeof s['timezone'] === 'string'
+    && typeof s['bootedAt'] === 'string'
+    && typeof m['defaultTier'] === 'string'
+    && Array.isArray(m['tiers'])
+    && m['tiers'].every(t =>
+      typeof t === 'object' && t !== null
+      && typeof (t as Record<string, unknown>)['tier'] === 'string'
+      && typeof (t as Record<string, unknown>)['model'] === 'string');
+}
+
+function capitalize(s: string): string {
+  return s.length ? s[0]!.toUpperCase() + s.slice(1) : s;
+}
+
+function SystemSection() {
+  const [info, setInfo] = useState<SystemInfo | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await apiFetch('/api/system');
+        if (!res.ok) throw new Error(await errorMessage(res));
+        const data = await res.json() as { system: unknown };
+        if (!isSystemInfo(data.system)) {
+          throw new Error('Malformed system response');
+        }
+        setInfo(data.system);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load system info');
+      }
+    }
+    void load();
+  }, []);
+
+  if (loadError) {
+    return (
+      <div className="settings-page-header">
+        <p className="autonomy-error">{loadError}</p>
+      </div>
+    );
+  }
+
+  if (!info) {
+    return (
+      <div className="settings-page-header">
+        <p className="settings-muted-hint">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="settings-page-header">
+        <h2 className="settings-page-title">System</h2>
+        <p className="settings-page-sub">
+          Environment and configuration for this Curia instance.
+        </p>
+      </div>
+
+      <div className="settings-callout settings-callout-readonly">
+        <p>
+          <strong>Read-only.</strong> These values reflect the currently running process.
+          Changing them requires a config change and a restart.
+        </p>
+      </div>
+
+      <section className="settings-section">
+        <div className="settings-section-head">
+          <h3 className="settings-section-title">Instance</h3>
+        </div>
+        <div className="settings-section-body">
+          <dl className="settings-kv-list">
+            <div className="settings-kv-row">
+              <dt>Curia version</dt>
+              <dd><code>{info.version}</code></dd>
+            </div>
+            <div className="settings-kv-row">
+              <dt>Node runtime</dt>
+              <dd><code>{info.nodeVersion}</code></dd>
+            </div>
+            <div className="settings-kv-row">
+              <dt>Timezone</dt>
+              <dd>{info.timezone}</dd>
+            </div>
+            <div className="settings-kv-row">
+              <dt>Booted</dt>
+              <dd title={info.bootedAt}>{timeAgo(info.bootedAt)}</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="settings-section-head">
+          <h3 className="settings-section-title">Models</h3>
+          <p className="settings-section-sub">
+            Capability tier → model routing. Agents pick a tier; the deployment maps it here.
+          </p>
+        </div>
+        <div className="settings-section-body">
+          <dl className="settings-kv-list">
+            {info.models.tiers.map(t => (
+              <div className="settings-kv-row" key={t.tier}>
+                <dt>
+                  {capitalize(t.tier)}
+                  {t.tier === info.models.defaultTier && (
+                    <span className="settings-kv-tag">default</span>
+                  )}
+                </dt>
+                <dd><code>{t.model}</code></dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+    </>
+  );
+}
+
+export function SystemPage() {
+  return (
+    <SettingsLayout activeSection="system">
+      <SystemSection />
+    </SettingsLayout>
+  );
+}
+
+export default SystemPage;

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -1,14 +1,11 @@
-import { useState, useEffect, useRef, type JSX, type CSSProperties } from 'react';
+import { useState, useEffect, useRef, type JSX } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { apiFetch } from '../api.js';
+import { TonePillGrid, AssistantToneSliders } from '../components/settings/ToneFields.js';
+import { PostureCardGrid } from '../components/settings/PostureFields.js';
 import {
   DEFAULT_WIZARD_STATE,
   PRINCIPAL_NAME_MAX_LENGTH,
-  TONE_OPTIONS,
-  toggleToneSelection,
-  verbosityBand,
-  directnessBand,
-  tonePreviewText,
   verbosityReviewDesc,
   directnessReviewDesc,
   postureReviewDesc,
@@ -893,64 +890,22 @@ export default function WizardPage() {
 
   // ── Step 4: Tone ───────────────────────────────────────────────────────────
 
-  const atToneMax = state.toneBaseline.length >= 3;
-
   const step4Tone = (
     <div className="wizard-content">
       <div className="wizard-heading">How should your assistant communicate?</div>
       <div className="wizard-subheading">Pick 1–3 words that describe the tone you want.</div>
-      <div className="wizard-label">
-        Tone <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>
-          (pick up to 3)
-        </span>
-      </div>
-      <div className="tone-pill-grid">
-        {TONE_OPTIONS.map(word => {
-          const selected = state.toneBaseline.includes(word);
-          const disabled = atToneMax && !selected;
-          return (
-            <button
-              key={word}
-              type="button"
-              className={`tone-pill${selected ? ' selected' : ''}`}
-              disabled={disabled}
-              onClick={() =>
-                setState(s => ({
-                  ...s,
-                  toneBaseline: toggleToneSelection(s.toneBaseline, word),
-                }))
-              }
-            >
-              {word}
-            </button>
-          );
-        })}
-      </div>
-      <div className="wizard-preview">{tonePreviewText(state.toneBaseline)}</div>
-      <label className="wizard-label" htmlFor="w-verbosity">Detail level</label>
-      <input
-        id="w-verbosity"
-        type="range"
-        min={0}
-        max={100}
-        value={state.verbosity}
-        style={{ width: '100%', marginBottom: 6 } as CSSProperties}
-        onChange={e => setState(s => ({ ...s, verbosity: Number(e.target.value) }))}
+      <TonePillGrid
+        selected={state.toneBaseline}
+        onChange={toneBaseline => setState(s => ({ ...s, toneBaseline }))}
+        idPrefix="w-tone"
       />
-      <div className="slider-labels"><span>Brief</span><span>Thorough</span></div>
-      <div className="wizard-sample">{verbosityBand(state.verbosity)}</div>
-      <label className="wizard-label" htmlFor="w-directness">Directness</label>
-      <input
-        id="w-directness"
-        type="range"
-        min={0}
-        max={100}
-        value={state.directness}
-        style={{ width: '100%', marginBottom: 6 } as CSSProperties}
-        onChange={e => setState(s => ({ ...s, directness: Number(e.target.value) }))}
+      <AssistantToneSliders
+        verbosity={state.verbosity}
+        directness={state.directness}
+        onVerbosityChange={verbosity => setState(s => ({ ...s, verbosity }))}
+        onDirectnessChange={directness => setState(s => ({ ...s, directness }))}
+        idPrefix="w"
       />
-      <div className="slider-labels"><span>Measured</span><span>Direct</span></div>
-      <div className="wizard-sample">{directnessBand(state.directness)}</div>
       <div className="wizard-nav">
         <button type="button" className="btn-wizard-back" onClick={handleBack}>
           ← Back
@@ -964,41 +919,18 @@ export default function WizardPage() {
 
   // ── Step 5: Posture & preferences ──────────────────────────────────────────
 
-  const POSTURE_OPTIONS: Array<{
-    value: WizardState['posture'];
-    title: string;
-    desc: string;
-  }> = [
-    { value: 'conservative', title: 'Conservative', desc: 'Verify before acting; flag ambiguity' },
-    { value: 'balanced',     title: 'Balanced',     desc: 'Act when confident, flag when uncertain' },
-    { value: 'proactive',    title: 'Proactive',    desc: 'Bias toward action; less checking in' },
-  ];
-
   const step5Posture = (
     <div className="wizard-content">
       <div className="wizard-heading">How should your assistant decide?</div>
       <div className="wizard-subheading">
-        Choose a default posture for external actions. You can adjust this later via Autonomy settings.
+        Choose a default posture for external actions. You can refine this later under Settings → Posture
+        (separate from the Autonomy score).
       </div>
-      <div className="wizard-label">
-        Decision posture{' '}
-        <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: 'var(--app-fg-muted)' }}>
-          (for external actions)
-        </span>
-      </div>
-      <div className="posture-grid">
-        {POSTURE_OPTIONS.map(opt => (
-          <button
-            key={opt.value}
-            type="button"
-            className={`posture-card${state.posture === opt.value ? ' selected' : ''}`}
-            onClick={() => setState(s => ({ ...s, posture: opt.value }))}
-          >
-            <div className="posture-card-title">{opt.title}</div>
-            <div className="posture-card-desc">{opt.desc}</div>
-          </button>
-        ))}
-      </div>
+      <PostureCardGrid
+        value={state.posture}
+        onChange={posture => setState(s => ({ ...s, posture }))}
+        scopeHint="(for external actions)"
+      />
       <div className="wizard-label" style={{ marginTop: 4 }}>
         Anything else? <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(Optional)</span>
       </div>

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, type JSX } from 'react';
+import { useState, useEffect, useRef, type JSX, type CSSProperties } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { apiFetch } from '../api.js';
 import { TonePillGrid, AssistantToneSliders } from '../components/settings/ToneFields.js';

--- a/apps/console/src/pages/wizard-utils.test.ts
+++ b/apps/console/src/pages/wizard-utils.test.ts
@@ -7,6 +7,8 @@ import {
   verbosityReviewDesc,
   directnessReviewDesc,
   postureReviewDesc,
+  formalityBand,
+  POSTURE_OPTIONS,
   validateNonEmptyName,
   validatePrincipalName,
   PRINCIPAL_NAME_MAX_LENGTH,
@@ -152,6 +154,25 @@ describe('postureReviewDesc', () => {
   });
   it('maps proactive', () => {
     expect(postureReviewDesc('proactive')).toBe('Biases toward action with less checking in.');
+  });
+});
+
+describe('formalityBand', () => {
+  it('returns a casual sample at low formality', () => {
+    expect(formalityBand(10)).toContain('Hey');
+  });
+  it('returns a formal sample at high formality', () => {
+    expect(formalityBand(90)).toContain('formally');
+  });
+});
+
+describe('POSTURE_OPTIONS', () => {
+  it('exposes the three decision postures', () => {
+    expect(POSTURE_OPTIONS.map(o => o.value)).toEqual([
+      'conservative',
+      'balanced',
+      'proactive',
+    ]);
   });
 });
 

--- a/apps/console/src/pages/wizard-utils.ts
+++ b/apps/console/src/pages/wizard-utils.ts
@@ -18,7 +18,7 @@ export interface WizardState {
   toneBaseline: string[];
   verbosity: number;   // 0–100
   directness: number;  // 0–100
-  posture: 'conservative' | 'balanced' | 'proactive';
+  posture: DecisionPosture;
   preferences: string;
   // Step 2 — Your details (principal operational profile, #392).
   timezone: string;
@@ -156,13 +156,33 @@ export function directnessReviewDesc(d: number): string {
   return 'States positions plainly; no softening.';
 }
 
-export function postureReviewDesc(posture: WizardState['posture']): string {
-  const map: Record<WizardState['posture'], string> = {
+export type DecisionPosture = 'conservative' | 'balanced' | 'proactive';
+
+export const POSTURE_OPTIONS: ReadonlyArray<{
+  value: DecisionPosture;
+  title: string;
+  desc: string;
+}> = [
+  { value: 'conservative', title: 'Conservative', desc: 'Verify before acting; flag ambiguity' },
+  { value: 'balanced',     title: 'Balanced',     desc: 'Act when confident, flag when uncertain' },
+  { value: 'proactive',    title: 'Proactive',    desc: 'Bias toward action; less checking in' },
+];
+
+export function postureReviewDesc(posture: DecisionPosture): string {
+  const map: Record<DecisionPosture, string> = {
     conservative: 'Verifies before acting on external requests.',
     balanced:     'Acts when confident; flags when uncertain.',
     proactive:    'Biases toward action with less checking in.',
   };
   return map[posture];
+}
+
+/** Live preview sentence under the executive writing-voice formality slider. */
+export function formalityBand(v: number): string {
+  if (v <= 25) return '"Hey — quick note on this."';
+  if (v <= 50) return '"Sharing a brief update on the situation."';
+  if (v <= 75) return '"Please find a concise summary below."';
+  return '"I am writing to formally address the matter."';
 }
 
 // Returns true if a string is non-empty after trimming. Shared validator for

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -14,9 +14,9 @@ const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const AutonomyPage = lazy(() =>
   import('./pages/SettingsPage').then(m => ({ default: m.AutonomyPage })),
 );
-const WorkspacePage = lazy(() =>
-  import('./pages/SettingsPage').then(m => ({ default: m.WorkspacePage })),
-);
+const AssistantPage = lazy(() => import('./pages/AssistantSettingsPage'));
+const PosturePage = lazy(() => import('./pages/PostureSettingsPage'));
+const MemoryPage = lazy(() => import('./pages/MemorySettingsPage'));
 const ToolsPage = lazy(() =>
   import('./pages/RegistrySettings').then(m => ({ default: m.ToolsPage })),
 );
@@ -92,7 +92,7 @@ const settingsRoute = createRoute({
   path: '/settings',
   beforeLoad: ({ location }) => {
     if (location.pathname === '/settings' || location.pathname === '/settings/') {
-      throw redirect({ to: '/settings/autonomy' });
+      throw redirect({ to: '/settings/assistant' });
     }
   },
   component: () => (
@@ -102,16 +102,28 @@ const settingsRoute = createRoute({
   ),
 });
 
+const assistantRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: '/assistant',
+  component: AssistantPage,
+});
+
+const postureRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: '/posture',
+  component: PosturePage,
+});
+
 const autonomyRoute = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/autonomy',
   component: AutonomyPage,
 });
 
-const workspaceRoute = createRoute({
+const memoryRoute = createRoute({
   getParentRoute: () => settingsRoute,
-  path: '/workspace',
-  component: WorkspacePage,
+  path: '/memory',
+  component: MemoryPage,
 });
 
 // Tools and Agents are standalone top-level pages (peer to Contacts/Tasks),
@@ -133,6 +145,13 @@ const agentsSettingsRedirect = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/agents',
   beforeLoad: () => { throw redirect({ to: '/agents' }); },
+});
+
+// Legacy stub — Workspace was removed in #1376; send bookmarks to the new default.
+const workspaceRedirect = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: '/workspace',
+  beforeLoad: () => { throw redirect({ to: '/settings/assistant' }); },
 });
 
 const loginRoute = createRoute({
@@ -225,7 +244,15 @@ const routeTree = rootRoute.addChildren([
     channelsRoute,
     mcpSkillsRoute,
     kgRoute,
-    settingsRoute.addChildren([autonomyRoute, workspaceRoute, skillsSettingsRedirect, agentsSettingsRedirect]),
+    settingsRoute.addChildren([
+      assistantRoute,
+      postureRoute,
+      autonomyRoute,
+      memoryRoute,
+      workspaceRedirect,
+      skillsSettingsRedirect,
+      agentsSettingsRedirect,
+    ]),
   ]),
   loginRoute,
   secretCaptureRoute,

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -14,9 +14,11 @@ const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const AutonomyPage = lazy(() =>
   import('./pages/SettingsPage').then(m => ({ default: m.AutonomyPage })),
 );
-const AssistantPage = lazy(() => import('./pages/AssistantSettingsPage'));
+const PersonalityPage = lazy(() => import('./pages/PersonalitySettingsPage'));
+const GhostwritingPage = lazy(() => import('./pages/GhostwritingSettingsPage'));
 const PosturePage = lazy(() => import('./pages/PostureSettingsPage'));
 const MemoryPage = lazy(() => import('./pages/MemorySettingsPage'));
+const SystemPage = lazy(() => import('./pages/SystemSettingsPage'));
 const ToolsPage = lazy(() =>
   import('./pages/RegistrySettings').then(m => ({ default: m.ToolsPage })),
 );
@@ -92,7 +94,7 @@ const settingsRoute = createRoute({
   path: '/settings',
   beforeLoad: ({ location }) => {
     if (location.pathname === '/settings' || location.pathname === '/settings/') {
-      throw redirect({ to: '/settings/assistant' });
+      throw redirect({ to: '/settings/personality' });
     }
   },
   component: () => (
@@ -102,10 +104,23 @@ const settingsRoute = createRoute({
   ),
 });
 
-const assistantRoute = createRoute({
+const personalityRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: '/personality',
+  component: PersonalityPage,
+});
+
+const ghostwritingRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: '/ghostwriting',
+  component: GhostwritingPage,
+});
+
+// Preserve the pre-rename URL introduced earlier in this PR (#1376).
+const assistantRedirect = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/assistant',
-  component: AssistantPage,
+  beforeLoad: () => { throw redirect({ to: '/settings/personality' }); },
 });
 
 const postureRoute = createRoute({
@@ -124,6 +139,12 @@ const memoryRoute = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/memory',
   component: MemoryPage,
+});
+
+const systemRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: '/system',
+  component: SystemPage,
 });
 
 // Tools and Agents are standalone top-level pages (peer to Contacts/Tasks),
@@ -151,7 +172,7 @@ const agentsSettingsRedirect = createRoute({
 const workspaceRedirect = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/workspace',
-  beforeLoad: () => { throw redirect({ to: '/settings/assistant' }); },
+  beforeLoad: () => { throw redirect({ to: '/settings/personality' }); },
 });
 
 const loginRoute = createRoute({
@@ -245,10 +266,13 @@ const routeTree = rootRoute.addChildren([
     mcpSkillsRoute,
     kgRoute,
     settingsRoute.addChildren([
-      assistantRoute,
+      personalityRoute,
+      ghostwritingRoute,
       postureRoute,
       autonomyRoute,
       memoryRoute,
+      systemRoute,
+      assistantRedirect,
       workspaceRedirect,
       skillsSettingsRedirect,
       agentsSettingsRedirect,

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -714,16 +714,33 @@ input:focus, textarea:focus, select:focus {
   margin: 0;
 }
 
-.settings-section {
-  max-width: 720px;
-  margin-bottom: 36px;
+/* The carded .settings-section (§10 above) is reused for the operator
+   config-refinement pages (Assistant / Posture / Memory). It has overflow:hidden
+   and no padding of its own, so section content lives in a padded body region
+   below the .settings-section-head divider — matching the UI-kit
+   Principal/Notifications form layout. (An earlier revision redefined
+   .settings-section here as a flat, chrome-less block; that override is removed so
+   the card treatment applies.) */
+.settings-section-body {
+  padding: 20px;
 }
-.settings-section-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--app-fg);
-  margin: 0 0 12px;
-  letter-spacing: 0.01em;
+/* Field components (.wizard-field, .wizard-label, .string-list-editor, …) carry
+   their own vertical margins; zero the outer edges so the card padding frames
+   them cleanly. Kept as block flow so adjacent sibling margins still collapse. */
+.settings-section-body > :first-child { margin-top: 0; }
+.settings-section-body > :last-child { margin-bottom: 0; }
+
+/* Change-note + Save action block sits flush at the foot of a card body. Strip
+   the standalone-card chrome .autonomy-control carries on the Autonomy page and
+   render it as a divided footer instead. */
+.settings-section-body .autonomy-control {
+  max-width: none;
+  margin: 20px 0 0;
+  padding: 16px 0 0;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--app-border-soft);
+  border-radius: 0;
 }
 .settings-version-meta {
   font-size: 12px;
@@ -826,6 +843,10 @@ input:focus, textarea:focus, select:focus {
   line-height: 1.45;
 }
 .retention-row dd strong { color: var(--app-fg); font-weight: 600; }
+/* Card body already pads top/bottom — drop the first/last row's outer padding
+   and the trailing divider so the dl sits cleanly inside the section card. */
+.retention-row:first-child { padding-top: 0; }
+.retention-row:last-child { border-bottom: none; padding-bottom: 0; }
 
 @media (max-width: 768px) {
   .retention-row {
@@ -848,6 +869,7 @@ input:focus, textarea:focus, select:focus {
   .settings-nav-item { width: auto; }
   .settings-content { padding: 22px 18px 80px; }
   .settings-page-title { font-size: 22px; }
+  .settings-section-body { padding: 16px; }
 }
 
 /* ── Wizard page ─────────────────────────────────────────────────── */

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -714,6 +714,126 @@ input:focus, textarea:focus, select:focus {
   margin: 0;
 }
 
+.settings-section {
+  max-width: 720px;
+  margin-bottom: 36px;
+}
+.settings-section-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--app-fg);
+  margin: 0 0 12px;
+  letter-spacing: 0.01em;
+}
+.settings-version-meta {
+  font-size: 12px;
+  color: var(--app-fg-muted);
+  margin: 6px 0 0;
+}
+.settings-muted-hint {
+  font-size: 13px;
+  color: var(--app-fg-muted);
+  margin: 0 0 10px;
+}
+.settings-callout {
+  max-width: 720px;
+  margin: 0 0 24px;
+  padding: 12px 14px;
+  border-left: 3px solid var(--app-teal);
+  background: color-mix(in srgb, var(--app-teal) 8%, transparent);
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--app-fg);
+}
+.settings-callout p { margin: 0; }
+.settings-callout a { color: var(--app-teal); }
+.settings-callout-readonly {
+  border-left-color: var(--app-fg-muted);
+  background: color-mix(in srgb, var(--app-fg-muted) 10%, transparent);
+}
+.settings-history-summary {
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--app-fg-muted);
+  margin-left: 8px;
+}
+
+.string-list-editor { margin-bottom: 16px; }
+.string-list {
+  list-style: none;
+  margin: 0 0 8px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.string-list-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-bg);
+}
+.string-list-text {
+  flex: 1;
+  font-size: 13px;
+  color: var(--app-fg);
+  word-break: break-word;
+}
+.string-list-remove {
+  flex-shrink: 0;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+.string-list-add-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.string-list-add-row input {
+  flex: 1;
+  font-size: 13px;
+  padding: 8px 10px;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-bg);
+  color: var(--app-fg);
+}
+
+.retention-list {
+  margin: 0;
+  max-width: 720px;
+}
+.retention-row {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--app-border);
+}
+.retention-row dt {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--app-fg);
+  margin: 0;
+}
+.retention-row dd {
+  font-size: 13px;
+  color: var(--app-fg-muted);
+  margin: 0;
+  line-height: 1.45;
+}
+.retention-row dd strong { color: var(--app-fg); font-weight: 600; }
+
+@media (max-width: 768px) {
+  .retention-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+}
+
 /* ── 12. Responsive ──────────────────────────────────────────────────── */
 @media (max-width: 768px) {
   .settings-shell { flex-direction: column; }

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -855,6 +855,55 @@ input:focus, textarea:focus, select:focus {
   }
 }
 
+/* Generic label/value rows — used by the read-only System settings page. */
+.settings-kv-list { margin: 0; }
+.settings-kv-row {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--app-border-soft);
+  align-items: baseline;
+}
+.settings-kv-row:first-child { padding-top: 0; }
+.settings-kv-row:last-child { border-bottom: none; padding-bottom: 0; }
+.settings-kv-row dt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--app-fg);
+}
+.settings-kv-row dd {
+  margin: 0;
+  font-size: 13px;
+  color: var(--app-fg);
+}
+.settings-kv-row dd code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--app-fg-muted);
+}
+.settings-kv-tag {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--app-teal);
+  background: var(--app-teal-soft);
+  padding: 1px 6px;
+  border-radius: 999px;
+}
+
+@media (max-width: 768px) {
+  .settings-kv-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+}
+
 /* ── 12. Responsive ──────────────────────────────────────────────────── */
 @media (max-width: 768px) {
   .settings-shell { flex-direction: column; }

--- a/docs/specs/13-office-identity.md
+++ b/docs/specs/13-office-identity.md
@@ -259,14 +259,20 @@ system_prompt: |
 
 ## Populating `behavioralPreferences`
 
-The `behavioralPreferences` array is populated through two paths:
+The `behavioralPreferences` array is populated through three paths:
 
-1. **Form wizard at `/setup`** — step 3 ("Posture") includes a free-form
-   textarea. Submitting step 4 calls `PUT /api/identity` with the wizard's
-   compiled identity payload, including any new preferences appended to
+1. **Form wizard at `/setup`** — step 5 ("Posture") includes a free-form
+   textarea. Submitting step 6 calls `PUT /api/identity` with the wizard's
+   compiled identity payload, including any new preferences **appended** to
    the existing array. See [spec 18 — Onboarding](18-onboarding.md#layer-2--form-wizard-at-setup).
 
-2. **`behavioral-preferences-update` skill** — invoked by the `setup-wizard`
+2. **Console Settings → Posture** (`/settings/posture`, #1376) — post-setup
+   editor that replaces the full `behavioralPreferences` list (and
+   `decisionStyle`) via `PUT /api/identity` with `changedBy: 'api'`. Persona
+   fields are preserved via read-modify-write so Assistant and Posture pages
+   do not clobber each other.
+
+3. **`behavioral-preferences-update` skill** — invoked by the `setup-wizard`
    specialist agent during the in-chat onboarding conversation (and any
    later "remember that I…" turn the coordinator delegates to it). The
    skill calls `OfficeIdentityService.update(...)` with `'skill'` as the

--- a/docs/specs/18-onboarding.md
+++ b/docs/specs/18-onboarding.md
@@ -118,6 +118,14 @@ configurable parts of the office identity, over six steps.
 | 5 — Posture | `posture` (Conservative / Balanced / Proactive), `preferences` textarea (appended to existing `behavioralPreferences`, not replaced) | none |
 | 6 — Review | Summary card, Confirm & save button | none |
 
+**Posture / standing preferences storage (confirmed, #1376):** both live on
+`OfficeIdentity` — `decisionStyle.externalActions` (wizard posture) and
+`behavioralPreferences` (standing prefs). They are versioned with the rest of
+office identity via `PUT /api/identity` and are **not** part of
+`ExecutiveProfile`. Post-setup editing is on `/settings/posture` (replaces the
+list; the wizard still appends). Decision posture is distinct from the
+autonomy score on `/settings/autonomy`.
+
 **Tone options.** The 1–3 baseline pills come from `TONE_OPTIONS` in
 [apps/console/src/pages/wizard-utils.ts](../../apps/console/src/pages/wizard-utils.ts).
 The server-side counterpart is `BASELINE_TONE_OPTIONS` in

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -45,6 +45,10 @@ import {
   memoryRetentionRoutes,
   type MemoryRetentionSnapshot,
 } from './routes/memory-retention.js';
+import {
+  systemRoutes,
+  type SystemSnapshot,
+} from './routes/system.js';
 import { registryRoutes } from './routes/registry.js';
 import { channelRegistryRoutes } from './routes/channel-registry.js';
 import { mcpRegistryRoutes } from './routes/mcp-registry.js';
@@ -150,6 +154,11 @@ export interface HttpAdapterConfig {
    * (console Memory settings, #1376). Read-only snapshot — not hot-reloaded.
    */
   memoryRetention?: MemoryRetentionSnapshot;
+  /**
+   * Read-only system/environment snapshot for GET /api/system (console System
+   * settings, #1376). Boot-time facts only — version, runtime, timezone, models.
+   */
+  system?: SystemSnapshot;
 }
 
 export class HttpAdapter implements Channel {
@@ -245,6 +254,7 @@ export class HttpAdapter implements Channel {
         routeUrl.startsWith('/api/antfarm') ||
         routeUrl.startsWith('/api/autonomy') ||
         routeUrl.startsWith('/api/memory') ||
+        routeUrl.startsWith('/api/system') ||
         routeUrl.startsWith('/api/registry') ||
         routeUrl.startsWith('/api/vault') ||
         // Secret-capture routes are token-authed (the single-use token in the URL is the
@@ -438,6 +448,15 @@ export class HttpAdapter implements Channel {
     if (webAppBootstrapSecret && this.config.memoryRetention) {
       await this.app.register(memoryRetentionRoutes, {
         retention: this.config.memoryRetention,
+        webAppBootstrapSecret,
+        sessions,
+      });
+    }
+
+    // System snapshot (read-only) — console System settings page (#1376).
+    if (webAppBootstrapSecret && this.config.system) {
+      await this.app.register(systemRoutes, {
+        system: this.config.system,
         webAppBootstrapSecret,
         sessions,
       });

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -41,6 +41,10 @@ import { knowledgeGraphRoutes } from './routes/kg.js';
 import { identityRoutes } from './routes/identity.js';
 import { executiveRoutes } from './routes/executive.js';
 import { autonomyRoutes } from './routes/autonomy.js';
+import {
+  memoryRetentionRoutes,
+  type MemoryRetentionSnapshot,
+} from './routes/memory-retention.js';
 import { registryRoutes } from './routes/registry.js';
 import { channelRegistryRoutes } from './routes/channel-registry.js';
 import { mcpRegistryRoutes } from './routes/mcp-registry.js';
@@ -141,6 +145,11 @@ export interface HttpAdapterConfig {
    * and delegates to the handler installed by SmsAdapter.start() (ADR-036).
    */
   smsWebhookBridge?: import('../sms/webhook-bridge.js').SmsWebhookBridge;
+  /**
+   * Effective boot-time KG/memory retention knobs for GET /api/memory/retention
+   * (console Memory settings, #1376). Read-only snapshot — not hot-reloaded.
+   */
+  memoryRetention?: MemoryRetentionSnapshot;
 }
 
 export class HttpAdapter implements Channel {
@@ -235,6 +244,7 @@ export class HttpAdapter implements Channel {
         routeUrl.startsWith('/api/jobs') ||
         routeUrl.startsWith('/api/antfarm') ||
         routeUrl.startsWith('/api/autonomy') ||
+        routeUrl.startsWith('/api/memory') ||
         routeUrl.startsWith('/api/registry') ||
         routeUrl.startsWith('/api/vault') ||
         // Secret-capture routes are token-authed (the single-use token in the URL is the
@@ -419,6 +429,15 @@ export class HttpAdapter implements Channel {
     if (webAppBootstrapSecret && this.config.autonomyService) {
       await this.app.register(autonomyRoutes, {
         autonomyService: this.config.autonomyService,
+        webAppBootstrapSecret,
+        sessions,
+      });
+    }
+
+    // Memory retention (read-only) — console Memory settings page (#1376).
+    if (webAppBootstrapSecret && this.config.memoryRetention) {
+      await this.app.register(memoryRetentionRoutes, {
+        retention: this.config.memoryRetention,
         webAppBootstrapSecret,
         sessions,
       });

--- a/src/channels/http/routes/memory-retention.ts
+++ b/src/channels/http/routes/memory-retention.ts
@@ -1,0 +1,73 @@
+// memory-retention.ts — Read-only retention policy for the console Memory settings page (#1376).
+//
+// Values are the effective boot-time config (YAML → defaults). Editing is deferred;
+// this endpoint exists so operators can see what the running process is using.
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { assertSecret, type SessionStore } from '../session-auth.js';
+
+/** Effective retention knobs as loaded at process boot. */
+export interface MemoryRetentionSnapshot {
+  workingMemoryTtlDays: number;
+  scratchTtlDays: number;
+  archiveThreshold: number;
+  halfLifeDays: {
+    slowDecay: number;
+    fastDecay: number;
+  };
+  warnHoldBackDays: number;
+  /** Always false for now — editing requires restart-aware plumbing. */
+  editable: false;
+}
+
+export interface MemoryRetentionRouteOptions {
+  retention: MemoryRetentionSnapshot;
+  webAppBootstrapSecret: string;
+  sessions: SessionStore;
+}
+
+export async function memoryRetentionRoutes(
+  app: FastifyInstance,
+  options: MemoryRetentionRouteOptions,
+): Promise<void> {
+  const { retention, webAppBootstrapSecret, sessions } = options;
+
+  function requireAuth(request: FastifyRequest, reply: FastifyReply): boolean {
+    return assertSecret(request, reply, webAppBootstrapSecret, sessions);
+  }
+
+  const AUTH_RATE = { config: { rateLimit: { max: 30, timeWindow: '1 minute' } } };
+
+  // -- GET /api/memory/retention — effective boot-time retention policy (read-only) --
+
+  app.get('/api/memory/retention', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+
+    return reply.send({ retention });
+  });
+}
+
+/** Resolve effective retention values from YAML config + known defaults. */
+export function resolveMemoryRetentionSnapshot(yaml: {
+  workingMemory?: { ttlDays?: number };
+  documentWorkspace?: { scratchTtlDays?: number };
+  dreaming?: {
+    decay?: {
+      archiveThreshold?: number;
+      halfLifeDays?: { slow_decay?: number; fast_decay?: number };
+      warnHoldBackDays?: number;
+    };
+  };
+}): MemoryRetentionSnapshot {
+  return {
+    workingMemoryTtlDays: yaml.workingMemory?.ttlDays ?? 30,
+    scratchTtlDays: yaml.documentWorkspace?.scratchTtlDays ?? 7,
+    archiveThreshold: yaml.dreaming?.decay?.archiveThreshold ?? 0.05,
+    halfLifeDays: {
+      slowDecay: yaml.dreaming?.decay?.halfLifeDays?.slow_decay ?? 180,
+      fastDecay: yaml.dreaming?.decay?.halfLifeDays?.fast_decay ?? 21,
+    },
+    warnHoldBackDays: yaml.dreaming?.decay?.warnHoldBackDays ?? 7,
+    editable: false,
+  };
+}

--- a/src/channels/http/routes/system.ts
+++ b/src/channels/http/routes/system.ts
@@ -1,0 +1,83 @@
+// system.ts — Read-only system/environment snapshot for the console System settings page (#1376).
+//
+// Values reflect the running process at boot: app version, Node runtime, the
+// configured timezone, and the tier → model routing map. Read-only, non-secret;
+// mirrors the memory-retention route pattern. Deliberately excludes anything
+// sensitive (API keys, DB URL, vault contents).
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { assertSecret, type SessionStore } from '../session-auth.js';
+
+/** One capability tier and the concrete model it currently routes to. */
+export interface SystemModelTier {
+  tier: string;
+  model: string;
+}
+
+/** Read-only environment snapshot as resolved at process boot. */
+export interface SystemSnapshot {
+  /** Curia application version (root package.json). */
+  version: string;
+  /** Node.js runtime version, e.g. "v24.14.0". */
+  nodeVersion: string;
+  /** Timezone Curia operates in (config.timezone). */
+  timezone: string;
+  /** ISO timestamp of when this process started — powers the uptime display. */
+  bootedAt: string;
+  /** Capability-tier → model routing (ADR-014), plus the default tier. */
+  models: {
+    defaultTier: string;
+    tiers: SystemModelTier[];
+  };
+}
+
+export interface SystemRouteOptions {
+  system: SystemSnapshot;
+  webAppBootstrapSecret: string;
+  sessions: SessionStore;
+}
+
+export async function systemRoutes(
+  app: FastifyInstance,
+  options: SystemRouteOptions,
+): Promise<void> {
+  const { system, webAppBootstrapSecret, sessions } = options;
+
+  function requireAuth(request: FastifyRequest, reply: FastifyReply): boolean {
+    return assertSecret(request, reply, webAppBootstrapSecret, sessions);
+  }
+
+  const AUTH_RATE = { config: { rateLimit: { max: 30, timeWindow: '1 minute' } } };
+
+  // -- GET /api/system — read-only environment snapshot --
+
+  app.get('/api/system', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+
+    return reply.send({ system });
+  });
+}
+
+/** Build the read-only system snapshot from boot-time inputs. */
+export function resolveSystemSnapshot(input: {
+  version: string;
+  nodeVersion: string;
+  timezone: string;
+  bootedAt: string;
+  modelRouting: { default_tier?: string; tiers: Record<string, { model: string }> };
+}): SystemSnapshot {
+  return {
+    version: input.version,
+    nodeVersion: input.nodeVersion,
+    timezone: input.timezone,
+    bootedAt: input.bootedAt,
+    models: {
+      defaultTier: input.modelRouting.default_tier ?? 'standard',
+      // Preserve YAML declaration order (fast → standard → powerful).
+      tiers: Object.entries(input.modelRouting.tiers).map(([tier, cfg]) => ({
+        tier,
+        model: cfg.model,
+      })),
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { runner } from 'node-pg-migrate';
 import { loadConfig, loadYamlConfig, resolveTasksConfig, resolveHealthConfig } from './config.js';
 import { createLogger } from './logger.js';
 import { HttpAdapter } from './channels/http/http-adapter.js';
+import { resolveMemoryRetentionSnapshot } from './channels/http/routes/memory-retention.js';
 import { createPool } from './db/connection.js';
 import { DbAvailabilityMonitor } from './db/availability-monitor.js';
 import { EventBus } from './bus/bus.js';
@@ -2544,6 +2545,10 @@ async function main(): Promise<void> {
   // the health check fired during a multi-minute catch-up and marked the container
   // unhealthy before the API was even bound. All HTTP adapter dependencies (bus,
   // pool, services, registries) are fully initialized by this point.
+  // Resolve retention snapshot once at boot for the read-only Memory settings API (#1376).
+  // Editing these values still requires a config change + restart.
+  const memoryRetention = resolveMemoryRetentionSnapshot(yamlConfig);
+
   const httpAdapter = new HttpAdapter({
     bus,
     logger,
@@ -2577,6 +2582,7 @@ async function main(): Promise<void> {
     healthService,
     auditLogRepo,
     smsWebhookBridge,
+    memoryRetention,
   });
 
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,11 +18,13 @@
  */
 
 import * as path from 'node:path';
+import { createRequire } from 'node:module';
 import { runner } from 'node-pg-migrate';
 import { loadConfig, loadYamlConfig, resolveTasksConfig, resolveHealthConfig } from './config.js';
 import { createLogger } from './logger.js';
 import { HttpAdapter } from './channels/http/http-adapter.js';
 import { resolveMemoryRetentionSnapshot } from './channels/http/routes/memory-retention.js';
+import { resolveSystemSnapshot } from './channels/http/routes/system.js';
 import { createPool } from './db/connection.js';
 import { DbAvailabilityMonitor } from './db/availability-monitor.js';
 import { EventBus } from './bus/bus.js';
@@ -2549,6 +2551,18 @@ async function main(): Promise<void> {
   // Editing these values still requires a config change + restart.
   const memoryRetention = resolveMemoryRetentionSnapshot(yamlConfig);
 
+  // Read-only system snapshot for the console System settings page (#1376).
+  // Version comes from the root package.json (resolved at runtime relative to the
+  // built module — same createRequire pattern the console's vite config uses).
+  const appPackage = createRequire(import.meta.url)('../package.json') as { version: string };
+  const systemSnapshot = resolveSystemSnapshot({
+    version: appPackage.version,
+    nodeVersion: process.version,
+    timezone: config.timezone,
+    bootedAt: bootStartedAt,
+    modelRouting: modelRoutingConfig,
+  });
+
   const httpAdapter = new HttpAdapter({
     bus,
     logger,
@@ -2583,6 +2597,7 @@ async function main(): Promise<void> {
     auditLogRepo,
     smsWebhookBridge,
     memoryRetention,
+    system: systemSnapshot,
   });
 
   try {

--- a/tests/unit/channels/http/memory-retention-routes.test.ts
+++ b/tests/unit/channels/http/memory-retention-routes.test.ts
@@ -1,0 +1,99 @@
+import Fastify from 'fastify';
+import cookie from '@fastify/cookie';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  memoryRetentionRoutes,
+  resolveMemoryRetentionSnapshot,
+  type MemoryRetentionSnapshot,
+} from '../../../../src/channels/http/routes/memory-retention.js';
+import { hashToken } from '../../../../src/channels/http/session-auth.js';
+
+const SECRET = 'test-bootstrap-secret';
+
+const SNAPSHOT: MemoryRetentionSnapshot = {
+  workingMemoryTtlDays: 30,
+  scratchTtlDays: 7,
+  archiveThreshold: 0.05,
+  halfLifeDays: { slowDecay: 180, fastDecay: 21 },
+  warnHoldBackDays: 7,
+  editable: false,
+};
+
+describe('resolveMemoryRetentionSnapshot', () => {
+  it('applies defaults when yaml omits retention keys', () => {
+    expect(resolveMemoryRetentionSnapshot({})).toEqual(SNAPSHOT);
+  });
+
+  it('passes through configured values', () => {
+    const resolved = resolveMemoryRetentionSnapshot({
+      workingMemory: { ttlDays: 14 },
+      documentWorkspace: { scratchTtlDays: 3 },
+      dreaming: {
+        decay: {
+          archiveThreshold: 0.1,
+          halfLifeDays: { slow_decay: 90, fast_decay: 14 },
+          warnHoldBackDays: 3,
+        },
+      },
+    });
+    expect(resolved.workingMemoryTtlDays).toBe(14);
+    expect(resolved.scratchTtlDays).toBe(3);
+    expect(resolved.archiveThreshold).toBe(0.1);
+    expect(resolved.halfLifeDays.slowDecay).toBe(90);
+    expect(resolved.halfLifeDays.fastDecay).toBe(14);
+    expect(resolved.warnHoldBackDays).toBe(3);
+    expect(resolved.editable).toBe(false);
+  });
+});
+
+describe('GET /api/memory/retention', () => {
+  const sessions = new Map<string, number>();
+
+  beforeEach(() => sessions.clear());
+
+  async function buildApp() {
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(memoryRetentionRoutes, {
+      retention: SNAPSHOT,
+      webAppBootstrapSecret: SECRET,
+      sessions,
+    });
+    return app;
+  }
+
+  it('returns the boot-time retention snapshot', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memory/retention',
+      headers: { 'x-web-bootstrap-secret': SECRET },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ retention: SNAPSHOT });
+    await app.close();
+  });
+
+  it('accepts a valid session cookie', async () => {
+    const token = 'valid-session-token';
+    sessions.set(hashToken(token), Date.now() + 60_000);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memory/retention',
+      headers: { cookie: `curia_session=${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memory/retention',
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+});

--- a/tests/unit/channels/http/system-routes.test.ts
+++ b/tests/unit/channels/http/system-routes.test.ts
@@ -1,0 +1,107 @@
+import Fastify from 'fastify';
+import { beforeEach, describe, expect, it } from 'vitest';
+import cookie from '@fastify/cookie';
+import {
+  systemRoutes,
+  resolveSystemSnapshot,
+  type SystemSnapshot,
+} from '../../../../src/channels/http/routes/system.js';
+import { hashToken } from '../../../../src/channels/http/session-auth.js';
+
+const SECRET = 'test-bootstrap-secret';
+
+const SNAPSHOT: SystemSnapshot = {
+  version: '0.41.0',
+  nodeVersion: 'v24.14.0',
+  timezone: 'America/Toronto',
+  bootedAt: '2026-07-25T12:00:00.000Z',
+  models: {
+    defaultTier: 'standard',
+    tiers: [
+      { tier: 'fast', model: 'claude-haiku-4-5' },
+      { tier: 'standard', model: 'claude-sonnet-4-6' },
+      { tier: 'powerful', model: 'claude-opus-4-6' },
+    ],
+  },
+};
+
+describe('resolveSystemSnapshot', () => {
+  it('maps tier → model preserving YAML order and passes runtime facts through', () => {
+    const resolved = resolveSystemSnapshot({
+      version: '0.41.0',
+      nodeVersion: 'v24.14.0',
+      timezone: 'America/Toronto',
+      bootedAt: '2026-07-25T12:00:00.000Z',
+      modelRouting: {
+        default_tier: 'standard',
+        tiers: {
+          fast: { model: 'claude-haiku-4-5' },
+          standard: { model: 'claude-sonnet-4-6' },
+          powerful: { model: 'claude-opus-4-6' },
+        },
+      },
+    });
+    expect(resolved).toEqual(SNAPSHOT);
+  });
+
+  it('defaults the tier to "standard" when default_tier is omitted', () => {
+    const resolved = resolveSystemSnapshot({
+      version: '1.0.0',
+      nodeVersion: 'v24.0.0',
+      timezone: 'UTC',
+      bootedAt: '2026-01-01T00:00:00.000Z',
+      modelRouting: { tiers: { standard: { model: 'm' } } },
+    });
+    expect(resolved.models.defaultTier).toBe('standard');
+    expect(resolved.models.tiers).toEqual([{ tier: 'standard', model: 'm' }]);
+  });
+});
+
+describe('GET /api/system', () => {
+  const sessions = new Map<string, number>();
+
+  beforeEach(() => sessions.clear());
+
+  async function buildApp() {
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(systemRoutes, {
+      system: SNAPSHOT,
+      webAppBootstrapSecret: SECRET,
+      sessions,
+    });
+    return app;
+  }
+
+  it('returns the boot-time system snapshot', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/system',
+      headers: { 'x-web-bootstrap-secret': SECRET },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ system: SNAPSHOT });
+    await app.close();
+  });
+
+  it('accepts a valid session cookie', async () => {
+    const token = 'valid-session-token';
+    sessions.set(hashToken(token), Date.now() + 60_000);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/system',
+      headers: { cookie: `curia_session=${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/system' });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1376.

Operators can refine post-setup config without re-running the wizard:

1. **Assistant** (`/settings/assistant`) — persona (name/title/signature + tone) via `PUT /api/identity`; writing voice via `PUT /api/executive`
2. **Posture** (`/settings/posture`) — decision style + standing preferences on office identity (storage confirmed/docs updated)
3. **Memory** (`/settings/memory`) — read-only retention policy via new `GET /api/memory/retention`
4. **IA** — remove Workspace stub; settings-nav order Assistant → Posture → Autonomy → Memory; Sidebar “Workspace” → `/settings`; dynamic Topbar title

## Design notes

- Shared tone/posture field components extracted for wizard + settings reuse
- Identity saves use read-modify-write (re-fetch before PUT) so Assistant and Posture don’t clobber each other
- Executive voice saves preserve the LLM-learned `guide` field
- Retention values are boot-time YAML defaults (restart-required to change); UI framed as read-only

## Test plan

- [ ] `/settings` redirects to `/settings/assistant`
- [ ] `/settings/workspace` redirects to assistant
- [ ] Sidebar Workspace item lands on settings (assistant)
- [ ] Edit + save persona; confirm hot-reload / next-turn effect; history + change note
- [ ] Edit + save writing voice without wiping `guide`
- [ ] Edit posture/prefs without clobbering persona fields (and vice versa)
- [ ] Memory page shows plain-language retention copy and read-only callout
- [ ] `pnpm test` (memory-retention unit tests) and typecheck pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-476012f7-3cd2-48c4-8263-93add73f599c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-476012f7-3cd2-48c4-8263-93add73f599c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

