### PR TITLE
feat(memory): stop guessing when a subject name is ambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`EntityMemory.resolveOrCreate`** — returns `ambiguous` when 2+ matches share the requested type, instead of taking the first. (#1694)
+- **`extract-facts`** — skips and counts an ambiguous subject rather than guessing; new `ambiguous` output. (#1694)
+- **Checkpoint extraction** — passes the conversation's external originator to `extract-facts` as a subject tiebreaker. (#1694)
 - **`EntityContextAssembler.assembleMany`** — new `nodeless` bucket, disjoint from `unresolved`; logged at warn. (#1694)
 - **`entity-context`** — output gains `nodeless`; agents read a missing node as a capability gap. (#1694)
 - **`entity-context` output schema** — new `nodeless` key on `ToolResult.data` (public API surface). (#1694)

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -45,6 +45,7 @@ function makeCtx(
   entityMemory: EntityMemory,
   input: Record<string, unknown>,
   infraLlm: InfraLlm,
+  contactService?: unknown,
 ): ToolContext {
   return {
     input,
@@ -52,6 +53,7 @@ function makeCtx(
     log: pino({ level: 'silent' }),
     entityMemory,
     infraLlm,
+    contactService,
   } as unknown as ToolContext;
 }
 
@@ -69,7 +71,7 @@ describe('ExtractFactsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: true, failed: 0 } });
+    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: true, failed: 0, ambiguous: 0 } });
     // Classifier was called; extraction was not
     expect(infraLlm.classify).toHaveBeenCalledTimes(1);
     expect(infraLlm.extract).not.toHaveBeenCalled();
@@ -89,7 +91,7 @@ describe('ExtractFactsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0 } });
+    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0, ambiguous: 0 } });
 
     // Fact node exists in the KG
     const josephNodes = await entityMemory.findEntities('Jane Doe');
@@ -173,14 +175,14 @@ describe('ExtractFactsHandler', () => {
     const handler1 = new ExtractFactsHandler();
     const ctx1 = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' }, infraLlm1);
     const result1 = await handler1.execute(ctx1);
-    expect(result1).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0 } });
+    expect(result1).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0, ambiguous: 0 } });
 
     // Second invocation with semantically identical fact — storeFact deduplicates internally
     const infraLlm2 = makeMockInfraLlm(['yes', facts]);
     const handler2 = new ExtractFactsHandler();
     const ctx2 = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' }, infraLlm2);
     const result2 = await handler2.execute(ctx2);
-    expect(result2).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0 } });
+    expect(result2).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0, ambiguous: 0 } });
 
     // Only one fact node should exist — storeFact merged the second call into the first
     const josephNodes = await entityMemory.findEntities('Jane Doe');
@@ -234,7 +236,7 @@ describe('ExtractFactsHandler', () => {
     const result = await handler.execute(ctx);
 
     // conflict is a semantic outcome — not counted as failed
-    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 0 } });
+    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 0, ambiguous: 0 } });
     expect(storeFact).toHaveBeenCalledOnce();
   });
 
@@ -260,7 +262,7 @@ describe('ExtractFactsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0 } });
+    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0, ambiguous: 0 } });
     // storeFact should use memoryWriteSource (task-scoped), not the LLM-provided 'agent:ceo-inbox'
     expect(storeFact.mock.calls[0]![0].source).toBe(memoryWriteSource);
   });
@@ -284,7 +286,7 @@ describe('ExtractFactsHandler', () => {
     const result = await handler.execute(ctx);
 
     // first fact stored, rate-limit counted as failed, loop stopped before fact 3
-    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 1 } });
+    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 1, ambiguous: 0 } });
     expect(storeFact).toHaveBeenCalledTimes(2);
   });
 
@@ -320,7 +322,7 @@ describe('ExtractFactsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 1 } });
+    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 1, ambiguous: 0 } });
 
     const malformedCall = warnSpy.mock.calls.find(
       (args) => typeof args[args.length - 1] === 'string' && (args[args.length - 1] as string).includes('skipping malformed fact'),
@@ -347,7 +349,7 @@ describe('ExtractFactsHandler', () => {
     const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' }, infraLlm);
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 1 } });
+    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 1, ambiguous: 0 } });
     expect(storeFact).toHaveBeenCalledTimes(1);
   });
 
