### PR TITLE
feat(entity-context): surface contacts that cannot hold a KG node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **ADR-040 (Accepted)** — contact-anchored KG node identity; a contact's node is keyed on the contact, not its label. (#1694)
+- **`scripts/kg-node-linkage-report.ts`** — read-only count of contacts holding no KG node, split across ADR-040's two backfill arms. `pnpm run report:kg-linkage`. (#1694)
 - **Signal voice calls** — anyone can Signal-call Curia; live conversation via VoiceRuntime, config-gated off. (#1672)
 - **`MemorySampler`** — periodic `process.memoryUsage()` logging to diagnose heap growth in prod. (#1650)
 - **Speech media service** — top-level `src/speech/` batch STT/TTS for voice notes. (#1597)
@@ -33,6 +35,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`EntityContextAssembler.assembleMany`** — returns a third bucket, `nodeless`, for contacts that exist but hold no KG node; disjoint from `unresolved`. (#1694)
+- **`entity-context`** — output gains `nodeless` (present only when non-empty) so an agent reads a missing node as a capability gap, not as an absence of facts. (#1694)
+- **`entity_enrichment`** — nodeless contacts get their own warn line instead of joining the unresolved-IDs line. (#1694)
 - **`contact-dedup-exclude`** — writes the exclusions table; outputs `created`, no `entityMemory` capability. (#1625)
 - **`contact-find-duplicates`** — loads exclusions in one query; `entityMemory` capability dropped. (#1625)
 - **Contact merge** — re-points and renormalizes exclusion rows onto the survivor. (#1625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **ADR-040 (Accepted)** — contact-anchored KG node identity; a contact's node is keyed on the contact, not its label. (#1694)
-- **`scripts/kg-node-linkage-report.ts`** — read-only count of contacts holding no KG node, split across ADR-040's two backfill arms. `pnpm run report:kg-linkage`. (#1694)
+- **`scripts/kg-node-linkage-report.ts`** — read-only count of nodeless contacts, split across ADR-040's two backfill arms. (#1694)
 - **Signal voice calls** — anyone can Signal-call Curia; live conversation via VoiceRuntime, config-gated off. (#1672)
 - **`MemorySampler`** — periodic `process.memoryUsage()` logging to diagnose heap growth in prod. (#1650)
 - **Speech media service** — top-level `src/speech/` batch STT/TTS for voice notes. (#1597)
@@ -35,8 +35,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
-- **`EntityContextAssembler.assembleMany`** — returns a third bucket, `nodeless`, for contacts that exist but hold no KG node; disjoint from `unresolved`. (#1694)
-- **`entity-context`** — output gains `nodeless` (present only when non-empty) so an agent reads a missing node as a capability gap, not as an absence of facts. (#1694)
+- **`EntityContextAssembler.assembleMany`** — new `nodeless` bucket, disjoint from `unresolved`; logged at warn. (#1694)
+- **`entity-context`** — output gains `nodeless`; agents read a missing node as a capability gap. (#1694)
+- **`entity-context` output schema** — new `nodeless` key on `ToolResult.data` (public API surface). (#1694)
 - **`entity_enrichment`** — nodeless contacts get their own warn line instead of joining the unresolved-IDs line. (#1694)
 - **`contact-dedup-exclude`** — writes the exclusions table; outputs `created`, no `entityMemory` capability. (#1625)
 - **`contact-find-duplicates`** — loads exclusions in one query; `entityMemory` capability dropped. (#1625)

--- a/docs/adr/039-decisions-in-the-ledger-not-the-knowledge-graph.md
+++ b/docs/adr/039-decisions-in-the-ledger-not-the-knowledge-graph.md
@@ -164,8 +164,9 @@ hold KG nodes; the second contact keeps `kg_node_id = NULL`. This ADR removes th
 KG citizens for facts, relationships, and entity-context enrichment: facts about them have
 nowhere to live, and enrichment returns nothing. That is a separate, still-open problem,
 tracked in **#1694**. It must not be treated as resolved by this change. The chosen
-resolution is ADR-040 (contact-anchored node identity), which supersedes this paragraph
-once it moves from Proposed to Accepted.
+resolution is ADR-040 (contact-anchored node identity), which supersedes this paragraph.
+Implementation is staged across #1694; until the identity model lands, nodeless contacts
+are at least *visible* rather than silently context-free.
 
 ## Related
 

--- a/docs/adr/040-contact-anchored-kg-node-identity.md
+++ b/docs/adr/040-contact-anchored-kg-node-identity.md
@@ -1,7 +1,7 @@
 # ADR-040: Contact-anchored KG node identity — a contact's node is identified by the contact, not by its label
 
 Date: 2026-09-01
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,7 +61,7 @@ Each ADR follows the [Nygard format](https://adr.github.io/):
 | [037](037-voice-channel-livekit-duplex.md) | Duplex voice via self-hosted LiveKit cascade (console WebRTC); STT/TTS provider seams; Phase 2 Signal/PSTN deferred | Accepted |
 | [038](038-voice-brain-shared-hardening.md) | Voice brain parity via shared-hardening prompt modules — reject full coordinator consolidation; text may use `stream()` (#1563) | Accepted |
 | [039](039-decisions-in-the-ledger-not-the-knowledge-graph.md) | Operational decisions live in the relational ledger, not the KG — dedup exclusions move to `contact_dedup_exclusions` (#1625) | Accepted |
-| [040](040-contact-anchored-kg-node-identity.md) | Contact-anchored KG node identity — a contact's node is keyed on the contact, not its label; unanchored nodes stay label-keyed (#1694) | Proposed |
+| [040](040-contact-anchored-kg-node-identity.md) | Contact-anchored KG node identity — a contact's node is keyed on the contact, not its label; unanchored nodes stay label-keyed (#1694) | Accepted |
 
 ## Adding new ADRs
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "redteam:report": "promptfoo view",
     "backfill:contact-attributes": "tsx --env-file=.env scripts/backfill-contact-attributes.ts",
     "rederive:contact-tiers": "tsx --env-file=.env scripts/rederive-contact-tiers.ts",
+    "report:kg-linkage": "tsx --env-file=.env scripts/kg-node-linkage-report.ts",
     "dedup:contacts": "tsx --env-file=.env scripts/dedup-contacts.ts",
     "seed-vault": "tsx --env-file=.env scripts/seed-vault.ts",
     "audit:verify": "tsx --env-file=.env scripts/audit-verify.ts"

--- a/scripts/kg-node-linkage-report.test.ts
+++ b/scripts/kg-node-linkage-report.test.ts
@@ -4,43 +4,26 @@
 //
 // The report's job is to size migration 085 before it is written: how many contacts
 // hold no KG node, and how do they split across the two backfill arms (organization
-// contacts that can be re-linked to their org's existing node, vs contacts that need
-// a node minted). Getting the arithmetic wrong here would mis-size the migration, so
-// the split is what these tests pin down.
+// contacts that can be re-linked to an existing org node, vs contacts that need a
+// node minted). A wrong number here mis-sizes the migration, and a *silently* wrong
+// number is worse than a loud failure — so several of these tests assert that the
+// report refuses to produce a plausible-looking answer rather than guessing.
 
 import { describe, it, expect, vi } from 'vitest';
 import { runLinkageReport } from './kg-node-linkage-report.js';
 
 type MockPool = { query: ReturnType<typeof vi.fn> };
 
-// Responds to queries in order. Throws on an unexpected extra call so a new query
-// added to the report can't silently read an unrelated stub.
-function makeSequentialPool(responses: Array<{ rows: unknown[] }>): MockPool {
-  let i = 0;
-  return {
-    query: vi.fn().mockImplementation(() => {
-      const res = responses[i++];
-      if (!res) throw new Error(`Unexpected query call #${i} — add a response`);
-      return Promise.resolve(res);
-    }),
-  };
+function makePool(rows: unknown[]): MockPool {
+  return { query: vi.fn().mockResolvedValue({ rows }) };
 }
 
 describe('runLinkageReport', () => {
   it('splits the nodeless population across the two backfill arms', async () => {
-    const pool = makeSequentialPool([
-      // 1. totals by kind
-      {
-        rows: [
-          { kind: 'person', total: '120', nodeless: '9' },
-          { kind: 'organization', total: '30', nodeless: '6' },
-          { kind: 'automated', total: '15', nodeless: '0' },
-        ],
-      },
-      // 2. org-arm eligible
-      { rows: [{ eligible: '4' }] },
-      // 3. shadowed by a same-name contact that does have a node
-      { rows: [{ shadowed: '7' }] },
+    const pool = makePool([
+      { kind: 'person', total: '120', nodeless: '9', org_arm: '0', shadowed: '7' },
+      { kind: 'organization', total: '30', nodeless: '6', org_arm: '4', shadowed: '0' },
+      { kind: 'automated', total: '15', nodeless: '0', org_arm: '0', shadowed: '0' },
     ]);
 
     const report = await runLinkageReport(pool as never);
@@ -59,10 +42,8 @@ describe('runLinkageReport', () => {
   });
 
   it('reports a clean database as zero work, not as an error', async () => {
-    const pool = makeSequentialPool([
-      { rows: [{ kind: 'person', total: '40', nodeless: '0' }] },
-      { rows: [{ eligible: '0' }] },
-      { rows: [{ shadowed: '0' }] },
+    const pool = makePool([
+      { kind: 'person', total: '40', nodeless: '0', org_arm: '0', shadowed: '0' },
     ]);
 
     const report = await runLinkageReport(pool as never);
@@ -72,41 +53,58 @@ describe('runLinkageReport', () => {
     expect(report.personArmMints).toBe(0);
   });
 
-  it('handles an empty contacts table without producing NaN', async () => {
-    const pool = makeSequentialPool([
-      { rows: [] },
-      { rows: [{ eligible: '0' }] },
-      { rows: [{ shadowed: '0' }] },
-    ]);
-
-    const report = await runLinkageReport(pool as never);
+  it('handles an empty contacts table', async () => {
+    const report = await runLinkageReport(makePool([]) as never);
 
     expect(report.totalContacts).toBe(0);
     expect(report.totalNodeless).toBe(0);
     expect(report.byKind).toEqual([]);
   });
 
-  it('tolerates a missing aggregate row rather than yielding NaN', async () => {
-    // count(*) always returns a row in practice, but a defensive default keeps a
-    // surprising empty result from turning the whole report into NaN arithmetic.
-    const pool = makeSequentialPool([
-      { rows: [{ kind: 'person', total: '10', nodeless: '3' }] },
-      { rows: [] },
-      { rows: [] },
+  it('throws rather than reporting zero when an aggregate column is missing', async () => {
+    // A count(*) column cannot legitimately be absent. Coercing it to 0 would print
+    // "arm B (mint a node) 0" — indistinguishable from a clean database, and enough
+    // to size migration 085 at zero inserts while the whole nodeless population stays
+    // permanently context-free. Failing loudly is the only safe answer.
+    const pool = makePool([{ kind: 'person', total: '10', nodeless: undefined }]);
+
+    await expect(runLinkageReport(pool as never)).rejects.toThrow(/nodeless.*not a number/s);
+  });
+
+  it('throws rather than reporting a fabricated count when a column is unparseable', async () => {
+    const pool = makePool([
+      { kind: 'person', total: '10', nodeless: '3', org_arm: 'n/a', shadowed: '0' },
     ]);
 
-    const report = await runLinkageReport(pool as never);
+    await expect(runLinkageReport(pool as never)).rejects.toThrow(/org_arm/);
+  });
 
-    expect(report.orgArmEligible).toBe(0);
-    expect(report.sameNameShadowed).toBe(0);
-    expect(report.personArmMints).toBe(3);
+  it('throws when arm A exceeds the nodeless total instead of clamping to zero', async () => {
+    // Internally inconsistent input means the query is wrong. Clamping would hide
+    // that behind a plausible arm-B number, which is the one output that matters.
+    const pool = makePool([
+      { kind: 'organization', total: '10', nodeless: '2', org_arm: '5', shadowed: '0' },
+    ]);
+
+    await expect(runLinkageReport(pool as never)).rejects.toThrow(/internally inconsistent/);
+  });
+
+  it('reads every count from a single statement so the arms cannot drift apart', async () => {
+    // Separate queries would run on separate MVCC snapshots. Against a live production
+    // database with contact ingestion running, the arms could then fail to sum to the
+    // total they are derived from.
+    const pool = makePool([
+      { kind: 'person', total: '1', nodeless: '0', org_arm: '0', shadowed: '0' },
+    ]);
+
+    await runLinkageReport(pool as never);
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
   });
 
   it('never issues a write', async () => {
-    const pool = makeSequentialPool([
-      { rows: [{ kind: 'person', total: '1', nodeless: '0' }] },
-      { rows: [{ eligible: '0' }] },
-      { rows: [{ shadowed: '0' }] },
+    const pool = makePool([
+      { kind: 'person', total: '1', nodeless: '0', org_arm: '0', shadowed: '0' },
     ]);
 
     await runLinkageReport(pool as never);

--- a/scripts/kg-node-linkage-report.test.ts
+++ b/scripts/kg-node-linkage-report.test.ts
@@ -61,6 +61,14 @@ describe('runLinkageReport', () => {
     expect(report.byKind).toEqual([]);
   });
 
+  it('throws when the grouping column is not a usable kind', async () => {
+    // String(undefined) would print "undefined" in the by-kind table, which reads
+    // like a real contact kind rather than a broken query.
+    const pool = makePool([{ total: '10', nodeless: '3', org_arm: '0', shadowed: '0' }]);
+
+    await expect(runLinkageReport(pool as never)).rejects.toThrow(/"kind"/);
+  });
+
   it('throws rather than reporting zero when an aggregate column is missing', async () => {
     // A count(*) column cannot legitimately be absent. Coercing it to 0 would print
     // "arm B (mint a node) 0" — indistinguishable from a clean database, and enough

--- a/scripts/kg-node-linkage-report.test.ts
+++ b/scripts/kg-node-linkage-report.test.ts
@@ -1,0 +1,119 @@
+// scripts/kg-node-linkage-report.test.ts
+//
+// Unit tests for the KG node linkage report (#1694 / ADR-040).
+//
+// The report's job is to size migration 085 before it is written: how many contacts
+// hold no KG node, and how do they split across the two backfill arms (organization
+// contacts that can be re-linked to their org's existing node, vs contacts that need
+// a node minted). Getting the arithmetic wrong here would mis-size the migration, so
+// the split is what these tests pin down.
+
+import { describe, it, expect, vi } from 'vitest';
+import { runLinkageReport } from './kg-node-linkage-report.js';
+
+type MockPool = { query: ReturnType<typeof vi.fn> };
+
+// Responds to queries in order. Throws on an unexpected extra call so a new query
+// added to the report can't silently read an unrelated stub.
+function makeSequentialPool(responses: Array<{ rows: unknown[] }>): MockPool {
+  let i = 0;
+  return {
+    query: vi.fn().mockImplementation(() => {
+      const res = responses[i++];
+      if (!res) throw new Error(`Unexpected query call #${i} — add a response`);
+      return Promise.resolve(res);
+    }),
+  };
+}
+
+describe('runLinkageReport', () => {
+  it('splits the nodeless population across the two backfill arms', async () => {
+    const pool = makeSequentialPool([
+      // 1. totals by kind
+      {
+        rows: [
+          { kind: 'person', total: '120', nodeless: '9' },
+          { kind: 'organization', total: '30', nodeless: '6' },
+          { kind: 'automated', total: '15', nodeless: '0' },
+        ],
+      },
+      // 2. org-arm eligible
+      { rows: [{ eligible: '4' }] },
+      // 3. shadowed by a same-name contact that does have a node
+      { rows: [{ shadowed: '7' }] },
+    ]);
+
+    const report = await runLinkageReport(pool as never);
+
+    expect(report.totalContacts).toBe(165);
+    expect(report.totalNodeless).toBe(15);
+    expect(report.byKind).toEqual([
+      { kind: 'person', total: 120, nodeless: 9 },
+      { kind: 'organization', total: 30, nodeless: 6 },
+      { kind: 'automated', total: 15, nodeless: 0 },
+    ]);
+    // Arm A re-links org contacts to an existing org node; arm B mints the rest.
+    expect(report.orgArmEligible).toBe(4);
+    expect(report.personArmMints).toBe(11);
+    expect(report.sameNameShadowed).toBe(7);
+  });
+
+  it('reports a clean database as zero work, not as an error', async () => {
+    const pool = makeSequentialPool([
+      { rows: [{ kind: 'person', total: '40', nodeless: '0' }] },
+      { rows: [{ eligible: '0' }] },
+      { rows: [{ shadowed: '0' }] },
+    ]);
+
+    const report = await runLinkageReport(pool as never);
+
+    expect(report.totalNodeless).toBe(0);
+    expect(report.orgArmEligible).toBe(0);
+    expect(report.personArmMints).toBe(0);
+  });
+
+  it('handles an empty contacts table without producing NaN', async () => {
+    const pool = makeSequentialPool([
+      { rows: [] },
+      { rows: [{ eligible: '0' }] },
+      { rows: [{ shadowed: '0' }] },
+    ]);
+
+    const report = await runLinkageReport(pool as never);
+
+    expect(report.totalContacts).toBe(0);
+    expect(report.totalNodeless).toBe(0);
+    expect(report.byKind).toEqual([]);
+  });
+
+  it('tolerates a missing aggregate row rather than yielding NaN', async () => {
+    // count(*) always returns a row in practice, but a defensive default keeps a
+    // surprising empty result from turning the whole report into NaN arithmetic.
+    const pool = makeSequentialPool([
+      { rows: [{ kind: 'person', total: '10', nodeless: '3' }] },
+      { rows: [] },
+      { rows: [] },
+    ]);
+
+    const report = await runLinkageReport(pool as never);
+
+    expect(report.orgArmEligible).toBe(0);
+    expect(report.sameNameShadowed).toBe(0);
+    expect(report.personArmMints).toBe(3);
+  });
+
+  it('never issues a write', async () => {
+    const pool = makeSequentialPool([
+      { rows: [{ kind: 'person', total: '1', nodeless: '0' }] },
+      { rows: [{ eligible: '0' }] },
+      { rows: [{ shadowed: '0' }] },
+    ]);
+
+    await runLinkageReport(pool as never);
+
+    // This script is run against production; every statement it issues must be a SELECT.
+    for (const call of pool.query.mock.calls) {
+      expect(String(call[0]).trim().toUpperCase().startsWith('SELECT')).toBe(true);
+    }
+  });
+});

--- a/scripts/kg-node-linkage-report.ts
+++ b/scripts/kg-node-linkage-report.ts
@@ -1,0 +1,179 @@
+// scripts/kg-node-linkage-report.ts
+//
+// Read-only report on contacts that hold no KG node (#1694 / ADR-040).
+//
+// A contact with kg_node_id = NULL cannot hold facts, relationships, or entity
+// context, and nothing about that is visible from the outside — it looks identical
+// to a contact nobody has learned anything about yet. This report is the standing
+// count, and it exists to size migration 085 before that migration is written:
+// ADR-040's backfill has two arms, and the work in each is very different.
+//
+//   Arm A (org)    — a nodeless contact with kind='organization' whose primary_email
+//                    domain matches an existing organization node's properties->>'domain'.
+//                    These get re-linked to that node, which is only legal once the
+//                    relaxed idx_contacts_kg_node_unique lands. No new nodes.
+//   Arm B (person) — everything else. Each gets a freshly minted anchored node, so
+//                    this count is exactly how many rows migration 085 inserts.
+//
+// `sameNameShadowed` is context rather than an arm: nodeless contacts that share a
+// display name with a contact that *does* hold a node. That is the Seth Berman
+// signature from #1623 — the collision that produced the NULL in the first place.
+//
+// Run locally:  pnpm run report:kg-linkage
+// Run on prod:  docker exec curia-curia-1 node --experimental-strip-types \
+//                 scripts/kg-node-linkage-report.ts
+//               (forward DATABASE_URL from the deploy .env)
+//
+// Safety: every statement is a SELECT. This script writes nothing.
+
+import pg from 'pg';
+import pino from 'pino';
+
+const logger = pino({ name: 'kg-node-linkage-report' });
+const { Pool } = pg;
+
+/** Minimal structural type so tests can pass a mock without the full pg.Pool shape. */
+type PoolLike = { query: (text: string, values?: unknown[]) => Promise<{ rows: unknown[] }> };
+
+export interface KindBreakdown {
+  kind: string;
+  total: number;
+  nodeless: number;
+}
+
+export interface LinkageReport {
+  totalContacts: number;
+  totalNodeless: number;
+  byKind: KindBreakdown[];
+  /** Arm A: nodeless org contacts re-linkable to an existing org node by email domain. */
+  orgArmEligible: number;
+  /** Arm B: nodeless contacts needing a freshly minted node — the insert count for 085. */
+  personArmMints: number;
+  /** Nodeless contacts whose display name is shared with a contact that has a node. */
+  sameNameShadowed: number;
+}
+
+// Postgres count(*) comes back as a string (int8 exceeds JS safe-integer range, so
+// node-postgres declines to narrow it). Parse explicitly; a missing or unparseable
+// value becomes 0 rather than NaN, which would silently poison every derived total.
+function toCount(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export async function runLinkageReport(pool: PoolLike): Promise<LinkageReport> {
+  // 1. Totals and nodeless counts per contact kind.
+  const kindResult = await pool.query(
+    `SELECT kind,
+            count(*)                                    AS total,
+            count(*) FILTER (WHERE kg_node_id IS NULL)  AS nodeless
+     FROM contacts
+     GROUP BY kind
+     ORDER BY kind`,
+  );
+
+  const byKind: KindBreakdown[] = (kindResult.rows as Array<Record<string, unknown>>).map(row => ({
+    kind: String(row['kind']),
+    total: toCount(row['total']),
+    nodeless: toCount(row['nodeless']),
+  }));
+
+  const totalContacts = byKind.reduce((sum, k) => sum + k.total, 0);
+  const totalNodeless = byKind.reduce((sum, k) => sum + k.nodeless, 0);
+
+  // 2. Arm A — nodeless org contacts whose email domain matches an existing org node.
+  //    Mirrors resolveOrCreateOrgNode's domain lookup: that is the node the original
+  //    collision denied them, and the node 085 re-links them to.
+  const orgResult = await pool.query(
+    `SELECT count(*) AS eligible
+     FROM contacts c
+     WHERE c.kg_node_id IS NULL
+       AND c.kind = 'organization'
+       AND c.primary_email IS NOT NULL
+       AND EXISTS (
+         SELECT 1
+         FROM kg_nodes n
+         WHERE n.type = 'organization'
+           AND n.archived_at IS NULL
+           AND lower(n.properties->>'domain') = lower(split_part(c.primary_email, '@', 2))
+       )`,
+  );
+  const orgArmEligible = toCount((orgResult.rows[0] as Record<string, unknown> | undefined)?.['eligible']);
+
+  // 3. Nodeless contacts shadowed by a same-display-name contact that does hold a node.
+  const shadowResult = await pool.query(
+    `SELECT count(*) AS shadowed
+     FROM contacts c
+     WHERE c.kg_node_id IS NULL
+       AND EXISTS (
+         SELECT 1
+         FROM contacts o
+         WHERE o.id <> c.id
+           AND lower(o.display_name) = lower(c.display_name)
+           AND o.kg_node_id IS NOT NULL
+       )`,
+  );
+  const sameNameShadowed = toCount((shadowResult.rows[0] as Record<string, unknown> | undefined)?.['shadowed']);
+
+  // Arm B is the remainder by construction: every nodeless contact that arm A cannot
+  // re-link needs a node minted. Deriving it rather than querying it separately keeps
+  // the two arms guaranteed to sum to the total.
+  const personArmMints = Math.max(0, totalNodeless - orgArmEligible);
+
+  return {
+    totalContacts,
+    totalNodeless,
+    byKind,
+    orgArmEligible,
+    personArmMints,
+    sameNameShadowed,
+  };
+}
+
+/** Render the report as a short human-readable block for terminal / docker logs. */
+export function formatReport(report: LinkageReport): string {
+  const lines = [
+    'KG node linkage report (#1694 / ADR-040)',
+    '',
+    `  contacts total          ${report.totalContacts}`,
+    `  contacts with no node   ${report.totalNodeless}`,
+    '',
+    '  by kind:',
+    ...report.byKind.map(k => `    ${k.kind.padEnd(14)} ${String(k.nodeless).padStart(5)} nodeless / ${k.total} total`),
+    '',
+    '  migration 085 sizing:',
+    `    arm A (org re-link)   ${report.orgArmEligible}`,
+    `    arm B (mint a node)   ${report.personArmMints}`,
+    '',
+    `  of which shadowed by a same-name contact that has a node: ${report.sameNameShadowed}`,
+  ];
+  return lines.join('\n');
+}
+
+// CLI entry point — only runs when executed directly (not when imported by tests)
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const databaseUrl = process.env['DATABASE_URL'];
+  if (!databaseUrl) {
+    logger.error('kg-node-linkage-report: DATABASE_URL is not set');
+    process.exit(1);
+  }
+  const main = async (): Promise<void> => {
+    const pool = new Pool({ connectionString: databaseUrl });
+    let exitCode = 0;
+    try {
+      const report = await runLinkageReport(pool);
+      // Printed rather than logged: this is the artifact a human reads off the
+      // terminal, and pino's JSON would bury it. The structured line follows so the
+      // same run is greppable when it is captured in container logs.
+      process.stdout.write(`${formatReport(report)}\n`);
+      logger.info(report, 'kg-node-linkage-report: done');
+    } catch (err) {
+      logger.error({ err }, 'kg-node-linkage-report: fatal error');
+      exitCode = 1;
+    } finally {
+      await pool.end();
+    }
+    process.exit(exitCode);
+  };
+  await main();
+}

--- a/scripts/kg-node-linkage-report.ts
+++ b/scripts/kg-node-linkage-report.ts
@@ -8,10 +8,10 @@
 // count, and it exists to size migration 085 before that migration is written:
 // ADR-040's backfill has two arms, and the work in each is very different.
 //
-//   Arm A (org)    — a nodeless contact with kind='organization' whose primary_email
-//                    domain matches an existing organization node's properties->>'domain'.
-//                    These get re-linked to that node, which is only legal once the
-//                    relaxed idx_contacts_kg_node_unique lands. No new nodes.
+//   Arm A (org)    — a nodeless contact with kind='organization' for which an existing
+//                    organization node is already findable. These get re-linked to that
+//                    node, which is only legal once the relaxed idx_contacts_kg_node_unique
+//                    lands. No new nodes.
 //   Arm B (person) — everything else. Each gets a freshly minted anchored node, so
 //                    this count is exactly how many rows migration 085 inserts.
 //
@@ -20,11 +20,14 @@
 // signature from #1623 — the collision that produced the NULL in the first place.
 //
 // Run locally:  pnpm run report:kg-linkage
-// Run on prod:  docker exec curia-curia-1 node --experimental-strip-types \
-//                 scripts/kg-node-linkage-report.ts
-//               (forward DATABASE_URL from the deploy .env)
+// Run on prod:  export the deploy .env's DATABASE_URL, then forward it into the
+//               container, which runs .ts through tsx (not node's type stripping —
+//               see the Dockerfile's note on dynamic .ts handler imports):
 //
-// Safety: every statement is a SELECT. This script writes nothing.
+//                 ssh <host> 'docker exec -e DATABASE_URL="$DATABASE_URL" \
+//                   curia-curia-1 ./node_modules/.bin/tsx scripts/kg-node-linkage-report.ts'
+//
+// Safety: one statement, and it is a SELECT. This script writes nothing.
 
 import pg from 'pg';
 import pino from 'pino';
@@ -45,7 +48,7 @@ export interface LinkageReport {
   totalContacts: number;
   totalNodeless: number;
   byKind: KindBreakdown[];
-  /** Arm A: nodeless org contacts re-linkable to an existing org node by email domain. */
+  /** Arm A: nodeless org contacts re-linkable to an organization node that already exists. */
   orgArmEligible: number;
   /** Arm B: nodeless contacts needing a freshly minted node — the insert count for 085. */
   personArmMints: number;
@@ -53,72 +56,103 @@ export interface LinkageReport {
   sameNameShadowed: number;
 }
 
+// Everything is counted in ONE statement so every number comes from a single MVCC
+// snapshot. Split across separate queries, contact ingestion running concurrently
+// could produce a report whose arms do not sum to its own total — and this report's
+// only job is to be an accurate number.
+//
+// The arm-A predicate mirrors ContactService.resolveOrCreateOrgNode's resolution
+// order rather than guessing at it, because arm A is defined as "the node the
+// original collision denied this contact". That resolver tries, in order:
+//   1. findEntities(domain)   → label or alias matches the email domain
+//   2. findEntities(name)     → label or alias matches the display name
+//   3. createEntity(...)      → mints a node carrying properties.domain
+// Matching only properties->>'domain' would miss every org node created by any other
+// path — notably EntityMemory.resolveOrCreate, used by memory-store and extract-facts,
+// which creates nodes with empty properties. Each such miss silently moves a contact
+// from arm A to arm B and inflates the migration's insert count.
+const REPORT_SQL = `
+  SELECT
+    c.kind,
+    count(*)                                     AS total,
+    count(*) FILTER (WHERE c.kg_node_id IS NULL) AS nodeless,
+    count(*) FILTER (
+      WHERE c.kg_node_id IS NULL
+        AND c.kind = 'organization'
+        AND c.primary_email IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM kg_nodes n
+          WHERE n.type = 'organization'
+            AND n.archived_at IS NULL
+            AND (
+              lower(n.label) = lower(split_part(c.primary_email, '@', 2))
+              OR n.aliases @> ARRAY[lower(split_part(c.primary_email, '@', 2))]
+              OR lower(n.label) = lower(c.display_name)
+              OR n.aliases @> ARRAY[lower(c.display_name)]
+              OR lower(n.properties->>'domain') = lower(split_part(c.primary_email, '@', 2))
+            )
+        )
+    ) AS org_arm,
+    count(*) FILTER (
+      WHERE c.kg_node_id IS NULL
+        AND EXISTS (
+          SELECT 1
+          FROM contacts o
+          WHERE o.id <> c.id
+            AND lower(o.display_name) = lower(c.display_name)
+            AND o.kg_node_id IS NOT NULL
+        )
+    ) AS shadowed
+  FROM contacts c
+  GROUP BY c.kind
+  ORDER BY c.kind
+`;
+
 // Postgres count(*) comes back as a string (int8 exceeds JS safe-integer range, so
-// node-postgres declines to narrow it). Parse explicitly; a missing or unparseable
-// value becomes 0 rather than NaN, which would silently poison every derived total.
-function toCount(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
+// node-postgres declines to narrow it). Throw rather than defaulting: an aggregate
+// column that is absent or unparseable means the query and this code have drifted
+// apart, and coercing that to 0 would report "no work to do" — indistinguishable
+// from a genuinely clean database, and precisely the silent failure that would size
+// migration 085 at zero and leave the whole nodeless population context-free.
+function requireCount(row: Record<string, unknown>, column: string): number {
+  const raw = row[column];
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    throw new Error(
+      `kg-node-linkage-report: aggregate column "${column}" was ${JSON.stringify(raw)}, not a number — `
+      + 'the query and the reader have drifted apart; refusing to report a fabricated count',
+    );
+  }
+  return n;
 }
 
 export async function runLinkageReport(pool: PoolLike): Promise<LinkageReport> {
-  // 1. Totals and nodeless counts per contact kind.
-  const kindResult = await pool.query(
-    `SELECT kind,
-            count(*)                                    AS total,
-            count(*) FILTER (WHERE kg_node_id IS NULL)  AS nodeless
-     FROM contacts
-     GROUP BY kind
-     ORDER BY kind`,
-  );
+  const result = await pool.query(REPORT_SQL);
+  const rows = result.rows as Array<Record<string, unknown>>;
 
-  const byKind: KindBreakdown[] = (kindResult.rows as Array<Record<string, unknown>>).map(row => ({
+  const byKind: KindBreakdown[] = rows.map(row => ({
     kind: String(row['kind']),
-    total: toCount(row['total']),
-    nodeless: toCount(row['nodeless']),
+    total: requireCount(row, 'total'),
+    nodeless: requireCount(row, 'nodeless'),
   }));
 
   const totalContacts = byKind.reduce((sum, k) => sum + k.total, 0);
   const totalNodeless = byKind.reduce((sum, k) => sum + k.nodeless, 0);
+  const orgArmEligible = rows.reduce((sum, row) => sum + requireCount(row, 'org_arm'), 0);
+  const sameNameShadowed = rows.reduce((sum, row) => sum + requireCount(row, 'shadowed'), 0);
 
-  // 2. Arm A — nodeless org contacts whose email domain matches an existing org node.
-  //    Mirrors resolveOrCreateOrgNode's domain lookup: that is the node the original
-  //    collision denied them, and the node 085 re-links them to.
-  const orgResult = await pool.query(
-    `SELECT count(*) AS eligible
-     FROM contacts c
-     WHERE c.kg_node_id IS NULL
-       AND c.kind = 'organization'
-       AND c.primary_email IS NOT NULL
-       AND EXISTS (
-         SELECT 1
-         FROM kg_nodes n
-         WHERE n.type = 'organization'
-           AND n.archived_at IS NULL
-           AND lower(n.properties->>'domain') = lower(split_part(c.primary_email, '@', 2))
-       )`,
-  );
-  const orgArmEligible = toCount((orgResult.rows[0] as Record<string, unknown> | undefined)?.['eligible']);
-
-  // 3. Nodeless contacts shadowed by a same-display-name contact that does hold a node.
-  const shadowResult = await pool.query(
-    `SELECT count(*) AS shadowed
-     FROM contacts c
-     WHERE c.kg_node_id IS NULL
-       AND EXISTS (
-         SELECT 1
-         FROM contacts o
-         WHERE o.id <> c.id
-           AND lower(o.display_name) = lower(c.display_name)
-           AND o.kg_node_id IS NOT NULL
-       )`,
-  );
-  const sameNameShadowed = toCount((shadowResult.rows[0] as Record<string, unknown> | undefined)?.['shadowed']);
-
-  // Arm B is the remainder by construction: every nodeless contact that arm A cannot
-  // re-link needs a node minted. Deriving it rather than querying it separately keeps
-  // the two arms guaranteed to sum to the total.
-  const personArmMints = Math.max(0, totalNodeless - orgArmEligible);
+  // Arm B is the remainder by construction: every nodeless contact arm A cannot
+  // re-link needs a node minted. Because all four counts come from one statement,
+  // arm A can never exceed the total — if it somehow does, the query is wrong and
+  // clamping would hide that behind a plausible-looking number.
+  if (orgArmEligible > totalNodeless) {
+    throw new Error(
+      `kg-node-linkage-report: arm A (${orgArmEligible}) exceeds the nodeless total (${totalNodeless}) — `
+      + 'the report is internally inconsistent and must not be used to size a migration',
+    );
+  }
+  const personArmMints = totalNodeless - orgArmEligible;
 
   return {
     totalContacts,
@@ -152,28 +186,31 @@ export function formatReport(report: LinkageReport): string {
 
 // CLI entry point — only runs when executed directly (not when imported by tests)
 if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
-  const databaseUrl = process.env['DATABASE_URL'];
-  if (!databaseUrl) {
-    logger.error('kg-node-linkage-report: DATABASE_URL is not set');
-    process.exit(1);
-  }
   const main = async (): Promise<void> => {
+    const databaseUrl = process.env['DATABASE_URL'];
+    if (!databaseUrl) {
+      logger.error('kg-node-linkage-report: DATABASE_URL is not set');
+      process.exitCode = 1;
+      return;
+    }
     const pool = new Pool({ connectionString: databaseUrl });
-    let exitCode = 0;
     try {
       const report = await runLinkageReport(pool);
-      // Printed rather than logged: this is the artifact a human reads off the
+      // Written rather than logged: this is the artifact a human reads off the
       // terminal, and pino's JSON would bury it. The structured line follows so the
       // same run is greppable when it is captured in container logs.
       process.stdout.write(`${formatReport(report)}\n`);
       logger.info(report, 'kg-node-linkage-report: done');
     } catch (err) {
       logger.error({ err }, 'kg-node-linkage-report: fatal error');
-      exitCode = 1;
+      process.exitCode = 1;
     } finally {
       await pool.end();
     }
-    process.exit(exitCode);
+    // Deliberately no process.exit(): stdout is asynchronous when piped (which the
+    // documented `docker exec ... | tee` invocation is), and exiting here would
+    // discard buffered output mid-report. Setting exitCode and returning lets the
+    // event loop drain the write first.
   };
   await main();
 }

--- a/scripts/kg-node-linkage-report.ts
+++ b/scripts/kg-node-linkage-report.ts
@@ -62,15 +62,20 @@ export interface LinkageReport {
 // only job is to be an accurate number.
 //
 // The arm-A predicate mirrors ContactService.resolveOrCreateOrgNode's resolution
-// order rather than guessing at it, because arm A is defined as "the node the
-// original collision denied this contact". That resolver tries, in order:
+// order rather than guessing at it, since arm A asks the same question that resolver
+// does: is there already an organization node for this contact? It tries, in order:
 //   1. findEntities(domain)   → label or alias matches the email domain
 //   2. findEntities(name)     → label or alias matches the display name
 //   3. createEntity(...)      → mints a node carrying properties.domain
 // Matching only properties->>'domain' would miss every org node created by any other
 // path — notably EntityMemory.resolveOrCreate, used by memory-store and extract-facts,
-// which creates nodes with empty properties. Each such miss silently moves a contact
-// from arm A to arm B and inflates the migration's insert count.
+// which creates nodes with empty properties.
+//
+// Every miss here is expensive in one direction only: it moves a contact from arm A
+// to arm B, and arm B mints. So a false negative makes migration 085 create a second
+// node for an organization that already has one — the label-keyed fragmentation
+// ADR-040 is trying to avoid. That asymmetry is why the predicate is deliberately
+// generous rather than exactly reproducing the historical collision path.
 const REPORT_SQL = `
   SELECT
     c.kind,
@@ -79,18 +84,29 @@ const REPORT_SQL = `
     count(*) FILTER (
       WHERE c.kg_node_id IS NULL
         AND c.kind = 'organization'
-        AND c.primary_email IS NOT NULL
         AND EXISTS (
           SELECT 1
           FROM kg_nodes n
           WHERE n.type = 'organization'
             AND n.archived_at IS NULL
             AND (
-              lower(n.label) = lower(split_part(c.primary_email, '@', 2))
-              OR n.aliases @> ARRAY[lower(split_part(c.primary_email, '@', 2))]
-              OR lower(n.label) = lower(c.display_name)
+              -- Name-based resolution needs no email. An org contact can be created
+              -- with kind='organization' and no address at all (POST /api/kg/contacts
+              -- takes kind directly), and migration 056 set the kind from the linked
+              -- node's type. Gating the whole predicate on primary_email would push
+              -- those into arm B and have 085 mint a second node for an organization
+              -- that already has one.
+              lower(n.label) = lower(c.display_name)
               OR n.aliases @> ARRAY[lower(c.display_name)]
-              OR lower(n.properties->>'domain') = lower(split_part(c.primary_email, '@', 2))
+              -- Domain-based resolution obviously does need one.
+              OR (
+                c.primary_email IS NOT NULL
+                AND (
+                  lower(n.label) = lower(split_part(c.primary_email, '@', 2))
+                  OR n.aliases @> ARRAY[lower(split_part(c.primary_email, '@', 2))]
+                  OR lower(n.properties->>'domain') = lower(split_part(c.primary_email, '@', 2))
+                )
+              )
             )
         )
     ) AS org_arm,
@@ -131,11 +147,21 @@ export async function runLinkageReport(pool: PoolLike): Promise<LinkageReport> {
   const result = await pool.query(REPORT_SQL);
   const rows = result.rows as Array<Record<string, unknown>>;
 
-  const byKind: KindBreakdown[] = rows.map(row => ({
-    kind: String(row['kind']),
-    total: requireCount(row, 'total'),
-    nodeless: requireCount(row, 'nodeless'),
-  }));
+  const byKind: KindBreakdown[] = rows.map(row => {
+    // Same reasoning as requireCount: a missing `kind` would render as the literal
+    // string "undefined" in the report, which reads like a real contact kind.
+    const kind = row['kind'];
+    if (typeof kind !== 'string' || kind === '') {
+      throw new Error(
+        `kg-node-linkage-report: grouping column "kind" was ${JSON.stringify(kind)}, not a non-empty string`,
+      );
+    }
+    return {
+      kind,
+      total: requireCount(row, 'total'),
+      nodeless: requireCount(row, 'nodeless'),
+    };
+  });
 
   const totalContacts = byKind.reduce((sum, k) => sum + k.total, 0);
   const totalNodeless = byKind.reduce((sum, k) => sum + k.nodeless, 0);
@@ -205,7 +231,16 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       logger.error({ err }, 'kg-node-linkage-report: fatal error');
       process.exitCode = 1;
     } finally {
-      await pool.end();
+      // pool.end() can reject (e.g. a client erroring during shutdown). Left
+      // unguarded it would reject main() itself — an unhandled rejection at the
+      // top-level await, after the report has already been printed. Surface it and
+      // fail the exit code instead of losing a successful run to a teardown error.
+      try {
+        await pool.end();
+      } catch (endErr) {
+        logger.error({ err: endErr }, 'kg-node-linkage-report: failed to close the pool');
+        process.exitCode = 1;
+      }
     }
     // Deliberately no process.exit(): stdout is asynchronous when piped (which the
     // documented `docker exec ... | tee` invocation is), and exiting here would

--- a/skills/entity-context/handler.ts
+++ b/skills/entity-context/handler.ts
@@ -17,14 +17,18 @@ import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/type
 // Shown to the LLM for every contact that resolved but holds no KG node.
 //
 // The wording is load-bearing. An empty result reads as "nothing is known about this
-// person", which invites the agent to fill the gap by asking or by storing what it
+// contact", which invites the agent to fill the gap by asking or by storing what it
 // learns — neither of which can work, because there is no node for a fact to attach
-// to. It has to read as a capability gap instead. Deliberately free of issue numbers
-// and internal schema terms: this string goes into a prompt, not a log.
+// to. It has to read as a capability gap instead.
+//
+// Kept free of issue numbers and internal schema vocabulary: this goes into a prompt
+// and may be paraphrased to the principal, so "stored profile" rather than "KG node".
+// Kept kind-neutral too — nodeless contacts include organizations, not just people
+// (ADR-040's arm A exists precisely because org contacts are a large share of them).
 const NODELESS_REASON =
-  'This contact exists but has no knowledge-graph entity, so it cannot hold facts, '
-  + 'relationships, or background context. Absence of context here does not mean the '
-  + 'person is unknown. Do not try to store facts about them; report the gap instead.';
+  'This contact exists but has no stored profile, so it cannot hold facts, '
+  + 'relationships, or background context. Having no context here does not mean the '
+  + 'contact is unknown to us. Do not try to store facts about them; report the gap instead.';
 
 export class EntityContextHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
@@ -69,22 +73,33 @@ export class EntityContextHandler implements ToolHandler {
         'entity-context: assembled context',
       );
 
+      // Key order is deliberate. The execution layer enforces an aggregate size cap by
+      // JSON.stringify-ing this object and head-slicing it (see skillOutputMaxLength),
+      // and JSON.stringify preserves insertion order. Emitting the small diagnostic
+      // buckets first means a truncated payload sacrifices bulk entity data rather
+      // than the warning that some contacts cannot hold knowledge at all — which,
+      // being absent from `unresolved` too, would otherwise vanish without trace.
       return {
         success: true,
         data: {
-          entities: result.entities,
-          unresolved: result.unresolved,
           // Only present when non-empty: on the common path every contact has a
           // node, and an always-there empty array is pure prompt noise.
           ...(result.nodeless.length > 0
             ? {
                 nodeless: result.nodeless.map(n => ({
+                  // inputId is echoed back so the agent can map the answer to what it
+                  // asked for. It matters most for email inputs, where contactId is a
+                  // UUID the caller has never seen and displayName may not resemble
+                  // the address.
+                  inputId: n.inputId,
                   contactId: n.contactId,
                   displayName: n.displayName,
                   reason: NODELESS_REASON,
                 })),
               }
             : {}),
+          unresolved: result.unresolved,
+          entities: result.entities,
         },
       };
     } catch (err) {

--- a/skills/entity-context/handler.ts
+++ b/skills/entity-context/handler.ts
@@ -7,8 +7,24 @@
 // For automatic pre-enrichment before skill invocation, use the
 // entity_enrichment manifest declaration instead — that runs the same
 // assembler without an extra LLM round-trip.
+//
+// Three buckets come back and all three are surfaced: entities that assembled,
+// `unresolved` IDs that matched nothing, and `nodeless` contacts that exist but
+// cannot hold knowledge (#1694 / ADR-040).
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
+
+// Shown to the LLM for every contact that resolved but holds no KG node.
+//
+// The wording is load-bearing. An empty result reads as "nothing is known about this
+// person", which invites the agent to fill the gap by asking or by storing what it
+// learns — neither of which can work, because there is no node for a fact to attach
+// to. It has to read as a capability gap instead. Deliberately free of issue numbers
+// and internal schema terms: this string goes into a prompt, not a log.
+const NODELESS_REASON =
+  'This contact exists but has no knowledge-graph entity, so it cannot hold facts, '
+  + 'relationships, or background context. Absence of context here does not mean the '
+  + 'person is unknown. Do not try to store facts about them; report the gap instead.';
 
 export class EntityContextHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
@@ -45,7 +61,11 @@ export class EntityContextHandler implements ToolHandler {
       });
 
       ctx.log.info(
-        { resolvedCount: result.entities.length, unresolvedCount: result.unresolved.length },
+        {
+          resolvedCount: result.entities.length,
+          unresolvedCount: result.unresolved.length,
+          nodelessCount: result.nodeless.length,
+        },
         'entity-context: assembled context',
       );
 
@@ -54,6 +74,17 @@ export class EntityContextHandler implements ToolHandler {
         data: {
           entities: result.entities,
           unresolved: result.unresolved,
+          // Only present when non-empty: on the common path every contact has a
+          // node, and an always-there empty array is pure prompt noise.
+          ...(result.nodeless.length > 0
+            ? {
+                nodeless: result.nodeless.map(n => ({
+                  contactId: n.contactId,
+                  displayName: n.displayName,
+                  reason: NODELESS_REASON,
+                })),
+              }
+            : {}),
         },
       };
     } catch (err) {

--- a/skills/entity-context/tool.json
+++ b/skills/entity-context/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "entity-context",
   "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers).",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -11,7 +11,8 @@
   },
   "outputs": {
     "entities": "EntityContext[] (assembled context payloads for each resolved entity)",
-    "unresolved": "string[] (IDs that could not be found in the KG or contacts table)"
+    "unresolved": "string[] (IDs that could not be found in the KG or contacts table)",
+    "nodeless": "{contactId, displayName, reason}[]? (present only when non-empty — contacts that exist but have no knowledge-graph entity, so they can hold no facts or context; an empty result for these is a capability gap, not evidence the person is unknown)"
   },
   "permissions": [],
   "secrets": [],

--- a/skills/entity-context/tool.json
+++ b/skills/entity-context/tool.json
@@ -1,6 +1,6 @@
 {
   "name": "entity-context",
-  "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers).",
+  "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers). Some contacts have no stored profile and can hold no facts at all; those come back under `nodeless` with a reason, and an empty result for them is a capability gap, not evidence the contact is unknown.",
   "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "none",
@@ -12,7 +12,7 @@
   "outputs": {
     "entities": "EntityContext[] (assembled context payloads for each resolved entity)",
     "unresolved": "string[] (IDs that could not be found in the KG or contacts table)",
-    "nodeless": "{contactId, displayName, reason}[]? (present only when non-empty — contacts that exist but have no knowledge-graph entity, so they can hold no facts or context; an empty result for these is a capability gap, not evidence the person is unknown)"
+    "nodeless": "{inputId, contactId, displayName, reason}[]? (present only when non-empty — contacts that exist but have no stored profile, so they can hold no facts or context; inputId echoes the ID or email you passed in)"
   },
   "permissions": [],
   "secrets": [],

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -20,6 +20,15 @@
 // assembleMany() wraps each per-ID call in its own try/catch so that a DB error
 // on one entity doesn't abort the entire batch — failed IDs are logged and placed
 // in the `unresolved` array rather than propagating.
+//
+// Misses are reported in two separate buckets, because they mean different things
+// (#1694 / ADR-040):
+//   unresolved — the ID matched no contact and no KG node, or assembly errored.
+//   nodeless   — the ID matched a real contact that holds no KG node. The contact
+//                exists but is structurally unable to carry facts, relationships,
+//                or context, and no amount of retrying will change that. Collapsing
+//                it into `unresolved` made an agent read "cannot hold knowledge" as
+//                "we know nothing about them", which is the silence #1694 is about.
 
 import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
@@ -34,6 +43,34 @@ interface CacheEntry {
   context: EntityContext;
   expiresAt: number;
 }
+
+/** A contact that exists but holds no KG node, so it can carry no context. */
+export interface NodelessContact {
+  /** The string the caller passed in (contact UUID or email), so it can correlate results. */
+  inputId: string;
+  contactId: string;
+  displayName: string;
+}
+
+export interface AssembleManyResult {
+  entities: EntityContext[];
+  /** IDs that matched nothing, or whose assembly threw. */
+  unresolved: string[];
+  /** Contacts that exist but cannot hold knowledge. Disjoint from `unresolved`. */
+  nodeless: NodelessContact[];
+}
+
+/** Outcome of resolving a caller-supplied ID to something assemblable. */
+type ResolvedInput =
+  | { kind: 'node'; kgNodeId: string }
+  | { kind: 'nodeless'; contactId: string; displayName: string }
+  | { kind: 'unknown' };
+
+/** Outcome of a single assembly attempt, with the reason for a miss preserved. */
+type AssembleOutcome =
+  | { kind: 'assembled'; context: EntityContext }
+  | { kind: 'nodeless'; entry: NodelessContact }
+  | { kind: 'unknown' };
 
 /**
  * Assembles EntityContext payloads from the database.
@@ -66,10 +103,11 @@ export class EntityContextAssembler {
   async assembleMany(
     ids: string[],
     options: { includeRelationships?: boolean } = {},
-  ): Promise<{ entities: EntityContext[]; unresolved: string[] }> {
+  ): Promise<AssembleManyResult> {
     const includeRelationships = options.includeRelationships ?? true;
     const entities: EntityContext[] = [];
     const unresolved: string[] = [];
+    const nodeless: NodelessContact[] = [];
 
     for (const id of ids) {
       // Cache stores full payloads (with relationships) only. Skipping the cache for
@@ -82,12 +120,21 @@ export class EntityContextAssembler {
       }
 
       try {
-        const ctx = await this.assembleOne(id, includeRelationships);
-        if (ctx) {
+        const outcome = await this.assembleOneClassified(id, includeRelationships);
+        if (outcome.kind === 'assembled') {
           if (includeRelationships) {
-            this.putInCache(id, ctx);
+            this.putInCache(id, outcome.context);
           }
-          entities.push(ctx);
+          entities.push(outcome.context);
+        } else if (outcome.kind === 'nodeless') {
+          // Deliberately not cached: a backfill or a contact merge can give this
+          // contact a node at any time, and a cached verdict would keep it
+          // context-free for the rest of the TTL.
+          this.logger.debug(
+            { contactId: outcome.entry.contactId },
+            'entity-context: contact resolved but holds no KG node — cannot carry facts, relationships, or context',
+          );
+          nodeless.push(outcome.entry);
         } else {
           this.logger.debug({ entityId: id }, 'entity-context: ID could not be resolved to a KG node');
           unresolved.push(id);
@@ -100,7 +147,7 @@ export class EntityContextAssembler {
       }
     }
 
-    return { entities, unresolved };
+    return { entities, unresolved, nodeless };
   }
 
   /**
@@ -108,15 +155,38 @@ export class EntityContextAssembler {
    * Throws on DB errors — callers should wrap in try/catch or use assembleMany().
    */
   async assembleOne(id: string, includeRelationships = true): Promise<EntityContext | undefined> {
+    const result = await this.assembleOneClassified(id, includeRelationships);
+    return result.kind === 'assembled' ? result.context : undefined;
+  }
+
+  /**
+   * assembleOne with the reason for a miss preserved.
+   *
+   * `assembleOne` collapses every miss to `undefined`, which loses the distinction
+   * between "no such entity" and "this contact exists but cannot hold knowledge".
+   * assembleMany needs that distinction to fill its `nodeless` bucket, and gets it
+   * here without issuing a second query or changing the public signature (#1694).
+   */
+  private async assembleOneClassified(
+    id: string,
+    includeRelationships = true,
+  ): Promise<AssembleOutcome> {
     try {
       // Step 1: Resolve the input ID to a KG node.
       // Try contact ID first, then fall back to direct KG node ID.
-      const kgNodeId = await this.resolveKgNodeId(id);
-      if (!kgNodeId) return undefined;
+      const resolved = await this.resolveInput(id);
+      if (resolved.kind === 'unknown') return { kind: 'unknown' };
+      if (resolved.kind === 'nodeless') {
+        return {
+          kind: 'nodeless',
+          entry: { inputId: id, contactId: resolved.contactId, displayName: resolved.displayName },
+        };
+      }
+      const kgNodeId = resolved.kgNodeId;
 
       // Step 2: Load the KG node
       const nodeRow = await this.getKgNode(kgNodeId);
-      if (!nodeRow) return undefined;
+      if (!nodeRow) return { kind: 'unknown' };
 
       // Steps 3-6: Run assembly pipeline in parallel where safe.
       // Contact lookup + connected accounts depend on each other (need contactId),
@@ -181,7 +251,7 @@ export class EntityContextAssembler {
         relationships,
       };
 
-      return ctx;
+      return { kind: 'assembled', context: ctx };
     } catch (err) {
       // Re-throw with the entity ID stamped in the error for upstream diagnostic logs.
       // assembleMany() catches this and logs `{ err, entityId: id }`.
@@ -298,15 +368,15 @@ export class EntityContextAssembler {
    * LLMs pass raw email addresses from CC preambles or inbox triage rather than
    * resolving to a contact UUID first.
    */
-  private async resolveKgNodeId(id: string): Promise<string | undefined> {
+  private async resolveInput(id: string): Promise<ResolvedInput> {
     try {
       // Email address detection: if the input looks like an email address (local-part @
       // domain with at least one dot), resolve via contact_channel_identities instead of
       // UUID columns. This handles CC flows and ceo-inbox triage where the LLM passes a
       // raw email rather than a contact UUID.
       if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(id)) {
-        const emailResult = await this.pool.query<{ contact_id: string; kg_node_id: string | null }>(
-          `SELECT c.id AS contact_id, c.kg_node_id
+        const emailResult = await this.pool.query<{ contact_id: string; kg_node_id: string | null; display_name: string }>(
+          `SELECT c.id AS contact_id, c.kg_node_id, c.display_name
            FROM contact_channel_identities cci
            JOIN contacts c ON c.id = cci.contact_id
            WHERE cci.channel = 'email' AND LOWER(cci.channel_identifier) = LOWER($1)`,
@@ -318,29 +388,30 @@ export class EntityContextAssembler {
           if (!kgNodeId) {
             // Use inputKind rather than the raw email — 'email' is on the pino redact list.
             this.logger.debug({ inputKind: 'email', contactId: row?.contact_id }, 'entity-context: email resolved to contact with no linked KG node');
-            return undefined;
+            return { kind: 'nodeless', contactId: row!.contact_id, displayName: row!.display_name };
           }
-          return kgNodeId;
+          return { kind: 'node', kgNodeId };
         }
         // Email not found in contact_channel_identities — unregistered contact
         this.logger.debug({ inputKind: 'email' }, 'entity-context: email not found in contact_channel_identities — treating as unresolved');
-        return undefined;
+        return { kind: 'unknown' };
       }
 
       // Try as a contact ID first
-      const contactResult = await this.pool.query<{ kg_node_id: string | null }>(
-        'SELECT kg_node_id FROM contacts WHERE id = $1',
+      const contactResult = await this.pool.query<{ kg_node_id: string | null; display_name: string }>(
+        'SELECT kg_node_id, display_name FROM contacts WHERE id = $1',
         [id],
       );
       if (contactResult.rows.length > 0) {
         const row = contactResult.rows[0];
         const kgNodeId = row?.kg_node_id;
-        // Contact found but has no linked KG node — return undefined (unresolved)
+        // Contact exists but holds no KG node — a different answer from "no such
+        // contact", and the caller needs to be able to tell them apart (#1694).
         if (!kgNodeId) {
           this.logger.debug({ contactId: id }, 'entity-context: contact has no linked KG node');
-          return undefined;
+          return { kind: 'nodeless', contactId: id, displayName: row!.display_name };
         }
-        return kgNodeId;
+        return { kind: 'node', kgNodeId };
       }
 
       // Try as a KG node ID directly
@@ -349,10 +420,11 @@ export class EntityContextAssembler {
         [id],
       );
       if (nodeResult.rows.length > 0) {
-        return nodeResult.rows[0]?.id;
+        const nodeId = nodeResult.rows[0]?.id;
+        if (nodeId) return { kind: 'node', kgNodeId: nodeId };
       }
 
-      return undefined;
+      return { kind: 'unknown' };
     } catch (err) {
       // PostgreSQL error 22P02 = invalid_text_representation: the ID is not a valid UUID.
       // This happens when the LLM passes a hallucinated or synthetic string (e.g.
@@ -367,8 +439,8 @@ export class EntityContextAssembler {
         // Warn rather than debug: after the contact-resolver fix ships, this path should be
         // unreachable in production. If it fires, something upstream is still leaking a
         // synthetic/hallucinated ID and operators need a searchable signal to trace it.
-        this.logger.warn({ id }, 'entity-context: non-UUID id passed to resolveKgNodeId — treating as unresolved');
-        return undefined;
+        this.logger.warn({ id }, 'entity-context: non-UUID id passed to resolveInput — treating as unresolved');
+        return { kind: 'unknown' };
       }
       throw err;
     }

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -130,9 +130,15 @@ export class EntityContextAssembler {
           // Deliberately not cached: a backfill or a contact merge can give this
           // contact a node at any time, and a cached verdict would keep it
           // context-free for the rest of the TTL.
-          this.logger.debug(
+          //
+          // warn, not debug: prod runs at LOG_LEVEL=info, so a debug line here would
+          // never fire and this whole diagnostic would be invisible in the one place
+          // it matters. Same reasoning already applied to the 22P02 branch below —
+          // operators need a searchable signal. This is the standing production
+          // record that a real contact was addressed with no context available.
+          this.logger.warn(
             { contactId: outcome.entry.contactId },
-            'entity-context: contact resolved but holds no KG node — cannot carry facts, relationships, or context',
+            'entity-context: contact holds no KG node — cannot carry facts, relationships, or context',
           );
           nodeless.push(outcome.entry);
         } else {
@@ -186,7 +192,16 @@ export class EntityContextAssembler {
 
       // Step 2: Load the KG node
       const nodeRow = await this.getKgNode(kgNodeId);
-      if (!nodeRow) return { kind: 'unknown' };
+      if (!nodeRow) {
+        // contacts.kg_node_id carries an FK, so a set pointer with no target row
+        // should be unreachable. If it happens, a real contact is being reported as
+        // unknown — log loudly rather than letting it look like an ordinary miss.
+        this.logger.warn(
+          { entityId: id, kgNodeId },
+          'entity-context: kg_node_id points at a missing node — referential integrity issue',
+        );
+        return { kind: 'unknown' };
+      }
 
       // Steps 3-6: Run assembly pipeline in parallel where safe.
       // Contact lookup + connected accounts depend on each other (need contactId),

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -1607,6 +1607,17 @@ export class ExecutionLayer {
           if (enrichmentResult.unresolved.length > 0) {
             skillLogger.warn({ toolName, unresolved: enrichmentResult.unresolved }, 'entity_enrichment: some IDs could not be resolved');
           }
+          // Nodeless contacts get their own line rather than joining `unresolved`.
+          // They are a different operational signal: the contact is real and was
+          // addressed by a skill, but it holds no KG node, so it ran with no context
+          // at all and no retry will change that (#1694 / ADR-040). This log is the
+          // only passive record of that happening in production.
+          if (enrichmentResult.nodeless.length > 0) {
+            skillLogger.warn(
+              { toolName, contactIds: enrichmentResult.nodeless.map(n => n.contactId) },
+              'entity_enrichment: contacts have no KG node — skill ran without their context',
+            );
+          }
           ctx.entityContext = enrichmentResult.entities;
           skillLogger.debug({ toolName, enrichedCount: enrichmentResult.entities.length }, 'entity_enrichment: pre-enrichment complete');
         } catch (err) {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -1610,8 +1610,12 @@ export class ExecutionLayer {
           // Nodeless contacts get their own line rather than joining `unresolved`.
           // They are a different operational signal: the contact is real and was
           // addressed by a skill, but it holds no KG node, so it ran with no context
-          // at all and no retry will change that (#1694 / ADR-040). This log is the
-          // only passive record of that happening in production.
+          // at all and no retry will change that (#1694 / ADR-040).
+          //
+          // No tool.json currently declares entity_enrichment, so this branch is
+          // dormant. It is kept because the assembler's own warn covers the live
+          // paths, and any future manifest that opts into pre-enrichment should
+          // report the gap with the skill name attached rather than silently.
           if (enrichmentResult.nodeless.length > 0) {
             skillLogger.warn(
               { toolName, contactIds: enrichmentResult.nodeless.map(n => n.contactId) },

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -219,10 +219,108 @@ describe('EntityContextAssembler', () => {
       ]);
 
       const assembler = new EntityContextAssembler(pool, logger);
-      const { entities, unresolved } = await assembler.assembleMany(['ghost-id']);
+      const { entities, unresolved, nodeless } = await assembler.assembleMany(['ghost-id']);
 
       expect(entities).toHaveLength(0);
       expect(unresolved).toEqual(['ghost-id']);
+      // An ID we have never heard of is *unknown*, not nodeless — the two buckets
+      // answer different questions and must not be conflated (#1694).
+      expect(nodeless).toHaveLength(0);
+    });
+  });
+
+  // -- Nodeless contacts (#1694 / ADR-040) --
+  //
+  // A contact with kg_node_id = NULL exists but cannot hold facts, relationships,
+  // or context. Before this bucket existed it landed in `unresolved` alongside IDs
+  // that match nothing at all, so a caller could not tell "we have never heard of
+  // this person" from "this person is structurally unable to hold knowledge".
+  describe('assembleMany — nodeless contacts', () => {
+    it('reports a contact with no KG node as nodeless, not unresolved', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: null, display_name: 'Seth Berman' }] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, nodeless } = await assembler.assembleMany(['contact-2']);
+
+      expect(entities).toHaveLength(0);
+      expect(unresolved).toHaveLength(0);
+      expect(nodeless).toEqual([
+        { inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' },
+      ]);
+    });
+
+    it('reports an email that resolves to a nodeless contact as nodeless', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ contact_id: 'contact-2', kg_node_id: null, display_name: 'Seth Berman' }] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, nodeless } = await assembler.assembleMany(['seth@example.com']);
+
+      expect(entities).toHaveLength(0);
+      expect(unresolved).toHaveLength(0);
+      // inputId keeps the caller's original string so it can correlate the result
+      // back to what it asked for; contactId is what the row actually resolved to.
+      expect(nodeless).toEqual([
+        { inputId: 'seth@example.com', contactId: 'contact-2', displayName: 'Seth Berman' },
+      ]);
+    });
+
+    it('separates resolved, nodeless, and unknown IDs in one batch', async () => {
+      const pool = makeSequentialPool([
+        // 'contact-1' — resolves fully
+        { rows: [{ kg_node_id: 'node-1', display_name: 'Jenna Smith' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },                // facts
+        { rows: [contactRow] },
+        { rows: [] },                // calendars
+        { rows: [] },                // relationships
+        // 'contact-2' — exists, no KG node
+        { rows: [{ kg_node_id: null, display_name: 'Seth Berman' }] },
+        // 'ghost-id' — matches nothing
+        { rows: [] },                // not a contact
+        { rows: [] },                // not a KG node
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, nodeless } = await assembler.assembleMany([
+        'contact-1',
+        'contact-2',
+        'ghost-id',
+      ]);
+
+      expect(entities).toHaveLength(1);
+      expect(entities[0].entityId).toBe('node-1');
+      expect(unresolved).toEqual(['ghost-id']);
+      expect(nodeless.map(n => n.contactId)).toEqual(['contact-2']);
+    });
+
+    it('leaves assembleOne returning undefined for a nodeless contact', async () => {
+      // assembleOne's signature is deliberately unchanged — the classification is
+      // only surfaced through assembleMany, which is what every caller uses.
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: null, display_name: 'Seth Berman' }] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      expect(await assembler.assembleOne('contact-2')).toBeUndefined();
+    });
+
+    it('does not cache nodeless results', async () => {
+      // Caching a nodeless verdict would keep a contact context-free for the whole
+      // TTL after a backfill or merge gave it a node.
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: null, display_name: 'Seth Berman' }] },
+        { rows: [{ kg_node_id: null, display_name: 'Seth Berman' }] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      await assembler.assembleMany(['contact-2']);
+      await assembler.assembleMany(['contact-2']);
+
+      expect(vi.mocked(pool.query)).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/tests/unit/entity-context/entity-context-handler.test.ts
+++ b/tests/unit/entity-context/entity-context-handler.test.ts
@@ -111,6 +111,39 @@ describe('EntityContextHandler', () => {
     expect(reason).not.toMatch(/^no (facts|context|information)/i);
   });
 
+  it('echoes inputId back so the agent can map the answer to what it asked for', async () => {
+    // The email case is why this matters: contactId is a UUID the caller never saw,
+    // and displayName may not resemble the address it supplied.
+    const ctx = makeCtx(
+      { entityIds: ['seth@example.com'] },
+      { nodeless: [{ inputId: 'seth@example.com', contactId: 'contact-2', displayName: 'Seth Berman' }] },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const data = expectData(result) as unknown as { nodeless: Array<{ inputId: string }> };
+
+    expect(data.nodeless[0].inputId).toBe('seth@example.com');
+  });
+
+  it('emits nodeless before entities so head-slice truncation cannot drop it', async () => {
+    // The execution layer caps aggregate output by JSON.stringify + slice(0, max),
+    // and stringify preserves insertion order. If entities came first, a large batch
+    // would truncate away the one signal saying some contacts can hold no knowledge —
+    // and they are absent from `unresolved` too, so they would vanish entirely.
+    const ctx = makeCtx(
+      { contactIds: ['contact-1', 'contact-2'] },
+      {
+        entities: [makeEntity()],
+        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }],
+      },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const keys = Object.keys(expectData(result));
+
+    expect(keys.indexOf('nodeless')).toBeLessThan(keys.indexOf('entities'));
+  });
+
   it('omits the nodeless key entirely when there is nothing to report', async () => {
     // An always-present empty array is prompt noise on the overwhelmingly common
     // path where every contact has a node.

--- a/tests/unit/entity-context/entity-context-handler.test.ts
+++ b/tests/unit/entity-context/entity-context-handler.test.ts
@@ -1,0 +1,150 @@
+// tests/unit/entity-context/entity-context-handler.test.ts
+//
+// Unit tests for the entity-context skill handler.
+//
+// The handler's job is to hand assembleMany's three buckets to the LLM in a form
+// it reads correctly. The bucket that matters here is `nodeless` (#1694 / ADR-040):
+// a contact that exists but holds no KG node. Reported as plain absence, an agent
+// concludes "we know nothing about this person"; it needs to conclude "this contact
+// cannot hold knowledge at all", which is a different and actionable thing.
+
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { EntityContextHandler } from '../../../skills/entity-context/handler.js';
+import type { ToolContext, ToolResult } from '../../../src/skills/types.js';
+import type { AssembleManyResult } from '../../../src/entity-context/assembler.js';
+import type { EntityContext } from '../../../src/entity-context/types.js';
+
+const logger = pino({ level: 'silent' });
+
+function makeEntity(overrides: Partial<EntityContext> = {}): EntityContext {
+  return {
+    entityId: 'node-1',
+    entityType: 'person',
+    label: 'Jenna Smith',
+    contact: null,
+    facts: [],
+    connectedAccounts: [],
+    relationships: [],
+    ...overrides,
+  } as EntityContext;
+}
+
+function makeCtx(
+  input: Record<string, unknown>,
+  result: Partial<AssembleManyResult>,
+  caller?: { contactId?: string },
+): ToolContext {
+  const full: AssembleManyResult = {
+    entities: result.entities ?? [],
+    unresolved: result.unresolved ?? [],
+    nodeless: result.nodeless ?? [],
+  };
+  return {
+    input,
+    log: logger,
+    caller,
+    entityContextAssembler: {
+      assembleMany: vi.fn().mockResolvedValue(full),
+      assembleOne: vi.fn(),
+    },
+  } as unknown as ToolContext;
+}
+
+// ToolResult is a discriminated union. These narrow it by throwing rather than by
+// `if (!result.success)`, so a test that unexpectedly fails reports the real error
+// instead of quietly skipping its assertions.
+function expectData(result: ToolResult): Record<string, unknown> {
+  if (!result.success) throw new Error(`expected success, got error: ${result.error}`);
+  return result.data as Record<string, unknown>;
+}
+
+function expectError(result: ToolResult): string {
+  if (result.success) throw new Error('expected failure, got success');
+  return result.error;
+}
+
+describe('EntityContextHandler', () => {
+  it('returns assembled entities', async () => {
+    const ctx = makeCtx({ contactIds: ['contact-1'] }, { entities: [makeEntity()] });
+    const result = await new EntityContextHandler().execute(ctx);
+
+    const data = expectData(result) as unknown as { entities: EntityContext[] };
+    expect(data.entities).toHaveLength(1);
+    expect(data.entities[0].entityId).toBe('node-1');
+  });
+
+  it('reports a nodeless contact separately from an unresolved ID', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-2', 'ghost-id'] },
+      {
+        unresolved: ['ghost-id'],
+        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }],
+      },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+
+    const data = expectData(result) as unknown as {
+      unresolved: string[];
+      nodeless: Array<{ contactId: string; displayName: string; reason: string }>;
+    };
+    expect(data.unresolved).toEqual(['ghost-id']);
+    expect(data.nodeless).toHaveLength(1);
+    expect(data.nodeless[0].contactId).toBe('contact-2');
+    expect(data.nodeless[0].displayName).toBe('Seth Berman');
+  });
+
+  it('gives each nodeless contact a reason the LLM cannot read as plain absence', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-2'] },
+      { nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }] },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const data = expectData(result) as unknown as { nodeless: Array<{ reason: string }> };
+    const reason = data.nodeless[0].reason;
+
+    // The wording must state the capability gap, not an empty result. Asserting on
+    // the distinction rather than the exact sentence so the copy can be reworded.
+    expect(reason).toMatch(/cannot/i);
+    expect(reason).not.toMatch(/^no (facts|context|information)/i);
+  });
+
+  it('omits the nodeless key entirely when there is nothing to report', async () => {
+    // An always-present empty array is prompt noise on the overwhelmingly common
+    // path where every contact has a node.
+    const ctx = makeCtx({ contactIds: ['contact-1'] }, { entities: [makeEntity()] });
+    const result = await new EntityContextHandler().execute(ctx);
+
+    expect(expectData(result)).not.toHaveProperty('nodeless');
+  });
+
+  it('falls back to the caller contact when no IDs are supplied', async () => {
+    const ctx = makeCtx({}, { entities: [makeEntity()] }, { contactId: 'caller-contact' });
+    await new EntityContextHandler().execute(ctx);
+
+    expect(vi.mocked(ctx.entityContextAssembler!.assembleMany)).toHaveBeenCalledWith(
+      ['caller-contact'],
+      { includeRelationships: true },
+    );
+  });
+
+  it('fails cleanly when the assembler is not configured', async () => {
+    const ctx = { input: {}, log: logger } as unknown as ToolContext;
+    const result = await new EntityContextHandler().execute(ctx);
+
+    expect(expectError(result)).toMatch(/not available/i);
+  });
+
+  it('does not leak DB internals into the error string', async () => {
+    const ctx = makeCtx({ contactIds: ['contact-1'] }, {});
+    vi.mocked(ctx.entityContextAssembler!.assembleMany).mockRejectedValue(
+      new Error('relation "contacts" does not exist'),
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+
+    expect(expectError(result)).not.toMatch(/relation|contacts/);
+  });
+});

--- a/tests/unit/entity-context/execution-enrichment.test.ts
+++ b/tests/unit/entity-context/execution-enrichment.test.ts
@@ -57,9 +57,18 @@ const sampleEntityContext: EntityContext = {
   relationships: [],
 };
 
-function makeMockAssembler(result: Awaited<ReturnType<EntityContextAssembler['assembleMany']>>): EntityContextAssembler {
+type AssembleManyResult = Awaited<ReturnType<EntityContextAssembler['assembleMany']>>;
+
+// Takes a partial so each test states only the bucket it cares about; the rest
+// default to empty. Keeps tests readable as assembleMany grows buckets.
+function makeMockAssembler(result: Partial<AssembleManyResult>): EntityContextAssembler {
+  const full: AssembleManyResult = {
+    entities: result.entities ?? [],
+    unresolved: result.unresolved ?? [],
+    nodeless: result.nodeless ?? [],
+  };
   return {
-    assembleMany: vi.fn().mockResolvedValue(result),
+    assembleMany: vi.fn().mockResolvedValue(full),
     assembleOne: vi.fn(),
     clearCacheForEntity: vi.fn(),
   } as unknown as EntityContextAssembler;
@@ -251,6 +260,53 @@ describe('ExecutionLayer — entity_enrichment', () => {
     const result = await execution.invoke('test-skill', { contacts: ['ghost-id'] });
     // Skill should still succeed even if the entity wasn't found
     expect(result.success).toBe(true);
+  });
+
+  // #1694 / ADR-040 — a contact that exists but holds no KG node is a different
+  // operational signal from an ID that matches nothing, and the log has to say so:
+  // it is the only passive record that a real contact ran through a skill with no
+  // context attached.
+  it('logs nodeless contacts on their own line, not lumped into unresolved', async () => {
+    const warn = vi.fn();
+    const spyLogger = { ...logger, warn, child: () => spyLogger } as unknown as typeof logger;
+
+    const handler: ToolHandler = { execute: async () => ({ success: true, data: 'ok' }) };
+    registry.register(makeManifest({ entity_enrichment: { param: 'contacts', default: 'caller' } }), handler);
+
+    const assembler = makeMockAssembler({
+      unresolved: ['ghost-id'],
+      nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }],
+    });
+    const execution = new ExecutionLayer(registry, spyLogger, {
+      entityContextAssembler: assembler,
+    });
+
+    const result = await execution.invoke('test-skill', { contacts: ['ghost-id', 'contact-2'] });
+    expect(result.success).toBe(true);
+
+    const messages = warn.mock.calls.map(call => String(call[1]));
+    const nodelessLine = warn.mock.calls.find(call => /no KG node/i.test(String(call[1])));
+    expect(nodelessLine, `expected a nodeless warn line, got: ${messages.join(' | ')}`).toBeDefined();
+
+    // The nodeless line carries contact IDs, and does not also list the unknown ID.
+    const payload = nodelessLine![0] as { contactIds?: string[] };
+    expect(payload.contactIds).toEqual(['contact-2']);
+  });
+
+  it('does not emit a nodeless warn when every contact has a node', async () => {
+    const warn = vi.fn();
+    const spyLogger = { ...logger, warn, child: () => spyLogger } as unknown as typeof logger;
+
+    const handler: ToolHandler = { execute: async () => ({ success: true, data: 'ok' }) };
+    registry.register(makeManifest({ entity_enrichment: { param: 'contacts', default: 'caller' } }), handler);
+
+    const execution = new ExecutionLayer(registry, spyLogger, {
+      entityContextAssembler: makeMockAssembler({ entities: [sampleEntityContext] }),
+    });
+
+    await execution.invoke('test-skill', { contacts: ['contact-1'] });
+
+    expect(warn.mock.calls.filter(call => /no KG node/i.test(String(call[1])))).toHaveLength(0);
   });
 
   it('exposes agentContactId on ctx for all skills', async () => {


### PR DESCRIPTION
## Summary

Increment 1 of 3 for #1694, per ADR-040. No schema change, no migration, no change to the identity model — this makes the existing failure *visible* so the migration that follows can be written against a real number.

Refs #1694 (does not close it — increments 2 and 3 still to come).

## The problem

A contact with `kg_node_id = NULL` can hold no facts, no relationships, and no entity context. `resolveKgNodeId` already knew the difference between "this contact has no node" and "this ID matches nothing" — it logged distinct debug lines for each — but returned `undefined` for both. `assembleMany` collapsed them into one `unresolved` bucket, and the distinction died there. Downstream, an agent reads a capability gap as an absence of facts, and goes on to ask questions or try to store what it learns, neither of which can work.

## Changes

**`EntityContextAssembler`**
- `assembleMany` returns a third bucket, `nodeless: { inputId, contactId, displayName }[]`, disjoint from `unresolved`.
- Nodeless verdicts are deliberately **not cached** — a backfill or a contact merge can give the contact a node at any time, and a cached verdict would keep it context-free for the rest of the TTL.
- `assembleOne` keeps its `EntityContext | undefined` signature. The classification comes from a private variant, so there's no extra query and no churn across the ~10 existing call sites.

**`entity-context` skill** (`1.0.0` → `1.1.0`)
- Output gains `nodeless`, present only when non-empty (an always-there empty array is prompt noise on the common path).
- Each entry carries a reason worded as a capability gap, not an empty result — the string tells the agent not to try storing facts and to report the gap instead. Kept free of issue numbers and schema terms since it lands in a prompt.

**`entity_enrichment` pre-enrichment**
- Nodeless contacts get their own `warn` line instead of joining the unresolved-IDs line. This is the only passive record that a real contact ran through a skill with no context attached.

**`scripts/kg-node-linkage-report.ts`** (new, read-only)
- Counts the standing population and splits it across ADR-040's two backfill arms: arm A (org contacts re-linkable to an existing org node by email domain) and arm B (contacts needing a node minted — exactly the insert count for migration `085`). Also reports how many nodeless contacts are shadowed by a same-name contact that *does* have a node, which is the #1623 signature.
- `pnpm run report:kg-linkage`, or on prod via `docker exec`. Every statement is a `SELECT`; a test asserts that.

**ADR-040** moves `Proposed` → `Accepted`.

## Testing

- `tests/unit/entity-context/assembler.test.ts` — 5 new cases: nodeless via contact UUID, nodeless via email, three-way batch separation, `assembleOne` signature unchanged, and no caching of a nodeless verdict.
- `tests/unit/entity-context/entity-context-handler.test.ts` — **new file**, the skill handler had no suite. 7 cases covering the buckets, the reason wording, key omission when empty, caller fallback, and that DB internals don't leak into the error string.
- `tests/unit/entity-context/execution-enrichment.test.ts` — 2 new cases pinning the separate warn line and its absence on the happy path. `makeMockAssembler` now takes a partial so tests state only the bucket they care about.
- `scripts/kg-node-linkage-report.test.ts` — 5 cases on the arm split, empty/clean database, defensive counts, and the read-only guarantee.

Full suite: 6044 passed, 0 failed. `pnpm run typecheck` exit 0, `pnpm run lint` 0 errors.

## Note

I skipped the usual pre-PR review subagents — this session is configured not to spawn agents unless asked. Happy to run them on request.
