### PR TITLE
fix(console): fit dashboard and chat on mobile viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Console mobile** — dashboard/chat fit phone viewports; voice Call control polished. (#1571)
 - **`resolve-learning-digest`** — accepts a unique task-id prefix for digest resolve. (#1545)
 - **`/api/health` mcp checks** — dynamic per enabled MCP server; 0 tools → degraded. (#1500)
 

--- a/apps/console/src/components/Icons.tsx
+++ b/apps/console/src/components/Icons.tsx
@@ -146,26 +146,26 @@ export function IconPlus({ size }: IconProps) {
   );
 }
 
-export function IconSend({ size }: IconProps) {
+export function IconSend({ size, ...rest }: IconProps) {
   return (
-    <Icon size={size}>
+    <Icon size={size} {...rest}>
       <line x1="22" y1="2" x2="11" y2="13" />
       <polygon points="22 2 15 22 11 13 2 9" />
     </Icon>
   );
 }
 
-export function IconPhone({ size }: IconProps) {
+export function IconPhone({ size, ...rest }: IconProps) {
   return (
-    <Icon size={size}>
+    <Icon size={size} {...rest}>
       <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z" />
     </Icon>
   );
 }
 
-export function IconPhoneOff({ size }: IconProps) {
+export function IconPhoneOff({ size, ...rest }: IconProps) {
   return (
-    <Icon size={size}>
+    <Icon size={size} {...rest}>
       <path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7a2 2 0 0 1 1.72 2v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.42 19.42 0 0 1-3.33-2.67" />
       <path d="M5.53 9.65a19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91" />
       <line x1="23" y1="1" x2="1" y2="23" />
@@ -173,9 +173,9 @@ export function IconPhoneOff({ size }: IconProps) {
   );
 }
 
-export function IconMic({ size }: IconProps) {
+export function IconMic({ size, ...rest }: IconProps) {
   return (
-    <Icon size={size}>
+    <Icon size={size} {...rest}>
       <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
       <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
       <line x1="12" y1="19" x2="12" y2="22" />
@@ -183,9 +183,9 @@ export function IconMic({ size }: IconProps) {
   );
 }
 
-export function IconMicOff({ size }: IconProps) {
+export function IconMicOff({ size, ...rest }: IconProps) {
   return (
-    <Icon size={size}>
+    <Icon size={size} {...rest}>
       <line x1="2" y1="2" x2="22" y2="22" />
       <path d="M8.89 9.11A3 3 0 0 0 9 10v2a3 3 0 0 0 5.19 2.06" />
       <path d="M12 2a3 3 0 0 1 3 3v3.34" />

--- a/apps/console/src/components/Icons.tsx
+++ b/apps/console/src/components/Icons.tsx
@@ -155,6 +155,47 @@ export function IconSend({ size }: IconProps) {
   );
 }
 
+export function IconPhone({ size }: IconProps) {
+  return (
+    <Icon size={size}>
+      <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z" />
+    </Icon>
+  );
+}
+
+export function IconPhoneOff({ size }: IconProps) {
+  return (
+    <Icon size={size}>
+      <path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7a2 2 0 0 1 1.72 2v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.42 19.42 0 0 1-3.33-2.67" />
+      <path d="M5.53 9.65a19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91" />
+      <line x1="23" y1="1" x2="1" y2="23" />
+    </Icon>
+  );
+}
+
+export function IconMic({ size }: IconProps) {
+  return (
+    <Icon size={size}>
+      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+    </Icon>
+  );
+}
+
+export function IconMicOff({ size }: IconProps) {
+  return (
+    <Icon size={size}>
+      <line x1="2" y1="2" x2="22" y2="22" />
+      <path d="M8.89 9.11A3 3 0 0 0 9 10v2a3 3 0 0 0 5.19 2.06" />
+      <path d="M12 2a3 3 0 0 1 3 3v3.34" />
+      <path d="M19 10v2a7 7 0 0 1-9.96 6.27" />
+      <path d="M5 10v2a7 7 0 0 0 .78 3.2" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+    </Icon>
+  );
+}
+
 export function IconAutonomy({ size }: IconProps) {
   return (
     <Icon size={size}>

--- a/apps/console/src/pages/chat/ChatComposer.tsx
+++ b/apps/console/src/pages/chat/ChatComposer.tsx
@@ -1,5 +1,6 @@
 // apps/console/src/pages/chat/ChatComposer.tsx
 import { useState, useRef } from 'react';
+import { IconSend } from '../../components/Icons.js';
 
 interface ChatComposerProps {
   disabled: boolean;
@@ -62,7 +63,9 @@ export function ChatComposer({ disabled, onSend }: ChatComposerProps) {
         type="submit"
         className="btn btn-primary"
         disabled={disabled || value.trim().length === 0}
+        aria-label="Send message"
       >
+        <IconSend size={14} aria-hidden="true" />
         Send
       </button>
     </form>

--- a/apps/console/src/pages/chat/ChatThread.tsx
+++ b/apps/console/src/pages/chat/ChatThread.tsx
@@ -26,16 +26,21 @@ export function ChatThread({ messages, hasMore, loadingHistory, loadMore }: Chat
     const prev = prevCount.current;
     prevCount.current = messages.length;
     const currentLastId = messages[messages.length - 1]?.id;
+    const container = scrollRef.current;
 
     if (messages.length === 0) {
       // Nothing to scroll — thread is empty.
     } else if (prev === 0) {
       // Initial history load: jump instantly so the user lands on the newest message
       // rather than the top of the thread (where the oldest loaded message sits).
-      bottomRef.current?.scrollIntoView({ behavior: 'instant' });
+      // Scroll the messages pane only — scrollIntoView can yank the page chrome on
+      // mobile when the flex column isn't height-bounded (#1571).
+      if (container) container.scrollTop = container.scrollHeight;
     } else if (currentLastId !== lastMessageId.current) {
-      // New user/agent message appended: smooth scroll to bottom.
-      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+      // New user/agent message appended: smooth scroll to bottom within the pane.
+      if (container) {
+        container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+      }
     }
     // If prev > 0 and lastId is unchanged, history was prepended — don't scroll.
     lastMessageId.current = currentLastId;

--- a/apps/console/src/pages/chat/VoiceCallBar.test.tsx
+++ b/apps/console/src/pages/chat/VoiceCallBar.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { VoiceCallBar } from './VoiceCallBar.js';
+import type { UseVoiceCallResult } from './useVoiceCall.js';
+
+function props(overrides: Partial<UseVoiceCallResult> = {}): UseVoiceCallResult {
+  return {
+    voiceAvailable: true,
+    callState: 'idle',
+    muted: false,
+    error: null,
+    sessionId: null,
+    startCall: vi.fn(),
+    toggleMute: vi.fn(),
+    hangUp: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('VoiceCallBar (#1571)', () => {
+  it('renders a Voice start control when idle', () => {
+    const html = renderToStaticMarkup(<VoiceCallBar {...props()} />);
+    expect(html).toContain('Voice');
+    expect(html).toContain('voice-call-start');
+    expect(html).toContain('Start voice call');
+  });
+
+  it('renders connecting status with muted mute control', () => {
+    const html = renderToStaticMarkup(<VoiceCallBar {...props({ callState: 'connecting' })} />);
+    expect(html).toContain('Connecting');
+    expect(html).toContain('disabled');
+    expect(html).toContain('Hang up');
+  });
+
+  it('renders in-call mute and hang up when connected', () => {
+    const html = renderToStaticMarkup(<VoiceCallBar {...props({ callState: 'connected' })} />);
+    expect(html).toContain('Listening');
+    expect(html).toContain('Mute');
+    expect(html).toContain('Hang up');
+  });
+
+  it('renders retry when error', () => {
+    const html = renderToStaticMarkup(
+      <VoiceCallBar {...props({ callState: 'error', error: 'LiveKit unreachable' })} />,
+    );
+    expect(html).toContain('Try again');
+    expect(html).toContain('LiveKit unreachable');
+  });
+
+  it('hides when voice is unavailable and idle', () => {
+    const html = renderToStaticMarkup(
+      <VoiceCallBar {...props({ voiceAvailable: false, callState: 'idle' })} />,
+    );
+    expect(html).toBe('');
+  });
+});

--- a/apps/console/src/pages/chat/VoiceCallBar.tsx
+++ b/apps/console/src/pages/chat/VoiceCallBar.tsx
@@ -1,3 +1,9 @@
+import {
+  IconMic,
+  IconMicOff,
+  IconPhone,
+  IconPhoneOff,
+} from '../../components/Icons.js';
 import type { UseVoiceCallResult } from './useVoiceCall.js';
 
 type VoiceCallBarProps = UseVoiceCallResult;
@@ -22,20 +28,24 @@ export function VoiceCallBar({
   if (!voiceAvailable && callState === 'idle') return null;
 
   if (callState === 'idle' || callState === 'error') {
+    const retry = callState === 'error';
     return (
       <div className={`voice-call-bar ${callState}`}>
         <button
           type="button"
-          className="btn btn-secondary btn-sm"
+          className="btn btn-secondary btn-sm voice-call-start"
           onClick={() => void startCall()}
-          aria-label={callState === 'error' ? 'Try voice call again' : 'Start voice call'}
+          aria-label={retry ? 'Try voice call again' : 'Start voice call'}
         >
-          {callState === 'error' ? 'Try call again' : 'Call'}
+          <IconPhone size={14} aria-hidden="true" />
+          {retry ? 'Try again' : 'Voice'}
         </button>
         {error && <span className="voice-call-error">{error}</span>}
       </div>
     );
   }
+
+  const connecting = callState === 'connecting';
 
   return (
     <div className={`voice-call-bar ${callState}`} role="status" aria-live="polite">
@@ -47,9 +57,10 @@ export function VoiceCallBar({
         type="button"
         className="btn btn-secondary btn-sm"
         onClick={() => void toggleMute()}
-        disabled={callState !== 'connected'}
+        disabled={connecting}
         aria-label={muted ? 'Unmute microphone' : 'Mute microphone'}
       >
+        {muted ? <IconMicOff size={14} aria-hidden="true" /> : <IconMic size={14} aria-hidden="true" />}
         {muted ? 'Unmute' : 'Mute'}
       </button>
       <button
@@ -58,6 +69,7 @@ export function VoiceCallBar({
         onClick={() => void hangUp()}
         aria-label="Hang up voice call"
       >
+        <IconPhoneOff size={14} aria-hidden="true" />
         Hang up
       </button>
     </div>

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -108,7 +108,15 @@ body {
 }
 
 #root { height: 100%; }
-.app-root { height: 100vh; width: 100%; display: flex; flex-direction: row; overflow: hidden; }
+.app-root {
+  /* Prefer dynamic viewport so iOS Safari chrome doesn't push chat below the fold (#1571). */
+  height: 100%;
+  height: 100dvh;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+}
 
 /* ── 3. Sidebar ──────────────────────────────────────────────────────── */
 .sidebar {
@@ -333,7 +341,9 @@ input:focus, textarea:focus, select:focus {
 
 /* ── 8. Login page ───────────────────────────────────────────────────── */
 .login-root {
-  height: 100vh; width: 100%;
+  height: 100%;
+  height: 100dvh;
+  width: 100%;
   display: flex; align-items: center; justify-content: center;
   background: var(--app-bg);
 }
@@ -374,10 +384,21 @@ input:focus, textarea:focus, select:focus {
 }
 
 /* ── 9b. Operator home (dashboard) ───────────────────────────────────── */
-.dash-scroll { flex: 1; overflow-y: auto; padding: 24px 20px 48px; }
+.dash-scroll {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 24px 20px 48px;
+}
 .dash-inner {
-  max-width: 1180px; margin: 0 auto;
+  width: 100%;
+  max-width: min(1180px, 100%);
+  min-width: 0;
+  margin: 0 auto;
   display: flex; flex-direction: column; gap: 20px;
+  box-sizing: border-box;
 }
 
 .dash-greeting {
@@ -483,6 +504,7 @@ input:focus, textarea:focus, select:focus {
 }
 .dash-activity-text {
   flex: 1; min-width: 0; font-size: 13px; line-height: 1.45; color: var(--app-fg-muted);
+  overflow-wrap: anywhere;
 }
 .dash-activity-text strong { color: var(--app-fg); font-weight: 600; }
 
@@ -545,6 +567,16 @@ input:focus, textarea:focus, select:focus {
 
 @media (max-width: 900px) {
   .dash-scroll { padding: 18px 14px 40px; }
+}
+
+@media (max-width: 768px) {
+  .dash-scroll { padding: 16px 12px 32px; }
+  .dash-promo-media,
+  .dash-promo-body {
+    min-width: 0;
+    max-width: none;
+    flex: 1 1 100%;
+  }
 }
 
 /* ── 10. Settings shell ──────────────────────────────────────────────── */
@@ -1583,15 +1615,17 @@ table.records-table tbody tr.active td { background: transparent; }
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0; /* match .kg-layout / .records-layout — contain scroll (#1571) */
   overflow: hidden;
 }
 
 .chat-messages {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  /* Reserve scrollbar gutter symmetrically so the content column stays
-     centered even on platforms with classic (non-overlay) scrollbars. */
-  scrollbar-gutter: stable both-edges;
+  /* Reserve scrollbar gutter so the content column stays centered on desktop.
+     On narrow screens both-edges steals width and clips the composer (#1571). */
+  scrollbar-gutter: stable;
   /* On wide screens, keep content in an 800px column centered in the pane.
      max(20px, …) ensures at least 20px side padding on narrow viewports.
      Must match the composer's minimum so both clamp at the same container width. */
@@ -1704,6 +1738,9 @@ table.records-table tbody tr.active td { background: transparent; }
 .chat-input-area {
   flex: none;
   border-top: 1px solid var(--app-border);
+  background: var(--app-bg);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  min-width: 0;
 }
 
 .voice-call-bar {
@@ -1712,8 +1749,25 @@ table.records-table tbody tr.active td { background: transparent; }
   align-items: center;
   gap: 8px;
   min-height: 32px;
+  min-width: 0;
   font-size: 12px;
   color: var(--app-fg-muted);
+  box-sizing: border-box;
+}
+
+.voice-call-start {
+  border-color: color-mix(in srgb, var(--app-teal) 45%, var(--app-input-bd));
+  color: var(--app-teal);
+  background: color-mix(in srgb, var(--app-teal) 8%, var(--app-card));
+}
+.voice-call-start:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--app-teal) 14%, var(--app-card));
+  border-color: var(--app-teal);
+  color: var(--app-teal);
+}
+.voice-call-start:disabled {
+  opacity: 0.7;
+  cursor: wait;
 }
 
 .voice-call-live-dot {
@@ -1742,6 +1796,9 @@ table.records-table tbody tr.active td { background: transparent; }
 
 .chat-composer {
   flex: none;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
   /* Match the 800px column constraint of .chat-messages so the input aligns. */
   padding: 12px max(20px, calc((100% - 800px) / 2));
   border-top: 1px solid var(--app-border);
@@ -1754,15 +1811,37 @@ table.records-table tbody tr.active td { background: transparent; }
   border-top: none;
 }
 
+.chat-input-area:has(.voice-call-bar) .chat-composer {
+  padding-top: 8px;
+}
+
 /* Override the global textarea defaults for the composer. */
 .chat-composer textarea {
   flex: 1;
+  min-width: 0; /* prevent flex min-content from clipping Send (#1571) */
   width: auto;
   resize: none;
   min-height: 42px;
   max-height: 160px;
   font-family: inherit;
   font-size: 13px;
+}
+
+.chat-composer .btn {
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .chat-messages,
+  .voice-call-bar,
+  .chat-composer {
+    padding-left: max(14px, env(safe-area-inset-left, 0px));
+    padding-right: max(14px, env(safe-area-inset-right, 0px));
+  }
+
+  .chat-messages {
+    scrollbar-gutter: auto;
+  }
 }
 
 @media (max-width: 560px) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1571.

Mobile Safari showed three related console bugs: dashboard cards clipped on the right, Chat’s first viewport empty with the composer below the fold, and a bare “Call” button above a cropped Send control.

### Changes

- **Dashboard:** `min-width: 0`, `overflow-x: hidden`, `max-width: min(1180px, 100%)`, tighter mobile padding, promo flex mins reset so cards stay inside the viewport.
- **Chat shell:** `min-height: 0` on `.chat-page` / `.chat-messages` (same pattern as KG/records), `100dvh` on `.app-root`, safe-area padding on the input chrome, composer `min-width: 0` so Send isn’t clipped.
- **Scroll:** ChatThread scrolls its own pane instead of `scrollIntoView` (which yanked page chrome on mobile).
- **Voice:** Teal-accented “Voice” start control with Lucide-style icons; clear idle / connecting / in-call / error states; Send uses `IconSend`.

## Test plan

- [x] `pnpm --filter @curia/console run typecheck`
- [x] `VoiceCallBar` unit tests (idle / connecting / connected / error / hidden)
- [ ] DevTools ~390px: Home has no horizontal overflow
- [ ] DevTools ~390px: Chat shows messages + composer (+ Voice) without page scroll
- [ ] Voice start / mute / hang-up when configured; no Send clipping at 360–430px
- [ ] Desktop dashboard/chat unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ef-face-73b6-a434-9c2af7cc97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

