### PR TITLE
chore: bound two latent unbounded Maps (#1664, #1665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **MCP health probe** — liveness uses `ping()` not `listTools()`, ending a ~145 MB/hr validator leak. (#1663)
+- **Scheduler** — `burstCounts` evicts one-shot completions inline and stale jobs on the watchdog sweep. (#1664)
 - **`RateLimiter`** — idle per-sender windows are reclaimed once elapsed, bounding memory. (#1665)
 - **`classifyError`** — `AbortSignal.timeout` / abort DOMExceptions map to `TIMEOUT`. (#1597)
 - **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **MCP health probe** — liveness uses `ping()` not `listTools()`, ending a ~145 MB/hr validator leak. (#1663)
+- **`RateLimiter`** — idle per-sender windows are reclaimed once elapsed, bounding memory. (#1665)
 - **`classifyError`** — `AbortSignal.timeout` / abort DOMExceptions map to `TIMEOUT`. (#1597)
 - **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)
 - **Coordinator** — ambient bullpen mentions no longer bleed into scheduler jobs and leak to the principal. (#1609)

--- a/src/dispatch/rate-limiter.ts
+++ b/src/dispatch/rate-limiter.ts
@@ -37,6 +37,10 @@ export class RateLimiter {
   /** Single global counter — tracks aggregate message rate across all senders. */
   private globalWindow: WindowEntry = { count: 0, windowStart: 0 };
 
+  /** Timestamp of the last idle-window sweep. Gates sweepExpired() to run at most
+   *  once per windowMs, so per-message cost stays O(1) amortized (#1665). */
+  private lastSweepAt = 0;
+
   constructor(config: RateLimiterConfig) {
     this.windowMs = config.windowMs;
     this.maxPerSender = config.maxPerSender;
@@ -64,12 +68,43 @@ export class RateLimiter {
    * The counter is NOT incremented on false — a rejected message does not consume quota.
    */
   checkSender(senderId: string): boolean {
+    // Reclaim windows for senders that have gone fully idle before touching this
+    // one. Without this, senderWindows grows by one entry per distinct sender ever
+    // seen and never shrinks — bounded by distinct-sender cardinality, but unbounded
+    // in principle (#1665).
+    this.sweepExpired();
+
     let entry = this.senderWindows.get(senderId);
     if (!entry) {
       entry = { count: 0, windowStart: 0 };
       this.senderWindows.set(senderId, entry);
     }
     return this.check(entry, this.maxPerSender);
+  }
+
+  /**
+   * Evict per-sender windows whose fixed window has fully elapsed.
+   *
+   * A sender whose window has expired holds no live rate-limit state — its next
+   * checkSender() would reset the window in place anyway. Deleting the entry is
+   * therefore behavior-preserving: a returning sender simply re-creates a fresh
+   * window on its next call, identical to the in-place reset it would have gotten.
+   *
+   * Gated to run at most once per windowMs (via lastSweepAt) so the O(n) scan is
+   * amortized to O(1) per message even under a high sender rate. Senders still
+   * inside their window are spared, so active rate-limiting is never disturbed. (#1665)
+   */
+  private sweepExpired(): void {
+    const now = Date.now();
+    if (now - this.lastSweepAt < this.windowMs) {
+      return;
+    }
+    this.lastSweepAt = now;
+    for (const [senderId, entry] of this.senderWindows) {
+      if (now - entry.windowStart >= this.windowMs) {
+        this.senderWindows.delete(senderId);
+      }
+    }
   }
 
   /**

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -202,6 +202,11 @@ export class Scheduler {
       this.recoverStuckJobs().catch((err) => {
         this.logger.error({ err }, 'Unhandled error in recoverStuckJobs watchdog');
       });
+      // Reclaim burst counters for jobs that went terminal without the poller
+      // observing it (cancel/delete/suspend all mutate the DB directly) (#1664).
+      this.pruneStaleBurstCounts().catch((err) => {
+        this.logger.error({ err }, 'Unhandled error in pruneStaleBurstCounts watchdog');
+      });
     }, WATCHDOG_INTERVAL_MS);
 
     // Dream engine — background KG maintenance (decay, and future passes).
@@ -697,6 +702,14 @@ export class Scheduler {
               }
             }
           }
+
+          // One-shot jobs (no cron_expr) fire exactly once and never burst again,
+          // so their counter is dead weight the moment the run completes — drop it
+          // inline. Recurring jobs keep their counter (checkEveryNBursts spans runs)
+          // and are reclaimed by the watchdog sweep once they go terminal (#1664).
+          if (!job.cronExpr) {
+            this.burstCounts.delete(jobId);
+          }
         }
       }
 
@@ -961,6 +974,41 @@ export class Scheduler {
         }
       } catch (err) {
         this.logger.error({ err, jobId: row.id }, 'Failed to recover stuck job — will retry on next watchdog tick');
+      }
+    }
+  }
+
+  /**
+   * Evict burst counters for jobs that are no longer active recurring jobs.
+   *
+   * `burstCounts` is only meaningful for a pending/running **recurring** job between
+   * its runs — it drives checkEveryNBursts. One-shot completion is evicted inline in
+   * handleCompletion, but cancel, delete, and suspend all mutate the DB directly via
+   * SchedulerService without the poller ever seeing it, so those entries would live
+   * for the whole process lifetime. This sweep is the catch-all: it keeps only the
+   * counters whose job is still a pending/running recurring job and drops the rest.
+   * Runs on the watchdog cadence.
+   *
+   * Over-eviction is harmless: a wrongly-dropped counter simply restarts its N-burst
+   * window, and a missed drift check is explicitly not a security failure (see the
+   * burstCounts field declaration). (#1664)
+   */
+  async pruneStaleBurstCounts(): Promise<void> {
+    if (this.burstCounts.size === 0) return;
+
+    const ids = [...this.burstCounts.keys()];
+    const { rows } = await this.pool.query(
+      `SELECT id FROM scheduled_jobs
+        WHERE id = ANY($1::uuid[])
+          AND status IN ('pending', 'running')
+          AND cron_expr IS NOT NULL`,
+      [ids],
+    );
+    const live = new Set((rows as Array<{ id: string }>).map((r) => r.id));
+
+    for (const id of ids) {
+      if (!live.has(id)) {
+        this.burstCounts.delete(id);
       }
     }
   }

--- a/tests/unit/dispatch/rate-limiter.test.ts
+++ b/tests/unit/dispatch/rate-limiter.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { RateLimiter } from '../../../src/dispatch/rate-limiter.js';
 
+/** Read the private per-sender Map's size to assert eviction bounds memory.
+ *  TypeScript `private` is not enforced at runtime, so a cast is the standard
+ *  way to inspect internal bookkeeping from a unit test. */
+function senderCount(limiter: RateLimiter): number {
+  return (limiter as unknown as { senderWindows: Map<string, unknown> }).senderWindows.size;
+}
+
 describe('RateLimiter', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -109,6 +116,64 @@ describe('RateLimiter', () => {
       // Window reset — alice is allowed again
       expect(limiter.checkSender('alice')).toBe(true);
       expect(limiter.checkSender('alice')).toBe(false); // blocked again
+    });
+  });
+
+  // -- Idle-sender eviction (#1665) --
+
+  describe('idle-sender eviction', () => {
+    it('evicts an idle sender window once its window has fully elapsed', async () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 5, maxGlobal: 100 });
+
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(senderCount(limiter)).toBe(1); // alice tracked
+
+      // Alice goes idle for longer than a full window, then bob sends. Bob's call
+      // triggers the once-per-window sweep, which drops alice's fully-elapsed window.
+      await vi.advanceTimersByTimeAsync(60_001);
+      expect(limiter.checkSender('bob')).toBe(true);
+
+      expect(senderCount(limiter)).toBe(1); // only bob remains — alice evicted
+    });
+
+    it('bounds memory under many one-shot senders', async () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 5, maxGlobal: 10_000 });
+
+      // 50 distinct senders each send one message inside the first window.
+      for (let i = 0; i < 50; i++) {
+        expect(limiter.checkSender(`sender-${i}`)).toBe(true);
+      }
+      expect(senderCount(limiter)).toBe(50);
+
+      // A full window passes with no activity from any of them; one new sender
+      // arrives and triggers the sweep. All 50 idle windows are reclaimed.
+      await vi.advanceTimersByTimeAsync(60_001);
+      expect(limiter.checkSender('newcomer')).toBe(true);
+
+      expect(senderCount(limiter)).toBe(1);
+    });
+
+    it('spares a sender whose window is still active when the sweep runs', async () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 100 });
+
+      // alice sends at t=0 (window [0, 60_000)).
+      expect(limiter.checkSender('alice')).toBe(true);
+
+      // bob sends at t=30_000 (window [30_000, 90_000)) — no sweep yet this window.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(limiter.checkSender('bob')).toBe(true);
+
+      // carol sends at t=60_001. Her call triggers the sweep: alice's window has
+      // fully elapsed (idle 60_001ms) → evicted; bob's window is still active
+      // (idle 30_001ms) → spared.
+      await vi.advanceTimersByTimeAsync(30_001);
+      expect(limiter.checkSender('carol')).toBe(true);
+
+      expect(senderCount(limiter)).toBe(2); // bob + carol; alice evicted
+
+      // bob survived the sweep with his window intact: still inside it and already
+      // used his single message, so he stays blocked.
+      expect(limiter.checkSender('bob')).toBe(false);
     });
   });
 

