### PR TITLE
feat(voice): Curia greets first on inbound console calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Voice opening greeting** — Curia speaks first on inbound console calls. (#1596)
 - **`async-offramp`** — voice hands heavyweight asks to async coordinator for principal callback. (#1614)
 - **ADR-038 (Accepted)** — shared-hardening; voice off-ramp shipped; text→streaming (#1563) unblocked. (#1595)
 - **`src/agents/prompts/`** — shared date-resolve guardrail composed by voice + coordinator. (#1595)

--- a/apps/console/src/pages/chat/VoiceCallBar.test.tsx
+++ b/apps/console/src/pages/chat/VoiceCallBar.test.tsx
@@ -10,6 +10,7 @@ function props(overrides: Partial<UseVoiceCallResult> = {}): UseVoiceCallResult 
     muted: false,
     error: null,
     sessionId: null,
+    heardAssistant: false,
     startCall: vi.fn(),
     toggleMute: vi.fn(),
     hangUp: vi.fn(),
@@ -32,8 +33,18 @@ describe('VoiceCallBar (#1571)', () => {
     expect(html).toContain('Hang up');
   });
 
-  it('renders in-call mute and hang up when connected', () => {
-    const html = renderToStaticMarkup(<VoiceCallBar {...props({ callState: 'connected' })} />);
+  it('renders Greeting before remote audio is heard (#1596)', () => {
+    const html = renderToStaticMarkup(
+      <VoiceCallBar {...props({ callState: 'connected', heardAssistant: false })} />,
+    );
+    expect(html).toContain('Greeting');
+    expect(html).not.toContain('Listening');
+  });
+
+  it('renders Listening once Curia audio has been heard', () => {
+    const html = renderToStaticMarkup(
+      <VoiceCallBar {...props({ callState: 'connected', heardAssistant: true })} />,
+    );
     expect(html).toContain('Listening');
     expect(html).toContain('Mute');
     expect(html).toContain('Hang up');

--- a/apps/console/src/pages/chat/VoiceCallBar.tsx
+++ b/apps/console/src/pages/chat/VoiceCallBar.tsx
@@ -8,9 +8,16 @@ import type { UseVoiceCallResult } from './useVoiceCall.js';
 
 type VoiceCallBarProps = UseVoiceCallResult;
 
-function statusText(callState: UseVoiceCallResult['callState'], muted: boolean): string {
+function statusText(
+  callState: UseVoiceCallResult['callState'],
+  muted: boolean,
+  heardAssistant: boolean,
+): string {
   if (callState === 'connecting') return 'Connecting…';
-  if (callState === 'connected') return muted ? 'On call · muted' : 'Listening…';
+  if (callState === 'connected') {
+    if (!heardAssistant) return 'Greeting…';
+    return muted ? 'On call · muted' : 'Listening…';
+  }
   return 'Voice call unavailable';
 }
 
@@ -19,6 +26,7 @@ export function VoiceCallBar({
   callState,
   muted,
   error,
+  heardAssistant = false,
   startCall,
   toggleMute,
   hangUp,
@@ -50,7 +58,7 @@ export function VoiceCallBar({
   return (
     <div className={`voice-call-bar ${callState}`} role="status" aria-live="polite">
       <span className="voice-call-live-dot" aria-hidden="true" />
-      <span className="voice-call-status">{statusText(callState, muted)}</span>
+      <span className="voice-call-status">{statusText(callState, muted, heardAssistant)}</span>
       {error && <span className="voice-call-error">{error}</span>}
       <span className="voice-call-spacer" />
       <button

--- a/apps/console/src/pages/chat/useVoiceCall.ts
+++ b/apps/console/src/pages/chat/useVoiceCall.ts
@@ -23,6 +23,11 @@ export interface UseVoiceCallResult {
   muted: boolean;
   error: string | null;
   sessionId: string | null;
+  /**
+   * True once a remote (Curia) audio track has been subscribed this call.
+   * Used to flip UI copy from "Greeting…" → "Listening…" (#1596).
+   */
+  heardAssistant: boolean;
   startCall: () => Promise<void>;
   toggleMute: () => Promise<void>;
   hangUp: () => Promise<void>;
@@ -65,6 +70,7 @@ export function useVoiceCall(): UseVoiceCallResult {
   const [muted, setMuted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [heardAssistant, setHeardAssistant] = useState(false);
 
   const mountedRef = useRef(true);
   const roomRef = useRef<Room | null>(null);
@@ -88,6 +94,7 @@ export function useVoiceCall(): UseVoiceCallResult {
     element.style.display = 'none';
     document.body.appendChild(element);
     audioElementsRef.current.push(element);
+    if (mountedRef.current) setHeardAssistant(true);
     void element.play().catch(() => {
       if (mountedRef.current) {
         setError('Audio playback was blocked. Use the call controls to reconnect.');
@@ -117,6 +124,7 @@ export function useVoiceCall(): UseVoiceCallResult {
     if (mountedRef.current) {
       setSessionId(null);
       setMuted(false);
+      setHeardAssistant(false);
     }
   }, [detachAllAudio]);
 
@@ -171,6 +179,7 @@ export function useVoiceCall(): UseVoiceCallResult {
     if (mountedRef.current) {
       setCallState('connecting');
       setError(null);
+      setHeardAssistant(false);
     }
 
     try {
@@ -287,6 +296,7 @@ export function useVoiceCall(): UseVoiceCallResult {
     muted,
     error,
     sessionId,
+    heardAssistant,
     startCall,
     toggleMute,
     hangUp,

--- a/apps/console/src/pages/chat/useVoiceCall.ts
+++ b/apps/console/src/pages/chat/useVoiceCall.ts
@@ -24,8 +24,10 @@ export interface UseVoiceCallResult {
   error: string | null;
   sessionId: string | null;
   /**
-   * True once a remote (Curia) audio track has been subscribed this call.
-   * Used to flip UI copy from "Greeting…" → "Listening…" (#1596).
+   * True once a remote (Curia) participant has actually spoken this call
+   * (LiveKit active-speaker / isSpeaking). Used to flip UI copy from
+   * "Greeting…" → "Listening…" (#1596). TrackSubscribed alone is too early —
+   * the agent publishes a silent audio track at connect time.
    */
   heardAssistant: boolean;
   startCall: () => Promise<void>;
@@ -94,7 +96,6 @@ export function useVoiceCall(): UseVoiceCallResult {
     element.style.display = 'none';
     document.body.appendChild(element);
     audioElementsRef.current.push(element);
-    if (mountedRef.current) setHeardAssistant(true);
     void element.play().catch(() => {
       if (mountedRef.current) {
         setError('Audio playback was blocked. Use the call controls to reconnect.');
@@ -196,30 +197,40 @@ export function useVoiceCall(): UseVoiceCallResult {
       sessionIdRef.current = session.sessionId;
       if (mountedRef.current) setSessionId(session.sessionId);
 
-      room = new Room();
+      const callRoom = new Room();
+      room = callRoom;
 
-      room.on(RoomEvent.TrackSubscribed, (track: RemoteTrack) => {
+      callRoom.on(RoomEvent.TrackSubscribed, (track: RemoteTrack) => {
         attachRemoteAudio(track);
       });
-      room.on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack) => {
+      callRoom.on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack) => {
         detachRemoteAudio(track);
       });
-      room.on(RoomEvent.Disconnected, () => {
-        if (roomRef.current !== room) return;
-        resetLocalCall(room);
+      // TrackSubscribed fires as soon as the agent publishes its (still silent)
+      // audio track at connect — that is not "heard greeting". Flip on actual
+      // speaking via LiveKit active-speaker detection (#1596).
+      callRoom.on(RoomEvent.ActiveSpeakersChanged, (speakers) => {
+        const localId = callRoom.localParticipant.identity;
+        if (speakers.some((p) => p.identity !== localId && p.isSpeaking)) {
+          if (mountedRef.current) setHeardAssistant(true);
+        }
+      });
+      callRoom.on(RoomEvent.Disconnected, () => {
+        if (roomRef.current !== callRoom) return;
+        resetLocalCall(callRoom);
         if (mountedRef.current) setCallState('idle');
       });
 
-      roomRef.current = room;
-      await room.connect(session.livekitUrl, session.token, { autoSubscribe: true });
+      roomRef.current = callRoom;
+      await callRoom.connect(session.livekitUrl, session.token, { autoSubscribe: true });
 
-      for (const participant of room.remoteParticipants.values()) {
+      for (const participant of callRoom.remoteParticipants.values()) {
         for (const publication of participant.audioTrackPublications.values()) {
           if (publication.track) attachRemoteAudio(publication.track);
         }
       }
 
-      await room.localParticipant.setMicrophoneEnabled(true);
+      await callRoom.localParticipant.setMicrophoneEnabled(true);
       if (mountedRef.current) {
         setMuted(false);
         setCallState('connected');

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -18,6 +18,7 @@ import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../s
 import { resolveConsoleOriginator } from '../console-originator.js';
 import { markdownToHtml } from '../../../format/markdown-to-html.js';
 import { stripOutboundContextPreamble } from '../../../dispatch/outbound-context.js';
+import { isVoiceGreetingCueContent } from '../../voice/greeting.js';
 import { validateTaskErrorBudget } from '../../../tasks/task-error-budget.js';
 
 export interface KnowledgeGraphRouteOptions {
@@ -1522,7 +1523,9 @@ export async function knowledgeGraphRoutes(
    *
    * Only user/assistant turns are returned — system turns (synthetic summaries
    * inserted by the summarisation pass) are excluded since they are internal
-   * artifacts not intended for display.
+   * artifacts not intended for display. The synthetic voice opening cue
+   * (`VOICE_GREETING_USER_MESSAGE`, #1596) is also excluded — it exists so
+   * Anthropic-safe user-first history, not for the principal to read.
    */
   app.get('/api/kg/chat/history', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
@@ -1577,7 +1580,12 @@ export async function knowledgeGraphRoutes(
       // Take at most `limit` rows, then restore chronological order.
       const rows = result.rows.slice(0, limit).reverse();
 
-      const messages = rows.map((row) => {
+      const messages = rows.flatMap((row) => {
+        // Voice opening cue is persisted so spoken-turn history stays user-first
+        // for Anthropic, but must not surface as a chat bubble (#1596).
+        if (row.role === 'user' && isVoiceGreetingCueContent(row.content)) {
+          return [];
+        }
         // Per-row try/catch so one bad message doesn't fail the whole page.
         let html: string | null = null;
         // Strip dispatcher-injected outbound context preambles from user messages
@@ -1593,13 +1601,13 @@ export async function knowledgeGraphRoutes(
             logger.warn({ err: convErr, messageId: row.id }, 'markdownToHtml failed for history row; falling back to plain text');
           }
         }
-        return {
+        return [{
           id: row.id,
           role: row.role as 'user' | 'assistant',
           content,
           html,
           timestamp: row.created_at.toISOString(),
-        };
+        }];
       });
 
       return reply.send({ messages, hasMore });

--- a/src/channels/voice/greeting.test.ts
+++ b/src/channels/voice/greeting.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VOICE_GREETING_USER_MESSAGE,
+  isVoiceGreetingCueContent,
+} from './greeting.js';
+
+describe('voice greeting cue (#1596)', () => {
+  it('identifies the synthetic opening cue for console history filtering', () => {
+    expect(isVoiceGreetingCueContent(VOICE_GREETING_USER_MESSAGE)).toBe(true);
+    expect(isVoiceGreetingCueContent('hello')).toBe(false);
+    expect(isVoiceGreetingCueContent(`${VOICE_GREETING_USER_MESSAGE} `)).toBe(false);
+  });
+});

--- a/src/channels/voice/greeting.ts
+++ b/src/channels/voice/greeting.ts
@@ -1,0 +1,19 @@
+/** Synthetic user message that triggers the opening turn. */
+export const VOICE_GREETING_USER_MESSAGE =
+  '[Call connected — open the conversation.]';
+
+/**
+ * Opening-turn instruction for inbound console calls (#1596). Appended to the
+ * spoken-turn system prompt so Curia greets first; lean on outbound-context and
+ * the time block when present. Not used for Curia-initiated outbound calls.
+ */
+export const VOICE_GREETING_INSTRUCTION =
+  'The principal just called and joined the line. Open the conversation naturally ' +
+  'and briefly — a short spoken greeting appropriate to the time of day. If active ' +
+  'outbound context is present, acknowledge it in one breath. Do not wait for them ' +
+  'to speak first. One or two short sentences only.';
+
+/** True when content is the synthetic voice opening cue (hide from console history). */
+export function isVoiceGreetingCueContent(content: string): boolean {
+  return content === VOICE_GREETING_USER_MESSAGE;
+}

--- a/src/channels/voice/voice-adapter.ts
+++ b/src/channels/voice/voice-adapter.ts
@@ -139,6 +139,10 @@ export class VoiceAdapter implements Channel {
         conversationId: session.conversationId,
         roomName: session.livekitRoom,
         agentToken,
+        // Console POST /api/voice/sessions is always principal-initiated inbound.
+        // A future Curia-initiated outbound path must pass openingGreeting: false
+        // so Curia does not talk over the CEO answering (#1596).
+        openingGreeting: true,
       })
       .catch(async err => {
         this.log.error({ err, sessionId: session.id }, 'Voice runtime failed to start session');

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -14,6 +14,8 @@ import {
   VOICE_SYSTEM_ADDENDUM,
   VOICE_TOOL_RESULT_POLICY,
   VOICE_DELEGATION_GUIDANCE,
+  VOICE_GREETING_INSTRUCTION,
+  VOICE_GREETING_USER_MESSAGE,
 } from './voice-runtime.js';
 import type { VoiceToolBridge } from './voice-runtime.js';
 import { FakeAudioTransport } from './fake-audio-transport.js';
@@ -158,6 +160,8 @@ function makeRuntime(overrides: {
   outboundContextService?: OutboundContextService;
   /** Late-bound coordinator bridge (tools + context providers), applied via configureTools(). */
   bridge?: VoiceToolBridge;
+  /** Opening greeting defaults off in unit tests so scripted LLM replies map 1:1 to user turns. */
+  openingGreeting?: boolean;
 }) {
   const bus = new EventBus(logger);
   const events: BusEvent[] = [];
@@ -187,6 +191,9 @@ function makeRuntime(overrides: {
     timezone: overrides.timezone,
     historyReadTimeoutMs: overrides.historyReadTimeoutMs,
     outboundContextService: overrides.outboundContextService,
+    // Default false so existing tests' LLM scripts are not consumed by the
+    // opening greeting (#1596). Greeting-specific tests opt in explicitly.
+    openingGreeting: overrides.openingGreeting ?? false,
   });
   if (overrides.bridge) runtime.configureTools(overrides.bridge);
   return { runtime, bus, events, stt, transport, tts, store };
@@ -1045,5 +1052,163 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
     expect(system.content).toBe(SLIM_VOICE_PROMPT);
     expect(system.content).not.toContain('[ACTIVE OUTBOUND CONTEXT');
     expect(transport.publishedFrames.length).toBeGreaterThan(0);
+  });
+});
+
+describe('VoiceRuntime opening greeting (#1596)', () => {
+  it('speaks an LLM greeting before any user speech and does not publish inbound.message', async () => {
+    const llm = new FakeStreamProvider([
+      replyScript('Good morning — what can I help with?'),
+    ]);
+    const { store, statuses } = fakeStore();
+    const { runtime, events, transport } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(3, 1),
+      store,
+      openingGreeting: true,
+      timezone: 'America/Toronto',
+    });
+
+    await runtime.startSession({
+      sessionId: 'g1',
+      conversationId: 'voice:g1',
+      roomName: 'voice-g1',
+      agentToken: 'tok',
+    });
+    await runtime.awaitIdle('g1');
+
+    expect(transport.publishedFrames.length).toBeGreaterThan(0);
+    expect(events.filter(e => e.type === 'inbound.message')).toHaveLength(0);
+    expect(statuses).toContain('active');
+
+    expect(llm.seenMessages).toHaveLength(1);
+    const messages = llm.seenMessages[0]!;
+    const system = messages[0]!;
+    expect(system.role).toBe('system');
+    expect(system.content).toContain(VOICE_GREETING_INSTRUCTION);
+    expect(system.content).toContain('## Current Date & Time');
+    const user = messages[messages.length - 1]!;
+    expect(user).toEqual({ role: 'user', content: VOICE_GREETING_USER_MESSAGE });
+  });
+
+  it('includes outbound-context in the greeting system prompt when active', async () => {
+    const llm = new FakeStreamProvider([
+      replyScript('Hey — is this about that Google alert?'),
+    ]);
+    const signalAlertEntry: OutboundContextRow = {
+      id: 'entry-signal-alert',
+      conversationId: 'signal:ceo',
+      channelId: 'signal',
+      agentId: 'coordinator',
+      contentPreview: 'Google security alert: new sign-in on your account.',
+      expectedReply: null,
+      delegationHint: null,
+      metadata: { subject: 'security-alert' },
+      createdAt: new Date(Date.now() - 2 * 60 * 1000),
+      expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1000),
+      released: false,
+    };
+    const real = new OutboundContextService(
+      { query: async () => ({ rows: [] }) } as never,
+      logger,
+    );
+    real.getActive = async () => [signalAlertEntry];
+
+    const { runtime } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      openingGreeting: true,
+      outboundContextService: real,
+    });
+
+    await runtime.startSession({
+      sessionId: 'g2',
+      conversationId: 'voice:g2',
+      roomName: 'voice-g2',
+      agentToken: 'tok',
+    });
+    await runtime.awaitIdle('g2');
+
+    const system = llm.seenMessages[0]![0]!;
+    expect(system.content).toContain('[ACTIVE OUTBOUND CONTEXT');
+    expect(system.content).toContain(VOICE_GREETING_INSTRUCTION);
+    expect(system.content).toContain('Google security alert');
+  });
+
+  it('barge-in cancels an in-flight greeting so the user turn can proceed', async () => {
+    const llm = new FakeStreamProvider(
+      [
+        [
+          { type: 'text_delta', text: 'Good afternoon, hope you are well today. ' },
+          { type: 'text_delta', text: 'What would you like to cover? ' },
+          {
+            type: 'message_end',
+            content: 'Good afternoon, hope you are well today. What would you like to cover?',
+            usage,
+            provenance,
+          },
+        ],
+        replyScript('Got it — calendar is clear.'),
+      ],
+      3,
+    );
+    const tts = new SlowTtsProvider(50, 5);
+    const { runtime, stt, events } = makeRuntime({ llm, tts, openingGreeting: true });
+
+    await runtime.startSession({
+      sessionId: 'g3',
+      conversationId: 'voice:g3',
+      roomName: 'voice-g3',
+      agentToken: 'tok',
+    });
+
+    // Let the greeting start speaking.
+    await delay(40);
+    expect(tts.requests.length).toBeGreaterThan(0);
+
+    // Principal interrupts mid-greeting.
+    stt.emit({ text: 'what is on my calendar', isFinal: false, confidence: 0.9 });
+    stt.emit({ text: 'what is on my calendar', isFinal: true, speechFinal: true });
+
+    await runtime.awaitIdle('g3');
+
+    expect(tts.cancelled.size).toBeGreaterThan(0);
+    const inbound = events.find(e => e.type === 'inbound.message');
+    expect(inbound).toBeDefined();
+    expect((inbound as { payload: { content: string } }).payload.content).toBe(
+      'what is on my calendar',
+    );
+    // Greeting + user turn both ran against the LLM.
+    expect(llm.seenMessages.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('persists only the spoken greeting to working memory (not the synthetic cue)', async () => {
+    const llm = new FakeStreamProvider([replyScript('Hey boss.')]);
+    const addTurn = vi.fn(async () => {});
+    const workingMemory = {
+      addTurn,
+      getHistory: vi.fn(async () => []),
+    } as unknown as WorkingMemory;
+
+    const { runtime } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      openingGreeting: true,
+      workingMemory,
+    });
+
+    await runtime.startSession({
+      sessionId: 'g4',
+      conversationId: 'voice:g4',
+      roomName: 'voice-g4',
+      agentToken: 'tok',
+    });
+    await runtime.awaitIdle('g4');
+
+    expect(addTurn).toHaveBeenCalledTimes(1);
+    expect(addTurn).toHaveBeenCalledWith('voice:g4', 'coordinator', {
+      role: 'assistant',
+      content: 'Hey boss.',
+    });
   });
 });

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -160,8 +160,6 @@ function makeRuntime(overrides: {
   outboundContextService?: OutboundContextService;
   /** Late-bound coordinator bridge (tools + context providers), applied via configureTools(). */
   bridge?: VoiceToolBridge;
-  /** Opening greeting defaults off in unit tests so scripted LLM replies map 1:1 to user turns. */
-  openingGreeting?: boolean;
 }) {
   const bus = new EventBus(logger);
   const events: BusEvent[] = [];
@@ -191,9 +189,6 @@ function makeRuntime(overrides: {
     timezone: overrides.timezone,
     historyReadTimeoutMs: overrides.historyReadTimeoutMs,
     outboundContextService: overrides.outboundContextService,
-    // Default false so existing tests' LLM scripts are not consumed by the
-    // opening greeting (#1596). Greeting-specific tests opt in explicitly.
-    openingGreeting: overrides.openingGreeting ?? false,
   });
   if (overrides.bridge) runtime.configureTools(overrides.bridge);
   return { runtime, bus, events, stt, transport, tts, store };
@@ -256,6 +251,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s2',
       roomName: 'voice-s2',
       agentToken: 'tok',
+      openingGreeting: false,
     });
 
     stt.emit({ text: 'tell me a long story', isFinal: true, speechFinal: true });
@@ -297,6 +293,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-echo',
       roomName: 'voice-s-echo',
       agentToken: 'tok',
+      openingGreeting: false,
     });
     stt.emit({ text: 'say something', isFinal: true, speechFinal: true });
     await delay(40);
@@ -321,6 +318,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-close',
       roomName: 'voice-s-close',
       agentToken: 'tok',
+      openingGreeting: false,
     });
     expect(runtime.activeSessionCount).toBe(1);
 
@@ -343,6 +341,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s3',
       roomName: 'voice-s3',
       agentToken: 'tok',
+      openingGreeting: false,
     });
     expect(runtime.activeSessionCount).toBe(1);
 
@@ -375,6 +374,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s5',
       roomName: 'voice-s5',
       agentToken: 'tok',
+      openingGreeting: false,
     });
 
     await expect(runtime.endSession('s5', 'stt_error')).resolves.toBeNull();
@@ -399,6 +399,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-tts-fail',
       roomName: 'voice-s-tts-fail',
       agentToken: 'tok',
+      openingGreeting: false,
     });
 
     stt.emit({ text: 'one', isFinal: true, speechFinal: true });
@@ -437,6 +438,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-tts-blip',
       roomName: 'voice-s-tts-blip',
       agentToken: 'tok',
+      openingGreeting: false,
     });
 
     stt.emit({ text: 'one', isFinal: true, speechFinal: true });
@@ -463,6 +465,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-tts-hard',
       roomName: 'voice-s-tts-hard',
       agentToken: 'tok',
+      openingGreeting: false,
     });
 
     stt.emit({ text: 'hello', isFinal: true, speechFinal: true });
@@ -501,6 +504,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-pub-fail',
       roomName: 'voice-s-pub-fail',
       agentToken: 'tok',
+      openingGreeting: false,
     });
 
     for (const utter of ['one', 'two', 'three'] as const) {
@@ -528,6 +532,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s4',
       roomName: 'voice-s4',
       agentToken: 'tok',
+      openingGreeting: false,
     });
     stt.emit({ text: 'look something up', isFinal: true, speechFinal: true });
     await runtime.awaitIdle('s4');
@@ -552,6 +557,7 @@ describe('VoiceRuntime brain/context parity (#1551)', () => {
       conversationId: `voice:${id}`,
       roomName: `voice-${id}`,
       agentToken: 'tok',
+      openingGreeting: false,
     });
   }
 
@@ -956,6 +962,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       conversationId: 'voice:oc1',
       roomName: 'voice-oc1',
       agentToken: 'tok',
+      openingGreeting: false,
     });
     stt.emit({ text: 'did you message me', isFinal: true, speechFinal: true });
     await runtime.awaitIdle('oc1');
@@ -989,6 +996,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       conversationId: 'voice:oc2',
       roomName: 'voice-oc2',
       agentToken: 'tok',
+      openingGreeting: false,
     });
     stt.emit({ text: 'hello', isFinal: true, speechFinal: true });
     await runtime.awaitIdle('oc2');
@@ -1017,6 +1025,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       conversationId: 'voice:oc3',
       roomName: 'voice-oc3',
       agentToken: 'tok',
+      openingGreeting: false,
     });
     stt.emit({ text: 'are you there', isFinal: true, speechFinal: true });
     await runtime.awaitIdle('oc3');
@@ -1044,6 +1053,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       conversationId: 'voice:oc4',
       roomName: 'voice-oc4',
       agentToken: 'tok',
+      openingGreeting: false,
     });
     stt.emit({ text: 'did you message me', isFinal: true, speechFinal: true });
     await runtime.awaitIdle('oc4');
@@ -1065,7 +1075,6 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       llm,
       tts: new SlowTtsProvider(3, 1),
       store,
-      openingGreeting: true,
       timezone: 'America/Toronto',
     });
 
@@ -1074,6 +1083,7 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       conversationId: 'voice:g1',
       roomName: 'voice-g1',
       agentToken: 'tok',
+      openingGreeting: true,
     });
     await runtime.awaitIdle('g1');
 
@@ -1117,7 +1127,6 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
     const { runtime } = makeRuntime({
       llm,
       tts: new SlowTtsProvider(2, 1),
-      openingGreeting: true,
       outboundContextService: real,
     });
 
@@ -1126,6 +1135,7 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       conversationId: 'voice:g2',
       roomName: 'voice-g2',
       agentToken: 'tok',
+      openingGreeting: true,
     });
     await runtime.awaitIdle('g2');
 