@@ -393,5 +395,165 @@ describe('ExtractFactsHandler', () => {
     const result = await handler.execute(ctx);
 
     expect(result).toEqual({ success: false, error: 'Extraction LLM call failed: Context window exceeded' });
+  });
+
+  // -- Ambiguous subject resolution (#1694 / ADR-040) --
+  //
+  // This path used to take candidates[0] "to avoid stalling a batch job". Once two
+  // contacts named "Seth Berman" each hold their own person node, that is a coin flip
+  // that writes the fact onto whichever node sorted first. A dropped fact can be
+  // re-extracted later; one silently attached to the wrong person cannot be found
+  // again to correct. The only admissible tiebreaker is subject_contact_id, and only
+  // when one candidate IS that contact's node — the hint identifies the conversation's
+  // counterpart, not the subject of every sentence in it.
+  describe('ambiguous subject', () => {
+    // Needs the store as well as the memory wrapper, to seed colliding nodes directly
+    // (upsertNode would merge them).
+    function makeMemoryWithStore() {
+      const embeddingService = EmbeddingService.createForTesting();
+      const store = KnowledgeGraphStore.createInMemory(embeddingService);
+      const validator = new MemoryValidator(store, embeddingService);
+      return {
+        mem: new EntityMemory(store, validator, embeddingService, createSilentLogger()),
+        store,
+      };
+    }
+
+    const SETH_FACT = JSON.stringify([
+      { subject: 'Seth Berman', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
+    ]);
+
+    function makeContactService(contactsById: Record<string, { id: string; kgNodeId: string | null }>) {
+      return {
+        getContact: vi.fn(async (id: string) => contactsById[id]),
+        findContactByKgNodeId: vi.fn(async () => undefined),
+        updateContactFields: vi.fn(),
+      };
+    }
+
+    async function seedTwoSeths(store: KnowledgeGraphStore) {
+      const a = await store.createNode({ type: 'person', label: 'Seth Berman', properties: {}, source: 'test' });
+      const b = await store.createNode({ type: 'person', label: 'Seth Berman', properties: {}, source: 'test' });
+      return { a, b };
+    }
+
+    it('skips and counts the fact when ambiguous and no contact hint is given', async () => {
+      const { mem, store } = makeMemoryWithStore();
+      await seedTwoSeths(store);
+
+      const result = await new ExtractFactsHandler().execute(
+        makeCtx(mem, { text: 'Seth lives in Toronto.', source: 'test' }, makeMockInfraLlm(['yes', SETH_FACT])),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { stored: 0, redirected: 0, skipped: false, failed: 0, ambiguous: 1 },
+      });
+    });
+
+    it('resolves to the hinted contact node when it is one of the candidates', async () => {
+      const { mem, store } = makeMemoryWithStore();
+      const { a, b } = await seedTwoSeths(store);
+      const contactService = makeContactService({ 'contact-b': { id: 'contact-b', kgNodeId: b.id } });
+
+      const result = await new ExtractFactsHandler().execute(
+        makeCtx(
+          mem,
+          { text: 'Seth lives in Toronto.', source: 'test', subject_contact_id: 'contact-b' },
+          makeMockInfraLlm(['yes', SETH_FACT]),
+          contactService,
+        ),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { stored: 1, redirected: 0, skipped: false, failed: 0, ambiguous: 0 },
+      });
+      // The fact hangs off contact B's node specifically, and does not leak onto the namesake.
+      expect(await mem.getFacts(b.id)).toHaveLength(1);
+      expect(await mem.getFacts(a.id)).toHaveLength(0);
+    });
+
+    it('skips rather than guessing when the hinted contact is not among the candidates', async () => {
+      const { mem, store } = makeMemoryWithStore();
+      await seedTwoSeths(store);
+      const other = await store.createNode({ type: 'person', label: 'Dana Wu', properties: {}, source: 'test' });
+      const contactService = makeContactService({ 'contact-c': { id: 'contact-c', kgNodeId: other.id } });
+
+      const result = await new ExtractFactsHandler().execute(
+        makeCtx(
+          mem,
+          { text: 'Seth lives in Toronto.', source: 'test', subject_contact_id: 'contact-c' },
+          makeMockInfraLlm(['yes', SETH_FACT]),
+          contactService,
+        ),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { stored: 0, redirected: 0, skipped: false, failed: 0, ambiguous: 1 },
+      });
+    });
+
+    it('skips when the hinted contact holds no KG node', async () => {
+      // Exactly the #1694 population: a hint exists but cannot identify a node.
+      const { mem, store } = makeMemoryWithStore();
+      await seedTwoSeths(store);
+      const contactService = makeContactService({ 'contact-d': { id: 'contact-d', kgNodeId: null } });
+
+      const result = await new ExtractFactsHandler().execute(
+        makeCtx(
+          mem,
+          { text: 'Seth lives in Toronto.', source: 'test', subject_contact_id: 'contact-d' },
+          makeMockInfraLlm(['yes', SETH_FACT]),
+          contactService,
+        ),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { stored: 0, redirected: 0, skipped: false, failed: 0, ambiguous: 1 },
+      });
+    });
+
+    it('degrades to no-tiebreaker when the contact lookup throws', async () => {
+      // A contacts-table hiccup must not fail the whole extraction batch.
+      const { mem, store } = makeMemoryWithStore();
+      await seedTwoSeths(store);
+      const contactService = {
+        getContact: vi.fn().mockRejectedValue(new Error('pool timeout')),
+        findContactByKgNodeId: vi.fn(async () => undefined),
+        updateContactFields: vi.fn(),
+      };
+
+      const result = await new ExtractFactsHandler().execute(
+        makeCtx(
+          mem,
+          { text: 'Seth lives in Toronto.', source: 'test', subject_contact_id: 'contact-b' },
+          makeMockInfraLlm(['yes', SETH_FACT]),
+          contactService,
+        ),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { stored: 0, redirected: 0, skipped: false, failed: 0, ambiguous: 1 },
+      });
+    });
+
+    it('leaves the unambiguous path untouched', async () => {
+      const { mem, store } = makeMemoryWithStore();
+      const only = await store.createNode({ type: 'person', label: 'Seth Berman', properties: {}, source: 'test' });
+
+      const result = await new ExtractFactsHandler().execute(
+        makeCtx(mem, { text: 'Seth lives in Toronto.', source: 'test' }, makeMockInfraLlm(['yes', SETH_FACT])),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { stored: 1, redirected: 0, skipped: false, failed: 0, ambiguous: 0 },
+      });
+      expect(await mem.getFacts(only.id)).toHaveLength(1);
+    });
   });
 });

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -541,6 +541,29 @@ describe('ExtractFactsHandler', () => {
       });
     });
 
