### PR TITLE
fix(llm): release the SDK stream on every exit path across all providers (#1648, #1651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Scheduler** — `burstCounts` evicts one-shot completions inline and stale jobs on the watchdog sweep. (#1664)
 - **`RateLimiter`** — idle per-sender windows are reclaimed once elapsed, bounding memory. (#1665)
 - **MCP `callTool`** — a timed-out skill now aborts the underlying MCP request instead of stranding it. (#1666)
+- **LLM provider streaming** — every provider releases its SDK stream on abort/error/early-exit, preventing a heap leak. (#1648, #1651)
 - **`classifyError`** — `AbortSignal.timeout` / abort DOMExceptions map to `TIMEOUT`. (#1597)
 - **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)
 - **Coordinator** — ambient bullpen mentions no longer bleed into scheduler jobs and leak to the principal. (#1609)

--- a/src/agents/llm/anthropic.test.ts
+++ b/src/agents/llm/anthropic.test.ts
@@ -41,6 +41,10 @@ function makeStream(events: unknown[], finalMessage: unknown) {
       }
     },
     finalMessage: vi.fn().mockResolvedValue(finalMessage),
+    // The provider calls stream.abort() in a finally to release the underlying fetch
+    // Response/ReadableStream on every exit path (leak fix #1648). Mock it so streaming
+    // tests still pass and cleanup can be asserted.
+    abort: vi.fn(),
   };
 }
 
@@ -343,5 +347,71 @@ describe('AnthropicProvider — stream', () => {
     }));
 
     expect(mockStream.mock.calls[0]![1]).toEqual({ signal: controller.signal });
+  });
+
+  // Leak fix (#1648): the provider must release the underlying SDK MessageStream (its
+  // fetch Response/ReadableStream) on every exit path, or undrained streams retain their
+  // response ArrayBuffers on the heap. See anthropics/claude-code#33380.
+  const streamFinal = () => ({
+    id: 'msg_cleanup',
+    model: 'claude-sonnet-4-6',
+    content: [{ type: 'text', text: 'done' }],
+    usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    stop_reason: 'end_turn',
+  });
+
+  it('aborts the underlying stream after normal completion (releases the response buffer)', async () => {
+    const stream = makeStream(
+      [{ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hi' } }],
+      streamFinal(),
+    );
+    mockStream.mockReturnValue(stream);
+
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    await collectStream(provider.stream({ messages: [{ role: 'user', content: 'Hello' }], model: 'claude-sonnet-4-6' }));
+
+    expect(stream.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the underlying stream when the consumer stops iterating early', async () => {
+    const stream = makeStream(
+      [
+        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'a' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'b' } },
+      ],
+      streamFinal(),
+    );
+    mockStream.mockReturnValue(stream);
+
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    // Break after the first event: the async generator's finally must still run and
+    // abort the SDK stream, otherwise its Response buffer leaks.
+    const seen: LLMStreamEvent[] = [];
+    for await (const event of provider.stream({ messages: [{ role: 'user', content: 'Hello' }], model: 'claude-sonnet-4-6' })) {
+      seen.push(event);
+      break;
+    }
+
+    expect(seen).toHaveLength(1);
+    expect(stream.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the underlying stream and yields an error when iteration throws', async () => {
+    const stream = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => Promise.reject(new Error('mid-stream boom')),
+        };
+      },
+      finalMessage: vi.fn(),
+      abort: vi.fn(),
+    };
+    mockStream.mockReturnValue(stream);
+
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    const events = await collectStream(provider.stream({ messages: [{ role: 'user', content: 'Hello' }], model: 'claude-sonnet-4-6' }));
+
+    expect(stream.abort).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)).toMatchObject({ type: 'error' });
   });
 });

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -297,50 +297,69 @@ export class AnthropicProvider implements LLMProvider {
       const { createParams, signal } = built;
       const stream = this.client.messages.stream(createParams, signal ? { signal } : undefined);
 
-      for await (const event of stream) {
-        if (event.type === 'content_block_delta' && event.delta.type === 'text_delta' && event.delta.text) {
-          yield { type: 'text_delta', text: event.delta.text };
+      // Guarantee the underlying fetch Response / ReadableStream is released on every
+      // exit path — normal completion, a thrown error, an AbortSignal firing, or a
+      // consumer that stops iterating this generator early (which runs this finally via
+      // the generator's .return()). An undrained SDK stream retains its response
+      // ArrayBuffers on the V8 heap; under the scheduler's steady background LLM calls
+      // that accumulates until an OOM restart (#1648; upstream anthropics/claude-code#33380).
+      // MessageStream.abort() is idempotent — calling it after finalMessage() is a no-op.
+      try {
+        for await (const event of stream) {
+          if (event.type === 'content_block_delta' && event.delta.type === 'text_delta' && event.delta.text) {
+            yield { type: 'text_delta', text: event.delta.text };
+          }
         }
-      }
 
-      const response = await stream.finalMessage();
-      this.logger.debug(
-        {
-          model,
-          inputTokens: response.usage.input_tokens,
-          outputTokens: response.usage.output_tokens,
-          cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
-          cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
-          stopReason: response.stop_reason,
-        },
-        'Anthropic streaming API call completed',
-      );
+        const response = await stream.finalMessage();
+        this.logger.debug(
+          {
+            model,
+            inputTokens: response.usage.input_tokens,
+            outputTokens: response.usage.output_tokens,
+            cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+            cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+            stopReason: response.stop_reason,
+          },
+          'Anthropic streaming API call completed',
+        );
 
-      const usage = this.usageFromResponse(response);
-      const provenance = this.provenanceFromResponse(response, model);
-      const toolCalls = this.toolCallsFromResponse(response);
-      const content = this.textFromResponse(response);
+        const usage = this.usageFromResponse(response);
+        const provenance = this.provenanceFromResponse(response, model);
+        const toolCalls = this.toolCallsFromResponse(response);
+        const content = this.textFromResponse(response);
 
-      if (toolCalls.length > 0) {
+        if (toolCalls.length > 0) {
+          yield {
+            type: 'tool_use',
+            toolCalls,
+            content: content || undefined,
+            usage,
+            provenance,
+          };
+          return;
+        }
+
+        if (!content) {
+          this.logger.error({ model, stopReason: response.stop_reason }, 'LLM returned empty streamed text response');
+        }
         yield {
-          type: 'tool_use',
-          toolCalls,
-          content: content || undefined,
+          type: 'message_end',
+          content,
           usage,
           provenance,
         };
-        return;
+      } finally {
+        // Best-effort cleanup; never let an abort() failure mask the real result or error.
+        try {
+          stream.abort();
+        } catch (abortErr) {
+          // warn (not debug): abort() IS the leak fix, so a persistent failure here means
+          // the stream leak has silently returned — we want that visible in prod, and it
+          // only ever logs when cleanup genuinely fails (never on the happy path).
+          this.logger.warn({ abortErr, model }, 'Anthropic stream cleanup abort() failed');
+        }
       }
-
-      if (!content) {
-        this.logger.error({ model, stopReason: response.stop_reason }, 'LLM returned empty streamed text response');
-      }
-      yield {
-        type: 'message_end',
-        content,
-        usage,
-        provenance,
-      };
     } catch (err) {
       this.logger.error({ err, model }, 'Anthropic streaming API call failed');
       yield { type: 'error', error: classifyError(err, 'anthropic') };

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -354,9 +354,10 @@ export class AnthropicProvider implements LLMProvider {
         try {
           stream.abort();
         } catch (abortErr) {
-          // warn (not debug): abort() IS the leak fix, so a persistent failure here means
-          // the stream leak has silently returned — we want that visible in prod, and it
-          // only ever logs when cleanup genuinely fails (never on the happy path).
+          // Best-effort cleanup, logged at warn (not error): the request result was already
+          // handled above and is unaffected — this is stream hygiene, not a request failure.
+          // It only fires if abort() itself fails (never on the happy path), so a recurring
+          // warn here is the signal that the stream leak (#1648/#1651) has returned.
           this.logger.warn({ abortErr, model }, 'Anthropic stream cleanup abort() failed');
         }
       }

--- a/src/agents/llm/openrouter.test.ts
+++ b/src/agents/llm/openrouter.test.ts
@@ -52,6 +52,11 @@ function makeStream(chunks: unknown[]) {
         yield chunk;
       }
     },
+    // The provider calls stream.controller.abort() in a finally to release the
+    // underlying fetch Response/ReadableStream on every exit path (leak fix #1648/#1651).
+    // Mirror the OpenAI SDK Stream's `controller: AbortController` so streaming tests
+    // still run and cleanup can be asserted.
+    controller: { abort: vi.fn() },
   };
 }
 
