### PR TITLE
fix: pair runtime fallback responses with agent.error for scheduler completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Scheduler runtime errors** — fallback `agent.response(isError)` paths now always emit paired `agent.error`. (#1647)
 - **MCP health probe** — liveness uses `ping()` not `listTools()`, ending a ~145 MB/hr validator leak. (#1663)
 - **Scheduler** — `burstCounts` evicts one-shot completions inline and stale jobs on the watchdog sweep. (#1664)
 - **`RateLimiter`** — idle per-sender windows are reclaimed once elapsed, bounding memory. (#1665)

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1826,6 +1826,7 @@ export class AgentRuntime {
     // than a real result — consumers (delegate, scheduler) check this flag.
     let responseContent: string;
     let isResponseError = false;
+    let responseAgentError: AgentError | null = null;
     if (response.type === 'tool_use') {
       // No execution layer, or streaming loop exhausted without a text completion.
       logger.warn(
@@ -1835,6 +1836,16 @@ export class AgentRuntime {
           : 'LLM returned tool_use but no execution layer configured',
       );
       isResponseError = true;
+      responseAgentError = {
+        type: 'UNKNOWN',
+        source: 'runtime',
+        message: response.toolCalls.length === 0
+          ? 'Tool loop exhausted without a text response'
+          : 'LLM returned tool_use but no execution layer configured',
+        retryable: false,
+        context: { toolCallCount: response.toolCalls.length },
+        timestamp: new Date(),
+      };
       responseContent = response.content ?? "I wasn't able to complete that request — I hit my tool-use limit. Please try rephrasing.";
     } else if (response.type === 'text') {
       logger.info(
@@ -1885,30 +1896,15 @@ export class AgentRuntime {
             },
             'LLM returned empty text response after tool use — recovery also failed, sending fallback',
           );
-          // Publish agent.error so the scheduler subscriber receives a completion signal.
-          // Without this, the scheduler only sees agent.response(isError: true), which it
-          // explicitly skips — leaving the job stuck in "running" until the watchdog fires.
-          // Wrapped in try-catch because a publish failure (e.g. audit hook / DB write)
-          // must not prevent the fallback agent.response below from being sent.
-          try {
-            await this.publishAgentError(
-              {
-                type: 'UNKNOWN',
-                source: 'runtime',
-                message: 'LLM returned empty text after tool use; recovery prompt also produced no output',
-                retryable: false,
-                context: { recoveryType: recovery.type, inputTokens: response.usage.inputTokens },
-                timestamp: new Date(),
-              },
-              taskEvent,
-            );
-          } catch (publishErr) {
-            logger.error(
-              { agentId, conversationId, err: publishErr },
-              'Failed to publish agent.error for empty-response recovery failure',
-            );
-          }
           isResponseError = true;
+          responseAgentError = {
+            type: 'UNKNOWN',
+            source: 'runtime',
+            message: 'LLM returned empty text after tool use; recovery prompt also produced no output',
+            retryable: false,
+            context: { recoveryType: recovery.type, inputTokens: response.usage.inputTokens },
+            timestamp: new Date(),
+          };
           responseContent = "I'm sorry, I wasn't able to formulate a response. Please try again.";
         }
       } else {
@@ -1918,12 +1914,24 @@ export class AgentRuntime {
       // Shouldn't reach here — chatWithRetry handles errors — but be safe
       logger.error({ agentId, error: response.error }, 'LLM call failed after retries');
       isResponseError = true;
+      responseAgentError = {
+        type: 'UNKNOWN',
+        source: 'runtime',
+        message: 'LLM call failed after retries',
+        retryable: false,
+        context: {},
+        timestamp: new Date(),
+      };
       responseContent = "I'm sorry, I was unable to process that request. Please try again.";
     }
 
     // Persist the assistant response
     if (memory) {
       await memory.addTurn(conversationId, agentId, { role: 'assistant', content: responseContent });
+    }
+
+    if (isResponseError && responseAgentError) {
+      await this.publishAgentErrorForFallback(taskEvent, responseAgentError);
     }
 
     const responseEvent = createAgentResponse({
@@ -2490,6 +2498,24 @@ export class AgentRuntime {
       parentEventId: taskEvent.id,
     });
     await bus.publish('agent', errorEvent);
+  }
+
+  /**
+   * Best-effort paired error signal for fallback response paths.
+   * Scheduler completion on failures relies on agent.error, while agent.response(isError)
+   * provides user-facing context; publish errors first without blocking the response event.
+   */
+  private async publishAgentErrorForFallback(taskEvent: AgentTaskEvent, agentErr: AgentError): Promise<void> {
+    const { logger, agentId } = this.config;
+    const { conversationId } = taskEvent.payload;
+    try {
+      await this.publishAgentError(agentErr, taskEvent);
+    } catch (publishErr) {
+      logger.error(
+        { agentId, conversationId, err: publishErr },
+        'Failed to publish agent.error for fallback response',
+      );
+    }
   }
 
   /**

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -257,7 +257,14 @@ export class AgentRuntime {
           ? attached
           : isDbUnavailableError(err)
             ? createDbUnavailableAgentError('runtime', err)
-            : null;
+            : {
+                type: 'UNKNOWN',
+                source: 'runtime',
+                message: err instanceof Error ? err.message : 'Unhandled error in agent task processing',
+                retryable: false,
+                context: {},
+                timestamp: new Date(),
+              } satisfies AgentError;
 
       this.config.logger.error(
         {
@@ -274,32 +281,15 @@ export class AgentRuntime {
       // Best-effort: try to send an error response so the user isn't left hanging.
       // Isolate agent.error from agent.response — a failed audit write on the
       // error event must not skip the user-facing response (#1381 review).
-      if (agentErr) {
-        try {
-          await this.publishAgentError(agentErr, taskEvent);
-        } catch (publishErr) {
-          this.config.logger.error({ err: publishErr }, 'Failed to publish agent.error');
-        }
-        try {
-          await this.sendErrorResponse(taskEvent, agentErr);
-        } catch (publishErr) {
-          this.config.logger.error({ err: publishErr }, 'Failed to publish error response');
-        }
-      } else {
-        try {
-          const responseEvent = createAgentResponse({
-            agentId: this.config.agentId,
-            conversationId: taskEvent.payload.conversationId,
-            content: "I'm sorry, an unexpected error occurred while processing your request.",
-            // Mark as an error response (same as sendErrorResponse) so delegate and other
-            // consumers don't treat this fallback message as a real agent result.
-            isError: true,
-            parentEventId: taskEvent.id,
-          });
-          await this.config.bus.publish('agent', responseEvent);
-        } catch (publishErr) {
-          this.config.logger.error({ err: publishErr }, 'Failed to publish error response');
-        }
+      try {
+        await this.publishAgentError(agentErr, taskEvent);
+      } catch (publishErr) {
+        this.config.logger.error({ err: publishErr }, 'Failed to publish agent.error');
+      }
+      try {
+        await this.sendErrorResponse(taskEvent, agentErr);
+      } catch (publishErr) {
+        this.config.logger.error({ err: publishErr }, 'Failed to publish error response');
       }
     } finally {
       // Clean up the rate limit entry for this task so the validator's writeCounts map
@@ -1925,13 +1915,13 @@ export class AgentRuntime {
       responseContent = "I'm sorry, I was unable to process that request. Please try again.";
     }
 
+    if (isResponseError && responseAgentError) {
+      await this.publishAgentErrorForFallback(taskEvent, responseAgentError);
+    }
+
     // Persist the assistant response
     if (memory) {
       await memory.addTurn(conversationId, agentId, { role: 'assistant', content: responseContent });
-    }
-
-    if (isResponseError && responseAgentError) {
-      await this.publishAgentErrorForFallback(taskEvent, responseAgentError);
     }
 
     const responseEvent = createAgentResponse({

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1645,6 +1645,15 @@ describe('AgentRuntime tool-use loop', () => {
     bus.subscribe('agent.response', 'dispatch', (event) => {
       agentResponses.push(event as AgentResponseEvent);
     });
+    const publishedOrder: Array<{ type: 'agent.error' | 'agent.response'; parentEventId: string | undefined }> = [];
+    bus.subscribe('agent.error', 'dispatch', (event) => {
+      const errorEvent = event as AgentErrorEvent;
+      publishedOrder.push({ type: 'agent.error', parentEventId: errorEvent.parentEventId });
+    });
+    bus.subscribe('agent.response', 'system', (event) => {
+      const responseEvent = event as AgentResponseEvent;
+      publishedOrder.push({ type: 'agent.response', parentEventId: responseEvent.parentEventId });
+    });
 
     const agent = new AgentRuntime({
       agentId: 'coordinator',
@@ -1669,9 +1678,12 @@ describe('AgentRuntime tool-use loop', () => {
 
     expect(agentResponses).toHaveLength(1);
     expect(agentResponses[0]!.payload.isError).toBe(true);
+    expect(agentResponses[0]!.parentEventId).toBe(task.id);
     expect(agentErrors).toHaveLength(1);
     expect(agentErrors[0]!.parentEventId).toBe(task.id);
     expect(agentErrors[0]!.payload.message).toContain('Tool loop exhausted');
+    expect(publishedOrder[0]).toEqual({ type: 'agent.error', parentEventId: task.id });
+    expect(publishedOrder[1]).toEqual({ type: 'agent.response', parentEventId: task.id });
   });
 
   it('publishes agent.error on defensive fallback when provider returns an unknown response shape', async () => {
@@ -1694,6 +1706,15 @@ describe('AgentRuntime tool-use loop', () => {
     const agentResponses: AgentResponseEvent[] = [];
     bus.subscribe('agent.response', 'dispatch', (event) => {
       agentResponses.push(event as AgentResponseEvent);
+    });
+    const publishedOrder: Array<{ type: 'agent.error' | 'agent.response'; parentEventId: string | undefined }> = [];
+    bus.subscribe('agent.error', 'dispatch', (event) => {
+      const errorEvent = event as AgentErrorEvent;
+      publishedOrder.push({ type: 'agent.error', parentEventId: errorEvent.parentEventId });
+    });
+    bus.subscribe('agent.response', 'system', (event) => {
+      const responseEvent = event as AgentResponseEvent;
+      publishedOrder.push({ type: 'agent.response', parentEventId: responseEvent.parentEventId });
     });
 
     const agent = new AgentRuntime({
@@ -1718,9 +1739,12 @@ describe('AgentRuntime tool-use loop', () => {
 
     expect(agentResponses).toHaveLength(1);
     expect(agentResponses[0]!.payload.isError).toBe(true);
+    expect(agentResponses[0]!.parentEventId).toBe(task.id);
     expect(agentErrors).toHaveLength(1);
     expect(agentErrors[0]!.parentEventId).toBe(task.id);
     expect(agentErrors[0]!.payload.message).toContain('failed after retries');
+    expect(publishedOrder[0]).toEqual({ type: 'agent.error', parentEventId: task.id });
+    expect(publishedOrder[1]).toEqual({ type: 'agent.response', parentEventId: task.id });
   });
 
   it('does not publish agent.error when empty-response recovery succeeds', async () => {

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1623,6 +1623,106 @@ describe('AgentRuntime tool-use loop', () => {
     expect(agentErrors[0]!.payload.errorType).toBe('UNKNOWN');
   });
 
+  it('publishes agent.error when tool loop exhausts without a final text response', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'tool_use' as const,
+        toolCalls: [],
+        usage: { inputTokens: 50, outputTokens: 10, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      }),
+    };
+
+    const agentErrors: AgentErrorEvent[] = [];
+    bus.subscribe('agent.error', 'system', (event) => {
+      agentErrors.push(event as AgentErrorEvent);
+    });
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      // Intentionally omit executionLayer so tool_use falls back to runtime error path.
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'scheduler:job-tool-loop:run-1',
+      channelId: 'scheduler',
+      senderId: 'scheduler',
+      content: 'Run scheduled work',
+      parentEventId: 'parent-tool-loop',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(agentResponses).toHaveLength(1);
+    expect(agentResponses[0]!.payload.isError).toBe(true);
+    expect(agentErrors).toHaveLength(1);
+    expect(agentErrors[0]!.parentEventId).toBe(task.id);
+    expect(agentErrors[0]!.payload.message).toContain('Tool loop exhausted');
+  });
+
+  it('publishes agent.error on defensive fallback when provider returns an unknown response shape', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'unexpected-shape',
+        usage: { inputTokens: 10, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
+      } as unknown as Awaited<ReturnType<LLMProvider['chat']>>),
+    };
+
+    const agentErrors: AgentErrorEvent[] = [];
+    bus.subscribe('agent.error', 'system', (event) => {
+      agentErrors.push(event as AgentErrorEvent);
+    });
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'scheduler:job-defensive-else:run-1',
+      channelId: 'scheduler',
+      senderId: 'scheduler',
+      content: 'Run scheduled work',
+      parentEventId: 'parent-defensive-else',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(agentResponses).toHaveLength(1);
+    expect(agentResponses[0]!.payload.isError).toBe(true);
+    expect(agentErrors).toHaveLength(1);
+    expect(agentErrors[0]!.parentEventId).toBe(task.id);
+    expect(agentErrors[0]!.payload.message).toContain('failed after retries');
+  });
+
   it('does not publish agent.error when empty-response recovery succeeds', async () => {
     const logger = createLogger('error');
     const bus = new EventBus(logger);

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -83,6 +83,10 @@ function burstCounts(s: Scheduler): Map<string, number> {
   return (s as unknown as { burstCounts: Map<string, number> }).burstCounts;
 }
 
+function pendingJobs(s: Scheduler): Map<string, string> {
+  return (s as unknown as { pendingJobs: Map<string, string> }).pendingJobs;
+}
+
 describe('Scheduler', () => {
   let pool: ReturnType<typeof mockPool>;
   let bus: ReturnType<typeof mockBus>;
@@ -898,6 +902,58 @@ describe('Scheduler', () => {
       });
 
       expect(schedulerService.completeJobRun).toHaveBeenCalledWith('job-1', false, 'budget blown', undefined);
+    });
+
+    it('does not double-complete when both agent.response(isError) and agent.error are published', async () => {
+      const row = fakeDbRow();
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { id: string }];
+      const taskEventId = taskEvent.id;
+
+      schedulerService.completeJobRun.mockResolvedValueOnce({ suspended: false });
+      scheduler.start();
+
+      const responseHandler = bus.subscribe.mock.calls[0]?.[2] as (event: unknown) => Promise<void>;
+      const errorHandler = bus.subscribe.mock.calls[1]?.[2] as (event: unknown) => Promise<void>;
+
+      // Runtime failure paths intentionally emit both events; scheduler must complete once.
+      await responseHandler({
+        id: 'resp-err-1',
+        type: 'agent.response',
+        sourceLayer: 'agent',
+        parentEventId: taskEventId,
+        timestamp: new Date(),
+        payload: { agentId: 'agent-1', conversationId: 'c1', content: 'fallback', isError: true },
+      });
+      await errorHandler({
+        id: 'err-2',
+        type: 'agent.error',
+        sourceLayer: 'agent',
+        parentEventId: taskEventId,
+        timestamp: new Date(),
+        payload: {
+          agentId: 'agent-1',
+          conversationId: 'c1',
+          errorType: 'UNKNOWN',
+          source: 'runtime',
+          message: 'Tool loop exhausted without a text response',
+          retryable: false,
+          context: {},
+        },
+      });
+
+      expect(schedulerService.completeJobRun).toHaveBeenCalledTimes(1);
+      expect(schedulerService.completeJobRun).toHaveBeenCalledWith(
+        'job-1',
+        false,
+        'Tool loop exhausted without a text response',
+        undefined,
+      );
+      expect(pendingJobs(scheduler).size).toBe(0);
+      expect(burstCounts(scheduler).has('job-1')).toBe(false);
     });
 
     it('ignores events not originating from the scheduler', async () => {


### PR DESCRIPTION
## Summary

Fixes a scheduler completion regression where some `AgentRuntime` fallback paths emitted `agent.response(isError: true)` without a paired `agent.error`, leaving scheduled jobs in `running` until watchdog recovery.

## Changes

- Centralized fallback error signaling in `AgentRuntime` so error fallback responses now best-effort publish a paired `agent.error` before `agent.response(isError)`.
- Covered the two missed paths from #801 follow-up: tool-loop exhaustion / no execution layer, and defensive unknown-response fallback.
- Added scheduler regression coverage proving no double-completion when both `agent.response(isError)` and `agent.error` are emitted for one task.
- Added a changelog `Unreleased` bug-fix entry.

## Related Issues

Closes #1647

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [x] CI passes
