### PR TITLE
fix(voice): inject active outbound-context into spoken turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Voice** — injects active outbound-context so spoken turns see recent cross-channel sends. (#1594)
 - **`calendar-list-events`** — all-calendar 401/403 failures name grant reconnect action. (#1561)
 - **Tool schemas** — emit union inputs as `anyOf` so Gemini/OpenRouter accept them. (#1508)
 - **Slack decode** — unescape `&amp;` last so `&amp;lt;` stays literal `&lt;`. (#1569)

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EventBus } from '../../bus/bus.js';
 import type { BusEvent } from '../../bus/events.js';
-import type { OutboundContextRow, OutboundContextService } from '../../dispatch/outbound-context.js';
+import type { OutboundContextRow } from '../../dispatch/outbound-context.js';
+import { OutboundContextService } from '../../dispatch/outbound-context.js';
 import { createSilentLogger } from '../../logger.js';
 import type { LLMProvider, LLMResponse, LLMStreamEvent, Message } from '../../agents/llm/provider.js';
 import { WorkingMemory } from '../../memory/working-memory.js';
@@ -861,44 +862,46 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
     released: false,
   };
 
-  /** Minimal OutboundContextService stand-in that formats like the real service. */
+  /**
+   * OutboundContextService stand-in that stubs getActive but uses the real
+   * formatInjectionBlock (pure — pool is unused) so prompt assembly exercises
+   * the same trailing-whitespace shape production does.
+   */
   function fakeOutboundContext(opts: {
     entries?: OutboundContextRow[];
     getActive?: () => Promise<OutboundContextRow[]>;
   }): OutboundContextService {
     const entries = opts.entries ?? [];
-    return {
-      getActive: opts.getActive ?? (async () => entries),
-      formatInjectionBlock(active: OutboundContextRow[], originalContent: string): string | null {
-        if (active.length === 0) return null;
-        const blocks = active.map(e =>
-          [
-            '---',
-            `entry_id: ${e.id}`,
-            `[sent just now via ${e.channelId}, on behalf of ${e.agentId}, expires in 6h]`,
-            `preview: "${e.contentPreview}"`,
-            '---',
-          ].join('\n'),
-        );
-        return [
-          '[ACTIVE OUTBOUND CONTEXT — messages you\'ve sent that may receive replies]',
-          ...blocks,
-          '',
-          originalContent,
-        ].join('\n');
-      },
-    } as unknown as OutboundContextService;
+    const real = new OutboundContextService(
+      // formatInjectionBlock is pure; getActive is overridden below.
+      { query: async () => ({ rows: [] }) } as never,
+      logger,
+    );
+    real.getActive = opts.getActive ?? (async () => entries);
+    return real;
   }
 
-  it('buildVoiceSystemPrompt appends the outbound-context block before the time block', () => {
+  it('buildVoiceSystemPrompt appends a real formatInjectionBlock before the time block', () => {
+    const real = new OutboundContextService(
+      { query: async () => ({ rows: [] }) } as never,
+      logger,
+    );
+    const preamble = real.formatInjectionBlock([signalAlertEntry], '');
+    expect(preamble).not.toBeNull();
+    // Voice trims the trailing blank line left by originalContent === ''.
+    const outboundContextBlock = preamble!.trimEnd();
+    expect(outboundContextBlock.endsWith('---')).toBe(true);
+    expect(outboundContextBlock).not.toMatch(/\n\n$/);
+
     const prompt = buildVoiceSystemPrompt({
       identityBlock: '## Identity\nYou are Vera.',
-      outboundContextBlock:
-        '[ACTIVE OUTBOUND CONTEXT — messages you\'ve sent that may receive replies]\n---\nentry_id: e1\n---',
+      outboundContextBlock,
       timeContextBlock: '## Current Date & Time\nTimezone: America/Toronto',
     });
     expect(prompt).toContain('[ACTIVE OUTBOUND CONTEXT');
-    expect(prompt).toContain('entry_id: e1');
+    expect(prompt).toContain('entry_id: entry-signal-alert');
+    expect(prompt).toContain('via signal');
+    expect(prompt).toContain('Google security alert: new sign-in on your account.');
     expect(prompt.indexOf('[ACTIVE OUTBOUND CONTEXT'))
       .toBeLessThan(prompt.indexOf('## Current Date & Time'));
     // Empty outbound → identical to the slim path without that section.
@@ -988,6 +991,34 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
 
     const system = llm.seenMessages[0]![0]!;
     expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}`);
+    expect(transport.publishedFrames.length).toBeGreaterThan(0);
+  });
+
+  it('skips injection and still speaks when getActive exceeds the voice deadline', async () => {
+    const llm = new FakeStreamProvider([reply('Still speaking.')]);
+    const outbound = fakeOutboundContext({
+      // Never settles — only the deadline can unblock the turn.
+      getActive: () => new Promise(() => {}),
+    });
+    const { runtime, stt, transport } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      outboundContextService: outbound,
+      historyReadTimeoutMs: 40,
+    });
+
+    await runtime.startSession({
+      sessionId: 'oc4',
+      conversationId: 'voice:oc4',
+      roomName: 'voice-oc4',
+      agentToken: 'tok',
+    });
+    stt.emit({ text: 'did you message me', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('oc4');
+
+    const system = llm.seenMessages[0]![0]!;
+    expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}`);
+    expect(system.content).not.toContain('[ACTIVE OUTBOUND CONTEXT');
     expect(transport.publishedFrames.length).toBeGreaterThan(0);
   });
 });

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EventBus } from '../../bus/bus.js';
 import type { BusEvent } from '../../bus/events.js';
