### PR TITLE
feat(agents): opt AgentRuntime.handleTask into streaming turn primitive (#1563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`AgentRuntime`** — text tool loop delegates to `runStreamingToolLoop` via chat adapter. (#1563)
 - **Voice** — composes `VOICE_ASYNC_OFFRAMP_GUIDANCE` now that real handoff exists. (#1614)
 - **coordinator** — date-resolve owned by shared module; no prompt plumbing stub (v0.18.2). (#1595)
 - **Console mobile** — dashboard/chat fit phone viewports; voice Call control polished. (#1571)

--- a/docs/adr/037-voice-channel-livekit-duplex.md
+++ b/docs/adr/037-voice-channel-livekit-duplex.md
@@ -97,13 +97,12 @@ voice reuses that for session minting (and optional LiveKit webhooks).
   (CHANGELOG must call it out); wrappers (`LLMProviderRouter`,
   `TelemetryLlmProvider`) must forward it.
 - Voice turns share coordinator tools but not the exact `AgentRuntime.handleTask`
-  code path. Voice tool-loop mechanism lives in `src/agents/llm/streaming-turn.ts`
-  (#1552): `VoiceTurnRunner` is a thin TTS/barge-in wrapper over that primitive.
-  Text channels still use a separate non-streaming `chat()` loop in `handleTask`
-  — opt-in is tracked as #1563 (requires an explicit "text goes streaming"
-  decision). Round caps stay parameterized (voice `DEFAULT_STREAMING_MAX_ROUNDS=8`
-  vs per-agent `maxTurns`). Autonomy/Gate-C remains `executionLayer.invoke` on both
-  paths. Brain/context + history read model landed via #1551.
+  code path. Both delegate tool-loop mechanism to `src/agents/llm/streaming-turn.ts`
+  (#1552 / #1563): voice opens `provider.stream()`; text uses a chat-compatible
+  `openStream` adapter over `chatWithRetry` (ADR-038). Round caps stay parameterized
+  (voice `DEFAULT_STREAMING_MAX_ROUNDS=8` vs per-agent `maxTurns`). Autonomy/Gate-C
+  remains `executionLayer.invoke` on both paths. Brain/context + history read model
+  landed via #1551.
 - **Voice "brain" is a curated subset of the coordinator's context (#1551):**
   spoken turns assemble the office identity/persona block, the voice-mode
   addendum (spoken brevity), an honest-negative tool-result policy (a failed

--- a/src/agents/llm/streaming-turn.test.ts
+++ b/src/agents/llm/streaming-turn.test.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_STREAMING_MAX_ROUNDS,
   StreamUnsupportedError,
   assertStreamingProvider,
+  llmResponseAsStream,
   runStreamingToolLoop,
 } from './streaming-turn.js';
 import { buildAssistantToolUseMessage, buildUserToolResultMessage } from './tool-loop-messages.js';
@@ -438,5 +439,174 @@ describe('runStreamingToolLoop (#1552)', () => {
         signal: new AbortController().signal,
       }),
     ).rejects.toThrow(/maxRounds/);
+  });
+
+  it('accepts openStream without provider.stream (chat-compatible adapter #1563)', async () => {
+    const openStream = vi.fn(async function* () {
+      yield textDelta('via ');
+      yield { type: 'message_end' as const, content: 'via adapter', usage, provenance };
+    });
+
+    const result = await runStreamingToolLoop([{ role: 'user', content: 'hi' }], {
+      provider: new NoStreamProvider(),
+      model: 'fake',
+      maxRounds: 2,
+      signal: new AbortController().signal,
+      openStream,
+    });
+
+    expect(openStream).toHaveBeenCalledTimes(1);
+    expect(result.stopReason).toBe('message_end');
+    expect(result.finalText).toBe('via adapter');
+  });
+
+  it('onToolUse returning stop exits before invokeTool (stopReason stopped)', async () => {
+    const toolCall: ToolCall = { id: 'call_1', name: 'lookup', input: {} };
+    const provider = new FakeStreamProvider([
+      [{ type: 'tool_use', toolCalls: [toolCall], usage, provenance }],
+    ]);
+    const invokeTool = vi.fn(async () => ({ content: 'should not run' }));
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: 3,
+      signal: new AbortController().signal,
+      invokeTool,
+      hooks: {
+        onToolUse: async () => 'stop',
+      },
+    });
+
+    expect(invokeTool).not.toHaveBeenCalled();
+    expect(result.stopReason).toBe('stopped');
+    expect(result.toolRounds).toBe(0);
+  });
+
+  it('afterTools returning stop exits after tool results are appended', async () => {
+    const toolCall: ToolCall = { id: 'call_1', name: 'lookup', input: {} };
+    const provider = new FakeStreamProvider([
+      [{ type: 'tool_use', toolCalls: [toolCall], content: 'checking', usage, provenance }],
+      [{ type: 'message_end', content: 'should not reach', usage, provenance }],
+    ]);
+
+    const result = await runStreamingToolLoop([], {
+      provider,
+      model: 'fake',
+      maxRounds: 3,
+      signal: new AbortController().signal,
+      invokeTool: async () => ({ content: '{"ok":true}' }),
+      hooks: {
+        afterTools: async () => 'stop',
+      },
+    });
+
+    expect(result.stopReason).toBe('stopped');
+    expect(result.toolRounds).toBe(1);
+    expect(provider.streamCalls).toBe(1);
+    // Assistant tool_use + user tool_result must both be present.
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toEqual(buildAssistantToolUseMessage([toolCall], 'checking'));
+    expect(result.messages[1]).toEqual(
+      buildUserToolResultMessage([{ id: 'call_1', content: '{"ok":true}' }]),
+    );
+  });
+
+  it('beforeRound receives mutable working messages each LLM round', async () => {
+    const toolCall: ToolCall = { id: 'call_1', name: 'lookup', input: {} };
+    const provider = new FakeStreamProvider([
+      [{ type: 'tool_use', toolCalls: [toolCall], usage, provenance }],
+      [{ type: 'message_end', content: 'done', usage, provenance }],
+    ]);
+    const rounds: number[] = [];
+
+    await runStreamingToolLoop([{ role: 'user', content: 'hi' }], {
+      provider,
+      model: 'fake',
+      maxRounds: 3,
+      signal: new AbortController().signal,
+      invokeTool: async (_call, ctx) => {
+        ctx?.messages.push({ role: 'system', content: 'injected' });
+        return { content: 'ok' };
+      },
+      hooks: {
+        beforeRound: async ({ round, messages: msgs }) => {
+          rounds.push(round);
+          if (round === 1) {
+            expect(msgs.some((m) => m.role === 'system' && m.content === 'injected')).toBe(true);
+          }
+        },
+      },
+    });
+
+    expect(rounds).toEqual([0, 1]);
+  });
+});
+
+describe('llmResponseAsStream (#1563)', () => {
+  it('maps text responses to text_delta + message_end', async () => {
+    const events: LLMStreamEvent[] = [];
+    for await (const event of llmResponseAsStream({
+      type: 'text',
+      content: 'hello',
+      usage,
+      provenance,
+    })) {
+      events.push(event);
+    }
+    expect(events).toEqual([
+      { type: 'text_delta', text: 'hello' },
+      { type: 'message_end', content: 'hello', usage, provenance },
+    ]);
+  });
+
+  it('maps empty text to message_end only', async () => {
+    const events: LLMStreamEvent[] = [];
+    for await (const event of llmResponseAsStream({
+      type: 'text',
+      content: '',
+      usage,
+      provenance,
+    })) {
+      events.push(event);
+    }
+    expect(events).toEqual([{ type: 'message_end', content: '', usage, provenance }]);
+  });
+
+  it('maps tool_use and error responses', async () => {
+    const toolCall: ToolCall = { id: 'c1', name: 'x', input: {} };
+    const toolEvents: LLMStreamEvent[] = [];
+    for await (const event of llmResponseAsStream({
+      type: 'tool_use',
+      toolCalls: [toolCall],
+      content: 'preamble',
+      usage,
+      provenance,
+    })) {
+      toolEvents.push(event);
+    }
+    expect(toolEvents).toEqual([
+      {
+        type: 'tool_use',
+        toolCalls: [toolCall],
+        content: 'preamble',
+        usage,
+        provenance,
+      },
+    ]);
+
+    const err = {
+      type: 'RATE_LIMIT' as const,
+      source: 'mock',
+      message: 'slow down',
+      retryable: true,
+      context: {},
+      timestamp: new Date(),
+    };
+    const errEvents: LLMStreamEvent[] = [];
+    for await (const event of llmResponseAsStream({ type: 'error', error: err })) {
+      errEvents.push(event);
+    }
+    expect(errEvents).toEqual([{ type: 'error', error: err }]);
   });
 });

--- a/src/agents/llm/streaming-turn.test.ts
+++ b/src/agents/llm/streaming-turn.test.ts
@@ -442,20 +442,41 @@ describe('runStreamingToolLoop (#1552)', () => {
   });
 
   it('accepts openStream without provider.stream (chat-compatible adapter #1563)', async () => {
-    const openStream = vi.fn(async function* () {
+    const openStream = vi.fn(async function* (_params: {
+      messages: Array<{ role: string; content: string }>;
+      model: string;
+      signal: AbortSignal;
+    }) {
       yield textDelta('via ');
       yield { type: 'message_end' as const, content: 'via adapter', usage, provenance };
     });
 
-    const result = await runStreamingToolLoop([{ role: 'user', content: 'hi' }], {
+    const initial = [{ role: 'user' as const, content: 'hi' }];
+    const result = await runStreamingToolLoop(initial, {
       provider: new NoStreamProvider(),
       model: 'fake',
       maxRounds: 2,
       signal: new AbortController().signal,
       openStream,
+      hooks: {
+        beforeRound: async ({ messages: msgs }) => {
+          msgs.push({ role: 'system', content: 'nudge' });
+        },
+      },
     });
 
     expect(openStream).toHaveBeenCalledTimes(1);
+    // Snapshot is taken AFTER beforeRound — adapter must see the nudge.
+    expect(openStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'system', content: 'nudge' },
+        ],
+        model: 'fake',
+        signal: expect.any(AbortSignal),
+      }),
+    );
     expect(result.stopReason).toBe('message_end');
     expect(result.finalText).toBe('via adapter');
   });

--- a/src/agents/llm/streaming-turn.test.ts
+++ b/src/agents/llm/streaming-turn.test.ts
@@ -14,6 +14,7 @@ import {
   assertStreamingProvider,
   llmResponseAsStream,
   runStreamingToolLoop,
+  type StreamingTurnOpenStreamParams,
 } from './streaming-turn.js';
 import { buildAssistantToolUseMessage, buildUserToolResultMessage } from './tool-loop-messages.js';
 
