### PR TITLE
fix(skills): emit union tool inputs as anyOf for Gemini safety (#1508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`calendar-list-events`** — all-calendar 401/403 failures name grant reconnect action. (#1561)
+- **Tool schemas** — emit union inputs as `anyOf` so Gemini/OpenRouter accept them. (#1508)
 - **Slack decode** — unescape `&amp;` last so `&amp;lt;` stays literal `&lt;`. (#1569)
 - **Ant Farm** — desk roster updates during scene boot are no longer dropped. (#1549)
 - **MCP bootstrap** — enabled servers with 0 tools now error-log and fail health. (#1500)

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -14,6 +14,114 @@ import { describeTimestampInput } from '../time/timestamp.js';
 // are loaded from JSON via a bare cast and TypeScript cannot enforce this at runtime.
 const ACTION_RISK_LABELS = new Set(['none', 'low', 'medium', 'high', 'critical']);
 
+// JSON Schema keyword classification. Schema transforms must recurse only into
+// positions that actually hold subschemas — never into instance-valued keywords,
+// whose literal contents may legitimately contain a `type` array that is real data,
+// not a union to expand (#1508 review). Names are matched only as keywords of a
+// schema object; a property *named* `default` inside `properties` is still a schema.
+const SUBSCHEMA_KEYWORDS = new Set([
+  'items', 'additionalItems', 'additionalProperties', 'contains', 'propertyNames',
+  'not', 'if', 'then', 'else', 'unevaluatedItems', 'unevaluatedProperties',
+]);
+const SUBSCHEMA_LIST_KEYWORDS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
+const SUBSCHEMA_MAP_KEYWORDS = new Set([
+  'properties', 'patternProperties', 'definitions', '$defs', 'dependentSchemas',
+]);
+const INSTANCE_KEYWORDS = new Set(['default', 'const', 'examples', 'enum']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Recursively rewrite JSON Schema `type: [...]` arrays to `anyOf` branches.
+ * Gemini's function-calling API rejects type-arrays (#1508); Anthropic/OpenAI
+ * accept either form. Used for MCP-sourced schemas that may still emit arrays.
+ *
+ * Recurses only into schema-bearing keywords (properties, items, anyOf, $defs, …),
+ * never into instance-valued keywords (default/const/examples/enum) — a `type`
+ * array inside those is literal data and must be preserved verbatim.
+ */
+export function expandTypeArraysToAnyOf(schema: unknown): unknown {
+  if (!isPlainObject(schema)) return schema;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    out[key] = expandKeyword(key, value);
+  }
+  if (!Array.isArray(out['type'])) return out;
+
+  const types = out['type'] as unknown[];
+  const items = out['items'];
+  const existingAnyOf = out['anyOf'];
+  delete out['type'];
+  delete out['items'];
+  delete out['anyOf'];
+  const anyOf = types.map((t) =>
+    t === 'array'
+      ? (items !== undefined ? { type: 'array', items } : { type: 'array' })
+      : { type: t },
+  );
+  // Compose with any pre-existing anyOf via allOf rather than clobbering it —
+  // overwriting would drop the original constraint and widen accepted inputs (#1508 review).
+  return existingAnyOf === undefined
+    ? { ...out, anyOf }
+    : { ...out, allOf: [{ anyOf }, { anyOf: existingAnyOf }] };
+}
+
+/** Transform one keyword's value, recursing only where the value holds subschema(s). */
+function expandKeyword(key: string, value: unknown): unknown {
+  if (INSTANCE_KEYWORDS.has(key)) return value;
+  if (SUBSCHEMA_LIST_KEYWORDS.has(key) && Array.isArray(value)) {
+    return value.map((s) => expandTypeArraysToAnyOf(s));
+  }
+  if (SUBSCHEMA_MAP_KEYWORDS.has(key) && isPlainObject(value)) {
+    const mapped: Record<string, unknown> = {};
+    for (const [name, sub] of Object.entries(value)) mapped[name] = expandTypeArraysToAnyOf(sub);
+    return mapped;
+  }
+  if (SUBSCHEMA_KEYWORDS.has(key)) {
+    if (Array.isArray(value)) return value.map((s) => expandTypeArraysToAnyOf(s)); // `items` tuple form
+    if (isPlainObject(value)) return expandTypeArraysToAnyOf(value);
+    return value; // boolean (e.g. additionalProperties: false) or absent
+  }
+  return value; // type/required/description/format/numeric bounds — scalars or string[]
+}
+
+/**
+ * Gemini-style strictness check: reject any schema position whose `type` is an array.
+ * Mirrors expandTypeArraysToAnyOf's traversal — only schema-bearing keywords are
+ * inspected, so a `type` array living inside instance data (default/const/examples/
+ * enum) is not a false violation. Used by regression tests (#1508).
+ */
+export function assertNoUnionTypeArrays(schema: unknown, path = '$'): void {
+  if (!isPlainObject(schema)) return;
+  if (Array.isArray(schema['type'])) {
+    throw new Error(
+      `Strict provider schema violation at ${path}: type-array ${JSON.stringify(schema['type'])} ` +
+      '(Gemini rejects these; use anyOf)',
+    );
+  }
+  for (const [key, value] of Object.entries(schema)) {
+    assertKeyword(key, value, path);
+  }
+}
+
+function assertKeyword(key: string, value: unknown, path: string): void {
+  if (INSTANCE_KEYWORDS.has(key)) return;
+  if (SUBSCHEMA_LIST_KEYWORDS.has(key) && Array.isArray(value)) {
+    value.forEach((s, i) => assertNoUnionTypeArrays(s, `${path}.${key}[${i}]`));
+    return;
+  }
+  if (SUBSCHEMA_MAP_KEYWORDS.has(key) && isPlainObject(value)) {
+    for (const [name, sub] of Object.entries(value)) assertNoUnionTypeArrays(sub, `${path}.${key}.${name}`);
+    return;
+  }
+  if (SUBSCHEMA_KEYWORDS.has(key)) {
+    if (Array.isArray(value)) value.forEach((s, i) => assertNoUnionTypeArrays(s, `${path}.${key}[${i}]`));
+    else if (isPlainObject(value)) assertNoUnionTypeArrays(value, `${path}.${key}`);
+  }
+}
+
 export class ToolRegistry {
   private tools = new Map<string, RegisteredTool>();
   /** IANA timezone name used to populate timestamp input descriptions in tool schemas. */
@@ -124,7 +232,8 @@ export class ToolRegistry {
         tools.push({
           name,
           description: skill.manifest.description,
-          input_schema: skill.mcpInputSchema,
+          // Normalize type-arrays → anyOf so MCP schemas are Gemini-safe too (#1508).
+          input_schema: expandTypeArraysToAnyOf(skill.mcpInputSchema) as ToolDefinition['input_schema'],
         });
         continue;
       }
@@ -165,17 +274,17 @@ export class ToolRegistry {
 
         const VALID_PRIMITIVE_TYPES = new Set(['string', 'number', 'integer', 'boolean', 'object', 'null']);
 
-        // Pipe unions → JSON Schema type-array. Covers both the common
-        // "string|null" (optional field that accepts explicit null, e.g. clear a
-        // FK) and genuinely polymorphic inputs like the checkpoint tool's
-        // `cursor` (string | object | null) or `accumulator` (an inline
-        // "object[]" OR a single spilled pointer "object"). Each member is a
-        // primitive or an array type ("object[]"); an array member contributes
-        // "array" to the type list and its item type to a shared `items`.
+        // Pipe unions → JSON Schema `anyOf` (NOT `type: [...]` arrays).
+        // Anthropic/OpenAI/DeepSeek accept type-arrays; Google Gemini's
+        // function-calling API does not — OpenRouter drops those properties
+        // but leaves them in `required`, and Gemini then 400s (#1508 /
+        // contacts outage 2026-07-23). `anyOf` is accepted by both families.
+        // Covers "string|null" and polymorphic inputs like checkpoint's
+        // `cursor` (string|object|null) or `accumulator` (object[]|object).
         if (baseType.includes('|')) {
           const members = baseType.split('|').map((m) => m.trim());
-          const types: string[] = [];
-          let arrayItemType: string | undefined;
+          const anyOf: Array<Record<string, unknown>> = [];
+          const seen = new Set<string>();
           for (const member of members) {
             if (member.endsWith('[]')) {
               const itemType = member.slice(0, -2);
@@ -185,15 +294,10 @@ export class ToolRegistry {
                   `Expected one of: ${[...VALID_PRIMITIVE_TYPES].join(', ')}.`,
                 );
               }
-              // JSON Schema `items` is shared across the type-array; two array
-              // members with different item types can't be represented — fail loudly.
-              if (arrayItemType && arrayItemType !== itemType) {
-                throw new Error(
-                  `Tool '${name}' input '${key}': conflicting array item types in union '${typeStr}'.`,
-                );
-              }
-              arrayItemType = itemType;
-              if (!types.includes('array')) types.push('array');
+              const branchKey = `array:${itemType}`;
+              if (seen.has(branchKey)) continue;
+              seen.add(branchKey);
+              anyOf.push({ type: 'array', items: { type: itemType } });
             } else {
               if (!VALID_PRIMITIVE_TYPES.has(member)) {
                 throw new Error(
@@ -201,12 +305,13 @@ export class ToolRegistry {
                   `Expected one of: ${[...VALID_PRIMITIVE_TYPES].join(', ')}, or an array type (e.g. object[]).`,
                 );
               }
-              if (!types.includes(member)) types.push(member);
+              if (seen.has(member)) continue;
+              seen.add(member);
+              anyOf.push({ type: member });
             }
           }
           properties[key] = {
-            type: types,
-            ...(arrayItemType ? { items: { type: arrayItemType } } : {}),
+            anyOf,
             ...(description ? { description } : {}),
           };
           if (!isOptional) {

--- a/tests/unit/skills/registry.test.ts
+++ b/tests/unit/skills/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { ToolRegistry } from '../../../src/skills/registry.js';
+import { ToolRegistry, expandTypeArraysToAnyOf, assertNoUnionTypeArrays } from '../../../src/skills/registry.js';
 import type { ToolManifest, ToolHandler } from '../../../src/skills/types.js';
 
 const stubHandler: ToolHandler = {
@@ -158,7 +158,7 @@ describe('ToolRegistry', () => {
     expect(tools[0].input_schema.required).toEqual(['ids']);
   });
 
-  it('converts string|null? inputs to JSON Schema string|null union', () => {
+  it('converts string|null? inputs to JSON Schema anyOf (Gemini-safe, #1508)', () => {
     registry.register(makeManifest({
       name: 'null-union-skill',
       description: 'Accepts explicit null',
@@ -170,20 +170,19 @@ describe('ToolRegistry', () => {
     const tools = registry.toToolDefinitions(['null-union-skill']);
     const props = tools[0]!.input_schema.properties;
     expect(props.blocked_by_task_id).toEqual({
-      type: ['string', 'null'],
+      anyOf: [{ type: 'string' }, { type: 'null' }],
       description: 'UUID, or null to clear',
     });
     expect(props.required_note).toEqual({
-      type: ['string', 'null'],
+      anyOf: [{ type: 'string' }, { type: 'null' }],
       description: 'always present, may be null',
     });
     expect(tools[0]!.input_schema.required).toEqual(['required_note']);
   });
 
-  it('converts multi-type unions (string|object|null) to a JSON Schema type array', () => {
+  it('converts multi-type unions (string|object|null) to anyOf, not type-arrays (#1508)', () => {
     // Polymorphic inputs: the checkpoint tool's `cursor` is string | object | null
-    // (ResumableCursor), which the shorthand must express so the LLM isn't told the
-    // value must be a string. Generalizes the string|null union to arbitrary members.
+    // (ResumableCursor). Type-arrays break Gemini via OpenRouter.
     registry.register(makeManifest({
       name: 'union-skill',
       description: 'Accepts a polymorphic cursor',
@@ -194,16 +193,16 @@ describe('ToolRegistry', () => {
     const tools = registry.toToolDefinitions(['union-skill']);
     const props = tools[0]!.input_schema.properties;
     expect(props.cursor).toEqual({
-      type: ['string', 'object', 'null'],
+      anyOf: [{ type: 'string' }, { type: 'object' }, { type: 'null' }],
       description: 'opaque resume position',
     });
     // Optional → not required
     expect(tools[0]!.input_schema.required).toEqual([]);
   });
 
-  it('converts an array|object union (object[]|object) to a type array with items', () => {
+  it('converts an array|object union (object[]|object) to anyOf with array items (#1508)', () => {
     // The checkpoint tool's `accumulator` is either an inline object array or a single
-    // spilled document-pointer object. The array member contributes `items`.
+    // spilled document-pointer object.
     registry.register(makeManifest({
       name: 'array-union-skill',
       description: 'Accepts an inline array or a single pointer object',
@@ -214,10 +213,94 @@ describe('ToolRegistry', () => {
     const tools = registry.toToolDefinitions(['array-union-skill']);
     const props = tools[0]!.input_schema.properties;
     expect(props.accumulator).toEqual({
-      type: ['array', 'object'],
-      items: { type: 'object' },
+      anyOf: [
+        { type: 'array', items: { type: 'object' } },
+        { type: 'object' },
+      ],
       description: 'inline results, or a spilled pointer',
     });
+  });
+
+  it('assembled schemas pass a Gemini-style strict validator (no type-arrays) (#1508)', () => {
+    registry.register(makeManifest({
+      name: 'checkpoint-shaped',
+      description: 'Mirrors checkpoint polymorphic inputs',
+      inputs: {
+        cursor: 'string|object|null?',
+        accumulator: 'object[]|object?',
+        note: 'string|null?',
+      },
+    }), stubHandler);
+    const tools = registry.toToolDefinitions(['checkpoint-shaped']);
+    expect(() => assertNoUnionTypeArrays(tools[0]!.input_schema)).not.toThrow();
+  });
+
+  it('expands MCP type-arrays to anyOf so pass-through schemas stay Gemini-safe (#1508)', () => {
+    const expanded = expandTypeArraysToAnyOf({
+      type: 'object',
+      properties: {
+        cursor: { type: ['string', 'object', 'null'] },
+      },
+      required: ['cursor'],
+    });
+    expect(expanded).toEqual({
+      type: 'object',
+      properties: {
+        cursor: { anyOf: [{ type: 'string' }, { type: 'object' }, { type: 'null' }] },
+      },
+      required: ['cursor'],
+    });
+    expect(() => assertNoUnionTypeArrays(expanded)).not.toThrow();
+  });
+
+  it('preserves type-arrays inside instance-valued keywords (default/const/examples/enum) (#1508)', () => {
+    // A `type` array under default/const/examples/enum is literal data, not a schema —
+    // it must survive verbatim and must not be flagged by the strict validator.
+    const schema = {
+      type: 'object',
+      properties: {
+        mode: {
+          type: 'string',
+          default: { type: ['a', 'b'] },
+          const: { type: ['c1', 'c2'] },
+          examples: [{ type: ['e1', 'e2'] }],
+          enum: [{ type: ['x', 'y'] }, 'plain'],
+        },
+      },
+    };
+    const expanded = expandTypeArraysToAnyOf(schema) as {
+      properties: { mode: Record<string, unknown> };
+    };
+    const mode = expanded.properties.mode;
+    expect(mode.default).toEqual({ type: ['a', 'b'] });
+    expect(mode.const).toEqual({ type: ['c1', 'c2'] });
+    expect(mode.examples).toEqual([{ type: ['e1', 'e2'] }]);
+    expect(mode.enum).toEqual([{ type: ['x', 'y'] }, 'plain']);
+    expect(() => assertNoUnionTypeArrays(expanded)).not.toThrow();
+  });
+
+  it('still transforms a property literally named "default" (context-aware, not name-based) (#1508)', () => {
+    // Here `default` is a property NAME whose value is a real schema — unlike a
+    // `default` keyword holding instance data, it must be transformed.
+    const expanded = expandTypeArraysToAnyOf({
+      type: 'object',
+      properties: { default: { type: ['string', 'null'] } },
+    }) as { properties: { default: unknown } };
+    expect(expanded.properties.default).toEqual({ anyOf: [{ type: 'string' }, { type: 'null' }] });
+  });
+
+  it('composes a generated union with an existing anyOf via allOf, not overwrite (#1508)', () => {
+    const expanded = expandTypeArraysToAnyOf({
+      type: ['string', 'number'],
+      anyOf: [{ minLength: 1 }],
+    });
+    expect(expanded).toEqual({
+      allOf: [
+        { anyOf: [{ type: 'string' }, { type: 'number' }] },
+        { anyOf: [{ minLength: 1 }] },
+      ],
+    });
+    expect(() => assertNoUnionTypeArrays(expanded)).not.toThrow();
   });
 
   it('throws on a union member with an invalid primitive type', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1508.

Root cause of the 2026-07-23 `contacts` outage: shorthand unions like `string|object|null` were emitted as JSON Schema `type: [...]` arrays. Anthropic/OpenAI accept those; **Gemini via OpenRouter drops the properties but leaves them in `required`**, then 400s with `INVALID_ARGUMENT`.

### Fix

- Emit pipe-unions as `anyOf` branches (Gemini-safe; still accepted by Anthropic/OpenAI/DeepSeek)
- Normalize MCP pass-through schemas the same way (`expandTypeArraysToAnyOf`)
- Regression: `assertNoUnionTypeArrays` Gemini-style strict validator

### Test plan

- [x] `pnpm exec vitest run tests/unit/skills/registry.test.ts` (24 passed)
- [x] `pnpm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

