### PR TITLE
fix(health): fail /api/health when enabled MCP servers have 0 tools (#1500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **`resolve-learning-digest`** — accepts a unique task-id prefix for digest resolve. (#1545)
+- **`/api/health` mcp checks** — dynamic per enabled MCP server; 0 tools → degraded. (#1500)
 
 ### Fixed
 
 - **Slack decode** — unescape `&amp;` last so `&amp;lt;` stays literal `&lt;`. (#1569)
 - **Ant Farm** — desk roster updates during scene boot are no longer dropped. (#1549)
+- **MCP bootstrap** — enabled servers with 0 tools now error-log and fail health. (#1500)
 
 ### Security
 

--- a/src/channels/http/routes/health.ts
+++ b/src/channels/http/routes/health.ts
@@ -40,7 +40,7 @@ export async function healthRoutes(
           signal: 'skipped' as const,
           email: 'skipped' as const,
           browser: 'skipped' as const,
-          mcp: { google_workspace: 'skipped' as const },
+          mcp: {},
           scheduler: 'fail' as const,
         },
       });

--- a/src/health/health-checks.ts
+++ b/src/health/health-checks.ts
@@ -42,8 +42,19 @@ export interface McpSessionHealth {
   serverId: string;
   client: {
     /** MCP SDK Client.listTools() — a lightweight round-trip that proves the subprocess is alive. */
-    listTools(): Promise<unknown>;
+    listTools(): Promise<{ tools?: unknown[] }>;
   };
+}
+
+/** Boot-time MCP load outcome (mirrors McpServerLoadStatus in mcp-loader). */
+export type McpServerBootStatus =
+  | { status: 'ok'; toolCount: number }
+  | { status: 'zero_tools' }
+  | { status: 'unavailable'; reason: string };
+
+/** Health check key for an MCP server name (`google-workspace` → `google_workspace`). */
+export function mcpHealthKey(serverName: string): string {
+  return serverName.replace(/-/g, '_');
 }
 
 // ---------------------------------------------------------------------------
@@ -163,9 +174,58 @@ export function checkBrowser(service: BrowserServiceHealth | undefined): CheckRe
 }
 
 /**
- * Check the google-workspace MCP subprocess via a tools/list call.
- * Non-critical. Skipped when the server is not in the active mcpSessions list.
- * Hard 3-second timeout.
+ * Check every **enabled** MCP server that was attempted at boot (#1500).
+ *
+ * - Boot `zero_tools` / `unavailable` → fail (no live probe needed)
+ * - Boot `ok` → live tools/list; fail if the call errors or returns 0 tools
+ * - Disabled servers are absent from `serverStatuses` and never appear here
+ *
+ * Hard 3-second timeout per live probe.
+ */
+export async function checkMcpServers(
+  serverStatuses: ReadonlyMap<string, McpServerBootStatus>,
+  mcpSessions: McpSessionHealth[],
+  logger: Logger,
+): Promise<Record<string, CheckResult>> {
+  // Probe every server concurrently: a liveness endpoint must stay bounded, not
+  // scale at ~3s × server count when several servers stall (each probe already has
+  // its own 3s cap, so the whole check is ~3s regardless of how many stall). Assemble
+  // the record from the resolved outcomes, preserving serverStatuses order.
+  const entries = await Promise.all(
+    [...serverStatuses].map(async ([serverName, boot]): Promise<[string, CheckResult]> => {
+      const key = mcpHealthKey(serverName);
+      if (boot.status === 'zero_tools' || boot.status === 'unavailable') {
+        return [key, 'fail'];
+      }
+
+      const session = mcpSessions.find((s) => s.serverId === serverName);
+      if (!session) {
+        // Boot said ok but session is gone — treat as fail.
+        return [key, 'fail'];
+      }
+
+      try {
+        const toolList = await Promise.race([
+          session.client.listTools(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('timeout')), 3_000),
+          ),
+        ]);
+        const count = toolList.tools?.length ?? 0;
+        return [key, count > 0 ? 'ok' : 'fail'];
+      } catch (err) {
+        logger.warn({ err, server: serverName }, 'checkMcpServers: MCP probe failed');
+        return [key, 'fail'];
+      }
+    }),
+  );
+
+  return Object.fromEntries(entries);
+}
+
+/**
+ * @deprecated Prefer checkMcpServers. Kept as a thin wrapper for callers that
+ * only care about google-workspace until they migrate.
  */
 export async function checkMcpGoogleWorkspace(
   mcpSessions: McpSessionHealth[],
@@ -174,13 +234,13 @@ export async function checkMcpGoogleWorkspace(
   const session = mcpSessions.find(s => s.serverId === 'google-workspace');
   if (!session) return 'skipped';
   try {
-    await Promise.race([
+    const toolList = await Promise.race([
       session.client.listTools(),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('timeout')), 3_000),
       ),
     ]);
-    return 'ok';
+    return (toolList.tools?.length ?? 0) > 0 ? 'ok' : 'fail';
   } catch (err) {
     logger.warn({ err }, 'checkMcpGoogleWorkspace: MCP probe failed');
     return 'fail';

--- a/src/health/health-service.ts
+++ b/src/health/health-service.ts
@@ -15,13 +15,14 @@ import type { Scheduler } from '../scheduler/scheduler.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
 import type { ModelRoutingConfig } from '../agents/llm/model-router.js';
 import type { McpSession } from '../skills/mcp-client.js';
+import type { McpServerLoadStatus } from '../skills/mcp-loader.js';
 import type { HealthConfig } from '../config.js';
 import type { LlmCallEvent, LlmErrorEvent, ToolResultEvent } from '../bus/events.js';
 import type { CheckResult, HealthResponse, HealthStatus, TrackerKey, CanaryResult } from './types.js';
 import { LlmOutcomeTracker } from './llm-outcome-tracker.js';
 import {
   checkDb, checkBus, checkEmail, checkSignal, checkBrowser,
-  checkMcpGoogleWorkspace, checkScheduler,
+  checkMcpServers, checkScheduler,
   type EmailAdapterHealth, type SignalRpcClientHealth, type BrowserServiceHealth,
 } from './health-checks.js';
 import type { NylasClient } from '../channels/email/nylas-client.js';
@@ -40,6 +41,11 @@ export interface HealthServiceDeps {
   signalRpcClient?: SignalRpcClientHealth;
   browserService?: BrowserServiceHealth;
   mcpSessions: McpSession[];
+  /**
+   * Boot outcomes for enabled MCP servers (#1500). Absent/empty → no mcp.*
+   * checks (equivalent to all skipped).
+   */
+  mcpServerStatuses?: ReadonlyMap<string, McpServerLoadStatus>;
   modelRoutingConfig: ModelRoutingConfig;
   config: HealthConfig;
   openaiApiKey?: string;
@@ -178,12 +184,13 @@ export class HealthService {
       mcpSessions, scheduler, config,
     } = this.deps;
     const { liveness } = config;
+    const mcpServerStatuses = this.deps.mcpServerStatuses ?? new Map();
 
     // Run all async probes concurrently to keep p99 latency low.
-    const [db_check, signal_check, mcp_gw] = await Promise.all([
+    const [db_check, signal_check, mcp_checks] = await Promise.all([
       checkDb(db, this.deps.logger),
       checkSignal(signalRpcClient, this.deps.logger),
-      checkMcpGoogleWorkspace(mcpSessions, this.deps.logger),
+      checkMcpServers(mcpServerStatuses, mcpSessions, this.deps.logger),
     ]);
 
     // Synchronous probes — no need to await.
@@ -198,7 +205,7 @@ export class HealthService {
       signal: signal_check,
       email: email_check,
       browser: browser_check,
-      mcp: { google_workspace: mcp_gw },
+      mcp: mcp_checks,
       scheduler: scheduler_check,
     };
 
@@ -282,7 +289,16 @@ export class HealthService {
     });
 
     // Google Workspace canary — credential file readable and refresh token not expired.
+    // Also fail when the enabled MCP session is missing or advertises 0 tools (#1500),
+    // so Better Stack heartbeats stop pinging instead of staying green.
     await run('google_workspace', async () => {
+      const boot = this.deps.mcpServerStatuses?.get('google-workspace');
+      if (boot?.status === 'zero_tools') {
+        return { name: 'google_workspace', status: 'fail', detail: 'MCP server advertises 0 tools' };
+      }
+      if (boot?.status === 'unavailable') {
+        return { name: 'google_workspace', status: 'fail', detail: boot.reason };
+      }
       const session = mcpSessions.find(s => s.serverId === 'google-workspace');
       if (!session || !googleWorkspaceConfigPath) return { name: 'google_workspace', status: 'skipped' };
       return this.canaryGoogleWorkspace(googleWorkspaceConfigPath);
@@ -316,7 +332,7 @@ export class HealthService {
       checks.signal,
       checks.email,
       checks.browser,
-      checks.mcp.google_workspace,
+      ...Object.values(checks.mcp),
       checks.scheduler,
     ];
     if (nonCritical.some(c => c === 'fail')) return 'degraded';

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -13,7 +13,8 @@ export interface HealthResponse {
     signal: CheckResult;
     email: CheckResult;
     browser: CheckResult;
-    mcp: { google_workspace: CheckResult };
+    /** Per enabled MCP server (hyphens → underscores). Empty when none enabled. */
+    mcp: Record<string, CheckResult>;
     scheduler: CheckResult;
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ import { ExecutionLayer } from './skills/execution.js';
 import { resolveBypassLadder } from './autonomy/effective-standing.js';
 import { loadToolsFromDirectory, discoverToolManifests, validateAllowedCallers } from './skills/loader.js';
 import type { ToolDiscovery } from './skills/loader.js';
-import { loadMcpServers, loadSkillsConfig, registerMcpProjectedSkills } from './skills/mcp-loader.js';
+import { loadMcpServers, loadSkillsConfig, registerMcpProjectedSkills, type McpServerLoadStatus } from './skills/mcp-loader.js';
 import type { McpSession } from './skills/mcp-client.js';
 import { ContactService } from './contacts/contact-service.js';
 import type { ChannelIdentity, Contact, PrincipalEmailRef } from './contacts/types.js';
@@ -1176,10 +1176,12 @@ async function main(): Promise<void> {
   // until the next restart.
   let mcpSessions: McpSession[] = [];
   let mcpProjectedTools = new Map<string, string[]>();
+  let mcpServerStatuses = new Map<string, McpServerLoadStatus>();
   try {
     const mcpLoad = await loadMcpServers(configDir, toolRegistry, logger, secretsService, enabledMcpServers);
     mcpSessions = mcpLoad.sessions;
     mcpProjectedTools = mcpLoad.projectedTools;
+    mcpServerStatuses = mcpLoad.serverStatuses;
   } catch (err) {
     // Malformed skills.yaml or unexpected loader error — degrade gracefully rather
     // than crashing. The startup validator catches schema violations, but a YAML
@@ -1190,6 +1192,19 @@ async function main(): Promise<void> {
   }
   if (mcpSessions.length > 0) {
     logger.info({ mcpServers: mcpSessions.map(s => s.serverId) }, 'MCP servers connected');
+  }
+  const mcpUnhealthy = [...mcpServerStatuses.entries()].filter(([, s]) => s.status !== 'ok');
+  if (mcpUnhealthy.length > 0) {
+    logger.error(
+      {
+        servers: mcpUnhealthy.map(([name, s]) => ({
+          name,
+          status: s.status,
+          reason: s.status === 'unavailable' ? s.reason : undefined,
+        })),
+      },
+      'One or more enabled MCP servers failed to load tools — /api/health will report degraded',
+    );
   }
 
   // ADR-032: each connected MCP server projects a skill into SkillRegistry so
@@ -2063,6 +2078,7 @@ async function main(): Promise<void> {
     signalRpcClient,
     browserService,
     mcpSessions,
+    mcpServerStatuses,
     modelRoutingConfig,
     config: healthConfig,
     openaiApiKey: config.openaiApiKey,

--- a/src/skills/mcp-loader.ts
+++ b/src/skills/mcp-loader.ts
@@ -6,8 +6,9 @@
 // orchestrator can close sessions and register MCP-as-skill projections
 // (ADR-032).
 //
-// Connection failures are warn-only — a missing MCP server should not take
-// down the whole system. The failed server's tools are simply not registered.
+// Connection failures are error-logged and tracked in serverStatuses for
+// /api/health (#1500) — a missing MCP server should not take down the whole
+// system, but it must not be silent either.
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -27,6 +28,11 @@ import type {
 } from './mcp-config-types.js';
 
 /** Result of loading MCP servers: live sessions + tools registered per server. */
+export type McpServerLoadStatus =
+  | { status: 'ok'; toolCount: number }
+  | { status: 'zero_tools' }
+  | { status: 'unavailable'; reason: string };
+
 export interface McpLoadResult {
   sessions: McpSession[];
   /**
@@ -34,6 +40,12 @@ export interface McpLoadResult {
    * Used to project each MCP server as a skill into SkillRegistry (ADR-032).
    */
   projectedTools: Map<string, string[]>;
+  /**
+   * Boot outcome for every **enabled** server that was attempted (not skipped
+   * by the registry filter). Consumed by HealthService so a silent 0-tool or
+   * connect failure surfaces on `/api/health` (#1500).
+   */
+  serverStatuses: Map<string, McpServerLoadStatus>;
 }
 
 // ---------------------------------------------------------------------------
@@ -306,13 +318,23 @@ export async function loadMcpServers(
 
   if (servers.length === 0) {
     logger.debug('No MCP servers configured in config/skills.yaml');
-    return { sessions: [], projectedTools: new Map() };
+    return { sessions: [], projectedTools: new Map(), serverStatuses: new Map() };
   }
 
   const sessions: McpSession[] = [];
   const projectedTools = new Map<string, string[]>();
+  const serverStatuses = new Map<string, McpServerLoadStatus>();
 
   for (const serverEntry of servers) {
+    // Registry filter first: disabled servers must not affect health (#1500).
+    if (enabledServerNames !== undefined && !enabledServerNames.has(serverEntry.name)) {
+      logger.debug(
+        { server: serverEntry.name },
+        'MCP server not in enabled registry set — skipping',
+      );
+      continue;
+    }
+
     // Validate required transport-specific fields here rather than in the JSON Schema
     // so that the error messages are human-readable and include the server name.
     if (serverEntry.transport === 'stdio' && !serverEntry.command) {
@@ -320,6 +342,10 @@ export async function loadMcpServers(
         { server: serverEntry.name },
         'MCP server config missing required "command" for stdio transport — skipping',
       );
+      serverStatuses.set(serverEntry.name, {
+        status: 'unavailable',
+        reason: 'missing stdio command',
+      });
       continue;
     }
     if (serverEntry.transport === 'sse' && !serverEntry.url) {
@@ -327,15 +353,10 @@ export async function loadMcpServers(
         { server: serverEntry.name },
         'MCP server config missing required "url" for sse transport — skipping',
       );
-      continue;
-    }
-
-    // Registry filter: skip servers not in the enabled set.
-    if (enabledServerNames !== undefined && !enabledServerNames.has(serverEntry.name)) {
-      logger.debug(
-        { server: serverEntry.name },
-        'MCP server not in enabled registry set — skipping',
-      );
+      serverStatuses.set(serverEntry.name, {
+        status: 'unavailable',
+        reason: 'missing sse url',
+      });
       continue;
     }
 
@@ -368,6 +389,10 @@ export async function loadMcpServers(
           { err, server: serverEntry.name },
           'secrets block resolution failed — skipping this MCP server',
         );
+        serverStatuses.set(serverEntry.name, {
+          status: 'unavailable',
+          reason: 'secrets resolution failed',
+        });
         continue;
       }
       // Non-secret literals in env: pass through; secrets block env values overlay them.
@@ -387,6 +412,10 @@ export async function loadMcpServers(
           "MCP server has secrets: block but fixed_inputs still contains 'env:VAR' sentinels — " +
           'migrate them to the secrets: block and remove from fixed_inputs; skipping this server',
         );
+        serverStatuses.set(serverEntry.name, {
+          status: 'unavailable',
+          reason: 'fixed_inputs env sentinels with secrets block',
+        });
         continue;
       }
       Object.assign(resolvedFixedInputs, literalFixed, secretsResult.fixedInputs);
@@ -415,7 +444,13 @@ export async function loadMcpServers(
             break;
           }
         }
-        if (resolutionFailed) continue;
+        if (resolutionFailed) {
+          serverStatuses.set(serverEntry.name, {
+            status: 'unavailable',
+            reason: 'fixed_inputs resolution failed',
+          });
+          continue;
+        }
         logger.info(
           { server: serverEntry.name, keys: Object.keys(resolvedFixedInputs) },
           'MCP server fixed_inputs resolved',
@@ -434,6 +469,10 @@ export async function loadMcpServers(
             { err, server: serverEntry.name },
             'env secret resolution from vault failed — skipping this MCP server',
           );
+          serverStatuses.set(serverEntry.name, {
+            status: 'unavailable',
+            reason: 'env secret resolution failed',
+          });
           continue;
         }
       }
@@ -452,6 +491,10 @@ export async function loadMcpServers(
         { err, server: serverEntry.name },
         'Failed to connect to MCP server — tools from this server will be unavailable until restart',
       );
+      serverStatuses.set(serverEntry.name, {
+        status: 'unavailable',
+        reason: 'connect failed',
+      });
       continue;
     }
 
@@ -468,20 +511,27 @@ export async function loadMcpServers(
       await session.close().catch((closeErr: unknown) => {
         logger.error({ err: closeErr, server: serverEntry.name }, 'Error closing MCP session after tools/list failure');
       });
+      serverStatuses.set(serverEntry.name, {
+        status: 'unavailable',
+        reason: 'tools/list failed',
+      });
       continue;
     }
 
     const tools = toolList.tools ?? [];
     if (tools.length === 0) {
-      // Zero tools most commonly means the OAuth flow hasn't been completed yet.
-      // The server starts and handshakes successfully but won't expose tools until
-      // the user authenticates. Check docs/dev/google-drive.md Step 5 if this is
-      // the google-workspace server. Token cache: ~/.workspace-mcp/cli-tokens/
-      logger.warn({ server: serverEntry.name }, 'MCP server advertises no tools — nothing to register. If this is the google-workspace server, the OAuth flow may not have been completed (see docs/dev/google-drive.md Step 5).');
+      // Zero tools most commonly means the OAuth flow hasn't been completed yet,
+      // or the server crashed mid-boot before advertising tools (curia-deploy#181).
+      // This is a loud health failure (#1500) — not a silent warn-and-continue.
+      logger.error(
+        { server: serverEntry.name },
+        'MCP server advertises no tools — tools from this server will be unavailable until restart. If this is google-workspace, the OAuth flow may not have been completed (see docs/dev/google-drive.md Step 5).',
+      );
       // Keep the session open — the server might add tools in a future protocol version.
       // Still project an empty skill so the server name is pinnable/discoverable.
       projectedTools.set(serverEntry.name, []);
       sessions.push(session);
+      serverStatuses.set(serverEntry.name, { status: 'zero_tools' });
       continue;
     }
 
@@ -594,9 +644,10 @@ export async function loadMcpServers(
       'MCP server tools registered',
     );
     sessions.push(session);
+    serverStatuses.set(serverEntry.name, { status: 'ok', toolCount: registeredNames.length });
   }
 
-  return { sessions, projectedTools };
+  return { sessions, projectedTools, serverStatuses };
 }
 
 /**

--- a/tests/integration/http-api.test.ts
+++ b/tests/integration/http-api.test.ts
@@ -27,7 +27,7 @@ function makeHealthServiceStub(): HealthService {
       checks: {
         db: 'ok', bus: 'ok', signal: 'skipped',
         email: 'skipped', browser: 'skipped',
-        mcp: { google_workspace: 'skipped' },
+        mcp: {},
         scheduler: 'ok',
       },
     }),

--- a/tests/unit/channels/http/health.test.ts
+++ b/tests/unit/channels/http/health.test.ts
@@ -17,7 +17,7 @@ describe('GET /api/health', () => {
       checks: {
         db: 'ok', bus: 'ok', signal: 'skipped',
         email: 'skipped', browser: 'skipped',
-        mcp: { google_workspace: 'skipped' },
+        mcp: {},
         scheduler: 'ok',
       },
     }),
@@ -55,7 +55,7 @@ describe('GET /api/health', () => {
         checks: {
           db: 'fail', bus: 'ok', signal: 'skipped',
           email: 'skipped', browser: 'skipped',
-          mcp: { google_workspace: 'skipped' },
+          mcp: {},
           scheduler: 'ok',
         },
       }),

--- a/tests/unit/health/check-mcp-servers.test.ts
+++ b/tests/unit/health/check-mcp-servers.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { checkMcpServers, mcpHealthKey } from '../../../src/health/health-checks.js';
+import { createSilentLogger } from '../../../src/logger.js';
+
+describe('checkMcpServers (#1500)', () => {
+  const logger = createSilentLogger();
+
+  it('fails boot zero_tools without calling listTools', async () => {
+    const listTools = vi.fn();
+    const result = await checkMcpServers(
+      new Map([['google-workspace', { status: 'zero_tools' }]]),
+      [{ serverId: 'google-workspace', client: { listTools } }],
+      logger,
+    );
+    expect(result).toEqual({ google_workspace: 'fail' });
+    expect(listTools).not.toHaveBeenCalled();
+  });
+
+  it('fails boot unavailable without calling listTools', async () => {
+    const result = await checkMcpServers(
+      new Map([['google-workspace', { status: 'unavailable', reason: 'connect failed' }]]),
+      [],
+      logger,
+    );
+    expect(result).toEqual({ google_workspace: 'fail' });
+  });
+
+  it('probes live tools/list for boot-ok servers and fails on empty', async () => {
+    const listTools = vi.fn().mockResolvedValue({ tools: [] });
+    const result = await checkMcpServers(
+      new Map([['google-workspace', { status: 'ok', toolCount: 10 }]]),
+      [{ serverId: 'google-workspace', client: { listTools } }],
+      logger,
+    );
+    expect(result).toEqual({ google_workspace: 'fail' });
+    expect(listTools).toHaveBeenCalled();
+  });
+
+  it('returns ok when live tools/list has tools', async () => {
+    const listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'drive_search' }] });
+    const result = await checkMcpServers(
+      new Map([['google-workspace', { status: 'ok', toolCount: 1 }]]),
+      [{ serverId: 'google-workspace', client: { listTools } }],
+      logger,
+    );
+    expect(result).toEqual({ google_workspace: 'ok' });
+  });
+
+  it('returns empty object when no enabled servers were attempted', async () => {
+    const result = await checkMcpServers(new Map(), [], logger);
+    expect(result).toEqual({});
+  });
+
+  it('returns a result for every enabled server (mixed outcomes)', async () => {
+    const result = await checkMcpServers(
+      new Map([
+        ['alpha', { status: 'zero_tools' }],
+        ['beta', { status: 'ok', toolCount: 3 }],
+        ['gamma', { status: 'ok', toolCount: 1 }], // boot-ok but no live session → fail
+      ]),
+      [{ serverId: 'beta', client: { listTools: vi.fn().mockResolvedValue({ tools: [{ name: 't' }] }) } }],
+      logger,
+    );
+    expect(result).toEqual({ alpha: 'fail', beta: 'ok', gamma: 'fail' });
+  });
+
+  it('probes servers concurrently, not serially (#1500 review)', async () => {
+    // Deferred probes: both must be in flight before either resolves. Serial
+    // probing would leave B uncalled until A settles.
+    let resolveA!: (value: { tools?: unknown[] }) => void;
+    let resolveB!: (value: { tools?: unknown[] }) => void;
+    const listToolsA = vi.fn(() => new Promise<{ tools?: unknown[] }>((resolve) => { resolveA = resolve; }));
+    const listToolsB = vi.fn(() => new Promise<{ tools?: unknown[] }>((resolve) => { resolveB = resolve; }));
+
+    const promise = checkMcpServers(
+      new Map([
+        ['server-a', { status: 'ok', toolCount: 1 }],
+        ['server-b', { status: 'ok', toolCount: 1 }],
+      ]),
+      [
+        { serverId: 'server-a', client: { listTools: listToolsA } },
+        { serverId: 'server-b', client: { listTools: listToolsB } },
+      ],
+      logger,
+    );
+
+    await Promise.resolve(); // flush microtasks; both probes should now be started
+    expect(listToolsA).toHaveBeenCalledTimes(1);
+    expect(listToolsB).toHaveBeenCalledTimes(1);
+
+    resolveA({ tools: [{ name: 'a' }] });
+    resolveB({ tools: [{ name: 'b' }] });
+    expect(await promise).toEqual({ server_a: 'ok', server_b: 'ok' });
+  });
+
+  it('mcpHealthKey normalizes hyphens to underscores', () => {
+    expect(mcpHealthKey('google-workspace')).toBe('google_workspace');
+  });
+});

--- a/tests/unit/health/health-route.test.ts
+++ b/tests/unit/health/health-route.test.ts
@@ -12,7 +12,7 @@ describe('GET /api/health', () => {
         checks: {
           db: 'ok', bus: 'ok', signal: 'skipped',
           email: 'skipped', browser: 'skipped',
-          mcp: { google_workspace: 'skipped' },
+          mcp: {},
           scheduler: 'ok',
         },
       }),
@@ -35,7 +35,7 @@ describe('GET /api/health', () => {
         checks: {
           db: 'fail', bus: 'ok', signal: 'skipped',
           email: 'skipped', browser: 'skipped',
-          mcp: { google_workspace: 'skipped' },
+          mcp: {},
           scheduler: 'ok',
         },
       }),
@@ -54,7 +54,7 @@ describe('GET /api/health', () => {
         checks: {
           db: 'ok', bus: 'ok', signal: 'fail',
           email: 'skipped', browser: 'skipped',
-          mcp: { google_workspace: 'skipped' },
+          mcp: {},
           scheduler: 'ok',
         },
       }),

--- a/tests/unit/health/health-service.test.ts
+++ b/tests/unit/health/health-service.test.ts
@@ -51,7 +51,45 @@ describe('HealthService.getStatus()', () => {
     expect(result.checks.signal).toBe('skipped');
     expect(result.checks.email).toBe('skipped');
     expect(result.checks.browser).toBe('skipped');
-    expect(result.checks.mcp.google_workspace).toBe('skipped');
+    expect(result.checks.mcp).toEqual({});
+  });
+
+  it('returns degraded when an enabled MCP server booted with 0 tools (#1500)', async () => {
+    const svc = new HealthService(makeDeps({
+      mcpServerStatuses: new Map([
+        ['google-workspace', { status: 'zero_tools' }],
+      ]),
+      mcpSessions: [{
+        serverId: 'google-workspace',
+        client: { listTools: vi.fn() },
+      }],
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.status).toBe('degraded');
+    expect(result.checks.mcp.google_workspace).toBe('fail');
+  });
+
+  it('returns degraded when an enabled MCP server failed to connect (#1500)', async () => {
+    const svc = new HealthService(makeDeps({
+      mcpServerStatuses: new Map([
+        ['google-workspace', { status: 'unavailable', reason: 'connect failed' }],
+      ]),
+      mcpSessions: [],
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.status).toBe('degraded');
+    expect(result.checks.mcp.google_workspace).toBe('fail');
+  });
+
+  it('does not fail health for MCP servers that were not enabled', async () => {
+    // Disabled servers are absent from mcpServerStatuses (loader skips them).
+    const svc = new HealthService(makeDeps({
+      mcpServerStatuses: new Map(),
+      mcpSessions: [],
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.status).toBe('ok');
+    expect(result.checks.mcp).toEqual({});
   });
 
   it('returns degraded when a non-critical check fails', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1500.

Enabled MCP servers that fail to connect or advertise **0 tools** used to warn (or skip) and leave `/api/health` green — the detection gap behind the curia-deploy#181 outage (~121 google-workspace tools gone for 9.5 hours).

### Changes

- `loadMcpServers` records per-enabled-server boot outcomes (`ok` / `zero_tools` / `unavailable`); disabled registry servers are omitted (no false alarms)
- Zero-tool case upgraded from **warn → error**
- New `checkMcpServers` liveness probe: boot failures → `fail`; boot-ok servers re-probed via `tools/list` (empty → fail)
- `HealthResponse.checks.mcp` is now `Record<string, CheckResult>` (public API; dashboard already flattens nested mcp keys)
- Overall status → **degraded** when any mcp check fails
- `google_workspace` canary fails (stops Better Stack heartbeat pings) on zero tools / unavailable
- Boot summary error when any enabled server is unhealthy

### Test plan

- [x] `pnpm exec vitest run tests/unit/health/check-mcp-servers.test.ts tests/unit/health/health-service.test.ts …`
- [x] `pnpm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

