### PR TITLE
fix(slack): unescape &amp; last in decodeSlackText (#1569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Slack decode** — unescape `&amp;` last so `&amp;lt;` stays literal `&lt;`. (#1569)
+
 ## [0.42.0] — 2026-07-26 — "KITT"
 
 > **KITT** *(Knight Rider, 1982, Glen A. Larson)* — the Knight Industries Two Thousand, a car-bound AI you simply talk to: it holds a conversation by voice and deploys a deep bag of specialized functions on command. This release gives Curia the same — a voice you speak with, new channels to reach it through, and a real toolkit of skills it draws on when asked.

--- a/src/channels/slack/slack-entities.ts
+++ b/src/channels/slack/slack-entities.ts
@@ -37,10 +37,12 @@ export function decodeSlackText(raw: string, options?: { botUserId?: string }): 
   text = text.replace(/<mailto:([^|>]+)(?:\|[^>]*)?>/gi, '$1');
 
   // Unescape HTML entities Slack applies to message text.
+  // `&amp;` must come last so an already-decoded `&` is not re-consumed
+  // by a later rule (e.g. `&amp;lt;` must stay the literal `&lt;`, not `<`).
   text = text
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
 
   return text.trim();
 }

--- a/tests/unit/channels/slack/slack-entities.test.ts
+++ b/tests/unit/channels/slack/slack-entities.test.ts
@@ -6,6 +6,14 @@ describe('decodeSlackText', () => {
     expect(decodeSlackText('A &amp; B &lt;C&gt;')).toBe('A & B <C>');
   });
 
+  it('does not double-unescape already-escaped entity sequences', () => {
+    // Slack sends a user-typed literal "&lt;" as "&amp;lt;" — decoding must
+    // yield the literal text "&lt;", not a further-unescaped "<".
+    expect(decodeSlackText('&amp;lt;')).toBe('&lt;');
+    expect(decodeSlackText('&amp;gt;')).toBe('&gt;');
+    expect(decodeSlackText('&amp;amp;')).toBe('&amp;');
+  });
+
   it('unwraps user and channel mentions', () => {
     expect(decodeSlackText('hi <@U123|alice> in <#C9|general>')).toBe(
       'hi @alice in #general',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1569.

CodeQL (`js/double-escaping`, alert #237) flagged `decodeSlackText` unescaping `&amp;` before `&lt;`/`&gt;`, so Slack-delivered `&amp;lt;` (a user-typed literal `&lt;`) was double-decoded to `<`.

- Unescape `&amp;` **last** in `src/channels/slack/slack-entities.ts`
- Unit tests for `&amp;lt;` → `&lt;`, `&amp;gt;` → `&gt;`, `&amp;amp;` → `&amp;`
- Existing plain entity decoding and mention/link unwrapping unchanged

## Test plan

- [x] `pnpm exec vitest run tests/unit/channels/slack/slack-entities.test.ts`
- [x] `pnpm run typecheck`
- [ ] Confirm CodeQL alert #237 clears on the next scan after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

