### PR TITLE
feat(voice): resolve caller identity via shared stampOriginator (#1598)

### DIFF
--- a/scripts/spikes/voice-brain-parity/latency-microbench.ts
+++ b/scripts/spikes/voice-brain-parity/latency-microbench.ts
@@ -52,6 +52,7 @@ function prompts(): Record<string, string> {
     identityBlock: fixtures.identityBlock,
     specialistRoster: fixtures.specialistRoster,
     timeContextBlock: time,
+    audience: { liveTurn: true },
   });
   const shared = [
     fixtures.identityBlock,

--- a/scripts/spikes/voice-brain-parity/run.ts
+++ b/scripts/spikes/voice-brain-parity/run.ts
@@ -150,6 +150,7 @@ function buildPrompts(fixtures: Fixtures, outbound: string | null): Record<ArmId
     specialistRoster: fixtures.specialistRoster,
     outboundContextBlock: outbound,
     timeContextBlock: timeBlock,
+    audience: { liveTurn: true },
   });
 
   // Shared-hardening: production baseline modules (date-resolve + async

--- a/src/channels/voice/caller-context.test.ts
+++ b/src/channels/voice/caller-context.test.ts
@@ -199,7 +199,7 @@ describe('resolveVoiceCallerFromToken', () => {
       callerToken: 'blocked-token',
     });
 
-    expect(result).toEqual({ ok: false, reason: 'unknown_sender' });
+    expect(result).toEqual({ ok: false, reason: 'blocked' });
   });
 
   it('does not short-circuit voice to principal — resolve goes to ContactResolver', async () => {

--- a/src/channels/voice/caller-context.test.ts
+++ b/src/channels/voice/caller-context.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import pino from 'pino';
+import type { ContactResolver } from '../../contacts/contact-resolver.js';
+import type { ContactService } from '../../contacts/contact-service.js';
+import type { ChannelPolicyConfig, SenderContext } from '../../contacts/types.js';
+import {
+  buildPrincipalSenderContext,
+  resolveConsoleVoiceCaller,
+  resolveVoiceCallerFromToken,
+  VOICE_CONSOLE_SENDER_ID,
+} from './caller-context.js';
+
+const logger = pino({ level: 'silent' });
+
+const PRINCIPAL_ID = '11111111-1111-1111-1111-111111111111';
+const PARTNER_ID = '22222222-2222-2222-2222-222222222222';
+
+function partnerSender(): SenderContext {
+  return {
+    resolved: true,
+    contactId: PARTNER_ID,
+    displayName: 'Alex Partner',
+    role: 'partner',
+    systemRole: null,
+    verified: true,
+    kgNodeId: null,
+    knowledgeSummary: '',
+    authorization: null,
+    contactConfidence: 0.9,
+    tier: 'trusted',
+    kind: 'person',
+  };
+}
+
+describe('buildPrincipalSenderContext', () => {
+  it('forces systemRole/tier/kind to principal even if the row is stale', () => {
+    const ctx = buildPrincipalSenderContext({
+      id: PRINCIPAL_ID,
+      displayName: 'Joseph',
+      role: 'ceo',
+      systemRole: null,
+      kgNodeId: 'kg-1',
+      tier: 'known',
+    });
+    expect(ctx.systemRole).toBe('principal');
+    expect(ctx.tier).toBe('principal');
+    expect(ctx.kind).toBe('principal');
+    expect(ctx.contactId).toBe(PRINCIPAL_ID);
+  });
+
+  it('falls back to the synthetic primary-user principal when no row exists', () => {
+    const ctx = buildPrincipalSenderContext(null);
+    expect(ctx.contactId).toBe('primary-user');
+    expect(ctx.systemRole).toBe('principal');
+    expect(ctx.tier).toBe('principal');
+  });
+});
+
+describe('resolveConsoleVoiceCaller', () => {
+  it('resolves the principal and stamps liveTurn=true via stampOriginator', async () => {
+    const contactService = {
+      findContactBySystemRole: vi.fn().mockResolvedValue({
+        id: PRINCIPAL_ID,
+        displayName: 'Joseph',
+        role: 'ceo',
+        systemRole: 'principal',
+        kgNodeId: null,
+        tier: 'principal',
+      }),
+    } as unknown as ContactService;
+
+    const caller = await resolveConsoleVoiceCaller({ contactService, logger });
+    expect(caller.liveTurn).toBe(true);
+    expect(caller.contactId).toBe(PRINCIPAL_ID);
+    expect(caller.senderId).toBe(VOICE_CONSOLE_SENDER_ID);
+    expect(caller.originator.systemRole).toBe('principal');
+    expect(caller.originator.channel).toBe('voice');
+    expect(caller.originator.tier).toBe('principal');
+  });
+});
+
+describe('resolveVoiceCallerFromToken', () => {
+  it('yields the contact tier/trust and liveTurn=false for a non-principal token', async () => {
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue(partnerSender()),
+    } as unknown as ContactResolver;
+
+    const result = await resolveVoiceCallerFromToken({
+      contactResolver,
+      callerToken: '+15551234567',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.caller.liveTurn).toBe(false);
+    expect(result.caller.contactId).toBe(PARTNER_ID);
+    expect(result.caller.tier).toBe('trusted');
+    expect(result.caller.originator.systemRole).toBeNull();
+    expect(result.caller.originator.tier).toBe('trusted');
+    expect(contactResolver.resolve).toHaveBeenCalledWith('voice', '+15551234567');
+  });
+
+  it('fail-closes an unresolved token under voice unknown_sender: ignore', async () => {
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: false,
+        channel: 'voice',
+        senderId: 'unknown-token',
+      }),
+    } as unknown as ContactResolver;
+    const channelPolicies: Record<string, ChannelPolicyConfig> = {
+      voice: { trust: 'high', unknownSender: 'ignore', threaded: false },
+    };
+
+    const result = await resolveVoiceCallerFromToken({
+      contactResolver,
+      callerToken: 'unknown-token',
+      channelPolicies,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'unknown_sender' });
+  });
+
+  it('defaults to ignore (fail-closed) when no voice policy is configured', async () => {
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: false,
+        channel: 'voice',
+        senderId: 'unknown-token',
+      }),
+    } as unknown as ContactResolver;
+
+    const result = await resolveVoiceCallerFromToken({
+      contactResolver,
+      callerToken: 'unknown-token',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'unknown_sender' });
+  });
+
+  it('does not short-circuit voice to principal — resolve goes to ContactResolver', async () => {
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue(partnerSender()),
+    } as unknown as ContactResolver;
+
+    await resolveVoiceCallerFromToken({
+      contactResolver,
+      callerToken: 'anything',
+    });
+
+    expect(contactResolver.resolve).toHaveBeenCalledWith('voice', 'anything');
+  });
+});

--- a/src/channels/voice/caller-context.test.ts
+++ b/src/channels/voice/caller-context.test.ts
@@ -77,6 +77,43 @@ describe('resolveConsoleVoiceCaller', () => {
     expect(caller.originator.channel).toBe('voice');
     expect(caller.originator.tier).toBe('principal');
   });
