### PR TITLE
fix(skills): abort the MCP request when a tool call times out (#1666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **MCP health probe** — liveness uses `ping()` not `listTools()`, ending a ~145 MB/hr validator leak. (#1663)
 - **Scheduler** — `burstCounts` evicts one-shot completions inline and stale jobs on the watchdog sweep. (#1664)
 - **`RateLimiter`** — idle per-sender windows are reclaimed once elapsed, bounding memory. (#1665)
+- **MCP `callTool`** — a timed-out skill now aborts the underlying MCP request instead of stranding it. (#1666)
 - **`classifyError`** — `AbortSignal.timeout` / abort DOMExceptions map to `TIMEOUT`. (#1597)
 - **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)
 - **Coordinator** — ambient bullpen mentions no longer bleed into scheduler jobs and leak to the principal. (#1609)

--- a/src/skills/mcp-loader.ts
+++ b/src/skills/mcp-loader.ts
@@ -287,6 +287,83 @@ export async function resolveSecretsBlock(
 }
 
 // ---------------------------------------------------------------------------
+// MCP tool handler
+// ---------------------------------------------------------------------------
+
+/** The subset of an {@link McpSession} the tool handler needs: a `callTool`-capable
+ *  client plus the server id for logs. Narrowed so unit tests can pass a mock
+ *  client without constructing a full SDK `Client`. */
+type McpToolSession = {
+  serverId: string;
+  client: Pick<McpSession['client'], 'callTool'>;
+};
+
+/**
+ * Build the execution handler for a single MCP tool.
+ *
+ * Extracted from loadMcpServers so the request-cancellation behavior below can be
+ * unit-tested against a mock MCP client.
+ *
+ * #1666 — the execution layer races this handler against `manifest.timeout` and,
+ * when the timeout wins, rejects our promise WITHOUT cancelling the underlying MCP
+ * request. That leaves the SDK's pending-request entry (and the captured request +
+ * closures) alive until the SDK's own default timeout fires. We tie an
+ * AbortController to a timer set to the same `timeoutMs` the execution layer uses,
+ * and also pass an explicit `timeout`, so a timed-out tool call also tears down the
+ * in-flight MCP request instead of stranding it.
+ */
+export function buildMcpToolHandler(params: {
+  session: McpToolSession;
+  toolName: string;
+  resolvedFixedInputs: Record<string, string>;
+  timeoutMs: number;
+  logger: Logger;
+}): ToolHandler {
+  const { session, toolName, resolvedFixedInputs, timeoutMs, logger } = params;
+  return {
+    async execute(ctx: ToolContext): Promise<ToolResult> {
+      // Abort the MCP request if it outlives the execution-layer timeout (#1666).
+      const controller = new AbortController();
+      const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        // Merge fixed_inputs into the tool call arguments. Fixed values take
+        // precedence — even if an agent somehow passed a value for a stripped
+        // parameter (e.g. via prompt injection), the config value wins.
+        const mergedInput = mergeFixedInputs(ctx.input, resolvedFixedInputs);
+        const rawResult = await session.client.callTool(
+          { name: toolName, arguments: mergedInput },
+          undefined, // use the SDK's default CallToolResultSchema
+          { signal: controller.signal, timeout: timeoutMs },
+        );
+        const result = mapMcpResult(rawResult, logger, session.serverId, toolName);
+        if (!result.success) {
+          // Log tool-level errors so operators can detect persistently failing tools.
+          logger.warn(
+            { server: session.serverId, tool: toolName, error: result.error },
+            'MCP tool returned an error result',
+          );
+        }
+        return result;
+      } catch (err) {
+        // Log before converting — a thrown rejection here (transport/subprocess
+        // crash, JSON-RPC protocol error, the SDK's RequestTimeout, or our own
+        // abort above) is a MORE severe failure than the tool-level `isError`
+        // result logged above, yet would otherwise be invisible: the execution
+        // layer only logs when handler.execute *throws*, and we deliberately
+        // return `{ success: false }` instead (skills must never throw).
+        logger.warn({ server: session.serverId, tool: toolName, err }, 'MCP tool call threw');
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: `MCP tool '${toolName}' error: ${message}` };
+      } finally {
+        // Always clear the timer so a completed call doesn't leave a pending abort
+        // (which would also keep the event loop alive during graceful shutdown).
+        clearTimeout(abortTimer);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
@@ -554,38 +631,15 @@ export async function loadMcpServers(
         timeout: serverEntry.timeout_ms ?? 30000,
       };
 
-      // Capture the session reference in the closure — each tool needs its own
-      // copy so the reference stays valid across the async loop.
-      const capturedSession = session;
-      const toolName = tool.name;
-
-      const handler: ToolHandler = {
-        async execute(ctx: ToolContext): Promise<ToolResult> {
-          try {
-            // Merge fixed_inputs into the tool call arguments. Fixed values take
-            // precedence — even if an agent somehow passed a value for a stripped
-            // parameter (e.g. via prompt injection), the config value wins.
-            const mergedInput = mergeFixedInputs(ctx.input, resolvedFixedInputs);
-            const rawResult = await capturedSession.client.callTool({
-              name: toolName,
-              arguments: mergedInput,
-            });
-            const result = mapMcpResult(rawResult, logger, capturedSession.serverId, toolName);
-            if (!result.success) {
-              // Log tool-level errors so operators can detect persistently failing tools.
-              logger.warn(
-                { server: capturedSession.serverId, tool: toolName, error: result.error },
-                'MCP tool returned an error result',
-              );
-            }
-            return result;
-          } catch (err) {
-            // Skills must never throw — return a failure result instead.
-            const message = err instanceof Error ? err.message : String(err);
-            return { success: false, error: `MCP tool '${toolName}' error: ${message}` };
-          }
-        },
-      };
+      // Passing `session` as an argument captures it per-tool, so the reference
+      // stays valid across the async loop even as the outer `session` is reassigned.
+      const handler = buildMcpToolHandler({
+        session,
+        toolName: tool.name,
+        resolvedFixedInputs,
+        timeoutMs: manifest.timeout,
+        logger,
+      });
 
       // Build the raw MCP input schema for the fast-path in toToolDefinitions.
       // The MCP SDK returns `inputSchema` as a full JSON Schema object; we cast

--- a/src/skills/mcp-loader.ts
+++ b/src/skills/mcp-loader.ts
@@ -337,9 +337,14 @@ export function buildMcpToolHandler(params: {
         );
         const result = mapMcpResult(rawResult, logger, session.serverId, toolName);
         if (!result.success) {
-          // Log tool-level errors so operators can detect persistently failing tools.
+          // Log stable metadata only so operators can spot persistently failing
+          // tools. We deliberately DON'T log result.error: an MCP server receives
+          // vault-resolved fixed_inputs (secrets) as tool arguments, and a
+          // misbehaving server can echo those back in its error text, which would
+          // then leak into pino logs. The detail still reaches the agent via the
+          // returned ToolResult (secret-redacted by the execution layer).
           logger.warn(
-            { server: session.serverId, tool: toolName, error: result.error },
+            { server: session.serverId, tool: toolName },
             'MCP tool returned an error result',
           );
         }
@@ -351,7 +356,14 @@ export function buildMcpToolHandler(params: {
         // result logged above, yet would otherwise be invisible: the execution
         // layer only logs when handler.execute *throws*, and we deliberately
         // return `{ success: false }` instead (skills must never throw).
-        logger.warn({ server: session.serverId, tool: toolName, err }, 'MCP tool call threw');
+        //
+        // Log the error CLASS (SDK/runtime-controlled — e.g. McpError, AbortError),
+        // never the raw message: like result.error above, a thrown message can carry
+        // server-echoed fixed_input secrets.
+        logger.warn(
+          { server: session.serverId, tool: toolName, errorName: err instanceof Error ? err.name : typeof err },
+          'MCP tool call threw',
+        );
         const message = err instanceof Error ? err.message : String(err);
         return { success: false, error: `MCP tool '${toolName}' error: ${message}` };
       } finally {

--- a/tests/unit/skills/mcp-loader.test.ts
+++ b/tests/unit/skills/mcp-loader.test.ts
@@ -40,7 +40,8 @@ vi.mock('../../../src/skills/mcp-client.js', () => ({
 }));
 
 // Import the loader AFTER setting up mocks.
-const { loadMcpServers } = await import('../../../src/skills/mcp-loader.js');
+const { loadMcpServers, buildMcpToolHandler } = await import('../../../src/skills/mcp-loader.js');
+type BuildHandlerParams = Parameters<typeof buildMcpToolHandler>[0];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -387,10 +388,13 @@ servers:
     });
 
     expect(result).toEqual({ success: true, data: 'file contents here' });
-    expect(session.client.callTool).toHaveBeenCalledWith({
-      name: 'read_file',
-      arguments: { path: '/tmp/test.txt' },
-    });
+    // callTool is invoked with the default result schema plus RequestOptions that
+    // carry the abort signal and the manifest timeout (default 30s here) (#1666).
+    expect(session.client.callTool).toHaveBeenCalledWith(
+      { name: 'read_file', arguments: { path: '/tmp/test.txt' } },
+      undefined,
+      expect.objectContaining({ timeout: 30_000, signal: expect.any(AbortSignal) }),
+    );
   });
 
   it('returns success: false when MCP tool returns isError: true', async () => {
@@ -452,5 +456,128 @@ servers:
     // Must never throw — returns ToolResult failure instead.
     expect(result.success).toBe(false);
     expect((result as { success: false; error: string }).error).toMatch(/connection lost/);
+  });
+});
+
+describe('buildMcpToolHandler — request cancellation (#1666)', () => {
+  // Minimal ToolContext — the handler only reads ctx.input.
+  const ctx = {
+    toolName: 'search',
+    toolVersion: '1.0.0',
+    input: { q: 'hi' },
+    secret: () => '',
+    log: logger,
+  } as unknown as import('../../../src/skills/types.js').ToolContext;
+
+  /** Build a session whose client.callTool is the supplied spy. Cast through the
+   *  handler's own param type so the mock needn't implement the full SDK Client. */
+  function sessionWith(callTool: ReturnType<typeof vi.fn>): BuildHandlerParams['session'] {
+    return { serverId: 'srv', client: { callTool } } as unknown as BuildHandlerParams['session'];
+  }
+
+  /** Read the RequestOptions (3rd arg) the handler passed to callTool. */
+  function optionsFrom(callTool: ReturnType<typeof vi.fn>): { signal: AbortSignal; timeout: number } {
+    return callTool.mock.calls[0]![2] as { signal: AbortSignal; timeout: number };
+  }
+
+  it('passes an abort signal and explicit timeout, and returns the mapped result on success', async () => {
+    vi.useFakeTimers();
+    try {
+      const callTool = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'done' }] });
+      const handler = buildMcpToolHandler({
+        session: sessionWith(callTool),
+        toolName: 'search',
+        resolvedFixedInputs: {},
+        timeoutMs: 30_000,
+        logger,
+      });
+
+      const result = await handler.execute(ctx);
+      expect(result).toEqual({ success: true, data: 'done' });
+
+      const [callParams, resultSchema] = callTool.mock.calls[0]! as [unknown, unknown, unknown];
+      expect(callParams).toEqual({ name: 'search', arguments: { q: 'hi' } });
+      expect(resultSchema).toBeUndefined(); // default CallToolResultSchema
+
+      const options = optionsFrom(callTool);
+      expect(options.timeout).toBe(30_000);
+      expect(options.signal).toBeInstanceOf(AbortSignal);
+      expect(options.signal.aborted).toBe(false);
+
+      // The abort timer is cleared on success: advancing past the deadline must NOT
+      // abort the (already-returned) signal — no stray abort, no leaked timer.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(options.signal.aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('aborts the underlying MCP request when the execution-layer timeout elapses', async () => {
+    vi.useFakeTimers();
+    try {
+      // A hung MCP call that only settles when its abort signal fires — models a
+      // slow/stuck subprocess the SDK would otherwise leave pending.
+      const callTool = vi.fn(
+        (_params: unknown, _schema: unknown, options: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options.signal.addEventListener('abort', () => reject(new Error('request aborted')));
+          }),
+      );
+      const handler = buildMcpToolHandler({
+        session: sessionWith(callTool),
+        toolName: 'search',
+        resolvedFixedInputs: {},
+        timeoutMs: 30_000,
+        logger,
+      });
+
+      const pending = handler.execute(ctx);
+      await vi.advanceTimersByTimeAsync(30_000); // execution-layer deadline fires
+
+      const result = await pending;
+      expect(result.success).toBe(false);
+      expect(optionsFrom(callTool).signal.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('merges fixed inputs so the config value wins over caller input', async () => {
+    const callTool = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    const handler = buildMcpToolHandler({
+      session: sessionWith(callTool),
+      toolName: 'search',
+      resolvedFixedInputs: { q: 'FIXED' },
+      timeoutMs: 30_000,
+      logger,
+    });
+
+    await handler.execute({ ...ctx, input: { q: 'caller' } } as unknown as typeof ctx);
+
+    const [callParams] = callTool.mock.calls[0]! as [{ arguments: Record<string, unknown> }];
+    expect(callParams.arguments).toEqual({ q: 'FIXED' });
+  });
+
+  it('returns a failure result AND logs when callTool rejects (transport/abort failures stay visible)', async () => {
+    const callTool = vi.fn().mockRejectedValue(new Error('boom'));
+    // Spy logger — a thrown rejection is otherwise invisible to operators, so the
+    // handler must log it (unlike the exec layer, which only logs actual throws).
+    const warn = vi.fn();
+    const spyLogger = { warn, error: vi.fn(), info: vi.fn(), debug: vi.fn(), child: () => spyLogger } as unknown as typeof logger;
+    const handler = buildMcpToolHandler({
+      session: sessionWith(callTool),
+      toolName: 'search',
+      resolvedFixedInputs: {},
+      timeoutMs: 30_000,
+      logger: spyLogger,
+    });
+
+    const result = await handler.execute(ctx);
+    expect(result).toEqual({ success: false, error: "MCP tool 'search' error: boom" });
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ server: 'srv', tool: 'search', err: expect.any(Error) }),
+      'MCP tool call threw',
+    );
   });
 });

--- a/tests/unit/skills/mcp-loader.test.ts
+++ b/tests/unit/skills/mcp-loader.test.ts
@@ -575,9 +575,14 @@ describe('buildMcpToolHandler — request cancellation (#1666)', () => {
 
     const result = await handler.execute(ctx);
     expect(result).toEqual({ success: false, error: "MCP tool 'search' error: boom" });
+    // Logs the error CLASS for diagnosis, never the raw message — a thrown message
+    // can carry server-echoed fixed_input secrets (#1666 review).
     expect(warn).toHaveBeenCalledWith(
-      expect.objectContaining({ server: 'srv', tool: 'search', err: expect.any(Error) }),
+      { server: 'srv', tool: 'search', errorName: 'Error' },
       'MCP tool call threw',
     );
+    // Guard: the raw message must not appear anywhere in the logged metadata.
+    const [logMeta] = warn.mock.calls[0]!;
+    expect(JSON.stringify(logMeta)).not.toContain('boom');
   });
 });