@@ -607,5 +612,72 @@ describe('OpenRouterProvider — stream', () => {
     }));
 
     expect(mockCreate.mock.calls[0]![1]).toEqual({ signal: controller.signal });
+  });
+
+  // Leak-parity fix (#1651, mirrors #1648): the provider must release the underlying
+  // OpenAI SDK Stream (its fetch Response/ReadableStream) on every exit path via
+  // stream.controller.abort(), or an undrained stream retains its response buffers on
+  // the V8 heap. Exercised by voice in prod today.
+  const okChunk = () => ({
+    id: 'chatcmpl-cleanup',
+    model: 'openai/gpt-4o',
+    choices: [{ index: 0, delta: { content: 'hi' }, finish_reason: 'stop', logprobs: null }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    object: 'chat.completion.chunk',
+    created: 1700000000,
+  });
+
+  it('aborts the underlying stream after normal completion (releases the response buffer)', async () => {
+    const stream = makeStream([okChunk()]);
+    mockCreate.mockResolvedValue(stream);
+
+    const provider = new OpenRouterProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    await collectStream(provider.stream({ messages: [{ role: 'user', content: 'Hello' }], model: 'openai/gpt-4o' }));
+
+    expect(stream.controller.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the underlying stream when the consumer stops iterating early', async () => {
+    const stream = makeStream([
+      {
+        id: 'chatcmpl-early', model: 'openai/gpt-4o',
+        choices: [{ index: 0, delta: { content: 'a' }, finish_reason: null, logprobs: null }],
+        usage: null, object: 'chat.completion.chunk', created: 1700000000,
+      },
+      {
+        id: 'chatcmpl-early', model: 'openai/gpt-4o',
+        choices: [{ index: 0, delta: { content: 'b' }, finish_reason: 'stop', logprobs: null }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }, object: 'chat.completion.chunk', created: 1700000000,
+      },
+    ]);
+    mockCreate.mockResolvedValue(stream);
+
+    const provider = new OpenRouterProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    // Break after the first event: the async generator's finally must still run and
+    // abort the SDK stream, otherwise its Response buffer leaks.
+    const seen: LLMStreamEvent[] = [];
+    for await (const event of provider.stream({ messages: [{ role: 'user', content: 'Hello' }], model: 'openai/gpt-4o' })) {
+      seen.push(event);
+      break;
+    }
+
+    expect(seen).toHaveLength(1);
+    expect(stream.controller.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the underlying stream and yields an error when iteration throws', async () => {
+    const stream = {
+      [Symbol.asyncIterator]() {
+        return { next: () => Promise.reject(new Error('mid-stream boom')) };
+      },
+      controller: { abort: vi.fn() },
+    };
+    mockCreate.mockResolvedValue(stream);
+
+    const provider = new OpenRouterProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    const events = await collectStream(provider.stream({ messages: [{ role: 'user', content: 'Hello' }], model: 'openai/gpt-4o' }));
+
+    expect(stream.controller.abort).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)).toMatchObject({ type: 'error' });
   });
 });