@@ -1153,13 +1163,14 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       3,
     );
     const tts = new SlowTtsProvider(50, 5);
-    const { runtime, stt, events } = makeRuntime({ llm, tts, openingGreeting: true });
+    const { runtime, stt, events } = makeRuntime({ llm, tts });
 
     await runtime.startSession({
       sessionId: 'g3',
       conversationId: 'voice:g3',
       roomName: 'voice-g3',
       agentToken: 'tok',
+      openingGreeting: true,
     });
 
     // Let the greeting start speaking.
@@ -1182,7 +1193,7 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
     expect(llm.seenMessages.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('persists only the spoken greeting to working memory (not the synthetic cue)', async () => {
+  it('persists synthetic user cue + greeting so later turns stay user-first', async () => {
     const llm = new FakeStreamProvider([replyScript('Hey boss.')]);
     const addTurn = vi.fn(async () => {});
     const workingMemory = {
@@ -1193,7 +1204,6 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
     const { runtime } = makeRuntime({
       llm,
       tts: new SlowTtsProvider(2, 1),
-      openingGreeting: true,
       workingMemory,
     });
 
@@ -1202,13 +1212,86 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       conversationId: 'voice:g4',
       roomName: 'voice-g4',
       agentToken: 'tok',
+      openingGreeting: true,
     });
     await runtime.awaitIdle('g4');
 
-    expect(addTurn).toHaveBeenCalledTimes(1);
-    expect(addTurn).toHaveBeenCalledWith('voice:g4', 'coordinator', {
+    expect(addTurn).toHaveBeenCalledTimes(2);
+    expect(addTurn).toHaveBeenNthCalledWith(1, 'voice:g4', 'coordinator', {
+      role: 'user',
+      content: VOICE_GREETING_USER_MESSAGE,
+    });
+    expect(addTurn).toHaveBeenNthCalledWith(2, 'voice:g4', 'coordinator', {
       role: 'assistant',
       content: 'Hey boss.',
     });
+  });
+
+  it('completed greeting → user turn assembles a user-first message array (Anthropic contract)', async () => {
+    /**
+     * Provider stub that throws if the first non-system message is not `user` —
+     * locks the regression that a completed greeting must not leave history
+     * assistant-led (Anthropic Messages API 400).
+     */
+    class UserFirstEnforcingProvider extends FakeStreamProvider {
+      override async *stream(params: {
+        messages?: Message[];
+        options?: Record<string, unknown>;
+      }): AsyncIterable<LLMStreamEvent> {
+        const nonSystem = (params.messages ?? []).filter(m => m.role !== 'system');
+        const first = nonSystem[0];
+        if (first && first.role !== 'user') {
+          throw new Error(
+            `provider contract violated: first non-system message must be user, got ${first.role}`,
+          );
+        }
+        yield* super.stream(params);
+      }
+    }
+
+    const llm = new UserFirstEnforcingProvider([
+      replyScript('Good morning.'),
+      replyScript('Your calendar is clear this afternoon.'),
+    ]);
+    const turns: Array<{ role: string; content: string }> = [];
+    const workingMemory = {
+      addTurn: vi.fn(async (_c: string, _a: string, turn: { role: string; content: string }) => {
+        turns.push(turn);
+      }),
+      getHistory: vi.fn(async () => [...turns]),
+    } as unknown as WorkingMemory;
+
+    const { runtime, stt, transport } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      workingMemory,
+    });
+
+    await runtime.startSession({
+      sessionId: 'g5',
+      conversationId: 'voice:g5',
+      roomName: 'voice-g5',
+      agentToken: 'tok',
+      openingGreeting: true,
+    });
+    await runtime.awaitIdle('g5');
+
+    // Greeting completed and persisted cue + assistant.
+    expect(turns).toEqual([
+      { role: 'user', content: VOICE_GREETING_USER_MESSAGE },
+      { role: 'assistant', content: 'Good morning.' },
+    ]);
+
+    stt.emit({ text: "what's on my calendar", isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('g5');
+
+    expect(llm.seenMessages).toHaveLength(2);
+    const userTurnMessages = llm.seenMessages[1]!;
+    const nonSystem = userTurnMessages.filter(m => m.role !== 'system');
+    expect(nonSystem[0]!.role).toBe('user');
+    expect(nonSystem[0]!.content).toBe(VOICE_GREETING_USER_MESSAGE);
+    expect(nonSystem[1]).toEqual({ role: 'assistant', content: 'Good morning.' });
+    expect(nonSystem[2]).toEqual({ role: 'user', content: "what's on my calendar" });
+    expect(transport.publishedFrames.length).toBeGreaterThan(0);
   });
 });

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -545,22 +545,53 @@ export class VoiceRuntime {
       .then(() => this.runGreetingTurn(session));
   }
 
+  /** Clear llmActive / currentController for a turn that is unwinding. */
+  private clearTurnState(session: ActiveSession, controller: AbortController): void {
+    session.llmActive = false;
+    if (session.currentController === controller) {
+      session.currentController = null;
+    }
+  }
+
+  private trimSessionHistory(session: ActiveSession): void {
+    if (session.history.length > MAX_HISTORY_MESSAGES) {
+      session.history.splice(0, session.history.length - MAX_HISTORY_MESSAGES);
+    }
+  }
+
   /**
-   * Opening turn for inbound console calls (#1596). Speaks an LLM greeting
-   * (context-aware via the outbound-context bridge + time block) before any
-   * user speech. Barge-in cancels it the same way as a normal assistant turn.
-   *
-   * On success, persists a synthetic leading user cue *and* the assistant
-   * greeting so later turns stay provider-safe (Anthropic requires user-first).
-   * The cue is never published as inbound.message; the console history endpoint
-   * filters it from display via isVoiceGreetingCueContent.
+   * Shared spoken-turn lifecycle for greeting and user turns (#1596 review).
+   * Owns: controller/`llmActive`, mark-active, ending/aborted checkpoints,
+   * speech handler, system prompt, VoiceTurnRunner, and a single finally teardown.
+   * Callers supply only what differs (TTFA key, message assembly, tools, persist).
    */
-  private async runGreetingTurn(session: ActiveSession): Promise<void> {
+  private async runAssistantTurn(
+    session: ActiveSession,
+    opts: {
+      ttfaLogKey: 'voice.ttfa_ms' | 'voice.greeting_ttfa_ms';
+      ttfaLogMessage: string;
+      failureLogMessage: string;
+      /**
+       * Prior history for message assembly. When omitted the core loads it
+       * (greeting). User turns pass the pre-loaded prior so the current
+       * utterance can be persisted before the assistant runs.
+       */
+      priorHistory?: Message[];
+      assembleMessages: (ctx: {
+        systemPrompt: string;
+        priorHistory: Message[];
+      }) => Message[];
+      /** Wire coordinator tools + filler (user turns). Greeting passes false. */
+      withTools: boolean;
+      /** Persist a completed spoken reply (in-process + working_memory). */
+      persistSuccess: (finalText: string) => Promise<void>;
+    },
+  ): Promise<void> {
     if (session.ending) return;
 
     // Register the controller BEFORE any await so a concurrent endSession can
     // abort this turn (otherwise updateStatus yields with currentController
-    // still null and a phantom greeting can persist after hangup).
+    // still null and a phantom reply can persist after hangup).
     const controller = new AbortController();
     session.currentController = controller;
     session.llmActive = true;
@@ -577,18 +608,18 @@ export class VoiceRuntime {
 
       if (session.ending || controller.signal.aborted) return;
 
-      const priorHistory = await this.loadTurnHistory(session);
+      const priorHistory = opts.priorHistory ?? await this.loadTurnHistory(session);
       if (session.ending || controller.signal.aborted) return;
 
-      const greetingStartedAt = Date.now();
+      const turnStartedAt = Date.now();
       let ttfaRecorded = false;
       const onSpeechText = this.createSpeechHandler(session, controller, {
         onFirstAudio: () => {
           if (ttfaRecorded) return;
           ttfaRecorded = true;
           this.log.debug(
-            { sessionId: session.sessionId, 'voice.greeting_ttfa_ms': Date.now() - greetingStartedAt },
-            'voice greeting time-to-first-audio',
+            { sessionId: session.sessionId, [opts.ttfaLogKey]: Date.now() - turnStartedAt },
+            opts.ttfaLogMessage,
           );
         },
       });
@@ -596,58 +627,128 @@ export class VoiceRuntime {
       const systemPrompt = await this.buildTurnSystemPrompt();
       if (session.ending || controller.signal.aborted) return;
 
-      const messages: Message[] = [
-        { role: 'system', content: `${systemPrompt}\n\n${VOICE_GREETING_INSTRUCTION}` },
-        ...priorHistory,
-        { role: 'user', content: VOICE_GREETING_USER_MESSAGE },
-      ];
+      const messages = opts.assembleMessages({ systemPrompt, priorHistory });
 
-      // No tools on the greeting — keep the open short and latency-tight; outbound
-      // context is already in the system prompt when present.
+      let tools: ToolDefinition[] | undefined;
+      let invokeTool: ((call: ToolCall) => Promise<{ content: string; is_error?: boolean }>) | undefined;
+      let onFiller: ((text: string) => Promise<void>) | undefined;
+
+      if (opts.withTools) {
+        tools = this.toolBridge
+          ? this.toolBridge.resolveVoiceTools()
+          : (this.config.resolveVoiceTools ? this.config.resolveVoiceTools() : this.config.tools);
+
+        const turnDateResolveTracker = new TurnDateResolveTracker();
+        invokeTool = this.toolBridge
+          ? async (call: ToolCall) => {
+            const result = await this.toolBridge!.invokeTool(call, {
+              conversationId: session.conversationId,
+              sessionId: session.sessionId,
+              turnDateResolveResults: turnDateResolveTracker.snapshot(),
+            });
+            if (call.name === 'date-resolve') {
+              turnDateResolveTracker.recordFromJsonContent(result.content, result.is_error);
+            }
+            return result;
+          }
+          : this.config.invokeTool
+            ? async (call: ToolCall) => {
+              const result = await this.config.invokeTool!(call, {
+                conversationId: session.conversationId,
+                sessionId: session.sessionId,
+                turnDateResolveResults: turnDateResolveTracker.snapshot(),
+              });
+              if (call.name === 'date-resolve') {
+                turnDateResolveTracker.recordFromJsonContent(result.content, result.is_error);
+              }
+              return result;
+            }
+            : undefined;
+
+        onFiller = async filler => {
+          await onSpeechText(filler, { streamId: `${session.sessionId}-filler` });
+        };
+      }
+
       const runner = new VoiceTurnRunner({
         provider: this.config.llm,
         model: this.config.model,
         logger: this.log,
+        tools,
+        invokeTool,
+        onFiller,
         onSpeechText,
       });
 
       const result = await runner.runTurn({ messages, signal: controller.signal });
       if (result.aborted || session.ending || result.finalText.length === 0) return;
 
-      // Persist cue + greeting together so history stays user-first for every
-      // subsequent provider call (Anthropic/Gemini reject a leading assistant).
-      session.history.push(
+      await opts.persistSuccess(result.finalText);
+    } catch (err) {
+      this.log.warn({ sessionId: session.sessionId, err }, opts.failureLogMessage);
+    } finally {
+      this.clearTurnState(session, controller);
+    }
+  }
+
+  /**
+   * Opening turn for inbound console calls (#1596). Speaks an LLM greeting
+   * (context-aware via the outbound-context bridge + time block) before any
+   * user speech. Barge-in cancels it the same way as a normal assistant turn.
+   *
+   * On success, persists a synthetic leading user cue *and* the assistant
+   * greeting so later turns stay provider-safe (Anthropic requires user-first).
+   * The cue is never published as inbound.message; the console history endpoint
+   * filters it from display via isVoiceGreetingCueContent.
+   */
+  private async runGreetingTurn(session: ActiveSession): Promise<void> {
+    await this.runAssistantTurn(session, {
+      ttfaLogKey: 'voice.greeting_ttfa_ms',
+      ttfaLogMessage: 'voice greeting time-to-first-audio',
+      failureLogMessage: 'voice greeting turn failed',
+      // No tools — keep the open short and latency-tight; outbound context is
+      // already in the system prompt when present.
+      withTools: false,
+      assembleMessages: ({ systemPrompt, priorHistory }) => [
+        { role: 'system', content: `${systemPrompt}\n\n${VOICE_GREETING_INSTRUCTION}` },
+        ...priorHistory,
         { role: 'user', content: VOICE_GREETING_USER_MESSAGE },
-        { role: 'assistant', content: result.finalText },
-      );
-      if (session.history.length > MAX_HISTORY_MESSAGES) {
-        session.history.splice(0, session.history.length - MAX_HISTORY_MESSAGES);
-      }
-      if (this.config.workingMemory) {
+      ],
+      persistSuccess: async (finalText) => {
+        // Persist cue + greeting together so history stays user-first for every
+        // subsequent provider call (Anthropic/Gemini reject a leading assistant).
+        session.history.push(
+          { role: 'user', content: VOICE_GREETING_USER_MESSAGE },
+          { role: 'assistant', content: finalText },
+        );
+        this.trimSessionHistory(session);
+        if (!this.config.workingMemory) return;
         try {
           await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
             role: 'user',
             content: VOICE_GREETING_USER_MESSAGE,
           });
-          await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
-            role: 'assistant',
-            content: result.finalText,
-          });
+          try {
+            await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
+              role: 'assistant',
+              content: finalText,
+            });
+          } catch (assistantErr) {
+            // Cue landed but the spoken reply did not — next loadTurnHistory will
+            // see a cue-only prefix and lose the fact Curia already greeted.
+            this.log.warn(
+              { sessionId: session.sessionId, err: assistantErr },
+              'greeting cue persisted but assistant reply write failed — working memory now missing the spoken greeting',
+            );
+          }
         } catch (err) {
           this.log.warn(
             { sessionId: session.sessionId, err },
             'failed to persist voice greeting to working memory',
           );
         }
-      }
-    } catch (err) {
-      this.log.warn({ sessionId: session.sessionId, err }, 'voice greeting turn failed');
-    } finally {
-      session.llmActive = false;
-      if (session.currentController === controller) {
-        session.currentController = null;
-      }
-    }
+      },
+    });
   }
 
   /**
@@ -900,6 +1001,7 @@ export class VoiceRuntime {
     // to the LLM context exactly once (turns are serialized per session, so the
     // read cannot race the write below).
     const priorHistory = await this.loadTurnHistory(session);
+    if (session.ending) return;
 
     // Persist user turn to working_memory so console history can show it.
     if (this.config.workingMemory) {
@@ -913,140 +1015,45 @@ export class VoiceRuntime {
       }
     }
 
-    // Register controller before mark-active await so hangup can abort this turn.
-    const controller = new AbortController();
-    session.currentController = controller;
-    session.llmActive = true;
-
-    // Flip DB status starting → active on the first real turn.
-    if (!session.markedActive) {
-      session.markedActive = true;
-      try {
-        await this.config.sessionStore.updateStatus(session.sessionId, 'active');
-      } catch (err) {
-        this.log.warn({ sessionId: session.sessionId, err }, 'failed to mark voice session active');
-      }
-    }
-
-    if (session.ending || controller.signal.aborted) {
-      session.llmActive = false;
-      if (session.currentController === controller) {
-        session.currentController = null;
-      }
-      return;
-    }
-
-    const userTurnEndAt = Date.now();
-    let ttfaRecorded = false;
-
-    const tools = this.toolBridge
-      ? this.toolBridge.resolveVoiceTools()
-      : (this.config.resolveVoiceTools ? this.config.resolveVoiceTools() : this.config.tools);
-
-    const turnDateResolveTracker = new TurnDateResolveTracker();
-
-    const invokeTool = this.toolBridge
-      ? async (call: ToolCall) => {
-        const result = await this.toolBridge!.invokeTool(call, {
-          conversationId: session.conversationId,
-          sessionId: session.sessionId,
-          turnDateResolveResults: turnDateResolveTracker.snapshot(),
-        });
-        if (call.name === 'date-resolve') {
-          turnDateResolveTracker.recordFromJsonContent(result.content, result.is_error);
-        }
-        return result;
-      }
-      : this.config.invokeTool
-        ? async (call: ToolCall) => {
-          const result = await this.config.invokeTool!(call, {
-            conversationId: session.conversationId,
-            sessionId: session.sessionId,
-            turnDateResolveResults: turnDateResolveTracker.snapshot(),
-          });
-          if (call.name === 'date-resolve') {
-            turnDateResolveTracker.recordFromJsonContent(result.content, result.is_error);
-          }
-          return result;
-        }
-        : undefined;
-
     const userMessage: Message = { role: 'user', content: utterance };
     // Retain the user request even if barge-in aborts the assistant reply —
     // otherwise the next turn loses conversational continuity. The in-process
     // copy is only the fallback context source (see loadTurnHistory).
     session.history.push(userMessage);
-    if (session.history.length > MAX_HISTORY_MESSAGES) {
-      session.history.splice(0, session.history.length - MAX_HISTORY_MESSAGES);
-    }
+    this.trimSessionHistory(session);
 
-    const messages: Message[] = [
-      { role: 'system', content: await this.buildTurnSystemPrompt() },
-      ...priorHistory,
-      userMessage,
-    ];
-
-    if (session.ending || controller.signal.aborted) {
-      session.llmActive = false;
-      if (session.currentController === controller) {
-        session.currentController = null;
-      }
-      return;
-    }
-
-    const onSpeechText = this.createSpeechHandler(session, controller, {
-      onFirstAudio: () => {
-        if (ttfaRecorded) return;
-        ttfaRecorded = true;
-        this.log.debug(
-          { sessionId: session.sessionId, 'voice.ttfa_ms': Date.now() - userTurnEndAt },
-          'voice time-to-first-audio',
-        );
-      },
-    });
-
-    const runner = new VoiceTurnRunner({
-      provider: this.config.llm,
-      model: this.config.model,
-      logger: this.log,
-      tools,
-      invokeTool,
-      onFiller: async filler => {
-        await onSpeechText(filler, { streamId: `${session.sessionId}-filler` });
-      },
-      onSpeechText,
-    });
-
-    try {
-      const result = await runner.runTurn({ messages, signal: controller.signal });
-      if (!result.aborted && !session.ending && result.finalText.length > 0) {
+    await this.runAssistantTurn(session, {
+      ttfaLogKey: 'voice.ttfa_ms',
+      ttfaLogMessage: 'voice time-to-first-audio',
+      failureLogMessage: 'voice turn failed',
+      priorHistory,
+      withTools: true,
+      assembleMessages: ({ systemPrompt, priorHistory: prior }) => [
+        { role: 'system', content: systemPrompt },
+        ...prior,
+        userMessage,
+      ],
+      persistSuccess: async (finalText) => {
         // Append only the completed assistant reply (user was already pushed).
-        session.history.push({ role: 'assistant', content: result.finalText });
-        if (session.history.length > MAX_HISTORY_MESSAGES) {
-          session.history.splice(0, session.history.length - MAX_HISTORY_MESSAGES);
-        }
+        session.history.push({ role: 'assistant', content: finalText });
+        this.trimSessionHistory(session);
         // Persist assistant transcript so console history can show what was spoken.
         // Spoken egress stays on TTS — we do not publish outbound.message (web chat
         // also skips OutboundGateway for principal console replies).
-        if (this.config.workingMemory) {
-          try {
-            await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
-              role: 'assistant',
-              content: result.finalText,
-            });
-          } catch (err) {
-            this.log.warn({ sessionId: session.sessionId, err }, 'failed to persist voice assistant turn to working memory');
-          }
+        if (!this.config.workingMemory) return;
+        try {
+          await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
+            role: 'assistant',
+            content: finalText,
+          });
+        } catch (err) {
+          this.log.warn(
+            { sessionId: session.sessionId, err },
+            'failed to persist voice assistant turn to working memory',
+          );
         }
-      }
-    } catch (err) {
-      this.log.warn({ sessionId: session.sessionId, err }, 'voice turn failed');
-    } finally {
-      session.llmActive = false;
-      if (session.currentController === controller) {
-        session.currentController = null;
-      }
-    }
+      },
+    });
   }
 
   async endSession(sessionId: string, reason: string): Promise<VoiceSessionRecord | null> {

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -102,6 +102,21 @@ export const VOICE_SYSTEM_ADDENDUM =
   'clearly. Keep it brief — the user can always ask for more.';
 
 /**
+ * Opening-turn instruction for inbound console calls (#1596). Appended to the
+ * spoken-turn system prompt so Curia greets first; lean on outbound-context and
+ * the time block when present. Not used for Curia-initiated outbound calls.
+ */
+export const VOICE_GREETING_INSTRUCTION =
+  'The principal just called and joined the line. Open the conversation naturally ' +
+  'and briefly — a short spoken greeting appropriate to the time of day. If active ' +
+  'outbound context is present, acknowledge it in one breath. Do not wait for them ' +
+  'to speak first. One or two short sentences only.';
+
+/** Synthetic user message that triggers the opening turn — never persisted to history. */
+export const VOICE_GREETING_USER_MESSAGE =
+  '[Call connected — open the conversation.]';
+
+/**
  * Honest-negative policy for spoken tool results. A failed or errored check must
  * be narrated as "couldn't check", never as a confident empty result — "your
  * calendar is clear" after a failed lookup is a trust hazard the principal may
@@ -255,6 +270,13 @@ export interface VoiceRuntimeConfig {
    * becomes a cross-channel audience leak.
    */
   outboundContextService?: OutboundContextService;
