### PR TITLE
fix(console): scope dashboard Recent Activity timeline fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Dashboard Recent Activity** — timeline fetch sends a 24h `from=` scope so the card loads. (#1548)
 - **Voice channel** — CodeRabbit review: hangup race, silent rooms, LiveKit opt-in, turn integrity. (#1414)
 - **Voice lifecycle hardening** — bounded STT socket waits, session cleanup on token failure, safe session end. (#1414)
 - **Voice TTS was unusable** — Cartesia voice id is now a required, console-set voice credential. (#1414)

--- a/apps/console/src/pages/dashboard/ActivityFeed.tsx
+++ b/apps/console/src/pages/dashboard/ActivityFeed.tsx
@@ -1,7 +1,8 @@
 // ActivityFeed — "what's been happening?": recent events from the interpreted
-// Ant Farm timeline (GET /api/antfarm/timeline). The timeline returns scene
-// directives, not raw audit rows (the only console-facing activity endpoint
-// today); each directive is mapped to a readable line, newest first.
+// Ant Farm timeline (GET /api/antfarm/timeline?from=<now-24h>&limit=20). The
+// timeline returns scene directives, not raw audit rows (the only console-facing
+// activity endpoint today); each directive is mapped to a readable line, newest
+// first. The from= scope is required by assertTimelineScope.
 
 import { fetchActivity } from './dashboard-utils.js';
 import { useAsyncData } from './useAsyncData.js';

--- a/apps/console/src/pages/dashboard/dashboard-utils.test.ts
+++ b/apps/console/src/pages/dashboard/dashboard-utils.test.ts
@@ -265,6 +265,24 @@ describe('fetchActivity', () => {
     expect(lines.map(l => l.id)).toEqual(['b', 'a']); // newest (higher logicalTs) first
   });
 
+  it('scopes the request with a from= lookback so assertTimelineScope accepts it', async () => {
+    const fetchMock = mockFetch(200, { directives: [] });
+    vi.stubGlobal('fetch', fetchMock);
+    const before = Date.now() - 24 * 60 * 60 * 1000;
+    await fetchActivity();
+    const after = Date.now() - 24 * 60 * 60 * 1000;
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = String(fetchMock.mock.calls[0]![0]);
+    expect(url).toMatch(/^\/api\/antfarm\/timeline\?/);
+    const params = new URL(url, 'http://test').searchParams;
+    expect(params.get('limit')).toBe('20');
+    const fromMs = Date.parse(params.get('from')!);
+    expect(Number.isFinite(fromMs)).toBe(true);
+    // from should be ~now-24h, allowing for the call itself.
+    expect(fromMs).toBeGreaterThanOrEqual(before - 1000);
+    expect(fromMs).toBeLessThanOrEqual(after + 1000);
+  });
+
   it('throws when the 200 body is missing its directives array', async () => {
     vi.stubGlobal('fetch', mockFetch(200, {}));
     await expect(fetchActivity()).rejects.toThrow(/unexpected response/);

--- a/apps/console/src/pages/dashboard/dashboard-utils.ts
+++ b/apps/console/src/pages/dashboard/dashboard-utils.ts
@@ -354,10 +354,16 @@ export function mapDirective(d: SceneDirective): ActivityLine | null {
   }
 }
 
-// GET /api/antfarm/timeline?limit=20 → interpreted lines, newest first.
+// Lookback window for the home Recent Activity card. Matches Ant Farm's
+// default 24h preload; also satisfies assertTimelineScope (requires ≥1 filter).
+const ACTIVITY_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+// GET /api/antfarm/timeline?from=<now-24h>&limit=20 → interpreted lines, newest first.
 export async function fetchActivity(signal?: AbortSignal): Promise<ActivityLine[]> {
+  const from = new Date(Date.now() - ACTIVITY_LOOKBACK_MS).toISOString();
+  const params = new URLSearchParams({ from, limit: '20' });
   const data = await fetchJson<{ directives?: SceneDirective[] }>(
-    '/api/antfarm/timeline?limit=20',
+    `/api/antfarm/timeline?${params.toString()}`,
     signal,
   );
   const directives = requireArray<SceneDirective>(data.directives, '/api/antfarm/timeline');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1548.

The dashboard "Recent Activity" card always rendered **Timeline unavailable / Failed to load timeline** because `fetchActivity` called `GET /api/antfarm/timeline?limit=20` with no scope filter, while `assertTimelineScope()` requires at least one of `from` / `to` / `conversationId` / `taskId` / etc.

## Fix

`fetchActivity` now passes `from=<now-24h>` (same default window as Ant Farm’s 24h preload), keeping the backend guard intact for genuinely scopeless callers.

## Acceptance

- [x] Dashboard Recent Activity no longer fails solely due to a missing scope filter
- [x] `assertTimelineScope` unchanged (not weakened to allow empty)
- [x] Unit test asserts the request includes a valid `from=` lookback + `limit=20`

## Test plan

- [x] `pnpm --filter @curia/console exec vitest run src/pages/dashboard/dashboard-utils.test.ts`
- [ ] Manual: load console home → Recent Activity shows entries or “No recent activity yet”, not “Timeline unavailable”
- [ ] Confirm logs no longer show `antfarm timeline query failed` from the dashboard caller on normal load

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d28931b-8ee5-48cb-9363-1f480599db65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d28931b-8ee5-48cb-9363-1f480599db65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

