### PR TITLE
feat(contacts): move dedup exclusions onto contact_dedup_exclusions (#1625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **LLM provider streaming** — every provider releases its SDK stream on abort/error/early-exit, preventing a heap leak. (#1648, #1651)
 - **`classifyError`** — `AbortSignal.timeout` / abort DOMExceptions map to `TIMEOUT`. (#1597)
 - **Dedup exclusions for same-name contacts** — excluding a pair with no KG node on either side now works. (#1625)
+- **Dedup sweep** — an exclusion inherited through an earlier merge in the same run is no longer ignored. (#1625)
 - **`contact-dedup-exclude`** — multi-valued exclusions coexist; agent leaves task open on write failure. (#1623)
 - **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)
 - **Coordinator** — ambient bullpen mentions no longer bleed into scheduler jobs and leak to the principal. (#1609)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Slack/SMS/Voice health probes** — `/api/health` reports each when enabled. (#1567)
 - **Model registry** — `streaming`/`tools` capabilities; voice boot gates on them. (#1553)
 - **Outbound queue** — durable Signal/Slack/SMS/email sends while down; Channel capability. (#1380)
+- **`contact_dedup_exclusions`** — dedup exclusions get a table; migration 084 backfills KG facts. (#1625)
+- **ADR-039 (Accepted)** — decisions belong in the relational ledger, learned knowledge in the KG. (#1625)
 
 ### Changed
 
+- **`contact-dedup-exclude`** — writes the exclusions table; outputs `created`, no `entityMemory` capability. (#1625)
+- **`contact-find-duplicates`** — loads exclusions in one query; `entityMemory` capability dropped. (#1625)
+- **Contact merge** — re-points and renormalizes exclusion rows onto the survivor. (#1625)
 - **markdown-it** — upgraded to v15; coerce `attrGet('href')` to string, drop redundant `@types/markdown-it`. (#1640)
 - **`AgentRuntime`** — text tool loop delegates to `runStreamingToolLoop` via chat adapter. (#1563)
 - **Voice** — composes `VOICE_ASYNC_OFFRAMP_GUIDANCE` now that real handoff exists. (#1614)
@@ -48,6 +53,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **MCP `callTool`** — a timed-out skill now aborts the underlying MCP request instead of stranding it. (#1666)
 - **LLM provider streaming** — every provider releases its SDK stream on abort/error/early-exit, preventing a heap leak. (#1648, #1651)
 - **`classifyError`** — `AbortSignal.timeout` / abort DOMExceptions map to `TIMEOUT`. (#1597)
+- **Dedup exclusions for same-name contacts** — excluding a pair with no KG node on either side now works. (#1625)
 - **`contact-dedup-exclude`** — multi-valued exclusions coexist; agent leaves task open on write failure. (#1623)
 - **`delegate`** — calendar briefs must match same-turn date-resolve output. (#1612)
 - **Coordinator** — ambient bullpen mentions no longer bleed into scheduler jobs and leak to the principal. (#1609)

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -1,5 +1,5 @@
 name: contacts
-version: "0.12.1"
+version: "0.12.2"
 role: specialist
 description: >
   Contact domain specialist — briefings, CRUD, deduplication, relationship management,
@@ -217,9 +217,9 @@ system_prompt: |
   2. Report the summary counts from the skill result:
      - filed: new tasks filed this run
      - skipped_existing: pairs already in the review queue (idempotent skip)
-     - skipped_excluded: pairs with a dedup_exclusion fact (do-not-resurface skip)
+     - skipped_excluded: pairs already ruled not-a-duplicate (do-not-resurface skip)
      - capped: pairs not filed because max_tasks was reached
-     - failed: pairs that errored during KG lookup or task creation
+     - failed: pairs that errored during task creation
      - total_scanned: qualifying pairs above the score threshold
      If failed > 0, note that those pairs will be retried on the next run.
   3. Call scheduler-report with the job_id and the summary as the report text.

--- a/docs/adr/039-decisions-in-the-ledger-not-the-knowledge-graph.md
+++ b/docs/adr/039-decisions-in-the-ledger-not-the-knowledge-graph.md
@@ -1,0 +1,165 @@
+# ADR-039: Operational decisions belong in the relational ledger, not the knowledge graph — dedup exclusions as the first instance
+
+Date: 2026-09-01
+Status: Accepted
+
+## Context
+
+Curia keeps two long-lived stores of what it knows:
+
+- **The relational ledger** — Postgres tables. Exact, permanent, transactional, with
+  foreign keys and cascades. `contacts`, `tasks`, `autonomy_action_log`, and friends.
+- **The knowledge graph** — `kg_nodes` / `kg_edges`. Fuzzy, embedded, confidence-scored,
+  decaying, deduplicated by cosine similarity, and with contradiction detection between
+  facts that share an `attribute`.
+
+Nothing has said out loud which store a given piece of state belongs in. Dedup exclusions
+picked the wrong one, and the resulting bugs are what prompted writing this down.
+
+### What a dedup exclusion is
+
+When the dedup sweep proposes that two contacts are the same person and the CEO says
+"no, they are two different people", we record that ruling so the pair is never proposed
+again. Since #1027 / PR #1040 it was stored as a pair of KG fact nodes — one on each
+contact's entity node — with `properties.attribute = 'dedup_exclusion'`,
+`properties.value = <the other contact's id>`, `decayClass: 'permanent'`, and
+`confidence: 1.0`.
+
+### Every KG mechanism it touched had to be disabled
+
+The `permanent` decay class and the pinned `confidence: 1.0` are the first tell: the fact
+had to opt out of the two mechanisms that make the KG a knowledge graph. The rest followed:
+
+- **Node prerequisite.** A fact must hang off an entity node. KG node identity is keyed on
+  `(lower(label), type)`, and `idx_contacts_kg_node_unique` allows one contact per node, so
+  when two contacts share a display name the second one is created with `kg_node_id = NULL`
+  by design (`createContact` retries without the link on collision). Two contacts with the
+  same display name are *exactly* the pairs the dedup sweep proposes most often — and
+  neither of them could hold an exclusion. In #1623 the Seth Berman pair had `NULL` on both
+  sides, `contact-dedup-exclude` had nowhere to write, and the review task closed anyway.
+- **Embedding dedup-merge.** `dedup_exclusion: <uuid-1>` and `dedup_exclusion: <uuid-2>`
+  are ~0.99 cosine neighbours: near-identical strings differing only in a UUID the
+  embedding model cannot meaningfully distinguish. The validator read the second exclusion
+  as a restatement of the first and merged them, silently dropping a ruling.
+- **Contradiction detection.** Two facts on the same entity with the same `attribute` and
+  different `value`s are, to the validator, a contradiction — which is correct for
+  `role` or `organization` and wrong for an attribute that is inherently multi-valued. A
+  contact excluded against three different people has three simultaneously-true exclusions.
+- **Cost.** Two nodes and two edges per pair, O(n²) inside a same-name cluster, and every
+  later fact write on those entities walks each edge for the cosine dedup check.
+
+PR #1624 landed the interim fix: a domain-agnostic `StoreFactOptions.multiValued` flag that
+exempts a fact from contradiction detection and embedding dedup-merge, plus a prompt gate
+so the contacts agent stops closing the review task when the exclude call fails. That made
+multi-person clusters work. It could not fix the null-node case, because nothing about a
+flag on a fact write conjures an entity node to write the fact onto.
+
+### The shape mismatch underneath all four
+
+A KG fact is an **attribute of one entity**, learned from observation, held with some
+confidence, and expected to age. A dedup exclusion is a **relation between two contacts**,
+produced by a review workflow, exact, and expected to hold forever. It is not something
+Curia learned about a person; it is something the review process decided about a pair.
+
+## Decision
+
+**Operational decisions and workflow state live in the relational ledger. Learned, fuzzy,
+decaying knowledge lives in the knowledge graph.**
+
+The test to apply when adding new state: *did a process decide this, or did Curia learn
+it?* A decision is exact, needs to be enforceable, has provenance rather than confidence,
+and must not decay, dedupe, or contradict — it gets a table. Learned knowledge is
+approximate, benefits from embedding-space neighbourhood search, and should lose
+confidence as it ages — it goes in the KG. If a candidate needs `decayClass: 'permanent'`
+and `confidence: 1.0` and an exemption from contradiction detection, it is a decision
+wearing a fact's clothes, and it belongs in a table.
+
+The first instance is `contact_dedup_exclusions` (migration 084):
+
+```sql
+CREATE TABLE contact_dedup_exclusions (
+  contact_a_id UUID        NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  contact_b_id UUID        NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  decided_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  decided_by   TEXT        NOT NULL,
+  PRIMARY KEY (contact_a_id, contact_b_id),
+  CONSTRAINT contact_dedup_exclusions_ordered_pair CHECK (contact_a_id < contact_b_id)
+);
+```
+
+- **One row per unordered pair.** The `CHECK` plus `normalizeExclusionPair()` in
+  `src/contacts/dedup-exclusions.ts` mean "is this pair excluded?" is a single indexed
+  lookup, not an OR of two orderings, and a pair cannot be recorded twice in mirror image.
+- **No node prerequisite.** Contacts with `kg_node_id = NULL` are first-class here.
+- **No embeddings, no decay, no confidence.** `decided_at` / `decided_by` are provenance.
+- **FK integrity, and we spend it.** Deleting a contact cascades its exclusions away.
+  Merging re-points them: `ContactService.mergeContacts` calls
+  `backend.reattachDedupExclusions(secondaryId, primaryId)`, which renormalizes each pair
+  into stored order, drops the row between the two contacts being merged (merging *is* the
+  decision that they are the same person, superseding the earlier ruling), and drops rows
+  that would duplicate one the survivor already holds.
+- **Narrow on purpose.** No `decision` column, no generalized "dedup decisions" table.
+  This table records exclusions. Merge outcomes are already recorded as `contact.merged`
+  events in the audit log; modelling them here would give two answers to one question.
+- **Single cutover, no dual write.** Migration 084 backfills existing `dedup_exclusion`
+  facts into rows, and from the first deploy new exclusions go only to the table. A
+  deprecated dual-write path invites drift between two stores of the same ruling, and the
+  data volume (~63 facts KG-wide) does not justify the risk. The legacy fact nodes are left
+  in place rather than deleted — they cost little and preserve the pre-migration audit
+  trail.
+
+`StoreFactOptions.multiValued` from #1624 **stays**. It is a legitimate general memory
+primitive for genuinely multi-valued attributes (a person has several email addresses).
+Exclusions simply stop being one of its users.
+
+### Rejected alternatives
+
+- **Disambiguated KG labels** (e.g. embedding a discriminator in the label so the two
+  exclusion facts are not cosine-identical). Fights the embedding rather than the model
+  mismatch, leaves the node prerequisite untouched, and makes labels unreadable.
+- **A `not_same_as` KG edge.** This is the honest way to model a pair relation *in* a
+  graph, and if the KG were the right store it would be the right shape. It still requires
+  a node on both sides — and the null-node population is precisely who this change serves.
+- **Force-write / confidence tiebreakers** (write the fact with a flag that bypasses the
+  validator, or a confidence high enough to win contradiction resolution). Suppresses the
+  symptom per-call, leaves the next KG mechanism to trip over, and still needs a node.
+- **A `uuid[]` column on `contacts`.** No FK integrity on array elements, so a merged-away
+  contact leaves dangling ids; and the relation has to be maintained on both rows in step,
+  which is the bidirectional-consistency problem the ordered-pair table removes.
+- **Config-store kv.** No foreign keys, no cascade, and concurrent writers racing on a
+  read-modify-write of a JSON blob. `ConfigStore.set` also soft-rejects on conflict rather
+  than throwing, so a lost exclusion would be silent.
+
+## Consequences
+
+**Easier.** Excluding a pair now works for any two contacts, which is what #1623 needed.
+The check is one indexed lookup, and sweeps load every exclusion in a single query instead
+of walking KG edges per pair — `contact-find-duplicates` and `scripts/dedup-contacts.ts`
+both drop their `entityMemory` dependency entirely. The exclusion set is directly
+inspectable and correctable in SQL, which matters for an operational ledger. Contact
+delete and merge now have defined, tested behaviour for exclusions instead of leaving
+facts pointing at deleted contact ids.
+
+**Harder / accepted trade-offs.** Exclusions no longer surface in entity-context assembly
+or KG queries — an agent asking "what do we know about this contact" will not see them.
+That is the correct boundary (they are not knowledge about the contact), but any future
+consumer that wants them must read the table. The one-way cutover means a rollback past
+migration 084 loses exclusions recorded after it shipped; the rollback comment in the
+migration says so. And the pattern only pays off if it is applied consistently — the point
+of writing the rule down is that the next "does this get a table?" question is answered by
+the rule rather than case-by-case.
+
+**Explicitly not fixed: KG same-name node identity.** KG node identity is keyed on
+`(lower(label), type)`, so two distinct people who share a display name still cannot both
+hold KG nodes; the second contact keeps `kg_node_id = NULL`. This ADR removes the
+*exclusions*' dependency on that, and nothing else. Same-name contacts remain second-class
+KG citizens for facts, relationships, and entity-context enrichment: facts about them have
+nowhere to live, and enrichment returns nothing. That is a separate, still-open problem,
+tracked in **#1694**. It must not be treated as resolved by this change.
+
+## Related
+
+- #1625 (this change), #1623 (the incident), PR #1624 (interim `multiValued` fix)
+- #1027 / PR #1040 (original decline → exclusion wiring)
+- #1694 (KG same-name node identity — still open)
+- ADR-028 (shared, unbound agent memory) for the surrounding memory-governance model

--- a/docs/adr/039-decisions-in-the-ledger-not-the-knowledge-graph.md
+++ b/docs/adr/039-decisions-in-the-ledger-not-the-knowledge-graph.md
@@ -140,6 +140,12 @@ inspectable and correctable in SQL, which matters for an operational ledger. Con
 delete and merge now have defined, tested behaviour for exclusions instead of leaving
 facts pointing at deleted contact ids.
 
+**Sharp edge this introduces.** A merge now rewrites exclusion rows, so any caller holding
+a cached view of the exclusion set must reconcile after merging or it will act on a stale
+snapshot — `scripts/dedup-contacts.ts` loads the set once and patches it after each merge
+for exactly this reason. `mergeContacts` is also still a non-transactional sequence of
+writes, and CEO rulings now move inside that window; making it atomic is tracked as #1695.
+
 **Harder / accepted trade-offs.** Exclusions no longer surface in entity-context assembly
 or KG queries — an agent asking "what do we know about this contact" will not see them.
 That is the correct boundary (they are not knowledge about the contact), but any future
@@ -162,4 +168,5 @@ tracked in **#1694**. It must not be treated as resolved by this change.
 - #1625 (this change), #1623 (the incident), PR #1624 (interim `multiValued` fix)
 - #1027 / PR #1040 (original decline → exclusion wiring)
 - #1694 (KG same-name node identity — still open)
+- #1695 (`mergeContacts` write sequence is not transactional — still open)
 - ADR-028 (shared, unbound agent memory) for the surrounding memory-governance model

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@ Each ADR follows the [Nygard format](https://adr.github.io/):
 | [036](036-telnyx-sms-channel.md) | Telnyx SMS on a dedicated office DID — medium trust, new-DID-only, carrier STOP (no app ledger), voice Phase 2 SIP note | Accepted |
 | [037](037-voice-channel-livekit-duplex.md) | Duplex voice via self-hosted LiveKit cascade (console WebRTC); STT/TTS provider seams; Phase 2 Signal/PSTN deferred | Accepted |
 | [038](038-voice-brain-shared-hardening.md) | Voice brain parity via shared-hardening prompt modules — reject full coordinator consolidation; text may use `stream()` (#1563) | Accepted |
+| [039](039-decisions-in-the-ledger-not-the-knowledge-graph.md) | Operational decisions live in the relational ledger, not the KG — dedup exclusions move to `contact_dedup_exclusions` (#1625) | Accepted |
 
 ## Adding new ADRs
 

--- a/docs/specs/01-memory-system.md
+++ b/docs/specs/01-memory-system.md
@@ -121,7 +121,7 @@ Before creating a new fact node, check for existing nodes with:
 ### Contradiction Detection
 Before writing a fact that updates an entity attribute (e.g., "the CEO lives in Toronto" when "the CEO lives in Kitchener" exists):
 - Check for existing facts on the same entity with the same attribute type
-- **Multi-valued facts** (`StoreFactOptions.multiValued: true`, e.g. `dedup_exclusion`): same attribute with different `value` properties are independent facts, not contradictions. Same attribute + same value still deduplicates normally. Callers persist `properties.multi_valued: true` so subsequent unrelated writes cannot silently merge into them.
+- **Multi-valued facts** (`StoreFactOptions.multiValued: true`, e.g. a person's several email addresses): same attribute with different `value` properties are independent facts, not contradictions. Same attribute + same value still deduplicates normally. Callers persist `properties.multi_valued: true` so subsequent unrelated writes cannot silently merge into them. (Introduced for `dedup_exclusion` in #1623; exclusions moved to the `contact_dedup_exclusions` table in #1625 — see ADR-039 for the ledger-vs-KG boundary rule — but the flag remains a general primitive.)
 - If contradicting fact exists with higher confidence: reject the write, log the conflict
 - If contradicting fact exists with lower confidence: update the existing fact, preserve the old value in `properties.previous_values` for audit
 - If contradicting fact exists with equal confidence: flag for human review via the alert channel

--- a/docs/wip/2026-09-01-contact-dedup-exclusions-table.md
+++ b/docs/wip/2026-09-01-contact-dedup-exclusions-table.md
@@ -1,0 +1,69 @@
+# Plan: move dedup exclusions off KG facts onto `contact_dedup_exclusions` (#1625)
+
+Date: 2026-09-01
+Issue: #1625 (follow-up from #1623 / PR #1624)
+
+## Goal
+
+Dedup exclusions ("these two contacts are not the same person") are an operational
+decision, not learned knowledge. Move them from KG fact nodes to a first-class
+relational table so they work for contacts with `kg_node_id = NULL`, get FK
+integrity, and stop fighting embedding dedup / contradiction detection.
+
+## Steps
+
+1. **Migration `084_contact_dedup_exclusions.sql`**
+   - `contact_dedup_exclusions (contact_a_id, contact_b_id, decided_at, decided_by)`
+     with `PRIMARY KEY (contact_a_id, contact_b_id)`, `CHECK (contact_a_id < contact_b_id)`,
+     both FKs `ON DELETE CASCADE`, plus an index on `contact_b_id`.
+   - Backfill from KG `dedup_exclusion` fact nodes: fact node -> `kg_edges` (either
+     direction) -> entity node -> `contacts.kg_node_id`; other side is
+     `properties->>'value'` cast to uuid, guarded by a UUID regex and an existence
+     check on `contacts`. Normalize with LEAST/GREATEST, `ON CONFLICT DO NOTHING`.
+   - Old fact nodes are left in place (archived, not deleted) — no dual-write.
+
+2. **`src/contacts/dedup-exclusions.ts`** — replace the KG read/write helpers with
+   pure ordered-pair normalization (`normalizeExclusionPair`) reused by the service,
+   the backend, and tests. `canonicalPairKey` in `dedup-pair-key.ts` stays the
+   task-tag key; normalization returns the ordered tuple the table stores.
+
+3. **`ContactServiceBackend` + both backends** — add
+   `addDedupExclusion`, `hasDedupExclusion`, `listDedupExclusions`,
+   `reattachDedupExclusions`. Postgres uses parameterized SQL; the in-memory
+   backend mirrors the same semantics for unit tests.
+
+4. **`ContactService`** — public `addDedupExclusion(a, b, decidedBy)`,
+   `hasDedupExclusion(a, b)`, `listDedupExclusionPairKeys()`. `mergeContacts`
+   calls `backend.reattachDedupExclusions(secondaryId, primaryId)` alongside
+   `reattachIdentities` / `reattachAuthOverrides`.
+
+5. **`contact-dedup-exclude` tool** — write to the table via `ctx.contactService`;
+   drop the `entityMemory` capability and the per-side KG branching. Outputs become
+   `excluded` / `already_excluded`. Version 0.1.1 -> 0.2.0.
+
+6. **`contact-find-duplicates` tool** — bulk-load exclusion pair keys once per run
+   from `ctx.contactService`; drop the `entityMemory` capability and the facts
+   cache. Version 2.1.0 -> 2.2.0.
+
+7. **`scripts/dedup-contacts.ts`** — `DedupRunOptions.getFacts` becomes
+   `hasExclusion(aId, bId)`; CLI wires it to `contactService`.
+
+8. **`agents/contacts.yaml`** — reword the `skipped_excluded` line (no longer "a
+   dedup_exclusion fact"). Version 0.12.1 -> 0.12.2.
+
+9. **ADR-039** — ledger-vs-KG boundary rule, why exclusions leave the KG, rejected
+   alternatives, and the still-open KG same-name node identity problem. Index row
+   in `docs/adr/README.md`.
+
+10. **Follow-up issue** for KG same-name node identity, linked from the ADR.
+
+11. **Tests** — null-node pairs, idempotent re-exclude, ordered-pair normalization,
+    cascade on contact delete, re-point + renormalize on merge, sweep/find-duplicates
+    skipping table-backed exclusions, backfill migration integration test.
+
+12. **CHANGELOG** entries under `[Unreleased]`. No package.json bump (release-only).
+
+## Out of scope
+
+- Removing `StoreFactOptions.multiValued` or its validation exemptions (#1624 stays).
+- Fixing KG same-name node identity (separate issue, named in the ADR).

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -360,6 +360,65 @@ describe('runDedup — unit', () => {
     expect(listExclusionPairKeysMock).toHaveBeenCalledOnce();
   });
 
+  it('honours an exclusion inherited through an earlier merge in the same run', async () => {
+    // Regression: excludedPairKeys is a snapshot taken before the O(n²) loop, but the
+    // loop merges, and a merge re-points the secondary's exclusion rows onto the
+    // survivor. c1/c2 merge structurally (exact name), which moves the CEO's (c2, c3)
+    // ruling to (c1, c3). If the snapshot is not updated to match, the (c1, c3) pair
+    // misses the check and is auto-merged — silently overriding the ruling.
+    listExclusionPairKeysMock.mockResolvedValue(new Set(['c2:c3']));
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Seth Berman' }),
+      makeContact({ id: 'c2', displayName: 'seth berman' }),
+      makeContact({ id: 'c3', displayName: 'Seth  Berman' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    // c1/c2 merged (c1 is primary — lower id, neither has a KG node).
+    expect(mergeMock).toHaveBeenCalledExactlyOnceWith('c1', 'c2');
+    // c1/c3 inherited the exclusion and must NOT have merged.
+    expect(result.skippedExcludedCount).toBe(1);
+    expect(result.mergedCount).toBe(1);
+  });
+
+  it('mirrors the merge re-point in dry-run so the preview matches a real run', async () => {
+    listExclusionPairKeysMock.mockResolvedValue(new Set(['c2:c3']));
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Seth Berman' }),
+      makeContact({ id: 'c2', displayName: 'seth berman' }),
+      makeContact({ id: 'c3', displayName: 'Seth  Berman' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, { ...opts, dryRun: true });
+
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(result.wouldMergeCount).toBe(1);
+    expect(result.skippedExcludedCount).toBe(1);
+  });
+
+  it('drops the exclusion between the two merged contacts from the snapshot', async () => {
+    // The CEO earlier ruled c1 ≠ c2, but they are now being merged (structural proof
+    // beats the stale ruling only because the pair is not in the snapshot — here it IS,
+    // so the pair must be skipped, not merged).
+    listExclusionPairKeysMock.mockResolvedValue(new Set(['c1:c2']));
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Seth Berman' }),
+      makeContact({ id: 'c2', displayName: 'seth berman' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(result.skippedExcludedCount).toBe(1);
+  });
+
   it('aborts the sweep when the exclusion load fails, rather than merging blind', async () => {
     // Fail closed: an empty exclusion set would auto-merge pairs the CEO ruled apart.
     listExclusionPairKeysMock.mockRejectedValue(new Error('exclusion table unavailable'));

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -11,7 +11,8 @@
 //   3. Principal-involving pair → task created (no merge), even if structural
 //   4. Excluded pair → skipped (no merge, no task)
 //   5. Dry-run mode → no writes of any kind (no merges, no tasks)
-// writeExclusion/hasExclusion unit tests live in src/contacts/dedup-exclusions.test.ts
+// Exclusion pair-normalization unit tests live in src/contacts/dedup-exclusions.test.ts;
+// the table itself is covered by tests/integration/contact-dedup-exclusions.test.ts.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
@@ -85,7 +86,7 @@ function makeIdentity(
 describe('runDedup — unit', () => {
   let mergeMock: ReturnType<typeof vi.fn>;
   let createTaskMock: ReturnType<typeof vi.fn>;
-  let getFactsMock: ReturnType<typeof vi.fn>;
+  let listExclusionPairKeysMock: ReturnType<typeof vi.fn>;
   let opts: DedupRunOptions;
 
   beforeEach(() => {
@@ -97,14 +98,14 @@ describe('runDedup — unit', () => {
       mergedAt: new Date(),
     });
     createTaskMock = vi.fn().mockResolvedValue({ id: 'task-1', title: 'test' });
-    getFactsMock = vi.fn().mockResolvedValue([]);
+    listExclusionPairKeysMock = vi.fn().mockResolvedValue(new Set<string>());
 
     opts = {
       dryRun: false,
       mergeContacts: mergeMock,
       createTask: createTaskMock,
-      // storeFact is not part of DedupRunOptions (F6)
-      getFacts: getFactsMock,
+      // The sweep only READS exclusions — it never records them (F6, #1625).
+      listExclusionPairKeys: listExclusionPairKeysMock,
     };
   });
 
@@ -294,26 +295,8 @@ describe('runDedup — unit', () => {
   // Test 4: excluded pair → skipped
   // -------------------------------------------------------------------------
 
-  it('skips pairs that have a dedup_exclusion fact', async () => {
-    // getFactsMock returns an exclusion fact for c1's KG node naming c2
-    getFactsMock.mockImplementation(async (kgNodeId: string) => {
-      if (kgNodeId === 'kg-c1') {
-        return [{
-          id: 'fn-excl',
-          type: 'fact',
-          label: 'dedup_exclusion: c2',
-          properties: { attribute: 'dedup_exclusion', value: 'c2' },
-          aliases: [],
-          embedding: null,
-          confidence: 1.0,
-          sensitivity: 'internal',
-          decayClass: 'permanent',
-          source: 'contacts-dedup',
-          temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
-        }];
-      }
-      return [];
-    });
+  it('skips pairs with a recorded exclusion', async () => {
+    listExclusionPairKeysMock.mockResolvedValue(new Set(['c1:c2']));
 
     const contacts: Contact[] = [
       makeContact({ id: 'c1', displayName: 'Frank Lee', kgNodeId: 'kg-c1' }),
@@ -328,29 +311,15 @@ describe('runDedup — unit', () => {
     expect(result.skippedExcludedCount).toBe(1);
   });
 
-  it('skips pairs where exclusion is recorded on contactB side', async () => {
-    getFactsMock.mockImplementation(async (kgNodeId: string) => {
-      if (kgNodeId === 'kg-c2') {
-        return [{
-          id: 'fn-excl',
-          type: 'fact',
-          label: 'dedup_exclusion: c1',
-          properties: { attribute: 'dedup_exclusion', value: 'c1' },
-          aliases: [],
-          embedding: null,
-          confidence: 1.0,
-          sensitivity: 'internal',
-          decayClass: 'permanent',
-          source: 'contacts-dedup',
-          temporal: { createdAt: new Date(), lastConfirmedAt: new Date() },
-        }];
-      }
-      return [];
-    });
+  it('skips excluded pairs when NEITHER contact has a kg_node_id (#1623 regression)', async () => {
+    // The KG-fact implementation could not hold an exclusion for this pair at all —
+    // same-display-name contacts deliberately carry kg_node_id = NULL. The table has
+    // no node prerequisite, so the sweep must now honour the exclusion.
+    listExclusionPairKeysMock.mockResolvedValue(new Set(['c1:c2']));
 
     const contacts: Contact[] = [
-      makeContact({ id: 'c1', displayName: 'Grace Park' }),
-      makeContact({ id: 'c2', displayName: 'grace park', kgNodeId: 'kg-c2' }),
+      makeContact({ id: 'c1', displayName: 'Seth Berman' }),
+      makeContact({ id: 'c2', displayName: 'seth berman' }),
     ];
     const identityMap = new Map<string, ChannelIdentity[]>();
 
@@ -358,6 +327,51 @@ describe('runDedup — unit', () => {
 
     expect(mergeMock).not.toHaveBeenCalled();
     expect(result.skippedExcludedCount).toBe(1);
+  });
+
+  it('honours an exclusion regardless of the order the pair is scanned in', async () => {
+    // The stored key is always ordered ascending; the sweep visits (c1, c2) but the
+    // exclusion could just as well have been recorded as (c2, c1).
+    listExclusionPairKeysMock.mockResolvedValue(new Set(['c1:c2']));
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c2', displayName: 'Grace Park', kgNodeId: 'kg-c2' }),
+      makeContact({ id: 'c1', displayName: 'grace park' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    const result = await runDedup(contacts, identityMap, opts);
+
+    expect(mergeMock).not.toHaveBeenCalled();
+    expect(result.skippedExcludedCount).toBe(1);
+  });
+
+  it('loads exclusions once per run, not once per pair', async () => {
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Ann One' }),
+      makeContact({ id: 'c2', displayName: 'ann one' }),
+      makeContact({ id: 'c3', displayName: 'Bea Two' }),
+      makeContact({ id: 'c4', displayName: 'bea two' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    await runDedup(contacts, identityMap, opts);
+
+    expect(listExclusionPairKeysMock).toHaveBeenCalledOnce();
+  });
+
+  it('aborts the sweep when the exclusion load fails, rather than merging blind', async () => {
+    // Fail closed: an empty exclusion set would auto-merge pairs the CEO ruled apart.
+    listExclusionPairKeysMock.mockRejectedValue(new Error('exclusion table unavailable'));
+
+    const contacts: Contact[] = [
+      makeContact({ id: 'c1', displayName: 'Frank Lee' }),
+      makeContact({ id: 'c2', displayName: 'frank lee' }),
+    ];
+    const identityMap = new Map<string, ChannelIdentity[]>();
+
+    await expect(runDedup(contacts, identityMap, opts)).rejects.toThrow('exclusion table unavailable');
+    expect(mergeMock).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
@@ -389,11 +403,10 @@ describe('runDedup — unit', () => {
     // is verified by reading the dedup-contacts.ts source — it's a documentation check
     // rather than a runtime assertion).
     //
-    // Trigger an error by making getFacts throw on the only structural pair.
-    getFactsMock.mockRejectedValue(new Error('DB error'));
-
+    // Trigger an error inside the per-pair guard: classifyPair normalizes the display
+    // name, so a contact with no name at all throws there.
     const contacts: Contact[] = [
-      makeContact({ id: 'c1', displayName: 'Dry Run Test', kgNodeId: 'kg-c1' }),
+      makeContact({ id: 'c1', displayName: null as unknown as string, kgNodeId: 'kg-c1' }),
       makeContact({ id: 'c2', displayName: 'dry run test', kgNodeId: 'kg-c2' }),
     ];
     const identityMap = new Map<string, ChannelIdentity[]>();
@@ -511,22 +524,13 @@ describe('runDedup — unit', () => {
   // F4: errors during exclusion check / classify must fail closed
   // -------------------------------------------------------------------------
 
-  it('skips pair and increments errorCount when getFacts throws, and continues to the next pair', async () => {
-    // c1 and c2 share an exact name — would normally be structural.
-    // But getFacts throws a DB error when checking exclusions for c1/c2.
+  it('skips pair and increments errorCount when classification throws, and continues to the next pair', async () => {
+    // c1 has no display name, so classifyPair throws while normalizing it.
     // F4: must fail closed (no merge, no task), increment errorCount, and continue.
-    // c3 and c4 also share an exact name — should still be processed (no error on that pair).
-    getFactsMock.mockImplementation(async (kgNodeId: string) => {
-      // c1 has a kg_node_id; trigger the error only on that node
-      if (kgNodeId === 'kg-c1') {
-        throw new Error('DB connection error');
-      }
-      return [];
-    });
-
+    // c3 and c4 share an exact name — they must still be processed.
     const contacts: Contact[] = [
-      makeContact({ id: 'c1', displayName: 'Marco Polo', kgNodeId: 'kg-c1' }),
-      makeContact({ id: 'c2', displayName: 'marco polo' }), // structural — exact name; getFacts throws
+      makeContact({ id: 'c1', displayName: null as unknown as string, kgNodeId: 'kg-c1' }),
+      makeContact({ id: 'c2', displayName: 'marco polo' }),
       makeContact({ id: 'c3', displayName: 'Anna Pavlova' }),
       makeContact({ id: 'c4', displayName: 'anna pavlova' }), // structural — exact name; no error
     ];
@@ -534,21 +538,15 @@ describe('runDedup — unit', () => {
 
     const result = await runDedup(contacts, identityMap, opts);
 
-    // The c1/c2 pair errored — must not have merged and must have incremented errorCount
-    // The c3/c4 pair had no error — must have merged
-    expect(result.errorCount).toBe(1);
-    // At least the c3/c4 pair merged (the sweep continued after c1/c2 error)
+    // Every pair involving c1 errors (c1/c2, c1/c3, c1/c4) — all fail closed.
+    expect(result.errorCount).toBe(3);
+    // The c3/c4 pair had no error — the sweep continued and merged it.
     expect(result.mergedCount).toBeGreaterThanOrEqual(1);
 
-    // Verify the c1/c2 pair specifically: mergeContacts must never have been called
-    // with c1 or c2 as arguments (fail closed — no merge on the errored pair)
+    // Verify no pair involving c1 was ever merged (fail closed).
     const mergeCallArgs = mergeMock.mock.calls.map((call) => [call[0] as string, call[1] as string]);
-    const c1c2WasMerged = mergeCallArgs.some(
-      ([primary, secondary]) =>
-        (primary === 'c1' || primary === 'c2') &&
-        (secondary === 'c1' || secondary === 'c2'),
-    );
-    expect(c1c2WasMerged).toBe(false);
+    const c1WasMerged = mergeCallArgs.some(([primary, secondary]) => primary === 'c1' || secondary === 'c1');
+    expect(c1WasMerged).toBe(false);
   });
 
   // -------------------------------------------------------------------------

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -8,7 +8,7 @@
 //   - Structural pair (shared channel identity / same kg_node_id / exact name) → auto-merge
 //     UNLESS either contact is the principal (system_role='principal') → task instead.
 //   - Fuzzy pair (name/JW similarity) → Curia-owned task (never auto-merge).
-//   - Excluded pair (dedup_exclusion KG fact) → skip entirely.
+//   - Excluded pair (row in contact_dedup_exclusions) → skip entirely.
 //
 // Dry-run mode (--dry-run flag): reports what would happen without writing anything.
 //
@@ -18,13 +18,6 @@ import pg from 'pg';
 import { createLogger } from '../src/logger.js';
 import { classifyPair, type PairClassification } from '../src/contacts/dedup-classifier.js';
 import type { Contact, ChannelIdentity, ContactKind } from '../src/contacts/types.js';
-import type { KgNode } from '../src/memory/types.js';
-import {
-  writeExclusion,
-  hasExclusion,
-  type WriteExclusionOptions,
-  type HasExclusionOptions,
-} from '../src/contacts/dedup-exclusions.js';
 import {
   canonicalPairKey,
   dedupPairTag,
@@ -59,7 +52,7 @@ export interface DedupRunResult {
   mergedCount: number;
   /** Number of fuzzy pairs that had tasks created (0 in dry-run). */
   taskCount: number;
-  /** Number of pairs skipped due to dedup_exclusion facts. */
+  /** Number of pairs skipped due to a recorded dedup exclusion. */
   skippedExcludedCount: number;
   /** Number of pairs skipped because an open dedup review task already exists. */
   skippedExistingCount: number;
@@ -121,14 +114,16 @@ export interface DedupRunOptions {
   }) => Promise<unknown>;
   /** Open dedup review tasks for idempotency checks. Omit in unit tests that don't need it. */
   listOpenDedupTasks?: () => Promise<Array<{ tags?: string[]; description?: string | null }>>;
-  // storeFact is NOT included here: the sweep never writes exclusion facts.
-  // Decline→exclusion writes go through the contacts agent calling contact-dedup-exclude.
-  /** Calls EntityMemory.getFacts for a KG node — returns fact nodes. */
-  getFacts: (kgNodeId: string) => Promise<KgNode[]>;
+  /**
+   * Every recorded exclusion as a canonical pair key (ContactService.listDedupExclusionPairKeys).
+   * Loaded once per run, before the O(n²) pair loop — one query instead of a lookup per pair.
+   *
+   * The sweep never WRITES exclusions: decline→exclude goes through the contacts agent
+   * calling contact-dedup-exclude. A failure here aborts the whole sweep (fail closed) —
+   * proceeding with an empty set would auto-merge pairs the CEO ruled apart.
+   */
+  listExclusionPairKeys: () => Promise<Set<string>>;
 }
-
-// Re-export shared helpers so existing test imports from this module keep working.
-export { writeExclusion, hasExclusion, type WriteExclusionOptions, type HasExclusionOptions };
 
 // ---------------------------------------------------------------------------
 // Core sweep logic (exported for tests)
@@ -150,21 +145,7 @@ export async function runDedup(
   identityMap: Map<string, ChannelIdentity[]>,
   opts: DedupRunOptions,
 ): Promise<DedupRunResult> {
-  const { dryRun, mergeContacts, createTask, getFacts, minScore, maxScore, maxTasks, noTasks, listOpenDedupTasks } = opts;
-
-  // Memoize getFacts per KG node for the duration of the sweep. The exclusion check
-  // runs inside the O(n²) pair loop, and a contact that appears in many candidate
-  // pairs would otherwise re-fetch its KG facts each time. Exclusion facts are static
-  // within a run (the sweep never writes them — that's the agent's decline path), so
-  // caching is safe. Keyed by kg_node_id; contacts without a node are never looked up.
-  const factsCache = new Map<string, KgNode[]>();
-  const cachedGetFacts = async (kgNodeId: string): Promise<KgNode[]> => {
-    const hit = factsCache.get(kgNodeId);
-    if (hit !== undefined) return hit;
-    const facts = await getFacts(kgNodeId);
-    factsCache.set(kgNodeId, facts);
-    return facts;
-  };
+  const { dryRun, mergeContacts, createTask, listExclusionPairKeys, minScore, maxScore, maxTasks, noTasks, listOpenDedupTasks } = opts;
 
   const result: DedupRunResult = {
     dryRun,
@@ -182,6 +163,12 @@ export async function runDedup(
   };
 
   if (contacts.length < 2) return result;
+
+  // Load exclusions before any pair is classified. Exclusions are static within a run
+  // (the sweep never writes them), so one bulk read covers the entire O(n²) loop.
+  // An error propagates and aborts the sweep — see listExclusionPairKeys' doc comment.
+  const excludedPairKeys = await listExclusionPairKeys();
+  logger.debug({ exclusions: excludedPairKeys.size }, 'dedup: loaded recorded exclusions');
 
   const existingPairKeys = new Set<string>();
   if (listOpenDedupTasks) {
@@ -223,41 +210,29 @@ export async function runDedup(
       const aIdentities = identityMap.get(a.id) ?? [];
       const bIdentities = identityMap.get(b.id) ?? [];
 
-      // F4: Wrap the exclusion check and classification in a try-catch so that
-      // a transient DB error (e.g. getFacts throws) does not abort the entire
-      // sweep. On error we FAIL CLOSED: the pair is skipped (never merged)
-      // and errorCount is incremented so the operator knows something went wrong.
+      // F4: Wrap classification in a try-catch so that an error on one pair does not
+      // abort the entire sweep. On error we FAIL CLOSED: the pair is skipped (never
+      // merged) and errorCount is incremented so the operator knows something went wrong.
       let classification: PairClassification | null;
-      let excluded: boolean;
       try {
         // Classify the pair: structural, fuzzy, or null (below threshold)
         classification = classifyPair(a, aIdentities, b, bIdentities);
-        if (classification === null) continue;
-
-        // ------------------------------------------------------------------
-        // Check for a prior dedup_exclusion in either direction
-        // ------------------------------------------------------------------
-        // We check regardless of classification type — exclusions apply to all matches.
-        excluded = await hasExclusion({
-          contactAId: a.id,
-          contactBId: b.id,
-          kgNodeIdA: a.kgNodeId,
-          kgNodeIdB: b.kgNodeId,
-          getFacts: cachedGetFacts,
-        });
       } catch (err) {
-        // Fail closed: any error during classification or exclusion check means
-        // we DO NOT proceed to merge. Log and move on to the next pair.
         logger.error(
           { err, contactAId: a.id, contactBId: b.id },
-          'dedup: error during classification/exclusion check — skipping pair (fail closed)',
+          'dedup: error during classification — skipping pair (fail closed)',
         );
         result.errorCount++;
         continue;
       }
+      if (classification === null) continue;
 
-      if (excluded) {
-        logger.debug({ contactAId: a.id, contactBId: b.id }, 'dedup: skipped — dedup_exclusion fact present');
+      // ------------------------------------------------------------------
+      // Check for a prior exclusion (order-independent)
+      // ------------------------------------------------------------------
+      // We check regardless of classification type — exclusions apply to all matches.
+      if (excludedPairKeys.has(key)) {
+        logger.debug({ contactAId: a.id, contactBId: b.id }, 'dedup: skipped — pair has a recorded exclusion');
         result.skippedExcludedCount++;
         continue;
       }
@@ -677,18 +652,16 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       logger.info({ contactCount: contacts.length }, 'dedup-contacts: loaded contacts');
 
       // Wire the real service stack — mirrors the construction order in src/index.ts.
-      // All four hand-rolled callbacks (mergeContacts, createTask, storeFact, getFacts)
-      // are replaced with delegates to real services so that:
+      // Every injected callback delegates to a real service, no hand-rolled SQL:
       //   - mergeContacts: uses ContactService.mergeContacts(), which is transactional,
-      //     repoints kg_node_id and contact_calendars, and fires the contact.merged bus
-      //     event (audit-logged by the write-ahead hook in EventBus).
+      //     repoints kg_node_id, contact_calendars and dedup exclusions, and fires the
+      //     contact.merged bus event (audit-logged by the write-ahead hook in EventBus).
       //   - createTask: uses TaskRepo.createTask(), which publishes task.created events.
-      //   - storeFact/getFacts: use EntityMemory, which embeds labels and validates facts.
+      //   - listExclusionPairKeys: reads contact_dedup_exclusions via ContactService.
       // A real sweep merges KG entity nodes (entityMemory.mergeEntities), which embeds fact
-      // labels and therefore needs OpenAI credentials. A dry-run only READS facts
-      // (getFacts → KG node reads, no embedding), so it can run with a fake embedding backend
-      // and no API key — keeping the preview usable in CI / minimal environments. Fail fast
-      // only for a real run.
+      // labels and therefore needs OpenAI credentials. A dry-run never embeds, so it can run
+      // with a fake embedding backend and no API key — keeping the preview usable in CI /
+      // minimal environments. Fail fast only for a real run.
       const openaiApiKey = process.env['OPENAI_API_KEY'];
       if (!dryRun && !openaiApiKey) {
         logger.error('dedup-contacts: OPENAI_API_KEY is required for a real sweep (KG entity merge embeds fact labels). Re-run with --dry-run to preview without it.');
@@ -781,11 +754,9 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
           return tasks;
         },
 
-        // storeFact is NOT included in DedupRunOptions — the sweep never writes exclusion
-        // facts directly. See writeExclusion() and its doc comment for the intended call site.
-
-        // EntityMemory.getFacts returns fact nodes linked to the KG entity node.
-        getFacts: (kgNodeId) => entityMemory.getFacts(kgNodeId),
+        // Read-only: the sweep never records exclusions. Decline→exclude goes through the
+        // contacts agent calling contact-dedup-exclude (#1625).
+        listExclusionPairKeys: () => contactService.listDedupExclusionPairKeys(),
       };
 
       const result = await runDedup(contacts, identityMap, opts);

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -68,7 +68,8 @@ export interface DedupRunResult {
   skippedAboveMaxScoreCount: number;
   /** Number of would-be review tasks suppressed by --no-tasks or the --max-tasks cap. */
   suppressedTaskCount: number;
-  /** Number of errors during merge/task-create operations. */
+  /** Number of pairs that failed and were skipped fail-closed. Three sources:
+   *  pair classification, contact merge, and review-task creation. */
   errorCount: number;
 }
 

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -164,11 +164,38 @@ export async function runDedup(
 
   if (contacts.length < 2) return result;
 
-  // Load exclusions before any pair is classified. Exclusions are static within a run
-  // (the sweep never writes them), so one bulk read covers the entire O(n²) loop.
-  // An error propagates and aborts the sweep — see listExclusionPairKeys' doc comment.
+  // Load exclusions before any pair is classified. The sweep never WRITES exclusions,
+  // so one bulk read covers the entire O(n²) loop. An error propagates and aborts the
+  // sweep — see listExclusionPairKeys' doc comment.
   const excludedPairKeys = await listExclusionPairKeys();
   logger.debug({ exclusions: excludedPairKeys.size }, 'dedup: loaded recorded exclusions');
+
+  /**
+   * Mirror ContactService.reattachDedupExclusions onto the in-memory snapshot after a
+   * merge. The sweep does not write exclusions, but it does MERGE, and a merge re-points
+   * the secondary's exclusion rows onto the survivor. Without this the snapshot goes
+   * stale mid-run and a transitively-inherited exclusion is invisible to later pairs:
+   *
+   *   c1, c2, c3 all named "Seth Berman"; the CEO ruled c2 ≠ c3.
+   *   (c1, c2) merges structurally on exact name → the DB row becomes (c1, c3).
+   *   (c1, c3) is then checked against a snapshot that still says (c2, c3) → miss →
+   *   auto-merged, silently overriding the CEO's ruling.
+   *
+   * Applied in dry-run too, so the preview reports what a real run would actually do.
+   */
+  function reattachExclusionsInSnapshot(primaryId: string, secondaryId: string): void {
+    for (const excludedKey of [...excludedPairKeys]) {
+      const [x, y] = excludedKey.split(':') as [string, string];
+      if (x !== secondaryId && y !== secondaryId) continue;
+
+      excludedPairKeys.delete(excludedKey);
+      const other = x === secondaryId ? y : x;
+      // The exclusion between the two merged contacts is superseded by the merge
+      // itself — the DB drops it for the same reason.
+      if (other === primaryId) continue;
+      excludedPairKeys.add(canonicalPairKey(primaryId, other));
+    }
+  }
 
   const existingPairKeys = new Set<string>();
   if (listOpenDedupTasks) {
@@ -271,6 +298,7 @@ export async function runDedup(
           // dry-run counts and recommendations accurate (no double-counting a
           // contact that a real run would already have removed).
           mergedAwayIds.add(secondaryId!);
+          reattachExclusionsInSnapshot(primaryId!, secondaryId!);
           continue;
         }
 
@@ -292,6 +320,10 @@ export async function runDedup(
           ];
           identityMap.set(primaryId!, mergedIdentities);
           identityMap.delete(secondaryId!);
+          // Same reasoning as identityMap above, for exclusions: mergeContacts has just
+          // re-pointed the secondary's exclusion rows onto the primary in the DB, so the
+          // snapshot the remaining pairs are checked against must follow.
+          reattachExclusionsInSnapshot(primaryId!, secondaryId!);
           logger.info({ primaryId, secondaryId }, 'dedup: merge complete');
         } catch (err) {
           logger.error({ err, primaryId, secondaryId }, 'dedup: merge failed — continuing');
@@ -653,9 +685,11 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
 
       // Wire the real service stack — mirrors the construction order in src/index.ts.
       // Every injected callback delegates to a real service, no hand-rolled SQL:
-      //   - mergeContacts: uses ContactService.mergeContacts(), which is transactional,
-      //     repoints kg_node_id, contact_calendars and dedup exclusions, and fires the
-      //     contact.merged bus event (audit-logged by the write-ahead hook in EventBus).
+      //   - mergeContacts: uses ContactService.mergeContacts(), which repoints kg_node_id,
+      //     contact_calendars and dedup exclusions, and fires the contact.merged bus event
+      //     (audit-logged by the write-ahead hook in EventBus). NOTE: it sequences those
+      //     writes and rethrows on failure — it is NOT transactional (see the partial-state
+      //     warning it logs, and #1695).
       //   - createTask: uses TaskRepo.createTask(), which publishes task.created events.
       //   - listExclusionPairKeys: reads contact_dedup_exclusions via ContactService.
       // A real sweep merges KG entity nodes (entityMemory.mergeEntities), which embeds fact

--- a/skills/contacts/tools/contact-dedup-exclude/handler.ts
+++ b/skills/contacts/tools/contact-dedup-exclude/handler.ts
@@ -13,6 +13,9 @@ import { ContactNotFoundError } from '../../../../src/contacts/types.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/** Postgres SQLSTATE for undefined_table — migration 084 has not been applied. */
+const PG_UNDEFINED_TABLE = '42P01';
+
 export class ContactDedupExcludeHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
     const input = ctx.input as Record<string, unknown>;
@@ -84,7 +87,11 @@ export class ContactDedupExcludeHandler implements ToolHandler {
       // 084 not applied — possible when the app image leads the DB) or contactService
       // predates this tool. Both look exactly like a DB blip in a generic message, and the
       // agent prompt tells the agent to retry — which would loop forever. Say so instead.
-      const tableMissing = /relation "contact_dedup_exclusions" does not exist/i.test(message);
+      //
+      // Detected by Postgres SQLSTATE 42P01 (undefined_table), not by matching the error
+      // text: the message is localised and version-dependent, and the repo rule is to
+      // branch on structured codes rather than strings.
+      const tableMissing = (err as { code?: string }).code === PG_UNDEFINED_TABLE;
       if (tableMissing || err instanceof TypeError) {
         return {
           success: false,

--- a/skills/contacts/tools/contact-dedup-exclude/handler.ts
+++ b/skills/contacts/tools/contact-dedup-exclude/handler.ts
@@ -9,6 +9,7 @@
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
 import { InvalidExclusionPairError } from '../../../../src/contacts/dedup-exclusions.js';
+import { ContactNotFoundError } from '../../../../src/contacts/types.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -32,11 +33,19 @@ export class ContactDedupExcludeHandler implements ToolHandler {
     }
 
     try {
-      // decided_by is provenance for the ruling. memoryWriteSource identifies the
-      // agent/task/channel that recorded it; the sweep-script default keeps manual
-      // and script-driven excludes distinguishable from agent ones.
-      const decidedBy = ctx.memoryWriteSource ?? 'contacts-dedup';
-      const { created } = await ctx.contactService.addDedupExclusion(contactAId, contactBId, decidedBy);
+      // decided_by is provenance for the ruling — memoryWriteSource identifies the
+      // agent/task/channel that recorded it. It is the only audit trail the row carries,
+      // and the row is written once and never revisited, so a missing or blank source is
+      // worth a warning: it means the execution layer did not populate the context.
+      const writeSource = ctx.memoryWriteSource?.trim();
+      if (!writeSource) {
+        ctx.log.warn(
+          { contactAId, contactBId },
+          'contact-dedup-exclude: ctx.memoryWriteSource absent — recording exclusion with generic provenance',
+        );
+      }
+      const decidedBy = writeSource || 'contacts-dedup';
+      const { pair, created } = await ctx.contactService.addDedupExclusion(contactAId, contactBId, decidedBy);
 
       ctx.log.info(
         { contactAId, contactBId, created },
@@ -48,8 +57,9 @@ export class ContactDedupExcludeHandler implements ToolHandler {
       return {
         success: true,
         data: {
-          contact_a_id: contactAId,
-          contact_b_id: contactBId,
+          // Echo the normalized (lowercase) ids so tool output matches the stored row.
+          contact_a_id: pair.contactAId,
+          contact_b_id: pair.contactBId,
           // false means the pair was already excluded. Still a success — the CEO's
           // decision is persisted either way, and the agent should close the task.
           created,
@@ -57,13 +67,31 @@ export class ContactDedupExcludeHandler implements ToolHandler {
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      // InvalidExclusionPairError is a caller mistake the validation above should
-      // already have caught; surface it as-is rather than as an infrastructure error.
-      const prefix = err instanceof InvalidExclusionPairError
-        ? 'Invalid contact pair'
-        : 'Failed to record dedup exclusion';
       ctx.log.error({ err, contactAId, contactBId }, 'contact-dedup-exclude: exclusion write failed');
-      return { success: false, error: `${prefix}: ${message}` };
+
+      // One of the contacts is gone — the agent should re-look-up, not retry blindly.
+      if (err instanceof ContactNotFoundError) {
+        return {
+          success: false,
+          error: `${message}. One of these contacts no longer exists — re-run contact-lookup before excluding.`,
+        };
+      }
+      // A caller mistake the validation above should already have caught.
+      if (err instanceof InvalidExclusionPairError) {
+        return { success: false, error: `Invalid contact pair: ${message}` };
+      }
+      // Deployment faults, not transient ones: the exclusions table is missing (migration
+      // 084 not applied — possible when the app image leads the DB) or contactService
+      // predates this tool. Both look exactly like a DB blip in a generic message, and the
+      // agent prompt tells the agent to retry — which would loop forever. Say so instead.
+      const tableMissing = /relation "contact_dedup_exclusions" does not exist/i.test(message);
+      if (tableMissing || err instanceof TypeError) {
+        return {
+          success: false,
+          error: `Dedup exclusions are unavailable in this deployment (${message}). This will not resolve on retry — an operator must confirm migration 084 has been applied. Leave the review task open.`,
+        };
+      }
+      return { success: false, error: `Failed to record dedup exclusion: ${message}` };
     }
   }
 }

--- a/skills/contacts/tools/contact-dedup-exclude/handler.ts
+++ b/skills/contacts/tools/contact-dedup-exclude/handler.ts
@@ -1,5 +1,14 @@
+// handler.ts — contact-dedup-exclude tool
+//
+// Records "these two contacts are NOT the same person" so dedup sweeps stop
+// proposing the pair. Backed by the contact_dedup_exclusions table (#1625,
+// ADR-039), not KG facts: an exclusion is an operational decision about a *pair*,
+// so it needs no KG node on either side and works for the same-display-name
+// contacts that carry kg_node_id = NULL — the population this tool used to fail
+// for outright (#1623).
+
 import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
-import { writeExclusion } from '../../../../src/contacts/dedup-exclusions.js';
+import { InvalidExclusionPairError } from '../../../../src/contacts/dedup-exclusions.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -15,103 +24,46 @@ export class ContactDedupExcludeHandler implements ToolHandler {
     if (typeof contactBId !== 'string' || !UUID_RE.test(contactBId)) {
       return { success: false, error: 'contact_b_id must be a valid UUID' };
     }
-    if (contactAId === contactBId) {
+    if (contactAId.toLowerCase() === contactBId.toLowerCase()) {
       return { success: false, error: 'contact_a_id and contact_b_id must be different' };
     }
     if (!ctx.contactService) {
       return { success: false, error: 'contactService not available' };
     }
-    if (!ctx.entityMemory) {
-      return { success: false, error: 'entityMemory not available' };
-    }
-
-    // Hoisted so both variables are in scope in the catch block for partial-write logging
-    let contactAExcluded = false;
-    let contactBExcluded = false;
 
     try {
-      const [contactA, contactB] = await Promise.all([
-        ctx.contactService.getContact(contactAId),
-        ctx.contactService.getContact(contactBId),
-      ]);
+      // decided_by is provenance for the ruling. memoryWriteSource identifies the
+      // agent/task/channel that recorded it; the sweep-script default keeps manual
+      // and script-driven excludes distinguishable from agent ones.
+      const decidedBy = ctx.memoryWriteSource ?? 'contacts-dedup';
+      const { created } = await ctx.contactService.addDedupExclusion(contactAId, contactBId, decidedBy);
 
-      if (!contactA) {
-        return { success: false, error: `Contact not found: ${contactAId}` };
-      }
-      if (!contactB) {
-        return { success: false, error: `Contact not found: ${contactBId}` };
-      }
-
-      const source = ctx.memoryWriteSource ?? 'contacts-dedup';
-      const storeFact = ctx.entityMemory.storeFact.bind(ctx.entityMemory);
-
-      // Write on A's node naming B. Each side is independent: if A's write fails (e.g.
-      // KG conflict), we still attempt B — hasExclusion is bidirectional so a single
-      // side is enough to prevent the pair from resurfacing.
-      //
-      // Note: kg_node_id = NULL is the designed outcome of same-display-name collisions
-      // (createContact retries without a KG link when idx_contacts_kg_node_unique fires).
-      // Do not invent a node here — that recreates the collision (#1623 review).
-      if (contactA.kgNodeId !== null) {
-        try {
-          await writeExclusion({ contactBId, kgNodeId: contactA.kgNodeId, storeFact, source });
-          contactAExcluded = true;
-        } catch (writeErrA) {
-          ctx.log.error(
-            { writeErrA, contactAId, contactBId },
-            'contact-dedup-exclude: failed to write exclusion on A — still attempting B',
-          );
-        }
-      } else {
-        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact A has no KG node — exclusion written on B only');
-      }
-
-      // Write on B's node naming A — bidirectional so hasExclusion finds it regardless of
-      // which contact's node is checked first
-      if (contactB.kgNodeId !== null) {
-        try {
-          await writeExclusion({ contactBId: contactAId, kgNodeId: contactB.kgNodeId, storeFact, source });
-          contactBExcluded = true;
-        } catch (writeErrB) {
-          ctx.log.error(
-            { writeErrB, contactAId, contactBId, contactAExcluded },
-            'contact-dedup-exclude: failed to write exclusion on B',
-          );
-        }
-      } else {
-        ctx.log.warn({ contactAId, contactBId }, 'contact-dedup-exclude: contact B has no KG node — exclusion written on A only');
-      }
-
-      // Both sides failed (no KG nodes, or both writes errored) — nothing was stored.
-      if (!contactAExcluded && !contactBExcluded) {
-        const bothMissingNodes = contactA.kgNodeId === null && contactB.kgNodeId === null;
-        ctx.log.warn(
-          { contactAId, contactBId, contactAHasNode: contactA.kgNodeId !== null, contactBHasNode: contactB.kgNodeId !== null },
-          'contact-dedup-exclude: exclusion could not be written on either contact',
-        );
-        return {
-          success: false,
-          error: bothMissingNodes
-            ? 'Could not write dedup exclusion — both contacts have no KG node (common for same-name collisions). Exclusion cannot be stored until at least one contact has a linked KG node.'
-            : 'Could not write dedup exclusion on either contact — no eligible KG write succeeded (missing KG node, conflict, or store error). Check logs for details.',
-        };
-      }
+      ctx.log.info(
+        { contactAId, contactBId, created },
+        created
+          ? 'contact-dedup-exclude: exclusion recorded'
+          : 'contact-dedup-exclude: pair was already excluded (no-op)',
+      );
 
       return {
         success: true,
         data: {
           contact_a_id: contactAId,
           contact_b_id: contactBId,
-          contact_a_excluded: contactAExcluded,
-          contact_b_excluded: contactBExcluded,
+          // false means the pair was already excluded. Still a success — the CEO's
+          // decision is persisted either way, and the agent should close the task.
+          created,
         },
       };
     } catch (err) {
-      // Outer catch: only contact lookup failures reach here (writeExclusion errors
-      // are handled above with their own per-side try/catch)
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, contactAId, contactBId }, 'contact-dedup-exclude: contact lookup failed');
-      return { success: false, error: `Failed to look up contacts: ${message}` };
+      // InvalidExclusionPairError is a caller mistake the validation above should
+      // already have caught; surface it as-is rather than as an infrastructure error.
+      const prefix = err instanceof InvalidExclusionPairError
+        ? 'Invalid contact pair'
+        : 'Failed to record dedup exclusion';
+      ctx.log.error({ err, contactAId, contactBId }, 'contact-dedup-exclude: exclusion write failed');
+      return { success: false, error: `${prefix}: ${message}` };
     }
   }
 }

--- a/skills/contacts/tools/contact-dedup-exclude/tool.json
+++ b/skills/contacts/tools/contact-dedup-exclude/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "contact-dedup-exclude",
-  "description": "Record a permanent dedup_exclusion KG fact on both contacts, preventing the pair from being proposed as duplicates again. Call this when the CEO explicitly says two contacts are not the same person. Pinned exclusively to the contacts agent — not available to other agents.",
-  "version": "0.1.1",
+  "description": "Record a permanent exclusion for a contact pair, preventing it from being proposed as a duplicate again. Call this when the CEO explicitly says two contacts are not the same person. Works for any two contacts, including same-name contacts with no knowledge-graph node. Pinned exclusively to the contacts agent — not available to other agents.",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -11,13 +11,10 @@
   "outputs": {
     "contact_a_id": "string — echoed back",
     "contact_b_id": "string — echoed back",
-    "contact_a_excluded": "boolean — true if an exclusion fact was written on contact A's KG node",
-    "contact_b_excluded": "boolean — true if an exclusion fact was written on contact B's KG node"
+    "created": "boolean — true if this call recorded a new exclusion, false if the pair was already excluded (both are success)"
   },
   "permissions": [],
   "secrets": [],
   "timeout": 10000,
-  "capabilities": [
-    "entityMemory"
-  ]
+  "capabilities": []
 }

--- a/skills/contacts/tools/contact-find-duplicates/handler.ts
+++ b/skills/contacts/tools/contact-find-duplicates/handler.ts
@@ -149,6 +149,10 @@ export class ContactFindDuplicatesHandler implements ToolHandler {
 
       // canonicalPairKey matches the order-independent key listDedupExclusionPairKeys
       // returns, so a pair excluded in either direction is caught here.
+      //
+      // Unlike the dedup sweep, this snapshot needs no mid-run maintenance: this handler
+      // only FILES tasks, it never merges, so nothing it does re-points an exclusion row.
+      // The worst case from a concurrent exclusion is one re-filed review task.
       if (excludedPairKeys.has(key)) {
         skippedExcluded++;
         continue;

--- a/skills/contacts/tools/contact-find-duplicates/handler.ts
+++ b/skills/contacts/tools/contact-find-duplicates/handler.ts
@@ -5,15 +5,12 @@
 // This is the scheduled-scan entry point: it files tasks (rather than returning
 // a raw list) so a single run never floods the agent context or causes a timeout.
 //
-// Idempotency: pairs that already have an open 'dedup' task, or that have a
-// dedup_exclusion KG fact in either direction, are skipped and counted in the
-// summary. This makes repeated weekly runs safe to run without accumulating
-// duplicate tasks.
+// Idempotency: pairs that already have an open 'dedup' task, or that have a row
+// in contact_dedup_exclusions, are skipped and counted in the summary. This makes
+// repeated weekly runs safe to run without accumulating duplicate tasks.
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
 import type { DuplicatePair, TaskOriginator } from '../../../../src/contacts/types.js';
-import type { KgNode } from '../../../../src/memory/types.js';
-import { hasExclusion } from '../../../../src/contacts/dedup-exclusions.js';
 import {
   canonicalPairKey,
   dedupPairTag,
@@ -65,22 +62,17 @@ export class ContactFindDuplicatesHandler implements ToolHandler {
         error: 'contact-find-duplicates: taskRepo not available — declare "taskRepo" in capabilities.',
       };
     }
-    if (!ctx.entityMemory) {
-      return {
-        success: false,
-        error: 'contact-find-duplicates: entityMemory not available — declare "entityMemory" in capabilities.',
-      };
-    }
 
     // Capture as local variables so closures below don't need non-null assertions.
     const taskRepo = ctx.taskRepo;
-    const entityMemory = ctx.entityMemory;
+    const contactService = ctx.contactService;
 
     ctx.log.info({ minScore, maxTasks }, 'contact-find-duplicates: starting scan');
 
     // -- Setup phase: failures here abort the scan entirely before any writes --
     let pairs: DuplicatePair[];
     let existingPairKeys: Set<string>;
+    let excludedPairKeys: Set<string>;
     try {
       // Fetch all pairs at the base floor (0.7) then filter to the requested threshold.
       // This avoids changing the ContactService/DedupService interface for a per-call
@@ -118,6 +110,12 @@ export class ContactFindDuplicatesHandler implements ToolHandler {
           unparseable++;
         }
       }
+      // Load every exclusion once instead of one lookup per pair. The table holds one
+      // row per pair the CEO has ruled on — small by construction, and a failure here
+      // aborts the scan (below) rather than silently re-filing excluded pairs.
+      excludedPairKeys = await contactService.listDedupExclusionPairKeys();
+      ctx.log.info({ exclusions: excludedPairKeys.size }, 'contact-find-duplicates: loaded dedup exclusions');
+
       if (unparseable > 0) {
         // Dedup-tagged tasks without parseable contact IDs (manually created, old format,
         // or truncated description) are invisible to the idempotency check — those pairs
@@ -130,21 +128,9 @@ export class ContactFindDuplicatesHandler implements ToolHandler {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'contact-find-duplicates: setup phase failed (findDuplicates or listTasks)');
+      ctx.log.error({ err }, 'contact-find-duplicates: setup phase failed (findDuplicates, listTasks, or exclusion load)');
       return { success: false, error: `Failed to scan for duplicates: ${message}` };
     }
-
-    // Memoize KG fact lookups for the duration of the run — a contact that appears
-    // in multiple pairs would otherwise re-fetch its facts each time. Exclusion
-    // facts are permanent and not written by this skill, so caching is safe.
-    const factsCache = new Map<string, KgNode[]>();
-    const cachedGetFacts = async (nodeId: string): Promise<KgNode[]> => {
-      const cached = factsCache.get(nodeId);
-      if (cached !== undefined) return cached;
-      const facts = await entityMemory.getFacts(nodeId);
-      factsCache.set(nodeId, facts);
-      return facts;
-    };
 
     let filed = 0;
     let skippedExisting = 0;
@@ -161,28 +147,9 @@ export class ContactFindDuplicatesHandler implements ToolHandler {
         continue;
       }
 
-      // Exclusion check is isolated from task filing: a transient getFacts failure
-      // should increment failed and skip the pair (same as a task-filing failure),
-      // but logging a distinct message lets operators tell the two apart.
-      let excluded: boolean;
-      try {
-        excluded = await hasExclusion({
-          contactAId: pair.contactA.id,
-          contactBId: pair.contactB.id,
-          kgNodeIdA: pair.contactA.kgNodeId,
-          kgNodeIdB: pair.contactB.kgNodeId,
-          getFacts: cachedGetFacts,
-        });
-      } catch (exclusionErr) {
-        failed++;
-        ctx.log.error(
-          { exclusionErr, contactAId: pair.contactA.id, contactBId: pair.contactB.id },
-          'contact-find-duplicates: exclusion check failed — skipping pair, may re-surface next sweep',
-        );
-        continue;
-      }
-
-      if (excluded) {
+      // canonicalPairKey matches the order-independent key listDedupExclusionPairKeys
+      // returns, so a pair excluded in either direction is caught here.
+      if (excludedPairKeys.has(key)) {
         skippedExcluded++;
         continue;
       }

--- a/skills/contacts/tools/contact-find-duplicates/tool.json
+++ b/skills/contacts/tools/contact-find-duplicates/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "contact-find-duplicates",
-  "description": "Scan all contacts for duplicate pairs above a score threshold, file Curia-owned review tasks for new pairs, and return a summary. Idempotent: pairs that already have an open 'dedup' task (matched by structured dedup-pair tag or description IDs) or a dedup_exclusion KG fact are skipped. Use this for the weekly scheduled scan — it files tasks rather than returning a raw list, so it never floods the agent context.",
-  "version": "2.1.0",
+  "description": "Scan all contacts for duplicate pairs above a score threshold, file Curia-owned review tasks for new pairs, and return a summary. Idempotent: pairs that already have an open 'dedup' task (matched by structured dedup-pair tag or description IDs) or a recorded dedup exclusion are skipped. Use this for the weekly scheduled scan — it files tasks rather than returning a raw list, so it never floods the agent context.",
+  "version": "2.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -16,7 +16,7 @@
     "failed": "number",
     "total_scanned": "number"
   },
-  "capabilities": ["taskRepo", "entityMemory"],
+  "capabilities": ["taskRepo"],
   "permissions": [],
   "secrets": [],
   "timeout": 60000

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1574,8 +1574,10 @@ export class ContactService {
    * generates the most duplicate proposals (#1623).
    *
    * @param decidedBy Provenance for the decision — an agent memory-write source key,
-   *                  or an operator/CEO identifier for manual excludes.
+   *                  or an operator/CEO identifier for manual excludes. Must be non-blank:
+   *                  it is the row's only audit trail and the row is never revisited.
    * @throws InvalidExclusionPairError when either ID is not a UUID or both are the same contact.
+   * @throws ContactValidationError when decidedBy is blank.
    * @throws ContactNotFoundError when either contact does not exist.
    */
   async addDedupExclusion(
@@ -1584,6 +1586,14 @@ export class ContactService {
     decidedBy: string,
   ): Promise<{ pair: ExclusionPair; created: boolean }> {
     const pair = normalizeExclusionPair(contactAId, contactBId);
+
+    // Reject blank provenance here rather than letting the CHECK constraint do it, so
+    // direct callers (ops scripts, future console routes) get a named error instead of a
+    // raw constraint violation. Store the trimmed value so ' ceo ' and 'ceo' are one source.
+    const provenance = decidedBy.trim();
+    if (provenance === '') {
+      throw new ContactValidationError('decidedBy is required — a dedup exclusion must record who decided it');
+    }
 
     // Check existence up front so callers get ContactNotFoundError rather than an
     // opaque FK violation from Postgres.
@@ -1594,9 +1604,9 @@ export class ContactService {
     if (!a) throw new ContactNotFoundError(pair.contactAId);
     if (!b) throw new ContactNotFoundError(pair.contactBId);
 
-    const created = await this.backend.addDedupExclusion(pair, decidedBy);
+    const created = await this.backend.addDedupExclusion(pair, provenance);
     this.logger?.info(
-      { contactAId: pair.contactAId, contactBId: pair.contactBId, decidedBy, created },
+      { contactAId: pair.contactAId, contactBId: pair.contactBId, decidedBy: provenance, created },
       created ? 'contacts: dedup exclusion recorded' : 'contacts: dedup exclusion already present',
     );
     return { pair, created };

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -39,6 +39,8 @@ import type {
 } from './types.js';
 import type { DedupService } from './dedup-service.js';
 import type { ContactCalendar, CreateCalendarLinkOptions, ResolvedCalendar } from './calendar-types.js';
+import { normalizeExclusionPair, type ExclusionPair } from './dedup-exclusions.js';
+import { canonicalPairKey } from './dedup-pair-key.js';
 
 /** Thrown when a caller provides invalid data for a contact field (e.g., primaryEmail not in CCI). */
 export class ContactValidationError extends Error {
@@ -197,6 +199,29 @@ interface ContactServiceBackend {
    * If primary already has an override for the same permission, secondary's is discarded.
    */
   reattachAuthOverrides(fromContactId: string, toContactId: string): Promise<void>;
+
+  // -- Dedup exclusions (#1625, ADR-039) --
+
+  /**
+   * Record a dedup exclusion for an already-normalized ordered pair
+   * (contactAId < contactBId, both lowercase — see normalizeExclusionPair).
+   * Idempotent: returns false when the pair was already excluded.
+   */
+  addDedupExclusion(pair: ExclusionPair, decidedBy: string): Promise<boolean>;
+
+  /** True when the normalized pair has an exclusion row. */
+  hasDedupExclusion(pair: ExclusionPair): Promise<boolean>;
+
+  /** Every exclusion row, in stored (normalized) order. */
+  listDedupExclusions(): Promise<ExclusionPair[]>;
+
+  /**
+   * Re-point exclusion rows from fromContactId → toContactId during a merge,
+   * renormalizing each pair into stored order. Rows that would become a self-pair
+   * (the two merged contacts excluded against each other) or that would duplicate
+   * an exclusion the survivor already holds are dropped.
+   */
+  reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<void>;
 
   /**
    * Delete a contact by ID. Call only after FK-referenced rows have been re-pointed.
@@ -1428,6 +1453,10 @@ export class ContactService {
     try {
       await this.backend.reattachIdentities(secondaryId, primaryId);
       await this.backend.reattachAuthOverrides(secondaryId, primaryId);
+      // Exclusions the secondary held move to the survivor, renormalized into stored
+      // pair order. The exclusion between the merging pair itself (if any) is dropped:
+      // merging is the decision that they ARE the same person (#1625, ADR-039).
+      await this.backend.reattachDedupExclusions(secondaryId, primaryId);
 
       // Write the golden record fields onto the primary contact. The surviving tier
       // is computed by computeGoldenRecord (blocked-on-either-side wins; else higher
@@ -1478,6 +1507,70 @@ export class ContactService {
       dryRun: false,
       mergedAt,
     };
+  }
+
+  // -- Dedup exclusions (#1625, ADR-039) --
+
+  /**
+   * Record that two contacts are NOT the same person, so dedup sweeps stop
+   * proposing the pair. Order-independent and idempotent: re-excluding an
+   * already-excluded pair returns `created: false` rather than failing.
+   *
+   * Unlike the KG-fact implementation this replaces, this works for contacts with
+   * `kg_node_id = NULL` — which is exactly the same-display-name population that
+   * generates the most duplicate proposals (#1623).
+   *
+   * @param decidedBy Provenance for the decision — an agent memory-write source key,
+   *                  or an operator/CEO identifier for manual excludes.
+   * @throws InvalidExclusionPairError when either ID is not a UUID or both are the same contact.
+   * @throws ContactNotFoundError when either contact does not exist.
+   */
+  async addDedupExclusion(
+    contactAId: string,
+    contactBId: string,
+    decidedBy: string,
+  ): Promise<{ pair: ExclusionPair; created: boolean }> {
+    const pair = normalizeExclusionPair(contactAId, contactBId);
+
+    // Check existence up front so callers get ContactNotFoundError rather than an
+    // opaque FK violation from Postgres.
+    const [a, b] = await Promise.all([
+      this.backend.getContact(pair.contactAId),
+      this.backend.getContact(pair.contactBId),
+    ]);
+    if (!a) throw new ContactNotFoundError(pair.contactAId);
+    if (!b) throw new ContactNotFoundError(pair.contactBId);
+
+    const created = await this.backend.addDedupExclusion(pair, decidedBy);
+    this.logger?.info(
+      { contactAId: pair.contactAId, contactBId: pair.contactBId, decidedBy, created },
+      created ? 'contacts: dedup exclusion recorded' : 'contacts: dedup exclusion already present',
+    );
+    return { pair, created };
+  }
+
+  /**
+   * True when the pair has been ruled "not the same person". Order-independent.
+   *
+   * Errors propagate — a caller that treated a DB failure as "not excluded" would
+   * re-file review tasks for pairs the CEO already ruled on.
+   */
+  async hasDedupExclusion(contactAId: string, contactBId: string): Promise<boolean> {
+    return this.backend.hasDedupExclusion(normalizeExclusionPair(contactAId, contactBId));
+  }
+
+  /**
+   * Every exclusion as a canonical pair key (`canonicalPairKey` format), for sweeps
+   * that check many pairs in one run. One query instead of one lookup per pair.
+   *
+   * Deliberately unpaginated: the table holds one row per pair a human has ruled on,
+   * so it is bounded by review throughput, not by contact count. If that ever stops
+   * being true, the fix is a per-pair `hasDedupExclusion` in the sweep loop, not a
+   * silently truncated set — a partial set would re-file pairs already ruled on.
+   */
+  async listDedupExclusionPairKeys(): Promise<Set<string>> {
+    const rows = await this.backend.listDedupExclusions();
+    return new Set(rows.map(pair => canonicalPairKey(pair.contactAId, pair.contactBId)));
   }
 
   /**
@@ -2305,6 +2398,74 @@ class PostgresContactBackend implements ContactServiceBackend {
     );
   }
 
+  async addDedupExclusion(pair: ExclusionPair, decidedBy: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_by)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (contact_a_id, contact_b_id) DO NOTHING
+       RETURNING contact_a_id`,
+      [pair.contactAId, pair.contactBId, decidedBy],
+    );
+    // rowCount 0 means ON CONFLICT swallowed the insert — the pair was already
+    // excluded. That is a successful no-op, not a failure: re-excluding a pair the
+    // CEO already ruled on must stay idempotent.
+    return result.rows.length > 0;
+  }
+
+  async hasDedupExclusion(pair: ExclusionPair): Promise<boolean> {
+    const result = await this.pool.query(
+      `SELECT 1 FROM contact_dedup_exclusions
+       WHERE contact_a_id = $1 AND contact_b_id = $2`,
+      [pair.contactAId, pair.contactBId],
+    );
+    return result.rows.length > 0;
+  }
+
+  async listDedupExclusions(): Promise<ExclusionPair[]> {
+    const result = await this.pool.query(
+      `SELECT contact_a_id, contact_b_id FROM contact_dedup_exclusions`,
+    );
+    return result.rows.map((row: { contact_a_id: string; contact_b_id: string }) => ({
+      contactAId: row.contact_a_id,
+      contactBId: row.contact_b_id,
+    }));
+  }
+
+  async reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<void> {
+    // Copy the loser's exclusions onto the survivor, renormalizing each pair with
+    // LEAST/GREATEST so the ordered-pair CHECK still holds after the swap.
+    //
+    // WHERE other <> $1 drops the exclusion between the two contacts being merged:
+    // merging them is a decision that they ARE the same person, which supersedes the
+    // earlier "not the same person" ruling. Keeping it would produce a self-pair.
+    //
+    // ON CONFLICT DO NOTHING drops rows the survivor already holds for the same
+    // counterparty; the survivor's own decided_at / decided_by provenance wins.
+    await this.pool.query(
+      `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_at, decided_by)
+       SELECT LEAST($1::uuid, other), GREATEST($1::uuid, other), decided_at, decided_by
+       FROM (
+         SELECT CASE WHEN contact_a_id = $2::uuid THEN contact_b_id ELSE contact_a_id END AS other,
+                decided_at,
+                decided_by
+         FROM contact_dedup_exclusions
+         WHERE contact_a_id = $2::uuid OR contact_b_id = $2::uuid
+       ) AS loser_pairs
+       WHERE other <> $1::uuid
+       ON CONFLICT (contact_a_id, contact_b_id) DO NOTHING`,
+      [toContactId, fromContactId],
+    );
+
+    // Delete the loser's rows explicitly rather than relying on the FK cascade that
+    // fires when the secondary contact row is deleted — reattach must leave a
+    // consistent table even when called outside the merge write sequence.
+    await this.pool.query(
+      `DELETE FROM contact_dedup_exclusions
+       WHERE contact_a_id = $1::uuid OR contact_b_id = $1::uuid`,
+      [fromContactId],
+    );
+  }
+
   async deleteContact(id: string): Promise<void> {
     this.logger.debug({ contactId: id }, 'contacts: deleting contact');
     await this.pool.query(`DELETE FROM contacts WHERE id = $1`, [id]);
@@ -2441,6 +2602,9 @@ class InMemoryContactBackend implements ContactServiceBackend {
   private identities = new Map<string, ChannelIdentity>();
   private overrides = new Map<string, AuthOverride>();
   private calendars = new Map<string, ContactCalendar>();
+  /** Keyed "<contactAId>:<contactBId>" in normalized order — the in-memory analogue
+   *  of the contact_dedup_exclusions primary key + ordered-pair CHECK. */
+  private dedupExclusions = new Map<string, { pair: ExclusionPair; decidedAt: Date; decidedBy: string }>();
 
   async createContact(contact: Contact): Promise<void> {
     // Enforce the partial unique index idx_contacts_kg_node_unique to match Postgres.
@@ -2823,6 +2987,44 @@ class InMemoryContactBackend implements ContactServiceBackend {
     }
   }
 
+  private static exclusionKey(pair: ExclusionPair): string {
+    return `${pair.contactAId}:${pair.contactBId}`;
+  }
+
+  async addDedupExclusion(pair: ExclusionPair, decidedBy: string): Promise<boolean> {
+    const key = InMemoryContactBackend.exclusionKey(pair);
+    if (this.dedupExclusions.has(key)) return false;
+    this.dedupExclusions.set(key, { pair, decidedAt: new Date(), decidedBy });
+    return true;
+  }
+
+  async hasDedupExclusion(pair: ExclusionPair): Promise<boolean> {
+    return this.dedupExclusions.has(InMemoryContactBackend.exclusionKey(pair));
+  }
+
+  async listDedupExclusions(): Promise<ExclusionPair[]> {
+    return [...this.dedupExclusions.values()].map(row => row.pair);
+  }
+
+  async reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<void> {
+    for (const [key, row] of this.dedupExclusions) {
+      const { contactAId, contactBId } = row.pair;
+      if (contactAId !== fromContactId && contactBId !== fromContactId) continue;
+
+      this.dedupExclusions.delete(key);
+
+      const other = contactAId === fromContactId ? contactBId : contactAId;
+      // The exclusion between the two merged contacts is superseded by the merge.
+      if (other === toContactId) continue;
+
+      const renormalized = normalizeExclusionPair(toContactId, other);
+      const newKey = InMemoryContactBackend.exclusionKey(renormalized);
+      // The survivor's own row wins when both sides excluded the same counterparty.
+      if (this.dedupExclusions.has(newKey)) continue;
+      this.dedupExclusions.set(newKey, { ...row, pair: renormalized });
+    }
+  }
+
   async deleteContact(id: string): Promise<void> {
     this.contacts.delete(id);
     // Cascade-delete related rows, matching Postgres ON DELETE CASCADE behavior.
@@ -2836,6 +3038,9 @@ class InMemoryContactBackend implements ContactServiceBackend {
     }
     for (const [rk, rec] of this.recommendations) {
       if (rec.contactId === id) this.recommendations.delete(rk);
+    }
+    for (const [ek, row] of this.dedupExclusions) {
+      if (row.pair.contactAId === id || row.pair.contactBId === id) this.dedupExclusions.delete(ek);
     }
   }
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -42,6 +42,16 @@ import type { ContactCalendar, CreateCalendarLinkOptions, ResolvedCalendar } fro
 import { normalizeExclusionPair, type ExclusionPair } from './dedup-exclusions.js';
 import { canonicalPairKey } from './dedup-pair-key.js';
 
+/** Outcome of re-pointing a merged-away contact's dedup exclusions onto the survivor. */
+export interface ReattachExclusionsResult {
+  /** Rows the loser held (all are removed from the loser). */
+  removed: number;
+  /** Rows carried across to the survivor. */
+  moved: number;
+  /** removed - moved: rulings discarded as superseded or already held by the survivor. */
+  dropped: number;
+}
+
 /** Thrown when a caller provides invalid data for a contact field (e.g., primaryEmail not in CCI). */
 export class ContactValidationError extends Error {
   constructor(message: string) {
@@ -220,8 +230,12 @@ interface ContactServiceBackend {
    * renormalizing each pair into stored order. Rows that would become a self-pair
    * (the two merged contacts excluded against each other) or that would duplicate
    * an exclusion the survivor already holds are dropped.
+   *
+   * Returns the counts so the caller can log dropped rulings — a dropped row is a CEO
+   * decision leaving the ledger, and it must be visible to an operator, not only
+   * explained in a comment.
    */
-  reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<void>;
+  reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<ReattachExclusionsResult>;
 
   /**
    * Delete a contact by ID. Call only after FK-referenced rows have been re-pointed.
@@ -339,9 +353,15 @@ export class ContactService {
     return new ContactService(new PostgresContactBackend(pool, logger), entityMemory, logger, options);
   }
 
-  /** Create an in-memory instance for testing */
-  static createInMemory(entityMemory?: EntityMemory, options?: ContactServiceOptions): ContactService {
-    return new ContactService(new InMemoryContactBackend(), entityMemory, undefined, options);
+  /** Create an in-memory instance for testing.
+   *  `logger` is optional and off by default — pass one only when a test needs to assert
+   *  on a log line (e.g. the dedup-exclusion override warning in mergeContacts). */
+  static createInMemory(
+    entityMemory?: EntityMemory,
+    options?: ContactServiceOptions,
+    logger?: Logger,
+  ): ContactService {
+    return new ContactService(new InMemoryContactBackend(), entityMemory, logger, options);
   }
 
   /**
@@ -1441,6 +1461,22 @@ export class ContactService {
       return { primaryContactId: primaryId, secondaryContactId: secondaryId, goldenRecord, dryRun: true };
     }
 
+    // A recorded exclusion means the CEO ruled these are different people. Merging is
+    // still allowed — every merge path has a human confirming it, and people change
+    // their minds — but the ruling is about to be discarded by reattachDedupExclusions,
+    // so it must not happen silently (#1625). Best-effort: a lookup failure must not
+    // abort a merge the CEO already confirmed.
+    try {
+      if (await this.backend.hasDedupExclusion(normalizeExclusionPair(primaryId, secondaryId))) {
+        this.logger?.warn(
+          { primaryId, secondaryId },
+          'contacts: merging a pair with a recorded dedup exclusion — overriding an earlier "not the same person" ruling',
+        );
+      }
+    } catch (err) {
+      this.logger?.warn({ err, primaryId, secondaryId }, 'contacts: dedup exclusion check failed before merge (non-fatal)');
+    }
+
     // Merge KG nodes (best-effort — failure does not abort the contact merge)
     if (primary.kgNodeId && secondary.kgNodeId && this.entityMemory) {
       try {
@@ -1456,7 +1492,16 @@ export class ContactService {
       // Exclusions the secondary held move to the survivor, renormalized into stored
       // pair order. The exclusion between the merging pair itself (if any) is dropped:
       // merging is the decision that they ARE the same person (#1625, ADR-039).
-      await this.backend.reattachDedupExclusions(secondaryId, primaryId);
+      const exclusions = await this.backend.reattachDedupExclusions(secondaryId, primaryId);
+      if (exclusions.dropped > 0) {
+        // A dropped row is a CEO ruling leaving the ledger. Both causes are expected and
+        // benign, but an operator asking "why was this pair re-proposed months later"
+        // needs the event in the log, not only in a code comment.
+        this.logger?.info(
+          { primaryId, secondaryId, ...exclusions },
+          'contacts: dedup exclusions dropped during merge (superseded by the merge, or already held by the survivor)',
+        );
+      }
 
       // Write the golden record fields onto the primary contact. The surviving tier
       // is computed by computeGoldenRecord (blocked-on-either-side wins; else higher
@@ -1477,7 +1522,15 @@ export class ContactService {
       await this.backend.updateContact(updatedPrimary);
       await this.backend.deleteContact(secondaryId);
     } catch (err) {
-      this.logger?.error({ err, primaryId, secondaryId }, 'Contact merge write failed — DB may be in partial state');
+      // Not a transaction: these are sequential pool queries. If a later write fails, the
+      // secondary can survive with its dedup exclusions already re-pointed away, so the
+      // next sweep sees it again with its rulings gone. Name that explicitly — "partial
+      // state" alone does not tell an operator what to go and check. Wrapping the whole
+      // sequence in one transaction is tracked separately (#1695).
+      this.logger?.error(
+        { err, primaryId, secondaryId },
+        'Contact merge write failed — DB may be in partial state; the secondary may survive with its dedup exclusions already moved (#1625). Verify contact_dedup_exclusions before re-running the sweep.',
+      );
       throw err;
     }
 
@@ -2406,7 +2459,7 @@ class PostgresContactBackend implements ContactServiceBackend {
        RETURNING contact_a_id`,
       [pair.contactAId, pair.contactBId, decidedBy],
     );
-    // rowCount 0 means ON CONFLICT swallowed the insert — the pair was already
+    // An empty result means ON CONFLICT swallowed the insert — the pair was already
     // excluded. That is a successful no-op, not a failure: re-excluding a pair the
     // CEO already ruled on must stay idempotent.
     return result.rows.length > 0;
@@ -2431,7 +2484,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     }));
   }
 
-  async reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<void> {
+  async reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<ReattachExclusionsResult> {
     // Copy the loser's exclusions onto the survivor, renormalizing each pair with
     // LEAST/GREATEST so the ordered-pair CHECK still holds after the swap.
     //
@@ -2441,7 +2494,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     //
     // ON CONFLICT DO NOTHING drops rows the survivor already holds for the same
     // counterparty; the survivor's own decided_at / decided_by provenance wins.
-    await this.pool.query(
+    const moved = await this.pool.query(
       `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_at, decided_by)
        SELECT LEAST($1::uuid, other), GREATEST($1::uuid, other), decided_at, decided_by
        FROM (
@@ -2452,18 +2505,29 @@ class PostgresContactBackend implements ContactServiceBackend {
          WHERE contact_a_id = $2::uuid OR contact_b_id = $2::uuid
        ) AS loser_pairs
        WHERE other <> $1::uuid
-       ON CONFLICT (contact_a_id, contact_b_id) DO NOTHING`,
+       ON CONFLICT (contact_a_id, contact_b_id) DO NOTHING
+       RETURNING contact_a_id`,
       [toContactId, fromContactId],
     );
 
     // Delete the loser's rows explicitly rather than relying on the FK cascade that
     // fires when the secondary contact row is deleted — reattach must leave a
     // consistent table even when called outside the merge write sequence.
-    await this.pool.query(
+    const removed = await this.pool.query(
       `DELETE FROM contact_dedup_exclusions
-       WHERE contact_a_id = $1::uuid OR contact_b_id = $1::uuid`,
+       WHERE contact_a_id = $1::uuid OR contact_b_id = $1::uuid
+       RETURNING contact_a_id`,
       [fromContactId],
     );
+
+    // The caller logs any drop. Reporting removed vs moved (rather than just "done")
+    // also surfaces a future divergence between what the INSERT carried across and what
+    // the DELETE removed, which would otherwise be silent data loss.
+    return {
+      removed: removed.rows.length,
+      moved: moved.rows.length,
+      dropped: removed.rows.length - moved.rows.length,
+    };
   }
 
   async deleteContact(id: string): Promise<void> {
@@ -3006,23 +3070,39 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return [...this.dedupExclusions.values()].map(row => row.pair);
   }
 
-  async reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<void> {
+  async reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<ReattachExclusionsResult> {
+    let removed = 0;
+    let moved = 0;
+
     for (const [key, row] of this.dedupExclusions) {
       const { contactAId, contactBId } = row.pair;
       if (contactAId !== fromContactId && contactBId !== fromContactId) continue;
 
+      // Safe to mutate mid-iteration: entries appended below are always
+      // (toContactId, other) with other !== fromContactId, so if the iterator revisits
+      // one it exits at the guard above rather than re-processing it.
       this.dedupExclusions.delete(key);
+      removed++;
 
       const other = contactAId === fromContactId ? contactBId : contactAId;
       // The exclusion between the two merged contacts is superseded by the merge.
       if (other === toContactId) continue;
 
-      const renormalized = normalizeExclusionPair(toContactId, other);
+      // Order the pair directly rather than via normalizeExclusionPair: the Postgres
+      // path uses LEAST/GREATEST, which does not validate UUID shape, and the two
+      // backends must agree on ids that came from the DB.
+      const renormalized: ExclusionPair = toContactId < other
+        ? { contactAId: toContactId, contactBId: other }
+        : { contactAId: other, contactBId: toContactId };
       const newKey = InMemoryContactBackend.exclusionKey(renormalized);
       // The survivor's own row wins when both sides excluded the same counterparty.
       if (this.dedupExclusions.has(newKey)) continue;
       this.dedupExclusions.set(newKey, { ...row, pair: renormalized });
+      moved++;
     }
+
+    // Same accounting as the Postgres backend so both report the same event.
+    return { removed, moved, dropped: removed - moved };
   }
 
   async deleteContact(id: string): Promise<void> {

--- a/src/contacts/dedup-exclusions.test.ts
+++ b/src/contacts/dedup-exclusions.test.ts
@@ -1,167 +1,43 @@
-import { describe, it, expect, vi } from 'vitest';
-import { writeExclusion, hasExclusion } from './dedup-exclusions.js';
-import type { KgNode } from '../memory/types.js';
+// Unit tests for ordered-pair normalization of contact dedup exclusions.
+//
+// Exclusions are stored one row per unordered pair in contact_dedup_exclusions,
+// with a CHECK (contact_a_id < contact_b_id). Normalization is the single
+// chokepoint that guarantees callers can pass a pair in either order and casing
+// and still hit (or create) the same row. See ADR-039.
 
-function makeFactNode(overrides: { attribute: string; value: string; id?: string }): KgNode {
-  return {
-    id: overrides.id ?? 'fn-1',
-    type: 'fact' as const,
-    label: `dedup_exclusion: ${overrides.value}`,
-    properties: { attribute: overrides.attribute, value: overrides.value },
-    aliases: [],
-    sensitivity: 'internal' as const,
-    temporal: {
-      createdAt: new Date(),
-      lastConfirmedAt: new Date(),
-      confidence: 1.0,
-      decayClass: 'permanent' as const,
-      source: 'contacts-dedup',
-    },
-  };
-}
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeExclusionPair,
+  InvalidExclusionPairError,
+} from './dedup-exclusions.js';
 
-// ---------------------------------------------------------------------------
-// writeExclusion
-// ---------------------------------------------------------------------------
+const A = '11111111-1111-4111-8111-111111111111';
+const B = '22222222-2222-4222-8222-222222222222';
 
-describe('writeExclusion', () => {
-  it('calls storeFact with the correct attribute and value for a dedup_exclusion', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-
-    await writeExclusion({
-      contactBId: 'c2',
-      kgNodeId: 'kg-c1',
-      storeFact: storeFactMock,
-    });
-
-    expect(storeFactMock).toHaveBeenCalledOnce();
-    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
-    expect(args.entityNodeId).toBe('kg-c1');
-    expect((args.properties as Record<string, unknown>).attribute).toBe('dedup_exclusion');
-    expect((args.properties as Record<string, unknown>).value).toBe('c2');
-    expect((args.properties as Record<string, unknown>).multi_valued).toBe(true);
-    expect(args.multiValued).toBe(true);
-    // Exclusion facts must be permanent so they survive decay
-    expect(args.decayClass).toBe('permanent');
+describe('normalizeExclusionPair', () => {
+  it('orders the pair ascending regardless of argument order', () => {
+    expect(normalizeExclusionPair(A, B)).toEqual({ contactAId: A, contactBId: B });
+    expect(normalizeExclusionPair(B, A)).toEqual({ contactAId: A, contactBId: B });
   });
 
-  it('writes the exclusion label in the expected format', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-
-    await writeExclusion({ contactBId: 'c2', kgNodeId: 'kg-c1', storeFact: storeFactMock });
-
-    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
-    expect(args.label).toBe('dedup_exclusion: c2');
+  it('lowercases both IDs so casing never splits a pair into two rows', () => {
+    // The UUID validators elsewhere accept uppercase; Postgres always returns lowercase.
+    expect(normalizeExclusionPair(A.toUpperCase(), B.toUpperCase())).toEqual({
+      contactAId: A,
+      contactBId: B,
+    });
   });
 
-  it('defaults source to contacts-dedup when not provided', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-
-    await writeExclusion({ contactBId: 'c2', kgNodeId: 'kg-c1', storeFact: storeFactMock });
-
-    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
-    expect(args.source).toBe('contacts-dedup');
+  it('rejects a self-pair (same contact on both sides)', () => {
+    expect(() => normalizeExclusionPair(A, A)).toThrow(InvalidExclusionPairError);
   });
 
-  it('uses the provided source when supplied', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-
-    await writeExclusion({
-      contactBId: 'c2',
-      kgNodeId: 'kg-c1',
-      storeFact: storeFactMock,
-      source: 'agent:contacts/task:t1/channel:cli',
-    });
-
-    const args = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
-    expect(args.source).toBe('agent:contacts/task:t1/channel:cli');
+  it('rejects a self-pair that differs only by casing', () => {
+    expect(() => normalizeExclusionPair(A, A.toUpperCase())).toThrow(InvalidExclusionPairError);
   });
 
-  it('throws when storeFact returns stored: false (e.g. conflict with existing exclusion for different pair)', async () => {
-    // This exercises the critical path where EntityMemory contradiction detection fires
-    // because the same attribute ('dedup_exclusion') already exists on the node for a
-    // different pair (different label/value). Without the throw, the handler would
-    // silently treat the non-stored fact as written and return success to the agent.
-    const storeFactMock = vi.fn().mockResolvedValue({
-      stored: false,
-      action: 'conflict',
-      conflict: 'Contradicts existing fact dedup_exclusion: c3 (same attribute, different label, equal confidence)',
-    });
-
-    await expect(
-      writeExclusion({ contactBId: 'c2', kgNodeId: 'kg-c1', storeFact: storeFactMock }),
-    ).rejects.toThrow(/not stored.*action: conflict/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// hasExclusion
-// ---------------------------------------------------------------------------
-
-describe('hasExclusion', () => {
-  it('returns true when the KG node has a dedup_exclusion fact for the other contact', async () => {
-    const getFactsMock = vi.fn().mockResolvedValue([
-      makeFactNode({ attribute: 'dedup_exclusion', value: 'c2' }),
-    ]);
-
-    const result = await hasExclusion({
-      contactAId: 'c1',
-      contactBId: 'c2',
-      kgNodeIdA: 'kg-c1',
-      kgNodeIdB: null,
-      getFacts: getFactsMock,
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it('returns false when no dedup_exclusion fact exists', async () => {
-    const getFactsMock = vi.fn().mockResolvedValue([]);
-
-    const result = await hasExclusion({
-      contactAId: 'c1',
-      contactBId: 'c2',
-      kgNodeIdA: 'kg-c1',
-      kgNodeIdB: null,
-      getFacts: getFactsMock,
-    });
-
-    expect(result).toBe(false);
-  });
-
-  it('returns false when neither contact has a kg_node_id', async () => {
-    const getFactsMock = vi.fn().mockResolvedValue([]);
-
-    const result = await hasExclusion({
-      contactAId: 'c1',
-      contactBId: 'c2',
-      kgNodeIdA: null,
-      kgNodeIdB: null,
-      getFacts: getFactsMock,
-    });
-
-    expect(result).toBe(false);
-    // No KG nodes → no facts possible; should not even attempt to fetch
-    expect(getFactsMock).not.toHaveBeenCalled();
-  });
-
-  it('checks both sides when both contacts have kg_node_ids', async () => {
-    // Exclusion is on B's node naming A
-    const getFactsMock = vi.fn().mockImplementation(async (kgNodeId: string) => {
-      if (kgNodeId === 'kg-c2') {
-        return [makeFactNode({ attribute: 'dedup_exclusion', value: 'c1', id: 'fn-2' })];
-      }
-      return [];
-    });
-
-    const result = await hasExclusion({
-      contactAId: 'c1',
-      contactBId: 'c2',
-      kgNodeIdA: 'kg-c1',
-      kgNodeIdB: 'kg-c2',
-      getFacts: getFactsMock,
-    });
-
-    expect(result).toBe(true);
+  it('rejects values that are not UUIDs before they reach SQL', () => {
+    expect(() => normalizeExclusionPair('not-a-uuid', B)).toThrow(InvalidExclusionPairError);
+    expect(() => normalizeExclusionPair(A, '')).toThrow(InvalidExclusionPairError);
   });
 });

--- a/src/contacts/dedup-exclusions.ts
+++ b/src/contacts/dedup-exclusions.ts
@@ -1,109 +1,56 @@
-import type { StoreFactOptions } from '../memory/types.js';
-import type { KgNode } from '../memory/types.js';
+// Contact dedup exclusions — ordered-pair normalization.
+//
+// An exclusion records a decision ("the CEO ruled these two contacts are not the
+// same person"), which lives in the relational ledger, not the knowledge graph.
+// It is persisted as one row per unordered pair in contact_dedup_exclusions,
+// under CHECK (contact_a_id < contact_b_id). See ADR-039 for why exclusions moved
+// off KG fact nodes (#1625).
+//
+// This module is the single normalization chokepoint: every read and write of an
+// exclusion goes through normalizeExclusionPair() so a pair passed in either order
+// or either casing always resolves to the same row.
 
-// Minimal structural return type for storeFact — matches StoreFactResult in entity-memory.ts
-// without creating a cross-module dependency. action values are the full union from that type.
-export interface StoreFactSummary {
-  stored: boolean;
-  action: 'created' | 'updated' | 'conflict' | 'auto_rejected' | 'auto_resolved' | 'entity_not_found' | 'rate_limited';
-  conflict?: string;
-}
-
-export interface WriteExclusionOptions {
-  /** The other contact's ID that this node is excluding. */
-  contactBId: string;
-  /** The KG node on which to record the exclusion fact (belongs to the other contact, A). */
-  kgNodeId: string;
-  storeFact: (options: StoreFactOptions) => Promise<StoreFactSummary>;
-  /** Source key for the storeFact call. Skills should pass ctx.memoryWriteSource.
-   *  Defaults to 'contacts-dedup' for backward compatibility with the sweep script. */
-  source?: string;
-}
-
-/**
- * Record a dedup_exclusion KG fact on kgNodeId naming contactBId.
- *
- * Uses permanent decay so the exclusion survives the normal decay schedule.
- * Format: label "dedup_exclusion: <contactBId>", properties.attribute = 'dedup_exclusion',
- * properties.value = contactBId — matching what hasExclusion() queries for.
- *
- * Throws if the fact was not stored (action: 'conflict' | 'auto_rejected' | ...).
- * Multiple exclusions per entity are supported via StoreFactOptions.multiValued —
- * different `value` properties do not trigger contradiction or dedup-merge (#1623).
- */
-export async function writeExclusion(opts: WriteExclusionOptions): Promise<void> {
-  const { contactBId: rawContactBId, kgNodeId, storeFact, source = 'contacts-dedup' } = opts;
-  // Normalize to lowercase so writes and reads are always comparable regardless of
-  // input casing (the UUID validator accepts uppercase; the DB always returns lowercase).
-  const contactBId = rawContactBId.toLowerCase();
-  const result = await storeFact({
-    entityNodeId: kgNodeId,
-    label: `dedup_exclusion: ${contactBId}`,
-    // multi_valued in properties so subsequent unrelated writes can detect this
-    // fact as multi-valued on the existing side (guard asymmetry fix, #1623).
-    properties: { attribute: 'dedup_exclusion', value: contactBId, multi_valued: true },
-    // Permanent decay — exclusion decisions must not quietly expire
-    decayClass: 'permanent',
-    confidence: 1.0,
-    source,
-    sensitivity: 'internal',
-    multiValued: true,
-  });
-  if (!result.stored) {
-    throw new Error(
-      `dedup_exclusion fact for ${contactBId} was not stored (action: ${result.action}${result.conflict ? `, reason: ${result.conflict}` : ''})`,
-    );
-  }
-}
-
-export interface HasExclusionOptions {
+/** A contact pair in canonical stored order: contactAId < contactBId, both lowercase. */
+export interface ExclusionPair {
   contactAId: string;
   contactBId: string;
-  kgNodeIdA: string | null;
-  kgNodeIdB: string | null;
-  /** getFacts errors propagate to the caller — callers must decide their own failure policy. */
-  getFacts: (kgNodeId: string) => Promise<KgNode[]>;
 }
 
+/** Thrown when a pair cannot be normalized into a storable exclusion row. */
+export class InvalidExclusionPairError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidExclusionPairError';
+  }
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
- * Check whether either contact has a dedup_exclusion fact naming the other.
- * Returns true if an exclusion exists in either direction (A→B or B→A).
- * Short-circuits immediately when neither contact has a KG node.
+ * Normalize a contact pair into the canonical order the table stores.
  *
- * Any error thrown by getFacts propagates to the caller unchanged — this function
- * has no internal retry or fallback. Callers that treat a getFacts error as "no
- * exclusion" would silently re-file tasks for previously-rejected pairs; callers
- * should treat the error as "unknown" and skip the pair rather than proceeding.
+ * Lowercases both IDs (callers accept uppercase UUIDs; Postgres always returns
+ * lowercase) and sorts them ascending so a pair is one row, not two.
+ *
+ * Throws InvalidExclusionPairError when either ID is not a UUID, or when both
+ * sides are the same contact — either would otherwise be rejected by the table's
+ * FK / CHECK constraints as an opaque database error at write time, and would
+ * silently match nothing at read time.
  */
-export async function hasExclusion(opts: HasExclusionOptions): Promise<boolean> {
-  const { contactAId: rawContactAId, contactBId: rawContactBId, kgNodeIdA, kgNodeIdB, getFacts } = opts;
-  const contactAId = rawContactAId.toLowerCase();
-  const contactBId = rawContactBId.toLowerCase();
-
-  // Short-circuit: no KG nodes means no facts can exist
-  if (kgNodeIdA === null && kgNodeIdB === null) return false;
-
-  // Check A's node for an exclusion naming B
-  if (kgNodeIdA !== null) {
-    const factsA = await getFacts(kgNodeIdA);
-    for (const fact of factsA) {
-      const props = fact.properties as Record<string, unknown>;
-      if (props.attribute === 'dedup_exclusion' && props.value === contactBId) {
-        return true;
-      }
-    }
+export function normalizeExclusionPair(aId: string, bId: string): ExclusionPair {
+  if (!UUID_RE.test(aId)) {
+    throw new InvalidExclusionPairError(`contact id is not a valid UUID: "${aId}"`);
+  }
+  if (!UUID_RE.test(bId)) {
+    throw new InvalidExclusionPairError(`contact id is not a valid UUID: "${bId}"`);
   }
 
-  // Check B's node for an exclusion naming A
-  if (kgNodeIdB !== null) {
-    const factsB = await getFacts(kgNodeIdB);
-    for (const fact of factsB) {
-      const props = fact.properties as Record<string, unknown>;
-      if (props.attribute === 'dedup_exclusion' && props.value === contactAId) {
-        return true;
-      }
-    }
+  const a = aId.toLowerCase();
+  const b = bId.toLowerCase();
+
+  if (a === b) {
+    throw new InvalidExclusionPairError(`a contact cannot be excluded against itself: ${a}`);
   }
 
-  return false;
+  return a < b ? { contactAId: a, contactBId: b } : { contactAId: b, contactBId: a };
 }

--- a/src/db/migrations/084_contact_dedup_exclusions.sql
+++ b/src/db/migrations/084_contact_dedup_exclusions.sql
@@ -45,31 +45,47 @@ CREATE INDEX idx_contact_dedup_exclusions_b
 -- contact, unparseable value) is dropped rather than backfilled. Old fact nodes
 -- are intentionally left in place — this is a single cutover, not a dual write,
 -- and keeping them preserves an audit trail of the pre-migration decisions.
+WITH exclusion_facts AS MATERIALIZED (
+  -- Resolve properties.value to a uuid ONLY for rows that pass the regex guard.
+  -- This must be its own MATERIALIZED CTE: in a single flat query the planner is
+  -- free to evaluate a cast in a join condition before the WHERE filter that guards
+  -- it, so one malformed legacy value would abort the migration — and migrations run
+  -- at process boot, so that takes the whole service down (cf. migration 070).
+  -- Within a single scan, quals are applied before the target list, and MATERIALIZED
+  -- stops the CTE being inlined back into the outer joins.
+  SELECT
+    fact.id                             AS fact_id,
+    fact.created_at                     AS created_at,
+    (fact.properties ->> 'value')::uuid AS other_contact_id
+  FROM kg_nodes AS fact
+  WHERE fact.type = 'fact'
+    AND fact.properties ->> 'attribute' = 'dedup_exclusion'
+    AND fact.properties ->> 'value' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+)
 INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_at, decided_by)
 SELECT
   LEAST(holder.id, other.id)    AS contact_a_id,
   GREATEST(holder.id, other.id) AS contact_b_id,
-  MIN(fact.created_at)          AS decided_at,
+  MIN(ef.created_at)            AS decided_at,
   'migration-084-backfill'      AS decided_by
-FROM kg_nodes AS fact
+FROM exclusion_facts AS ef
 JOIN kg_edges AS edge
-  ON edge.source_node_id = fact.id OR edge.target_node_id = fact.id
+  ON edge.source_node_id = ef.fact_id OR edge.target_node_id = ef.fact_id
 JOIN kg_nodes AS entity
-  ON entity.id = CASE WHEN edge.source_node_id = fact.id
+  ON entity.id = CASE WHEN edge.source_node_id = ef.fact_id
                       THEN edge.target_node_id
                       ELSE edge.source_node_id END
+  -- The node on the other end of the edge must be the entity, not another fact.
+  AND entity.type <> 'fact'
 JOIN contacts AS holder
   ON holder.kg_node_id = entity.id
 JOIN contacts AS other
-  ON other.id = (fact.properties ->> 'value')::uuid
-WHERE fact.type = 'fact'
-  AND fact.properties ->> 'attribute' = 'dedup_exclusion'
-  -- Guard the ::uuid cast — a malformed value would abort the whole migration.
-  AND fact.properties ->> 'value' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-  AND entity.type <> 'fact'
-  -- A self-referential exclusion (contact excluded against itself) is corrupt data
-  -- and would violate the ordered-pair CHECK.
-  AND holder.id <> other.id
+  ON other.id = ef.other_contact_id
+-- A self-referential exclusion (contact excluded against itself) is corrupt data
+-- and would violate the ordered-pair CHECK.
+WHERE holder.id <> other.id
+-- Both mirrored facts of one pair (the old writeExclusion wrote one per side)
+-- collapse into a single row; the earliest fact dates the decision.
 GROUP BY LEAST(holder.id, other.id), GREATEST(holder.id, other.id)
 ON CONFLICT (contact_a_id, contact_b_id) DO NOTHING;
 -- <<< END BACKFILL

--- a/src/db/migrations/084_contact_dedup_exclusions.sql
+++ b/src/db/migrations/084_contact_dedup_exclusions.sql
@@ -1,0 +1,81 @@
+-- Up Migration: first-class contact dedup exclusions table (#1625)
+--
+-- Dedup exclusions ("the CEO ruled these two contacts are NOT the same person")
+-- used to live as KG fact nodes on each contact's entity node. That was the wrong
+-- store: an exclusion is pair-relational operational state, not learned knowledge
+-- about one entity. Consequences we are fixing here (see ADR-039):
+--   - It required a KG node on at least one side. Contacts that share a display
+--     name deliberately carry kg_node_id = NULL (createContact drops the link on
+--     idx_contacts_kg_node_unique collisions), so the population that most needs
+--     an exclusion could not hold one at all (#1623).
+--   - "dedup_exclusion: <uuid>" labels are ~0.99 cosine neighbours of each other,
+--     so every additional exclusion looked like a duplicate fact or a contradiction.
+--   - Cost: 2 nodes + 2 edges per pair, and every later fact write on those
+--     entities walked each edge for cosine dedup.
+
+CREATE TABLE contact_dedup_exclusions (
+  contact_a_id UUID        NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  contact_b_id UUID        NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  decided_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Provenance only (agent memory-write source key, or 'ceo'). Deliberately not a
+  -- decision enum: this table records exclusions, never merge outcomes (#1625).
+  decided_by   TEXT        NOT NULL,
+  PRIMARY KEY (contact_a_id, contact_b_id),
+  -- Normalized ordered pair: exactly one row can exist per unordered pair, so
+  -- "is this pair excluded?" is a single indexed lookup with no OR-of-two-orders.
+  CONSTRAINT contact_dedup_exclusions_ordered_pair CHECK (contact_a_id < contact_b_id)
+);
+
+-- The primary key covers lookups anchored on contact_a_id. Exclusions are also
+-- scanned from the B side (contact delete cascade, merge re-pointing), which
+-- would otherwise be a sequential scan.
+CREATE INDEX idx_contact_dedup_exclusions_b
+  ON contact_dedup_exclusions (contact_b_id);
+
+-- >>> BEGIN BACKFILL (integration test re-runs this section standalone; keep the sentinel)
+-- Backfill from existing KG dedup_exclusion facts.
+--
+-- Shape of the legacy data: a 'fact' node with properties.attribute =
+-- 'dedup_exclusion' and properties.value = the OTHER contact's id, linked by a
+-- 'relates_to' kg_edge to the entity node of the contact holding the exclusion.
+-- storeFact always writes the edge entity -> fact, but getFacts() reads edges in
+-- both directions, so the join below accepts either orientation for safety.
+--
+-- Both sides must still resolve to live contacts; anything dangling (deleted
+-- contact, unparseable value) is dropped rather than backfilled. Old fact nodes
+-- are intentionally left in place — this is a single cutover, not a dual write,
+-- and keeping them preserves an audit trail of the pre-migration decisions.
+INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_at, decided_by)
+SELECT
+  LEAST(holder.id, other.id)    AS contact_a_id,
+  GREATEST(holder.id, other.id) AS contact_b_id,
+  MIN(fact.created_at)          AS decided_at,
+  'migration-084-backfill'      AS decided_by
+FROM kg_nodes AS fact
+JOIN kg_edges AS edge
+  ON edge.source_node_id = fact.id OR edge.target_node_id = fact.id
+JOIN kg_nodes AS entity
+  ON entity.id = CASE WHEN edge.source_node_id = fact.id
+                      THEN edge.target_node_id
+                      ELSE edge.source_node_id END
+JOIN contacts AS holder
+  ON holder.kg_node_id = entity.id
+JOIN contacts AS other
+  ON other.id = (fact.properties ->> 'value')::uuid
+WHERE fact.type = 'fact'
+  AND fact.properties ->> 'attribute' = 'dedup_exclusion'
+  -- Guard the ::uuid cast — a malformed value would abort the whole migration.
+  AND fact.properties ->> 'value' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  AND entity.type <> 'fact'
+  -- A self-referential exclusion (contact excluded against itself) is corrupt data
+  -- and would violate the ordered-pair CHECK.
+  AND holder.id <> other.id
+GROUP BY LEAST(holder.id, other.id), GREATEST(holder.id, other.id)
+ON CONFLICT (contact_a_id, contact_b_id) DO NOTHING;
+-- <<< END BACKFILL
+
+-- Rollback:
+--   DROP TABLE contact_dedup_exclusions;
+-- The legacy KG dedup_exclusion fact nodes are untouched by this migration, so a
+-- rollback restores the previous behaviour for every pair that had one. Pairs
+-- excluded after this migration ships exist only in the table and would be lost.

--- a/src/db/migrations/084_contact_dedup_exclusions.sql
+++ b/src/db/migrations/084_contact_dedup_exclusions.sql
@@ -19,9 +19,10 @@ CREATE TABLE contact_dedup_exclusions (
   decided_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   -- Provenance only (agent memory-write source key, or 'ceo'). Deliberately not a
   -- decision enum: this table records exclusions, never merge outcomes (#1625).
-  -- Non-empty: NOT NULL alone would let a blank source through, and provenance is the
-  -- only audit trail a row carries.
-  decided_by   TEXT        NOT NULL CHECK (decided_by <> ''),
+  -- Non-blank: NOT NULL alone would let '' through, and a bare <> '' would still let
+  -- '   ' through. Provenance is the only audit trail a row carries, and the row is
+  -- written once and never revisited.
+  decided_by   TEXT        NOT NULL CHECK (btrim(decided_by) <> ''),
   PRIMARY KEY (contact_a_id, contact_b_id),
   -- Normalized ordered pair: exactly one row can exist per unordered pair, so
   -- "is this pair excluded?" is a single indexed lookup with no OR-of-two-orders.

--- a/src/db/migrations/084_contact_dedup_exclusions.sql
+++ b/src/db/migrations/084_contact_dedup_exclusions.sql
@@ -19,7 +19,9 @@ CREATE TABLE contact_dedup_exclusions (
   decided_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   -- Provenance only (agent memory-write source key, or 'ceo'). Deliberately not a
   -- decision enum: this table records exclusions, never merge outcomes (#1625).
-  decided_by   TEXT        NOT NULL,
+  -- Non-empty: NOT NULL alone would let a blank source through, and provenance is the
+  -- only audit trail a row carries.
+  decided_by   TEXT        NOT NULL CHECK (decided_by <> ''),
   PRIMARY KEY (contact_a_id, contact_b_id),
   -- Normalized ordered pair: exactly one row can exist per unordered pair, so
   -- "is this pair excluded?" is a single indexed lookup with no OR-of-two-orders.
@@ -88,6 +90,65 @@ WHERE holder.id <> other.id
 -- collapse into a single row; the earliest fact dates the decision.
 GROUP BY LEAST(holder.id, other.id), GREATEST(holder.id, other.id)
 ON CONFLICT (contact_a_id, contact_b_id) DO NOTHING;
+
+-- Report legacy facts the backfill could NOT carry over. Without this the migration is
+-- green whether it recovered 40 of 40 rulings or 12 of 40, and the first symptom of a
+-- partial recovery is a dedup review task for a pair the CEO settled months ago.
+--
+-- The likeliest cause is the one this whole change is about: a holder contact whose
+-- kg_node_id was NULLed by an idx_contacts_kg_node_unique collision after its exclusion
+-- fact was written no longer joins to its own fact, so the same-display-name population
+-- is also the population most likely to lose history here. The fact nodes are left in
+-- place, so anything reported below can still be recovered by hand.
+--
+-- The resolution join is deliberately repeated rather than approximated by "does any
+-- exclusion row mention this contact" — that shortcut counts a fact as recovered when
+-- an unrelated pair involving the same contact made it across, which under-reports
+-- exactly the loss this warning exists to surface. Both mirrored facts of one pair
+-- resolve, so a fully-recovered dataset has total = resolved.
+DO $$
+DECLARE
+  total_facts    INT;
+  resolved_facts INT;
+BEGIN
+  SELECT count(*) INTO total_facts
+  FROM kg_nodes AS fact
+  WHERE fact.type = 'fact'
+    AND fact.properties ->> 'attribute' = 'dedup_exclusion';
+
+  SELECT count(DISTINCT ef.fact_id) INTO resolved_facts
+  FROM (
+    SELECT
+      fact.id                             AS fact_id,
+      (fact.properties ->> 'value')::uuid AS other_contact_id
+    FROM kg_nodes AS fact
+    WHERE fact.type = 'fact'
+      AND fact.properties ->> 'attribute' = 'dedup_exclusion'
+      AND fact.properties ->> 'value' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    -- OFFSET 0 is an optimization fence: it stops the subquery being pulled up into the
+    -- joins below, which would let the planner reach the ::uuid cast before the regex.
+    OFFSET 0
+  ) AS ef
+  JOIN kg_edges AS edge
+    ON edge.source_node_id = ef.fact_id OR edge.target_node_id = ef.fact_id
+  JOIN kg_nodes AS entity
+    ON entity.id = CASE WHEN edge.source_node_id = ef.fact_id
+                        THEN edge.target_node_id
+                        ELSE edge.source_node_id END
+    AND entity.type <> 'fact'
+  JOIN contacts AS holder
+    ON holder.kg_node_id = entity.id
+  JOIN contacts AS other
+    ON other.id = ef.other_contact_id
+  WHERE holder.id <> other.id;
+
+  IF total_facts > resolved_facts THEN
+    RAISE WARNING 'migration 084: % of % legacy dedup_exclusion fact(s) could NOT be backfilled (holder contact has no kg_node_id link, counterparty deleted, or malformed value). Those CEO rulings are absent from contact_dedup_exclusions; the fact nodes are preserved for manual recovery.',
+      total_facts - resolved_facts, total_facts;
+  ELSE
+    RAISE NOTICE 'migration 084: all % legacy dedup_exclusion fact(s) backfilled.', total_facts;
+  END IF;
+END $$;
 -- <<< END BACKFILL
 
 -- Rollback:

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -105,8 +105,9 @@ export interface StoreFactOptions {
    * When true, this fact is multi-valued: multiple facts with the same
    * `properties.attribute` but different `properties.value` may coexist on one
    * entity. Contradiction detection and embedding dedup-merge skip when values
-   * differ. Callers that write multi-valued facts (e.g. `writeExclusion`) must
-   * set this flag — the validator stays domain-agnostic (#1623).
+   * differ. Callers that write a genuinely multi-valued attribute (e.g. a person's
+   * several email addresses) must set this flag — the validator stays
+   * domain-agnostic (#1623).
    */
   multiValued?: boolean;
 }

--- a/tests/integration/contact-dedup-exclusions.test.ts
+++ b/tests/integration/contact-dedup-exclusions.test.ts
@@ -162,6 +162,30 @@ describeIf('contact_dedup_exclusions (migration 084)', () => {
     ).rejects.toThrow(/decided_by/);
   });
 
+  it('rejects whitespace-only provenance', async () => {
+    // A bare <> '' check would let '   ' through — still unusable as an audit trail.
+    const a = await makeContact('Blank C');
+    const b = await makeContact('Blank D');
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+    await expect(
+      pool.query(
+        `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_by) VALUES ($1, $2, '   ')`,
+        [lo, hi],
+      ),
+    ).rejects.toThrow(/decided_by/);
+  });
+
+  it('stores provenance trimmed so padded and bare sources are one value', async () => {
+    const a = await makeContact('Trim A');
+    const b = await makeContact('Trim B');
+
+    await contactService.addDedupExclusion(a, b, '  ops-1625  ');
+
+    const rows = await exclusionRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.decidedBy).toBe('ops-1625');
+  });
+
   it('rejects an exclusion naming a contact that does not exist', async () => {
     const a = await makeContact('Real Contact');
     const ghost = '00000000-0000-4000-8000-000000000000';

--- a/tests/integration/contact-dedup-exclusions.test.ts
+++ b/tests/integration/contact-dedup-exclusions.test.ts
@@ -1,0 +1,346 @@
+// Integration test — contact_dedup_exclusions against a live Postgres (#1625, ADR-039).
+//
+// Covers the parts unit tests with the in-memory backend cannot prove:
+//   - the ordered-pair CHECK and primary key actually reject bad rows
+//   - ON DELETE CASCADE really removes exclusions with their contacts
+//   - the Postgres backend's merge re-point + renormalize SQL
+//   - migration 084's backfill of legacy KG dedup_exclusion facts
+//
+// Every fixture row is created by this suite and deleted by id in afterEach, so the
+// suite never touches pre-existing contacts, KG nodes, or exclusions.
+// Skips gracefully when DATABASE_URL is not set.
+
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import pg from 'pg';
+import { readFile } from 'node:fs/promises';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { DedupService } from '../../src/contacts/dedup-service.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { requireCuriaTestDatabase } from './require-test-db.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const MIGRATION_SQL_URL = new URL(
+  '../../src/db/migrations/084_contact_dedup_exclusions.sql',
+  import.meta.url,
+);
+
+describeIf('contact_dedup_exclusions (migration 084)', () => {
+  let pool: pg.Pool;
+  let contactService: ContactService;
+  let backfillSql: string;
+
+  // Fixtures created per test, torn down in afterEach. Contacts cascade to their
+  // exclusion rows; KG nodes are removed explicitly.
+  const createdContactIds: string[] = [];
+  const createdKgNodeIds: string[] = [];
+
+  /** Insert a contact directly so we control kg_node_id (including NULL) exactly. */
+  async function makeContact(displayName: string, kgNodeId: string | null = null): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO contacts (display_name, kg_node_id) VALUES ($1, $2) RETURNING id`,
+      [displayName, kgNodeId],
+    );
+    const id = rows[0]!.id;
+    createdContactIds.push(id);
+    return id;
+  }
+
+  async function makeKgNode(type: string, label: string, properties: Record<string, unknown> = {}): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, source) VALUES ($1, $2, $3::jsonb, 'itest-1625') RETURNING id`,
+      [type, label, JSON.stringify(properties)],
+    );
+    const id = rows[0]!.id;
+    createdKgNodeIds.push(id);
+    return id;
+  }
+
+  async function exclusionRows(): Promise<Array<{ a: string; b: string; decidedBy: string }>> {
+    if (createdContactIds.length === 0) return [];
+    const { rows } = await pool.query<{ contact_a_id: string; contact_b_id: string; decided_by: string }>(
+      `SELECT contact_a_id, contact_b_id, decided_by FROM contact_dedup_exclusions
+       WHERE contact_a_id = ANY($1::uuid[]) OR contact_b_id = ANY($1::uuid[])
+       ORDER BY contact_a_id, contact_b_id`,
+      [createdContactIds],
+    );
+    return rows.map(r => ({ a: r.contact_a_id, b: r.contact_b_id, decidedBy: r.decided_by }));
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    // The backfill assertions below re-run migration 084's UNSCOPED INSERT...SELECT over
+    // every kg_nodes row, so this suite must never point at a real database. (The insert
+    // is idempotent, but it is still a table-wide write.) Everything else in this file is
+    // scoped to ids it created.
+    await requireCuriaTestDatabase(pool);
+
+    const logger = createSilentLogger();
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    const entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+    contactService = ContactService.createWithPostgres(pool, entityMemory, logger, {
+      dedupService: new DedupService(),
+    });
+
+    // Fails fast when migration 084 has not been applied.
+    await pool.query('SELECT 1 FROM contact_dedup_exclusions LIMIT 0');
+
+    // Isolate the backfill half of the migration so it can be re-run standalone.
+    // The CREATE TABLE half would fail on an already-migrated database.
+    const full = await readFile(MIGRATION_SQL_URL, 'utf8');
+    const begin = full.indexOf('-- >>> BEGIN BACKFILL');
+    const end = full.indexOf('-- <<< END BACKFILL');
+    expect(begin).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(begin);
+    backfillSql = full.slice(begin, end);
+  });
+
+  afterEach(async () => {
+    // Contacts cascade to contact_dedup_exclusions; delete edges before their nodes.
+    if (createdContactIds.length > 0) {
+      await pool.query(`DELETE FROM contacts WHERE id = ANY($1::uuid[])`, [createdContactIds]);
+      createdContactIds.length = 0;
+    }
+    if (createdKgNodeIds.length > 0) {
+      await pool.query(
+        `DELETE FROM kg_edges WHERE source_node_id = ANY($1::uuid[]) OR target_node_id = ANY($1::uuid[])`,
+        [createdKgNodeIds],
+      );
+      await pool.query(`DELETE FROM kg_nodes WHERE id = ANY($1::uuid[])`, [createdKgNodeIds]);
+      createdKgNodeIds.length = 0;
+    }
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  // -- Schema constraints --
+
+  it('rejects a row whose pair is not in ascending order', async () => {
+    const a = await makeContact('Ordered A');
+    const b = await makeContact('Ordered B');
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+
+    await expect(
+      pool.query(
+        `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_by) VALUES ($1, $2, 'itest')`,
+        [hi, lo],
+      ),
+    ).rejects.toThrow(/contact_dedup_exclusions_ordered_pair/);
+  });
+
+  it('rejects a self-pair', async () => {
+    const a = await makeContact('Self Pair');
+    await expect(
+      pool.query(
+        `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_by) VALUES ($1, $1, 'itest')`,
+        [a],
+      ),
+    ).rejects.toThrow(/contact_dedup_exclusions_ordered_pair/);
+  });
+
+  it('rejects an exclusion naming a contact that does not exist', async () => {
+    const a = await makeContact('Real Contact');
+    const ghost = '00000000-0000-4000-8000-000000000000';
+    const [lo, hi] = a < ghost ? [a, ghost] : [ghost, a];
+    await expect(
+      pool.query(
+        `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_by) VALUES ($1, $2, 'itest')`,
+        [lo, hi],
+      ),
+    ).rejects.toThrow(/foreign key/i);
+  });
+
+  // -- Service behaviour on real Postgres --
+
+  it('excludes a pair where BOTH contacts have kg_node_id = NULL (#1623 regression)', async () => {
+    const a = await makeContact('Seth Berman');
+    const b = await makeContact('Seth Berman');
+
+    const { created } = await contactService.addDedupExclusion(a, b, 'itest-ceo');
+
+    expect(created).toBe(true);
+    expect(await contactService.hasDedupExclusion(a, b)).toBe(true);
+    expect(await contactService.hasDedupExclusion(b, a)).toBe(true);
+    expect(await exclusionRows()).toHaveLength(1);
+  });
+
+  it('is idempotent across argument orders', async () => {
+    const a = await makeContact('Idem A');
+    const b = await makeContact('Idem B');
+
+    expect((await contactService.addDedupExclusion(a, b, 'itest-ceo')).created).toBe(true);
+    expect((await contactService.addDedupExclusion(b, a, 'itest-again')).created).toBe(false);
+
+    const rows = await exclusionRows();
+    expect(rows).toHaveLength(1);
+    // The first write's provenance is preserved — a repeat call does not overwrite it.
+    expect(rows[0]!.decidedBy).toBe('itest-ceo');
+  });
+
+  it('cascades exclusion rows away when a contact is deleted', async () => {
+    const a = await makeContact('Cascade A');
+    const b = await makeContact('Cascade B');
+    await contactService.addDedupExclusion(a, b, 'itest-ceo');
+    expect(await exclusionRows()).toHaveLength(1);
+
+    await pool.query(`DELETE FROM contacts WHERE id = $1`, [b]);
+
+    expect(await exclusionRows()).toHaveLength(0);
+  });
+
+  // -- Merge re-pointing --
+
+  it('re-points the loser exclusions onto the survivor, renormalized', async () => {
+    const primary = await makeContact('Merge Primary');
+    const secondary = await makeContact('Merge Secondary');
+    const other = await makeContact('Unrelated Other');
+
+    await contactService.addDedupExclusion(secondary, other, 'itest-ceo');
+
+    await contactService.mergeContacts(primary, secondary, false);
+
+    expect(await contactService.hasDedupExclusion(primary, other)).toBe(true);
+    const rows = await exclusionRows();
+    expect(rows).toHaveLength(1);
+    // Still stored ascending after the swap — the CHECK would have rejected it otherwise.
+    expect(rows[0]!.a < rows[0]!.b).toBe(true);
+  });
+
+  it('drops the exclusion between the two merged contacts', async () => {
+    const primary = await makeContact('Same Person A');
+    const secondary = await makeContact('Same Person B');
+    await contactService.addDedupExclusion(primary, secondary, 'itest-ceo');
+
+    await contactService.mergeContacts(primary, secondary, false);
+
+    expect(await exclusionRows()).toHaveLength(0);
+  });
+
+  it('collapses duplicates when both merged contacts excluded the same counterparty', async () => {
+    const primary = await makeContact('Dup Primary');
+    const secondary = await makeContact('Dup Secondary');
+    const other = await makeContact('Dup Other');
+
+    await contactService.addDedupExclusion(primary, other, 'itest-primary');
+    await contactService.addDedupExclusion(secondary, other, 'itest-secondary');
+    expect(await exclusionRows()).toHaveLength(2);
+
+    await contactService.mergeContacts(primary, secondary, false);
+
+    const rows = await exclusionRows();
+    expect(rows).toHaveLength(1);
+    // The survivor's own row wins — the ON CONFLICT DO NOTHING branch.
+    expect(rows[0]!.decidedBy).toBe('itest-primary');
+  });
+
+  // -- Migration 084 backfill --
+
+  it('backfills a legacy KG dedup_exclusion fact into a normalized row', async () => {
+    const holderNode = await makeKgNode('person', 'Backfill Holder');
+    const holder = await makeContact('Backfill Holder', holderNode);
+    const other = await makeContact('Backfill Other');
+
+    const factNode = await makeKgNode('fact', `dedup_exclusion: ${other}`, {
+      attribute: 'dedup_exclusion',
+      value: other,
+      multi_valued: true,
+    });
+    await pool.query(
+      `INSERT INTO kg_edges (source_node_id, target_node_id, type, source)
+       VALUES ($1, $2, 'relates_to', 'itest-1625')`,
+      [holderNode, factNode],
+    );
+
+    await pool.query(backfillSql);
+
+    const rows = await exclusionRows();
+    expect(rows).toHaveLength(1);
+    const [lo, hi] = holder < other ? [holder, other] : [other, holder];
+    expect(rows[0]).toEqual({ a: lo, b: hi, decidedBy: 'migration-084-backfill' });
+  });
+
+  it('collapses the two mirrored facts of one pair into a single row', async () => {
+    // The old writeExclusion path wrote one fact on each side of the pair.
+    const nodeA = await makeKgNode('person', 'Mirror A');
+    const nodeB = await makeKgNode('person', 'Mirror B');
+    const a = await makeContact('Mirror A', nodeA);
+    const b = await makeContact('Mirror B', nodeB);
+
+    const factOnA = await makeKgNode('fact', `dedup_exclusion: ${b}`, { attribute: 'dedup_exclusion', value: b });
+    const factOnB = await makeKgNode('fact', `dedup_exclusion: ${a}`, { attribute: 'dedup_exclusion', value: a });
+    await pool.query(
+      `INSERT INTO kg_edges (source_node_id, target_node_id, type, source)
+       VALUES ($1, $2, 'relates_to', 'itest-1625'), ($3, $4, 'relates_to', 'itest-1625')`,
+      [nodeA, factOnA, nodeB, factOnB],
+    );
+
+    await pool.query(backfillSql);
+
+    expect(await exclusionRows()).toHaveLength(1);
+  });
+
+  it('is safe to re-run — a second pass adds no duplicate rows', async () => {
+    const holderNode = await makeKgNode('person', 'Rerun Holder');
+    await makeContact('Rerun Holder', holderNode);
+    const other = await makeContact('Rerun Other');
+    const factNode = await makeKgNode('fact', `dedup_exclusion: ${other}`, { attribute: 'dedup_exclusion', value: other });
+    await pool.query(
+      `INSERT INTO kg_edges (source_node_id, target_node_id, type, source)
+       VALUES ($1, $2, 'relates_to', 'itest-1625')`,
+      [holderNode, factNode],
+    );
+
+    await pool.query(backfillSql);
+    await pool.query(backfillSql);
+
+    expect(await exclusionRows()).toHaveLength(1);
+  });
+
+  it('skips a fact whose value names a contact that no longer exists', async () => {
+    const holderNode = await makeKgNode('person', 'Dangling Holder');
+    await makeContact('Dangling Holder', holderNode);
+    const factNode = await makeKgNode('fact', 'dedup_exclusion: gone', {
+      attribute: 'dedup_exclusion',
+      value: '00000000-0000-4000-8000-000000000000',
+    });
+    await pool.query(
+      `INSERT INTO kg_edges (source_node_id, target_node_id, type, source)
+       VALUES ($1, $2, 'relates_to', 'itest-1625')`,
+      [holderNode, factNode],
+    );
+
+    await pool.query(backfillSql);
+
+    expect(await exclusionRows()).toHaveLength(0);
+  });
+
+  it('does not abort on a fact whose value is not a UUID', async () => {
+    // A malformed value would blow up the ::uuid cast and take the whole migration
+    // (and therefore process startup) down — the regex guard must filter it first.
+    const holderNode = await makeKgNode('person', 'Malformed Holder');
+    await makeContact('Malformed Holder', holderNode);
+    const factNode = await makeKgNode('fact', 'dedup_exclusion: junk', {
+      attribute: 'dedup_exclusion',
+      value: 'not-a-uuid-at-all',
+    });
+    await pool.query(
+      `INSERT INTO kg_edges (source_node_id, target_node_id, type, source)
+       VALUES ($1, $2, 'relates_to', 'itest-1625')`,
+      [holderNode, factNode],
+    );
+
+    await expect(pool.query(backfillSql)).resolves.toBeDefined();
+    expect(await exclusionRows()).toHaveLength(0);
+  });
+});

--- a/tests/integration/contact-dedup-exclusions.test.ts
+++ b/tests/integration/contact-dedup-exclusions.test.ts
@@ -149,6 +149,19 @@ describeIf('contact_dedup_exclusions (migration 084)', () => {
     ).rejects.toThrow(/contact_dedup_exclusions_ordered_pair/);
   });
 
+  it('rejects blank provenance', async () => {
+    // decided_by is the only audit trail a row carries; NOT NULL alone would let '' through.
+    const a = await makeContact('Blank A');
+    const b = await makeContact('Blank B');
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+    await expect(
+      pool.query(
+        `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_by) VALUES ($1, $2, '')`,
+        [lo, hi],
+      ),
+    ).rejects.toThrow(/decided_by/);
+  });
+
   it('rejects an exclusion naming a contact that does not exist', async () => {
     const a = await makeContact('Real Contact');
     const ghost = '00000000-0000-4000-8000-000000000000';

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -1435,6 +1435,25 @@ describe('ContactService', () => {
       expect((await service.listDedupExclusionPairKeys()).size).toBe(0);
     });
 
+    it('warns when merging a pair that carries a recorded exclusion', async () => {
+      // The ruling is about to be discarded by the merge. That is allowed (a human is
+      // confirming), but it must not be silent.
+      const warn = vi.fn();
+      const loggedService = ContactService.createInMemory(
+        entityMemory,
+        undefined,
+        { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() } as never,
+      );
+
+      const primary = await loggedService.createContact({ displayName: 'Warn Primary', source: 'test' });
+      const secondary = await loggedService.createContact({ displayName: 'Warn Secondary', source: 'test' });
+      await loggedService.addDedupExclusion(primary.id, secondary.id, 'ceo');
+
+      await loggedService.mergeContacts(primary.id, secondary.id, false);
+
+      expect(warn.mock.calls.some(([, msg]) => String(msg).includes('recorded dedup exclusion'))).toBe(true);
+    });
+
     it('collapses duplicate exclusions when both sides excluded the same contact', async () => {
       const primary = await service.createContact({ displayName: 'Alice Smith', source: 'test' });
       const secondary = await service.createContact({ displayName: 'Alice Smith', source: 'test' });

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ContactService } from '../../../src/contacts/contact-service.js';
 import type { Contact } from '../../../src/contacts/types.js';
 import { ContactNotFoundError } from '../../../src/contacts/types.js';
+import { ContactValidationError } from '../../../src/contacts/contact-service.js';
 import { InvalidExclusionPairError } from '../../../src/contacts/dedup-exclusions.js';
 import { canonicalPairKey } from '../../../src/contacts/dedup-pair-key.js';
 import { DedupService } from '../../../src/contacts/dedup-service.js';
@@ -1379,6 +1380,18 @@ describe('ContactService', () => {
     it('rejects excluding a contact against itself', async () => {
       const a = await service.createContact({ displayName: 'Ann One', source: 'test' });
       await expect(service.addDedupExclusion(a.id, a.id, 'ceo')).rejects.toThrow(InvalidExclusionPairError);
+    });
+
+    it('rejects blank provenance, including whitespace-only', async () => {
+      // decided_by is the row's only audit trail and the row is never revisited, so a
+      // blank source must fail at the service boundary with a named error rather than as
+      // a raw CHECK violation from Postgres.
+      const a = await service.createContact({ displayName: 'Prov A', source: 'test' });
+      const b = await service.createContact({ displayName: 'Prov B', source: 'test' });
+
+      await expect(service.addDedupExclusion(a.id, b.id, '')).rejects.toThrow(ContactValidationError);
+      await expect(service.addDedupExclusion(a.id, b.id, '   ')).rejects.toThrow(ContactValidationError);
+      expect((await service.listDedupExclusionPairKeys()).size).toBe(0);
     });
 
     it('rejects an unknown contact rather than writing a dangling row', async () => {

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -2,6 +2,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ContactService } from '../../../src/contacts/contact-service.js';
 import type { Contact } from '../../../src/contacts/types.js';
+import { ContactNotFoundError } from '../../../src/contacts/types.js';
+import { InvalidExclusionPairError } from '../../../src/contacts/dedup-exclusions.js';
+import { canonicalPairKey } from '../../../src/contacts/dedup-pair-key.js';
 import { DedupService } from '../../../src/contacts/dedup-service.js';
 import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../../src/memory/embedding.js';
@@ -1319,6 +1322,137 @@ describe('ContactService', () => {
       expect(onContactElevated).not.toHaveBeenCalled();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Dedup exclusions (#1625, ADR-039)
+  // -------------------------------------------------------------------------
+
+  describe('dedup exclusions', () => {
+    it('records an exclusion and reports it in both argument orders', async () => {
+      const a = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const b = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+
+      const { created } = await service.addDedupExclusion(a.id, b.id, 'ceo');
+      expect(created).toBe(true);
+
+      expect(await service.hasDedupExclusion(a.id, b.id)).toBe(true);
+      expect(await service.hasDedupExclusion(b.id, a.id)).toBe(true);
+    });
+
+    it('works when BOTH contacts have kg_node_id = NULL (#1623 regression)', async () => {
+      // Two contacts sharing a display name: createContact drops the KG link on the
+      // second one because of idx_contacts_kg_node_unique. That pair could not hold a
+      // KG-fact exclusion at all — the whole reason exclusions moved to a table.
+      const a = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const b = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      expect(b.kgNodeId).toBeNull();
+
+      // Force the null-node case on both sides.
+      await service.saveContact({ ...a, kgNodeId: null });
+
+      const { created } = await service.addDedupExclusion(a.id, b.id, 'ceo');
+      expect(created).toBe(true);
+      expect(await service.hasDedupExclusion(a.id, b.id)).toBe(true);
+    });
+
+    it('normalizes the stored pair into ascending order regardless of call order', async () => {
+      const a = await service.createContact({ displayName: 'Ann One', source: 'test' });
+      const b = await service.createContact({ displayName: 'Bea Two', source: 'test' });
+      const [lo, hi] = a.id < b.id ? [a.id, b.id] : [b.id, a.id];
+
+      const { pair } = await service.addDedupExclusion(hi, lo, 'ceo');
+      expect(pair).toEqual({ contactAId: lo, contactBId: hi });
+    });
+
+    it('is idempotent — re-excluding returns created: false and stores one row', async () => {
+      const a = await service.createContact({ displayName: 'Ann One', source: 'test' });
+      const b = await service.createContact({ displayName: 'Bea Two', source: 'test' });
+
+      expect((await service.addDedupExclusion(a.id, b.id, 'ceo')).created).toBe(true);
+      // Reversed order must hit the same row, not create a second one.
+      expect((await service.addDedupExclusion(b.id, a.id, 'ceo')).created).toBe(false);
+
+      const keys = await service.listDedupExclusionPairKeys();
+      expect(keys.size).toBe(1);
+    });
+
+    it('rejects excluding a contact against itself', async () => {
+      const a = await service.createContact({ displayName: 'Ann One', source: 'test' });
+      await expect(service.addDedupExclusion(a.id, a.id, 'ceo')).rejects.toThrow(InvalidExclusionPairError);
+    });
+
+    it('rejects an unknown contact rather than writing a dangling row', async () => {
+      const a = await service.createContact({ displayName: 'Ann One', source: 'test' });
+      const ghost = '00000000-0000-4000-8000-000000000000';
+      await expect(service.addDedupExclusion(a.id, ghost, 'ceo')).rejects.toThrow(ContactNotFoundError);
+      expect(await service.hasDedupExclusion(a.id, ghost)).toBe(false);
+    });
+
+    it('exposes exclusions as canonical pair keys', async () => {
+      const a = await service.createContact({ displayName: 'Ann One', source: 'test' });
+      const b = await service.createContact({ displayName: 'Bea Two', source: 'test' });
+      await service.addDedupExclusion(a.id, b.id, 'ceo');
+
+      const keys = await service.listDedupExclusionPairKeys();
+      expect(keys.has(canonicalPairKey(a.id, b.id))).toBe(true);
+      expect(keys.has(canonicalPairKey(b.id, a.id))).toBe(true); // same key either way
+    });
+
+    it('drops exclusion rows when a contact is deleted (ON DELETE CASCADE)', async () => {
+      const a = await service.createContact({ displayName: 'Ann One', source: 'test' });
+      const b = await service.createContact({ displayName: 'Bea Two', source: 'test' });
+      await service.addDedupExclusion(a.id, b.id, 'ceo');
+
+      await service.deleteContact(b.id);
+
+      expect((await service.listDedupExclusionPairKeys()).size).toBe(0);
+    });
+
+    it('re-points the loser\'s exclusions onto the survivor on merge', async () => {
+      const primary = await service.createContact({ displayName: 'Alice Smith', source: 'test' });
+      const secondary = await service.createContact({ displayName: 'Alice Smith', source: 'test' });
+      const other = await service.createContact({ displayName: 'Carol Jones', source: 'test' });
+
+      // The secondary was ruled "not the same person" as `other`.
+      await service.addDedupExclusion(secondary.id, other.id, 'ceo');
+
+      await service.mergeContacts(primary.id, secondary.id, false);
+
+      // The ruling survives, now anchored on the survivor.
+      expect(await service.hasDedupExclusion(primary.id, other.id)).toBe(true);
+      expect((await service.listDedupExclusionPairKeys()).size).toBe(1);
+    });
+
+    it('drops the exclusion between the two contacts being merged', async () => {
+      const primary = await service.createContact({ displayName: 'Alice Smith', source: 'test' });
+      const secondary = await service.createContact({ displayName: 'Alice Smith', source: 'test' });
+
+      // An earlier ruling said they were different people; the merge overrides it.
+      await service.addDedupExclusion(primary.id, secondary.id, 'ceo');
+
+      await service.mergeContacts(primary.id, secondary.id, false);
+
+      expect((await service.listDedupExclusionPairKeys()).size).toBe(0);
+    });
+
+    it('collapses duplicate exclusions when both sides excluded the same contact', async () => {
+      const primary = await service.createContact({ displayName: 'Alice Smith', source: 'test' });
+      const secondary = await service.createContact({ displayName: 'Alice Smith', source: 'test' });
+      const other = await service.createContact({ displayName: 'Carol Jones', source: 'test' });
+
+      await service.addDedupExclusion(primary.id, other.id, 'ceo');
+      await service.addDedupExclusion(secondary.id, other.id, 'ceo');
+      expect((await service.listDedupExclusionPairKeys()).size).toBe(2);
+
+      await service.mergeContacts(primary.id, secondary.id, false);
+
+      // One surviving row, not a PK violation and not a stale duplicate.
+      const keys = await service.listDedupExclusionPairKeys();
+      expect(keys.size).toBe(1);
+      expect(keys.has(canonicalPairKey(primary.id, other.id))).toBe(true);
+    });
+  });
+
 });
 
 describe('EntityMemory.mergeEntities', () => {

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -1,6 +1,16 @@
+// Unit tests for the contact-dedup-exclude tool.
+//
+// Since #1625 the tool writes a row to contact_dedup_exclusions via ContactService
+// instead of a pair of KG facts. The behaviour that matters here: it works for
+// contacts with no KG node (the null-node population from #1623), it is idempotent,
+// and a persistence failure is reported as failure so the contacts agent leaves the
+// review task open (the #1624 prompt gate depends on `success`).
+
 import { describe, it, expect, vi } from 'vitest';
 import { ContactDedupExcludeHandler } from '../../../skills/contacts/tools/contact-dedup-exclude/handler.js';
 import type { ToolContext } from '../../../src/skills/types.js';
+import { InvalidExclusionPairError } from '../../../src/contacts/dedup-exclusions.js';
+import { ContactNotFoundError } from '../../../src/contacts/types.js';
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
@@ -10,7 +20,7 @@ const UUID_B = '550e8400-e29b-41d4-a716-446655440001';
 function makeCtx(input: Record<string, unknown>, overrides?: Partial<ToolContext>): ToolContext {
   return {
     toolName: 'contact-dedup-exclude',
-    toolVersion: '0.1.0',
+    toolVersion: '0.2.0',
     input,
     secret: () => { throw new Error('no secrets'); },
     log: logger,
@@ -18,8 +28,15 @@ function makeCtx(input: Record<string, unknown>, overrides?: Partial<ToolContext
   };
 }
 
+/** Minimal ContactService stub exposing only addDedupExclusion. */
+function makeContactService(addDedupExclusion: unknown): ToolContext['contactService'] {
+  return { addDedupExclusion } as unknown as ToolContext['contactService'];
+}
+
 describe('ContactDedupExcludeHandler', () => {
   const handler = new ContactDedupExcludeHandler();
+
+  // -- Input validation --
 
   it('fails when contact_a_id is missing', async () => {
     const result = await handler.execute(makeCtx({ contact_b_id: UUID_B }));
@@ -45,241 +62,140 @@ describe('ContactDedupExcludeHandler', () => {
     if (!result.success) expect(result.error).toContain('different');
   });
 
+  it('fails when both IDs are the same but differ only in casing', async () => {
+    const result = await handler.execute(
+      makeCtx({ contact_a_id: UUID_A, contact_b_id: UUID_A.toUpperCase() }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('different');
+  });
+
   it('fails when contactService is not available', async () => {
     const result = await handler.execute(makeCtx({ contact_a_id: UUID_A, contact_b_id: UUID_B }));
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('contactService');
   });
 
-  it('fails when entityMemory is not available', async () => {
-    const contactService = { getContact: vi.fn() } as unknown as ToolContext['contactService'];
+  // -- Happy path --
+
+  it('records the exclusion and reports created: true', async () => {
+    const addDedupExclusion = vi.fn().mockResolvedValue({
+      pair: { contactAId: UUID_A, contactBId: UUID_B },
+      created: true,
+    });
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService: makeContactService(addDedupExclusion) },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(addDedupExclusion).toHaveBeenCalledWith(UUID_A, UUID_B, 'contacts-dedup');
+    if (result.success) {
+      expect(result.data).toEqual({
+        contact_a_id: UUID_A,
+        contact_b_id: UUID_B,
+        created: true,
+      });
+    }
+  });
+
+  it('succeeds for a pair where BOTH contacts have no KG node (#1623 regression)', async () => {
+    // The whole point of #1625: the handler no longer consults kg_node_id at all,
+    // so it cannot fail on the same-display-name null-node population.
+    const addDedupExclusion = vi.fn().mockResolvedValue({
+      pair: { contactAId: UUID_A, contactBId: UUID_B },
+      created: true,
+    });
+    const contactService = makeContactService(addDedupExclusion);
+    // A getContact stub deliberately not provided — the handler must not need it.
     const result = await handler.execute(makeCtx(
       { contact_a_id: UUID_A, contact_b_id: UUID_B },
       { contactService },
     ));
-    expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('entityMemory');
+
+    expect(result.success).toBe(true);
   });
 
-  it('fails when contact A is not found', async () => {
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) =>
-        id === UUID_B ? { id: UUID_B, kgNodeId: 'kg-b' } : undefined,
-      ),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = { storeFact: vi.fn() } as unknown as ToolContext['entityMemory'];
-
+  it('is idempotent — re-excluding an already-excluded pair still succeeds', async () => {
+    const addDedupExclusion = vi.fn().mockResolvedValue({
+      pair: { contactAId: UUID_A, contactBId: UUID_B },
+      created: false,
+    });
     const result = await handler.execute(makeCtx(
       { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
+      { contactService: makeContactService(addDedupExclusion) },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as { created: boolean }).created).toBe(false);
+    }
+  });
+
+  it('passes the pair through in the caller-supplied order (service normalizes)', async () => {
+    const addDedupExclusion = vi.fn().mockResolvedValue({
+      pair: { contactAId: UUID_A, contactBId: UUID_B },
+      created: true,
+    });
+    await handler.execute(makeCtx(
+      { contact_a_id: UUID_B, contact_b_id: UUID_A },
+      { contactService: makeContactService(addDedupExclusion) },
+    ));
+    expect(addDedupExclusion).toHaveBeenCalledWith(UUID_B, UUID_A, 'contacts-dedup');
+  });
+
+  it('uses ctx.memoryWriteSource as decided_by provenance when available', async () => {
+    const addDedupExclusion = vi.fn().mockResolvedValue({
+      pair: { contactAId: UUID_A, contactBId: UUID_B },
+      created: true,
+    });
+    await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      {
+        contactService: makeContactService(addDedupExclusion),
+        memoryWriteSource: 'agent:contacts/task:t1/channel:signal',
+      },
+    ));
+    expect(addDedupExclusion).toHaveBeenCalledWith(UUID_A, UUID_B, 'agent:contacts/task:t1/channel:signal');
+  });
+
+  // -- Failure reporting (the #1624 prompt gate depends on this) --
+
+  it('reports failure when the exclusion write throws', async () => {
+    const addDedupExclusion = vi.fn().mockRejectedValue(new Error('connection terminated'));
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService: makeContactService(addDedupExclusion) },
     ));
 
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain(UUID_A);
+    if (!result.success) {
+      expect(result.error).toContain('Failed to record dedup exclusion');
+      expect(result.error).toContain('connection terminated');
+    }
   });
 
-  it('fails when contact B is not found', async () => {
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) =>
-        id === UUID_A ? { id: UUID_A, kgNodeId: 'kg-a' } : undefined,
-      ),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = { storeFact: vi.fn() } as unknown as ToolContext['entityMemory'];
-
+  it('reports a missing contact as failure', async () => {
+    const addDedupExclusion = vi.fn().mockRejectedValue(new ContactNotFoundError(UUID_B));
     const result = await handler.execute(makeCtx(
       { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
+      { contactService: makeContactService(addDedupExclusion) },
     ));
 
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain(UUID_B);
   });
 
-  it('writes exclusion facts on both KG nodes when both contacts have KG nodes', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({
-        id,
-        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
-        displayName: id === UUID_A ? 'Alice' : 'Bob',
-      })),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = { storeFact: storeFactMock } as unknown as ToolContext['entityMemory'];
-
+  it('labels an invalid pair distinctly from an infrastructure failure', async () => {
+    const addDedupExclusion = vi.fn().mockRejectedValue(
+      new InvalidExclusionPairError('a contact cannot be excluded against itself'),
+    );
     const result = await handler.execute(makeCtx(
       { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
-    ));
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      const data = result.data as { contact_a_excluded: boolean; contact_b_excluded: boolean };
-      expect(data.contact_a_excluded).toBe(true);
-      expect(data.contact_b_excluded).toBe(true);
-    }
-    expect(storeFactMock).toHaveBeenCalledTimes(2);
-
-    // A's node names B
-    const callA = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
-    expect(callA.entityNodeId).toBe('kg-a');
-    expect((callA.properties as Record<string, unknown>).value).toBe(UUID_B);
-
-    // B's node names A
-    const callB = storeFactMock.mock.calls[1]![0] as Record<string, unknown>;
-    expect(callB.entityNodeId).toBe('kg-b');
-    expect((callB.properties as Record<string, unknown>).value).toBe(UUID_A);
-  });
-
-  it('skips writing on a contact with no KG node', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({
-        id,
-        kgNodeId: id === UUID_A ? 'kg-a' : null, // B has no KG node
-      })),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = { storeFact: storeFactMock } as unknown as ToolContext['entityMemory'];
-
-    const result = await handler.execute(makeCtx(
-      { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
-    ));
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      const data = result.data as { contact_a_excluded: boolean; contact_b_excluded: boolean };
-      expect(data.contact_a_excluded).toBe(true);
-      expect(data.contact_b_excluded).toBe(false);
-    }
-    // Only one write — B has no KG node to attach a fact to
-    expect(storeFactMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns failure when getContact throws', async () => {
-    const contactService = {
-      getContact: vi.fn().mockRejectedValue(new Error('DB connection refused')),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = { storeFact: vi.fn() } as unknown as ToolContext['entityMemory'];
-
-    const result = await handler.execute(makeCtx(
-      { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
+      { contactService: makeContactService(addDedupExclusion) },
     ));
 
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('DB connection refused');
-  });
-
-  it('returns failure when storeFact throws on both sides', async () => {
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({
-        id,
-        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
-      })),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = {
-      storeFact: vi.fn().mockRejectedValue(new Error('KG write failed')),
-    } as unknown as ToolContext['entityMemory'];
-
-    const result = await handler.execute(makeCtx(
-      { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
-    ));
-
-    // Each write is attempted independently; when both fail the handler returns failure
-    expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('dedup exclusion');
-  });
-
-  it('returns success when only one write succeeds (partial exclusion is valid)', async () => {
-    // hasExclusion is bidirectional, so one side is enough to block re-surfacing
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({
-        id,
-        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
-      })),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = {
-      storeFact: vi.fn()
-        // First call (A-side) conflicts; second call (B-side) succeeds
-        .mockResolvedValueOnce({ stored: false, action: 'conflict', conflict: 'existing exclusion' })
-        .mockResolvedValue({ stored: true, action: 'created' }),
-    } as unknown as ToolContext['entityMemory'];
-
-    const result = await handler.execute(makeCtx(
-      { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
-    ));
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      const data = result.data as { contact_a_excluded: boolean; contact_b_excluded: boolean };
-      expect(data.contact_a_excluded).toBe(false);
-      expect(data.contact_b_excluded).toBe(true);
-    }
-  });
-
-  it('returns failure when storeFact returns stored: false (second exclusion silent-drop)', async () => {
-    // Validates the critical path where EntityMemory contradiction detection fires for
-    // a contact that already has a dedup_exclusion for a different pair. Before the fix,
-    // writeExclusion ignored the return value and the handler falsely returned success.
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({
-        id,
-        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
-      })),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = {
-      storeFact: vi.fn().mockResolvedValue({
-        stored: false,
-        action: 'conflict',
-        conflict: 'Contradicts existing dedup_exclusion fact for a different pair',
-      }),
-    } as unknown as ToolContext['entityMemory'];
-
-    const result = await handler.execute(makeCtx(
-      { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
-    ));
-
-    expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('dedup exclusion');
-  });
-
-  it('returns failure with a clear message when neither contact has a KG node', async () => {
-    const storeFactMock = vi.fn();
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({ id, kgNodeId: null })),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = { storeFact: storeFactMock } as unknown as ToolContext['entityMemory'];
-
-    const result = await handler.execute(makeCtx(
-      { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory },
-    ));
-
-    expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('no KG node');
-    // No facts should be written when there's nowhere to attach them
-    expect(storeFactMock).not.toHaveBeenCalled();
-  });
-
-  it('uses ctx.memoryWriteSource as the storeFact source', async () => {
-    const storeFactMock = vi.fn().mockResolvedValue({ stored: true, action: 'created' });
-    const contactService = {
-      getContact: vi.fn().mockImplementation(async (id: string) => ({
-        id,
-        kgNodeId: id === UUID_A ? 'kg-a' : 'kg-b',
-      })),
-    } as unknown as ToolContext['contactService'];
-    const entityMemory = { storeFact: storeFactMock } as unknown as ToolContext['entityMemory'];
-
-    await handler.execute(makeCtx(
-      { contact_a_id: UUID_A, contact_b_id: UUID_B },
-      { contactService, entityMemory, memoryWriteSource: 'agent:contacts/task:t1/channel:cli' },
-    ));
-
-    const call = storeFactMock.mock.calls[0]![0] as Record<string, unknown>;
-    expect(call.source).toBe('agent:contacts/task:t1/channel:cli');
+    if (!result.success) expect(result.error).toContain('Invalid contact pair');
   });
 });

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -186,6 +186,91 @@ describe('ContactDedupExcludeHandler', () => {
     if (!result.success) expect(result.error).toContain(UUID_B);
   });
 
+  it('tells the agent not to retry when the exclusions table is missing', async () => {
+    // Migration 084 not applied (the app image can lead the DB on a GHCR deploy). A
+    // generic "failed to record" reads like a transient blip and the prompt says retry,
+    // which would loop forever.
+    const addDedupExclusion = vi.fn().mockRejectedValue(
+      new Error('relation "contact_dedup_exclusions" does not exist'),
+    );
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService: makeContactService(addDedupExclusion) },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('will not resolve on retry');
+      expect(result.error).toContain('migration 084');
+      expect(result.error).toContain('Leave the review task open');
+    }
+  });
+
+  it('tells the agent not to retry when contactService predates the tool', async () => {
+    const addDedupExclusion = vi.fn().mockRejectedValue(
+      new TypeError('ctx.contactService.addDedupExclusion is not a function'),
+    );
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService: makeContactService(addDedupExclusion) },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('will not resolve on retry');
+  });
+
+  it('warns but still records when memoryWriteSource is missing', async () => {
+    // decided_by is the row's only audit trail, and the row is never revisited.
+    const addDedupExclusion = vi.fn().mockResolvedValue({
+      pair: { contactAId: UUID_A, contactBId: UUID_B },
+      created: true,
+    });
+    const warn = vi.fn();
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      {
+        contactService: makeContactService(addDedupExclusion),
+        log: { ...logger, warn, error: vi.fn(), info: vi.fn() } as never,
+      },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    expect(addDedupExclusion).toHaveBeenCalledWith(UUID_A, UUID_B, 'contacts-dedup');
+  });
+
+  it('treats a blank memoryWriteSource as missing rather than storing empty provenance', async () => {
+    const addDedupExclusion = vi.fn().mockResolvedValue({
+      pair: { contactAId: UUID_A, contactBId: UUID_B },
+      created: true,
+    });
+    await handler.execute(makeCtx(
+      { contact_a_id: UUID_A, contact_b_id: UUID_B },
+      { contactService: makeContactService(addDedupExclusion), memoryWriteSource: '   ' },
+    ));
+    // The column is NOT NULL CHECK (decided_by <> ''), so a blank would be rejected by
+    // Postgres — fall back before it gets there.
+    expect(addDedupExclusion).toHaveBeenCalledWith(UUID_A, UUID_B, 'contacts-dedup');
+  });
+
+  it('echoes the normalized (lowercase) ids so output matches the stored row', async () => {
+    const addDedupExclusion = vi.fn().mockResolvedValue({
+      pair: { contactAId: UUID_A, contactBId: UUID_B },
+      created: true,
+    });
+    const result = await handler.execute(makeCtx(
+      { contact_a_id: UUID_A.toUpperCase(), contact_b_id: UUID_B.toUpperCase() },
+      { contactService: makeContactService(addDedupExclusion) },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { contact_a_id: string; contact_b_id: string };
+      expect(data.contact_a_id).toBe(UUID_A);
+      expect(data.contact_b_id).toBe(UUID_B);
+    }
+  });
+
   it('labels an invalid pair distinctly from an infrastructure failure', async () => {
     const addDedupExclusion = vi.fn().mockRejectedValue(
       new InvalidExclusionPairError('a contact cannot be excluded against itself'),

--- a/tests/unit/skills/contact-dedup-exclude.test.ts
+++ b/tests/unit/skills/contact-dedup-exclude.test.ts
@@ -190,8 +190,10 @@ describe('ContactDedupExcludeHandler', () => {
     // Migration 084 not applied (the app image can lead the DB on a GHCR deploy). A
     // generic "failed to record" reads like a transient blip and the prompt says retry,
     // which would loop forever.
+    // Detected by SQLSTATE 42P01, not by the message text — pg messages are localised
+    // and version-dependent.
     const addDedupExclusion = vi.fn().mockRejectedValue(
-      new Error('relation "contact_dedup_exclusions" does not exist'),
+      Object.assign(new Error('relation "contact_dedup_exclusions" does not exist'), { code: '42P01' }),
     );
     const result = await handler.execute(makeCtx(
       { contact_a_id: UUID_A, contact_b_id: UUID_B },

--- a/tests/unit/skills/contact-find-duplicates.test.ts
+++ b/tests/unit/skills/contact-find-duplicates.test.ts
@@ -43,23 +43,32 @@ function makeTaskRow(aId: string, bId: string, aName = 'A', bName = 'B'): Partia
 function makeContext(
   input: Record<string, unknown>,
   overrides: {
-    contactService?: { findDuplicates: () => Promise<DuplicatePair[]> };
+    contactService?: {
+      findDuplicates: () => Promise<DuplicatePair[]>;
+      // Optional in the stub so the many tests that don't care about exclusions can
+      // keep passing a bare { findDuplicates } literal; defaulted to empty below.
+      listDedupExclusionPairKeys?: () => Promise<Set<string>>;
+    };
     taskRepo?: {
       listTasks: () => Promise<Partial<TaskRow>[]>;
       createTask: (p: unknown) => Promise<Partial<TaskRow>>;
     };
-    entityMemory?: { getFacts: (nodeId: string) => Promise<unknown[]> };
   } = {},
 ): ToolContext {
+  const contactService = overrides.contactService
+    ? {
+        listDedupExclusionPairKeys: async () => new Set<string>(),
+        ...overrides.contactService,
+      }
+    : undefined;
   return {
     toolName: 'contact-find-duplicates',
-    toolVersion: '2.1.0',
+    toolVersion: '2.2.0',
     input,
     secret: () => { throw new Error('no secrets'); },
     log: logger,
-    contactService: overrides.contactService as never,
+    contactService: contactService as never,
     taskRepo: overrides.taskRepo as never,
-    entityMemory: overrides.entityMemory as never,
   };
 }
 
@@ -67,10 +76,6 @@ function makeContext(
 const emptyTaskRepo = {
   listTasks: async () => [],
   createTask: async () => ({ id: 'task-1' }),
-};
-
-const noFactsEntityMemory = {
-  getFacts: async () => [],
 };
 
 describe('ContactFindDuplicatesHandler', () => {
@@ -93,14 +98,6 @@ describe('ContactFindDuplicatesHandler', () => {
     if (!result.success) expect(result.error).toContain('taskRepo');
   });
 
-  it('returns failure when entityMemory is not available', async () => {
-    const contactService = { findDuplicates: async () => [] };
-    const taskRepo = { listTasks: async () => [], createTask: async () => ({}) };
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
-    expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('entityMemory');
-  });
-
   // ---------------------------------------------------------------------------
   // Input validation
   // ---------------------------------------------------------------------------
@@ -108,7 +105,7 @@ describe('ContactFindDuplicatesHandler', () => {
   it('rejects min_score outside [0, 1]', async () => {
     const contactService = { findDuplicates: async () => [] };
     const result = await handler.execute(
-      makeContext({ min_score: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never, entityMemory: noFactsEntityMemory }),
+      makeContext({ min_score: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never }),
     );
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('min_score');
@@ -117,7 +114,7 @@ describe('ContactFindDuplicatesHandler', () => {
   it('rejects non-integer max_tasks', async () => {
     const contactService = { findDuplicates: async () => [] };
     const result = await handler.execute(
-      makeContext({ max_tasks: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never, entityMemory: noFactsEntityMemory }),
+      makeContext({ max_tasks: 1.5 }, { contactService, taskRepo: emptyTaskRepo as never }),
     );
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('max_tasks');
@@ -135,7 +132,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -154,7 +151,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -174,7 +171,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeContext({ min_score: 0.7 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({ min_score: 0.7 }, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -199,7 +196,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeContext({ max_tasks: 1 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({ max_tasks: 1 }, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -218,7 +215,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeContext({ max_tasks: 0 }, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({ max_tasks: 0 }, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -244,7 +241,7 @@ describe('ContactFindDuplicatesHandler', () => {
       createTask,
     };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -267,7 +264,7 @@ describe('ContactFindDuplicatesHandler', () => {
       createTask,
     };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -288,7 +285,7 @@ describe('ContactFindDuplicatesHandler', () => {
       createTask,
     };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -307,7 +304,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -319,26 +316,23 @@ describe('ContactFindDuplicatesHandler', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Idempotency: dedup_exclusion KG fact
+  // Idempotency: recorded dedup exclusions (contact_dedup_exclusions, #1625)
   // ---------------------------------------------------------------------------
 
-  it('skips pairs that have a dedup_exclusion fact on contact A naming contact B', async () => {
+  it('skips pairs with a recorded exclusion, in either stored order', async () => {
     const pairs = [
       makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', 'kg-node-b', 0.95),
     ];
-    const contactService = { findDuplicates: async () => pairs };
+    const contactService = {
+      findDuplicates: async () => pairs,
+      // The service returns canonical (ordered, lowercase) keys; the pair here is
+      // presented A-then-B, so this also covers order independence.
+      listDedupExclusionPairKeys: async () => new Set([`${UUID_A}:${UUID_B}`]),
+    };
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
-    const entityMemory = {
-      getFacts: async (nodeId: string) => {
-        if (nodeId === 'kg-node-b') {
-          return [{ properties: { attribute: 'dedup_exclusion', value: UUID_A } }];
-        }
-        return [];
-      },
-    };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -348,25 +342,66 @@ describe('ContactFindDuplicatesHandler', () => {
     }
   });
 
-  it('does not skip pairs when neither contact has a kgNodeId', async () => {
+  it('skips an excluded pair even when both contacts have no kgNodeId', async () => {
+    // The null-node population is exactly what the KG-fact implementation could not
+    // serve (#1623) — the table has no node prerequisite.
     const pairs = [
       makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
     ];
-    const contactService = { findDuplicates: async () => pairs };
+    const contactService = {
+      findDuplicates: async () => pairs,
+      listDedupExclusionPairKeys: async () => new Set([`${UUID_A}:${UUID_B}`]),
+    };
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
-    const getFacts = vi.fn().mockResolvedValue([]);
-    const entityMemory = { getFacts };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
-    // getFacts should never be called because both kgNodeIds are null
-    expect(getFacts).not.toHaveBeenCalled();
+    if (result.success) {
+      const data = result.data as { filed: number; skipped_excluded: number };
+      expect(data.skipped_excluded).toBe(1);
+      expect(data.filed).toBe(0);
+      expect(createTask).not.toHaveBeenCalled();
+    }
+  });
+
+  it('files the pair when no exclusion is recorded', async () => {
+    const pairs = [
+      makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95),
+    ];
+    const listDedupExclusionPairKeys = vi.fn().mockResolvedValue(new Set<string>());
+    const contactService = { findDuplicates: async () => pairs, listDedupExclusionPairKeys };
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
+
+    expect(result.success).toBe(true);
+    // Loaded once for the whole run, not once per pair.
+    expect(listDedupExclusionPairKeys).toHaveBeenCalledOnce();
     if (result.success) {
       const data = result.data as { filed: number };
       expect(data.filed).toBe(1);
     }
+  });
+
+  it('aborts the scan when the exclusion load fails, rather than filing excluded pairs', async () => {
+    // Fail closed: treating a load error as "nothing is excluded" would re-file
+    // review tasks for every pair the CEO already ruled apart.
+    const pairs = [makePair(UUID_A, 'Alice', null, UUID_B, 'Bob', null, 0.95)];
+    const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const contactService = {
+      findDuplicates: async () => pairs,
+      listDedupExclusionPairKeys: async () => { throw new Error('exclusion table unavailable'); },
+    };
+    const taskRepo = { listTasks: async () => [], createTask };
+
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('exclusion table unavailable');
+    expect(createTask).not.toHaveBeenCalled();
   });
 
   // ---------------------------------------------------------------------------
@@ -385,7 +420,7 @@ describe('ContactFindDuplicatesHandler', () => {
       createTask,
     };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -411,7 +446,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn();
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -436,7 +471,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const malformedTask = { id: 'manual-task', description: 'Manually filed dedup task — no IDs', tags: ['dedup'] };
     const taskRepo = { listTasks: async () => [malformedTask], createTask };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     // Should not crash, and should still file the task since the malformed entry
     // is not recognized as an existing task for this pair
@@ -466,7 +501,7 @@ describe('ContactFindDuplicatesHandler', () => {
     });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    const result = await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     // Scan reports success (partial), not failure
     expect(result.success).toBe(true);
@@ -490,7 +525,7 @@ describe('ContactFindDuplicatesHandler', () => {
     const createTask = vi.fn().mockResolvedValue({ id: 'task-1' });
     const taskRepo = { listTasks: async () => [], createTask };
 
-    await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never, entityMemory: noFactsEntityMemory }));
+    await handler.execute(makeContext({}, { contactService, taskRepo: taskRepo as never }));
 
     expect(createTask).toHaveBeenCalledOnce();
     const callArg = createTask.mock.calls[0]![0] as { description: string; tags: string[] };


### PR DESCRIPTION
## Summary

Dedup exclusions ("the CEO ruled these two contacts are not the same person") move off KG fact nodes onto a first-class `contact_dedup_exclusions` table, with **ADR-039** recording the boundary rule the change instantiates: operational decisions belong in the relational ledger; learned, fuzzy, decaying knowledge belongs in the knowledge graph.

The KG was the wrong store, and every mechanism it offered had to be disabled to make exclusions work there: `decayClass: 'permanent'` and `confidence: 1.0` to opt out of decay and scoring, the `multiValued` flag from #1624 to opt out of contradiction detection and embedding dedup-merge — and there was no opt-out at all for the node prerequisite. Same-display-name contacts carry `kg_node_id = NULL` by design (`createContact` drops the link on `idx_contacts_kg_node_unique` collisions), and those are exactly the pairs the sweep proposes most. In #1623 the Seth Berman pair had `NULL` on both sides and the exclusion could not be written anywhere.

Closes #1625.

## Changes

### Migration 084 — `contact_dedup_exclusions`

One row per unordered pair: `PRIMARY KEY (contact_a_id, contact_b_id)` plus `CHECK (contact_a_id < contact_b_id)`, both FKs `ON DELETE CASCADE`, index on `contact_b_id`. No embeddings, no decay, no confidence — `decided_at` / `decided_by` are provenance. Backfills existing `dedup_exclusion` facts (both mirrored sides collapse into one row); the `::uuid` cast is regex-guarded so a malformed legacy value cannot abort the migration and take down startup. Legacy fact nodes are left in place as an audit trail. **Single cutover, no dual write.**

### Service layer

- `ContactService.addDedupExclusion` / `hasDedupExclusion` / `listDedupExclusionPairKeys`, backed by `contact_dedup_exclusions` in the Postgres backend and mirrored in the in-memory backend.
- `normalizeExclusionPair` in `src/contacts/dedup-exclusions.ts` replaces the KG `writeExclusion` / `hasExclusion` helpers as the single chokepoint — lowercases and sorts so either call order resolves to the same row, and rejects self-pairs and non-UUIDs before they reach SQL.
- **Merge:** `mergeContacts` calls `reattachDedupExclusions(secondary, primary)` — re-points the loser's rows onto the survivor with pair renormalization, drops the row between the two merged contacts (merging *is* the decision that they are the same person), and drops rows that would duplicate one the survivor already holds.
- **Delete:** handled by the FK cascade.

### Tools and sweep

- `contact-dedup-exclude` writes one row via `ctx.contactService` instead of a fact per side, so it succeeds for pairs with no KG node on either side. Returns `created` (`false` when already excluded — still a success). `entityMemory` capability dropped. `0.1.1` → `0.2.0`.
- `contact-find-duplicates` and `scripts/dedup-contacts.ts` load every exclusion once per run as canonical pair keys instead of walking KG facts per pair. `entityMemory` capability dropped from the skill. `2.1.0` → `2.2.0`.
- Both **fail closed**: a failed exclusion load aborts the run rather than proceeding with an empty set, which would merge pairs the CEO ruled apart.
- `agents/contacts.yaml` `skipped_excluded` / `failed` wording updated. `0.12.1` → `0.12.2`.

### Explicitly unchanged

`StoreFactOptions.multiValued` and its validation exemptions and tests from #1624 stay put — it is a legitimate general memory primitive for genuinely multi-valued attributes (a person's several email addresses). Exclusions simply stop being one of its users.

## Review findings addressed

Two review agents independently flagged the same critical bug, and it is worth calling out because it is the exact failure this PR exists to prevent: the sweep loads exclusions once before its O(n²) loop, but the loop **merges**, and a merge re-points the loser's exclusion rows onto the survivor. The snapshot went stale, so a transitively inherited exclusion was invisible:

> c1, c2, c3 all named "Seth Berman"; the CEO ruled c2 ≠ c3. `(c1, c2)` merges structurally on exact name, so the DB row correctly becomes `(c1, c3)`. `(c1, c3)` is then checked against a snapshot still holding `(c2, c3)` → miss → **auto-merged**, silently overriding the ruling.

`runDedup` now mirrors `reattachDedupExclusions` onto the snapshot after every merge (dry-run included, so the preview matches a real run). Two regression tests cover it; I verified both fail without the fix.

The rest of the round, all aimed at making a lost CEO ruling impossible to miss:

- `reattachDedupExclusions` returns `removed`/`moved`/`dropped`; `mergeContacts` logs any drop. This also catches a future divergence between what the INSERT carries across and what the DELETE removes.
- `mergeContacts` warns when the pair being merged carries an exclusion — the merge is about to discard it.
- Migration 084 now reports legacy facts the backfill could **not** carry over. Without it the migration is green whether it recovered 40 of 40 rulings or 12 of 40. The check repeats the resolution join rather than the cheaper "does any row mention this contact", which under-reports exactly the loss it exists to surface.
- `decided_by` gains `CHECK (decided_by <> '')`; the tool warns on a missing `memoryWriteSource` instead of quietly storing generic provenance.
- The exclude tool distinguishes a missing table (migration 084 not applied — possible when the app image leads the DB) or a missing service method from a transient failure, and tells the agent not to retry forever.
- The in-memory backend orders pairs directly instead of via `normalizeExclusionPair`, matching Postgres `LEAST`/`GREATEST`, which does not validate UUID shape.
- Corrected a pre-existing sweep comment claiming `mergeContacts` is transactional. **It is not** — it is a sequence of pool queries, and this PR moves CEO decisions into that window. Making it atomic is out of scope here and filed as **#1695**.

## Not fixed by this PR — filed as #1694

KG node identity is still keyed on `(lower(label), type)`, so two distinct people who share a display name still cannot both hold KG nodes. This PR removes that dependency for **exclusions only**. Same-name contacts remain second-class KG citizens for facts, relationships, and entity-context enrichment, and that degradation is silent. ADR-039 names this explicitly so it does not disappear behind this fix. #1694 has no milestone yet — needs triage.

## Tests

- `src/contacts/dedup-exclusions.test.ts` — ordered-pair normalization: either order, either casing, self-pair rejection, non-UUID rejection.
- `tests/unit/contacts/contact-service.test.ts` — null-node pairs, idempotent re-exclude in both orders, normalization, unknown-contact rejection, cascade on delete, and three merge cases (re-point, self-pair drop, duplicate collapse).
- `tests/unit/skills/contact-dedup-exclude.test.ts` — rewritten for the table path, including the failure-reporting cases the #1624 prompt gate depends on.
- `tests/unit/skills/contact-find-duplicates.test.ts` + `scripts/dedup-contacts.test.ts` — order-independent skips, null-node skips, one load per run, and fail-closed on a failed load.
- `scripts/dedup-contacts.test.ts` — three new cases for the stale-snapshot bug: inherited exclusion after a merge, the dry-run mirror, and the merging pair's own exclusion.
- `tests/integration/contact-dedup-exclusions.test.ts` (new) — against real Postgres: the ordered-pair `CHECK`, the `decided_by` non-empty `CHECK`, FK rejection, cascade, the merge re-point SQL, and migration 084's backfill (normalization, mirrored-fact collapse, re-run idempotency, dangling values, malformed non-UUID values).

Full suite green locally: **5977 passed, 347 skipped** (the skips are DB integration suites — Docker was unavailable locally, so the new integration test runs for the first time in CI).

## Post-deploy step (carried over from #1623)

The incident pair `8d387a2d` / `9d682d2c` (Seth Berman, both `kg_node_id = NULL`) still needs its exclusion recorded — the original review task `027b5731` closed despite the failed write and will not reopen itself. After deploy, either ask the contacts agent to exclude the pair, or record it directly:

```sql
INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_by)
SELECT LEAST(a.id, b.id), GREATEST(a.id, b.id), 'ops-1625-backfill'
FROM contacts a, contacts b
WHERE a.id::text LIKE '8d387a2d%' AND b.id::text LIKE '9d682d2c%'
ON CONFLICT DO NOTHING;
```

Also check the other Seth Berman pairing at the same time — `1bb8e745` / `8d387a2d` was prepared for merge and is awaiting CEO confirmation.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [x] ADR added and indexed
- [ ] CI passes
