### PR TITLE
fix(docker): flush shell command hash after npm strip in runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Slack decode** — unescape `&amp;` last so `&amp;lt;` stays literal `&lt;`. (#1569)
 - **Ant Farm** — desk roster updates during scene boot are no longer dropped. (#1549)
 - **MCP bootstrap** — enabled servers with 0 tools now error-log and fail health. (#1500)
+- **Docker build** — flush shell hash after npm strip so the removal assertion stops false-failing publish. (#1568)
 
 ### Security
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,11 +91,17 @@ RUN corepack enable
 # already gone, so a future Node base image that relocates npm would leave the
 # vulnerable bundled deps (brace-expansion, tar) in place while the build stayed
 # green. These assertions turn that silent regression into a hard build failure.
+# `hash -r` after the rm is load-bearing, not cosmetic: the `command -v npm/npx`
+# pre-checks populate the shell's command-location hash table, and dash (this
+# image's /bin/sh) answers a later `command -v` from that cache without re-stat'ing
+# the filesystem. Without the flush, the post-removal checks report the now-deleted
+# npm/npx as "still resolvable" and fail the build on every run (a false positive).
 RUN set -e; \
     test -e /usr/local/lib/node_modules/npm; \
     command -v npm >/dev/null; \
     command -v npx >/dev/null; \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx; \
+    hash -r; \
     if command -v npm >/dev/null 2>&1; then echo 'npm still resolvable after removal' >&2; exit 1; fi; \
     if command -v npx >/dev/null 2>&1; then echo 'npx still resolvable after removal' >&2; exit 1; fi
 


### PR DESCRIPTION
## Summary

`docker-publish` is failing on `main` at the runtime-stage npm-strip step with `npm still resolvable after removal`. This fixes it by flushing the shell command hash after the `rm`.

The npm-strip block (added in #1568 to remove the bundled global npm and its recurring brace-expansion/tar CVE surface) asserts fail-closed that npm/npx are unresolvable after removal. That assertion was firing a **false positive on every build**.

## Root cause

Not a relocated npm — the `rm` succeeds and all three targets are deleted (confirmed by inspecting the image). The culprit is **dash's command hash table** (`/bin/sh` in `node:24-slim`):

1. The pre-removal `command -v npm` / `command -v npx` existence checks cause dash to **cache** npm's resolved path.
2. `rm -rf …` deletes the files.
3. The post-removal `command -v npm` returns the **stale cached path** without re-stat'ing the filesystem → reports npm as still resolvable → `exit 1`.

The assertion was self-defeating: verifying npm exists before removal poisoned the lookup so the after-check could never see it gone. This is the first CI run of the block, so it isn't a base-image regression — it would have failed on every build.

## Fix

Add `hash -r` after the `rm` to flush dash's remembered command locations, so the post-removal checks resolve fresh against the real filesystem/PATH. This preserves the *stronger* "npm is not resolvable anywhere on PATH" semantics (which also catches a genuinely relocated npm in a future base image) rather than downgrading to hardcoded path checks.

## Verification

Reproduced and validated under **buildkit** against the pinned `node:24-slim@sha256:6f7b03…` digest:

- **Before** (no `hash -r`): build fails with `npm still resolvable after removal` — reproduces CI exactly.
- **After** (`hash -r`): build succeeds; inspecting the resulting image shows `command -v npm` and `command -v npx` both empty (removed), while `node` and `corepack` remain intact.

CI's full `docker-publish` will exercise the complete multi-stage build on this PR.

Related: #1568 (this repairs a regression introduced by that change; the security posture is unchanged — npm is still fully removed).