### PR TITLE
feat(health): add Slack, SMS, and Voice channel liveness probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **`nylas_calendar` health check** — probes the principal calendar grant separately from email. (#1561)
+- **Slack/SMS/Voice health probes** — `/api/health` reports each when enabled. (#1567)
 
 ### Changed
 

--- a/docs/dev/health-monitoring.md
+++ b/docs/dev/health-monitoring.md
@@ -20,6 +20,9 @@ Curia exposes a three-state health endpoint and a daily credential canary that f
     "browser":   "ok | fail | skipped",
     "mcp":       { "google_workspace": "ok | fail | skipped" },
     "nylas_calendar": "ok | fail | skipped",
+    "slack":     "ok | fail | skipped",
+    "sms":       "ok | fail | skipped",
+    "voice":     "ok | fail | skipped",
     "scheduler": "ok | fail"
   }
 }
@@ -30,15 +33,25 @@ Curia exposes a three-state health endpoint and a daily credential canary that f
 | `status` | HTTP | Meaning |
 |---|---|---|
 | `ok` | 200 | All enabled checks pass |
-| `degraded` | 200 | A non-critical service is down (signal, email, browser, MCP, calendar, scheduler) |
+| `degraded` | 200 | A non-critical service is down (signal, email, browser, MCP, calendar, slack, sms, voice, scheduler) |
 | `down` | 503 | A critical service is unreachable (db or bus) — Curia cannot function |
 
 `skipped` means a check's underlying service is not configured (e.g. Signal is disabled). Skipped checks never affect the overall status.
 
+### Channel liveness probes
+
+| Check | Probe | Skipped when |
+|---|---|---|
+| `signal` | Signal-cli RPC `listGroups()` | Signal client not configured |
+| `email` | Last successful Nylas poll within stall window | Email adapter not constructed |
+| `slack` | Socket Mode `connected` (with short boot grace) | Slack adapter not constructed (disabled / no tokens) |
+| `sms` | Telnyx webhook handler installed | SMS adapter not constructed (disabled / no credentials) |
+| `voice` | LiveKit RoomService `listRooms()` on the **management** URL | Voice adapter not constructed (disabled / incomplete credentials) |
+
 ### Which checks are critical vs. non-critical
 
 **Critical (down → 503):** `db`, `bus`
-**Non-critical (degraded → 200):** `signal`, `email`, `browser`, `mcp.*`, `nylas_calendar`, `scheduler`
+**Non-critical (degraded → 200):** `signal`, `email`, `browser`, `mcp.*`, `nylas_calendar`, `slack`, `sms`, `voice`, `scheduler`
 
 Rationale: a dead Signal socket should not page as a full outage when email still works.
 

--- a/src/channels/http/routes/health.ts
+++ b/src/channels/http/routes/health.ts
@@ -42,6 +42,9 @@ export async function healthRoutes(
           browser: 'skipped' as const,
           mcp: {},
           nylas_calendar: 'skipped' as const,
+          slack: 'skipped' as const,
+          sms: 'skipped' as const,
+          voice: 'skipped' as const,
           scheduler: 'fail' as const,
         },
       });