+
+  it('falls back to synthetic principal when findContactBySystemRole returns null', async () => {
+    const contactService = {
+      findContactBySystemRole: vi.fn().mockResolvedValue(null),
+    } as unknown as ContactService;
+    const warnLogger = pino({ level: 'silent' });
+    const warnSpy = vi.spyOn(warnLogger, 'warn');
+
+    const caller = await resolveConsoleVoiceCaller({ contactService, logger: warnLogger });
+    expect(caller.liveTurn).toBe(true);
+    expect(caller.contactId).toBe('primary-user');
+    expect(caller.originator.systemRole).toBe('principal');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('falls back to synthetic principal on a DB error (SQLSTATE code), logs a warning', async () => {
+    const dbError = Object.assign(new Error('connection reset'), { code: '08006' });
+    const contactService = {
+      findContactBySystemRole: vi.fn().mockRejectedValue(dbError),
+    } as unknown as ContactService;
+    const warnLogger = pino({ level: 'silent' });
+    const warnSpy = vi.spyOn(warnLogger, 'warn');
+
+    const caller = await resolveConsoleVoiceCaller({ contactService, logger: warnLogger });
+    expect(caller.liveTurn).toBe(true);
+    expect(caller.contactId).toBe('primary-user');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('re-throws non-DB errors (e.g. TypeError) so they are not silently promoted to principal', async () => {
+    const typeError = new TypeError('unexpected undefined');
+    const contactService = {
+      findContactBySystemRole: vi.fn().mockRejectedValue(typeError),
+    } as unknown as ContactService;
+
+    await expect(resolveConsoleVoiceCaller({ contactService, logger })).rejects.toThrow('unexpected undefined');
+  });
 });
 
 describe('resolveVoiceCallerFromToken', () => {
@@ -133,6 +170,33 @@ describe('resolveVoiceCallerFromToken', () => {
     const result = await resolveVoiceCallerFromToken({
       contactResolver,
       callerToken: 'unknown-token',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'unknown_sender' });
+  });
+
+  it('rejects a resolved but blocked-tier contact (mirrors dispatcher blocked-sender gate)', async () => {
+    const blockedSender: SenderContext = {
+      resolved: true,
+      contactId: PARTNER_ID,
+      displayName: 'Blocked Person',
+      role: 'partner',
+      systemRole: null,
+      verified: true,
+      kgNodeId: null,
+      knowledgeSummary: '',
+      authorization: null,
+      contactConfidence: 0.9,
+      tier: 'blocked',
+      kind: 'person',
+    };
+    const contactResolver = {
+      resolve: vi.fn().mockResolvedValue(blockedSender),
+    } as unknown as ContactResolver;
+
+    const result = await resolveVoiceCallerFromToken({
+      contactResolver,
+      callerToken: 'blocked-token',
     });
 
     expect(result).toEqual({ ok: false, reason: 'unknown_sender' });

--- a/src/channels/voice/caller-context.ts
+++ b/src/channels/voice/caller-context.ts
@@ -131,7 +131,15 @@ export async function resolveConsoleVoiceCaller(opts: {
   try {
     principal = await opts.contactService.findContactBySystemRole('principal');
   } catch (err) {
-    opts.logger.warn({ err }, 'Unable to resolve principal contact for voice session; using synthetic principal');
+    // Narrow to real pg/SQLSTATE errors (five-character alphanumeric code) before
+    // suppressing — a TypeError or programming bug must not be silently promoted to
+    // a synthetic principal identity. Mirrors contact-resolver.ts:79-89 (#1598).
+    const sqlState = err !== null && typeof err === 'object' && 'code' in err
+      ? (err as { code?: unknown }).code
+      : undefined;
+    const isDbError = typeof sqlState === 'string' && /^[0-9A-Z]{5}$/.test(sqlState);
+    if (!isDbError) throw err;
+    opts.logger.warn({ err }, 'Unable to resolve principal contact for voice session (DB error); using synthetic principal');
   }
   if (!principal) {
     opts.logger.warn('No principal contact found for voice session; using synthetic principal');
@@ -154,10 +162,18 @@ export async function resolveVoiceCallerFromToken(opts: {
   /**
    * senderId stamped on inbound.message when resolved. Defaults to the contact id
    * (or the raw token when unresolved and admitted).
+   * Note: for a token-resolved caller this is the contact UUID, not a channel address —
+   * safe because the dispatcher skips voice inbound.message (dispatcher.ts:258) so it
+   * is audit-only and never re-resolved as a channel identity.
    */
   senderId?: string;
 }): Promise<ResolveVoiceCallerResult> {
   const senderContext = await opts.contactResolver.resolve('voice', opts.callerToken);
+  // Blocked contacts are denied before constructing a caller — mirrors dispatcher.ts
+  // which drops blocked senders before reaching the coordinator (#1598).
+  if (senderContext.resolved && senderContext.tier === 'blocked') {
+    return { ok: false, reason: 'unknown_sender' };
+  }
   if (!senderContext.resolved) {
     const policy = opts.channelPolicies?.voice?.unknownSender ?? 'ignore';
     if (policy === 'ignore') {

--- a/src/channels/voice/caller-context.ts
+++ b/src/channels/voice/caller-context.ts
@@ -1,0 +1,173 @@
+// caller-context.ts — resolve voice session caller identity once at create time.
+//
+// Voice bypasses the dispatcher turn loop (latency / per-session identity), but must
+// reuse the same ContactResolver + stampOriginator path every other channel uses so
+// the elevated-gate signal stays consistent (#1598). Console transport remains
+// principal-proven by the bootstrap secret; token-based resolution is the seam for
+// future transports (#1602) and is unit-tested here without a live entry point.
+
+import type { ContactResolver } from '../../contacts/contact-resolver.js';
+import type { ContactService } from '../../contacts/contact-service.js';
+import type {
+  ChannelPolicyConfig,
+  ContactTier,
+  InboundSenderContext,
+  SenderContext,
+  SystemRole,
+  TaskOriginator,
+} from '../../contacts/types.js';
+import { stampOriginator } from '../../dispatch/stamp-originator.js';
+import type { Logger } from '../../logger.js';
+
+/** Synthetic principal sender id shared with the web console chat path. */
+export const VOICE_CONSOLE_SENDER_ID = 'ceo-web-user';
+
+export interface VoiceCallerContext {
+  contactId: string;
+  displayName: string;
+  systemRole: SystemRole | null;
+  tier: ContactTier;
+  /** Live-principal-turn signal — gates elevated skills and outbound-context injection. */
+  liveTurn: boolean;
+  originator: TaskOriginator;
+  /** senderId stamped on inbound.message for this session. */
+  senderId: string;
+  /** Resolved (or synthetic) sender context that produced originator/liveTurn. */
+  senderContext: InboundSenderContext;
+}
+
+export type ResolveVoiceCallerResult =
+  | { ok: true; caller: VoiceCallerContext }
+  | { ok: false; reason: 'unknown_sender' };
+
+/**
+ * Build a SenderContext for the principal contact (or the synthetic CLI/web fallback).
+ * Used by the console voice transport — principal-proven by the bootstrap secret,
+ * same standing as the `'web'` channel short-circuit, but deliberately NOT routed
+ * through ContactResolver.resolve('voice', …) so a future real caller token still
+ * hits resolveByChannelIdentity (#1598).
+ */
+export function buildPrincipalSenderContext(principal: {
+  id: string;
+  displayName: string;
+  role: string | null;
+  systemRole: SystemRole | null;
+  kgNodeId: string | null;
+  tier?: ContactTier;
+} | null): SenderContext {
+  if (principal) {
+    return {
+      resolved: true,
+      contactId: principal.id,
+      displayName: principal.displayName,
+      role: principal.role,
+      systemRole: 'principal',
+      verified: true,
+      kgNodeId: principal.kgNodeId,
+      knowledgeSummary: '',
+      authorization: null,
+      contactConfidence: 1.0,
+      tier: 'principal',
+      kind: 'principal',
+    };
+  }
+  // Fresh install / DB blip — same synthetic fallback ContactResolver uses for cli/web.
+  return {
+    resolved: true,
+    contactId: 'primary-user',
+    displayName: 'CEO',
+    role: 'ceo',
+    systemRole: 'principal',
+    verified: true,
+    kgNodeId: null,
+    knowledgeSummary: '',
+    authorization: null,
+    contactConfidence: 1.0,
+    tier: 'principal',
+    kind: 'principal',
+  };
+}
+
+function toCallerContext(
+  senderContext: InboundSenderContext,
+  channel: string,
+  senderId: string,
+): VoiceCallerContext {
+  const { originator, liveTurn } = stampOriginator({ senderContext, channel, senderId });
+  if (senderContext.resolved) {
+    return {
+      contactId: senderContext.contactId,
+      displayName: senderContext.displayName,
+      systemRole: senderContext.systemRole,
+      tier: senderContext.tier,
+      liveTurn,
+      originator,
+      senderId,
+      senderContext,
+    };
+  }
+  return {
+    contactId: senderId,
+    displayName: 'Unknown caller',
+    systemRole: null,
+    tier: 'unknown',
+    liveTurn,
+    originator,
+    senderId,
+    senderContext,
+  };
+}
+
+/**
+ * Console (CEO web) voice transport: resolve the principal explicitly, then stamp
+ * originator/liveTurn via the shared helper. Never falls back to a non-principal
+ * identity — the bootstrap secret already proved the caller is the CEO.
+ */
+export async function resolveConsoleVoiceCaller(opts: {
+  contactService: ContactService;
+  logger: Logger;
+}): Promise<VoiceCallerContext> {
+  let principal: Awaited<ReturnType<ContactService['findContactBySystemRole']>> = null;
+  try {
+    principal = await opts.contactService.findContactBySystemRole('principal');
+  } catch (err) {
+    opts.logger.warn({ err }, 'Unable to resolve principal contact for voice session; using synthetic principal');
+  }
+  if (!principal) {
+    opts.logger.warn('No principal contact found for voice session; using synthetic principal');
+  }
+  const senderContext = buildPrincipalSenderContext(principal);
+  return toCallerContext(senderContext, 'voice', VOICE_CONSOLE_SENDER_ID);
+}
+
+/**
+ * Resolve a transport-supplied caller token via ContactResolver + stampOriginator.
+ * Honors the voice channel's unknown_sender policy (default: ignore → fail closed).
+ *
+ * No HTTP entry point uses this yet — it is the seam for #1602 and is unit-tested
+ * so non-principal / unresolved tokens cannot silently inherit principal standing.
+ */
+export async function resolveVoiceCallerFromToken(opts: {
+  contactResolver: ContactResolver;
+  callerToken: string;
+  channelPolicies?: Record<string, ChannelPolicyConfig>;
+  /**
+   * senderId stamped on inbound.message when resolved. Defaults to the contact id
+   * (or the raw token when unresolved and admitted).
+   */
+  senderId?: string;
+}): Promise<ResolveVoiceCallerResult> {
+  const senderContext = await opts.contactResolver.resolve('voice', opts.callerToken);
+  if (!senderContext.resolved) {
+    const policy = opts.channelPolicies?.voice?.unknownSender ?? 'ignore';
+    if (policy === 'ignore') {
+      return { ok: false, reason: 'unknown_sender' };
+    }
+    // 'allow' — admit with unknown-tier originator (not used by default voice policy).
+    const senderId = opts.senderId ?? opts.callerToken;
+    return { ok: true, caller: toCallerContext(senderContext, 'voice', senderId) };
+  }
+
+  const senderId = opts.senderId ?? senderContext.contactId;
+  return { ok: true, caller: toCallerContext(senderContext, 'voice', senderId) };
+}

--- a/src/channels/voice/caller-context.ts
+++ b/src/channels/voice/caller-context.ts
@@ -38,7 +38,7 @@ export interface VoiceCallerContext {
 
 export type ResolveVoiceCallerResult =
   | { ok: true; caller: VoiceCallerContext }
-  | { ok: false; reason: 'unknown_sender' };
+  | { ok: false; reason: 'unknown_sender' | 'blocked' };
 
 /**
  * Build a SenderContext for the principal contact (or the synthetic CLI/web fallback).
@@ -154,6 +154,11 @@ export async function resolveConsoleVoiceCaller(opts: {
  *
  * No HTTP entry point uses this yet — it is the seam for #1602 and is unit-tested
  * so non-principal / unresolved tokens cannot silently inherit principal standing.
+ *
+ * Policy note (#1598 follow-up): the unknown_sender default (`?? 'ignore'`) and the
+ * blocked-tier gate below duplicate dispatcher policy rather than reading the shared
+ * channel-trust config. Reconcile against the dispatcher's config path when #1602
+ * wires a real transport — do not extend these independently.
  */
 export async function resolveVoiceCallerFromToken(opts: {
   contactResolver: ContactResolver;
@@ -171,8 +176,9 @@ export async function resolveVoiceCallerFromToken(opts: {
   const senderContext = await opts.contactResolver.resolve('voice', opts.callerToken);
   // Blocked contacts are denied before constructing a caller — mirrors dispatcher.ts
   // which drops blocked senders before reaching the coordinator (#1598).
+  // Distinct reason from unknown_sender so audit can tell "unknown" from "denied".
   if (senderContext.resolved && senderContext.tier === 'blocked') {
-    return { ok: false, reason: 'unknown_sender' };
+    return { ok: false, reason: 'blocked' };
   }
   if (!senderContext.resolved) {
     const policy = opts.channelPolicies?.voice?.unknownSender ?? 'ignore';

--- a/src/channels/voice/livekit/room-session.test.ts
+++ b/src/channels/voice/livekit/room-session.test.ts
@@ -1,32 +1,67 @@
 // room-session.test.ts — unit tests for LiveKitRoomSession.
 //
-// @livekit/rtc-node is a native addon loaded lazily. Tests mock the dynamic
-// import so no native binary is needed. Full integration (connect / audio / teardown
-// on real events) requires the native binary and is out of scope for unit tests;
-// these cover the observable config wiring that the ParticipantDisconnected handler
-// depends on (#1598 blocker 2 fix).
+// @livekit/rtc-node is a native addon loaded lazily via dynamic import() inside
+// connect(). Tests mock the package so no native binary is needed, and drive
+// the real ParticipantDisconnected handler — the regression that previously
+// silently broke session teardown when LiveKit identity changed (#1598).
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import pino from 'pino';
-import type { LiveKitRoomSessionConfig } from './room-session.js';
+import { LiveKitRoomSession } from './room-session.js';
 
 const logger = pino({ level: 'silent' });
 
-vi.mock('@livekit/rtc-node', () => ({
-  Room: class {},
-  RoomEvent: { TrackSubscribed: 'TrackSubscribed', ParticipantDisconnected: 'ParticipantDisconnected', Disconnected: 'Disconnected' },
-  TrackKind: { KIND_AUDIO: 1 },
-  TrackSource: { SOURCE_MICROPHONE: 0 },
-  AudioSource: class { close = vi.fn(); captureFrame = vi.fn(); },
-  LocalAudioTrack: class { static createAudioTrack = vi.fn(() => ({})); close = vi.fn(); },
-  AudioStream: class { getReader() { return { read: vi.fn(async () => ({ done: true })), releaseLock: vi.fn(), cancel: vi.fn() }; } },
-  AudioFrame: class {},
-  TrackPublishOptions: class {},
+// vi.mock is hoisted — declare the shared handler map with vi.hoisted() to avoid TDZ.
+const { handlers } = vi.hoisted(() => ({
+  handlers: new Map<string, (p: unknown) => void>(),
 }));
 
-describe('LiveKitRoomSession — callerIdentity config field (#1598)', () => {
-  it('stores callerIdentity when provided', async () => {
-    const { LiveKitRoomSession } = await import('./room-session.js');
+vi.mock('@livekit/rtc-node', () => ({
+  Room: class {
+    localParticipant = { publishTrack: vi.fn(async () => undefined) };
+    on(event: string, cb: (p: unknown) => void) {
+      handlers.set(event, cb);
+      return this;
+    }
+    connect = vi.fn(async () => undefined);
+    disconnect = vi.fn(async () => undefined);
+  },
+  RoomEvent: {
+    TrackSubscribed: 'TrackSubscribed',
+    ParticipantDisconnected: 'ParticipantDisconnected',
+    Disconnected: 'Disconnected',
+  },
+  TrackKind: { KIND_AUDIO: 1 },
+  TrackSource: { SOURCE_MICROPHONE: 0 },
+  AudioSource: class {
+    close = vi.fn(async () => undefined);
+    captureFrame = vi.fn(async () => undefined);
+  },
+  LocalAudioTrack: class {
+    close = vi.fn(async () => undefined);
+    static createAudioTrack = vi.fn(() => new (this as unknown as { new (): unknown })());
+  },
+  AudioStream: class {
+    getReader() {
+      return {
+        read: vi.fn(async () => ({ done: true, value: undefined })),
+        releaseLock: vi.fn(),
+        cancel: vi.fn(async () => undefined),
+      };
+    }
+  },
+  AudioFrame: class {},
+  TrackPublishOptions: class {
+    constructor(_opts: unknown) {}
+  },
+}));
+
+describe('LiveKitRoomSession — ParticipantDisconnected teardown (#1598)', () => {
+  beforeEach(() => {
+    handlers.clear();
+  });
+
+  it('fires onClose when the resolved caller identity disconnects', async () => {
     const uuid = '11111111-1111-1111-1111-111111111111';
     const session = new LiveKitRoomSession({
       url: 'wss://livekit.test',
@@ -34,28 +69,60 @@ describe('LiveKitRoomSession — callerIdentity config field (#1598)', () => {
       callerIdentity: uuid,
       logger,
     });
-    expect((session as unknown as { config: LiveKitRoomSessionConfig }).config.callerIdentity).toBe(uuid);
+    const closed: string[] = [];
+    session.onClose(r => closed.push(r));
+    await session.connect();
+
+    handlers.get('ParticipantDisconnected')!({ identity: uuid });
+    expect(closed).toEqual(['principal_disconnected']);
   });
 
-  it('leaves callerIdentity undefined when omitted (connect() falls back to "principal")', async () => {
-    const { LiveKitRoomSession } = await import('./room-session.js');
+  it('ignores a disconnect from any other participant identity', async () => {
+    const uuid = '11111111-1111-1111-1111-111111111111';
     const session = new LiveKitRoomSession({
       url: 'wss://livekit.test',
       token: 'tok',
+      callerIdentity: uuid,
       logger,
     });
-    // Verify the fallback path: undefined → 'principal' via `?? 'principal'` in connect()
-    expect((session as unknown as { config: LiveKitRoomSessionConfig }).config.callerIdentity).toBeUndefined();
+    const closed: string[] = [];
+    session.onClose(r => closed.push(r));
+    await session.connect();
+
+    handlers.get('ParticipantDisconnected')!({ identity: 'curia-agent' });
+    expect(closed).toEqual([]);
   });
 
-  it('onClose callbacks are registered and called exactly once per close', async () => {
-    const { LiveKitRoomSession } = await import('./room-session.js');
-    const session = new LiveKitRoomSession({ url: 'wss://livekit.test', token: 'tok', logger });
-    const reasons: string[] = [];
-    session.onClose(r => reasons.push(r));
-    // emitClose is private; trigger via disconnect() path — disconnect() sets disconnecting=true
-    // before emitting so it won't fire onClose. Instead call the internal path directly.
-    // We verify the callback list is populated (integration of onClose registration).
-    expect((session as unknown as { closeCallbacks: unknown[] }).closeCallbacks).toHaveLength(1);
+  it('does not fire onClose for the literal "principal" when callerIdentity is a contact id', async () => {
+    // Sanity: the exact pre-#1598 regression — comparing against the hardcoded
+    // 'principal' string while the minted identity is a UUID — must not match.
+    const uuid = '22222222-2222-2222-2222-222222222222';
+    const session = new LiveKitRoomSession({
+      url: 'wss://livekit.test',
+      token: 'tok',
+      callerIdentity: uuid,
+      logger,
+    });
+    const closed: string[] = [];
+    session.onClose(r => closed.push(r));
+    await session.connect();
+
+    handlers.get('ParticipantDisconnected')!({ identity: 'principal' });
+    expect(closed).toEqual([]);
+  });
+
+  it('fires onClose for RoomEvent.Disconnected', async () => {
+    const session = new LiveKitRoomSession({
+      url: 'wss://livekit.test',
+      token: 'tok',
+      callerIdentity: '11111111-1111-1111-1111-111111111111',
+      logger,
+    });
+    const closed: string[] = [];
+    session.onClose(r => closed.push(r));
+    await session.connect();
+
+    handlers.get('Disconnected')!(undefined);
+    expect(closed).toEqual(['room_disconnected']);
   });
 });

--- a/src/channels/voice/livekit/room-session.test.ts
+++ b/src/channels/voice/livekit/room-session.test.ts
@@ -1,0 +1,61 @@
+// room-session.test.ts — unit tests for LiveKitRoomSession.
+//
+// @livekit/rtc-node is a native addon loaded lazily. Tests mock the dynamic
+// import so no native binary is needed. Full integration (connect / audio / teardown
+// on real events) requires the native binary and is out of scope for unit tests;
+// these cover the observable config wiring that the ParticipantDisconnected handler
+// depends on (#1598 blocker 2 fix).
+
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import type { LiveKitRoomSessionConfig } from './room-session.js';
+
+const logger = pino({ level: 'silent' });
+
+vi.mock('@livekit/rtc-node', () => ({
+  Room: class {},
+  RoomEvent: { TrackSubscribed: 'TrackSubscribed', ParticipantDisconnected: 'ParticipantDisconnected', Disconnected: 'Disconnected' },
+  TrackKind: { KIND_AUDIO: 1 },
+  TrackSource: { SOURCE_MICROPHONE: 0 },
+  AudioSource: class { close = vi.fn(); captureFrame = vi.fn(); },
+  LocalAudioTrack: class { static createAudioTrack = vi.fn(() => ({})); close = vi.fn(); },
+  AudioStream: class { getReader() { return { read: vi.fn(async () => ({ done: true })), releaseLock: vi.fn(), cancel: vi.fn() }; } },
+  AudioFrame: class {},
+  TrackPublishOptions: class {},
+}));
+
+describe('LiveKitRoomSession — callerIdentity config field (#1598)', () => {
+  it('stores callerIdentity when provided', async () => {
+    const { LiveKitRoomSession } = await import('./room-session.js');
+    const uuid = '11111111-1111-1111-1111-111111111111';
+    const session = new LiveKitRoomSession({
+      url: 'wss://livekit.test',
+      token: 'tok',
+      callerIdentity: uuid,
+      logger,
+    });
+    expect((session as unknown as { config: LiveKitRoomSessionConfig }).config.callerIdentity).toBe(uuid);
+  });
+
+  it('leaves callerIdentity undefined when omitted (connect() falls back to "principal")', async () => {
+    const { LiveKitRoomSession } = await import('./room-session.js');
+    const session = new LiveKitRoomSession({
+      url: 'wss://livekit.test',
+      token: 'tok',
+      logger,
+    });
+    // Verify the fallback path: undefined → 'principal' via `?? 'principal'` in connect()
+    expect((session as unknown as { config: LiveKitRoomSessionConfig }).config.callerIdentity).toBeUndefined();
+  });
+
+  it('onClose callbacks are registered and called exactly once per close', async () => {
+    const { LiveKitRoomSession } = await import('./room-session.js');
+    const session = new LiveKitRoomSession({ url: 'wss://livekit.test', token: 'tok', logger });
+    const reasons: string[] = [];
+    session.onClose(r => reasons.push(r));
+    // emitClose is private; trigger via disconnect() path — disconnect() sets disconnecting=true
+    // before emitting so it won't fire onClose. Instead call the internal path directly.
+    // We verify the callback list is populated (integration of onClose registration).
+    expect((session as unknown as { closeCallbacks: unknown[] }).closeCallbacks).toHaveLength(1);
+  });
+});

--- a/src/channels/voice/livekit/room-session.ts
+++ b/src/channels/voice/livekit/room-session.ts
@@ -43,10 +43,10 @@ export interface LiveKitRoomSessionConfig {
   /**
    * LiveKit identity minted for the remote (human) participant — the value passed
    * to mintVoiceParticipantToken as `identity` in VoiceAdapter.createSession.
-   * Used to detect caller disconnect (ParticipantDisconnected teardown).
-   * Defaults to 'principal' for backward-compat (pre-#1598 sessions without this field).
+   * Required: the ParticipantDisconnected teardown handler compares against this
+   * so a missing/wrong value silently leaves STT sockets and active rows behind (#1598).
    */
-  callerIdentity?: string;
+  callerIdentity: string;
   /** Inbound (remote → STT) sample rate. Default 16000 (Deepgram-friendly). */
   inboundSampleRate?: number;
   /** Outbound (TTS → publish) sample rate. Default 24000 (Cartesia default). */
@@ -121,8 +121,8 @@ export class LiveKitRoomSession implements AudioTransport {
 
       // Caller closed the console tab / lost WebRTC — tear the Curia session down
       // so we don't leave STT sockets and an `active` voice_sessions row behind.
-      // callerIdentity is the resolved contact id (post-#1598) or 'principal' (legacy/compat).
-      const callerIdentity = this.config.callerIdentity ?? 'principal';
+      // callerIdentity is the resolved contact id minted in the caller's LiveKit token (#1598).
+      const callerIdentity = this.config.callerIdentity;
       room.on(rtc.RoomEvent.ParticipantDisconnected, (participant: RemoteParticipant) => {
         if (participant.identity === callerIdentity) {
           this.log.info({ identity: participant.identity }, 'Caller left LiveKit room');

--- a/src/channels/voice/livekit/room-session.ts
+++ b/src/channels/voice/livekit/room-session.ts
@@ -34,15 +34,19 @@ import type {
 /** The LiveKit npm module shape we consume, resolved at runtime via dynamic import. */
 type RtcModule = typeof import('@livekit/rtc-node');
 
-/** Console principal identity minted by VoiceAdapter.createSession. */
-const PRINCIPAL_IDENTITY = 'principal';
-
 export interface LiveKitRoomSessionConfig {
   /** LiveKit WebSocket URL (wss://…). */
   url: string;
   /** Agent participant JWT (mint with identity 'curia-agent'). */
   token: string;
   logger: Logger;
+  /**
+   * LiveKit identity minted for the remote (human) participant — the value passed
+   * to mintVoiceParticipantToken as `identity` in VoiceAdapter.createSession.
+   * Used to detect caller disconnect (ParticipantDisconnected teardown).
+   * Defaults to 'principal' for backward-compat (pre-#1598 sessions without this field).
+   */
+  callerIdentity?: string;
   /** Inbound (remote → STT) sample rate. Default 16000 (Deepgram-friendly). */
   inboundSampleRate?: number;
   /** Outbound (TTS → publish) sample rate. Default 24000 (Cartesia default). */
@@ -115,11 +119,13 @@ export class LiveKitRoomSession implements AudioTransport {
         this.startConsuming(rtc, track);
       });
 
-      // Principal closed the console tab / lost WebRTC — tear the Curia session down
+      // Caller closed the console tab / lost WebRTC — tear the Curia session down
       // so we don't leave STT sockets and an `active` voice_sessions row behind.
+      // callerIdentity is the resolved contact id (post-#1598) or 'principal' (legacy/compat).
+      const callerIdentity = this.config.callerIdentity ?? 'principal';
       room.on(rtc.RoomEvent.ParticipantDisconnected, (participant: RemoteParticipant) => {
-        if (participant.identity === PRINCIPAL_IDENTITY) {
-          this.log.info({ identity: participant.identity }, 'Principal left LiveKit room');
+        if (participant.identity === callerIdentity) {
+          this.log.info({ identity: participant.identity }, 'Caller left LiveKit room');
           this.emitClose('principal_disconnected');
         }
       });

--- a/src/channels/voice/session-bridge.test.ts
+++ b/src/channels/voice/session-bridge.test.ts
@@ -4,15 +4,22 @@ import pino from 'pino';
 import type { ContactService } from '../../contacts/contact-service.js';
 import { voiceSessionRoutes } from './session-routes.js';
 import { VoiceSessionBridge } from './session-bridge.js';
+import { VOICE_CONSOLE_SENDER_ID } from './caller-context.js';
 
 const BOOTSTRAP = 'test-bootstrap-secret';
 const auth = { 'x-web-bootstrap-secret': BOOTSTRAP };
 const logger = pino({ level: 'silent' });
+const PRINCIPAL_ID = '11111111-1111-1111-1111-111111111111';
 
 function contactService(): ContactService {
   return {
     findContactBySystemRole: vi.fn().mockResolvedValue({
-      id: '11111111-1111-1111-1111-111111111111',
+      id: PRINCIPAL_ID,
+      displayName: 'Joseph',
+      role: 'ceo',
+      systemRole: 'principal',
+      kgNodeId: null,
+      tier: 'principal',
     }),
   } as unknown as ContactService;
 }
@@ -48,7 +55,7 @@ describe('VoiceSessionBridge routes', () => {
     expect(create.json()).toEqual({ error: 'Voice channel not available' });
   });
 
-  it('delegates create and end calls to the installed handler', async () => {
+  it('delegates create and end calls to the installed handler with resolved principal caller', async () => {
     const bridge = new VoiceSessionBridge();
     const createSession = vi.fn().mockResolvedValue({ status: 201, body: { sessionId: 's1' } });
     const endSession = vi.fn().mockResolvedValue({ status: 200, body: { ok: true } });
@@ -67,10 +74,14 @@ describe('VoiceSessionBridge routes', () => {
     });
     expect(create.statusCode).toBe(201);
     expect(create.json()).toEqual({ sessionId: 's1' });
-    expect(createSession).toHaveBeenCalledWith({
-      principalContactId: '11111111-1111-1111-1111-111111111111',
-      metadata: { source: 'test' },
-    });
+    expect(createSession).toHaveBeenCalledOnce();
+    const req = createSession.mock.calls[0]![0];
+    expect(req.metadata).toEqual({ source: 'test' });
+    expect(req.caller.contactId).toBe(PRINCIPAL_ID);
+    expect(req.caller.liveTurn).toBe(true);
+    expect(req.caller.senderId).toBe(VOICE_CONSOLE_SENDER_ID);
+    expect(req.caller.originator.systemRole).toBe('principal');
+    expect(req.caller.originator.channel).toBe('voice');
 
     const end = await app.inject({ method: 'DELETE', url: '/api/voice/sessions/s1', headers: auth });
     expect(end.statusCode).toBe(200);

--- a/src/channels/voice/session-bridge.ts
+++ b/src/channels/voice/session-bridge.ts
@@ -1,5 +1,8 @@
+import type { VoiceCallerContext } from './caller-context.js';
+
 export interface VoiceSessionCreateRequest {
-  principalContactId?: string;
+  /** Resolved caller identity (originator / tier / liveTurn) — stamped once at create. */
+  caller: VoiceCallerContext;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/channels/voice/session-routes.ts
+++ b/src/channels/voice/session-routes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { Logger } from '../../logger.js';
 import type { ContactService } from '../../contacts/contact-service.js';
 import { assertSecret, type SessionStore } from '../http/session-auth.js';
+import { resolveConsoleVoiceCaller } from './caller-context.js';
 import type { VoiceSessionBridge } from './session-bridge.js';
 
 export interface VoiceSessionRouteOptions {
@@ -37,8 +38,13 @@ export async function voiceSessionRoutes(
     if (!handler) return reply.status(503).send({ error: 'Voice channel not available' });
 
     try {
+      // Console transport is principal-proven by the bootstrap secret (same as 'web').
+      // Resolve the principal explicitly, then stamp originator/liveTurn via the shared
+      // helper — do NOT route through ContactResolver.resolve('voice', …) so a future
+      // real caller token still hits resolveByChannelIdentity (#1598 / #1602).
+      const caller = await resolveConsoleVoiceCaller({ contactService, logger: log });
       const result = await handler.createSession({
-        principalContactId: await resolvePrincipalContactId(contactService, log),
+        caller,
         metadata: parseMetadata(request.body),
       });
       return reply.status(result.status).send(result.body);
@@ -61,18 +67,6 @@ export async function voiceSessionRoutes(
       return reply.status(500).send({ error: 'Internal voice session error' });
     }
   });
-}
-
-async function resolvePrincipalContactId(
-  contactService: ContactService,
-  logger: Logger,
-): Promise<string | undefined> {
-  try {
-    return (await contactService.findContactBySystemRole('principal'))?.id;
-  } catch (err) {
-    logger.warn({ err }, 'Unable to resolve principal contact for voice session');
-    return undefined;
-  }
 }
 
 function parseMetadata(body: unknown): Record<string, unknown> | undefined {

--- a/src/channels/voice/test-fixtures.ts
+++ b/src/channels/voice/test-fixtures.ts
@@ -1,0 +1,76 @@
+import type { VoiceCallerContext } from './caller-context.js';
+import { VOICE_CONSOLE_SENDER_ID } from './caller-context.js';
+
+const PRINCIPAL_ID = '11111111-1111-1111-1111-111111111111';
+
+/** Principal console caller fixture for adapter / bridge tests. */
+export function principalCaller(overrides: Partial<VoiceCallerContext> = {}): VoiceCallerContext {
+  const contactId = overrides.contactId ?? PRINCIPAL_ID;
+  const senderContext = {
+    resolved: true as const,
+    contactId,
+    displayName: overrides.displayName ?? 'Joseph',
+    role: 'ceo',
+    systemRole: 'principal' as const,
+    verified: true,
+    kgNodeId: null,
+    knowledgeSummary: '',
+    authorization: null,
+    contactConfidence: 1.0,
+    tier: 'principal' as const,
+    kind: 'principal' as const,
+  };
+  return {
+    contactId,
+    displayName: senderContext.displayName,
+    systemRole: 'principal',
+    tier: 'principal',
+    liveTurn: true,
+    originator: {
+      contactId,
+      systemRole: 'principal',
+      channel: 'voice',
+      initiatedAt: '2026-07-29T12:00:00.000Z',
+      tier: 'principal',
+    },
+    senderId: VOICE_CONSOLE_SENDER_ID,
+    senderContext,
+    ...overrides,
+  };
+}
+
+/** Non-principal caller fixture (liveTurn=false). */
+export function partnerCaller(overrides: Partial<VoiceCallerContext> = {}): VoiceCallerContext {
+  const contactId = overrides.contactId ?? '22222222-2222-2222-2222-222222222222';
+  const senderContext = {
+    resolved: true as const,
+    contactId,
+    displayName: overrides.displayName ?? 'Alex Partner',
+    role: 'partner',
+    systemRole: null,
+    verified: true,
+    kgNodeId: null,
+    knowledgeSummary: '',
+    authorization: null,
+    contactConfidence: 0.9,
+    tier: 'trusted' as const,
+    kind: 'person' as const,
+  };
+  return {
+    contactId,
+    displayName: senderContext.displayName,
+    systemRole: null,
+    tier: 'trusted',
+    liveTurn: false,
+    originator: {
+      contactId,
+      systemRole: null,
+      channel: 'voice',
+      initiatedAt: '2026-07-29T12:00:00.000Z',
+      tier: 'trusted',
+    },
+    senderId: contactId,
+    senderContext,
+    ...overrides,
+  };
+}

--- a/src/channels/voice/voice-adapter.test.ts
+++ b/src/channels/voice/voice-adapter.test.ts
@@ -7,6 +7,7 @@ import type { VoiceRuntime } from './voice-runtime.js';
 import { VoiceSessionBridge } from './session-bridge.js';
 import { VoiceAdapter } from './voice-adapter.js';
 import { mintVoiceParticipantToken } from './livekit/token.js';
+import { partnerCaller, principalCaller } from './test-fixtures.js';
 
 // Mock JWT minting so tests don't need real keys and can simulate a signing
 // failure on the agent token (the second mint) independently of the principal.
@@ -15,6 +16,7 @@ vi.mock('./livekit/token.js', () => ({
 }));
 
 const logger = pino({ level: 'silent' });
+const PRINCIPAL_ID = '11111111-1111-1111-1111-111111111111';
 
 beforeEach(() => {
   // Reset to the default resolving implementation before every test so a
@@ -85,7 +87,7 @@ function fakeRuntime(): VoiceRuntime {
 }
 
 describe('VoiceAdapter', () => {
-  it('installs a handler that creates sessions, mints a token, and publishes started', async () => {
+  it('installs a handler that creates sessions, mints a token with the resolved contact id, and publishes started', async () => {
     const bridge = new VoiceSessionBridge();
     const { bus, publish, subscribe } = fakeBus();
     const { store, create } = fakeStore();
@@ -106,8 +108,9 @@ describe('VoiceAdapter', () => {
     const handler = bridge.getHandler();
     expect(handler).not.toBeNull();
 
+    const caller = principalCaller();
     const result = await handler!.createSession({
-      principalContactId: '11111111-1111-1111-1111-111111111111',
+      caller,
       metadata: { source: 'test' },
     });
 
@@ -119,12 +122,52 @@ describe('VoiceAdapter', () => {
     expect(create).toHaveBeenCalledWith(expect.objectContaining({
       conversationId: result.body.conversationId,
       livekitRoom: result.body.roomName,
-      principalContactId: '11111111-1111-1111-1111-111111111111',
+      principalContactId: PRINCIPAL_ID,
       metadata: { source: 'test' },
     }));
-    expect(runtime.startSession).toHaveBeenCalledOnce();
+    expect(mintVoiceParticipantToken).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ identity: PRINCIPAL_ID, name: 'Joseph' }),
+    );
+    expect(runtime.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({ caller }),
+    );
     expect(publish.mock.calls[0]![0]).toBe('channel');
     expect(publish.mock.calls[0]![1].type).toBe('voice.session.started');
+  });
+
+  it('mints LiveKit identity from a non-principal contact id (not the literal principal)', async () => {
+    const bridge = new VoiceSessionBridge();
+    const { bus } = fakeBus();
+    const { store } = fakeStore();
+    const runtime = fakeRuntime();
+    const adapter = new VoiceAdapter({
+      bus,
+      logger,
+      sessionBridge: bridge,
+      sessionStore: store,
+      livekitUrl: 'wss://voice.example.test',
+      livekitApiKey: 'devkey',
+      livekitApiSecret: 'devsecret',
+      voiceRuntime: runtime,
+    });
+    await adapter.start();
+
+    const caller = partnerCaller();
+    await bridge.getHandler()!.createSession({ caller });
+
+    expect(mintVoiceParticipantToken).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        identity: caller.contactId,
+        name: 'Alex Partner',
+      }),
+    );
+    // Must not mint the hardcoded 'principal' identity.
+    const identities = vi.mocked(mintVoiceParticipantToken).mock.calls
+      .map(c => c[1]?.identity)
+      .filter(id => id !== 'curia-agent');
+    expect(identities).not.toContain('principal');
   });
 
   it('rejects session creation when VoiceRuntime is unavailable', async () => {
@@ -143,7 +186,7 @@ describe('VoiceAdapter', () => {
 
     await adapter.start();
     const result = await bridge.getHandler()!.createSession({
-      principalContactId: '11111111-1111-1111-1111-111111111111',
+      caller: principalCaller(),
     });
 
     expect(result.status).toBe(503);
@@ -202,7 +245,7 @@ describe('VoiceAdapter', () => {
 
     await adapter.start();
     const result = await bridge.getHandler()!.createSession({
-      principalContactId: '11111111-1111-1111-1111-111111111111',
+      caller: principalCaller(),
     });
 
     // Fail closed with 500; the runtime loop is never started; and the persisted

--- a/src/channels/voice/voice-adapter.ts
+++ b/src/channels/voice/voice-adapter.ts
@@ -11,6 +11,8 @@ import { mintVoiceParticipantToken } from './livekit/token.js';
 
 /** LiveKit identity for the server-side agent participant that VoiceRuntime joins as. */
 const AGENT_IDENTITY = 'curia-agent';
+/** voice_sessions.principal_contact_id is UUID — only persist real contact ids. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export interface VoiceAdapterConfig {
   bus: EventBus;
@@ -79,6 +81,10 @@ export class VoiceAdapter implements Channel {
     const sessionId = randomUUID();
     const conversationId = `voice:${sessionId}`;
     const roomName = `voice-${sessionId}`;
+    const { caller } = req;
+    // LiveKit participant identity is the resolved contact id (not the literal
+    // 'principal') so a future non-principal transport cannot inherit CEO standing
+    // at the media layer (#1598).
     const token = await mintVoiceParticipantToken(
       {
         apiKey: this.config.livekitApiKey,
@@ -86,16 +92,20 @@ export class VoiceAdapter implements Channel {
       },
       {
         roomName,
-        identity: 'principal',
-        name: 'Principal',
+        identity: caller.contactId,
+        name: caller.displayName || (caller.liveTurn ? 'Principal' : 'Caller'),
       },
     );
+
+    // voice_sessions.principal_contact_id is UUID NOT NULL REFERENCES — only store
+    // a real contact UUID (synthetic 'primary-user' stays null).
+    const principalContactId = UUID_RE.test(caller.contactId) ? caller.contactId : undefined;
 
     const session = await this.config.sessionStore.create({
       id: sessionId,
       conversationId,
       livekitRoom: roomName,
-      principalContactId: req.principalContactId,
+      principalContactId,
       metadata: req.metadata,
     });
 
@@ -139,6 +149,7 @@ export class VoiceAdapter implements Channel {
         conversationId: session.conversationId,
         roomName: session.livekitRoom,
         agentToken,
+        caller,
         // Console POST /api/voice/sessions is always principal-initiated inbound.
         // A future Curia-initiated outbound path must pass openingGreeting: false
         // so Curia does not talk over the CEO answering (#1596).

--- a/src/channels/voice/voice-adapter.ts
+++ b/src/channels/voice/voice-adapter.ts
@@ -97,7 +97,7 @@ export class VoiceAdapter implements Channel {
       },
     );
 
-    // voice_sessions.principal_contact_id is UUID NOT NULL REFERENCES — only store
+    // voice_sessions.principal_contact_id is UUID NULL ON DELETE SET NULL — only store
     // a real contact UUID (synthetic 'primary-user' stays null).
     const principalContactId = UUID_RE.test(caller.contactId) ? caller.contactId : undefined;
 

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -12,12 +12,14 @@ import {
   VoiceRuntime,
   buildVoiceSystemPrompt,
   VOICE_SYSTEM_ADDENDUM,
+  VOICE_SPOKEN_STYLE_ADDENDUM,
   VOICE_TOOL_RESULT_POLICY,
   VOICE_DELEGATION_GUIDANCE,
   VOICE_GREETING_INSTRUCTION,
   VOICE_GREETING_USER_MESSAGE,
 } from './voice-runtime.js';
 import type { VoiceToolBridge } from './voice-runtime.js';
+import { partnerCaller } from './test-fixtures.js';
 import { FakeAudioTransport } from './fake-audio-transport.js';
 import { FakeSttProvider, TtsHttpError } from '../../speech/index.js';
 import type { PcmFrame, TextToSpeechProvider, TtsSynthesizeOptions } from '../../speech/index.js';
@@ -947,6 +949,24 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       .toBeLessThan(prompt.indexOf(VOICE_ASYNC_OFFRAMP_GUIDANCE));
   });
 
+  it('buildVoiceSystemPrompt reflects a non-principal audience (#1598)', () => {
+    const prompt = buildVoiceSystemPrompt({
+      audience: { liveTurn: false, displayName: 'Alex Partner' },
+    });
+    expect(prompt).toContain('You are speaking to Alex Partner in a live voice call.');
+    expect(prompt).toContain('They are not the principal');
+    expect(prompt).not.toContain('You are speaking to the principal');
+    expect(prompt).toContain(VOICE_SPOKEN_STYLE_ADDENDUM);
+  });
+
+  it('buildVoiceSystemPrompt keeps the principal audience line for liveTurn callers', () => {
+    const prompt = buildVoiceSystemPrompt({
+      audience: { liveTurn: true, displayName: 'Joseph' },
+    });
+    expect(prompt).toContain(VOICE_SYSTEM_ADDENDUM);
+    expect(prompt).toBe(SLIM_VOICE_PROMPT);
+  });
+
   it('injects an active Signal outbound-context entry into the spoken-turn system prompt', async () => {
     const llm = new FakeStreamProvider([reply('Yes, I messaged you on Signal about the Google alert.')]);
     const outbound = fakeOutboundContext({ entries: [signalAlertEntry] });
@@ -978,6 +998,35 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       content: 'did you message me',
     });
     expect(systemText).not.toContain('did you message me');
+  });
+
+  it('does not inject outbound context for a non-principal (liveTurn=false) caller (#1598)', async () => {
+    const llm = new FakeStreamProvider([reply('Hello.')]);
+    const getActive = vi.fn(async () => [signalAlertEntry]);
+    const outbound = fakeOutboundContext({ getActive });
+    const { runtime, stt } = makeRuntime({
+      llm,
+      tts: new SlowTtsProvider(2, 1),
+      outboundContextService: outbound,
+    });
+
+    await runtime.startSession({
+      sessionId: 'oc-nonprincipal',
+      conversationId: 'voice:oc-nonprincipal',
+      roomName: 'voice-oc-nonprincipal',
+      agentToken: 'tok',
+      openingGreeting: false,
+      caller: partnerCaller(),
+    });
+    stt.emit({ text: 'did you message me', isFinal: true, speechFinal: true });
+    await runtime.awaitIdle('oc-nonprincipal');
+
+    expect(getActive).not.toHaveBeenCalled();
+    const system = llm.seenMessages[0]![0]!;
+    const systemText = typeof system.content === 'string' ? system.content : '';
+    expect(systemText).not.toContain('[ACTIVE OUTBOUND CONTEXT');
+    expect(systemText).toContain('You are speaking to Alex Partner');
+    expect(systemText).not.toContain('You are speaking to the principal');
   });
 
   it('leaves the system prompt unchanged when getActive returns no entries', async () => {

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -921,6 +921,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       identityBlock: '## Identity\nYou are Vera.',
       outboundContextBlock,
       timeContextBlock: '## Current Date & Time\nTimezone: America/Toronto',
+      audience: { liveTurn: true },
     });
     expect(prompt).toContain('[ACTIVE OUTBOUND CONTEXT');
     expect(prompt).toContain('entry_id: entry-signal-alert');
@@ -930,11 +931,11 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       .toBeLessThan(prompt.indexOf('## Current Date & Time'));
     // Empty outbound → identical to the slim path without that section (still
     // includes shared date-resolve + async off-ramp — ADR-038 / #1614).
-    expect(buildVoiceSystemPrompt({})).toBe(SLIM_VOICE_PROMPT);
+    expect(buildVoiceSystemPrompt({ audience: { liveTurn: true } })).toBe(SLIM_VOICE_PROMPT);
   });
 
   it('buildVoiceSystemPrompt composes the shared date-resolve guardrail', () => {
-    const prompt = buildVoiceSystemPrompt({});
+    const prompt = buildVoiceSystemPrompt({ audience: { liveTurn: true } });
     expect(prompt).toContain('date-resolve to verify');
     expect(prompt).toContain('### Date & time');
     expect(prompt.indexOf(VOICE_TOOL_RESULT_POLICY))
@@ -942,7 +943,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
   });
 
   it('buildVoiceSystemPrompt composes the voice async off-ramp guidance (#1614)', () => {
-    const prompt = buildVoiceSystemPrompt({});
+    const prompt = buildVoiceSystemPrompt({ audience: { liveTurn: true } });
     expect(prompt).toContain('async-offramp');
     expect(prompt).toContain('Live-call scope and async off-ramp');
     expect(prompt.indexOf(DATE_RESOLVE_GUARDRAIL))

--- a/src/channels/voice/voice-runtime.test.ts
+++ b/src/channels/voice/voice-runtime.test.ts
@@ -19,7 +19,7 @@ import {
   VOICE_GREETING_USER_MESSAGE,
 } from './voice-runtime.js';
 import type { VoiceToolBridge } from './voice-runtime.js';
-import { partnerCaller } from './test-fixtures.js';
+import { partnerCaller, principalCaller } from './test-fixtures.js';
 import { FakeAudioTransport } from './fake-audio-transport.js';
 import { FakeSttProvider, TtsHttpError } from '../../speech/index.js';
 import type { PcmFrame, TextToSpeechProvider, TtsSynthesizeOptions } from '../../speech/index.js';
@@ -220,6 +220,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s1',
       roomName: 'voice-s1',
       agentToken: 'tok',
+      caller: principalCaller(),
     });
 
     stt.emit({ text: 'hello curia', isFinal: true, speechFinal: true });
@@ -252,6 +253,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s2',
       roomName: 'voice-s2',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
 
@@ -294,6 +296,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-echo',
       roomName: 'voice-s-echo',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
     stt.emit({ text: 'say something', isFinal: true, speechFinal: true });
@@ -319,6 +322,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-close',
       roomName: 'voice-s-close',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
     expect(runtime.activeSessionCount).toBe(1);
@@ -342,6 +346,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s3',
       roomName: 'voice-s3',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
     expect(runtime.activeSessionCount).toBe(1);
@@ -375,6 +380,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s5',
       roomName: 'voice-s5',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
 
@@ -400,6 +406,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-tts-fail',
       roomName: 'voice-s-tts-fail',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
 
@@ -439,6 +446,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-tts-blip',
       roomName: 'voice-s-tts-blip',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
 
@@ -466,6 +474,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-tts-hard',
       roomName: 'voice-s-tts-hard',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
 
@@ -505,6 +514,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s-pub-fail',
       roomName: 'voice-s-pub-fail',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
 
@@ -533,6 +543,7 @@ describe('VoiceRuntime', () => {
       conversationId: 'voice:s4',
       roomName: 'voice-s4',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
     stt.emit({ text: 'look something up', isFinal: true, speechFinal: true });
@@ -558,6 +569,7 @@ describe('VoiceRuntime brain/context parity (#1551)', () => {
       conversationId: `voice:${id}`,
       roomName: `voice-${id}`,
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
   }
@@ -982,6 +994,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       conversationId: 'voice:oc1',
       roomName: 'voice-oc1',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
     stt.emit({ text: 'did you message me', isFinal: true, speechFinal: true });
@@ -1045,6 +1058,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       conversationId: 'voice:oc2',
       roomName: 'voice-oc2',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
     stt.emit({ text: 'hello', isFinal: true, speechFinal: true });
@@ -1074,6 +1088,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       conversationId: 'voice:oc3',
       roomName: 'voice-oc3',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
     stt.emit({ text: 'are you there', isFinal: true, speechFinal: true });
@@ -1102,6 +1117,7 @@ describe('VoiceRuntime outbound-context bridge (#1594)', () => {
       conversationId: 'voice:oc4',
       roomName: 'voice-oc4',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: false,
     });
     stt.emit({ text: 'did you message me', isFinal: true, speechFinal: true });
@@ -1132,6 +1148,7 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       conversationId: 'voice:g1',
       roomName: 'voice-g1',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: true,
     });
     await runtime.awaitIdle('g1');
@@ -1184,6 +1201,7 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       conversationId: 'voice:g2',
       roomName: 'voice-g2',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: true,
     });
     await runtime.awaitIdle('g2');
@@ -1219,6 +1237,7 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       conversationId: 'voice:g3',
       roomName: 'voice-g3',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: true,
     });
 
@@ -1261,6 +1280,7 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       conversationId: 'voice:g4',
       roomName: 'voice-g4',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: true,
     });
     await runtime.awaitIdle('g4');
@@ -1321,6 +1341,7 @@ describe('VoiceRuntime opening greeting (#1596)', () => {
       conversationId: 'voice:g5',
       roomName: 'voice-g5',
       agentToken: 'tok',
+      caller: principalCaller(),
       openingGreeting: true,
     });
     await runtime.awaitIdle('g5');

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -17,7 +17,13 @@
 // History: spoken-turn context reloads from working_memory (the same rows the
 // console chat history endpoint reads) each turn; the in-process session history
 // is only a fallback when the store is absent or the read fails (#1551).
-
+//
+// liveTurn scope (#1598 / #1126): voice stamps liveTurn once per *session* at
+// create time (a continuous call with one human), whereas every other channel
+// stamps it per inbound *turn*. The elevated skill gate therefore stays
+// satisfied for the call's full duration. This widening is deliberate — a
+// voice session is one live conversation, not a sequence of independent
+// messages — and must not be copied onto text channels.
 import type { EventBus } from '../../bus/bus.js';
 import { createInboundMessage, createVoiceSessionEnded } from '../../bus/events.js';
 import type { OutboundContextService } from '../../dispatch/outbound-context.js';
@@ -245,16 +251,14 @@ export function buildVoiceSystemPrompt(parts: {
   /** Pre-formatted "## Current Date & Time" block; omitted when null/empty. */
   timeContextBlock?: string | null;
   /**
-   * Resolved audience for the voice addendum. Defaults to principal so console
-   * calls and existing tests keep the historical "speaking to the principal" line.
+   * Resolved audience for the voice addendum. Required so a missing audience
+   * cannot silently default to principal framing (#1598).
    */
-  audience?: { liveTurn: boolean; displayName?: string | null };
+  audience: { liveTurn: boolean; displayName?: string | null };
 }): string {
   const sections: string[] = [];
   if (parts.identityBlock) sections.push(parts.identityBlock);
-  sections.push(
-    parts.audience ? buildVoiceSystemAddendum(parts.audience) : VOICE_SYSTEM_ADDENDUM,
-  );
+  sections.push(buildVoiceSystemAddendum(parts.audience));
   sections.push(VOICE_TOOL_RESULT_POLICY);
   // Channel-agnostic date-arithmetic rule — same module the coordinator composes
   // (ADR-038 / #1595). Always present: voice already pins date-resolve via

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -30,6 +30,8 @@ import type { WorkingMemory } from '../../memory/working-memory.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
 import { formatTimeContextBlock } from '../../time/time-context.js';
 import type { AudioTransport } from './audio-transport.js';
+import type { VoiceCallerContext } from './caller-context.js';
+import { VOICE_CONSOLE_SENDER_ID } from './caller-context.js';
 import {
   VOICE_GREETING_INSTRUCTION,
   VOICE_GREETING_USER_MESSAGE,
@@ -47,8 +49,6 @@ export {
 
 const DEFAULT_INBOUND_SAMPLE_RATE = 16000;
 const DEFAULT_PUBLISH_SAMPLE_RATE = 24000;
-/** Console chat and voice share the same synthetic principal sender id. */
-const DEFAULT_SENDER_ID = 'ceo-web-user';
 /**
  * How many messages (user + assistant) of in-process history to keep per session.
  * This is the FALLBACK context source only — spoken turns load history from
@@ -91,25 +91,93 @@ function isHardTtsFailure(err: unknown): boolean {
 }
 
 /**
- * Voice-mode system addendum. Keeps spoken replies short and free of markup that
- * makes no sense read aloud. Always part of the spoken-turn system prompt.
- *
- * Brain stance (#1551, revised by ADR-038): spoken turns get a curated subset
- * of the coordinator's context — office identity/persona block, specialist
- * roster + delegation guidance, shared channel-agnostic guardrails (starting
- * with date-resolve, #1595), the voice async off-ramp (#1614), and a fresh
- * date/time block — assembled by buildVoiceSystemPrompt(). They deliberately
- * do NOT get the coordinator's full YAML system prompt or KG/sender enrichment
- * (latency + text-channel content that makes no sense spoken). Active
- * outbound-context entries are included (#1594) so voice can acknowledge
- * recent proactive sends on other channels. See ADR-037 Consequences and
- * ADR-038.
+ * Default principal caller for tests / legacy startSession calls that omit
+ * `caller`. Mirrors resolveConsoleVoiceCaller with the synthetic fallback so
+ * liveTurn stays true and outbound-context injection remains enabled.
  */
-export const VOICE_SYSTEM_ADDENDUM =
-  'You are speaking to the principal in a live voice call. Reply in a natural, ' +
+function defaultPrincipalCaller(senderId: string): VoiceCallerContext {
+  const senderContext = {
+    resolved: true as const,
+    contactId: 'primary-user',
+    displayName: 'CEO',
+    role: 'ceo',
+    systemRole: 'principal' as const,
+    verified: true,
+    kgNodeId: null,
+    knowledgeSummary: '',
+    authorization: null,
+    contactConfidence: 1.0,
+    tier: 'principal' as const,
+    kind: 'principal' as const,
+  };
+  return {
+    contactId: senderContext.contactId,
+    displayName: senderContext.displayName,
+    systemRole: senderContext.systemRole,
+    tier: senderContext.tier,
+    liveTurn: true,
+    originator: {
+      contactId: senderContext.contactId,
+      systemRole: 'principal',
+      channel: 'voice',
+      initiatedAt: new Date().toISOString(),
+      tier: 'principal',
+    },
+    senderId,
+    senderContext,
+  };
+}
+
+/**
+ * Spoken-style guidance shared by every voice audience. The audience line
+ * ("You are speaking to …") is composed separately by buildVoiceAudienceLine()
+ * so a non-principal caller never inherits the principal framing (#1598).
+ */
+export const VOICE_SPOKEN_STYLE_ADDENDUM =
+  'Reply in a natural, ' +
   'conversational spoken style: 1-3 short sentences, no markdown, no bullet lists, ' +
   'no tables, no code blocks, and no emoji. Spell out anything that must be heard ' +
   'clearly. Keep it brief — the user can always ask for more.';
+
+/**
+ * Audience line for the spoken-turn system prompt. Principal framing is only
+ * emitted when liveTurn is true — never inferred from channel alone (#1598).
+ */
+export function buildVoiceAudienceLine(audience: {
+  liveTurn: boolean;
+  displayName?: string | null;
+}): string {
+  if (audience.liveTurn) {
+    return 'You are speaking to the principal in a live voice call.';
+  }
+  const name = audience.displayName?.trim();
+  if (name) {
+    return (
+      `You are speaking to ${name} in a live voice call. They are not the principal — ` +
+      'do not treat them as having principal authority.'
+    );
+  }
+  return (
+    'You are speaking to a non-principal caller in a live voice call. ' +
+    'Do not treat them as having principal authority.'
+  );
+}
+
+/**
+ * Compose the voice system addendum (audience + spoken style) for a resolved caller.
+ */
+export function buildVoiceSystemAddendum(audience: {
+  liveTurn: boolean;
+  displayName?: string | null;
+}): string {
+  return `${buildVoiceAudienceLine(audience)} ${VOICE_SPOKEN_STYLE_ADDENDUM}`;
+}
+
+/**
+ * Default principal-audience addendum. Kept as a constant so existing tests and
+ * the slim-prompt path stay behaviorally identical for console (principal) calls.
+ */
+export const VOICE_SYSTEM_ADDENDUM = buildVoiceSystemAddendum({ liveTurn: true });
 
 /**
  * Honest-negative policy for spoken tool results. A failed or errored check must
@@ -150,6 +218,17 @@ export const VOICE_DELEGATION_GUIDANCE =
  *
  * Shared guardrails (ADR-038) are composed from `src/agents/prompts/` — do not
  * copy-paste coordinator YAML lines here.
+ *
+ * Brain stance (#1551, revised by ADR-038): spoken turns get a curated subset
+ * of the coordinator's context — office identity/persona block, specialist
+ * roster + delegation guidance, shared channel-agnostic guardrails (starting
+ * with date-resolve, #1595), the voice async off-ramp (#1614), and a fresh
+ * date/time block. They deliberately do NOT get the coordinator's full YAML
+ * system prompt or KG/sender enrichment (latency + text-channel content that
+ * makes no sense spoken). Active outbound-context entries are included for
+ * principal (liveTurn) callers only (#1594 / #1598) so voice can acknowledge
+ * recent proactive sends on other channels without leaking them to a
+ * non-principal audience. See ADR-037 Consequences and ADR-038.
  */
 export function buildVoiceSystemPrompt(parts: {
   /** Compiled office identity/persona block; omitted when null/empty. */
@@ -160,14 +239,22 @@ export function buildVoiceSystemPrompt(parts: {
    * Pre-formatted [ACTIVE OUTBOUND CONTEXT] block from
    * OutboundContextService.formatInjectionBlock (cross-channel proactive sends).
    * Omitted when null/empty — same bridge text channels get via the dispatcher (#1594).
+   * Callers must already have gated this on liveTurn (#1598).
    */
   outboundContextBlock?: string | null;
   /** Pre-formatted "## Current Date & Time" block; omitted when null/empty. */
   timeContextBlock?: string | null;
+  /**
+   * Resolved audience for the voice addendum. Defaults to principal so console
+   * calls and existing tests keep the historical "speaking to the principal" line.
+   */
+  audience?: { liveTurn: boolean; displayName?: string | null };
 }): string {
   const sections: string[] = [];
   if (parts.identityBlock) sections.push(parts.identityBlock);
-  sections.push(VOICE_SYSTEM_ADDENDUM);
+  sections.push(
+    parts.audience ? buildVoiceSystemAddendum(parts.audience) : VOICE_SYSTEM_ADDENDUM,
+  );
   sections.push(VOICE_TOOL_RESULT_POLICY);
   // Channel-agnostic date-arithmetic rule — same module the coordinator composes
   // (ADR-038 / #1595). Always present: voice already pins date-resolve via
@@ -208,7 +295,11 @@ export interface VoiceRuntimeConfig {
   createTransport: (opts: { roomName: string; token: string; livekitUrl: string }) => AudioTransport;
   /** Optional TTS voice id. */
   voiceId?: string;
-  /** Synthetic sender id for inbound.message (defaults to the console principal id). */
+  /**
+   * Fallback synthetic sender id for inbound.message when a session starts
+   * without an explicit caller (tests). Defaults to the console principal id.
+   * Production sessions always pass caller on startSession (#1598).
+   */
   senderId?: string;
   /**
    * Optional working-memory store so user + assistant transcripts appear in
@@ -259,10 +350,8 @@ export interface VoiceRuntimeConfig {
    * VoiceRuntime must read getActive() itself (#1594). Optional: absent → no
    * injection (tests / pool-less boots).
    *
-   * TODO(#1599 / E-series non-principal callers): voice is principal-only
-   * today, so injecting "messages you've sent" is safe. Gate this to principal
-   * calls before any non-principal voice participant is admitted, or it
-   * becomes a cross-channel audience leak.
+   * Gated on the session caller's liveTurn (#1598): non-principal callers must
+   * never hear "messages you've sent" (cross-channel audience leak).
    */
   outboundContextService?: OutboundContextService;
 }
@@ -299,6 +388,11 @@ interface StartVoiceSessionParams {
   /** Agent participant JWT (identity 'curia-agent'). */
   agentToken: string;
   /**
+   * Resolved caller identity for this session (#1598). When omitted (tests),
+   * the runtime assumes a principal console caller so existing behaviour holds.
+   */
+  caller?: VoiceCallerContext;
+  /**
    * When true (default), run one LLM greeting turn after the transport connects
    * so Curia opens the call (#1596). Per-session — not a runtime-wide flag — so
    * a future Curia-initiated outbound path can pass false without affecting
@@ -311,6 +405,8 @@ interface ActiveSession {
   sessionId: string;
   conversationId: string;
   roomName: string;
+  /** Per-session resolved caller — drives prompt audience, senderId, liveTurn gates. */
+  caller: VoiceCallerContext;
   transport: AudioTransport;
   stt: SttSession;
   publishSampleRate: number;
@@ -400,6 +496,7 @@ export class VoiceRuntime {
         sessionId: params.sessionId,
         conversationId: params.conversationId,
         roomName: params.roomName,
+        caller: params.caller ?? defaultPrincipalCaller(this.config.senderId ?? VOICE_CONSOLE_SENDER_ID),
         transport,
         stt,
         publishSampleRate,
@@ -624,7 +721,7 @@ export class VoiceRuntime {
         },
       });
 
-      const systemPrompt = await this.buildTurnSystemPrompt();
+      const systemPrompt = await this.buildTurnSystemPrompt(session);
       if (session.ending || controller.signal.aborted) return;
 
       const messages = opts.assembleMessages({ systemPrompt, priorHistory });
@@ -829,7 +926,7 @@ export class VoiceRuntime {
    * never abort the spoken turn) and assemble the per-turn system prompt.
    * Mirrors AgentRuntime.processTask's guard-and-omit pattern for the same blocks.
    */
-  private async buildTurnSystemPrompt(): Promise<string> {
+  private async buildTurnSystemPrompt(session: ActiveSession): Promise<string> {
     let identityBlock: string | null = null;
     if (this.toolBridge?.identityBlock) {
       try {
@@ -852,8 +949,11 @@ export class VoiceRuntime {
     // text channels (#1594). Empty result → null → prompt unchanged. Failure
     // and deadline expiry are best-effort: log and continue without the bridge
     // (parity with dispatcher failure mode + loadTurnHistory latency contract).
+    //
+    // Gate on liveTurn (#1598): "messages you've sent" is principal-audience
+    // content — never inject it for a non-principal voice caller.
     let outboundContextBlock: string | null = null;
-    if (this.config.outboundContextService) {
+    if (this.config.outboundContextService && session.caller.liveTurn) {
       const timeoutMs = this.config.historyReadTimeoutMs ?? DEFAULT_HISTORY_READ_TIMEOUT_MS;
       const read = this.config.outboundContextService.getActive();
       // A read that loses the deadline race settles later with no awaiter —
@@ -918,6 +1018,10 @@ export class VoiceRuntime {
       specialistRoster,
       outboundContextBlock,
       timeContextBlock,
+      audience: {
+        liveTurn: session.caller.liveTurn,
+        displayName: session.caller.displayName,
+      },
     });
   }
 
@@ -988,7 +1092,7 @@ export class VoiceRuntime {
         createInboundMessage({
           conversationId: session.conversationId,
           channelId: 'voice',
-          senderId: this.config.senderId ?? DEFAULT_SENDER_ID,
+          senderId: session.caller.senderId,
           content: sanitizeOutput(utterance),
         }),
       );

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -37,7 +37,6 @@ import { sanitizeOutput } from '../../skills/sanitize.js';
 import { formatTimeContextBlock } from '../../time/time-context.js';
 import type { AudioTransport } from './audio-transport.js';
 import type { VoiceCallerContext } from './caller-context.js';
-import { VOICE_CONSOLE_SENDER_ID } from './caller-context.js';
 import {
   VOICE_GREETING_INSTRUCTION,
   VOICE_GREETING_USER_MESSAGE,
@@ -94,44 +93,6 @@ const HARD_TTS_STATUS_CODES = new Set([401, 403, 404]);
 /** Auth / missing-voice hard failures should not wait for the soft threshold. */
 function isHardTtsFailure(err: unknown): boolean {
   return err instanceof TtsHttpError && HARD_TTS_STATUS_CODES.has(err.statusCode);
-}
-
-/**
- * Default principal caller for tests / legacy startSession calls that omit
- * `caller`. Mirrors resolveConsoleVoiceCaller with the synthetic fallback so
- * liveTurn stays true and outbound-context injection remains enabled.
- */
-function defaultPrincipalCaller(senderId: string): VoiceCallerContext {
-  const senderContext = {
-    resolved: true as const,
-    contactId: 'primary-user',
-    displayName: 'CEO',
-    role: 'ceo',
-    systemRole: 'principal' as const,
-    verified: true,
-    kgNodeId: null,
-    knowledgeSummary: '',
-    authorization: null,
-    contactConfidence: 1.0,
-    tier: 'principal' as const,
-    kind: 'principal' as const,
-  };
-  return {
-    contactId: senderContext.contactId,
-    displayName: senderContext.displayName,
-    systemRole: senderContext.systemRole,
-    tier: senderContext.tier,
-    liveTurn: true,
-    originator: {
-      contactId: senderContext.contactId,
-      systemRole: 'principal',
-      channel: 'voice',
-      initiatedAt: new Date().toISOString(),
-      tier: 'principal',
-    },
-    senderId,
-    senderContext,
-  };
 }
 
 /**
@@ -304,12 +265,6 @@ export interface VoiceRuntimeConfig {
   /** Optional TTS voice id. */
   voiceId?: string;
   /**
-   * Fallback synthetic sender id for inbound.message when a session starts
-   * without an explicit caller (tests). Defaults to the console principal id.
-   * Production sessions always pass caller on startSession (#1598).
-   */
-  senderId?: string;
-  /**
    * Optional working-memory store so user + assistant transcripts appear in
    * console chat history (same path as web chat). Spoken egress stays on TTS —
    * this does not go through OutboundGateway (parity with web chat).
@@ -331,6 +286,8 @@ export interface VoiceRuntimeConfig {
     ctx: {
       conversationId: string;
       sessionId: string;
+      /** Resolved caller identity — required so the fallback path cannot drop authorization context. */
+      caller: VoiceCallerContext;
       turnDateResolveResults?: readonly import('../../agents/delegate-brief-date-validation.js').TurnDateResolveResult[];
     },
   ) => Promise<{ content: string; is_error?: boolean }>;
@@ -398,10 +355,11 @@ interface StartVoiceSessionParams {
   /** Agent participant JWT (identity 'curia-agent'). */
   agentToken: string;
   /**
-   * Resolved caller identity for this session (#1598). When omitted (tests),
-   * the runtime assumes a principal console caller so existing behaviour holds.
+   * Resolved caller identity for this session (#1598). Required — omitting it
+   * must not silently grant principal standing. Tests pass principalCaller() /
+   * partnerCaller() from test-fixtures.ts.
    */
-  caller?: VoiceCallerContext;
+  caller: VoiceCallerContext;
   /**
    * When true (default), run one LLM greeting turn after the transport connects
    * so Curia opens the call (#1596). Per-session — not a runtime-wide flag — so
@@ -472,12 +430,11 @@ export class VoiceRuntime {
       return;
     }
 
-    const resolvedCaller = params.caller ?? defaultPrincipalCaller(this.config.senderId ?? VOICE_CONSOLE_SENDER_ID);
     const transport = this.config.createTransport({
       roomName: params.roomName,
       token: params.agentToken,
       livekitUrl: this.config.livekitUrl,
-      callerIdentity: resolvedCaller.contactId,
+      callerIdentity: params.caller.contactId,
     }) as RateAwareTransport;
 
     const inboundSampleRate = transport.inboundSampleRate ?? DEFAULT_INBOUND_SAMPLE_RATE;
@@ -504,17 +461,11 @@ export class VoiceRuntime {
         },
       });
 
-      if (!params.caller) {
-        this.log.warn(
-          { sessionId: params.sessionId },
-          'startSession called without a resolved caller; defaulting to principal (test/legacy path only)',
-        );
-      }
       const session: ActiveSession = {
         sessionId: params.sessionId,
         conversationId: params.conversationId,
         roomName: params.roomName,
-        caller: resolvedCaller,
+        caller: params.caller,
         transport,
         stt,
         publishSampleRate,
@@ -772,6 +723,7 @@ export class VoiceRuntime {
               const result = await this.config.invokeTool!(call, {
                 conversationId: session.conversationId,
                 sessionId: session.sessionId,
+                caller: session.caller,
                 turnDateResolveResults: turnDateResolveTracker.snapshot(),
               });
               if (call.name === 'date-resolve') {

--- a/src/channels/voice/voice-runtime.ts
+++ b/src/channels/voice/voice-runtime.ts
@@ -291,8 +291,12 @@ export interface VoiceRuntimeConfig {
   llm: LLMProvider;
   model: string;
   livekitUrl: string;
-  /** Builds the per-session audio transport (LiveKitRoomSession in prod, fake in tests). */
-  createTransport: (opts: { roomName: string; token: string; livekitUrl: string }) => AudioTransport;
+  /**
+   * Builds the per-session audio transport (LiveKitRoomSession in prod, fake in tests).
+   * `callerIdentity` is the resolved contact id minted in the caller's LiveKit token (#1598);
+   * the transport uses it to detect caller disconnect (ParticipantDisconnected).
+   */
+  createTransport: (opts: { roomName: string; token: string; livekitUrl: string; callerIdentity: string }) => AudioTransport;
   /** Optional TTS voice id. */
   voiceId?: string;
   /**
@@ -369,6 +373,8 @@ export interface VoiceToolBridge {
     ctx: {
       conversationId: string;
       sessionId: string;
+      /** Resolved caller identity for this session — drives liveTurn/originator at the execution layer. */
+      caller: VoiceCallerContext;
       turnDateResolveResults?: readonly import('../../agents/delegate-brief-date-validation.js').TurnDateResolveResult[];
     },
   ) => Promise<{ content: string; is_error?: boolean }>;
@@ -462,10 +468,12 @@ export class VoiceRuntime {
       return;
     }
 
+    const resolvedCaller = params.caller ?? defaultPrincipalCaller(this.config.senderId ?? VOICE_CONSOLE_SENDER_ID);
     const transport = this.config.createTransport({
       roomName: params.roomName,
       token: params.agentToken,
       livekitUrl: this.config.livekitUrl,
+      callerIdentity: resolvedCaller.contactId,
     }) as RateAwareTransport;
 
     const inboundSampleRate = transport.inboundSampleRate ?? DEFAULT_INBOUND_SAMPLE_RATE;
@@ -492,11 +500,17 @@ export class VoiceRuntime {
         },
       });
 
+      if (!params.caller) {
+        this.log.warn(
+          { sessionId: params.sessionId },
+          'startSession called without a resolved caller; defaulting to principal (test/legacy path only)',
+        );
+      }
       const session: ActiveSession = {
         sessionId: params.sessionId,
         conversationId: params.conversationId,
         roomName: params.roomName,
-        caller: params.caller ?? defaultPrincipalCaller(this.config.senderId ?? VOICE_CONSOLE_SENDER_ID),
+        caller: resolvedCaller,
         transport,
         stt,
         publishSampleRate,
@@ -741,6 +755,7 @@ export class VoiceRuntime {
             const result = await this.toolBridge!.invokeTool(call, {
               conversationId: session.conversationId,
               sessionId: session.sessionId,
+              caller: session.caller,
               turnDateResolveResults: turnDateResolveTracker.snapshot(),
             });
             if (call.name === 'date-resolve') {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -7,7 +7,7 @@ import {
   summarizeAuthorizationDecision,
   formatAuthorizationSubjectSummary,
 } from '../contacts/authorization.js';
-import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy, TaskOriginator } from '../contacts/types.js';
+import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy } from '../contacts/types.js';
 import { isAutomatedKind } from '../contacts/types.js';
 import { JUDGMENT_ELEVATION_THRESHOLD } from '../contacts/confidence-scorer.js';
 import type { InboundScanner } from './inbound-scanner.js';
@@ -16,6 +16,7 @@ import type { DbPool } from '../db/connection.js';
 import { computeTrustScore, DEFAULT_TRUST_WEIGHTS } from './trust-scorer.js';
 import type { TrustScorerWeights } from './trust-scorer.js';
 import { parseEmailMetadata, sanitizeNylasMessageId, buildCcPreamble, buildThreadParticipantsBlock } from './email-metadata.js';
+import { stampOriginator } from './stamp-originator.js';
 import {
   CONTENT_BLOCK_MAX_RETRIES,
   buildContentBlockRewriteTask,
@@ -804,41 +805,14 @@ export class Dispatcher {
     // SECURITY: originator is the ONLY source of systemRole for downstream authorization.
     // Channel-supplied originator is stripped in mergeTaskMetadata.
     //
-    // Defence in depth (#1059): inbound messages are external by definition. When the sender
-    // could not be resolved to a contact — the channel adapter's first-contact creation was
-    // skipped (rate caps, a creation failure, a malformed From) or no resolver is wired — we
-    // still stamp an originator with tier='unknown'. The Dispatch layer must not assume the
-    // Channel layer always pre-creates the contact: a missing originator would make the
-    // execution layer's Gate C fail-open (skip) on a consequential action, whereas tier='unknown'
-    // routes it through normal tier enforcement (which escalates third-party-facing sends). No
-    // contact UUID exists, so the raw channel sender id is the contactId sentinel — consistent
-    // with the existing non-UUID originator.contactId values ('system', 'primary-user'); the
-    // skill layer already guards UUID-typed lookups against non-UUID caller ids.
-    const originator: TaskOriginator = senderContext?.resolved
-      ? {
-          contactId: senderContext.contactId,
-          systemRole: senderContext.systemRole ?? null,
-          channel: payload.channelId,
-          initiatedAt: new Date().toISOString(),
-          tier: senderContext.tier,
-        }
-      : {
-          contactId: payload.senderId,
-          systemRole: null,
-          channel: payload.channelId,
-          initiatedAt: new Date().toISOString(),
-          tier: 'unknown',
-        };
-    // The LIVE PRINCIPAL TURN signal (#1126) is `true` iff this inbound resolved to the principal.
-    // It is the sole satisfier of the `elevated` skill gate. It is stamped as a DISTINCT field on
-    // the agent.task payload (below), NOT inside the metadata bag — so no skill that forwards
-    // `metadata` to a persisted row can ever sweep it into wakeable state. It is structurally
-    // absent from every wake, scheduler fire, and persisted task (those construct their own
-    // agent.task without it); `delegate` forwards it across a synchronous delegation only. A woken
-    // principal-LINEAGE task therefore carries the principal originator (for the autonomy
-    // principal-bypass ladder) but NOT this signal — which is what closes the self-approval hole.
+    // Derivation lives in stampOriginator() — shared with the voice session-create path so
+    // the elevated-gate signal has one source of truth (#1598 / #1126 / #1059).
+    const { originator, liveTurn } = stampOriginator({
+      senderContext,
+      channel: payload.channelId,
+      senderId: payload.senderId,
+    });
     const originatorMeta: Record<string, unknown> = { originator };
-    const liveTurn = originator.systemRole === 'principal';
     if (!senderContext?.resolved) {
       this.logger.warn(
         { channelId: payload.channelId, senderId: payload.senderId },

--- a/src/dispatch/stamp-originator.test.ts
+++ b/src/dispatch/stamp-originator.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { InboundSenderContext, SenderContext } from '../contacts/types.js';
+import { stampOriginator } from './stamp-originator.js';
+
+const FIXED_AT = '2026-07-29T12:00:00.000Z';
+
+function principalSender(overrides: Partial<SenderContext> = {}): SenderContext {
+  return {
+    resolved: true,
+    contactId: '11111111-1111-1111-1111-111111111111',
+    displayName: 'CEO',
+    role: 'ceo',
+    systemRole: 'principal',
+    verified: true,
+    kgNodeId: null,
+    knowledgeSummary: '',
+    authorization: null,
+    contactConfidence: 1.0,
+    tier: 'principal',
+    kind: 'principal',
+    ...overrides,
+  };
+}
+
+function knownSender(overrides: Partial<SenderContext> = {}): SenderContext {
+  return {
+    resolved: true,
+    contactId: '22222222-2222-2222-2222-222222222222',
+    displayName: 'Alex Partner',
+    role: 'partner',
+    systemRole: null,
+    verified: true,
+    kgNodeId: null,
+    knowledgeSummary: '',
+    authorization: null,
+    contactConfidence: 0.8,
+    tier: 'trusted',
+    kind: 'person',
+    ...overrides,
+  };
+}
+
+describe('stampOriginator', () => {
+  it('stamps principal originator with liveTurn=true', () => {
+    const { originator, liveTurn } = stampOriginator({
+      senderContext: principalSender(),
+      channel: 'voice',
+      senderId: 'ceo-web-user',
+      initiatedAt: FIXED_AT,
+    });
+
+    expect(liveTurn).toBe(true);
+    expect(originator).toEqual({
+      contactId: '11111111-1111-1111-1111-111111111111',
+      systemRole: 'principal',
+      channel: 'voice',
+      initiatedAt: FIXED_AT,
+      tier: 'principal',
+    });
+  });
+
+  it('stamps a non-principal caller with their tier/trust and liveTurn=false', () => {
+    const { originator, liveTurn } = stampOriginator({
+      senderContext: knownSender({ tier: 'known' }),
+      channel: 'voice',
+      senderId: '+15551234567',
+      initiatedAt: FIXED_AT,
+    });
+
+    expect(liveTurn).toBe(false);
+    expect(originator).toEqual({
+      contactId: '22222222-2222-2222-2222-222222222222',
+      systemRole: null,
+      channel: 'voice',
+      initiatedAt: FIXED_AT,
+      tier: 'known',
+    });
+  });
+
+  it('fail-closes unresolved senders with tier=unknown and liveTurn=false', () => {
+    const senderContext: InboundSenderContext = {
+      resolved: false,
+      channel: 'voice',
+      senderId: 'unknown-token',
+    };
+    const { originator, liveTurn } = stampOriginator({
+      senderContext,
+      channel: 'voice',
+      senderId: 'unknown-token',
+      initiatedAt: FIXED_AT,
+    });
+
+    expect(liveTurn).toBe(false);
+    expect(originator).toEqual({
+      contactId: 'unknown-token',
+      systemRole: null,
+      channel: 'voice',
+      initiatedAt: FIXED_AT,
+      tier: 'unknown',
+    });
+  });
+
+  it('treats a missing senderContext like unresolved (#1059)', () => {
+    const { originator, liveTurn } = stampOriginator({
+      senderContext: undefined,
+      channel: 'email',
+      senderId: 'stranger@example.com',
+      initiatedAt: FIXED_AT,
+    });
+
+    expect(liveTurn).toBe(false);
+    expect(originator.tier).toBe('unknown');
+    expect(originator.contactId).toBe('stranger@example.com');
+    expect(originator.systemRole).toBeNull();
+  });
+
+  it('does not treat agent/system roles as a live principal turn', () => {
+    const { liveTurn: agentTurn } = stampOriginator({
+      senderContext: knownSender({ systemRole: 'agent', tier: 'trusted' }),
+      channel: 'voice',
+      senderId: 'agent-1',
+    });
+    const { liveTurn: systemTurn } = stampOriginator({
+      senderContext: knownSender({ systemRole: 'system', tier: 'trusted' }),
+      channel: 'voice',
+      senderId: 'system',
+    });
+    expect(agentTurn).toBe(false);
+    expect(systemTurn).toBe(false);
+  });
+});

--- a/src/dispatch/stamp-originator.ts
+++ b/src/dispatch/stamp-originator.ts
@@ -1,0 +1,64 @@
+// stamp-originator.ts — shared originator / liveTurn derivation for inbound work.
+//
+// The dispatcher and the voice session-create path both need the same security-critical
+// mapping from a resolved (or unresolved) sender context to TaskOriginator + the
+// live-principal-turn signal. Keeping that derivation in one pure helper means the
+// elevated skill gate has a single source of truth (#1598 / #1126).
+
+import type { InboundSenderContext, TaskOriginator } from '../contacts/types.js';
+
+export interface StampOriginatorInput {
+  /** Resolved/unresolved sender context from ContactResolver (or a console-built equivalent). */
+  senderContext: InboundSenderContext | undefined | null;
+  /** Channel the inbound arrived on (e.g. 'email', 'voice'). */
+  channel: string;
+  /**
+   * Raw channel sender id. Used as the originator.contactId sentinel when the sender
+   * could not be resolved — consistent with non-UUID values like 'system' / 'primary-user'.
+   */
+  senderId: string;
+  /** Optional fixed timestamp for tests; defaults to now. */
+  initiatedAt?: string;
+}
+
+export interface StampOriginatorResult {
+  originator: TaskOriginator;
+  /**
+   * Live-principal-turn signal (#1126). True iff the originator resolved to the principal.
+   * Sole satisfier of the `elevated` skill gate when paired with principal lineage.
+   */
+  liveTurn: boolean;
+}
+
+/**
+ * Stamp TaskOriginator + the live-principal-turn signal from a sender context.
+ *
+ * Defence in depth (#1059): when the sender could not be resolved, still stamp an
+ * originator with tier='unknown' so Gate C enforces tier policy instead of fail-open
+ * skipping a missing originator.
+ */
+export function stampOriginator(input: StampOriginatorInput): StampOriginatorResult {
+  const initiatedAt = input.initiatedAt ?? new Date().toISOString();
+  const originator: TaskOriginator = input.senderContext?.resolved
+    ? {
+        contactId: input.senderContext.contactId,
+        systemRole: input.senderContext.systemRole ?? null,
+        channel: input.channel,
+        initiatedAt,
+        tier: input.senderContext.tier,
+      }
+    : {
+        contactId: input.senderId,
+        systemRole: null,
+        channel: input.channel,
+        initiatedAt,
+        tier: 'unknown',
+      };
+
+  // The LIVE PRINCIPAL TURN signal (#1126) is `true` iff this inbound resolved to the principal.
+  // It is the sole satisfier of the `elevated` skill gate. Callers stamp it as a DISTINCT field
+  // on the agent.task payload (dispatcher) or session caller context (voice) — never inside a
+  // metadata bag that could be persisted into wakeable state.
+  const liveTurn = originator.systemRole === 'principal';
+  return { originator, liveTurn };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1915,8 +1915,8 @@ async function main(): Promise<void> {
         llm: voiceLlmProvider,
         model: voiceModel,
         livekitUrl: voiceLivekitUrl,
-        createTransport: ({ token, livekitUrl }) =>
-          new LiveKitRoomSession({ url: livekitUrl, token, logger }),
+        createTransport: ({ token, livekitUrl, callerIdentity }) =>
+          new LiveKitRoomSession({ url: livekitUrl, token, callerIdentity, logger }),
         workingMemory: memory,
         maxUtteranceBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
         // Same per-turn date/timezone grounding the coordinator gets — without it
@@ -2614,28 +2614,24 @@ async function main(): Promise<void> {
         specialistRoster: () =>
           agentRegistry.listSpecialists().length > 0 ? agentRegistry.specialistSummary() : null,
         invokeTool: async (call, ctx) => {
-          const caller = {
-            contactId: principalContact?.id ?? 'ceo-web-user',
-            role: 'ceo',
+          // Use the per-session resolved caller from VoiceCallerContext (#1598).
+          // liveTurn and originator come from the shared stampOriginator derivation —
+          // one source of truth for the elevated gate instead of the prior literals.
+          const { caller: sessionCaller } = ctx;
+          const executionCaller = {
+            contactId: sessionCaller.originator.contactId,
+            role: sessionCaller.originator.systemRole ?? 'unknown',
             channel: 'voice',
           };
-          const result = await executionLayer.invoke(call.name, call.input, caller, {
+          const result = await executionLayer.invoke(call.name, call.input, executionCaller, {
             agentId: 'coordinator',
             channelId: 'voice',
             conversationId: ctx.conversationId,
             taskEventId: ctx.sessionId,
-            liveTurn: true,
+            liveTurn: sessionCaller.liveTurn,
             turnDateResolveResults: ctx.turnDateResolveResults,
-            // Stamp a proper TaskOriginator so elevated skills / Gate C see a
-            // live principal turn (same shape the dispatcher uses for web chat).
             taskMetadata: {
-              originator: {
-                contactId: principalContact?.id ?? 'ceo-web-user',
-                systemRole: 'principal',
-                channel: 'voice',
-                initiatedAt: new Date().toISOString(),
-                tier: principalContact?.tier ?? 'known',
-              },
+              originator: sessionCaller.originator,
               voiceSessionId: ctx.sessionId,
             },
           });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2618,9 +2618,13 @@ async function main(): Promise<void> {
           // liveTurn and originator come from the shared stampOriginator derivation —
           // one source of truth for the elevated gate instead of the prior literals.
           const { caller: sessionCaller } = ctx;
+          // CallerContext.role is a job role ('ceo', 'cfo', …), not systemRole.
+          // Prefer the resolved senderContext.role when available.
           const executionCaller = {
             contactId: sessionCaller.originator.contactId,
-            role: sessionCaller.originator.systemRole ?? 'unknown',
+            role: sessionCaller.senderContext.resolved
+              ? sessionCaller.senderContext.role
+              : null,
             channel: 'voice',
           };
           const result = await executionLayer.invoke(call.name, call.input, executionCaller, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1598.

De-hardcodes voice caller identity so the console remains principal-proven, while a future transport (#1602) can supply a real caller token without inheriting `systemRole: 'principal'` / `liveTurn` elevated standing.

Applies and lands the ready-to-apply work archived in [curia-deploy#194](https://github.com/josephfung/curia-deploy/pull/194) (local commit `9cfd99e4` from a prior curia-deploy-bound agent that could not push here).

### Changes

- Extract `stampOriginator()` — single source of truth for originator + `liveTurn`, used by the dispatcher and voice session-create
- Console `POST /api/voice/sessions` resolves the principal explicitly (bootstrap-secret proven), then stamps via the helper — does **not** add `'voice'` to ContactResolver's short-circuit list
- `resolveVoiceCallerFromToken` seam for #1602: ContactResolver + `unknown_sender: ignore` fail-closed (unit-tested; no new HTTP entry point)
- LiveKit participant identity = resolved contact id (not literal `'principal'`)
- Audience-aware `buildVoiceSystemPrompt()` / `buildVoiceAudienceLine()`
- Cross-channel outbound-context injection gated on `liveTurn`

### Acceptance

- [x] Shared `stampOriginator` used by dispatcher + voice
- [x] Non-principal token → that contact's tier/trust, `liveTurn = false` (unit-tested)
- [x] Unresolved token → `unknown_sender: ignore` fail-closed
- [x] Audience-aware voice prompt (no hardcoded principal-only line as the only path)
- [x] Outbound-context injection gated on `liveTurn`
- [x] Principal console calls behaviorally unchanged
- [x] No new non-principal voice entry point

### Verification

- `pnpm run typecheck` — pass
- Focused vitest (stamp-originator, caller-context, session-bridge, voice-adapter, voice-runtime, dispatcher) — **119/119 pass**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fae9b-e117-7a34-b42b-48ff1d14b67a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fae9b-e117-7a34-b42b-48ff1d14b67a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

