### PR TITLE
fix: CC preamble omittedCount should ignore empty sanitized addresses

### DIFF
--- a/src/dispatch/email-metadata.ts
+++ b/src/dispatch/email-metadata.ts
@@ -131,13 +131,14 @@ export function buildCcPreamble(
   // from the Nylas To-field (attacker-controlled) and is injected into
   // taskContent after the injection scanner has already run on payload.content.
   // Without sanitization a crafted address could bypass Layer 1.
-  const sanitizedRecipients = meta.primaryRecipientEmails
+  const nonEmptyRecipients = meta.primaryRecipientEmails
     .map((addr) => sanitizeEmailField(addr))
-    .filter((addr) => addr.length > 0)
-    .slice(0, MAX_RECIPIENTS_IN_PREAMBLE);
+    .filter((addr) => addr.length > 0);
+  const sanitizedRecipients = nonEmptyRecipients.slice(0, MAX_RECIPIENTS_IN_PREAMBLE);
 
-  // Count items dropped by the empty-string filter or by the 10-item cap.
-  const omittedCount = Math.max(0, meta.primaryRecipientEmails.length - sanitizedRecipients.length);
+  // Only count valid addresses omitted by the display cap — empty/sanitized-away
+  // addresses must not inflate "+N more".
+  const omittedCount = Math.max(0, nonEmptyRecipients.length - sanitizedRecipients.length);
 
   // Only append "+N more" when there are named recipients to precede it —
   // "unknown recipients, +3 more" is misleading when every address was stripped.

--- a/tests/unit/dispatch/email-metadata.test.ts
+++ b/tests/unit/dispatch/email-metadata.test.ts
@@ -191,8 +191,8 @@ describe('buildCcPreamble', () => {
     expect(result).not.toContain('+');
   });
 
-  it('counts filtered-out (empty-after-sanitize) recipients in the omitted total', () => {
-    // '\n\r' sanitizes to empty and should be counted as omitted
+  it('does not count filtered-out (empty-after-sanitize) recipients in the omitted total', () => {
+    // '\n\r' sanitizes to empty and should not be counted as omitted
     const result = buildCcPreamble(
       makeMeta({ primaryRecipientEmails: ['\n\r', 'alice@example.com'] }),
       'curia',
@@ -200,6 +200,20 @@ describe('buildCcPreamble', () => {
     );
 
     expect(result).toContain('alice@example.com');
+    expect(result).not.toContain('+');
+  });
+
+  it('does not show +N more when 12 addresses have 2 empty and 10 valid', () => {
+    const recipients = ['\n\r', '\n\r\n', ...Array.from({ length: 10 }, (_, i) => `user${i}@example.com`)];
+    const result = buildCcPreamble(makeMeta({ primaryRecipientEmails: recipients }), 'curia', 'msg-abc123');
+
+    expect(result).not.toContain('+');
+  });
+
+  it('shows +1 more when 11 valid addresses are provided', () => {
+    const recipients = Array.from({ length: 11 }, (_, i) => `user${i}@example.com`);
+    const result = buildCcPreamble(makeMeta({ primaryRecipientEmails: recipients }), 'curia', 'msg-abc123');
+
     expect(result).toContain('+1 more');
   });
 


### PR DESCRIPTION
## Summary

CC preamble omittedCount should ignore empty sanitized addresses

## Changes

- omittedCount only counts cap-truncated valid recipients, not empty sanitizations

Fixes #464
