### PR TITLE
feat(voice): real async-offramp handoff to coordinator (#1614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`async-offramp`** — voice hands heavyweight asks to async coordinator for principal callback. (#1614)
 - **ADR-038 (Proposed)** — corrected paired-variance evidence; per-module compose gates. #1612/#1613/#1614. (#1595)
 - **`src/agents/prompts/`** — shared date-resolve guardrail composed by voice + coordinator. (#1595)
 - **`resolve-time-window`** — diagnostics agent resolves natural-language time windows for audit queries. (#1592)
@@ -25,6 +26,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Voice** — composes `VOICE_ASYNC_OFFRAMP_GUIDANCE` now that real handoff exists. (#1614)
+- **coordinator** — pins `async-offramp`; version 0.19.0. (#1614)
 - **coordinator** — date-resolve owned by shared module; no prompt plumbing stub (v0.18.2). (#1595)
 - **Console mobile** — dashboard/chat fit phone viewports; voice Call control polished. (#1571)
 - **`resolve-learning-digest`** — accepts a unique task-id prefix for digest resolve. (#1545)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **Voice** — composes `VOICE_ASYNC_OFFRAMP_GUIDANCE` now that real handoff exists. (#1614)
-- **coordinator** — pins `async-offramp`; version 0.19.0. (#1614)
 - **coordinator** — date-resolve owned by shared module; no prompt plumbing stub (v0.18.2). (#1595)
 - **Console mobile** — dashboard/chat fit phone viewports; voice Call control polished. (#1571)
 - **`resolve-learning-digest`** — accepts a unique task-id prefix for digest resolve. (#1545)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.19.0"
+version: "0.18.2"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -687,10 +687,6 @@ pinned_skills:
   # human channel (#1609).
   - bullpen
   - delegate
-  # Voice → async coordinator handoff (#1614 / ADR-038). Voice inherits this
-  # pin via the coordinator tool bridge; text turns rarely need it but the
-  # tool is harmless there (opt-in, action_risk: low).
-  - async-offramp
   - drive-download-file
   - signal-send
   - sms-send

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.18.2"
+version: "0.19.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -687,6 +687,10 @@ pinned_skills:
   # human channel (#1609).
   - bullpen
   - delegate
+  # Voice → async coordinator handoff (#1614 / ADR-038). Voice inherits this
+  # pin via the coordinator tool bridge; text turns rarely need it but the
+  # tool is harmless there (opt-in, action_risk: low).
+  - async-offramp
   - drive-download-file
   - signal-send
   - sms-send

--- a/config/registry-defaults.yaml
+++ b/config/registry-defaults.yaml
@@ -95,6 +95,7 @@ tools:
   - context-bridge-release
   - decay-warnings-list
   - delegate
+  - async-offramp
   - file-parse
   - request-clarification
   - bullpen

--- a/docs/adr/038-voice-brain-shared-hardening.md
+++ b/docs/adr/038-voice-brain-shared-hardening.md
@@ -100,7 +100,7 @@ on its own measured benefit — do **not** ship the bundle:
 |---|---|---|
 | **Routing** (`ROUTING_DECISION_GUARDRAIL`) | transfer-ownership Δ +0.075 (3/5 +, 2/5 0) — **not** a ≥4/5 paired win | **Hold** — no clean win, and the bundle it rides in regresses honest-negative (#1613) |
 | **Pronoun** (`PRONOUN_RESOLUTION_GUARDRAIL`) | Δ identically **0**; `pronoun-your` 0/5 — yet full-consolidation solves it 5/5, so the case is solvable, the module just doesn't | **Hold** — pure token cost today (#1613) |
-| **Off-ramp** (`VOICE_ASYNC_OFFRAMP_GUIDANCE`) | the one category paired win (Δ +0.267, 5/5 +) — tool was mocked at measurement; real tool now lands in #1614 | **Compose** with real handoff (#1614) |
+| **Off-ramp** (`VOICE_ASYNC_OFFRAMP_GUIDANCE`) | historical paired win (Δ +0.267, 5/5 +) measured while tool was mocked and baseline lacked the module | **Compose** with real handoff (#1614). Production baseline now includes it — fresh paired runs no longer isolate an off-ramp delta; archive the pre-compose evidence |
 | **Date-resolve** (already in prod) | wash / distraction risk (`date-next-friday` ↑, `date-next-tuesday` ↓ 5/5→4/5) | Keep; close handoff via **#1612**, not more prompt text |
 | **Bundle cost** | stacking the modules **regressed** honest-negative (−0.05; shared 2 fails vs baseline 0) | Real cost of composing more instruction — weigh per module, not as a bundle |
 
@@ -186,7 +186,10 @@ When a request exceeds live-call scope, voice should:
    not handed off (tool returns `success: false` on enqueue failure).
 
 Prompt module: `src/agents/prompts/voice-async-offramp.ts` (voice-only).
-Tool: `skills/async-offramp/` (pinned on coordinator; voice inherits).
+Tool: `skills/async-offramp/` — injected by the voice tool bridge
+(`src/index.ts`), **not** pinned on the coordinator (the async destination
+must not advertise a recursive off-ramp). Excluded from text-turn discovery;
+handler rejects non-voice `channelId`.
 Eval scores against the **real** handler (spike `invokeTool`), not a mock.
 
 ### Tentative resolution of #1563's blocking question
@@ -203,7 +206,7 @@ Issue #1563 stays blocked on this decision.
 | `DATE_RESOLVE_GUARDRAIL` | yes | **yes** (both; YAML has no pointer stub) |
 | `ROUTING_DECISION_GUARDRAIL` | yes | **hold** (#1613) — no clean paired win; +0.075 transfer only |
 | `PRONOUN_RESOLUTION_GUARDRAIL` | yes | **hold** — zero paired benefit until `pronoun-your` moves (#1613) |
-| `VOICE_ASYNC_OFFRAMP_GUIDANCE` + real `async-offramp` tool | yes / real tool | **yes** (voice compose + tool — #1614; Accept gate #3 cleared) |
+| `VOICE_ASYNC_OFFRAMP_GUIDANCE` + real `async-offramp` tool | yes / real tool | **yes** (voice compose + voice-bridge tool — #1614; Accept gate #3 cleared). Not a coordinator pin — injected by the voice tool bridge only |
 
 ### Prompt-shape rule
 

--- a/docs/adr/038-voice-brain-shared-hardening.md
+++ b/docs/adr/038-voice-brain-shared-hardening.md
@@ -87,8 +87,8 @@ module compose**. Gates:
    `VOICE_ASYNC_OFFRAMP_GUIDANCE` + fixture `mustCallTools: ["async-offramp"]`
    measure recognition only. Acceptance requires an `async-offramp` tool that
    actually enqueues coordinator work and reaches the principal on
-   Signal/email. Do not ship the prompt that offers follow-ups until that
-   path exists. Implementation tracked in #1614.
+   Signal/email. **Shipped in #1614** — compose into production voice is now
+   safe.
 
 ### Per-module compose gates (#1605 reframed)
 
@@ -100,7 +100,7 @@ on its own measured benefit — do **not** ship the bundle:
 |---|---|---|
 | **Routing** (`ROUTING_DECISION_GUARDRAIL`) | transfer-ownership Δ +0.075 (3/5 +, 2/5 0) — **not** a ≥4/5 paired win | **Hold** — no clean win, and the bundle it rides in regresses honest-negative (#1613) |
 | **Pronoun** (`PRONOUN_RESOLUTION_GUARDRAIL`) | Δ identically **0**; `pronoun-your` 0/5 — yet full-consolidation solves it 5/5, so the case is solvable, the module just doesn't | **Hold** — pure token cost today (#1613) |
-| **Off-ramp** (`VOICE_ASYNC_OFFRAMP_GUIDANCE`) | the one category paired win (Δ +0.267, 5/5 +) — but the tool is **mocked** | **Compose only after real handoff** (gate #3, handoff #1614; compose per #1613) |
+| **Off-ramp** (`VOICE_ASYNC_OFFRAMP_GUIDANCE`) | the one category paired win (Δ +0.267, 5/5 +) — tool was mocked at measurement; real tool now lands in #1614 | **Compose** with real handoff (#1614) |
 | **Date-resolve** (already in prod) | wash / distraction risk (`date-next-friday` ↑, `date-next-tuesday` ↓ 5/5→4/5) | Keep; close handoff via **#1612**, not more prompt text |
 | **Bundle cost** | stacking the modules **regressed** honest-negative (−0.05; shared 2 fails vs baseline 0) | Real cost of composing more instruction — weigh per module, not as a bundle |
 
@@ -170,7 +170,7 @@ tokens every spoken turn.
 Outbound-context: both prototype arms inject `formatInjectionBlock` **once**
 on the voice system-prompt path. Preserve that invariant.
 
-### Async off-ramp design (required mitigation — handoff not done)
+### Async off-ramp design (required mitigation — handoff shipped in #1614)
 
 When a request exceeds live-call scope, voice should:
 
@@ -178,13 +178,16 @@ When a request exceeds live-call scope, voice should:
    coordinator-depth (see `VOICE_ASYNC_OFFRAMP_GUIDANCE`).
 2. **Offer** — natural spoken deferral.
 3. **Hand off** — on agreement, call `async-offramp` with brief + follow-up
-   channel. **Implementation required before Accept:** enqueue on the normal
-   async dispatch path (coordinator task / inbound.message).
-4. **Close the loop** — reach the principal on Signal/email when done.
-   Never claim a follow-up that was not handed off.
+   channel. The real tool (`skills/async-offramp/`) enqueues a coordinator
+   `agent.task` on the normal dispatch path (voice re-enters the path it
+   bypasses at `dispatcher.ts`).
+4. **Close the loop** — the async coordinator reaches the principal on
+   Signal/email via existing send skills. Never claim a follow-up that was
+   not handed off (tool returns `success: false` on enqueue failure).
 
 Prompt module: `src/agents/prompts/voice-async-offramp.ts` (voice-only).
-Eval currently measures recognition against a **mocked** tool only.
+Tool: `skills/async-offramp/` (pinned on coordinator; voice inherits).
+Eval scores against the **real** handler (spike `invokeTool`), not a mock.
 
 ### Tentative resolution of #1563's blocking question
 
@@ -200,7 +203,7 @@ Issue #1563 stays blocked on this decision.
 | `DATE_RESOLVE_GUARDRAIL` | yes | **yes** (both; YAML has no pointer stub) |
 | `ROUTING_DECISION_GUARDRAIL` | yes | **hold** (#1613) — no clean paired win; +0.075 transfer only |
 | `PRONOUN_RESOLUTION_GUARDRAIL` | yes | **hold** — zero paired benefit until `pronoun-your` moves (#1613) |
-| `VOICE_ASYNC_OFFRAMP_GUIDANCE` + real `async-offramp` tool | guidance yes / tool mocked | **no** — real handoff (#1614) is an Accept + compose gate (compose per #1613) |
+| `VOICE_ASYNC_OFFRAMP_GUIDANCE` + real `async-offramp` tool | yes / real tool | **yes** (voice compose + tool — #1614; Accept gate #3 cleared) |
 
 ### Prompt-shape rule
 
@@ -212,8 +215,8 @@ The coordinator's sole `### Date & time` instruction is the composed
 ### Related issues
 
 - #1612 — structural date-resolve → brief validation (orthogonal, high impact)
-- #1613 — compose modules that **pay for themselves** (all three currently HOLD — routing/pronoun show no clean win on the corrected harness; off-ramp only after its real handoff); supersedes bundled #1605
-- #1614 — implement the real async off-ramp handoff (gate #3)
+- #1613 — compose modules that **pay for themselves** (routing/pronoun still HOLD; off-ramp compose landed with #1614 once the real handoff existed); supersedes bundled #1605
+- #1614 — implement the real async off-ramp handoff (gate #3) — **done**
 - #1563 — text → streaming (unblocks on Accept)
 
 ## Consequences (if Accepted)

--- a/scripts/spikes/voice-brain-parity/run.ts
+++ b/scripts/spikes/voice-brain-parity/run.ts
@@ -10,8 +10,9 @@
 //   full-consolidation — coordinator.yaml system_prompt + spoken addendum
 //
 // Tools are load-bearing: calendar delegate rejects briefs lacking the ISO
-// date that date-resolve should have produced. Counts are utterances ×
-// assertion-checks — not an exhaustive suite.
+// date that date-resolve should have produced. async-offramp invokes the
+// real handler (skills/async-offramp) against a fake bus — not a mock (#1614).
+// Counts are utterances × assertion-checks — not an exhaustive suite.
 //
 // Usage:
 //   ANTHROPIC_API_KEY=... pnpm exec tsx scripts/spikes/voice-brain-parity/run.ts
@@ -42,6 +43,14 @@ import {
 } from '../../../src/channels/voice/voice-runtime.js';
 import { createSilentLogger } from '../../../src/logger.js';
 import { formatTimeContextBlock } from '../../../src/time/time-context.js';
+import {
+  AsyncOfframpHandler,
+  resetAsyncOfframpDedupForTests,
+} from '../../../skills/async-offramp/handler.js';
+import type { ToolContext } from '../../../src/skills/types.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { BusEvent } from '../../../src/bus/events.js';
+import pino from 'pino';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../..');
 const FIXTURES_PATH = resolve(import.meta.dirname, 'fixtures.json');
@@ -143,9 +152,9 @@ function buildPrompts(fixtures: Fixtures, outbound: string | null): Record<ArmId
     timeContextBlock: timeBlock,
   });
 
-  // Shared-hardening: all staged modules + voice async off-ramp (the safety
-  // mitigation that makes the slim brain non-regressive on heavyweight asks).
-  const sharedSections = [
+  // Shared-hardening: production baseline modules (date-resolve + async
+  // off-ramp after #1614) plus the still-staged routing + pronoun modules.
+  const sharedHardening = [
     fixtures.identityBlock,
     VOICE_SYSTEM_ADDENDUM,
     VOICE_TOOL_RESULT_POLICY,
@@ -154,24 +163,23 @@ function buildPrompts(fixtures: Fixtures, outbound: string | null): Record<ArmId
     DATE_RESOLVE_GUARDRAIL,
     VOICE_ASYNC_OFFRAMP_GUIDANCE,
     VOICE_DELEGATION_GUIDANCE + '\n\n## Available Specialists\n' + fixtures.specialistRoster,
-  ];
-  if (outbound) sharedSections.push(outbound);
-  sharedSections.push(timeBlock);
-  const sharedHardening = sharedSections.join('\n\n');
+    ...(outbound ? [outbound] : []),
+    timeBlock,
+  ].join('\n\n');
 
   // Full consolidation: coordinator brain + spoken addendum. Outbound injected
   // exactly once on the system suffix (voice path) — never also via dispatcher.
-  const fullSections = [
+  // Off-ramp guidance stays explicit here (coordinator YAML does not carry it).
+  const fullConsolidation = [
     fixtures.identityBlock,
     loadCoordinatorSystemPrompt(),
     VOICE_SYSTEM_ADDENDUM,
     VOICE_TOOL_RESULT_POLICY,
     VOICE_ASYNC_OFFRAMP_GUIDANCE,
     '## Available Specialists\n' + fixtures.specialistRoster,
-  ];
-  if (outbound) fullSections.push(outbound);
-  fullSections.push(timeBlock);
-  const fullConsolidation = fullSections.join('\n\n');
+    ...(outbound ? [outbound] : []),
+    timeBlock,
+  ].join('\n\n');
 
   return {
     baseline,
@@ -277,24 +285,65 @@ function briefContainsResolvedDate(brief: string, iso: string): boolean {
   return alias ? alias.test(brief) : false;
 }
 
+function makeSpikeOfframpBus() {
+  const published: BusEvent[] = [];
+  const bus = {
+    subscribe() {
+      /* unused in spike */
+    },
+    async publish(_layer: string, event: BusEvent) {
+      published.push(event);
+    },
+  } as unknown as EventBus;
+  return { bus, published };
+}
+
+const spikeOfframpHandler = new AsyncOfframpHandler();
+
+/** Invoke the real async-offramp handler (#1614) — no mocked success payload. */
+async function invokeRealAsyncOfframp(
+  call: ToolCall,
+): Promise<{ content: string; is_error?: boolean }> {
+  const { bus } = makeSpikeOfframpBus();
+  const ctx = {
+    input: call.input,
+    log: pino({ level: 'silent' }),
+    bus,
+    agentId: 'coordinator',
+    conversationId: 'voice:spike-eval',
+    channelId: 'voice',
+    taskEventId: 'spike-session',
+    liveTurn: true,
+    caller: { contactId: 'ceo-spike', role: 'ceo', channel: 'voice' },
+    taskMetadata: {
+      originator: {
+        contactId: 'ceo-spike',
+        systemRole: 'principal',
+        channel: 'voice',
+        initiatedAt: new Date().toISOString(),
+        tier: 'known',
+      },
+      voiceSessionId: 'spike-session',
+    },
+  } as unknown as ToolContext;
+
+  const result = await spikeOfframpHandler.execute(ctx);
+  if (result.success) {
+    return { content: JSON.stringify(result.data ?? { ok: true }) };
+  }
+  return { content: result.error ?? 'async-offramp failed', is_error: true };
+}
+
 function defaultToolResult(
   call: ToolCall,
   fixtures: Fixtures,
   prior: ToolTrace[],
-): { content: string; is_error?: boolean } {
+): { content: string; is_error?: boolean } | Promise<{ content: string; is_error?: boolean }> {
   if (call.name === 'date-resolve') return defaultDateResolveResult(call, fixtures);
 
+  // Real handler — scores against actual enqueue shape, not a hardcoded mock (#1614).
   if (call.name === 'async-offramp') {
-    return {
-      content: JSON.stringify({
-        success: true,
-        data: {
-          accepted: true,
-          follow_up_channel: call.input.follow_up_channel ?? 'email',
-          note: 'Handed to async coordinator path; principal will be reached when done.',
-        },
-      }),
-    };
+    return invokeRealAsyncOfframp(call);
   }
 
   if (call.name === 'delegate') {
@@ -643,6 +692,9 @@ async function runCase(
   fixtures: Fixtures,
   provider: AnthropicProvider,
 ): Promise<CaseResult> {
+  // Fresh dedup map per case so real async-offramp enqueues don't collide across fixtures.
+  resetAsyncOfframpDedupForTests();
+
   const messages: Message[] = [
     { role: 'system', content: systemPrompt },
     ...(fixture.history ?? []).map(h => ({ role: h.role, content: h.content }) as Message),

--- a/scripts/spikes/voice-brain-parity/run.ts
+++ b/scripts/spikes/voice-brain-parity/run.ts
@@ -154,6 +154,9 @@ function buildPrompts(fixtures: Fixtures, outbound: string | null): Record<ArmId
 
   // Shared-hardening: production baseline modules (date-resolve + async
   // off-ramp after #1614) plus the still-staged routing + pronoun modules.
+  // Note: baseline via buildVoiceSystemPrompt() now also includes off-ramp, so
+  // paired shared−baseline no longer isolates an off-ramp delta — that evidence
+  // is historical (pre-compose). Future paired runs measure routing/pronoun only.
   const sharedHardening = [
     fixtures.identityBlock,
     VOICE_SYSTEM_ADDENDUM,

--- a/skills/async-offramp/handler.test.ts
+++ b/skills/async-offramp/handler.test.ts
@@ -161,6 +161,31 @@ describe('AsyncOfframpHandler', () => {
     }
   });
 
+  it('scopes explicit idempotency_key to the conversation (no cross-session swallow)', async () => {
+    const { bus, published } = makeBus();
+    await handler.execute(
+      makeCtx(bus, { brief: 'Deck A', follow_up_channel: 'email', idempotency_key: 'deck' }),
+    );
+    await handler.execute(
+      makeCtx(
+        bus,
+        { brief: 'Deck B for another call', follow_up_channel: 'email', idempotency_key: 'deck' },
+        { conversationId: 'voice:other-session' },
+      ),
+    );
+    expect(published).toHaveLength(2);
+  });
+
+  it('rejects non-voice channel invocations (voice-only backstop)', async () => {
+    const { bus, published } = makeBus();
+    const result = await handler.execute(
+      makeCtx(bus, { brief: 'Should not enqueue' }, { channelId: 'email' }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/voice-only/i);
+    expect(published).toHaveLength(0);
+  });
+
   it('returns honest failure when enqueue publish fails (no false confirm)', async () => {
     const { bus, published } = makeBus({ failPublish: true });
     const result = await handler.execute(

--- a/skills/async-offramp/handler.test.ts
+++ b/skills/async-offramp/handler.test.ts
@@ -1,0 +1,216 @@
+// handler.test.ts — async-offramp skill (#1614 / ADR-038 gate #3).
+import { describe, it, expect, beforeEach } from 'vitest';
+import pino from 'pino';
+import { AsyncOfframpHandler, resetAsyncOfframpDedupForTests } from './handler.js';
+import type { ToolContext } from '../../src/skills/types.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import type { AgentTaskEvent, BusEvent } from '../../src/bus/events.js';
+
+function makeBus(opts: { failPublish?: boolean } = {}) {
+  const published: BusEvent[] = [];
+  const bus = {
+    subscribe() {
+      /* unused */
+    },
+    async publish(_layer: string, event: BusEvent) {
+      if (opts.failPublish) {
+        throw new Error('bus unavailable');
+      }
+      published.push(event);
+    },
+  } as unknown as EventBus;
+  return { bus, published };
+}
+
+function makeCtx(
+  bus: EventBus,
+  input: Record<string, unknown>,
+  over: Partial<ToolContext> = {},
+): ToolContext {
+  return {
+    input,
+    log: pino({ level: 'silent' }),
+    bus,
+    agentId: 'coordinator',
+    conversationId: 'voice:session-abc',
+    channelId: 'voice',
+    taskEventId: 'voice-session-abc',
+    liveTurn: true,
+    caller: { contactId: 'ceo-1', role: 'ceo', channel: 'voice' },
+    taskMetadata: {
+      originator: {
+        contactId: 'ceo-1',
+        systemRole: 'principal',
+        channel: 'voice',
+        initiatedAt: '2026-07-28T12:00:00.000Z',
+        tier: 'known',
+      },
+      voiceSessionId: 'session-abc',
+    },
+    ...over,
+  } as unknown as ToolContext;
+}
+
+const handler = new AsyncOfframpHandler();
+
+describe('AsyncOfframpHandler', () => {
+  beforeEach(() => {
+    resetAsyncOfframpDedupForTests();
+  });
+
+  it('enqueues a coordinator agent.task on the dispatch path (happy path)', async () => {
+    const { bus, published } = makeBus();
+    const result = await handler.execute(
+      makeCtx(bus, {
+        brief: 'Draft a research deck on Q3 competitors and email me when ready',
+        follow_up_channel: 'email',
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as Record<string, unknown>;
+    expect(data).toMatchObject({
+      accepted: true,
+      follow_up_channel: 'email',
+      deduplicated: false,
+    });
+    expect(typeof data['task_event_id']).toBe('string');
+
+    expect(published).toHaveLength(1);
+    const task = published[0] as AgentTaskEvent;
+    expect(task.type).toBe('agent.task');
+    expect(task.payload.agentId).toBe('coordinator');
+    expect(task.payload.channelId).toBe('internal');
+    expect(task.payload.senderId).toBe('ceo-1');
+    expect(task.payload.liveTurn).toBeUndefined();
+    expect(task.payload.content).toContain('Voice async off-ramp');
+    expect(task.payload.content).toContain('Draft a research deck');
+    expect(task.payload.content).toContain('email-send');
+    expect(task.payload.metadata).toMatchObject({
+      voiceOfframp: true,
+      followUpChannel: 'email',
+      sourceVoiceConversationId: 'voice:session-abc',
+      originator: { contactId: 'ceo-1', systemRole: 'principal' },
+    });
+    expect(task.parentEventId).toBe('voice-session-abc');
+  });
+
+  it('defaults follow_up_channel to email and uses signal-send when signal', async () => {
+    const { bus, published } = makeBus();
+    const result = await handler.execute(
+      makeCtx(bus, { brief: 'Triage my inbox for vendor invoices' }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>)['follow_up_channel']).toBe('email');
+    }
+    expect((published[0] as AgentTaskEvent).payload.content).toContain('email-send');
+
+    resetAsyncOfframpDedupForTests();
+    const { bus: bus2, published: pub2 } = makeBus();
+    await handler.execute(makeCtx(bus2, { brief: 'Same work via Signal', follow_up_channel: 'signal' }));
+    expect((pub2[0] as AgentTaskEvent).payload.content).toContain('signal-send');
+  });
+
+  it('is idempotent — duplicate call does not spawn a second task', async () => {
+    const { bus, published } = makeBus();
+    const input = {
+      brief: 'Build the competitive research deck',
+      follow_up_channel: 'email',
+    };
+    const first = await handler.execute(makeCtx(bus, input));
+    const second = await handler.execute(makeCtx(bus, input));
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    if (!first.success || !second.success) return;
+
+    expect(published).toHaveLength(1);
+    const firstData = first.data as Record<string, unknown>;
+    expect(second.data).toMatchObject({
+      accepted: true,
+      deduplicated: true,
+      task_event_id: firstData['task_event_id'],
+    });
+  });
+
+  it('honors an explicit idempotency_key across brief wording drift', async () => {
+    const { bus, published } = makeBus();
+    const first = await handler.execute(
+      makeCtx(bus, {
+        brief: 'Do the deck',
+        follow_up_channel: 'email',
+        idempotency_key: 'call-1',
+      }),
+    );
+    const second = await handler.execute(
+      makeCtx(bus, {
+        brief: 'Do the research deck please',
+        follow_up_channel: 'email',
+        idempotency_key: 'call-1',
+      }),
+    );
+    expect(published).toHaveLength(1);
+    expect(first.success && second.success).toBe(true);
+    if (first.success && second.success) {
+      const firstData = first.data as Record<string, unknown>;
+      const secondData = second.data as Record<string, unknown>;
+      expect(secondData['deduplicated']).toBe(true);
+      expect(secondData['task_event_id']).toBe(firstData['task_event_id']);
+    }
+  });
+
+  it('returns honest failure when enqueue publish fails (no false confirm)', async () => {
+    const { bus, published } = makeBus({ failPublish: true });
+    const result = await handler.execute(
+      makeCtx(bus, { brief: 'Heavy research ask', follow_up_channel: 'email' }),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/failed to hand off/i);
+    }
+    expect(published).toHaveLength(0);
+
+    // Dedup claim rolled back — a retry after recovery can succeed.
+    const { bus: bus2, published: pub2 } = makeBus();
+    const retry = await handler.execute(
+      makeCtx(bus2, { brief: 'Heavy research ask', follow_up_channel: 'email' }),
+    );
+    expect(retry.success).toBe(true);
+    expect(pub2).toHaveLength(1);
+  });
+
+  it('rejects missing brief and invalid follow_up_channel', async () => {
+    const { bus } = makeBus();
+    const missing = await handler.execute(makeCtx(bus, {}));
+    expect(missing.success).toBe(false);
+    if (!missing.success) expect(missing.error).toMatch(/brief/i);
+
+    const badChannel = await handler.execute(
+      makeCtx(bus, { brief: 'ok', follow_up_channel: 'carrier-pigeon' }),
+    );
+    expect(badChannel.success).toBe(false);
+    if (!badChannel.success) expect(badChannel.error).toMatch(/signal.*email/i);
+  });
+
+  it('returns error when bus is unavailable (honest degradation)', async () => {
+    const result = await handler.execute(
+      makeCtx(null as unknown as EventBus, { brief: 'anything' }, { bus: undefined }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/bus/i);
+  });
+
+  it('negative contract: handler is opt-in — no publish without an execute call', async () => {
+    // In-scope live-call asks must stay on the voice turn (spike fixture
+    // offramp-should-not-trigger). The tool never auto-fires: without execute(),
+    // nothing is enqueued. Distinct briefs still enqueue separately when called.
+    const { bus, published } = makeBus();
+    expect(published).toHaveLength(0);
+    await handler.execute(makeCtx(bus, { brief: 'Heavyweight A', follow_up_channel: 'email' }));
+    await handler.execute(makeCtx(bus, { brief: 'Heavyweight B', follow_up_channel: 'email' }));
+    expect(published).toHaveLength(2);
+  });
+});

--- a/skills/async-offramp/handler.ts
+++ b/skills/async-offramp/handler.ts
@@ -1,0 +1,227 @@
+// skills/async-offramp/handler.ts
+//
+// Voice → async coordinator handoff (#1614 / ADR-038 gate #3).
+//
+// Voice bypasses normal inbound→coordinator dispatch (dispatcher.ts skips
+// channelId === 'voice'). When a live-call request exceeds the slim brain's
+// scope, this tool re-enters the normal path by publishing a coordinator
+// agent.task directly (impersonating the dispatch layer, same as delegate).
+//
+// The async task deliberately does NOT forward liveTurn — crossing the async
+// boundary must not preserve the elevated self-approval signal (#1126).
+// channelId is 'internal' so agent.response is not auto-relayed to voice TTS;
+// the coordinator reaches the principal via signal-send / email-send using
+// the injected Principal Contact Details block.
+//
+// Idempotent: a process-local map keyed by (conversation + brief + channel)
+// returns the prior task_event_id on retry instead of spawning duplicates.
+
+import { createHash, randomUUID } from 'node:crypto';
+import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
+import { createAgentTask } from '../../src/bus/events.js';
+
+const FOLLOW_UP_CHANNELS = new Set(['signal', 'email']);
+const DEFAULT_FOLLOW_UP = 'email';
+/** Cap the in-process dedup map so a long-lived process cannot grow without bound. */
+const MAX_DEDUP_ENTRIES = 5_000;
+
+interface DedupEntry {
+  taskEventId: string;
+  followUpChannel: string;
+}
+
+/** Module-scoped so duplicate tool calls in the same process hit the same map.
+ *  Process restart clears it — a re-offramp after restart is rare for voice and
+ *  at worst schedules one extra coordinator task the principal can ignore. */
+const enqueuedByKey = new Map<string, DedupEntry>();
+
+function normalizeBrief(brief: string): string {
+  return brief.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function resolveFollowUpChannel(raw: unknown): string | { error: string } {
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_FOLLOW_UP;
+  if (typeof raw !== 'string') {
+    return { error: "follow_up_channel must be 'signal' or 'email'" };
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (!FOLLOW_UP_CHANNELS.has(normalized)) {
+    return { error: "follow_up_channel must be 'signal' or 'email'" };
+  }
+  return normalized;
+}
+
+function buildIdempotencyKey(
+  conversationId: string | undefined,
+  brief: string,
+  followUpChannel: string,
+  explicitKey: string | undefined,
+): string {
+  if (explicitKey) return `explicit:${explicitKey}`;
+  const material = `${conversationId ?? 'unknown'}|${normalizeBrief(brief)}|${followUpChannel}`;
+  return createHash('sha256').update(material).digest('hex');
+}
+
+function rememberDedup(key: string, entry: DedupEntry): void {
+  if (enqueuedByKey.has(key)) enqueuedByKey.delete(key);
+  enqueuedByKey.set(key, entry);
+  while (enqueuedByKey.size > MAX_DEDUP_ENTRIES) {
+    const oldest = enqueuedByKey.keys().next().value;
+    if (oldest === undefined) break;
+    enqueuedByKey.delete(oldest);
+  }
+}
+
+/** Build the coordinator task content — clear provenance + follow-up instruction. */
+function buildTaskContent(brief: string, followUpChannel: string, sourceConversationId: string | undefined): string {
+  const channelSkill = followUpChannel === 'signal' ? 'signal-send' : 'email-send';
+  const source = sourceConversationId ?? '(unknown voice conversation)';
+  return [
+    'Voice async off-ramp — the principal asked you during a live voice call to handle',
+    'the following asynchronously. Complete the work, then reach the principal on',
+    `${followUpChannel} using ${channelSkill} and their Principal Contact Details.`,
+    'Do not try to reply on the voice channel.',
+    '',
+    '## Brief',
+    brief.trim(),
+    '',
+    `## Follow-up channel: ${followUpChannel}`,
+    `## Source voice conversation: ${source}`,
+  ].join('\n');
+}
+
+/** Exported for tests — clears the process-local dedup map between cases. */
+export function resetAsyncOfframpDedupForTests(): void {
+  enqueuedByKey.clear();
+}
+
+export class AsyncOfframpHandler implements ToolHandler {
+  async execute(ctx: ToolContext): Promise<ToolResult> {
+    if (!ctx.bus) {
+      return { success: false, error: 'async-offramp requires bus capability — handoff unavailable' };
+    }
+
+    const input = (ctx.input ?? {}) as Record<string, unknown>;
+    const briefRaw = input.brief;
+    if (typeof briefRaw !== 'string' || !briefRaw.trim()) {
+      return { success: false, error: 'Missing required input: brief (string)' };
+    }
+    const brief = briefRaw.trim();
+
+    const channelResult = resolveFollowUpChannel(input.follow_up_channel);
+    if (typeof channelResult === 'object') {
+      return { success: false, error: channelResult.error };
+    }
+    const followUpChannel = channelResult;
+
+    const explicitKey =
+      typeof input.idempotency_key === 'string' && input.idempotency_key.trim()
+        ? input.idempotency_key.trim()
+        : undefined;
+    const idempotencyKey = buildIdempotencyKey(
+      ctx.conversationId,
+      brief,
+      followUpChannel,
+      explicitKey,
+    );
+
+    const prior = enqueuedByKey.get(idempotencyKey);
+    if (prior) {
+      ctx.log.info(
+        {
+          taskEventId: prior.taskEventId,
+          followUpChannel: prior.followUpChannel,
+          idempotencyKey,
+          briefPreview: brief.slice(0, 80),
+        },
+        'voice off-ramped to async (deduplicated — prior enqueue reused)',
+      );
+      return {
+        success: true,
+        data: {
+          accepted: true,
+          task_event_id: prior.taskEventId,
+          follow_up_channel: prior.followUpChannel,
+          deduplicated: true,
+          note: 'Already handed to async coordinator path; principal will be reached when done.',
+        },
+      };
+    }
+
+    const originator = ctx.taskMetadata?.originator as
+      | { contactId?: string; systemRole?: string; channel?: string; initiatedAt?: string; tier?: string }
+      | undefined;
+    const senderId =
+      originator?.contactId ??
+      ctx.caller?.contactId ??
+      'ceo-web-user';
+
+    const parentEventId = ctx.taskEventId ?? `async-offramp-${randomUUID()}`;
+    const conversationId = `voice-offramp:${idempotencyKey.slice(0, 32)}`;
+
+    const taskEvent = createAgentTask({
+      agentId: 'coordinator',
+      conversationId,
+      channelId: 'internal',
+      senderId,
+      content: buildTaskContent(brief, followUpChannel, ctx.conversationId),
+      metadata: {
+        voiceOfframp: true,
+        followUpChannel,
+        sourceVoiceConversationId: ctx.conversationId,
+        sourceVoiceSessionId: ctx.taskMetadata?.['voiceSessionId'],
+        brief,
+        idempotencyKey,
+        ...(originator ? { originator } : {}),
+      },
+      // Deliberately omit liveTurn — async boundary (#1126).
+      parentEventId,
+    });
+
+    // Claim before publish so a concurrent duplicate cannot enqueue twice.
+    // Roll back on publish failure so an honest retry can succeed.
+    rememberDedup(idempotencyKey, {
+      taskEventId: taskEvent.id,
+      followUpChannel,
+    });
+
+    try {
+      // Publish as 'dispatch' — only dispatch/system may publish agent.task
+      // (permissions.ts). Infrastructure skills are trusted to impersonate.
+      await ctx.bus.publish('dispatch', taskEvent);
+    } catch (err) {
+      enqueuedByKey.delete(idempotencyKey);
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error(
+        { err, briefPreview: brief.slice(0, 80), followUpChannel },
+        'voice async off-ramp enqueue failed — do not confirm follow-up to principal',
+      );
+      return {
+        success: false,
+        error: `Failed to hand off to async path: ${message}`,
+      };
+    }
+
+    ctx.log.info(
+      {
+        taskEventId: taskEvent.id,
+        followUpChannel,
+        idempotencyKey,
+        sourceConversationId: ctx.conversationId,
+        briefPreview: brief.slice(0, 80),
+      },
+      'voice off-ramped work to async coordinator',
+    );
+
+    return {
+      success: true,
+      data: {
+        accepted: true,
+        task_event_id: taskEvent.id,
+        follow_up_channel: followUpChannel,
+        deduplicated: false,
+        note: 'Handed to async coordinator path; principal will be reached when done.',
+      },
+    };
+  }
+}

--- a/skills/async-offramp/handler.ts
+++ b/skills/async-offramp/handler.ts
@@ -2,6 +2,12 @@
 //
 // Voice → async coordinator handoff (#1614 / ADR-038 gate #3).
 //
+// Voice-only tool: advertised by the voice tool bridge (src/index.ts), NOT
+// pinned on the coordinator. The coordinator is the async *destination* — pinning
+// here would let text turns (and off-ramped tasks) call it recursively.
+// allowed_callers stays ["coordinator"] because the bridge invokes with
+// agentId: 'coordinator'; the channelId === 'voice' guard is the real gate.
+//
 // Voice bypasses normal inbound→coordinator dispatch (dispatcher.ts skips
 // channelId === 'voice'). When a live-call request exceeds the slim brain's
 // scope, this tool re-enters the normal path by publishing a coordinator
@@ -22,6 +28,14 @@ import { createAgentTask } from '../../src/bus/events.js';
 
 const FOLLOW_UP_CHANNELS = new Set(['signal', 'email']);
 const DEFAULT_FOLLOW_UP = 'email';
+/**
+ * Last-resort sender when originator and caller are both missing.
+ * Same synthetic principal id the voice runtime / web chat use
+ * (`DEFAULT_SENDER_ID` in voice-runtime.ts) — voice is principal-only today
+ * (#1598), so attributing to that identity is safer than inventing a new one
+ * or refusing a handoff the principal already agreed to.
+ */
+const FALLBACK_PRINCIPAL_SENDER_ID = 'ceo-web-user';
 /** Cap the in-process dedup map so a long-lived process cannot grow without bound. */
 const MAX_DEDUP_ENTRIES = 5_000;
 
@@ -57,7 +71,11 @@ function buildIdempotencyKey(
   followUpChannel: string,
   explicitKey: string | undefined,
 ): string {
-  if (explicitKey) return `explicit:${explicitKey}`;
+  // Always scope to conversation — an LLM-supplied key like "deck" must not
+  // collide across sessions (CodeRabbit #1617).
+  if (explicitKey) {
+    return `explicit:${conversationId ?? 'unknown'}|${explicitKey}`;
+  }
   const material = `${conversationId ?? 'unknown'}|${normalizeBrief(brief)}|${followUpChannel}`;
   return createHash('sha256').update(material).digest('hex');
 }
@@ -97,6 +115,20 @@ export function resetAsyncOfframpDedupForTests(): void {
 
 export class AsyncOfframpHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
+    // Voice-only backstop: not pinned on the coordinator, but discovery could
+    // otherwise resurface it to a text turn (allowed_callers includes coordinator).
+    // Reject anything that isn't a live voice channel invocation.
+    if (ctx.channelId !== 'voice') {
+      ctx.log.warn(
+        { channelId: ctx.channelId, agentId: ctx.agentId },
+        'async-offramp rejected — voice-only tool (not available on text/async turns)',
+      );
+      return {
+        success: false,
+        error: 'async-offramp is voice-only — use the normal coordinator path for async work',
+      };
+    }
+
     if (!ctx.bus) {
       return { success: false, error: 'async-offramp requires bus capability — handoff unavailable' };
     }
@@ -154,7 +186,7 @@ export class AsyncOfframpHandler implements ToolHandler {
     const senderId =
       originator?.contactId ??
       ctx.caller?.contactId ??
-      'ceo-web-user';
+      FALLBACK_PRINCIPAL_SENDER_ID;
 
     const parentEventId = ctx.taskEventId ?? `async-offramp-${randomUUID()}`;
     const conversationId = `voice-offramp:${idempotencyKey.slice(0, 32)}`;

--- a/skills/async-offramp/tool.json
+++ b/skills/async-offramp/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "async-offramp",
-  "description": "Hand a heavyweight request off the live voice call to the async coordinator path. Use after the principal agrees to a follow-up, or when the ask is clearly async-shaped (deep research, bulk triage, multi-document drafting, clarification loops). Provide a crisp brief of what to do and how to follow up (signal or email). Returns accepted:true only when the work was actually enqueued — never claim a follow-up on failure.",
-  "version": "0.1.0",
+  "description": "Hand a heavyweight request off the live voice call to the async coordinator path. Voice-only — not available on text turns. Use after the principal agrees to a follow-up, or when the ask is clearly async-shaped (deep research, bulk triage, multi-document drafting, clarification loops). Provide a crisp brief of what to do and how to follow up (signal or email). Returns accepted:true only when the work was actually enqueued — never claim a follow-up on failure.",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/async-offramp/tool.json
+++ b/skills/async-offramp/tool.json
@@ -1,0 +1,24 @@
+{
+  "name": "async-offramp",
+  "description": "Hand a heavyweight request off the live voice call to the async coordinator path. Use after the principal agrees to a follow-up, or when the ask is clearly async-shaped (deep research, bulk triage, multi-document drafting, clarification loops). Provide a crisp brief of what to do and how to follow up (signal or email). Returns accepted:true only when the work was actually enqueued — never claim a follow-up on failure.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "brief": "string (required — crisp description of the work to do asynchronously)",
+    "follow_up_channel": "string? (signal | email — channel to reach the principal when done; defaults to email)",
+    "idempotency_key": "string? (optional stable key; duplicates return the prior enqueue without spawning another task)"
+  },
+  "outputs": {
+    "accepted": "boolean (true when the async coordinator task was enqueued or deduplicated)",
+    "task_event_id": "string? (bus event id of the enqueued agent.task)",
+    "follow_up_channel": "string? (normalized follow-up channel)",
+    "deduplicated": "boolean? (true when this call reused a prior enqueue)",
+    "note": "string? (short status for the spoken confirm)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["bus"],
+  "allowed_callers": ["coordinator"]
+}

--- a/src/agents/prompts/voice-async-offramp.ts
+++ b/src/agents/prompts/voice-async-offramp.ts
@@ -11,9 +11,9 @@
 
 /**
  * Spoken-turn guidance for deferring work that exceeds live-call scope.
- * Recognition + offer language only — the actual async handoff (publish
- * inbound / schedule coordinator task / follow up on Signal/email) is the
- * implementation follow-up tracked beside ADR-038.
+ * Recognition + offer language; the real handoff is the `async-offramp` tool
+ * (`skills/async-offramp/`), which enqueues a coordinator `agent.task` and
+ * reaches the principal on Signal/email when done (#1614 / ADR-038 gate #3).
  */
 export const VOICE_ASYNC_OFFRAMP_GUIDANCE = [
   '### Live-call scope and async off-ramp',

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -6,6 +6,7 @@ import { OutboundContextService } from '../../dispatch/outbound-context.js';
 import { createSilentLogger } from '../../logger.js';
 import type { LLMProvider, LLMResponse, LLMStreamEvent, Message } from '../../agents/llm/provider.js';
 import { DATE_RESOLVE_GUARDRAIL } from '../../agents/prompts/date-resolve-guardrail.js';
+import { VOICE_ASYNC_OFFRAMP_GUIDANCE } from '../../agents/prompts/voice-async-offramp.js';
 import { WorkingMemory } from '../../memory/working-memory.js';
 import {
   VoiceRuntime,
@@ -20,6 +21,14 @@ import { FakeSttProvider } from './speech/fake-stt.js';
 import type { PcmFrame, TextToSpeechProvider, TtsSynthesizeOptions } from './speech/types.js';
 import { TtsHttpError } from './speech/types.js';
 import type { VoiceSessionRecord, VoiceSessionStore } from './session-store.js';
+
+/** Slim spoken prompt with no identity/roster/outbound/time — includes shared modules. */
+const SLIM_VOICE_PROMPT = [
+  VOICE_SYSTEM_ADDENDUM,
+  VOICE_TOOL_RESULT_POLICY,
+  DATE_RESOLVE_GUARDRAIL,
+  VOICE_ASYNC_OFFRAMP_GUIDANCE,
+].join('\n\n');
 
 const logger = createSilentLogger();
 const usage = { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
@@ -590,7 +599,7 @@ describe('VoiceRuntime brain/context parity (#1551)', () => {
     await runtime.awaitIdle('sp2');
 
     const system = llm.seenMessages[0]![0]!;
-    expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}\n\n${DATE_RESOLVE_GUARDRAIL}`);
+    expect(system.content).toBe(SLIM_VOICE_PROMPT);
   });
 
   it('omits a throwing identity block and still runs the turn', async () => {
@@ -906,10 +915,8 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
     expect(prompt.indexOf('[ACTIVE OUTBOUND CONTEXT'))
       .toBeLessThan(prompt.indexOf('## Current Date & Time'));
     // Empty outbound → identical to the slim path without that section (still
-    // includes the shared date-resolve guardrail — ADR-038).
-    expect(buildVoiceSystemPrompt({})).toBe(
-      `${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}\n\n${DATE_RESOLVE_GUARDRAIL}`,
-    );
+    // includes shared date-resolve + async off-ramp — ADR-038 / #1614).
+    expect(buildVoiceSystemPrompt({})).toBe(SLIM_VOICE_PROMPT);
   });
 
   it('buildVoiceSystemPrompt composes the shared date-resolve guardrail', () => {
@@ -918,6 +925,14 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
     expect(prompt).toContain('### Date & time');
     expect(prompt.indexOf(VOICE_TOOL_RESULT_POLICY))
       .toBeLessThan(prompt.indexOf(DATE_RESOLVE_GUARDRAIL));
+  });
+
+  it('buildVoiceSystemPrompt composes the voice async off-ramp guidance (#1614)', () => {
+    const prompt = buildVoiceSystemPrompt({});
+    expect(prompt).toContain('async-offramp');
+    expect(prompt).toContain('Live-call scope and async off-ramp');
+    expect(prompt.indexOf(DATE_RESOLVE_GUARDRAIL))
+      .toBeLessThan(prompt.indexOf(VOICE_ASYNC_OFFRAMP_GUIDANCE));
   });
 
   it('injects an active Signal outbound-context entry into the spoken-turn system prompt', async () => {
@@ -973,7 +988,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
 
     expect(getActive).toHaveBeenCalledOnce();
     const system = llm.seenMessages[0]![0]!;
-    expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}\n\n${DATE_RESOLVE_GUARDRAIL}`);
+    expect(system.content).toBe(SLIM_VOICE_PROMPT);
     expect(system.content).not.toContain('[ACTIVE OUTBOUND CONTEXT');
   });
 
@@ -1000,7 +1015,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
     await runtime.awaitIdle('oc3');
 
     const system = llm.seenMessages[0]![0]!;
-    expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}\n\n${DATE_RESOLVE_GUARDRAIL}`);
+    expect(system.content).toBe(SLIM_VOICE_PROMPT);
     expect(transport.publishedFrames.length).toBeGreaterThan(0);
   });
 
@@ -1027,7 +1042,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
     await runtime.awaitIdle('oc4');
 
     const system = llm.seenMessages[0]![0]!;
-    expect(system.content).toBe(`${VOICE_SYSTEM_ADDENDUM}\n\n${VOICE_TOOL_RESULT_POLICY}\n\n${DATE_RESOLVE_GUARDRAIL}`);
+    expect(system.content).toBe(SLIM_VOICE_PROMPT);
     expect(system.content).not.toContain('[ACTIVE OUTBOUND CONTEXT');
     expect(transport.publishedFrames.length).toBeGreaterThan(0);
   });

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -24,6 +24,7 @@ import type { OutboundContextService } from '../../dispatch/outbound-context.js'
 import type { Logger } from '../../logger.js';
 import type { LLMProvider, Message, ToolCall, ToolDefinition } from '../../agents/llm/provider.js';
 import { DATE_RESOLVE_GUARDRAIL } from '../../agents/prompts/date-resolve-guardrail.js';
+import { VOICE_ASYNC_OFFRAMP_GUIDANCE } from '../../agents/prompts/voice-async-offramp.js';
 import { TurnDateResolveTracker } from '../../agents/delegate-brief-date-validation.js';
 import type { WorkingMemory } from '../../memory/working-memory.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
@@ -86,12 +87,13 @@ function isHardTtsFailure(err: unknown): boolean {
  * Brain stance (#1551, revised by ADR-038): spoken turns get a curated subset
  * of the coordinator's context — office identity/persona block, specialist
  * roster + delegation guidance, shared channel-agnostic guardrails (starting
- * with date-resolve, #1595), and a fresh date/time block — assembled by
- * buildVoiceSystemPrompt(). They deliberately do NOT get the coordinator's
- * full YAML system prompt or KG/sender enrichment (latency + text-channel
- * content that makes no sense spoken). Active outbound-context entries are
- * included (#1594) so voice can acknowledge recent proactive sends on other
- * channels. See ADR-037 Consequences and ADR-038.
+ * with date-resolve, #1595), the voice async off-ramp (#1614), and a fresh
+ * date/time block — assembled by buildVoiceSystemPrompt(). They deliberately
+ * do NOT get the coordinator's full YAML system prompt or KG/sender enrichment
+ * (latency + text-channel content that makes no sense spoken). Active
+ * outbound-context entries are included (#1594) so voice can acknowledge
+ * recent proactive sends on other channels. See ADR-037 Consequences and
+ * ADR-038.
  */
 export const VOICE_SYSTEM_ADDENDUM =
   'You are speaking to the principal in a live voice call. Reply in a natural, ' +
@@ -161,6 +163,9 @@ export function buildVoiceSystemPrompt(parts: {
   // (ADR-038 / #1595). Always present: voice already pins date-resolve via
   // coordinator tools; the failure mode was missing instruction, not missing tool.
   sections.push(DATE_RESOLVE_GUARDRAIL);
+  // Async off-ramp (#1614 / ADR-038 gate #3): composed only once the real
+  // async-offramp tool exists — never promise a follow-up we cannot deliver.
+  sections.push(VOICE_ASYNC_OFFRAMP_GUIDANCE);
   if (parts.specialistRoster) {
     sections.push(
       VOICE_DELEGATION_GUIDANCE + '\n\n## Available Specialists\n' + parts.specialistRoster,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2568,6 +2568,12 @@ async function main(): Promise<void> {
           if (!voiceToolNames.includes(discoveryTool)) voiceToolNames.push(discoveryTool);
         }
       }
+      // Voice-only async off-ramp (#1614 / ADR-038): NOT a coordinator pin — the
+      // coordinator is the async destination and must not advertise (or re-call)
+      // an off-ramp tool on text/async turns. Injected here beside discovery tools.
+      if (!voiceToolNames.includes('async-offramp')) {
+        voiceToolNames.push('async-offramp');
+      }
       const voiceToolDefs = toolRegistry.toToolDefinitions(voiceToolNames);
       runtime.configureTools({
         resolveVoiceTools: () => voiceToolDefs,

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -1441,7 +1441,10 @@ export class ExecutionLayer {
           if (!skillRegistry) {
             // Fallback: tools-only (pre-Phase-3a behaviour) when skillRegistry unset.
             return this.registry.search(query)
-              .filter(s => s.manifest.name !== 'tool-registry' && s.manifest.name !== 'skill-activate')
+              .filter(s =>
+                s.manifest.name !== 'tool-registry'
+                && s.manifest.name !== 'skill-activate'
+                && s.manifest.name !== 'async-offramp')
               .filter(s => {
                 const allowed = s.manifest.allowed_callers;
                 if (!allowed || allowed.length === 0) return true;

--- a/src/skills/skill-activation.ts
+++ b/src/skills/skill-activation.ts
@@ -25,6 +25,8 @@ export {
 } from './skill-instruction-format.js';
 
 export const SKILL_ACTIVATE_TOOL_NAME = 'skill-activate';
+/** Voice-bridge-only tools excluded from text-turn discovery (#1614). */
+export const ASYNC_OFFRAMP_TOOL_NAME = 'async-offramp';
 export const SKILL_ACTIVATION_PROTOCOL = 'skill_activation' as const;
 
 export interface DiscoveryHit {
@@ -71,7 +73,7 @@ export function unifiedToolSearch(options: {
   toolRegistry: ToolRegistry;
   skillRegistry: SkillRegistry;
   agentId: string;
-  /** Tool names excluded from results (e.g. tool-registry, skill-activate). */
+  /** Tool names excluded from results (e.g. tool-registry, skill-activate, async-offramp). */
   excludeToolNames?: ReadonlySet<string>;
 }): DiscoveryHit[] {
   const {
@@ -79,7 +81,12 @@ export function unifiedToolSearch(options: {
     toolRegistry,
     skillRegistry,
     agentId,
-    excludeToolNames = new Set(['tool-registry', SKILL_ACTIVATE_TOOL_NAME]),
+    excludeToolNames = new Set([
+      'tool-registry',
+      SKILL_ACTIVATE_TOOL_NAME,
+      // Voice-only: injected by the voice tool bridge, never discoverable on text (#1614).
+      ASYNC_OFFRAMP_TOOL_NAME,
+    ]),
   } = options;
 
   const results: DiscoveryHit[] = [];

--- a/tests/unit/skills/skill-activation.test.ts
+++ b/tests/unit/skills/skill-activation.test.ts
@@ -120,9 +120,10 @@ describe('unifiedToolSearch', () => {
     expect(hits.some((h) => h.name === 'secret-admin')).toBe(false);
   });
 
-  it('excludes tool-registry and skill-activate from results', () => {
+  it('excludes tool-registry, skill-activate, and async-offramp from results', () => {
     const { tools, skills } = setup();
     tools.register(toolManifest('skill-activate', { description: 'Activate a skill' }), noopHandler);
+    tools.register(toolManifest('async-offramp', { description: 'Voice async off-ramp' }), noopHandler);
     const hits = unifiedToolSearch({
       query: '',
       toolRegistry: tools,
@@ -131,6 +132,7 @@ describe('unifiedToolSearch', () => {
     });
     expect(hits.map((h) => h.name)).not.toContain('tool-registry');
     expect(hits.map((h) => h.name)).not.toContain('skill-activate');
+    expect(hits.map((h) => h.name)).not.toContain('async-offramp');
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements ADR-038 gate #3: a real voice → async coordinator handoff so the slim spoken brain can defer heavyweight work without promising undeliverable follow-ups.

Closes #1614.

## Changes

- New `skills/async-offramp/` tool (`action_risk: low`) that publishes a coordinator `agent.task` on the normal dispatch path (impersonating `dispatch`, same pattern as `delegate`)
- **Voice-bridge injection** — not pinned on the coordinator (async destination); injected beside discovery tools in `src/index.ts`. Excluded from text-turn discovery; handler rejects non-voice `channelId`
- Idempotent enqueue (conversation-scoped keys, including explicit `idempotency_key`); publish failure rolls back and returns `success: false`
- Async task uses `channelId: 'internal'` and omits `liveTurn`; coordinator reaches the principal via `signal-send` / `email-send`
- Composes `VOICE_ASYNC_OFFRAMP_GUIDANCE` into production `buildVoiceSystemPrompt`
- Spike harness invokes the real handler; ADR-038 notes off-ramp paired evidence is historical once baseline includes the module

## Related Issues

Closes #1614

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes (ADR-038)
- [ ] CI passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa99e-631b-7a73-8ff6-212da240710f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa99e-631b-7a73-8ff6-212da240710f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

