### PR TITLE
feat(diagnostics): add resolve-time-window for NL audit time ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`resolve-time-window`** — diagnostics agent resolves natural-language time windows for audit queries. (#1592)
 - **`nylas_calendar` health check** — probes the principal calendar grant separately from email. (#1561)
 - **Slack/SMS/Voice health probes** — `/api/health` reports each when enabled. (#1567)
 - **Model registry** — `streaming`/`tools` capabilities; voice boot gates on them. (#1553)

--- a/agents/diagnostics.yaml
+++ b/agents/diagnostics.yaml
@@ -1,5 +1,5 @@
 name: diagnostics
-version: "0.3.0"
+version: "0.4.0"
 role: specialist
 description: >-
   Read-only forensic investigator for the PRINCIPAL. Diagnoses "what happened /
@@ -32,9 +32,17 @@ system_prompt: |
 
   ## Your tools
 
-  - **date-resolve** — turn a natural time reference ("8:01am today", "last
-    Tuesday morning") into concrete ISO timestamps before querying. Do this first
-    whenever the question is time-anchored rather than ID-anchored.
+  - **resolve-time-window** — turn a natural time reference ("around 11:44am",
+    "8-9am yesterday", "yesterday", "last 2 hours") into concrete `since`/`until`
+    ISO timestamps that `audit-query` accepts. Do this first whenever the
+    question is time-anchored rather than ID-anchored. Never hand-format
+    timestamps yourself — pass the tool's `since`/`until` straight through, and
+    check its `interpretation` so a wrong-timezone or off-by-a-day window is
+    visible.
+  - **date-resolve** — calendar-date helper only. Resolves or verifies a
+    day-of-week for an absolute or relative *date* ("next Monday", "May 19,
+    2026"). It returns a date-only string, not a timestamp — do **not** use it
+    to build `audit-query` `since`/`until` windows (use `resolve-time-window`).
   - **audit-query** — read the append-only `audit_log`. Anchor on an `event_id`,
     a blocked-message `block_id`, a `conversation_id`, a `task_id`, one or more
     `event_types`, structured dimensions (`outcome`, `target_type`/`target_id`,
@@ -67,8 +75,9 @@ system_prompt: |
   ## How to investigate
 
   1. **Anchor.** Pull the specific thing out of the question — an ID, or a
-     time window (resolve it with date-resolve first). If only a symptom is
-     given, pick the narrowest scope you can (a conversation, a task, a window).
+     time window (resolve it with resolve-time-window first). If only a symptom
+     is given, pick the narrowest scope you can (a conversation, a task, a
+     window).
   2. **Widen, then correlate.** `audit_log` tells you *what fired*; the ops
      tables tell you *what the agent knew and intended*. Real diagnoses come from
      joining them — e.g. a scheduler double-fire shows up as two `scheduled_jobs`

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@slack/web-api": "^8.0.0",
     "ajv": "^8.20.0",
     "chokidar": "^5.0.0",
+    "chrono-node": "^2.10.1",
     "cose-base": "^2.2.0",
     "cron-parser": "^5.6.2",
     "cytoscape": "^3.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
+      chrono-node:
+        specifier: ^2.10.1
+        version: 2.10.1
       cose-base:
         specifier: ^2.2.0
         version: 2.2.0
@@ -2522,6 +2525,10 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chrono-node@2.10.1:
+    resolution: {integrity: sha512-tPOsBzYVAK5zth+CiHCgp5NGeqRc4mMD8FPthQ5IxkgjPWWxIFdM5odnmfw//IRAzl6C++Xy8olQW7wn5qBR1g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -7819,6 +7826,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chrono-node@2.10.1: {}
 
   cli-cursor@5.0.0:
     dependencies:

--- a/skills/diagnostics/SKILL.md
+++ b/skills/diagnostics/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: diagnostics
 description: >
-  Read-only ops diagnostics — audit-query, audit-trace, and ops-lookup.
-version: "0.1.0"
+  Read-only ops diagnostics — resolve-time-window, audit-query, audit-trace, and ops-lookup.
+version: "0.2.0"
 tools:
+  - resolve-time-window
   - audit-query
   - audit-trace
   - ops-lookup

--- a/skills/diagnostics/tools/resolve-time-window/handler.test.ts
+++ b/skills/diagnostics/tools/resolve-time-window/handler.test.ts
@@ -1,0 +1,186 @@
+// skills/diagnostics/tools/resolve-time-window/handler.test.ts
+//
+// Pure-computation tests for the diagnostics time-window resolver (#1592).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ResolveTimeWindowHandler } from './handler.js';
+import type { ToolContext } from '../../../../src/skills/types.js';
+import { DateTime, Settings } from 'luxon';
+import pino from 'pino';
+
+/** Mirror of audit-query's since/until validator — emitted values must pass it. */
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function makeCtx(input: Record<string, unknown>, timezone = 'America/Toronto'): ToolContext {
+  return {
+    input,
+    timezone,
+    log: pino({ level: 'silent' }),
+  } as unknown as ToolContext;
+}
+
+function expectAuditIso(value: unknown): asserts value is string {
+  expect(typeof value).toBe('string');
+  expect(value).toMatch(ISO_DATETIME_RE);
+  expect(Number.isNaN(new Date(value as string).getTime())).toBe(false);
+}
+
+const handler = new ResolveTimeWindowHandler();
+
+describe('ResolveTimeWindowHandler', () => {
+  // Fixed "now": Mon Jul 27, 2026 11:44 AM EDT (America/Toronto, UTC-4).
+  const fixedMs = DateTime.fromISO('2026-07-27T11:44:00', { zone: 'America/Toronto' }).toMillis();
+
+  beforeEach(() => {
+    Settings.now = () => fixedMs;
+  });
+
+  afterEach(() => {
+    Settings.now = () => Date.now();
+  });
+
+  it('returns error when expression is missing', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/expression/i);
+      expect(result.error).toMatch(/supported forms/i);
+    }
+  });
+
+  it('returns error for unparseable input with supported forms', async () => {
+    const result = await handler.execute(makeCtx({ expression: 'not a time at all xyzzy' }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/could not parse/i);
+      expect(result.error).toMatch(/supported forms/i);
+    }
+  });
+
+  it('returns error for non-positive default_window_minutes', async () => {
+    const result = await handler.execute(
+      makeCtx({ expression: 'around 11:44am', default_window_minutes: 0 }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/default_window_minutes/i);
+  });
+
+  it('resolves a point-in-time expression to ±30 minutes by default', async () => {
+    const result = await handler.execute(makeCtx({ expression: 'around 11:44am' }));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const data = result.data as Record<string, unknown>;
+    expectAuditIso(data.since);
+    expectAuditIso(data.until);
+    expect(data.since).toBe('2026-07-27T11:14:00-04:00');
+    expect(data.until).toBe('2026-07-27T12:14:00-04:00');
+    expect(data.interpretation).toMatch(/11:14\s*AM/i);
+    expect(data.interpretation).toMatch(/12:14\s*PM/i);
+    expect(typeof data.displayTimezone).toBe('string');
+    expect(data.displayTimezone).toMatch(/UTC/);
+  });
+
+  it('honors custom default_window_minutes for point-in-time', async () => {
+    const result = await handler.execute(
+      makeCtx({ expression: 'around 11:44am', default_window_minutes: 15 }),
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const data = result.data as Record<string, unknown>;
+    expectAuditIso(data.since);
+    expectAuditIso(data.until);
+    expect(data.since).toBe('2026-07-27T11:29:00-04:00');
+    expect(data.until).toBe('2026-07-27T11:59:00-04:00');
+  });
+
+  it('resolves an explicit range to the stated bounds', async () => {
+    const result = await handler.execute(makeCtx({ expression: '8-9am yesterday' }));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const data = result.data as Record<string, unknown>;
+    expectAuditIso(data.since);
+    expectAuditIso(data.until);
+    expect(data.since).toBe('2026-07-26T08:00:00-04:00');
+    expect(data.until).toBe('2026-07-26T09:00:00-04:00');
+    expect(data.interpretation).toMatch(/8:00\s*AM/i);
+    expect(data.interpretation).toMatch(/9:00\s*AM/i);
+  });
+
+  it('resolves a whole-day expression to start-of-day through end-of-day', async () => {
+    const result = await handler.execute(makeCtx({ expression: 'yesterday' }));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const data = result.data as Record<string, unknown>;
+    expectAuditIso(data.since);
+    expectAuditIso(data.until);
+    expect(data.since).toBe('2026-07-26T00:00:00-04:00');
+    expect(data.until).toBe('2026-07-26T23:59:59-04:00');
+  });
+
+  it('resolves last Tuesday as a whole local day', async () => {
+    // Fixed now is Monday Jul 27 → last Tuesday is Jul 21.
+    const result = await handler.execute(makeCtx({ expression: 'last Tuesday' }));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const data = result.data as Record<string, unknown>;
+    expectAuditIso(data.since);
+    expectAuditIso(data.until);
+    expect(data.since).toBe('2026-07-21T00:00:00-04:00');
+    expect(data.until).toBe('2026-07-21T23:59:59-04:00');
+  });
+
+  it('resolves "last 2 hours" as [now-2h, now]', async () => {
+    const result = await handler.execute(makeCtx({ expression: 'last 2 hours' }));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const data = result.data as Record<string, unknown>;
+    expectAuditIso(data.since);
+    expectAuditIso(data.until);
+    expect(data.since).toBe('2026-07-27T09:44:00-04:00');
+    expect(data.until).toBe('2026-07-27T11:44:00-04:00');
+  });
+
+  it('emits DST-correct offsets for the same wall clock in winter vs summer', async () => {
+    // Summer (EDT, UTC-4) — already fixed above.
+    const summer = await handler.execute(makeCtx({ expression: 'around 11:44am' }));
+    expect(summer.success).toBe(true);
+    if (!summer.success) return;
+    const summerData = summer.data as Record<string, unknown>;
+    expect(summerData.since).toBe('2026-07-27T11:14:00-04:00');
+
+    // Winter (EST, UTC-5): Thu Jan 15, 2026 11:44 AM.
+    const winterMs = DateTime.fromISO('2026-01-15T11:44:00', { zone: 'America/Toronto' }).toMillis();
+    Settings.now = () => winterMs;
+
+    const winter = await handler.execute(makeCtx({ expression: 'around 11:44am' }));
+    expect(winter.success).toBe(true);
+    if (!winter.success) return;
+    const winterData = winter.data as Record<string, unknown>;
+    expectAuditIso(winterData.since);
+    expectAuditIso(winterData.until);
+    expect(winterData.since).toBe('2026-01-15T11:14:00-05:00');
+    expect(winterData.until).toBe('2026-01-15T12:14:00-05:00');
+  });
+
+  it('falls back to UTC when timezone is not configured', async () => {
+    const ctx = makeCtx({ expression: 'around 11:44am' });
+    (ctx as unknown as Record<string, unknown>).timezone = undefined;
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const data = result.data as Record<string, unknown>;
+    expectAuditIso(data.since);
+    expectAuditIso(data.until);
+    // Without ctx.timezone, wall-clock "11:44am" is interpreted in UTC.
+    expect(data.since).toBe('2026-07-27T11:14:00+00:00');
+    expect(data.until).toBe('2026-07-27T12:14:00+00:00');
+    expect(data.displayTimezone).toBeNull();
+  });
+});

--- a/skills/diagnostics/tools/resolve-time-window/handler.ts
+++ b/skills/diagnostics/tools/resolve-time-window/handler.ts
@@ -1,0 +1,216 @@
+// skills/diagnostics/tools/resolve-time-window/handler.ts
+//
+// Resolve a fuzzy natural-language time reference into a concrete ISO time
+// window for audit-query (#1592). Uses chrono-node for NL parsing and luxon for
+// timezone-correct, DST-aware ISO formatting against ctx.timezone.
+//
+// Pure computation. No external services, no side effects.
+
+import * as chrono from 'chrono-node';
+import { DateTime } from 'luxon';
+import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
+import { formatDisplayTimezone } from '../../../../src/time/timestamp.js';
+
+/** Same shape audit-query requires for since/until. */
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const DEFAULT_WINDOW_MINUTES = 30;
+
+const SUPPORTED_FORMS =
+  'Supported forms: point-in-time ("around 11:44am", "8:01am today"), ' +
+  'explicit ranges ("8-9am yesterday"), whole days ("yesterday", "last Tuesday"), ' +
+  'and recent relative windows ("last 2 hours", "past 30 minutes").';
+
+function toAuditIso(dt: DateTime): string {
+  // Prefer seconds + offset without fractional ms so the string stays tidy while
+  // still matching audit-query's ISO_DATETIME_RE.
+  const iso = dt.set({ millisecond: 0 }).toFormat("yyyy-MM-dd'T'HH:mm:ssZZ");
+  if (!ISO_DATETIME_RE.test(iso)) {
+    // Defensive fallback — luxon's toISO always includes offset for zoned DateTimes.
+    const fallback = dt.toISO();
+    if (!fallback || !ISO_DATETIME_RE.test(fallback)) {
+      throw new Error(`resolve-time-window: failed to format ISO datetime for ${dt.toString()}`);
+    }
+    return fallback;
+  }
+  return iso;
+}
+
+/**
+ * Build a luxon DateTime from chrono components in the caller's IANA zone.
+ * Prefer component wall-clock values over chrono's JS Date — that Date is
+ * timezone-offset sensitive and can mis-handle DST transitions.
+ */
+function componentsToDateTime(components: chrono.ParsedComponents, zone: string): DateTime {
+  const year = components.get('year');
+  const month = components.get('month');
+  const day = components.get('day');
+  if (year === null || month === null || day === null) {
+    throw new Error('resolve-time-window: chrono result missing year/month/day');
+  }
+  return DateTime.fromObject(
+    {
+      year,
+      month,
+      day,
+      hour: components.get('hour') ?? 0,
+      minute: components.get('minute') ?? 0,
+      second: components.get('second') ?? 0,
+      millisecond: 0,
+    },
+    { zone },
+  );
+}
+
+function formatInterpretation(since: DateTime, until: DateTime): string {
+  const abbr = since.toFormat('ZZZZ');
+  if (since.hasSame(until, 'day')) {
+    return `${since.toFormat('h:mm a')} to ${until.toFormat('h:mm a')} ${abbr}, ${since.toFormat('MMM d')}`;
+  }
+  return `${since.toFormat('h:mm a MMM d')} to ${until.toFormat('h:mm a MMM d')} ${abbr}`;
+}
+
+/** True when the expression names a backward-looking duration ending at "now". */
+function isRecentRelativeWindow(expression: string, result: chrono.ParsedResult): boolean {
+  if (!/^\s*(last|past)\b/i.test(expression)) return false;
+  // Chrono tags relative duration parses (e.g. "last 2 hours") this way.
+  return result.start.tags().has('result/relativeDateAndTime');
+}
+
+export class ResolveTimeWindowHandler implements ToolHandler {
+  async execute(ctx: ToolContext): Promise<ToolResult> {
+    const input = (ctx.input ?? {}) as Record<string, unknown>;
+    const expression = typeof input.expression === 'string' ? input.expression.trim() : '';
+
+    if (!expression) {
+      return {
+        success: false,
+        error: `Provide 'expression' (a natural-language time reference). ${SUPPORTED_FORMS}`,
+      };
+    }
+
+    let windowMinutes = DEFAULT_WINDOW_MINUTES;
+    if (input.default_window_minutes !== undefined) {
+      if (
+        typeof input.default_window_minutes !== 'number' ||
+        !Number.isFinite(input.default_window_minutes) ||
+        input.default_window_minutes <= 0
+      ) {
+        return {
+          success: false,
+          error: 'default_window_minutes must be a positive number',
+        };
+      }
+      windowMinutes = input.default_window_minutes;
+    }
+
+    const timezone = ctx.timezone ?? 'UTC';
+    const now = DateTime.now().setZone(timezone);
+    if (!now.isValid) {
+      return { success: false, error: `Invalid timezone: "${timezone}"` };
+    }
+
+    let results: chrono.ParsedResult[];
+    try {
+      results = chrono.parse(expression, {
+        instant: now.toJSDate(),
+        timezone: now.offset,
+      });
+    } catch (err) {
+      ctx.log.error({ err, expression }, 'resolve-time-window: chrono parse threw');
+      return {
+        success: false,
+        error: `Could not parse time expression: "${expression}". ${SUPPORTED_FORMS}`,
+      };
+    }
+
+    const parsed = results[0];
+    if (!parsed) {
+      return {
+        success: false,
+        error: `Could not parse time expression: "${expression}". ${SUPPORTED_FORMS}`,
+      };
+    }
+
+    let since: DateTime;
+    let until: DateTime;
+
+    try {
+      if (parsed.end) {
+        // Explicit range ("8-9am yesterday") — use the stated bounds.
+        since = componentsToDateTime(parsed.start, timezone);
+        until = componentsToDateTime(parsed.end, timezone);
+      } else if (parsed.start.isCertain('hour')) {
+        const center = componentsToDateTime(parsed.start, timezone);
+        if (isRecentRelativeWindow(expression, parsed) && center < now) {
+          // "last 2 hours" / "past 30 minutes" → [then, now].
+          since = center;
+          until = now.set({ millisecond: 0 });
+        } else {
+          // Point-in-time → center ± windowMinutes.
+          since = center.minus({ minutes: windowMinutes });
+          until = center.plus({ minutes: windowMinutes });
+        }
+      } else {
+        // Date-only / whole-day ("yesterday", "last Tuesday") — start..end of day.
+        const day = componentsToDateTime(parsed.start, timezone).startOf('day');
+        since = day;
+        // 23:59:59 local — keeps seconds clean for audit-query's regex.
+        until = day.plus({ days: 1 }).minus({ seconds: 1 });
+      }
+    } catch (err) {
+      ctx.log.error({ err, expression }, 'resolve-time-window: failed to build window');
+      return {
+        success: false,
+        error: `Could not resolve time expression: "${expression}". ${SUPPORTED_FORMS}`,
+      };
+    }
+
+    if (!since.isValid || !until.isValid) {
+      return {
+        success: false,
+        error: `Could not resolve time expression: "${expression}". ${SUPPORTED_FORMS}`,
+      };
+    }
+
+    if (until <= since) {
+      return {
+        success: false,
+        error: `Resolved window is empty or inverted for "${expression}" (since >= until). Try a more specific expression.`,
+      };
+    }
+
+    let sinceIso: string;
+    let untilIso: string;
+    try {
+      sinceIso = toAuditIso(since);
+      untilIso = toAuditIso(until);
+    } catch (err) {
+      ctx.log.error({ err, expression }, 'resolve-time-window: ISO format failed');
+      return {
+        success: false,
+        error: `Could not format timestamps for "${expression}". ${SUPPORTED_FORMS}`,
+      };
+    }
+
+    const interpretation = formatInterpretation(since, until);
+    const displayTimezone = ctx.timezone
+      ? formatDisplayTimezone(ctx.timezone, since.toJSDate())
+      : null;
+
+    ctx.log.info(
+      { expression, since: sinceIso, until: untilIso, interpretation },
+      'resolve-time-window: resolved',
+    );
+
+    return {
+      success: true,
+      data: {
+        since: sinceIso,
+        until: untilIso,
+        interpretation,
+        displayTimezone,
+      },
+    };
+  }
+}

--- a/skills/diagnostics/tools/resolve-time-window/tool.json
+++ b/skills/diagnostics/tools/resolve-time-window/tool.json
@@ -1,0 +1,22 @@
+{
+  "name": "resolve-time-window",
+  "description": "Resolve a natural-language time reference into a concrete ISO time window for audit-query. Use this for any time-anchored diagnostics question ('around 11:44am', '8-9am yesterday', 'yesterday', 'last 2 hours') instead of hand-formatting timestamps. Returns since/until as strict zone-bearing ISO 8601 strings that audit-query accepts, plus a human-readable interpretation so wrong windows are visible.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "expression": "string (natural-language time reference, e.g. 'around 11:44am', '8-9am yesterday', 'yesterday', 'last 2 hours')",
+    "default_window_minutes": "number? (half-width for point-in-time expressions; default 30)"
+  },
+  "outputs": {
+    "since": "string (ISO 8601 datetime with seconds and timezone offset)",
+    "until": "string (ISO 8601 datetime with seconds and timezone offset)",
+    "interpretation": "string (human-readable window echo, e.g. '11:14 AM to 12:14 PM EDT, Jul 27')",
+    "displayTimezone": "string? (human-readable timezone label, e.g. 'EDT (UTC-04:00)')"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 5000,
+  "capabilities": [],
+  "allowed_callers": ["diagnostics"]
+}

--- a/tests/unit/agents/resolved-pins-regression.test.ts
+++ b/tests/unit/agents/resolved-pins-regression.test.ts
@@ -124,9 +124,16 @@ function resolveAgent(agentFile: string): string[] {
 }
 
 describe('resolved pin sets after #1494 bundling', () => {
-  it('diagnostics resolves only the three read-only query tools + date-resolve + request-clarification', () => {
+  it('diagnostics resolves query tools + resolve-time-window + date-resolve + request-clarification', () => {
     expect(resolveAgent('diagnostics.yaml')).toEqual(
-      ['audit-query', 'audit-trace', 'date-resolve', 'ops-lookup', 'request-clarification'].sort(),
+      [
+        'audit-query',
+        'audit-trace',
+        'date-resolve',
+        'ops-lookup',
+        'request-clarification',
+        'resolve-time-window',
+      ].sort(),
     );
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1592.

The diagnostics agent could not run time-windowed `audit-query` lookups: `date-resolve` only returns calendar dates, while `audit-query` requires zone-bearing ISO datetimes with seconds. The agent was left hand-formatting timestamps and repeatedly failed validation.

This adds a diagnostics-scoped **`resolve-time-window`** tool that turns natural-language time references into concrete `since`/`until` strings `audit-query` accepts.

### Changes

- New tool at `skills/diagnostics/tools/resolve-time-window/` (`chrono-node` + luxon)
  - Point-in-time → ±30 minutes (overridable via `default_window_minutes`)
  - Explicit ranges → stated bounds
  - Whole-day expressions → start-of-day to end-of-day in `ctx.timezone`
  - Recent relatives (`last 2 hours`) → `[then, now]`
  - Returns `interpretation` + `displayTimezone`; unparseable inputs return `{ success: false, error }`
- Diagnostics `SKILL.md` lists the new tool; agent prompt documents it and corrects the `date-resolve` description
- Versions: tool `0.1.0`, diagnostics skill `0.2.0`, diagnostics agent `0.4.0`
- Dependency: `chrono-node@^2.10.1`

### Testing

- Unit tests cover point / range / whole-day / DST offset / custom window / unparseable / audit-query ISO regex compliance
- `pnpm exec vitest run skills/diagnostics/tools/resolve-time-window/handler.test.ts`
- `pnpm run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-589c215d-2629-4956-91fd-f0f04fcbcba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-589c215d-2629-4956-91fd-f0f04fcbcba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

