### PR TITLE
fix(entity-context): exclude archived KG nodes from assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Decay warnings** — anchored nodes are never listed for re-confirmation nor archived by dismissal. (#1694)
 - **`deleteContact`** — archives the contact's anchored KG node, freeing its label for reuse. (#1694)
 - **`entity-context` nodeless** — retired-profile contacts get `cause: archived` and a distinct reason. (#1707)
-- **`entity-context` output schema** — `nodeless` entries gain `cause` (`missing` or `archived`) (public API surface). (#1707)
+- **`entity-context` output schema** — `nodeless` entries gain `cause` (`missing` or `archived`); skill v1.3.0 (public API surface). (#1707)
+- **`entity-context`** — archived node IDs owned by a contact land in `nodeless`. (#1707)
 - **`EntityMemory.resolveOrCreate`** — returns `ambiguous` when 2+ matches share the requested type, instead of taking the first. (#1694)
 - **`extract-facts`** — skips and counts an ambiguous subject rather than guessing; new `ambiguous` output. (#1694)
 - **`extract-relationships`** — skips and counts ambiguous endpoints instead of taking the first match. (#1714)
@@ -66,6 +67,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`entity-context` assembler** — archived nodes, facts, and edges no longer assemble. (#1707)
+- **`entity-context` cache** — an archived node is re-checked before a TTL hit is served. (#1707)
+- **`DreamEngine`** — flushes entity-context cache after a decay pass archives. (#1707)
 - **`extract-facts`** — fact-loop logs use node id instead of the raw subject name. (#1706)
 - **`extract-facts`** — fact-loop logs omit `attribute` unless it is snake_case. (#1706)
 - **`buildCanonicalPatch`** — phone fallback reason is a stable code, not the raw number. (#1706)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`DreamEngine`** — contact-anchored nodes no longer decay or archive; their facts still do. (#1694)
 - **Decay warnings** — anchored nodes are never listed for re-confirmation nor archived by dismissal. (#1694)
 - **`deleteContact`** — archives the contact's anchored KG node, freeing its label for reuse. (#1694)
+- **`entity-context` nodeless** — retired-profile contacts get `cause: archived` and a distinct reason. (#1707)
+- **`entity-context` output schema** — `nodeless` entries gain `cause` (`missing` or `archived`) (public API surface). (#1707)
 - **`EntityMemory.resolveOrCreate`** — returns `ambiguous` when 2+ matches share the requested type, instead of taking the first. (#1694)
 - **`extract-facts`** — skips and counts an ambiguous subject rather than guessing; new `ambiguous` output. (#1694)
 - **`extract-relationships`** — skips and counts ambiguous endpoints instead of taking the first match. (#1714)
@@ -63,6 +65,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`entity-context` assembler** — archived nodes, facts, and edges no longer assemble. (#1707)
 - **`extract-facts`** — fact-loop logs use node id instead of the raw subject name. (#1706)
 - **`extract-facts`** — fact-loop logs omit `attribute` unless it is snake_case. (#1706)
 - **`buildCanonicalPatch`** — phone fallback reason is a stable code, not the raw number. (#1706)

--- a/docs/specs/11-entity-context-enrichment.md
+++ b/docs/specs/11-entity-context-enrichment.md
@@ -221,9 +221,10 @@ When every requested ID lands in `failed` and `entities`, `unresolved`, and `nod
 2. If the ID matches a `contacts.id` with a null `kg_node_id` → include in `nodeless` with `cause: "missing"` (contact exists but never had a stored profile)
 3. If the ID matches a `contacts.id` whose `kg_node_id` points at an archived node → include in `nodeless` with `cause: "archived"` (the profile was retired; not silently assembled)
 4. If the ID matches a live `kg_nodes.id` directly → assemble from that KG node
-5. Special values: `"caller"` → resolve to `ctx.caller.contactId`, `"agent"` → resolve to the agent's contactId
-6. If no match (including a direct lookup of an archived node ID) → include in the `unresolved` array (not a hard error)
-7. If assembly throws → include in `failed` with a retry classification (not `unresolved`)
+5. If the ID matches an archived `kg_nodes.id` owned by a contact → include in `nodeless` with `cause: "archived"` (agents reuse `entities[].entityId` across turns)
+6. Special values: `"caller"` → resolve to `ctx.caller.contactId`, `"agent"` → resolve to the agent's contactId
+7. If no match (including an unanchored archived node ID) → include in the `unresolved` array (not a hard error)
+8. If assembly throws → include in `failed` with a retry classification (not `unresolved`)
 
 ### Assembly Pipeline
 
@@ -255,7 +256,9 @@ The pipeline is a database read path — no LLM involvement, no external API cal
 
 ### Caching
 
-Entity context changes infrequently compared to how often it's queried. A simple TTL cache (keyed by entity ID, 5-minute TTL) avoids redundant DB queries when multiple skills operate on the same entity in a single conversation. Cache invalidation on contact/KG mutations is straightforward since those writes go through `ContactService` and `EntityMemory`, which can clear the cache.
+Entity context changes infrequently compared to how often it's queried. A simple TTL cache (keyed by entity ID, 5-minute TTL) avoids redundant DB queries when multiple skills operate on the same entity in a single conversation.
+
+A cache hit always re-checks that the entity node is still live (`archived_at IS NULL`). If DreamEngine or contact deletion archived it, the cached payload is dropped and the ID is re-assembled into `nodeless`. DreamEngine also flushes the whole cache after a decay pass that archives any node or edge, so retired facts hanging off a still-live entity cannot keep assembling from a TTL hit. Per-mutation invalidation for ordinary contact/KG writes (`clearCacheForEntity`) is still not wired (see Known Deficiencies).
 
 ---
 
@@ -576,7 +579,7 @@ A scheduled job runs `cleanupExpired()` on a fixed cadence. The dispatcher's rea
 
 - **Entity context is read-only.** The assembly pipeline queries the KG, contacts, and connected accounts but never writes. All mutations go through their respective services (ContactService, EntityMemory).
 - **No cross-entity leakage.** The entity-context payload includes only the requested entities. A skill asking for Jenna's context does not receive the CEO's connected accounts.
-- **Cached context is TTL-bounded.** A 5-minute TTL caps staleness. Per-mutation invalidation (`clearCacheForEntity`) exists but is not yet wired to the contact/KG write paths (see Known Deficiencies). Either way, stale context is a convenience issue (slightly outdated preferences), not a security issue (wrong person's data).
+- **Cached context is TTL-bounded, with an archival live-check.** A 5-minute TTL caps staleness for ordinary mutations. Archival is a correctness boundary (#1707): cache hits re-validate `archived_at IS NULL` on the entity node, and DreamEngine flushes the cache after a decay pass that archives anything. Per-mutation invalidation (`clearCacheForEntity`) exists but is not yet wired to the contact/KG write paths (see Known Deficiencies). Stale *preferences* from an unwired write are a convenience issue; stale *retired* knowledge is not served.
 - **Agent self-identity is seeded, not self-created.** Curia's contact record is created during bootstrap by the orchestrator, not by the agent itself. The agent cannot modify its own identity.
 - **LLM sees entity IDs, not raw KG internals.** The payload exposes curated facts with labels, not raw JSONB properties or internal node IDs beyond what's needed for skill invocation.
 
@@ -599,7 +602,7 @@ A scheduled job runs `cleanupExpired()` on a fixed cadence. The dispatcher's rea
 ## Known Deficiencies
 
 - **Proactive account discovery** — the `discoveredAccounts` field in the entity-context assembly pipeline is not yet implemented.
-- **Cache invalidation on mutations is not wired** — `EntityContextAssembler.clearCacheForEntity()` exists and is unit-tested, but no contact/KG write path (`ContactService`, `EntityMemory`) actually calls it. Cached entity context is bounded only by the 5-minute TTL, so a mutation may not be reflected until the entry expires. Low severity — staleness is a convenience issue, not a correctness/security one (see Security Considerations) — but the "invalidated on contact/KG writes" behaviour those sections describe is not yet true.
+- **Cache invalidation on mutations is not wired** — `EntityContextAssembler.clearCacheForEntity()` exists and is unit-tested, but no contact/KG write path (`ContactService`, `EntityMemory`) actually calls it. Cached entity context for ordinary mutations (renames, new facts) is bounded only by the 5-minute TTL. Archival is handled separately: cache hits re-check `archived_at`, and DreamEngine flushes the cache after a decay pass that archives (#1707). Remaining gap is convenience-level staleness, not retired knowledge leaking back into context.
 - **Calendar `entity_enrichment` manifests** — calendar skills do not yet declare `entity_enrichment` in their manifests. (#544)
 - **Remove `calendarId` from tool definitions** — `calendarId` has not yet been removed from LLM-visible tool definitions; pending cleanup.
 - **Calendar integration test** — the end-to-end "What's on Jenna's calendar?" integration test is not yet implemented. (#544)

--- a/docs/specs/11-entity-context-enrichment.md
+++ b/docs/specs/11-entity-context-enrichment.md
@@ -197,7 +197,7 @@ A new skill that assembles the full context payload for one or more entities. Av
   "outputs": {
     "entities": "EntityContext[]",
     "unresolved": "string[] (IDs that matched no contact and no KG node)",
-    "nodeless": "{inputId, contactId, displayName, reason}[]? (contacts that exist but have no stored profile — cannot hold facts; not evidence of absence)",
+    "nodeless": "{inputId, contactId, displayName, cause, reason}[]? (contacts that exist but cannot hold facts: cause `missing` = never had a stored profile, cause `archived` = profile was retired; not evidence of absence)",
     "failed": "{inputId, reason}[]? (lookups that errored — retry may succeed; not evidence of absence)"
   }
 }
@@ -209,7 +209,7 @@ A new skill that assembles the full context payload for one or more entities. Av
 |---|---|---|
 | `entities` | Full `EntityContext` assembled | Use the payload |
 | `unresolved` | ID matched no contact and no KG node | Treat as genuinely unknown |
-| `nodeless` | Contact exists but holds no KG node (#1694) | Report capability gap; do not store facts or infer absence |
+| `nodeless` | Contact exists but cannot hold a KG node — never had one, or the linked node is archived (#1694, #1707) | Report capability gap; do not store facts or infer absence |
 | `failed` | Assembly threw (#1702) | If reason says retryable: retry. If not: report failure. **Not** evidence the contact is unknown |
 
 Diagnostic buckets (`nodeless`, `failed`, `unresolved`) are emitted before `entities` in the skill result so head-slice output truncation sacrifices bulk entity data rather than the warnings.
@@ -217,21 +217,23 @@ Diagnostic buckets (`nodeless`, `failed`, `unresolved`) are emitted before `enti
 When every requested ID lands in `failed` and `entities`, `unresolved`, and `nodeless` are all empty, the skill returns `success: false` (not a success-shaped empty result with retry hints) so the agent does not loop against a hard-down database. Batches mixing `failed` with `unresolved` or `nodeless` still return `success: true` with all diagnostic buckets.
 
 **Resolution priority for each ID:**
-1. If the ID matches a `contacts.id` with a non-null `kg_node_id` → assemble from that KG node
-2. If the ID matches a `contacts.id` with a null `kg_node_id` → include in `nodeless` (contact exists but cannot hold knowledge)
-3. If the ID matches a `kg_nodes.id` directly → assemble from that KG node
-4. Special values: `"caller"` → resolve to `ctx.caller.contactId`, `"agent"` → resolve to the agent's contactId
-5. If no match → include in the `unresolved` array (not a hard error)
-6. If assembly throws → include in `failed` with a retry classification (not `unresolved`)
+1. If the ID matches a `contacts.id` with a non-null `kg_node_id` pointing at a live (`archived_at IS NULL`) KG node → assemble from that KG node
+2. If the ID matches a `contacts.id` with a null `kg_node_id` → include in `nodeless` with `cause: "missing"` (contact exists but never had a stored profile)
+3. If the ID matches a `contacts.id` whose `kg_node_id` points at an archived node → include in `nodeless` with `cause: "archived"` (the profile was retired; not silently assembled)
+4. If the ID matches a live `kg_nodes.id` directly → assemble from that KG node
+5. Special values: `"caller"` → resolve to `ctx.caller.contactId`, `"agent"` → resolve to the agent's contactId
+6. If no match (including a direct lookup of an archived node ID) → include in the `unresolved` array (not a hard error)
+7. If assembly throws → include in `failed` with a retry classification (not `unresolved`)
 
 ### Assembly Pipeline
 
 For each resolved entity:
 
 ```
-KG node lookup
+KG node lookup (live rows only — `archived_at IS NULL`)
     │
     ├─→ Extract facts (kg_nodes where type='fact', linked via kg_edges)
+    │     Skip archived fact nodes and archived edges
     │     Group by category, include confidence + freshness
     │
     ├─→ Contact record lookup (contacts table, via kg_node_id)
@@ -243,6 +245,7 @@ KG node lookup
     │     contact_integrations (future)
     │
     ├─→ First-degree relationships (kg_edges, depth=1)
+    │     Skip archived edges and archived related nodes
     │     Include related entity label + type
     │
     └─→ Compose EntityContext payload

--- a/scripts/kg-node-linkage-report.test.ts
+++ b/scripts/kg-node-linkage-report.test.ts
@@ -10,7 +10,7 @@
 // report refuses to produce a plausible-looking answer rather than guessing.
 
 import { describe, it, expect, vi } from 'vitest';
-import { runLinkageReport } from './kg-node-linkage-report.js';
+import { runLinkageReport, formatReport } from './kg-node-linkage-report.js';
 
 type MockPool = { query: ReturnType<typeof vi.fn> };
 
@@ -39,6 +39,7 @@ describe('runLinkageReport', () => {
     expect(report.orgArmEligible).toBe(4);
     expect(report.personArmMints).toBe(11);
     expect(report.sameNameShadowed).toBe(7);
+    expect(report.archivedLink).toBe(0);
   });
 
   it('reports a clean database as zero work, not as an error', async () => {
@@ -49,6 +50,7 @@ describe('runLinkageReport', () => {
     const report = await runLinkageReport(pool as never);
 
     expect(report.totalNodeless).toBe(0);
+    expect(report.archivedLink).toBe(0);
     expect(report.orgArmEligible).toBe(0);
     expect(report.personArmMints).toBe(0);
   });
@@ -58,6 +60,7 @@ describe('runLinkageReport', () => {
 
     expect(report.totalContacts).toBe(0);
     expect(report.totalNodeless).toBe(0);
+    expect(report.archivedLink).toBe(0);
     expect(report.byKind).toEqual([]);
   });
 
@@ -108,6 +111,43 @@ describe('runLinkageReport', () => {
     await runLinkageReport(pool as never);
 
     expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts contacts pointing at an archived node separately from nodeless', async () => {
+    // Folding these into nodeless would inflate the 085 mint count: they already
+    // have a node, it is just retired. The entity-context read path still treats
+    // them as context-free (#1707), so archivedLink has to show the number.
+    const pool = makePool([
+      { kind: 'person', total: '50', nodeless: '3', org_arm: '0', shadowed: '0', archived_link: '2', anchored_orphans: '0' },
+      { kind: 'organization', total: '10', nodeless: '1', org_arm: '1', shadowed: '0', archived_link: '1', anchored_orphans: '0' },
+    ]);
+
+    const report = await runLinkageReport(pool as never);
+
+    expect(report.totalNodeless).toBe(4);
+    expect(report.archivedLink).toBe(3);
+    expect(report.personArmMints).toBe(3);
+    expect(formatReport(report)).toMatch(/linked to an ARCHIVED node\s+3/);
+  });
+
+  it('throws rather than reporting zero when the archived-link column is missing', async () => {
+    const pool = makePool([
+      { kind: 'person', total: '10', nodeless: '3', org_arm: '0', shadowed: '0', anchored_orphans: '0' },
+    ]);
+
+    await expect(runLinkageReport(pool as never)).rejects.toThrow(/archived_link.*not a number/s);
+  });
+
+  it('counts archived-node contacts in the same statement as nodeless', async () => {
+    const pool = makePool([
+      { kind: 'person', total: '1', nodeless: '0', org_arm: '0', shadowed: '0', archived_link: '0', anchored_orphans: '0' },
+    ]);
+
+    await runLinkageReport(pool as never);
+
+    const sql = String(pool.query.mock.calls[0]![0]);
+    expect(sql).toMatch(/archived_at IS NOT NULL/);
+    expect(sql).toMatch(/AS archived_link/);
   });
 
   it('never issues a write', async () => {

--- a/scripts/kg-node-linkage-report.ts
+++ b/scripts/kg-node-linkage-report.ts
@@ -8,6 +8,12 @@
 // count, and it exists to size migration 085 before that migration is written:
 // ADR-040's backfill has two arms, and the work in each is very different.
 //
+// A second population is context-free for a different reason (#1707): the contact
+// *has* a kg_node_id, but the node is archived. Entity-context treats those the
+// same as NULL (they cannot assemble). They are counted as `archivedLink` below —
+// not folded into `nodeless` / the 085 mint arms, because they already have a node,
+// it is just retired. Migration 085 step 2a repairs them.
+//
 //   Arm A (org)    — a nodeless contact with kind='organization' for which an existing
 //                    organization node is already findable. These get re-linked to that
 //                    node, which is only legal once the relaxed idx_contacts_kg_node_unique

--- a/skills/entity-context/handler.ts
+++ b/skills/entity-context/handler.ts
@@ -10,11 +10,12 @@
 //
 // Four buckets come back and all are surfaced: entities that assembled,
 // `unresolved` IDs that matched nothing, `nodeless` contacts that exist but
-// cannot hold knowledge (#1694 / ADR-040), and `failed` IDs whose lookup errored
+// cannot hold knowledge — either they never had a stored profile or theirs
+// was retired (#1694 / ADR-040, #1707) — and `failed` IDs whose lookup errored
 // (#1702). The handler owns all LLM-facing wording for `nodeless` and `failed`.
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
-import type { AssembleManyFailedEntry, AssembleManyResult } from '../../src/entity-context/assembler.js';
+import type { AssembleManyFailedEntry, AssembleManyResult, NodelessCause } from '../../src/entity-context/assembler.js';
 
 // Shown to the LLM for every contact that resolved but holds no KG node.
 //
@@ -27,10 +28,23 @@ import type { AssembleManyFailedEntry, AssembleManyResult } from '../../src/enti
 // and may be paraphrased to the principal, so "stored profile" rather than "KG node".
 // Kept kind-neutral too — nodeless contacts include organizations, not just people
 // (ADR-040's arm A exists precisely because org contacts are a large share of them).
-const NODELESS_REASON =
+const NODELESS_MISSING_REASON =
   'This contact exists but has no stored profile, so it cannot hold facts, '
   + 'relationships, or background context. Having no context here does not mean the '
   + 'contact is unknown to us. Do not try to store facts about them; report the gap instead.';
+
+// Same capability-gap shape, but the contact *had* a profile that was retired
+// (dream-engine decay, or contact deletion under ADR-040). Must not read as
+// "never had a profile" — that would send the agent looking for a backfill that
+// already happened and then got archived (#1707).
+const NODELESS_ARCHIVED_REASON =
+  'This contact\'s stored profile was retired, so it cannot hold facts, '
+  + 'relationships, or background context. Having no context here does not mean the '
+  + 'contact is unknown to us. Do not try to store facts about them; report the gap instead.';
+
+function formatNodelessReason(cause: NodelessCause): string {
+  return cause === 'archived' ? NODELESS_ARCHIVED_REASON : NODELESS_MISSING_REASON;
+}
 
 const NOT_UNKNOWN_SUFFIX =
   'This is not evidence the contact or entity is unknown.';
@@ -72,7 +86,8 @@ function buildSuccessData(result: AssembleManyResult): Record<string, unknown> {
             inputId: n.inputId,
             contactId: n.contactId,
             displayName: n.displayName,
-            reason: NODELESS_REASON,
+            cause: n.cause,
+            reason: formatNodelessReason(n.cause),
           })),
         }
       : {}),

--- a/skills/entity-context/tool.json
+++ b/skills/entity-context/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "entity-context",
-  "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers). Some contacts have no stored profile and can hold no facts at all; those come back under `nodeless` with a reason, and an empty result for them is a capability gap, not evidence the contact is unknown. Transient lookup failures come back under `failed` with a retry hint — also not evidence of absence.",
-  "version": "1.2.0",
+  "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers). Some contacts have no stored profile (or theirs was retired) and can hold no facts at all; those come back under `nodeless` with a reason, and an empty result for them is a capability gap, not evidence the contact is unknown. Transient lookup failures come back under `failed` with a retry hint — also not evidence of absence.",
+  "version": "1.2.1",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -12,7 +12,7 @@
   "outputs": {
     "entities": "EntityContext[] (assembled context payloads for each resolved entity)",
     "unresolved": "string[] (IDs that could not be found in the KG or contacts table)",
-    "nodeless": "{inputId, contactId, displayName, reason}[]? (present only when non-empty — contacts that exist but have no stored profile, so they can hold no facts or context; inputId echoes the ID or email you passed in)",
+    "nodeless": "{inputId, contactId, displayName, cause, reason}[]? (present only when non-empty — contacts that exist but cannot hold facts or context: cause 'missing' means they never had a stored profile, cause 'archived' means the profile was retired; inputId echoes the ID or email you passed in)",
     "failed": "{inputId, reason}[]? (present only when non-empty — lookups that errored; reason distinguishes retryable transient failures from permanent system errors; never evidence of absence)"
   },
   "permissions": [],

--- a/skills/entity-context/tool.json
+++ b/skills/entity-context/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "entity-context",
   "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers). Some contacts have no stored profile (or theirs was retired) and can hold no facts at all; those come back under `nodeless` with a reason, and an empty result for them is a capability gap, not evidence the contact is unknown. Transient lookup failures come back under `failed` with a retry hint — also not evidence of absence.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -22,13 +22,14 @@
 // in the `failed` array rather than propagating.
 //
 // Misses are reported in three separate buckets, because they mean different things
-// (#1694 / ADR-040, #1702):
-//   unresolved — the ID matched no contact and no KG node.
-//   nodeless   — the ID matched a real contact that holds no KG node. The contact
-//                exists but is structurally unable to carry facts, relationships,
-//                or context, and no amount of retrying will change that. Collapsing
-//                it into `unresolved` made an agent read "cannot hold knowledge" as
-//                "we know nothing about them", which is the silence #1694 is about.
+// (#1694 / ADR-040, #1702, #1707):
+//   unresolved — the ID matched no contact and no live KG node.
+//   nodeless   — the ID matched a real contact that cannot carry context. Either it
+//                never had a KG node (`cause: 'missing'`), or its node was archived
+//                (`cause: 'archived'`) — decay retirement, or contact deletion under
+//                ADR-040. Both are structurally unable to carry facts, relationships,
+//                or context. Collapsing either into `unresolved` made an agent read
+//                "cannot hold knowledge" as "we know nothing about them".
 //   failed     — assembly threw. Classified as retryable or not; never evidence the
 //                contact is unknown (#1702).
 
@@ -46,12 +47,21 @@ interface CacheEntry {
   expiresAt: number;
 }
 
-/** A contact that exists but holds no KG node, so it can carry no context. */
+/** Why a real contact cannot carry context. */
+export type NodelessCause = 'missing' | 'archived';
+
+/** A contact that exists but cannot carry context. */
 export interface NodelessContact {
   /** The string the caller passed in (contact UUID or email), so it can correlate results. */
   inputId: string;
   contactId: string;
   displayName: string;
+  /**
+   * `missing` — `kg_node_id` is NULL; the contact never had a stored profile.
+   * `archived` — `kg_node_id` points at a node with `archived_at` set; the profile
+   * was retired (dream-engine decay, or contact deletion under ADR-040).
+   */
+  cause: NodelessCause;
 }
 
 /** An ID whose assembly threw — classified for retry, not a miss. */
@@ -66,7 +76,7 @@ export interface AssembleManyResult {
   entities: EntityContext[];
   /** IDs that matched no contact and no KG node. */
   unresolved: string[];
-  /** Contacts that exist but cannot hold knowledge. Disjoint from `unresolved`. */
+  /** Contacts that exist but cannot hold knowledge (no node, or archived node). Disjoint from `unresolved`. */
   nodeless: NodelessContact[];
   /** IDs whose assembly errored. Disjoint from `unresolved` and `nodeless`. */
   failed: AssembleManyFailedEntry[];
@@ -75,7 +85,7 @@ export interface AssembleManyResult {
 /** Outcome of resolving a caller-supplied ID to something assemblable. */
 type ResolvedInput =
   | { kind: 'node'; kgNodeId: string }
-  | { kind: 'nodeless'; contactId: string; displayName: string }
+  | { kind: 'nodeless'; contactId: string; displayName: string; cause: NodelessCause }
   | { kind: 'unknown' };
 
 /** Outcome of a single assembly attempt, with the reason for a miss preserved. */
@@ -102,9 +112,10 @@ export class EntityContextAssembler {
    * Resolve one or more IDs to EntityContext payloads.
    *
    * Resolution priority for each ID:
-   *   1. Matches a contacts.id → look up kg_node_id, assemble from that KG node
-   *   2. Matches a kg_nodes.id directly → assemble from that KG node
-   *   3. No match → included in `unresolved` (not a hard error)
+   *   1. Matches a contacts.id with a live kg_node_id → assemble from that KG node
+   *   2. Matches a contacts.id with no node, or whose node is archived → `nodeless`
+   *   3. Matches a live kg_nodes.id directly → assemble from that KG node
+   *   4. No match → included in `unresolved` (not a hard error)
    *
    * Each ID is assembled independently; a DB error on one ID logs at error and
    * adds the ID to `failed` without aborting the remaining IDs in the batch.
@@ -150,8 +161,10 @@ export class EntityContextAssembler {
           // operators need a searchable signal. This is the standing production
           // record that a real contact was addressed with no context available.
           this.logger.warn(
-            { contactId: outcome.entry.contactId },
-            'entity-context: contact holds no KG node — cannot carry facts, relationships, or context',
+            { contactId: outcome.entry.contactId, cause: outcome.entry.cause },
+            outcome.entry.cause === 'archived'
+              ? 'entity-context: contact KG node is archived — cannot carry facts, relationships, or context'
+              : 'entity-context: contact holds no KG node — cannot carry facts, relationships, or context',
           );
           nodeless.push(outcome.entry);
         } else {
@@ -198,7 +211,12 @@ export class EntityContextAssembler {
       if (resolved.kind === 'nodeless') {
         return {
           kind: 'nodeless',
-          entry: { inputId: id, contactId: resolved.contactId, displayName: resolved.displayName },
+          entry: {
+            inputId: id,
+            contactId: resolved.contactId,
+            displayName: resolved.displayName,
+            cause: resolved.cause,
+          },
         };
       }
       const kgNodeId = resolved.kgNodeId;
@@ -403,22 +421,34 @@ export class EntityContextAssembler {
       // UUID columns. This handles CC flows and ceo-inbox triage where the LLM passes a
       // raw email rather than a contact UUID.
       if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(id)) {
-        const emailResult = await this.pool.query<{ contact_id: string; kg_node_id: string | null; display_name: string }>(
-          `SELECT c.id AS contact_id, c.kg_node_id, c.display_name
+        const emailResult = await this.pool.query<{
+          contact_id: string;
+          kg_node_id: string | null;
+          display_name: string;
+          node_archived: boolean | null;
+        }>(
+          `SELECT c.id AS contact_id, c.kg_node_id, c.display_name,
+                  (n.archived_at IS NOT NULL) AS node_archived
            FROM contact_channel_identities cci
            JOIN contacts c ON c.id = cci.contact_id
+           LEFT JOIN kg_nodes n ON n.id = c.kg_node_id
            WHERE cci.channel = 'email' AND LOWER(cci.channel_identifier) = LOWER($1)`,
           [id],
         );
         if (emailResult.rows.length > 0) {
-          const row = emailResult.rows[0];
-          const kgNodeId = row?.kg_node_id;
-          if (!kgNodeId) {
+          const row = emailResult.rows[0]!;
+          const nodeless = classifyLinkedNode(row.kg_node_id, row.node_archived);
+          if (nodeless) {
             // Use inputKind rather than the raw email — 'email' is on the pino redact list.
-            this.logger.debug({ inputKind: 'email', contactId: row?.contact_id }, 'entity-context: email resolved to contact with no linked KG node');
-            return { kind: 'nodeless', contactId: row!.contact_id, displayName: row!.display_name };
+            this.logger.debug(
+              { inputKind: 'email', contactId: row.contact_id, cause: nodeless },
+              nodeless === 'archived'
+                ? 'entity-context: email resolved to contact whose KG node is archived'
+                : 'entity-context: email resolved to contact with no linked KG node',
+            );
+            return { kind: 'nodeless', contactId: row.contact_id, displayName: row.display_name, cause: nodeless };
           }
-          return { kind: 'node', kgNodeId };
+          return { kind: 'node', kgNodeId: row.kg_node_id! };
         }
         // Email not found in contact_channel_identities — unregistered contact
         this.logger.debug({ inputKind: 'email' }, 'entity-context: email not found in contact_channel_identities — treating as unresolved');
@@ -426,25 +456,40 @@ export class EntityContextAssembler {
       }
 
       // Try as a contact ID first
-      const contactResult = await this.pool.query<{ kg_node_id: string | null; display_name: string }>(
-        'SELECT kg_node_id, display_name FROM contacts WHERE id = $1',
+      const contactResult = await this.pool.query<{
+        kg_node_id: string | null;
+        display_name: string;
+        node_archived: boolean | null;
+      }>(
+        `SELECT c.kg_node_id, c.display_name,
+                (n.archived_at IS NOT NULL) AS node_archived
+         FROM contacts c
+         LEFT JOIN kg_nodes n ON n.id = c.kg_node_id
+         WHERE c.id = $1`,
         [id],
       );
       if (contactResult.rows.length > 0) {
-        const row = contactResult.rows[0];
-        const kgNodeId = row?.kg_node_id;
-        // Contact exists but holds no KG node — a different answer from "no such
-        // contact", and the caller needs to be able to tell them apart (#1694).
-        if (!kgNodeId) {
-          this.logger.debug({ contactId: id }, 'entity-context: contact has no linked KG node');
-          return { kind: 'nodeless', contactId: id, displayName: row!.display_name };
+        const row = contactResult.rows[0]!;
+        const nodeless = classifyLinkedNode(row.kg_node_id, row.node_archived);
+        // Contact exists but cannot carry context — a different answer from "no such
+        // contact", and the caller needs to be able to tell them apart (#1694, #1707).
+        if (nodeless) {
+          this.logger.debug(
+            { contactId: id, cause: nodeless },
+            nodeless === 'archived'
+              ? 'entity-context: contact KG node is archived'
+              : 'entity-context: contact has no linked KG node',
+          );
+          return { kind: 'nodeless', contactId: id, displayName: row.display_name, cause: nodeless };
         }
-        return { kind: 'node', kgNodeId };
+        return { kind: 'node', kgNodeId: row.kg_node_id! };
       }
 
-      // Try as a KG node ID directly
+      // Try as a KG node ID directly. Archived nodes are not live entities — looking
+      // one up by ID is an unresolved miss, not a nodeless contact (no contact row
+      // was addressed). getKgNode filters archived_at again as defence in depth.
       const nodeResult = await this.pool.query<{ id: string }>(
-        'SELECT id FROM kg_nodes WHERE id = $1',
+        'SELECT id FROM kg_nodes WHERE id = $1 AND archived_at IS NULL',
         [id],
       );
       if (nodeResult.rows.length > 0) {
@@ -476,7 +521,7 @@ export class EntityContextAssembler {
 
   private async getKgNode(id: string): Promise<KgNodeRow | undefined> {
     const result = await this.pool.query<KgNodeRow>(
-      'SELECT id, type, label, properties FROM kg_nodes WHERE id = $1',
+      'SELECT id, type, label, properties FROM kg_nodes WHERE id = $1 AND archived_at IS NULL',
       [id],
     );
     return result.rows[0];
@@ -496,13 +541,17 @@ export class EntityContextAssembler {
        WHERE e.source_node_id = $1
          AND e.type = 'relates_to'
          AND n.type = 'fact'
+         AND e.archived_at IS NULL
+         AND n.archived_at IS NULL
        UNION ALL
        SELECT n.label, n.properties, n.confidence, n.last_confirmed_at
        FROM kg_edges e
        JOIN kg_nodes n ON n.id = e.source_node_id
        WHERE e.target_node_id = $1
          AND e.type = 'relates_to'
-         AND n.type = 'fact'`,
+         AND n.type = 'fact'
+         AND e.archived_at IS NULL
+         AND n.archived_at IS NULL`,
       [entityNodeId],
     );
 
@@ -592,6 +641,8 @@ export class EntityContextAssembler {
        JOIN kg_nodes n ON n.id = e.target_node_id
        WHERE e.source_node_id = $1
          AND n.type != 'fact'
+         AND e.archived_at IS NULL
+         AND n.archived_at IS NULL
        UNION ALL
        SELECT
          e.type AS edge_type,
@@ -602,7 +653,9 @@ export class EntityContextAssembler {
        FROM kg_edges e
        JOIN kg_nodes n ON n.id = e.source_node_id
        WHERE e.target_node_id = $1
-         AND n.type != 'fact'`,
+         AND n.type != 'fact'
+         AND e.archived_at IS NULL
+         AND n.archived_at IS NULL`,
       [entityNodeId],
     );
 
@@ -670,6 +723,21 @@ interface RelationshipRow {
   related_id: string;
   related_label: string;
   related_type: string;
+}
+
+/**
+ * Classify a contact's linked KG node for the nodeless bucket.
+ * `nodeArchived` is the SQL `(n.archived_at IS NOT NULL)` boolean from the LEFT JOIN;
+ * undefined/null means the mock (or a missing node row) did not set it — treat as live
+ * so a dangling FK still falls through to getKgNode's referential-integrity warning.
+ */
+function classifyLinkedNode(
+  kgNodeId: string | null | undefined,
+  nodeArchived: boolean | null | undefined,
+): NodelessCause | null {
+  if (!kgNodeId) return 'missing';
+  if (nodeArchived === true) return 'archived';
+  return null;
 }
 
 /**

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -115,7 +115,8 @@ export class EntityContextAssembler {
    *   1. Matches a contacts.id with a live kg_node_id → assemble from that KG node
    *   2. Matches a contacts.id with no node, or whose node is archived → `nodeless`
    *   3. Matches a live kg_nodes.id directly → assemble from that KG node
-   *   4. No match → included in `unresolved` (not a hard error)
+   *   4. Matches an archived kg_nodes.id owned by a contact → `nodeless` (cause archived)
+   *   5. No match → included in `unresolved` (not a hard error)
    *
    * Each ID is assembled independently; a DB error on one ID logs at error and
    * adds the ID to `failed` without aborting the remaining IDs in the batch.
@@ -137,13 +138,20 @@ export class EntityContextAssembler {
       // Cache stores full payloads (with relationships) only. Skipping the cache for
       // includeRelationships=false requests prevents a partial payload from being served
       // to a later caller that wants the full payload (and vice versa).
-      const cached = includeRelationships ? this.getFromCache(id) : undefined;
-      if (cached) {
-        entities.push(cached);
-        continue;
-      }
-
       try {
+        const cached = includeRelationships ? this.getFromCache(id) : undefined;
+        if (cached) {
+          // Archival is a correctness boundary (#1707): a payload cached before
+          // DreamEngine (or contact deletion) archived the node must not be served.
+          // One indexed lookup per hit; if the node is gone, drop every alias and
+          // fall through to assembleOneClassified so the caller gets `nodeless`.
+          if (await this.isLiveKgNode(cached.entityId)) {
+            entities.push(cached);
+            continue;
+          }
+          this.clearCacheForEntity(cached.entityId);
+        }
+
         const outcome = await this.assembleOneClassified(id, includeRelationships);
         if (outcome.kind === 'assembled') {
           if (includeRelationships) {
@@ -341,6 +349,17 @@ export class EntityContextAssembler {
     }
   }
 
+  /**
+   * Drop every cached payload. Called after DreamEngine archives nodes or edges
+   * so a fact/relationship retired on a still-live entity does not keep assembling
+   * from a TTL hit. Per-entity invalidation cannot see parent entity IDs from a
+   * bulk `UPDATE kg_nodes SET archived_at`.
+   */
+  clearCache(): void {
+    this.cache.clear();
+    this.entityToCacheKeys.clear();
+  }
+
   // -- Private helpers --
 
   private getFromCache(id: string): EntityContext | undefined {
@@ -485,16 +504,36 @@ export class EntityContextAssembler {
         return { kind: 'node', kgNodeId: row.kg_node_id! };
       }
 
-      // Try as a KG node ID directly. Archived nodes are not live entities — looking
-      // one up by ID is an unresolved miss, not a nodeless contact (no contact row
-      // was addressed). getKgNode filters archived_at again as defence in depth.
-      const nodeResult = await this.pool.query<{ id: string }>(
-        'SELECT id FROM kg_nodes WHERE id = $1 AND archived_at IS NULL',
+      // Try as a KG node ID directly. Live nodes assemble. Archived nodes look up
+      // the owning contact (agents routinely reuse `entities[].entityId` across
+      // turns) and land in `nodeless` with cause archived — the same #1694 silence
+      // class as the contactIds path. Unanchored archived nodes stay unresolved.
+      const nodeResult = await this.pool.query<{ id: string; archived: boolean }>(
+        'SELECT id, (archived_at IS NOT NULL) AS archived FROM kg_nodes WHERE id = $1',
         [id],
       );
       if (nodeResult.rows.length > 0) {
-        const nodeId = nodeResult.rows[0]?.id;
-        if (nodeId) return { kind: 'node', kgNodeId: nodeId };
+        const nodeRow = nodeResult.rows[0]!;
+        if (!nodeRow.archived) return { kind: 'node', kgNodeId: nodeRow.id };
+
+        const owner = await this.pool.query<{ id: string; display_name: string }>(
+          'SELECT id, display_name FROM contacts WHERE kg_node_id = $1',
+          [id],
+        );
+        if (owner.rows.length > 0) {
+          const contact = owner.rows[0]!;
+          this.logger.debug(
+            { kgNodeId: id, contactId: contact.id },
+            'entity-context: archived KG node is owned by a contact',
+          );
+          return {
+            kind: 'nodeless',
+            contactId: contact.id,
+            displayName: contact.display_name,
+            cause: 'archived',
+          };
+        }
+        return { kind: 'unknown' };
       }
 
       return { kind: 'unknown' };
@@ -525,6 +564,15 @@ export class EntityContextAssembler {
       [id],
     );
     return result.rows[0];
+  }
+
+  /** True when the node exists and has not been archived. Used to reject stale cache hits. */
+  private async isLiveKgNode(id: string): Promise<boolean> {
+    const result = await this.pool.query<{ id: string }>(
+      'SELECT id FROM kg_nodes WHERE id = $1 AND archived_at IS NULL',
+      [id],
+    );
+    return result.rows.length > 0;
   }
 
   /**
@@ -727,9 +775,10 @@ interface RelationshipRow {
 
 /**
  * Classify a contact's linked KG node for the nodeless bucket.
- * `nodeArchived` is the SQL `(n.archived_at IS NOT NULL)` boolean from the LEFT JOIN;
- * undefined/null means the mock (or a missing node row) did not set it — treat as live
- * so a dangling FK still falls through to getKgNode's referential-integrity warning.
+ * `nodeArchived` is the SQL `(n.archived_at IS NOT NULL)` boolean from the LEFT JOIN.
+ * An unmatched join (dangling `kg_node_id`) yields `false`, not null — both are
+ * treated as live so the miss still falls through to getKgNode's referential-integrity
+ * warning. `true` is the only archived signal.
  */
 function classifyLinkedNode(
   kgNodeId: string | null | undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2095,6 +2095,7 @@ async function main(): Promise<void> {
     yamlConfig.documentWorkspace?.scratchTtlDays ?? DEFAULT_SCRATCH_DOC_TTL_DAYS,
     llmCallArchiveRetentionDays,
   );
+  dreamEngine.setOnArchived(() => entityContextAssembler.clearCache());
   logger.info(
     {
       decayConfig,

--- a/src/memory/dream-engine.test.ts
+++ b/src/memory/dream-engine.test.ts
@@ -98,6 +98,63 @@ describe('DreamEngine.runDecayPass', () => {
     expect(result.edgesArchived).toBe(2);
   });
 
+  it('invokes onArchived after COMMIT when the pass archived nodes or edges', async () => {
+    const { pool } = makePoolWithResponses([
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rows: [{ threshold: 10 }] },
+      { rowCount: 0, rows: [] },
+      { rowCount: 0 },
+      { rowCount: 2 },
+      { rowCount: 0 },
+    ]);
+    const onArchived = vi.fn();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    engine.setOnArchived(onArchived);
+
+    await engine.runDecayPass();
+
+    expect(onArchived).toHaveBeenCalledTimes(1);
+    const client = await (pool.connect as ReturnType<typeof vi.fn>).mock.results[0]!.value;
+    const allSqls = (client.query as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: unknown[]) => (c as [string])[0],
+    );
+    expect(allSqls[allSqls.length - 1]).toBe('COMMIT');
+  });
+
+  it('does not invoke onArchived when the pass archived nothing', async () => {
+    const { pool } = makePoolWithResponses(defaultResponses());
+    const onArchived = vi.fn();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    engine.setOnArchived(onArchived);
+
+    await engine.runDecayPass();
+
+    expect(onArchived).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the decay pass when onArchived throws', async () => {
+    const { pool } = makePoolWithResponses([
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rowCount: 0 },
+      { rows: [{ threshold: 10 }] },
+      { rowCount: 0, rows: [] },
+      { rowCount: 0 },
+      { rowCount: 1 },
+      { rowCount: 0 },
+    ]);
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    engine.setOnArchived(() => {
+      throw new Error('cache flush failed');
+    });
+
+    await expect(engine.runDecayPass()).resolves.toMatchObject({ nodesArchived: 1 });
+  });
+
   it('does not run any SQL for permanent nodes (halfLifeDays.permanent is null)', async () => {
     const { pool, queries } = makePoolWithResponses(defaultResponses());
     const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -70,6 +70,8 @@ export class DreamEngine {
   private workingDocsRepo?: WorkingDocsRepo;
   private scratchTtlDays?: number;
   private llmCallArchiveRetentionDays?: number;
+  /** Called after a decay pass COMMITs at least one node or edge archive. */
+  private onArchived?: () => void;
 
   constructor(
     pool: Pool,
@@ -92,6 +94,16 @@ export class DreamEngine {
     this.workingDocsRepo = workingDocsRepo;
     this.scratchTtlDays = scratchTtlDays;
     this.llmCallArchiveRetentionDays = llmCallArchiveRetentionDays;
+  }
+
+  /**
+   * Register a callback fired after a decay pass commits at least one archive.
+   * Used to drop the entity-context TTL cache so retired nodes/facts cannot
+   * keep assembling from a hit (#1707). Invoked after COMMIT so a rolled-back
+   * pass cannot evict live cache, and a failure here cannot roll back decay.
+   */
+  setOnArchived(handler: () => void): void {
+    this.onArchived = handler;
   }
 
   /**
@@ -177,6 +189,20 @@ export class DreamEngine {
       const result = await this._runDecayPassOnClient(client, archiveThreshold, halfLifeDays);
 
       await client.query('COMMIT');
+
+      // Entity-context cache is a correctness boundary once archival retires
+      // knowledge (#1707). Flush after COMMIT so a rolled-back pass cannot
+      // evict live entries, and a callback failure cannot roll back decay.
+      if (result.nodesArchived + result.nodesExpired + result.edgesArchived > 0) {
+        try {
+          this.onArchived?.();
+        } catch (err) {
+          this.logger.error(
+            { err },
+            'DreamEngine: entity-context cache invalidation after archive failed',
+          );
+        }
+      }
 
       // Emit bus events AFTER commit — DB state is now authoritative.
       // Bus/audit failures here don't affect the committed warn state.

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -1618,7 +1618,11 @@ export class ExecutionLayer {
           // report the gap with the skill name attached rather than silently.
           if (enrichmentResult.nodeless.length > 0) {
             skillLogger.warn(
-              { toolName, contactIds: enrichmentResult.nodeless.map(n => n.contactId) },
+              {
+                toolName,
+                contactIds: enrichmentResult.nodeless.map(n => n.contactId),
+                causes: enrichmentResult.nodeless.map(n => n.cause),
+              },
               'entity_enrichment: contacts have no KG node — skill ran without their context',
             );
           }

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -251,7 +251,7 @@ describe('EntityContextAssembler', () => {
       expect(entities).toHaveLength(0);
       expect(unresolved).toHaveLength(0);
       expect(nodeless).toEqual([
-        { inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' },
+        { inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'missing' },
       ]);
     });
 
@@ -268,7 +268,7 @@ describe('EntityContextAssembler', () => {
       // inputId keeps the caller's original string so it can correlate the result
       // back to what it asked for; contactId is what the row actually resolved to.
       expect(nodeless).toEqual([
-        { inputId: 'seth@example.com', contactId: 'contact-2', displayName: 'Seth Berman' },
+        { inputId: 'seth@example.com', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'missing' },
       ]);
     });
 
@@ -325,6 +325,143 @@ describe('EntityContextAssembler', () => {
       await assembler.assembleMany(['contact-2']);
 
       expect(vi.mocked(pool.query)).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -- Archived nodes (#1707) --
+  //
+  // DreamEngine (and, once ADR-040 increment 3 lands, contact deletion) retires
+  // knowledge by setting archived_at. The write path has always respected that;
+  // the entity-context read path did not, so retired facts still assembled.
+  describe('assembleMany — archived nodes', () => {
+    function querySql(pool: DbPool): string[] {
+      return vi.mocked(pool.query).mock.calls.map(call => String(call[0]));
+    }
+
+    it('reports a contact whose KG node is archived as nodeless, not assembled', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-retired', display_name: 'Retired Person', node_archived: true }] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, nodeless } = await assembler.assembleMany(['contact-retired']);
+
+      expect(entities).toHaveLength(0);
+      expect(unresolved).toHaveLength(0);
+      expect(nodeless).toEqual([
+        {
+          inputId: 'contact-retired',
+          contactId: 'contact-retired',
+          displayName: 'Retired Person',
+          cause: 'archived',
+        },
+      ]);
+    });
+
+    it('reports an email that resolves to an archived-node contact as nodeless', async () => {
+      const pool = makeSequentialPool([
+        {
+          rows: [{
+            contact_id: 'contact-retired',
+            kg_node_id: 'node-retired',
+            display_name: 'Retired Person',
+            node_archived: true,
+          }],
+        },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, nodeless } = await assembler.assembleMany(['retired@example.com']);
+
+      expect(entities).toHaveLength(0);
+      expect(unresolved).toHaveLength(0);
+      expect(nodeless).toEqual([
+        {
+          inputId: 'retired@example.com',
+          contactId: 'contact-retired',
+          displayName: 'Retired Person',
+          cause: 'archived',
+        },
+      ]);
+    });
+
+    it('treats a direct lookup of an archived node ID as unresolved', async () => {
+      // No contact was addressed, so this is not a nodeless contact — the node is
+      // simply not a live entity. The kg_nodes query must filter archived_at so
+      // we do not then log a false referential-integrity warning.
+      const pool = makeSequentialPool([
+        { rows: [] }, // not a contact
+        { rows: [] }, // not a live KG node
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, nodeless } = await assembler.assembleMany(['node-retired']);
+
+      expect(entities).toHaveLength(0);
+      expect(nodeless).toHaveLength(0);
+      expect(unresolved).toEqual(['node-retired']);
+
+      const nodeIdLookup = querySql(pool).find(s =>
+        s.includes('FROM kg_nodes') && !s.includes('SELECT id, type, label'),
+      );
+      expect(nodeIdLookup).toMatch(/archived_at IS NULL/);
+    });
+
+    it('does not cache archived-node nodeless results', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-retired', display_name: 'Retired Person', node_archived: true }] },
+        { rows: [{ kg_node_id: 'node-retired', display_name: 'Retired Person', node_archived: true }] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      await assembler.assembleMany(['contact-retired']);
+      await assembler.assembleMany(['contact-retired']);
+
+      expect(vi.mocked(pool.query)).toHaveBeenCalledTimes(2);
+    });
+
+    it('excludes archived entity nodes, facts, and relationship endpoints from the read SQL', async () => {
+      // Three cases in one assembly of a live contact:
+      //   1. getKgNode must not return an archived entity node
+      //   2. getFacts must not return an archived fact hanging off a live node
+      //   3. getRelationships must not return an edge whose other end is archived
+      // The mock pool does not execute SQL, so the assertions are on the predicates
+      // both UNION halves send to Postgres.
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1', display_name: 'Jenna Smith' }] },
+        { rows: [personNodeRow] },
+        { rows: [timezoneFactRow] },
+        { rows: [contactRow] },
+        { rows: [calendarRow] },
+        { rows: [relationshipRow] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('contact-1');
+      expect(ctx).toBeDefined();
+
+      const sql = querySql(pool);
+
+      const nodeLookup = sql.find(s => s.includes('SELECT id, type, label, properties'));
+      expect(nodeLookup, 'getKgNode query').toMatch(/archived_at IS NULL/);
+
+      const facts = sql.find(s => s.includes("e.type = 'relates_to'"));
+      expect(facts, 'getFacts query').toBeDefined();
+      const factHalves = facts!.split(/UNION ALL/i);
+      expect(factHalves).toHaveLength(2);
+      for (const half of factHalves) {
+        expect(half).toMatch(/e\.archived_at IS NULL/);
+        expect(half).toMatch(/n\.archived_at IS NULL/);
+      }
+
+      const rels = sql.find(s => s.includes("n.type != 'fact'"));
+      expect(rels, 'getRelationships query').toBeDefined();
+      const relHalves = rels!.split(/UNION ALL/i);
+      expect(relHalves).toHaveLength(2);
+      for (const half of relHalves) {
+        expect(half).toMatch(/e\.archived_at IS NULL/);
+        expect(half).toMatch(/n\.archived_at IS NULL/);
+      }
     });
   });
 

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -385,13 +385,35 @@ describe('EntityContextAssembler', () => {
       ]);
     });
 
-    it('treats a direct lookup of an archived node ID as unresolved', async () => {
-      // No contact was addressed, so this is not a nodeless contact — the node is
-      // simply not a live entity. The kg_nodes query must filter archived_at so
-      // we do not then log a false referential-integrity warning.
+    it('reports a direct lookup of an archived node ID as nodeless when a contact owns it', async () => {
+      // Agents reuse entities[].entityId across turns. An archived node reached
+      // that way must not read as "genuinely unknown" (#1694 / #1707).
       const pool = makeSequentialPool([
-        { rows: [] }, // not a contact
-        { rows: [] }, // not a live KG node
+        { rows: [] }, // not a contact UUID
+        { rows: [{ id: 'node-retired', archived: true }] },
+        { rows: [{ id: 'contact-retired', display_name: 'Retired Person' }] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved, nodeless } = await assembler.assembleMany(['node-retired']);
+
+      expect(entities).toHaveLength(0);
+      expect(unresolved).toHaveLength(0);
+      expect(nodeless).toEqual([
+        {
+          inputId: 'node-retired',
+          contactId: 'contact-retired',
+          displayName: 'Retired Person',
+          cause: 'archived',
+        },
+      ]);
+    });
+
+    it('treats a direct lookup of an unanchored archived node as unresolved', async () => {
+      const pool = makeSequentialPool([
+        { rows: [] }, // not a contact UUID
+        { rows: [{ id: 'node-retired', archived: true }] },
+        { rows: [] }, // no owning contact
       ]);
 
       const assembler = new EntityContextAssembler(pool, logger);
@@ -400,11 +422,6 @@ describe('EntityContextAssembler', () => {
       expect(entities).toHaveLength(0);
       expect(nodeless).toHaveLength(0);
       expect(unresolved).toEqual(['node-retired']);
-
-      const nodeIdLookup = querySql(pool).find(s =>
-        s.includes('FROM kg_nodes') && !s.includes('SELECT id, type, label'),
-      );
-      expect(nodeIdLookup).toMatch(/archived_at IS NULL/);
     });
 
     it('does not cache archived-node nodeless results', async () => {
@@ -469,7 +486,7 @@ describe('EntityContextAssembler', () => {
     // Cache is keyed by the input ID in assembleMany. Direct assembleOne()
     // calls bypass the cache — the cache only applies when going through assembleMany().
 
-    it('returns cached result on second assembleMany call without hitting DB again', async () => {
+    it('returns cached result on second assembleMany call after confirming the node is still live', async () => {
       const pool = makeSequentialPool([
         { rows: [{ kg_node_id: 'node-1' }] },
         { rows: [personNodeRow] },
@@ -477,17 +494,46 @@ describe('EntityContextAssembler', () => {
         { rows: [contactRow] },
         { rows: [] },
         { rows: [] },
+        { rows: [{ id: 'node-1' }] }, // isLiveKgNode
       ]);
 
       const assembler = new EntityContextAssembler(pool, logger);
 
-      // First call — hits DB
       await assembler.assembleMany(['contact-1']);
       const callsAfterFirst = vi.mocked(pool.query).mock.calls.length;
 
-      // Second call — should hit cache, no additional DB queries
       await assembler.assembleMany(['contact-1']);
-      expect(vi.mocked(pool.query).mock.calls.length).toBe(callsAfterFirst);
+      // One indexed live-check; the assembly queries must not re-run.
+      expect(vi.mocked(pool.query).mock.calls.length).toBe(callsAfterFirst + 1);
+      expect(String(vi.mocked(pool.query).mock.calls[callsAfterFirst]![0])).toMatch(/archived_at IS NULL/);
+    });
+
+    it('does not serve a cached payload after the entity node is archived', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1', display_name: 'Jenna Smith' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },
+        { rows: [contactRow] },
+        { rows: [] },
+        { rows: [] },
+        { rows: [] }, // isLiveKgNode: archived
+        { rows: [{ kg_node_id: 'node-1', display_name: 'Jenna Smith', node_archived: true }] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const first = await assembler.assembleMany(['contact-1']);
+      expect(first.entities).toHaveLength(1);
+
+      const second = await assembler.assembleMany(['contact-1']);
+      expect(second.entities).toHaveLength(0);
+      expect(second.nodeless).toEqual([
+        {
+          inputId: 'contact-1',
+          contactId: 'contact-1',
+          displayName: 'Jenna Smith',
+          cause: 'archived',
+        },
+      ]);
     });
 
     it('clears cache for entity on clearCacheForEntity()', async () => {
@@ -643,7 +689,7 @@ describe('EntityContextAssembler', () => {
     it('assembleMany resolves a mix of email addresses and contact UUIDs', async () => {
       // putInCache stores under all aliases: inputId ('jenna@example.com'),
       // entityId ('node-1'), and contactId ('contact-1'). So the second
-      // lookup for 'contact-1' is a cache hit — no extra DB queries needed.
+      // lookup for 'contact-1' is a cache hit — one live-check, no re-assembly.
       const pool = makeSequentialPool([
         // First ID: email address — full resolution + assembly
         { rows: [channelIdentityRow] },    // email resolution
@@ -652,7 +698,7 @@ describe('EntityContextAssembler', () => {
         { rows: [contactRow] },             // getContactByKgNodeId
         { rows: [] },                       // getConnectedAccounts
         { rows: [] },                       // getRelationships
-        // Second ID 'contact-1': cache hit, no DB queries
+        { rows: [{ id: 'node-1' }] },       // isLiveKgNode for cached 'contact-1'
       ]);
 
       const assembler = new EntityContextAssembler(pool, logger);

--- a/tests/unit/entity-context/entity-context-handler.test.ts
+++ b/tests/unit/entity-context/entity-context-handler.test.ts
@@ -80,7 +80,7 @@ describe('EntityContextHandler', () => {
       { contactIds: ['contact-2', 'ghost-id'] },
       {
         unresolved: ['ghost-id'],
-        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }],
+        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'missing' }],
       },
     );
 
@@ -88,18 +88,19 @@ describe('EntityContextHandler', () => {
 
     const data = expectData(result) as unknown as {
       unresolved: string[];
-      nodeless: Array<{ contactId: string; displayName: string; reason: string }>;
+      nodeless: Array<{ contactId: string; displayName: string; reason: string; cause: string }>;
     };
     expect(data.unresolved).toEqual(['ghost-id']);
     expect(data.nodeless).toHaveLength(1);
     expect(data.nodeless[0].contactId).toBe('contact-2');
     expect(data.nodeless[0].displayName).toBe('Seth Berman');
+    expect(data.nodeless[0].cause).toBe('missing');
   });
 
   it('gives each nodeless contact a reason the LLM cannot read as plain absence', async () => {
     const ctx = makeCtx(
       { contactIds: ['contact-2'] },
-      { nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }] },
+      { nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'missing' }] },
     );
 
     const result = await new EntityContextHandler().execute(ctx);
@@ -110,6 +111,25 @@ describe('EntityContextHandler', () => {
     // the distinction rather than the exact sentence so the copy can be reworded.
     expect(reason).toMatch(/cannot/i);
     expect(reason).not.toMatch(/^no (facts|context|information)/i);
+    expect(reason).toMatch(/has no stored profile/i);
+    expect(reason).not.toMatch(/retired/i);
+  });
+
+  it('gives an archived-node contact a reason that distinguishes retirement from never-had', async () => {
+    const ctx = makeCtx(
+      { contactIds: ['contact-2'] },
+      { nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'archived' }] },
+    );
+
+    const result = await new EntityContextHandler().execute(ctx);
+    const data = expectData(result) as unknown as {
+      nodeless: Array<{ cause: string; reason: string }>;
+    };
+
+    expect(data.nodeless[0].cause).toBe('archived');
+    expect(data.nodeless[0].reason).toMatch(/retired/i);
+    expect(data.nodeless[0].reason).toMatch(/cannot/i);
+    expect(data.nodeless[0].reason).not.toMatch(/has no stored profile/i);
   });
 
   it('echoes inputId back so the agent can map the answer to what it asked for', async () => {
@@ -117,7 +137,7 @@ describe('EntityContextHandler', () => {
     // and displayName may not resemble the address it supplied.
     const ctx = makeCtx(
       { entityIds: ['seth@example.com'] },
-      { nodeless: [{ inputId: 'seth@example.com', contactId: 'contact-2', displayName: 'Seth Berman' }] },
+      { nodeless: [{ inputId: 'seth@example.com', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'missing' }] },
     );
 
     const result = await new EntityContextHandler().execute(ctx);
@@ -135,7 +155,7 @@ describe('EntityContextHandler', () => {
       { contactIds: ['contact-1', 'contact-2'] },
       {
         entities: [makeEntity()],
-        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }],
+        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'missing' }],
       },
     );
 
@@ -266,7 +286,7 @@ describe('EntityContextHandler', () => {
       { contactIds: ['contact-1', 'contact-2'] },
       {
         failed: [{ inputId: 'contact-1', retryable: true }],
-        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }],
+        nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'missing' }],
       },
     );
 

--- a/tests/unit/entity-context/execution-enrichment.test.ts
+++ b/tests/unit/entity-context/execution-enrichment.test.ts
@@ -276,7 +276,7 @@ describe('ExecutionLayer — entity_enrichment', () => {
 
     const assembler = makeMockAssembler({
       unresolved: ['ghost-id'],
-      nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman' }],
+      nodeless: [{ inputId: 'contact-2', contactId: 'contact-2', displayName: 'Seth Berman', cause: 'missing' }],
     });
     const execution = new ExecutionLayer(registry, spyLogger, {
       entityContextAssembler: assembler,
@@ -290,8 +290,9 @@ describe('ExecutionLayer — entity_enrichment', () => {
     expect(nodelessLine, `expected a nodeless warn line, got: ${messages.join(' | ')}`).toBeDefined();
 
     // The nodeless line carries contact IDs, and does not also list the unknown ID.
-    const payload = nodelessLine![0] as { contactIds?: string[] };
+    const payload = nodelessLine![0] as { contactIds?: string[]; causes?: string[] };
     expect(payload.contactIds).toEqual(['contact-2']);
+    expect(payload.causes).toEqual(['missing']);
   });
 
   it('does not emit a nodeless warn when every contact has a node', async () => {


### PR DESCRIPTION
## Summary

Entity-context assembly ignored `archived_at`, so DreamEngine-retired KG nodes, facts, and edges still showed up in agent context. Archiving is the only way to retire stale knowledge; once ADR-040 increment 3 lands, an unfiltered read path would also assemble context for deleted contacts.

This PR filters archived rows on the read path, reports contacts whose node was retired in the existing `nodeless` bucket with a distinct `cause`/`reason`, and counts those contacts in the linkage report so the diagnostic and the read path agree.

Review follow-up (d72a2118): cache hits re-check `archived_at` and DreamEngine flushes the assembler cache after a decay pass archives; an archived node requested by `entityIds` looks up the owning contact and lands in `nodeless`; skill version is 1.3.0 for the new `cause` field.

Closes #1707

## Changes

- `getKgNode`, `getFacts`, and `getRelationships` exclude `archived_at IS NOT NULL` rows (edges and related nodes too)
- A contact whose `kg_node_id` points at an archived node lands in `nodeless` with `cause: "archived"` instead of assembling
- Direct `entityIds` lookup of an archived node owned by a contact also lands in `nodeless`
- Cache hits re-validate that the entity node is still live; DreamEngine flushes the cache after archival
- Handler reason text distinguishes "never had a stored profile" from "profile was retired"
- `scripts/kg-node-linkage-report.ts` counts archived-node contacts alongside NULL-node contacts, without folding them into the migration 085 mint arms
- Spec 11 resolution/pipeline/caching updated; `entity-context` tool.json bumped to 1.3.0

## Related Issues

Closes #1707

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [x] CI passes