### PR TITLE
feat(learning): accept unique task-id prefixes in resolve-learning-digest (#1545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **`resolve-learning-digest`** — accepts a unique task-id prefix for digest resolve. (#1545)
+
 ### Fixed
 
 - **Slack decode** — unescape `&amp;` last so `&amp;lt;` stays literal `&lt;`. (#1569)

--- a/skills/learning/tools/resolve-learning-digest/handler.test.ts
+++ b/skills/learning/tools/resolve-learning-digest/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { ResolveLearningDigestHandler } from './handler.js';
+import { ResolveLearningDigestHandler, resolveDigestTaskId } from './handler.js';
 import type { ToolContext } from '../../../../src/skills/types.js';
 import { CONFIG_NAMESPACE, DISMISSED_KEY } from '../voice-learn/handler.js';
 import {
@@ -524,5 +524,147 @@ describe('ResolveLearningDigestHandler', () => {
     // The actioned item is removed from the config map so resolved items don't accumulate.
     const updated = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
     expect(updated.t1).toBeUndefined();
+  });
+
+  describe('task_id prefix resolution (#1545)', () => {
+    const FULL_A = '3502c6bb-8a37-4783-8140-ec6f1730a70e';
+    const FULL_B = '3502c6bb-aaaa-bbbb-cccc-dddddddddddd';
+    const FULL_C = 'aaaaaaaa-1111-2222-3333-444444444444';
+
+    it('resolveDigestTaskId: exact, unique prefix, ambiguous, and miss', () => {
+      const map: CompletionDigestMap = {
+        [FULL_A]: { kind: 'confirm', taskId: FULL_A, taskTitle: 'Follow up', note: 'n' },
+        [FULL_B]: { kind: 'confirm', taskId: FULL_B, taskTitle: 'Other', note: 'n' },
+        [FULL_C]: { kind: 'undo', taskId: FULL_C, taskTitle: 'Undo me', note: 'n' },
+      };
+      expect(resolveDigestTaskId(map, FULL_A)).toEqual({ ok: true, taskId: FULL_A });
+      expect(resolveDigestTaskId(map, 'aaaaaaaa')).toEqual({ ok: true, taskId: FULL_C });
+      const amb = resolveDigestTaskId(map, '3502c6bb');
+      expect(amb.ok).toBe(false);
+      if (!amb.ok) {
+        expect(amb.error).toContain('Ambiguous');
+        expect(amb.error).toContain(FULL_A);
+        expect(amb.error).toContain('Follow up');
+        expect(amb.error).toContain(FULL_B);
+      }
+      // Miss keeps the caller id so the existing "No actionable …" path fires.
+      expect(resolveDigestTaskId(map, 'deadbeef')).toEqual({ ok: true, taskId: 'deadbeef' });
+    });
+
+    it('dismiss_completion succeeds with a unique task-id prefix', async () => {
+      const mem = makeMem();
+      const digestMap: CompletionDigestMap = {
+        [FULL_A]: {
+          kind: 'confirm',
+          taskId: FULL_A,
+          taskTitle: 'Follow up',
+          note: 'Did emailing them complete it?',
+        },
+      };
+      mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
+      const ctx = {
+        input: { action: 'dismiss_completion', task_id: '3502c6bb' },
+        entityMemory: mem,
+        executiveProfileService: { get: vi.fn(), update: vi.fn() },
+        taskRepo: { reopenTask: vi.fn(), completeTask: vi.fn(), getTask: vi.fn() },
+        agentId: 'coordinator',
+        log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      } as unknown as ToolContext;
+
+      const result = await new ResolveLearningDigestHandler().execute(ctx);
+      expect(result.success).toBe(true);
+      const updated = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+      expect(updated[FULL_A]).toBeUndefined();
+    });
+
+    it('confirm_completion succeeds with a unique prefix and uses the full id for taskRepo', async () => {
+      const mem = makeMem();
+      const digestMap: CompletionDigestMap = {
+        [FULL_A]: {
+          kind: 'confirm',
+          taskId: FULL_A,
+          taskTitle: 'Follow up',
+          note: 'Did emailing them complete it?',
+        },
+      };
+      mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
+      const getTask = vi.fn(async () => ({ id: FULL_A, status: 'open' }));
+      const completeTask = vi.fn(async () => undefined);
+      const ctx = {
+        input: { action: 'confirm_completion', task_id: '3502c6bb' },
+        entityMemory: mem,
+        executiveProfileService: { get: vi.fn(), update: vi.fn() },
+        taskRepo: { reopenTask: vi.fn(), completeTask, getTask },
+        agentId: 'coordinator',
+        log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      } as unknown as ToolContext;
+
+      const result = await new ResolveLearningDigestHandler().execute(ctx);
+      expect(result.success).toBe(true);
+      expect(getTask).toHaveBeenCalledWith(FULL_A);
+      expect(completeTask).toHaveBeenCalledWith(FULL_A, expect.any(String), 'coordinator');
+      const updated = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+      expect(updated[FULL_A]).toBeUndefined();
+    });
+
+    it('dismiss_completion and confirm_completion reject an ambiguous prefix without mutating', async () => {
+      const mem = makeMem();
+      const digestMap: CompletionDigestMap = {
+        [FULL_A]: { kind: 'confirm', taskId: FULL_A, taskTitle: 'Follow up', note: 'n' },
+        [FULL_B]: { kind: 'confirm', taskId: FULL_B, taskTitle: 'Other', note: 'n' },
+      };
+      mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
+      const completeTask = vi.fn();
+      const getTask = vi.fn();
+
+      for (const action of ['dismiss_completion', 'confirm_completion'] as const) {
+        mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
+        const ctx = {
+          input: { action, task_id: '3502c6bb' },
+          entityMemory: mem,
+          executiveProfileService: { get: vi.fn(), update: vi.fn() },
+          taskRepo: { reopenTask: vi.fn(), completeTask, getTask },
+          agentId: 'coordinator',
+          log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        } as unknown as ToolContext;
+
+        const result = await new ResolveLearningDigestHandler().execute(ctx);
+        expect(result.success).toBe(false);
+        expect((result as { error: string }).error).toMatch(/Ambiguous task_id prefix/);
+        expect((result as { error: string }).error).toContain('Follow up');
+        expect(completeTask).not.toHaveBeenCalled();
+        expect(getTask).not.toHaveBeenCalled();
+        const updated = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+        expect(updated[FULL_A]).toEqual(digestMap[FULL_A]);
+        expect(updated[FULL_B]).toEqual(digestMap[FULL_B]);
+      }
+    });
+
+    it('dismiss_completion and confirm_completion miss on unknown id as before', async () => {
+      const mem = makeMem();
+      const digestMap: CompletionDigestMap = {
+        [FULL_A]: { kind: 'confirm', taskId: FULL_A, taskTitle: 'Follow up', note: 'n' },
+      };
+      mem.__values.set(COMPLETION_DIGEST_KEY, JSON.stringify(digestMap));
+
+      for (const action of ['dismiss_completion', 'confirm_completion'] as const) {
+        const ctx = {
+          input: { action, task_id: 'deadbeef' },
+          entityMemory: mem,
+          executiveProfileService: { get: vi.fn(), update: vi.fn() },
+          taskRepo: { reopenTask: vi.fn(), completeTask: vi.fn(), getTask: vi.fn() },
+          agentId: 'coordinator',
+          log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        } as unknown as ToolContext;
+
+        const result = await new ResolveLearningDigestHandler().execute(ctx);
+        expect(result.success).toBe(false);
+        expect((result as { error: string }).error).toBe(
+          'No actionable confirm item for task deadbeef',
+        );
+        const updated = JSON.parse(mem.__values.get(COMPLETION_DIGEST_KEY)!) as CompletionDigestMap;
+        expect(updated[FULL_A]).toEqual(digestMap[FULL_A]);
+      }
+    });
   });
 });

--- a/skills/learning/tools/resolve-learning-digest/handler.ts
+++ b/skills/learning/tools/resolve-learning-digest/handler.ts
@@ -6,6 +6,7 @@ import {
   writeVoiceProposal,
   readCompletionDigest,
   writeCompletionDigest,
+  type CompletionDigestMap,
 } from '../../../_shared/learning-state.js';
 
 const ACTIONS = new Set([
@@ -15,6 +16,41 @@ const ACTIONS = new Set([
   'confirm_completion',
   'dismiss_completion',
 ]);
+
+/**
+ * Resolve a completion-digest task id. Exact key wins; otherwise a unique
+ * prefix of a digest map key is accepted (humans/LLMs often relay the first
+ * 8 chars of the UUID). Ambiguous prefixes fail closed with the candidates
+ * named — never a silent pick.
+ */
+export function resolveDigestTaskId(
+  digestMap: CompletionDigestMap,
+  taskId: string,
+): { ok: true; taskId: string } | { ok: false; error: string } {
+  if (Object.hasOwn(digestMap, taskId)) {
+    return { ok: true, taskId };
+  }
+
+  const matches = Object.keys(digestMap).filter((key) => key.startsWith(taskId));
+  if (matches.length === 1) {
+    return { ok: true, taskId: matches[0]! };
+  }
+  if (matches.length > 1) {
+    const named = matches
+      .map((id) => {
+        const title = digestMap[id]?.taskTitle?.trim();
+        return title ? `${id} (${title})` : id;
+      })
+      .join(', ');
+    return {
+      ok: false,
+      error: `Ambiguous task_id prefix '${taskId}' matches multiple digest items: ${named}`,
+    };
+  }
+
+  // No prefix hit — keep the caller id so the existing "No actionable …" path fires.
+  return { ok: true, taskId };
+}
 
 export class ResolveLearningDigestHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
@@ -116,11 +152,18 @@ export class ResolveLearningDigestHandler implements ToolHandler {
     }
 
     // completion actions
-    const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
-    if (!taskId) return { success: false, error: 'task_id is required for completion actions' };
+    const rawTaskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
+    if (!rawTaskId) return { success: false, error: 'task_id is required for completion actions' };
 
     const store = new ConfigStore(ctx.entityMemory, ctx.log);
     const digestMap = await readCompletionDigest(store, ctx.log);
+    const resolved = resolveDigestTaskId(digestMap, rawTaskId);
+    if (!resolved.ok) {
+      return { success: false, error: resolved.error };
+    }
+    // Use the resolved full key for digest lookup AND taskRepo calls — a short
+    // prefix is not a valid task UUID and must not be passed to getTask/etc.
+    const taskId = resolved.taskId;
     const item = digestMap[taskId];
 
     // Require an actionable digest item of the matching kind before mutating a task —
@@ -128,7 +171,7 @@ export class ResolveLearningDigestHandler implements ToolHandler {
     // still report success even when the digest held no such item.
     const expectedKind = action === 'undo_completion' ? 'undo' : 'confirm';
     if (!item || item.kind !== expectedKind) {
-      return { success: false, error: `No actionable ${expectedKind} item for task ${taskId}` };
+      return { success: false, error: `No actionable ${expectedKind} item for task ${rawTaskId}` };
     }
 
     if (action === 'undo_completion') {

--- a/skills/learning/tools/resolve-learning-digest/tool.json
+++ b/skills/learning/tools/resolve-learning-digest/tool.json
@@ -1,12 +1,12 @@
 {
   "name": "resolve-learning-digest",
   "description": "Resolve a learning-digest item: approve/dismiss a voice proposal, undo an auto-completed task, or confirm/dismiss a task-completion candidate.",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
     "action": "string (approve_voice | dismiss_voice | undo_completion | confirm_completion | dismiss_completion)",
-    "task_id": "string? (required for completion actions)"
+    "task_id": "string? (required for completion actions; full UUID or unique prefix of a digest item's task id)"
   },
   "outputs": {
     "resolved": "boolean",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1545.

`resolve-learning-digest` previously required an exact task UUID key in the completion-digest map. In prod the CEO/coordinator often relayed an 8-char prefix (`3502c6bb`), which failed with `No actionable confirm item…`.

### Behavior

- Exact key match unchanged
- Unique prefix of a digest map key resolves successfully (dismiss/confirm/undo)
- Ambiguous prefix errors with matching candidates named (no silent pick)
- Miss errors as before (`No actionable … item for task <id>`)
- `taskRepo` calls always use the **resolved full UUID**, never the short prefix

### Changes

- `skills/learning/tools/resolve-learning-digest/handler.ts` — `resolveDigestTaskId()` + wire-up
- `handler.test.ts` — unique / ambiguous / miss coverage for dismiss + confirm
- `tool.json` — version `0.1.3` → `0.2.0`; document prefix acceptance
- `CHANGELOG.md` — Changed entry under `[Unreleased]`

## Test plan

- [x] `pnpm exec vitest run skills/learning/tools/resolve-learning-digest/handler.test.ts` (18 passed)
- [x] `pnpm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

