### PR TITLE
fix(extract-facts): keep raw subject names out of remaining fact-loop logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`extract-facts`** — fact-loop logs use node id instead of the raw subject name. (#1706)
+- **`buildCanonicalPatch`** — phone fallback reason is a stable code, not the raw number. (#1706)
 - **`createContact`** — a display-name collision now mints a node instead of dropping the link. (#1694)
 - **Orphan cleanup** — a failed contact create no longer archives a KG node it merely adopted. (#1694)
 - **Signal inbound** — ACI-only senders keep a non-empty sender and conversation identity. (#1600)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`extract-facts`** — fact-loop logs use node id instead of the raw subject name. (#1706)
 - **`createContact`** — a display-name collision now mints a node instead of dropping the link. (#1694)
 - **Orphan cleanup** — a failed contact create no longer archives a KG node it merely adopted. (#1694)
 - **Signal inbound** — ACI-only senders keep a non-empty sender and conversation identity. (#1600)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`extract-facts`** — fact-loop logs use node id instead of the raw subject name. (#1706)
+- **`extract-facts`** — fact-loop logs omit `attribute` unless it is snake_case. (#1706)
 - **`buildCanonicalPatch`** — phone fallback reason is a stable code, not the raw number. (#1706)
 - **`createContact`** — a display-name collision now mints a node instead of dropping the link. (#1694)
 - **Orphan cleanup** — a failed contact create no longer archives a KG node it merely adopted. (#1694)

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -587,8 +587,8 @@ describe('ExtractFactsHandler', () => {
   // These ten pre-existing call sites still logged it. `subject` is an LLM-extracted
   // entity name (usually a person's name) and the pino redact list does not cover it.
   // Substitute: entityNodeId where a node is resolved; omit it when resolution has
-  // not completed. `attribute` is a snake_case key and is kept — it is not identifying
-  // on its own.
+  // not completed. `attribute` is logged only when it is snake_case — the LLM can
+  // put a name in that field, and pino does not redact it.
   describe('fact-loop logs never carry the raw subject name (PII guard)', () => {
     const PII_SUBJECT = 'Priya Ramanathan';
     const UNNORMALIZABLE_PHONE = '020 7946 0958';
@@ -834,6 +834,29 @@ describe('ExtractFactsHandler', () => {
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
+    });
+
+    it('does not log a non-snake_case attribute (PII guard)', async () => {
+      // The extraction prompt asks for snake_case keys, but the model can ignore
+      // that and put a person's name in `attribute`. pino does not redact it.
+      const entityMemory = makeEntityMemory();
+      vi.spyOn(entityMemory, 'storeFact').mockResolvedValueOnce({
+        stored: false,
+        action: 'conflict',
+        conflict: 'contradicts existing value: London',
+      });
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} is vegetarian.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson(PII_SUBJECT, 'vegetarian')]),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.warn, /fact not stored/);
+      expectNoPii(call);
+      expect(call![0]).not.toHaveProperty('attribute');
     });
 
     it('programming-error in fact loop', async () => {

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -586,19 +586,23 @@ describe('ExtractFactsHandler', () => {
   // The malformed-fact and ambiguity paths already omit the raw subject name.
   // These ten pre-existing call sites still logged it. `subject` is an LLM-extracted
   // entity name (usually a person's name) and the pino redact list does not cover it.
-  // Substitute: entityNodeId where a node is resolved; presence flags otherwise.
-  // `attribute` is a snake_case key and is kept — it is not identifying on its own.
+  // Substitute: entityNodeId where a node is resolved; omit it when resolution has
+  // not completed. `attribute` is a snake_case key and is kept — it is not identifying
+  // on its own.
   describe('fact-loop logs never carry the raw subject name (PII guard)', () => {
     const PII_SUBJECT = 'Priya Ramanathan';
+    const UNNORMALIZABLE_PHONE = '020 7946 0958';
 
     function spyLog() {
-      return {
+      const log = {
         warn: vi.fn(),
         info: vi.fn(),
         debug: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       };
+      log.child.mockReturnValue(log);
+      return log;
     }
 
     function attachSpyLog(ctx: ToolContext) {
@@ -611,9 +615,24 @@ describe('ExtractFactsHandler', () => {
       return fn.mock.calls.find(c => messageRe.test(String(c[c.length - 1])));
     }
 
-    function expectNoRawSubject(call: unknown[] | undefined) {
+    // JSON.stringify skips Error.message (non-enumerable). Pino does serialize it,
+    // so fold err.message/stack in or the guard is inert on the three `err` sites.
+    function serializeLogPayload(payload: unknown): string {
+      const obj = payload as Record<string, unknown> | null;
+      const err = obj?.err;
+      const errText = err instanceof Error
+        ? `${err.name} ${err.message} ${err.stack ?? ''}`
+        : '';
+      return `${JSON.stringify(payload)}\n${errText}`;
+    }
+
+    function expectNoPii(call: unknown[] | undefined, extraForbidden: string[] = []) {
       expect(call).toBeDefined();
-      expect(JSON.stringify(call![0])).not.toContain(PII_SUBJECT);
+      const serialized = serializeLogPayload(call![0]);
+      expect(serialized).not.toContain(PII_SUBJECT);
+      for (const s of extraForbidden) {
+        expect(serialized).not.toContain(s);
+      }
       expect(call![0]).not.toHaveProperty('subject');
     }
 
@@ -638,8 +657,8 @@ describe('ExtractFactsHandler', () => {
       const entityMemory = makeEntityMemory();
       const ctx = makeCtx(
         entityMemory,
-        { text: `${PII_SUBJECT} phone is not-a-phone-number.`, source: 'test' },
-        makeMockInfraLlm(['yes', factJson('phone', 'not-a-phone-number')]),
+        { text: `${PII_SUBJECT} phone is ${UNNORMALIZABLE_PHONE}.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('phone', UNNORMALIZABLE_PHONE)]),
         makeContactService(),
       );
       const log = attachSpyLog(ctx);
@@ -647,10 +666,11 @@ describe('ExtractFactsHandler', () => {
       await new ExtractFactsHandler().execute(ctx);
 
       const call = findCall(log.warn, /canonical attribute normalization failed/);
-      expectNoRawSubject(call);
+      expectNoPii(call, [UNNORMALIZABLE_PHONE, '7946 0958']);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'phone');
+      expect(call![0]).toHaveProperty('reason', 'phone_normalization_failed');
     });
 
     it('findContactByKgNodeId-failed warn', async () => {
@@ -668,7 +688,7 @@ describe('ExtractFactsHandler', () => {
       await new ExtractFactsHandler().execute(ctx);
 
       const call = findCall(log.warn, /findContactByKgNodeId failed/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'timezone');
@@ -691,7 +711,7 @@ describe('ExtractFactsHandler', () => {
         data: { stored: 0, redirected: 1, skipped: false, failed: 0, ambiguous: 0 },
       });
       const call = findCall(log.info, /canonical attribute redirected/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'timezone');
@@ -715,7 +735,7 @@ describe('ExtractFactsHandler', () => {
       await new ExtractFactsHandler().execute(ctx);
 
       const call = findCall(log.warn, /canonical attribute validation failed/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'primary_email');
@@ -741,7 +761,7 @@ describe('ExtractFactsHandler', () => {
         data: { stored: 0, redirected: 0, skipped: false, failed: 1, ambiguous: 0 },
       });
       const call = findCall(log.error, /canonical attribute redirect failed with unexpected error/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'timezone');
@@ -756,7 +776,7 @@ describe('ExtractFactsHandler', () => {
       });
       const ctx = makeCtx(
         entityMemory,
-        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        { text: `${PII_SUBJECT} is vegetarian.`, source: 'test' },
         makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
       );
       const log = attachSpyLog(ctx);
@@ -764,7 +784,7 @@ describe('ExtractFactsHandler', () => {
       await new ExtractFactsHandler().execute(ctx);
 
       const call = findCall(log.info, /fact auto-resolved/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
@@ -779,7 +799,7 @@ describe('ExtractFactsHandler', () => {
       });
       const ctx = makeCtx(
         entityMemory,
-        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        { text: `${PII_SUBJECT} is vegetarian.`, source: 'test' },
         makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
       );
       const log = attachSpyLog(ctx);
@@ -787,7 +807,7 @@ describe('ExtractFactsHandler', () => {
       await new ExtractFactsHandler().execute(ctx);
 
       const call = findCall(log.error, /write rate limit exceeded/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
@@ -802,7 +822,7 @@ describe('ExtractFactsHandler', () => {
       });
       const ctx = makeCtx(
         entityMemory,
-        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        { text: `${PII_SUBJECT} is vegetarian.`, source: 'test' },
         makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
       );
       const log = attachSpyLog(ctx);
@@ -810,7 +830,7 @@ describe('ExtractFactsHandler', () => {
       await new ExtractFactsHandler().execute(ctx);
 
       const call = findCall(log.warn, /fact not stored/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
       expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
@@ -823,7 +843,7 @@ describe('ExtractFactsHandler', () => {
       );
       const ctx = makeCtx(
         entityMemory,
-        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        { text: `${PII_SUBJECT} is vegetarian.`, source: 'test' },
         makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
       );
       const log = attachSpyLog(ctx);
@@ -831,10 +851,10 @@ describe('ExtractFactsHandler', () => {
       await new ExtractFactsHandler().execute(ctx);
 
       const call = findCall(log.error, /unexpected programming error in fact loop/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
-      expect(call![0]).toHaveProperty('hasSubject', true);
+      expect(call![0]).not.toHaveProperty('hasSubject');
       expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
     });
 
@@ -843,7 +863,7 @@ describe('ExtractFactsHandler', () => {
       vi.spyOn(entityMemory, 'storeFact').mockRejectedValueOnce(new Error('DB connection lost'));
       const ctx = makeCtx(
         entityMemory,
-        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        { text: `${PII_SUBJECT} is vegetarian.`, source: 'test' },
         makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
       );
       const log = attachSpyLog(ctx);
@@ -851,10 +871,10 @@ describe('ExtractFactsHandler', () => {
       await new ExtractFactsHandler().execute(ctx);
 
       const call = findCall(log.error, /failed to persist fact/);
-      expectNoRawSubject(call);
+      expectNoPii(call);
       const nodes = await entityMemory.findEntities(PII_SUBJECT);
       expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
-      expect(call![0]).toHaveProperty('hasSubject', true);
+      expect(call![0]).not.toHaveProperty('hasSubject');
       expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
     });
   });

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -11,6 +11,7 @@ import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../src/memory/validation.js';
 import { createSilentLogger } from '../../src/logger.js';
 import { ExtractFactsHandler } from './handler.js';
+import { ContactValidationError } from '../../src/contacts/contact-service.js';
 import type { ToolContext } from '../../src/skills/types.js';
 import type { InfraLlm, InfraLlmResult } from '../../src/skills/infra-llm.js';
 
@@ -577,6 +578,284 @@ describe('ExtractFactsHandler', () => {
         data: { stored: 1, redirected: 0, skipped: false, failed: 0, ambiguous: 0 },
       });
       expect(await mem.getFacts(only.id)).toHaveLength(1);
+    });
+  });
+
+  // -- PII guard: remaining fact-loop logs (#1706) --
+  //
+  // The malformed-fact and ambiguity paths already omit the raw subject name.
+  // These ten pre-existing call sites still logged it. `subject` is an LLM-extracted
+  // entity name (usually a person's name) and the pino redact list does not cover it.
+  // Substitute: entityNodeId where a node is resolved; presence flags otherwise.
+  // `attribute` is a snake_case key and is kept — it is not identifying on its own.
+  describe('fact-loop logs never carry the raw subject name (PII guard)', () => {
+    const PII_SUBJECT = 'Priya Ramanathan';
+
+    function spyLog() {
+      return {
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      };
+    }
+
+    function attachSpyLog(ctx: ToolContext) {
+      const log = spyLog();
+      (ctx as unknown as { log: typeof log }).log = log;
+      return log;
+    }
+
+    function findCall(fn: ReturnType<typeof vi.fn>, messageRe: RegExp) {
+      return fn.mock.calls.find(c => messageRe.test(String(c[c.length - 1])));
+    }
+
+    function expectNoRawSubject(call: unknown[] | undefined) {
+      expect(call).toBeDefined();
+      expect(JSON.stringify(call![0])).not.toContain(PII_SUBJECT);
+      expect(call![0]).not.toHaveProperty('subject');
+    }
+
+    function factJson(attribute: string, value: string) {
+      return JSON.stringify([
+        { subject: PII_SUBJECT, subjectType: 'person', attribute, value, confidence: 0.9, decayClass: 'slow_decay' },
+      ]);
+    }
+
+    function makeContactService(overrides: {
+      findContactByKgNodeId?: ReturnType<typeof vi.fn>;
+      updateContactFields?: ReturnType<typeof vi.fn>;
+    } = {}) {
+      return {
+        getContact: vi.fn(async () => undefined),
+        findContactByKgNodeId: overrides.findContactByKgNodeId ?? vi.fn(async () => ({ id: 'contact-1' })),
+        updateContactFields: overrides.updateContactFields ?? vi.fn(async () => ({ id: 'contact-1' })),
+      };
+    }
+
+    it('canonical-normalization-failed warn', async () => {
+      const entityMemory = makeEntityMemory();
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} phone is not-a-phone-number.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('phone', 'not-a-phone-number')]),
+        makeContactService(),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.warn, /canonical attribute normalization failed/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('attribute', 'phone');
+    });
+
+    it('findContactByKgNodeId-failed warn', async () => {
+      const entityMemory = makeEntityMemory();
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} timezone is America/Toronto.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('timezone', 'America/Toronto')]),
+        makeContactService({
+          findContactByKgNodeId: vi.fn().mockRejectedValue(new Error('connection timeout')),
+        }),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.warn, /findContactByKgNodeId failed/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('attribute', 'timezone');
+    });
+
+    it('canonical-redirected info', async () => {
+      const entityMemory = makeEntityMemory();
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} timezone is America/Toronto.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('timezone', 'America/Toronto')]),
+        makeContactService(),
+      );
+      const log = attachSpyLog(ctx);
+
+      const result = await new ExtractFactsHandler().execute(ctx);
+
+      expect(result).toEqual({
+        success: true,
+        data: { stored: 0, redirected: 1, skipped: false, failed: 0, ambiguous: 0 },
+      });
+      const call = findCall(log.info, /canonical attribute redirected/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('attribute', 'timezone');
+      expect(call![0]).toHaveProperty('contactId', 'contact-1');
+    });
+
+    it('canonical-validation-failed warn', async () => {
+      const entityMemory = makeEntityMemory();
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} email is priya@example.com.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('primary_email', 'priya@example.com')]),
+        makeContactService({
+          updateContactFields: vi.fn().mockRejectedValue(
+            new ContactValidationError('primaryEmail not found in contact_channel_identities'),
+          ),
+        }),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.warn, /canonical attribute validation failed/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('attribute', 'primary_email');
+      expect(call![0]).toHaveProperty('contactId', 'contact-1');
+    });
+
+    it('canonical-redirect unexpected-error', async () => {
+      const entityMemory = makeEntityMemory();
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} timezone is America/Toronto.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('timezone', 'America/Toronto')]),
+        makeContactService({
+          updateContactFields: vi.fn().mockRejectedValue(new Error('pool timeout')),
+        }),
+      );
+      const log = attachSpyLog(ctx);
+
+      const result = await new ExtractFactsHandler().execute(ctx);
+
+      expect(result).toEqual({
+        success: true,
+        data: { stored: 0, redirected: 0, skipped: false, failed: 1, ambiguous: 0 },
+      });
+      const call = findCall(log.error, /canonical attribute redirect failed with unexpected error/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('attribute', 'timezone');
+    });
+
+    it('auto-resolved info', async () => {
+      const entityMemory = makeEntityMemory();
+      vi.spyOn(entityMemory, 'storeFact').mockResolvedValueOnce({
+        stored: true,
+        action: 'auto_resolved',
+        nodeId: 'fact-1',
+      });
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.info, /fact auto-resolved/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
+    });
+
+    it('rate-limited error', async () => {
+      const entityMemory = makeEntityMemory();
+      vi.spyOn(entityMemory, 'storeFact').mockResolvedValueOnce({
+        stored: false,
+        action: 'rate_limited',
+        conflict: '50-write limit reached',
+      });
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.error, /write rate limit exceeded/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
+    });
+
+    it('fact-not-stored warn', async () => {
+      const entityMemory = makeEntityMemory();
+      vi.spyOn(entityMemory, 'storeFact').mockResolvedValueOnce({
+        stored: false,
+        action: 'conflict',
+        conflict: 'contradicts existing value: London',
+      });
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.warn, /fact not stored/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
+    });
+
+    it('programming-error in fact loop', async () => {
+      const entityMemory = makeEntityMemory();
+      vi.spyOn(entityMemory, 'storeFact').mockRejectedValueOnce(
+        new TypeError("Cannot read properties of undefined (reading 'id')"),
+      );
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.error, /unexpected programming error in fact loop/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('hasSubject', true);
+      expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
+    });
+
+    it('failed-to-persist error', async () => {
+      const entityMemory = makeEntityMemory();
+      vi.spyOn(entityMemory, 'storeFact').mockRejectedValueOnce(new Error('DB connection lost'));
+      const ctx = makeCtx(
+        entityMemory,
+        { text: `${PII_SUBJECT} prefers aisle seats.`, source: 'test' },
+        makeMockInfraLlm(['yes', factJson('dietary_preference', 'vegetarian')]),
+      );
+      const log = attachSpyLog(ctx);
+
+      await new ExtractFactsHandler().execute(ctx);
+
+      const call = findCall(log.error, /failed to persist fact/);
+      expectNoRawSubject(call);
+      const nodes = await entityMemory.findEntities(PII_SUBJECT);
+      expect(call![0]).toHaveProperty('entityNodeId', nodes[0]!.id);
+      expect(call![0]).toHaveProperty('hasSubject', true);
+      expect(call![0]).toHaveProperty('attribute', 'dietary_preference');
     });
   });
 });

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -12,7 +12,7 @@
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
 import { DECAY_CLASSES, NODE_TYPES } from '../../src/memory/types.js';
-import type { DecayClass, NodeType } from '../../src/memory/types.js';
+import type { DecayClass, NodeType, KgNode } from '../../src/memory/types.js';
 import { buildCanonicalPatch } from '../../src/contacts/canonical-attribute-guard.js';
 import type { Contact } from '../../src/contacts/types.js';
 import { ContactValidationError } from '../../src/contacts/contact-service.js';
@@ -179,7 +179,7 @@ ${text}`,
         let attribute = typeof fact?.attribute === 'string' ? fact.attribute.trim() : '';
         // Hoisted so catch can log entityNodeId when resolution completed.
         // Undefined until then — never log the raw subject name (PII).
-        let entityNode: { id: string; type: NodeType } | undefined;
+        let entityNode: KgNode | undefined;
 
         try {
           // Guard: skip malformed entries where required string fields are absent or blank.
@@ -414,10 +414,9 @@ ${text}`,
             ctx.log.error(
               {
                 err,
-                // Never the raw subject name. Node id when resolution completed;
-                // hasSubject is enough to tell malformed/pre-resolve failures apart.
+                // Never the raw subject name. entityNodeId is set after resolveOrCreate
+                // succeeds; undefined here is the pre-resolve signal.
                 entityNodeId: entityNode?.id,
-                hasSubject: Boolean(subject),
                 attribute,
               },
               'extract-facts: unexpected programming error in fact loop — re-throwing',
@@ -430,7 +429,6 @@ ${text}`,
             {
               err,
               entityNodeId: entityNode?.id,
-              hasSubject: Boolean(subject),
               attribute,
             },
             'extract-facts: failed to persist fact, skipping',

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -27,6 +27,15 @@ interface ExtractedFact {
   decayClass: DecayClass;
 }
 
+// LLM-extracted attribute keys are supposed to be snake_case (`home_city`).
+// The model can ignore that and put a name in the field; pino does not redact
+// `attribute`. Only log the key when it matches the trusted shape.
+const LOG_SAFE_ATTRIBUTE = /^[a-z][a-z0-9_]{0,62}$/;
+
+function logSafeAttribute(attribute: string): { attribute?: string } {
+  return LOG_SAFE_ATTRIBUTE.test(attribute) ? { attribute } : {};
+}
+
 // 'fact' is excluded from the prompt's subject-type list so the LLM never emits
 // subjectType:"fact" in its output — entity subjects must be non-fact nodes.
 // The ENTITY_NODE_TYPES Set below is the runtime safety net for the same constraint.
@@ -287,8 +296,9 @@ ${text}`,
               if (patch.fallbackToKg) {
                 ctx.log.warn(
                   // entityNodeId, not subject: the LLM-extracted name is PII and the
-                  // pino redact list does not cover it. attribute is a snake_case key.
-                  { entityNodeId: entityNode.id, attribute, reason: patch.reason },
+                  // pino redact list does not cover it. attribute is logged only when
+                  // it matches snake_case — otherwise it may itself be a name.
+                  { entityNodeId: entityNode.id, ...logSafeAttribute(attribute), reason: patch.reason },
                   'extract-facts: canonical attribute normalization failed — falling back to KG write',
                 );
               } else {
@@ -306,7 +316,7 @@ ${text}`,
                     contactLookupCache.set(entityNode.id, contact ?? null);
                   } catch (lookupErr) {
                     ctx.log.warn(
-                      { entityNodeId: entityNode.id, attribute, err: lookupErr },
+                      { entityNodeId: entityNode.id, ...logSafeAttribute(attribute), err: lookupErr },
                       'extract-facts: findContactByKgNodeId failed — falling back to KG write',
                     );
                     // Leave contact undefined — the guard below treats undefined the same as null.
@@ -318,7 +328,7 @@ ${text}`,
                   try {
                     await ctx.contactService.updateContactFields(contact.id, patch.fields);
                     ctx.log.info(
-                      { entityNodeId: entityNode.id, attribute, contactId: contact.id },
+                      { entityNodeId: entityNode.id, ...logSafeAttribute(attribute), contactId: contact.id },
                       'extract-facts: canonical attribute redirected to ContactService',
                     );
                     redirected++;
@@ -329,14 +339,14 @@ ${text}`,
                       // Validation failure (e.g. primaryEmail not in CCI) — this is expected
                       // for some inputs; fall through so the information is preserved in the KG.
                       ctx.log.warn(
-                        { entityNodeId: entityNode.id, attribute, contactId: contact.id, reason: err.message },
+                        { entityNodeId: entityNode.id, ...logSafeAttribute(attribute), contactId: contact.id, reason: err.message },
                         'extract-facts: canonical attribute validation failed — falling back to KG write',
                       );
                     } else {
                       // Infrastructure or programming error — do not silently diverge the
                       // contacts table from the KG. Increment failed and skip the KG write.
                       ctx.log.error(
-                        { entityNodeId: entityNode.id, attribute, contactId: contact.id, err },
+                        { entityNodeId: entityNode.id, ...logSafeAttribute(attribute), contactId: contact.id, err },
                         'extract-facts: canonical attribute redirect failed with unexpected error — skipping fact',
                       );
                       failed++;
@@ -379,7 +389,7 @@ ${text}`,
             if (result.action === 'auto_resolved') {
               // Incoming fact superseded a lower-confidence existing fact — audit trail preserved.
               ctx.log.info(
-                { entityNodeId: entityNode.id, attribute, source: effectiveSource, nodeId: result.nodeId },
+                { entityNodeId: entityNode.id, ...logSafeAttribute(attribute), source: effectiveSource, nodeId: result.nodeId },
                 'extract-facts: fact auto-resolved — existing superseded by higher-confidence incoming',
               );
             }
@@ -390,14 +400,14 @@ ${text}`,
             // in this batch will also fail, so break immediately rather than burning
             // through the rest of the loop and mis-reporting them as conflicts.
             ctx.log.error(
-              { entityNodeId: entityNode.id, attribute, source: effectiveSource, reason: result.conflict },
+              { entityNodeId: entityNode.id, ...logSafeAttribute(attribute), source: effectiveSource, reason: result.conflict },
               'extract-facts: write rate limit exceeded — aborting remaining facts in batch',
             );
             failed++;
             break;
           } else {
             // conflict, auto_rejected, or entity_not_found — expected semantic outcomes, not infra failures.
-            ctx.log.warn({ entityNodeId: entityNode.id, attribute, conflict: result.conflict, action: result.action, source: effectiveSource }, 'extract-facts: fact not stored');
+            ctx.log.warn({ entityNodeId: entityNode.id, ...logSafeAttribute(attribute), conflict: result.conflict, action: result.action, source: effectiveSource }, 'extract-facts: fact not stored');
           }
         } catch (err) {
           // Re-throw programming errors — these indicate bugs in this handler (wrong
@@ -417,7 +427,7 @@ ${text}`,
                 // Never the raw subject name. entityNodeId is set after resolveOrCreate
                 // succeeds; undefined here is the pre-resolve signal.
                 entityNodeId: entityNode?.id,
-                attribute,
+                ...logSafeAttribute(attribute),
               },
               'extract-facts: unexpected programming error in fact loop — re-throwing',
             );
@@ -429,7 +439,7 @@ ${text}`,
             {
               err,
               entityNodeId: entityNode?.id,
-              attribute,
+              ...logSafeAttribute(attribute),
             },
             'extract-facts: failed to persist fact, skipping',
           );

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -177,6 +177,9 @@ ${text}`,
         // below fires correctly when subject or attribute could not be determined.
         let subject = typeof fact?.subject === 'string' ? fact.subject.trim() : '';
         let attribute = typeof fact?.attribute === 'string' ? fact.attribute.trim() : '';
+        // Hoisted so catch can log entityNodeId when resolution completed.
+        // Undefined until then — never log the raw subject name (PII).
+        let entityNode: { id: string; type: NodeType } | undefined;
 
         try {
           // Guard: skip malformed entries where required string fields are absent or blank.
@@ -233,7 +236,6 @@ ${text}`,
             confidence: 0.6,
           });
 
-          let entityNode;
           if (resolved.kind === 'ambiguous') {
             // The only admissible tiebreaker is the caller's subject-contact hint, and
             // only when one candidate IS that contact's node. The hint identifies the
@@ -284,7 +286,9 @@ ${text}`,
             if (patch !== null) {
               if (patch.fallbackToKg) {
                 ctx.log.warn(
-                  { subject, attribute, reason: patch.reason },
+                  // entityNodeId, not subject: the LLM-extracted name is PII and the
+                  // pino redact list does not cover it. attribute is a snake_case key.
+                  { entityNodeId: entityNode.id, attribute, reason: patch.reason },
                   'extract-facts: canonical attribute normalization failed — falling back to KG write',
                 );
               } else {
@@ -302,7 +306,7 @@ ${text}`,
                     contactLookupCache.set(entityNode.id, contact ?? null);
                   } catch (lookupErr) {
                     ctx.log.warn(
-                      { subject, attribute, entityNodeId: entityNode.id, err: lookupErr },
+                      { entityNodeId: entityNode.id, attribute, err: lookupErr },
                       'extract-facts: findContactByKgNodeId failed — falling back to KG write',
                     );
                     // Leave contact undefined — the guard below treats undefined the same as null.
@@ -314,7 +318,7 @@ ${text}`,
                   try {
                     await ctx.contactService.updateContactFields(contact.id, patch.fields);
                     ctx.log.info(
-                      { subject, attribute, contactId: contact.id },
+                      { entityNodeId: entityNode.id, attribute, contactId: contact.id },
                       'extract-facts: canonical attribute redirected to ContactService',
                     );
                     redirected++;
@@ -325,14 +329,14 @@ ${text}`,
                       // Validation failure (e.g. primaryEmail not in CCI) — this is expected
                       // for some inputs; fall through so the information is preserved in the KG.
                       ctx.log.warn(
-                        { subject, attribute, contactId: contact.id, reason: err.message },
+                        { entityNodeId: entityNode.id, attribute, contactId: contact.id, reason: err.message },
                         'extract-facts: canonical attribute validation failed — falling back to KG write',
                       );
                     } else {
                       // Infrastructure or programming error — do not silently diverge the
                       // contacts table from the KG. Increment failed and skip the KG write.
                       ctx.log.error(
-                        { subject, attribute, contactId: contact.id, err },
+                        { entityNodeId: entityNode.id, attribute, contactId: contact.id, err },
                         'extract-facts: canonical attribute redirect failed with unexpected error — skipping fact',
                       );
                       failed++;
@@ -375,7 +379,7 @@ ${text}`,
             if (result.action === 'auto_resolved') {
               // Incoming fact superseded a lower-confidence existing fact — audit trail preserved.
               ctx.log.info(
-                { subject, attribute, source: effectiveSource, nodeId: result.nodeId },
+                { entityNodeId: entityNode.id, attribute, source: effectiveSource, nodeId: result.nodeId },
                 'extract-facts: fact auto-resolved — existing superseded by higher-confidence incoming',
               );
             }
@@ -386,14 +390,14 @@ ${text}`,
             // in this batch will also fail, so break immediately rather than burning
             // through the rest of the loop and mis-reporting them as conflicts.
             ctx.log.error(
-              { subject, attribute, source: effectiveSource, reason: result.conflict },
+              { entityNodeId: entityNode.id, attribute, source: effectiveSource, reason: result.conflict },
               'extract-facts: write rate limit exceeded — aborting remaining facts in batch',
             );
             failed++;
             break;
           } else {
             // conflict, auto_rejected, or entity_not_found — expected semantic outcomes, not infra failures.
-            ctx.log.warn({ subject, attribute, conflict: result.conflict, action: result.action, source: effectiveSource }, 'extract-facts: fact not stored');
+            ctx.log.warn({ entityNodeId: entityNode.id, attribute, conflict: result.conflict, action: result.action, source: effectiveSource }, 'extract-facts: fact not stored');
           }
         } catch (err) {
           // Re-throw programming errors — these indicate bugs in this handler (wrong
@@ -407,13 +411,30 @@ ${text}`,
             err instanceof EvalError ||
             err instanceof URIError
           ) {
-            ctx.log.error({ err, subject, attribute }, 'extract-facts: unexpected programming error in fact loop — re-throwing');
+            ctx.log.error(
+              {
+                err,
+                // Never the raw subject name. Node id when resolution completed;
+                // hasSubject is enough to tell malformed/pre-resolve failures apart.
+                entityNodeId: entityNode?.id,
+                hasSubject: Boolean(subject),
+                attribute,
+              },
+              'extract-facts: unexpected programming error in fact loop — re-throwing',
+            );
             throw err;
           }
           // Infrastructure errors (DB outage, connection loss) — log at error so they
           // surface in Sentry, then continue processing the remaining facts in the batch.
-          // subject and attribute are always in scope here (declared before this try).
-          ctx.log.error({ err, subject, attribute }, 'extract-facts: failed to persist fact, skipping');
+          ctx.log.error(
+            {
+              err,
+              entityNodeId: entityNode?.id,
+              hasSubject: Boolean(subject),
+              attribute,
+            },
+            'extract-facts: failed to persist fact, skipping',
+          );
           failed++;
         }
       }

--- a/skills/extract-facts/tool.json
+++ b/skills/extract-facts/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "extract-facts",
   "description": "Extract single-entity attribute facts from a passage of text and persist them as knowledge graph fact nodes. Self-classifies internally — always safe to call; exits early if no facts are found.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/src/contacts/canonical-attribute-guard.test.ts
+++ b/src/contacts/canonical-attribute-guard.test.ts
@@ -116,15 +116,24 @@ describe('buildCanonicalPatch', () => {
   });
 
   it('returns fallbackToKg when phone cannot be normalized', () => {
-    const result = buildCanonicalPatch('phone', 'not-a-phone');
+    const result = buildCanonicalPatch('phone', '020 7946 0958');
     expect(result).not.toBeNull();
     expect(result?.fallbackToKg).toBe(true);
+    if (result?.fallbackToKg) {
+      expect(result.reason).toBe('phone_normalization_failed');
+      expect(result.reason).not.toContain('020');
+      expect(result.reason).not.toContain('7946');
+    }
   });
 
   it('returns fallbackToKg for mobile with unnormalizable number', () => {
     const result = buildCanonicalPatch('mobile', '555-1234'); // 7-digit local, no area code
     expect(result).not.toBeNull();
     expect(result?.fallbackToKg).toBe(true);
+    if (result?.fallbackToKg) {
+      expect(result.reason).toBe('phone_normalization_failed');
+      expect(result.reason).not.toContain('555-1234');
+    }
   });
 
   it('is case-insensitive on attribute key', () => {

--- a/src/contacts/canonical-attribute-guard.ts
+++ b/src/contacts/canonical-attribute-guard.ts
@@ -120,7 +120,8 @@ export function normalizePhone(value: string): string | null {
  *   - The attribute is not in the canonical deny-list (caller should write to KG).
  *   - The attribute IS canonical but the value failed normalization (e.g. a phone
  *     number that cannot be parsed to E.164). In this case `fallbackToKg` is true
- *     in the returned tuple so the caller can log and write to the KG instead.
+ *     and `reason` is a stable code (`phone_normalization_failed`) so callers can
+ *     log the outcome without interpolating the raw value (which may be PII).
  */
 export function buildCanonicalPatch(
   attribute: string,
@@ -134,7 +135,9 @@ export function buildCanonicalPatch(
     if (!normalized) {
       return {
         fallbackToKg: true,
-        reason: `Phone value could not be normalized to E.164: "${value}". Writing to KG instead.`,
+        // Stable code, not the raw value — failed E.164 parse does not mean
+        // "not a real number", and `reason` is not on the pino redact list.
+        reason: 'phone_normalization_failed',
       };
     }
     return { fields: { primaryPhone: normalized }, fallbackToKg: false };


### PR DESCRIPTION
## Summary

`extract-facts` already refused to log raw `subject` on the malformed-fact and ambiguity paths — it is an LLM-extracted entity name, usually a person's name, and pino does not redact it. Ten older fact-loop call sites still logged it. Surfaced by CodeRabbit on PR #1705; that PR fixed the two lines it added and filed this for the rest.

This applies the same substitution: log `entityNodeId` where a node is resolved. `attribute` stays — it is a snake_case key and is not identifying once unpaired from the name.

Review follow-up: `buildCanonicalPatch` no longer interpolates the raw phone into `reason` (stable code `phone_normalization_failed`). Remaining callee/sibling leaks (`resolveOrCreate`, `addAlias`, `memory-store`) are tracked in #1713.

## Changes

- Replace `subject` with `entityNodeId` on the ten remaining fact-loop log sites in `skills/extract-facts/handler.ts`
- Hoist `entityNode` as `KgNode | undefined` so the catch can log the id when resolution completed
- `buildCanonicalPatch` phone fallback reason is a stable code, not the raw number
- Add a PII-guard test per affected path (Error.message folded into the serializer)
- Patch-bump `extract-facts` to 1.3.1

## Related Issues

Closes #1706

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes — N/A (log hygiene only)
- [x] CI passes
