### PR TITLE
fix(entity-context): surface transient DB failures in `failed` bucket, not `unresolved`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`EntityContextAssembler.assembleMany`** — new `nodeless` bucket, disjoint from `unresolved`; logged at warn. (#1694)
 - **`entity-context`** — output gains `nodeless`; agents read a missing node as a capability gap. (#1694)
 - **`entity-context` output schema** — new `nodeless` key on `ToolResult.data` (public API surface). (#1694)
+- **`entity-context` output schema** — new `failed` key on `ToolResult.data` (public API surface). (#1702)
 - **`entity_enrichment`** — nodeless contacts get their own warn line instead of joining the unresolved-IDs line. (#1694)
 - **`contact-dedup-exclude`** — writes the exclusions table; outputs `created`, no `entityMemory` capability. (#1625)
 - **`contact-find-duplicates`** — loads exclusions in one query; `entityMemory` capability dropped. (#1625)
@@ -54,6 +55,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Signal inbound** — ACI-only senders keep a non-empty sender and conversation identity. (#1600)
+- **`entity-context`** — transient DB failures surface in `failed`, not `unresolved`. (#1702)
+- **`entity_enrichment`** — failed lookups get their own warn line instead of joining unresolved. (#1702)
 - **Slack file download** — abort streamed bodies once they exceed the voice-note size cap. (#1600)
 - **Contact merge** — merge writes run in one transaction; a failure no longer strands identities or dedup rulings. (#1695)
 - **Signal voice calls** — duplicate `RINGING_INCOMING` for one call no longer self-rejects it as busy. (#1672)

--- a/docs/specs/11-entity-context-enrichment.md
+++ b/docs/specs/11-entity-context-enrichment.md
@@ -214,7 +214,7 @@ A new skill that assembles the full context payload for one or more entities. Av
 
 Diagnostic buckets (`nodeless`, `failed`, `unresolved`) are emitted before `entities` in the skill result so head-slice output truncation sacrifices bulk entity data rather than the warnings.
 
-When every requested ID lands in `failed` and `entities` is empty, the skill returns `success: false` (not a success-shaped empty result with retry hints) so the agent does not loop against a hard-down database.
+When every requested ID lands in `failed` and `entities`, `unresolved`, and `nodeless` are all empty, the skill returns `success: false` (not a success-shaped empty result with retry hints) so the agent does not loop against a hard-down database. Batches mixing `failed` with `unresolved` or `nodeless` still return `success: true` with all diagnostic buckets.
 
 **Resolution priority for each ID:**
 1. If the ID matches a `contacts.id` with a non-null `kg_node_id` → assemble from that KG node

--- a/docs/specs/11-entity-context-enrichment.md
+++ b/docs/specs/11-entity-context-enrichment.md
@@ -196,16 +196,33 @@ A new skill that assembles the full context payload for one or more entities. Av
   },
   "outputs": {
     "entities": "EntityContext[]",
-    "unresolved": "string[] (IDs that couldn't be found)"
+    "unresolved": "string[] (IDs that matched no contact and no KG node)",
+    "nodeless": "{inputId, contactId, displayName, reason}[]? (contacts that exist but have no stored profile — cannot hold facts; not evidence of absence)",
+    "failed": "{inputId, reason}[]? (lookups that errored — retry may succeed; not evidence of absence)"
   }
 }
 ```
 
+**Result buckets** — `assembleMany` and the skill surface four disjoint outcomes per input ID:
+
+| Bucket | Meaning | Agent action |
+|---|---|---|
+| `entities` | Full `EntityContext` assembled | Use the payload |
+| `unresolved` | ID matched no contact and no KG node | Treat as genuinely unknown |
+| `nodeless` | Contact exists but holds no KG node (#1694) | Report capability gap; do not store facts or infer absence |
+| `failed` | Assembly threw (#1702) | If reason says retryable: retry. If not: report failure. **Not** evidence the contact is unknown |
+
+Diagnostic buckets (`nodeless`, `failed`, `unresolved`) are emitted before `entities` in the skill result so head-slice output truncation sacrifices bulk entity data rather than the warnings.
+
+When every requested ID lands in `failed` and `entities` is empty, the skill returns `success: false` (not a success-shaped empty result with retry hints) so the agent does not loop against a hard-down database.
+
 **Resolution priority for each ID:**
-1. If the ID matches a `contacts.id` → look up `kg_node_id` from the contact, then assemble from the KG node
-2. If the ID matches a `kg_nodes.id` directly → assemble from the KG node
-3. Special values: `"caller"` → resolve to `ctx.caller.contactId`, `"agent"` → resolve to the agent's contactId
-4. If no match → include in the `unresolved` array (not a hard error)
+1. If the ID matches a `contacts.id` with a non-null `kg_node_id` → assemble from that KG node
+2. If the ID matches a `contacts.id` with a null `kg_node_id` → include in `nodeless` (contact exists but cannot hold knowledge)
+3. If the ID matches a `kg_nodes.id` directly → assemble from that KG node
+4. Special values: `"caller"` → resolve to `ctx.caller.contactId`, `"agent"` → resolve to the agent's contactId
+5. If no match → include in the `unresolved` array (not a hard error)
+6. If assembly throws → include in `failed` with a retry classification (not `unresolved`)
 
 ### Assembly Pipeline
 

--- a/skills/entity-context/handler.ts
+++ b/skills/entity-context/handler.ts
@@ -8,11 +8,13 @@
 // entity_enrichment manifest declaration instead — that runs the same
 // assembler without an extra LLM round-trip.
 //
-// Three buckets come back and all three are surfaced: entities that assembled,
-// `unresolved` IDs that matched nothing, and `nodeless` contacts that exist but
-// cannot hold knowledge (#1694 / ADR-040).
+// Four buckets come back and all are surfaced: entities that assembled,
+// `unresolved` IDs that matched nothing, `nodeless` contacts that exist but
+// cannot hold knowledge (#1694 / ADR-040), and `failed` IDs whose lookup errored
+// (#1702). The handler owns all LLM-facing wording for `nodeless` and `failed`.
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
+import type { AssembleManyFailedEntry, AssembleManyResult } from '../../src/entity-context/assembler.js';
 
 // Shown to the LLM for every contact that resolved but holds no KG node.
 //
@@ -29,6 +31,49 @@ const NODELESS_REASON =
   'This contact exists but has no stored profile, so it cannot hold facts, '
   + 'relationships, or background context. Having no context here does not mean the '
   + 'contact is unknown to us. Do not try to store facts about them; report the gap instead.';
+
+const NOT_UNKNOWN_SUFFIX =
+  'This is not evidence the contact or entity is unknown.';
+
+function formatFailedReason(retryable: boolean): string {
+  if (retryable) {
+    return `Entity context lookup failed due to a transient error. Retry the lookup; ${NOT_UNKNOWN_SUFFIX}`;
+  }
+  return `Entity context lookup failed due to a system error. Do not retry; report the failure. ${NOT_UNKNOWN_SUFFIX}`;
+}
+
+function formatTotalFailureError(failed: AssembleManyFailedEntry[]): string {
+  const retryable = failed.some(f => f.retryable);
+  if (retryable) {
+    return `Entity context lookup failed for all requested IDs due to transient errors. Retry; ${NOT_UNKNOWN_SUFFIX}`;
+  }
+  return `Entity context lookup failed for all requested IDs due to a system error. Do not retry; report the failure. ${NOT_UNKNOWN_SUFFIX}`;
+}
+
+function buildSuccessData(result: AssembleManyResult): Record<string, unknown> {
+  return {
+    ...(result.nodeless.length > 0
+      ? {
+          nodeless: result.nodeless.map(n => ({
+            inputId: n.inputId,
+            contactId: n.contactId,
+            displayName: n.displayName,
+            reason: NODELESS_REASON,
+          })),
+        }
+      : {}),
+    ...(result.failed.length > 0
+      ? {
+          failed: result.failed.map(f => ({
+            inputId: f.inputId,
+            reason: formatFailedReason(f.retryable),
+          })),
+        }
+      : {}),
+    unresolved: result.unresolved,
+    entities: result.entities,
+  };
+}
 
 export class EntityContextHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
@@ -69,9 +114,25 @@ export class EntityContextHandler implements ToolHandler {
           resolvedCount: result.entities.length,
           unresolvedCount: result.unresolved.length,
           nodelessCount: result.nodeless.length,
+          failedCount: result.failed.length,
         },
         'entity-context: assembled context',
       );
+
+      if (result.failed.length > 0) {
+        const retryableCount = result.failed.filter(f => f.retryable).length;
+        ctx.log.warn(
+          { failedCount: result.failed.length, retryableCount },
+          'entity-context: some lookups failed — see failed bucket in result',
+        );
+      }
+
+      // Total failure: every ID errored and nothing assembled. A success-shaped
+      // result with only a retry hint has nothing to stop the agent retrying into
+      // a hard-down DB (#1702 review).
+      if (result.entities.length === 0 && result.failed.length > 0) {
+        return { success: false, error: formatTotalFailureError(result.failed) };
+      }
 
       // Key order is deliberate. The execution layer enforces an aggregate size cap by
       // JSON.stringify-ing this object and head-slicing it (see skillOutputMaxLength),
@@ -81,26 +142,7 @@ export class EntityContextHandler implements ToolHandler {
       // being absent from `unresolved` too, would otherwise vanish without trace.
       return {
         success: true,
-        data: {
-          // Only present when non-empty: on the common path every contact has a
-          // node, and an always-there empty array is pure prompt noise.
-          ...(result.nodeless.length > 0
-            ? {
-                nodeless: result.nodeless.map(n => ({
-                  // inputId is echoed back so the agent can map the answer to what it
-                  // asked for. It matters most for email inputs, where contactId is a
-                  // UUID the caller has never seen and displayName may not resemble
-                  // the address.
-                  inputId: n.inputId,
-                  contactId: n.contactId,
-                  displayName: n.displayName,
-                  reason: NODELESS_REASON,
-                })),
-              }
-            : {}),
-          unresolved: result.unresolved,
-          entities: result.entities,
-        },
+        data: buildSuccessData(result),
       };
     } catch (err) {
       // Log the full error server-side but don't expose DB internals (table names,

--- a/skills/entity-context/handler.ts
+++ b/skills/entity-context/handler.ts
@@ -43,11 +43,25 @@ function formatFailedReason(retryable: boolean): string {
 }
 
 function formatTotalFailureError(failed: AssembleManyFailedEntry[]): string {
-  const retryable = failed.some(f => f.retryable);
-  if (retryable) {
+  const retryableCount = failed.filter(f => f.retryable).length;
+  const nonRetryableCount = failed.length - retryableCount;
+  if (retryableCount > 0 && nonRetryableCount > 0) {
+    return 'Entity context lookup failed for all requested IDs. Some failures may be transient (retry those lookups); others are system errors (do not retry those). '
+      + NOT_UNKNOWN_SUFFIX;
+  }
+  if (retryableCount > 0) {
     return `Entity context lookup failed for all requested IDs due to transient errors. Retry; ${NOT_UNKNOWN_SUFFIX}`;
   }
   return `Entity context lookup failed for all requested IDs due to a system error. Do not retry; report the failure. ${NOT_UNKNOWN_SUFFIX}`;
+}
+
+function isTotalFailure(result: AssembleManyResult): boolean {
+  return (
+    result.entities.length === 0
+    && result.failed.length > 0
+    && result.unresolved.length === 0
+    && result.nodeless.length === 0
+  );
 }
 
 function buildSuccessData(result: AssembleManyResult): Record<string, unknown> {
@@ -127,10 +141,10 @@ export class EntityContextHandler implements ToolHandler {
         );
       }
 
-      // Total failure: every ID errored and nothing assembled. A success-shaped
-      // result with only a retry hint has nothing to stop the agent retrying into
-      // a hard-down DB (#1702 review).
-      if (result.entities.length === 0 && result.failed.length > 0) {
+      // Total failure: every ID errored and no other bucket has entries. A
+      // success-shaped result with only a retry hint has nothing to stop the
+      // agent retrying into a hard-down DB (#1702 review).
+      if (isTotalFailure(result)) {
         return { success: false, error: formatTotalFailureError(result.failed) };
       }
 

--- a/skills/entity-context/tool.json
+++ b/skills/entity-context/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "entity-context",
-  "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers). Some contacts have no stored profile and can hold no facts at all; those come back under `nodeless` with a reason, and an empty result for them is a capability gap, not evidence the contact is unknown.",
-  "version": "1.1.0",
+  "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers). Some contacts have no stored profile and can hold no facts at all; those come back under `nodeless` with a reason, and an empty result for them is a capability gap, not evidence the contact is unknown. Transient lookup failures come back under `failed` with a retry hint — also not evidence of absence.",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -12,7 +12,8 @@
   "outputs": {
     "entities": "EntityContext[] (assembled context payloads for each resolved entity)",
     "unresolved": "string[] (IDs that could not be found in the KG or contacts table)",
-    "nodeless": "{inputId, contactId, displayName, reason}[]? (present only when non-empty — contacts that exist but have no stored profile, so they can hold no facts or context; inputId echoes the ID or email you passed in)"
+    "nodeless": "{inputId, contactId, displayName, reason}[]? (present only when non-empty — contacts that exist but have no stored profile, so they can hold no facts or context; inputId echoes the ID or email you passed in)",
+    "failed": "{inputId, reason}[]? (present only when non-empty — lookups that errored; reason distinguishes retryable transient failures from permanent system errors; never evidence of absence)"
   },
   "permissions": [],
   "secrets": [],

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -18,17 +18,19 @@
 // callers (ContactService, EntityMemory) call after mutations.
 //
 // assembleMany() wraps each per-ID call in its own try/catch so that a DB error
-// on one entity doesn't abort the entire batch — failed IDs are logged and placed
-// in the `unresolved` array rather than propagating.
+// on one entity doesn't abort the entire batch — errored IDs are logged and placed
+// in the `failed` array rather than propagating.
 //
-// Misses are reported in two separate buckets, because they mean different things
-// (#1694 / ADR-040):
-//   unresolved — the ID matched no contact and no KG node, or assembly errored.
+// Misses are reported in three separate buckets, because they mean different things
+// (#1694 / ADR-040, #1702):
+//   unresolved — the ID matched no contact and no KG node.
 //   nodeless   — the ID matched a real contact that holds no KG node. The contact
 //                exists but is structurally unable to carry facts, relationships,
 //                or context, and no amount of retrying will change that. Collapsing
 //                it into `unresolved` made an agent read "cannot hold knowledge" as
 //                "we know nothing about them", which is the silence #1694 is about.
+//   failed     — assembly threw. Classified as retryable or not; never evidence the
+//                contact is unknown (#1702).
 
 import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
@@ -52,12 +54,22 @@ export interface NodelessContact {
   displayName: string;
 }
 
+/** An ID whose assembly threw — classified for retry, not a miss. */
+export interface AssembleManyFailedEntry {
+  /** The string the caller passed in (contact UUID, KG node ID, or email). */
+  inputId: string;
+  /** True when the error is likely transient (timeout, connection limit, reset). */
+  retryable: boolean;
+}
+
 export interface AssembleManyResult {
   entities: EntityContext[];
-  /** IDs that matched nothing, or whose assembly threw. */
+  /** IDs that matched no contact and no KG node. */
   unresolved: string[];
   /** Contacts that exist but cannot hold knowledge. Disjoint from `unresolved`. */
   nodeless: NodelessContact[];
+  /** IDs whose assembly errored. Disjoint from `unresolved` and `nodeless`. */
+  failed: AssembleManyFailedEntry[];
 }
 
 /** Outcome of resolving a caller-supplied ID to something assemblable. */
@@ -94,8 +106,8 @@ export class EntityContextAssembler {
    *   2. Matches a kg_nodes.id directly → assemble from that KG node
    *   3. No match → included in `unresolved` (not a hard error)
    *
-   * Each ID is assembled independently; a DB error on one ID logs a warning and
-   * adds the ID to `unresolved` without aborting the remaining IDs in the batch.
+   * Each ID is assembled independently; a DB error on one ID logs at error and
+   * adds the ID to `failed` without aborting the remaining IDs in the batch.
    *
    * @param ids   Array of contact IDs or KG node IDs to resolve.
    * @param includeRelationships  If false, the relationships field is skipped.
@@ -108,6 +120,7 @@ export class EntityContextAssembler {
     const entities: EntityContext[] = [];
     const unresolved: string[] = [];
     const nodeless: NodelessContact[] = [];
+    const failed: AssembleManyFailedEntry[] = [];
 
     for (const id of ids) {
       // Cache stores full payloads (with relationships) only. Skipping the cache for
@@ -147,13 +160,13 @@ export class EntityContextAssembler {
         }
       } catch (err) {
         // Per-ID failure is non-fatal for the batch — log with full context and
-        // treat as unresolved so the caller gets partial results instead of nothing.
-        this.logger.error({ err, entityId: id }, 'entity-context: assembleOne failed — treating as unresolved');
-        unresolved.push(id);
+        // place in `failed` so the caller can retry instead of reading absence.
+        this.logger.error({ err, entityId: id }, 'entity-context: assembleOne failed — treating as failed');
+        failed.push({ inputId: id, retryable: isRetryableAssemblyError(err) });
       }
     }
 
-    return { entities, unresolved, nodeless };
+    return { entities, unresolved, nodeless, failed };
   }
 
   /**
@@ -684,4 +697,44 @@ function isContactRowColumnPopulated(
     case 'bio':           return row.bio != null;
     case 'birthday':      return row.birthday != null;
   }
+}
+
+/**
+ * Classify whether a thrown assembly error is likely transient.
+ * The handler owns LLM-facing wording; this only supplies the retry signal.
+ */
+export function isRetryableAssemblyError(err: unknown): boolean {
+  if (err !== null && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code: string }).code;
+    switch (code) {
+      // Transient: pool pressure, timeouts, connection loss, deadlocks
+      case '53300': // too_many_connections
+      case '57014': // query_canceled (statement timeout)
+      case '08000': // connection_exception
+      case '08003': // connection_does_not_exist
+      case '08006': // connection_failure
+      case '40001': // serialization_failure
+      case '40P01': // deadlock_detected
+      case '57P03': // cannot_connect_now
+        return true;
+      // Permanent: schema drift, missing objects, privilege
+      case '42703': // undefined_column
+      case '42P01': // undefined_table
+      case '42501': // insufficient_privilege
+        return false;
+    }
+  }
+  if (err instanceof TypeError) return false;
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    if (
+      msg.includes('econnreset')
+      || msg.includes('connection reset')
+      || msg.includes('pool timeout')
+    ) {
+      return true;
+    }
+  }
+  // Unknown errors: do not invite a retry loop
+  return false;
 }

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -1622,6 +1622,16 @@ export class ExecutionLayer {
               'entity_enrichment: contacts have no KG node — skill ran without their context',
             );
           }
+          if (enrichmentResult.failed.length > 0) {
+            const retryableCount = enrichmentResult.failed.filter(f => f.retryable).length;
+            // Same dormant note as the nodeless branch above — no tool.json currently
+            // declares entity_enrichment, but a future manifest should report failures
+            // with the skill name attached rather than silently.
+            skillLogger.warn(
+              { toolName, failedCount: enrichmentResult.failed.length, retryableCount },
+              'entity_enrichment: some entity lookups failed — see assembler failed bucket',
+            );
+          }
           ctx.entityContext = enrichmentResult.entities;
           skillLogger.debug({ toolName, enrichedCount: enrichmentResult.entities.length }, 'entity_enrichment: pre-enrichment complete');
         } catch (err) {

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import pino from 'pino';
-import { EntityContextAssembler } from '../../../src/entity-context/assembler.js';
+import { EntityContextAssembler, isRetryableAssemblyError } from '../../../src/entity-context/assembler.js';
 import type { DbPool } from '../../../src/db/connection.js';
 
 const logger = pino({ level: 'silent' });
@@ -23,18 +23,22 @@ function makeMockPool(): DbPool {
 }
 
 // Helper: build a pool mock that responds to queries in order.
-// Each call to pool.query() returns the next response in the queue.
-function makeSequentialPool(responses: Array<{ rows: unknown[] }>): DbPool {
+// Each call to pool.query() returns the next response in the queue, or rejects
+// when the step is `{ reject: Error }`.
+type SequentialPoolStep = { rows: unknown[] } | { reject: Error };
+
+function makeSequentialPool(steps: SequentialPoolStep[]): DbPool {
   const pool = makeMockPool();
   let callIndex = 0;
   vi.mocked(pool.query).mockImplementation(() => {
-    const res = responses[callIndex++];
-    if (!res) {
-      // Throw so tests fail fast when the assembler issues more queries than expected.
-      // A silent empty-rows fallback would mask regressions where extra DB calls are added.
+    const step = steps[callIndex++];
+    if (!step) {
       throw new Error(`Unexpected query call #${callIndex} — add a response to makeSequentialPool`);
     }
-    return Promise.resolve(res as unknown as ReturnType<DbPool['query']>);
+    if ('reject' in step) {
+      return Promise.reject(step.reject);
+    }
+    return Promise.resolve({ rows: step.rows } as unknown as ReturnType<DbPool['query']>);
   });
   return pool;
 }
@@ -561,14 +565,90 @@ describe('EntityContextAssembler', () => {
       await expect(assembler.assembleOne('jenna@example.com')).rejects.toThrow('Connection reset by peer');
     });
 
-    it('treats email DB errors as unresolved in assembleMany', async () => {
+    it('treats email DB errors as failed in assembleMany, not unresolved', async () => {
       const pool = makeMockPool();
       vi.mocked(pool.query).mockRejectedValueOnce(new Error('pool timeout'));
 
       const assembler = new EntityContextAssembler(pool, logger);
-      const { entities, unresolved } = await assembler.assembleMany(['jenna@example.com']);
+      const { entities, unresolved, failed } = await assembler.assembleMany(['jenna@example.com']);
       expect(entities).toHaveLength(0);
-      expect(unresolved).toEqual(['jenna@example.com']);
+      expect(unresolved).toHaveLength(0);
+      expect(failed).toEqual([
+        { inputId: 'jenna@example.com', retryable: true },
+      ]);
+    });
+
+    it('classifies permanent schema errors as non-retryable', async () => {
+      const pool = makeMockPool();
+      vi.mocked(pool.query).mockRejectedValueOnce(
+        Object.assign(new Error('column does not exist'), { code: '42703' }),
+      );
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { failed } = await assembler.assembleMany(['contact-1']);
+      expect(failed).toEqual([{ inputId: 'contact-1', retryable: false }]);
+    });
+
+    it('returns partial entities plus failed when a mid-batch DB error occurs', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },
+        { rows: [contactRow] },
+        { rows: [] },
+        { rows: [] },
+        { reject: Object.assign(new Error('too many connections'), { code: '53300' }) },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, failed } = await assembler.assembleMany(['contact-1', 'contact-2']);
+
+      expect(entities).toHaveLength(1);
+      expect(entities[0]!.entityId).toBe('node-1');
+      expect(unresolved).toHaveLength(0);
+      expect(failed).toEqual([{ inputId: 'contact-2', retryable: true }]);
+    });
+  });
+
+  describe('isRetryableAssemblyError', () => {
+    it('treats connection-limit and schema errors differently', () => {
+      expect(isRetryableAssemblyError(Object.assign(new Error('limit'), { code: '53300' }))).toBe(true);
+      expect(isRetryableAssemblyError(Object.assign(new Error('missing col'), { code: '42703' }))).toBe(false);
+      expect(isRetryableAssemblyError(new TypeError('cannot read property'))).toBe(false);
+    });
+  });
+
+  describe('assembleMany — all four buckets', () => {
+    it('places each ID in exactly one bucket in a mixed batch', async () => {
+      const pool = makeSequentialPool([
+        // contact-1 — resolves fully
+        { rows: [{ kg_node_id: 'node-1', display_name: 'Jenna Smith' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },
+        { rows: [contactRow] },
+        { rows: [] },
+        { rows: [] },
+        // contact-2 — nodeless
+        { rows: [{ kg_node_id: null, display_name: 'Seth Berman' }] },
+        // ghost-id — unknown
+        { rows: [] },
+        { rows: [] },
+        // contact-3 — DB error
+        { reject: Object.assign(new Error('too many connections'), { code: '53300' }) },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, nodeless, failed } = await assembler.assembleMany([
+        'contact-1',
+        'contact-2',
+        'ghost-id',
+        'contact-3',
+      ]);
+
+      expect(entities).toHaveLength(1);
+      expect(nodeless.map(n => n.contactId)).toEqual(['contact-2']);
+      expect(unresolved).toEqual(['ghost-id']);
+      expect(failed).toEqual([{ inputId: 'contact-3', retryable: true }]);
     });
   });
 });

--- a/tests/unit/entity-context/entity-context-handler.test.ts
+++ b/tests/unit/entity-context/entity-context-handler.test.ts
@@ -39,6 +39,7 @@ function makeCtx(
     entities: result.entities ?? [],
     unresolved: result.unresolved ?? [],
     nodeless: result.nodeless ?? [],
+    failed: result.failed ?? [],
   };
   return {
     input,
@@ -151,6 +152,97 @@ describe('EntityContextHandler', () => {
     const result = await new EntityContextHandler().execute(ctx);
 
     expect(expectData(result)).not.toHaveProperty('nodeless');
+  });
+
+  it('reports a failed lookup separately from unresolved', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-1', 'contact-2'] },
+      {
+        entities: [makeEntity()],
+        failed: [{ inputId: 'contact-2', retryable: true }],
+      },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const data = expectData(result) as unknown as {
+      failed: Array<{ inputId: string; reason: string }>;
+      unresolved: string[];
+    };
+
+    expect(data.failed).toHaveLength(1);
+    expect(data.failed[0].inputId).toBe('contact-2');
+    expect(data.failed[0].reason).toMatch(/retry/i);
+    expect(data.failed[0].reason).toMatch(/not evidence/i);
+    expect(data.unresolved).toEqual([]);
+  });
+
+  it('does not describe permanent failures as retryable', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-1', 'contact-2'] },
+      {
+        entities: [makeEntity()],
+        failed: [{ inputId: 'contact-2', retryable: false }],
+      },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const data = expectData(result) as unknown as { failed: Array<{ reason: string }> };
+
+    expect(data.failed[0].reason).toMatch(/do not retry/i);
+    expect(data.failed[0].reason).not.toMatch(/retry the lookup/i);
+  });
+
+  it('emits failed before entities so head-slice truncation cannot drop it', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-1', 'contact-2'] },
+      {
+        entities: [makeEntity()],
+        failed: [{ inputId: 'contact-2', retryable: true }],
+      },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const keys = Object.keys(expectData(result));
+
+    expect(keys.indexOf('failed')).toBeLessThan(keys.indexOf('entities'));
+  });
+
+  it('omits the failed key entirely when there is nothing to report', async () => {
+    const ctx = makeCtx({ contactIds: ['contact-1'] }, { entities: [makeEntity()] });
+    const result = await new EntityContextHandler().execute(ctx);
+
+    expect(expectData(result)).not.toHaveProperty('failed');
+  });
+
+  it('returns success false when every ID failed and nothing assembled', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-1', 'contact-2'] },
+      { failed: [{ inputId: 'contact-1', retryable: true }, { inputId: 'contact-2', retryable: true }] },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.error).toMatch(/retry/i);
+    expect(result.error).toMatch(/not evidence/i);
+  });
+
+  it('warns when some lookups failed without logging raw input IDs', async () => {
+    const warn = vi.fn();
+    const spyLogger = { ...logger, warn, child: () => spyLogger } as unknown as typeof logger;
+    const ctx = makeCtx(
+      { entityIds: ['jenna@example.com'] },
+      { failed: [{ inputId: 'jenna@example.com', retryable: true }] },
+    );
+    ctx.log = spyLogger;
+
+    await new EntityContextHandler().execute(ctx);
+
+    const failedWarn = warn.mock.calls.find(call => /lookups failed/i.test(String(call[1])));
+    expect(failedWarn).toBeDefined();
+    expect(failedWarn![0]).toEqual({ failedCount: 1, retryableCount: 1 });
+    expect(JSON.stringify(failedWarn![0])).not.toContain('jenna@example.com');
   });
 
   it('falls back to the caller contact when no IDs are supplied', async () => {

--- a/tests/unit/entity-context/entity-context-handler.test.ts
+++ b/tests/unit/entity-context/entity-context-handler.test.ts
@@ -228,6 +228,55 @@ describe('EntityContextHandler', () => {
     expect(result.error).toMatch(/not evidence/i);
   });
 
+  it('does not claim all failures were transient when retryability is mixed', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-1', 'contact-2'] },
+      {
+        failed: [
+          { inputId: 'contact-1', retryable: true },
+          { inputId: 'contact-2', retryable: false },
+        ],
+      },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.error).toMatch(/some failures may be transient/i);
+    expect(result.error).toMatch(/do not retry those/i);
+    expect(result.error).not.toMatch(/due to transient errors\. Retry/i);
+  });
+
+  it('returns success true when failed is mixed with unresolved', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-1', 'ghost-id'] },
+      { failed: [{ inputId: 'contact-1', retryable: true }], unresolved: ['ghost-id'] },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const data = expectData(result) as unknown as { failed: unknown[]; unresolved: string[] };
+
+    expect(data.failed).toHaveLength(1);
+    expect(data.unresolved).toEqual(['ghost-id']);
+  });
+
+  it('returns success true when failed is mixed with nodeless', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-1', 'contact-2'] },
+      {
+        failed: [{ inputId: 'contact-1', retryable: true }],
+        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }],
+      },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const data = expectData(result) as unknown as { failed: unknown[]; nodeless: unknown[] };
+
+    expect(data.failed).toHaveLength(1);
+    expect(data.nodeless).toHaveLength(1);
+  });
+
   it('warns when some lookups failed without logging raw input IDs', async () => {
     const warn = vi.fn();
     const spyLogger = { ...logger, warn, child: () => spyLogger } as unknown as typeof logger;

--- a/tests/unit/entity-context/execution-enrichment.test.ts
+++ b/tests/unit/entity-context/execution-enrichment.test.ts
@@ -66,6 +66,7 @@ function makeMockAssembler(result: Partial<AssembleManyResult>): EntityContextAs
     entities: result.entities ?? [],
     unresolved: result.unresolved ?? [],
     nodeless: result.nodeless ?? [],
+    failed: result.failed ?? [],
   };
   return {
     assembleMany: vi.fn().mockResolvedValue(full),
@@ -307,6 +308,30 @@ describe('ExecutionLayer — entity_enrichment', () => {
     await execution.invoke('test-skill', { contacts: ['contact-1'] });
 
     expect(warn.mock.calls.filter(call => /no KG node/i.test(String(call[1])))).toHaveLength(0);
+  });
+
+  it('logs failed lookups on their own line, not lumped into unresolved', async () => {
+    const warn = vi.fn();
+    const spyLogger = { ...logger, warn, child: () => spyLogger } as unknown as typeof logger;
+
+    const handler: ToolHandler = { execute: async () => ({ success: true, data: 'ok' }) };
+    registry.register(makeManifest({ entity_enrichment: { param: 'contacts', default: 'caller' } }), handler);
+
+    const assembler = makeMockAssembler({
+      entities: [sampleEntityContext],
+      failed: [{ inputId: 'contact-2', retryable: true }],
+    });
+    const execution = new ExecutionLayer(registry, spyLogger, {
+      entityContextAssembler: assembler,
+    });
+
+    const result = await execution.invoke('test-skill', { contacts: ['contact-1', 'contact-2'] });
+    expect(result.success).toBe(true);
+
+    const failedLine = warn.mock.calls.find(call => /lookups failed/i.test(String(call[1])));
+    expect(failedLine).toBeDefined();
+    expect((failedLine![0] as { failedCount?: number; retryableCount?: number }).failedCount).toBe(1);
+    expect((failedLine![0] as { inputIds?: string[] }).inputIds).toBeUndefined();
   });
 
   it('exposes agentContactId on ctx for all skills', async () => {


### PR DESCRIPTION
## Summary

Fixes #1702. When `assembleMany` hit a transient DB error mid-batch, the errored ID landed in `unresolved` — indistinguishable from "contact not found." This adds a `failed` bucket (symmetric with `nodeless` from #1694) with retry classification owned by the assembler and LLM-facing wording owned by the handler.

## Changes

- `EntityContextAssembler.assembleMany` returns `failed: { inputId, retryable }[]`; permanent errors (e.g. `42703`) are not classified retryable
- `entity-context` handler surfaces `failed` before `entities`, warns with counts (not raw emails), and returns `success: false` on total failure
- `entity_enrichment` logs failed lookups on their own warn line (with dormant-branch note)
- `tool.json` bumped to 1.2.0; spec 11 documents the four-bucket contract and total-failure behaviour
- Tests: non-retryable classification, all four buckets in one batch, handler warn line, `makeSequentialPool` reject steps

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [x] CI passes