--- a/src/channels/slack/slack-client.ts
+++ b/src/channels/slack/slack-client.ts
@@ -38,6 +38,8 @@ export class SlackClient extends EventEmitter {
   private stopping = false;
   private identity: SlackAuthIdentity | undefined;
   private started = false;
+  /** True while Socket Mode reports an active connection (#1567 health). */
+  private socketConnected = false;
 
   constructor(config: SlackClientConfig) {
     super();
@@ -55,10 +57,12 @@ export class SlackClient extends EventEmitter {
   /** Attach the Socket Mode event handlers. Called once from the constructor. */
   private registerSocketHandlers(): void {
     this.socket.on('connected', () => {
+      this.socketConnected = true;
       this.log.info('Slack Socket Mode connected');
       this.emit('connected');
     });
     this.socket.on('disconnected', () => {
+      this.socketConnected = false;
       if (this.stopping) return;
       this.log.warn('Slack Socket Mode disconnected — client will reconnect');
       this.emit('disconnected');
@@ -116,6 +120,16 @@ export class SlackClient extends EventEmitter {
     return this.identity;
   }
 
+  /** True after connect() until disconnect() — used by health probes (#1567). */
+  isStarted(): boolean {
+    return this.started;
+  }
+
+  /** True while Socket Mode is connected — used by health probes (#1567). */
+  isSocketConnected(): boolean {
+    return this.socketConnected;
+  }
+
   /**
    * Start Socket Mode. Resolves after auth.test + socket start attempt begins.
    * Does not block boot on a live Slack connection — Socket Mode reconnects
@@ -162,6 +176,7 @@ export class SlackClient extends EventEmitter {
       this.log.warn({ err }, 'Slack Socket Mode disconnect error');
     }
     this.started = false;
+    this.socketConnected = false;
     this.log.info('Slack client disconnected');
   }
 

--- a/src/channels/voice/livekit/token.ts
+++ b/src/channels/voice/livekit/token.ts
@@ -37,6 +37,31 @@ export async function mintVoiceParticipantToken(
   return token.toJwt();
 }
 
+/** Map a LiveKit URL to the HTTP(S) host RoomServiceClient expects. */
+export function toLiveKitHttpUrl(livekitManagementUrl: string): string {
+  return livekitManagementUrl
+    .replace(/^wss:/i, 'https:')
+    .replace(/^ws:/i, 'http:');
+}
+
+/**
+ * Lightweight LiveKit management reachability probe for /api/health (#1567).
+ *
+ * `livekitManagementUrl` must be the server→LiveKit HTTP(S) base (e.g.
+ * `http://livekit:7880` on the compose network), **not** the browser signaling
+ * URL (`wss://…`) — same constraint as deleteVoiceRoom (#1555 / ADR-037).
+ */
+export async function listVoiceRooms(
+  config: LiveKitTokenConfig & { livekitManagementUrl: string },
+): Promise<unknown[]> {
+  const client = new RoomServiceClient(
+    toLiveKitHttpUrl(config.livekitManagementUrl),
+    config.apiKey,
+    config.apiSecret,
+  );
+  return client.listRooms();
+}
+
 /**
  * Best-effort room teardown after a session ends so a leaked JWT cannot rejoin
  * an empty room. Failures are logged by the caller — never throw into hangup.
@@ -50,11 +75,10 @@ export async function deleteVoiceRoom(
   config: LiveKitTokenConfig & { livekitManagementUrl: string },
   roomName: string,
 ): Promise<void> {
-  // RoomServiceClient expects an HTTP(S) host. Defensively map ws(s) → http(s)
-  // if an operator pastes a WebSocket URL by mistake.
-  const httpUrl = config.livekitManagementUrl
-    .replace(/^wss:/i, 'https:')
-    .replace(/^ws:/i, 'http:');
-  const client = new RoomServiceClient(httpUrl, config.apiKey, config.apiSecret);
+  const client = new RoomServiceClient(
+    toLiveKitHttpUrl(config.livekitManagementUrl),
+    config.apiKey,
+    config.apiSecret,
+  );
   await client.deleteRoom(roomName);
 }

--- a/src/channels/voice/livekit/token.ts
+++ b/src/channels/voice/livekit/token.ts
@@ -54,10 +54,13 @@ export function toLiveKitHttpUrl(livekitManagementUrl: string): string {
 export async function listVoiceRooms(
   config: LiveKitTokenConfig & { livekitManagementUrl: string },
 ): Promise<unknown[]> {
+  // Bound the SDK request itself — Promise.race in checkVoice only stops waiting;
+  // without requestTimeout a dead LiveKit host keeps sockets open (#1567 review).
   const client = new RoomServiceClient(
     toLiveKitHttpUrl(config.livekitManagementUrl),
     config.apiKey,
     config.apiSecret,
+    { requestTimeout: 5 },
   );
   return client.listRooms();
 }

--- a/src/health/health-checks.ts
+++ b/src/health/health-checks.ts
@@ -61,6 +61,28 @@ export interface NylasCalendarClientHealth {
   listCalendars(): Promise<unknown[]>;
 }
 
+/** Slack Socket Mode surface for /api/health (#1567). */
+export interface SlackClientHealth {
+  isStarted(): boolean;
+  isSocketConnected(): boolean;
+}
+
+/**
+ * SMS channel surface for /api/health (#1567).
+ * Credentials are implied by adapter construction; liveness = webhook installed.
+ */
+export interface SmsChannelHealth {
+  isWebhookInstalled(): boolean;
+}
+
+/** LiveKit management reachability for the voice channel (#1567). */
+export interface VoiceLiveKitHealth {
+  listRooms(): Promise<unknown[]>;
+}
+
+/** Boot grace before Slack Socket Mode's first `connected` event (#1567). */
+export const SLACK_CONNECT_GRACE_MS = 60_000;
+
 // ---------------------------------------------------------------------------
 // Probe implementations
 // ---------------------------------------------------------------------------
@@ -286,6 +308,57 @@ export async function checkNylasCalendar(
       ? (err as { statusCode?: unknown }).statusCode
       : undefined;
     return { status: 'fail', authFailure: code === 401 || code === 403 };
+  }
+}
+
+/**
+ * Slack Socket Mode connection state (#1567). Non-critical.
+ * Skipped when the Slack adapter was not constructed (disabled / no credentials).
+ * Allows a short boot grace before the first `connected` event; after that,
+ * a disconnected socket is `fail` (Socket Mode reconnects are visible as degraded).
+ */
+export function checkSlack(
+  client: SlackClientHealth | undefined,
+  startedAt: Date,
+  graceMs: number = SLACK_CONNECT_GRACE_MS,
+): CheckResult {
+  if (!client) return 'skipped';
+  if (!client.isStarted()) return 'fail';
+  if (client.isSocketConnected()) return 'ok';
+  return Date.now() - startedAt.getTime() < graceMs ? 'ok' : 'fail';
+}
+
+/**
+ * SMS (Telnyx) adapter readiness (#1567). Non-critical.
+ * Skipped when the SMS adapter was not constructed. Healthy when the webhook
+ * handler is installed (adapter started) — no outbound send.
+ */
+export function checkSms(health: SmsChannelHealth | undefined): CheckResult {
+  if (!health) return 'skipped';
+  return health.isWebhookInstalled() ? 'ok' : 'fail';
+}
+
+/**
+ * Voice / LiveKit management reachability (#1567). Non-critical.
+ * Skipped when the voice adapter was not constructed. Probes listRooms() against
+ * the internal management URL (not the browser signaling URL). Hard 5s timeout.
+ */
+export async function checkVoice(
+  livekit: VoiceLiveKitHealth | undefined,
+  logger: Logger,
+): Promise<CheckResult> {
+  if (!livekit) return 'skipped';
+  try {
+    await Promise.race([
+      livekit.listRooms(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), 5_000),
+      ),
+    ]);
+    return 'ok';
+  } catch (err) {
+    logger.warn({ err }, 'checkVoice: LiveKit management probe failed');
+    return 'fail';
   }
 }
 

--- a/src/health/health-service.ts
+++ b/src/health/health-service.ts
@@ -22,8 +22,10 @@ import type { CheckResult, HealthResponse, HealthStatus, TrackerKey, CanaryResul
 import { LlmOutcomeTracker } from './llm-outcome-tracker.js';
 import {
   checkDb, checkBus, checkEmail, checkSignal, checkBrowser,
-  checkMcpServers, checkNylasCalendar, checkScheduler,
+  checkMcpServers, checkNylasCalendar, checkSlack, checkSms, checkVoice,
+  checkScheduler,
   type EmailAdapterHealth, type SignalRpcClientHealth, type BrowserServiceHealth,
+  type SlackClientHealth, type SmsChannelHealth, type VoiceLiveKitHealth,
 } from './health-checks.js';
 import type { NylasClient } from '../channels/email/nylas-client.js';
 import type { NylasCalendarClient } from '../channels/calendar/nylas-calendar-client.js';
@@ -46,6 +48,21 @@ export interface HealthServiceDeps {
   nylasCalendarClient?: Pick<NylasCalendarClient, 'listCalendars'>;
   signalRpcClient?: SignalRpcClientHealth;
   browserService?: BrowserServiceHealth;
+  /**
+   * Slack Socket Mode client when the Slack adapter was constructed (#1567).
+   * Omit (don't pass a credential-only client) when the channel is disabled.
+   */
+  slackClient?: SlackClientHealth;
+  /**
+   * SMS readiness surface when the SMS adapter was constructed (#1567).
+   * Omit when the channel is disabled / uninstalled.
+   */
+  smsHealth?: SmsChannelHealth;
+  /**
+   * LiveKit management probe when the voice adapter was constructed (#1567).
+   * Must target the internal management URL, not browser signaling.
+   */
+  voiceLiveKit?: VoiceLiveKitHealth;
   mcpSessions: McpSession[];
   /**
    * Boot outcomes for enabled MCP servers (#1500). Absent/empty → no mcp.*
@@ -188,22 +205,26 @@ export class HealthService {
     const {
       db, bus, emailAdapter, signalRpcClient, browserService,
       mcpSessions, scheduler, config, nylasCalendarClient,
+      slackClient, smsHealth, voiceLiveKit,
     } = this.deps;
     const { liveness } = config;
     const mcpServerStatuses = this.deps.mcpServerStatuses ?? new Map();
 
     // Run all async probes concurrently to keep p99 latency low.
-    const [db_check, signal_check, mcp_checks, nylas_cal] = await Promise.all([
+    const [db_check, signal_check, mcp_checks, nylas_cal, voice_check] = await Promise.all([
       checkDb(db, this.deps.logger),
       checkSignal(signalRpcClient, this.deps.logger),
       checkMcpServers(mcpServerStatuses, mcpSessions, this.deps.logger),
       checkNylasCalendar(nylasCalendarClient, this.deps.logger),
+      checkVoice(voiceLiveKit, this.deps.logger),
     ]);
 
     // Synchronous probes — no need to await.
     const bus_check = checkBus(bus);
     const browser_check = checkBrowser(browserService);
     const email_check = checkEmail(emailAdapter, liveness.emailStallFactor, this.startedAt);
+    const slack_check = checkSlack(slackClient, this.startedAt);
+    const sms_check = checkSms(smsHealth);
     const scheduler_check = checkScheduler(scheduler, liveness.schedulerMaxTickS, this.startedAt);
 
     const checks: HealthResponse['checks'] = {
@@ -214,6 +235,9 @@ export class HealthService {
       browser: browser_check,
       mcp: mcp_checks,
       nylas_calendar: nylas_cal.status,
+      slack: slack_check,
+      sms: sms_check,
+      voice: voice_check,
       scheduler: scheduler_check,
     };
 
@@ -360,6 +384,9 @@ export class HealthService {
       checks.browser,
       ...Object.values(checks.mcp),
       checks.nylas_calendar,
+      checks.slack,
+      checks.sms,
+      checks.voice,
       checks.scheduler,
     ];
     if (nonCritical.some(c => c === 'fail')) return 'degraded';

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -17,6 +17,12 @@ export interface HealthResponse {
     mcp: Record<string, CheckResult>;
     /** Principal calendar grant (`ceo_nylas_grant_id`); skipped when calendar client absent. */
     nylas_calendar: CheckResult;
+    /** Slack Socket Mode; skipped when Slack adapter not constructed (#1567). */
+    slack: CheckResult;
+    /** SMS/Telnyx webhook readiness; skipped when SMS adapter not constructed (#1567). */
+    sms: CheckResult;
+    /** Voice/LiveKit management reachability; skipped when voice adapter absent (#1567). */
+    voice: CheckResult;
     scheduler: CheckResult;
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ import { VoiceRuntime } from './channels/voice/voice-runtime.js';
 import { DeepgramSttProvider } from './channels/voice/speech/deepgram-stt.js';
 import { CartesiaTtsProvider } from './channels/voice/speech/cartesia-tts.js';
 import { LiveKitRoomSession } from './channels/voice/livekit/room-session.js';
-import { deleteVoiceRoom } from './channels/voice/livekit/token.js';
+import { deleteVoiceRoom, listVoiceRooms } from './channels/voice/livekit/token.js';
 import { loadAuthConfig } from './contacts/config-loader.js';
 import { AuthorizationService } from './contacts/authorization.js';
 import { DEFAULT_ERROR_BUDGET } from './errors/types.js';
@@ -2078,6 +2078,21 @@ async function main(): Promise<void> {
     nylasCalendarClient,
     signalRpcClient,
     browserService,
+    // Pass channel health deps only when the adapter was constructed (enabled +
+    // credentials) so disabled channels stay `skipped`, never `fail` (#1567).
+    slackClient: slackAdapter ? slackClient : undefined,
+    smsHealth: smsAdapter
+      ? { isWebhookInstalled: () => smsWebhookBridge.getHandler() !== null }
+      : undefined,
+    voiceLiveKit: voiceAdapter
+      ? {
+          listRooms: () => listVoiceRooms({
+            livekitManagementUrl: config.voiceLivekitManagementUrl,
+            apiKey: config.voiceLivekitApiKey!,
+            apiSecret: config.voiceLivekitApiSecret!,
+          }),
+        }
+      : undefined,
     mcpSessions,
     mcpServerStatuses,
     modelRoutingConfig,

--- a/tests/unit/health/health-checks.test.ts
+++ b/tests/unit/health/health-checks.test.ts
@@ -5,6 +5,9 @@ import {
   checkBrowser,
   checkEmail,
   checkScheduler,
+  checkSlack,
+  checkSms,
+  checkVoice,
 } from '../../../src/health/health-checks.js';
 import type { Logger } from '../../../src/logger.js';
 
@@ -109,5 +112,73 @@ describe('checkScheduler', () => {
   it('returns fail when last tick is stale', () => {
     const scheduler = { lastTickAt: new Date(Date.now() - 300_000) } as never;
     expect(checkScheduler(scheduler, 120, new Date(0))).toBe('fail');
+  });
+});
+
+describe('checkSlack (#1567)', () => {
+  it('returns skipped when Slack is not configured', () => {
+    expect(checkSlack(undefined, new Date())).toBe('skipped');
+  });
+
+  it('returns ok when Socket Mode is connected', () => {
+    const client = {
+      isStarted: () => true,
+      isSocketConnected: () => true,
+    };
+    expect(checkSlack(client, new Date(0))).toBe('ok');
+  });
+
+  it('returns ok within boot grace when started but not yet connected', () => {
+    const client = {
+      isStarted: () => true,
+      isSocketConnected: () => false,
+    };
+    expect(checkSlack(client, new Date(Date.now() - 5_000), 60_000)).toBe('ok');
+  });
+
+  it('returns fail past boot grace when Socket Mode is disconnected', () => {
+    const client = {
+      isStarted: () => true,
+      isSocketConnected: () => false,
+    };
+    expect(checkSlack(client, new Date(Date.now() - 120_000), 60_000)).toBe('fail');
+  });
+
+  it('returns fail when client was never started', () => {
+    const client = {
+      isStarted: () => false,
+      isSocketConnected: () => false,
+    };
+    expect(checkSlack(client, new Date())).toBe('fail');
+  });
+});
+
+describe('checkSms (#1567)', () => {
+  it('returns skipped when SMS is not configured', () => {
+    expect(checkSms(undefined)).toBe('skipped');
+  });
+
+  it('returns ok when the Telnyx webhook handler is installed', () => {
+    expect(checkSms({ isWebhookInstalled: () => true })).toBe('ok');
+  });
+
+  it('returns fail when the webhook handler is missing', () => {
+    expect(checkSms({ isWebhookInstalled: () => false })).toBe('fail');
+  });
+});
+
+describe('checkVoice (#1567)', () => {
+  it('returns skipped when voice is not configured', async () => {
+    expect(await checkVoice(undefined, stubLogger)).toBe('skipped');
+  });
+
+  it('returns ok when listRooms succeeds', async () => {
+    const livekit = { listRooms: vi.fn().mockResolvedValue([]) };
+    expect(await checkVoice(livekit, stubLogger)).toBe('ok');
+  });
+
+  it('returns fail when listRooms throws', async () => {
+    const livekit = { listRooms: vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) };
+    expect(await checkVoice(livekit, stubLogger)).toBe('fail');
   });
 });

--- a/tests/unit/health/health-service.test.ts
+++ b/tests/unit/health/health-service.test.ts
@@ -45,7 +45,7 @@ describe('HealthService.getStatus()', () => {
     expect(result.checks.db).toBe('fail');
   });
 
-  it('skips signal/email/browser when not configured', async () => {
+  it('skips signal/email/browser/slack/sms/voice when not configured', async () => {
     const svc = new HealthService(makeDeps() as never);
     const result = await svc.getStatus();
     expect(result.checks.signal).toBe('skipped');
@@ -53,6 +53,57 @@ describe('HealthService.getStatus()', () => {
     expect(result.checks.browser).toBe('skipped');
     expect(result.checks.mcp).toEqual({});
     expect(result.checks.nylas_calendar).toBe('skipped');
+    expect(result.checks.slack).toBe('skipped');
+    expect(result.checks.sms).toBe('skipped');
+    expect(result.checks.voice).toBe('skipped');
+  });
+
+  it('returns degraded when Slack client never started (#1567)', async () => {
+    // Enabled adapter that failed start → fail (not skipped). Disconnect-past-grace
+    // is covered in checkSlack unit tests.
+    const svc = new HealthService(makeDeps({
+      slackClient: {
+        isStarted: () => false,
+        isSocketConnected: () => false,
+      },
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.status).toBe('degraded');
+    expect(result.checks.slack).toBe('fail');
+  });
+
+  it('returns degraded when SMS webhook is not installed (#1567)', async () => {
+    const svc = new HealthService(makeDeps({
+      smsHealth: { isWebhookInstalled: () => false },
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.status).toBe('degraded');
+    expect(result.checks.sms).toBe('fail');
+  });
+
+  it('returns degraded when LiveKit management probe fails (#1567)', async () => {
+    const svc = new HealthService(makeDeps({
+      voiceLiveKit: { listRooms: vi.fn().mockRejectedValue(new Error('timeout')) },
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.status).toBe('degraded');
+    expect(result.checks.voice).toBe('fail');
+  });
+
+  it('reports ok for healthy Slack/SMS/Voice probes (#1567)', async () => {
+    const svc = new HealthService(makeDeps({
+      slackClient: {
+        isStarted: () => true,
+        isSocketConnected: () => true,
+      },
+      smsHealth: { isWebhookInstalled: () => true },
+      voiceLiveKit: { listRooms: vi.fn().mockResolvedValue([]) },
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.status).toBe('ok');
+    expect(result.checks.slack).toBe('ok');
+    expect(result.checks.sms).toBe('ok');
+    expect(result.checks.voice).toBe('ok');
   });
 
   it('returns degraded when an enabled MCP server booted with 0 tools (#1500)', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1567.

v0.42 shipped Slack, SMS, and Voice without `/api/health` probes, so operators got no signal when those channels were down — unlike Signal and email.

### Changes

| Check | Probe | Skipped when |
|---|---|---|
| `slack` | Socket Mode connected (60s boot grace) | Slack adapter not constructed |
| `sms` | Telnyx webhook handler installed | SMS adapter not constructed |
| `voice` | LiveKit `listRooms()` on the **management** URL | Voice adapter not constructed |

- Disabled / uninstalled channels omit the health dep → `skipped` (never `fail`).
- Failures are non-critical → overall `degraded` (HTTP 200), same as signal/email.
- Docs: `docs/dev/health-monitoring.md` updated.
- Unit tests cover healthy / failed / disabled for each probe.

## Test plan

- [x] `pnpm run typecheck`
- [x] `vitest` health unit suites
- [ ] With Slack enabled + connected: `checks.slack === "ok"`
- [ ] With SMS started: `checks.sms === "ok"`; stop adapter → `fail`
- [ ] With Voice enabled + LiveKit up: `checks.voice === "ok"`
- [ ] Disabled channels remain `skipped` and do not degrade overall status

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

