### PR TITLE
docs(adr): accept ADR-038 — all three gates cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **`async-offramp`** — voice hands heavyweight asks to async coordinator for principal callback. (#1614)
-- **ADR-038 (Proposed)** — corrected paired-variance evidence; per-module compose gates. #1612/#1613/#1614. (#1595)
+- **ADR-038 (Accepted)** — shared-hardening; voice off-ramp shipped; text→streaming (#1563) unblocked. (#1595)
 - **`src/agents/prompts/`** — shared date-resolve guardrail composed by voice + coordinator. (#1595)
 - **`resolve-time-window`** — diagnostics agent resolves natural-language time windows for audit queries. (#1592)
 - **`nylas_calendar` health check** — probes the principal calendar grant separately from email. (#1561)

--- a/docs/adr/038-voice-brain-shared-hardening.md
+++ b/docs/adr/038-voice-brain-shared-hardening.md
@@ -1,7 +1,7 @@
 # ADR-038: Voice brain parity — shared-hardening vs full consolidation
 
 Date: 2026-07-27
-Status: Proposed
+Status: Accepted
 
 ## Context
 
@@ -58,7 +58,7 @@ effect. Call a comparison a **paired win** when the delta is positive in
 ≥4/5 reps and never negative (`variance.json` → `paired`). Marginal
 min>max separation remains a stricter optional signal.
 
-## Proposed decision
+## Decision
 
 **Reject full consolidation** as the voice brain direction — the ~19×
 instruction-token cost alone carries that rejection (latency microbench +
@@ -66,8 +66,9 @@ prompt-size estimates). On quality it does not win either: full-consolidation
 trails shared-hardening (Δ +0.044, not a paired win) and is roughly tied with
 baseline, while carrying that token load on every spoken turn.
 
-**Lean shared-hardening**, but **do not Accept yet**, and **do not bundle
-module compose**. Gates:
+**Accept shared-hardening.** All three gates below are now cleared (quality
+evidence, #1612 date-in-brief, #1614 off-ramp handoff). Compose modules **per
+measured benefit, not as a bundle**. Gates:
 
 1. **Quality claim (paired, not marginal).** Across 5 interleaved reps
    (corrected harness), the `shared − baseline` **check-rate** delta is +0.036
@@ -192,12 +193,11 @@ must not advertise a recursive off-ramp). Excluded from text-turn discovery;
 handler rejects non-voice `channelId`.
 Eval scores against the **real** handler (spike `invokeTool`), not a mock.
 
-### Tentative resolution of #1563's blocking question
+### Resolution of #1563's blocking question
 
-**Pending ADR acceptance:** if shared-hardening is Accepted (gates cleared),
-text channels **may** use `LLMProvider.stream()` — convergence onto the
-shared streaming primitive with separately composed prompts. Until then
-Issue #1563 stays blocked on this decision.
+Shared-hardening is **Accepted** (all gates cleared), so text channels **may**
+use `LLMProvider.stream()` — convergence onto the shared streaming primitive
+with separately composed prompts. **#1563 is unblocked** and is the follow-up.
 
 ### What is / is not in production on this branch
 
@@ -222,7 +222,7 @@ The coordinator's sole `### Date & time` instruction is the composed
 - #1614 — implement the real async off-ramp handoff (gate #3) — **done**
 - #1563 — text → streaming (unblocks on Accept)
 
-## Consequences (if Accepted)
+## Consequences
 
 - Voice stays a curated subset brain (ADR-037) **plus** shared guardrail
   modules **plus** a real async off-ramp — no full YAML on the spoken path.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,7 +59,7 @@ Each ADR follows the [Nygard format](https://adr.github.io/):
 | [035](035-channel-owned-outbound-recipient-projection.md) | Channel-owned outbound recipient projection — request variants + `extractRecipients` so the gateway needs no per-channel projection edit | Accepted |
 | [036](036-telnyx-sms-channel.md) | Telnyx SMS on a dedicated office DID — medium trust, new-DID-only, carrier STOP (no app ledger), voice Phase 2 SIP note | Accepted |
 | [037](037-voice-channel-livekit-duplex.md) | Duplex voice via self-hosted LiveKit cascade (console WebRTC); STT/TTS provider seams; Phase 2 Signal/PSTN deferred | Accepted |
-| [038](038-voice-brain-shared-hardening.md) | Voice brain parity via shared-hardening prompt modules — reject full coordinator consolidation; text may use `stream()` (#1563) | Proposed |
+| [038](038-voice-brain-shared-hardening.md) | Voice brain parity via shared-hardening prompt modules — reject full coordinator consolidation; text may use `stream()` (#1563) | Accepted |
 
 ## Adding new ADRs
 


### PR DESCRIPTION
## Summary

All three ADR-038 acceptance gates are now cleared:
- **Gate 1** — quality / corrected paired-variance evidence (#1616)
- **Gate 2** — #1612 date-in-brief validation (merged)
- **Gate 3** — #1614 off-ramp handoff (PR #1617, merged)

This flips ADR-038 `Status: Proposed → Accepted`, removes the "do not Accept yet" / "Pending ADR acceptance" framing, drops the "(if Accepted)" conditional on Consequences, and updates the README index.

**Resolves #1563's blocking question:** shared-hardening is Accepted, so text channels **may** use `LLMProvider.stream()` — #1563 is now unblocked and is the follow-up implementation.

Docs-only (ADR-038 + README + CHANGELOG). No code changes.