--- a/src/agents/llm/openrouter.ts
+++ b/src/agents/llm/openrouter.ts
@@ -473,6 +473,17 @@ export class OpenRouterProvider implements LLMProvider {
 
     let model: string | undefined = params.model ?? (typeof params.options?.model === 'string' ? params.options.model : undefined);
 
+    // Abort handle for the SDK stream, captured once it's created and invoked in the
+    // finally below so the underlying fetch Response / ReadableStream is released on
+    // EVERY exit path — normal completion, a thrown error, an AbortSignal firing, or a
+    // consumer that stops iterating this generator early (which runs the finally via
+    // the generator's .return()). An undrained SDK stream retains its response buffers
+    // on the V8 heap; under the scheduler's steady background LLM calls that would
+    // accumulate until an OOM restart. Parity with the Anthropic path (#1648/#1651).
+    // The OpenAI SDK exposes stream.controller (AbortController); abort() is idempotent,
+    // so calling it after the stream has already completed is a harmless no-op.
+    let abortStream: (() => void) | undefined;
+
     try {
       const built = this.buildCreateParams(params, 'stream');
       model = built.model;
@@ -483,6 +494,7 @@ export class OpenRouterProvider implements LLMProvider {
         stream_options: { include_usage: true },
       };
       const stream = await this.client.chat.completions.create(streamParams, signal ? { signal } : undefined);
+      abortStream = () => stream.controller.abort();
 
       let content = '';
       let usage: LLMUsage = {
@@ -601,6 +613,18 @@ export class OpenRouterProvider implements LLMProvider {
     } catch (err) {
       this.logger.error({ err, model }, 'OpenRouter streaming API call failed');
       yield { type: 'error', error: this.classifyProviderError(err) };
+    } finally {
+      // Best-effort cleanup; never let an abort() failure mask the real result or error.
+      if (abortStream) {
+        try {
+          abortStream();
+        } catch (abortErr) {
+          // warn (not debug): abort() IS the leak fix, so a persistent failure here means
+          // the stream leak has silently returned — we want that visible in prod, and it
+          // only ever logs when cleanup genuinely fails (never on the happy path).
+          this.logger.warn({ abortErr, model }, 'OpenRouter stream cleanup abort() failed');
+        }
+      }
     }
   }
 }

--- a/src/agents/llm/openrouter.ts
+++ b/src/agents/llm/openrouter.ts
@@ -619,9 +619,10 @@ export class OpenRouterProvider implements LLMProvider {
         try {
           abortStream();
         } catch (abortErr) {
-          // warn (not debug): abort() IS the leak fix, so a persistent failure here means
-          // the stream leak has silently returned — we want that visible in prod, and it
-          // only ever logs when cleanup genuinely fails (never on the happy path).
+          // Best-effort cleanup, logged at warn (not error): the request result was already
+          // handled above and is unaffected — this is stream hygiene, not a request failure.
+          // It only fires if abort() itself fails (never on the happy path), so a recurring
+          // warn here is the signal that the stream leak (#1648/#1651) has returned.
           this.logger.warn({ abortErr, model }, 'OpenRouter stream cleanup abort() failed');
         }
       }

--- a/src/agents/llm/provider-router.test.ts
+++ b/src/agents/llm/provider-router.test.ts
@@ -203,6 +203,38 @@ describe('LLMProviderRouter', () => {
     expect(events).toEqual(streamEvents);
   });
 
+  it('propagates cleanup to the inner stream when the consumer stops iterating early (#1651)', async () => {
+    // The router delegates via `for await (... of inner.stream()) { yield }`. When the
+    // outer consumer breaks early, the router generator's .return() must reach the inner
+    // stream's finally — that's what runs a real provider's abort() cleanup. If the router
+    // ever swallowed that propagation, the leak fix in the underlying providers would be
+    // silently defeated when routed through here.
+    let innerCleanedUp = false;
+    const inner = makeProvider('anthropic');
+    inner.stream = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        try {
+          yield { type: 'text_delta', text: 'a' } as LLMStreamEvent;
+          yield { type: 'text_delta', text: 'b' } as LLMStreamEvent;
+        } finally {
+          innerCleanedUp = true;
+        }
+      },
+    }));
+    providerRegistry.set('anthropic', inner);
+    const modelRegistry = makeModelRegistry({ 'claude-sonnet-4-6': 'anthropic' });
+    const router = new LLMProviderRouter(modelRegistry, providerRegistry);
+
+    const seen: LLMStreamEvent[] = [];
+    for await (const event of router.stream({ messages: MESSAGES, model: 'claude-sonnet-4-6' })) {
+      seen.push(event);
+      break;
+    }
+
+    expect(seen).toHaveLength(1);
+    expect(innerCleanedUp).toBe(true);
+  });
+
   it('yields an error event when the resolved provider does not support stream', async () => {
     const modelRegistry = makeModelRegistry({ 'claude-sonnet-4-6': 'anthropic' });
     const router = new LLMProviderRouter(modelRegistry, providerRegistry);

--- a/src/agents/llm/telemetry-provider.test.ts
+++ b/src/agents/llm/telemetry-provider.test.ts
@@ -1,0 +1,53 @@
+// telemetry-provider.test.ts — cleanup-propagation coverage for the telemetry decorator.
+//
+// TelemetryLlmProvider wraps an inner provider's stream() in a try/catch (to normalize
+// unexpected throws into error events). This test proves that wrapper does NOT swallow
+// the early-exit cleanup propagation: when a consumer stops iterating early, the inner
+// provider's stream generator finally must still run — that finally is where the real
+// providers (Anthropic/OpenRouter) release their SDK stream (#1648/#1651).
+
+import { describe, it, expect, vi } from 'vitest';
+import { TelemetryLlmProvider } from './telemetry-provider.js';
+import { ModelRegistry } from './model-registry.js';
+import { createSilentLogger } from '../../logger.js';
+import type { LLMProvider, LLMStreamEvent } from './provider.js';
+import type { EventBus } from '../../bus/bus.js';
+
+describe('TelemetryLlmProvider — stream cleanup propagation', () => {
+  it('runs the inner stream finally when the consumer stops iterating early (#1651)', async () => {
+    let innerCleanedUp = false;
+    const inner: LLMProvider = {
+      id: 'anthropic',
+      chat: vi.fn(),
+      stream: vi.fn(() => ({
+        async *[Symbol.asyncIterator]() {
+          try {
+            yield { type: 'text_delta', text: 'a' } as LLMStreamEvent;
+            yield { type: 'text_delta', text: 'b' } as LLMStreamEvent;
+          } finally {
+            // A real provider aborts its SDK stream here; the decorator's try/catch
+            // (which only catches throws) must not block this from running.
+            innerCleanedUp = true;
+          }
+        },
+      })),
+    };
+    const bus = { publish: vi.fn() } as unknown as EventBus;
+    const provider = new TelemetryLlmProvider(
+      inner,
+      bus,
+      createSilentLogger(),
+      'test-service',
+      new ModelRegistry(createSilentLogger()),
+    );
+
+    const seen: LLMStreamEvent[] = [];
+    for await (const event of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      seen.push(event);
+      break;
+    }
+
+    expect(seen).toHaveLength(1);
+    expect(innerCleanedUp).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Defensive stream-cleanup hardening for LLM providers. Every provider that owns an SDK stream now releases it (aborts the underlying fetch `Response`/`ReadableStream`) on **every** exit path: normal completion, thrown error, abort signal, and early consumer `.return()`. An undrained SDK stream retains its response buffers on the V8 heap; under the scheduler's steady background LLM calls that would accumulate over time.

**Reframing (this is not the OOM fix).** This issue was originally opened as the suspected cause of the prod OOM restart loop. That hypothesis was **disproven**: the OOM was a ~145 MB/hr leak in the MCP healthcheck (Ajv validator recompilation on every `listTools()`), root-caused and fixed in #1663 and confirmed in prod (19h+ uptime, flat heap). This PR is **defensive parity hardening** so the streaming path is correct whenever it's used. Streaming is exercised by **voice** in prod today.

- Closes #1648 (reframed from the OOM hypothesis)
- Closes #1651 (OpenRouter parity)

## What changed

**Providers that own an SDK stream (fixed):**
- **`AnthropicProvider.stream()`** — wraps stream consumption in `try/finally` and calls `stream.abort()` (idempotent) in the finally.
- **`OpenRouterProvider.stream()`** — captures the OpenAI SDK `stream.controller` and calls `stream.controller.abort()` (idempotent) in a `finally` on every exit path.

Both aborts are guarded in their own `try/catch` and logged at `warn` so cleanup can never mask the real result or the error event.

**Wrapper providers (audited — no code change needed):**
- **`LLMProviderRouter`** and **`TelemetryLlmProvider`** both delegate via `for await (inner.stream()) { yield }`. An early consumer `.return()` propagates through to the inner provider's `finally`, so the real providers' cleanup runs even when routed/decorated. The telemetry decorator's `try/catch` only catches throws, not the return-completion, so it doesn't block propagation. Added propagation tests to lock this in — a regression there would silently defeat the providers' cleanup.

## Tests

- **OpenRouter**: 3 cleanup tests (normal completion, early break, mid-stream throw), each asserting `controller.abort()` — each fails without the fix.
- **Anthropic**: equivalent 3 tests (on the branch already).
- **`provider-router.test.ts`** + new **`telemetry-provider.test.ts`**: propagation tests proving early-exit cleanup reaches the inner provider's `finally` through each wrapper.

51 provider tests green; `pnpm run typecheck` + eslint clean.

## Notes

- The branch name (`fix/anthropic-stream-leak`) predates the reframe; the change now covers all providers. Left as-is to preserve this PR.
- #1663 is the actual prod OOM fix, noted here for the record.
