### PR TITLE
fix(deps): bump fast-uri floor to >=4.1.2 (CVE-2026-18446)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   hono: '>=4.12.27'
-  fast-uri: '>=4.1.1'
+  fast-uri: '>=4.1.2'
   vite: '>=8.0.5'
   qs: '>=6.15.2'
   ip-address: '>=10.1.1'
@@ -3377,8 +3377,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.3:
+    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6414,7 +6414,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.1
+      fast-uri: 4.1.3
 
   '@fastify/cookie@11.1.2':
     dependencies:
@@ -7890,7 +7890,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8699,7 +8699,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.1
+      fast-uri: 4.1.3
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -8719,7 +8719,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ minimumReleaseAge: 1440
 #     is ESM-only and would break `require('uuid')`.
 overrides:
   hono: '>=4.12.27'
-  fast-uri: '>=4.1.1'
+  fast-uri: '>=4.1.2'  # GHSA-7p8r-x3mc-p8w7 / CVE-2026-18446 (host confusion via backslash authority introducer, HIGH)
   vite: '>=8.0.5'
   qs: '>=6.15.2'
   ip-address: '>=10.1.1'


### PR DESCRIPTION
## What

Raises the `fast-uri` pnpm override floor from `>=4.1.1` to `>=4.1.2`, refreshing the lockfile to resolve **4.1.3**.

## Why

`fast-uri` versions `>=4.0.0, <4.1.2` are vulnerable to **host confusion via a backslash authority introducer** ([GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / CVE-2026-18446, **HIGH**). The floor was already pinned at `>=4.1.1` for an earlier advisory, so this is a one-line bump to the patched release.

Clears three open code-scanning alerts, all the same underlying CVE:

| Alert | Tool | Location |
|---|---|---|
| #248 | Trivy | `app/node_modules/.pnpm/fast-uri@4.1.1/…/package.json` |
| #241 | Trivy | `pnpm-lock.yaml` |
| #155 | Scorecard | `VulnerabilitiesID` (same GHSA) |

## Blast radius

`fast-uri` is transitive-only. Consumers in the lockfile are all JSON-schema validation paths:

- `ajv@8.20.0`
- `fast-json-stringify@7.0.1`
- `@fastify/ajv-compiler`

Patch-level move within `4.1.x`, no API change. Lockfile diff touches only the `fast-uri` entries.

## Verification

- `pnpm install` → resolves `fast-uri@4.1.3` at every call site
- `pnpm run typecheck` → clean
- `pnpm test` → **476 files passed / 58 skipped**, **5959 tests passed / 332 skipped**, 0 failures
- `pnpm install --frozen-lockfile` → passes (satisfies the 24h `minimumReleaseAge` floor; 4.1.3 published 2026-08-23)