+import type { OutboundContextRow, OutboundContextService } from '../../dispatch/outbound-context.js';
 import { createSilentLogger } from '../../logger.js';
 import type { LLMProvider, LLMResponse, LLMStreamEvent, Message } from '../../agents/llm/provider.js';
 import { WorkingMemory } from '../../memory/working-memory.js';
 import {
   VoiceRuntime,
+  buildVoiceSystemPrompt,
   VOICE_SYSTEM_ADDENDUM,
   VOICE_TOOL_RESULT_POLICY,
   VOICE_DELEGATION_GUIDANCE,
@@ -142,6 +144,7 @@ function makeRuntime(overrides: {
   workingMemory?: WorkingMemory;
   timezone?: string;
   historyReadTimeoutMs?: number;
+  outboundContextService?: OutboundContextService;
   /** Late-bound coordinator bridge (tools + context providers), applied via configureTools(). */
   bridge?: VoiceToolBridge;
 }) {
@@ -172,6 +175,7 @@ function makeRuntime(overrides: {
     workingMemory: overrides.workingMemory,
     timezone: overrides.timezone,
     historyReadTimeoutMs: overrides.historyReadTimeoutMs,
+    outboundContextService: overrides.outboundContextService,
   });
   if (overrides.bridge) runtime.configureTools(overrides.bridge);
   return { runtime, bus, events, stt, transport, tts, store };
@@ -834,5 +838,156 @@ describe('VoiceRuntime brain/context parity (#1551)', () => {
     // The spoken answer reflects the delegated result and lands in the shared history.
     const history = await wm.getHistory('voice:cal1', 'coordinator');
     expect(history[history.length - 1]).toEqual({ role: 'assistant', content: spoken });
+  });
+});
+
+describe('VoiceRuntime outbound-context bridge (#1594)', () => {
+  const reply = (text: string): LLMStreamEvent[] => [
+    { type: 'text_delta', text: `${text} ` },
+    { type: 'message_end', content: text, usage, provenance },
+  ];
+
+  const signalAlertEntry: OutboundContextRow = {
+    id: 'entry-signal-alert',
+    conversationId: 'signal:ceo',
+    channelId: 'signal',
+    agentId: 'coordinator',
+    contentPreview: 'Google security alert: new sign-in on your account.',
+    expectedReply: null,
+    delegationHint: null,
+    metadata: { subject: 'security-alert' },
+    createdAt: new Date(Date.now() - 2 * 60 * 1000),
+    expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1000),
+    released: false,
+  };
+
+  /** Minimal OutboundContextService stand-in that formats like the real service. */
+  function fakeOutboundContext(opts: {
+    entries?: OutboundContextRow[];
+    getActive?: () => Promise<OutboundContextRow[]>;
+  }): OutboundContextService {
+    const entries = opts.entries ?? [];
+    return {
+      getActive: opts.getActive ?? (async () => entries),
+      formatInjectionBlock(active: OutboundContextRow[], originalContent: string): string | null {
+        if (active.length === 0) return null;
+        const blocks = active.map(e =>
+          [
+            '---',
+            `entry_id: ${e.id}`,
+            `[sent just now via ${e.channelId}, on behalf of ${e.agentId}, expires in 6h]`,
+            `preview: "${e.contentPreview}"`,
+            '---',
+          ].join('\n'),
+        );
+        return [
+          '[ACTIVE OUTBOUND CONTEXT — messages you\'ve sent that may receive replies]',
+          ...blocks,
+          '',
+          originalContent,
+        ].join('\n');
+      },
+    } as unknown as OutboundContextService;
+  }
+
+  it('buildVoiceSystemPrompt appends the outbound-context block before the time block', () => {
+    const prompt = buildVoiceSystemPrompt({
+      identityBlock: '## Identity\nYou are Vera.',
+      outboundContextBlock:
+        '[ACTIVE OUTBOUND CONTEXT — messages you\'ve sent that may receive replies]\n---\nentry_id: e1\n---',
+      timeContextBlock: '## Current Date & Time\nTimezone: America/Toronto',
+    });
+    expect(prompt).toContain('[ACTIVE OUTBOUND CONTEXT');
+    expect(prompt).toContain('entry_id: e1');
+    expect(prompt.indexOf('[ACTIVE OUTBOUND CONTEXT'))
+      .toBeLessThan(prompt.indexOf('## Current Date & Time'));
+    // Empty outbound → identical to the slim path without that section.
+    expect(buildVoiceSystemPrompt({})).toBe(
+      `${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}`,
+    );
+  });
+
+  it('injects an active Signal outbound-context entry into the spoken-turn system prompt', async () => {
+    const llm = new FakeStreamProvider([reply('Yes, I messaged you on Signal about the Google alert.')]);
+    const outbound = fakeOutboundContext({ entries: [signalAlertEntry] });
+    const { runtime, stt } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      outboundContextService: outbound,
+    });
+
+    await runtime.startSession({
+      sessionId: 'oc1',
+      conversationId: 'voice:oc1',
+      roomName: 'voice-oc1',
+      agentToken: 'tok',
+    });
+    stt.emit({ text: 'did you message me', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('oc1');
+
+    const system = llm.seenMessages[0]![0]!;
+    const systemText = typeof system.content === 'string' ? system.content : '';
+    expect(systemText).toContain('[ACTIVE OUTBOUND CONTEXT');
+    expect(systemText).toContain('entry_id: entry-signal-alert');
+    expect(systemText).toContain('via signal');
+    expect(systemText).toContain('Google security alert: new sign-in on your account.');
+    // Utterance stays a separate user message — not wrapped into the system block.
+    expect(llm.seenMessages[0]![llm.seenMessages[0]!.length - 1]).toEqual({
+      role: 'user',
+      content: 'did you message me',
+    });
+    expect(systemText).not.toContain('did you message me');
+  });
+
+  it('leaves the system prompt unchanged when getActive returns no entries', async () => {
+    const llm = new FakeStreamProvider([reply('Hi.')]);
+    const getActive = vi.fn(async () => [] as OutboundContextRow[]);
+    const outbound = fakeOutboundContext({ getActive });
+    const { runtime, stt } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      outboundContextService: outbound,
+    });
+
+    await runtime.startSession({
+      sessionId: 'oc2',
+      conversationId: 'voice:oc2',
+      roomName: 'voice-oc2',
+      agentToken: 'tok',
+    });
+    stt.emit({ text: 'hello', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('oc2');
+
+    expect(getActive).toHaveBeenCalledOnce();
+    const system = llm.seenMessages[0]![0]!;
+    expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}`);
+    expect(system.content).not.toContain('[ACTIVE OUTBOUND CONTEXT');
+  });
+
+  it('still completes the turn when getActive throws', async () => {
+    const llm = new FakeStreamProvider([reply('Still here.')]);
+    const outbound = fakeOutboundContext({
+      getActive: async () => {
+        throw new Error('db down');
+      },
+    });
+    const { runtime, stt, transport } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      outboundContextService: outbound,
+    });
+
+    await runtime.startSession({
+      sessionId: 'oc3',
+      conversationId: 'voice:oc3',
+      roomName: 'voice-oc3',
+      agentToken: 'tok',
+    });
+    stt.emit({ text: 'are you there', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('oc3');
+
+    const system = llm.seenMessages[0]![0]!;
+    expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}`);
+    expect(transport.publishedFrames.length).toBeGreaterThan(0);
   });
 });

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -218,8 +218,10 @@ export interface VoiceRuntimeConfig {
    */
   timezone?: string;
   /**
-   * Deadline (ms) for the per-turn working_memory history read; on expiry the
-   * turn falls back to in-process history. Default 1000ms.
+   * Deadline (ms) for per-turn Postgres reads on the spoken critical path
+   * (working_memory history and outbound-context getActive). On expiry the
+   * turn degrades — in-process history / no context injection — rather than
+   * stalling. Default 1000ms.
    */
   historyReadTimeoutMs?: number;
   /**
@@ -227,6 +229,11 @@ export interface VoiceRuntimeConfig {
    * injects into text-channel task content. Voice bypasses the dispatcher, so
    * VoiceRuntime must read getActive() itself (#1594). Optional: absent → no
    * injection (tests / pool-less boots).
+   *
+   * TODO(#1599 / E-series non-principal callers): voice is principal-only
+   * today, so injecting "messages you've sent" is safe. Gate this to principal
+   * calls before any non-principal voice participant is admitted, or it
+   * becomes a cross-channel audience leak.
    */
   outboundContextService?: OutboundContextService;
 }
