### PR TITLE
feat(llm): declare streaming/tools capabilities; gate voice on resolved model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **`nylas_calendar` health check** — probes the principal calendar grant separately from email. (#1561)
 - **Slack/SMS/Voice health probes** — `/api/health` reports each when enabled. (#1567)
+- **Model registry** — `streaming`/`tools` capabilities; voice boot gates on them. (#1553)
 
 ### Changed
 

--- a/docs/adr/014-capability-tier-model-routing.md
+++ b/docs/adr/014-capability-tier-model-routing.md
@@ -79,6 +79,8 @@ model_routing:
 | `coding` | Code generation and analysis optimized | claude-sonnet-4-6, gpt-4o, deepseek-coder |
 | `audio` | Audio input/output modality | gpt-4o-audio-preview, gemini-1.5-pro |
 | `image_generation` | Image synthesis output | dall-e-3, imagen-3, stable-diffusion |
+| `streaming` | Token streaming via `LLMProvider.stream()` (not buffered chat) | chat models in `MODEL_REGISTRY`; not embeddings |
+| `tools` | Tool / function calling during generation | chat models in `MODEL_REGISTRY`; not embeddings |
 
 **Migration:** Existing `model.provider` + `model.model` fields are deprecated but remain valid during a transition period. At startup, the runtime emits a deprecation warning for any agent still using the old schema. A migration guide documents the mapping.
 
@@ -93,7 +95,7 @@ model_routing:
 
 **Trade-offs:**
 - Agents lose direct control over which model executes their prompts. Agents that have been carefully tuned for a specific model's behavior may need re-evaluation when the operator changes the tier mapping.
-- The `needs` system covers the main modality and capability classes (`vision`, `large_context`, `reasoning`, `coding`, `audio`, `image_generation`), but agents with requirements outside this set (e.g., a specific fine-tune) must use a named alias approach rather than declaring a raw model ID.
+- The `needs` system covers the main modality and capability classes (`vision`, `large_context`, `reasoning`, `coding`, `audio`, `image_generation`, `streaming`, `tools`), but agents with requirements outside this set (e.g., a specific fine-tune) must use a named alias approach rather than declaring a raw model ID.
 - The transition period (supporting both old and new schema) adds short-term complexity to the validation layer.
 
 ## Amendment (2026-05-20)
@@ -112,3 +114,7 @@ model_routing:
 ```
 
 Additionally, the OpenRouter provider (#379) was added, enabling routing to non-Anthropic models (Gemini Flash, DeepSeek V3, GPT-4o) via `OPENROUTER_API_KEY`. This fulfills the multi-provider aspiration described in the original decision without requiring per-tier `provider` declarations.
+
+## Amendment (2026-07-27) — streaming / tools (#1553)
+
+`ModelRegistry` entries now declare `streaming` and `tools` on every chat model (embeddings stay `embedding`-only). Provider-level `typeof stream === 'function'` is insufficient for voice: OpenRouter implements `stream()` for every routed model, including ones that do not truly stream or tool-call. The voice channel boot guard therefore also requires the **resolved** model (`channels.voice.model` or the `fast` tier) to advertise both capabilities, and only wires coordinator tools when `tools` is present.

--- a/src/agents/llm/model-registry.test.ts
+++ b/src/agents/llm/model-registry.test.ts
@@ -202,5 +202,28 @@ describe('ModelRegistry', () => {
       expect(pricing!.cacheCreationPerMToken).toBeUndefined();
       expect(pricing!.cacheReadPerMToken).toBeUndefined();
     });
+
+    it('text-embedding-3-small does not declare streaming or tools', () => {
+      const meta = registry.getModel('text-embedding-3-small');
+      expect(meta!.capabilities).not.toContain('streaming');
+      expect(meta!.capabilities).not.toContain('tools');
+    });
+  });
+
+  describe('streaming and tools capabilities (#1553)', () => {
+    it.each([
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5',
+      'google/gemini-3.1-flash-lite',
+      'deepseek/deepseek-chat-v3-0324',
+      'deepseek/deepseek-v4-pro',
+      'openai/gpt-4o',
+    ])('%s declares streaming and tools', (model) => {
+      const meta = registry.getModel(model);
+      expect(meta).toBeDefined();
+      expect(meta!.capabilities).toContain('streaming');
+      expect(meta!.capabilities).toContain('tools');
+    });
   });
 });

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -47,7 +47,7 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       cacheCreationPerMToken: 18.75,
       cacheReadPerMToken: 1.50,
     },
-    capabilities: ['vision', 'reasoning', 'coding', 'large_context'],
+    capabilities: ['vision', 'reasoning', 'coding', 'large_context', 'streaming', 'tools'],
   },
   'claude-sonnet-4-6': {
     provider: 'anthropic',
@@ -58,7 +58,7 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       cacheCreationPerMToken: 3.75,
       cacheReadPerMToken: 0.30,
     },
-    capabilities: ['vision', 'reasoning', 'coding'],
+    capabilities: ['vision', 'reasoning', 'coding', 'streaming', 'tools'],
   },
   'claude-haiku-4-5': {
     provider: 'anthropic',
@@ -69,7 +69,7 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       cacheCreationPerMToken: 1.00,
       cacheReadPerMToken: 0.08,
     },
-    capabilities: ['vision', 'coding'],
+    capabilities: ['vision', 'coding', 'streaming', 'tools'],
   },
 
   // OpenRouter models — non-Claude models routed via OpenRouter's OpenAI-compatible API.
@@ -82,7 +82,7 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       inputPerMToken: 0.25,
       outputPerMToken: 1.50,
     },
-    capabilities: ['vision', 'coding'],
+    capabilities: ['vision', 'coding', 'streaming', 'tools'],
     maxOutputTokens: 8_192,
   },
   // Removed from OpenRouter ~2026-05-31. Entry retained for audit log provenance.
@@ -93,7 +93,7 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       inputPerMToken: 0.10,
       outputPerMToken: 0.40,
     },
-    capabilities: ['vision', 'coding'],
+    capabilities: ['vision', 'coding', 'streaming', 'tools'],
     maxOutputTokens: 8_192,
   },
   'deepseek/deepseek-chat-v3-0324': {
@@ -103,7 +103,7 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       inputPerMToken: 0.27,
       outputPerMToken: 1.10,
     },
-    capabilities: ['coding'],
+    capabilities: ['coding', 'streaming', 'tools'],
     maxOutputTokens: 8_192,
   },
   'deepseek/deepseek-v4-pro': {
@@ -113,7 +113,7 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       inputPerMToken: 0.435,
       outputPerMToken: 0.87,
     },
-    capabilities: ['coding', 'reasoning'],
+    capabilities: ['coding', 'reasoning', 'streaming', 'tools'],
     // 8_192 was too low — long-form writing tasks (e.g. import_to_google_doc with
     // a full essay body) exceeded it, producing truncated JSON tool call arguments.
     // DeepSeek V4 Pro on OpenRouter supports up to 64k output tokens (#934).
@@ -126,13 +126,14 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
       inputPerMToken: 2.50,
       outputPerMToken: 10.00,
     },
-    capabilities: ['vision', 'coding', 'reasoning'],
+    capabilities: ['vision', 'coding', 'reasoning', 'streaming', 'tools'],
     maxOutputTokens: 16_384,
   },
 
   // OpenAI embedding model — used by EmbeddingService for semantic search and entity resolution.
   // inputPerMToken matches current OpenAI pricing for text-embedding-3-small.
   // outputPerMToken is 0: embeddings produce no billed output tokens.
+  // No streaming/tools — embeddings are not chat models (#1553).
   'text-embedding-3-small': {
     provider: 'openai',
     contextWindow: 8191,

--- a/src/channels/voice/voice-model-capabilities.test.ts
+++ b/src/channels/voice/voice-model-capabilities.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateVoiceModelCapabilities } from './voice-model-capabilities.js';
+
+describe('evaluateVoiceModelCapabilities (#1553)', () => {
+  it('passes for a streaming+tools model', () => {
+    expect(
+      evaluateVoiceModelCapabilities('claude-haiku-4-5', ['vision', 'coding', 'streaming', 'tools']),
+    ).toEqual({ ok: true });
+  });
+
+  it('refuses a non-streaming model', () => {
+    const result = evaluateVoiceModelCapabilities('hypothetical/batch-only', [
+      'coding',
+      'tools',
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.missing).toContain('streaming');
+      expect(result.unknownModel).toBe(false);
+    }
+  });
+
+  it('refuses a non-tool model', () => {
+    const result = evaluateVoiceModelCapabilities('hypothetical/stream-only', [
+      'coding',
+      'streaming',
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.missing).toEqual(['tools']);
+    }
+  });
+
+  it('refuses an unknown model (fail closed)', () => {
+    const result = evaluateVoiceModelCapabilities('totally-unknown-model', undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.unknownModel).toBe(true);
+      expect(result.missing).toEqual(['streaming', 'tools']);
+    }
+  });
+});

--- a/src/channels/voice/voice-model-capabilities.ts
+++ b/src/channels/voice/voice-model-capabilities.ts
@@ -1,0 +1,30 @@
+/**
+ * Voice model capability preflight (#1553).
+ *
+ * Voice turns need true streaming (ADR-037) and tool calls. The provider
+ * exposing `stream()` is necessary but not sufficient — OpenRouter implements
+ * stream() for every routed model, including ones that don't stream or tool-call.
+ * Gate on the resolved model's registry capabilities instead.
+ */
+
+export const VOICE_REQUIRED_CAPABILITIES = ['streaming', 'tools'] as const;
+
+export type VoiceCapabilityResult =
+  | { ok: true }
+  | { ok: false; missing: string[]; unknownModel: boolean };
+
+export function evaluateVoiceModelCapabilities(
+  _modelId: string,
+  capabilities: readonly string[] | undefined,
+): VoiceCapabilityResult {
+  if (!capabilities) {
+    return {
+      ok: false,
+      missing: [...VOICE_REQUIRED_CAPABILITIES],
+      unknownModel: true,
+    };
+  }
+  const missing = VOICE_REQUIRED_CAPABILITIES.filter((c) => !capabilities.includes(c));
+  if (missing.length === 0) return { ok: true };
+  return { ok: false, missing: [...missing], unknownModel: false };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ import { VoiceAdapter } from './channels/voice/voice-adapter.js';
 import { VoiceSessionBridge } from './channels/voice/session-bridge.js';
 import { VoiceSessionStore } from './channels/voice/session-store.js';
 import { VoiceRuntime } from './channels/voice/voice-runtime.js';
+import { evaluateVoiceModelCapabilities } from './channels/voice/voice-model-capabilities.js';
 import { DeepgramSttProvider } from './channels/voice/speech/deepgram-stt.js';
 import { CartesiaTtsProvider } from './channels/voice/speech/cartesia-tts.js';
 import { LiveKitRoomSession } from './channels/voice/livekit/room-session.js';
@@ -1814,11 +1815,33 @@ async function main(): Promise<void> {
     config.voiceCartesiaVoiceId
   ) {
     // Voice turns use the 'fast' tier by default (ADR-037 §3), overridable via
-    // channels.voice.model. The runtime needs a provider that supports stream();
-    // without stream() we do not advertise voice (no silent rooms).
+    // channels.voice.model. Need both a provider that exposes stream() and a
+    // registry entry advertising streaming+tools (#1553) — OpenRouter's
+    // stream() alone does not prove the resolved model can duplex or tool-call.
     const voiceModel = config.voiceModel ?? modelRouter.resolve('fast').model;
     const voiceBaseProvider = resolveProviderForModel(voiceModel, 'VoiceRuntime');
-    if (typeof voiceBaseProvider.stream === 'function') {
+    const voiceCaps = evaluateVoiceModelCapabilities(
+      voiceModel,
+      modelRegistry.getModel(voiceModel)?.capabilities,
+    );
+    if (typeof voiceBaseProvider.stream !== 'function') {
+      logger.warn(
+        { voiceModel, provider: voiceBaseProvider.id },
+        'Voice channel enabled but the resolved LLM provider does not support stream(); '
+        + 'voice adapter not started. Remap channels.voice.model / the fast tier to a streaming provider.',
+      );
+    } else if (!voiceCaps.ok) {
+      logger.warn(
+        {
+          voiceModel,
+          missingCapabilities: voiceCaps.missing,
+          unknownModel: voiceCaps.unknownModel,
+        },
+        'Voice channel enabled but the resolved model lacks required capabilities '
+        + `(${voiceCaps.missing.join(', ')}); voice adapter not started. `
+        + 'Remap channels.voice.model / the fast tier to a model with streaming and tools.',
+      );
+    } else {
       // Wrap in telemetry so voice turns emit llm.call cost events like every other path.
       const voiceLlmProvider = new TelemetryLlmProvider(voiceBaseProvider, bus, logger, 'voice-turn', modelRegistry);
       const voiceLivekitUrl = config.voiceLivekitUrl;
@@ -1854,7 +1877,7 @@ async function main(): Promise<void> {
         // voiceRuntime.configureTools() after the coordinator is registered
         // (ExecutionLayer + pinned tools + agent registry exist then).
       });
-      logger.info({ voiceModel }, 'Voice runtime constructed (streaming provider available)');
+      logger.info({ voiceModel }, 'Voice runtime constructed (streaming provider + model capabilities ok)');
 
       voiceAdapter = new VoiceAdapter({
         bus,
@@ -1867,12 +1890,6 @@ async function main(): Promise<void> {
         voiceModel: config.voiceModel,
         voiceRuntime,
       });
-    } else {
-      logger.warn(
-        { voiceModel, provider: voiceBaseProvider.id },
-        'Voice channel enabled but the resolved LLM provider does not support stream(); '
-        + 'voice adapter not started. Remap channels.voice.model / the fast tier to a streaming provider.',
-      );
     }
   } else if (channelShouldStart.has('voice')) {
     logger.warn('channel voice is enabled + resolvable but runtime credentials are missing (LiveKit, Deepgram, Cartesia, or the Cartesia voice ID); no Voice adapter constructed — check vault credentials and restart');
@@ -2488,9 +2505,18 @@ async function main(): Promise<void> {
 
   // Wire coordinator tools into VoiceRuntime so spoken turns can invoke skills
   // (#1414 AC6). ExecutionLayer still enforces autonomy / outbound gates.
+  // Only advertise tools when the resolved voice model declares `tools` (#1553).
   {
     const runtime = voiceAdapter?.getRuntime();
     if (runtime) {
+      const resolvedVoiceModel = config.voiceModel ?? modelRouter.resolve('fast').model;
+      const voiceModelCaps = modelRegistry.getModel(resolvedVoiceModel)?.capabilities ?? [];
+      if (!voiceModelCaps.includes('tools')) {
+        logger.warn(
+          { voiceModel: resolvedVoiceModel },
+          'Voice runtime started without tool wiring — resolved model lacks tools capability',
+        );
+      } else {
       const coordinatorEntry = agentConfigs.find(a => a.role === 'coordinator' || a.name === 'coordinator');
       const pinResolution = coordinatorEntry
         ? resolvePinnedSkills(
@@ -2557,6 +2583,7 @@ async function main(): Promise<void> {
           };
         },
       });
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1818,19 +1818,14 @@ async function main(): Promise<void> {
     // channels.voice.model. Need both a provider that exposes stream() and a
     // registry entry advertising streaming+tools (#1553) — OpenRouter's
     // stream() alone does not prove the resolved model can duplex or tool-call.
+    // Capability check runs BEFORE resolveProviderForModel so an unknown voice
+    // override warns and disables voice instead of process.exit(1) (#1553 review).
     const voiceModel = config.voiceModel ?? modelRouter.resolve('fast').model;
-    const voiceBaseProvider = resolveProviderForModel(voiceModel, 'VoiceRuntime');
     const voiceCaps = evaluateVoiceModelCapabilities(
       voiceModel,
       modelRegistry.getModel(voiceModel)?.capabilities,
     );
-    if (typeof voiceBaseProvider.stream !== 'function') {
-      logger.warn(
-        { voiceModel, provider: voiceBaseProvider.id },
-        'Voice channel enabled but the resolved LLM provider does not support stream(); '
-        + 'voice adapter not started. Remap channels.voice.model / the fast tier to a streaming provider.',
-      );
-    } else if (!voiceCaps.ok) {
+    if (!voiceCaps.ok) {
       logger.warn(
         {
           voiceModel,
@@ -1842,6 +1837,14 @@ async function main(): Promise<void> {
         + 'Remap channels.voice.model / the fast tier to a model with streaming and tools.',
       );
     } else {
+      const voiceBaseProvider = resolveProviderForModel(voiceModel, 'VoiceRuntime');
+      if (typeof voiceBaseProvider.stream !== 'function') {
+        logger.warn(
+          { voiceModel, provider: voiceBaseProvider.id },
+          'Voice channel enabled but the resolved LLM provider does not support stream(); '
+          + 'voice adapter not started. Remap channels.voice.model / the fast tier to a streaming provider.',
+        );
+      } else {
       // Wrap in telemetry so voice turns emit llm.call cost events like every other path.
       const voiceLlmProvider = new TelemetryLlmProvider(voiceBaseProvider, bus, logger, 'voice-turn', modelRegistry);
       const voiceLivekitUrl = config.voiceLivekitUrl;
@@ -1890,6 +1893,7 @@ async function main(): Promise<void> {
         voiceModel: config.voiceModel,
         voiceRuntime,
       });
+      }
     }
   } else if (channelShouldStart.has('voice')) {
     logger.warn('channel voice is enabled + resolvable but runtime credentials are missing (LiveKit, Deepgram, Cartesia, or the Cartesia voice ID); no Voice adapter constructed — check vault credentials and restart');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1553.

Voice boot previously only checked `typeof provider.stream === 'function'`. OpenRouter implements `stream()` for every routed model, so a non-streaming / non-tool `fast`-tier remap (or `channels.voice.model` override) could pass the guard and only fail mid-call.

### Changes

- Document `streaming` and `tools` in ADR-014 capability vocabulary (+ amendment).
- Declare both on every chat `MODEL_REGISTRY` entry; embeddings stay `embedding`-only.
- Voice boot requires provider `stream()` **and** resolved-model `streaming` + `tools` (warn with model + missing caps; refuse adapter start).
- Coordinator tool wiring runs only when the resolved model has `tools`.
- Unit tests for the capability evaluator and registry declarations.

Text channels stay on non-streaming `chat()` — no behavior change there.

## Test plan

- [x] `pnpm run typecheck`
- [x] `vitest` for `model-registry.test.ts` and `voice-model-capabilities.test.ts`
- [ ] Confirm voice still boots with a streaming+tools `fast` model (e.g. DeepSeek / Claude)
- [ ] Confirm a hypothetical remap without `streaming`/`tools` logs the new warning and does not start the voice adapter

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

