### PR TITLE
docs(adr-040): identity does not decay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **ADR-040 (Accepted)** — contact-anchored KG node identity; a contact's node is keyed on the contact, not its label. (#1694)
 - **ADR-040 measured population** — migration `085` sizing recorded from production: 14 nodeless contacts, arm A empty. (#1694)
+- **ADR-040 identity decay rule** — contact-anchored KG nodes are excluded from decay and archival; facts still decay. (#1694)
 - **`scripts/kg-node-linkage-report.ts`** — read-only count of nodeless contacts, split across ADR-040's two backfill arms. (#1694)
 - **Signal voice calls** — anyone can Signal-call Curia; live conversation via VoiceRuntime, config-gated off. (#1672)
 - **`MemorySampler`** — periodic `process.memoryUsage()` logging to diagnose heap growth in prod. (#1650)

--- a/docs/adr/040-contact-anchored-kg-node-identity.md
+++ b/docs/adr/040-contact-anchored-kg-node-identity.md
@@ -158,8 +158,9 @@ onto the wrong person is not.
 
 ### Contact deletion
 
-Deleting a contact **archives its anchored node** (`archived_at = now()`). Archiving is the
-right instrument here for three reasons: `idx_kg_nodes_unique` already excludes archived
+Deleting a contact **archives its anchored node** (`archived_at = now()`), which is only
+unambiguous because nothing else archives anchored nodes — see *Identity does not decay*
+below. Archiving is the right instrument here for three reasons: `idx_kg_nodes_unique` already excludes archived
 rows, so the label is freed for reuse without a demote step that could itself raise a
 unique violation *during a delete*; the node and its facts are soft-deleted, so the
 knowledge is recoverable in SQL rather than destroyed; and it reuses the dream engine's
@@ -167,6 +168,47 @@ existing archival semantics instead of inventing an orphan state nothing else un
 
 Organization nodes are exempt — they are unanchored and shared, and outlive any one
 contact.
+
+### Identity does not decay
+
+Archiving an anchored node on contact deletion gives `archived_at` a specific meaning for
+these rows: *this contact is gone*. That meaning only holds if nothing else archives them.
+Today something does.
+
+`DreamEngine` decays every non-permanent node continuously and archives anything at or
+below `archiveThreshold` (0.05), with no exclusion for nodes a contact points at. Its
+decay-warning mechanism does not help: a node is "important" enough to warn only if it
+carries high sensitivity or has an edge count at or above the p95 floor of 5, and being a
+contact's node is not a criterion. Warned nodes are archived anyway after
+`warnHoldBackDays`. Measured in production: **532 of 534** contact-linked nodes are
+non-permanent, and **478** of those would be archived with no warning at all.
+
+Nor does interaction protect them. The only writes that refresh an entity node's
+`last_confirmed_at` are an explicit `updateNode`, a human confirming a decay warning, and a
+creation-time upsert collision. Receiving mail from someone, replying to them, and storing
+facts *about* them all leave the entity node untouched — `storeFact`'s `updateNode` calls
+target the fact node, not the entity. A contact you email daily decays at exactly the same
+rate as one you met once. The decay is monotonic and universal.
+
+So: **a contact's node is the container for its memory, not a memory itself. Containers
+persist as long as the contact does; contents age normally.**
+
+Contact-anchored nodes are excluded from decay and from archival — the predicate
+`identity_source = 'label'` is added to `DreamEngine`'s decay passes (1a, 1b) and its
+node-archival pass (2b). Facts hanging off an anchored node keep decaying exactly as
+before, so this does not freeze memory; it stops the *anchor* from evaporating out from
+under a live contact.
+
+This is ADR-039's rule applied consistently rather than a new one. *Did a process decide
+this, or did Curia learn it?* A contact-anchored node's existence is decided by contact
+creation. Its facts are learned. The first gets a durable row; the second decays.
+
+Rejected: promoting anchored nodes to `decay_class = 'permanent'` in the backfill. It
+needs no `DreamEngine` change and reuses migration 062's mechanism, but it is a data fix
+rather than a rule — `createContact` and every future node-writing path has to remember to
+set it, and any `updateNode` can silently clear it. That is an invariant maintained by
+convention across N call sites, which is the same shape this ADR rejected for the identity
+pointer. It also overloads `permanent`, which today means "a fact that will never change".
 
 ### Backfill
 
@@ -223,6 +265,13 @@ merge. The identity rule is enforced by Postgres rather than maintained by conve
 `identity_source` makes "why does this node not dedup by label?" answerable from a single
 column.
 
+**Accepted: the graph stops self-pruning contact anchors.** Excluding anchored nodes from
+decay means the node count for contacts only grows, and a contact who is never heard from
+again keeps their anchor indefinitely. That is deliberate — the alternative is an identity
+that evaporates on a timer — but it moves the cleanup question onto contact deletion, which
+is now the only thing that retires an anchor. Facts still decay, so the storage that
+actually accumulates is still bounded by the existing mechanism.
+
 **Harder / accepted trade-offs.** There are now two identity tiers to keep in mind, and the
 `upsertNode`-is-label-only invariant is the seam where a careless caller could put an
 anchored node back into the label pool. Name-only writes return `ambiguous` far more often
@@ -265,5 +314,7 @@ contacts a durable identity; it does not give the KG one for everyone else.
 - PR #1700 (this ADR), PR #1701 (increment 1 — visibility, and the measurement above)
 - #1702 (`entity-context` reports a DB failure as "contact not found" — the same
   absence-of-evidence failure on the error path, found while reviewing #1701)
+- #1707 (the entity-context read path ignores `archived_at`, so archived nodes and facts
+  still assemble — adjacent, and made load-bearing by the deletion rule above)
 - Migrations 010, 016, 027, 056 (the indexes and backfills this supersedes or amends)
 - ADR-028 (shared, unbound agent memory) for the surrounding memory-governance model


### PR DESCRIPTION
## Summary

Settles the DreamEngine interaction before increment 3 starts, so the design is decided rather than discovered mid-migration. Docs only.

Refs #1694.

## The problem

ADR-040 already had contact deletion archive the anchored node, which gives `archived_at` a specific meaning for those rows: *this contact is gone.* That meaning only holds if nothing else archives them. Today something does — `DreamEngine` Pass 2b archives any non-permanent node at or below `archiveThreshold` (0.05) with no exclusion for nodes a contact points at.

The decay-warning mechanism doesn't cover it. A node is "important" enough to warn only on high sensitivity or an edge count at the p95 floor of 5; being a contact's node isn't a criterion. And warned nodes archive anyway after `warnHoldBackDays: 7`.

**Measured in production:**

| | |
|---|---|
| contact-linked nodes, non-permanent | **532** of 534 |
| of those, archivable with no warning at all | **478** |
| already below 0.5 confidence | 227 |
| avg / min confidence | 0.521 / 0.347 |

Nothing refreshes these on interaction, either. The only writes that touch an entity node's `last_confirmed_at` are an explicit `updateNode`, a human confirming a decay warning, and a creation-time upsert collision. `storeFact`'s `updateNode` calls target the **fact** node, not the entity — so receiving mail from someone, replying, and storing facts about them all leave the anchor untouched. A contact you email daily decays at exactly the same rate as one you met once. It's monotonic and universal; ~500–600 days is a floor, not an estimate.

## The decision

**A contact's node is the container for its memory, not a memory itself. Containers persist as long as the contact does; contents age normally.**

Contact-anchored nodes are excluded from decay (Passes 1a/1b) and archival (Pass 2b) via `identity_source = 'label'`. Facts hanging off an anchored node keep decaying exactly as before — this does not freeze memory, it stops the anchor evaporating out from under a live contact.

This is ADR-039's test applied consistently, not a new rule: *did a process decide this, or did Curia learn it?* A contact-anchored node's existence is decided by contact creation; its facts are learned.

## Rejected

`decay_class = 'permanent'` on anchored nodes in the backfill. Needs no engine change and reuses migration 062's mechanism — but it's a data fix rather than a rule. `createContact` and every future node-writing path has to remember to set it, and any `updateNode` can silently clear it. That's an invariant maintained by convention across N call sites, the same shape this ADR already rejected for the identity pointer. It also overloads `permanent`, which today means "a fact that will never change".

## Accepted trade-off

Recorded in Consequences: the graph stops self-pruning contact anchors, so a contact never heard from again keeps theirs indefinitely. Deliberate — the alternative is identity on a timer — but it moves cleanup onto contact deletion, now the only thing that retires an anchor. Facts still decay, so accumulating storage stays bounded by the existing mechanism.

## Also

Filed **#1707** for the adjacent read-path gap: `getKgNode` / `getFacts` / `getRelationships` apply no `archived_at` filter, so archived nodes and facts still assemble into agent context. It's pre-existing and independent, it currently masks the impact of everything above, and the deletion rule makes it semantically load-bearing in increment 3.

## Testing

Docs only — no code changes. The implementation lands in increment 3 alongside the `identity_source` column the predicate depends on.