@@ -508,31 +515,57 @@ export class VoiceRuntime {
     }
 
     // Same getActive() + formatInjectionBlock() path the dispatcher uses for
-    // text channels (#1594). Empty result → null → prompt unchanged. Failure is
-    // best-effort: log and continue without the bridge (parity with dispatcher).
+    // text channels (#1594). Empty result → null → prompt unchanged. Failure
+    // and deadline expiry are best-effort: log and continue without the bridge
+    // (parity with dispatcher failure mode + loadTurnHistory latency contract).
     let outboundContextBlock: string | null = null;
     if (this.config.outboundContextService) {
-      try {
-        const activeEntries = await this.config.outboundContextService.getActive();
-        // Pass '' for originalContent — the utterance stays a separate user
-        // message; only the [ACTIVE OUTBOUND CONTEXT] preamble goes into the
-        // system prompt.
-        const preamble = this.config.outboundContextService.formatInjectionBlock(
-          activeEntries,
-          '',
+      const timeoutMs = this.config.historyReadTimeoutMs ?? DEFAULT_HISTORY_READ_TIMEOUT_MS;
+      const read = this.config.outboundContextService.getActive();
+      // A read that loses the deadline race settles later with no awaiter —
+      // absorb its eventual rejection so it cannot become an unhandled rejection.
+      read.catch(err => {
+        this.log.debug(
+          { err },
+          'late outbound-context getActive failure (turn already proceeded)',
         );
-        if (preamble !== null) {
-          outboundContextBlock = preamble.trimEnd();
-          this.log.debug(
-            { entryCount: activeEntries.length },
-            'Injected active outbound context into voice system prompt',
+      });
+      let timer: NodeJS.Timeout | undefined;
+      try {
+        const outcome = await Promise.race([
+          read,
+          new Promise<'timeout'>(resolve => {
+            timer = setTimeout(() => resolve('timeout'), timeoutMs);
+          }),
+        ]);
+        if (outcome === 'timeout') {
+          this.log.warn(
+            { timeoutMs },
+            'outbound-context getActive exceeded the voice deadline; proceeding without context injection',
           );
+        } else {
+          // Pass '' for originalContent — the utterance stays a separate user
+          // message; only the [ACTIVE OUTBOUND CONTEXT] preamble goes into the
+          // system prompt.
+          const preamble = this.config.outboundContextService.formatInjectionBlock(
+            outcome,
+            '',
+          );
+          if (preamble !== null) {
+            outboundContextBlock = preamble.trimEnd();
+            this.log.debug(
+              { entryCount: outcome.length },
+              'Injected active outbound context into voice system prompt',
+            );
+          }
         }
       } catch (err) {
         this.log.error(
           { err },
           'Failed to read outbound context entries — proceeding without context injection',
         );
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
       }
     }
 

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -20,6 +20,7 @@
 
 import type { EventBus } from '../../bus/bus.js';
 import { createInboundMessage, createVoiceSessionEnded } from '../../bus/events.js';
+import type { OutboundContextService } from '../../dispatch/outbound-context.js';
 import type { Logger } from '../../logger.js';
 import type { LLMProvider, Message, ToolCall, ToolDefinition } from '../../agents/llm/provider.js';
 import type { WorkingMemory } from '../../memory/working-memory.js';
@@ -85,8 +86,9 @@ function isHardTtsFailure(err: unknown): boolean {
  * guidance, and a fresh date/time block — assembled by buildVoiceSystemPrompt().
  * They deliberately do NOT get the coordinator's full YAML system prompt or
  * KG/sender enrichment (latency + text-channel content that makes no sense
- * spoken). See ADR-037 Consequences and
- * docs/wip/2026-07-25-voice-channel-design.md §"Phase 1 brain".
+ * spoken). Active outbound-context entries are included (#1594) so voice can
+ * acknowledge recent proactive sends on other channels. See ADR-037
+ * Consequences and docs/wip/2026-07-25-voice-channel-design.md §"Phase 1 brain".
  */
 export const VOICE_SYSTEM_ADDENDUM =
   'You are speaking to the principal in a live voice call. Reply in a natural, ' +
@@ -128,13 +130,20 @@ export const VOICE_DELEGATION_GUIDANCE =
  * Assemble the per-turn system prompt for a spoken turn. Static sections come
  * first and the (per-minute changing) time block last, so provider prompt
  * caching keeps a stable prefix across turns. Pure — callers resolve/guard the
- * dynamic parts (identity compile, roster lookup, time formatting) themselves.
+ * dynamic parts (identity compile, roster lookup, outbound context, time
+ * formatting) themselves.
  */
 export function buildVoiceSystemPrompt(parts: {
   /** Compiled office identity/persona block; omitted when null/empty. */
   identityBlock?: string | null;
   /** Specialist roster body ("- @name: description" lines); enables delegation guidance. */
   specialistRoster?: string | null;
+  /**
+   * Pre-formatted [ACTIVE OUTBOUND CONTEXT] block from
+   * OutboundContextService.formatInjectionBlock (cross-channel proactive sends).
+   * Omitted when null/empty — same bridge text channels get via the dispatcher (#1594).
+   */
+  outboundContextBlock?: string | null;
   /** Pre-formatted "## Current Date & Time" block; omitted when null/empty. */
   timeContextBlock?: string | null;
 }): string {
@@ -147,6 +156,9 @@ export function buildVoiceSystemPrompt(parts: {
       VOICE_DELEGATION_GUIDANCE + '\n\n## Available Specialists\n' + parts.specialistRoster,
     );
   }
+  // Dynamic suffix: outbound context then time. Time stays last so the static
+  // prefix (+ identity/roster) remains provider-cacheable across turns.
+  if (parts.outboundContextBlock) sections.push(parts.outboundContextBlock);
   if (parts.timeContextBlock) sections.push(parts.timeContextBlock);
   return sections.join('\n\n');
 }
@@ -210,6 +222,13 @@ export interface VoiceRuntimeConfig {
    * turn falls back to in-process history. Default 1000ms.
    */
   historyReadTimeoutMs?: number;
+  /**
+   * Cross-channel outbound-context bridge — the same service the dispatcher
+   * injects into text-channel task content. Voice bypasses the dispatcher, so
+   * VoiceRuntime must read getActive() itself (#1594). Optional: absent → no
+   * injection (tests / pool-less boots).
+   */
+  outboundContextService?: OutboundContextService;
 }
 
 /**
@@ -464,12 +483,12 @@ export class VoiceRuntime {
   }
 
   /**
-   * Resolve the dynamic prompt parts (guarding each — a compile failure or bad
-   * timezone must degrade to a slimmer prompt, never abort the spoken turn) and
-   * assemble the per-turn system prompt. Mirrors AgentRuntime.processTask's
-   * guard-and-omit pattern for the same blocks.
+   * Resolve the dynamic prompt parts (guarding each — a compile failure, bad
+   * timezone, or outbound-context read failure must degrade to a slimmer prompt,
+   * never abort the spoken turn) and assemble the per-turn system prompt.
+   * Mirrors AgentRuntime.processTask's guard-and-omit pattern for the same blocks.
    */
-  private buildTurnSystemPrompt(): string {
+  private async buildTurnSystemPrompt(): Promise<string> {
     let identityBlock: string | null = null;
     if (this.toolBridge?.identityBlock) {
       try {
@@ -488,6 +507,35 @@ export class VoiceRuntime {
       }
     }
 
+    // Same getActive() + formatInjectionBlock() path the dispatcher uses for
+    // text channels (#1594). Empty result → null → prompt unchanged. Failure is
+    // best-effort: log and continue without the bridge (parity with dispatcher).
+    let outboundContextBlock: string | null = null;
+    if (this.config.outboundContextService) {
+      try {
+        const activeEntries = await this.config.outboundContextService.getActive();
+        // Pass '' for originalContent — the utterance stays a separate user
+        // message; only the [ACTIVE OUTBOUND CONTEXT] preamble goes into the
+        // system prompt.
+        const preamble = this.config.outboundContextService.formatInjectionBlock(
+          activeEntries,
+          '',
+        );
+        if (preamble !== null) {
+          outboundContextBlock = preamble.trimEnd();
+          this.log.debug(
+            { entryCount: activeEntries.length },
+            'Injected active outbound context into voice system prompt',
+          );
+        }
+      } catch (err) {
+        this.log.error(
+          { err },
+          'Failed to read outbound context entries — proceeding without context injection',
+        );
+      }
+    }
+
     let timeContextBlock: string | null = null;
     const timezone = this.config.timezone?.trim();
     if (timezone) {
@@ -498,7 +546,12 @@ export class VoiceRuntime {
       }
     }
 
-    return buildVoiceSystemPrompt({ identityBlock, specialistRoster, timeContextBlock });
+    return buildVoiceSystemPrompt({
+      identityBlock,
+      specialistRoster,
+      outboundContextBlock,
+      timeContextBlock,
+    });
   }
 
   /**
@@ -637,7 +690,7 @@ export class VoiceRuntime {
     }
 
     const messages: Message[] = [
-      { role: 'system', content: this.buildTurnSystemPrompt() },
+      { role: 'system', content: await this.buildTurnSystemPrompt() },
       ...priorHistory,
       userMessage,
     ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1830,6 +1830,17 @@ async function main(): Promise<void> {
     logger.warn('channel sms is enabled + resolvable but its runtime client/credentials are missing (api key, from number, or webhook public key); no SMS adapter constructed — check vault/env credentials and restart');
   }
 
+  // Outbound context bridge — delegation-aware context registry for
+  // specialist-initiated outbound. Requires pool (Postgres).
+  // Constructed before VoiceRuntime (so voice turns can inject active entries —
+  // #1594) and before Scheduler (startup + daily cleanup).
+  const outboundContextService = pool
+    ? new OutboundContextService(pool, logger, {
+        defaultExpiryHours: yamlConfig.contextBridge?.defaultExpiryHours,
+        explicitExpiryHours: yamlConfig.contextBridge?.explicitExpiryHours,
+      })
+    : undefined;
+
   // Construct the Voice adapter (HTTP session handler installed on start).
   if (
     channelShouldStart.has('voice') &&
@@ -1890,6 +1901,9 @@ async function main(): Promise<void> {
         // Same per-turn date/timezone grounding the coordinator gets — without it
         // "tomorrow / next week" is un-anchored for every voice tool call (#1551).
         timezone: config.timezone,
+        // Cross-channel outbound-context bridge — voice bypasses the dispatcher,
+        // so VoiceRuntime reads getActive() itself (#1594).
+        outboundContextService,
         deleteRoom: async (roomName) => {
           await deleteVoiceRoom(
             {
@@ -2019,16 +2033,6 @@ async function main(): Promise<void> {
     },
     'DreamEngine configured',
   );
-
-  // Outbound context bridge — delegation-aware context registry for
-  // specialist-initiated outbound. Requires pool (Postgres).
-  // Constructed here (before Scheduler) so the scheduler can run startup + daily cleanup.
-  const outboundContextService = pool
-    ? new OutboundContextService(pool, logger, {
-        defaultExpiryHours: yamlConfig.contextBridge?.defaultExpiryHours,
-        explicitExpiryHours: yamlConfig.contextBridge?.explicitExpiryHours,
-      })
-    : undefined;
 
   const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine, outboundContextService, defaultExpectedDurationSeconds: yamlConfig.scheduler?.defaultExpectedDurationSeconds });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1594

Voice bypasses the dispatcher’s early-return for `channelId === 'voice'`, so spoken turns never saw the cross-channel `outbound_context` bridge. After a proactive Signal send, a voice call could deny having messaged the principal.

This wires `OutboundContextService` into `VoiceRuntime` and, each turn, calls the same `getActive()` + `formatInjectionBlock()` path text channels use, appending the block to the spoken-turn system prompt via `buildVoiceSystemPrompt`.

## Changes

- **`VoiceRuntime`** — optional `outboundContextService` config; `buildTurnSystemPrompt` is async and injects the active outbound-context block (best-effort; empty/failure/timeout → prompt unchanged)
- **Latency** — `getActive()` is deadline-bounded with the same `historyReadTimeoutMs` contract as `loadTurnHistory` (default 1000ms)
- **`buildVoiceSystemPrompt`** — new `outboundContextBlock` section (before the time block)
- **`src/index.ts`** — hoist outbound-context construction before voice so it can be passed in
- **Tests** — prompt assembly (real `formatInjectionBlock`), turn injection / empty / throw / timeout cases
- **CHANGELOG** — Fixed entry under `[Unreleased]`

## Acceptance criteria

- [x] After a Signal send registers an outbound-context entry, a voice turn’s system prompt contains that entry’s injection block (unit test)
- [ ] Manual repro: proactive Signal message → voice call → “did you message me?” → Curia acknowledges (needs live env)
- [x] No regression when `getActive()` returns empty (prompt unchanged; failure/timeout is non-fatal)

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/channels/voice/voice-runtime.test.ts` (27 passed)

## Review follow-ups

- Labels applied (`bug`, `channels`, `memory-context`, `size:M`)
- Milestone `v0.43 - Hardening` needs a human attach (App token cannot set milestones)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-506c55ae-493b-48e5-8306-94335fc2ace6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-506c55ae-493b-48e5-8306-94335fc2ace6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

