### PR TITLE
docs(adr-040): record the measured nodeless population

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **ADR-040 (Accepted)** — contact-anchored KG node identity; a contact's node is keyed on the contact, not its label. (#1694)
+- **ADR-040 measured population** — migration `085` sizing recorded from production: 14 nodeless contacts, arm A empty. (#1694)
 - **`scripts/kg-node-linkage-report.ts`** — read-only count of nodeless contacts, split across ADR-040's two backfill arms. (#1694)
 - **Signal voice calls** — anyone can Signal-call Curia; live conversation via VoiceRuntime, config-gated off. (#1672)
 - **`MemorySampler`** — periodic `process.memoryUsage()` logging to diagnose heap growth in prod. (#1650)

--- a/docs/adr/040-contact-anchored-kg-node-identity.md
+++ b/docs/adr/040-contact-anchored-kg-node-identity.md
@@ -35,6 +35,13 @@ contacts legitimately represent one organization, and forcing them to compete fo
 link is a modelling error rather than an identity ambiguity. A fix that only re-keys person
 identity leaves this half of the nodeless population untouched.
 
+**Measured after acceptance (2026-09-02, production):** the org population is *empirically
+zero*. Of 548 contacts, 14 hold no node; none of them are `kind='organization'` (all 38 org
+contacts are linked). The collision path above is real and reachable in code, but it has not
+yet occurred in this deployment. The org half of this section describes a latent defect, not
+an observed one — the relaxed `idx_contacts_kg_node_unique` is worth keeping as prevention,
+but it should not be sequenced as though it were clearing a backlog. See Consequences.
+
 ### Why label-keyed identity exists at all
 
 The unique index is not the disease; it is the coping mechanism. `upsertNode`'s
@@ -51,11 +58,18 @@ not; the name is all there is.
 ### The latent misattribution bug
 
 `EntityMemory.resolveOrCreate` currently handles 2+ exact matches by returning
-`matches.find(n => n.type === options.type)` as `found`. Today the unique index makes two
-same-type matches impossible, so the branch is unreachable for the case that matters. The
-moment N nodes may share a label, every `memory-store` write for "Seth Berman" silently
-lands on whichever node sorts first. That is strictly worse than the present silent no-op,
-and fixing it is a prerequisite for the migration rather than a follow-up.
+`matches.find(n => n.type === options.type)` as `found`. The moment N nodes may share a
+label, every `memory-store` write for "Seth Berman" silently lands on whichever node sorts
+first — strictly worse than the present silent no-op, and so a prerequisite for the
+migration rather than a follow-up.
+
+It is also not purely latent today, contrary to an earlier draft of this ADR.
+`findNodesByLabel` matches `lower(label)` **or** `aliases`, and aliases carry no cross-node
+uniqueness — no unique index on the column, and `addAlias` only checks that the alias is
+absent from the node it is writing to. Two person nodes can therefore both carry the alias
+"Seth" and the same silent first-match pick applies. `resolveOrCreate`'s own fuzzy path
+calls `addAlias` automatically, so such a collision can arise without anyone doing anything
+unusual. Rare, but live.
 
 ## Decision
 
@@ -217,10 +231,27 @@ will silently skip facts about common names until callers pass subject context. 
 contact now archives real knowledge along with it; recoverable, but a behaviour change from
 today's leave-it-orphaned.
 
-**Risk concentrated in the migration.** `085` mints a node per nodeless contact, and the
-true size of that population is not yet measured in production. The visibility increment
-lands first specifically so the migration is written against a known number rather than an
-assumed one.
+**Migration risk, now measured.** The visibility increment (#1701) landed first specifically
+so `085` could be written against a known number rather than an assumed one. Run against
+production on 2026-09-02 via `scripts/kg-node-linkage-report.ts`:
+
+| | |
+|---|---|
+| contacts total | 548 |
+| holding no KG node | 14 (2.6%) |
+| arm A — org re-link | **0** |
+| arm B — mint a node | **14** |
+| shadowed by a same-name contact that has a node | 12 |
+
+By kind, the nodeless 14 are 12 `person` and 2 `automated`; `organization`, `principal` and
+`agent` are fully linked. Across the whole table there are 14 same-name clusters and the
+largest holds 3 contacts.
+
+So the migration inserts 14 rows, and 12 of the 14 are the same-name case #1623 described.
+This is a much smaller and better-bounded change than this ADR assumed when it was accepted,
+and it moves the risk out of the migration. Two consequences for sequencing: the org index
+relaxation is prevention rather than repair and should not lead, and the `resolveOrCreate`
+ambiguity fix — which addresses a live alias-collision path, per Context — should.
 
 **Not addressed.** Nothing here improves resolution *quality* for names Curia has never
 associated with a contact — an unanchored "Seth Berman" mentioned in an email body still
@@ -231,5 +262,8 @@ contacts a durable identity; it does not give the KG one for everyone else.
 
 - #1694 (this change), #1623 (the incident), #1625 / ADR-039 (named this as the remaining gap)
 - PR #1624 (design review that rejected `ensureKgNode` as the fix)
+- PR #1700 (this ADR), PR #1701 (increment 1 — visibility, and the measurement above)
+- #1702 (`entity-context` reports a DB failure as "contact not found" — the same
+  absence-of-evidence failure on the error path, found while reviewing #1701)
 - Migrations 010, 016, 027, 056 (the indexes and backfills this supersedes or amends)
 - ADR-028 (shared, unbound agent memory) for the surrounding memory-governance model

--- a/scripts/kg-node-linkage-report.ts
+++ b/scripts/kg-node-linkage-report.ts
@@ -20,12 +20,14 @@
 // signature from #1623 — the collision that produced the NULL in the first place.
 //
 // Run locally:  pnpm run report:kg-linkage
-// Run on prod:  export the deploy .env's DATABASE_URL, then forward it into the
-//               container, which runs .ts through tsx (not node's type stripping —
-//               see the Dockerfile's note on dynamic .ts handler imports):
+// Run on prod:  DATABASE_URL is already present in the app container's environment, so
+//               nothing needs forwarding. The container runs .ts through tsx, not node's
+//               type stripping (see the Dockerfile's note on dynamic .ts handler imports):
 //
-//                 ssh <host> 'docker exec -e DATABASE_URL="$DATABASE_URL" \
-//                   curia-curia-1 ./node_modules/.bin/tsx scripts/kg-node-linkage-report.ts'
+//                 ssh <host> 'docker exec curia-curia-1 \
+//                   ./node_modules/.bin/tsx scripts/kg-node-linkage-report.ts'
+//
+//               Verified against production 2026-09-02.
 //
 // Safety: one statement, and it is a SELECT. This script writes nothing.
 


### PR DESCRIPTION
## Summary

Records the production measurement in ADR-040, now that #1701 has shipped and the report could actually be run. Docs plus one comment fix — no behaviour change.

Refs #1694.

## The numbers

`scripts/kg-node-linkage-report.ts`, production, 2026-09-02:

| | |
|---|---|
| contacts total | 548 |
| holding no KG node | 14 (2.6%) |
| arm A — org re-link | **0** |
| arm B — mint a node | **14** |
| shadowed by a same-name contact that has a node | 12 |

Nodeless by kind: 12 `person`, 2 `automated`. All 38 `organization` contacts are linked, as are `principal` and `agent`. Table-wide there are 14 same-name clusters, largest holds 3.

## Two claims this ADR made before measuring, now corrected

**The org population is empirically zero.** ADR-040 introduced role-address collisions as a second, co-equal population and said a person-only fix "leaves this half of the nodeless population untouched." There is no such half here — every org contact is linked. The collision path is real and reachable in code, but has never fired in this deployment. The `idx_contacts_kg_node_unique` relaxation stays as prevention; it stops leading increment 2.

**The `resolveOrCreate` misattribution is not latent.** The ADR said the unique index makes two same-type matches impossible today. That is only true for labels. `findNodesByLabel` matches `lower(label)` **or** `aliases`, and aliases carry no cross-node uniqueness — no unique index on the column, and `addAlias` only checks the alias is absent from the node it writes to. Two person nodes can both carry the alias "Seth" and hit the same silent first-match pick, and `resolveOrCreate`'s fuzzy path calls `addAlias` automatically, so it can arise with nobody doing anything unusual. Rare, but live — and it is why this now leads increment 2.

## Consequence for sequencing

Migration `085` inserts 14 rows against a table whose largest same-name cluster is 3. That is materially lower-risk than the ADR assumed, and it moves the risk out of increment 3. Increment 2 is reordered in #1694: `resolveOrCreate` first, `extract-facts` context second, org relaxation last.

## Also

Corrects the script's prod runbook. `DATABASE_URL` **is** present in the app container's environment, so nothing needs forwarding — the documented `docker exec -e DATABASE_URL=...` was unnecessary. That claim came from a review comment I took on trust and did not verify until running it for real.

## Testing

`pnpm run typecheck` exit 0; `scripts/kg-node-linkage-report.test.ts` 9 passed. No source behaviour changed.