+  /**
+   * When true (default), run one LLM greeting turn after the transport connects
+   * so Curia opens inbound console calls (#1596). Set false in unit tests that
+   * script only user-turn LLM responses. Curia-initiated outbound calls are out
+   * of scope until an outbound-call path exists.
+   */
+  openingGreeting?: boolean;
 }
 
 /**
@@ -419,6 +441,13 @@ export class VoiceRuntime {
         this.handleTranscript(session, event);
       });
 
+      // Inbound console calls: Curia opens the conversation (#1596). Enqueued on
+      // the turn chain so a barged-in greeting fully unwinds before the first
+      // user turn. Outbound (Curia-initiated) greets are deferred — no path yet.
+      if (this.config.openingGreeting !== false) {
+        this.enqueueGreetingTurn(session);
+      }
+
       this.log.info(
         { sessionId: params.sessionId, conversationId: params.conversationId, inboundSampleRate, publishSampleRate },
         'Voice session runtime started',
@@ -510,6 +539,169 @@ export class VoiceRuntime {
         this.log.warn({ sessionId: session.sessionId, err }, 'previous voice turn rejected; continuing chain');
       })
       .then(() => this.runUserTurn(session, utterance));
+  }
+
+  private enqueueGreetingTurn(session: ActiveSession): void {
+    session.turnTail = session.turnTail
+      .catch(err => {
+        this.log.warn({ sessionId: session.sessionId, err }, 'previous voice turn rejected; continuing chain');
+      })
+      .then(() => this.runGreetingTurn(session));
+  }
+
+  /**
+   * Opening turn for inbound console calls (#1596). Speaks an LLM greeting
+   * (context-aware via the outbound-context bridge + time block) before any
+   * user speech. Barge-in cancels it the same way as a normal assistant turn.
+   * The synthetic user cue is never persisted; only the spoken reply is.
+   */
+  private async runGreetingTurn(session: ActiveSession): Promise<void> {
+    if (session.ending) return;
+
+    if (!session.markedActive) {
+      session.markedActive = true;
+      try {
+        await this.config.sessionStore.updateStatus(session.sessionId, 'active');
+      } catch (err) {
+        this.log.warn({ sessionId: session.sessionId, err }, 'failed to mark voice session active');
+      }
+    }
+
+    const controller = new AbortController();
+    session.currentController = controller;
+    session.llmActive = true;
+
+    const greetingStartedAt = Date.now();
+    let ttfaRecorded = false;
+    const onSpeechText = this.createSpeechHandler(session, controller, {
+      onFirstAudio: () => {
+        if (ttfaRecorded) return;
+        ttfaRecorded = true;
+        this.log.debug(
+          { sessionId: session.sessionId, 'voice.greeting_ttfa_ms': Date.now() - greetingStartedAt },
+          'voice greeting time-to-first-audio',
+        );
+      },
+    });
+
+    const priorHistory = await this.loadTurnHistory(session);
+    const systemPrompt = await this.buildTurnSystemPrompt();
+    const messages: Message[] = [
+      { role: 'system', content: `${systemPrompt}\n\n${VOICE_GREETING_INSTRUCTION}` },
+      ...priorHistory,
+      { role: 'user', content: VOICE_GREETING_USER_MESSAGE },
+    ];
+
+    // No tools on the greeting — keep the open short and latency-tight; outbound
+    // context is already in the system prompt when present.
+    const runner = new VoiceTurnRunner({
+      provider: this.config.llm,
+      model: this.config.model,
+      logger: this.log,
+      onSpeechText,
+    });
+
+    try {
+      const result = await runner.runTurn({ messages, signal: controller.signal });
+      if (!result.aborted && result.finalText.length > 0) {
+        session.history.push({ role: 'assistant', content: result.finalText });
+        if (session.history.length > MAX_HISTORY_MESSAGES) {
+          session.history.splice(0, session.history.length - MAX_HISTORY_MESSAGES);
+        }
+        if (this.config.workingMemory) {
+          try {
+            await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
+              role: 'assistant',
+              content: result.finalText,
+            });
+          } catch (err) {
+            this.log.warn(
+              { sessionId: session.sessionId, err },
+              'failed to persist voice greeting to working memory',
+            );
+          }
+        }
+      }
+    } catch (err) {
+      this.log.warn({ sessionId: session.sessionId, err }, 'voice greeting turn failed');
+    } finally {
+      session.llmActive = false;
+      if (session.currentController === controller) {
+        session.currentController = null;
+      }
+    }
+  }
+
+  /**
+   * Shared TTS publish path for user turns and the opening greeting. Counts soft
+   * TTS failures toward the session teardown threshold (#1556).
+   */
+  private createSpeechHandler(
+    session: ActiveSession,
+    controller: AbortController,
+    opts: { onFirstAudio?: () => void },
+  ): (sentence: string, meta: { streamId: string }) => Promise<void> {
+    return async (sentence: string, meta: { streamId: string }): Promise<void> => {
+      if (controller.signal.aborted || session.ending) return;
+      const ttsStreamId = `${meta.streamId}:${session.ttsSeq++}`;
+      session.activeTtsStreamIds.add(ttsStreamId);
+      session.ttsActive = true;
+      try {
+        for await (const frame of this.config.tts.synthesize({
+          text: sentence,
+          streamId: ttsStreamId,
+          voiceId: this.config.voiceId,
+          sampleRate: session.publishSampleRate,
+          signal: controller.signal,
+        })) {
+          if (controller.signal.aborted || session.ending) break;
+          opts.onFirstAudio?.();
+          // Publish is outside the TTS failure streak — a LiveKit blip must not
+          // be recorded as tts_error (#1556 review).
+          try {
+            await session.transport.publishAudio(frame);
+          } catch (publishErr) {
+            this.log.warn(
+              { sessionId: session.sessionId, err: publishErr },
+              'failed to publish TTS audio frame; not counted as a TTS synthesis failure',
+            );
+            break;
+          }
+        }
+        // Healthy synthesis (including barge-in abort mid-stream) clears the streak.
+        if (!session.ending) session.consecutiveTtsFailures = 0;
+      } catch (err) {
+        if (controller.signal.aborted || session.ending) return;
+        session.consecutiveTtsFailures += 1;
+        const hard = isHardTtsFailure(err);
+        this.log.warn(
+          {
+            sessionId: session.sessionId,
+            err,
+            consecutiveFailures: session.consecutiveTtsFailures,
+            hard,
+          },
+          'TTS synthesis failed',
+        );
+        // Soft: tolerate a blip. Hard (auth / bad voice id) or repeated soft → end
+        // with tts_error so the console reflects it (mirrors stt_error).
+        if (hard || session.consecutiveTtsFailures >= TTS_CONSECUTIVE_FAILURE_LIMIT) {
+          this.log.error(
+            {
+              sessionId: session.sessionId,
+              err,
+              consecutiveFailures: session.consecutiveTtsFailures,
+              hard,
+            },
+            'TTS synthesis failures exceeded threshold; ending session',
+          );
+          void this.endSession(session.sessionId, 'tts_error');
+        }
+      } finally {
+        session.activeTtsStreamIds.delete(ttsStreamId);
+        if (session.activeTtsStreamIds.size === 0) session.ttsActive = false;
+      }
+    };
   }
 
   /**
@@ -767,73 +959,16 @@ export class VoiceRuntime {
       userMessage,
     ];
 
-    const onSpeechText = async (sentence: string, meta: { streamId: string }): Promise<void> => {
-      if (controller.signal.aborted || session.ending) return;
-      const ttsStreamId = `${meta.streamId}:${session.ttsSeq++}`;
-      session.activeTtsStreamIds.add(ttsStreamId);
-      session.ttsActive = true;
-      try {
-        for await (const frame of this.config.tts.synthesize({
-          text: sentence,
-          streamId: ttsStreamId,
-          voiceId: this.config.voiceId,
-          sampleRate: session.publishSampleRate,
-          signal: controller.signal,
-        })) {
-          if (controller.signal.aborted || session.ending) break;
-          if (!ttfaRecorded) {
-            ttfaRecorded = true;
-            this.log.debug(
-              { sessionId: session.sessionId, 'voice.ttfa_ms': Date.now() - userTurnEndAt },
-              'voice time-to-first-audio',
-            );
-          }
-          // Publish is outside the TTS failure streak — a LiveKit blip must not
-          // be recorded as tts_error (#1556 review).
-          try {
-            await session.transport.publishAudio(frame);
-          } catch (publishErr) {
-            this.log.warn(
-              { sessionId: session.sessionId, err: publishErr },
-              'failed to publish TTS audio frame; not counted as a TTS synthesis failure',
-            );
-            break;
-          }
-        }
-        // Healthy synthesis (including barge-in abort mid-stream) clears the streak.
-        if (!session.ending) session.consecutiveTtsFailures = 0;
-      } catch (err) {
-        if (controller.signal.aborted || session.ending) return;
-        session.consecutiveTtsFailures += 1;
-        const hard = isHardTtsFailure(err);
-        this.log.warn(
-          {
-            sessionId: session.sessionId,
-            err,
-            consecutiveFailures: session.consecutiveTtsFailures,
-            hard,
-          },
-          'TTS synthesis failed',
+    const onSpeechText = this.createSpeechHandler(session, controller, {
+      onFirstAudio: () => {
+        if (ttfaRecorded) return;
+        ttfaRecorded = true;
+        this.log.debug(
+          { sessionId: session.sessionId, 'voice.ttfa_ms': Date.now() - userTurnEndAt },
+          'voice time-to-first-audio',
         );
-        // Soft: tolerate a blip. Hard (auth / bad voice id) or repeated soft → end
-        // with tts_error so the console reflects it (mirrors stt_error).
-        if (hard || session.consecutiveTtsFailures >= TTS_CONSECUTIVE_FAILURE_LIMIT) {
-          this.log.error(
-            {
-              sessionId: session.sessionId,
-              err,
-              consecutiveFailures: session.consecutiveTtsFailures,
-              hard,
-            },
-            'TTS synthesis failures exceeded threshold; ending session',
-          );
-          void this.endSession(session.sessionId, 'tts_error');
-        }
-      } finally {
-        session.activeTtsStreamIds.delete(ttsStreamId);
-        if (session.activeTtsStreamIds.size === 0) session.ttsActive = false;
-      }
-    };
+      },
+    });
 
     const runner = new VoiceTurnRunner({
       provider: this.config.llm,

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -30,10 +30,20 @@ import type { WorkingMemory } from '../../memory/working-memory.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
 import { formatTimeContextBlock } from '../../time/time-context.js';
 import type { AudioTransport } from './audio-transport.js';
+import {
+  VOICE_GREETING_INSTRUCTION,
+  VOICE_GREETING_USER_MESSAGE,
+} from './greeting.js';
 import type { SpeechToTextProvider, SttSession, SttTranscriptEvent, TextToSpeechProvider } from './speech/types.js';
 import { TtsHttpError } from './speech/types.js';
 import type { VoiceSessionRecord, VoiceSessionStore } from './session-store.js';
 import { VoiceTurnRunner } from './turn-runner.js';
+
+export {
+  VOICE_GREETING_INSTRUCTION,
+  VOICE_GREETING_USER_MESSAGE,
+  isVoiceGreetingCueContent,
+} from './greeting.js';
 
 const DEFAULT_INBOUND_SAMPLE_RATE = 16000;
 const DEFAULT_PUBLISH_SAMPLE_RATE = 24000;
@@ -100,21 +110,6 @@ export const VOICE_SYSTEM_ADDENDUM =
   'conversational spoken style: 1-3 short sentences, no markdown, no bullet lists, ' +
   'no tables, no code blocks, and no emoji. Spell out anything that must be heard ' +
   'clearly. Keep it brief — the user can always ask for more.';
-
-/**
- * Opening-turn instruction for inbound console calls (#1596). Appended to the
- * spoken-turn system prompt so Curia greets first; lean on outbound-context and
- * the time block when present. Not used for Curia-initiated outbound calls.
- */
-export const VOICE_GREETING_INSTRUCTION =
-  'The principal just called and joined the line. Open the conversation naturally ' +
-  'and briefly — a short spoken greeting appropriate to the time of day. If active ' +
-  'outbound context is present, acknowledge it in one breath. Do not wait for them ' +
-  'to speak first. One or two short sentences only.';
-
-/** Synthetic user message that triggers the opening turn — never persisted to history. */
-export const VOICE_GREETING_USER_MESSAGE =
-  '[Call connected — open the conversation.]';
 
 /**
  * Honest-negative policy for spoken tool results. A failed or errored check must
@@ -270,13 +265,6 @@ export interface VoiceRuntimeConfig {
    * becomes a cross-channel audience leak.
    */
   outboundContextService?: OutboundContextService;