--- a/tests/unit/dispatch/rate-limiter.test.ts
+++ b/tests/unit/dispatch/rate-limiter.test.ts
@@ -122,6 +122,14 @@ describe('RateLimiter', () => {
   // -- Idle-sender eviction (#1665) --
 
   describe('idle-sender eviction', () => {
+    // Pin the fake clock to a fixed epoch far larger than windowMs. lastSweepAt
+    // starts at 0, so this guarantees the first checkSender trips the sweep gate
+    // and resets each sender's windowStart to "now" — making these tests
+    // deterministic instead of dependent on the machine's wall-clock.
+    beforeEach(() => {
+      vi.setSystemTime(1_600_000_000_000); // 2020-09-13T12:26:40Z, >> windowMs
+    });
+
     it('evicts an idle sender window once its window has fully elapsed', async () => {
       const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 5, maxGlobal: 100 });
 
@@ -156,13 +164,11 @@ describe('RateLimiter', () => {
     it('spares a sender whose window is still active when the sweep runs', async () => {
       const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 100 });
 
-      // NOTE: t below is relative — vitest's fake clock starts at real wall-clock
-      // time, which is far larger than windowMs. That is load-bearing here: it makes
-      // the first checkSender stamp lastSweepAt and reset each sender's windowStart to
-      // "now" so the t=60_001 sweep sees bob's window as still active. Pinning the
-      // clock to a small base (e.g. vi.setSystemTime(0)) would break this test.
+      // Clock is pinned in beforeEach to a fixed epoch >> windowMs, so the first
+      // checkSender stamps lastSweepAt and resets each sender's windowStart to "now".
+      // t below is relative to that pinned base.
 
-      // alice sends at t≈0 (window [t, t+60_000)).
+      // alice sends at t=0 (window [t, t+60_000)).
       expect(limiter.checkSender('alice')).toBe(true);
 
       // bob sends at t=30_000 (window [30_000, 90_000)) — no sweep yet this window.

--- a/tests/unit/dispatch/rate-limiter.test.ts
+++ b/tests/unit/dispatch/rate-limiter.test.ts
@@ -156,7 +156,13 @@ describe('RateLimiter', () => {
     it('spares a sender whose window is still active when the sweep runs', async () => {
       const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 100 });
 
-      // alice sends at t=0 (window [0, 60_000)).
+      // NOTE: t below is relative — vitest's fake clock starts at real wall-clock
+      // time, which is far larger than windowMs. That is load-bearing here: it makes
+      // the first checkSender stamp lastSweepAt and reset each sender's windowStart to
+      // "now" so the t=60_001 sweep sees bob's window as still active. Pinning the
+      // clock to a small base (e.g. vi.setSystemTime(0)) would break this test.
+
+      // alice sends at t≈0 (window [t, t+60_000)).
       expect(limiter.checkSender('alice')).toBe(true);
 
       // bob sends at t=30_000 (window [30_000, 90_000)) — no sweep yet this window.

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -1467,8 +1467,8 @@ describe('Scheduler', () => {
       expect(burst.has('job-gone')).toBe(false);
 
       // Parameterized query — the tracked ids are bound, never interpolated.
-      const [, params] = pool.query.mock.calls[0] as [string, unknown[]];
-      expect(params[0]).toEqual(['job-live', 'job-gone']);
+      const [, params] = pool.query.mock.calls[0]! as [string, unknown[]];
+      expect(params[0]!).toEqual(['job-live', 'job-gone']);
     });
 
     it('does not query the DB when no burst counters are tracked', async () => {

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -76,6 +76,13 @@ function fakeDbRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/** Read the Scheduler's private burst-counter Map to assert eviction (#1664).
+ *  TypeScript `private` is not enforced at runtime, so a cast is the standard way
+ *  to inspect internal bookkeeping from a unit test. */
+function burstCounts(s: Scheduler): Map<string, number> {
+  return (s as unknown as { burstCounts: Map<string, number> }).burstCounts;
+}
+
 describe('Scheduler', () => {
   let pool: ReturnType<typeof mockPool>;
   let bus: ReturnType<typeof mockBus>;
@@ -1354,6 +1361,119 @@ describe('Scheduler', () => {
       // The "Reason:" line stays a single line — the embedded newline did not split the message.
       const reasonLine = content.split('\n').find((l) => l.startsWith('Reason:'));
       expect(reasonLine).toContain('Now: re-send the debrief prompt');
+    });
+
+    it('evicts the burst counter when a one-shot drift-eligible job completes (#1664)', async () => {
+      // A one-shot job (no cron_expr) fires exactly once, so its burst counter is
+      // never needed again — it must be dropped inline on completion, not left to
+      // linger in the Map for the process lifetime.
+      const oneShotRow = fakeDbRow({
+        cron_expr: null,
+        run_at: new Date().toISOString(),
+        agent_task_id: 'task-os',
+        intent_anchor: 'Send the one-off report.',
+        task_payload: { skill: 'web-search', query: 'report' },
+      });
+      driftPool.query.mockResolvedValueOnce({ rows: [oneShotRow] });
+      driftPool.query.mockResolvedValueOnce({ rows: [] });
+      await driftScheduler.pollDueJobs();
+      const [, taskEvent] = driftBus.publish.mock.calls[1] as [string, { id: string }];
+
+      driftSchedulerService.getJob.mockResolvedValueOnce({
+        id: 'job-1',
+        agentId: 'agent-1',
+        cronExpr: null, // one-shot
+        agentTaskId: 'task-os',
+        intentAnchor: 'Send the one-off report.',
+        taskPayload: { skill: 'web-search', query: 'report' },
+        lastRunSummary: null,
+      });
+      driftDetector.check.mockResolvedValueOnce({ drifted: false, reason: 'Aligned.', confidence: 'high' });
+      driftDetector.shouldPause.mockReturnValueOnce(false);
+      driftSchedulerService.completeJobRun.mockResolvedValueOnce({ suspended: false });
+
+      driftScheduler.start();
+      const responseHandler = driftBus.subscribe.mock.calls[0]?.[2] as (event: unknown) => Promise<void>;
+      await responseHandler({
+        id: 'resp-os',
+        type: 'agent.response',
+        sourceLayer: 'agent',
+        parentEventId: taskEvent.id,
+        timestamp: new Date(),
+        payload: { agentId: 'agent-1', conversationId: 'c1', content: 'done' },
+      });
+
+      await vi.waitFor(() => {
+        expect(driftSchedulerService.completeJobRun).toHaveBeenCalledWith('job-1', true, undefined, 'done');
+      });
+      expect(burstCounts(driftScheduler).has('job-1')).toBe(false);
+    });
+
+    it('keeps the burst counter across runs of a recurring drift-eligible job (#1664)', async () => {
+      // A recurring job's counter drives checkEveryNBursts and MUST persist between
+      // runs — the one-shot eviction must not touch it.
+      driftPool.query.mockResolvedValueOnce({ rows: [persistentRow] });
+      driftPool.query.mockResolvedValueOnce({ rows: [] });
+      await driftScheduler.pollDueJobs();
+      const [, taskEvent] = driftBus.publish.mock.calls[1] as [string, { id: string }];
+
+      driftSchedulerService.getJob.mockResolvedValueOnce({
+        id: 'job-1',
+        agentId: 'agent-1',
+        cronExpr: '0 9 * * *', // recurring
+        agentTaskId: 'task-99',
+        intentAnchor: 'Research AI safety articles weekly.',
+        taskPayload: { skill: 'web-search', query: 'AI safety' },
+        lastRunSummary: null,
+      });
+      driftDetector.check.mockResolvedValueOnce({ drifted: false, reason: 'Aligned.', confidence: 'high' });
+      driftDetector.shouldPause.mockReturnValueOnce(false);
+      driftSchedulerService.completeJobRun.mockResolvedValueOnce({ suspended: false });
+
+      driftScheduler.start();
+      const responseHandler = driftBus.subscribe.mock.calls[0]?.[2] as (event: unknown) => Promise<void>;
+      await responseHandler({
+        id: 'resp-rec',
+        type: 'agent.response',
+        sourceLayer: 'agent',
+        parentEventId: taskEvent.id,
+        timestamp: new Date(),
+        payload: { agentId: 'agent-1', conversationId: 'c1', content: 'done' },
+      });
+
+      await vi.waitFor(() => {
+        expect(driftSchedulerService.completeJobRun).toHaveBeenCalledWith('job-1', true, undefined, 'done');
+      });
+      expect(burstCounts(driftScheduler).get('job-1')).toBe(1);
+    });
+  });
+
+  // -- burst-counter sweep (#1664) --
+
+  describe('pruneStaleBurstCounts', () => {
+    it('evicts burst counters for jobs that are no longer active recurring jobs', async () => {
+      // The poller never observes a cancel/delete/suspend (they mutate the DB via
+      // SchedulerService), so the watchdog sweep reconciles burstCounts against the
+      // set of jobs that are still pending/running recurring jobs.
+      const burst = burstCounts(scheduler);
+      burst.set('job-live', 3);
+      burst.set('job-gone', 1);
+
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-live' }] });
+
+      await scheduler.pruneStaleBurstCounts();
+
+      expect(burst.has('job-live')).toBe(true);
+      expect(burst.has('job-gone')).toBe(false);
+
+      // Parameterized query — the tracked ids are bound, never interpolated.
+      const [, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      expect(params[0]).toEqual(['job-live', 'job-gone']);
+    });
+
+    it('does not query the DB when no burst counters are tracked', async () => {
+      await scheduler.pruneStaleBurstCounts();
+      expect(pool.query).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Two in-memory Maps found during the #1650 production OOM hunt grow without an upper bound in principle. Neither was the ~145 MB/hr OOM cause (that was the MCP Ajv-recompile leak, fixed in #1663), but both are genuine latent unbounded-growth bugs worth closing. This bounds them.

- Closes #1664
- Closes #1665

## #1665 — `RateLimiter.senderWindows`

`checkSender()` added a Map entry per distinct inbound sender and never removed it; the fixed window was reset in place but the entry lived for the whole process lifetime, so distinct-sender cardinality set an unbounded floor on memory.

**Fix:** `checkSender()` now runs a `sweepExpired()` pass, gated by `lastSweepAt` to fire **at most once per `windowMs`** (O(1) amortized per message), that deletes entries whose window has fully elapsed. Behavior-preserving: a returning sender re-creates a fresh window identical to the in-place reset it would otherwise get. Senders still inside their window are spared, so active rate-limiting is never disturbed and there's no quota-bypass.

## #1664 — `Scheduler.burstCounts`

`burstCounts` (drives `checkEveryNBursts`) accumulated an entry per drift-eligible jobId and only deleted on drift-pause and watchdog recovery. One-shot completions, cancels, deletes, and suspensions all left an entry alive for the process lifetime.

**Fix — two evictions:**
- **Inline** in `handleCompletion`: a one-shot job (no `cron_expr`) fires exactly once, so its counter is dropped as soon as the run completes. Recurring jobs keep their counter — `checkEveryNBursts` spans runs.
- **Watchdog sweep** (`pruneStaleBurstCounts`): reconciles the Map against the set of still-pending/running recurring jobs (parameterized query), catching cancel/delete/suspend, which the poller never observes (they mutate the DB directly via `SchedulerService`).

Over-eviction is harmless: a dropped counter just restarts its N-burst window, and a missed drift check is explicitly not a security failure (per the `burstCounts` field contract).

## Tests

- **RateLimiter**: idle-window eviction after elapse; memory bounded under 50 one-shot senders; a sweep spares a still-active sender while evicting the idle one. All existing window/limit tests unchanged.
- **Scheduler**: one-shot completion evicts inline; recurring completion retains the counter; `pruneStaleBurstCounts` keeps live jobs and drops stale ones (asserting the parameterized bind); empty-Map short-circuits without a query.

`pnpm run typecheck` clean; rate-limiter (69) and scheduler (466) unit suites green; eslint clean on changed files.

## Notes

- Both issues were labeled size:XS/S. #1664 landed a touch larger than XS because correctly covering the cancel/delete case requires the watchdog reconciliation sweep (the poller can't observe those DB-only transitions inline).