@@ -442,11 +443,7 @@ describe('runStreamingToolLoop (#1552)', () => {
   });
 
   it('accepts openStream without provider.stream (chat-compatible adapter #1563)', async () => {
-    const openStream = vi.fn(async function* (_params: {
-      messages: Array<{ role: string; content: string }>;
-      model: string;
-      signal: AbortSignal;
-    }) {
+    const openStream = vi.fn(async function* (_params: StreamingTurnOpenStreamParams) {
       yield textDelta('via ');
       yield { type: 'message_end' as const, content: 'via adapter', usage, provenance };
     });

--- a/src/agents/llm/streaming-turn.test.ts
+++ b/src/agents/llm/streaming-turn.test.ts
@@ -139,7 +139,10 @@ describe('runStreamingToolLoop (#1552)', () => {
       toolCalls: [toolCall],
       content: 'Checking.',
     });
-    expect(invokeTool).toHaveBeenCalledWith(toolCall);
+    expect(invokeTool).toHaveBeenCalledWith(
+      toolCall,
+      expect.objectContaining({ messages: expect.any(Array) }),
+    );
     expect(result.toolRounds).toBe(1);
     expect(result.stopReason).toBe('message_end');
     expect(result.finalText).toBe('Sunny.');

--- a/src/agents/llm/streaming-turn.ts
+++ b/src/agents/llm/streaming-turn.ts
@@ -1,20 +1,24 @@
-// streaming-turn.ts — streaming tool-loop primitive (#1552).
+// streaming-turn.ts — streaming tool-loop primitive (#1552 / #1563).
 //
-// What shipped: VoiceTurnRunner delegates stream()+tool assembly here. Text
-// AgentRuntime.handleTask still owns its own non-streaming chat() tool loop —
-// convergence requires an explicit "text goes streaming" decision (#1563), not
-// just finishing this extraction. Do **not** fold voice into handleTask.
+// Both VoiceTurnRunner and AgentRuntime.handleTask delegate tool-loop /
+// message assembly here. Voice opens provider.stream() directly; text uses a
+// chat-compatible openStream adapter over chatWithRetry (ADR-038: text may use
+// stream() — adapter keeps retry/fallback/telemetry intact while sharing round
+// cap, invoke sequencing, and sanitization policy). Do **not** fold voice into
+// handleTask — both call this primitive.
 //
-// Owns: provider.stream() consume, AbortSignal cancel, tool_use / tool_result
-// message assembly (via tool-loop-messages.ts), round cap, invokeTool sequencing.
+// Owns: stream consume (or openStream), AbortSignal cancel, tool_use /
+// tool_result message assembly (via tool-loop-messages.ts), round cap,
+// invokeTool sequencing, optional onToolUse / afterTools policy hooks.
 // Does NOT own: sentence-chunk TTS, filler speech, barge-in UX, chatWithRetry,
-// DelegationGuard, clarification short-circuits, or autonomy prompt injection.
+// DelegationGuard, clarification short-circuits, or autonomy prompt injection
+// (those stay in callers / openStream adapters).
 //
 // Round-cap policy: callers pass maxRounds. Voice uses DEFAULT_STREAMING_MAX_ROUNDS
-// (8) so a runaway tool loop fails fast into an audible fallback; text AgentRuntime
-// keeps per-agent error_budget.max_turns on the chat() path (often 20–40). Sharing
-// the coordinator's maxTurns=40 with spoken turns would leave the line silent far
-// too long — the divergence is intentional and parameterized here.
+// (8) so a runaway tool loop fails fast into an audible fallback; text passes
+// error_budget.max_turns and enforces turnsUsed semantics via onToolUse (often
+// 20–40). Sharing the coordinator's maxTurns=40 with spoken turns would leave
+// the line silent far too long — the divergence is intentional and parameterized.
 //
 // Autonomy / Gate-C: this primitive never bypasses ExecutionLayer. Callers supply
 // invokeTool; voice and handleTask both route through executionLayer.invoke, so
@@ -36,6 +40,8 @@ import {
 } from './tool-loop-messages.js';
 import type {
   LLMProvider,
+  LLMResponse,
+  LLMStreamEvent,
   Message,
   ToolCall,
   ToolDefinition,
@@ -52,9 +58,39 @@ const DEFAULT_MISSING_INVOKE_TOOL_RESULT =
 
 export type StreamingTurnInvokeTool = (
   call: ToolCall,
+  /** Mutable working transcript — text path splices skill-activate system blocks here. */
+  ctx?: { messages: Message[] },
 ) => Promise<{ content: string; is_error?: boolean }>;
 
+/** Hook decision: continue the loop, or stop and return to the caller. */
+export type StreamingTurnRoundDecision = 'continue' | 'stop';
+
+export interface StreamingTurnOpenStreamParams {
+  messages: Message[];
+  tools?: ToolDefinition[];
+  model: string;
+  signal: AbortSignal;
+}
+
+/**
+ * Optional stream opener for callers that wrap chat()/retry (text path #1563)
+ * or otherwise cannot use provider.stream() directly. When set,
+ * assertStreamingProvider is skipped.
+ */
+export type StreamingTurnOpenStream = (
+  params: StreamingTurnOpenStreamParams,
+) => AsyncIterable<LLMStreamEvent>;
+
 export interface StreamingTurnHooks {
+  /**
+   * Called at the start of each LLM round with the mutable working transcript.
+   * Text uses this for Bullpen refresh + checkpoint budget nudges before chat.
+   */
+  beforeRound?: (info: {
+    messages: Message[];
+    round: number;
+    toolRounds: number;
+  }) => void | Promise<void>;
   /** Called for each text_delta from the model (before sentence chunking). */
   onTextDelta?: (text: string) => void | Promise<void>;
   /**
@@ -66,14 +102,39 @@ export interface StreamingTurnHooks {
     toolCalls: ToolCall[];
     content?: string;
   }) => void | Promise<void>;
+  /**
+   * Called after tool_use is observed, before onBeforeTools / invokeTool.
+   * Text AgentRuntime uses this for turnsUsed / maxTurns budget checks.
+   * Return `'stop'` to exit without invoking tools (stopReason: `'stopped'`).
+   */
+  onToolUse?: (info: {
+    toolCalls: ToolCall[];
+    content?: string;
+    round: number;
+    messages: Message[];
+  }) => Promise<StreamingTurnRoundDecision>;
+  /**
+   * Called after tool results are appended to `messages` (mutable working
+   * transcript). Text uses this for clarification / delegation short-circuits
+   * and consecutive-error budget checks.
+   * Return `'stop'` to exit (stopReason: `'stopped'`).
+   */
+  afterTools?: (info: {
+    messages: Message[];
+    toolCalls: ToolCall[];
+    toolRounds: number;
+  }) => Promise<StreamingTurnRoundDecision>;
 }
 
 export interface StreamingTurnConfig {
-  /** Must implement stream() — construct-time callers should refuse otherwise. */
+  /**
+   * Must implement stream() unless `openStream` is provided (chat-compatible
+   * adapter path). Construct-time voice callers should still assertStreamingProvider.
+   */
   provider: LLMProvider;
   model: string;
   tools?: ToolDefinition[];
-  /** Hard cap on tool-use rounds. Required — see DEFAULT_STREAMING_MAX_ROUNDS. */
+  /** Hard cap on LLM rounds. Required — see DEFAULT_STREAMING_MAX_ROUNDS. */
   maxRounds: number;
   signal: AbortSignal;
   invokeTool?: StreamingTurnInvokeTool;
@@ -81,6 +142,12 @@ export interface StreamingTurnConfig {
   logger?: Logger;
   /** Placeholder tool_result content when invokeTool is missing. */
   missingInvokeToolResult?: string;
+  /**
+   * Custom per-round stream source. Text AgentRuntime passes a chatWithRetry
+   * adapter here so retry/fallback/telemetry stay on the chat path while the
+   * tool loop is shared (#1563 / ADR-038).
+   */
+  openStream?: StreamingTurnOpenStream;
 }
 
 export type StreamingTurnStopReason =
@@ -88,7 +155,9 @@ export type StreamingTurnStopReason =
   | 'aborted'
   | 'exhausted'
   | 'stream_error'
-  | 'empty_stream';
+  | 'empty_stream'
+  /** Caller hook (onToolUse / afterTools) requested an early exit. */
+  | 'stopped';
 
 export interface StreamingTurnResult {
   /**
@@ -137,8 +206,40 @@ export function assertStreamingProvider(provider: LLMProvider): void {
 }
 
 /**
+ * Adapt a single chat()/LLMResponse into stream events so callers can feed
+ * chatWithRetry (or any non-streaming round) into runStreamingToolLoop (#1563).
+ */
+export async function* llmResponseAsStream(
+  response: LLMResponse,
+): AsyncIterable<LLMStreamEvent> {
+  if (response.type === 'error') {
+    yield { type: 'error', error: response.error, ...(response.usage ? { usage: response.usage } : {}) };
+    return;
+  }
+  if (response.type === 'tool_use') {
+    yield {
+      type: 'tool_use',
+      toolCalls: response.toolCalls,
+      content: response.content,
+      usage: response.usage,
+      provenance: response.provenance,
+    };
+    return;
+  }
+  if (response.content.length > 0) {
+    yield { type: 'text_delta', text: response.content };
+  }
+  yield {
+    type: 'message_end',
+    content: response.content,
+    usage: response.usage,
+    provenance: response.provenance,
+  };
+}
+
+/**
  * Run one streaming assistant turn with a tool-use loop.
- * Resolves on message_end, abort, round-cap exhaustion, or empty stream.
+ * Resolves on message_end, abort, round-cap exhaustion, caller stop, or empty stream.
  * Stream terminal errors are returned on the result (not thrown) so callers
  * can map them to channel-specific error types.
  */
@@ -146,7 +247,9 @@ export async function runStreamingToolLoop(
   initialMessages: Message[],
   config: StreamingTurnConfig,
 ): Promise<StreamingTurnResult> {
-  assertStreamingProvider(config.provider);
+  if (!config.openStream) {
+    assertStreamingProvider(config.provider);
+  }
 
   if (!Number.isFinite(config.maxRounds) || config.maxRounds < 1) {
     throw new Error(`streaming turn maxRounds must be a positive integer; got ${config.maxRounds}`);
@@ -172,6 +275,14 @@ export async function runStreamingToolLoop(
       };
     }
 
+    if (config.hooks?.beforeRound) {
+      await config.hooks.beforeRound({
+        messages: workingMessages,
+        round,
+        toolRounds,
+      });
+    }
+
     // Per-round delta accumulator — used for empty message_end transcript
     // fallback so we do not re-append pre-tool narration already present in a
     // prior assistant tool_use turn (whole-turn streamedText still tracks all
@@ -180,12 +291,20 @@ export async function runStreamingToolLoop(
 
     // Snapshot for the provider — never hand out the live workingMessages array
     // (providers/tests often retain the reference; we mutate after tool rounds).
-    const stream = config.provider.stream!({
+    const streamParams: StreamingTurnOpenStreamParams = {
       messages: [...workingMessages],
       tools: config.tools,
       model: config.model,
-      options: { signal },
-    });
+      signal,
+    };
+    const stream = config.openStream
+      ? config.openStream(streamParams)
+      : config.provider.stream!({
+          messages: streamParams.messages,
+          tools: streamParams.tools,
+          model: streamParams.model,
+          options: { signal },
+        });
 
     let toolUse: { toolCalls: ToolCall[]; content?: string } | undefined;
     let messageEnd: { content: string } | undefined;
@@ -270,6 +389,26 @@ export async function runStreamingToolLoop(
     }
 
     if (toolUse) {
+      if (config.hooks?.onToolUse) {
+        const decision = await config.hooks.onToolUse({
+          toolCalls: toolUse.toolCalls,
+          content: toolUse.content,
+          round,
+          messages: workingMessages,
+        });
+        if (decision === 'stop') {
+          return {
+            finalText: streamedText,
+            streamedText,
+            messages: workingMessages,
+            toolRounds,
+            aborted: false,
+            exhausted: false,
+            stopReason: 'stopped',
+          };
+        }
+      }
+
       toolRounds += 1;
       if (config.hooks?.onBeforeTools) {
         await config.hooks.onBeforeTools(toolUse);
@@ -287,7 +426,7 @@ export async function runStreamingToolLoop(
         let result: { content: string; is_error?: boolean };
         if (config.invokeTool) {
           try {
-            result = await config.invokeTool(call);
+            result = await config.invokeTool(call, { messages: workingMessages });
           } catch (err) {
             config.logger?.warn({ tool: call.name, err }, 'streaming turn tool invocation threw');
             result = {
@@ -332,6 +471,25 @@ export async function runStreamingToolLoop(
       }
 
       workingMessages.push(buildUserToolResultMessage(toolResults));
+
+      if (config.hooks?.afterTools) {
+        const decision = await config.hooks.afterTools({
+          messages: workingMessages,
+          toolCalls: toolUse.toolCalls,
+          toolRounds,
+        });
+        if (decision === 'stop') {
+          return {
+            finalText: streamedText,
+            streamedText,
+            messages: workingMessages,
+            toolRounds,
+            aborted: false,
+            exhausted: false,
+            stopReason: 'stopped',
+          };
+        }
+      }
       continue;
     }
 

--- a/src/agents/llm/tool-loop-messages.ts
+++ b/src/agents/llm/tool-loop-messages.ts
@@ -1,11 +1,12 @@
 // tool-loop-messages.ts — shared ContentBlock assembly for tool_use / tool_result turns.
 //
-// Used by the shared streaming turn primitive (streaming-turn.ts) and by
-// AgentRuntime.handleTask (non-streaming chat path). Both must emit
-// Anthropic-compatible assistant+user message pairs when a model requests tools.
+// Used by the shared streaming turn primitive (streaming-turn.ts). Both voice
+// (VoiceTurnRunner) and text (AgentRuntime.handleTask via chat-compatible
+// openStream) assemble Anthropic-compatible assistant+user message pairs here
+// when a model requests tools.
 //
 // See also: src/agents/llm/streaming-turn.ts, src/channels/voice/turn-runner.ts,
-// src/agents/runtime.ts (~tool_use loop). Issue #1552.
+// src/agents/runtime.ts. Issues #1552 / #1563.
 
 import type {
   ContentBlock,

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1206,8 +1206,11 @@ export class AgentRuntime {
             }
             maybeAppendCheckpointBudgetNudge(workingMessages);
           },
-          onToolUse: async ({ toolCalls }) => {
+          onToolUse: async ({ toolCalls, messages: workingMessages }) => {
+            // Match former while-loop order: increment, nudge (uses updated
+            // turnsUsed), then enforce maxTurns before invoking tools.
             budget.turnsUsed++;
+            maybeAppendCheckpointBudgetNudge(workingMessages);
             if (budget.turnsUsed >= budget.maxTurns) {
               await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', budgetHandoff);
               earlyExitHandled = true;

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1156,12 +1156,17 @@ export class AgentRuntime {
       let lastLlmUsage: LLMUsage | undefined;
       let lastLlmProvenance: LLMCallProvenance | undefined;
 
+      // Text turns are intentionally non-cancellable today (same as pre-#1563):
+      // chatWithRetry does not take an AbortSignal, and openStream ignores
+      // params.signal. The controller is kept reachable as a required-arg
+      // placeholder for a future turn-level cancel/timeout.
+      const turnAbort = new AbortController();
       const streamResult = await runStreamingToolLoop(messages, {
         provider,
         model: streamModel,
         tools: workingToolDefs,
         maxRounds: budget.maxTurns,
-        signal: new AbortController().signal,
+        signal: turnAbort.signal,
         logger,
         openStream: async function* (this: AgentRuntime, params: StreamingTurnOpenStreamParams) {
           // NOTE: beforeRound already mutated working messages; params.messages is a
@@ -1327,7 +1332,9 @@ export class AgentRuntime {
             return 'continue';
           },
         },
-        invokeTool: async (toolCall, ctx) => {
+          invokeTool: async (toolCall, ctx) => {
+          // Prefer the primitive's working transcript (ctx.messages) so mid-turn
+          // splices (skill-activate) are visible to the next openStream snapshot.
           const transcript = ctx?.messages ?? messages;
 
           // When escalation is pending mid-batch, skip remaining tools (matches
@@ -1737,7 +1744,13 @@ export class AgentRuntime {
         },
       });
 
-      // Sync working transcript for empty-recovery / any post-loop message use.
+      // Sync the outer messages array from the primitive's working transcript.
+      // On message_end, streamResult.messages ends with the terminal assistant
+      // turn (streaming-turn appends it). Pre-#1563 the loop left messages at
+      // the last user tool_result — final assistant text was never pushed here.
+      // Harmless today: this array is not re-sent post-loop; memory persists
+      // responseContent separately; empty-recovery only runs when no terminal
+      // turn was appended (empty finalText). Do not double-append the assistant.
       messages.length = 0;
       messages.push(...streamResult.messages);
 
@@ -1746,6 +1759,12 @@ export class AgentRuntime {
       }
 
       if (streamResult.stopReason === 'stopped') {
+        // Defensive: every hook 'stop' sets earlyExitHandled above and has already
+        // published a response. Reaching here means a hook stopped silently.
+        logger.warn(
+          { agentId, conversationId },
+          'Streaming tool loop stopped without a published response — no reply sent to the user',
+        );
         return;
       }
 
@@ -1757,6 +1776,8 @@ export class AgentRuntime {
           provenance: lastLlmProvenance ?? fallbackProvenance,
         };
       } else if (streamResult.stopReason === 'exhausted') {
+        // Unreachable on the text path (defensive): onToolUse bails when
+        // turnsUsed >= maxTurns one round before this maxRounds cap would fire.
         // Treat like tool_use without completion — existing fallback / isResponseError.
         response = {
           type: 'tool_use',
@@ -1766,6 +1787,9 @@ export class AgentRuntime {
           provenance: lastLlmProvenance ?? fallbackProvenance,
         };
       } else if (streamResult.stopReason === 'stream_error') {
+        // Unreachable on the text path (defensive): chatWithRetry returns null on
+        // every failure (caught by llmFailureHandled), never a materialized
+        // type:'error' for llmResponseAsStream to surface here.
         const streamErr = streamResult.error ?? {
           type: 'UNKNOWN' as const,
           source: 'runtime',

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1,5 +1,9 @@
-import type { LLMProvider, LLMResponse, LLMUsage, Message, ToolDefinition, ContentBlock } from './llm/provider.js';
-import { buildAssistantToolUseMessage, buildToolResultBlock } from './llm/tool-loop-messages.js';
+import type { LLMProvider, LLMResponse, LLMUsage, Message, ToolDefinition, LLMCallProvenance } from './llm/provider.js';
+import {
+  llmResponseAsStream,
+  runStreamingToolLoop,
+  type StreamingTurnOpenStreamParams,
+} from './llm/streaming-turn.js';
 import type { EventBus } from '../bus/bus.js';
 import { createAgentResponse, createAgentError, createToolInvoke, createToolResult, createLlmCall, createLlmError, createContextBudget, createModelFallbackEngaged, type AgentResponseFailureReason, type AgentTaskEvent } from '../bus/events.js';
 import type { Tier } from './llm/model-router.js';
@@ -1004,7 +1008,7 @@ export class AgentRuntime {
     messages.push(...budgetedHistory);
     messages.push({ role: 'user', content: promptContent });
 
-    const maybeAppendCheckpointBudgetNudge = (): void => {
+    const maybeAppendCheckpointBudgetNudge = (target: Message[] = messages): void => {
       if (!resumableActive || checkpointBudgetNudgeSent) return;
       if (!shouldSendCheckpointBudgetNudge(
         budget.turnsUsed,
@@ -1018,7 +1022,7 @@ export class AgentRuntime {
       const throughputMetrics = resumableNudgeCtx
         ? computeResumableThroughput(resumableNudgeCtx.resumable, resumableNudgeCtx.circuit)
         : null;
-      messages.push({
+      target.push({
         role: 'user',
         content: buildCheckpointBudgetNudgeMessage(remaining, budget.maxTurns, throughputMetrics),
       });
@@ -1058,19 +1062,6 @@ export class AgentRuntime {
     } catch (err) {
       logger.error({ err, agentId }, 'Failed to publish context.budget event — budget tracking gap');
     }
-
-    // Tool-use loop: call LLM, handle tool calls, feed results back, repeat.
-    // The Anthropic API requires the full conversation context including the
-    // assistant's tool_use content blocks and the user's tool_result blocks.
-    // We build these as structured ContentBlock[] in the messages array so
-    // the provider can pass them through to the API correctly.
-    //
-    // Budget-driven loop: each LLM round-trip consumes one turn from the budget.
-    // The loop exits when: the LLM returns text, the budget is exhausted, or
-    // consecutive errors exceed the threshold.
-    maybeAppendCheckpointBudgetNudge();
-    let response = await this.chatWithRetry(provider, { messages, tools: workingToolDefs }, budget, taskEvent, budgetHandoff);
-    if (!response) return; // chatWithRetry already published error events
 
     // Extract caller context once — it doesn't change between tool-use rounds.
     // Primary source: senderContext from the inbound message (set by the dispatcher).
@@ -1112,398 +1103,594 @@ export class AgentRuntime {
     const turnDateResolveTracker = new TurnDateResolveTracker();
     let pendingDelegationEscalation: (DelegationFailureInfo & { task: string; escalated: boolean }) | null = null;
 
-    // TWO TOOL LOOPS (#1552 / #1563): this non-streaming chat() loop is still
-    // the text-channel path. Voice uses streaming-turn.ts via a thin
-    // VoiceTurnRunner wrapper — they share tool-loop-messages.ts shapes, but
-    // handleTask does NOT yet delegate here. Opting text into the streaming
-    // primitive requires an explicit "text goes streaming" decision (#1563):
-    // this loop also owns retry/fallback, error budgets, DelegationGuard,
-    // clarification, tool bus events, and delegate timeout injection.
-    // Round caps stay parameterized (errorBudget.maxTurns vs voice's
-    // DEFAULT_STREAMING_MAX_ROUNDS=8). Autonomy/Gate-C: both call
-    // executionLayer.invoke. Assistant text is not sanitizeOutput'd on either
-    // path (skill results are, inside invoke).
-    while (response.type === 'tool_use' && executionLayer) {
-      // Check turn budget before processing this round of tool calls
-      budget.turnsUsed++;
+    // Tool-use loop: call LLM, handle tool calls, feed results back, repeat.
+    // The Anthropic API requires the full conversation context including the
+    // assistant's tool_use content blocks and the user's tool_result blocks.
+    // We build these as structured ContentBlock[] in the messages array so
+    // the provider can pass them through to the API correctly.
+    //
+    // Budget-driven loop: each LLM round-trip consumes one turn from the budget.
+    // The loop exits when: the LLM returns text, the budget is exhausted, or
+    // consecutive errors exceed the threshold.
+    //
+    // TWO TOOL LOOPS (#1552 / #1563): text delegates to runStreamingToolLoop via a
+    // chat-compatible openStream adapter over chatWithRetry (ADR-038) so retry /
+    // fallback / telemetry stay intact while sharing round cap, invoke sequencing,
+    // and message assembly with voice. Voice still opens provider.stream() directly
+    // — do not fold voice into handleTask. Round caps stay parameterized
+    // (errorBudget.maxTurns vs voice's DEFAULT_STREAMING_MAX_ROUNDS=8). Autonomy /
+    // Gate-C: both call executionLayer.invoke. Assistant text is not
+    // sanitizeOutput'd on either path (skill results are, inside invoke).
+
+    const zeroUsage: LLMUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    };
+    const streamModel = this.config.resolvedModel ?? this.config.modelName ?? 'unknown';
+    const fallbackProvenance: LLMCallProvenance = {
+      requestedModel: streamModel,
+      actualModel: streamModel,
+      providerRequestId: 'n/a',
+    };
+
+    let response: LLMResponse;
+
+    if (!executionLayer) {
+      // No execution layer: single chatWithRetry shot, then fall through to
+      // final-response handling (tool_use-without-EL / text / error).
       maybeAppendCheckpointBudgetNudge();
-      if (budget.turnsUsed >= budget.maxTurns) {
-        await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', budgetHandoff);
-        return;
-      }
-
-      logger.info(
-        { agentId, turn: budget.turnsUsed, toolCalls: response.toolCalls.map(tc => tc.name) },
-        'LLM requested tool calls',
+      const noElResponse = await this.chatWithRetry(
+        provider,
+        { messages, tools: workingToolDefs },
+        budget,
+        taskEvent,
+        budgetHandoff,
       );
+      if (!noElResponse) return; // chatWithRetry already published error events
+      response = noElResponse;
+    } else {
+      let earlyExitHandled = false;
+      let llmFailureHandled = false;
+      let lastLlmUsage: LLMUsage | undefined;
+      let lastLlmProvenance: LLMCallProvenance | undefined;
 
-      // Build the assistant turn with the actual tool_use content blocks.
-      // The Anthropic API requires these to exist so tool_result blocks can
-      // reference their IDs in the next user turn. Shape shared with the
-      // streaming turn primitive via tool-loop-messages.ts (#1552).
-      messages.push(buildAssistantToolUseMessage(response.toolCalls, response.content));
-
-      // Execute each tool call through the execution layer.
-      // Publish tool.invoke and tool.result bus events for audit coverage.
-      const toolResultBlocks: ContentBlock[] = [];
-      for (const toolCall of response.toolCalls) {
-        logger.info({ agentId, skill: toolCall.name, callId: toolCall.id }, 'Invoking skill');
-        skillsCalled.push(toolCall.name);
-
-        // For delegate calls: inject timeout_ms so the specialist gets an appropriate wait
-        // window. Two sources, checked in priority order:
-        //   1. Scheduled task: the task event's expectedDurationSeconds (from the scheduler)
-        //   2. Target agent config: the target agent's expected_duration_seconds (from YAML)
-        // The LLM's explicit timeout_ms always wins if provided.
-        // This is transparent to the LLM — it doesn't need to know about scheduling internals.
-        let skillInput = toolCall.input;
-        if (toolCall.name === 'delegate') {
-          // Guard: only proceed if the input is a plain non-null object. The `in` operator
-          // throws a TypeError on null or primitives, and an array input is malformed anyway.
-          if (typeof skillInput !== 'object' || skillInput === null || Array.isArray(skillInput)) {
-            logger.warn(
-              { agentId, taskEventId: taskEvent.id, inputType: Array.isArray(skillInput) ? 'array' : typeof skillInput },
-              'delegate call has non-object input — skipping timeout injection; delegate will use default timeout',
-            );
-          } else {
-            const inputRecord = skillInput as Record<string, unknown>;
-
-            // Normalize agent name: LLMs sometimes produce "@agent-name" (bullpen @-mention
-            // style). Strip the leading '@' so the registry lookup and downstream handler
-            // see the canonical registered name.
-            if (typeof inputRecord['agent'] === 'string' && (inputRecord['agent'] as string).startsWith('@')) {
-              const rawName = inputRecord['agent'] as string;
-              inputRecord['agent'] = rawName.slice(1);
-              logger.info(
-                { agentId, rawAgent: rawName, normalizedAgent: inputRecord['agent'] },
-                'Stripped leading @ from delegate agent name',
+      const streamResult = await runStreamingToolLoop(messages, {
+        provider,
+        model: streamModel,
+        tools: workingToolDefs,
+        maxRounds: budget.maxTurns,
+        signal: new AbortController().signal,
+        logger,
+        openStream: async function* (this: AgentRuntime, params: StreamingTurnOpenStreamParams) {
+          // NOTE: beforeRound already mutated working messages; params.messages is a
+          // snapshot taken AFTER beforeRound — use params for chatWithRetry.
+          const chatResponse = await this.chatWithRetry(
+            provider,
+            { messages: params.messages, tools: workingToolDefs },
+            budget,
+            taskEvent,
+            budgetHandoff,
+          );
+          if (!chatResponse) {
+            llmFailureHandled = true;
+            yield {
+              type: 'error' as const,
+              error: {
+                type: 'UNKNOWN' as const,
+                source: 'runtime',
+                message: 'chatWithRetry handled failure',
+                retryable: false,
+                context: { handled: true },
+                timestamp: new Date(),
+              },
+            };
+            return;
+          }
+          if (chatResponse.type !== 'error') {
+            lastLlmUsage = chatResponse.usage;
+            lastLlmProvenance = chatResponse.provenance;
+          }
+          yield* llmResponseAsStream(chatResponse);
+        }.bind(this),
+        hooks: {
+          beforeRound: async ({ messages: workingMessages, round }) => {
+            if (round > 0 && !suppressAmbientBullpen) {
+              await this.refreshBullpenContext(
+                workingMessages,
+                bullpenInsertAt,
+                agentId,
+                injectedBullpenThreadIds,
               );
             }
+            maybeAppendCheckpointBudgetNudge(workingMessages);
+          },
+          onToolUse: async ({ toolCalls }) => {
+            budget.turnsUsed++;
+            if (budget.turnsUsed >= budget.maxTurns) {
+              await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns', budgetHandoff);
+              earlyExitHandled = true;
+              return 'stop';
+            }
+            logger.info(
+              { agentId, turn: budget.turnsUsed, toolCalls: toolCalls.map(tc => tc.name) },
+              'LLM requested tool calls',
+            );
+            return 'continue';
+          },
+          afterTools: async () => {
+            if (budget.consecutiveErrors >= budget.maxConsecutiveErrors) {
+              if (pendingClarification) {
+                logger.warn(
+                  { agentId, question: pendingClarification.question.slice(0, 100) },
+                  'Discarding pending clarification due to error budget exhaustion — specialist question will not reach the CEO',
+                );
+              }
+              await this.handleBudgetExceeded(budget, taskEvent, 'maxConsecutiveErrors');
+              earlyExitHandled = true;
+              return 'stop';
+            }
 
-            if (!('timeout_ms' in inputRecord) || inputRecord['timeout_ms'] === undefined) {
-              // Source 1: scheduler's expectedDurationSeconds on the task event
-              let durationSeconds = taskEvent.payload.expectedDurationSeconds;
+            if (pendingClarification) {
+              const resumeToken = encodeResumeToken({
+                agent: agentId,
+                originalTask: taskEvent.payload.content,
+                context: pendingClarification.context,
+              });
 
-              // Source 2: target agent's expected_duration_seconds from agent YAML config
-              // Only used when the scheduler didn't provide a value.
-              if (durationSeconds === undefined && this.config.agentRegistry) {
-                const rawAgent = inputRecord['agent'];
-                if (typeof rawAgent !== 'string') {
-                  // LLM produced a malformed delegate call — agent field missing or non-string.
-                  // Warn so the audit log shows the root cause rather than a silent timeout miss.
-                  logger.warn(
-                    { agentId, taskEventId: taskEvent.id, agentFieldType: typeof rawAgent },
-                    'delegate call has non-string agent field — cannot look up expected_duration_seconds; delegate will use default timeout',
-                  );
-                } else {
-                  const targetEntry = this.config.agentRegistry.get(rawAgent);
-                  if (targetEntry === undefined) {
-                    // Agent name is valid but unknown to the registry — likely a YAML typo or a
-                    // newly added agent that hasn't been registered yet.
-                    logger.warn(
-                      { agentId, taskEventId: taskEvent.id, targetAgent: rawAgent },
-                      'delegate target agent not found in registry — cannot look up expected_duration_seconds; delegate will use default timeout',
-                    );
-                  } else {
-                    durationSeconds = targetEntry.expectedDurationSeconds;
-                  }
-                }
+              const clarificationContent = JSON.stringify({
+                _curia_protocol: 'clarification_request',
+                question: pendingClarification.question,
+                context: pendingClarification.context,
+                resume_token: resumeToken,
+              });
+
+              if (memory) {
+                await memory.addTurn(conversationId, agentId, { role: 'assistant', content: clarificationContent });
               }
 
-              if (durationSeconds !== undefined) {
-                try {
-                  const timeoutMs = computeDelegateTimeoutMs(durationSeconds);
-                  skillInput = { ...inputRecord, timeout_ms: timeoutMs };
-                } catch (err) {
-                  logger.warn(
-                    { err, agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds },
-                    'Could not compute delegate timeout from expectedDurationSeconds — skipping injection; delegate will use default timeout',
-                  );
+              const clarificationResponse = createAgentResponse({
+                agentId,
+                conversationId,
+                content: clarificationContent,
+                skillsCalled,
+                parentEventId: taskEvent.id,
+              });
+              await bus.publish('agent', clarificationResponse);
+
+              logger.info(
+                { agentId, conversationId, question: pendingClarification.question.slice(0, 100) },
+                'Task paused for clarification — specialist requested CEO direction',
+              );
+              earlyExitHandled = true;
+              return 'stop';
+            }
+
+            if (pendingDelegationEscalation) {
+              const esc = pendingDelegationEscalation;
+              const agentLabel = esc.agent || 'specialist';
+              if (!esc.agent) {
+                logger.warn(
+                  { agentId, conversationId },
+                  'pendingDelegationEscalation has empty agent name — humanized message using fallback label',
+                );
+              }
+              const parts: string[] = [];
+              if (esc.reason === 'timeout') {
+                parts.push(`I wasn't able to get a response from the ${agentLabel} in time.`);
+                if (esc.possiblySucceeded) parts.push('The request may still be completing in the background.');
+              } else if (esc.reason === 'blocked') {
+                parts.push(`The ${agentLabel} was blocked and couldn't complete the task.`);
+              } else {
+                logger.info(
+                  { agentId, conversationId, targetAgent: esc.agent, reason: esc.reason },
+                  'Humanizing delegation failure with generic message',
+                );
+                parts.push(`The ${agentLabel} wasn't able to complete the task.`);
+              }
+              if (esc.escalated) parts.push("I've logged a follow-up task to review the outcome.");
+              const escalationContent = parts.join(' ');
+
+              if (memory) {
+                await memory.addTurn(conversationId, agentId, { role: 'assistant', content: escalationContent });
+              }
+
+              const escalationResponse = createAgentResponse({
+                agentId,
+                conversationId,
+                content: escalationContent,
+                skillsCalled,
+                parentEventId: taskEvent.id,
+              });
+              await bus.publish('agent', escalationResponse);
+
+              logger.info(
+                {
+                  agentId,
+                  conversationId,
+                  targetAgent: pendingDelegationEscalation.agent,
+                  reason: pendingDelegationEscalation.reason,
+                  escalated: pendingDelegationEscalation.escalated,
+                },
+                pendingDelegationEscalation.escalated
+                  ? 'Task stopped after non-retryable delegation failure — escalated to CEO backlog'
+                  : 'Task stopped after non-retryable delegation failure — CEO backlog escalation failed',
+              );
+              earlyExitHandled = true;
+              return 'stop';
+            }
+
+            return 'continue';
+          },
+        },
+        invokeTool: async (toolCall, ctx) => {
+          const transcript = ctx?.messages ?? messages;
+
+          // When escalation is pending mid-batch, skip remaining tools (matches
+          // the former `break` after pendingDelegationEscalation is set).
+          if (pendingDelegationEscalation) {
+            return {
+              content: 'Skipped — delegation failure escalation pending for this turn.',
+              is_error: true,
+            };
+          }
+
+          logger.info({ agentId, skill: toolCall.name, callId: toolCall.id }, 'Invoking skill');
+          skillsCalled.push(toolCall.name);
+
+          // For delegate calls: inject timeout_ms so the specialist gets an appropriate wait
+          // window. Two sources, checked in priority order:
+          //   1. Scheduled task: the task event's expectedDurationSeconds (from the scheduler)
+          //   2. Target agent config: the target agent's expected_duration_seconds (from YAML)
+          // The LLM's explicit timeout_ms always wins if provided.
+          // This is transparent to the LLM — it doesn't need to know about scheduling internals.
+          let skillInput = toolCall.input;
+          if (toolCall.name === 'delegate') {
+            // Guard: only proceed if the input is a plain non-null object. The `in` operator
+            // throws a TypeError on null or primitives, and an array input is malformed anyway.
+            if (typeof skillInput !== 'object' || skillInput === null || Array.isArray(skillInput)) {
+              logger.warn(
+                { agentId, taskEventId: taskEvent.id, inputType: Array.isArray(skillInput) ? 'array' : typeof skillInput },
+                'delegate call has non-object input — skipping timeout injection; delegate will use default timeout',
+              );
+            } else {
+              const inputRecord = skillInput as Record<string, unknown>;
+
+              // Normalize agent name: LLMs sometimes produce "@agent-name" (bullpen @-mention
+              // style). Strip the leading '@' so the registry lookup and downstream handler
+              // see the canonical registered name.
+              if (typeof inputRecord['agent'] === 'string' && (inputRecord['agent'] as string).startsWith('@')) {
+                const rawName = inputRecord['agent'] as string;
+                inputRecord['agent'] = rawName.slice(1);
+                logger.info(
+                  { agentId, rawAgent: rawName, normalizedAgent: inputRecord['agent'] },
+                  'Stripped leading @ from delegate agent name',
+                );
+              }
+
+              if (!('timeout_ms' in inputRecord) || inputRecord['timeout_ms'] === undefined) {
+                // Source 1: scheduler's expectedDurationSeconds on the task event
+                let durationSeconds = taskEvent.payload.expectedDurationSeconds;
+
+                // Source 2: target agent's expected_duration_seconds from agent YAML config
+                // Only used when the scheduler didn't provide a value.
+                if (durationSeconds === undefined && this.config.agentRegistry) {
+                  const rawAgent = inputRecord['agent'];
+                  if (typeof rawAgent !== 'string') {
+                    // LLM produced a malformed delegate call — agent field missing or non-string.
+                    // Warn so the audit log shows the root cause rather than a silent timeout miss.
+                    logger.warn(
+                      { agentId, taskEventId: taskEvent.id, agentFieldType: typeof rawAgent },
+                      'delegate call has non-string agent field — cannot look up expected_duration_seconds; delegate will use default timeout',
+                    );
+                  } else {
+                    const targetEntry = this.config.agentRegistry.get(rawAgent);
+                    if (targetEntry === undefined) {
+                      // Agent name is valid but unknown to the registry — likely a YAML typo or a
+                      // newly added agent that hasn't been registered yet.
+                      logger.warn(
+                        { agentId, taskEventId: taskEvent.id, targetAgent: rawAgent },
+                        'delegate target agent not found in registry — cannot look up expected_duration_seconds; delegate will use default timeout',
+                      );
+                    } else {
+                      durationSeconds = targetEntry.expectedDurationSeconds;
+                    }
+                  }
+                }
+
+                if (durationSeconds !== undefined) {
+                  try {
+                    const timeoutMs = computeDelegateTimeoutMs(durationSeconds);
+                    skillInput = { ...inputRecord, timeout_ms: timeoutMs };
+                  } catch (err) {
+                    logger.warn(
+                      { err, agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds },
+                      'Could not compute delegate timeout from expectedDurationSeconds — skipping injection; delegate will use default timeout',
+                    );
+                  }
                 }
               }
             }
           }
-        }
 
-        // Publish tool.invoke for audit trail — after injection so the recorded input
-        // reflects the actual values passed to the skill (including injected timeout_ms).
-        const invokeEvent = createToolInvoke({
-          agentId,
-          conversationId,
-          toolName: toolCall.name,
-          input: skillInput,
-          taskEventId: taskEvent.id,
-          parentEventId: taskEvent.id,
-        });
-        await bus.publish('agent', invokeEvent);
+          // Publish tool.invoke for audit trail — after injection so the recorded input
+          // reflects the actual values passed to the skill (including injected timeout_ms).
+          const invokeEvent = createToolInvoke({
+            agentId,
+            conversationId,
+            toolName: toolCall.name,
+            input: skillInput,
+            taskEventId: taskEvent.id,
+            parentEventId: taskEvent.id,
+          });
+          await bus.publish('agent', invokeEvent);
 
-        const invokeOptions = {
-          taskEventId: taskEvent.id,
-          agentId,
-          channelId: taskEvent.payload.channelId,
-          conversationId,
-          parentEventId: invokeEvent.id,
-          taskMetadata: taskEvent.payload.metadata,
-          liveTurn: taskEvent.payload.liveTurn,
-          delegationGuard,
-          turnDateResolveResults: turnDateResolveTracker.snapshot(),
-        };
+          const invokeOptions = {
+            taskEventId: taskEvent.id,
+            agentId,
+            channelId: taskEvent.payload.channelId,
+            conversationId,
+            parentEventId: invokeEvent.id,
+            taskMetadata: taskEvent.payload.metadata,
+            liveTurn: taskEvent.payload.liveTurn,
+            delegationGuard,
+            turnDateResolveResults: turnDateResolveTracker.snapshot(),
+          };
 
-        const startTime = Date.now();
-        let delegateBlocked = false;
-        let result: Awaited<ReturnType<ExecutionLayer['invoke']>>;
-        if (
-          toolCall.name === 'delegate' &&
-          typeof skillInput === 'object' &&
-          skillInput !== null &&
-          !Array.isArray(skillInput)
-        ) {
-          const delegateInput = skillInput as Record<string, unknown>;
-          const delegateAgent = typeof delegateInput['agent'] === 'string' ? delegateInput['agent'] : '';
-          const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
-          const hasResumeToken =
-            typeof delegateInput['resume_token'] === 'string' && delegateInput['resume_token'] !== '';
-          if (!hasResumeToken && delegateAgent && delegateTask) {
-            const dKey = delegationKey(delegateAgent, delegateTask);
-            if (!delegationGuard.canAttempt(dKey)) {
-              delegateBlocked = true;
-              const prior = delegationGuard.getFailure(dKey);
-              logger.warn(
-                { agentId, targetAgent: delegateAgent, reason: prior?.reason },
-                'Blocked identical re-delegation after specialist failure',
-              );
-              result = {
-                success: true,
-                data: {
-                  agent: delegateAgent,
-                  failed: true,
-                  blocked: true,
-                  reason: prior?.reason ?? 'blocked',
-                  retryable: false,
-                  message: prior?.message
-                    ?? `Re-delegation to '${delegateAgent}' is blocked for this task.`,
-                  escalated: delegationGuard.isEscalated(dKey),
-                },
-              };
+          const startTime = Date.now();
+          let delegateBlocked = false;
+          let result: Awaited<ReturnType<ExecutionLayer['invoke']>>;
+          if (
+            toolCall.name === 'delegate' &&
+            typeof skillInput === 'object' &&
+            skillInput !== null &&
+            !Array.isArray(skillInput)
+          ) {
+            const delegateInput = skillInput as Record<string, unknown>;
+            const delegateAgent = typeof delegateInput['agent'] === 'string' ? delegateInput['agent'] : '';
+            const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
+            const hasResumeToken =
+              typeof delegateInput['resume_token'] === 'string' && delegateInput['resume_token'] !== '';
+            if (!hasResumeToken && delegateAgent && delegateTask) {
+              const dKey = delegationKey(delegateAgent, delegateTask);
+              if (!delegationGuard.canAttempt(dKey)) {
+                delegateBlocked = true;
+                const prior = delegationGuard.getFailure(dKey);
+                logger.warn(
+                  { agentId, targetAgent: delegateAgent, reason: prior?.reason },
+                  'Blocked identical re-delegation after specialist failure',
+                );
+                result = {
+                  success: true,
+                  data: {
+                    agent: delegateAgent,
+                    failed: true,
+                    blocked: true,
+                    reason: prior?.reason ?? 'blocked',
+                    retryable: false,
+                    message: prior?.message
+                      ?? `Re-delegation to '${delegateAgent}' is blocked for this task.`,
+                    escalated: delegationGuard.isEscalated(dKey),
+                  },
+                };
+              } else {
+                result = await executionLayer.invoke(toolCall.name, skillInput, caller, invokeOptions);
+              }
             } else {
               result = await executionLayer.invoke(toolCall.name, skillInput, caller, invokeOptions);
             }
           } else {
             result = await executionLayer.invoke(toolCall.name, skillInput, caller, invokeOptions);
           }
-        } else {
-          result = await executionLayer.invoke(toolCall.name, skillInput, caller, invokeOptions);
-        }
-        const durationMs = Date.now() - startTime;
+          const durationMs = Date.now() - startTime;
 
-        // Publish tool.result for audit trail
-        // Published by agent layer on behalf of the execution layer —
-        // the execution layer doesn't have bus access in Phase 3.
-        // TODO: When execution layer gets bus access, move this publish there.
-        const resultEvent = createToolResult({
-          agentId,
-          conversationId,
-          toolName: toolCall.name,
-          result,
-          durationMs,
-          parentEventId: invokeEvent.id,
-        });
-        await bus.publish('agent', resultEvent);
+          // Publish tool.result for audit trail
+          // Published by agent layer on behalf of the execution layer —
+          // the execution layer doesn't have bus access in Phase 3.
+          // TODO: When execution layer gets bus access, move this publish there.
+          const resultEvent = createToolResult({
+            agentId,
+            conversationId,
+            toolName: toolCall.name,
+            result,
+            durationMs,
+            parentEventId: invokeEvent.id,
+          });
+          await bus.publish('agent', resultEvent);
 
-        if (toolCall.name === 'date-resolve') {
-          turnDateResolveTracker.recordFromToolResult(result);
-        }
-
-        if (result.success) {
-          // Success: reset consecutive error counter
-          budget.consecutiveErrors = 0;
-
-          // When a tool result is (partly) re-emitted into the turn by the runtime
-          // — e.g. skill-activate, whose instructions/reference bodies are spliced
-          // as system messages below — the generic tool_result JSON is slimmed to a
-          // metadata-only acknowledgement so the payload is not injected twice (#1505).
-          let toolResultOverride: string | undefined;
-
-          // Dynamic tool-list expansion: when tool-registry returns successfully,
-          // append discovered kind:'tool' atoms to the working list. kind:'skill'
-          // results require skill-activate (instructions + member tools together).
-          // Expansion is per-task (workingToolDefs is a local copy) — concurrent tasks
-          // never see each other's discovered tools.
-          if (toolCall.name === 'tool-registry' && workingToolDefs) {
-            try {
-              const data = typeof result.data === 'string'
-                ? JSON.parse(result.data) as unknown
-                : result.data;
-              const discovered = (data as {
-                tools?: Array<{ name: string; kind?: 'tool' | 'skill' }>;
-              })?.tools ?? [];
-              const currentNames = new Set(workingToolDefs.map(t => t.name));
-              const newNames = discovered
-                .filter(s => !s.kind || s.kind === 'tool')
-                .map(s => s.name)
-                .filter(name => !currentNames.has(name));
-              if (newNames.length > 0) {
-                workingToolDefs.push(...executionLayer.getToolDefinitions(newNames));
-                logger.info(
-                  { agentId, addedTools: newNames },
-                  'Expanded working tool list with discovered tools',
-                );
-              }
-            } catch (err) {
-              // Non-fatal: if we can't parse the tool-registry result, the LLM simply
-              // cannot call discovered tools this turn. Log at warn and continue —
-              // failing to expand the tool list must not abort the task.
-              logger.warn({ err, agentId }, 'Failed to expand tool list from tool-registry result');
-            }
+          if (toolCall.name === 'date-resolve') {
+            turnDateResolveTracker.recordFromToolResult(result);
           }
 
-          // Skill activation (#1495/#1490): expand member tools + inject SKILL.md
-          // instructions (and optional progressive-disclosure reference content)
-          // into the in-flight turn. Durable persistence is handled by skill-activate itself.
-          if (toolCall.name === SKILL_ACTIVATE_TOOL_NAME && workingToolDefs) {
-            try {
-              const data = typeof result.data === 'string'
-                ? JSON.parse(result.data) as unknown
-                : result.data;
-              const activation = parseSkillActivationProtocol(data);
-              if (activation) {
+          if (result.success) {
+            // Success: reset consecutive error counter
+            budget.consecutiveErrors = 0;
+
+            // When a tool result is (partly) re-emitted into the turn by the runtime
+            // — e.g. skill-activate, whose instructions/reference bodies are spliced
+            // as system messages below — the generic tool_result JSON is slimmed to a
+            // metadata-only acknowledgement so the payload is not injected twice (#1505).
+            let toolResultOverride: string | undefined;
+
+            // Dynamic tool-list expansion: when tool-registry returns successfully,
+            // append discovered kind:'tool' atoms to the working list. kind:'skill'
+            // results require skill-activate (instructions + member tools together).
+            // Expansion is per-task (workingToolDefs is a local copy) — concurrent tasks
+            // never see each other's discovered tools.
+            if (toolCall.name === 'tool-registry' && workingToolDefs) {
+              try {
+                const data = typeof result.data === 'string'
+                  ? JSON.parse(result.data) as unknown
+                  : result.data;
+                const discovered = (data as {
+                  tools?: Array<{ name: string; kind?: 'tool' | 'skill' }>;
+                })?.tools ?? [];
                 const currentNames = new Set(workingToolDefs.map(t => t.name));
-                const newNames = activation.tools.filter(name => !currentNames.has(name));
+                const newNames = discovered
+                  .filter(s => !s.kind || s.kind === 'tool')
+                  .map(s => s.name)
+                  .filter(name => !currentNames.has(name));
                 if (newNames.length > 0) {
                   workingToolDefs.push(...executionLayer.getToolDefinitions(newNames));
+                  logger.info(
+                    { agentId, addedTools: newNames },
+                    'Expanded working tool list with discovered tools',
+                  );
                 }
-                const instructionBlock = formatActivatedSkillInstructionBlock(
-                  activation.skill,
-                  activation.instructions,
-                  { references: activation.references, assets: activation.assets },
-                );
-                const insertAt = messages.findIndex(m => m.role !== 'system') === -1
-                  ? messages.length
-                  : Math.max(1, messages.findIndex(m => m.role !== 'system'));
-                let spliceAt = insertAt;
-                if (instructionBlock) {
-                  // Inject after the system prompt so subsequent LLM rounds see the
-                  // discipline block (mirrors Bullpen mid-turn system-message splice).
-                  messages.splice(spliceAt, 0, { role: 'system', content: instructionBlock });
-                  spliceAt += 1;
-                }
-                if (activation.referenceContent) {
-                  messages.splice(spliceAt, 0, {
-                    role: 'system',
-                    content: formatSkillReferenceBlock(
-                      activation.skill,
-                      activation.referenceContent.path,
-                      activation.referenceContent.content,
-                      activation.referenceContent.truncated,
-                    ),
-                  });
-                }
-                logger.info(
-                  {
-                    agentId,
-                    skill: activation.skill,
-                    addedTools: newNames,
-                    instructionsLoaded: activation.instructions.length > 0,
-                    skippedTools: activation.skippedTools,
-                    references: activation.references.length,
-                    assets: activation.assets.length,
-                    referenceLoaded: activation.referenceContent?.path,
-                  },
-                  'Activated skill for task turn',
-                );
-                // Instructions + reference content are now in the turn as system
-                // messages; slim the tool_result to metadata so they aren't injected
-                // a second time via the generic JSON stringify below (#1505).
-                toolResultOverride = JSON.stringify(buildSkillActivationAck(activation));
+              } catch (err) {
+                // Non-fatal: if we can't parse the tool-registry result, the LLM simply
+                // cannot call discovered tools this turn. Log at warn and continue —
+                // failing to expand the tool list must not abort the task.
+                logger.warn({ err, agentId }, 'Failed to expand tool list from tool-registry result');
               }
-            } catch (err) {
-              logger.warn({ err, agentId }, 'Failed to apply skill-activate result to working tool list');
             }
-          }
 
-          // Clarification protocol detection: when request-clarification returns
-          // successfully, capture the question and findings for the short-circuit exit.
-          // Follows the same pattern as the tool-registry check above — inspect by
-          // skill name, parse the structured result, take runtime-level action.
-          if (toolCall.name === 'request-clarification') {
-            try {
-              const clarData = typeof result.data === 'string'
-                ? JSON.parse(result.data) as unknown
-                : result.data;
-              const typed = clarData as { _curia_protocol?: string; question?: string; context?: string };
-              if (typed?._curia_protocol === 'clarification_request') {
-                if (!typed.question || !typed.context) {
-                  // Protocol marker is present but required fields are missing — the
-                  // handler should prevent this, but a modified or third-party skill
-                  // could emit an incomplete marker. Log so it's visible in audit.
-                  logger.warn(
-                    { agentId, hasQuestion: !!typed.question, hasContext: !!typed.context },
-                    'request-clarification result has protocol marker but missing required fields — cannot short-circuit',
-                  );
-                } else if (pendingClarification) {
-                  logger.warn(
-                    { agentId },
-                    'Multiple request-clarification calls in one turn — using the first',
-                  );
-                } else {
-                  pendingClarification = {
-                    question: typed.question,
-                    context: typed.context,
-                  };
-                }
-              }
-            } catch (err) {
-              // Non-fatal: if we can't parse the result, the clarification simply isn't
-              // detected and the loop continues normally. The specialist will produce a
-              // regular text response.
-              logger.warn({ err, agentId }, 'Failed to parse request-clarification result — skipping short-circuit');
-            }
-          }
-
-          // Delegation failure circuit-breaker (#1171): when delegate returns failed{retryable},
-          // record the outcome and escalate to the CEO backlog when retries are exhausted or
-          // the failure is non-retryable. Short-circuit the turn after escalation so the LLM
-          // cannot blind-re-delegate in subsequent rounds.
-          // Paused delegate results (#1174) are success at the delegation layer — do not record.
-          if (
-            toolCall.name === 'delegate' &&
-            !delegateBlocked &&
-            typeof skillInput === 'object' &&
-            skillInput !== null &&
-            !Array.isArray(skillInput)
-          ) {
-            const delegatePaused = parseDelegatePausedData(result.data, logger);
-            if (!delegatePaused) {
-              const delegateFailure = parseDelegateFailureData(result.data, logger);
-              if (delegateFailure) {
-                const delegateInput = skillInput as Record<string, unknown>;
-                const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
-                const dKey = delegationKey(delegateFailure.agent, delegateTask);
-                delegationGuard.recordFailure(dKey, delegateFailure);
-                if (delegationGuard.shouldEscalate(dKey)) {
-                  const escalated = await escalateDelegationFailure(
-                    executionLayer,
-                    caller,
-                    invokeOptions,
-                    { ...delegateFailure, task: delegateTask },
-                    logger,
-                  );
-                  if (escalated) {
-                    delegationGuard.markEscalated(dKey);
+            // Skill activation (#1495/#1490): expand member tools + inject SKILL.md
+            // instructions (and optional progressive-disclosure reference content)
+            // into the in-flight turn. Durable persistence is handled by skill-activate itself.
+            if (toolCall.name === SKILL_ACTIVATE_TOOL_NAME && workingToolDefs) {
+              try {
+                const data = typeof result.data === 'string'
+                  ? JSON.parse(result.data) as unknown
+                  : result.data;
+                const activation = parseSkillActivationProtocol(data);
+                if (activation) {
+                  const currentNames = new Set(workingToolDefs.map(t => t.name));
+                  const newNames = activation.tools.filter(name => !currentNames.has(name));
+                  if (newNames.length > 0) {
+                    workingToolDefs.push(...executionLayer.getToolDefinitions(newNames));
                   }
-                  pendingDelegationEscalation = { ...delegateFailure, task: delegateTask, escalated };
+                  const instructionBlock = formatActivatedSkillInstructionBlock(
+                    activation.skill,
+                    activation.instructions,
+                    { references: activation.references, assets: activation.assets },
+                  );
+                  const insertAt = transcript.findIndex(m => m.role !== 'system') === -1
+                    ? transcript.length
+                    : Math.max(1, transcript.findIndex(m => m.role !== 'system'));
+                  let spliceAt = insertAt;
+                  if (instructionBlock) {
+                    // Inject after the system prompt so subsequent LLM rounds see the
+                    // discipline block (mirrors Bullpen mid-turn system-message splice).
+                    transcript.splice(spliceAt, 0, { role: 'system', content: instructionBlock });
+                    spliceAt += 1;
+                  }
+                  if (activation.referenceContent) {
+                    transcript.splice(spliceAt, 0, {
+                      role: 'system',
+                      content: formatSkillReferenceBlock(
+                        activation.skill,
+                        activation.referenceContent.path,
+                        activation.referenceContent.content,
+                        activation.referenceContent.truncated,
+                      ),
+                    });
+                  }
+                  logger.info(
+                    {
+                      agentId,
+                      skill: activation.skill,
+                      addedTools: newNames,
+                      instructionsLoaded: activation.instructions.length > 0,
+                      skippedTools: activation.skippedTools,
+                      references: activation.references.length,
+                      assets: activation.assets.length,
+                      referenceLoaded: activation.referenceContent?.path,
+                    },
+                    'Activated skill for task turn',
+                  );
+                  // Instructions + reference content are now in the turn as system
+                  // messages; slim the tool_result to metadata so they aren't injected
+                  // a second time via the generic JSON stringify below (#1505).
+                  toolResultOverride = JSON.stringify(buildSkillActivationAck(activation));
+                }
+              } catch (err) {
+                logger.warn({ err, agentId }, 'Failed to apply skill-activate result to working tool list');
+              }
+            }
+
+            // Clarification protocol detection: when request-clarification returns
+            // successfully, capture the question and findings for the short-circuit exit.
+            // Follows the same pattern as the tool-registry check above — inspect by
+            // skill name, parse the structured result, take runtime-level action.
+            if (toolCall.name === 'request-clarification') {
+              try {
+                const clarData = typeof result.data === 'string'
+                  ? JSON.parse(result.data) as unknown
+                  : result.data;
+                const typed = clarData as { _curia_protocol?: string; question?: string; context?: string };
+                if (typed?._curia_protocol === 'clarification_request') {
+                  if (!typed.question || !typed.context) {
+                    // Protocol marker is present but required fields are missing — the
+                    // handler should prevent this, but a modified or third-party skill
+                    // could emit an incomplete marker. Log so it's visible in audit.
+                    logger.warn(
+                      { agentId, hasQuestion: !!typed.question, hasContext: !!typed.context },
+                      'request-clarification result has protocol marker but missing required fields — cannot short-circuit',
+                    );
+                  } else if (pendingClarification) {
+                    logger.warn(
+                      { agentId },
+                      'Multiple request-clarification calls in one turn — using the first',
+                    );
+                  } else {
+                    pendingClarification = {
+                      question: typed.question,
+                      context: typed.context,
+                    };
+                  }
+                }
+              } catch (err) {
+                // Non-fatal: if we can't parse the result, the clarification simply isn't
+                // detected and the loop continues normally. The specialist will produce a
+                // regular text response.
+                logger.warn({ err, agentId }, 'Failed to parse request-clarification result — skipping short-circuit');
+              }
+            }
+
+            // Delegation failure circuit-breaker (#1171): when delegate returns failed{retryable},
+            // record the outcome and escalate to the CEO backlog when retries are exhausted or
+            // the failure is non-retryable. Short-circuit the turn after escalation so the LLM
+            // cannot blind-re-delegate in subsequent rounds.
+            // Paused delegate results (#1174) are success at the delegation layer — do not record.
+            if (
+              toolCall.name === 'delegate' &&
+              !delegateBlocked &&
+              typeof skillInput === 'object' &&
+              skillInput !== null &&
+              !Array.isArray(skillInput)
+            ) {
+              const delegatePaused = parseDelegatePausedData(result.data, logger);
+              if (!delegatePaused) {
+                const delegateFailure = parseDelegateFailureData(result.data, logger);
+                if (delegateFailure) {
+                  const delegateInput = skillInput as Record<string, unknown>;
+                  const delegateTask = typeof delegateInput['task'] === 'string' ? delegateInput['task'] : '';
+                  const dKey = delegationKey(delegateFailure.agent, delegateTask);
+                  delegationGuard.recordFailure(dKey, delegateFailure);
+                  if (delegationGuard.shouldEscalate(dKey)) {
+                    const escalated = await escalateDelegationFailure(
+                      executionLayer,
+                      caller,
+                      invokeOptions,
+                      { ...delegateFailure, task: delegateTask },
+                      logger,
+                    );
+                    if (escalated) {
+                      delegationGuard.markEscalated(dKey);
+                    }
+                    pendingDelegationEscalation = { ...delegateFailure, task: delegateTask, escalated };
+                  }
                 }
               }
             }
+
+            const resultContent = toolResultOverride
+              ?? (typeof result.data === 'string' ? result.data : JSON.stringify(result.data));
+            return { content: resultContent };
           }
 
-          const resultContent = toolResultOverride
-            ?? (typeof result.data === 'string' ? result.data : JSON.stringify(result.data));
-          toolResultBlocks.push(buildToolResultBlock(toolCall.id, resultContent));
-          if (pendingDelegationEscalation) {
-            break;
-          }
-        } else {
           // Failure: classify the error and format as a structured <task_error> block
           // so the LLM gets machine-readable error context instead of raw strings.
           // Transient DB outages (#1381) are tracked on budget.dbFailures and do NOT
@@ -1543,145 +1730,68 @@ export class AgentRuntime {
             isDbFailure ? budget.dbFailures : budget.consecutiveErrors,
             isDbFailure ? budget.dbFailures : budget.maxConsecutiveErrors,
           );
-          toolResultBlocks.push(buildToolResultBlock(toolCall.id, formattedError, true));
-        }
-      }
+          return { content: formattedError, is_error: true };
+        },
+      });
 
-      // Check consecutive error budget after processing all tool calls in this turn
-      if (budget.consecutiveErrors >= budget.maxConsecutiveErrors) {
-        if (pendingClarification) {
-          logger.warn(
-            { agentId, question: pendingClarification.question.slice(0, 100) },
-            'Discarding pending clarification due to error budget exhaustion — specialist question will not reach the CEO',
-          );
-        }
-        // Still append results so the LLM history is consistent, then bail
-        messages.push({ role: 'user', content: toolResultBlocks });
-        await this.handleBudgetExceeded(budget, taskEvent, 'maxConsecutiveErrors');
+      // Sync working transcript for empty-recovery / any post-loop message use.
+      messages.length = 0;
+      messages.push(...streamResult.messages);
+
+      if (earlyExitHandled || llmFailureHandled) {
         return;
       }
 
-      // Append tool results as a user turn with structured content blocks.
-      // This is the format the Anthropic API expects — each tool_result references
-      // a tool_use_id from the preceding assistant turn.
-      messages.push({ role: 'user', content: toolResultBlocks });
+      if (streamResult.stopReason === 'stopped') {
+        return;
+      }
 
-      // Clarification short-circuit: if request-clarification was called successfully
-      // in this batch, bypass further LLM rounds and emit a deterministic protocol
-      // response. The DelegateHandler parses this JSON to return a typed result to
-      // the coordinator — no LLM text parsing involved.
-      if (pendingClarification) {
-        // Construct resume_token via the shared helper so the format stays in one place
-        // (consumed by the delegate skill on re-delegation). Base64-encoded, versioned, capped.
-        const resumeToken = encodeResumeToken({
-          agent: agentId,
-          originalTask: taskEvent.payload.content,
-          context: pendingClarification.context,
-        });
-
-        const clarificationContent = JSON.stringify({
-          _curia_protocol: 'clarification_request',
-          question: pendingClarification.question,
-          context: pendingClarification.context,
-          resume_token: resumeToken,
-        });
-
-        // Persist the protocol response as the assistant turn
-        if (memory) {
-          await memory.addTurn(conversationId, agentId, { role: 'assistant', content: clarificationContent });
-        }
-
-        const clarificationResponse = createAgentResponse({
-          agentId,
-          conversationId,
-          content: clarificationContent,
-          skillsCalled,
-          parentEventId: taskEvent.id,
-        });
-        await bus.publish('agent', clarificationResponse);
-
-        logger.info(
-          { agentId, conversationId, question: pendingClarification.question.slice(0, 100) },
-          'Task paused for clarification — specialist requested CEO direction',
+      if (streamResult.stopReason === 'message_end') {
+        response = {
+          type: 'text',
+          content: streamResult.finalText,
+          usage: lastLlmUsage ?? zeroUsage,
+          provenance: lastLlmProvenance ?? fallbackProvenance,
+        };
+      } else if (streamResult.stopReason === 'exhausted') {
+        // Treat like tool_use without completion — existing fallback / isResponseError.
+        response = {
+          type: 'tool_use',
+          toolCalls: [],
+          content: "I wasn't able to complete that request — I hit my tool-use limit. Please try rephrasing.",
+          usage: lastLlmUsage ?? zeroUsage,
+          provenance: lastLlmProvenance ?? fallbackProvenance,
+        };
+      } else if (streamResult.stopReason === 'stream_error') {
+        const streamErr = streamResult.error ?? {
+          type: 'UNKNOWN' as const,
+          source: 'runtime',
+          message: 'Streaming tool loop failed',
+          retryable: false,
+          context: {},
+          timestamp: new Date(),
+        };
+        await this.publishAgentError(streamErr, taskEvent);
+        await this.sendErrorResponse(taskEvent, streamErr);
+        return;
+      } else {
+        // empty_stream / aborted — sensible fallback error response
+        logger.error(
+          { agentId, conversationId, stopReason: streamResult.stopReason },
+          'Streaming tool loop ended without a usable response',
         );
-        return;
-      }
-
-      // Delegation failure short-circuit (#1171, #1329): after a non-retryable specialist
-      // failure (or exhausted retryable attempts), emit a human-readable response so the
-      // coordinator reports the honest reason instead of confabulating or re-delegating.
-      // The `delegate` skill is only available to the coordinator — no other agent is wired
-      // with it — so this path is only reachable by the coordinator, and its response goes
-      // directly to the principal's channel. Emitting a _curia_protocol JSON signal here
-      // would be meaningless (there is no parent to consume it) and leaks raw JSON to the user.
-      if (pendingDelegationEscalation) {
-        const esc = pendingDelegationEscalation;
-        // Guard against an empty agent name (external payload field); fallback avoids
-        // a confusing blank in the user-facing message ("from the  specialist").
-        // No article prefix — templates below unconditionally prepend "the ".
-        const agentLabel = esc.agent || 'specialist';
-        if (!esc.agent) {
-          logger.warn(
-            { agentId, conversationId },
-            'pendingDelegationEscalation has empty agent name — humanized message using fallback label',
-          );
-        }
-        const parts: string[] = [];
-        if (esc.reason === 'timeout') {
-          parts.push(`I wasn't able to get a response from the ${agentLabel} in time.`);
-          if (esc.possiblySucceeded) parts.push('The request may still be completing in the background.');
-        } else if (esc.reason === 'blocked') {
-          parts.push(`The ${agentLabel} was blocked and couldn't complete the task.`);
-        } else {
-          // maxTurns, maxConsecutiveErrors, tool_error, api_error, or unknown reason.
-          logger.info(
-            { agentId, conversationId, targetAgent: esc.agent, reason: esc.reason },
-            'Humanizing delegation failure with generic message',
-          );
-          parts.push(`The ${agentLabel} wasn't able to complete the task.`);
-        }
-        if (esc.escalated) parts.push("I've logged a follow-up task to review the outcome.");
-        const escalationContent = parts.join(' ');
-
-        if (memory) {
-          await memory.addTurn(conversationId, agentId, { role: 'assistant', content: escalationContent });
-        }
-
-        const escalationResponse = createAgentResponse({
-          agentId,
-          conversationId,
-          content: escalationContent,
-          skillsCalled,
-          parentEventId: taskEvent.id,
-        });
-        await bus.publish('agent', escalationResponse);
-
-        logger.info(
-          {
-            agentId,
-            conversationId,
-            targetAgent: pendingDelegationEscalation.agent,
-            reason: pendingDelegationEscalation.reason,
-            escalated: pendingDelegationEscalation.escalated,
+        response = {
+          type: 'error',
+          error: {
+            type: 'UNKNOWN',
+            source: 'runtime',
+            message: `Streaming tool loop ended: ${streamResult.stopReason}`,
+            retryable: false,
+            context: { stopReason: streamResult.stopReason },
+            timestamp: new Date(),
           },
-          pendingDelegationEscalation.escalated
-            ? 'Task stopped after non-retryable delegation failure — escalated to CEO backlog'
-            : 'Task stopped after non-retryable delegation failure — CEO backlog escalation failed',
-        );
-        return;
+        };
       }
-
-      // Refresh Bullpen context before the next LLM round so the model sees
-      // any new replies or closures that occurred during skill execution (#213).
-      // Suppressed for scheduler runs — see the suppressAmbientBullpen note above (#1609).
-      if (!suppressAmbientBullpen) {
-        await this.refreshBullpenContext(messages, bullpenInsertAt, agentId, injectedBullpenThreadIds);
-      }
-
-      maybeAppendCheckpointBudgetNudge();
-      // Continue the loop — the full conversation history is now in messages
-      response = await this.chatWithRetry(provider, { messages, tools: workingToolDefs }, budget, taskEvent, budgetHandoff);
-      if (!response) return; // chatWithRetry already published error events
     }
 
     // Handle the final response (text or tool_use without execution layer).
@@ -1690,8 +1800,13 @@ export class AgentRuntime {
     let responseContent: string;
     let isResponseError = false;
     if (response.type === 'tool_use') {
-      // No execution layer configured — the LLM wanted tools but we can't run them
-      logger.warn({ agentId }, 'LLM returned tool_use but no execution layer configured');
+      // No execution layer, or streaming loop exhausted without a text completion.
+      logger.warn(
+        { agentId, toolCallCount: response.toolCalls.length },
+        response.toolCalls.length === 0
+          ? 'Tool loop exhausted without a text response'
+          : 'LLM returned tool_use but no execution layer configured',
+      );
       isResponseError = true;
       responseContent = response.content ?? "I wasn't able to complete that request — I hit my tool-use limit. Please try rephrasing.";
     } else if (response.type === 'text') {

--- a/src/channels/voice/turn-runner.test.ts
+++ b/src/channels/voice/turn-runner.test.ts
@@ -145,7 +145,7 @@ describe('VoiceTurnRunner', () => {
     const result = await runner.runTurn({ messages: [{ role: 'user', content: 'weather?' }], signal: new AbortController().signal });
 
     expect(invokeTool).toHaveBeenCalledOnce();
-    expect(invokeTool).toHaveBeenCalledWith(toolCall);
+    expect(invokeTool).toHaveBeenCalledWith(toolCall, expect.objectContaining({ messages: expect.any(Array) }));
     expect(fillers).toEqual(['One moment.']);
     // Preceding text ("Let me check.") is spoken before the filler, then the answer.
     expect(spoken).toContain('Let me check.');

--- a/src/channels/voice/turn-runner.ts
+++ b/src/channels/voice/turn-runner.ts
@@ -1,14 +1,14 @@
 // turn-runner.ts — VoiceTurnRunner drives a single spoken assistant turn.
 //
 // Thin voice wrapper over the streaming turn primitive
-// (src/agents/llm/streaming-turn.ts, #1552). This file owns only voice UX:
+// (src/agents/llm/streaming-turn.ts, #1552 / #1563). This file owns only voice UX:
 // sentence-chunk TTS, filler speech, barge-in AbortSignal semantics, and the
 // audible exhaustion fallback. Tool-loop / message assembly / round-cap /
 // stream+abort live in the shared primitive.
 //
-// Text AgentRuntime.handleTask stays on non-streaming provider.chat() — opt-in
-// is tracked as #1563 (requires a "text goes streaming" decision). Do not fold
-// voice into handleTask. Cross-link: src/agents/runtime.ts tool_use loop.
+// Text AgentRuntime.handleTask also delegates here via a chat-compatible
+// openStream adapter over chatWithRetry (ADR-038) — do not fold voice into
+// handleTask; both call the same primitive. Cross-link: src/agents/runtime.ts.
 // Sibling: #1551 (brain/context + history read model).
 
 import { randomUUID } from 'node:crypto';

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1720,7 +1720,10 @@ describe('AgentRuntime skill-activate (#1495)', () => {
     input_schema: { type: 'object' as const, properties: {}, required: [] as string[] },
   };
 
-  it('splices instruction block and expands workingToolDefs after skill-activate', async () => {
+  it('splices instruction block into streaming transcript so the next LLM round sees it (#1563)', async () => {
+    // skill-activate writes into ctx.messages (the primitive's workingMessages),
+    // not the outer messages array. This test fails if that splice targets the
+    // wrong array — the following openStream/chat round would miss the block.
     const logger = createLogger('error');
     const bus = new EventBus(logger);
     bus.subscribe('agent.response', 'dispatch', () => {});
@@ -1806,7 +1809,9 @@ describe('AgentRuntime skill-activate (#1495)', () => {
     expect(secondTools).toContain('task-create');
     expect(secondTools).toContain('task-list');
 
-    // Instruction block spliced as a system message.
+    // Instruction block must appear in the FOLLOWING LLM round's messages —
+    // proof the splice landed on the streaming working transcript (ctx.messages),
+    // which openStream snapshots for chatWithRetry.
     const secondMessages = chatCalls[1]!.messages as Array<{ role: string; content: unknown }>;
     const instructionMsg = secondMessages.find(
       (m) => m.role === 'system'
@@ -1815,6 +1820,15 @@ describe('AgentRuntime skill-activate (#1495)', () => {
         && m.content.includes('Task Management'),
     );
     expect(instructionMsg).toBeDefined();
+    // First round must NOT yet have the activation block (splice happens mid-tool).
+    const firstMessages = chatCalls[0]!.messages as Array<{ role: string; content: unknown }>;
+    expect(
+      firstMessages.some(
+        (m) => m.role === 'system'
+          && typeof m.content === 'string'
+          && m.content.includes('[Activated skill: tasks]'),
+      ),
+    ).toBe(false);
   });
 
   it('re-loads active skills on wake without rewriting when the set is unchanged', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1563.

Converges the text-channel tool loop onto the shared streaming primitive (`runStreamingToolLoop`) per ADR-038. Voice already used this path; text now does too via a **chat-compatible `openStream` adapter** over `chatWithRetry` — so retry/fallback, llm.call telemetry, error budgets, DelegationGuard, clarification short-circuits, and tool bus events stay intact while round-cap / invoke sequencing / message assembly cannot silently diverge.

> Note: #1563 was auto-closed when ADR-038 acceptance (#1618) landed with “Resolves #1563’s blocking question.” That PR only cleared the decision gate; this PR is the implementation.

### What changed

- **`streaming-turn.ts`** — `openStream`, `llmResponseAsStream`, `beforeRound` / `onToolUse` / `afterTools` hooks, `stopReason: 'stopped'`, optional `invokeTool` messages ctx for skill-activate splices
- **`AgentRuntime.processTask`** — with `executionLayer`, delegates the tool loop to `runStreamingToolLoop`; without EL, keeps a single `chatWithRetry` shot
- Round caps remain parameterized: text `error_budget.max_turns` via `onToolUse` turnsUsed semantics; voice `DEFAULT_STREAMING_MAX_ROUNDS=8`
- Docs: ADR-037 consequences + file headers updated

### Review follow-ups (`ae27853f`)

- Warn on defensive silent `'stopped'`; document inert AbortSignal / unreachable branches / post-loop messages shape
- Strengthen skill-activate + `openStream` snapshot unit coverage

### Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] vitest: `streaming-turn`, `tool-loop-messages`, `runtime` (unit + src), `turn-runner`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faa28-80b7-755a-ac9a-10c98031a43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faa28-80b7-755a-ac9a-10c98031a43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

