### PR TITLE
feat(agents): extract shared streaming turn primitive (#1552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Voice setup docs** — LiveKit Compose sample and operator security/privacy guide. (#1414)
 - **ADR-037** — self-hosted LiveKit voice cascade; STT/TTS provider seams. (#1414)
 - **Voice hangup hardening** — principal disconnect ends session; 1h JWT TTL; room delete. (#1414)
-- **Tool-loop shape helper** — shared `tool_use`/`tool_result` assembly for voice and text. (#1552)
-- **Streaming turn primitive** — shared `stream()` tool-loop; voice is a thin TTS wrapper. (#1552)
+- **Tool-loop shape helper** — shared `tool_use`/`tool_result` assembly for voice and text. (#1544)
+- **Streaming turn primitive** — voice tool-loop extracted; text `handleTask` still separate (#1552, #1563).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **ADR-037** — self-hosted LiveKit voice cascade; STT/TTS provider seams. (#1414)
 - **Voice hangup hardening** — principal disconnect ends session; 1h JWT TTL; room delete. (#1414)
 - **Tool-loop shape helper** — shared `tool_use`/`tool_result` assembly for voice and text. (#1552)
+- **Streaming turn primitive** — shared `stream()` tool-loop; voice is a thin TTS wrapper. (#1552)
 
 ### Fixed
 

--- a/docs/adr/037-voice-channel-livekit-duplex.md
+++ b/docs/adr/037-voice-channel-livekit-duplex.md
@@ -92,11 +92,12 @@ voice reuses that for session minting (and optional LiveKit webhooks).
   (CHANGELOG must call it out); wrappers (`LLMProviderRouter`,
   `TelemetryLlmProvider`) must forward it.
 - Voice turns share coordinator tools but not the exact `AgentRuntime.handleTask`
-  code path. Tool-loop mechanism is shared via `src/agents/llm/streaming-turn.ts`
-  (#1552): `VoiceTurnRunner` is a thin TTS/barge-in wrapper over that primitive;
-  text channels stay on non-streaming `chat()` unless explicitly opted in.
-  Round caps stay parameterized (voice `DEFAULT_STREAMING_MAX_ROUNDS=8` vs
-  per-agent `maxTurns`). Autonomy/Gate-C remains `executionLayer.invoke` on both
+  code path. Voice tool-loop mechanism lives in `src/agents/llm/streaming-turn.ts`
+  (#1552): `VoiceTurnRunner` is a thin TTS/barge-in wrapper over that primitive.
+  Text channels still use a separate non-streaming `chat()` loop in `handleTask`
+  — opt-in is tracked as #1563 (requires an explicit "text goes streaming"
+  decision). Round caps stay parameterized (voice `DEFAULT_STREAMING_MAX_ROUNDS=8`
+  vs per-agent `maxTurns`). Autonomy/Gate-C remains `executionLayer.invoke` on both
   paths. Brain/context + history read model landed via #1551.
 - **Voice "brain" is a curated subset of the coordinator's context (#1551):**
   spoken turns assemble the office identity/persona block, the voice-mode

--- a/docs/adr/037-voice-channel-livekit-duplex.md
+++ b/docs/adr/037-voice-channel-livekit-duplex.md
@@ -92,11 +92,12 @@ voice reuses that for session minting (and optional LiveKit webhooks).
   (CHANGELOG must call it out); wrappers (`LLMProviderRouter`,
   `TelemetryLlmProvider`) must forward it.
 - Voice turns share coordinator tools but not the exact `AgentRuntime.handleTask`
-  code path — drift risk is accepted and mitigated by reusing the same
-  provider, tool definitions, and bus `tool.invoke` / autonomy checks where
-  practical. A later refactor extracts a shared streaming turn primitive that
-  both paths delegate to — **not** a literal fold into `handleTask`
-  (tracked: #1552; brain/context + history read model landed via #1551).
+  code path. Tool-loop mechanism is shared via `src/agents/llm/streaming-turn.ts`
+  (#1552): `VoiceTurnRunner` is a thin TTS/barge-in wrapper over that primitive;
+  text channels stay on non-streaming `chat()` unless explicitly opted in.
+  Round caps stay parameterized (voice `DEFAULT_STREAMING_MAX_ROUNDS=8` vs
+  per-agent `maxTurns`). Autonomy/Gate-C remains `executionLayer.invoke` on both
+  paths. Brain/context + history read model landed via #1551.
 - **Voice "brain" is a curated subset of the coordinator's context (#1551):**
   spoken turns assemble the office identity/persona block, the voice-mode
   addendum (spoken brevity), an honest-negative tool-result policy (a failed

--- a/docs/wip/2026-07-25-voice-channel-design.md
+++ b/docs/wip/2026-07-25-voice-channel-design.md
@@ -254,9 +254,9 @@ coordinator's full YAML system prompt (text-channel mechanics — email/CC/
 scheduler — that hurt the spoken latency budget without helping spoken Q&A),
 KG/sender enrichment (precomputed on the dispatcher path voice bypasses;
 contacts delegation covers it), and the autonomy/security blocks (enforced by
-`ExecutionLayer` on every tool call regardless). The shared streaming turn
-primitive landed in #1552 (`src/agents/llm/streaming-turn.ts`); VoiceTurnRunner
-is a thin TTS/barge-in wrapper over it. Text channels stay on `chat()`.
+`ExecutionLayer` on every tool call regardless). Streaming tool-loop extraction
+is #1552 (`src/agents/llm/streaming-turn.ts`); VoiceTurnRunner is a thin
+TTS/barge-in wrapper. Text `handleTask` opt-in remains #1563.
 
 ### Outbound judge parity
 

--- a/docs/wip/2026-07-25-voice-channel-design.md
+++ b/docs/wip/2026-07-25-voice-channel-design.md
@@ -255,7 +255,8 @@ scheduler — that hurt the spoken latency budget without helping spoken Q&A),
 KG/sender enrichment (precomputed on the dispatcher path voice bypasses;
 contacts delegation covers it), and the autonomy/security blocks (enforced by
 `ExecutionLayer` on every tool call regardless). The shared streaming turn
-primitive remains #1552.
+primitive landed in #1552 (`src/agents/llm/streaming-turn.ts`); VoiceTurnRunner
+is a thin TTS/barge-in wrapper over it. Text channels stay on `chat()`.
 
 ### Outbound judge parity
 

--- a/docs/wip/2026-07-25-voice-channel-implementation.md
+++ b/docs/wip/2026-07-25-voice-channel-implementation.md
@@ -113,7 +113,7 @@ with incremental commits. Each phase below should leave `pnpm run typecheck` and
 
 | Risk | Mitigation |
 |---|---|
-| AgentRuntime drift | VoiceTurnRunner is a thin TTS wrapper over `streaming-turn.ts` (#1552); text stays on chat() |
+| AgentRuntime drift | Voice uses `streaming-turn.ts` (#1552); text `handleTask` opt-in is #1563 |
 | OpenRouter TTFT | Measure `voice.ttfa_ms`; optional model override; refuse non-streaming |
 | WebRTC NAT | Ops doc first-class; Compose comments for UDP ports |
 | Scope creep | No Phase 2 Signal/PSTN; no S2S; no OutboundGateway |

--- a/docs/wip/2026-07-25-voice-channel-implementation.md
+++ b/docs/wip/2026-07-25-voice-channel-implementation.md
@@ -113,7 +113,7 @@ with incremental commits. Each phase below should leave `pnpm run typecheck` and
 
 | Risk | Mitigation |
 |---|---|
-| AgentRuntime drift | Keep VoiceTurnRunner thin; document reuse points; follow-up issue to merge streaming into runtime |
+| AgentRuntime drift | VoiceTurnRunner is a thin TTS wrapper over `streaming-turn.ts` (#1552); text stays on chat() |
 | OpenRouter TTFT | Measure `voice.ttfa_ms`; optional model override; refuse non-streaming |
 | WebRTC NAT | Ops doc first-class; Compose comments for UDP ports |
 | Scope creep | No Phase 2 Signal/PSTN; no S2S; no OutboundGateway |

--- a/src/agents/llm/streaming-turn.test.ts
+++ b/src/agents/llm/streaming-turn.test.ts
@@ -117,7 +117,8 @@ describe('runStreamingToolLoop (#1552)', () => {
       options?: Record<string, unknown>;
     }) {
       if (provider.streamCalls === 1) {
-        secondCallMessages = params.messages;
+        // Snapshot — workingMessages is mutated after this round completes.
+        secondCallMessages = [...(params.messages ?? [])];
       }
       yield* origStream(params as never);
     } as never;
@@ -134,11 +135,17 @@ describe('runStreamingToolLoop (#1552)', () => {
     });
 
     expect(beforeTools).toHaveBeenCalledOnce();
+    expect(beforeTools).toHaveBeenCalledWith({
+      toolCalls: [toolCall],
+      content: 'Checking.',
+    });
     expect(invokeTool).toHaveBeenCalledWith(toolCall);
     expect(result.toolRounds).toBe(1);
     expect(result.stopReason).toBe('message_end');
     expect(result.finalText).toBe('Sunny.');
     expect(provider.streamCalls).toBe(2);
+    // Terminal assistant reply is appended so messages is a complete transcript.
+    expect(result.messages.at(-1)).toEqual({ role: 'assistant', content: 'Sunny.' });
 
     // Shape contract: second stream call must carry assistant tool_use + user tool_result.
     expect(secondCallMessages).toEqual([
@@ -146,6 +153,95 @@ describe('runStreamingToolLoop (#1552)', () => {
       buildAssistantToolUseMessage([toolCall], 'Checking.'),
       buildUserToolResultMessage([{ id: 'call_1', content: 'sunny, 25C' }]),
     ]);
+  });
+
+  it('uses missingInvokeToolResult when invokeTool is absent', async () => {
+    const toolCall: ToolCall = { id: 'call_1', name: 'lookup', input: {} };
+    let captured: { content?: string; is_error?: boolean } | undefined;
+    const provider = new FakeStreamProvider([
+      [{ type: 'tool_use', toolCalls: [toolCall], usage, provenance }],
+      [{ type: 'message_end', content: 'ok', usage, provenance }],
+    ]);
+    const origStream = provider.stream.bind(provider);
+    provider.stream = async function* (params: {
+      messages?: unknown[];
+      options?: Record<string, unknown>;
+    }) {
+      if (provider.streamCalls === 1 && Array.isArray(params.messages)) {
+        const lastMsg = params.messages[params.messages.length - 1]! as {
+          content: Array<{ content?: string; is_error?: boolean }>;
+        };
+        captured = lastMsg.content[0]!;
+      }
+      yield* origStream(params as never);
+    } as never;
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: DEFAULT_STREAMING_MAX_ROUNDS,
+      signal: new AbortController().signal,
+      missingInvokeToolResult: 'Tool execution is not wired for this streaming turn.',
+    });
+
+    expect(captured?.content).toContain('not wired');
+    expect(captured?.is_error).toBe(true);
+    expect(result.finalText).toBe('ok');
+    expect(result.toolRounds).toBe(1);
+  });
+
+  it('returns empty_stream when the iterable ends with no terminal event', async () => {
+    const provider = new FakeStreamProvider([[textDelta('orphan text')]]);
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: 2,
+      signal: new AbortController().signal,
+      logger,
+    });
+
+    expect(result.stopReason).toBe('empty_stream');
+    expect(result.streamedText).toBe('orphan text');
+    expect(result.finalText).toBe('orphan text');
+    expect(result.exhausted).toBe(false);
+    expect(result.aborted).toBe(false);
+  });
+
+  it('preserves empty message_end content on finalText (no streamedText fallback)', async () => {
+    const provider = new FakeStreamProvider([
+      [
+        textDelta('Pre-tool. '),
+        {
+          type: 'tool_use',
+          toolCalls: [{ id: 'call_1', name: 'lookup', input: {} }],
+          content: 'Pre-tool.',
+          usage,
+          provenance,
+        },
+      ],
+      [
+        textDelta('Post-tool spoken. '),
+        { type: 'message_end', content: '', usage, provenance },
+      ],
+    ]);
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: DEFAULT_STREAMING_MAX_ROUNDS,
+      signal: new AbortController().signal,
+      invokeTool: async () => ({ content: 'ok' }),
+    });
+
+    expect(result.stopReason).toBe('message_end');
+    // Callers (voice) must fall back to their own delivered text — not streamedText.
+    expect(result.finalText).toBe('');
+    expect(result.streamedText).toBe('Pre-tool. Post-tool spoken. ');
+    // Transcript still gets a usable assistant turn via streamedText fallback.
+    expect(result.messages.at(-1)).toEqual({
+      role: 'assistant',
+      content: 'Pre-tool. Post-tool spoken. ',
+    });
   });
 
   it('stops cleanly on abort mid-stream', async () => {

--- a/src/agents/llm/streaming-turn.test.ts
+++ b/src/agents/llm/streaming-turn.test.ts
@@ -237,11 +237,53 @@ describe('runStreamingToolLoop (#1552)', () => {
     // Callers (voice) must fall back to their own delivered text — not streamedText.
     expect(result.finalText).toBe('');
     expect(result.streamedText).toBe('Pre-tool. Post-tool spoken. ');
-    // Transcript still gets a usable assistant turn via streamedText fallback.
+    // Terminal assistant uses THIS ROUND's deltas only — pre-tool narration is
+    // already on the prior tool_use assistant turn and must not be duplicated.
     expect(result.messages.at(-1)).toEqual({
       role: 'assistant',
-      content: 'Pre-tool. Post-tool spoken. ',
+      content: 'Post-tool spoken. ',
     });
+  });
+
+  it('closes unanswered tool_use ids with cancelled results on abort mid-invoke', async () => {
+    const toolCalls: ToolCall[] = [
+      { id: 'call_1', name: 'lookup', input: { q: 'a' } },
+      { id: 'call_2', name: 'lookup', input: { q: 'b' } },
+    ];
+    const provider = new FakeStreamProvider([
+      [{ type: 'tool_use', toolCalls, usage, provenance }],
+    ]);
+    const controller = new AbortController();
+    let invokeCount = 0;
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: DEFAULT_STREAMING_MAX_ROUNDS,
+      signal: controller.signal,
+      invokeTool: async () => {
+        invokeCount += 1;
+        if (invokeCount === 1) {
+          controller.abort();
+          return { content: 'first-ok' };
+        }
+        return { content: 'should-not-run' };
+      },
+      logger,
+    });
+
+    expect(result.aborted).toBe(true);
+    expect(result.stopReason).toBe('aborted');
+    expect(invokeCount).toBe(1);
+    // Assistant tool_use + user tool_result pairing must both be present.
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]!.role).toBe('assistant');
+    expect(result.messages[1]).toEqual(
+      buildUserToolResultMessage([
+        { id: 'call_1', content: 'first-ok' },
+        { id: 'call_2', content: 'Tool execution cancelled (turn aborted).', isError: true },
+      ]),
+    );
   });
 
   it('stops cleanly on abort mid-stream', async () => {

--- a/src/agents/llm/streaming-turn.test.ts
+++ b/src/agents/llm/streaming-turn.test.ts
@@ -1,0 +1,301 @@
+// streaming-turn.test.ts — unit coverage for the shared streaming tool-loop (#1552).
+
+import { describe, it, expect, vi } from 'vitest';
+import { createSilentLogger } from '../../logger.js';
+import type {
+  LLMProvider,
+  LLMResponse,
+  LLMStreamEvent,
+  ToolCall,
+} from './provider.js';
+import {
+  DEFAULT_STREAMING_MAX_ROUNDS,
+  StreamUnsupportedError,
+  assertStreamingProvider,
+  runStreamingToolLoop,
+} from './streaming-turn.js';
+import { buildAssistantToolUseMessage, buildUserToolResultMessage } from './tool-loop-messages.js';
+
+const logger = createSilentLogger();
+const usage = { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
+const provenance = { requestedModel: 'fake', actualModel: 'fake', providerRequestId: 'req_1' };
+
+class FakeStreamProvider implements LLMProvider {
+  readonly id = 'fake-stream';
+  streamCalls = 0;
+
+  constructor(
+    private readonly scripts: LLMStreamEvent[][],
+    private readonly delayMs = 0,
+  ) {}
+
+  async chat(): Promise<LLMResponse> {
+    return { type: 'text', content: '', usage, provenance };
+  }
+
+  async *stream(params: { options?: Record<string, unknown> }): AsyncIterable<LLMStreamEvent> {
+    const script = this.scripts[this.streamCalls] ?? [];
+    this.streamCalls += 1;
+    const signal = params.options?.signal as AbortSignal | undefined;
+    for (const event of script) {
+      if (this.delayMs > 0) await new Promise((r) => setTimeout(r, this.delayMs));
+      if (signal?.aborted) return;
+      yield event;
+    }
+  }
+}
+
+class NoStreamProvider implements LLMProvider {
+  readonly id = 'no-stream';
+  async chat(): Promise<LLMResponse> {
+    return { type: 'text', content: '', usage, provenance };
+  }
+}
+
+function textDelta(text: string): LLMStreamEvent {
+  return { type: 'text_delta', text };
+}
+
+describe('runStreamingToolLoop (#1552)', () => {
+  it('refuses a provider without stream()', async () => {
+    expect(() => assertStreamingProvider(new NoStreamProvider())).toThrow(StreamUnsupportedError);
+    await expect(
+      runStreamingToolLoop([], {
+        provider: new NoStreamProvider(),
+        model: 'fake',
+        maxRounds: 2,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toBeInstanceOf(StreamUnsupportedError);
+  });
+
+  it('streams text_delta then returns on message_end', async () => {
+    const provider = new FakeStreamProvider([
+      [
+        textDelta('Hello '),
+        textDelta('world.'),
+        { type: 'message_end', content: 'Hello world.', usage, provenance },
+      ],
+    ]);
+    const deltas: string[] = [];
+    const result = await runStreamingToolLoop([{ role: 'user', content: 'hi' }], {
+      provider,
+      model: 'fake',
+      maxRounds: DEFAULT_STREAMING_MAX_ROUNDS,
+      signal: new AbortController().signal,
+      hooks: {
+        onTextDelta: (text) => {
+          deltas.push(text);
+        },
+      },
+    });
+
+    expect(deltas).toEqual(['Hello ', 'world.']);
+    expect(result.stopReason).toBe('message_end');
+    expect(result.finalText).toBe('Hello world.');
+    expect(result.streamedText).toBe('Hello world.');
+    expect(result.aborted).toBe(false);
+    expect(result.toolRounds).toBe(0);
+  });
+
+  it('runs tool_use → invokeTool → continues with tool_result shape', async () => {
+    const toolCall: ToolCall = { id: 'call_1', name: 'lookup', input: { q: 'weather' } };
+    const provider = new FakeStreamProvider([
+      [
+        textDelta('Checking. '),
+        { type: 'tool_use', toolCalls: [toolCall], content: 'Checking.', usage, provenance },
+      ],
+      [{ type: 'message_end', content: 'Sunny.', usage, provenance }],
+    ]);
+
+    const beforeTools = vi.fn();
+    const invokeTool = vi.fn(async () => ({ content: 'sunny, 25C' }));
+    let secondCallMessages: unknown[] | undefined;
+    const origStream = provider.stream.bind(provider);
+    provider.stream = async function* (params: {
+      messages?: unknown[];
+      options?: Record<string, unknown>;
+    }) {
+      if (provider.streamCalls === 1) {
+        secondCallMessages = params.messages;
+      }
+      yield* origStream(params as never);
+    } as never;
+
+    const result = await runStreamingToolLoop([{ role: 'user', content: 'weather?' }], {
+      provider,
+      model: 'fake',
+      maxRounds: DEFAULT_STREAMING_MAX_ROUNDS,
+      signal: new AbortController().signal,
+      tools: [{ name: 'lookup', description: 'lookup', input_schema: { type: 'object', properties: {} } }],
+      invokeTool,
+      hooks: { onBeforeTools: beforeTools },
+      logger,
+    });
+
+    expect(beforeTools).toHaveBeenCalledOnce();
+    expect(invokeTool).toHaveBeenCalledWith(toolCall);
+    expect(result.toolRounds).toBe(1);
+    expect(result.stopReason).toBe('message_end');
+    expect(result.finalText).toBe('Sunny.');
+    expect(provider.streamCalls).toBe(2);
+
+    // Shape contract: second stream call must carry assistant tool_use + user tool_result.
+    expect(secondCallMessages).toEqual([
+      { role: 'user', content: 'weather?' },
+      buildAssistantToolUseMessage([toolCall], 'Checking.'),
+      buildUserToolResultMessage([{ id: 'call_1', content: 'sunny, 25C' }]),
+    ]);
+  });
+
+  it('stops cleanly on abort mid-stream', async () => {
+    const provider = new FakeStreamProvider(
+      [
+        [
+          textDelta('First. '),
+          textDelta('Second partial'),
+          { type: 'message_end', content: 'x', usage, provenance },
+        ],
+      ],
+      5,
+    );
+    const controller = new AbortController();
+    const deltas: string[] = [];
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: DEFAULT_STREAMING_MAX_ROUNDS,
+      signal: controller.signal,
+      hooks: {
+        onTextDelta: (text) => {
+          deltas.push(text);
+          if (text === 'First. ') controller.abort();
+        },
+      },
+    });
+
+    expect(result.aborted).toBe(true);
+    expect(result.stopReason).toBe('aborted');
+    expect(deltas).toEqual(['First. ']);
+    expect(deltas).not.toContain('Second partial');
+  });
+
+  it('returns aborted immediately when the signal is already aborted', async () => {
+    const provider = new FakeStreamProvider([
+      [textDelta('never'), { type: 'message_end', content: 'x', usage, provenance }],
+    ]);
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: 4,
+      signal: controller.signal,
+    });
+
+    expect(result.aborted).toBe(true);
+    expect(result.stopReason).toBe('aborted');
+    expect(provider.streamCalls).toBe(0);
+  });
+
+  it('returns stream_error without throwing', async () => {
+    const provider = new FakeStreamProvider([
+      [
+        {
+          type: 'error',
+          error: {
+            type: 'PROVIDER_ERROR',
+            source: 'fake-stream',
+            message: 'boom',
+            retryable: true,
+            context: {},
+            timestamp: new Date(),
+          },
+        },
+      ],
+    ]);
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: 2,
+      signal: new AbortController().signal,
+      logger,
+    });
+
+    expect(result.stopReason).toBe('stream_error');
+    expect(result.error?.message).toBe('boom');
+  });
+
+  it('converts a throwing invokeTool into a tool_result error and continues', async () => {
+    const toolCall: ToolCall = { id: 'call_1', name: 'lookup', input: {} };
+    let captured: { content?: string; is_error?: boolean } | undefined;
+    const provider = new FakeStreamProvider([
+      [{ type: 'tool_use', toolCalls: [toolCall], usage, provenance }],
+      [{ type: 'message_end', content: 'recovered', usage, provenance }],
+    ]);
+    const origStream = provider.stream.bind(provider);
+    provider.stream = async function* (params: {
+      messages?: unknown[];
+      options?: Record<string, unknown>;
+    }) {
+      if (provider.streamCalls === 1 && Array.isArray(params.messages)) {
+        const lastMsg = params.messages[params.messages.length - 1]! as {
+          content: Array<{ content?: string; is_error?: boolean }>;
+        };
+        captured = lastMsg.content[0]!;
+      }
+      yield* origStream(params as never);
+    } as never;
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: DEFAULT_STREAMING_MAX_ROUNDS,
+      signal: new AbortController().signal,
+      invokeTool: async () => {
+        throw new Error('boom');
+      },
+      logger,
+    });
+
+    expect(captured?.content).toContain("Tool 'lookup' failed: boom");
+    expect(captured?.is_error).toBe(true);
+    expect(result.finalText).toBe('recovered');
+    expect(result.toolRounds).toBe(1);
+  });
+
+  it('exhausts at maxRounds and reports exhausted', async () => {
+    const toolCall: ToolCall = { id: 'call_1', name: 'lookup', input: {} };
+    const scripts: LLMStreamEvent[][] = Array.from({ length: DEFAULT_STREAMING_MAX_ROUNDS }, () => [
+      { type: 'tool_use', toolCalls: [toolCall], usage, provenance },
+    ]);
+    const provider = new FakeStreamProvider(scripts);
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: DEFAULT_STREAMING_MAX_ROUNDS,
+      signal: new AbortController().signal,
+      invokeTool: async () => ({ content: 'ok' }),
+    });
+
+    expect(result.exhausted).toBe(true);
+    expect(result.stopReason).toBe('exhausted');
+    expect(result.toolRounds).toBe(DEFAULT_STREAMING_MAX_ROUNDS);
+    expect(provider.streamCalls).toBe(DEFAULT_STREAMING_MAX_ROUNDS);
+  });
+
+  it('rejects non-positive maxRounds', async () => {
+    await expect(
+      runStreamingToolLoop([], {
+        provider: new FakeStreamProvider([]),
+        model: 'fake',
+        maxRounds: 0,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(/maxRounds/);
+  });
+});

--- a/src/agents/llm/streaming-turn.ts
+++ b/src/agents/llm/streaming-turn.ts
@@ -101,11 +101,13 @@ export interface StreamingTurnResult {
   finalText: string;
   /** Concatenation of text_delta chunks observed this turn (may be empty). */
   streamedText: string;
-  /**
+    /**
    * Working transcript including tool_use / tool_result pairs.
    * On `message_end`, also includes a final assistant text turn when there is
-   * non-empty terminal content, otherwise `streamedText` when non-empty — so
-   * consumers can treat `messages` as a complete conversation transcript.
+   * non-empty terminal content, otherwise this round's streamed deltas when
+   * non-empty (not whole-turn streamedText — that would duplicate pre-tool
+   * narration already on a prior tool_use turn). On abort mid-tool-round,
+   * unanswered tool_use ids are closed with cancelled placeholder results.
    */
   messages: Message[];
   toolRounds: number;
@@ -157,10 +159,6 @@ export async function runStreamingToolLoop(
   let streamedText = '';
   let toolRounds = 0;
 
-  const appendStreamed = (text: string): void => {
-    streamedText = streamedText.length > 0 ? `${streamedText}${text}` : text;
-  };
-
   for (let round = 0; round < config.maxRounds; round += 1) {
     if (signal.aborted) {
       return {
@@ -173,6 +171,12 @@ export async function runStreamingToolLoop(
         stopReason: 'aborted',
       };
     }
+
+    // Per-round delta accumulator — used for empty message_end transcript
+    // fallback so we do not re-append pre-tool narration already present in a
+    // prior assistant tool_use turn (whole-turn streamedText still tracks all
+    // deltas for callers that need the full spoken/streamed string).
+    let roundStreamedText = '';
 
     // Snapshot for the provider — never hand out the live workingMessages array
     // (providers/tests often retain the reference; we mutate after tool rounds).
@@ -191,7 +195,9 @@ export async function runStreamingToolLoop(
       if (signal.aborted) break;
 
       if (event.type === 'text_delta') {
-        appendStreamed(event.text);
+        streamedText = streamedText.length > 0 ? `${streamedText}${event.text}` : event.text;
+        roundStreamedText =
+          roundStreamedText.length > 0 ? `${roundStreamedText}${event.text}` : event.text;
         if (config.hooks?.onTextDelta) {
           await config.hooks.onTextDelta(event.text);
         }
@@ -241,8 +247,11 @@ export async function runStreamingToolLoop(
       // consumers get a complete conversation — but do not mutate
       // workingMessages after the last stream() call (callers/tests often hold
       // a reference to the messages array that was passed into stream).
+      // Empty terminal content falls back to THIS ROUND's deltas only — not
+      // whole-turn streamedText, which would duplicate pre-tool narration
+      // already carried on a prior assistant tool_use turn.
       const transcriptReply =
-        messageEnd.content.length > 0 ? messageEnd.content : streamedText;
+        messageEnd.content.length > 0 ? messageEnd.content : roundStreamedText;
       const messages =
         transcriptReply.length > 0
           ? [...workingMessages, { role: 'assistant' as const, content: transcriptReply }]
@@ -297,6 +306,20 @@ export async function runStreamingToolLoop(
       }
 
       if (signal.aborted) {
+        // Every tool_use id must be answered, even on barge-in — otherwise the
+        // returned transcript ends in an unanswered assistant tool_use turn
+        // and any later replay against Anthropic is rejected.
+        const answered = new Set(toolResults.map((r) => r.id));
+        for (const call of toolUse.toolCalls) {
+          if (!answered.has(call.id)) {
+            toolResults.push({
+              id: call.id,
+              content: 'Tool execution cancelled (turn aborted).',
+              isError: true,
+            });
+          }
+        }
+        workingMessages.push(buildUserToolResultMessage(toolResults));
         return {
           finalText: streamedText,
           streamedText,

--- a/src/agents/llm/streaming-turn.ts
+++ b/src/agents/llm/streaming-turn.ts
@@ -1,10 +1,9 @@
-// streaming-turn.ts — shared streaming tool-loop primitive (#1552).
+// streaming-turn.ts — streaming tool-loop primitive (#1552).
 //
-// Target end state (issue #1552): a provider-agnostic streaming turn that *both*
-// VoiceTurnRunner and (optionally later) AgentRuntime.handleTask delegate to —
-// **not** voice calling handleTask. Text channels stay on non-streaming chat()
-// until explicitly opted in; this module is the stream() + tool_use / tool_result
-// assembly path.
+// What shipped: VoiceTurnRunner delegates stream()+tool assembly here. Text
+// AgentRuntime.handleTask still owns its own non-streaming chat() tool loop —
+// convergence requires an explicit "text goes streaming" decision (#1563), not
+// just finishing this extraction. Do **not** fold voice into handleTask.
 //
 // Owns: provider.stream() consume, AbortSignal cancel, tool_use / tool_result
 // message assembly (via tool-loop-messages.ts), round cap, invokeTool sequencing.
@@ -27,7 +26,7 @@
 // through sanitizeOutput on either path. sanitizeOutput is for untrusted skill
 // output before it re-enters the model context — ExecutionLayer.invoke already
 // applies it. User inbound is sanitized at channel boundaries where applicable.
-// Cross-link: src/channels/voice/turn-runner.ts, src/agents/runtime.ts.
+// Cross-link: src/channels/voice/turn-runner.ts, src/agents/runtime.ts, #1563.
 
 import type { AgentError } from '../../errors/types.js';
 import type { Logger } from '../../logger.js';
@@ -93,13 +92,21 @@ export type StreamingTurnStopReason =
 
 export interface StreamingTurnResult {
   /**
-   * Preferred assistant text for this turn: message_end.content when present,
-   * otherwise accumulated text_delta content.
+   * On `message_end`: the model's terminal `content` **as-is** (may be empty).
+   * Callers that transform deltas (e.g. voice sentence-chunking / whitespace
+   * join) MUST fall back to their own delivered text when this is empty — do
+   * not assume `streamedText` matches what was spoken or persisted.
+   * On other stop reasons: accumulated `streamedText`.
    */
   finalText: string;
   /** Concatenation of text_delta chunks observed this turn (may be empty). */
   streamedText: string;
-  /** Working transcript including any tool_use / tool_result pairs appended. */
+  /**
+   * Working transcript including tool_use / tool_result pairs.
+   * On `message_end`, also includes a final assistant text turn when there is
+   * non-empty terminal content, otherwise `streamedText` when non-empty — so
+   * consumers can treat `messages` as a complete conversation transcript.
+   */
   messages: Message[];
   toolRounds: number;
   aborted: boolean;
@@ -229,10 +236,18 @@ export async function runStreamingToolLoop(
     }
 
     if (messageEnd) {
-      const finalText =
+      // Append the terminal assistant reply so `messages` is a complete
+      // transcript for future consumers (voice rebuilds history from finalText
+      // / spokenText and ignores this field today).
+      const transcriptReply =
         messageEnd.content.length > 0 ? messageEnd.content : streamedText;
+      if (transcriptReply.length > 0) {
+        workingMessages.push({ role: 'assistant', content: transcriptReply });
+      }
       return {
-        finalText,
+        // Preserve empty terminal content — callers decide their own fallback
+        // (voice uses spokenText, not streamedText).
+        finalText: messageEnd.content,
         streamedText,
         messages: workingMessages,
         toolRounds,

--- a/src/agents/llm/streaming-turn.ts
+++ b/src/agents/llm/streaming-turn.ts
@@ -1,0 +1,319 @@
+// streaming-turn.ts — shared streaming tool-loop primitive (#1552).
+//
+// Target end state (issue #1552): a provider-agnostic streaming turn that *both*
+// VoiceTurnRunner and (optionally later) AgentRuntime.handleTask delegate to —
+// **not** voice calling handleTask. Text channels stay on non-streaming chat()
+// until explicitly opted in; this module is the stream() + tool_use / tool_result
+// assembly path.
+//
+// Owns: provider.stream() consume, AbortSignal cancel, tool_use / tool_result
+// message assembly (via tool-loop-messages.ts), round cap, invokeTool sequencing.
+// Does NOT own: sentence-chunk TTS, filler speech, barge-in UX, chatWithRetry,
+// DelegationGuard, clarification short-circuits, or autonomy prompt injection.
+//
+// Round-cap policy: callers pass maxRounds. Voice uses DEFAULT_STREAMING_MAX_ROUNDS
+// (8) so a runaway tool loop fails fast into an audible fallback; text AgentRuntime
+// keeps per-agent error_budget.max_turns on the chat() path (often 20–40). Sharing
+// the coordinator's maxTurns=40 with spoken turns would leave the line silent far
+// too long — the divergence is intentional and parameterized here.
+//
+// Autonomy / Gate-C: this primitive never bypasses ExecutionLayer. Callers supply
+// invokeTool; voice and handleTask both route through executionLayer.invoke, so
+// Gates A/B/C stay equivalent. Voice's bridge is intentionally thinner (no
+// DelegationGuard / clarification protocol / tool.invoke bus events) — those are
+// handleTask concerns, not Gate-C divergences.
+//
+// Assistant-text sanitization policy: LLM-authored assistant text is NOT passed
+// through sanitizeOutput on either path. sanitizeOutput is for untrusted skill
+// output before it re-enters the model context — ExecutionLayer.invoke already
+// applies it. User inbound is sanitized at channel boundaries where applicable.
+// Cross-link: src/channels/voice/turn-runner.ts, src/agents/runtime.ts.
+
+import type { AgentError } from '../../errors/types.js';
+import type { Logger } from '../../logger.js';
+import {
+  buildAssistantToolUseMessage,
+  buildUserToolResultMessage,
+} from './tool-loop-messages.js';
+import type {
+  LLMProvider,
+  Message,
+  ToolCall,
+  ToolDefinition,
+} from './provider.js';
+
+/**
+ * Default max tool-use rounds for streaming turns (voice).
+ * Intentionally lower than typical agent `error_budget.max_turns` — see file header.
+ */
+export const DEFAULT_STREAMING_MAX_ROUNDS = 8;
+
+const DEFAULT_MISSING_INVOKE_TOOL_RESULT =
+  'Tool execution is not wired for this streaming turn.';
+
+export type StreamingTurnInvokeTool = (
+  call: ToolCall,
+) => Promise<{ content: string; is_error?: boolean }>;
+
+export interface StreamingTurnHooks {
+  /** Called for each text_delta from the model (before sentence chunking). */
+  onTextDelta?: (text: string) => void | Promise<void>;
+  /**
+   * Called when the model requests tools, after any preceding text has been
+   * delivered via onTextDelta, and before invokeTool runs. Voice uses this for
+   * filler TTS so the line is not silent during tool work.
+   */
+  onBeforeTools?: (info: {
+    toolCalls: ToolCall[];
+    content?: string;
+  }) => void | Promise<void>;
+}
+
+export interface StreamingTurnConfig {
+  /** Must implement stream() — construct-time callers should refuse otherwise. */
+  provider: LLMProvider;
+  model: string;
+  tools?: ToolDefinition[];
+  /** Hard cap on tool-use rounds. Required — see DEFAULT_STREAMING_MAX_ROUNDS. */
+  maxRounds: number;
+  signal: AbortSignal;
+  invokeTool?: StreamingTurnInvokeTool;
+  hooks?: StreamingTurnHooks;
+  logger?: Logger;
+  /** Placeholder tool_result content when invokeTool is missing. */
+  missingInvokeToolResult?: string;
+}
+
+export type StreamingTurnStopReason =
+  | 'message_end'
+  | 'aborted'
+  | 'exhausted'
+  | 'stream_error'
+  | 'empty_stream';
+
+export interface StreamingTurnResult {
+  /**
+   * Preferred assistant text for this turn: message_end.content when present,
+   * otherwise accumulated text_delta content.
+   */
+  finalText: string;
+  /** Concatenation of text_delta chunks observed this turn (may be empty). */
+  streamedText: string;
+  /** Working transcript including any tool_use / tool_result pairs appended. */
+  messages: Message[];
+  toolRounds: number;
+  aborted: boolean;
+  /** True when the round cap was hit without a message_end. */
+  exhausted: boolean;
+  stopReason: StreamingTurnStopReason;
+  /** Set when stopReason === 'stream_error'. */
+  error?: AgentError;
+}
+
+/** Thrown when a provider without stream() is used with the streaming primitive. */
+export class StreamUnsupportedError extends Error {
+  constructor(providerId: string) {
+    super(
+      `Streaming turn requires a streaming LLM provider; '${providerId}' does not implement stream()`,
+    );
+    this.name = 'StreamUnsupportedError';
+  }
+}
+
+/** Assert provider.stream exists — call from wrappers that refuse silent full-buffer. */
+export function assertStreamingProvider(provider: LLMProvider): void {
+  if (typeof provider.stream !== 'function') {
+    throw new StreamUnsupportedError(provider.id);
+  }
+}
+
+/**
+ * Run one streaming assistant turn with a tool-use loop.
+ * Resolves on message_end, abort, round-cap exhaustion, or empty stream.
+ * Stream terminal errors are returned on the result (not thrown) so callers
+ * can map them to channel-specific error types.
+ */
+export async function runStreamingToolLoop(
+  initialMessages: Message[],
+  config: StreamingTurnConfig,
+): Promise<StreamingTurnResult> {
+  assertStreamingProvider(config.provider);
+
+  if (!Number.isFinite(config.maxRounds) || config.maxRounds < 1) {
+    throw new Error(`streaming turn maxRounds must be a positive integer; got ${config.maxRounds}`);
+  }
+
+  const workingMessages: Message[] = [...initialMessages];
+  const signal = config.signal;
+  const missingResult =
+    config.missingInvokeToolResult ?? DEFAULT_MISSING_INVOKE_TOOL_RESULT;
+  let streamedText = '';
+  let toolRounds = 0;
+
+  const appendStreamed = (text: string): void => {
+    streamedText = streamedText.length > 0 ? `${streamedText}${text}` : text;
+  };
+
+  for (let round = 0; round < config.maxRounds; round += 1) {
+    if (signal.aborted) {
+      return {
+        finalText: streamedText,
+        streamedText,
+        messages: workingMessages,
+        toolRounds,
+        aborted: true,
+        exhausted: false,
+        stopReason: 'aborted',
+      };
+    }
+
+    // stream() is guaranteed present by assertStreamingProvider.
+    const stream = config.provider.stream!({
+      messages: workingMessages,
+      tools: config.tools,
+      model: config.model,
+      options: { signal },
+    });
+
+    let toolUse: { toolCalls: ToolCall[]; content?: string } | undefined;
+    let messageEnd: { content: string } | undefined;
+    let streamError: AgentError | undefined;
+
+    for await (const event of stream) {
+      if (signal.aborted) break;
+
+      if (event.type === 'text_delta') {
+        appendStreamed(event.text);
+        if (config.hooks?.onTextDelta) {
+          await config.hooks.onTextDelta(event.text);
+        }
+      } else if (event.type === 'tool_use') {
+        toolUse = { toolCalls: event.toolCalls, content: event.content };
+        break;
+      } else if (event.type === 'message_end') {
+        messageEnd = { content: event.content };
+        break;
+      } else if (event.type === 'error') {
+        streamError = event.error;
+        break;
+      }
+    }
+
+    if (signal.aborted) {
+      return {
+        finalText: streamedText,
+        streamedText,
+        messages: workingMessages,
+        toolRounds,
+        aborted: true,
+        exhausted: false,
+        stopReason: 'aborted',
+      };
+    }
+
+    if (streamError) {
+      config.logger?.warn(
+        { error: streamError.type, source: streamError.source },
+        'streaming turn stream error',
+      );
+      return {
+        finalText: streamedText,
+        streamedText,
+        messages: workingMessages,
+        toolRounds,
+        aborted: false,
+        exhausted: false,
+        stopReason: 'stream_error',
+        error: streamError,
+      };
+    }
+
+    if (messageEnd) {
+      const finalText =
+        messageEnd.content.length > 0 ? messageEnd.content : streamedText;
+      return {
+        finalText,
+        streamedText,
+        messages: workingMessages,
+        toolRounds,
+        aborted: false,
+        exhausted: false,
+        stopReason: 'message_end',
+      };
+    }
+
+    if (toolUse) {
+      toolRounds += 1;
+      if (config.hooks?.onBeforeTools) {
+        await config.hooks.onBeforeTools(toolUse);
+      }
+
+      // Assistant turn must carry tool_use blocks so the following tool_result
+      // blocks can reference their ids (Anthropic requirement).
+      workingMessages.push(
+        buildAssistantToolUseMessage(toolUse.toolCalls, toolUse.content),
+      );
+
+      const toolResults: Array<{ id: string; content: string; isError?: boolean }> = [];
+      for (const call of toolUse.toolCalls) {
+        if (signal.aborted) break;
+        let result: { content: string; is_error?: boolean };
+        if (config.invokeTool) {
+          try {
+            result = await config.invokeTool(call);
+          } catch (err) {
+            config.logger?.warn({ tool: call.name, err }, 'streaming turn tool invocation threw');
+            result = {
+              content: `Tool '${call.name}' failed: ${err instanceof Error ? err.message : String(err)}`,
+              is_error: true,
+            };
+          }
+        } else {
+          result = { content: missingResult, is_error: true };
+        }
+        toolResults.push({
+          id: call.id,
+          content: result.content,
+          isError: result.is_error,
+        });
+      }
+
+      if (signal.aborted) {
+        return {
+          finalText: streamedText,
+          streamedText,
+          messages: workingMessages,
+          toolRounds,
+          aborted: true,
+          exhausted: false,
+          stopReason: 'aborted',
+        };
+      }
+
+      workingMessages.push(buildUserToolResultMessage(toolResults));
+      continue;
+    }
+
+    // Stream ended with no terminal event (unexpected).
+    config.logger?.warn({ round }, 'streaming turn stream ended without a terminal event');
+    return {
+      finalText: streamedText,
+      streamedText,
+      messages: workingMessages,
+      toolRounds,
+      aborted: false,
+      exhausted: false,
+      stopReason: 'empty_stream',
+    };
+  }
+
+  return {
+    finalText: streamedText,
+    streamedText,
+    messages: workingMessages,
+    toolRounds,
+    aborted: false,
+    exhausted: true,
+    stopReason: 'exhausted',
+  };
+}

--- a/src/agents/llm/streaming-turn.ts
+++ b/src/agents/llm/streaming-turn.ts
@@ -174,9 +174,10 @@ export async function runStreamingToolLoop(
       };
     }
 
-    // stream() is guaranteed present by assertStreamingProvider.
+    // Snapshot for the provider — never hand out the live workingMessages array
+    // (providers/tests often retain the reference; we mutate after tool rounds).
     const stream = config.provider.stream!({
-      messages: workingMessages,
+      messages: [...workingMessages],
       tools: config.tools,
       model: config.model,
       options: { signal },
@@ -236,20 +237,22 @@ export async function runStreamingToolLoop(
     }
 
     if (messageEnd) {
-      // Append the terminal assistant reply so `messages` is a complete
-      // transcript for future consumers (voice rebuilds history from finalText
-      // / spokenText and ignores this field today).
+      // Build the returned transcript with the terminal assistant reply so
+      // consumers get a complete conversation — but do not mutate
+      // workingMessages after the last stream() call (callers/tests often hold
+      // a reference to the messages array that was passed into stream).
       const transcriptReply =
         messageEnd.content.length > 0 ? messageEnd.content : streamedText;
-      if (transcriptReply.length > 0) {
-        workingMessages.push({ role: 'assistant', content: transcriptReply });
-      }
+      const messages =
+        transcriptReply.length > 0
+          ? [...workingMessages, { role: 'assistant' as const, content: transcriptReply }]
+          : workingMessages;
       return {
         // Preserve empty terminal content — callers decide their own fallback
         // (voice uses spokenText, not streamedText).
         finalText: messageEnd.content,
         streamedText,
-        messages: workingMessages,
+        messages,
         toolRounds,
         aborted: false,
         exhausted: false,

--- a/src/agents/llm/tool-loop-messages.ts
+++ b/src/agents/llm/tool-loop-messages.ts
@@ -1,11 +1,11 @@
 // tool-loop-messages.ts — shared ContentBlock assembly for tool_use / tool_result turns.
 //
-// VoiceTurnRunner (streaming) and AgentRuntime.handleTask (non-streaming) both must
-// emit Anthropic-compatible assistant+user message pairs when a model requests tools.
-// Keeping the *shape* of those blocks in one place prevents the two loops from
-// silently drifting while #1552 (shared streaming turn primitive) is outstanding.
+// Used by the shared streaming turn primitive (streaming-turn.ts) and by
+// AgentRuntime.handleTask (non-streaming chat path). Both must emit
+// Anthropic-compatible assistant+user message pairs when a model requests tools.
 //
-// See also: src/channels/voice/turn-runner.ts, src/agents/runtime.ts (~tool_use loop).
+// See also: src/agents/llm/streaming-turn.ts, src/channels/voice/turn-runner.ts,
+// src/agents/runtime.ts (~tool_use loop). Issue #1552.
 
 import type {
   ContentBlock,

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1078,15 +1078,16 @@ export class AgentRuntime {
     const delegationGuard = new DelegationGuard();
     let pendingDelegationEscalation: (DelegationFailureInfo & { task: string; escalated: boolean }) | null = null;
 
-    // WHY TWO LOOPS EXIST (#1552, supersedes #1550): this non-streaming tool
-    // loop (provider.chat) is the text-channel path. Voice uses VoiceTurnRunner
-    // over provider.stream() with barge-in abort + sentence-chunk TTS — see
-    // src/channels/voice/turn-runner.ts. Do not fold voice into handleTask until
-    // a shared streaming turn primitive exists (#1552). Until then, keep
-    // tool_use / tool_result ContentBlock shapes in sync via
-    // src/agents/llm/tool-loop-messages.ts. Divergence risks: round caps
-    // (maxTurns vs MAX_TOOL_ROUNDS), autonomy/Gate-C invoke path, assistant
-    // output sanitization. Sibling: #1551 (brain/context + history read model).
+    // TWO PATHS, ONE PRIMITIVE FAMILY (#1552): this non-streaming tool loop
+    // (provider.chat) is the text-channel path — keep it here unless a caller
+    // explicitly opts into streaming. Voice delegates stream()+tool assembly to
+    // src/agents/llm/streaming-turn.ts via a thin VoiceTurnRunner wrapper
+    // (sentence-chunk TTS / filler / barge-in only). Both paths share
+    // tool-loop-messages.ts block shapes. Round caps stay parameterized:
+    // text uses per-agent errorBudget.maxTurns; voice uses
+    // DEFAULT_STREAMING_MAX_ROUNDS (8) — intentional (spoken fail-fast).
+    // Autonomy/Gate-C: both call executionLayer.invoke. Assistant text is not
+    // sanitizeOutput'd on either path (skill results are, inside invoke).
     while (response.type === 'tool_use' && executionLayer) {
       // Check turn budget before processing this round of tool calls
       budget.turnsUsed++;
@@ -1103,8 +1104,8 @@ export class AgentRuntime {
 
       // Build the assistant turn with the actual tool_use content blocks.
       // The Anthropic API requires these to exist so tool_result blocks can
-      // reference their IDs in the next user turn. Shape shared with
-      // VoiceTurnRunner via tool-loop-messages.ts (#1552).
+      // reference their IDs in the next user turn. Shape shared with the
+      // streaming turn primitive via tool-loop-messages.ts (#1552).
       messages.push(buildAssistantToolUseMessage(response.toolCalls, response.content));
 
       // Execute each tool call through the execution layer.

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1078,16 +1078,17 @@ export class AgentRuntime {
     const delegationGuard = new DelegationGuard();
     let pendingDelegationEscalation: (DelegationFailureInfo & { task: string; escalated: boolean }) | null = null;
 
-    // TWO PATHS, ONE PRIMITIVE FAMILY (#1552): this non-streaming tool loop
-    // (provider.chat) is the text-channel path — keep it here unless a caller
-    // explicitly opts into streaming. Voice delegates stream()+tool assembly to
-    // src/agents/llm/streaming-turn.ts via a thin VoiceTurnRunner wrapper
-    // (sentence-chunk TTS / filler / barge-in only). Both paths share
-    // tool-loop-messages.ts block shapes. Round caps stay parameterized:
-    // text uses per-agent errorBudget.maxTurns; voice uses
-    // DEFAULT_STREAMING_MAX_ROUNDS (8) — intentional (spoken fail-fast).
-    // Autonomy/Gate-C: both call executionLayer.invoke. Assistant text is not
-    // sanitizeOutput'd on either path (skill results are, inside invoke).
+    // TWO TOOL LOOPS (#1552 / #1563): this non-streaming chat() loop is still
+    // the text-channel path. Voice uses streaming-turn.ts via a thin
+    // VoiceTurnRunner wrapper — they share tool-loop-messages.ts shapes, but
+    // handleTask does NOT yet delegate here. Opting text into the streaming
+    // primitive requires an explicit "text goes streaming" decision (#1563):
+    // this loop also owns retry/fallback, error budgets, DelegationGuard,
+    // clarification, tool bus events, and delegate timeout injection.
+    // Round caps stay parameterized (errorBudget.maxTurns vs voice's
+    // DEFAULT_STREAMING_MAX_ROUNDS=8). Autonomy/Gate-C: both call
+    // executionLayer.invoke. Assistant text is not sanitizeOutput'd on either
+    // path (skill results are, inside invoke).
     while (response.type === 'tool_use' && executionLayer) {
       // Check turn budget before processing this round of tool calls
       budget.turnsUsed++;

--- a/src/channels/voice/turn-runner.test.ts
+++ b/src/channels/voice/turn-runner.test.ts
@@ -317,4 +317,44 @@ describe('VoiceTurnRunner', () => {
     expect(provider.streamCalls).toBe(0);
     expect(spoken).toEqual([]);
   });
+
+  it('falls back to spokenText when message_end.content is empty', async () => {
+    // Multi-round: deltas are spoken via sentence chunker; terminal content is
+    // empty. finalText must be the TTS-delivered spokenText, not raw streamedText
+    // (#1562 review §3).
+    const toolCall: ToolCall = { id: 'call_1', name: 'lookup', input: {} };
+    const provider = new FakeStreamProvider([
+      [
+        textDelta('Let me check. '),
+        { type: 'tool_use', toolCalls: [toolCall], content: 'Let me check.', usage, provenance },
+      ],
+      [
+        textDelta('It is sunny. '),
+        { type: 'message_end', content: '', usage, provenance },
+      ],
+    ]);
+    const spoken: string[] = [];
+    const runner = new VoiceTurnRunner({
+      provider,
+      model: 'fake',
+      logger,
+      invokeTool: async () => ({ content: 'ok' }),
+      onFiller: async () => {},
+      onSpeechText: async text => {
+        spoken.push(text);
+      },
+    });
+
+    const result = await runner.runTurn({
+      messages: [],
+      signal: new AbortController().signal,
+    });
+
+    expect(spoken).toContain('Let me check.');
+    expect(spoken).toContain('It is sunny.');
+    expect(result.aborted).toBe(false);
+    // speak() joins with single spaces — not raw delta concat.
+    expect(result.finalText).toBe('Let me check. It is sunny.');
+    expect(result.finalText).not.toBe('Let me check. It is sunny. ');
+  });
 });

--- a/src/channels/voice/turn-runner.ts
+++ b/src/channels/voice/turn-runner.ts
@@ -1,31 +1,17 @@
 // turn-runner.ts — VoiceTurnRunner drives a single spoken assistant turn.
 //
-// Unlike AgentRuntime.handleTask (which buffers a complete reply before the
-// channel delivers it), the voice turn must start speaking mid-generation.
-// VoiceTurnRunner consumes LLMProvider.stream(), sentence-chunks the text
-// deltas, and hands each finished sentence to onSpeechText for TTS. It also
-// runs the streaming tool loop: when the model emits tool_use, the runner
-// speaks a short filler, invokes the tools, and continues the stream with the
-// tool results appended — looping until message_end, error, or abort.
+// Thin voice wrapper over the shared streaming turn primitive
+// (src/agents/llm/streaming-turn.ts, #1552). This file owns only voice UX:
+// sentence-chunk TTS, filler speech, barge-in AbortSignal semantics, and the
+// audible exhaustion fallback. Tool-loop / message assembly / round-cap /
+// stream+abort live in the shared primitive.
 //
-// WHY TWO LOOPS EXIST (#1552, supersedes #1550): AgentRuntime.handleTask is a
-// non-streaming while(tool_use) over provider.chat(), entangled with
-// retry/fallback, error budgets, and full-buffer-then-deliver. Voice needs
-// stream() + barge-in abort + sentence-chunk TTS — forcing it through
-// handleTask now would risk every text channel. Both paths MUST keep Anthropic
-// tool_use / tool_result message shapes in sync via
-// src/agents/llm/tool-loop-messages.ts until a shared streaming turn primitive
-// lands (#1552). Do not re-diverge block assembly here.
-// Sibling debt (brain/context parity + history read model): #1551.
-// Cross-link: src/agents/runtime.ts tool_use loop.
-//
-// Barge-in: runTurn honours the caller's AbortSignal. When the signal fires
-// (the principal started speaking over the assistant), the runner stops
-// consuming the stream promptly and returns { aborted: true } without flushing
-// any buffered partial sentence.
+// Text AgentRuntime.handleTask stays on non-streaming provider.chat() unless
+// explicitly opted into the streaming primitive later — do not fold voice into
+// handleTask. Cross-link: src/agents/runtime.ts tool_use loop.
+// Sibling: #1551 (brain/context + history read model).
 
 import { randomUUID } from 'node:crypto';
-import type { AgentError } from '../../errors/types.js';
 import type { Logger } from '../../logger.js';
 import type {
   LLMProvider,
@@ -33,11 +19,16 @@ import type {
   ToolCall,
   ToolDefinition,
 } from '../../agents/llm/provider.js';
+import type { AgentError } from '../../errors/types.js';
 import {
-  buildAssistantToolUseMessage,
-  buildUserToolResultMessage,
-} from '../../agents/llm/tool-loop-messages.js';
+  DEFAULT_STREAMING_MAX_ROUNDS,
+  StreamUnsupportedError,
+  assertStreamingProvider,
+  runStreamingToolLoop,
+} from '../../agents/llm/streaming-turn.js';
 import { SentenceChunker } from './sentence-chunker.js';
+
+export { StreamUnsupportedError, DEFAULT_STREAMING_MAX_ROUNDS };
 
 /** Filler spoken before invoking (potentially slow) tools so the line is not silent. */
 const DEFAULT_FILLER = 'One moment.';
@@ -45,8 +36,8 @@ const DEFAULT_FILLER = 'One moment.';
 /** Spoken when the tool loop exhausts without a message_end so the line is not silent. */
 const EXHAUSTION_FALLBACK = 'Sorry, I could not finish that — please try again.';
 
-/** Hard cap on tool-use rounds to guard against a tool loop that never terminates. */
-const MAX_TOOL_ROUNDS = 8;
+/** Placeholder when voice has no invokeTool bridge (should not happen in production). */
+const MISSING_INVOKE_TOOL_RESULT = 'Tool execution is not wired for voice turns yet.';
 
 export interface VoiceTurnRunnerConfig {
   /** LLM provider — must implement stream(). */
@@ -57,6 +48,11 @@ export interface VoiceTurnRunnerConfig {
   tools?: ToolDefinition[];
   /** Invoke a tool and return result text; used when the stream yields tool_use. */
   invokeTool?: (call: ToolCall) => Promise<{ content: string; is_error?: boolean }>;
+  /**
+   * Max tool-use rounds. Defaults to DEFAULT_STREAMING_MAX_ROUNDS (8).
+   * Intentionally not the coordinator's text-path maxTurns — see streaming-turn.ts.
+   */
+  maxRounds?: number;
   /** Spoken filler emitted before long tool work. */
   onFiller?: (text: string) => Promise<void>;
   /** Sentence chunks ready for TTS. */
@@ -74,14 +70,6 @@ export interface VoiceTurnResult {
   streamId: string;
 }
 
-/** Thrown when a provider without stream() support is used to construct a runner. */
-export class StreamUnsupportedError extends Error {
-  constructor(providerId: string) {
-    super(`VoiceTurnRunner requires a streaming LLM provider; '${providerId}' does not implement stream()`);
-    this.name = 'StreamUnsupportedError';
-  }
-}
-
 /** Thrown when the LLM stream yields a terminal error event. */
 export class VoiceTurnError extends Error {
   constructor(public readonly agentError: AgentError) {
@@ -92,28 +80,27 @@ export class VoiceTurnError extends Error {
 
 export class VoiceTurnRunner {
   private readonly log: Logger;
+  private readonly maxRounds: number;
 
   constructor(private readonly config: VoiceTurnRunnerConfig) {
     // Refuse to construct against a non-streaming provider — voice must never
     // silently full-buffer then speak (ADR-037).
-    if (typeof config.provider.stream !== 'function') {
-      throw new StreamUnsupportedError(config.provider.id);
-    }
+    assertStreamingProvider(config.provider);
+    this.maxRounds = config.maxRounds ?? DEFAULT_STREAMING_MAX_ROUNDS;
     this.log = config.logger.child({ component: 'voice-turn-runner' });
   }
 
   /**
    * Run one spoken assistant turn. Streams text to onSpeechText and drives the
-   * tool loop. Resolves when the model finishes (message_end) or the signal
-   * aborts; throws VoiceTurnError if the stream yields a terminal error.
+   * tool loop via the shared streaming primitive. Resolves when the model
+   * finishes (message_end) or the signal aborts; throws VoiceTurnError if the
+   * stream yields a terminal error.
    */
   async runTurn({ messages, signal }: { messages: Message[]; signal: AbortSignal }): Promise<VoiceTurnResult> {
     const streamId = randomUUID();
     const chunker = new SentenceChunker();
-    const workingMessages: Message[] = [...messages];
     const turnStartedAt = Date.now();
     let ttftLogged = false;
-    let toolRounds = 0;
     // Everything handed to TTS this turn, so finalText matches what was heard
     // even when we fall out of the loop without a message_end.
     let spokenText = '';
@@ -122,129 +109,69 @@ export class VoiceTurnRunner {
       await this.config.onSpeechText(text, { streamId });
     };
 
-    for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
-      if (signal.aborted) {
-        chunker.reset();
-        return { finalText: spokenText, aborted: true, toolRounds, streamId };
-      }
-
-      // stream() is guaranteed present by the constructor guard.
-      const stream = this.config.provider.stream!({
-        messages: workingMessages,
-        tools: this.config.tools,
-        model: this.config.model,
-        options: { signal },
-      });
-
-      let toolUse: { toolCalls: ToolCall[]; content?: string } | undefined;
-      let messageEnd: { content: string } | undefined;
-      let streamError: AgentError | undefined;
-
-      for await (const event of stream) {
-        if (signal.aborted) break;
-
-        if (event.type === 'text_delta') {
+    const result = await runStreamingToolLoop(messages, {
+      provider: this.config.provider,
+      model: this.config.model,
+      tools: this.config.tools,
+      maxRounds: this.maxRounds,
+      signal,
+      invokeTool: this.config.invokeTool,
+      missingInvokeToolResult: MISSING_INVOKE_TOOL_RESULT,
+      logger: this.log,
+      hooks: {
+        onTextDelta: async (text) => {
           if (!ttftLogged) {
             ttftLogged = true;
             this.log.debug({ streamId, llm_ttft_ms: Date.now() - turnStartedAt }, 'voice llm first token');
           }
-          for (const sentence of chunker.push(event.text)) {
+          for (const sentence of chunker.push(text)) {
             if (signal.aborted) break;
             await speak(sentence);
           }
-        } else if (event.type === 'tool_use') {
-          toolUse = { toolCalls: event.toolCalls, content: event.content };
-          break;
-        } else if (event.type === 'message_end') {
-          messageEnd = { content: event.content };
-          break;
-        } else if (event.type === 'error') {
-          streamError = event.error;
-          break;
-        }
-      }
-
-      if (signal.aborted) {
-        // Barge-in: drop any buffered partial sentence — it must not be spoken
-        // or recorded as a completed assistant turn.
-        chunker.reset();
-        return { finalText: spokenText, aborted: true, toolRounds, streamId };
-      }
-
-      if (streamError) {
-        chunker.reset();
-        this.log.warn({ streamId, error: streamError.type, source: streamError.source }, 'voice turn stream error');
-        throw new VoiceTurnError(streamError);
-      }
-
-      if (messageEnd) {
-        // Speak any trailing partial sentence that never hit a boundary.
-        const remainder = chunker.flush();
-        if (remainder && !signal.aborted) {
-          await speak(remainder);
-        }
-        // Prefer the model's terminal content when present; otherwise fall back
-        // to what was actually handed to TTS (covers multi-round tool turns).
-        const finalText = messageEnd.content.length > 0 ? messageEnd.content : spokenText;
-        return { finalText, aborted: signal.aborted, toolRounds, streamId };
-      }
-
-      if (toolUse) {
-        toolRounds += 1;
-        // Speak whatever preceded the tool call, then a short filler so the
-        // line is not silent while the tool runs.
-        const remainder = chunker.flush();
-        if (remainder) await speak(remainder);
-        if (this.config.onFiller) {
-          await this.config.onFiller(DEFAULT_FILLER);
-          // Filler is heard but is not part of the assistant reply transcript.
-        }
-
-        // Assistant turn must carry the tool_use blocks so the following
-        // tool_result blocks can reference their ids (Anthropic requirement).
-        // Shape shared with AgentRuntime via tool-loop-messages.ts (#1552).
-        workingMessages.push(buildAssistantToolUseMessage(toolUse.toolCalls, toolUse.content));
-
-        const toolResults: Array<{ id: string; content: string; isError?: boolean }> = [];
-        for (const call of toolUse.toolCalls) {
-          if (signal.aborted) break;
-          let result: { content: string; is_error?: boolean };
-          if (this.config.invokeTool) {
-            try {
-              result = await this.config.invokeTool(call);
-            } catch (err) {
-              this.log.warn({ streamId, tool: call.name, err }, 'voice tool invocation threw');
-              result = {
-                content: `Tool '${call.name}' failed: ${err instanceof Error ? err.message : String(err)}`,
-                is_error: true,
-              };
-            }
-          } else {
-            result = { content: 'Tool execution is not wired for voice turns yet.', is_error: true };
+        },
+        onBeforeTools: async () => {
+          // Speak whatever preceded the tool call, then a short filler so the
+          // line is not silent while the tool runs.
+          const remainder = chunker.flush();
+          if (remainder) await speak(remainder);
+          if (this.config.onFiller) {
+            await this.config.onFiller(DEFAULT_FILLER);
+            // Filler is heard but is not part of the assistant reply transcript.
           }
-          toolResults.push({
-            id: call.id,
-            content: result.content,
-            isError: result.is_error,
-          });
-        }
+        },
+      },
+    });
 
-        if (signal.aborted) {
-          chunker.reset();
-          return { finalText: spokenText, aborted: true, toolRounds, streamId };
-        }
-
-        workingMessages.push(buildUserToolResultMessage(toolResults));
-        continue;
-      }
-
-      // Stream ended with no terminal event (unexpected). Stop the loop.
-      this.log.warn({ streamId, round }, 'voice turn stream ended without a terminal event');
-      break;
+    if (result.aborted) {
+      // Barge-in: drop any buffered partial sentence — it must not be spoken
+      // or recorded as a completed assistant turn.
+      chunker.reset();
+      return { finalText: spokenText, aborted: true, toolRounds: result.toolRounds, streamId };
     }
 
-    // Fell out of the loop (hit MAX_TOOL_ROUNDS or an empty stream). Flush any
-    // buffered text so it is still spoken, and never leave the principal silent.
+    if (result.stopReason === 'stream_error' && result.error) {
+      chunker.reset();
+      this.log.warn(
+        { streamId, error: result.error.type, source: result.error.source },
+        'voice turn stream error',
+      );
+      throw new VoiceTurnError(result.error);
+    }
+
+    if (result.stopReason === 'message_end') {
+      // Speak any trailing partial sentence that never hit a boundary.
+      const remainder = chunker.flush();
+      if (remainder && !signal.aborted) {
+        await speak(remainder);
+      }
+      // Prefer the model's terminal content when present; otherwise fall back
+      // to what was actually handed to TTS (covers multi-round tool turns).
+      const finalText = result.finalText.length > 0 ? result.finalText : spokenText;
+      return { finalText, aborted: signal.aborted, toolRounds: result.toolRounds, streamId };
+    }
+
+    // Exhausted or empty stream: flush any buffered text and never leave the
+    // principal silent.
     const remainder = chunker.flush();
     if (remainder && !signal.aborted) {
       await speak(remainder);
@@ -252,6 +179,6 @@ export class VoiceTurnRunner {
     if (spokenText.length === 0 && !signal.aborted) {
       await speak(EXHAUSTION_FALLBACK);
     }
-    return { finalText: spokenText, aborted: signal.aborted, toolRounds, streamId };
+    return { finalText: spokenText, aborted: signal.aborted, toolRounds: result.toolRounds, streamId };
   }
 }

--- a/src/channels/voice/turn-runner.ts
+++ b/src/channels/voice/turn-runner.ts
@@ -1,14 +1,14 @@
 // turn-runner.ts — VoiceTurnRunner drives a single spoken assistant turn.
 //
-// Thin voice wrapper over the shared streaming turn primitive
+// Thin voice wrapper over the streaming turn primitive
 // (src/agents/llm/streaming-turn.ts, #1552). This file owns only voice UX:
 // sentence-chunk TTS, filler speech, barge-in AbortSignal semantics, and the
 // audible exhaustion fallback. Tool-loop / message assembly / round-cap /
 // stream+abort live in the shared primitive.
 //
-// Text AgentRuntime.handleTask stays on non-streaming provider.chat() unless
-// explicitly opted into the streaming primitive later — do not fold voice into
-// handleTask. Cross-link: src/agents/runtime.ts tool_use loop.
+// Text AgentRuntime.handleTask stays on non-streaming provider.chat() — opt-in
+// is tracked as #1563 (requires a "text goes streaming" decision). Do not fold
+// voice into handleTask. Cross-link: src/agents/runtime.ts tool_use loop.
 // Sibling: #1551 (brain/context + history read model).
 
 import { randomUUID } from 'node:crypto';
@@ -164,8 +164,10 @@ export class VoiceTurnRunner {
       if (remainder && !signal.aborted) {
         await speak(remainder);
       }
-      // Prefer the model's terminal content when present; otherwise fall back
-      // to what was actually handed to TTS (covers multi-round tool turns).
+      // Prefer the model's terminal content when non-empty; otherwise fall back
+      // to what was actually handed to TTS (sentence-chunked spokenText) — NOT
+      // the primitive's streamedText. Empty message_end.content must not silently
+      // persist raw delta concat (#1562 review §3).
       const finalText = result.finalText.length > 0 ? result.finalText : spokenText;
       return { finalText, aborted: signal.aborted, toolRounds: result.toolRounds, streamId };
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1552. Follow-up for text convergence: #1563.

Extracts a streaming tool-loop primitive (`src/agents/llm/streaming-turn.ts`) and makes `VoiceTurnRunner` a thin TTS/barge-in wrapper over it — **not** voice calling `handleTask`.

### What this does

- **`runStreamingToolLoop`** owns `stream()` consume, AbortSignal cancel, `tool_use` / `tool_result` assembly, round cap, and `invokeTool` sequencing.
- **`VoiceTurnRunner`** keeps only voice UX: sentence-chunk TTS, filler, barge-in, audible exhaustion fallback.
- Voice tool-loop is unit-tested in isolation; stream/abort/round-cap semantics live in one place for the eventual text opt-in.

### What this does *not* do

- **Does not** migrate `AgentRuntime.handleTask` onto the primitive. Text channels still use the separate non-streaming `while (tool_use)` + `provider.chat()` loop (retry/fallback, error budgets, DelegationGuard, clarification, tool bus events, delegate timeout injection).
- **Does not** reduce the number of divergent tool loops in the system (still two). Divergence (round cap, Gate-C wrapper richness, sanitization) is **documented and parameterized**, not structurally unified.
- Convergence is blocked on an explicit **"text goes streaming"** decision — tracked as **#1563**, referenced from `runtime.ts` / ADR-037.

### Policy notes

- **Round cap:** voice `DEFAULT_STREAMING_MAX_ROUNDS = 8` (spoken fail-fast); text keeps per-agent `error_budget.max_turns`.
- **Autonomy / Gate-C:** both paths call `executionLayer.invoke`; voice bridge stays thinner by design.
- **Assistant sanitization:** LLM-authored assistant text is not `sanitizeOutput`'d on either path; skill results are sanitized inside `ExecutionLayer.invoke`.
- **`finalText` on empty `message_end`:** primitive returns empty terminal content; voice falls back to **spokenText** (TTS-delivered), not raw `streamedText`.
- **`result.messages`:** includes tool pairs **and** the terminal assistant reply (per-round deltas on empty terminal; abort mid-invoke closes unanswered tool_use ids).

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `vitest` for `streaming-turn`, `tool-loop-messages`, `turn-runner`, `voice-runtime`
- [x] CI green (re-check after CodeRabbit fixes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9e54-b4e8-76e8-87dd-a97a991ab86e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9e54-b4e8-76e8-87dd-a97a991ab86e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