+    it('never logs the raw subject name on the ambiguous path (PII guard)', async () => {
+      // `subject` is an LLM-extracted entity name from a transcript — usually a person's
+      // name — and the pino redact list covers senderId/email/phoneNumber, not this.
+      // The handler already states the rule for malformed facts ("never the raw values");
+      // the ambiguity path has to hold to it too.
+      const { mem, store } = makeMemoryWithStore();
+      await seedTwoSeths(store);
+
+      const warn = vi.fn();
+      const ctx = makeCtx(mem, { text: 'Seth lives in Toronto.', source: 'test' }, makeMockInfraLlm(['yes', SETH_FACT]));
+      (ctx as unknown as { log: Record<string, unknown> }).log = {
+        warn, info: vi.fn(), debug: vi.fn(), error: vi.fn(), child: vi.fn(),
+      };
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const ambiguityWarn = warn.mock.calls.find(c => /ambiguous subject entity/.test(String(c[1])));
+      expect(ambiguityWarn).toBeDefined();
+      expect(JSON.stringify(ambiguityWarn![0])).not.toContain('Seth Berman');
+      // The node ids are the non-PII substitute, and identify the same entities.
+      expect(ambiguityWarn![0]).toHaveProperty('candidateIds');
+    });
+
     it('leaves the unambiguous path untouched', async () => {
       const { mem, store } = makeMemoryWithStore();
       const only = await store.createNode({ type: 'person', label: 'Seth Berman', properties: {}, source: 'test' });

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -35,7 +35,12 @@ const DECAY_CLASSES_LIST = DECAY_CLASSES.join(', ');
 
 export class ExtractFactsHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
-    const { text, source, max_stored } = ctx.input as { text?: string; source?: string; max_stored?: number };
+    const { text, source, max_stored, subject_contact_id } = ctx.input as {
+      text?: string;
+      source?: string;
+      max_stored?: number;
+      subject_contact_id?: string;
+    };
 
     if (!text || typeof text !== 'string') {
       // Log only safe metadata — never log ctx.input directly (contains full transcript)
@@ -64,7 +69,7 @@ export class ExtractFactsHandler implements ToolHandler {
 
       if (maxStored === 0) {
         ctx.log.info({ stored: 0, redirected: 0, failed: 0 }, 'extract-facts: complete');
-        return { success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 0 } };
+        return { success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 0, ambiguous: 0 } };
       }
 
       // -- Step 1: Classifier gate --
@@ -83,7 +88,7 @@ export class ExtractFactsHandler implements ToolHandler {
 
       if (!classifierAnswer.startsWith('yes')) {
         ctx.log.debug({ textPreview: text.slice(0, 80) }, 'extract-facts: classifier gate — no facts, skipping');
-        return { success: true, data: { stored: 0, redirected: 0, skipped: true, failed: 0 } };
+        return { success: true, data: { stored: 0, redirected: 0, skipped: true, failed: 0, ambiguous: 0 } };
       }
 
       // -- Step 2: Extraction prompt --
@@ -148,6 +153,11 @@ ${text}`,
       // Contradictions (action:'conflict') are NOT counted as failed — they are expected
       // semantic outcomes logged at warn.
       let failed = 0;
+      // ambiguous counts facts dropped because the subject label matched several
+      // entity nodes of the same type and nothing could break the tie. Deliberately
+      // separate from `failed`: nothing malfunctioned, and the caller's remedy is to
+      // supply subject_contact_id (or disambiguate the entities), not to retry. (#1694)
+      let ambiguous = 0;
 
       // Entity node types (fact nodes themselves are excluded as subjects —
       // we look up or create entity nodes, then attach facts to them).
@@ -210,20 +220,49 @@ ${text}`,
             : 0.7;
 
           // Resolve entity node — finds or auto-creates via resolveOrCreate().
-          // Ambiguous case (2+ nodes, no type match) takes candidates[0] rather than
-          // stalling the background batch job with a disambiguation loop.
+          //
+          // On ambiguity this used to take candidates[0] "to avoid stalling a batch
+          // job". Under ADR-040 two contacts named "Seth Berman" each hold their own
+          // person node, so that is a coin flip that writes the fact onto whichever
+          // node sorted first. A dropped fact can be re-extracted; a fact silently
+          // attached to the wrong person cannot be found again to correct. (#1694)
           const resolved = await ctx.entityMemory.resolveOrCreate({
             label: subject,
             type: subjectType,
             source,
             confidence: 0.6,
           });
+
           let entityNode;
           if (resolved.kind === 'ambiguous') {
-            entityNode = resolved.candidates[0]!;
-            ctx.log.warn(
-              { subject, candidateCount: resolved.candidates.length, chosenId: entityNode.id },
-              'extract-facts: ambiguous subject entity — taking first candidate',
+            // The only admissible tiebreaker is the caller's subject-contact hint, and
+            // only when one candidate IS that contact's node. The hint identifies the
+            // conversation's counterpart, which is not a claim that every fact in the
+            // transcript is about them — so a hint that matches nothing tells us
+            // nothing, and must not be used to pick.
+            const hinted = await this.resolveHintedNodeId(ctx, subject_contact_id);
+            const match = hinted
+              ? resolved.candidates.find(n => n.id === hinted)
+              : undefined;
+
+            if (!match) {
+              ambiguous++;
+              ctx.log.warn(
+                {
+                  subject,
+                  candidateCount: resolved.candidates.length,
+                  hadContactHint: subject_contact_id !== undefined,
+                  hintResolvedToNode: hinted !== undefined,
+                },
+                'extract-facts: ambiguous subject entity — skipping fact rather than guessing',
+              );
+              continue;
+            }
+
+            entityNode = match;
+            ctx.log.debug(
+              { subject, chosenId: match.id, candidateCount: resolved.candidates.length },
+              'extract-facts: ambiguous subject resolved via subject_contact_id',
             );
           } else {
             entityNode = resolved.node;
@@ -373,8 +412,8 @@ ${text}`,
         }
       }
 
-      ctx.log.info({ stored, redirected, failed }, 'extract-facts: complete');
-      return { success: true, data: { stored, redirected, skipped: false, failed } };
+      ctx.log.info({ stored, redirected, failed, ambiguous }, 'extract-facts: complete');
+      return { success: true, data: { stored, redirected, skipped: false, failed, ambiguous } };
     } catch (err) {
       // Two categories of errors reach here:
       // 1. LLMProvider errors (rate limits, auth, timeouts, 5xx) — these are returned as
@@ -384,6 +423,47 @@ ${text}`,
       //    re-thrown from the per-fact loop — indicate bugs in this handler, not infra issues.
       ctx.log.error({ err }, 'extract-facts: unexpected error');
       return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Resolve `subject_contact_id` to the KG node that contact holds, or undefined.
+   *
+   * Undefined for every "we cannot tell" case, and they are deliberately not
+   * distinguished here: no hint supplied, no ContactService wired, the contact does
+   * not exist, the contact holds no node (#1694's population), or the lookup failed.
+   * All of them mean the same thing to the caller — there is no tiebreaker — and the
+   * caller's response is identical: skip the fact rather than guess.
+   *
+   * Never throws. A contacts-table hiccup must not fail a whole extraction batch;
+   * it degrades to "no hint available", which is the safe direction.
+   */
+  private async resolveHintedNodeId(
+    ctx: ToolContext,
+    subjectContactId: string | undefined,
+  ): Promise<string | undefined> {
+    if (!subjectContactId || !ctx.contactService) return undefined;
+
+    try {
+      const contact = await ctx.contactService.getContact(subjectContactId);
+      if (!contact) {
+        ctx.log.debug({ subjectContactId }, 'extract-facts: subject_contact_id matched no contact');
+        return undefined;
+      }
+      if (!contact.kgNodeId) {
+        ctx.log.debug(
+          { subjectContactId },
+          'extract-facts: subject contact holds no KG node — cannot disambiguate',
+        );
+        return undefined;
+      }
+      return contact.kgNodeId;
+    } catch (err) {
+      ctx.log.warn(
+        { err, subjectContactId },
+        'extract-facts: subject contact lookup failed — proceeding without a tiebreaker',
+      );
+      return undefined;
     }
   }
 }

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -249,7 +249,12 @@ ${text}`,
               ambiguous++;
               ctx.log.warn(
                 {
-                  subject,
+                  // Deliberately not `subject`: it is an LLM-extracted entity name lifted
+                  // from a transcript, so it is usually a person's name, and the pino
+                  // redact list covers senderId/email/phoneNumber but not this. The node
+                  // ids identify the same entities without the PII, and are strictly more
+                  // useful for diagnosis — an operator can look each one up.
+                  candidateIds: resolved.candidates.map(n => n.id),
                   candidateCount: resolved.candidates.length,
                   hadContactHint: subject_contact_id !== undefined,
                   hintResolvedToNode: hinted !== undefined,
@@ -261,7 +266,8 @@ ${text}`,
 
             entityNode = match;
             ctx.log.debug(
-              { subject, chosenId: match.id, candidateCount: resolved.candidates.length },
+              // Same reasoning as the warn above — chosenId identifies the entity.
+              { chosenId: match.id, candidateCount: resolved.candidates.length },
               'extract-facts: ambiguous subject resolved via subject_contact_id',
             );
           } else {

--- a/skills/extract-facts/tool.json
+++ b/skills/extract-facts/tool.json
@@ -1,19 +1,21 @@
 {
   "name": "extract-facts",
   "description": "Extract single-entity attribute facts from a passage of text and persist them as knowledge graph fact nodes. Self-classifies internally — always safe to call; exits early if no facts are found.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
     "text": "string (the message or turn text to extract facts from)",
     "source": "string (provenance string, e.g. 'system:checkpoint/conversation:abc/agent:coordinator/channel:cli')",
+    "subject_contact_id": "string? (optional contact UUID for the conversation's counterpart. Used ONLY to break a tie when a subject name matches several entities of the same type, and only when one of them is that contact's own node. Not a claim that every extracted fact is about this contact.)",
     "max_stored": "number? (optional cap on facts persisted in this invocation)"
   },
   "outputs": {
     "stored": "number (new or updated fact nodes persisted to the KG)",
     "redirected": "number (canonical contact attribute writes redirected to ContactService instead of KG)",
     "skipped": "boolean (true if the classifier gate determined no facts were present)",
-    "failed": "number (facts that could not be persisted due to errors)"
+    "failed": "number (facts that could not be persisted due to errors)",
+    "ambiguous": "number (facts dropped because the subject name matched several same-type entities and nothing could break the tie — distinct from `failed`: nothing malfunctioned, and the fix is to supply subject_contact_id or disambiguate the entities, not to retry)"
   },
   "permissions": [],
   "secrets": [],
@@ -22,5 +24,7 @@
     "entityMemory",
     "infraLlm"
   ],
-  "allowed_callers": ["system"]
+  "allowed_callers": [
+    "system"
+  ]
 }

--- a/src/checkpoint/processor.ts
+++ b/src/checkpoint/processor.ts
@@ -7,7 +7,7 @@ import { createCheckpointExtractionSkipped } from '../bus/events.js';
 import type { ToolResult } from '../skills/types.js';
 import type { ChannelPolicyConfig } from '../contacts/types.js';
 import {
-  loadFirstExternalOriginatorTier,
+  loadFirstExternalOriginator,
   resolveChannelTrust,
   shouldSkipCheckpointKgExtraction,
 } from './trust-gate.js';
@@ -40,7 +40,10 @@ export class ConversationCheckpointProcessor {
     if (turns.length === 0) return;
 
     const channelTrust = resolveChannelTrust(channelId, this.channelPolicies);
-    const firstExternalTier = await loadFirstExternalOriginatorTier(this.pool, conversationId);
+    // One audit read serves two consumers: the trust gate needs the tier, and
+    // extract-facts needs the contact id as a subject tiebreaker (#1694).
+    const firstExternal = await loadFirstExternalOriginator(this.pool, conversationId);
+    const firstExternalTier = firstExternal === 'none' ? 'none' : firstExternal.tier;
     const skipKgExtraction = shouldSkipCheckpointKgExtraction(channelTrust, firstExternalTier);
 
     if (skipKgExtraction) {
@@ -97,9 +100,26 @@ export class ConversationCheckpointProcessor {
     // others or prevent the watermark from advancing — hence Promise.allSettled.
     // Check both rejected promises (thrown errors) and resolved { success: false }
     // results — ExecutionLayer never throws, so the latter is the normal failure path.
+    // The conversation's external counterpart, passed to extract-facts so an ambiguous
+    // subject name ("Seth Berman", when two contacts share it) can be resolved to this
+    // contact's own node instead of being dropped. It is a tiebreaker, not an assertion
+    // that every fact in the transcript is about them — extract-facts only applies it
+    // when one of the ambiguous candidates IS this contact's node (#1694 / ADR-040).
+    // Undefined for principal/system/agent-originated conversations, which have no
+    // external counterpart to disambiguate against.
+    const subjectContactId = firstExternal === 'none' ? undefined : firstExternal.contactId ?? undefined;
+
     const results = await Promise.allSettled(
       CHECKPOINT_TOOLS.map(skill =>
-        this.executionLayer.invoke(skill.name, { text: transcript, source }, callerContext),
+        this.executionLayer.invoke(
+          skill.name,
+          // Only extract-facts accepts the hint; extract-relationships has no single
+          // subject to disambiguate, so it keeps the original input shape.
+          skill.name === 'extract-facts' && subjectContactId !== undefined
+            ? { text: transcript, source, subject_contact_id: subjectContactId }
+            : { text: transcript, source },
+          callerContext,
+        ),
       ),
     );
 

--- a/src/checkpoint/trust-gate.ts
+++ b/src/checkpoint/trust-gate.ts
@@ -26,21 +26,35 @@ export function isExternalContactOriginator(originator: TaskOriginator): boolean
 /** Sentinel returned when no external originator appears in the conversation audit trail. */
 export type NoExternalOriginator = 'none';
 
+/** The first external originator of a conversation, as far as the audit trail records it. */
+export interface FirstExternalOriginator {
+  /** Contact tier at task initiation. Null for rows stamped before #950. */
+  tier: ContactTier | null;
+  /** Contact id of that originator. Null when the audit row predates the field. */
+  contactId: string | null;
+}
+
 /**
- * Load the tier of the first external contact who originated an agent.task in this
- * conversation. Returns 'none' when every task is principal/system/agent-originated.
+ * Load the first external contact who originated an agent.task in this conversation.
+ * Returns 'none' when every task is principal/system/agent-originated.
  *
  * Spec 10 maps every `agent.task` row's structured initiator to `system`/`dispatch`
  * (originator detail stays in `payload.metadata.originator`). So this query always
  * uses the payload path for Phase 1 + pre-hardening rows — there is no structured
  * `initiator_type = 'human'` shortcut for agent.task. Uses idx_audit_conversation.
+ *
+ * `contactId` is read for a second purpose beyond the trust gate: it is the
+ * conversation's counterpart, and checkpoint extraction passes it to extract-facts as
+ * a tiebreaker for ambiguous subject names (#1694). Both consumers come from this one
+ * row, so there is no extra query.
  */
-export async function loadFirstExternalOriginatorTier(
+export async function loadFirstExternalOriginator(
   pool: DbPool,
   conversationId: string,
-): Promise<ContactTier | null | NoExternalOriginator> {
-  const result = await pool.query<{ tier: string | null }>(
-    `SELECT payload->'metadata'->'originator'->>'tier' AS tier
+): Promise<FirstExternalOriginator | NoExternalOriginator> {
+  const result = await pool.query<{ tier: string | null; contact_id: string | null }>(
+    `SELECT payload->'metadata'->'originator'->>'tier'      AS tier,
+            payload->'metadata'->'originator'->>'contactId' AS contact_id
      FROM audit_log
      WHERE conversation_id = $1
        AND event_type = 'agent.task'
@@ -57,7 +71,22 @@ export async function loadFirstExternalOriginatorTier(
 
   const row = result.rows[0];
   if (!row) return 'none';
-  return (row.tier as ContactTier | null) ?? null;
+  return {
+    tier: (row.tier as ContactTier | null) ?? null,
+    contactId: row.contact_id ?? null,
+  };
+}
+
+/**
+ * Tier-only view of {@link loadFirstExternalOriginator}, kept as the shape the trust
+ * gate reasons about.
+ */
+export async function loadFirstExternalOriginatorTier(
+  pool: DbPool,
+  conversationId: string,
+): Promise<ContactTier | null | NoExternalOriginator> {
+  const originator = await loadFirstExternalOriginator(pool, conversationId);
+  return originator === 'none' ? 'none' : originator.tier;
 }
 
 export function resolveChannelTrust(

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -99,6 +99,63 @@ describe('EntityMemory.resolveOrCreate', () => {
     expect(result.candidates).toHaveLength(2);
   });
 
+  // #1694 / ADR-040 — two candidates of the *requested* type cannot be told apart by
+  // type, and picking the first silently attributes a fact to the wrong entity. That
+  // is worse than declining, so these must report ambiguous.
+  it('returns ambiguous when 2+ matches share the requested type', async () => {
+    const { mem, store } = makeEntityMemory();
+
+    await store.createNode({ type: 'person', label: 'Seth Berman', properties: {}, source: 'test' });
+    await store.createNode({ type: 'person', label: 'Seth Berman', properties: {}, source: 'test' });
+
+    const result = await mem.resolveOrCreate({
+      label: 'Seth Berman',
+      type: 'person',
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind !== 'ambiguous') throw new Error('narrowing');
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  it('returns ambiguous when 2+ matches share the requested type via a shared alias', async () => {
+    // The live path today: aliases carry no cross-node uniqueness (no unique index,
+    // and addAlias only checks the node it writes to), and resolveOrCreate's own fuzzy
+    // branch calls addAlias automatically. So two person nodes can end up sharing an
+    // alias without anyone doing anything unusual.
+    const { mem, store } = makeEntityMemory();
+
+    const a = await store.createNode({ type: 'person', label: 'Seth Berman', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Seth Berkowitz', properties: {}, source: 'test' });
+    await store.addAlias(a.id, 'seth');
+    await store.addAlias(b.id, 'seth');
+
+    const result = await mem.resolveOrCreate({ label: 'seth', type: 'person', source: 'test' });
+
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind !== 'ambiguous') throw new Error('narrowing');
+    expect(result.candidates.map(n => n.id).sort()).toEqual([a.id, b.id].sort());
+  });
+
+  it('still returns found when exactly one match has the requested type', async () => {
+    // Regression guard for the narrowing above: one person + one organization sharing
+    // a label is NOT ambiguous when the caller asks for a person. Type is a sufficient
+    // discriminator with a single candidate of that type, and treating this as
+    // ambiguous would make every cross-type label collision unresolvable.
+    const { mem, store } = makeEntityMemory();
+
+    const person = await store.createNode({ type: 'person', label: 'River', properties: {}, source: 'test' });
+    await store.createNode({ type: 'organization', label: 'River', properties: {}, source: 'test' });
+    await store.createNode({ type: 'project', label: 'River', properties: {}, source: 'test' });
+
+    const result = await mem.resolveOrCreate({ label: 'River', type: 'person', source: 'test' });
+
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') throw new Error('narrowing');
+    expect(result.node.id).toBe(person.id);
+  });
+
   it('returns found (with existing type) when 1 match exists but type differs from caller hint', async () => {
     const { mem } = makeEntityMemory();
     const { entity } = await mem.createEntity({

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -280,8 +280,9 @@ export class EntityMemory {
    *
    * Resolution logic (in order):
    *   1 exact match  → return { kind: 'found', node }
-   *   2+ exact matches, one has the expected type → return { kind: 'found', node: typeMatch }
-   *   2+ exact matches, no type match → return { kind: 'ambiguous', candidates }
+   *   2+ exact matches, exactly one has the expected type → { kind: 'found', node: typeMatch }
+   *   2+ exact matches, several share the expected type → { kind: 'ambiguous', candidates }
+   *   2+ exact matches, none has the expected type → { kind: 'ambiguous', candidates }
    *   0 exact matches, fuzzy score ≥ 0.90 → auto-resolve, learn alias, return { kind: 'found', node }
    *   0 exact matches, fuzzy score 0.75–0.90 → return { kind: 'ambiguous', candidates }
    *   0 exact matches, fuzzy score < 0.75 → create via createEntity(), return { kind: 'created', node }
@@ -292,7 +293,8 @@ export class EntityMemory {
    * This is the shared primitive used by both memory-store (agent-directed writes)
    * and extract-facts (background batch extraction). Callers handle 'ambiguous'
    * differently: memory-store surfaces candidates to the agent for disambiguation;
-   * extract-facts takes candidates[0] to avoid stalling a batch job.
+   * extract-facts tries its optional subject_contact_id tiebreaker and otherwise skips
+   * the fact, counting it. Neither guesses — see #1694.
    */
   async resolveOrCreate(options: ResolveOrCreateOptions): Promise<ResolveOrCreateResult> {
     // Phase 1: exact match on canonical label + aliases
@@ -317,13 +319,33 @@ export class EntityMemory {
     }
 
     if (matches.length > 1) {
-      // 2+ matches — prefer a node whose type matches the caller's expected type.
-      const typeMatch = matches.find(n => n.type === options.type);
-      if (typeMatch) {
-        return { kind: 'found', node: typeMatch };
+      // 2+ matches — type is the discriminator, but only when it actually discriminates.
+      //
+      // Exactly one candidate of the requested type is unambiguous: a person "River" and
+      // an organization "River" are different entities, and a caller asking for a person
+      // means the person. Treating that as ambiguous would make every cross-type label
+      // collision unresolvable.
+      //
+      // Two or more candidates of the requested type is a different situation entirely.
+      // Nothing in the label, the type, or the ordering distinguishes them, so returning
+      // the first is not a resolution — it is a coin flip that silently attaches the
+      // caller's fact to whichever node the backend happened to return first. Under
+      // ADR-040, where two contacts named "Seth Berman" each hold their own person node,
+      // that coin flip is the misattribution the whole change exists to prevent. It is
+      // also already reachable today through shared aliases, which carry no cross-node
+      // uniqueness. Declining and letting the caller disambiguate loses a fact; guessing
+      // corrupts one. (#1694)
+      const typeMatches = matches.filter(n => n.type === options.type);
+      if (typeMatches.length === 1) {
+        return { kind: 'found', node: typeMatches[0]! };
       }
-      // No type match — caller must ask the user to pick one.
-      return { kind: 'ambiguous', candidates: matches };
+      // Either nothing matched the requested type, or several did. Both need the caller
+      // to pick. When several share the type, surface only those — the cross-type
+      // candidates are noise for a caller that already told us which type it wants.
+      return {
+        kind: 'ambiguous',
+        candidates: typeMatches.length > 1 ? typeMatches : matches,
+      };
     }
 
     // Phase 2: no exact match — try embedding-based fuzzy resolution.

--- a/tests/unit/checkpoint/processor.test.ts
+++ b/tests/unit/checkpoint/processor.test.ts
@@ -67,6 +67,95 @@ describe('ConversationCheckpointProcessor', () => {
     );
   });
 
+  // #1694 / ADR-040 — the hint has to actually be supplied. An optional input no
+  // caller passes is dead code, which is how the entity_enrichment warn in #1701 ended
+  // up on a path no manifest reaches.
+  describe('subject_contact_id wiring', () => {
+    // The audit row the trust gate already reads also carries the originator contact id.
+    const externalOriginator = {
+      rows: [{ tier: 'known', contact_id: 'contact-seth-2' }],
+    };
+
+    it('passes the external originator contact id to extract-facts', async () => {
+      stubs.queryMock.mockResolvedValueOnce(externalOriginator);
+      const processor = new ConversationCheckpointProcessor(
+        stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+        { cli: { trust: 'high' } } as never,
+      );
+      processor.register();
+
+      await fireCheckpoint(stubs.subscribeHandlers, {
+        conversationId: 'conv-1', agentId: 'coordinator', channelId: 'cli',
+        since: '2026-01-01T00:00:00Z',
+        turns: [{ role: 'user', content: 'Seth lives in Toronto' }],
+      });
+
+      const factsCall = vi.mocked(stubs.executionLayer.invoke).mock.calls
+        .find(call => call[0] === 'extract-facts');
+      expect(factsCall).toBeDefined();
+      expect(factsCall![1]).toMatchObject({ subject_contact_id: 'contact-seth-2' });
+    });
+
+    it('does not pass the hint to extract-relationships', async () => {
+      // It has no single subject to disambiguate; sending the field would imply otherwise.
+      stubs.queryMock.mockResolvedValueOnce(externalOriginator);
+      const processor = new ConversationCheckpointProcessor(
+        stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+        { cli: { trust: 'high' } } as never,
+      );
+      processor.register();
+
+      await fireCheckpoint(stubs.subscribeHandlers, {
+        conversationId: 'conv-1', agentId: 'coordinator', channelId: 'cli',
+        since: '2026-01-01T00:00:00Z',
+        turns: [{ role: 'user', content: 'Seth lives in Toronto' }],
+      });
+
+      const relCall = vi.mocked(stubs.executionLayer.invoke).mock.calls
+        .find(call => call[0] === 'extract-relationships');
+      expect(relCall![1]).not.toHaveProperty('subject_contact_id');
+    });
+
+    it('omits the hint when the conversation has no external originator', async () => {
+      // principal/system/agent-originated: no counterpart to disambiguate against.
+      stubs.queryMock.mockResolvedValueOnce({ rows: [] });
+      const processor = new ConversationCheckpointProcessor(
+        stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+        { cli: { trust: 'high' } } as never,
+      );
+      processor.register();
+
+      await fireCheckpoint(stubs.subscribeHandlers, {
+        conversationId: 'conv-1', agentId: 'coordinator', channelId: 'cli',
+        since: '2026-01-01T00:00:00Z',
+        turns: [{ role: 'user', content: 'hello' }],
+      });
+
+      const factsCall = vi.mocked(stubs.executionLayer.invoke).mock.calls
+        .find(call => call[0] === 'extract-facts');
+      expect(factsCall![1]).not.toHaveProperty('subject_contact_id');
+    });
+
+    it('omits the hint when the audit row predates the contactId field', async () => {
+      stubs.queryMock.mockResolvedValueOnce({ rows: [{ tier: 'known', contact_id: null }] });
+      const processor = new ConversationCheckpointProcessor(
+        stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+        { cli: { trust: 'high' } } as never,
+      );
+      processor.register();
+
+      await fireCheckpoint(stubs.subscribeHandlers, {
+        conversationId: 'conv-1', agentId: 'coordinator', channelId: 'cli',
+        since: '2026-01-01T00:00:00Z',
+        turns: [{ role: 'user', content: 'hello' }],
+      });
+
+      const factsCall = vi.mocked(stubs.executionLayer.invoke).mock.calls
+        .find(call => call[0] === 'extract-facts');
+      expect(factsCall![1]).not.toHaveProperty('subject_contact_id');
+    });
+  });
+
   it('calls extract-relationships with concatenated transcript', async () => {
     const processor = new ConversationCheckpointProcessor(
       stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,


### PR DESCRIPTION
## Summary

Increment 2 of #1694, per ADR-040. Application logic only — **no migration, no schema change**.

Refs #1694 (does not close it — increment 3 remains).

## What's here

**1. `resolveOrCreate` stops guessing on a multi-match.** It returned `matches.find(n => n.type === type)`, which is a coin flip once two nodes share both label and type. The new rule is narrower than "return ambiguous on 2+ matches" — there's an existing behaviour that must survive:

| candidates of the requested type | result |
|---|---|
| exactly one | `found` — **unchanged**. A person "River" and an org "River" are different entities; a caller asking for a person means the person. |
| two or more | `ambiguous`, carrying only the same-type candidates (cross-type ones are noise for a caller that stated its type) |
| none | `ambiguous` — unchanged |

**This is not purely forward-looking.** `findNodesByLabel` matches `lower(label)` **or** `aliases`; aliases carry no cross-node uniqueness (no unique index, and `addAlias` only checks the node it writes to); and `resolveOrCreate`'s own fuzzy branch calls `addAlias` automatically. Two person nodes can already share an alias today with nobody doing anything unusual. There's a test for that path specifically.

**2. `extract-facts` skips instead of guessing.** It took `candidates[0]` "to avoid stalling a batch job". A dropped fact can be re-extracted; a fact silently attached to the wrong person cannot be found again to correct.

New optional `subject_contact_id`, applied **only** when one of the ambiguous candidates IS that contact's node. The hint identifies the conversation's counterpart, not the subject of every sentence in the transcript — so a hint matching no candidate tells us nothing and must not be used to pick. Everything unresolved is skipped and counted under a new `ambiguous` output, deliberately separate from `failed`: nothing malfunctioned, and the remedy is to supply the hint or disambiguate the entities, not to retry.

**3. The hint is actually supplied.** The checkpoint processor reads it from the same `audit_log` row the trust gate already queries for tier (`TaskOriginator.contactId`), so no extra query. Wired and tested in this PR on purpose — an optional input no caller passes is dead code, which is exactly what the `entity_enrichment` warn in #1701 turned out to be.

## Deferred to increment 3

The `idx_contacts_kg_node_unique` org relaxation. It needs a migration, ADR-040 changes both indexes as one invariant, and arm A measured **0** — so it's prevention rather than repair, and belongs with its sibling index change and the backfill. `085` stays the name ADR-040 already uses for the backfill.

## Testing

- `src/memory/entity-memory.resolve-or-create.test.ts` — 3 new: 2+ same-type via shared label, 2+ same-type via shared alias (the live path), and a regression guard that one-of-type still resolves.
- `skills/extract-facts/handler.test.ts` — 6 new covering no-hint, hint-matches-a-candidate (including that the fact does *not* leak onto the namesake), hint-matches-nothing, hint-contact-has-no-node, contact lookup throwing, and the unambiguous path.
- `tests/unit/checkpoint/processor.test.ts` — 4 new pinning that the hint reaches `extract-facts`, does not reach `extract-relationships`, and is omitted for principal/system conversations and pre-#950 audit rows.
- Updated 9 existing `toEqual` assertions in `handler.test.ts` for the new counter, and added `ambiguous: 0` to both early-return paths so the result shape stays fixed rather than having one sometimes-absent field.

Full suite **6063 passed, 0 failed** (up 13). `typecheck` exit 0, `lint` 0 errors.

## Public API surface

`extract-facts` `1.2.0 → 1.3.0`: new optional input `subject_contact_id`, new output `ambiguous`.
