### PR TITLE
fix(voice): wire Cartesia voice ID so TTS can synthesize replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Voice channel** — CodeRabbit review: hangup race, silent rooms, LiveKit opt-in, turn integrity. (#1414)
 - **Voice lifecycle hardening** — bounded STT socket waits, session cleanup on token failure, safe session end. (#1414)
+- **Voice TTS was unusable** — Cartesia voice id is now a required, console-set voice credential. (#1414)
 
 ### Changed
 

--- a/docs/dev/voice-setup.md
+++ b/docs/dev/voice-setup.md
@@ -120,6 +120,10 @@ Enter these in **Settings → Channels → Voice**:
 - `channel.voice.livekit_api_secret`
 - `channel.voice.deepgram_api_key`
 - `channel.voice.cartesia_api_key`
+- `channel.voice.cartesia_voice_id` — the voice to speak in. Pick one from
+  [play.cartesia.ai](https://play.cartesia.ai) and copy its voice id (a UUID).
+  Required: Cartesia cannot synthesize a reply without it, so the channel stays
+  disabled until it is set.
 
 Then install/enable the Voice channel and restart Curia. The runtime reads the
 vault values on startup; changing a key does not affect already-running calls.

--- a/skills/setup/tools/setup-status/catalog.yaml
+++ b/skills/setup/tools/setup-status/catalog.yaml
@@ -104,7 +104,8 @@ tasks:
         - channel.voice.livekit_api_secret
         - channel.voice.deepgram_api_key
         - channel.voice.cartesia_api_key
-    credential_how_to: "Run a self-hosted LiveKit server (see docs/dev/voice-setup.md), create Deepgram and Cartesia API keys, then enter LiveKit URL/API key/secret plus Deepgram and Cartesia keys in Settings → Channels → Voice. Enable the channel and restart."
+        - channel.voice.cartesia_voice_id
+    credential_how_to: "Run a self-hosted LiveKit server (see docs/dev/voice-setup.md), create Deepgram and Cartesia API keys, and pick a Cartesia voice id from play.cartesia.ai, then enter LiveKit URL/API key/secret, Deepgram and Cartesia keys, and the Cartesia voice ID in Settings → Channels → Voice. Enable the channel and restart."
     docs_url: /channels/voice-setup
 
   - id: web_research

--- a/src/channels/apply-channel-vault-secrets.test.ts
+++ b/src/channels/apply-channel-vault-secrets.test.ts
@@ -35,6 +35,7 @@ function baseConfig(): Config {
     voiceLivekitApiSecret: undefined,
     voiceDeepgramApiKey: undefined,
     voiceCartesiaApiKey: undefined,
+    voiceCartesiaVoiceId: undefined,
     voiceModel: undefined,
   } as Config;
 }
@@ -63,6 +64,7 @@ describe('applyChannelVaultSecrets', () => {
       'channel.voice.livekit_api_secret': 'lk_secret',
       'channel.voice.deepgram_api_key': 'dg_secret',
       'channel.voice.cartesia_api_key': 'cartesia_secret',
+      'channel.voice.cartesia_voice_id': 'voice_abc123',
     });
 
     await applyChannelVaultSecrets(config, secrets, {}, logger);
@@ -82,6 +84,7 @@ describe('applyChannelVaultSecrets', () => {
     expect(config.voiceLivekitApiSecret).toBe('lk_secret');
     expect(config.voiceDeepgramApiKey).toBe('dg_secret');
     expect(config.voiceCartesiaApiKey).toBe('cartesia_secret');
+    expect(config.voiceCartesiaVoiceId).toBe('voice_abc123');
   });
 
   it('activates Signal from a console-only entry — channel.signal.phone_number alone, no flat bootstrap, no env', async () => {
@@ -182,6 +185,7 @@ describe('applyChannelVaultSecrets', () => {
       'channel.sms.from_number',
       'channel.sms.webhook_public_key',
       'channel.voice.cartesia_api_key',
+      'channel.voice.cartesia_voice_id',
       'channel.voice.deepgram_api_key',
       'channel.voice.livekit_api_key',
       'channel.voice.livekit_api_secret',

--- a/src/channels/apply-channel-vault-secrets.ts
+++ b/src/channels/apply-channel-vault-secrets.ts
@@ -68,6 +68,7 @@ export async function applyChannelVaultSecrets(
     voiceLivekitApiSecret,
     voiceDeepgramApiKey,
     voiceCartesiaApiKey,
+    voiceCartesiaVoiceId,
   ] = await Promise.all([
     resolve('channel.email.nylas_api_key', 'NYLAS_API_KEY', config.nylasApiKey),
     resolve('channel.email.nylas_grant_id', 'NYLAS_GRANT_ID', config.nylasGrantId),
@@ -88,6 +89,9 @@ export async function applyChannelVaultSecrets(
     readVaultKey(secrets, 'channel.voice.livekit_api_secret', logger),
     readVaultKey(secrets, 'channel.voice.deepgram_api_key', logger),
     readVaultKey(secrets, 'channel.voice.cartesia_api_key', logger),
+    // Not a secret (a Cartesia voice id), but sits with the voice creds so the
+    // console can set it; TTS cannot synthesize without it.
+    readVaultKey(secrets, 'channel.voice.cartesia_voice_id', logger),
   ]);
 
   config.nylasApiKey = nylasApiKey;
@@ -106,6 +110,7 @@ export async function applyChannelVaultSecrets(
   config.voiceLivekitApiSecret = voiceLivekitApiSecret;
   config.voiceDeepgramApiKey = voiceDeepgramApiKey;
   config.voiceCartesiaApiKey = voiceCartesiaApiKey;
+  config.voiceCartesiaVoiceId = voiceCartesiaVoiceId;
 
   // Names only — never values. Lets an operator confirm which channel creds the vault/env
   // supplied vs. which are absent (feature-off), the same debuggability win as applyVaultSecrets.
@@ -125,6 +130,7 @@ export async function applyChannelVaultSecrets(
     'channel.voice.livekit_api_secret': voiceLivekitApiSecret !== undefined,
     'channel.voice.deepgram_api_key': voiceDeepgramApiKey !== undefined,
     'channel.voice.cartesia_api_key': voiceCartesiaApiKey !== undefined,
+    'channel.voice.cartesia_voice_id': voiceCartesiaVoiceId !== undefined,
   };
   logger.info({ present }, 'Applied channel credentials onto config (vault ▸ env ▸ config)');
 }

--- a/src/channels/catalog.test.ts
+++ b/src/channels/catalog.test.ts
@@ -43,6 +43,7 @@ describe('CHANNEL_CATALOG', () => {
       'livekit_api_secret',
       'deepgram_api_key',
       'cartesia_api_key',
+      'cartesia_voice_id',
     ]);
     expect(voice.credentialFields.every(f => f.envFallback === undefined)).toBe(true);
   });

--- a/src/channels/catalog.ts
+++ b/src/channels/catalog.ts
@@ -85,6 +85,9 @@ export const CHANNEL_CATALOG: ChannelDescriptor[] = [
       { key: 'livekit_api_secret', label: 'LiveKit API secret', secret: true },
       { key: 'deepgram_api_key', label: 'Deepgram API key', secret: true },
       { key: 'cartesia_api_key', label: 'Cartesia API key', secret: true },
+      // Not a secret — a voice id from the Cartesia library (play.cartesia.ai).
+      // Required: Cartesia TTS cannot synthesize a reply without it.
+      { key: 'cartesia_voice_id', label: 'Cartesia voice ID', secret: false },
     ],
     requiredSecretKeys: [
       'livekit_url',
@@ -92,6 +95,7 @@ export const CHANNEL_CATALOG: ChannelDescriptor[] = [
       'livekit_api_secret',
       'deepgram_api_key',
       'cartesia_api_key',
+      'cartesia_voice_id',
     ],
   },
   {

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,10 @@ export interface Config {
   voiceLivekitApiSecret: string | undefined;
   voiceDeepgramApiKey: string | undefined;
   voiceCartesiaApiKey: string | undefined;
+  /** Cartesia voice to synthesize with (a voice id from the Cartesia library). Not a
+   * secret, but lives alongside the other voice credentials so it is console-settable.
+   * TTS cannot synthesize without it, so the voice channel treats it as required. */
+  voiceCartesiaVoiceId: string | undefined;
   /** Optional model override for voice turns; defaults to the fast tier when unset. */
   voiceModel?: string;
 }
@@ -1281,6 +1285,7 @@ export function loadConfig(): Config {
     voiceLivekitApiSecret: undefined,
     voiceDeepgramApiKey: undefined,
     voiceCartesiaApiKey: undefined,
+    voiceCartesiaVoiceId: undefined,
     voiceModel: undefined,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -923,11 +923,12 @@ async function main(): Promise<void> {
     config.voiceLivekitApiKey &&
     config.voiceLivekitApiSecret &&
     config.voiceDeepgramApiKey &&
-    config.voiceCartesiaApiKey
+    config.voiceCartesiaApiKey &&
+    config.voiceCartesiaVoiceId
   ) {
     logger.info({ hasVoiceModelOverride: config.voiceModel !== undefined }, 'Voice credentials configured (LiveKit + STT/TTS)');
   } else {
-    logger.warn('Voice credentials not fully configured — voice channel disabled. Set LiveKit, Deepgram, and Cartesia credentials in the console (Settings → Channels → Voice); credentials are vault-only (no env fallback).');
+    logger.warn('Voice credentials not fully configured — voice channel disabled. Set the LiveKit, Deepgram, and Cartesia values (including the Cartesia voice ID) in the console (Settings → Channels → Voice); credentials are vault-only (no env fallback).');
   }
 
   // Calendar client — operates as the PRINCIPAL (the CEO), not as Curia's mailbox.
@@ -1792,7 +1793,8 @@ async function main(): Promise<void> {
     config.voiceLivekitApiKey &&
     config.voiceLivekitApiSecret &&
     config.voiceDeepgramApiKey &&
-    config.voiceCartesiaApiKey
+    config.voiceCartesiaApiKey &&
+    config.voiceCartesiaVoiceId
   ) {
     // Voice turns use the 'fast' tier by default (ADR-037 §3), overridable via
     // channels.voice.model. The runtime needs a provider that supports stream();
@@ -1808,7 +1810,7 @@ async function main(): Promise<void> {
         logger,
         sessionStore: voiceSessionStore,
         stt: new DeepgramSttProvider(config.voiceDeepgramApiKey, logger),
-        tts: new CartesiaTtsProvider(config.voiceCartesiaApiKey, logger),
+        tts: new CartesiaTtsProvider(config.voiceCartesiaApiKey, logger, config.voiceCartesiaVoiceId),
         llm: voiceLlmProvider,
         model: voiceModel,
         livekitUrl: voiceLivekitUrl,
@@ -1850,7 +1852,7 @@ async function main(): Promise<void> {
       );
     }
   } else if (channelShouldStart.has('voice')) {
-    logger.warn('channel voice is enabled + resolvable but runtime credentials are missing (LiveKit, Deepgram, or Cartesia); no Voice adapter constructed — check vault credentials and restart');
+    logger.warn('channel voice is enabled + resolvable but runtime credentials are missing (LiveKit, Deepgram, Cartesia, or the Cartesia voice ID); no Voice adapter constructed — check vault credentials and restart');
   }
 
   // Scheduler — Postgres-backed job scheduler for cron and one-shot tasks.

--- a/src/secrets/apply-vault-secrets.test.ts
+++ b/src/secrets/apply-vault-secrets.test.ts
@@ -36,6 +36,7 @@ function baseConfig(): Config {
     voiceLivekitApiSecret: undefined,
     voiceDeepgramApiKey: undefined,
     voiceCartesiaApiKey: undefined,
+    voiceCartesiaVoiceId: undefined,
     voiceModel: undefined,
   };
 }


### PR DESCRIPTION
## Summary

The voice channel connected, transcribed speech (Deepgram), and generated an LLM reply — but **never spoke**. `CartesiaTtsProvider` was constructed with only the API key; its `defaultVoiceId` was left `undefined`, and no config or vault path supplied a voice id. Every synthesis threw `Cartesia TTS requires a voiceId or defaultVoiceId`, so each turn died at the final step and the console just sat in "Listening…".

Found while bringing up voice in production: STT + streaming LLM were fully working; only TTS voice selection was unwired.

## Fix

Add the Cartesia voice id as a **required, non-secret voice credential** and thread it through, mirroring the existing voice creds:

- **Vault overlay** (`apply-channel-vault-secrets.ts`) reads `channel.voice.cartesia_voice_id` → `config.voiceCartesiaVoiceId`. Same fixed allowlist — no `list()` / prefix scan (NAMESPACE SAFETY invariant preserved).
- **Catalog**: a non-secret `cartesia_voice_id` credential field, added to `requiredSecretKeys` so voice stays disabled (with a clear log) until it's set, instead of enabling and throwing per turn. The console renders it as a text input automatically.
- **Wiring**: passed to `new CartesiaTtsProvider(apiKey, logger, voiceCartesiaVoiceId)`; both boot gates now require it.
- **Docs**: `voice-setup.md` + setup-status catalog note the new key and where to get a voice id ([play.cartesia.ai](https://play.cartesia.ai)).

## Testing

- TDD: extended the vault-overlay test first (red on the missing read + unpopulated field), then wired it green.
- ✅ `pnpm run typecheck` clean · ✅ eslint clean · ✅ 69 unit tests pass (voice + catalog + vault overlay).

## Reviews

Ran a code-review and a silent-failure review before opening. Code review: no issues. Silent-failure review confirmed the **missing**-voice-id case is genuinely gated at boot (not deferred to call time), and flagged one message-completeness nit (fixed here: the construction-gate fallback warning now names the voice ID too).

## Follow-ups filed (out of scope here)

- **#1556** — a *wrong* voice id (or any TTS failure) is currently `warn`-and-swallowed per turn; the caller hears silence with no escalation. Pre-existing resilience gap the reviewer flagged; needs a design choice (escalate / tear down / notify).
- **#1555** — hangup `DeleteRoom` 404s because the LiveKit management client uses the public signaling URL instead of internal `livekit:7880`.

## Verifying in prod after merge

New `:edge` build → `deploy.sh` → paste a Cartesia voice id into the new **Settings → Channels → Voice → Cartesia voice ID** field → restart the app.

Related: #1414 (voice channel).
