### PR TITLE
fix(delegate): validate calendar briefs against same-turn date-resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)
 - **Coordinator** — ambient bullpen mentions no longer bleed into scheduler jobs and leak to the principal. (#1609)
 - **Voice** — injects active outbound-context so spoken turns see recent cross-channel sends. (#1594)
 - **`calendar-list-events`** — all-calendar 401/403 failures name grant reconnect action. (#1561)

--- a/skills/delegate/handler.test.ts
+++ b/skills/delegate/handler.test.ts
@@ -1,5 +1,5 @@
 // handler.test.ts — delegate skill: forwarding of relay context for specialist resume (#995).
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import pino from 'pino';
 import { DelegateHandler } from './handler.js';
 import type { ToolContext } from '../../src/skills/types.js';
@@ -35,11 +35,29 @@ function makeBus() {
   return { bus, published };
 }
 
-const agentRegistry = {
+const agentRegistryMock: {
+  has: (n: string) => boolean;
+  get: (n: string) => { name: string; role: string };
+  listSpecialists: () => Array<{ name: string }>;
+} = {
   has: (n: string) => n === 'research-analyst',
   get: (n: string) => ({ name: n, role: 'specialist' }),
   listSpecialists: () => [{ name: 'research-analyst' }],
-} as unknown as ToolContext['agentRegistry'];
+};
+
+const agentRegistry = agentRegistryMock as unknown as ToolContext['agentRegistry'];
+
+function useCalendarRegistry(): void {
+  agentRegistryMock.has = (n: string) => n === 'calendar';
+  agentRegistryMock.get = (n: string) => ({ name: n, role: 'specialist' });
+  agentRegistryMock.listSpecialists = () => [{ name: 'calendar' }];
+}
+
+function restoreDefaultRegistry(): void {
+  agentRegistryMock.has = (n: string) => n === 'research-analyst';
+  agentRegistryMock.get = (n: string) => ({ name: n, role: 'specialist' });
+  agentRegistryMock.listSpecialists = () => [{ name: 'research-analyst' }];
+}
 
 function makeCtx(bus: EventBus, over: Partial<ToolContext> = {}): ToolContext {
   return {
@@ -116,6 +134,86 @@ describe('DelegateHandler relay-context forwarding (#995)', () => {
 
     const task = published.find(e => e.type === 'agent.task') as AgentTaskEvent;
     expect(task.payload.liveTurn).toBeUndefined();
+  });
+});
+
+describe('DelegateHandler date-resolve brief validation (#1612)', () => {
+  afterEach(() => {
+    restoreDefaultRegistry();
+  });
+
+  it('rejects a calendar brief that contradicts date-resolve output from this turn', async () => {
+    const { bus, published } = makeBus();
+    useCalendarRegistry();
+
+    const result = await new DelegateHandler().execute(
+      makeCtx(bus, {
+        input: {
+          agent: 'calendar',
+          task: 'Schedule a catch-up on August 1, 2026 at 2pm.',
+        },
+        turnDateResolveResults: [{ isoDate: '2026-07-31', formatted: 'Friday, July 31, 2026' }],
+      }),
+    );
+    if (result.success) throw new Error('expected delegate to reject a contradicting calendar brief');
+    expect(result.error).toMatch(/must include a date date-resolve produced/i);
+    expect(published.find(e => e.type === 'agent.task')).toBeUndefined();
+  });
+
+  it('accepts a calendar brief that matches date-resolve output from this turn', async () => {
+    const { bus, published } = makeBus();
+    useCalendarRegistry();
+
+    const result = await new DelegateHandler().execute(
+      makeCtx(bus, {
+        input: {
+          agent: 'calendar',
+          task: 'Schedule a catch-up on Friday, July 31, 2026 at 2pm.',
+        },
+        turnDateResolveResults: [{ isoDate: '2026-07-31', formatted: 'Friday, July 31, 2026' }],
+      }),
+    );
+    expect(result.success).toBe(true);
+    expect(published.find(e => e.type === 'agent.task')).toBeDefined();
+  });
+
+  it('rejects relative calendar asks when date-resolve was not called this turn', async () => {
+    const { bus, published } = makeBus();
+    useCalendarRegistry();
+
+    const result = await new DelegateHandler().execute(
+      makeCtx(bus, {
+        input: {
+          agent: 'calendar',
+          task: "What's on my calendar next Tuesday?",
+        },
+      }),
+    );
+    if (result.success) throw new Error('expected delegate to require date-resolve first');
+    expect(result.error).toMatch(/requires date-resolve first/i);
+    expect(published.find(e => e.type === 'agent.task')).toBeUndefined();
+  });
+
+  it('skips date validation when resuming with a resume_token', async () => {
+    const { bus, published } = makeBus();
+    useCalendarRegistry();
+    const resume_token = encodeResumeToken({
+      agent: 'calendar',
+      originalTask: 'Schedule the Friday meeting.',
+      context: 'Waiting on CEO direction for the exact time.',
+    });
+
+    const result = await new DelegateHandler().execute(
+      makeCtx(bus, {
+        input: {
+          agent: 'calendar',
+          task: 'Use 2pm.',
+          resume_token,
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+    expect(published.find(e => e.type === 'agent.task')).toBeDefined();
   });
 });
 

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -32,6 +32,7 @@ import {
   formatPausedProgressMessage,
   parseExecutionPausedPayload,
 } from '../../src/agents/resumable-task.js';
+import { validateDelegateBriefDates } from '../../src/agents/delegate-brief-date-validation.js';
 
 // Default wait for the specialist to respond — appropriate for interactive tasks.
 // Long-running scheduled tasks should pass timeout_ms explicitly (injected by the runtime
@@ -141,10 +142,25 @@ export class DelegateHandler implements ToolHandler {
 
     const conversationId = conversation_id ?? `delegate-${randomUUID()}`;
 
+    const hasResumeToken = typeof resume_token === 'string' && resume_token !== '';
+    if (!hasResumeToken) {
+      const briefValidation = validateDelegateBriefDates({
+        agent,
+        task,
+        priorDateResolves: ctx.turnDateResolveResults ?? [],
+      });
+      if (!briefValidation.ok) {
+        ctx.log.warn(
+          { targetAgent: agent, priorDates: (ctx.turnDateResolveResults ?? []).map(r => r.isoDate) },
+          'Rejected calendar delegate brief — date handoff validation failed',
+        );
+        return { success: false, error: briefValidation.error };
+      }
+    }
+
     // Identical-delegation guard (#1171): resume continuations are exempt — they carry new
     // CEO direction and a different effective brief. Without a resume_token, block when the
     // runtime has already recorded a non-retryable failure for this agent+task pair.
-    const hasResumeToken = typeof resume_token === 'string' && resume_token !== '';
     if (!hasResumeToken && ctx.delegationGuard) {
       const dKey = delegationKey(agent, task);
       if (!ctx.delegationGuard.canAttempt(dKey)) {

--- a/skills/delegate/tool.json
+++ b/skills/delegate/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "delegate",
   "description": "Delegate a task to a specialist agent. Use this when the user's request requires specialized expertise (research, expense tracking, etc.). Provide the specialist's name and a clear task description.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/skills/delegate/tool.json
+++ b/skills/delegate/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "delegate",
   "description": "Delegate a task to a specialist agent. Use this when the user's request requires specialized expertise (research, expense tracking, etc.). Provide the specialist's name and a clear task description.",
-  "version": "1.4.0",
+  "version": "1.3.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/src/agents/delegate-brief-date-validation.test.ts
+++ b/src/agents/delegate-brief-date-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   briefContainsResolvedDate,
+  briefHasDateLikeContent,
   calendarBriefNeedsResolvedDate,
   extractDateResolveResult,
   isCalendarDelegation,
@@ -24,17 +25,33 @@ describe('isCalendarDelegation', () => {
 
 describe('calendarBriefNeedsResolvedDate', () => {
   it('requires a date for relative phrasing', () => {
-    expect(calendarBriefNeedsResolvedDate("What's on my calendar next Tuesday?", [])).toBe(true);
+    expect(calendarBriefNeedsResolvedDate("What's on my calendar next Tuesday?")).toBe(true);
+  });
+
+  it('requires a date for bare weekdays', () => {
+    expect(calendarBriefNeedsResolvedDate("What's on my calendar Friday?")).toBe(true);
   });
 
   it('does not require a date for move-without-day requests', () => {
-    expect(calendarBriefNeedsResolvedDate('Move my three PM to four thirty.', [])).toBe(false);
+    expect(calendarBriefNeedsResolvedDate('Move my three PM to four thirty.')).toBe(false);
   });
 
-  it('requires a date when date-resolve already ran this turn', () => {
-    expect(
-      calendarBriefNeedsResolvedDate('Schedule the meeting.', [{ isoDate: '2026-07-31' }]),
-    ).toBe(true);
+  it('does not treat "next meeting" / "this call" / bare schedule as relative dates', () => {
+    expect(calendarBriefNeedsResolvedDate('Reschedule my next meeting.')).toBe(false);
+    expect(calendarBriefNeedsResolvedDate('Join this call at 3.')).toBe(false);
+    expect(calendarBriefNeedsResolvedDate('Schedule the meeting.')).toBe(false);
+  });
+});
+
+describe('briefHasDateLikeContent', () => {
+  it('detects ISO and natural month-day forms', () => {
+    expect(briefHasDateLikeContent('Check 2026-07-31.')).toBe(true);
+    expect(briefHasDateLikeContent('Book July 31 at 2pm.')).toBe(true);
+    expect(briefHasDateLikeContent('Book July 31st, 2026.')).toBe(true);
+  });
+
+  it('does not treat time-only move briefs as date-like', () => {
+    expect(briefHasDateLikeContent('Move my three PM to four thirty.')).toBe(false);
   });
 });
 
@@ -51,12 +68,21 @@ describe('briefContainsResolvedDate', () => {
     );
   });
 
-  it('matches month-day without weekday', () => {
+  it('matches month-day without weekday when brief has no year', () => {
     expect(briefContainsResolvedDate('Book July 31 at 2pm.', resolved)).toBe(true);
+  });
+
+  it('matches ordinal-suffixed dates', () => {
+    expect(briefContainsResolvedDate('Book July 31st at 2pm.', resolved)).toBe(true);
+    expect(briefContainsResolvedDate('Book July 31st, 2026 at 2pm.', resolved)).toBe(true);
   });
 
   it('rejects a contradicting date', () => {
     expect(briefContainsResolvedDate('Schedule on August 1, 2026 at 2pm.', resolved)).toBe(false);
+  });
+
+  it('rejects correct month-day with the wrong year', () => {
+    expect(briefContainsResolvedDate('Schedule on July 31, 2027 at 2pm.', resolved)).toBe(false);
   });
 });
 
@@ -83,7 +109,7 @@ describe('validateDelegateBriefDates', () => {
     expect(result.error).toMatch(/must include a date date-resolve produced/i);
   });
 
-  it('rejects calendar asks that skip date-resolve', () => {
+  it('rejects relative calendar asks that skip date-resolve', () => {
     const result = validateDelegateBriefDates({
       agent: 'calendar',
       task: "What's on my calendar next Tuesday?",
@@ -110,6 +136,32 @@ describe('validateDelegateBriefDates', () => {
       priorDateResolves: [],
     });
     expect(result.ok).toBe(true);
+  });
+
+  it('allows date-free calendar briefs even when an earlier date-resolve ran', () => {
+    const result = validateDelegateBriefDates({
+      agent: 'calendar',
+      task: 'Move my three PM to four thirty.',
+      priorDateResolves: [friday],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('does not over-trigger on "next meeting" / bare schedule without date-resolve', () => {
+    expect(
+      validateDelegateBriefDates({
+        agent: 'calendar',
+        task: 'Reschedule my next meeting.',
+        priorDateResolves: [],
+      }).ok,
+    ).toBe(true);
+    expect(
+      validateDelegateBriefDates({
+        agent: 'calendar',
+        task: 'Schedule the meeting.',
+        priorDateResolves: [],
+      }).ok,
+    ).toBe(true);
   });
 });
 

--- a/src/agents/delegate-brief-date-validation.test.ts
+++ b/src/agents/delegate-brief-date-validation.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import {
+  briefContainsResolvedDate,
+  calendarBriefNeedsResolvedDate,
+  extractDateResolveResult,
+  isCalendarDelegation,
+  TurnDateResolveTracker,
+  validateDelegateBriefDates,
+} from './delegate-brief-date-validation.js';
+
+describe('isCalendarDelegation', () => {
+  it('detects calendar agent name', () => {
+    expect(isCalendarDelegation('calendar', 'list events')).toBe(true);
+  });
+
+  it('detects calendar mentioned in the brief', () => {
+    expect(isCalendarDelegation('research-analyst', 'check my calendar tomorrow')).toBe(true);
+  });
+
+  it('returns false for non-calendar work', () => {
+    expect(isCalendarDelegation('contacts', 'who is Jordan?')).toBe(false);
+  });
+});
+
+describe('calendarBriefNeedsResolvedDate', () => {
+  it('requires a date for relative phrasing', () => {
+    expect(calendarBriefNeedsResolvedDate("What's on my calendar next Tuesday?", [])).toBe(true);
+  });
+
+  it('does not require a date for move-without-day requests', () => {
+    expect(calendarBriefNeedsResolvedDate('Move my three PM to four thirty.', [])).toBe(false);
+  });
+
+  it('requires a date when date-resolve already ran this turn', () => {
+    expect(
+      calendarBriefNeedsResolvedDate('Schedule the meeting.', [{ isoDate: '2026-07-31' }]),
+    ).toBe(true);
+  });
+});
+
+describe('briefContainsResolvedDate', () => {
+  const resolved = { isoDate: '2026-07-31', formatted: 'Friday, July 31, 2026' };
+
+  it('matches ISO dates', () => {
+    expect(briefContainsResolvedDate('Check 2026-07-31 for conflicts.', resolved)).toBe(true);
+  });
+
+  it('matches formatted natural dates', () => {
+    expect(briefContainsResolvedDate('Schedule on Friday, July 31, 2026 at 2pm.', resolved)).toBe(
+      true,
+    );
+  });
+
+  it('matches month-day without weekday', () => {
+    expect(briefContainsResolvedDate('Book July 31 at 2pm.', resolved)).toBe(true);
+  });
+
+  it('rejects a contradicting date', () => {
+    expect(briefContainsResolvedDate('Schedule on August 1, 2026 at 2pm.', resolved)).toBe(false);
+  });
+});
+
+describe('validateDelegateBriefDates', () => {
+  const friday = { isoDate: '2026-07-31', formatted: 'Friday, July 31, 2026' };
+
+  it('accepts a brief that matches date-resolve output', () => {
+    const result = validateDelegateBriefDates({
+      agent: 'calendar',
+      task: 'Schedule a catch-up on Friday, July 31, 2026 at 2pm.',
+      priorDateResolves: [friday],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a brief that contradicts date-resolve output', () => {
+    const result = validateDelegateBriefDates({
+      agent: 'calendar',
+      task: 'Schedule a catch-up on August 1, 2026 at 2pm.',
+      priorDateResolves: [friday],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected validation failure');
+    expect(result.error).toMatch(/must include a date date-resolve produced/i);
+  });
+
+  it('rejects calendar asks that skip date-resolve', () => {
+    const result = validateDelegateBriefDates({
+      agent: 'calendar',
+      task: "What's on my calendar next Tuesday?",
+      priorDateResolves: [],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected validation failure');
+    expect(result.error).toMatch(/requires date-resolve first/i);
+  });
+
+  it('allows non-calendar delegations without date-resolve', () => {
+    const result = validateDelegateBriefDates({
+      agent: 'contacts',
+      task: 'Look up Jordan Lee.',
+      priorDateResolves: [],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('allows calendar move requests without relative dates', () => {
+    const result = validateDelegateBriefDates({
+      agent: 'calendar',
+      task: 'Move my three PM to four thirty.',
+      priorDateResolves: [],
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('extractDateResolveResult', () => {
+  it('parses a flat date-resolve payload', () => {
+    expect(
+      extractDateResolveResult({
+        date: '2026-07-28',
+        formatted: 'Tuesday, July 28, 2026',
+      }),
+    ).toEqual({
+      isoDate: '2026-07-28',
+      formatted: 'Tuesday, July 28, 2026',
+    });
+  });
+
+  it('parses nested ToolResult.data payloads', () => {
+    expect(
+      extractDateResolveResult({
+        data: { date: '2026-07-28', formatted: 'Tuesday, July 28, 2026' },
+      }),
+    ).toEqual({
+      isoDate: '2026-07-28',
+      formatted: 'Tuesday, July 28, 2026',
+    });
+  });
+});
+
+describe('TurnDateResolveTracker', () => {
+  it('accumulates successful date-resolve results across a turn', () => {
+    const tracker = new TurnDateResolveTracker();
+    tracker.recordFromToolResult({
+      success: true,
+      data: { date: '2026-07-28', formatted: 'Tuesday, July 28, 2026' },
+    });
+    tracker.recordFromToolResult({ success: false, error: 'bad input' });
+    tracker.recordFromJsonContent(
+      JSON.stringify({ date: '2026-07-31', formatted: 'Friday, July 31, 2026' }),
+    );
+
+    expect(tracker.snapshot()).toEqual([
+      { isoDate: '2026-07-28', formatted: 'Tuesday, July 28, 2026' },
+      { isoDate: '2026-07-31', formatted: 'Friday, July 31, 2026' },
+    ]);
+  });
+});

--- a/src/agents/delegate-brief-date-validation.ts
+++ b/src/agents/delegate-brief-date-validation.ts
@@ -25,9 +25,24 @@ export type ValidateDelegateBriefDatesResult =
 
 const CALENDAR_AGENT_PATTERN = /calendar/i;
 
-/** Relative / day-of-week phrasing that requires a resolved date in calendar briefs. */
-const RELATIVE_DATE_IN_BRIEF =
-  /\b(tomorrow|today|monday|tuesday|wednesday|thursday|friday|saturday|sunday|next\s+\w+|this\s+\w+|what'?s on|what is on|anything\s+(on|scheduled)|schedule\b)/i;
+const WEEKDAY =
+  'monday|tuesday|wednesday|thursday|friday|saturday|sunday';
+
+/**
+ * Genuine relative / day-of-week phrasing that requires a resolved date.
+ * Deliberately excludes bare "next meeting" / "this call" / "schedule" —
+ * those are not calendar dates to resolve.
+ */
+const RELATIVE_DATE_IN_BRIEF = new RegExp(
+  String.raw`\b(tomorrow|today|${WEEKDAY}|next\s+(?:${WEEKDAY})|this\s+(?:${WEEKDAY}))\b`,
+  'i',
+);
+
+/** ISO date or month+day natural forms that look like a stated calendar date. */
+const DATE_LIKE_IN_BRIEF =
+  /\b\d{4}-\d{2}-\d{2}\b|\b(?:january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)\.?\s+\d{1,2}(?:st|nd|rd|th)?\b/i;
+
+const YEAR_IN_BRIEF = /\b(?:19|20)\d{2}\b/;
 
 export function isCalendarDelegation(agent: string, task: string): boolean {
   const agentLower = agent.toLowerCase();
@@ -35,11 +50,14 @@ export function isCalendarDelegation(agent: string, task: string): boolean {
   return CALENDAR_AGENT_PATTERN.test(agentLower) || taskLower.includes('calendar');
 }
 
-export function calendarBriefNeedsResolvedDate(
-  task: string,
-  priorDateResolves: readonly TurnDateResolveResult[],
-): boolean {
-  return RELATIVE_DATE_IN_BRIEF.test(task) || priorDateResolves.length > 0;
+/** True when the brief uses relative/day-of-week language that needs date-resolve. */
+export function calendarBriefNeedsResolvedDate(task: string): boolean {
+  return RELATIVE_DATE_IN_BRIEF.test(task);
+}
+
+/** True when the brief states a concrete calendar date (ISO or month+day). */
+export function briefHasDateLikeContent(task: string): boolean {
+  return DATE_LIKE_IN_BRIEF.test(task);
 }
 
 /** Parse a successful date-resolve tool payload into a turn record. */
@@ -62,6 +80,21 @@ export function extractDateResolveResult(data: unknown): TurnDateResolveResult |
   };
 }
 
+function dayWithOrdinal(day: number): string {
+  const mod100 = day % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${day}th`;
+  switch (day % 10) {
+    case 1:
+      return `${day}st`;
+    case 2:
+      return `${day}nd`;
+    case 3:
+      return `${day}rd`;
+    default:
+      return `${day}th`;
+  }
+}
+
 /** True when the brief mentions the ISO date or a natural form date-resolve produced. */
 export function briefContainsResolvedDate(
   brief: string,
@@ -72,15 +105,29 @@ export function briefContainsResolvedDate(
   const dt = DateTime.fromISO(resolved.isoDate);
   if (!dt.isValid) return false;
 
+  const month = dt.toFormat('MMMM');
+  const monthShort = dt.toFormat('MMM');
+  const day = dt.day;
+  const year = dt.toFormat('yyyy');
+  const ordinalDay = dayWithOrdinal(day);
+
+  // Full-date candidates (always safe — year pins the match).
   const candidates = new Set<string>();
   if (resolved.formatted) candidates.add(resolved.formatted);
-  candidates.add(dt.toFormat('MMMM d, yyyy'));
-  candidates.add(dt.toFormat('MMMM d yyyy'));
-  candidates.add(dt.toFormat('MMM d, yyyy'));
-  candidates.add(dt.toFormat('d MMMM yyyy'));
-  candidates.add(dt.toFormat('MMMM do, yyyy'));
-  candidates.add(dt.toFormat('MMMM do'));
-  candidates.add(dt.toFormat('MMMM d'));
+  candidates.add(`${month} ${day}, ${year}`);
+  candidates.add(`${month} ${day} ${year}`);
+  candidates.add(`${monthShort} ${day}, ${year}`);
+  candidates.add(`${day} ${month} ${year}`);
+  candidates.add(`${month} ${ordinalDay}, ${year}`);
+  candidates.add(`${month} ${ordinalDay} ${year}`);
+
+  // Yearless month/day only when the brief does not already spell out a year —
+  // otherwise "July 31, 2027" would falsely match a 2026-07-31 resolve.
+  if (!YEAR_IN_BRIEF.test(brief)) {
+    candidates.add(`${month} ${day}`);
+    candidates.add(`${month} ${ordinalDay}`);
+    candidates.add(`${monthShort} ${day}`);
+  }
 
   const briefLower = brief.toLowerCase();
   for (const candidate of candidates) {
@@ -98,11 +145,11 @@ export function validateDelegateBriefDates(
     return { ok: true };
   }
 
-  if (!calendarBriefNeedsResolvedDate(task, priorDateResolves)) {
-    return { ok: true };
-  }
+  const needsResolved = calendarBriefNeedsResolvedDate(task);
+  const hasDateLike = briefHasDateLikeContent(task);
 
-  if (priorDateResolves.length === 0) {
+  // Relative/day-of-week asks must call date-resolve this turn.
+  if (needsResolved && priorDateResolves.length === 0) {
     return {
       ok: false,
       error:
@@ -110,14 +157,20 @@ export function validateDelegateBriefDates(
     };
   }
 
-  const matched = priorDateResolves.find(resolved => briefContainsResolvedDate(task, resolved));
-  if (!matched) {
-    const isoList = priorDateResolves.map(r => r.isoDate).join(', ');
-    return {
-      ok: false,
-      error:
-        `Brief must include a date date-resolve produced this turn (${isoList}); natural form OK (e.g. July 28, 2026)`,
-    };
+  // When the brief states a date (relative ask, or concrete date-like text) and
+  // date-resolve already ran, require the brief to cite one of those results.
+  // Unrelated earlier date-resolve calls do NOT force date-free briefs (e.g.
+  // "move my 3pm to 4:30") to include a resolved date.
+  if (priorDateResolves.length > 0 && (needsResolved || hasDateLike)) {
+    const matched = priorDateResolves.find(resolved => briefContainsResolvedDate(task, resolved));
+    if (!matched) {
+      const isoList = priorDateResolves.map(r => r.isoDate).join(', ');
+      return {
+        ok: false,
+        error:
+          `Brief must include a date date-resolve produced this turn (${isoList}); natural form OK (e.g. July 28, 2026)`,
+      };
+    }
   }
 
   return { ok: true };

--- a/src/agents/delegate-brief-date-validation.ts
+++ b/src/agents/delegate-brief-date-validation.ts
@@ -1,0 +1,151 @@
+// delegate-brief-date-validation.ts — structural handoff from date-resolve to delegate (#1612).
+//
+// The DATE_RESOLVE_GUARDRAIL induces date-resolve tool calls, but the model can still
+// pass a wrong calendar date into the specialist brief. This module rejects calendar
+// delegations whose brief contradicts date-resolve results from the same turn.
+
+import { DateTime } from 'luxon';
+import type { ToolResult } from '../skills/types.js';
+
+/** One resolved date produced by date-resolve earlier in the same agent turn. */
+export interface TurnDateResolveResult {
+  isoDate: string;
+  formatted?: string;
+}
+
+export interface ValidateDelegateBriefDatesInput {
+  agent: string;
+  task: string;
+  priorDateResolves: readonly TurnDateResolveResult[];
+}
+
+export type ValidateDelegateBriefDatesResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+const CALENDAR_AGENT_PATTERN = /calendar/i;
+
+/** Relative / day-of-week phrasing that requires a resolved date in calendar briefs. */
+const RELATIVE_DATE_IN_BRIEF =
+  /\b(tomorrow|today|monday|tuesday|wednesday|thursday|friday|saturday|sunday|next\s+\w+|this\s+\w+|what'?s on|what is on|anything\s+(on|scheduled)|schedule\b)/i;
+
+export function isCalendarDelegation(agent: string, task: string): boolean {
+  const agentLower = agent.toLowerCase();
+  const taskLower = task.toLowerCase();
+  return CALENDAR_AGENT_PATTERN.test(agentLower) || taskLower.includes('calendar');
+}
+
+export function calendarBriefNeedsResolvedDate(
+  task: string,
+  priorDateResolves: readonly TurnDateResolveResult[],
+): boolean {
+  return RELATIVE_DATE_IN_BRIEF.test(task) || priorDateResolves.length > 0;
+}
+
+/** Parse a successful date-resolve tool payload into a turn record. */
+export function extractDateResolveResult(data: unknown): TurnDateResolveResult | null {
+  let record: Record<string, unknown> | null = null;
+  if (typeof data === 'object' && data !== null) {
+    record = data as Record<string, unknown>;
+    if (typeof record.date !== 'string' && typeof record.data === 'object' && record.data !== null) {
+      record = record.data as Record<string, unknown>;
+    }
+  }
+  if (!record) return null;
+
+  const isoDate = typeof record.date === 'string' ? record.date : null;
+  if (!isoDate || !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)) return null;
+
+  return {
+    isoDate,
+    formatted: typeof record.formatted === 'string' ? record.formatted : undefined,
+  };
+}
+
+/** True when the brief mentions the ISO date or a natural form date-resolve produced. */
+export function briefContainsResolvedDate(
+  brief: string,
+  resolved: TurnDateResolveResult,
+): boolean {
+  if (brief.includes(resolved.isoDate)) return true;
+
+  const dt = DateTime.fromISO(resolved.isoDate);
+  if (!dt.isValid) return false;
+
+  const candidates = new Set<string>();
+  if (resolved.formatted) candidates.add(resolved.formatted);
+  candidates.add(dt.toFormat('MMMM d, yyyy'));
+  candidates.add(dt.toFormat('MMMM d yyyy'));
+  candidates.add(dt.toFormat('MMM d, yyyy'));
+  candidates.add(dt.toFormat('d MMMM yyyy'));
+  candidates.add(dt.toFormat('MMMM do, yyyy'));
+  candidates.add(dt.toFormat('MMMM do'));
+  candidates.add(dt.toFormat('MMMM d'));
+
+  const briefLower = brief.toLowerCase();
+  for (const candidate of candidates) {
+    if (briefLower.includes(candidate.toLowerCase())) return true;
+  }
+  return false;
+}
+
+export function validateDelegateBriefDates(
+  input: ValidateDelegateBriefDatesInput,
+): ValidateDelegateBriefDatesResult {
+  const { agent, task, priorDateResolves } = input;
+
+  if (!isCalendarDelegation(agent, task)) {
+    return { ok: true };
+  }
+
+  if (!calendarBriefNeedsResolvedDate(task, priorDateResolves)) {
+    return { ok: true };
+  }
+
+  if (priorDateResolves.length === 0) {
+    return {
+      ok: false,
+      error:
+        'Calendar specialist requires date-resolve first — no resolved date was produced this turn',
+    };
+  }
+
+  const matched = priorDateResolves.find(resolved => briefContainsResolvedDate(task, resolved));
+  if (!matched) {
+    const isoList = priorDateResolves.map(r => r.isoDate).join(', ');
+    return {
+      ok: false,
+      error:
+        `Brief must include a date date-resolve produced this turn (${isoList}); natural form OK (e.g. July 28, 2026)`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/** Tracks date-resolve outputs within one agent turn (text or voice). */
+export class TurnDateResolveTracker {
+  private readonly results: TurnDateResolveResult[] = [];
+
+  snapshot(): readonly TurnDateResolveResult[] {
+    return this.results;
+  }
+
+  recordFromToolResult(result: ToolResult): void {
+    if (!result.success) return;
+    const extracted = extractDateResolveResult(result.data);
+    if (extracted) this.results.push(extracted);
+  }
+
+  /** Record from a voice bridge JSON tool_result string. */
+  recordFromJsonContent(content: string, isError?: boolean): void {
+    if (isError) return;
+    try {
+      const parsed: unknown = JSON.parse(content);
+      const extracted = extractDateResolveResult(parsed);
+      if (extracted) this.results.push(extracted);
+    } catch {
+      // Non-JSON tool results are not date-resolve payloads.
+    }
+  }
+}

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -22,6 +22,7 @@ import { AutonomyService } from '../autonomy/autonomy-service.js';
 import { formatTimeContextBlock } from '../time/time-context.js';
 import { formatTurnBudgetBlock } from './turn-budget.js';
 import { DATE_RESOLVE_GUARDRAIL } from './prompts/date-resolve-guardrail.js';
+import { TurnDateResolveTracker } from './delegate-brief-date-validation.js';
 import type { OfficeIdentityService } from '../identity/service.js';
 import {
   buildCheckpointBudgetNudgeMessage,
@@ -1108,6 +1109,7 @@ export class AgentRuntime {
     // Delegation circuit-breaker state (#1171). Tracks identical delegate(agent, task)
     // calls within this turn so non-retryable specialist failures cannot be blind-retried.
     const delegationGuard = new DelegationGuard();
+    const turnDateResolveTracker = new TurnDateResolveTracker();
     let pendingDelegationEscalation: (DelegationFailureInfo & { task: string; escalated: boolean }) | null = null;
 
     // TWO TOOL LOOPS (#1552 / #1563): this non-streaming chat() loop is still
@@ -1244,6 +1246,7 @@ export class AgentRuntime {
           taskMetadata: taskEvent.payload.metadata,
           liveTurn: taskEvent.payload.liveTurn,
           delegationGuard,
+          turnDateResolveResults: turnDateResolveTracker.snapshot(),
         };
 
         const startTime = Date.now();
@@ -1306,6 +1309,10 @@ export class AgentRuntime {
           parentEventId: invokeEvent.id,
         });
         await bus.publish('agent', resultEvent);
+
+        if (toolCall.name === 'date-resolve') {
+          turnDateResolveTracker.recordFromToolResult(result);
+        }
 
         if (result.success) {
           // Success: reset consecutive error counter

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -24,6 +24,7 @@ import type { OutboundContextService } from '../../dispatch/outbound-context.js'
 import type { Logger } from '../../logger.js';
 import type { LLMProvider, Message, ToolCall, ToolDefinition } from '../../agents/llm/provider.js';
 import { DATE_RESOLVE_GUARDRAIL } from '../../agents/prompts/date-resolve-guardrail.js';
+import { TurnDateResolveTracker } from '../../agents/delegate-brief-date-validation.js';
 import type { WorkingMemory } from '../../memory/working-memory.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
 import { formatTimeContextBlock } from '../../time/time-context.js';
@@ -257,7 +258,11 @@ export interface VoiceToolBridge {
   resolveVoiceTools: () => ToolDefinition[];
   invokeTool: (
     call: ToolCall,
-    ctx: { conversationId: string; sessionId: string },
+    ctx: {
+      conversationId: string;
+      sessionId: string;
+      turnDateResolveResults?: readonly import('../../agents/delegate-brief-date-validation.js').TurnDateResolveResult[];
+    },
   ) => Promise<{ content: string; is_error?: boolean }>;
   /**
    * Per-turn compiled office identity/persona block (hot-reloadable, same as
@@ -710,16 +715,31 @@ export class VoiceRuntime {
       ? this.toolBridge.resolveVoiceTools()
       : (this.config.resolveVoiceTools ? this.config.resolveVoiceTools() : this.config.tools);
 
+    const turnDateResolveTracker = new TurnDateResolveTracker();
+
     const invokeTool = this.toolBridge
-      ? (call: ToolCall) => this.toolBridge!.invokeTool(call, {
-        conversationId: session.conversationId,
-        sessionId: session.sessionId,
-      })
-      : this.config.invokeTool
-        ? (call: ToolCall) => this.config.invokeTool!(call, {
+      ? async (call: ToolCall) => {
+        const result = await this.toolBridge!.invokeTool(call, {
           conversationId: session.conversationId,
           sessionId: session.sessionId,
-        })
+          turnDateResolveResults: turnDateResolveTracker.snapshot(),
+        });
+        if (call.name === 'date-resolve') {
+          turnDateResolveTracker.recordFromJsonContent(result.content, result.is_error);
+        }
+        return result;
+      }
+      : this.config.invokeTool
+        ? async (call: ToolCall) => {
+          const result = await this.config.invokeTool!(call, {
+            conversationId: session.conversationId,
+            sessionId: session.sessionId,
+          });
+          if (call.name === 'date-resolve') {
+            turnDateResolveTracker.recordFromJsonContent(result.content, result.is_error);
+          }
+          return result;
+        }
         : undefined;
 
     const userMessage: Message = { role: 'user', content: utterance };

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -214,7 +214,11 @@ export interface VoiceRuntimeConfig {
   /** Optional tool invoker; when absent the runner returns a not-wired placeholder. */
   invokeTool?: (
     call: ToolCall,
-    ctx: { conversationId: string; sessionId: string },
+    ctx: {
+      conversationId: string;
+      sessionId: string;
+      turnDateResolveResults?: readonly import('../../agents/delegate-brief-date-validation.js').TurnDateResolveResult[];
+    },
   ) => Promise<{ content: string; is_error?: boolean }>;
   /**
    * Max UTF-8 bytes for an accumulated STT utterance before it is dropped.
@@ -734,6 +738,7 @@ export class VoiceRuntime {
           const result = await this.config.invokeTool!(call, {
             conversationId: session.conversationId,
             sessionId: session.sessionId,
+            turnDateResolveResults: turnDateResolveTracker.snapshot(),
           });
           if (call.name === 'date-resolve') {
             turnDateResolveTracker.recordFromJsonContent(result.content, result.is_error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2591,6 +2591,7 @@ async function main(): Promise<void> {
             conversationId: ctx.conversationId,
             taskEventId: ctx.sessionId,
             liveTurn: true,
+            turnDateResolveResults: ctx.turnDateResolveResults,
             // Stamp a proper TaskOriginator so elevated skills / Gate C see a
             // live principal turn (same shape the dispatcher uses for web chat).
             taskMetadata: {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -109,6 +109,8 @@ export interface InvokeOptions {
   /** Per-task-turn guard against blind identical re-delegation (#1171). Owned by the agent
    *  runtime; forwarded to the delegate skill for defense in depth. */
   delegationGuard?: import('../agents/delegation-guard.js').DelegationGuard;
+  /** date-resolve outputs from earlier in this agent turn (#1612). Forwarded to delegate. */
+  turnDateResolveResults?: readonly import('../agents/delegate-brief-date-validation.js').TurnDateResolveResult[];
 }
 
 /** Cap on the input rendering passed to the escalation judge — keeps full email bodies and
@@ -1284,6 +1286,7 @@ export class ExecutionLayer {
       // Distinct from taskMetadata so no persistence skill can sweep it into a wakeable row.
       liveTurn: options?.liveTurn,
       delegationGuard: options?.delegationGuard,
+      turnDateResolveResults: options?.turnDateResolveResults,
       // Expose the configured timezone so skills can format output timestamps
       // in the user's local time. See toLocalIso() in src/time/timestamp.ts.
       timezone: this.timezone,

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -318,6 +318,9 @@ export interface ToolContext {
   /** Per-task-turn guard against blind identical re-delegation (#1171). Populated by the
    *  agent runtime and read by the delegate skill. */
   delegationGuard?: import('../agents/delegation-guard.js').DelegationGuard;
+  /** date-resolve outputs from earlier in this agent turn (#1612). Populated by the runtime
+   *  / voice bridge and read by the delegate skill for brief validation. */
+  turnDateResolveResults?: readonly import('../agents/delegate-brief-date-validation.js').TurnDateResolveResult[];
   /** Shared sensitivity classifier — available to skills declaring 'sensitivityClassifier'.
    *  Classifies free text against config sensitivity_rules. */
   sensitivityClassifier?: import('../memory/sensitivity.js').SensitivityClassifier;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1612

The shared `DATE_RESOLVE_GUARDRAIL` reliably induces `date-resolve` tool calls, but the model can still pass a wrong calendar date into the specialist brief afterward (e.g. resolving "next Friday" → 2026-07-31, then briefing calendar with "August 1, 2026"). This adds a structural fix on the delegate path rather than more prompt text.

## Changes

- New `src/agents/delegate-brief-date-validation.ts` module validates calendar delegations:
  - Rejects relative-date calendar asks that skip `date-resolve` in the same turn
  - Rejects briefs whose stated date does not match a `date-resolve` result from the same turn (ISO or natural form, including ordinals)
  - Does not over-trigger on "next meeting" / bare "schedule", or force dates onto date-free briefs after an unrelated `date-resolve`
  - Exempts resume-token continuations
- `TurnDateResolveTracker` accumulates `date-resolve` outputs per agent turn in text (`AgentRuntime`) and voice (`VoiceRuntime`, both bridge and `config.invokeTool` paths)
- `delegate` skill (v1.3.1) enforces validation via `ctx.turnDateResolveResults`
- Unit coverage for validation logic and delegate handler integration

## Testing

- `pnpm exec vitest run src/agents/delegate-brief-date-validation.test.ts skills/delegate/handler.test.ts` (39 tests)
- `pnpm run typecheck`

## Review follow-up

Addressed CodeRabbit feedback in 359aef38 (inline replies posted as @josephfung).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa94b-5c2d-73da-bd6a-142cab2821bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa94b-5c2d-73da-bd6a-142cab2821bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