-  /**
-   * When true (default), run one LLM greeting turn after the transport connects
-   * so Curia opens inbound console calls (#1596). Set false in unit tests that
-   * script only user-turn LLM responses. Curia-initiated outbound calls are out
-   * of scope until an outbound-call path exists.
-   */
-  openingGreeting?: boolean;
 }
 
 /**
@@ -310,6 +298,13 @@ interface StartVoiceSessionParams {
   roomName: string;
   /** Agent participant JWT (identity 'curia-agent'). */
   agentToken: string;
+  /**
+   * When true (default), run one LLM greeting turn after the transport connects
+   * so Curia opens the call (#1596). Per-session — not a runtime-wide flag — so
+   * a future Curia-initiated outbound path can pass false without affecting
+   * inbound console calls on the same VoiceRuntime instance.
+   */
+  openingGreeting?: boolean;
 }
 
 interface ActiveSession {
@@ -443,8 +438,9 @@ export class VoiceRuntime {
 
       // Inbound console calls: Curia opens the conversation (#1596). Enqueued on
       // the turn chain so a barged-in greeting fully unwinds before the first
-      // user turn. Outbound (Curia-initiated) greets are deferred — no path yet.
-      if (this.config.openingGreeting !== false) {
+      // user turn. Per-session flag — outbound (Curia-initiated) callers pass
+      // openingGreeting: false when that path exists.
+      if (params.openingGreeting !== false) {
         this.enqueueGreetingTurn(session);
       }
 
@@ -553,73 +549,95 @@ export class VoiceRuntime {
    * Opening turn for inbound console calls (#1596). Speaks an LLM greeting
    * (context-aware via the outbound-context bridge + time block) before any
    * user speech. Barge-in cancels it the same way as a normal assistant turn.
-   * The synthetic user cue is never persisted; only the spoken reply is.
+   *
+   * On success, persists a synthetic leading user cue *and* the assistant
+   * greeting so later turns stay provider-safe (Anthropic requires user-first).
+   * The cue is never published as inbound.message; the console history endpoint
+   * filters it from display via isVoiceGreetingCueContent.
    */
   private async runGreetingTurn(session: ActiveSession): Promise<void> {
     if (session.ending) return;
 
-    if (!session.markedActive) {
-      session.markedActive = true;
-      try {
-        await this.config.sessionStore.updateStatus(session.sessionId, 'active');
-      } catch (err) {
-        this.log.warn({ sessionId: session.sessionId, err }, 'failed to mark voice session active');
-      }
-    }
-
+    // Register the controller BEFORE any await so a concurrent endSession can
+    // abort this turn (otherwise updateStatus yields with currentController
+    // still null and a phantom greeting can persist after hangup).
     const controller = new AbortController();
     session.currentController = controller;
     session.llmActive = true;
 
-    const greetingStartedAt = Date.now();
-    let ttfaRecorded = false;
-    const onSpeechText = this.createSpeechHandler(session, controller, {
-      onFirstAudio: () => {
-        if (ttfaRecorded) return;
-        ttfaRecorded = true;
-        this.log.debug(
-          { sessionId: session.sessionId, 'voice.greeting_ttfa_ms': Date.now() - greetingStartedAt },
-          'voice greeting time-to-first-audio',
-        );
-      },
-    });
-
-    const priorHistory = await this.loadTurnHistory(session);
-    const systemPrompt = await this.buildTurnSystemPrompt();
-    const messages: Message[] = [
-      { role: 'system', content: `${systemPrompt}\n\n${VOICE_GREETING_INSTRUCTION}` },
-      ...priorHistory,
-      { role: 'user', content: VOICE_GREETING_USER_MESSAGE },
-    ];
-
-    // No tools on the greeting — keep the open short and latency-tight; outbound
-    // context is already in the system prompt when present.
-    const runner = new VoiceTurnRunner({
-      provider: this.config.llm,
-      model: this.config.model,
-      logger: this.log,
-      onSpeechText,
-    });
-
     try {
-      const result = await runner.runTurn({ messages, signal: controller.signal });
-      if (!result.aborted && result.finalText.length > 0) {
-        session.history.push({ role: 'assistant', content: result.finalText });
-        if (session.history.length > MAX_HISTORY_MESSAGES) {
-          session.history.splice(0, session.history.length - MAX_HISTORY_MESSAGES);
+      if (!session.markedActive) {
+        session.markedActive = true;
+        try {
+          await this.config.sessionStore.updateStatus(session.sessionId, 'active');
+        } catch (err) {
+          this.log.warn({ sessionId: session.sessionId, err }, 'failed to mark voice session active');
         }
-        if (this.config.workingMemory) {
-          try {
-            await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
-              role: 'assistant',
-              content: result.finalText,
-            });
-          } catch (err) {
-            this.log.warn(
-              { sessionId: session.sessionId, err },
-              'failed to persist voice greeting to working memory',
-            );
-          }
+      }
+
+      if (session.ending || controller.signal.aborted) return;
+
+      const priorHistory = await this.loadTurnHistory(session);
+      if (session.ending || controller.signal.aborted) return;
+
+      const greetingStartedAt = Date.now();
+      let ttfaRecorded = false;
+      const onSpeechText = this.createSpeechHandler(session, controller, {
+        onFirstAudio: () => {
+          if (ttfaRecorded) return;
+          ttfaRecorded = true;
+          this.log.debug(
+            { sessionId: session.sessionId, 'voice.greeting_ttfa_ms': Date.now() - greetingStartedAt },
+            'voice greeting time-to-first-audio',
+          );
+        },
+      });
+
+      const systemPrompt = await this.buildTurnSystemPrompt();
+      if (session.ending || controller.signal.aborted) return;
+
+      const messages: Message[] = [
+        { role: 'system', content: `${systemPrompt}\n\n${VOICE_GREETING_INSTRUCTION}` },
+        ...priorHistory,
+        { role: 'user', content: VOICE_GREETING_USER_MESSAGE },
+      ];
+
+      // No tools on the greeting — keep the open short and latency-tight; outbound
+      // context is already in the system prompt when present.
+      const runner = new VoiceTurnRunner({
+        provider: this.config.llm,
+        model: this.config.model,
+        logger: this.log,
+        onSpeechText,
+      });
+
+      const result = await runner.runTurn({ messages, signal: controller.signal });
+      if (result.aborted || session.ending || result.finalText.length === 0) return;
+
+      // Persist cue + greeting together so history stays user-first for every
+      // subsequent provider call (Anthropic/Gemini reject a leading assistant).
+      session.history.push(
+        { role: 'user', content: VOICE_GREETING_USER_MESSAGE },
+        { role: 'assistant', content: result.finalText },
+      );
+      if (session.history.length > MAX_HISTORY_MESSAGES) {
+        session.history.splice(0, session.history.length - MAX_HISTORY_MESSAGES);
+      }
+      if (this.config.workingMemory) {
+        try {
+          await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
+            role: 'user',
+            content: VOICE_GREETING_USER_MESSAGE,
+          });
+          await this.config.workingMemory.addTurn(session.conversationId, VOICE_HISTORY_AGENT_ID, {
+            role: 'assistant',
+            content: result.finalText,
+          });
+        } catch (err) {
+          this.log.warn(
+            { sessionId: session.sessionId, err },
+            'failed to persist voice greeting to working memory',
+          );
         }
       }
     } catch (err) {
@@ -895,6 +913,11 @@ export class VoiceRuntime {
       }
     }
 
+    // Register controller before mark-active await so hangup can abort this turn.
+    const controller = new AbortController();
+    session.currentController = controller;
+    session.llmActive = true;
+
     // Flip DB status starting → active on the first real turn.
     if (!session.markedActive) {
       session.markedActive = true;
@@ -905,9 +928,13 @@ export class VoiceRuntime {
       }
     }
 
-    const controller = new AbortController();
-    session.currentController = controller;
-    session.llmActive = true;
+    if (session.ending || controller.signal.aborted) {
+      session.llmActive = false;
+      if (session.currentController === controller) {
+        session.currentController = null;
+      }
+      return;
+    }
 
     const userTurnEndAt = Date.now();
     let ttfaRecorded = false;
@@ -959,6 +986,14 @@ export class VoiceRuntime {
       userMessage,
     ];
 
+    if (session.ending || controller.signal.aborted) {
+      session.llmActive = false;
+      if (session.currentController === controller) {
+        session.currentController = null;
+      }
+      return;
+    }
+
     const onSpeechText = this.createSpeechHandler(session, controller, {
       onFirstAudio: () => {
         if (ttfaRecorded) return;
@@ -984,7 +1019,7 @@ export class VoiceRuntime {
 
     try {
       const result = await runner.runTurn({ messages, signal: controller.signal });
-      if (!result.aborted && result.finalText.length > 0) {
+      if (!result.aborted && !session.ending && result.finalText.length > 0) {
         // Append only the completed assistant reply (user was already pushed).
         session.history.push({ role: 'assistant', content: result.finalText });
         if (session.history.length > MAX_HISTORY_MESSAGES) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1596.

When the CEO clicks **Call**, Curia opens the conversation with an LLM-generated greeting instead of waiting silently for the first utterance.

### Backend (`VoiceRuntime`)
- After the LiveKit transport connects and STT is wired, enqueue one **opening greeting turn** on the same serialized turn chain as user turns.
- Greeting uses the existing spoken-turn system prompt (identity, specialists, outbound-context bridge, time block) plus a synthetic instruction to open briefly and naturally.
- Speaks via the shared TTS path / `VoiceTurnRunner`; **barge-in still cancels** mid-greeting so a user utterance can proceed.
- On success, persists a **synthetic leading user cue + assistant greeting** so history stays provider-safe (Anthropic rejects a leading assistant). Cue is never published as `inbound.message`; `GET /api/kg/chat/history` filters it via `isVoiceGreetingCueContent`.
- No tools on the greeting turn (latency); outbound-context awareness comes from the system prompt injection (#1594).
- Per-session `openingGreeting` on `startSession` (console inbound passes `true`). Outbound Curia-initiated greets remain out of scope.

### Console
- Status copy: `Connecting…` → `Greeting…` → `Listening…` once a remote participant actually speaks (`ActiveSpeakersChanged` / `isSpeaking` — not `TrackSubscribed`, which fires on the silent connect-time track).

## Test plan
- [x] Unit: greeting speaks before user speech, no `inbound.message`
- [x] Unit: outbound-context appears in greeting system prompt
- [x] Unit: barge-in cancels greeting; user turn still runs
- [x] Unit: persists cue + greeting; console cue helper identifies the marker
- [x] Unit: **completed greeting → user turn is user-first** (provider stub enforces Anthropic contract)
- [x] Console: VoiceCallBar shows Greeting vs Listening
- [ ] Manual: click Call → hear Curia before speaking; talk over greeting → barge-in works; history does not show the synthetic cue

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7566bd8-0601-45d3-8fbf-a36936d8ad82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7566bd8-0601-45d3-8fbf-a36936d8ad82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