### PR DESCRIPTION
## Summary

The MCP tool handler called `client.callTool({ name, arguments })` with **no `RequestOptions`** — no timeout, no signal. Meanwhile the execution layer races the handler against `manifest.timeout` and, when the timeout wins, rejects our promise **without cancelling the underlying MCP request**. A slow/hung MCP subprocess therefore left the SDK's pending-request entry (and the captured request + closures) alive until the SDK's own default 60s timeout fired.

Found during the #1650 leak hunt as the initial MCP hypothesis. It was **not** the ~145 MB/hr leak (that was the Ajv-recompile path, fixed in #1663), but it's a real robustness gap.

Closes #1666

## Change

- Tie an `AbortController` to a timer set to the **same `manifest.timeout`** the execution layer races against, and pass `{ signal, timeout }` to `callTool` (with `undefined` for the default result schema). A timed-out tool call now also tears down the in-flight MCP request. The timer is cleared in a `finally` so a completed call leaves no pending abort.
- Extract the inline handler into an exported `buildMcpToolHandler()` so the cancellation behavior is unit-testable against a mock MCP client (the AC requires "verified via a mock MCP client asserting abort") without a full connect harness. This preserves the original per-tool session-capture semantics (`session` is passed by value).
- **Silent-failure fix** (from pre-PR review): the catch converted every `callTool` rejection into `{ success: false }` with no log, while the *less severe* tool-level `isError` result *was* logged. Since the execution layer only logs actual throws, transport/subprocess/protocol failures — and the new abort/timeout path — were invisible to operators. The catch now `logger.warn`s before converting, restoring symmetry.

## Tests

New `buildMcpToolHandler` suite:
- passes an abort signal + explicit timeout and returns the mapped result on success; asserts the timer is cleared (no stray abort after the deadline);
- **aborts the underlying request when the execution-layer timeout elapses** (fake timers + a mock `callTool` that rejects on `signal` abort → asserts `signal.aborted === true` and a failure result);
- fixed-input precedence preserved through the extracted path;
- a rejecting `callTool` returns a failure result **and** logs (spy logger).

The existing `tools/call round-trip` test now also asserts the timeout/signal flow through the full `loadMcpServers` path.

`pnpm run typecheck` clean; `mcp-loader` suites (116) green; eslint clean on changed files.