### PR TITLE
fix(voice): ignore duplicate RINGING_INCOMING instead of self-rejecting the call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Signal voice calls** — duplicate `RINGING_INCOMING` for one call no longer self-rejects it as busy. (#1672)
 - **Scheduler runtime errors** — fallback `agent.response(isError)` paths now always emit paired `agent.error`. (#1647)
 - **MCP health probe** — liveness uses `ping()` not `listTools()`, ending a ~145 MB/hr validator leak. (#1663)
 - **Scheduler** — `burstCounts` evicts one-shot completions inline and stale jobs on the watchdog sweep. (#1664)

--- a/src/channels/voice/signal/signal-call-bridge.test.ts
+++ b/src/channels/voice/signal/signal-call-bridge.test.ts
@@ -804,6 +804,65 @@ describe('SignalCallBridge', () => {
     await vi.waitFor(() => expect(startSession).toHaveBeenCalledTimes(1));
   });
 
+  it('ignores a duplicate RINGING_INCOMING for the already-active connected call (no reject, no re-accept)', async () => {
+    const { bridge, rpc, startSession } = setup();
+    bridge.start();
+    const callId = 112n;
+
+    rpc.emit('callEvent', ringingEvent(callId));
+    await vi.waitFor(() => expect(rpc.acceptCall).toHaveBeenCalledWith(callId));
+    rpc.emit('callEvent', connectedEvent(callId));
+    await vi.waitFor(() => expect(startSession).toHaveBeenCalledTimes(1));
+
+    // A stray RINGING re-emit for the SAME call after it is live and `active`
+    // must be ignored — not re-accepted, not rejected (rejecting would tear
+    // down the live call). Pins the `active?.callId === ev.callId` clause.
+    rpc.emit('callEvent', ringingEvent(callId));
+    await new Promise(resolve => setImmediate(resolve));
+    expect(rpc.rejectCall).not.toHaveBeenCalled();
+    expect(rpc.acceptCall).toHaveBeenCalledTimes(1);
+    expect(startSession).toHaveBeenCalledTimes(1);
+  });
+
+  // Pins the `connecting` clause specifically — the only window where the id
+  // sits in `connecting` but NONE of active/pending/ringing: after ENDED lands
+  // mid-startSession, handleEnded nulls `active` and pending is already cleared,
+  // yet `connecting` still holds the id until setup's finally runs. Without the
+  // connecting clause the busy check would see an idle bridge and freshly
+  // ACCEPT the duplicate for an already-ending call (RED: acceptCall twice).
+  it('ignores a duplicate RINGING_INCOMING while the call is still in the connecting slot after ENDED', async () => {
+    let resolveStartSession!: () => void;
+    const { bridge, rpc, startSession, endSession } = setup({
+      startSessionImpl: () =>
+        new Promise<void>(resolve => {
+          resolveStartSession = resolve;
+        }),
+    });
+    bridge.start();
+    const callId = 113n;
+
+    rpc.emit('callEvent', ringingEvent(callId));
+    await vi.waitFor(() => expect(rpc.acceptCall).toHaveBeenCalledWith(callId));
+    rpc.emit('callEvent', connectedEvent(callId));
+    await vi.waitFor(() => expect(startSession).toHaveBeenCalledTimes(1));
+    const sessionId = startSession.mock.calls[0]![0].sessionId;
+
+    // ENDED while startSession is still pending: active → null, pending already
+    // cleared, id remains only in `connecting`.
+    rpc.emit('callEvent', endedEvent(callId));
+    await new Promise(resolve => setImmediate(resolve));
+
+    // Duplicate RINGING in that gap must be ignored, not re-accepted.
+    rpc.emit('callEvent', ringingEvent(callId));
+    await new Promise(resolve => setImmediate(resolve));
+    expect(rpc.acceptCall).toHaveBeenCalledTimes(1);
+    expect(rpc.rejectCall).not.toHaveBeenCalled();
+
+    // Setup completes and tears the ended call down cleanly.
+    resolveStartSession();
+    await vi.waitFor(() => expect(endSession).toHaveBeenCalledWith(sessionId, 'remote_hangup'));
+  });
+
   // I1: ENDED arriving in the window between `active` being assigned and
   // `startSession` resolving must not orphan a runtime session — the
   // teardown has to happen AFTER startSession registers it, not before.

--- a/src/channels/voice/signal/signal-call-bridge.test.ts
+++ b/src/channels/voice/signal/signal-call-bridge.test.ts
@@ -741,6 +741,69 @@ describe('SignalCallBridge', () => {
     expect(rpc.rejectCall).not.toHaveBeenCalledWith(callA);
   });
 
+  // Prod bug (2026-08-20): signal-cli re-emits RINGING_INCOMING for the SAME
+  // call while it rings. The busy check treated the repeat as a competing call
+  // and rejected it — tearing down the very call being answered. A duplicate
+  // for a call already in flight must be ignored (no reject), not busy-rejected.
+  it('ignores a duplicate RINGING_INCOMING for the same call still resolving (no self-reject)', async () => {
+    let resolveFirst!: (v: InboundSenderContext) => void;
+    let resolveCalls = 0;
+    const resolveImpl = async (): Promise<InboundSenderContext> => {
+      resolveCalls += 1;
+      if (resolveCalls === 1) {
+        // Hold the first handler open in its resolve await so the duplicate
+        // lands while the callId is still in `ringing` (not yet pending).
+        return new Promise<InboundSenderContext>(resolve => {
+          resolveFirst = resolve;
+        });
+      }
+      return resolvedSenderContext();
+    };
+    const { bridge, rpc, startSession } = setup({ resolveImpl });
+    bridge.start();
+    const callId = 110n;
+
+    // Two RINGING_INCOMING for the SAME callId, back-to-back in one tick —
+    // the second arrives before the first's resolve settles.
+    rpc.emit('callEvent', ringingEvent(callId));
+    rpc.emit('callEvent', ringingEvent(callId));
+
+    // The duplicate must NOT have been rejected — it's the same call.
+    await new Promise(resolve => setImmediate(resolve));
+    expect(rpc.rejectCall).not.toHaveBeenCalled();
+
+    // The one real handler proceeds: accept exactly once, then CONNECTED
+    // starts a session — proving the call survived the duplicate.
+    resolveFirst(resolvedSenderContext());
+    await vi.waitFor(() => expect(rpc.acceptCall).toHaveBeenCalledWith(callId));
+    expect(rpc.acceptCall).toHaveBeenCalledTimes(1);
+
+    rpc.emit('callEvent', connectedEvent(callId));
+    await vi.waitFor(() => expect(startSession).toHaveBeenCalledTimes(1));
+    expect(rpc.rejectCall).not.toHaveBeenCalled();
+  });
+
+  it('ignores a duplicate RINGING_INCOMING for a call already pending accept (no self-reject)', async () => {
+    const { bridge, rpc, startSession } = setup();
+    bridge.start();
+    const callId = 111n;
+
+    // First ring is accepted and sits in `pending` awaiting CONNECTED.
+    rpc.emit('callEvent', ringingEvent(callId));
+    await vi.waitFor(() => expect(rpc.acceptCall).toHaveBeenCalledWith(callId));
+
+    // signal-cli re-emits RINGING for the same call before CONNECTED — must be
+    // ignored, not busy-rejected (which would hang up the accepted call).
+    rpc.emit('callEvent', ringingEvent(callId));
+    await new Promise(resolve => setImmediate(resolve));
+    expect(rpc.rejectCall).not.toHaveBeenCalled();
+    expect(rpc.acceptCall).toHaveBeenCalledTimes(1);
+
+    // The call still connects normally.
+    rpc.emit('callEvent', connectedEvent(callId));
+    await vi.waitFor(() => expect(startSession).toHaveBeenCalledTimes(1));
+  });
+
   // I1: ENDED arriving in the window between `active` being assigned and
   // `startSession` resolving must not orphan a runtime session — the
   // teardown has to happen AFTER startSession registers it, not before.

--- a/src/channels/voice/signal/signal-call-bridge.ts
+++ b/src/channels/voice/signal/signal-call-bridge.ts
@@ -260,9 +260,30 @@ export class SignalCallBridge {
   }
 
   private async handleRingingIncoming(ev: SignalCallEvent): Promise<void> {
-    // Only one call may be in flight at a time — a second ring while one is
-    // active (or mid-accept, i.e. still pending, or still resolving caller
-    // identity) is rejected as busy.
+    // A repeat RINGING_INCOMING for a call we are ALREADY handling is a
+    // duplicate event, not a competing call. signal-cli re-emits RINGING while
+    // the call rings (observed live 2026-08-20: the second event for the very
+    // first call tripped the busy check below and rejected the very call we
+    // were answering, so no call could ever connect). Ignore it — the original
+    // handler is still driving this callId through accept → CONNECTED. Checked
+    // against all three in-flight slots plus `connecting` (the CONNECTED-setup
+    // window, during which the id may briefly sit in none of the other three).
+    if (
+      this.active?.callId === ev.callId ||
+      this.pending.has(ev.callId) ||
+      this.ringing.has(ev.callId) ||
+      this.connecting.has(ev.callId)
+    ) {
+      this.log.debug(
+        { callId: ev.callId.toString() },
+        'Duplicate RINGING_INCOMING for a call already in flight; ignoring',
+      );
+      return;
+    }
+
+    // Only one call may be in flight at a time — a ring for a DIFFERENT callId
+    // while one is active (or mid-accept, i.e. still pending, or still
+    // resolving caller identity) is rejected as busy.
     if (this.active !== null || this.pending.size > 0 || this.ringing.size > 0) {
       this.fireAndLog(this.config.rpcClient.rejectCall(ev.callId), 'rejectCall', ev.callId);
       this.log.info({ callId: ev.callId.toString(), reason: 'busy' }, 'Rejecting incoming Signal call');


### PR DESCRIPTION
## Summary

Found live in prod validation of Signal voice calls (#1672): **every** inbound call was rejected as "busy" and none ever reached CONNECTED.

Root cause: **signal-cli re-emits `RINGING_INCOMING` for the same call while it rings.** The busy check in `handleRingingIncoming` treated the repeat as a competing call and sent `rejectCall` for the callId it was actively answering, tearing the call down. Proof from the prod logs: the very first call after startup was rejected as "busy" — impossible unless a duplicate same-call event tripped the gate.

## Fix

Guard `handleRingingIncoming` so a `RINGING_INCOMING` whose callId is already in flight (`active` / `pending` / `ringing` / `connecting`) is **ignored**, not busy-rejected. The one-call-at-a-time invariant is unchanged: a ring for a *different* callId while one is in flight is still rejected as busy.

The `connecting` slot matters for a subtle window: after `ENDED` lands mid-`startSession`, `active` is nulled and `pending` cleared, but the id stays in `connecting` until setup's `finally` runs — without that clause a duplicate in that gap would be freshly accepted for an already-ending call.

## Tests

Four regression tests, one per guard slot, each verified RED without the fix:
- `ringing` slot (duplicate while still resolving caller)
- `pending` slot (duplicate after accept, before CONNECTED)
- `active` slot (stray re-emit on the live connected call)
- `connecting` slot (duplicate in the ENDED-during-startSession gap — RED = `acceptCall` fires twice without the clause)

Full bridge suite: 79 passed. Typecheck clean. Reviewed by code-reviewer + silent-failure-hunter (both clean; the added `active`/`connecting` tests came from the code-reviewer's finding).

Relates to #1672. Merge + redeploy needed before the prod validation call can be retried.