### PR TITLE
fix(contacts): run the contact merge write sequence in one transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Signal inbound** — ACI-only senders keep a non-empty sender and conversation identity. (#1600)
 - **Slack file download** — abort streamed bodies once they exceed the voice-note size cap. (#1600)
+- **Contact merge** — the write sequence runs in one transaction; a failed merge rolls back whole instead of stranding identities, auth overrides and dedup exclusions on the survivor. (#1695)
 - **Signal voice calls** — duplicate `RINGING_INCOMING` for one call no longer self-rejects it as busy. (#1672)
 - **Scheduler runtime errors** — fallback `agent.response(isError)` paths now always emit paired `agent.error`. (#1647)
 - **MCP health probe** — liveness uses `ping()` not `listTools()`, ending a ~145 MB/hr validator leak. (#1663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Signal inbound** — ACI-only senders keep a non-empty sender and conversation identity. (#1600)
 - **Slack file download** — abort streamed bodies once they exceed the voice-note size cap. (#1600)
-- **Contact merge** — the write sequence runs in one transaction; a failed merge rolls back whole instead of stranding identities, auth overrides and dedup exclusions on the survivor. (#1695)
+- **Contact merge** — merge writes run in one transaction; a failure no longer strands identities or dedup rulings. (#1695)
 - **Signal voice calls** — duplicate `RINGING_INCOMING` for one call no longer self-rejects it as busy. (#1672)
 - **Scheduler runtime errors** — fallback `agent.response(isError)` paths now always emit paired `agent.error`. (#1647)
 - **MCP health probe** — liveness uses `ping()` not `listTools()`, ending a ~145 MB/hr validator leak. (#1663)

--- a/docs/adr/039-decisions-in-the-ledger-not-the-knowledge-graph.md
+++ b/docs/adr/039-decisions-in-the-ledger-not-the-knowledge-graph.md
@@ -143,8 +143,10 @@ facts pointing at deleted contact ids.
 **Sharp edge this introduces.** A merge now rewrites exclusion rows, so any caller holding
 a cached view of the exclusion set must reconcile after merging or it will act on a stale
 snapshot — `scripts/dedup-contacts.ts` loads the set once and patches it after each merge
-for exactly this reason. `mergeContacts` is also still a non-transactional sequence of
-writes, and CEO rulings now move inside that window; making it atomic is tracked as #1695.
+for exactly this reason. CEO rulings also move inside `mergeContacts`' write sequence,
+which was a non-transactional run of pool queries when this ADR was written; #1695 closed
+that by running the whole sequence in one transaction, so a failed merge no longer leaves
+rulings re-pointed onto a survivor that was never written.
 
 **Harder / accepted trade-offs.** Exclusions no longer surface in entity-context assembly
 or KG queries — an agent asking "what do we know about this contact" will not see them.
@@ -168,5 +170,5 @@ tracked in **#1694**. It must not be treated as resolved by this change.
 - #1625 (this change), #1623 (the incident), PR #1624 (interim `multiValued` fix)
 - #1027 / PR #1040 (original decline → exclusion wiring)
 - #1694 (KG same-name node identity — still open)
-- #1695 (`mergeContacts` write sequence is not transactional — still open)
+- #1695 (`mergeContacts` write sequence made transactional — closed)
 - ADR-028 (shared, unbound agent memory) for the surrounding memory-governance model

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -688,9 +688,11 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       // Every injected callback delegates to a real service, no hand-rolled SQL:
       //   - mergeContacts: uses ContactService.mergeContacts(), which repoints kg_node_id,
       //     contact_calendars and dedup exclusions, and fires the contact.merged bus event
-      //     (audit-logged by the write-ahead hook in EventBus). NOTE: it sequences those
-      //     writes and rethrows on failure — it is NOT transactional (see the partial-state
-      //     warning it logs, and #1695).
+      //     (audit-logged by the write-ahead hook in EventBus). Its contact writes run in
+      //     one transaction (#1695), so a failed merge rolls back whole and rethrows — the
+      //     sweep can treat it as "this pair did not merge", with no partial state to
+      //     reconcile. The KG node merge it attempts first is best-effort and outside that
+      //     transaction.
       //   - createTask: uses TaskRepo.createTask(), which publishes task.created events.
       //   - listExclusionPairKeys: reads contact_dedup_exclusions via ContactService.
       // A real sweep merges KG entity nodes (entityMemory.mergeEntities), which embeds fact

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -764,9 +764,11 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
         noTasks,
 
         // ContactService.mergeContacts handles: identity dedup (resolves the unique-email
-        // constraint violation the old UPDATE would have caused), kg_node_id repointing,
-        // contact_calendars reattachment, golden-record field consolidation, and deletion
-        // of the loser row — all in a single transaction.
+        // constraint violation the old UPDATE would have caused), auth-override and
+        // dedup-exclusion re-pointing, golden-record field consolidation, and deletion of
+        // the loser row — all in one transaction since #1695. The KG entity merge it
+        // attempts first is best-effort and sits outside that transaction, and the loser's
+        // contact_calendars rows cascade away with the row rather than being reattached.
         mergeContacts: (primaryId, secondaryId) => contactService.mergeContacts(primaryId, secondaryId, false),
 
         // TaskRepo.createTask publishes task.created and handles progress/error_budget cols.

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -201,14 +201,16 @@ interface ContactServiceBackend {
   /**
    * Re-point all channel identities from fromContactId → toContactId.
    * Identities that would violate UNIQUE(channel, channelIdentifier) are deleted.
+   * Pass `client` to enlist in a caller's transaction (mergeContacts does — #1695).
    */
-  reattachIdentities(fromContactId: string, toContactId: string): Promise<void>;
+  reattachIdentities(fromContactId: string, toContactId: string, client?: DbPoolClient): Promise<void>;
 
   /**
    * Re-point active auth overrides from fromContactId → toContactId.
    * If primary already has an override for the same permission, secondary's is discarded.
+   * Pass `client` to enlist in a caller's transaction (#1695).
    */
-  reattachAuthOverrides(fromContactId: string, toContactId: string): Promise<void>;
+  reattachAuthOverrides(fromContactId: string, toContactId: string, client?: DbPoolClient): Promise<void>;
 
   // -- Dedup exclusions (#1625, ADR-039) --
 
@@ -235,12 +237,13 @@ interface ContactServiceBackend {
    * decision leaving the ledger, and it must be visible to an operator, not only
    * explained in a comment.
    */
-  reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<ReattachExclusionsResult>;
+  reattachDedupExclusions(fromContactId: string, toContactId: string, client?: DbPoolClient): Promise<ReattachExclusionsResult>;
 
   /**
    * Delete a contact by ID. Call only after FK-referenced rows have been re-pointed.
+   * Pass `client` to enlist in a caller's transaction (#1695).
    */
-  deleteContact(id: string): Promise<void>;
+  deleteContact(id: string, client?: DbPoolClient): Promise<void>;
 
   /**
    * Update scoring-owned fields on a contact. Uses atomic increments for message
@@ -1486,52 +1489,66 @@ export class ContactService {
       }
     }
 
+    // The whole write sequence runs on one client inside one transaction (#1695).
+    // Before that it was five independent pool queries, so a failure part-way could
+    // leave the secondary alive with its identities, auth overrides and CEO dedup
+    // rulings already re-pointed onto the survivor — the next sweep would then see the
+    // secondary again with none of its "not the same person" rulings attached.
+    //
+    // Deliberately outside the transaction: the KG mergeEntities call above (a different
+    // store, documented as best-effort) and the notifications below, which must describe
+    // committed state only.
+    let exclusions: ReattachExclusionsResult;
     try {
-      await this.backend.reattachIdentities(secondaryId, primaryId);
-      await this.backend.reattachAuthOverrides(secondaryId, primaryId);
-      // Exclusions the secondary held move to the survivor, renormalized into stored
-      // pair order. The exclusion between the merging pair itself (if any) is dropped:
-      // merging is the decision that they ARE the same person (#1625, ADR-039).
-      const exclusions = await this.backend.reattachDedupExclusions(secondaryId, primaryId);
-      if (exclusions.dropped > 0) {
-        // A dropped row is a CEO ruling leaving the ledger. Both causes are expected and
-        // benign, but an operator asking "why was this pair re-proposed months later"
-        // needs the event in the log, not only in a code comment.
-        this.logger?.info(
-          { primaryId, secondaryId, ...exclusions },
-          'contacts: dedup exclusions dropped during merge (superseded by the merge, or already held by the survivor)',
-        );
-      }
+      exclusions = await this.backend.withTransaction(async (client) => {
+        await this.backend.reattachIdentities(secondaryId, primaryId, client);
+        await this.backend.reattachAuthOverrides(secondaryId, primaryId, client);
+        // Exclusions the secondary held move to the survivor, renormalized into stored
+        // pair order. The exclusion between the merging pair itself (if any) is dropped:
+        // merging is the decision that they ARE the same person (#1625, ADR-039).
+        const reattached = await this.backend.reattachDedupExclusions(secondaryId, primaryId, client);
 
-      // Write the golden record fields onto the primary contact. The surviving tier
-      // is computed by computeGoldenRecord (blocked-on-either-side wins; else higher
-      // TIER_RANK) — the single source of survivorship truth. Rationale: tier
-      // represents a CEO grant (e.g. the CEO explicitly trusted a secondary contact).
-      // Merging should never silently downgrade that grant — losing a 'trusted' tier
-      // because the primary happened to be 'known' is incorrect, especially since
-      // #944's dedup calls mergeContacts. A 'blocked' tier on either side always wins
-      // so a merge can never un-block a contact.
-      const updatedPrimary: Contact = {
-        ...primary,
-        displayName: goldenRecord.displayName,
-        role: goldenRecord.role,
-        notes: goldenRecord.notes,
-        tier: goldenRecord.tier,
-        updatedAt: new Date(),
-      };
-      await this.backend.updateContact(updatedPrimary);
-      await this.backend.deleteContact(secondaryId);
+        // Write the golden record fields onto the primary contact. The surviving tier
+        // is computed by computeGoldenRecord (blocked-on-either-side wins; else higher
+        // TIER_RANK) — the single source of survivorship truth. Rationale: tier
+        // represents a CEO grant (e.g. the CEO explicitly trusted a secondary contact).
+        // Merging should never silently downgrade that grant — losing a 'trusted' tier
+        // because the primary happened to be 'known' is incorrect, especially since
+        // #944's dedup calls mergeContacts. A 'blocked' tier on either side always wins
+        // so a merge can never un-block a contact.
+        const updatedPrimary: Contact = {
+          ...primary,
+          displayName: goldenRecord.displayName,
+          role: goldenRecord.role,
+          notes: goldenRecord.notes,
+          tier: goldenRecord.tier,
+          updatedAt: new Date(),
+        };
+        await this.backend.updateContact(updatedPrimary, client);
+        await this.backend.deleteContact(secondaryId, client);
+        return reattached;
+      });
     } catch (err) {
-      // Not a transaction: these are sequential pool queries. If a later write fails, the
-      // secondary can survive with its dedup exclusions already re-pointed away, so the
-      // next sweep sees it again with its rulings gone. Name that explicitly — "partial
-      // state" alone does not tell an operator what to go and check. Wrapping the whole
-      // sequence in one transaction is tracked separately (#1695).
+      // One transaction, so the failure rolled the whole sequence back: both contacts,
+      // their identities, auth overrides and exclusion rows are exactly as they were and
+      // the merge can simply be retried. The KG node merge above is the one thing not
+      // covered — it may already have collapsed the two nodes.
       this.logger?.error(
         { err, primaryId, secondaryId },
-        'Contact merge write failed — DB may be in partial state; the secondary may survive with its dedup exclusions already moved (#1625). Verify contact_dedup_exclusions before re-running the sweep.',
+        'Contact merge rolled back — no contact rows changed; a KG node merge may already have been applied (#1695)',
       );
       throw err;
+    }
+
+    if (exclusions.dropped > 0) {
+      // A dropped row is a CEO ruling leaving the ledger. Both causes are expected and
+      // benign, but an operator asking "why was this pair re-proposed months later"
+      // needs the event in the log, not only in a code comment. Logged after commit so
+      // a rolled-back merge never claims rulings were dropped.
+      this.logger?.info(
+        { primaryId, secondaryId, ...exclusions },
+        'contacts: dedup exclusions dropped during merge (superseded by the merge, or already held by the survivor)',
+      );
     }
 
     const mergedAt = new Date();
@@ -2424,9 +2441,10 @@ class PostgresContactBackend implements ContactServiceBackend {
     return this.rowToCalendar(row);
   }
 
-  async reattachIdentities(fromContactId: string, toContactId: string): Promise<void> {
+  async reattachIdentities(fromContactId: string, toContactId: string, client?: DbPoolClient): Promise<void> {
+    const q = client ?? this.pool;
     // Delete identities that would conflict with the primary's existing ones
-    await this.pool.query(
+    await q.query(
       `DELETE FROM contact_channel_identities
        WHERE contact_id = $1
          AND (channel, channel_identifier) IN (
@@ -2436,14 +2454,15 @@ class PostgresContactBackend implements ContactServiceBackend {
          )`,
       [fromContactId, toContactId],
     );
-    await this.pool.query(
+    await q.query(
       `UPDATE contact_channel_identities SET contact_id = $1 WHERE contact_id = $2`,
       [toContactId, fromContactId],
     );
   }
 
-  async reattachAuthOverrides(fromContactId: string, toContactId: string): Promise<void> {
-    await this.pool.query(
+  async reattachAuthOverrides(fromContactId: string, toContactId: string, client?: DbPoolClient): Promise<void> {
+    const q = client ?? this.pool;
+    await q.query(
       `DELETE FROM contact_auth_overrides
        WHERE contact_id = $1
          AND revoked_at IS NULL
@@ -2455,7 +2474,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     );
     // Only re-point active (non-revoked) rows; revoked rows stay on the secondary
     // and will be effectively deleted when the secondary contact is deleted.
-    await this.pool.query(
+    await q.query(
       `UPDATE contact_auth_overrides SET contact_id = $1 WHERE contact_id = $2 AND revoked_at IS NULL`,
       [toContactId, fromContactId],
     );
@@ -2494,7 +2513,8 @@ class PostgresContactBackend implements ContactServiceBackend {
     }));
   }
 
-  async reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<ReattachExclusionsResult> {
+  async reattachDedupExclusions(fromContactId: string, toContactId: string, client?: DbPoolClient): Promise<ReattachExclusionsResult> {
+    const q = client ?? this.pool;
     // Copy the loser's exclusions onto the survivor, renormalizing each pair with
     // LEAST/GREATEST so the ordered-pair CHECK still holds after the swap.
     //
@@ -2504,7 +2524,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     //
     // ON CONFLICT DO NOTHING drops rows the survivor already holds for the same
     // counterparty; the survivor's own decided_at / decided_by provenance wins.
-    const moved = await this.pool.query(
+    const moved = await q.query(
       `INSERT INTO contact_dedup_exclusions (contact_a_id, contact_b_id, decided_at, decided_by)
        SELECT LEAST($1::uuid, other), GREATEST($1::uuid, other), decided_at, decided_by
        FROM (
@@ -2523,7 +2543,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     // Delete the loser's rows explicitly rather than relying on the FK cascade that
     // fires when the secondary contact row is deleted — reattach must leave a
     // consistent table even when called outside the merge write sequence.
-    const removed = await this.pool.query(
+    const removed = await q.query(
       `DELETE FROM contact_dedup_exclusions
        WHERE contact_a_id = $1::uuid OR contact_b_id = $1::uuid
        RETURNING contact_a_id`,
@@ -2540,9 +2560,9 @@ class PostgresContactBackend implements ContactServiceBackend {
     };
   }
 
-  async deleteContact(id: string): Promise<void> {
+  async deleteContact(id: string, client?: DbPoolClient): Promise<void> {
     this.logger.debug({ contactId: id }, 'contacts: deleting contact');
-    await this.pool.query(`DELETE FROM contacts WHERE id = $1`, [id]);
+    await (client ?? this.pool).query(`DELETE FROM contacts WHERE id = $1`, [id]);
   }
 
   // -- Row mapping helpers --
@@ -3019,7 +3039,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return null;
   }
 
-  async reattachIdentities(fromContactId: string, toContactId: string): Promise<void> {
+  async reattachIdentities(fromContactId: string, toContactId: string, _client?: DbPoolClient): Promise<void> {
     // Build set of channel:channelIdentifier keys already owned by the primary
     const primaryKeys = new Set<string>();
     for (const identity of this.identities.values()) {
@@ -3041,7 +3061,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     }
   }
 
-  async reattachAuthOverrides(fromContactId: string, toContactId: string): Promise<void> {
+  async reattachAuthOverrides(fromContactId: string, toContactId: string, _client?: DbPoolClient): Promise<void> {
     // Build set of permissions already held (active) by the primary
     const primaryPerms = new Set<string>();
     for (const override of this.overrides.values()) {
@@ -3080,7 +3100,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return [...this.dedupExclusions.values()].map(row => row.pair);
   }
 
-  async reattachDedupExclusions(fromContactId: string, toContactId: string): Promise<ReattachExclusionsResult> {
+  async reattachDedupExclusions(fromContactId: string, toContactId: string, _client?: DbPoolClient): Promise<ReattachExclusionsResult> {
     let removed = 0;
     let moved = 0;
 
@@ -3115,7 +3135,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return { removed, moved, dropped: removed - moved };
   }
 
-  async deleteContact(id: string): Promise<void> {
+  async deleteContact(id: string, _client?: DbPoolClient): Promise<void> {
     this.contacts.delete(id);
     // Cascade-delete related rows, matching Postgres ON DELETE CASCADE behavior.
     // Without this, deleted contacts leave dangling identities/overrides in the in-memory

--- a/tests/integration/contact-merge-transaction.test.ts
+++ b/tests/integration/contact-merge-transaction.test.ts
@@ -1,0 +1,222 @@
+// Integration test — ContactService.mergeContacts is one transaction (#1695).
+//
+// The in-memory backend cannot prove this: it has no rollback, so a unit test can only
+// check that the client is threaded and that the post-commit notifications stay quiet.
+// What needs a live Postgres is the guarantee itself — when a write in the middle of the
+// sequence fails, every earlier write in it is undone.
+//
+// The failure is forced with a BEFORE DELETE trigger scoped by id to the secondary
+// contact, so the last write in the sequence (deleteContact) raises while the four
+// writes before it have already run. Nothing else in the database is affected, and the
+// trigger is dropped in afterEach.
+//
+// Every fixture row is created by this suite and deleted by id in afterEach.
+// Skips gracefully when DATABASE_URL is not set.
+
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import pg from 'pg';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { requireCuriaTestDatabase } from './require-test-db.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+const FAIL_TRIGGER = 'itest_1695_block_secondary_delete';
+
+describeIf('mergeContacts transactionality (#1695)', () => {
+  let pool: pg.Pool;
+  let contactService: ContactService;
+
+  const createdContactIds: string[] = [];
+
+  /** Insert a contact directly: kg_node_id stays NULL so no KG merge is attempted. */
+  async function makeContact(displayName: string): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO contacts (display_name, kg_node_id) VALUES ($1, NULL) RETURNING id`,
+      [displayName],
+    );
+    const id = rows[0]!.id;
+    createdContactIds.push(id);
+    return id;
+  }
+
+  async function addIdentity(contactId: string, channel: string, identifier: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO contact_channel_identities (contact_id, channel, channel_identifier, source)
+       VALUES ($1, $2, $3, 'itest-1695')`,
+      [contactId, channel, identifier],
+    );
+  }
+
+  async function addOverride(contactId: string, permission: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO contact_auth_overrides (contact_id, permission, granted, granted_by)
+       VALUES ($1, $2, true, 'itest-1695')`,
+      [contactId, permission],
+    );
+  }
+
+  /** Identity owner rows for the fixture contacts, ordered so comparisons are stable. */
+  async function identityOwners(): Promise<Array<{ contactId: string; identifier: string }>> {
+    const { rows } = await pool.query<{ contact_id: string; channel_identifier: string }>(
+      `SELECT contact_id, channel_identifier FROM contact_channel_identities
+       WHERE contact_id = ANY($1::uuid[]) ORDER BY channel_identifier`,
+      [createdContactIds],
+    );
+    return rows.map(r => ({ contactId: r.contact_id, identifier: r.channel_identifier }));
+  }
+
+  async function overrideOwners(): Promise<Array<{ contactId: string; permission: string }>> {
+    const { rows } = await pool.query<{ contact_id: string; permission: string }>(
+      `SELECT contact_id, permission FROM contact_auth_overrides
+       WHERE contact_id = ANY($1::uuid[]) ORDER BY permission`,
+      [createdContactIds],
+    );
+    return rows.map(r => ({ contactId: r.contact_id, permission: r.permission }));
+  }
+
+  async function exclusionRows(): Promise<Array<{ a: string; b: string }>> {
+    const { rows } = await pool.query<{ contact_a_id: string; contact_b_id: string }>(
+      `SELECT contact_a_id, contact_b_id FROM contact_dedup_exclusions
+       WHERE contact_a_id = ANY($1::uuid[]) OR contact_b_id = ANY($1::uuid[])
+       ORDER BY contact_a_id, contact_b_id`,
+      [createdContactIds],
+    );
+    return rows.map(r => ({ a: r.contact_a_id, b: r.contact_b_id }));
+  }
+
+  /**
+   * Make DELETE on one specific contact row raise, so the merge's final write fails
+   * with the four writes before it already applied inside the transaction.
+   */
+  async function blockDeleteOf(contactId: string): Promise<void> {
+    await pool.query(
+      `CREATE OR REPLACE FUNCTION ${FAIL_TRIGGER}() RETURNS trigger AS $$
+       BEGIN
+         RAISE EXCEPTION 'forced merge failure (#1695 integration test)';
+       END;
+       $$ LANGUAGE plpgsql`,
+    );
+    // DDL cannot take bind parameters, so the id is quoted by Postgres itself via
+    // format(%L) and the resulting statement is then executed — never string-concatenated
+    // in JS. The WHEN clause keeps the trigger scoped to this suite's own contact row, so
+    // suites running in parallel against the same database are untouched.
+    const { rows } = await pool.query<{ sql: string }>(
+      `SELECT format(
+         $fmt$CREATE TRIGGER ${FAIL_TRIGGER} BEFORE DELETE ON contacts
+              FOR EACH ROW WHEN (OLD.id = %L::uuid)
+              EXECUTE FUNCTION ${FAIL_TRIGGER}()$fmt$,
+         $1::uuid
+       ) AS sql`,
+      [contactId],
+    );
+    await pool.query(rows[0]!.sql);
+  }
+
+  async function unblockDelete(): Promise<void> {
+    await pool.query(`DROP TRIGGER IF EXISTS ${FAIL_TRIGGER} ON contacts`);
+    await pool.query(`DROP FUNCTION IF EXISTS ${FAIL_TRIGGER}()`);
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    // This suite creates and drops a trigger on the shared `contacts` table, so it must
+    // never point at a real database even though every row it writes is its own.
+    await requireCuriaTestDatabase(pool);
+
+    // No EntityMemory: the fixtures have kg_node_id = NULL, so mergeContacts skips the
+    // KG merge entirely and the suite needs no embedding credentials.
+    contactService = ContactService.createWithPostgres(pool, undefined, createSilentLogger());
+
+    // Fails fast when migration 084 has not been applied.
+    await pool.query('SELECT 1 FROM contact_dedup_exclusions LIMIT 0');
+  });
+
+  afterEach(async () => {
+    // Drop the trigger first — otherwise fixture teardown hits it too.
+    await unblockDelete();
+    if (createdContactIds.length > 0) {
+      await pool.query(`DELETE FROM contacts WHERE id = ANY($1::uuid[])`, [createdContactIds]);
+      createdContactIds.length = 0;
+    }
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('rolls the whole write sequence back when the final write fails', async () => {
+    const primary = await makeContact('Tx Primary 1695');
+    const secondary = await makeContact('Tx Secondary 1695');
+    const other = await makeContact('Tx Bystander 1695');
+
+    await addIdentity(primary, 'email', 'tx-primary-1695@example.com');
+    await addIdentity(secondary, 'email', 'tx-secondary-1695@example.com');
+    await addOverride(primary, 'itest:1695:primary-perm');
+    await addOverride(secondary, 'itest:1695:secondary-perm');
+    // A CEO ruling held by the secondary: exactly the row #1625 moved into this sequence.
+    await contactService.addDedupExclusion(secondary, other, 'itest-1695');
+
+    const identitiesBefore = await identityOwners();
+    const overridesBefore = await overrideOwners();
+    const exclusionsBefore = await exclusionRows();
+
+    await blockDeleteOf(secondary);
+
+    await expect(contactService.mergeContacts(primary, secondary, false))
+      .rejects.toThrow(/forced merge failure/);
+
+    // Both contacts survive — the golden-record update on the primary is rolled back too.
+    const { rows: survivors } = await pool.query<{ id: string; display_name: string }>(
+      `SELECT id, display_name FROM contacts WHERE id = ANY($1::uuid[]) ORDER BY display_name`,
+      [[primary, secondary]],
+    );
+    expect(survivors).toHaveLength(2);
+
+    // Identities, overrides and the CEO ruling are all exactly where they were: nothing
+    // was left re-pointed onto a survivor whose golden record was never written.
+    expect(await identityOwners()).toEqual(identitiesBefore);
+    expect(await overrideOwners()).toEqual(overridesBefore);
+    expect(await exclusionRows()).toEqual(exclusionsBefore);
+    expect(exclusionsBefore).toHaveLength(1);
+    expect(exclusionsBefore[0]).toEqual({
+      a: secondary < other ? secondary : other,
+      b: secondary < other ? other : secondary,
+    });
+  });
+
+  it('commits the same sequence when nothing fails', async () => {
+    // The mirror of the rollback case: without the trigger the identical fixture merges,
+    // which is what makes the assertions above evidence of rollback rather than of a
+    // merge that never started.
+    const primary = await makeContact('Commit Primary 1695');
+    const secondary = await makeContact('Commit Secondary 1695');
+    const other = await makeContact('Commit Bystander 1695');
+
+    await addIdentity(secondary, 'email', 'commit-secondary-1695@example.com');
+    await addOverride(secondary, 'itest:1695:moved-perm');
+    await contactService.addDedupExclusion(secondary, other, 'itest-1695');
+
+    await contactService.mergeContacts(primary, secondary, false);
+
+    const { rows: survivors } = await pool.query<{ id: string }>(
+      `SELECT id FROM contacts WHERE id = ANY($1::uuid[])`,
+      [[primary, secondary]],
+    );
+    expect(survivors.map(r => r.id)).toEqual([primary]);
+
+    expect(await identityOwners()).toEqual([
+      { contactId: primary, identifier: 'commit-secondary-1695@example.com' },
+    ]);
+    expect(await overrideOwners()).toEqual([
+      { contactId: primary, permission: 'itest:1695:moved-perm' },
+    ]);
+    expect(await exclusionRows()).toEqual([{
+      a: primary < other ? primary : other,
+      b: primary < other ? other : primary,
+    }]);
+  });
+});

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -1485,6 +1485,90 @@ describe('ContactService', () => {
     });
   });
 
+  // -- Merge transactionality (#1695) --
+
+  describe('mergeContacts transaction', () => {
+    /**
+     * The slice of the backend the transaction tests stub or observe. Reaching into the
+     * private field is the only way to see which client each write received — the whole
+     * point of #1695 is that all five run on one client.
+     */
+    interface MergeBackend {
+      withTransaction<T>(fn: (client?: unknown) => Promise<T>): Promise<T>;
+      reattachIdentities(from: string, to: string, client?: unknown): Promise<void>;
+      reattachAuthOverrides(from: string, to: string, client?: unknown): Promise<void>;
+      reattachDedupExclusions(from: string, to: string, client?: unknown): Promise<unknown>;
+      updateContact(contact: Contact, client?: unknown): Promise<void>;
+      deleteContact(id: string, client?: unknown): Promise<void>;
+    }
+
+    const backendOf = (svc: ContactService): MergeBackend =>
+      (svc as unknown as { backend: MergeBackend }).backend;
+
+    it('runs every merge write on the client withTransaction handed it', async () => {
+      const primary = await service.createContact({ displayName: 'Tx Primary', source: 'test' });
+      const secondary = await service.createContact({ displayName: 'Tx Secondary', source: 'test' });
+
+      const backend = backendOf(service);
+      // The in-memory backend runs the callback with no client, so stand one in. What is
+      // being proven is the threading: whatever withTransaction supplies must reach all
+      // five writes, otherwise a write would run on the pool outside the transaction.
+      const client = { marker: 'tx-client' };
+      const withTransaction = vi.spyOn(backend, 'withTransaction')
+        .mockImplementation(fn => fn(client));
+      const reattachIdentities = vi.spyOn(backend, 'reattachIdentities');
+      const reattachAuthOverrides = vi.spyOn(backend, 'reattachAuthOverrides');
+      const reattachDedupExclusions = vi.spyOn(backend, 'reattachDedupExclusions');
+      const updateContact = vi.spyOn(backend, 'updateContact');
+      const deleteContact = vi.spyOn(backend, 'deleteContact');
+
+      await service.mergeContacts(primary.id, secondary.id, false);
+
+      expect(withTransaction).toHaveBeenCalledTimes(1);
+      expect(reattachIdentities).toHaveBeenCalledWith(secondary.id, primary.id, client);
+      expect(reattachAuthOverrides).toHaveBeenCalledWith(secondary.id, primary.id, client);
+      expect(reattachDedupExclusions).toHaveBeenCalledWith(secondary.id, primary.id, client);
+      expect(updateContact).toHaveBeenCalledWith(expect.objectContaining({ id: primary.id }), client);
+      expect(deleteContact).toHaveBeenCalledWith(secondary.id, client);
+    });
+
+    it('does not fire onContactMerged or onIdentitiesChanged when a merge write fails', async () => {
+      // Both notifications describe committed state — a rolled-back merge must publish
+      // neither, or downstream consumers act on a merge that never happened.
+      const onContactMerged = vi.fn();
+      const onIdentitiesChanged = vi.fn();
+      const svc = ContactService.createInMemory(entityMemory, { onContactMerged, onIdentitiesChanged });
+
+      const primary = await svc.createContact({ displayName: 'Rollback Primary', source: 'test' });
+      const secondary = await svc.createContact({ displayName: 'Rollback Secondary', source: 'test' });
+
+      vi.spyOn(backendOf(svc), 'deleteContact')
+        .mockRejectedValue(new Error('forced delete failure'));
+
+      await expect(svc.mergeContacts(primary.id, secondary.id, false))
+        .rejects.toThrow('forced delete failure');
+
+      expect(onContactMerged).not.toHaveBeenCalled();
+      expect(onIdentitiesChanged).not.toHaveBeenCalled();
+    });
+
+    it('propagates the failure out of the transaction rather than returning a merge result', async () => {
+      const svc = ContactService.createInMemory(entityMemory);
+      const primary = await svc.createContact({ displayName: 'Throw Primary', source: 'test' });
+      const secondary = await svc.createContact({ displayName: 'Throw Secondary', source: 'test' });
+
+      const backend = backendOf(svc);
+      vi.spyOn(backend, 'updateContact').mockRejectedValue(new Error('forced update failure'));
+      const deleteContact = vi.spyOn(backend, 'deleteContact');
+
+      await expect(svc.mergeContacts(primary.id, secondary.id, false))
+        .rejects.toThrow('forced update failure');
+
+      // The sequence aborts at the failing write — the delete never runs.
+      expect(deleteContact).not.toHaveBeenCalled();
+    });
+  });
+
 });
 
 describe('EntityMemory.mergeEntities', () => {


### PR DESCRIPTION
Closes #1695.

## What was wrong

`ContactService.mergeContacts` ran its five writes as independent `pool.query` calls with
no `BEGIN`/`COMMIT`. A failure part-way through left real inconsistency behind:

- identities re-pointed but the secondary not deleted → a contact with no channel identities,
  unreachable and unresolvable
- auth overrides re-pointed but the primary never updated → permissions on a contact whose
  golden record was never written
- since #1625, **CEO dedup rulings** re-pointed while the secondary survives → the next sweep
  sees that contact again with none of its "not the same person" rulings attached, and can
  re-propose (or, for a structural pair, auto-merge) a pair the CEO explicitly ruled apart

## What changed

- The whole sequence now runs inside the backend's existing `withTransaction`, with the
  client threaded through all five writes, so it commits or rolls back as a unit.
- `reattachIdentities`, `reattachAuthOverrides`, `reattachDedupExclusions` and
  `deleteContact` gained an optional `client` (the other two already had one). The Postgres
  backend runs on `client ?? this.pool`; the in-memory backend accepts and ignores it, so its
  no-op transaction path is unchanged.
- The dropped-exclusions `info` log moved out of the write sequence to after the commit,
  alongside `onContactMerged` / `notifyIdentitiesChanged` — nothing now reports state that a
  rollback undid.
- The catch's `'DB may be in partial state'` warning now names the real guarantee (rolled
  back whole; only the best-effort KG node merge may already have been applied). Stale
  transactionality comments in `scripts/dedup-contacts.ts` and ADR-039 updated to match.

Explicitly still outside the transaction, as the issue specified: the KG `mergeEntities`
call above (a different store, documented best-effort) and the post-commit notifications.

## Tests

- Unit (`tests/unit/contacts/contact-service.test.ts`): all five writes receive the client
  `withTransaction` supplied; `onContactMerged` / `onIdentitiesChanged` stay silent when a
  write fails; the sequence aborts at the failing write.
- Integration (`tests/integration/contact-merge-transaction.test.ts`, new): a `BEFORE DELETE`
  trigger scoped by id to the secondary forces the final write to fail, and the contact, its
  identities, its auth overrides and its `contact_dedup_exclusions` rows are all exactly as
  they were. A mirror test proves the same fixture commits cleanly without the trigger.

Verified locally against `curia_test`: the rollback test fails on `main` (the secondary's
identity is stranded on the primary while the secondary still exists) and passes on this
branch. Full unit suite green (5981 passed); full integration suite green when run with
`--no-file-parallelism` (the parallel run has pre-existing cross-suite interference on
`main` too).

## Spotted, not touched

`mergeContacts` does not reattach `contact_calendars`: the secondary's calendar links
cascade away with its row. The sweep script's comment claimed they were reattached; the
comment is corrected here, but the behaviour is unchanged and may deserve its own issue.