### PR TITLE
feat(voice): coordinator brain/context parity + working_memory history read model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Voice brain** — spoken turns gain persona, specialist delegation guidance, and date/timezone context. (#1551)
+- **Voice history** — spoken-turn context reloads from `working_memory`; in-process history is now only a fallback. (#1551)
+- **Voice honesty** — failed tool checks are spoken as "couldn't check," never as empty results. (#1551)
 - **Voice docs** — folded security memo into ADR-037 + `voice-setup.md`; deleted duplicate. (#1414)
 - **Audit log Phase 1** — structured columns, `seq`-ordered hash chain, `llm_call_archive` (kill-switch + TTL), `pnpm audit:verify`. (#1383)
 - **DB outage resilience** — `DATABASE_UNAVAILABLE` errors, pool timeouts, skill retry, CEO alert after 5 min. (#1381)

--- a/docs/adr/037-voice-channel-livekit-duplex.md
+++ b/docs/adr/037-voice-channel-livekit-duplex.md
@@ -96,12 +96,25 @@ voice reuses that for session minting (and optional LiveKit webhooks).
   provider, tool definitions, and bus `tool.invoke` / autonomy checks where
   practical. A later refactor extracts a shared streaming turn primitive that
   both paths delegate to — **not** a literal fold into `handleTask`
-  (tracked: #1552; brain/context + history read model: #1551).
-- **Phase 1 voice "brain" is deliberately slim:** spoken turns receive the
-  voice-mode addendum + last-N in-memory turns + coordinator tools — **not**
-  the full coordinator system prompt, office persona injection, KG/entity
-  enrichment, or DB-backed working-memory reload. Sufficient for quick spoken
-  Q&A; closing the gap is a follow-up, not an accidental omission.
+  (tracked: #1552; brain/context + history read model landed via #1551).
+- **Voice "brain" is a curated subset of the coordinator's context (#1551):**
+  spoken turns assemble the office identity/persona block, the voice-mode
+  addendum (spoken brevity), an honest-negative tool-result policy (a failed
+  check is spoken as "couldn't check", never narrated as an empty result),
+  delegation guidance + the specialist roster (so calendar / contacts /
+  research stay reachable from voice), and a per-turn date/timezone block —
+  plus coordinator tools. Deliberately still **not** the coordinator's full
+  YAML system prompt (text-channel mechanics that hurt the spoken latency
+  budget without helping spoken Q&A) or KG/sender enrichment (precomputed on
+  the dispatcher path voice bypasses; contacts delegation covers it).
+- **Voice history is single-sourced from `working_memory` (#1551):** each
+  spoken turn reloads the `voice:<sessionId>` conversation (agent id
+  `coordinator` — the same rows console chat history reads) before the LLM
+  call; the in-process last-N window is only a fallback when the store is
+  absent or a read fails. Turns persisted mid-call therefore survive a process
+  restart in console history; a restart still ends the live call (rooms are
+  ephemeral, no auto-rejoin) and a reconnect starts a new `voice:<id>`
+  conversation by design.
 - **Outbound judge parity with web chat:** spoken TTS bypasses
   `OutboundGateway` / Stage-2 judge the same way principal console text does
   (web chat never calls the gateway). Tool calls from a live call still go

--- a/docs/wip/2026-07-25-voice-channel-design.md
+++ b/docs/wip/2026-07-25-voice-channel-design.md
@@ -212,7 +212,9 @@ for barge-in cancel.
 2. Console connects with LiveKit client SDK; publishes mic track.
 3. VoiceRuntime joins as agent participant; subscribes to principal audio.
 4. Pipe PCM → STT session; on **final + endpoint**, start `VoiceTurnRunner`.
-5. Runner: inject voice-mode system addendum; `stream()`; sentence-chunk text
+5. Runner: assemble the voice system prompt (persona + addendum + honest-negative
+   policy + delegation guidance/roster + date/time — see §"Phase 1 brain" below)
+   and reload history from `working_memory`; `stream()`; sentence-chunk text
    deltas → TTS → publish audio track. On `tool_use`, speak a short filler,
    invoke tool via execution path, continue stream with tool results.
    Persist user + assistant turns to `WorkingMemory` for console history.
@@ -224,13 +226,36 @@ for barge-in cancel.
    LiveKit room, publish `voice.session.ended`, stop tracks, update DB.
    Transport `onClose` covers ungraceful tab close without `DELETE`.
 
-### Phase 1 brain (explicit non-goal)
+### Phase 1 brain (updated by #1551)
 
-Spoken turns deliberately do **not** load the coordinator's full system prompt,
-office persona injection, KG/entity-context enrichment, or DB-backed working
-memory into the LLM context. The model sees the voice addendum, last-N
-in-memory turns for this session, and coordinator pinned tools. Closing the
-gap with `AgentRuntime.handleTask` is a tracked follow-up.
+Spoken turns load a curated subset of the coordinator's context, assembled per
+turn by `buildVoiceSystemPrompt()` in `voice-runtime.ts` (static sections
+first, the dynamic time block last, so the prompt prefix stays
+provider-cacheable):
+
+1. Office identity/persona block (`OfficeIdentityService.compileSystemPromptBlock`,
+   per-turn so hot-reloads apply — same as the coordinator preamble)
+2. Voice-mode addendum (spoken brevity — unchanged)
+3. Honest-negative tool-result policy: a failed or errored check is spoken as
+   "couldn't check", never narrated as an authoritative empty result
+4. Delegation guidance + `## Available Specialists` roster, so specialist
+   domains (calendar, contacts, research, the principal's inbox) are reachable
+   from voice via the `delegate` tool
+5. `## Current Date & Time` block (`formatTimeContextBlock`) so "tomorrow /
+   next week" is anchored for every voice tool call
+
+History is single-sourced: each turn reloads the `voice:<sessionId>`
+conversation from `working_memory` (agent id `coordinator` — the same rows the
+console history endpoint reads); the in-process last-N window is only a
+fallback when the store is absent or a read fails.
+
+Still deliberately excluded (documented trade-off, not an omission): the
+coordinator's full YAML system prompt (text-channel mechanics — email/CC/
+scheduler — that hurt the spoken latency budget without helping spoken Q&A),
+KG/sender enrichment (precomputed on the dispatcher path voice bypasses;
+contacts delegation covers it), and the autonomy/security blocks (enforced by
+`ExecutionLayer` on every tool call regardless). The shared streaming turn
+primitive remains #1552.
 
 ### Outbound judge parity
 

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect, vi } from 'vitest';
 import { EventBus } from '../../bus/bus.js';
 import type { BusEvent } from '../../bus/events.js';
 import { createSilentLogger } from '../../logger.js';
-import type { LLMProvider, LLMResponse, LLMStreamEvent } from '../../agents/llm/provider.js';
-import { VoiceRuntime } from './voice-runtime.js';
+import type { LLMProvider, LLMResponse, LLMStreamEvent, Message } from '../../agents/llm/provider.js';
+import { WorkingMemory } from '../../memory/working-memory.js';
+import {
+  VoiceRuntime,
+  VOICE_SYSTEM_ADDENDUM,
+  VOICE_TOOL_RESULT_POLICY,
+  VOICE_DELEGATION_GUIDANCE,
+} from './voice-runtime.js';
+import type { VoiceToolBridge } from './voice-runtime.js';
 import { FakeAudioTransport } from './fake-audio-transport.js';
 import { FakeSttProvider } from './speech/fake-stt.js';
 import type { PcmFrame, TextToSpeechProvider, TtsSynthesizeOptions } from './speech/types.js';
@@ -17,6 +24,8 @@ const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
 /** Fake streaming LLM provider driven by scripted event sequences. */
 class FakeStreamProvider implements LLMProvider {
   readonly id = 'fake-stream';
+  /** Messages passed to each stream() call, for context-assembly assertions. */
+  readonly seenMessages: Message[][] = [];
   constructor(
     private readonly scripts: LLMStreamEvent[][],
     private readonly delayMs = 0,
@@ -25,7 +34,8 @@ class FakeStreamProvider implements LLMProvider {
   async chat(): Promise<LLMResponse> {
     return { type: 'text', content: '', usage, provenance };
   }
-  async *stream(params: { options?: Record<string, unknown> }): AsyncIterable<LLMStreamEvent> {
+  async *stream(params: { messages?: Message[]; options?: Record<string, unknown> }): AsyncIterable<LLMStreamEvent> {
+    this.seenMessages.push(params.messages ?? []);
     const script = this.scripts[this.call] ?? [];
     this.call += 1;
     const signal = params.options?.signal as AbortSignal | undefined;
@@ -92,6 +102,10 @@ function makeRuntime(overrides: {
   store?: VoiceSessionStore;
   invokeTool?: (call: never, ctx?: { conversationId: string; sessionId: string }) => Promise<{ content: string; is_error?: boolean }>;
   deleteRoom?: (roomName: string) => Promise<void>;
+  workingMemory?: WorkingMemory;
+  timezone?: string;
+  /** Late-bound coordinator bridge (tools + context providers), applied via configureTools(). */
+  bridge?: VoiceToolBridge;
 }) {
   const bus = new EventBus(logger);
   const events: BusEvent[] = [];
@@ -117,7 +131,10 @@ function makeRuntime(overrides: {
     createTransport: () => transport,
     invokeTool: overrides.invokeTool as never,
     deleteRoom: overrides.deleteRoom,
+    workingMemory: overrides.workingMemory,
+    timezone: overrides.timezone,
   });
+  if (overrides.bridge) runtime.configureTools(overrides.bridge);
   return { runtime, bus, events, stt, transport, tts, store };
 }
 
@@ -323,5 +340,239 @@ describe('VoiceRuntime', () => {
     await runtime.awaitIdle('s4');
 
     expect(invokeTool).toHaveBeenCalledOnce();
+  });
+});
+
+describe('VoiceRuntime brain/context parity (#1551)', () => {
+  const reply = (text: string): LLMStreamEvent[] => [
+    { type: 'text_delta', text: `${text} ` },
+    { type: 'message_end', content: text, usage, provenance },
+  ];
+
+  /** Plain-string contents of a message list (voice turns never build block-array content here). */
+  const textContents = (msgs: Message[]): string[] =>
+    msgs.map(m => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content)));
+
+  async function start(runtime: VoiceRuntime, id: string): Promise<void> {
+    await runtime.startSession({
+      sessionId: id,
+      conversationId: `voice:${id}`,
+      roomName: `voice-${id}`,
+      agentToken: 'tok',
+    });
+  }
+
+  it('assembles the spoken-turn system prompt: identity, brevity, honesty, delegation + roster, time', async () => {
+    const llm = new FakeStreamProvider([reply('Hello.')]);
+    const bridge: VoiceToolBridge = {
+      resolveVoiceTools: () => [],
+      invokeTool: async () => ({ content: 'ok' }),
+      identityBlock: () => '## Identity & Communication Contract\nYou are Vera, Chief of Staff.',
+      specialistRoster: () => '- @calendar: Manages the calendar\n- @contacts: Contact intelligence',
+    };
+    const { runtime, stt } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      timezone: 'America/Toronto',
+      bridge,
+    });
+    await start(runtime, 'sp1');
+    stt.emit({ text: 'what is on my calendar tomorrow', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('sp1');
+
+    const messages = llm.seenMessages[0]!;
+    const system = messages[0]!;
+    expect(system.role).toBe('system');
+    const systemText = typeof system.content === 'string' ? system.content : '';
+    // Persona/identity parity with the coordinator preamble.
+    expect(systemText).toContain('You are Vera, Chief of Staff.');
+    // Spoken brevity policy still applies with fuller context enabled.
+    expect(systemText).toContain(VOICE_SYSTEM_ADDENDUM);
+    // Honest-negative policy: failed checks are never narrated as empty results.
+    expect(systemText).toContain(VOICE_TOOL_RESULT_POLICY);
+    // Delegation guidance + roster so specialist domains are reachable from voice.
+    expect(systemText).toContain(VOICE_DELEGATION_GUIDANCE);
+    expect(systemText).toContain('## Available Specialists');
+    expect(systemText).toContain('- @calendar: Manages the calendar');
+    // Same date/timezone grounding the coordinator gets; dynamic block last so
+    // the static prefix stays provider-cacheable.
+    expect(systemText).toContain('## Current Date & Time');
+    expect(systemText).toContain('Timezone: America/Toronto');
+    expect(systemText.indexOf('## Current Date & Time'))
+      .toBeGreaterThan(systemText.indexOf('## Available Specialists'));
+    // The utterance is the final message, exactly once.
+    expect(messages[messages.length - 1]).toEqual({ role: 'user', content: 'what is on my calendar tomorrow' });
+    expect(messages.filter(m => m.content === 'what is on my calendar tomorrow')).toHaveLength(1);
+  });
+
+  it('degrades to the slim prompt when no bridge context or timezone is configured', async () => {
+    const llm = new FakeStreamProvider([reply('Hi.')]);
+    const { runtime, stt } = makeRuntime({ llm, tts: new SlowTtsProvider(2, 1) });
+    await start(runtime, 'sp2');
+    stt.emit({ text: 'hello', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('sp2');
+
+    const system = llm.seenMessages[0]![0]!;
+    expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}`);
+  });
+
+  it('omits a throwing identity block and still runs the turn', async () => {
+    const llm = new FakeStreamProvider([reply('Still here.')]);
+    const bridge: VoiceToolBridge = {
+      resolveVoiceTools: () => [],
+      invokeTool: async () => ({ content: 'ok' }),
+      identityBlock: () => {
+        throw new Error('identity compile failed');
+      },
+      specialistRoster: () => '- @calendar: Manages the calendar',
+    };
+    const { runtime, stt, transport } = makeRuntime({ llm, tts: new SlowTtsProvider(2, 1), bridge });
+    await start(runtime, 'sp3');
+    stt.emit({ text: 'are you there', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('sp3');
+
+    const system = llm.seenMessages[0]![0]!;
+    expect(system.content).toContain(VOICE_SYSTEM_ADDENDUM);
+    expect(system.content).toContain('## Available Specialists');
+    expect(transport.publishedFrames.length).toBeGreaterThan(0);
+  });
+
+  it('sources spoken-turn context from working_memory, including turns persisted before this process', async () => {
+    const wm = WorkingMemory.createInMemory();
+    // Turns persisted mid-call by a previous process — must not be silently dropped.
+    await wm.addTurn('voice:wm1', 'coordinator', { role: 'user', content: 'remember the budget is 50k' });
+    await wm.addTurn('voice:wm1', 'coordinator', { role: 'assistant', content: 'Noted: the budget is 50k.' });
+
+    const llm = new FakeStreamProvider([reply('It is 50k.')]);
+    const { runtime, stt } = makeRuntime({ llm, tts: new SlowTtsProvider(2, 1), workingMemory: wm });
+    await start(runtime, 'wm1');
+    stt.emit({ text: 'what was the budget again', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm1');
+
+    const messages = llm.seenMessages[0]!;
+    const contents = textContents(messages);
+    expect(contents).toContain('remember the budget is 50k');
+    expect(contents).toContain('Noted: the budget is 50k.');
+    // Current utterance appended exactly once, as the last message.
+    expect(messages[messages.length - 1]!.content).toBe('what was the budget again');
+    expect(contents.filter(c => c === 'what was the budget again')).toHaveLength(1);
+  });
+
+  it('keeps console history and spoken-turn context single-sourced across turns', async () => {
+    const wm = WorkingMemory.createInMemory();
+    const llm = new FakeStreamProvider([reply('Hi there.'), reply('Yes, still here.')]);
+    const { runtime, stt } = makeRuntime({ llm, tts: new SlowTtsProvider(2, 1), workingMemory: wm });
+    await start(runtime, 'wm2');
+
+    stt.emit({ text: 'hello curia', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm2');
+    stt.emit({ text: 'still with me', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm2');
+
+    // Turn 2's LLM context contains turn 1 as reloaded from the store.
+    const second = llm.seenMessages[1]!;
+    const contents = textContents(second);
+    expect(contents).toContain('hello curia');
+    expect(contents).toContain('Hi there.');
+    expect(second[second.length - 1]!.content).toBe('still with me');
+
+    // The store holds exactly what the console history endpoint would read.
+    const history = await wm.getHistory('voice:wm2', 'coordinator');
+    expect(history).toEqual([
+      { role: 'user', content: 'hello curia' },
+      { role: 'assistant', content: 'Hi there.' },
+      { role: 'user', content: 'still with me' },
+      { role: 'assistant', content: 'Yes, still here.' },
+    ]);
+  });
+
+  it('falls back to in-process history when the working_memory read fails', async () => {
+    const failing = {
+      addTurn: vi.fn(async () => {}),
+      getHistory: vi.fn(async () => {
+        throw new Error('db down');
+      }),
+      purgeExpired: vi.fn(async () => 0),
+    } as unknown as WorkingMemory;
+
+    const llm = new FakeStreamProvider([reply('First answer.'), reply('Second answer.')]);
+    const { runtime, stt, events } = makeRuntime({ llm, tts: new SlowTtsProvider(2, 1), workingMemory: failing });
+    await start(runtime, 'wm3');
+
+    stt.emit({ text: 'first question', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm3');
+    stt.emit({ text: 'second question', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm3');
+
+    // Both turns completed despite the failing store...
+    expect(events.filter(e => e.type === 'inbound.message')).toHaveLength(2);
+    // ...and turn 2 still carried turn 1 via the in-process fallback.
+    const second = llm.seenMessages[1]!;
+    const contents = textContents(second);
+    expect(contents).toContain('first question');
+    expect(contents).toContain('First answer.');
+    expect(second[second.length - 1]!.content).toBe('second question');
+  });
+
+  it('reaches specialist-delegated domains: calendar-tomorrow flows through the delegate tool', async () => {
+    const calendarEvents = JSON.stringify({
+      events: [
+        { title: 'Board meeting', start: '2026-07-27T09:00:00-04:00' },
+        { title: 'Lunch with Dana', start: '2026-07-27T12:00:00-04:00' },
+      ],
+    });
+    const spoken = 'You have the board meeting at nine and lunch with Dana at noon.';
+    const llm = new FakeStreamProvider([
+      [{
+        type: 'tool_use',
+        toolCalls: [{
+          id: 'c1',
+          name: 'delegate',
+          input: { agent: 'calendar', task: "What is on the principal's calendar tomorrow?" },
+        }],
+        usage,
+        provenance,
+      }],
+      reply(spoken),
+    ]);
+    const invokeTool = vi.fn(async () => ({ content: calendarEvents }));
+    const wm = WorkingMemory.createInMemory();
+    const bridge: VoiceToolBridge = {
+      resolveVoiceTools: () => [{
+        name: 'delegate',
+        description: 'Delegate a task to a specialist agent',
+        input_schema: { type: 'object', properties: {} },
+      }],
+      invokeTool,
+      specialistRoster: () => "- @calendar: Manages the principal's calendar",
+    };
+    const { runtime, stt } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      timezone: 'America/Toronto',
+      workingMemory: wm,
+      bridge,
+    });
+    await start(runtime, 'cal1');
+    stt.emit({ text: 'what is on my calendar tomorrow', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('cal1');
+
+    // The turn had time grounding for "tomorrow" and the roster to know delegation exists.
+    const system = llm.seenMessages[0]![0]!;
+    expect(system.content).toContain('## Current Date & Time');
+    expect(system.content).toContain("- @calendar: Manages the principal's calendar");
+
+    // The delegate tool was invoked against the calendar specialist.
+    expect(invokeTool).toHaveBeenCalledOnce();
+    const [delegateCall] = invokeTool.mock.calls[0]! as unknown as [
+      { name: string; input: { agent: string } },
+      { conversationId: string; sessionId: string },
+    ];
+    expect(delegateCall.name).toBe('delegate');
+    expect(delegateCall.input.agent).toBe('calendar');
+
+    // The spoken answer reflects the delegated result and lands in the shared history.
+    const history = await wm.getHistory('voice:cal1', 'coordinator');
+    expect(history[history.length - 1]).toEqual({ role: 'assistant', content: spoken });
   });
 });

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -104,6 +104,7 @@ function makeRuntime(overrides: {
   deleteRoom?: (roomName: string) => Promise<void>;
   workingMemory?: WorkingMemory;
   timezone?: string;
+  historyReadTimeoutMs?: number;
   /** Late-bound coordinator bridge (tools + context providers), applied via configureTools(). */
   bridge?: VoiceToolBridge;
 }) {
@@ -133,6 +134,7 @@ function makeRuntime(overrides: {
     deleteRoom: overrides.deleteRoom,
     workingMemory: overrides.workingMemory,
     timezone: overrides.timezone,
+    historyReadTimeoutMs: overrides.historyReadTimeoutMs,
   });
   if (overrides.bridge) runtime.configureTools(overrides.bridge);
   return { runtime, bus, events, stt, transport, tts, store };
@@ -484,6 +486,95 @@ describe('VoiceRuntime brain/context parity (#1551)', () => {
       { role: 'user', content: 'still with me' },
       { role: 'assistant', content: 'Yes, still here.' },
     ]);
+  });
+
+  it('survives a throwing roster provider and an invalid timezone (slimmer prompt, turn completes)', async () => {
+    const llm = new FakeStreamProvider([reply('Still speaking.')]);
+    const bridge: VoiceToolBridge = {
+      resolveVoiceTools: () => [],
+      invokeTool: async () => ({ content: 'ok' }),
+      identityBlock: () => '## Identity & Communication Contract\nYou are Vera, Chief of Staff.',
+      specialistRoster: () => {
+        throw new Error('registry down');
+      },
+    };
+    const { runtime, stt, transport } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      timezone: 'Not/AZone',
+      bridge,
+    });
+    await start(runtime, 'sp4');
+    stt.emit({ text: 'are you still there', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('sp4');
+
+    const system = llm.seenMessages[0]![0]!;
+    const systemText = typeof system.content === 'string' ? system.content : '';
+    // Healthy blocks still apply; the failing ones are omitted, not fatal.
+    expect(systemText).toContain(VOICE_SYSTEM_ADDENDUM);
+    expect(systemText).toContain('You are Vera, Chief of Staff.');
+    expect(systemText).not.toContain('## Available Specialists');
+    expect(systemText).not.toContain('## Current Date & Time');
+    expect(transport.publishedFrames.length).toBeGreaterThan(0);
+  });
+
+  it('prefers in-process history when the store reads back empty after failed writes', async () => {
+    // addTurn fails warn-only, so a clean read returns [] while session.history
+    // still holds the conversation — the turn must not go amnesiac.
+    const failingWrites = {
+      addTurn: vi.fn(async () => {
+        throw new Error('insert failed');
+      }),
+      getHistory: vi.fn(async () => []),
+      purgeExpired: vi.fn(async () => 0),
+    } as unknown as WorkingMemory;
+
+    const llm = new FakeStreamProvider([reply('First answer.'), reply('Second answer.')]);
+    const { runtime, stt } = makeRuntime({ llm, tts: new SlowTtsProvider(2, 1), workingMemory: failingWrites });
+    await start(runtime, 'wm4');
+
+    stt.emit({ text: 'first question', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm4');
+    stt.emit({ text: 'second question', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm4');
+
+    const second = llm.seenMessages[1]!;
+    const contents = textContents(second);
+    expect(contents).toContain('first question');
+    expect(contents).toContain('First answer.');
+    expect(second[second.length - 1]!.content).toBe('second question');
+  });
+
+  it('falls back to in-process history when the working_memory read exceeds the voice deadline', async () => {
+    const stalled = {
+      addTurn: vi.fn(async () => {}),
+      // Never settles — only the deadline can unblock the turn.
+      getHistory: vi.fn(() => new Promise(() => {})),
+      purgeExpired: vi.fn(async () => 0),
+    } as unknown as WorkingMemory;
+
+    const llm = new FakeStreamProvider([reply('First answer.'), reply('Second answer.')]);
+    const { runtime, stt, events } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      workingMemory: stalled,
+      historyReadTimeoutMs: 40,
+    });
+    await start(runtime, 'wm5');
+
+    stt.emit({ text: 'first question', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm5');
+    stt.emit({ text: 'second question', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('wm5');
+
+    // Both turns completed despite the stalled store...
+    expect(events.filter(e => e.type === 'inbound.message')).toHaveLength(2);
+    // ...and turn 2 still carried turn 1 via the in-process fallback.
+    const second = llm.seenMessages[1]!;
+    const contents = textContents(second);
+    expect(contents).toContain('first question');
+    expect(contents).toContain('First answer.');
+    expect(second[second.length - 1]!.content).toBe('second question');
   });
 
   it('falls back to in-process history when the working_memory read fails', async () => {

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -48,6 +48,12 @@ const MAX_HISTORY_MESSAGES = 8;
  * configured on the shared store) condenses older turns before this cap bites.
  */
 const VOICE_HISTORY_MAX_TURNS = 20;
+/**
+ * Deadline for the per-turn working_memory history read. Pool checkout timeouts
+ * do not bound the query itself — a stalled read must not stall the spoken turn,
+ * so on expiry the turn falls back to in-process history.
+ */
+const DEFAULT_HISTORY_READ_TIMEOUT_MS = 1_000;
 /** Ignore tiny interim blobs (echo / noise) when deciding barge-in. */
 const BARGE_IN_MIN_CHARS = 3;
 /** Ignore low-confidence interims when the provider reports confidence. */
@@ -186,6 +192,11 @@ export interface VoiceRuntimeConfig {
    * un-anchored for every voice tool call (#1551). Omitted → no time block.
    */
   timezone?: string;
+  /**
+   * Deadline (ms) for the per-turn working_memory history read; on expiry the
+   * turn falls back to in-process history. Default 1000ms.
+   */
+  historyReadTimeoutMs?: number;
 }
 
 /**
@@ -477,26 +488,56 @@ export class VoiceRuntime {
   /**
    * Load spoken-turn context from working_memory — the same rows console chat
    * history reads — so persistence and LLM context are single-sourced (#1551).
-   * Falls back to the in-process session history when no store is configured or
-   * the read fails: a degraded slim turn beats failing the call. Callers invoke
+   * Falls back to the in-process session history when no store is configured,
+   * the read fails or exceeds its deadline, or the store reads back empty while
+   * the in-process copy is not (a prior addTurn write failed warn-only): a
+   * degraded slim turn beats failing — or stalling — the call. Callers invoke
    * this BEFORE persisting the current utterance, so the returned turns are
    * strictly prior history.
    */
   private async loadTurnHistory(session: ActiveSession): Promise<Message[]> {
     if (!this.config.workingMemory) return [...session.history];
-    try {
-      const turns = await this.config.workingMemory.getHistory(
-        session.conversationId,
-        VOICE_HISTORY_AGENT_ID,
-        { maxTurns: VOICE_HISTORY_MAX_TURNS },
+    const timeoutMs = this.config.historyReadTimeoutMs ?? DEFAULT_HISTORY_READ_TIMEOUT_MS;
+    const read = this.config.workingMemory.getHistory(
+      session.conversationId,
+      VOICE_HISTORY_AGENT_ID,
+      { maxTurns: VOICE_HISTORY_MAX_TURNS },
+    );
+    // A read that loses the deadline race settles later with no awaiter —
+    // absorb its eventual rejection so it cannot become an unhandled rejection.
+    read.catch(err => {
+      this.log.debug(
+        { sessionId: session.sessionId, err },
+        'late working-memory history read failure (turn already proceeded)',
       );
-      return turns.map(t => ({ role: t.role, content: t.content }));
+    });
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      const outcome = await Promise.race([
+        read,
+        new Promise<'timeout'>(resolve => {
+          timer = setTimeout(() => resolve('timeout'), timeoutMs);
+        }),
+      ]);
+      if (outcome === 'timeout') {
+        this.log.warn(
+          { sessionId: session.sessionId, timeoutMs },
+          'working-memory history read exceeded the voice deadline; falling back to in-process history',
+        );
+        return [...session.history];
+      }
+      // A prior addTurn may have failed (warn-only), leaving the store behind
+      // the in-process copy. Prefer the fallback over starting the turn amnesiac.
+      if (outcome.length === 0 && session.history.length > 0) return [...session.history];
+      return outcome.map(t => ({ role: t.role, content: t.content }));
     } catch (err) {
       this.log.warn(
         { sessionId: session.sessionId, err },
         'failed to load voice history from working memory; falling back to in-process history',
       );
       return [...session.history];
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
     }
   }
 

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -10,7 +10,13 @@
 //
 // Skills: tools default to empty at construction (bootstrap order — ExecutionLayer
 // and coordinator pins land later). Call `configureTools()` once the coordinator
-// tool set + ExecutionLayer.invoke are available. See ADR-037 §6.
+// tool set + ExecutionLayer.invoke are available; the same bridge carries the
+// coordinator context providers (identity block, specialist roster) for spoken-
+// turn brain parity (#1551). See ADR-037 §6.
+//
+// History: spoken-turn context reloads from working_memory (the same rows the
+// console chat history endpoint reads) each turn; the in-process session history
+// is only a fallback when the store is absent or the read fails (#1551).
 
 import type { EventBus } from '../../bus/bus.js';
 import { createInboundMessage, createVoiceSessionEnded } from '../../bus/events.js';
@@ -18,6 +24,7 @@ import type { Logger } from '../../logger.js';
 import type { LLMProvider, Message, ToolCall, ToolDefinition } from '../../agents/llm/provider.js';
 import type { WorkingMemory } from '../../memory/working-memory.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
+import { formatTimeContextBlock } from '../../time/time-context.js';
 import type { AudioTransport } from './audio-transport.js';
 import type { SpeechToTextProvider, SttSession, SttTranscriptEvent, TextToSpeechProvider } from './speech/types.js';
 import type { VoiceSessionRecord, VoiceSessionStore } from './session-store.js';
@@ -27,8 +34,20 @@ const DEFAULT_INBOUND_SAMPLE_RATE = 16000;
 const DEFAULT_PUBLISH_SAMPLE_RATE = 24000;
 /** Console chat and voice share the same synthetic principal sender id. */
 const DEFAULT_SENDER_ID = 'ceo-web-user';
-/** How many messages (user + assistant) of history to keep per session. */
+/**
+ * How many messages (user + assistant) of in-process history to keep per session.
+ * This is the FALLBACK context source only — spoken turns load history from
+ * working_memory when it is configured (#1551); the in-process copy covers
+ * store-less deployments/tests and mid-call DB read failures.
+ */
 const MAX_HISTORY_MESSAGES = 8;
+/**
+ * Max working_memory turns reloaded into a spoken turn's context. Spoken turns
+ * are short (1-3 sentences), so this stays well inside the latency budget while
+ * giving far more continuity than the in-process window. Summarization (when
+ * configured on the shared store) condenses older turns before this cap bites.
+ */
+const VOICE_HISTORY_MAX_TURNS = 20;
 /** Ignore tiny interim blobs (echo / noise) when deciding barge-in. */
 const BARGE_IN_MIN_CHARS = 3;
 /** Ignore low-confidence interims when the provider reports confidence. */
@@ -40,18 +59,78 @@ const DEFAULT_MAX_UTTERANCE_BYTES = 102_400;
 
 /**
  * Voice-mode system addendum. Keeps spoken replies short and free of markup that
- * makes no sense read aloud. Prepended as a system message on every turn.
+ * makes no sense read aloud. Always part of the spoken-turn system prompt.
  *
- * Phase 1 deliberate non-goal: this is NOT the coordinator's full system prompt /
- * persona / KG enrichment / working-memory reload. Spoken turns are a slim
- * Q&A loop (addendum + last N in-memory turns + tools). See ADR-037 Consequences
- * and docs/wip/2026-07-25-voice-channel-design.md §3.7 / §"Phase 1 brain".
+ * Brain stance (#1551): spoken turns get a curated subset of the coordinator's
+ * context — office identity/persona block, specialist roster + delegation
+ * guidance, and a fresh date/time block — assembled by buildVoiceSystemPrompt().
+ * They deliberately do NOT get the coordinator's full YAML system prompt or
+ * KG/sender enrichment (latency + text-channel content that makes no sense
+ * spoken). See ADR-037 Consequences and
+ * docs/wip/2026-07-25-voice-channel-design.md §"Phase 1 brain".
  */
 export const VOICE_SYSTEM_ADDENDUM =
   'You are speaking to the principal in a live voice call. Reply in a natural, ' +
   'conversational spoken style: 1-3 short sentences, no markdown, no bullet lists, ' +
   'no tables, no code blocks, and no emoji. Spell out anything that must be heard ' +
   'clearly. Keep it brief — the user can always ask for more.';
+
+/**
+ * Honest-negative policy for spoken tool results. A failed or errored check must
+ * be narrated as "couldn't check", never as a confident empty result — "your
+ * calendar is clear" after a failed lookup is a trust hazard the principal may
+ * act on (#1551).
+ */
+export const VOICE_TOOL_RESULT_POLICY =
+  'When a tool call or delegation fails, errors out, or cannot complete, say plainly ' +
+  'that you could not check — for example "I couldn\'t reach your calendar just now" — ' +
+  'and offer to try again. Never present a failed or incomplete lookup as a definitive ' +
+  'answer. Only report an empty result ("nothing on your calendar tomorrow") when the ' +
+  'check succeeded and genuinely returned no items.';
+
+/**
+ * Delegation guidance for spoken turns. The slim Phase 1 prompt never told the
+ * voice model that specialist-delegated domains (calendar, contacts, research,
+ * the principal's inbox) are reached via the delegate tool, so those domains
+ * were effectively unreachable from voice (#1551). Included only when a
+ * specialist roster is available from the bridge.
+ */
+export const VOICE_DELEGATION_GUIDANCE =
+  'Many requests are handled by delegating to a specialist with the delegate tool: ' +
+  'calendar and scheduling, contacts and people lookups, research, and the ' +
+  'principal\'s inbox all belong to the specialists listed below. When a request ' +
+  'falls in a specialist\'s domain, delegate rather than answering from memory or ' +
+  'guessing. Resolve pronouns before delegating: "my calendar" spoken by the ' +
+  'principal means the principal\'s calendar. Fold the specialist\'s result into ' +
+  'your own short spoken answer — never mention specialists, delegation, or tools ' +
+  'out loud.';
+
+/**
+ * Assemble the per-turn system prompt for a spoken turn. Static sections come
+ * first and the (per-minute changing) time block last, so provider prompt
+ * caching keeps a stable prefix across turns. Pure — callers resolve/guard the
+ * dynamic parts (identity compile, roster lookup, time formatting) themselves.
+ */
+export function buildVoiceSystemPrompt(parts: {
+  /** Compiled office identity/persona block; omitted when null/empty. */
+  identityBlock?: string | null;
+  /** Specialist roster body ("- @name: description" lines); enables delegation guidance. */
+  specialistRoster?: string | null;
+  /** Pre-formatted "## Current Date & Time" block; omitted when null/empty. */
+  timeContextBlock?: string | null;
+}): string {
+  const sections: string[] = [];
+  if (parts.identityBlock) sections.push(parts.identityBlock);
+  sections.push(VOICE_SYSTEM_ADDENDUM);
+  sections.push(VOICE_TOOL_RESULT_POLICY);
+  if (parts.specialistRoster) {
+    sections.push(
+      VOICE_DELEGATION_GUIDANCE + '\n\n## Available Specialists\n' + parts.specialistRoster,
+    );
+  }
+  if (parts.timeContextBlock) sections.push(parts.timeContextBlock);
+  return sections.join('\n\n');
+}
 
 /** Transport optionally advertises its negotiated sample rates for STT/TTS. */
 type RateAwareTransport = AudioTransport & {
@@ -101,15 +180,33 @@ export interface VoiceRuntimeConfig {
    * Mirrors the dispatcher `maxMessageBytes` guard (voice bypasses the dispatcher).
    */
   maxUtteranceBytes?: number;
+  /**
+   * IANA timezone for the per-turn date/time block (same block the coordinator
+   * gets — formatTimeContextBlock). Without it, "tomorrow / next week" is
+   * un-anchored for every voice tool call (#1551). Omitted → no time block.
+   */
+  timezone?: string;
 }
 
-/** Late-bound tool wiring — set after coordinator pins + ExecutionLayer exist. */
+/**
+ * Late-bound coordinator wiring — set after coordinator pins + ExecutionLayer
+ * exist. Besides tools, the bridge carries the coordinator context providers
+ * for spoken-turn brain parity (#1551); all are optional so partial wiring
+ * (and older tests) degrade to the slim prompt rather than failing.
+ */
 export interface VoiceToolBridge {
   resolveVoiceTools: () => ToolDefinition[];
   invokeTool: (
     call: ToolCall,
     ctx: { conversationId: string; sessionId: string },
   ) => Promise<{ content: string; is_error?: boolean }>;
+  /**
+   * Per-turn compiled office identity/persona block (hot-reloadable, same as
+   * AgentRuntime's preamble). May throw — the runtime guards and omits.
+   */
+  identityBlock?: () => string | null;
+  /** Specialist roster body for the "## Available Specialists" block; null → no delegation guidance. */
+  specialistRoster?: () => string | null;
 }
 
 interface StartVoiceSessionParams {
@@ -339,6 +436,70 @@ export class VoiceRuntime {
       .then(() => this.runUserTurn(session, utterance));
   }
 
+  /**
+   * Resolve the dynamic prompt parts (guarding each — a compile failure or bad
+   * timezone must degrade to a slimmer prompt, never abort the spoken turn) and
+   * assemble the per-turn system prompt. Mirrors AgentRuntime.processTask's
+   * guard-and-omit pattern for the same blocks.
+   */
+  private buildTurnSystemPrompt(): string {
+    let identityBlock: string | null = null;
+    if (this.toolBridge?.identityBlock) {
+      try {
+        identityBlock = this.toolBridge.identityBlock();
+      } catch (err) {
+        this.log.error({ err }, 'Failed to compile identity block for voice turn — identity omitted this turn');
+      }
+    }
+
+    let specialistRoster: string | null = null;
+    if (this.toolBridge?.specialistRoster) {
+      try {
+        specialistRoster = this.toolBridge.specialistRoster();
+      } catch (err) {
+        this.log.error({ err }, 'Failed to resolve specialist roster for voice turn — delegation guidance omitted this turn');
+      }
+    }
+
+    let timeContextBlock: string | null = null;
+    const timezone = this.config.timezone?.trim();
+    if (timezone) {
+      try {
+        timeContextBlock = formatTimeContextBlock(timezone, new Date());
+      } catch (err) {
+        this.log.error({ err, timezone }, 'formatTimeContextBlock failed — time context not injected into voice turn; check TIMEZONE config');
+      }
+    }
+
+    return buildVoiceSystemPrompt({ identityBlock, specialistRoster, timeContextBlock });
+  }
+
+  /**
+   * Load spoken-turn context from working_memory — the same rows console chat
+   * history reads — so persistence and LLM context are single-sourced (#1551).
+   * Falls back to the in-process session history when no store is configured or
+   * the read fails: a degraded slim turn beats failing the call. Callers invoke
+   * this BEFORE persisting the current utterance, so the returned turns are
+   * strictly prior history.
+   */
+  private async loadTurnHistory(session: ActiveSession): Promise<Message[]> {
+    if (!this.config.workingMemory) return [...session.history];
+    try {
+      const turns = await this.config.workingMemory.getHistory(
+        session.conversationId,
+        VOICE_HISTORY_AGENT_ID,
+        { maxTurns: VOICE_HISTORY_MAX_TURNS },
+      );
+      return turns.map(t => ({ role: t.role, content: t.content }));
+    } catch (err) {
+      this.log.warn(
+        { sessionId: session.sessionId, err },
+        'failed to load voice history from working memory; falling back to in-process history',
+      );
+      return [...session.history];
+    }
+  }
+
   private async runUserTurn(session: ActiveSession, utterance: string): Promise<void> {
     if (session.ending) return;
 
@@ -357,6 +518,12 @@ export class VoiceRuntime {
     } catch (err) {
       this.log.warn({ sessionId: session.sessionId, err }, 'failed to publish voice inbound.message');
     }
+
+    // Single authoritative history (#1551): reload prior turns from working_memory
+    // BEFORE persisting this utterance, so the current user message is appended
+    // to the LLM context exactly once (turns are serialized per session, so the
+    // read cannot race the write below).
+    const priorHistory = await this.loadTurnHistory(session);
 
     // Persist user turn to working_memory so console history can show it.
     if (this.config.workingMemory) {
@@ -405,15 +572,17 @@ export class VoiceRuntime {
 
     const userMessage: Message = { role: 'user', content: utterance };
     // Retain the user request even if barge-in aborts the assistant reply —
-    // otherwise the next turn loses conversational continuity.
+    // otherwise the next turn loses conversational continuity. The in-process
+    // copy is only the fallback context source (see loadTurnHistory).
     session.history.push(userMessage);
     if (session.history.length > MAX_HISTORY_MESSAGES) {
       session.history.splice(0, session.history.length - MAX_HISTORY_MESSAGES);
     }
 
     const messages: Message[] = [
-      { role: 'system', content: VOICE_SYSTEM_ADDENDUM },
-      ...session.history,
+      { role: 'system', content: this.buildTurnSystemPrompt() },
+      ...priorHistory,
+      userMessage,
     ];
 
     const onSpeechText = async (sentence: string, meta: { streamId: string }): Promise<void> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1818,6 +1818,9 @@ async function main(): Promise<void> {
           new LiveKitRoomSession({ url: livekitUrl, token, logger }),
         workingMemory: memory,
         maxUtteranceBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
+        // Same per-turn date/timezone grounding the coordinator gets — without it
+        // "tomorrow / next week" is un-anchored for every voice tool call (#1551).
+        timezone: config.timezone,
         deleteRoom: async (roomName) => {
           await deleteVoiceRoom(
             {
@@ -1828,8 +1831,9 @@ async function main(): Promise<void> {
             roomName,
           );
         },
-        // Tools are late-bound via voiceRuntime.configureTools() after the
-        // coordinator is registered (ExecutionLayer + pinned tools exist then).
+        // Tools + coordinator context providers are late-bound via
+        // voiceRuntime.configureTools() after the coordinator is registered
+        // (ExecutionLayer + pinned tools + agent registry exist then).
       });
       logger.info({ voiceModel }, 'Voice runtime constructed (streaming provider available)');
 
@@ -2471,6 +2475,14 @@ async function main(): Promise<void> {
       const voiceToolDefs = toolRegistry.toToolDefinitions(voiceToolNames);
       runtime.configureTools({
         resolveVoiceTools: () => voiceToolDefs,
+        // Coordinator context providers for spoken-turn brain parity (#1551).
+        // Per-turn closures so identity hot-reloads take effect on the next
+        // spoken turn, same as AgentRuntime's preamble injection.
+        identityBlock: () => officeIdentityService.compileSystemPromptBlock(),
+        // Roster gated on actual specialists so the delegation guidance never
+        // ships alongside a "No specialist agents..." placeholder.
+        specialistRoster: () =>
+          agentRegistry.listSpecialists().length > 0 ? agentRegistry.specialistSummary() : null,
         invokeTool: async (call, ctx) => {
           const caller = {
             contactId: principalContact?.id ?? 'ceo-web-user',


### PR DESCRIPTION
## Summary

Closes #1551

Phase 1 voice used a slim spoken "brain" (`[VOICE_SYSTEM_ADDENDUM, last-8 in-process turns, coordinator tools]`) and dual-sourced history (wrote `working_memory`, read `session.history`). Per the issue's clarifying comment, that made specialist-delegated domains effectively unreachable from voice, left "tomorrow" un-anchored, and let failed tool checks be narrated as confident negatives ("your calendar is completely clear").

### Brain / context assembly

Spoken turns now build a **curated subset of the coordinator's context** via `buildVoiceSystemPrompt()` (static sections first, dynamic time block last, so the prompt prefix stays provider-cacheable):

1. **Office identity/persona block** — per-turn `OfficeIdentityService.compileSystemPromptBlock()` through the late-bound coordinator bridge, so identity hot-reloads apply (same guard-and-omit pattern as `AgentRuntime`).
2. **Voice-mode addendum** — unchanged; spoken brevity + barge-in behavior still apply.
3. **Honest-negative policy** (`VOICE_TOOL_RESULT_POLICY`) — a failed/errored check is spoken as "couldn't check", never as an authoritative empty result.
4. **Delegation guidance + `## Available Specialists` roster** — so calendar / contacts / research / inbox are reachable from voice via `delegate` (already in the voice toolset and permitted through the `allowed_callers` gate; the prompt just never said so). Roster is gated on actual specialists existing.
5. **`## Current Date & Time` block** — same `formatTimeContextBlock` the coordinator gets, anchored to the deploy timezone.

Deliberately still excluded, now documented as the product stance in ADR-037 + the design doc: the coordinator's full YAML system prompt (text-channel mechanics that hurt the spoken latency budget), KG/sender enrichment (precomputed on the dispatcher path voice bypasses; contacts delegation covers it), and the autonomy/security blocks (`ExecutionLayer` enforces those on every tool call regardless).

### History read model

- Each spoken turn **reloads the `voice:<sessionId>` conversation from `working_memory`** (agent id `coordinator` — the same rows the console history endpoint reads) before the LLM call. Prior turns are read **before** the current utterance is persisted, so it enters the context exactly once.
- The in-process last-8 window is now **only a fallback** (store absent, or read fails — a DB blip degrades the turn instead of killing the call).
- Turns persisted mid-call survive a process restart in console history; a restart still ends the live call (rooms are ephemeral, no auto-rejoin) and a reconnect starts a new `voice:<id>` conversation by design — noted in ADR-037.

## Acceptance criteria mapping

- **Date/timezone parity** — `timezone` wired into `VoiceRuntime`; time block injected per turn (`voice-runtime.ts`).
- **Specialist domains reachable** — delegation guidance + roster in the voice prompt; covered by a calendar-tomorrow-via-`delegate` test.
- **No authoritative negatives from failed tools** — `VOICE_TOOL_RESULT_POLICY` in every spoken-turn prompt; `is_error` tool results already flow to the model.
- **Single authoritative history / console consistency / restart durability** — `working_memory` reload; tests assert turn 2's LLM context equals the store contents and that turns persisted before the process started are loaded.
- **Addendum + barge-in + brevity still apply** — addendum asserted alongside the new blocks; existing barge-in tests unchanged and passing.
- **Docs updated** — ADR-037 Consequences and the design doc's "Phase 1 brain" section now state the chosen stance and remaining exclusions.

## Test plan

- 7 new unit tests in `voice-runtime.test.ts`: full prompt assembly (incl. block ordering), slim-prompt degradation, throwing identity provider, `working_memory` reload incl. pre-process turns, cross-turn console/LLM consistency, failing-store fallback, and the calendar-tomorrow delegate repro.
- Full suite: 5637 passed / 332 skipped. `pnpm run typecheck` and `eslint` clean.
- Note: one **pre-existing** timing-sensitive barge-in test (`voice-runtime.test.ts:205`, 40 ms window) flaked once under full-suite CPU load and passed on re-run and in 4 isolated runs — unrelated to this change, mentioning for visibility.

Live validation still worth doing on a real deploy: "what's on my calendar tomorrow?" over voice should now delegate and return real events.