### PR TITLE
fix: dedup exclusion fails for multi-person clusters; agent still closes task (#1623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **MCP `callTool`** — a timed-out skill now aborts the underlying MCP request instead of stranding it. (#1666)
 - **LLM provider streaming** — every provider releases its SDK stream on abort/error/early-exit, preventing a heap leak. (#1648, #1651)
 - **`classifyError`** — `AbortSignal.timeout` / abort DOMExceptions map to `TIMEOUT`. (#1597)
+- **`contact-dedup-exclude`** — multi-valued exclusions coexist; agent leaves task open on write failure. (#1623)
 - **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)
 - **Coordinator** — ambient bullpen mentions no longer bleed into scheduler jobs and leak to the principal. (#1609)
 - **Voice** — injects active outbound-context so spoken turns see recent cross-channel sends. (#1594)

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -1,5 +1,5 @@
 name: contacts
-version: "0.12.0"
+version: "0.12.1"
 role: specialist
 description: >
   Contact domain specialist — briefings, CRUD, deduplication, relationship management,
@@ -158,7 +158,8 @@ system_prompt: |
   5. On confirmation: call contact-merge with dry_run: false.
   6. If the CEO explicitly says they are not the same person ("not a duplicate",
      "different people", "don't merge them"): call contact-dedup-exclude with both
-     contact IDs. This prevents the pair from being proposed again.
+     contact IDs. If it returns `success: false`, tell the CEO the exclusion could
+     not be saved and will need a retry — do not silently proceed.
   7. Never auto-merge without CEO confirmation.
 
   ### When you have a dedup review task
@@ -173,8 +174,10 @@ system_prompt: |
      succeeds, close out the task (see "Closing a dedup task" below).
   6. **Pair excluded.** If the CEO explicitly says they are not the same person
      ("not a duplicate", "different people", "don't merge them"): call
-     contact-dedup-exclude with both contact IDs (this prevents the pair from
-     resurfacing on future sweeps), then close out the task.
+     contact-dedup-exclude with both contact IDs. If it returns `success: true`,
+     close out the task (see "Closing a dedup task" below). If it returns
+     `success: false`, do NOT close the task — leave it open and tell the CEO
+     that the "not a duplicate" decision could not be saved and will need a retry.
   7. **Deferred.** If the CEO defers or wants to decide later: do NOT call
      contact-dedup-exclude (the pair may resurface on a future sweep), but still
      close out the task — a deferral is a terminal outcome for this review.

--- a/docs/specs/01-memory-system.md
+++ b/docs/specs/01-memory-system.md
@@ -121,6 +121,7 @@ Before creating a new fact node, check for existing nodes with:
 ### Contradiction Detection
 Before writing a fact that updates an entity attribute (e.g., "the CEO lives in Toronto" when "the CEO lives in Kitchener" exists):
 - Check for existing facts on the same entity with the same attribute type
+- **Multi-valued attributes** (e.g. `dedup_exclusion`) are exempt: same attribute with different `value` properties are independent facts, not contradictions. Same attribute + same value still deduplicates normally.
 - If contradicting fact exists with higher confidence: reject the write, log the conflict
 - If contradicting fact exists with lower confidence: update the existing fact, preserve the old value in `properties.previous_values` for audit
 - If contradicting fact exists with equal confidence: flag for human review via the alert channel

--- a/docs/specs/01-memory-system.md
+++ b/docs/specs/01-memory-system.md
@@ -121,7 +121,7 @@ Before creating a new fact node, check for existing nodes with:
 ### Contradiction Detection
 Before writing a fact that updates an entity attribute (e.g., "the CEO lives in Toronto" when "the CEO lives in Kitchener" exists):
 - Check for existing facts on the same entity with the same attribute type
-- **Multi-valued attributes** (e.g. `dedup_exclusion`) are exempt: same attribute with different `value` properties are independent facts, not contradictions. Same attribute + same value still deduplicates normally.
+- **Multi-valued facts** (`StoreFactOptions.multiValued: true`, e.g. `dedup_exclusion`): same attribute with different `value` properties are independent facts, not contradictions. Same attribute + same value still deduplicates normally. Callers persist `properties.multi_valued: true` so subsequent unrelated writes cannot silently merge into them.
 - If contradicting fact exists with higher confidence: reject the write, log the conflict
 - If contradicting fact exists with lower confidence: update the existing fact, preserve the old value in `properties.previous_values` for audit
 - If contradicting fact exists with equal confidence: flag for human review via the alert channel

--- a/skills/contacts/tools/contact-dedup-exclude/handler.ts
+++ b/skills/contacts/tools/contact-dedup-exclude/handler.ts
@@ -30,7 +30,7 @@ export class ContactDedupExcludeHandler implements ToolHandler {
     let contactBExcluded = false;
 
     try {
-      let [contactA, contactB] = await Promise.all([
+      const [contactA, contactB] = await Promise.all([
         ctx.contactService.getContact(contactAId),
         ctx.contactService.getContact(contactBId),
       ]);
@@ -42,52 +42,58 @@ export class ContactDedupExcludeHandler implements ToolHandler {
         return { success: false, error: `Contact not found: ${contactBId}` };
       }
 
-      // Ensure both contacts have KG nodes so exclusion facts can be attached.
-      // Contacts created by auto-extraction may not have nodes until enriched;
-      // we backfill them here rather than failing (#1623 bug 3).
-      if (contactA.kgNodeId === null) {
-        ctx.log.info({ contactAId }, 'contact-dedup-exclude: contact A has no KG node — creating one');
-        contactA = await ctx.contactService.ensureKgNode(contactAId);
-      }
-      if (contactB.kgNodeId === null) {
-        ctx.log.info({ contactBId }, 'contact-dedup-exclude: contact B has no KG node — creating one');
-        contactB = await ctx.contactService.ensureKgNode(contactBId);
-      }
-
       const source = ctx.memoryWriteSource ?? 'contacts-dedup';
       const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
 
       // Write on A's node naming B. Each side is independent: if A's write fails (e.g.
       // KG conflict), we still attempt B — hasExclusion is bidirectional so a single
       // side is enough to prevent the pair from resurfacing.
-      try {
-        await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId!, storeFact, source });
-        contactAExcluded = true;
-      } catch (writeErrA) {
-        ctx.log.error(
-          { writeErrA, contactAId, contactBId },
-          'contact-dedup-exclude: failed to write exclusion on A — still attempting B',
-        );
+      //
+      // Note: kg_node_id = NULL is the designed outcome of same-display-name collisions
+      // (createContact retries without a KG link when idx_contacts_kg_node_unique fires).
+      // Do not invent a node here — that recreates the collision (#1623 review).
+      if (contactA.kgNodeId !== null) {
+        try {
+          await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
+          contactAExcluded = true;
+        } catch (writeErrA) {
+          ctx.log.error(
+            { writeErrA, contactAId, contactBId },
+            'contact-dedup-exclude: failed to write exclusion on A — still attempting B',
+          );
+        }
+      } else {
+        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact A has no KG node — exclusion written on B only');
       }
 
       // Write on B's node naming A — bidirectional so hasExclusion finds it regardless of
       // which contact's node is checked first
-      try {
-        await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId!, storeFact, source });
-        contactBExcluded = true;
-      } catch (writeErrB) {
-        ctx.log.error(
-          { writeErrB, contactAId, contactBId, contactAExcluded },
-          'contact-dedup-exclude: failed to write exclusion on B',
-        );
+      if (contactB.kgNodeId !== null) {
+        try {
+          await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
+          contactBExcluded = true;
+        } catch (writeErrB) {
+          ctx.log.error(
+            { writeErrB, contactAId, contactBId, contactAExcluded },
+            'contact-dedup-exclude: failed to write exclusion on B',
+          );
+        }
+      } else {
+        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact B has no KG node — exclusion written on A only');
       }
 
-      // Both writes failed — nothing was stored.
+      // Both sides failed (no KG nodes, or both writes errored) — nothing was stored.
       if (!contactAExcluded && !contactBExcluded) {
-        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: exclusion could not be written on either contact');
+        const bothMissingNodes = contactA.kgNodeId === null && contactB.kgNodeId === null;
+        ctx.log.warn(
+          { contactAId, contactBId, contactAHasNode: contactA.kgNodeId !== null, contactBHasNode: contactB.kgNodeId !== null },
+          'contact-dedup-exclude: exclusion could not be written on either contact',
+        );
         return {
           success: false,
-          error: 'Could not write dedup exclusion on either contact — both KG writes failed (conflict or store error). Check logs for details.',
+          error: bothMissingNodes
+            ? 'Could not write dedup exclusion — both contacts have no KG node (common for same-name collisions). Exclusion cannot be stored until at least one contact has a linked KG node.'
+            : 'Could not write dedup exclusion on either contact — both KG writes failed (conflict or store error). Check logs for details.',
         };
       }
 

--- a/skills/contacts/tools/contact-dedup-exclude/handler.ts
+++ b/skills/contacts/tools/contact-dedup-exclude/handler.ts
@@ -93,7 +93,7 @@ export class ContactDedupExcludeHandler implements ToolHandler {
           success: false,
           error: bothMissingNodes
             ? 'Could not write dedup exclusion — both contacts have no KG node (common for same-name collisions). Exclusion cannot be stored until at least one contact has a linked KG node.'
-            : 'Could not write dedup exclusion on either contact — both KG writes failed (conflict or store error). Check logs for details.',
+            : 'Could not write dedup exclusion on either contact — no eligible KG write succeeded (missing KG node, conflict, or store error). Check logs for details.',
         };
       }
 

--- a/skills/contacts/tools/contact-dedup-exclude/handler.ts
+++ b/skills/contacts/tools/contact-dedup-exclude/handler.ts
@@ -30,7 +30,7 @@ export class ContactDedupExcludeHandler implements ToolHandler {
     let contactBExcluded = false;
 
     try {
-      const [contactA, contactB] = await Promise.all([
+      let [contactA, contactB] = await Promise.all([
         ctx.contactService.getContact(contactAId),
         ctx.contactService.getContact(contactBId),
       ]);
@@ -42,50 +42,52 @@ export class ContactDedupExcludeHandler implements ToolHandler {
         return { success: false, error: `Contact not found: ${contactBId}` };
       }
 
+      // Ensure both contacts have KG nodes so exclusion facts can be attached.
+      // Contacts created by auto-extraction may not have nodes until enriched;
+      // we backfill them here rather than failing (#1623 bug 3).
+      if (contactA.kgNodeId === null) {
+        ctx.log.info({ contactAId }, 'contact-dedup-exclude: contact A has no KG node — creating one');
+        contactA = await ctx.contactService.ensureKgNode(contactAId);
+      }
+      if (contactB.kgNodeId === null) {
+        ctx.log.info({ contactBId }, 'contact-dedup-exclude: contact B has no KG node — creating one');
+        contactB = await ctx.contactService.ensureKgNode(contactBId);
+      }
+
       const source = ctx.memoryWriteSource ?? 'contacts-dedup';
       const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
 
       // Write on A's node naming B. Each side is independent: if A's write fails (e.g.
       // KG conflict), we still attempt B — hasExclusion is bidirectional so a single
       // side is enough to prevent the pair from resurfacing.
-      if (contactA.kgNodeId !== null) {
-        try {
-          await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
-          contactAExcluded = true;
-        } catch (writeErrA) {
-          ctx.log.error(
-            { writeErrA, contactAId, contactBId },
-            'contact-dedup-exclude: failed to write exclusion on A — still attempting B',
-          );
-        }
-      } else {
-        // A has no KG node — exclusion written on B only (best-effort); if B's node is
-        // later lost the exclusion may not be checkable. Logged so operators can audit.
-        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact A has no KG node — exclusion written on B only');
+      try {
+        await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId!, storeFact, source });
+        contactAExcluded = true;
+      } catch (writeErrA) {
+        ctx.log.error(
+          { writeErrA, contactAId, contactBId },
+          'contact-dedup-exclude: failed to write exclusion on A — still attempting B',
+        );
       }
 
       // Write on B's node naming A — bidirectional so hasExclusion finds it regardless of
       // which contact's node is checked first
-      if (contactB.kgNodeId !== null) {
-        try {
-          await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
-          contactBExcluded = true;
-        } catch (writeErrB) {
-          ctx.log.error(
-            { writeErrB, contactAId, contactBId, contactAExcluded },
-            'contact-dedup-exclude: failed to write exclusion on B',
-          );
-        }
-      } else {
-        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact B has no KG node — exclusion written on A only');
+      try {
+        await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId!, storeFact, source });
+        contactBExcluded = true;
+      } catch (writeErrB) {
+        ctx.log.error(
+          { writeErrB, contactAId, contactBId, contactAExcluded },
+          'contact-dedup-exclude: failed to write exclusion on B',
+        );
       }
 
-      // Both sides failed (no KG nodes, or both writes errored) — nothing was stored.
+      // Both writes failed — nothing was stored.
       if (!contactAExcluded && !contactBExcluded) {
-        ctx.log.warn({ contactAId, contactBId, contactA: !!contactA.kgNodeId, contactB: !!contactB.kgNodeId }, 'contact-dedup-exclude: exclusion could not be written on either contact');
+        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: exclusion could not be written on either contact');
         return {
           success: false,
-          error: 'Could not write dedup exclusion on either contact — exclusion not stored. Retry after enrichment or resolve the KG conflict.',
+          error: 'Could not write dedup exclusion on either contact — both KG writes failed (conflict or store error). Check logs for details.',
         };
       }
 

--- a/skills/contacts/tools/contact-dedup-exclude/tool.json
+++ b/skills/contacts/tools/contact-dedup-exclude/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "contact-dedup-exclude",
   "description": "Record a permanent dedup_exclusion KG fact on both contacts, preventing the pair from being proposed as duplicates again. Call this when the CEO explicitly says two contacts are not the same person. Pinned exclusively to the contacts agent — not available to other agents.",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/skills/contacts/tools/contact-dedup-exclude/tool.json
+++ b/skills/contacts/tools/contact-dedup-exclude/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "contact-dedup-exclude",
   "description": "Record a permanent dedup_exclusion KG fact on both contacts, preventing the pair from being proposed as duplicates again. Call this when the CEO explicitly says two contacts are not the same person. Pinned exclusively to the contacts agent — not available to other agents.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -646,34 +646,6 @@ export class ContactService {
     return this.backend.getContact(id);
   }
 
-  /**
-   * Ensure a contact has a linked KG person node. If `kgNodeId` is already set,
-   * re-fetches and returns the contact unchanged. If null, creates a person entity
-   * via EntityMemory and links it, then returns the updated contact.
-   *
-   * Requires EntityMemory — throws if not available.
-   */
-  async ensureKgNode(contactId: string): Promise<Contact> {
-    const contact = await this.backend.getContact(contactId);
-    if (!contact) throw new ContactNotFoundError(contactId);
-    if (contact.kgNodeId !== null) return contact;
-
-    if (!this.entityMemory) {
-      throw new Error('ensureKgNode requires entityMemory but it is not configured');
-    }
-
-    const { entity } = await this.entityMemory.createEntity({
-      type: 'person',
-      label: contact.displayName,
-      properties: {},
-      source: 'contacts-dedup',
-    });
-
-    const linked: Contact = { ...contact, kgNodeId: entity.id, updatedAt: new Date() };
-    await this.backend.updateContact(linked);
-    return linked;
-  }
-
   /** Find contacts by display name (case-insensitive exact match). */
   async findContactByName(name: string): Promise<Contact[]> {
     return this.backend.findContactByName(name);

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -646,6 +646,34 @@ export class ContactService {
     return this.backend.getContact(id);
   }
 
+  /**
+   * Ensure a contact has a linked KG person node. If `kgNodeId` is already set,
+   * re-fetches and returns the contact unchanged. If null, creates a person entity
+   * via EntityMemory and links it, then returns the updated contact.
+   *
+   * Requires EntityMemory — throws if not available.
+   */
+  async ensureKgNode(contactId: string): Promise<Contact> {
+    const contact = await this.backend.getContact(contactId);
+    if (!contact) throw new ContactNotFoundError(contactId);
+    if (contact.kgNodeId !== null) return contact;
+
+    if (!this.entityMemory) {
+      throw new Error('ensureKgNode requires entityMemory but it is not configured');
+    }
+
+    const { entity } = await this.entityMemory.createEntity({
+      type: 'person',
+      label: contact.displayName,
+      properties: {},
+      source: 'contacts-dedup',
+    });
+
+    const linked: Contact = { ...contact, kgNodeId: entity.id, updatedAt: new Date() };
+    await this.backend.updateContact(linked);
+    return linked;
+  }
+
   /** Find contacts by display name (case-insensitive exact match). */
   async findContactByName(name: string): Promise<Contact[]> {
     return this.backend.findContactByName(name);

--- a/src/contacts/dedup-exclusions.test.ts
+++ b/src/contacts/dedup-exclusions.test.ts
@@ -39,6 +39,8 @@ describe('writeExclusion', () => {
     expect(args.entityNodeId).toBe('kg-c1');
     expect((args.properties as Record<string, unknown>).attribute).toBe('dedup_exclusion');
     expect((args.properties as Record<string, unknown>).value).toBe('c2');
+    expect((args.properties as Record<string, unknown>).multi_valued).toBe(true);
+    expect(args.multiValued).toBe(true);
     // Exclusion facts must be permanent so they survive decay
     expect(args.decayClass).toBe('permanent');
   });

--- a/src/contacts/dedup-exclusions.ts
+++ b/src/contacts/dedup-exclusions.ts
@@ -28,9 +28,8 @@ export interface WriteExclusionOptions {
  * properties.value = contactBId — matching what hasExclusion() queries for.
  *
  * Throws if the fact was not stored (action: 'conflict' | 'auto_rejected' | ...).
- * Multiple exclusions per entity are supported: `dedup_exclusion` is registered as
- * a multi-valued attribute in MemoryValidator, so different `value` properties do
- * not trigger contradiction or dedup-merge (#1623).
+ * Multiple exclusions per entity are supported via StoreFactOptions.multiValued —
+ * different `value` properties do not trigger contradiction or dedup-merge (#1623).
  */
 export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
   const { contactBId: rawContactBId, kgNodeId, storeFact, source = 'contacts-dedup' } = opts;
@@ -40,12 +39,15 @@ export async function writeExclusion(opts: WriteExclusionOptions): Promise<void>
   const result = await storeFact({
     entityNodeId: kgNodeId,
     label: `dedup_exclusion: ${contactBId}`,
-    properties: { attribute: 'dedup_exclusion', value: contactBId },
+    // multi_valued in properties so subsequent unrelated writes can detect this
+    // fact as multi-valued on the existing side (guard asymmetry fix, #1623).
+    properties: { attribute: 'dedup_exclusion', value: contactBId, multi_valued: true },
     // Permanent decay — exclusion decisions must not quietly expire
     decayClass: 'permanent',
     confidence: 1.0,
     source,
     sensitivity: 'internal',
+    multiValued: true,
   });
   if (!result.stored) {
     throw new Error(

--- a/src/contacts/dedup-exclusions.ts
+++ b/src/contacts/dedup-exclusions.ts
@@ -28,15 +28,9 @@ export interface WriteExclusionOptions {
  * properties.value = contactBId — matching what hasExclusion() queries for.
  *
  * Throws if the fact was not stored (action: 'conflict' | 'auto_rejected' | ...).
- * The 'conflict' case typically fires when a contact already has a dedup_exclusion
- * for a DIFFERENT pair — EntityMemory's contradiction detection treats same-attribute,
- * different-label facts at equal confidence as conflicts. Callers should catch and
- * surface this rather than treating a non-throwing return as a guarantee of persistence.
- *
- * @TODO: The underlying fix is to key contradiction detection on (attribute + value)
- * rather than (attribute + label), so multiple dedup_exclusion facts per node are
- * permitted. That change touches shared memory-validation semantics and should be
- * done in a dedicated issue (see curia#1027 discussion).
+ * Multiple exclusions per entity are supported: `dedup_exclusion` is registered as
+ * a multi-valued attribute in MemoryValidator, so different `value` properties do
+ * not trigger contradiction or dedup-merge (#1623).
  */
 export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
   const { contactBId: rawContactBId, kgNodeId, storeFact, source = 'contacts-dedup' } = opts;

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -101,6 +101,14 @@ export interface StoreFactOptions {
   // Optional category hint passed to the classifier (e.g. 'financial').
   // Allows skills that know the category of their data to skip keyword scanning.
   sensitivityCategory?: string;
+  /**
+   * When true, this fact is multi-valued: multiple facts with the same
+   * `properties.attribute` but different `properties.value` may coexist on one
+   * entity. Contradiction detection and embedding dedup-merge skip when values
+   * differ. Callers that write multi-valued facts (e.g. `writeExclusion`) must
+   * set this flag — the validator stays domain-agnostic (#1623).
+   */
+  multiValued?: boolean;
 }
 
 // -- Validated data for a new fact node, produced by MemoryValidator --

--- a/src/memory/validation.ts
+++ b/src/memory/validation.ts
@@ -7,6 +7,13 @@ import type { StoreFactOptions, ValidationResult } from './types.js';
 // Spec line 116: cosine similarity threshold for deduplication
 const DEDUP_SIMILARITY_THRESHOLD = 0.92;
 
+// Attributes that are multi-valued by design — multiple facts with the same attribute
+// but different `value` properties may coexist on one entity. Contradiction detection
+// and embedding dedup-merge must both be skipped when `value` differs (#1623).
+const MULTI_VALUED_ATTRIBUTES: ReadonlySet<string> = new Set([
+  'dedup_exclusion',
+]);
+
 // Spec line 126: max writes per agent per task
 // Exported so tests can exhaust the limit without hard-coding the magic number.
 export const MAX_WRITES_PER_AGENT_TASK = 50;
@@ -106,6 +113,16 @@ export class MemoryValidator {
 
       const similarity = EmbeddingService.cosineSimilarity(newEmbedding, targetNode.embedding);
       if (similarity >= DEDUP_SIMILARITY_THRESHOLD) {
+        // Multi-valued attributes must not be merged when their `value` differs —
+        // the similar labels (differing only by UUID) would cause the dedup-merge
+        // to overwrite `value` and silently destroy the first exclusion.
+        const incomingAttr = (options.properties as Record<string, unknown> | undefined)?.attribute;
+        if (typeof incomingAttr === 'string' && MULTI_VALUED_ATTRIBUTES.has(incomingAttr)) {
+          const existingValue = (targetNode.properties as Record<string, unknown>).value;
+          const incomingValue = (options.properties as Record<string, unknown>).value;
+          if (existingValue !== incomingValue) continue;
+        }
+
         // Near-duplicate detected — signal a merge. Caller is responsible for
         // persisting the merged properties via store.updateNode().
         return {
@@ -177,6 +194,15 @@ export class MemoryValidator {
 
       const existingAttribute = (targetNode.properties as Record<string, unknown>).attribute;
       if (existingAttribute !== attribute) continue;
+
+      // Multi-valued attributes (e.g. dedup_exclusion) can hold N distinct values
+      // per entity. Skip contradiction when the attribute is allowlisted and the
+      // value property differs — these are independent facts, not contradictions.
+      if (typeof attribute === 'string' && MULTI_VALUED_ATTRIBUTES.has(attribute)) {
+        const existingValue = (targetNode.properties as Record<string, unknown>).value;
+        const incomingValue = (options.properties as Record<string, unknown> | undefined)?.value;
+        if (existingValue !== incomingValue) continue;
+      }
 
       // Same entity, same attribute, different label → contradiction.
       // Identical label is not a contradiction (dedup will handle it).

--- a/src/memory/validation.ts
+++ b/src/memory/validation.ts
@@ -7,16 +7,31 @@ import type { StoreFactOptions, ValidationResult } from './types.js';
 // Spec line 116: cosine similarity threshold for deduplication
 const DEDUP_SIMILARITY_THRESHOLD = 0.92;
 
-// Attributes that are multi-valued by design — multiple facts with the same attribute
-// but different `value` properties may coexist on one entity. Contradiction detection
-// and embedding dedup-merge must both be skipped when `value` differs (#1623).
-const MULTI_VALUED_ATTRIBUTES: ReadonlySet<string> = new Set([
-  'dedup_exclusion',
-]);
-
 // Spec line 126: max writes per agent per task
 // Exported so tests can exhaust the limit without hard-coding the magic number.
 export const MAX_WRITES_PER_AGENT_TASK = 50;
+
+/**
+ * True when either the incoming write or the existing fact is multi-valued AND
+ * their `value` properties differ — these are independent facts, not duplicates
+ * or contradictions. Incoming writes set `StoreFactOptions.multiValued`; existing
+ * facts persist the marker as `properties.multi_valued` so subsequent unrelated
+ * writes cannot silently merge into them (#1623).
+ */
+function isDistinctMultiValuedFact(
+  options: StoreFactOptions,
+  existingProperties: Record<string, unknown>,
+): boolean {
+  const incomingMulti =
+    options.multiValued === true ||
+    (options.properties as Record<string, unknown> | undefined)?.multi_valued === true;
+  const existingMulti = existingProperties.multi_valued === true;
+  if (!incomingMulti && !existingMulti) return false;
+
+  const existingValue = existingProperties.value;
+  const incomingValue = (options.properties as Record<string, unknown> | undefined)?.value;
+  return existingValue !== incomingValue;
+}
 
 /**
  * Memory validation gates per spec 01 (lines 107-131).
@@ -113,14 +128,12 @@ export class MemoryValidator {
 
       const similarity = EmbeddingService.cosineSimilarity(newEmbedding, targetNode.embedding);
       if (similarity >= DEDUP_SIMILARITY_THRESHOLD) {
-        // Multi-valued attributes must not be merged when their `value` differs —
-        // the similar labels (differing only by UUID) would cause the dedup-merge
-        // to overwrite `value` and silently destroy the first exclusion.
-        const incomingAttr = (options.properties as Record<string, unknown> | undefined)?.attribute;
-        if (typeof incomingAttr === 'string' && MULTI_VALUED_ATTRIBUTES.has(incomingAttr)) {
-          const existingValue = (targetNode.properties as Record<string, unknown>).value;
-          const incomingValue = (options.properties as Record<string, unknown>).value;
-          if (existingValue !== incomingValue) continue;
+        // Multi-valued facts must not be merged when their `value` differs —
+        // near-identical labels would otherwise overwrite `value` and destroy
+        // the first fact. Check either side so an unrelated incoming write
+        // cannot merge into an existing multi-valued fact either.
+        if (isDistinctMultiValuedFact(options, targetNode.properties as Record<string, unknown>)) {
+          continue;
         }
 
         // Near-duplicate detected — signal a merge. Caller is responsible for
@@ -195,13 +208,10 @@ export class MemoryValidator {
       const existingAttribute = (targetNode.properties as Record<string, unknown>).attribute;
       if (existingAttribute !== attribute) continue;
 
-      // Multi-valued attributes (e.g. dedup_exclusion) can hold N distinct values
-      // per entity. Skip contradiction when the attribute is allowlisted and the
-      // value property differs — these are independent facts, not contradictions.
-      if (typeof attribute === 'string' && MULTI_VALUED_ATTRIBUTES.has(attribute)) {
-        const existingValue = (targetNode.properties as Record<string, unknown>).value;
-        const incomingValue = (options.properties as Record<string, unknown> | undefined)?.value;
-        if (existingValue !== incomingValue) continue;
+      // Multi-valued facts can hold N distinct values per entity. Skip contradiction
+      // when either side is multi-valued and the value property differs.
+      if (isDistinctMultiValuedFact(options, targetNode.properties as Record<string, unknown>)) {
+        continue;
       }
 
       // Same entity, same attribute, different label → contradiction.

--- a/tests/unit/memory/validation.test.ts
+++ b/tests/unit/memory/validation.test.ts
@@ -471,15 +471,15 @@ describe('MemoryValidator', () => {
     });
   });
 
-  describe('multi-valued attributes (dedup_exclusion)', () => {
-    it('allows two exclusions with different values on the same entity (no contradiction)', async () => {
+  describe('multi-valued facts (StoreFactOptions.multiValued)', () => {
+    it('allows two facts with different values on the same entity (no contradiction)', async () => {
       const entity = await store.createNode({
         type: 'person', label: 'Seth', properties: {}, source: 'test',
       });
       const firstExclusion = await store.createNode({
         type: 'fact',
         label: 'dedup_exclusion: c2',
-        properties: { attribute: 'dedup_exclusion', value: 'c2' },
+        properties: { attribute: 'dedup_exclusion', value: 'c2', multi_valued: true },
         confidence: 1.0,
         source: 'test',
       });
@@ -494,22 +494,23 @@ describe('MemoryValidator', () => {
       const result = await validator.validateContradiction({
         entityNodeId: entity.id,
         label: 'dedup_exclusion: c3',
-        properties: { attribute: 'dedup_exclusion', value: 'c3' },
+        properties: { attribute: 'dedup_exclusion', value: 'c3', multi_valued: true },
         confidence: 1.0,
         source: 'test',
+        multiValued: true,
       });
 
       expect(result.action).toBe('create');
     });
 
-    it('still deduplicates when re-writing the same exclusion value', async () => {
+    it('still deduplicates when re-writing the same multi-valued value', async () => {
       const entity = await store.createNode({
         type: 'person', label: 'Seth', properties: {}, source: 'test',
       });
       const existingExclusion = await store.createNode({
         type: 'fact',
         label: 'dedup_exclusion: c2',
-        properties: { attribute: 'dedup_exclusion', value: 'c2' },
+        properties: { attribute: 'dedup_exclusion', value: 'c2', multi_valued: true },
         confidence: 1.0,
         source: 'test',
       });
@@ -524,9 +525,10 @@ describe('MemoryValidator', () => {
       const result = await validator.validateContradiction({
         entityNodeId: entity.id,
         label: 'dedup_exclusion: c2',
-        properties: { attribute: 'dedup_exclusion', value: 'c2' },
+        properties: { attribute: 'dedup_exclusion', value: 'c2', multi_valued: true },
         confidence: 1.0,
         source: 'test',
+        multiValued: true,
       });
 
       // Same label → falls through to validate() dedup → update (idempotent)
@@ -563,14 +565,14 @@ describe('MemoryValidator', () => {
       expect(result.action).toBe('conflict');
     });
 
-    it('exempts multi-valued attributes from dedup-merge when values differ', async () => {
+    it('exempts multi-valued facts from dedup-merge when values differ', async () => {
       const entity = await store.createNode({
         type: 'person', label: 'Seth', properties: {}, source: 'test',
       });
       const firstExclusion = await store.createNode({
         type: 'fact',
         label: 'dedup_exclusion: c2',
-        properties: { attribute: 'dedup_exclusion', value: 'c2' },
+        properties: { attribute: 'dedup_exclusion', value: 'c2', multi_valued: true },
         confidence: 1.0,
         source: 'test',
       });
@@ -586,10 +588,45 @@ describe('MemoryValidator', () => {
       const result = await validator.validate({
         entityNodeId: entity.id,
         label: 'dedup_exclusion: c3',
-        properties: { attribute: 'dedup_exclusion', value: 'c3' },
+        properties: { attribute: 'dedup_exclusion', value: 'c3', multi_valued: true },
+        source: 'test',
+        multiValued: true,
+      });
+
+      expect(result.action).toBe('create');
+    });
+
+    it('does not merge an unrelated fact into an existing multi-valued fact (guard asymmetry)', async () => {
+      const entity = await store.createNode({
+        type: 'person', label: 'Seth', properties: {}, source: 'test',
+      });
+      // Existing multi-valued exclusion — incoming write is NOT multiValued but has a
+      // near-identical label. Without checking the existing side, validate() would merge.
+      const existingExclusion = await store.createNode({
+        type: 'fact',
+        label: 'dedup_exclusion: c2',
+        properties: { attribute: 'dedup_exclusion', value: 'c2', multi_valued: true },
+        confidence: 1.0,
+        source: 'test',
+      });
+      await store.createEdge({
+        sourceNodeId: entity.id,
+        targetNodeId: existingExclusion.id,
+        type: 'relates_to',
+        properties: {},
         source: 'test',
       });
 
+      const result = await validator.validate({
+        entityNodeId: entity.id,
+        // Same label text as the exclusion → fake embedder yields cosine 1.0
+        label: 'dedup_exclusion: c2',
+        properties: { note: 'unrelated' },
+        source: 'test',
+        // deliberately NOT multiValued
+      });
+
+      // Existing is multi-valued with value c2; incoming has no value → values differ → create
       expect(result.action).toBe('create');
     });
   });

--- a/tests/unit/memory/validation.test.ts
+++ b/tests/unit/memory/validation.test.ts
@@ -471,6 +471,129 @@ describe('MemoryValidator', () => {
     });
   });
 
+  describe('multi-valued attributes (dedup_exclusion)', () => {
+    it('allows two exclusions with different values on the same entity (no contradiction)', async () => {
+      const entity = await store.createNode({
+        type: 'person', label: 'Seth', properties: {}, source: 'test',
+      });
+      const firstExclusion = await store.createNode({
+        type: 'fact',
+        label: 'dedup_exclusion: c2',
+        properties: { attribute: 'dedup_exclusion', value: 'c2' },
+        confidence: 1.0,
+        source: 'test',
+      });
+      await store.createEdge({
+        sourceNodeId: entity.id,
+        targetNodeId: firstExclusion.id,
+        type: 'relates_to',
+        properties: {},
+        source: 'test',
+      });
+
+      const result = await validator.validateContradiction({
+        entityNodeId: entity.id,
+        label: 'dedup_exclusion: c3',
+        properties: { attribute: 'dedup_exclusion', value: 'c3' },
+        confidence: 1.0,
+        source: 'test',
+      });
+
+      expect(result.action).toBe('create');
+    });
+
+    it('still deduplicates when re-writing the same exclusion value', async () => {
+      const entity = await store.createNode({
+        type: 'person', label: 'Seth', properties: {}, source: 'test',
+      });
+      const existingExclusion = await store.createNode({
+        type: 'fact',
+        label: 'dedup_exclusion: c2',
+        properties: { attribute: 'dedup_exclusion', value: 'c2' },
+        confidence: 1.0,
+        source: 'test',
+      });
+      await store.createEdge({
+        sourceNodeId: entity.id,
+        targetNodeId: existingExclusion.id,
+        type: 'relates_to',
+        properties: {},
+        source: 'test',
+      });
+
+      const result = await validator.validateContradiction({
+        entityNodeId: entity.id,
+        label: 'dedup_exclusion: c2',
+        properties: { attribute: 'dedup_exclusion', value: 'c2' },
+        confidence: 1.0,
+        source: 'test',
+      });
+
+      // Same label → falls through to validate() dedup → update (idempotent)
+      expect(result.action).toBe('update');
+    });
+
+    it('still flags contradiction for single-valued attributes (e.g. role)', async () => {
+      const entity = await store.createNode({
+        type: 'person', label: 'Bob', properties: {}, source: 'test',
+      });
+      const existingFact = await store.createNode({
+        type: 'fact',
+        label: 'Bob is a CFO',
+        properties: { attribute: 'role', value: 'CFO' },
+        confidence: 1.0,
+        source: 'test',
+      });
+      await store.createEdge({
+        sourceNodeId: entity.id,
+        targetNodeId: existingFact.id,
+        type: 'relates_to',
+        properties: {},
+        source: 'test',
+      });
+
+      const result = await validator.validateContradiction({
+        entityNodeId: entity.id,
+        label: 'Bob is a CEO',
+        properties: { attribute: 'role', value: 'CEO' },
+        confidence: 1.0,
+        source: 'test',
+      });
+
+      expect(result.action).toBe('conflict');
+    });
+
+    it('exempts multi-valued attributes from dedup-merge when values differ', async () => {
+      const entity = await store.createNode({
+        type: 'person', label: 'Seth', properties: {}, source: 'test',
+      });
+      const firstExclusion = await store.createNode({
+        type: 'fact',
+        label: 'dedup_exclusion: c2',
+        properties: { attribute: 'dedup_exclusion', value: 'c2' },
+        confidence: 1.0,
+        source: 'test',
+      });
+      await store.createEdge({
+        sourceNodeId: entity.id,
+        targetNodeId: firstExclusion.id,
+        type: 'relates_to',
+        properties: {},
+        source: 'test',
+      });
+
+      // Even if labels are embedding-similar, different values must not merge
+      const result = await validator.validate({
+        entityNodeId: entity.id,
+        label: 'dedup_exclusion: c3',
+        properties: { attribute: 'dedup_exclusion', value: 'c3' },
+        source: 'test',
+      });
+
+      expect(result.action).toBe('create');
+    });
+  });
+
   describe('source attribution', () => {
     it('records full provenance chain on validation result', async () => {
       const entity = await store.createNode({

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -130,13 +130,19 @@ describe('ContactDedupExcludeHandler', () => {
     expect((callB.properties as Record<string, unknown>).value).toBe(UUID_A);
   });
 
-  it('skips writing on a contact with no KG node', async () => {
+  it('ensures KG node on contact B when it has no kgNodeId, then writes both sides', async () => {
     const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
     const contactService = {
       getContact: vi.fn().mockImplementation(async (id: string) => ({
         id,
-        kgNodeId: id === UUID_A ? 'kg-a' : null, // B has no KG node
+        kgNodeId: id === UUID_A ? 'kg-a' : null,
+        displayName: id === UUID_A ? 'Alice' : 'Bob',
       })),
+      ensureKgNode: vi.fn().mockResolvedValue({
+        id: UUID_B,
+        kgNodeId: 'kg-b-new',
+        displayName: 'Bob',
+      }),
     } as unknown as ToolContext['contactService'];
     const entityMemory = { storeFact: storeFactMock } as unknown as ToolContext['entityMemory'];
 
@@ -149,10 +155,10 @@ describe('ContactDedupExcludeHandler', () => {
     if (result.success) {
       const data = result.data as { contact_a_excluded: boolean; contact_b_excluded: boolean };
       expect(data.contact_a_excluded).toBe(true);
-      expect(data.contact_b_excluded).toBe(false);
+      expect(data.contact_b_excluded).toBe(true);
     }
-    // Only one write — B has no KG node to attach a fact to
-    expect(storeFactMock).toHaveBeenCalledTimes(1);
+    expect(contactService!.ensureKgNode).toHaveBeenCalledWith(UUID_B);
+    expect(storeFactMock).toHaveBeenCalledTimes(2);
   });
 
   it('returns failure when getContact throws', async () => {
@@ -246,10 +252,19 @@ describe('ContactDedupExcludeHandler', () => {
     if (!result.success) expect(result.error).toContain('dedup exclusion');
   });
 
-  it('returns failure when neither contact has a KG node', async () => {
-    const storeFactMock = vi.fn();
+  it('ensures KG nodes and writes exclusions when both contacts have null kgNodeId', async () => {
+    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
     const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({ id, kgNodeId: null })),
+      getContact: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: null,
+        displayName: id === UUID_A ? 'Seth A' : 'Seth B',
+      })),
+      ensureKgNode: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        kgNodeId: id === UUID_A ? 'kg-a-new' : 'kg-b-new',
+        displayName: id === UUID_A ? 'Seth A' : 'Seth B',
+      })),
     } as unknown as ToolContext['contactService'];
     const entityMemory = { storeFact: storeFactMock } as unknown as ToolContext['entityMemory'];
 
@@ -258,10 +273,9 @@ describe('ContactDedupExcludeHandler', () => {
       { contactService, entityMemory },
     ));
 
-    expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('dedup exclusion');
-    // No facts should be written when there's nowhere to attach them
-    expect(storeFactMock).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(contactService!.ensureKgNode).toHaveBeenCalledTimes(2);
+    expect(storeFactMock).toHaveBeenCalledTimes(2);
   });
 
   it('uses ctx.memoryWriteSource as the storeFact source', async () => {

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -130,19 +130,13 @@ describe('ContactDedupExcludeHandler', () => {
     expect((callB.properties as Record<string, unknown>).value).toBe(UUID_A);
   });
 
-  it('ensures KG node on contact B when it has no kgNodeId, then writes both sides', async () => {
+  it('skips writing on a contact with no KG node', async () => {
     const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
     const contactService = {
       getContact: vi.fn().mockImplementation(async (id: string) => ({
         id,
-        kgNodeId: id === UUID_A ? 'kg-a' : null,
-        displayName: id === UUID_A ? 'Alice' : 'Bob',
+        kgNodeId: id === UUID_A ? 'kg-a' : null, // B has no KG node
       })),
-      ensureKgNode: vi.fn().mockResolvedValue({
-        id: UUID_B,
-        kgNodeId: 'kg-b-new',
-        displayName: 'Bob',
-      }),
     } as unknown as ToolContext['contactService'];
     const entityMemory = { storeFact: storeFactMock } as unknown as ToolContext['entityMemory'];
 
@@ -155,10 +149,10 @@ describe('ContactDedupExcludeHandler', () => {
     if (result.success) {
       const data = result.data as { contact_a_excluded: boolean; contact_b_excluded: boolean };
       expect(data.contact_a_excluded).toBe(true);
-      expect(data.contact_b_excluded).toBe(true);
+      expect(data.contact_b_excluded).toBe(false);
     }
-    expect(contactService!.ensureKgNode).toHaveBeenCalledWith(UUID_B);
-    expect(storeFactMock).toHaveBeenCalledTimes(2);
+    // Only one write — B has no KG node to attach a fact to
+    expect(storeFactMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns failure when getContact throws', async () => {
@@ -252,19 +246,10 @@ describe('ContactDedupExcludeHandler', () => {
     if (!result.success) expect(result.error).toContain('dedup exclusion');
   });
 
-  it('ensures KG nodes and writes exclusions when both contacts have null kgNodeId', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
+  it('returns failure with a clear message when neither contact has a KG node', async () => {
+    const storeFactMock = vi.fn();
     const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({
-        id,
-        kgNodeId: null,
-        displayName: id === UUID_A ? 'Seth A' : 'Seth B',
-      })),
-      ensureKgNode: vi.fn().mockImplementation(async (id: string) => ({
-        id,
-        kgNodeId: id === UUID_A ? 'kg-a-new' : 'kg-b-new',
-        displayName: id === UUID_A ? 'Seth A' : 'Seth B',
-      })),
+      getContact: vi.fn().mockImplementation(async (id: string) => ({ id, kgNodeId: null })),
     } as unknown as ToolContext['contactService'];
     const entityMemory = { storeFact: storeFactMock } as unknown as ToolContext['entityMemory'];
 
@@ -273,9 +258,10 @@ describe('ContactDedupExcludeHandler', () => {
       { contactService, entityMemory },
     ));
 
-    expect(result.success).toBe(true);
-    expect(contactService!.ensureKgNode).toHaveBeenCalledTimes(2);
-    expect(storeFactMock).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('no KG node');
+    // No facts should be written when there's nowhere to attach them
+    expect(storeFactMock).not.toHaveBeenCalled();
   });
 
   it('uses ctx.memoryWriteSource as the storeFact source', async () => {


### PR DESCRIPTION
## Summary

Fixes two of the three bugs from the Seth Berman dedup incident (#1623): multi-exclusion KG writes were rejected as contradictions, and the contacts agent closed the review task even when `contact-dedup-exclude` failed.

**Bug 3 (`ensureKgNode`) was pulled after review** — same-display-name contacts share one KG label, so inventing a node recreates the `idx_contacts_kg_node_unique` collision that left `kg_node_id = NULL`. Durable fix for null-node pairs: #1625 (SQL exclusions table + ADR).

Addresses #1623 (bugs 1 & 2). Remaining null-node exclusion path → #1625.

## Changes

### Bug 1 — Multi-valued facts (`StoreFactOptions.multiValued`)
- Domain-agnostic flag on `StoreFactOptions` (set by `writeExclusion`), not a hardcoded attribute allowlist in `MemoryValidator`.
- Persists `properties.multi_valued: true` so the **existing** side is detectable — dedup-merge checks either side (guard asymmetry fix).
- Contradiction + embedding dedup-merge both skip when values differ; same value remains idempotent.

### Bug 2 — Prompt: gate task-close on exclude success (`agents/contacts.yaml`)
- Exclude path mirrors merge: only `task-complete` after `contact-dedup-exclude` returns `success: true`.
- On failure: leave task open, tell the CEO the decision could not be persisted.
- Version bump `0.12.0` → `0.12.1`.
- Note: this is belt-and-braces prompt policy, not a deterministic task-complete hook.

### Skill error clarity (no ensureKgNode)
- Distinguishes both-contacts-missing-KG-node vs KG write conflict.
- Per-side writes remain independent when only one contact has a node.
- Patch version `0.1.0` → `0.1.1`.

### Out of this PR
- Ensuring / inventing KG nodes for null-node contacts (architecturally wrong here).
- Moving exclusions onto a `contact_dedup_exclusions` table (#1625 + ADR).

## Related Issues

Addresses #1623 (bugs 1 & 2). Follow-up: #1625.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [ ] CI passes

