### PR TITLE
fix(health): MCP liveness probe uses ping() not listTools() — stops ~145 MB/hr OOM leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **MCP health probe** — liveness uses `ping()` not `listTools()`, ending a ~145 MB/hr validator leak. (#1663)
 - **`classifyError`** — `AbortSignal.timeout` / abort DOMExceptions map to `TIMEOUT`. (#1597)
 - **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)
 - **Coordinator** — ambient bullpen mentions no longer bleed into scheduler jobs and leak to the principal. (#1609)

--- a/src/health/health-checks.ts
+++ b/src/health/health-checks.ts
@@ -41,8 +41,19 @@ export interface BrowserServiceHealth {
 export interface McpSessionHealth {
   serverId: string;
   client: {
-    /** MCP SDK Client.listTools() — a lightweight round-trip that proves the subprocess is alive. */
-    listTools(): Promise<{ tools?: unknown[] }>;
+    /**
+     * MCP SDK `Client.ping()` — the protocol's liveness RPC. Proves the subprocess
+     * is alive with an empty-result JSON-RPC round-trip.
+     *
+     * Deliberately NOT `listTools()`: the SDK recompiles an Ajv validator for every
+     * tool's `outputSchema` on every `listTools()` call and retains it on a shared,
+     * process-lifetime Ajv instance (its cache is keyed by schema object reference,
+     * and each response is freshly parsed → cache miss every time). With the Docker
+     * healthcheck hitting `/api/health` every 30s, that leaked ~145 MB/hr and OOM-
+     * restarted prod (#1663). `ping()` returns no schemas, so it triggers no
+     * compilation. Tool discovery still uses `listTools()`, but only at boot.
+     */
+    ping(): Promise<unknown>;
   };
 }
 
@@ -203,10 +214,12 @@ export function checkBrowser(service: BrowserServiceHealth | undefined): CheckRe
  * Check every **enabled** MCP server that was attempted at boot (#1500).
  *
  * - Boot `zero_tools` / `unavailable` → fail (no live probe needed)
- * - Boot `ok` → live tools/list; fail if the call errors or returns 0 tools
+ * - Boot `ok` → live `ping()` liveness probe; fail if it errors or times out
  * - Disabled servers are absent from `serverStatuses` and never appear here
  *
- * Hard 3-second timeout per live probe.
+ * Hard 3-second timeout per live probe. The probe is `ping()`, not `listTools()`,
+ * so it triggers no MCP-SDK Ajv validator recompilation (the ~145 MB/hr leak, #1663).
+ * The boot-time `zero_tools` gate above still catches servers that expose no tools.
  */
 export async function checkMcpServers(
   serverStatuses: ReadonlyMap<string, McpServerBootStatus>,
@@ -231,14 +244,17 @@ export async function checkMcpServers(
       }
 
       try {
-        const toolList = await Promise.race([
-          session.client.listTools(),
+        // Liveness only: a resolved ping proves the subprocess is up and answering
+        // JSON-RPC. Zero-tools/unavailable servers were already failed by the boot
+        // gate above, so we don't re-count tools here (and must not — see the
+        // McpSessionHealth doc: listTools() leaks compiled validators, #1663).
+        await Promise.race([
+          session.client.ping(),
           new Promise<never>((_, reject) =>
             setTimeout(() => reject(new Error('timeout')), 3_000),
           ),
         ]);
-        const count = toolList.tools?.length ?? 0;
-        return [key, count > 0 ? 'ok' : 'fail'];
+        return [key, 'ok'];
       } catch (err) {
         logger.warn({ err, server: serverName }, 'checkMcpServers: MCP probe failed');
         return [key, 'fail'];
@@ -247,30 +263,6 @@ export async function checkMcpServers(
   );
 
   return Object.fromEntries(entries);
-}
-
-/**
- * @deprecated Prefer checkMcpServers. Kept as a thin wrapper for callers that
- * only care about google-workspace until they migrate.
- */
-export async function checkMcpGoogleWorkspace(
-  mcpSessions: McpSessionHealth[],
-  logger: Logger,
-): Promise<CheckResult> {
-  const session = mcpSessions.find(s => s.serverId === 'google-workspace');
-  if (!session) return 'skipped';
-  try {
-    const toolList = await Promise.race([
-      session.client.listTools(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), 3_000),
-      ),
-    ]);
-    return (toolList.tools?.length ?? 0) > 0 ? 'ok' : 'fail';
-  } catch (err) {
-    logger.warn({ err }, 'checkMcpGoogleWorkspace: MCP probe failed');
-    return 'fail';
-  }
 }
 
 /** Outcome of the principal calendar grant probe, distinguishing auth failures. */

--- a/tests/unit/health/check-mcp-servers.test.ts
+++ b/tests/unit/health/check-mcp-servers.test.ts
@@ -1,49 +1,84 @@
 import { describe, it, expect, vi } from 'vitest';
-import { checkMcpServers, mcpHealthKey } from '../../../src/health/health-checks.js';
+import { checkMcpServers, mcpHealthKey, type McpServerBootStatus } from '../../../src/health/health-checks.js';
 import { createSilentLogger } from '../../../src/logger.js';
 
-describe('checkMcpServers (#1500)', () => {
-  const logger = createSilentLogger();
+const logger = createSilentLogger();
 
-  it('fails boot zero_tools without calling listTools', async () => {
-    const listTools = vi.fn();
+/**
+ * Mock MCP session exposing both `ping` and `listTools` spies, so tests can
+ * assert the liveness probe uses `ping()` and never `listTools()` — the latter
+ * makes the MCP SDK recompile Ajv validators per call and leaked ~145 MB/hr
+ * in prod (#1663).
+ */
+function makeSession(serverId: string, ping: () => Promise<unknown> = () => Promise.resolve({})) {
+  return {
+    serverId,
+    client: {
+      ping: vi.fn(ping),
+      listTools: vi.fn(() => Promise.resolve({ tools: [{ name: 't' }] })),
+    },
+  };
+}
+
+describe('checkMcpServers (#1500, #1663)', () => {
+  it('pings a boot-ok server, reports ok, and NEVER calls listTools (#1663 leak guard)', async () => {
+    const session = makeSession('google-workspace');
     const result = await checkMcpServers(
-      new Map([['google-workspace', { status: 'zero_tools' }]]),
-      [{ serverId: 'google-workspace', client: { listTools } }],
+      new Map<string, McpServerBootStatus>([['google-workspace', { status: 'ok', toolCount: 121 }]]),
+      [session],
+      logger,
+    );
+    expect(result).toEqual({ google_workspace: 'ok' });
+    expect(session.client.ping).toHaveBeenCalledOnce();
+    expect(session.client.listTools).not.toHaveBeenCalled();
+  });
+
+  it('fails a boot-ok server when ping rejects (dead/unresponsive subprocess)', async () => {
+    const session = makeSession('atproto', () => Promise.reject(new Error('EPIPE')));
+    const result = await checkMcpServers(
+      new Map<string, McpServerBootStatus>([['atproto', { status: 'ok', toolCount: 8 }]]),
+      [session],
+      logger,
+    );
+    expect(result).toEqual({ atproto: 'fail' });
+    expect(session.client.ping).toHaveBeenCalledOnce();
+  });
+
+  it('fails a hung server via the 3s probe timeout, without listing tools', async () => {
+    vi.useFakeTimers();
+    try {
+      const session = makeSession('google-workspace', () => new Promise<unknown>(() => {}));
+      const pending = checkMcpServers(
+        new Map<string, McpServerBootStatus>([['google-workspace', { status: 'ok', toolCount: 121 }]]),
+        [session],
+        logger,
+      );
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(await pending).toEqual({ google_workspace: 'fail' });
+      expect(session.client.listTools).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('fails boot zero_tools without a live probe', async () => {
+    const session = makeSession('google-workspace');
+    const result = await checkMcpServers(
+      new Map<string, McpServerBootStatus>([['google-workspace', { status: 'zero_tools' }]]),
+      [session],
       logger,
     );
     expect(result).toEqual({ google_workspace: 'fail' });
-    expect(listTools).not.toHaveBeenCalled();
+    expect(session.client.ping).not.toHaveBeenCalled();
   });
 
-  it('fails boot unavailable without calling listTools', async () => {
+  it('fails boot unavailable without a live probe', async () => {
     const result = await checkMcpServers(
-      new Map([['google-workspace', { status: 'unavailable', reason: 'connect failed' }]]),
+      new Map<string, McpServerBootStatus>([['google-workspace', { status: 'unavailable', reason: 'connect failed' }]]),
       [],
       logger,
     );
     expect(result).toEqual({ google_workspace: 'fail' });
-  });
-
-  it('probes live tools/list for boot-ok servers and fails on empty', async () => {
-    const listTools = vi.fn().mockResolvedValue({ tools: [] });
-    const result = await checkMcpServers(
-      new Map([['google-workspace', { status: 'ok', toolCount: 10 }]]),
-      [{ serverId: 'google-workspace', client: { listTools } }],
-      logger,
-    );
-    expect(result).toEqual({ google_workspace: 'fail' });
-    expect(listTools).toHaveBeenCalled();
-  });
-
-  it('returns ok when live tools/list has tools', async () => {
-    const listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'drive_search' }] });
-    const result = await checkMcpServers(
-      new Map([['google-workspace', { status: 'ok', toolCount: 1 }]]),
-      [{ serverId: 'google-workspace', client: { listTools } }],
-      logger,
-    );
-    expect(result).toEqual({ google_workspace: 'ok' });
   });
 
   it('returns empty object when no enabled servers were attempted', async () => {
@@ -53,12 +88,12 @@ describe('checkMcpServers (#1500)', () => {
 
   it('returns a result for every enabled server (mixed outcomes)', async () => {
     const result = await checkMcpServers(
-      new Map([
+      new Map<string, McpServerBootStatus>([
         ['alpha', { status: 'zero_tools' }],
         ['beta', { status: 'ok', toolCount: 3 }],
         ['gamma', { status: 'ok', toolCount: 1 }], // boot-ok but no live session → fail
       ]),
-      [{ serverId: 'beta', client: { listTools: vi.fn().mockResolvedValue({ tools: [{ name: 't' }] }) } }],
+      [makeSession('beta')],
       logger,
     );
     expect(result).toEqual({ alpha: 'fail', beta: 'ok', gamma: 'fail' });
@@ -67,29 +102,29 @@ describe('checkMcpServers (#1500)', () => {
   it('probes servers concurrently, not serially (#1500 review)', async () => {
     // Deferred probes: both must be in flight before either resolves. Serial
     // probing would leave B uncalled until A settles.
-    let resolveA!: (value: { tools?: unknown[] }) => void;
-    let resolveB!: (value: { tools?: unknown[] }) => void;
-    const listToolsA = vi.fn(() => new Promise<{ tools?: unknown[] }>((resolve) => { resolveA = resolve; }));
-    const listToolsB = vi.fn(() => new Promise<{ tools?: unknown[] }>((resolve) => { resolveB = resolve; }));
+    let resolveA!: (value: unknown) => void;
+    let resolveB!: (value: unknown) => void;
+    const pingA = vi.fn(() => new Promise<unknown>((resolve) => { resolveA = resolve; }));
+    const pingB = vi.fn(() => new Promise<unknown>((resolve) => { resolveB = resolve; }));
 
     const promise = checkMcpServers(
-      new Map([
+      new Map<string, McpServerBootStatus>([
         ['server-a', { status: 'ok', toolCount: 1 }],
         ['server-b', { status: 'ok', toolCount: 1 }],
       ]),
       [
-        { serverId: 'server-a', client: { listTools: listToolsA } },
-        { serverId: 'server-b', client: { listTools: listToolsB } },
+        { serverId: 'server-a', client: { ping: pingA } },
+        { serverId: 'server-b', client: { ping: pingB } },
       ],
       logger,
     );
 
     await Promise.resolve(); // flush microtasks; both probes should now be started
-    expect(listToolsA).toHaveBeenCalledTimes(1);
-    expect(listToolsB).toHaveBeenCalledTimes(1);
+    expect(pingA).toHaveBeenCalledTimes(1);
+    expect(pingB).toHaveBeenCalledTimes(1);
 
-    resolveA({ tools: [{ name: 'a' }] });
-    resolveB({ tools: [{ name: 'b' }] });
+    resolveA({});
+    resolveB({});
     expect(await promise).toEqual({ server_a: 'ok', server_b: 'ok' });
   });
 

--- a/tests/unit/health/health-checks.test.ts
+++ b/tests/unit/health/health-checks.test.ts
@@ -11,8 +11,8 @@ import {
 } from '../../../src/health/health-checks.js';
 import type { Logger } from '../../../src/logger.js';
 
-// Stub logger — all three probe functions (checkDb, checkSignal, checkMcpGoogleWorkspace)
-// now require a logger to warn on failure. Tests that don't care about log output pass this.
+// Stub logger — the probe functions (checkDb, checkSignal, checkMcpServers, ...)
+// require a logger to warn on failure. Tests that don't care about log output pass this.
 const stubLogger = { warn: () => {} } as unknown as Logger;
 
 describe('checkDb', () => {


### PR DESCRIPTION
## Summary

Fixes the production OOM restart loop (#1650, root-caused in #1663). The MCP liveness health probe called `client.listTools()` on every `/api/health` request; the Docker healthcheck hits `/api/health` every 30s. The MCP SDK recompiles an Ajv validator for every tool's `outputSchema` on **every** `listTools()` call and retains them on a shared, process-lifetime Ajv instance whose cache is keyed by schema object reference — each response is freshly parsed, so it's a cache miss every time. At ~121 tools × ~120 checks/hr that accumulated **~145 MB/hr** of compiled validator functions on the JS heap (`heapUsed` climbs, `external`/`arrayBuffers` flat), OOM-restarting prod every ~4h41m.

The fix switches the liveness probe to the MCP protocol's **`client.ping()`** (strict empty result: no tools, no `outputSchema`, no compilation). `listTools()` remains for boot-time discovery only.

Closes #1663.

## How it was found

`MemorySampler` (#1650 / PR #1652) confirmed the shape (JS-heap, not buffers) and the ~145 MB/hr slope over a 4h prod run. A parallel code sweep cleared all of Curia's own subsystems (scheduler, agent runtime/LLM, bus/dispatch/memory, skills/execution) — the retention was entirely inside the SDK's Ajv cache, triggered by our probe. The onset (`a8ad2e28`, which extended `listTools()` probing to all servers) matches the Aug 3 deploy when prod trouble began.

## Changes

- `src/health/health-checks.ts`: liveness probe → `client.ping()`; `McpSessionHealth.client` interface now declares `ping()`; doc comments explain the leak and the boot-only role of `listTools()`.
- Removed the dead, deprecated `checkMcpGoogleWorkspace` (zero callers, same leaky `listTools()` pattern).
- Rewrote `tests/unit/health/check-mcp-servers.test.ts` for `ping()` semantics, including a **regression guard** asserting the probe calls `ping()` and **never** `listTools()`, plus ping-reject and 3s-timeout cases.
- CHANGELOG entry; fixed a stale comment referencing the removed function.

## Behavior change (reviewed, accepted)

The probe no longer re-counts tools at runtime — a boot-`ok` server is `ok` as long as it answers `ping()` within 3s. The boot-time `zero_tools`/`unavailable` gate is unchanged, so zero-tools detection does not regress. The only dropped signal is a server that had tools at boot but later exposes **0** live tools; that's a *readiness/degradation* condition (not liveness — a container restart is the wrong remedy), it's rare for our static-tool-set servers, and for the highest-stakes server (google-workspace) it remains independently covered by the separate `canaryGoogleWorkspace` credential probe. If functional tool-presence ever needs monitoring, it belongs in a low-frequency readiness canary, never back on the 30s liveness path. Both a code review and a silent-failure review confirmed no dead/hung server is masked as `ok`.

## Upstream

The underlying SDK behavior (recompile-per-`listTools()` on a shared, reference-keyed Ajv cache) is a genuine bug affecting anyone who polls `listTools()`. It will be reported to `@modelcontextprotocol/sdk` separately.

## Test plan

- `pnpm run typecheck` — clean.
- `pnpm exec vitest run tests/unit/health/` — 68/68 pass.
- Regression guard proves `listTools()` is not called by the probe; ping-reject and fake-timer-timeout cases prove dead/hung servers still report `fail`.
- End-to-end: `MemorySampler` slope should flatten to ~0 after deploy.

Refs #1650. Follow-ups filed: #1664, #1665, #1666.
