### PR TITLE
fix(antfarm): flush desk roster when OfficeScene finishes booting (#1549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Slack decode** — unescape `&amp;` last so `&amp;lt;` stays literal `&lt;`. (#1569)
+- **Ant Farm** — desk roster updates during scene boot are no longer dropped. (#1549)
 
 ### Security
 

--- a/apps/antfarm/src/App.tsx
+++ b/apps/antfarm/src/App.tsx
@@ -15,6 +15,7 @@ import {
   agentRosterKey,
   buildDeskLayout,
   ensureAgentDesk,
+  parseRegistryAgents,
   type RegistryAgent,
 } from './layout/desk-layout.js';
 import { totalAnimationDurationMs } from './conductor/schedule.js';
@@ -70,8 +71,18 @@ export function App() {
         setAuthed(false);
       });
     void apiFetch('/api/registry/agents')
-      .then((res) => res.ok ? res.json() : { agents: [] })
-      .then((data: { agents?: RegistryAgent[] }) => setRegistryAgents(data.agents ?? []))
+      .then(async (res): Promise<RegistryAgent[]> => {
+        if (!res.ok) {
+          // Do not silently degrade to [] — same visible symptom as the
+          // scene-boot race (coordinator-only roster) with no signal (#1549).
+          clientWarn(`failed to load registry agents: HTTP ${res.status}`);
+          return [];
+        }
+        // Validate before narrowing: a malformed `agents` field must not reach
+        // the roster/layout code, which assumes an array of well-formed agents.
+        return parseRegistryAgents(await res.json(), clientWarn);
+      })
+      .then((agents: RegistryAgent[]) => setRegistryAgents(agents))
       .catch((err) => {
         clientWarn('failed to load registry agents', err);
         setRegistryAgents([]);

--- a/apps/antfarm/src/game/PhaserOffice.tsx
+++ b/apps/antfarm/src/game/PhaserOffice.tsx
@@ -3,6 +3,7 @@ import Phaser from 'phaser';
 import type { SceneDirective } from '@curia/shared-types';
 import type { DeskSlot } from '../layout/desk-layout.js';
 import { deskLayoutKey } from '../layout/desk-layout.js';
+import { applyDeskLayoutSync, type DeskSyncState } from '../layout/desk-layout-sync.js';
 import type { ScheduledDirective } from '../conductor/types.js';
 import { OfficeScene, type OfficeSceneCallbacks } from './OfficeScene.js';
 import { STAGE_HEIGHT, STAGE_WIDTH } from './world-layout.js';
@@ -25,7 +26,7 @@ export function PhaserOffice({
   const containerRef = useRef<HTMLDivElement>(null);
   const gameRef = useRef<Phaser.Game | null>(null);
   const lastFiredRef = useRef(-1);
-  const lastDeskKeyRef = useRef('');
+  const deskSyncRef = useRef<DeskSyncState>({ lastKey: '' });
   const callbacksRef = useRef<OfficeSceneCallbacks>({ onAgentClick, onDirectiveClick });
   const desksRef = useRef(desks);
 
@@ -63,24 +64,67 @@ export function PhaserOffice({
     game.registry.set('callbacks', callbacks);
 
     game.events.once('ready', () => {
-      game.scene.start('OfficeScene', { desks: desksRef.current, callbacks });
+      const bootDesks = desksRef.current;
+      game.scene.start('OfficeScene', { desks: bootDesks, callbacks });
+      // Record the boot roster as already applied so a flush of the same key
+      // does not call updateLayout → scene.restart() for no reason.
+      deskSyncRef.current.lastKey = deskLayoutKey(bootDesks);
     });
 
     return () => {
       game.destroy(true);
       gameRef.current = null;
       lastFiredRef.current = -1;
+      deskSyncRef.current = { lastKey: '' };
     };
   }, []);
 
   useEffect(() => {
     const game = gameRef.current;
-    if (!game?.scene.isActive('OfficeScene')) return;
-    const key = deskLayoutKey(desks);
-    if (key === lastDeskKeyRef.current) return;
-    lastDeskKeyRef.current = key;
-    const scene = game.scene.getScene('OfficeScene') as OfficeScene;
-    scene.updateLayout(desks);
+    if (!game) return;
+
+    let cancelled = false;
+
+    const trySync = (): boolean => {
+      if (cancelled) return true;
+      const result = applyDeskLayoutSync(
+        deskSyncRef.current,
+        desks,
+        game.scene.isActive('OfficeScene'),
+        (next) => {
+          const scene = game.scene.getScene('OfficeScene') as OfficeScene;
+          scene.updateLayout(next);
+        },
+      );
+      return result !== 'waiting';
+    };
+
+    if (trySync()) return;
+
+    // Roster arrived mid-boot: retry on scene wake + rAF until active so the
+    // update is not dropped when React's effect does not re-fire (#1549).
+    const scene = game.scene.getScene('OfficeScene') as OfficeScene | undefined;
+    const onAwake = () => {
+      trySync();
+    };
+    scene?.events.on('start', onAwake);
+    scene?.events.on('ready', onAwake);
+    scene?.events.on('wake', onAwake);
+
+    let raf = 0;
+    const poll = () => {
+      if (trySync()) return;
+      raf = requestAnimationFrame(poll);
+    };
+    raf = requestAnimationFrame(poll);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      scene?.events.off('start', onAwake);
+      scene?.events.off('ready', onAwake);
+      scene?.events.off('wake', onAwake);
+    };
   }, [desks]);
 
   useEffect(() => {

--- a/apps/antfarm/src/layout/desk-layout-sync.test.ts
+++ b/apps/antfarm/src/layout/desk-layout-sync.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyDeskLayoutSync, type DeskSyncState } from './desk-layout-sync.js';
+import { deskLayoutKey, type DeskSlot } from './desk-layout.js';
+
+const COORD_ONLY: DeskSlot[] = [{ agentId: 'coordinator', row: 'boss', column: 0 }];
+const FULL_ROSTER: DeskSlot[] = [
+  { agentId: 'coordinator', row: 'boss', column: 0 },
+  { agentId: 'research', row: 'floor', column: 0 },
+  { agentId: 'calendar', row: 'floor', column: 1 },
+];
+
+describe('applyDeskLayoutSync (#1549 scene-boot race)', () => {
+  it('returns waiting without advancing lastKey when the scene is inactive', () => {
+    const state: DeskSyncState = { lastKey: '' };
+    const apply = vi.fn();
+    expect(applyDeskLayoutSync(state, FULL_ROSTER, false, apply)).toBe('waiting');
+    expect(apply).not.toHaveBeenCalled();
+    expect(state.lastKey).toBe('');
+  });
+
+  it('applies a pending roster once the scene becomes active (boot-race regression)', () => {
+    const state: DeskSyncState = { lastKey: '' };
+    const apply = vi.fn();
+
+    // Mid-boot: registry fetch lands while OfficeScene is not yet active.
+    expect(applyDeskLayoutSync(state, FULL_ROSTER, false, apply)).toBe('waiting');
+    expect(apply).not.toHaveBeenCalled();
+
+    // Scene wakes — same desks must now flush (the bug was dropping this update).
+    expect(applyDeskLayoutSync(state, FULL_ROSTER, true, apply)).toBe('applied');
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledWith(FULL_ROSTER);
+    expect(state.lastKey).toBe(deskLayoutKey(FULL_ROSTER));
+  });
+
+  it('noops when the active scene already has the same roster', () => {
+    const state: DeskSyncState = { lastKey: deskLayoutKey(COORD_ONLY) };
+    const apply = vi.fn();
+    expect(applyDeskLayoutSync(state, COORD_ONLY, true, apply)).toBe('noop');
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('applies when the active scene roster changes', () => {
+    const state: DeskSyncState = { lastKey: deskLayoutKey(COORD_ONLY) };
+    const apply = vi.fn();
+    expect(applyDeskLayoutSync(state, FULL_ROSTER, true, apply)).toBe('applied');
+    expect(apply).toHaveBeenCalledWith(FULL_ROSTER);
+    expect(state.lastKey).toBe(deskLayoutKey(FULL_ROSTER));
+  });
+});

--- a/apps/antfarm/src/layout/desk-layout-sync.ts
+++ b/apps/antfarm/src/layout/desk-layout-sync.ts
@@ -1,0 +1,28 @@
+import { deskLayoutKey, type DeskSlot } from './desk-layout.js';
+
+export interface DeskSyncState {
+  lastKey: string;
+}
+
+/**
+ * Apply a desk-roster update to the Phaser scene when it is active.
+ *
+ * Returns:
+ * - `waiting` — scene not active yet; caller must retry on wake (do NOT record
+ *   the key as applied — that is the scene-boot race in #1549)
+ * - `noop` — scene active and roster unchanged
+ * - `applied` — `apply` was invoked and `state.lastKey` advanced
+ */
+export function applyDeskLayoutSync(
+  state: DeskSyncState,
+  desks: DeskSlot[],
+  sceneActive: boolean,
+  apply: (desks: DeskSlot[]) => void,
+): 'applied' | 'waiting' | 'noop' {
+  if (!sceneActive) return 'waiting';
+  const key = deskLayoutKey(desks);
+  if (key === state.lastKey) return 'noop';
+  state.lastKey = key;
+  apply(desks);
+  return 'applied';
+}

--- a/apps/antfarm/src/layout/desk-layout.test.ts
+++ b/apps/antfarm/src/layout/desk-layout.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { SceneDirective } from '@curia/shared-types';
-import { agentIdsFromDirectives, agentRosterKey, buildDeskLayout, deskLayoutKey, ensureAgentDesk } from './desk-layout.js';
+import { agentIdsFromDirectives, agentRosterKey, buildDeskLayout, deskLayoutKey, ensureAgentDesk, parseRegistryAgents } from './desk-layout.js';
 
 describe('desk layout', () => {
   it('places coordinator in the boss row and others on the floor', () => {
@@ -69,5 +69,48 @@ describe('desk layout', () => {
       { agentId: 'calendar', row: 'floor' as const, column: 0 },
     ];
     expect(deskLayoutKey(desks)).toBe(deskLayoutKey([...desks]));
+  });
+});
+
+describe('parseRegistryAgents', () => {
+  it('returns well-formed agents unchanged', () => {
+    const onWarn = vi.fn();
+    const agents = parseRegistryAgents(
+      { agents: [{ name: 'coordinator', metadata: { role: 'coordinator' } }, { name: 'research' }] },
+      onWarn,
+    );
+    expect(agents).toEqual([
+      { name: 'coordinator', metadata: { role: 'coordinator' } },
+      { name: 'research' },
+    ]);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('accepts null or absent metadata', () => {
+    expect(parseRegistryAgents({ agents: [{ name: 'a', metadata: null }, { name: 'b' }] })).toHaveLength(2);
+  });
+
+  it('degrades to an empty roster and warns when "agents" is not an array', () => {
+    const onWarn = vi.fn();
+    expect(parseRegistryAgents({ agents: 'nope' }, onWarn)).toEqual([]);
+    expect(parseRegistryAgents(null, onWarn)).toEqual([]);
+    expect(parseRegistryAgents('garbage', onWarn)).toEqual([]);
+    expect(onWarn).toHaveBeenCalledTimes(3);
+  });
+
+  it('drops malformed entries, keeps valid ones, and warns about the drop', () => {
+    const onWarn = vi.fn();
+    const agents = parseRegistryAgents(
+      { agents: [{ name: 'ok' }, { name: 42 }, null, { role: 'no-name' }, { name: 'ok2' }] },
+      onWarn,
+    );
+    expect(agents).toEqual([{ name: 'ok' }, { name: 'ok2' }]);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('dropped 3'));
+  });
+
+  it('does not throw when fed to buildDeskLayout after parsing junk', () => {
+    const agents = parseRegistryAgents({ agents: [{ bogus: true }, 7, 'x'] });
+    expect(() => buildDeskLayout(agents, [])).not.toThrow();
   });
 });

--- a/apps/antfarm/src/layout/desk-layout.ts
+++ b/apps/antfarm/src/layout/desk-layout.ts
@@ -11,6 +11,42 @@ export interface RegistryAgent {
   metadata?: { role?: string } | null;
 }
 
+/** Type guard for one registry entry: the roster/layout code assumes `name` is a string. */
+function isRegistryAgent(value: unknown): value is RegistryAgent {
+  if (typeof value !== 'object' || value === null) return false;
+  const agent = value as { name?: unknown; metadata?: unknown };
+  if (typeof agent.name !== 'string') return false;
+  // metadata is optional; when present it must be an object (role is read via `?.`).
+  return agent.metadata == null || typeof agent.metadata === 'object';
+}
+
+/**
+ * Validate the /api/registry/agents payload before it reaches the roster/layout code,
+ * which assumes an iterable array of well-formed agents. A malformed payload (backend
+ * contract drift, partial response) degrades to the valid subset — or an empty roster —
+ * rather than crashing downstream on a non-array or a nameless entry. `onWarn` keeps this
+ * module logger-free while still surfacing the degrade (the point of #1549: never silently).
+ */
+export function parseRegistryAgents(
+  payload: unknown,
+  onWarn?: (message: string) => void,
+): RegistryAgent[] {
+  const agents =
+    typeof payload === 'object' && payload !== null
+      ? (payload as { agents?: unknown }).agents
+      : undefined;
+  if (!Array.isArray(agents)) {
+    onWarn?.('registry agents payload malformed: "agents" is not an array');
+    return [];
+  }
+  const valid = agents.filter(isRegistryAgent);
+  const dropped = agents.length - valid.length;
+  if (dropped > 0) {
+    onWarn?.(`registry agents payload dropped ${dropped} malformed entr${dropped === 1 ? 'y' : 'ies'}`);
+  }
+  return valid;
+}
+
 /**
  * Ids that show up as delegation targets but are NOT agents — they're channels/rooms (e.g. the
  * "bullpen", a shared discussion space). These must never get a desk, label, or agent sprite: a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1549.

Ant Farm intermittently rendered only the coordinator because a `desks` roster update that arrived while `OfficeScene` was mid-boot early-returned from the sync effect without recording state or scheduling a retry. Once `desks` stabilized, the effect never re-fired and the scene stayed on the coordinator-only boot roster until refresh.

### Fix

- Extract `applyDeskLayoutSync` — does **not** advance `lastKey` while the scene is inactive (`waiting`), so a later flush can still apply
- `PhaserOffice` retries via scene `start`/`ready`/`wake` plus rAF until active
- Record the boot roster key when `scene.start` runs to avoid a no-op `updateLayout` → `restart`
- Log non-OK `/api/registry/agents` responses (previously swallowed to `[]` with no signal)

### Tests

- Regression coverage for waiting → apply after scene becomes active

## Test plan

- [x] `pnpm exec vitest run apps/antfarm/src/layout/desk-layout-sync.test.ts`
- [x] `pnpm --filter @curia/antfarm run typecheck` / `pnpm run typecheck`
- [ ] Manual: hard-reload Ant Farm several times and confirm specialists appear without a second refresh
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

