### PR TITLE
fix(voice): escalate repeated TTS failures with tts_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Voice TTS failures** — repeated or hard synthesis errors end the call with `tts_error`. (#1556)
 - **Dashboard Recent Activity** — timeline fetch sends a 24h `from=` scope so the card loads. (#1548)
 - **Voice channel** — CodeRabbit review: hangup race, silent rooms, LiveKit opt-in, turn integrity. (#1414)
 - **Voice lifecycle hardening** — bounded STT socket waits, session cleanup on token failure, safe session end. (#1414)

--- a/src/channels/voice/speech/cartesia-tts.test.ts
+++ b/src/channels/voice/speech/cartesia-tts.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createSilentLogger } from '../../../logger.js';
 import { CartesiaTtsProvider } from './cartesia-tts.js';
-import type { PcmFrame } from './types.js';
+import { TtsHttpError, type PcmFrame } from './types.js';
 
 function bytesFromSamples(samples: number[]): Uint8Array {
   const bytes = new Uint8Array(samples.length * 2);
@@ -98,8 +98,14 @@ describe('CartesiaTtsProvider', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('bad', { status: 401 })));
     const provider = new CartesiaTtsProvider('cartesia-key', createSilentLogger(), 'voice-1');
 
-    await expect(collect(provider.synthesize({ text: 'hello', streamId: 's1' })))
-      .rejects.toThrow('Cartesia TTS request failed with HTTP 401');
+    try {
+      await collect(provider.synthesize({ text: 'hello', streamId: 's1' }));
+      expect.unreachable('expected TtsHttpError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TtsHttpError);
+      expect((err as TtsHttpError).statusCode).toBe(401);
+      expect((err as TtsHttpError).message).toBe('Cartesia TTS request failed with HTTP 401');
+    }
   });
 
   it('cancel stops further frames', async () => {

--- a/src/channels/voice/speech/cartesia-tts.ts
+++ b/src/channels/voice/speech/cartesia-tts.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '../../../logger.js';
-import type { PcmFrame, TextToSpeechProvider, TtsSynthesizeOptions } from './types.js';
+import { TtsHttpError, type PcmFrame, type TextToSpeechProvider, type TtsSynthesizeOptions } from './types.js';
 
 const CARTESIA_TTS_BYTES_URL = 'https://api.cartesia.ai/tts/bytes';
 const CARTESIA_VERSION = '2026-03-01';
@@ -40,8 +40,8 @@ function pcmFrameFromBytes(bytes: Uint8Array, sampleRate: number): PcmFrame {
   return { pcm, sampleRate, channels: 1 };
 }
 
-function responseErrorMessage(response: Response): string {
-  return `Cartesia TTS request failed with HTTP ${response.status}`;
+function responseError(response: Response): TtsHttpError {
+  return new TtsHttpError(response.status, `Cartesia TTS request failed with HTTP ${response.status}`);
 }
 
 function isAbortError(err: unknown): boolean {
@@ -112,7 +112,7 @@ export class CartesiaTtsProvider implements TextToSpeechProvider {
       });
 
       if (!response.ok) {
-        throw new Error(responseErrorMessage(response));
+        throw responseError(response);
       }
 
       const body = asByteReadableStream(response.body);

--- a/src/channels/voice/speech/types.ts
+++ b/src/channels/voice/speech/types.ts
@@ -45,3 +45,17 @@ export interface TextToSpeechProvider {
   synthesize(opts: TtsSynthesizeOptions): AsyncIterable<PcmFrame>;
   cancel(streamId: string): void;
 }
+
+/**
+ * Structured HTTP failure from a TTS provider. Prefer this over embedding the
+ * status in `Error.message` so callers can classify without string matching.
+ */
+export class TtsHttpError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number, message?: string) {
+    super(message ?? `TTS request failed with HTTP ${statusCode}`);
+    this.name = 'TtsHttpError';
+    this.statusCode = statusCode;
+  }
+}

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -14,6 +14,7 @@ import type { VoiceToolBridge } from './voice-runtime.js';
 import { FakeAudioTransport } from './fake-audio-transport.js';
 import { FakeSttProvider } from './speech/fake-stt.js';
 import type { PcmFrame, TextToSpeechProvider, TtsSynthesizeOptions } from './speech/types.js';
+import { TtsHttpError } from './speech/types.js';
 import type { VoiceSessionRecord, VoiceSessionStore } from './session-store.js';
 
 const logger = createSilentLogger();
@@ -106,10 +107,10 @@ function fakeStore(): { store: VoiceSessionStore; statuses: string[]; ended: str
 class FailingTtsProvider implements TextToSpeechProvider {
   readonly id = 'failing-tts';
   readonly failures: string[] = [];
-  constructor(private readonly message = 'Cartesia TTS request failed with HTTP 500') {}
+  constructor(private readonly err: Error = new TtsHttpError(500, 'Cartesia TTS request failed with HTTP 500')) {}
   async *synthesize(opts: TtsSynthesizeOptions): AsyncIterable<PcmFrame> {
     this.failures.push(opts.text);
-    throw new Error(this.message);
+    throw this.err;
   }
   cancel(): void {}
 }
@@ -123,7 +124,7 @@ class FlakyThenOkTtsProvider implements TextToSpeechProvider {
   async *synthesize(opts: TtsSynthesizeOptions): AsyncIterable<PcmFrame> {
     if (this.failures < this.failCount) {
       this.failures += 1;
-      throw new Error('Cartesia TTS request failed with HTTP 503');
+      throw new TtsHttpError(503, 'Cartesia TTS request failed with HTTP 503');
     }
     this.successes += 1;
     yield { pcm: new Int16Array(160), sampleRate: opts.sampleRate ?? 24000, channels: 1 };
@@ -431,7 +432,7 @@ describe('VoiceRuntime', () => {
 
   it('ends immediately on a hard TTS auth/voice-id failure (#1556)', async () => {
     const llm = new FakeStreamProvider([replyScript('Hello.')]);
-    const tts = new FailingTtsProvider('Cartesia TTS request failed with HTTP 401');
+    const tts = new FailingTtsProvider(new TtsHttpError(401, 'Cartesia TTS request failed with HTTP 401'));
     const { store, endReasons } = fakeStore();
     const { runtime, events, stt } = makeRuntime({ llm, tts, store });
 
@@ -450,6 +451,46 @@ describe('VoiceRuntime', () => {
     expect(runtime.activeSessionCount).toBe(0);
     expect(endReasons).toEqual(['tts_error']);
     expect(events.filter(e => e.type === 'voice.session.ended')).toHaveLength(1);
+  });
+
+  it('does not count transport publish failures as TTS synthesis failures (#1556)', async () => {
+    const llm = new FakeStreamProvider([
+      replyScript('First reply.'),
+      replyScript('Second reply.'),
+      replyScript('Third reply.'),
+    ]);
+    // Healthy TTS — every synthesize succeeds. Transport publish throws every time.
+    class ThrowingPublishTransport extends FakeAudioTransport {
+      override async publishAudio(): Promise<void> {
+        throw new Error('livekit publish failed');
+      }
+    }
+    const transport = new ThrowingPublishTransport();
+    const { store, endReasons } = fakeStore();
+    const { runtime, events, stt } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      transport,
+      store,
+    });
+
+    await runtime.startSession({
+      sessionId: 's-pub-fail',
+      conversationId: 'voice:s-pub-fail',
+      roomName: 'voice-s-pub-fail',
+      agentToken: 'tok',
+    });
+
+    for (const utter of ['one', 'two', 'three'] as const) {
+      stt.emit({ text: utter, isFinal: true, speechFinal: true });
+      await runtime.awaitIdle('s-pub-fail');
+    }
+    await delay(30);
+
+    // Three publish-failed turns must not escalate to tts_error.
+    expect(runtime.activeSessionCount).toBe(1);
+    expect(endReasons).toEqual([]);
+    expect(events.filter(e => e.type === 'voice.session.ended')).toHaveLength(0);
   });
 
   it('invokes tools during a voice turn via the runner tool loop', async () => {

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -107,7 +107,6 @@ class FailingTtsProvider implements TextToSpeechProvider {
   readonly id = 'failing-tts';
   readonly failures: string[] = [];
   constructor(private readonly message = 'Cartesia TTS request failed with HTTP 500') {}
-  // eslint-disable-next-line require-yield -- always throws before yielding
   async *synthesize(opts: TtsSynthesizeOptions): AsyncIterable<PcmFrame> {
     this.failures.push(opts.text);
     throw new Error(this.message);

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -21,6 +21,11 @@ const usage = { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, ca
 const provenance = { requestedModel: 'fake', actualModel: 'fake', providerRequestId: 'req_1' };
 const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
 
+const replyScript = (text: string): LLMStreamEvent[] => [
+  { type: 'text_delta', text: `${text} ` },
+  { type: 'message_end', content: text, usage, provenance },
+];
+
 /** Fake streaming LLM provider driven by scripted event sequences. */
 class FakeStreamProvider implements LLMProvider {
   readonly id = 'fake-stream';
@@ -67,10 +72,11 @@ class SlowTtsProvider implements TextToSpeechProvider {
 }
 
 /** In-memory VoiceSessionStore stand-in. */
-function fakeStore(): { store: VoiceSessionStore; statuses: string[]; ended: string[] } {
+function fakeStore(): { store: VoiceSessionStore; statuses: string[]; ended: string[]; endReasons: string[] } {
   const statuses: string[] = [];
   const ended: string[] = [];
-  const rec = (id: string, status: string): VoiceSessionRecord => ({
+  const endReasons: string[] = [];
+  const rec = (id: string, status: string, endReason: string | null = null): VoiceSessionRecord => ({
     id,
     conversationId: `voice:${id}`,
     livekitRoom: `voice-${id}`,
@@ -78,7 +84,7 @@ function fakeStore(): { store: VoiceSessionStore; statuses: string[]; ended: str
     status: status as VoiceSessionRecord['status'],
     startedAt: new Date(Date.now() - 1000),
     endedAt: status === 'ended' ? new Date() : null,
-    endReason: status === 'ended' ? 'test' : null,
+    endReason: status === 'ended' ? (endReason ?? 'test') : null,
     metadata: {},
   });
   const store = {
@@ -86,13 +92,44 @@ function fakeStore(): { store: VoiceSessionStore; statuses: string[]; ended: str
       statuses.push(status);
       return rec(id, status);
     },
-    async endSession(id: string) {
+    async endSession(id: string, reason: string) {
       if (ended.includes(id)) return null;
       ended.push(id);
-      return rec(id, 'ended');
+      endReasons.push(reason);
+      return rec(id, 'ended', reason);
     },
   } as unknown as VoiceSessionStore;
-  return { store, statuses, ended };
+  return { store, statuses, ended, endReasons };
+}
+
+/** TTS that throws on every synthesize() call (persistent provider failure). */
+class FailingTtsProvider implements TextToSpeechProvider {
+  readonly id = 'failing-tts';
+  readonly failures: string[] = [];
+  constructor(private readonly message = 'Cartesia TTS request failed with HTTP 500') {}
+  // eslint-disable-next-line require-yield -- always throws before yielding
+  async *synthesize(opts: TtsSynthesizeOptions): AsyncIterable<PcmFrame> {
+    this.failures.push(opts.text);
+    throw new Error(this.message);
+  }
+  cancel(): void {}
+}
+
+/** TTS that fails a fixed number of times, then synthesizes normally. */
+class FlakyThenOkTtsProvider implements TextToSpeechProvider {
+  readonly id = 'flaky-tts';
+  failures = 0;
+  successes = 0;
+  constructor(private readonly failCount: number) {}
+  async *synthesize(opts: TtsSynthesizeOptions): AsyncIterable<PcmFrame> {
+    if (this.failures < this.failCount) {
+      this.failures += 1;
+      throw new Error('Cartesia TTS request failed with HTTP 503');
+    }
+    this.successes += 1;
+    yield { pcm: new Int16Array(160), sampleRate: opts.sampleRate ?? 24000, channels: 1 };
+  }
+  cancel(): void {}
 }
 
 function makeRuntime(overrides: {
@@ -322,6 +359,98 @@ describe('VoiceRuntime', () => {
     // Transport teardown still ran before the failing store write.
     expect(transport.disconnectCount).toBe(1);
     expect(runtime.activeSessionCount).toBe(0);
+  });
+
+  it('ends the session with tts_error after repeated TTS synthesis failures (#1556)', async () => {
+    const llm = new FakeStreamProvider([
+      replyScript('First reply.'),
+      replyScript('Second reply.'),
+      replyScript('Third reply.'),
+    ]);
+    const tts = new FailingTtsProvider();
+    const { store, endReasons } = fakeStore();
+    const deleteRoom = vi.fn(async () => {});
+    const { runtime, events, stt, transport } = makeRuntime({ llm, tts, store, deleteRoom });
+
+    await runtime.startSession({
+      sessionId: 's-tts-fail',
+      conversationId: 'voice:s-tts-fail',
+      roomName: 'voice-s-tts-fail',
+      agentToken: 'tok',
+    });
+
+    stt.emit({ text: 'one', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('s-tts-fail');
+    expect(runtime.activeSessionCount).toBe(1);
+
+    stt.emit({ text: 'two', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('s-tts-fail');
+    expect(runtime.activeSessionCount).toBe(1);
+
+    stt.emit({ text: 'three', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('s-tts-fail');
+    // void endSession from the third failure — let it settle.
+    await delay(30);
+
+    expect(tts.failures.length).toBeGreaterThanOrEqual(3);
+    expect(runtime.activeSessionCount).toBe(0);
+    expect(transport.disconnectCount).toBe(1);
+    expect(endReasons).toEqual(['tts_error']);
+    const ended = events.filter(e => e.type === 'voice.session.ended');
+    expect(ended).toHaveLength(1);
+    expect((ended[0] as { payload: { reason: string } }).payload.reason).toBe('tts_error');
+    expect(deleteRoom).toHaveBeenCalledWith('voice-s-tts-fail');
+  });
+
+  it('does not tear down on a single transient TTS failure (#1556)', async () => {
+    const llm = new FakeStreamProvider([
+      replyScript('First reply.'),
+      replyScript('Second reply.'),
+    ]);
+    const tts = new FlakyThenOkTtsProvider(1);
+    const { runtime, events, stt, transport } = makeRuntime({ llm, tts });
+
+    await runtime.startSession({
+      sessionId: 's-tts-blip',
+      conversationId: 'voice:s-tts-blip',
+      roomName: 'voice-s-tts-blip',
+      agentToken: 'tok',
+    });
+
+    stt.emit({ text: 'one', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('s-tts-blip');
+    stt.emit({ text: 'two', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('s-tts-blip');
+    await delay(20);
+
+    expect(tts.failures).toBe(1);
+    expect(tts.successes).toBe(1);
+    expect(runtime.activeSessionCount).toBe(1);
+    expect(transport.publishedFrames.length).toBeGreaterThan(0);
+    expect(events.filter(e => e.type === 'voice.session.ended')).toHaveLength(0);
+  });
+
+  it('ends immediately on a hard TTS auth/voice-id failure (#1556)', async () => {
+    const llm = new FakeStreamProvider([replyScript('Hello.')]);
+    const tts = new FailingTtsProvider('Cartesia TTS request failed with HTTP 401');
+    const { store, endReasons } = fakeStore();
+    const { runtime, events, stt } = makeRuntime({ llm, tts, store });
+
+    await runtime.startSession({
+      sessionId: 's-tts-hard',
+      conversationId: 'voice:s-tts-hard',
+      roomName: 'voice-s-tts-hard',
+      agentToken: 'tok',
+    });
+
+    stt.emit({ text: 'hello', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('s-tts-hard');
+    await delay(30);
+
+    expect(tts.failures).toHaveLength(1);
+    expect(runtime.activeSessionCount).toBe(0);
+    expect(endReasons).toEqual(['tts_error']);
+    expect(events.filter(e => e.type === 'voice.session.ended')).toHaveLength(1);
   });
 
   it('invokes tools during a voice turn via the runner tool loop', async () => {

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -62,6 +62,18 @@ const BARGE_IN_MIN_CONFIDENCE = 0.4;
 const VOICE_HISTORY_AGENT_ID = 'coordinator';
 /** Default max utterance size — matches Dispatcher maxMessageBytes. */
 const DEFAULT_MAX_UTTERANCE_BYTES = 102_400;
+/**
+ * Consecutive TTS synthesis failures before ending the session. A single
+ * transient blip must not tear down an otherwise-healthy call (#1556).
+ */
+const TTS_CONSECUTIVE_FAILURE_LIMIT = 3;
+
+/** Auth / missing-voice hard failures should not wait for the soft threshold. */
+function isHardTtsFailure(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  // Cartesia (and similar HTTP TTS providers) include the status in the message.
+  return /\bHTTP (401|403|404)\b/.test(err.message);
+}
 
 /**
  * Voice-mode system addendum. Keeps spoken replies short and free of markup that
@@ -247,6 +259,8 @@ interface ActiveSession {
   pendingFinalText: string;
   ttsSeq: number;
   ending: boolean;
+  /** Consecutive synthesize() failures; reset on a successful synthesis (#1556). */
+  consecutiveTtsFailures: number;
 }
 
 export class VoiceRuntime {
@@ -332,6 +346,7 @@ export class VoiceRuntime {
         pendingFinalText: '',
         ttsSeq: 0,
         ending: false,
+        consecutiveTtsFailures: 0,
       };
       this.sessions.set(params.sessionId, session);
 
@@ -649,9 +664,34 @@ export class VoiceRuntime {
           }
           await session.transport.publishAudio(frame);
         }
+        // Healthy synthesis (including barge-in abort mid-stream) clears the streak.
+        if (!session.ending) session.consecutiveTtsFailures = 0;
       } catch (err) {
-        if (!controller.signal.aborted) {
-          this.log.warn({ sessionId: session.sessionId, err }, 'TTS synthesis failed');
+        if (controller.signal.aborted || session.ending) return;
+        session.consecutiveTtsFailures += 1;
+        const hard = isHardTtsFailure(err);
+        this.log.warn(
+          {
+            sessionId: session.sessionId,
+            err,
+            consecutiveFailures: session.consecutiveTtsFailures,
+            hard,
+          },
+          'TTS synthesis failed',
+        );
+        // Soft: tolerate a blip. Hard (auth / bad voice id) or repeated soft → end
+        // with tts_error so the console reflects it (mirrors stt_error).
+        if (hard || session.consecutiveTtsFailures >= TTS_CONSECUTIVE_FAILURE_LIMIT) {
+          this.log.error(
+            {
+              sessionId: session.sessionId,
+              err,
+              consecutiveFailures: session.consecutiveTtsFailures,
+              hard,
+            },
+            'TTS synthesis failures exceeded threshold; ending session',
+          );
+          void this.endSession(session.sessionId, 'tts_error');
         }
       } finally {
         session.activeTtsStreamIds.delete(ttsStreamId);

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -27,6 +27,7 @@ import { sanitizeOutput } from '../../skills/sanitize.js';
 import { formatTimeContextBlock } from '../../time/time-context.js';
 import type { AudioTransport } from './audio-transport.js';
 import type { SpeechToTextProvider, SttSession, SttTranscriptEvent, TextToSpeechProvider } from './speech/types.js';
+import { TtsHttpError } from './speech/types.js';
 import type { VoiceSessionRecord, VoiceSessionStore } from './session-store.js';
 import { VoiceTurnRunner } from './turn-runner.js';
 
@@ -68,11 +69,11 @@ const DEFAULT_MAX_UTTERANCE_BYTES = 102_400;
  */
 const TTS_CONSECUTIVE_FAILURE_LIMIT = 3;
 
+const HARD_TTS_STATUS_CODES = new Set([401, 403, 404]);
+
 /** Auth / missing-voice hard failures should not wait for the soft threshold. */
 function isHardTtsFailure(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  // Cartesia (and similar HTTP TTS providers) include the status in the message.
-  return /\bHTTP (401|403|404)\b/.test(err.message);
+  return err instanceof TtsHttpError && HARD_TTS_STATUS_CODES.has(err.statusCode);
 }
 
 /**
@@ -662,7 +663,17 @@ export class VoiceRuntime {
               'voice time-to-first-audio',
             );
           }
-          await session.transport.publishAudio(frame);
+          // Publish is outside the TTS failure streak — a LiveKit blip must not
+          // be recorded as tts_error (#1556 review).
+          try {
+            await session.transport.publishAudio(frame);
+          } catch (publishErr) {
+            this.log.warn(
+              { sessionId: session.sessionId, err: publishErr },
+              'failed to publish TTS audio frame; not counted as a TTS synthesis failure',
+            );
+            break;
+          }
         }
         // Healthy synthesis (including barge-in abort mid-stream) clears the streak.
         if (!session.ending) session.consecutiveTtsFailures = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1556.

TTS synthesis failures in the voice duplex loop were logged at `warn` and swallowed, so a bad Cartesia voice id / expired key / provider outage left the caller on indefinite dead air with no escalation.

## Changes

- Track consecutive TTS `synthesize()` failures per session.
- Soft failures: warn and continue until **3** consecutive failures, then `endSession(..., 'tts_error')`.
- Hard failures (HTTP 401/403/404 via typed `TtsHttpError.statusCode`): end immediately.
- Successful synthesis resets the streak.
- Transport `publishAudio` failures are isolated and do **not** count toward the TTS streak.
- Teardown reuses the existing `stt_error` path (session status + `voice.session.ended`).

## Tests

- Repeated soft failures → session ends with `tts_error` and publishes `voice.session.ended`.
- Single transient failure → call stays up.
- Hard 401 (`TtsHttpError`) → immediate teardown.
- Repeated transport publish failures → session stays up (not `tts_error`).

## Changelog

- **Voice TTS failures** — repeated or hard synthesis errors end the call with `tts_error`. (#1556)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9f53-28d2-784e-9e82-12a0c7d2f582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9f53-28d2-784e-9e82-12a0c7d2f582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

