### PR TITLE
feat(kg): contact-anchored node identity (ADR-040 increment 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Contact-anchored KG identity** — same-name contacts each hold their own node, facts, and enrichment. (#1694)
 - **ADR-040 (Accepted)** — contact-anchored KG node identity; a contact's node is keyed on the contact, not its label. (#1694)
 - **ADR-040 measured population** — migration `085` sizing recorded from production: 14 nodeless contacts, arm A empty. (#1694)
 - **ADR-040 identity decay rule** — contact-anchored KG nodes are excluded from decay and archival; facts still decay. (#1694)
@@ -37,6 +38,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`DreamEngine`** — contact-anchored nodes no longer decay or archive; their facts still do. (#1694)
+- **`deleteContact`** — archives the contact's anchored KG node, freeing its label for reuse. (#1694)
 - **`EntityMemory.resolveOrCreate`** — returns `ambiguous` when 2+ matches share the requested type, instead of taking the first. (#1694)
 - **`extract-facts`** — skips and counts an ambiguous subject rather than guessing; new `ambiguous` output. (#1694)
 - **Checkpoint extraction** — passes the conversation's external originator to `extract-facts` as a subject tiebreaker. (#1694)
@@ -58,6 +61,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`createContact`** — a display-name collision now mints a node instead of dropping the link. (#1694)
 - **Signal inbound** — ACI-only senders keep a non-empty sender and conversation identity. (#1600)
 - **`entity-context`** — transient DB failures surface in `failed`, not `unresolved`. (#1702)
 - **`entity_enrichment`** — failed lookups get their own warn line instead of joining unresolved. (#1702)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`deleteContact`** — archives the contact's anchored KG node, freeing its label for reuse. (#1694)
 - **`EntityMemory.resolveOrCreate`** — returns `ambiguous` when 2+ matches share the requested type, instead of taking the first. (#1694)
 - **`extract-facts`** — skips and counts an ambiguous subject rather than guessing; new `ambiguous` output. (#1694)
+- **`extract-relationships`** — skips and counts ambiguous endpoints instead of taking the first match. (#1714)
 - **Checkpoint extraction** — passes the conversation's external originator to `extract-facts` as a subject tiebreaker. (#1694)
 - **`EntityContextAssembler.assembleMany`** — new `nodeless` bucket, disjoint from `unresolved`; logged at warn. (#1694)
 - **`entity-context`** — output gains `nodeless`; agents read a missing node as a capability gap. (#1694)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **`DreamEngine`** — contact-anchored nodes no longer decay or archive; their facts still do. (#1694)
+- **Decay warnings** — anchored nodes are never listed for re-confirmation nor archived by dismissal. (#1694)
 - **`deleteContact`** — archives the contact's anchored KG node, freeing its label for reuse. (#1694)
 - **`EntityMemory.resolveOrCreate`** — returns `ambiguous` when 2+ matches share the requested type, instead of taking the first. (#1694)
 - **`extract-facts`** — skips and counts an ambiguous subject rather than guessing; new `ambiguous` output. (#1694)
@@ -62,6 +63,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`createContact`** — a display-name collision now mints a node instead of dropping the link. (#1694)
+- **Orphan cleanup** — a failed contact create no longer archives a KG node it merely adopted. (#1694)
 - **Signal inbound** — ACI-only senders keep a non-empty sender and conversation identity. (#1600)
 - **`entity-context`** — transient DB failures surface in `failed`, not `unresolved`. (#1702)
 - **`entity_enrichment`** — failed lookups get their own warn line instead of joining unresolved. (#1702)

--- a/docs/adr/040-contact-anchored-kg-node-identity.md
+++ b/docs/adr/040-contact-anchored-kg-node-identity.md
@@ -308,6 +308,25 @@ and it moves the risk out of the migration. Two consequences for sequencing: the
 relaxation is prevention rather than repair and should not lead, and the `resolveOrCreate`
 ambiguity fix — which addresses a live alias-collision path, per Context — should.
 
+**Name-only extraction gets quieter, not smarter.** Two contacts sharing a display name now
+produce two same-label person nodes, and `findNodesByLabel` returns both by design. So every
+name-only write about that name resolves `ambiguous`: `extract-facts` skips and counts it
+unless `subject_contact_id` picks a side, and the only caller supplying that hint is the
+checkpoint processor, which passes the conversation's counterpart — so a fact about a *third
+party* named in a transcript is dropped rather than stored. The nodes exist and can hold
+facts; the automatic extraction path largely cannot write to them without a hint. Watch the
+`ambiguous` counter after deploy. `extract-relationships` is worse and is tracked in #1714:
+it still takes `candidates[0]`, so it misattributes rather than skipping.
+
+**Orphaned anchors accumulate.** An anchored node whose contact goes away without archival
+never decays, because every decay and archival path now excludes the anchored tier. Three
+paths produce them: an adoption abandoned when the contact INSERT fails, orphan cleanup after
+a lost `linkIdentity` race (which must not archive, since the node may predate the attempt),
+and a contact merge whose KG half fails on the foreign key (#1711). The first two are logged
+at `warn`; the third is repaired inline. `scripts/kg-node-linkage-report.ts` counts them, and
+a growing number is the signal that name-only extraction is silently degrading, since two
+same-label nodes make every write about that name ambiguous.
+
 **Not addressed.** Nothing here improves resolution *quality* for names Curia has never
 associated with a contact — an unanchored "Seth Berman" mentioned in an email body still
 resolves by label and embedding, with all the fuzziness that implies. This ADR gives
@@ -324,5 +343,7 @@ contacts a durable identity; it does not give the KG one for everyone else.
   still assemble — adjacent, and made load-bearing by the deletion rule above)
 - #1711 (contact merge loses KG memory on a foreign-key violation — pre-existing, and the
   reason the Backfill section above no longer claims `085` fixes merges)
+- #1714 (`extract-relationships` still picks `candidates[0]` — pre-existing, but this ADR
+  makes same-label collisions routine rather than rare)
 - Migrations 010, 016, 027, 056 (the indexes and backfills this supersedes or amends)
 - ADR-028 (shared, unbound agent memory) for the surrounding memory-governance model

--- a/docs/adr/040-contact-anchored-kg-node-identity.md
+++ b/docs/adr/040-contact-anchored-kg-node-identity.md
@@ -315,8 +315,10 @@ unless `subject_contact_id` picks a side, and the only caller supplying that hin
 checkpoint processor, which passes the conversation's counterpart — so a fact about a *third
 party* named in a transcript is dropped rather than stored. The nodes exist and can hold
 facts; the automatic extraction path largely cannot write to them without a hint. Watch the
-`ambiguous` counter after deploy. `extract-relationships` is worse and is tracked in #1714:
-it still takes `candidates[0]`, so it misattributes rather than skipping.
+`ambiguous` counter after deploy. `extract-relationships` took `candidates[0]` and so would
+have misattributed rather than skipped; it now skips and counts on the same contract (#1714),
+which means relationships about a shared name are dropped rather than attached to the wrong
+one of two real people. Dropping is recoverable; misattributing is not.
 
 **Orphaned anchors accumulate.** An anchored node whose contact goes away without archival
 never decays, because every decay and archival path now excludes the anchored tier. Three
@@ -343,7 +345,7 @@ contacts a durable identity; it does not give the KG one for everyone else.
   still assemble — adjacent, and made load-bearing by the deletion rule above)
 - #1711 (contact merge loses KG memory on a foreign-key violation — pre-existing, and the
   reason the Backfill section above no longer claims `085` fixes merges)
-- #1714 (`extract-relationships` still picks `candidates[0]` — pre-existing, but this ADR
-  makes same-label collisions routine rather than rare)
+- #1714 (`extract-relationships` picked `candidates[0]` — pre-existing, but this ADR makes
+  same-label collisions routine rather than rare, so it is fixed here rather than deferred)
 - Migrations 010, 016, 027, 056 (the indexes and backfills this supersedes or amends)
 - ADR-028 (shared, unbound agent memory) for the surrounding memory-governance model

--- a/docs/adr/040-contact-anchored-kg-node-identity.md
+++ b/docs/adr/040-contact-anchored-kg-node-identity.md
@@ -226,10 +226,16 @@ Existing linked nodes are flipped to `identity_source = 'contact'` in the same m
 Everything else keeps the default `'label'`.
 
 The backfill deliberately makes no attempt to detect that two nodeless "Seth Berman"
-contacts might be one person. That is the dedup sweep's job, and it now works better:
-`mergeContacts` only calls `mergeEntities` when *both* sides have a node
-(`src/contacts/contact-service.ts`), so giving every contact a node is what finally lets a
-contact merge carry memory across.
+contacts might be one person. That is the dedup sweep's job.
+
+An earlier draft of this ADR claimed the backfill also makes contact merges carry KG memory,
+because `mergeContacts` only calls `mergeEntities` when *both* sides have a node. The
+precondition is right and the conclusion is wrong. `mergeEntities` hard-`DELETE`s the
+secondary node while the secondary contact still points at it, and `contacts.kg_node_id`
+is a `NO ACTION` foreign key, so the delete raises `23503` and the merge is swallowed as
+"KG node merge failed (non-fatal)". This is pre-existing and already near-universal —
+534 of 548 contacts were linked before `085` — so the backfill neither causes it nor cures
+it. Tracked separately in #1711; until that lands, a contact merge still loses KG memory.
 
 ### Rejected alternatives
 
@@ -316,5 +322,7 @@ contacts a durable identity; it does not give the KG one for everyone else.
   absence-of-evidence failure on the error path, found while reviewing #1701)
 - #1707 (the entity-context read path ignores `archived_at`, so archived nodes and facts
   still assemble — adjacent, and made load-bearing by the deletion rule above)
+- #1711 (contact merge loses KG memory on a foreign-key violation — pre-existing, and the
+  reason the Backfill section above no longer claims `085` fixes merges)
 - Migrations 010, 016, 027, 056 (the indexes and backfills this supersedes or amends)
 - ADR-028 (shared, unbound agent memory) for the surrounding memory-governance model

--- a/scripts/kg-node-linkage-report.test.ts
+++ b/scripts/kg-node-linkage-report.test.ts
@@ -21,9 +21,9 @@ function makePool(rows: unknown[]): MockPool {
 describe('runLinkageReport', () => {
   it('splits the nodeless population across the two backfill arms', async () => {
     const pool = makePool([
-      { kind: 'person', total: '120', nodeless: '9', org_arm: '0', shadowed: '7' },
-      { kind: 'organization', total: '30', nodeless: '6', org_arm: '4', shadowed: '0' },
-      { kind: 'automated', total: '15', nodeless: '0', org_arm: '0', shadowed: '0' },
+      { kind: 'person', total: '120', nodeless: '9', org_arm: '0', shadowed: '7', archived_link: '0', anchored_orphans: '0' },
+      { kind: 'organization', total: '30', nodeless: '6', org_arm: '4', shadowed: '0', archived_link: '0', anchored_orphans: '0' },
+      { kind: 'automated', total: '15', nodeless: '0', org_arm: '0', shadowed: '0', archived_link: '0', anchored_orphans: '0' },
     ]);
 
     const report = await runLinkageReport(pool as never);
@@ -43,7 +43,7 @@ describe('runLinkageReport', () => {
 
   it('reports a clean database as zero work, not as an error', async () => {
     const pool = makePool([
-      { kind: 'person', total: '40', nodeless: '0', org_arm: '0', shadowed: '0' },
+      { kind: 'person', total: '40', nodeless: '0', org_arm: '0', shadowed: '0', archived_link: '0', anchored_orphans: '0' },
     ]);
 
     const report = await runLinkageReport(pool as never);
@@ -64,7 +64,7 @@ describe('runLinkageReport', () => {
   it('throws when the grouping column is not a usable kind', async () => {
     // String(undefined) would print "undefined" in the by-kind table, which reads
     // like a real contact kind rather than a broken query.
-    const pool = makePool([{ total: '10', nodeless: '3', org_arm: '0', shadowed: '0' }]);
+    const pool = makePool([{ total: '10', nodeless: '3', org_arm: '0', shadowed: '0', archived_link: '0', anchored_orphans: '0' }]);
 
     await expect(runLinkageReport(pool as never)).rejects.toThrow(/"kind"/);
   });
@@ -81,7 +81,7 @@ describe('runLinkageReport', () => {
 
   it('throws rather than reporting a fabricated count when a column is unparseable', async () => {
     const pool = makePool([
-      { kind: 'person', total: '10', nodeless: '3', org_arm: 'n/a', shadowed: '0' },
+      { kind: 'person', total: '10', nodeless: '3', org_arm: 'n/a', shadowed: '0', archived_link: '0', anchored_orphans: '0' },
     ]);
 
     await expect(runLinkageReport(pool as never)).rejects.toThrow(/org_arm/);
@@ -91,7 +91,7 @@ describe('runLinkageReport', () => {
     // Internally inconsistent input means the query is wrong. Clamping would hide
     // that behind a plausible arm-B number, which is the one output that matters.
     const pool = makePool([
-      { kind: 'organization', total: '10', nodeless: '2', org_arm: '5', shadowed: '0' },
+      { kind: 'organization', total: '10', nodeless: '2', org_arm: '5', shadowed: '0', archived_link: '0', anchored_orphans: '0' },
     ]);
 
     await expect(runLinkageReport(pool as never)).rejects.toThrow(/internally inconsistent/);
@@ -102,7 +102,7 @@ describe('runLinkageReport', () => {
     // database with contact ingestion running, the arms could then fail to sum to the
     // total they are derived from.
     const pool = makePool([
-      { kind: 'person', total: '1', nodeless: '0', org_arm: '0', shadowed: '0' },
+      { kind: 'person', total: '1', nodeless: '0', org_arm: '0', shadowed: '0', archived_link: '0', anchored_orphans: '0' },
     ]);
 
     await runLinkageReport(pool as never);
@@ -112,7 +112,7 @@ describe('runLinkageReport', () => {
 
   it('never issues a write', async () => {
     const pool = makePool([
-      { kind: 'person', total: '1', nodeless: '0', org_arm: '0', shadowed: '0' },
+      { kind: 'person', total: '1', nodeless: '0', org_arm: '0', shadowed: '0', archived_link: '0', anchored_orphans: '0' },
     ]);
 
     await runLinkageReport(pool as never);

--- a/scripts/kg-node-linkage-report.ts
+++ b/scripts/kg-node-linkage-report.ts
@@ -52,6 +52,10 @@ export interface LinkageReport {
   byKind: KindBreakdown[];
   /** Arm A: nodeless org contacts re-linkable to an organization node that already exists. */
   orgArmEligible: number;
+  /** Contacts linked to an ARCHIVED node: linked-looking but unable to hold anything. */
+  archivedLink: number;
+  /** Anchored nodes no contact references. Post-ADR-040 these never decay; watch it grow. */
+  anchoredOrphans: number;
   /** Arm B: nodeless contacts needing a freshly minted node — the insert count for 085. */
   personArmMints: number;
   /** Nodeless contacts whose display name is shared with a contact that has a node. */
@@ -121,7 +125,31 @@ const REPORT_SQL = `
             AND lower(o.display_name) = lower(c.display_name)
             AND o.kg_node_id IS NOT NULL
         )
-    ) AS shadowed
+    ) AS shadowed,
+    -- Contacts whose kg_node_id points at an ARCHIVED node. These look linked and are
+    -- broken: getNode() filters archived_at, so they resolve to nothing and hold no facts,
+    -- relationships or enrichment — the #1694 failure with a non-NULL pointer. They are
+    -- invisible to the nodeless count above, which is why this column exists. Migration
+    -- 085 step 2a repairs them; this is how you check the count before and after.
+    count(*) FILTER (
+      WHERE c.kg_node_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM kg_nodes n
+           WHERE n.id = c.kg_node_id
+             AND n.archived_at IS NOT NULL
+        )
+    ) AS archived_link,
+    -- Anchored nodes with no contact pointing at them. Post-ADR-040 these never decay and
+    -- are never archived, so they accumulate: an abandoned adoption, or a contact merge
+    -- whose KG half failed (#1711). Two same-label person nodes make resolveOrCreate
+    -- return 'ambiguous', so a growing number here means facts silently stop landing.
+    -- Not per-kind (it counts nodes, not contacts) — read it from any row.
+    (
+      SELECT count(*) FROM kg_nodes n
+       WHERE n.identity_source = 'contact'
+         AND n.archived_at IS NULL
+         AND NOT EXISTS (SELECT 1 FROM contacts oc WHERE oc.kg_node_id = n.id)
+    ) AS anchored_orphans
   FROM contacts c
   GROUP BY c.kind
   ORDER BY c.kind
@@ -169,6 +197,11 @@ export async function runLinkageReport(pool: PoolLike): Promise<LinkageReport> {
   const totalNodeless = byKind.reduce((sum, k) => sum + k.nodeless, 0);
   const orgArmEligible = rows.reduce((sum, row) => sum + requireCount(row, 'org_arm'), 0);
   const sameNameShadowed = rows.reduce((sum, row) => sum + requireCount(row, 'shadowed'), 0);
+  const archivedLink = rows.reduce((sum, row) => sum + requireCount(row, 'archived_link'), 0);
+  // Scalar subquery: identical on every group row, so read it once rather than summing.
+  // An empty contacts table yields no rows at all, in which case there is nothing linked
+  // and therefore nothing orphaned either.
+  const anchoredOrphans = rows[0] ? requireCount(rows[0], 'anchored_orphans') : 0;
 
   // Arm B is the remainder by construction: every nodeless contact arm A cannot
   // re-link needs a node minted. Because all four counts come from one statement,
@@ -189,6 +222,8 @@ export async function runLinkageReport(pool: PoolLike): Promise<LinkageReport> {
     orgArmEligible,
     personArmMints,
     sameNameShadowed,
+    archivedLink,
+    anchoredOrphans,
   };
 }
 
@@ -208,6 +243,10 @@ export function formatReport(report: LinkageReport): string {
     `    arm B (mint a node)   ${report.personArmMints}`,
     '',
     `  of which shadowed by a same-name contact that has a node: ${report.sameNameShadowed}`,
+    '',
+    '  other broken linkage (not part of the nodeless count above):',
+    `    linked to an ARCHIVED node   ${report.archivedLink}   (085 step 2a repairs these)`,
+    `    anchored nodes with no contact ${report.anchoredOrphans}   (never decay — watch this grow)`,
   ];
   return lines.join('\n');
 }

--- a/skills/contacts/tools/contact-register/handler.ts
+++ b/skills/contacts/tools/contact-register/handler.ts
@@ -155,7 +155,9 @@ export class ContactRegisterHandler implements ToolHandler {
           // but it will leave a dangling row. Log as warn so it can be caught by a
           // periodic cleanup sweep if needed.
           try {
-            await ctx.contactService.deleteContact(contact.id);
+            // Orphan cleanup — do not archive the KG node; createContact may have adopted
+            // a pre-existing one (ADR-040, see deleteContact).
+            await ctx.contactService.deleteContact(contact.id, { archiveAnchoredNode: false });
           } catch (deleteErr) {
             ctx.log.warn(
               { deleteErr, orphanId: contact.id },

--- a/skills/contacts/tools/contact-register/handler.ts
+++ b/skills/contacts/tools/contact-register/handler.ts
@@ -104,7 +104,7 @@ export class ContactRegisterHandler implements ToolHandler {
       if (!resolvedSender) {
         ctx.log.info({ channel }, 'contact-register: no existing contact — creating at tier=unknown');
 
-        const contact = await ctx.contactService.createContact({
+        const { contact, kgNodeCreated } = await ctx.contactService.createContactWithKgOutcome({
           displayName,
           // Use the identifier (e.g. email address) as a fallback display name in
           // case the displayName sanitizes to empty (prompt injection defense).
@@ -155,9 +155,10 @@ export class ContactRegisterHandler implements ToolHandler {
           // but it will leave a dangling row. Log as warn so it can be caught by a
           // periodic cleanup sweep if needed.
           try {
-            // Orphan cleanup — do not archive the KG node; createContact may have adopted
-            // a pre-existing one (ADR-040, see deleteContact).
-            await ctx.contactService.deleteContact(contact.id, { archiveAnchoredNode: false });
+            // Orphan cleanup — retire the KG node only if THIS call minted it. An adopted
+            // node may carry pre-existing facts and is not ours to remove; a minted one is
+            // anchored and never decays, so it cannot just be abandoned (ADR-040).
+            await ctx.contactService.deleteContact(contact.id, { archiveAnchoredNode: kgNodeCreated });
           } catch (deleteErr) {
             ctx.log.warn(
               { deleteErr, orphanId: contact.id },

--- a/skills/extract-relationships/handler.test.ts
+++ b/skills/extract-relationships/handler.test.ts
@@ -65,7 +65,7 @@ describe('ExtractRelationshipsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 0, skipped: true } });
+    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 0, failed: 0, ambiguous: 0, skipped: true } });
     // Classifier was called; extraction was not
     expect(infraLlm.classify).toHaveBeenCalledTimes(1);
     expect(infraLlm.extract).not.toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe('ExtractRelationshipsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, failed: 0, skipped: false } });
+    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, failed: 0, ambiguous: 0, skipped: false } });
 
     // Verify the edge exists in the KG
     const adaNodes = await entityMemory.findEntities('Ada Lovelace');
@@ -116,7 +116,7 @@ describe('ExtractRelationshipsHandler', () => {
     const ctx2 = makeCtx(entityMemory, { text: 'John Smith is Bob\'s wife.', source: 'test' }, infraLlm2);
     const result = await handler2.execute(ctx2);
 
-    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 1, failed: 0, skipped: false } });
+    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 1, failed: 0, ambiguous: 0, skipped: false } });
 
     // Exactly two person nodes, one edge — no duplicate
     const josephNodes = await entityMemory.findEntities('Jane Doe');
@@ -166,7 +166,7 @@ describe('ExtractRelationshipsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, failed: 0, skipped: false } });
+    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, failed: 0, ambiguous: 0, skipped: false } });
 
     const xiaopuNodes = await entityMemory.findEntities('John Smith');
     const josephNodes = await entityMemory.findEntities('Jane Doe');
@@ -195,5 +195,147 @@ describe('ExtractRelationshipsHandler', () => {
     expect(aliceNodes).toHaveLength(1);
     const queryResult = await entityMemory.query(aliceNodes[0]!.id);
     expect(queryResult.relationships[0]!.edge.type).toBe('relates_to');
+  });
+
+  // -- Ambiguity (#1714 / ADR-040) --
+  //
+  // ADR-040 lets two contacts sharing a display name each hold their own person node, and
+  // findNodesByLabel returns both by design. Before this, resolution took matches[0] — a
+  // coin flip that attached the relationship to whichever node came back first. Attaching a
+  // relationship to the wrong one of two real people is worse than not recording it.
+
+  describe('ambiguous endpoints', () => {
+    /** Two anchored person nodes sharing a label, as migration 085 produces. */
+    async function twoNamesakes(entityMemory: EntityMemory, label: string): Promise<string[]> {
+      const a = await entityMemory.createAnchoredEntity({
+        type: 'person', label, properties: {}, source: 'test',
+      });
+      const b = await entityMemory.createAnchoredEntity({
+        type: 'person', label, properties: {}, source: 'test',
+      });
+      return [a.id, b.id];
+    }
+
+    it('skips and counts a triple whose SUBJECT matches two nodes', async () => {
+      const entityMemory = makeEntityMemory();
+      const [a, b] = await twoNamesakes(entityMemory, 'Seth Berman');
+      const infraLlm = makeMockInfraLlm([
+        'yes',
+        JSON.stringify([{ subject: 'Seth Berman', predicate: 'works_on', object: 'Project Atlas',
+                          subjectType: 'person', objectType: 'project', confidence: 0.9 }]),
+      ]);
+      const handler = new ExtractRelationshipsHandler();
+
+      const result = await handler.execute(
+        makeCtx(entityMemory, { text: 'Seth Berman works on Project Atlas.', source: 'test' }, infraLlm),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { extracted: 0, confirmed: 0, failed: 0, ambiguous: 1, skipped: false },
+      });
+      // Neither namesake picked up the edge.
+      expect(await entityMemory.findEdges(a!)).toHaveLength(0);
+      expect(await entityMemory.findEdges(b!)).toHaveLength(0);
+    });
+
+    it('skips and counts a triple whose OBJECT matches two nodes', async () => {
+      // An edge needs both ends; half a relationship is not a relationship.
+      const entityMemory = makeEntityMemory();
+      const [a, b] = await twoNamesakes(entityMemory, 'Seth Berman');
+      const infraLlm = makeMockInfraLlm([
+        'yes',
+        JSON.stringify([{ subject: 'Dana Wu', predicate: 'reports_to', object: 'Seth Berman',
+                          subjectType: 'person', objectType: 'person', confidence: 0.9 }]),
+      ]);
+      const handler = new ExtractRelationshipsHandler();
+
+      const result = await handler.execute(
+        makeCtx(entityMemory, { text: 'Dana Wu reports to Seth Berman.', source: 'test' }, infraLlm),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { extracted: 0, confirmed: 0, failed: 0, ambiguous: 1, skipped: false },
+      });
+      expect(await entityMemory.findEdges(a!)).toHaveLength(0);
+      expect(await entityMemory.findEdges(b!)).toHaveLength(0);
+    });
+
+    it('still resolves when exactly one candidate has the requested type', async () => {
+      // Cross-type collisions must keep working: "River" the organization is not "River"
+      // the person, so the type is a real tiebreaker rather than a guess.
+      const entityMemory = makeEntityMemory();
+      await entityMemory.createAnchoredEntity({
+        type: 'person', label: 'River', properties: {}, source: 'test',
+      });
+      await entityMemory.createEntity({
+        type: 'organization', label: 'River', properties: {}, source: 'test',
+      });
+      const infraLlm = makeMockInfraLlm([
+        'yes',
+        JSON.stringify([{ subject: 'River', predicate: 'works_on', object: 'Project Atlas',
+                          subjectType: 'person', objectType: 'project', confidence: 0.9 }]),
+      ]);
+      const handler = new ExtractRelationshipsHandler();
+
+      const result = await handler.execute(
+        makeCtx(entityMemory, { text: 'River works on Project Atlas.', source: 'test' }, infraLlm),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { extracted: 1, confirmed: 0, failed: 0, ambiguous: 0, skipped: false },
+      });
+    });
+
+    it('does not let one ambiguous triple stop the others in the batch', async () => {
+      const entityMemory = makeEntityMemory();
+      await twoNamesakes(entityMemory, 'Seth Berman');
+      const infraLlm = makeMockInfraLlm([
+        'yes',
+        JSON.stringify([
+          { subject: 'Seth Berman', predicate: 'works_on', object: 'Project Atlas',
+            subjectType: 'person', objectType: 'project', confidence: 0.9 },
+          { subject: 'Dana Wu', predicate: 'works_on', object: 'Project Borealis',
+            subjectType: 'person', objectType: 'project', confidence: 0.9 },
+        ]),
+      ]);
+      const handler = new ExtractRelationshipsHandler();
+
+      const result = await handler.execute(
+        makeCtx(entityMemory, { text: 'Two relationships.', source: 'test' }, infraLlm),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: { extracted: 1, confirmed: 0, failed: 0, ambiguous: 1, skipped: false },
+      });
+    });
+
+    it('reports the skip at a level production can see, without the raw label', async () => {
+      // prod runs at info, so a debug line would be no signal at all. The label is an
+      // extracted entity name and therefore PII (#1706) — ids only.
+      const entityMemory = makeEntityMemory();
+      const [a, b] = await twoNamesakes(entityMemory, 'Seth Berman');
+      const infraLlm = makeMockInfraLlm([
+        'yes',
+        JSON.stringify([{ subject: 'Seth Berman', predicate: 'works_on', object: 'Project Atlas',
+                          subjectType: 'person', objectType: 'project', confidence: 0.9 }]),
+      ]);
+      const warn = vi.fn();
+      const ctx = makeCtx(entityMemory, { text: 'x', source: 'test' }, infraLlm);
+      (ctx as unknown as { log: unknown }).log = {
+        info: vi.fn(), warn, error: vi.fn(), debug: vi.fn(),
+      };
+
+      await new ExtractRelationshipsHandler().execute(ctx);
+
+      const call = warn.mock.calls.find(c => /ambiguous endpoint/.test(String(c[1])));
+      expect(call).toBeDefined();
+      const payload = call![0] as { subjectCandidateIds?: string[] };
+      expect(payload.subjectCandidateIds).toEqual(expect.arrayContaining([a, b]));
+      expect(JSON.stringify(payload)).not.toContain('Seth Berman');
+    });
   });
 });

--- a/skills/extract-relationships/handler.test.ts
+++ b/skills/extract-relationships/handler.test.ts
@@ -237,6 +237,10 @@ describe('ExtractRelationshipsHandler', () => {
       // Neither namesake picked up the edge.
       expect(await entityMemory.findEdges(a!)).toHaveLength(0);
       expect(await entityMemory.findEdges(b!)).toHaveLength(0);
+      // And the OTHER endpoint was never minted. Looking up both ends before creating
+      // either is what prevents an edgeless node being persisted for a triple the handler
+      // decided not to record.
+      expect(await entityMemory.findEntities('Project Atlas')).toHaveLength(0);
     });
 
     it('skips and counts a triple whose OBJECT matches two nodes', async () => {
@@ -260,6 +264,8 @@ describe('ExtractRelationshipsHandler', () => {
       });
       expect(await entityMemory.findEdges(a!)).toHaveLength(0);
       expect(await entityMemory.findEdges(b!)).toHaveLength(0);
+      // The subject is the new label this time — it must not be minted either.
+      expect(await entityMemory.findEntities('Dana Wu')).toHaveLength(0);
     });
 
     it('still resolves when exactly one candidate has the requested type', async () => {

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -12,7 +12,7 @@
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../src/skills/types.js';
 import { EDGE_TYPES, NODE_TYPES } from '../../src/memory/types.js';
-import type { EdgeType, NodeType } from '../../src/memory/types.js';
+import type { EdgeType, NodeType, KgNode } from '../../src/memory/types.js';
 
 // Shape of each triple returned by the LLM extraction prompt.
 interface ExtractedTriple {
@@ -58,7 +58,7 @@ export class ExtractRelationshipsHandler implements ToolHandler {
 
       if (maxStored === 0) {
         ctx.log.info({ extracted: 0, confirmed: 0, failed: 0 }, 'extract-relationships: complete');
-        return { success: true, data: { extracted: 0, confirmed: 0, failed: 0, skipped: false } };
+        return { success: true, data: { extracted: 0, confirmed: 0, failed: 0, ambiguous: 0, skipped: false } };
       }
 
       // -- Step 1: Classifier gate --
@@ -77,7 +77,7 @@ export class ExtractRelationshipsHandler implements ToolHandler {
 
     if (!classifierAnswer.startsWith('yes')) {
       ctx.log.debug({ textPreview: text.slice(0, 80) }, 'extract-relationships: classifier gate — no relationships, skipping');
-      return { success: true, data: { extracted: 0, confirmed: 0, skipped: true } };
+      return { success: true, data: { extracted: 0, confirmed: 0, failed: 0, ambiguous: 0, skipped: true } };
     }
 
     // -- Step 2: Extraction prompt --
@@ -119,18 +119,19 @@ ${text}`,
       if (!Array.isArray(parsed)) {
         // Log length only — rawText may contain extracted entity names (PII).
         ctx.log.warn({ responseLength: rawText.length }, 'extract-relationships: extraction returned non-array, treating as empty');
-        return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
+        return { success: true, data: { extracted: 0, confirmed: 0, failed: 0, ambiguous: 0, skipped: false } };
       }
       triples = parsed as ExtractedTriple[];
     } catch (err) {
       ctx.log.warn({ err, responseLength: rawText.length }, 'extract-relationships: failed to parse extraction JSON, treating as empty');
-      return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
+      return { success: true, data: { extracted: 0, confirmed: 0, failed: 0, ambiguous: 0, skipped: false } };
     }
 
     // -- Steps 3 & 4: Node resolution + edge upsert --
     let extracted = 0;
     let confirmed = 0;
     let failed = 0;
+    let ambiguous = 0;
 
     // Entity types that are valid relationship endpoints. 'fact' is excluded —
     // facts describe a single entity and should not appear as nodes in a
@@ -138,6 +139,63 @@ ${text}`,
     const ENTITY_NODE_TYPES: ReadonlySet<string> = new Set(
       NODE_TYPES.filter(t => t !== 'fact'),
     );
+
+    /**
+     * Resolve one endpoint of a triple, or report that the label is ambiguous.
+     *
+     * Mirrors `EntityMemory.resolveOrCreate`'s exact-match contract (#1705):
+     *   0 matches                                   → create
+     *   1 match                                     → that node, even if its type differs
+     *                                                 (a lone label match is almost always
+     *                                                 the same real-world entity)
+     *   2+ matches, exactly one of the wanted type  → that node
+     *   2+ matches, several or none of that type    → ambiguous
+     *
+     * It deliberately does NOT use resolveOrCreate itself: that adds an embedding-based
+     * fuzzy phase, and this handler runs over whole transcripts in a background pipeline
+     * where an extra embed + vector search per endpoint is real cost. The exact-match half
+     * is what this fix needs; the two must be kept in step if either changes.
+     *
+     * Before ADR-040 this took `matches[0]` when several nodes shared a label. That was
+     * always a coin flip, but two contacts with the same display name could not both hold
+     * a node, so it was rare. Now they can, so it would be routine — and attaching a
+     * relationship to the wrong one of two real people is worse than dropping it (#1714).
+     */
+    // Bind the narrowed values once: the guards above have already established both, but
+    // a closure defined here does not carry that narrowing on its own.
+    const entityMemory = ctx.entityMemory;
+    const edgeSource = source;
+
+    async function resolveEndpoint(
+      label: string,
+      wantedType: NodeType,
+    ): Promise<
+      | { kind: 'resolved'; node: KgNode }
+      | { kind: 'ambiguous'; candidateIds: string[] }
+    > {
+      const matches = await entityMemory.findEntities(label);
+
+      if (matches.length === 0) {
+        const { entity } = await entityMemory.createEntity({
+          type: wantedType,
+          label,
+          properties: {},
+          source: edgeSource,
+          confidence: 0.6,
+        });
+        return { kind: 'resolved', node: entity };
+      }
+
+      if (matches.length === 1) return { kind: 'resolved', node: matches[0]! };
+
+      const typeMatches = matches.filter(n => n.type === wantedType);
+      if (typeMatches.length === 1) return { kind: 'resolved', node: typeMatches[0]! };
+
+      return {
+        kind: 'ambiguous',
+        candidateIds: (typeMatches.length > 1 ? typeMatches : matches).map(n => n.id),
+      };
+    }
 
     for (const triple of triples) {
       try {
@@ -168,29 +226,28 @@ ${text}`,
           ? triple.objectType as NodeType
           : 'person';
 
-        // Resolve subject — prefer a node whose type matches the extraction.
-        // Falling back to the first match handles cases where a node was previously
-        // created under a different type; creating a new node is the last resort.
-        const subjectMatches = await ctx.entityMemory.findEntities(triple.subject);
-        const subjectMatch = subjectMatches.find(n => n.type === subjectType) ?? subjectMatches[0];
-        const subjectNode = subjectMatch ?? (await ctx.entityMemory.createEntity({
-          type: subjectType,
-          label: triple.subject,
-          properties: {},
-          source,
-          confidence: 0.6,
-        })).entity;
+        // Resolve both endpoints. Either one being ambiguous drops the whole triple:
+        // an edge needs both ends, and half a relationship is not a relationship.
+        const subjectResolution = await resolveEndpoint(triple.subject, subjectType);
+        const objectResolution = await resolveEndpoint(triple.object, objectType);
 
-        // Resolve object — same pattern
-        const objectMatches = await ctx.entityMemory.findEntities(triple.object);
-        const objectMatch = objectMatches.find(n => n.type === objectType) ?? objectMatches[0];
-        const objectNode = objectMatch ?? (await ctx.entityMemory.createEntity({
-          type: objectType,
-          label: triple.object,
-          properties: {},
-          source,
-          confidence: 0.6,
-        })).entity;
+        if (subjectResolution.kind === 'ambiguous' || objectResolution.kind === 'ambiguous') {
+          // Candidate ids, never the raw label — those are extracted entity names and
+          // therefore PII (#1706). The ids are enough to inspect the collision by hand.
+          ctx.log.warn(
+            {
+              predicate,
+              subjectCandidateIds: subjectResolution.kind === 'ambiguous' ? subjectResolution.candidateIds : undefined,
+              objectCandidateIds: objectResolution.kind === 'ambiguous' ? objectResolution.candidateIds : undefined,
+            },
+            'extract-relationships: ambiguous endpoint — skipping triple rather than guessing',
+          );
+          ambiguous++;
+          continue;
+        }
+
+        const subjectNode = subjectResolution.node;
+        const objectNode = objectResolution.node;
 
         // Skip self-loops — subject and object resolved to the same node.
         // The extraction prompt asks for two distinct entities but the LLM can still
@@ -232,8 +289,8 @@ ${text}`,
       }
     }
 
-    ctx.log.info({ extracted, confirmed, failed }, 'extract-relationships: complete');
-    return { success: true, data: { extracted, confirmed, failed, skipped: false } };
+    ctx.log.info({ extracted, confirmed, failed, ambiguous }, 'extract-relationships: complete');
+    return { success: true, data: { extracted, confirmed, failed, ambiguous, skipped: false } };
     } catch (err) {
       // Top-level catch for unexpected errors (e.g. provider implementation bugs that
       // throw instead of returning { type: 'error' }).

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -140,11 +140,16 @@ ${text}`,
       NODE_TYPES.filter(t => t !== 'fact'),
     );
 
+    // Bind the narrowed values once: the guards above have already established both, but
+    // a closure defined here does not carry that narrowing on its own.
+    const entityMemory = ctx.entityMemory;
+    const edgeSource = source;
+
     /**
-     * Resolve one endpoint of a triple, or report that the label is ambiguous.
+     * Look one endpoint up. Pure read — it never writes, which is the point.
      *
      * Mirrors `EntityMemory.resolveOrCreate`'s exact-match contract (#1705):
-     *   0 matches                                   → create
+     *   0 matches                                   → absent (caller decides whether to mint)
      *   1 match                                     → that node, even if its type differs
      *                                                 (a lone label match is almost always
      *                                                 the same real-world entity)
@@ -156,45 +161,44 @@ ${text}`,
      * where an extra embed + vector search per endpoint is real cost. The exact-match half
      * is what this fix needs; the two must be kept in step if either changes.
      *
-     * Before ADR-040 this took `matches[0]` when several nodes shared a label. That was
-     * always a coin flip, but two contacts with the same display name could not both hold
-     * a node, so it was rare. Now they can, so it would be routine — and attaching a
+     * Before ADR-040 resolution took `matches[0]` when several nodes shared a label. That
+     * was always a coin flip, but two contacts with the same display name could not both
+     * hold a node, so it was rare. Now they can, so it would be routine — and attaching a
      * relationship to the wrong one of two real people is worse than dropping it (#1714).
      */
-    // Bind the narrowed values once: the guards above have already established both, but
-    // a closure defined here does not carry that narrowing on its own.
-    const entityMemory = ctx.entityMemory;
-    const edgeSource = source;
-
-    async function resolveEndpoint(
+    async function lookupEndpoint(
       label: string,
       wantedType: NodeType,
     ): Promise<
-      | { kind: 'resolved'; node: KgNode }
+      | { kind: 'found'; node: KgNode }
       | { kind: 'ambiguous'; candidateIds: string[] }
+      | { kind: 'absent' }
     > {
       const matches = await entityMemory.findEntities(label);
 
-      if (matches.length === 0) {
-        const { entity } = await entityMemory.createEntity({
-          type: wantedType,
-          label,
-          properties: {},
-          source: edgeSource,
-          confidence: 0.6,
-        });
-        return { kind: 'resolved', node: entity };
-      }
-
-      if (matches.length === 1) return { kind: 'resolved', node: matches[0]! };
+      if (matches.length === 0) return { kind: 'absent' };
+      if (matches.length === 1) return { kind: 'found', node: matches[0]! };
 
       const typeMatches = matches.filter(n => n.type === wantedType);
-      if (typeMatches.length === 1) return { kind: 'resolved', node: typeMatches[0]! };
+      if (typeMatches.length === 1) return { kind: 'found', node: typeMatches[0]! };
 
       return {
         kind: 'ambiguous',
         candidateIds: (typeMatches.length > 1 ? typeMatches : matches).map(n => n.id),
       };
+    }
+
+    /** Mint an endpoint node. Separate from the lookup so nothing is written until BOTH
+     *  endpoints are known to be resolvable — see the call site. */
+    async function createEndpoint(label: string, wantedType: NodeType): Promise<KgNode> {
+      const { entity } = await entityMemory.createEntity({
+        type: wantedType,
+        label,
+        properties: {},
+        source: edgeSource,
+        confidence: 0.6,
+      });
+      return entity;
     }
 
     for (const triple of triples) {
@@ -226,19 +230,22 @@ ${text}`,
           ? triple.objectType as NodeType
           : 'person';
 
-        // Resolve both endpoints. Either one being ambiguous drops the whole triple:
-        // an edge needs both ends, and half a relationship is not a relationship.
-        const subjectResolution = await resolveEndpoint(triple.subject, subjectType);
-        const objectResolution = await resolveEndpoint(triple.object, objectType);
+        // Look BOTH endpoints up before minting either. An edge needs both ends, so a
+        // triple with one ambiguous endpoint is dropped — and if the lookup and the mint
+        // were interleaved, dropping it would still leave behind whichever endpoint had
+        // already been created: an edgeless node persisted for a relationship this handler
+        // decided not to record.
+        const subjectLookup = await lookupEndpoint(triple.subject, subjectType);
+        const objectLookup = await lookupEndpoint(triple.object, objectType);
 
-        if (subjectResolution.kind === 'ambiguous' || objectResolution.kind === 'ambiguous') {
+        if (subjectLookup.kind === 'ambiguous' || objectLookup.kind === 'ambiguous') {
           // Candidate ids, never the raw label — those are extracted entity names and
           // therefore PII (#1706). The ids are enough to inspect the collision by hand.
           ctx.log.warn(
             {
               predicate,
-              subjectCandidateIds: subjectResolution.kind === 'ambiguous' ? subjectResolution.candidateIds : undefined,
-              objectCandidateIds: objectResolution.kind === 'ambiguous' ? objectResolution.candidateIds : undefined,
+              subjectCandidateIds: subjectLookup.kind === 'ambiguous' ? subjectLookup.candidateIds : undefined,
+              objectCandidateIds: objectLookup.kind === 'ambiguous' ? objectLookup.candidateIds : undefined,
             },
             'extract-relationships: ambiguous endpoint — skipping triple rather than guessing',
           );
@@ -246,8 +253,15 @@ ${text}`,
           continue;
         }
 
-        const subjectNode = subjectResolution.node;
-        const objectNode = objectResolution.node;
+        // Both resolvable, so minting is safe. A triple naming the same new label at both
+        // ends mints once, not twice: createEntity upserts on (lower(label), type), so the
+        // second call returns the first node and the self-loop guard below catches it.
+        const subjectNode = subjectLookup.kind === 'found'
+          ? subjectLookup.node
+          : await createEndpoint(triple.subject, subjectType);
+        const objectNode = objectLookup.kind === 'found'
+          ? objectLookup.node
+          : await createEndpoint(triple.object, objectType);
 
         // Skip self-loops — subject and object resolved to the same node.
         // The extraction prompt asks for two distinct entities but the LLM can still

--- a/skills/extract-relationships/tool.json
+++ b/skills/extract-relationships/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "extract-relationships",
   "description": "Extract entity-to-entity relationships from a passage of text and persist them as knowledge graph edges. Self-classifies internally — always safe to call; exits early if no relationships are found.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -12,6 +12,8 @@
   "outputs": {
     "extracted": "number (new edges created)",
     "confirmed": "number (existing edges re-asserted and updated)",
+    "failed": "number (triples dropped by a malformed shape or a persistence error)",
+    "ambiguous": "number (triples dropped because an endpoint label matched several nodes)",
     "skipped": "boolean (true if the classifier gate determined no relationships were present)"
   },
   "permissions": [],

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -1009,7 +1009,7 @@ export class EmailAdapter implements Channel {
         // sanitizes to empty (e.g., pure injection text), the email is used instead.
         // primaryEmail is passed so createContact() can route business senders to an
         // existing or new organization KG node instead of minting a person node.
-        const contact = await contactService.createContact({
+        const { contact, kgNodeCreated } = await contactService.createContactWithKgOutcome({
           displayName: p.name || p.email,
           fallbackDisplayName: p.email,
           source: 'email_participant',
@@ -1035,11 +1035,11 @@ export class EmailAdapter implements Channel {
         } catch (linkErr) {
           const pgCode = (linkErr as { code?: string }).code;
           try {
-            // Orphan cleanup, so do not archive the KG node: createContact may have
-            // adopted a pre-existing one carrying facts (ADR-040). This path runs per
-            // participant on every inbound email, so an archiving cleanup here would be
-            // the highest-traffic way to lose knowledge in the system.
-            await contactService.deleteContact(contact.id, { archiveAnchoredNode: false });
+            // Orphan cleanup. Retire the node only if THIS call minted it: an adopted node
+            // carries facts accrued long before this attempt (ADR-040), and this path runs
+            // per participant on every inbound email — archiving indiscriminately here
+            // would be the highest-traffic way to lose knowledge in the system.
+            await contactService.deleteContact(contact.id, { archiveAnchoredNode: kgNodeCreated });
           } catch (deleteErr) {
             // Include linkErr so both failure modes are co-located in the log entry.
             logger.warn(

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -1035,7 +1035,11 @@ export class EmailAdapter implements Channel {
         } catch (linkErr) {
           const pgCode = (linkErr as { code?: string }).code;
           try {
-            await contactService.deleteContact(contact.id);
+            // Orphan cleanup, so do not archive the KG node: createContact may have
+            // adopted a pre-existing one carrying facts (ADR-040). This path runs per
+            // participant on every inbound email, so an archiving cleanup here would be
+            // the highest-traffic way to lose knowledge in the system.
+            await contactService.deleteContact(contact.id, { archiveAnchoredNode: false });
           } catch (deleteErr) {
             // Include linkErr so both failure modes are co-located in the log entry.
             logger.warn(

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -142,9 +142,11 @@ export async function setupRoutes(
           await contactService.updateDisplayName(result.contactId, trimmed);
           renamed = true;
           // Best-effort: keep the KG person-node label in sync so KG browsing shows the
-          // corrected name. The unique index idx_kg_nodes_unique (lower(label), type) can
-          // reject the rename if another non-fact node already owns that label; that's
-          // non-fatal — the contact column is the authoritative display name.
+          // corrected name. Since ADR-040 the principal's node is contact-anchored and so
+          // outside idx_kg_nodes_unique, meaning the rename normally succeeds even when
+          // another node owns that label. The catch stays for nodes still in the label
+          // tier — a rejected rename is non-fatal either way, because the contact column
+          // is the authoritative display name.
           try {
             await pool.query(
               `UPDATE kg_nodes SET label = $1, last_confirmed_at = now()

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -78,6 +78,11 @@ export async function repairPrincipalMetadata(contactId: string, pool: DbPool, l
  * person node per label — and the identity_source predicate makes it a compare-and-set,
  * so two concurrent boots cannot both adopt.
  *
+ * Clearing warned_at mirrors anchorNode() and migration 085: DreamEngine may have warned
+ * the extraction node before we adopted it, and nothing clears an anchored node's warning
+ * afterwards (the decay passes, listDecayWarnings and dismissDecayWarning all skip the
+ * anchored tier now), so it would sit warned forever.
+ *
  * Step 2 mints a fresh anchored node. It needs no ON CONFLICT: anchored nodes are outside
  * idx_kg_nodes_unique, so the INSERT cannot raise 23505 on the label. The cost is that
  * two concurrent boots can each mint one; both call sites resolve that by keeping the
@@ -100,7 +105,9 @@ export async function insertKgPersonNode(
         SET identity_source   = 'contact',
             last_confirmed_at = now(),
             decay_class       = 'permanent',
-            confidence        = GREATEST(confidence, 1.0)
+            confidence        = GREATEST(confidence, 1.0),
+            warned_at         = NULL,
+            warn_reason       = NULL
       WHERE type = 'person'
         AND lower(label) = lower($1)
         AND archived_at IS NULL

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -83,10 +83,18 @@ export async function repairPrincipalMetadata(contactId: string, pool: DbPool, l
  * two concurrent boots can each mint one; both call sites resolve that by keeping the
  * node the winning contact actually points at and deleting the unreferenced loser.
  *
+ * Returns `created` alongside the id so callers can tell an ADOPTED node — which may
+ * already carry facts and edges from extraction — apart from one this call minted. Only
+ * the latter is safe to delete on a lost race; deleting the former destroys pre-existing
+ * knowledge that was never ours to remove.
+ *
  * Exported so ensure-principal.ts can reuse the exact same node-creation semantics
  * for the wizard's no-channel principal-creation path.
  */
-export async function insertKgPersonNode(displayName: string, pool: DbPool): Promise<string> {
+export async function insertKgPersonNode(
+  displayName: string,
+  pool: DbPool,
+): Promise<{ id: string; created: boolean }> {
   const adopted = await pool.query<{ id: string }>(
     `UPDATE kg_nodes
         SET identity_source   = 'contact',
@@ -101,7 +109,7 @@ export async function insertKgPersonNode(displayName: string, pool: DbPool): Pro
     [displayName],
   );
   const adoptedId = adopted.rows[0]?.id;
-  if (adoptedId) return adoptedId;
+  if (adoptedId) return { id: adoptedId, created: false };
 
   const created = await pool.query<{ id: string }>(
     `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, identity_source)
@@ -113,7 +121,7 @@ export async function insertKgPersonNode(displayName: string, pool: DbPool): Pro
   if (!id) {
     throw new Error('ceo-bootstrap: INSERT INTO kg_nodes returned no rows or no id — check migrations 004, 016 and 085 were applied');
   }
-  return id;
+  return { id, created: true };
 }
 
 /**
@@ -124,7 +132,7 @@ export async function insertKgPersonNode(displayName: string, pool: DbPool): Pro
  * Exported so ensure-principal.ts can reuse the same backfill semantics.
  */
 export async function createAndLinkKgNode(contactId: string, displayName: string, pool: DbPool): Promise<string> {
-  const newKgNodeId = await insertKgPersonNode(displayName, pool);
+  const { id: newKgNodeId, created } = await insertKgPersonNode(displayName, pool);
   await pool.query(
     `UPDATE contacts SET kg_node_id = $1, updated_at = now() WHERE id = $2 AND kg_node_id IS NULL`,
     [newKgNodeId, contactId],
@@ -143,7 +151,13 @@ export async function createAndLinkKgNode(contactId: string, displayName: string
   // longer collide on the label, so a lost race leaves OUR node unreferenced rather than
   // resolving to the same row. Mirrors ensure-principal.ts — the NOT EXISTS guard keeps
   // the delete safe if a further concurrent writer claimed it in the meantime.
-  if (linkedKgNodeId !== newKgNodeId) {
+  //
+  // Gated on `created`. An ADOPTED node predates this call and may carry extraction facts
+  // and edges that would go with it (kg_edges cascades on node delete); losing a link race
+  // is no licence to destroy them. Such a node is left anchored but unreferenced — a
+  // harmless orphan, and deliberately not reverted to the label tier, since another node
+  // may have taken that label in the meantime and the revert would raise 23505 here.
+  if (created && linkedKgNodeId !== newKgNodeId) {
     await pool.query(
       `DELETE FROM kg_nodes
         WHERE id = $1

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -60,39 +60,58 @@ export async function repairPrincipalMetadata(contactId: string, pool: DbPool, l
  * Uses decay_class='permanent' and confidence=1.0 to match the agent identity pattern —
  * bootstrap nodes are never decayed by the DreamEngine.
  *
- * Uses ON CONFLICT on the idx_kg_nodes_unique index (migration 016) rather than a blind
- * INSERT, because a person node with the same label may already exist — either from a
- * concurrent startup or from email-based contact extraction that ran before bootstrap.
- * Without this, a blind INSERT would 23505 outside the contact-identity recovery block
- * and propagate as an unhandled error.
+ * Adopt-or-mint, the ADR-040 rule applied to the principal. A person node with the same
+ * label may already exist — from a concurrent startup, or from email-based contact
+ * extraction that ran before bootstrap — and the principal should inherit it rather than
+ * start empty beside it.
  *
- * The DO UPDATE also promotes decay_class to 'permanent' and pins confidence to 1.0
- * on the conflicting row. Email-based extraction creates person nodes with the default
- * slow_decay, which makes them eligible for DreamEngine archival once confidence decays.
- * When that pre-existing node belongs to the principal, bootstrap must repair it — and
+ * Step 1 promotes an existing *unanchored* node to the principal's identity. It also
+ * pins decay_class='permanent' and confidence 1.0: extraction creates person nodes at the
+ * default slow_decay, which used to make them eligible for DreamEngine archival once
+ * confidence decayed. ADR-040's anchoring now covers that on its own, but the explicit
+ * values are kept so the repair still holds for anyone reading decay_class directly.
  * GREATEST ensures we never *demote* a node that already has a higher confidence value.
  * `source` is intentionally not updated: preserving the original creator (e.g.
- * 'extraction') keeps the audit trail honest; decay protection is controlled
- * exclusively by decay_class, not source.
- * (Issue #1004)
+ * 'extraction') keeps the audit trail honest. (Issue #1004)
+ *
+ * At most one row can match step 1 — idx_kg_nodes_unique still guarantees one label-tier
+ * person node per label — and the identity_source predicate makes it a compare-and-set,
+ * so two concurrent boots cannot both adopt.
+ *
+ * Step 2 mints a fresh anchored node. It needs no ON CONFLICT: anchored nodes are outside
+ * idx_kg_nodes_unique, so the INSERT cannot raise 23505 on the label. The cost is that
+ * two concurrent boots can each mint one; both call sites resolve that by keeping the
+ * node the winning contact actually points at and deleting the unreferenced loser.
  *
  * Exported so ensure-principal.ts can reuse the exact same node-creation semantics
  * for the wizard's no-channel principal-creation path.
  */
 export async function insertKgPersonNode(displayName: string, pool: DbPool): Promise<string> {
-  const result = await pool.query<{ id: string }>(
-    `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
-     VALUES ('person', $1, '{}', 1.0, 'permanent', 'bootstrap', now(), now())
-     ON CONFLICT (lower(label), type) WHERE type != 'fact' AND archived_at IS NULL
-     DO UPDATE SET last_confirmed_at = now(),
-                   decay_class       = 'permanent',
-                   confidence        = GREATEST(kg_nodes.confidence, 1.0)
+  const adopted = await pool.query<{ id: string }>(
+    `UPDATE kg_nodes
+        SET identity_source   = 'contact',
+            last_confirmed_at = now(),
+            decay_class       = 'permanent',
+            confidence        = GREATEST(confidence, 1.0)
+      WHERE type = 'person'
+        AND lower(label) = lower($1)
+        AND archived_at IS NULL
+        AND identity_source = 'label'
+      RETURNING id`,
+    [displayName],
+  );
+  const adoptedId = adopted.rows[0]?.id;
+  if (adoptedId) return adoptedId;
+
+  const created = await pool.query<{ id: string }>(
+    `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, identity_source)
+     VALUES ('person', $1, '{}', 1.0, 'permanent', 'bootstrap', now(), now(), 'contact')
      RETURNING id`,
     [displayName],
   );
-  const id = result.rows[0]?.id;
+  const id = created.rows[0]?.id;
   if (!id) {
-    throw new Error('ceo-bootstrap: INSERT INTO kg_nodes returned no rows or no id — check migrations 004 and 016 were applied');
+    throw new Error('ceo-bootstrap: INSERT INTO kg_nodes returned no rows or no id — check migrations 004, 016 and 085 were applied');
   }
   return id;
 }
@@ -116,8 +135,21 @@ export async function createAndLinkKgNode(contactId: string, displayName: string
     `SELECT kg_node_id FROM contacts WHERE id = $1`,
     [contactId],
   );
-  if (!result.rows[0]?.kg_node_id) {
+  const linkedKgNodeId = result.rows[0]?.kg_node_id;
+  if (!linkedKgNodeId) {
     throw new Error(`ceo-bootstrap: contact ${contactId} still has no kg_node_id after UPDATE — possible concurrent conflict`);
   }
-  return result.rows[0].kg_node_id;
+  // Loser-path cleanup: under ADR-040 insertKgPersonNode mints anchored nodes, which no
+  // longer collide on the label, so a lost race leaves OUR node unreferenced rather than
+  // resolving to the same row. Mirrors ensure-principal.ts — the NOT EXISTS guard keeps
+  // the delete safe if a further concurrent writer claimed it in the meantime.
+  if (linkedKgNodeId !== newKgNodeId) {
+    await pool.query(
+      `DELETE FROM kg_nodes
+        WHERE id = $1
+          AND NOT EXISTS (SELECT 1 FROM contacts WHERE kg_node_id = $1)`,
+      [newKgNodeId],
+    );
+  }
+  return linkedKgNodeId;
 }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -518,6 +518,22 @@ export class ContactService {
       }
 
       const candidate = candidates[0]!;
+
+      // identity_source = 'label' is a proxy for "no contact owns this", and a proxy can
+      // be wrong: any node inserted without an explicit identity_source defaults to the
+      // label tier even when a contact points at it. Ask the contacts table directly
+      // rather than trusting the tier alone — adopting a node out from under an existing
+      // contact is the one outcome ADR-040 forbids outright.
+      const owner = await this.backend.findContactByKgNodeId(candidate.id);
+      if (owner) {
+        this.logger?.warn(
+          { displayName: safeName, nodeId: candidate.id, ownerContactId: owner.id },
+          'createContact: label-tier KG node is already claimed by a contact — not adopting; '
+            + 'this is an ADR-040 invariant violation worth investigating',
+        );
+        return undefined;
+      }
+
       if (!(await this.entityMemory.adoptEntity(candidate.id))) {
         // Lost the race, or the node was archived between the lookup and the CAS.
         this.logger?.info(
@@ -1101,7 +1117,9 @@ export class ContactService {
       // 23505: identity already belongs to an existing contact (concurrent create).
       // Non-23505: unexpected failure. In both cases the new contact row is orphaned.
       try {
-        await this.deleteContact(contact.id);
+        // Orphan cleanup: createContact may have adopted a pre-existing node. See the
+        // archiveAnchoredNode note on deleteContact.
+        await this.deleteContact(contact.id, { archiveAnchoredNode: false });
       } catch (cleanupErr) {
         this.logger?.warn(
           {
@@ -1605,10 +1623,21 @@ export class ContactService {
       this.logger?.warn({ err, primaryId, secondaryId }, 'contacts: dedup exclusion check failed before merge (non-fatal)');
     }
 
-    // Merge KG nodes (best-effort — failure does not abort the contact merge)
+    // Merge KG nodes (best-effort — failure does not abort the contact merge).
+    //
+    // This currently fails on essentially every merge: mergeEntities ends by hard-deleting
+    // the secondary node while the secondary contact still references it, and
+    // contacts.kg_node_id is a NO ACTION foreign key, so Postgres raises 23503 (#1711).
+    // Track the outcome — since ADR-040 the secondary's node is anchored, and an anchored
+    // node excluded from every decay and archival pass would otherwise survive forever with
+    // no contact pointing at it. Two same-label person nodes make resolveOrCreate return
+    // 'ambiguous', so extract-facts would then drop every fact about that name: merging two
+    // contacts to consolidate their memory would stop memory being written about them.
+    let kgMerged = false;
     if (primary.kgNodeId && secondary.kgNodeId && this.entityMemory) {
       try {
         await this.entityMemory.mergeEntities(primary.kgNodeId, secondary.kgNodeId);
+        kgMerged = true;
       } catch (err) {
         this.logger?.warn({ err, primaryId, secondaryId, primaryKgNodeId: primary.kgNodeId, secondaryKgNodeId: secondary.kgNodeId }, 'KG node merge failed (non-fatal)');
       }
@@ -1663,6 +1692,15 @@ export class ContactService {
         'Contact merge rolled back — no contact rows changed; a KG node merge may already have been applied (#1695)',
       );
       throw err;
+    }
+
+    // The secondary contact row is now gone. If the KG merge did not fold its node into the
+    // survivor's, that node is orphaned — and anchored, so nothing will ever retire it.
+    // Archive it here, which is what deleteContact would have done had this path used it.
+    // Runs after commit so it can never claim to have retired a node for a merge that
+    // rolled back, and guarded so it cannot touch the survivor's own node.
+    if (!kgMerged && secondary.kgNodeId && secondary.kgNodeId !== primary.kgNodeId) {
+      await this.archiveAnchoredNode(secondaryId, secondary.kgNodeId);
     }
 
     if (exclusions.dropped > 0) {
@@ -1786,22 +1824,41 @@ export class ContactService {
    * Primarily used during contact merge (to remove the secondary) and during
    * error recovery (to remove orphaned contacts created by a failed identify).
    *
-   * Also archives the contact's KG node when that node was its identity (ADR-040). An
-   * anchored node means nothing without the contact it anchors, and archiving rather
-   * than deleting frees the label for reuse (idx_kg_nodes_unique already excludes
+   * By default also archives the contact's KG node when that node was its identity
+   * (ADR-040). An anchored node means nothing without the contact it anchors, and archiving
+   * rather than deleting frees the label for reuse (idx_kg_nodes_unique already excludes
    * archived rows) while leaving the accumulated knowledge recoverable in SQL.
    *
-   * Note mergeContacts deletes the secondary through the backend directly, deliberately
-   * bypassing this: mergeEntities has already folded the secondary's node into the
-   * survivor's, so there is nothing left to archive.
+   * `archiveAnchoredNode: false` is for ORPHAN CLEANUP — undoing a contact whose creation
+   * failed part-way (a lost `linkIdentity` race). Those callers must not archive, because
+   * `createContact` may have ADOPTED a pre-existing node carrying facts and edges accrued
+   * long before this failed attempt. Archiving cascades to incident edges, so the cleanup
+   * would destroy knowledge that was never this contact's to take. The cost of skipping it
+   * is an anchored node with no contact, which no longer decays — see
+   * `scripts/kg-node-linkage-report.ts` for the query that finds them.
+   *
+   * mergeContacts deletes the secondary through the backend directly and handles its own
+   * node disposal — see the note there. (It cannot rely on `mergeEntities` having folded
+   * the node into the survivor's: that call currently fails on a foreign key, #1711.)
    */
-  async deleteContact(id: string): Promise<void> {
+  async deleteContact(
+    id: string,
+    options?: { archiveAnchoredNode?: boolean },
+  ): Promise<void> {
     // Read the link before the delete — afterwards there is no row to read it from.
     const contact = await this.backend.getContact(id);
     await this.backend.deleteContact(id);
-    if (contact?.kgNodeId) {
-      await this.archiveAnchoredNode(id, contact.kgNodeId);
+    if (!contact?.kgNodeId) return;
+
+    if (options?.archiveAnchoredNode === false) {
+      this.logger?.warn(
+        { contactId: id, kgNodeId: contact.kgNodeId },
+        'contacts: contact removed without archiving its KG node (orphan cleanup) — '
+          + 'if the node was anchored it now has no contact and will not decay',
+      );
+      return;
     }
+    await this.archiveAnchoredNode(id, contact.kgNodeId);
   }
 
   /**
@@ -1828,7 +1885,9 @@ export class ContactService {
 
       const stillReferenced = await this.backend.findContactByKgNodeId(kgNodeId);
       if (stillReferenced) {
-        this.logger?.debug(
+        // info, not debug: prod runs at info, and this is the only line distinguishing
+        // "retired this contact's identity" from "left it in place for its siblings".
+        this.logger?.info(
           { contactId, kgNodeId, remainingContactId: stillReferenced.id },
           'contacts: anchored KG node still referenced by another contact — not archiving',
         );

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -443,6 +443,123 @@ export class ContactService {
   }
 
   /**
+   * Mint a fresh contact-anchored person node after losing a race for an existing one
+   * (ADR-040). Anchored nodes sit outside idx_kg_nodes_unique, so this cannot collide on
+   * the label no matter how many namesakes are already stored.
+   *
+   * Returns null rather than throwing: this runs inside createContact's 23505 recovery,
+   * and a contact with no KG link is a degraded contact, whereas a thrown error is no
+   * contact at all. A null is logged by the caller with the full collision context.
+   */
+  private async mintAnchoredNodeForContact(
+    contact: Contact,
+    source: string,
+  ): Promise<string | null> {
+    if (!this.entityMemory) return null;
+    try {
+      const entity = await this.entityMemory.createAnchoredEntity({
+        type: 'person',
+        label: contact.displayName,
+        properties: contact.role ? { role: contact.role } : {},
+        source,
+      });
+      return entity.id;
+    } catch (err) {
+      if (err instanceof TypeError || err instanceof RangeError) throw err;
+      this.logger?.error(
+        { err, contactId: contact.id, step: 'mintAnchoredNodeForContact' },
+        'createContact: could not mint a replacement KG node after a link collision',
+      );
+      return null;
+    }
+  }
+
+  /**
+   * ADR-040 adoption: claim an existing *unanchored* person node whose label matches, so
+   * a new contact inherits facts Curia already accumulated about that name (learned from
+   * an email body, say) instead of starting empty.
+   *
+   * Returns the adopted node id, or undefined when there is nothing safe to adopt — the
+   * caller then mints a fresh anchored node. "Nothing safe" covers three cases, and all
+   * three must mint rather than share:
+   *   - no label match at all;
+   *   - every match is already anchored to some other contact (the case that used to
+   *     produce a nodeless contact, which is the whole reason #1694 exists);
+   *   - two or more unanchored candidates of the right type. Aliases carry no cross-node
+   *     uniqueness, so this is reachable; picking one would be the same silent
+   *     first-match guess resolveOrCreate stopped making in #1705.
+   *
+   * Adoption itself is a compare-and-set inside the store, so two contacts racing for one
+   * node cannot both win — the loser sees false here and mints.
+   *
+   * KG I/O failures return undefined rather than propagating: falling back to a fresh
+   * node loses an inheritance, while failing the create loses the contact.
+   */
+  private async adoptUnanchoredPersonNode(
+    safeName: string,
+    role: string | null | undefined,
+  ): Promise<string | undefined> {
+    if (!this.entityMemory) return undefined;
+
+    try {
+      const matches = await this.entityMemory.findEntities(safeName);
+      const candidates = matches.filter(
+        n => n.type === 'person' && n.identitySource === 'label',
+      );
+
+      if (candidates.length !== 1) {
+        if (candidates.length > 1) {
+          this.logger?.warn(
+            { displayName: safeName, candidateIds: candidates.map(n => n.id) },
+            'createContact: several unanchored person nodes share this label — minting a fresh node rather than guessing',
+          );
+        }
+        return undefined;
+      }
+
+      const candidate = candidates[0]!;
+      if (!(await this.entityMemory.adoptEntity(candidate.id))) {
+        // Lost the race, or the node was archived between the lookup and the CAS.
+        this.logger?.info(
+          { displayName: safeName, nodeId: candidate.id },
+          'createContact: KG node was claimed before adoption — minting a fresh node',
+        );
+        return undefined;
+      }
+
+      // Apply the role only when the node does not already carry one: the existing node
+      // may have been created without one (extract-relationships always passes empty
+      // properties), but a role already there is better-sourced than ours.
+      if (role && !candidate.properties.role) {
+        try {
+          await this.entityMemory.updateNode(candidate.id, {
+            properties: { ...candidate.properties, role },
+          });
+        } catch (err) {
+          // Non-fatal: the adoption is already committed and is the valuable part.
+          this.logger?.warn(
+            { err, nodeId: candidate.id, step: 'adoptUnanchoredPersonNode_role' },
+            'createContact: adopted KG node but could not apply role property',
+          );
+        }
+      }
+
+      this.logger?.info(
+        { displayName: safeName, nodeId: candidate.id },
+        'createContact: adopted an unanchored KG node as this contact\'s identity',
+      );
+      return candidate.id;
+    } catch (err) {
+      if (err instanceof TypeError || err instanceof RangeError) throw err;
+      this.logger?.error(
+        { err, displayName: safeName, step: 'adoptUnanchoredPersonNode' },
+        'createContact: KG adoption lookup failed — minting a fresh node instead',
+      );
+      return undefined;
+    }
+  }
+
+  /**
    * Create a new contact. If entityMemory is available and no kgNodeId is provided,
    * auto-creates or resolves a KG node and links it to the contact. When primaryEmail
    * is set and classifies as an org sender, routes to an organization KG node instead
@@ -521,23 +638,20 @@ export class ContactService {
         }
       }
 
-      // If no org node was resolved, auto-create a person KG node as before.
+      // If no org node was resolved, resolve a person KG node under the ADR-040
+      // adoption rule: adopt an unanchored node whose label matches, otherwise mint a
+      // fresh anchored one. Never take a node that already belongs to another contact.
       if (!kgNodeId) {
-        const { entity, created } = await this.entityMemory.createEntity({
-          type: 'person',
-          label: safeName,
-          properties: options.role ? { role: options.role } : {},
-          source: options.source,
-        });
-        if (!created && options.role) {
-          // A KG node already existed for this label. Apply the role property if
-          // it isn't already set — the existing node may have been created without
-          // one (e.g. by extract-relationships which always passes empty properties).
-          const { node } = await this.entityMemory.updateNode(entity.id, {
-            properties: { ...entity.properties, role: options.role },
-          });
-          kgNodeId = node.id;
+        const adopted = await this.adoptUnanchoredPersonNode(safeName, options.role);
+        if (adopted) {
+          kgNodeId = adopted;
         } else {
+          const entity = await this.entityMemory.createAnchoredEntity({
+            type: 'person',
+            label: safeName,
+            properties: options.role ? { role: options.role } : {},
+            source: options.source,
+          });
           kgNodeId = entity.id;
         }
 
@@ -613,21 +727,32 @@ export class ContactService {
     } catch (err) {
       const pgCode = (err as { code?: string }).code;
       const constraint = (err as { constraint?: string }).constraint;
-      // idx_contacts_kg_node_unique (partial unique index on kg_node_id) fires when
-      // upsertNode returned an existing kg_node that is already claimed by another
-      // contact — e.g. two people both named "Alice Smith". Retry without a KG link;
-      // the two contacts can be merged later via the contact-merge flow.
+      // idx_contacts_kg_node_unique fires when the node we resolved was claimed by
+      // another contact between our lookup and this INSERT — two people both named
+      // "Alice Smith", or a lost adoption race.
+      //
+      // Before ADR-040 the retry dropped the link and stored kg_node_id = NULL, leaving a
+      // contact that could hold no facts, relationships or entity-context enrichment.
+      // That is the behaviour #1694 exists to remove: retry with a FRESH anchored node
+      // instead. Anchored nodes are exempt from label uniqueness, so minting one cannot
+      // collide however many namesakes already exist.
       if (pgCode === '23505' && constraint === 'idx_contacts_kg_node_unique') {
-        // Downgrade kind to 'person' alongside stripping the KG link — but only if the
-        // contact was an org contact, to avoid violating the invariant that org contacts
-        // are always linked to a KG org node. Automated contacts keep their kind even
-        // without a KG link (their person-type node may still be around; the link is just
-        // lost for this contact instance due to the collision).
+        const replacement = await this.mintAnchoredNodeForContact(contact, options.source);
         this.logger?.warn(
-          { contactId: contact.id, kgNodeId: contact.kgNodeId, contactKind: contact.kind },
-          'KG node already claimed by another contact — creating contact without KG link; org kind downgraded to person',
+          {
+            contactId: contact.id,
+            claimedKgNodeId: contact.kgNodeId,
+            replacementKgNodeId: replacement,
+            contactKind: contact.kind,
+          },
+          replacement
+            ? 'KG node already claimed by another contact — minted a fresh anchored node for this contact'
+            : 'KG node already claimed by another contact and minting a replacement failed — creating contact without KG link',
         );
-        contact.kgNodeId = null;
+        contact.kgNodeId = replacement;
+        // Only downgrade kind when we genuinely ended up without a link: an org contact
+        // with no KG org node would violate the kind/type invariant migration 056 keeps.
+        // A contact that got a replacement person node is downgraded for the same reason.
         if (contact.kind === 'organization') {
           contact.kind = 'person';
         }
@@ -1660,9 +1785,67 @@ export class ContactService {
    *
    * Primarily used during contact merge (to remove the secondary) and during
    * error recovery (to remove orphaned contacts created by a failed identify).
+   *
+   * Also archives the contact's KG node when that node was its identity (ADR-040). An
+   * anchored node means nothing without the contact it anchors, and archiving rather
+   * than deleting frees the label for reuse (idx_kg_nodes_unique already excludes
+   * archived rows) while leaving the accumulated knowledge recoverable in SQL.
+   *
+   * Note mergeContacts deletes the secondary through the backend directly, deliberately
+   * bypassing this: mergeEntities has already folded the secondary's node into the
+   * survivor's, so there is nothing left to archive.
    */
   async deleteContact(id: string): Promise<void> {
+    // Read the link before the delete — afterwards there is no row to read it from.
+    const contact = await this.backend.getContact(id);
     await this.backend.deleteContact(id);
+    if (contact?.kgNodeId) {
+      await this.archiveAnchoredNode(id, contact.kgNodeId);
+    }
+  }
+
+  /**
+   * Archive a deleted contact's KG node, if that node was its identity and nothing else
+   * still points at it.
+   *
+   * Both guards matter:
+   *   - identity_source: a label-tier node (an organization, or a person Curia only knows
+   *     from an email body) outlives any one contact and must not be archived.
+   *   - no remaining referents: organization contacts are exempt from
+   *     idx_contacts_kg_node_unique, so several can share one node — including, after
+   *     migration 085's backfill, an anchored one. Deleting one of them must not archive
+   *     the node the others are still using.
+   *
+   * Best-effort by design. The contacts row is already gone and committed; a KG failure
+   * here leaves a recoverable orphan, whereas throwing would report a delete as failed
+   * that in fact succeeded.
+   */
+  private async archiveAnchoredNode(contactId: string, kgNodeId: string): Promise<void> {
+    if (!this.entityMemory) return;
+    try {
+      const node = await this.entityMemory.getEntity(kgNodeId);
+      if (!node || node.identitySource !== 'contact') return;
+
+      const stillReferenced = await this.backend.findContactByKgNodeId(kgNodeId);
+      if (stillReferenced) {
+        this.logger?.debug(
+          { contactId, kgNodeId, remainingContactId: stillReferenced.id },
+          'contacts: anchored KG node still referenced by another contact — not archiving',
+        );
+        return;
+      }
+
+      await this.entityMemory.archiveEntity(kgNodeId);
+      this.logger?.info(
+        { contactId, kgNodeId },
+        'contacts: archived the deleted contact\'s anchored KG node (ADR-040)',
+      );
+    } catch (err) {
+      this.logger?.warn(
+        { err, contactId, kgNodeId, step: 'archiveAnchoredNode' },
+        'contacts: contact deleted but archiving its anchored KG node failed — node is now orphaned',
+      );
+    }
   }
 
   /**
@@ -2702,9 +2885,12 @@ class InMemoryContactBackend implements ContactServiceBackend {
 
   async createContact(contact: Contact): Promise<void> {
     // Enforce the partial unique index idx_contacts_kg_node_unique to match Postgres.
-    if (contact.kgNodeId !== null) {
+    // Mirrors idx_contacts_kg_node_unique as narrowed by migration 085: organization
+    // contacts are exempt, because several role addresses at one domain legitimately
+    // share their organization's node (ADR-040).
+    if (contact.kgNodeId !== null && contact.kind !== 'organization') {
       for (const existing of this.contacts.values()) {
-        if (existing.kgNodeId === contact.kgNodeId) {
+        if (existing.kgNodeId === contact.kgNodeId && existing.kind !== 'organization') {
           const err = Object.assign(new Error('duplicate key value violates unique constraint "idx_contacts_kg_node_unique"'), {
             code: '23505',
             constraint: 'idx_contacts_kg_node_unique',

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -582,7 +582,28 @@ export class ContactService {
    * of minting a person node.
    */
   async createContact(options: CreateContactOptions): Promise<Contact> {
+    return (await this.createContactWithKgOutcome(options)).contact;
+  }
+
+  /**
+   * `createContact`, plus whether the KG node it linked was MINTED here or was already
+   * there (adopted, caller-supplied, or a shared organization node).
+   *
+   * Orphan-cleanup paths need this. When `linkIdentity` loses its race they delete the
+   * contact, and what should happen to the node depends entirely on where it came from: a
+   * node minted moments ago for this failed attempt should go with it, whereas an adopted
+   * one may carry facts and edges accrued long before and is not ours to remove. Since
+   * ADR-040 a minted anchored node also never decays, so leaving it behind is a permanent
+   * leak that makes later resolution ambiguous — the reason this is threaded rather than
+   * left to a periodic sweep.
+   */
+  async createContactWithKgOutcome(
+    options: CreateContactOptions,
+  ): Promise<{ contact: Contact; kgNodeCreated: boolean }> {
     const now = new Date();
+    // Set only where this call actually mints a node. Adoption, an explicit kgNodeId and
+    // organization routing all leave it false: those nodes outlive this contact.
+    let kgNodeCreated = false;
 
     // Defense-in-depth: sanitize display names at storage time to prevent
     // stored prompt injection. External sources (email participants, CRM imports)
@@ -669,6 +690,7 @@ export class ContactService {
             source: options.source,
           });
           kgNodeId = entity.id;
+          kgNodeCreated = true;
         }
 
         // Org routing did not fire or returned null (KG transient failure), so we fell
@@ -754,6 +776,7 @@ export class ContactService {
       // collide however many namesakes already exist.
       if (pgCode === '23505' && constraint === 'idx_contacts_kg_node_unique') {
         const replacement = await this.mintAnchoredNodeForContact(contact, options.source);
+        kgNodeCreated = replacement !== null;
         this.logger?.warn(
           {
             contactId: contact.id,
@@ -827,7 +850,7 @@ export class ContactService {
       });
     }
 
-    return contact;
+    return { contact, kgNodeCreated };
   }
 
   /** Retrieve a contact by ID. Returns undefined if not found. */
@@ -1096,7 +1119,7 @@ export class ContactService {
       return { contactId: existing.contactId, tier: existing.tier, created: false };
     }
 
-    const contact = await this.createContact({
+    const { contact, kgNodeCreated } = await this.createContactWithKgOutcome({
       displayName: params.displayName,
       fallbackDisplayName: params.fallbackDisplayName,
       source: params.source,
@@ -1117,9 +1140,10 @@ export class ContactService {
       // 23505: identity already belongs to an existing contact (concurrent create).
       // Non-23505: unexpected failure. In both cases the new contact row is orphaned.
       try {
-        // Orphan cleanup: createContact may have adopted a pre-existing node. See the
-        // archiveAnchoredNode note on deleteContact.
-        await this.deleteContact(contact.id, { archiveAnchoredNode: false });
+        // Orphan cleanup. Retire the node only if THIS call minted it: an adopted node may
+        // carry facts and edges accrued long before this failed attempt (ADR-040). A minted
+        // one is anchored and so never decays, which is why it cannot simply be left.
+        await this.deleteContact(contact.id, { archiveAnchoredNode: kgNodeCreated });
       } catch (cleanupErr) {
         this.logger?.warn(
           {

--- a/src/contacts/ensure-principal.test.ts
+++ b/src/contacts/ensure-principal.test.ts
@@ -48,7 +48,7 @@ function makePool(
 
 // We need to mock ceo-bootstrap's exported helpers because they reach the DB.
 vi.mock('./ceo-bootstrap.js', () => ({
-  insertKgPersonNode: vi.fn().mockResolvedValue('kg-node-123'),
+  insertKgPersonNode: vi.fn().mockResolvedValue({ id: 'kg-node-123', created: true }),
   createAndLinkKgNode: vi.fn().mockResolvedValue('kg-node-existing'),
   repairPrincipalMetadata: vi.fn().mockResolvedValue(undefined),
 }));

--- a/src/contacts/ensure-principal.ts
+++ b/src/contacts/ensure-principal.ts
@@ -82,7 +82,7 @@ export async function ensurePrincipalContact(
   // 2. Create the principal. KG node first (outside the transaction so a concurrent
   // race can rescue it onto the winner), then the contacts row in a transaction so
   // a partial failure can't leave an orphan.
-  const kgNodeId = await insertKgPersonNode(displayName, pool);
+  const { id: kgNodeId, created: kgNodeCreated } = await insertKgPersonNode(displayName, pool);
   const contactId = randomUUID();
   const client = await pool.connect();
   try {
@@ -133,11 +133,15 @@ export async function ensurePrincipalContact(
           );
         }
         // Loser-path orphan cleanup: if the winner already had their own kg_node_id
-        // before we got here, the node we created at line 80 is now unreferenced.
+        // before we got here, the node we created above is now unreferenced.
         // The NOT EXISTS guard makes the delete safe under further concurrent races
         // (some other process may have linked our node to their own contact between
         // our UPDATE recheck above and this DELETE).
-        if (winnerKgNodeId !== kgNodeId) {
+        //
+        // Gated on kgNodeCreated: insertKgPersonNode may have ADOPTED a pre-existing
+        // extraction node rather than minting one, and that node's facts and edges are
+        // not ours to delete just because we lost the principal race (ADR-040).
+        if (kgNodeCreated && winnerKgNodeId !== kgNodeId) {
           await pool.query(
             `DELETE FROM kg_nodes
              WHERE id = $1

--- a/src/contacts/ensure-principal.ts
+++ b/src/contacts/ensure-principal.ts
@@ -83,6 +83,14 @@ export async function ensurePrincipalContact(
   // race can rescue it onto the winner), then the contacts row in a transaction so
   // a partial failure can't leave an orphan.
   const { id: kgNodeId, created: kgNodeCreated } = await insertKgPersonNode(displayName, pool);
+  // Adoption inherits whatever an LLM previously attached to this label and is one-way
+  // (identity_source never moves back), so record which branch fired.
+  logger.info(
+    { kgNodeId, created: kgNodeCreated, displayName },
+    kgNodeCreated
+      ? 'ensure-principal: minted a new KG node for the principal'
+      : 'ensure-principal: adopted an existing KG node as the principal identity',
+  );
   const contactId = randomUUID();
   const client = await pool.connect();
   try {
@@ -160,6 +168,36 @@ export async function ensurePrincipalContact(
       logger.warn(
         { pgCode, constraint },
         'ensure-principal: 23505 on principal index but winner re-query returned no rows — re-throwing',
+      );
+    }
+
+    // The contacts INSERT failed and we are giving up, so the node minted above has no
+    // owner. It must not be left behind: since ADR-040 it is contact-anchored, which means
+    // permanent, undecayable and unarchivable, and it carries the principal's display name.
+    // Every failed boot would add another, until resolveOrCreate() sees N candidates for
+    // that name, returns 'ambiguous', and facts about the principal stop landing at all.
+    // Before ADR-040 the old ON CONFLICT made a retry reuse the same row, so this leak is
+    // new. Gated on kgNodeCreated for the usual reason — an ADOPTED node predates us.
+    if (kgNodeCreated) {
+      try {
+        await pool.query(
+          `DELETE FROM kg_nodes
+            WHERE id = $1
+              AND NOT EXISTS (SELECT 1 FROM contacts WHERE kg_node_id = $1)`,
+          [kgNodeId],
+        );
+      } catch (cleanupErr) {
+        // Best-effort: the original failure is the one worth propagating.
+        logger.warn(
+          { cleanupErr, kgNodeId },
+          'ensure-principal: could not remove the orphaned principal KG node after a failed create',
+        );
+      }
+    } else {
+      logger.warn(
+        { kgNodeId },
+        'ensure-principal: adopted KG node left anchored with no contact after a failed create — '
+          + 'it will not decay; see the anchored-orphan query in scripts/kg-node-linkage-report.ts',
       );
     }
     throw err;

--- a/src/contacts/ensure-principal.ts
+++ b/src/contacts/ensure-principal.ts
@@ -187,11 +187,18 @@ export async function ensurePrincipalContact(
           [kgNodeId],
         );
       } catch (cleanupErr) {
-        // Best-effort: the original failure is the one worth propagating.
-        logger.warn(
+        // The contacts INSERT failure stays the thrown error — it is the cause, and
+        // callers branch on its pgCode/constraint. The cleanup failure is attached as
+        // `cause` rather than discarded, so a caller or error reporter that walks the
+        // chain still sees that a permanent, undecayable node was left behind.
+        logger.error(
           { cleanupErr, kgNodeId },
-          'ensure-principal: could not remove the orphaned principal KG node after a failed create',
+          'ensure-principal: could not remove the orphaned principal KG node after a failed create — '
+            + 'it is anchored and will not decay; see the anchored-orphan query in scripts/kg-node-linkage-report.ts',
         );
+        if (err instanceof Error && err.cause === undefined) {
+          err.cause = cleanupErr;
+        }
       }
     } else {
       logger.warn(

--- a/src/db/migrations/085_contact_anchored_kg_identity.sql
+++ b/src/db/migrations/085_contact_anchored_kg_identity.sql
@@ -35,12 +35,11 @@ UPDATE kg_nodes n
    AND n.type <> 'organization'
    AND n.archived_at IS NULL;
 
--- Clear decay warnings on the nodes just anchored. DreamEngine's Pass 2a archives any
--- node whose warning outlives warnHoldBackDays, and it is deliberately left without an
--- identity_source predicate: a node can only be warned once its confidence falls to the
--- archive threshold, which an anchored node no longer decays towards. That reasoning
--- only holds for warnings raised from here on, so retire the ones already in flight —
--- a pending "confirm or lose this" prompt is void for a node we now guarantee to keep.
+-- Clear decay warnings on the nodes just anchored. DreamEngine now excludes anchored rows
+-- from its warn pass and from both archival passes, so no NEW warning can be raised for
+-- one. This retires the warnings already in flight: a pending "confirm this or lose it"
+-- prompt is void for a node we have just guaranteed to keep, and Pass 2a would otherwise
+-- leave it warned forever.
 
 UPDATE kg_nodes
    SET warned_at = NULL,
@@ -116,8 +115,8 @@ UPDATE contacts c
 -- safe to run against an unknown deployment.
 --
 -- Deliberately makes no attempt to detect that two nodeless "Seth Berman" contacts might
--- be one person. That is the dedup sweep's ruling to make, and it now works better:
--- mergeContacts only carries KG memory when both sides have a node.
+-- be one person. That is the dedup sweep's ruling to make. (Note the sweep does NOT yet
+-- carry KG memory across a merge — mergeEntities trips the contacts FK; see #1711.)
 --
 -- Convention (confidence 0.5, slow_decay, internal, no embedding) mirrors migration 056.
 -- The contact id is recorded in properties so the nodes can be mapped back below and so

--- a/src/db/migrations/085_contact_anchored_kg_identity.sql
+++ b/src/db/migrations/085_contact_anchored_kg_identity.sql
@@ -35,6 +35,35 @@ UPDATE kg_nodes n
    AND n.type <> 'organization'
    AND n.archived_at IS NULL;
 
+-- Step 2a — un-archive the nodes of contacts that are still live.
+--
+-- A contact can point at an ARCHIVED node: pre-085 DreamEngine Pass 2b archived any node
+-- at or below archiveThreshold with no contact exclusion, and dismissDecayWarning archives
+-- on demand. Such a contact is already broken in exactly the way #1694 is about — getNode()
+-- filters archived_at, so it resolves to nothing and the contact holds no facts, no
+-- relationships and no enrichment, while its kg_node_id looks perfectly healthy.
+--
+-- Without this step it would stay broken and be invisible to both arms: step 2 skips it
+-- (archived), and arm B skips it (kg_node_id IS NOT NULL). It would fall through the
+-- migration entirely.
+--
+-- Restoring is the ADR-040 position rather than a judgement call: a live contact's anchor
+-- should never have decayed away, and any dismissal predates the existence of the anchored
+-- tier. The facts underneath stay exactly as they are; only the container comes back.
+-- Confidence is lifted clear of the archive threshold so the node is not re-archived on the
+-- next pass by some path this migration has not anticipated.
+
+UPDATE kg_nodes n
+   SET archived_at = NULL,
+       identity_source = 'contact',
+       confidence = GREATEST(n.confidence, 0.5),
+       warned_at = NULL,
+       warn_reason = NULL
+  FROM contacts c
+ WHERE c.kg_node_id = n.id
+   AND n.type <> 'organization'
+   AND n.archived_at IS NOT NULL;
+
 -- Clear decay warnings on the nodes just anchored. DreamEngine now excludes anchored rows
 -- from its warn pass and from both archival passes, so no NEW warning can be raised for
 -- one. This retires the warnings already in flight: a pending "confirm this or lose it"
@@ -105,10 +134,21 @@ UPDATE contacts c
  WHERE c.id = candidates.contact_id;
 
 -- -------------------------------------------------------------------------
--- Step 6 — backfill arm B: mint an anchored node per remaining nodeless contact
+-- Step 6 — backfill arm B: give every remaining nodeless contact a node
 -- -------------------------------------------------------------------------
--- One node per CONTACT, not one per distinct display_name. Migration 056 minted per
--- display_name, which is precisely why 12 same-name contacts were left nodeless.
+-- Split by kind, because the two tiers need different collision strategies.
+--
+-- Both halves skip system_role IS NOT NULL rows, exactly as migration 056 did. A nodeless
+-- principal or agent contact is backfilled at startup by ensurePrincipalContact() /
+-- bootstrapAgentIdentity(), which resolve their nodes through their own singleton indexes.
+-- Minting a plain person node for one here would leave bootstrap's ON CONFLICT unable to
+-- match it, and it would insert a second agent contact and trip
+-- idx_contacts_system_role_agent on every startup.
+
+-- Step 6a — non-organization contacts: one ANCHORED node per CONTACT.
+--
+-- Per contact, not per distinct display_name. Migration 056 minted per display_name, which
+-- is precisely why 12 same-name contacts were left nodeless.
 --
 -- Anchored nodes are outside idx_kg_nodes_unique, so this INSERT cannot raise a unique
 -- violation however many contacts share a name — the property that keeps this migration
@@ -116,7 +156,7 @@ UPDATE contacts c
 --
 -- Deliberately makes no attempt to detect that two nodeless "Seth Berman" contacts might
 -- be one person. That is the dedup sweep's ruling to make. (Note the sweep does NOT yet
--- carry KG memory across a merge — mergeEntities trips the contacts FK; see #1711.)
+-- carry KG memory across a merge, because mergeEntities trips the contacts FK: see #1711.)
 --
 -- Convention (confidence 0.5, slow_decay, internal, no embedding) mirrors migration 056.
 -- The contact id is recorded in properties so the nodes can be mapped back below and so
@@ -125,7 +165,7 @@ UPDATE contacts c
 WITH minted AS (
   INSERT INTO kg_nodes (type, label, properties, source, confidence, decay_class, sensitivity, identity_source)
   SELECT
-    CASE WHEN c.kind = 'organization' THEN 'organization' ELSE 'person' END,
+    'person',
     c.display_name,
     jsonb_build_object('backfilled_for_contact', c.id),
     'migration_085',
@@ -135,6 +175,8 @@ WITH minted AS (
     'contact'
   FROM contacts c
   WHERE c.kg_node_id IS NULL
+    AND c.kind <> 'organization'
+    AND c.system_role IS NULL
   RETURNING id, (properties->>'backfilled_for_contact')::uuid AS contact_id
 )
 UPDATE contacts c
@@ -142,6 +184,64 @@ UPDATE contacts c
        updated_at = now()
   FROM minted
  WHERE c.id = minted.contact_id;
+
+-- Step 6b — organization contacts: a LABEL-TIER node, shared by display name.
+--
+-- Organization nodes stay unanchored, matching step 2 and ADR-040: they are legitimately
+-- shared by several role addresses and outlive any one contact. Anchoring them would take
+-- them out of idx_kg_nodes_unique, so resolveOrCreateOrgNode could mint a second node for
+-- the same organization, and contact deletion could archive a node its siblings still use.
+--
+-- Being label-tier means these CAN collide, so unlike 6a this is one node per distinct
+-- display_name with ON CONFLICT DO NOTHING, then a separate link step — the same two-step
+-- shape migration 056 used for the same reason. DO NOTHING also covers the case where a
+-- label-tier org node with that label already exists; step 6c then links to it.
+
+-- The domain is carried into properties so resolveOrCreateOrgNode()'s FIRST lookup
+-- (properties->>'domain') can find this node later. Without it, the next role address at
+-- the same domain resolves nothing and mints a second org node for one organization.
+INSERT INTO kg_nodes (type, label, properties, source, confidence, decay_class, sensitivity, identity_source)
+SELECT
+  'organization',
+  display_name,
+  CASE
+    WHEN domain <> '' THEN jsonb_build_object('domain', domain)
+    ELSE '{}'::jsonb
+  END,
+  'migration_085',
+  0.5,
+  'slow_decay',
+  'internal',
+  'label'
+FROM (
+  SELECT DISTINCT ON (lower(display_name))
+         display_name,
+         lower(split_part(COALESCE(primary_email, ''), '@', 2)) AS domain
+    FROM contacts
+   WHERE kg_node_id IS NULL
+     AND kind = 'organization'
+     AND system_role IS NULL
+   ORDER BY lower(display_name), created_at ASC
+) unmatched
+ON CONFLICT (lower(label), type)
+  WHERE type != 'fact' AND archived_at IS NULL AND identity_source = 'label'
+  DO NOTHING;
+
+-- Step 6c — link organization contacts to their label-tier node.
+-- No ROW_NUMBER guard is needed on the contacts side: step 4 exempted kind='organization'
+-- from idx_contacts_kg_node_unique precisely so several may share one node.
+
+UPDATE contacts c
+   SET kg_node_id = n.id,
+       updated_at = now()
+  FROM kg_nodes n
+ WHERE c.kg_node_id IS NULL
+   AND c.kind = 'organization'
+   AND c.system_role IS NULL
+   AND n.type = 'organization'
+   AND n.archived_at IS NULL
+   AND n.identity_source = 'label'
+   AND lower(n.label) = lower(c.display_name);
 
 -- Down Migration
 

--- a/src/db/migrations/085_contact_anchored_kg_identity.sql
+++ b/src/db/migrations/085_contact_anchored_kg_identity.sql
@@ -1,0 +1,171 @@
+-- Up Migration
+--
+-- ADR-040: contact-anchored KG node identity.
+--
+-- A KG node that backs a contact is identified by that contact; its label is a display
+-- attribute carrying no identity. Nodes that back no contact keep (lower(label), type)
+-- identity exactly as before. `identity_source` records which tier a node is in so
+-- Postgres can enforce the split rather than leaving it to convention.
+--
+-- Before this migration, two contacts sharing a display name could not both hold a node:
+-- the second collided on idx_contacts_kg_node_unique and was stored with kg_node_id = NULL,
+-- unable to hold facts, relationships, or entity-context enrichment (#1694, #1623).
+
+-- -------------------------------------------------------------------------
+-- Step 1 — the tier column
+-- -------------------------------------------------------------------------
+
+ALTER TABLE kg_nodes
+  ADD COLUMN identity_source TEXT NOT NULL DEFAULT 'label'
+  CHECK (identity_source IN ('label', 'contact'));
+
+COMMENT ON COLUMN kg_nodes.identity_source IS 'ADR-040 identity tier. label = identified by (lower(label), type) and deduplicated by idx_kg_nodes_unique; the default for every node not backing a contact. contact = identified by the contact pointing at it via contacts.kg_node_id; its label is free to collide and DreamEngine never decays or archives it.';
+
+-- -------------------------------------------------------------------------
+-- Step 2 — promote existing contact-linked nodes to the anchored tier
+-- -------------------------------------------------------------------------
+-- Organization nodes are deliberately excluded: they are legitimately shared by several
+-- role-address contacts at one domain, so they stay label-keyed and unanchored. Every
+-- other linked node becomes the durable identity of the contact pointing at it.
+
+UPDATE kg_nodes n
+   SET identity_source = 'contact'
+  FROM contacts c
+ WHERE c.kg_node_id = n.id
+   AND n.type <> 'organization'
+   AND n.archived_at IS NULL;
+
+-- Clear decay warnings on the nodes just anchored. DreamEngine's Pass 2a archives any
+-- node whose warning outlives warnHoldBackDays, and it is deliberately left without an
+-- identity_source predicate: a node can only be warned once its confidence falls to the
+-- archive threshold, which an anchored node no longer decays towards. That reasoning
+-- only holds for warnings raised from here on, so retire the ones already in flight —
+-- a pending "confirm or lose this" prompt is void for a node we now guarantee to keep.
+
+UPDATE kg_nodes
+   SET warned_at = NULL,
+       warn_reason = NULL
+ WHERE identity_source = 'contact'
+   AND warned_at IS NOT NULL;
+
+-- -------------------------------------------------------------------------
+-- Step 3 — narrow label uniqueness to the label tier
+-- -------------------------------------------------------------------------
+-- The new predicate is a strict subset of the old one (same columns, one extra AND), so
+-- the index cannot fail to build on rows the previous index already accepted.
+
+DROP INDEX idx_kg_nodes_unique;
+CREATE UNIQUE INDEX idx_kg_nodes_unique
+  ON kg_nodes (lower(label), type)
+  WHERE type != 'fact' AND archived_at IS NULL AND identity_source = 'label';
+
+-- -------------------------------------------------------------------------
+-- Step 4 — let organization contacts share their organization's node
+-- -------------------------------------------------------------------------
+-- resolveOrCreateOrgNode() returns the SAME org node for every role address at a domain
+-- (info@acme.com mints it, support@acme.com resolves to it). The 1:1 invariant is simply
+-- wrong for that shape. Also a strict subset of the old predicate, so it cannot fail.
+
+DROP INDEX idx_contacts_kg_node_unique;
+CREATE UNIQUE INDEX idx_contacts_kg_node_unique
+  ON contacts (kg_node_id)
+  WHERE kg_node_id IS NOT NULL AND kind <> 'organization';
+
+-- -------------------------------------------------------------------------
+-- Step 5 — backfill arm A: re-link nodeless organization contacts
+-- -------------------------------------------------------------------------
+-- A nodeless organization contact whose email domain matches an existing org node's
+-- properties->>'domain' is linked to that node — reconstructing exactly the link the
+-- original collision denied. Legal only now that step 4 has relaxed the contacts index.
+--
+-- DISTINCT ON picks one node deterministically if several org nodes claim the domain
+-- (highest confidence, then oldest, then id) rather than failing the migration.
+--
+-- Measured at 0 rows in production on 2026-09-02 (scripts/kg-node-linkage-report.ts):
+-- this arm is prevention for other deployments, not repair of a known backlog.
+
+WITH candidates AS (
+  SELECT DISTINCT ON (c.id)
+         c.id AS contact_id,
+         n.id AS node_id
+    FROM contacts c
+    JOIN kg_nodes n
+      ON  n.type = 'organization'
+      AND n.archived_at IS NULL
+      AND lower(n.properties->>'domain') = lower(split_part(c.primary_email, '@', 2))
+   WHERE c.kg_node_id IS NULL
+     AND c.kind = 'organization'
+     AND c.primary_email IS NOT NULL
+     AND position('@' in c.primary_email) > 0
+   ORDER BY c.id, n.confidence DESC, n.created_at ASC, n.id ASC
+)
+UPDATE contacts c
+   SET kg_node_id = candidates.node_id,
+       updated_at = now()
+  FROM candidates
+ WHERE c.id = candidates.contact_id;
+
+-- -------------------------------------------------------------------------
+-- Step 6 — backfill arm B: mint an anchored node per remaining nodeless contact
+-- -------------------------------------------------------------------------
+-- One node per CONTACT, not one per distinct display_name. Migration 056 minted per
+-- display_name, which is precisely why 12 same-name contacts were left nodeless.
+--
+-- Anchored nodes are outside idx_kg_nodes_unique, so this INSERT cannot raise a unique
+-- violation however many contacts share a name — the property that keeps this migration
+-- safe to run against an unknown deployment.
+--
+-- Deliberately makes no attempt to detect that two nodeless "Seth Berman" contacts might
+-- be one person. That is the dedup sweep's ruling to make, and it now works better:
+-- mergeContacts only carries KG memory when both sides have a node.
+--
+-- Convention (confidence 0.5, slow_decay, internal, no embedding) mirrors migration 056.
+-- The contact id is recorded in properties so the nodes can be mapped back below and so
+-- the provenance survives in the row itself.
+
+WITH minted AS (
+  INSERT INTO kg_nodes (type, label, properties, source, confidence, decay_class, sensitivity, identity_source)
+  SELECT
+    CASE WHEN c.kind = 'organization' THEN 'organization' ELSE 'person' END,
+    c.display_name,
+    jsonb_build_object('backfilled_for_contact', c.id),
+    'migration_085',
+    0.5,
+    'slow_decay',
+    'internal',
+    'contact'
+  FROM contacts c
+  WHERE c.kg_node_id IS NULL
+  RETURNING id, (properties->>'backfilled_for_contact')::uuid AS contact_id
+)
+UPDATE contacts c
+   SET kg_node_id = minted.id,
+       updated_at = now()
+  FROM minted
+ WHERE c.id = minted.contact_id;
+
+-- Down Migration
+
+-- Restore the pre-ADR-040 index predicates, then drop the column.
+--
+-- NOT reliably reversible: once two contacts hold same-label anchored nodes, recreating
+-- the un-narrowed idx_kg_nodes_unique raises a unique violation and this down migration
+-- fails. That is correct — silently deleting one of two real people's nodes to satisfy an
+-- index would be worse. Resolve the duplicates by hand (merge or archive) and re-run.
+--
+-- The backfilled rows themselves are left in place; to remove them:
+--   UPDATE contacts SET kg_node_id = NULL
+--     WHERE kg_node_id IN (SELECT id FROM kg_nodes WHERE source = 'migration_085');
+--   DELETE FROM kg_nodes WHERE source = 'migration_085';
+
+DROP INDEX IF EXISTS idx_contacts_kg_node_unique;
+CREATE UNIQUE INDEX idx_contacts_kg_node_unique
+  ON contacts (kg_node_id)
+  WHERE kg_node_id IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_kg_nodes_unique;
+CREATE UNIQUE INDEX idx_kg_nodes_unique
+  ON kg_nodes (lower(label), type)
+  WHERE type != 'fact' AND archived_at IS NULL;
+
+ALTER TABLE kg_nodes DROP COLUMN IF EXISTS identity_source;

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -49,8 +49,13 @@ export async function bootstrapAgentIdentity(
   // ON CONFLICT fires when a concurrent INSERT tries to create a second agent node.
   try {
     const nodeResult = await pool.query<{ id: string }>(
-      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
-       VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now())
+      // identity_source = 'contact' (ADR-040): this node backs the agent's contact row, so
+      // it belongs to the anchored tier. Without it a FRESH install would leave the agent's
+      // node label-keyed while a MIGRATED install anchors it (migration 085 step 2) — and a
+      // label-tier node that is contact-linked is exactly what adoptUnanchoredPersonNode
+      // looks for, so a stranger's contact with the agent's display name could adopt it.
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, identity_source)
+       VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now(), 'contact')
        ON CONFLICT ((properties->>'is_agent')) WHERE (properties->>'is_agent') = 'true'
        DO UPDATE SET label = EXCLUDED.label, last_confirmed_at = now()
        RETURNING id`,

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -12,7 +12,8 @@
 //
 // Idempotency is guaranteed by two partial unique indexes added in migration 010:
 //   - idx_kg_nodes_agent_singleton on (properties->>'is_agent') WHERE = 'true'
-//   - idx_contacts_kg_node_unique on (kg_node_id) WHERE kg_node_id IS NOT NULL
+//   - idx_contacts_kg_node_unique on (kg_node_id)
+//     WHERE kg_node_id IS NOT NULL AND kind <> 'organization'  (narrowed by migration 085)
 //
 // The returned contactId is injected into:
 //   - The coordinator's system prompt (so "you" resolves correctly)
@@ -69,9 +70,11 @@ export async function bootstrapAgentIdentity(
     logger.debug({ kgNodeId, displayName }, 'agent-bootstrap: agent KG node ready');
 
     // Step 2: Find or create the agent's contact record linked to the KG node.
-    // The partial unique index idx_contacts_kg_node_unique (migration 010) ensures
-    // ON CONFLICT fires when a concurrent INSERT tries to create a second contact for
-    // the same KG node.
+    // The partial unique index idx_contacts_kg_node_unique (migration 010, narrowed by
+    // 085) ensures ON CONFLICT fires when a concurrent INSERT tries to create a second
+    // contact for the same KG node. The predicate must be repeated verbatim for Postgres
+    // to infer the index — omit the kind clause and this INSERT fails with 42P10 on every
+    // startup. kind is 'agent' here, so the row is always inside the index.
     //
     // display_name is included in DO UPDATE so renames made via the wizard
     // (PUT /api/identity → version bump → process restart → bootstrap re-runs with
@@ -86,7 +89,7 @@ export async function bootstrapAgentIdentity(
       // Legacy status column not written here (#955).
       `INSERT INTO contacts (kg_node_id, display_name, role, system_role, tier, kind, created_at, updated_at)
        VALUES ($1, $2, 'agent', 'agent', 'known', 'agent', now(), now())
-       ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL
+       ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL AND kind <> 'organization'
        DO UPDATE SET display_name = EXCLUDED.display_name, role = 'agent', system_role = 'agent', tier = 'known', kind = 'agent', updated_at = now()
        RETURNING id`,
       [kgNodeId, displayName],
@@ -95,7 +98,7 @@ export async function bootstrapAgentIdentity(
     if (!contactResult.rows[0]) {
       throw new Error(
         `agent-bootstrap: INSERT ... ON CONFLICT returned no rows for kgNodeId="${kgNodeId}" — ` +
-        'check that migration 010 was applied (idx_contacts_kg_node_unique must exist)',
+        'check that migrations 010 and 085 were applied (idx_contacts_kg_node_unique must exist)',
       );
     }
     const contactId = contactResult.rows[0].id;

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -57,7 +57,21 @@ export async function bootstrapAgentIdentity(
       `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, identity_source)
        VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now(), 'contact')
        ON CONFLICT ((properties->>'is_agent')) WHERE (properties->>'is_agent') = 'true'
-       DO UPDATE SET label = EXCLUDED.label, last_confirmed_at = now()
+       DO UPDATE SET label = EXCLUDED.label,
+                     last_confirmed_at = now(),
+                     -- The conflict path must anchor too, not just the insert. An agent
+                     -- node that exists while no contact points at it (a previous boot
+                     -- whose contact INSERT failed) is skipped by migration 085 step 2, so
+                     -- it arrives here still label-tier. Without this the contact upsert
+                     -- below would link a label-tier node — contact-linked but adoptable,
+                     -- which is exactly the invariant ADR-040 exists to hold.
+                     identity_source = 'contact',
+                     -- Anchoring clears any pending warning, for the same reason
+                     -- anchorNode() does: nothing retires an anchored node's warning now
+                     -- that the decay passes, listDecayWarnings and dismissDecayWarning
+                     -- all skip the anchored tier, so it would sit warned forever.
+                     warned_at = NULL,
+                     warn_reason = NULL
        RETURNING id`,
       [
         displayName,

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -278,8 +278,8 @@ export class DreamEngine {
     archiveThreshold: number,
     halfLifeDays: DecayConfig['halfLifeDays'],
   ): Promise<Omit<DecayPassResult, 'durationMs'> & { warnedRows: Array<{ id: string; type: string; label: string; confidence: number; sensitivity: string; edge_count: string; warn_reason: string; warned_at: Date }> }> {
-    // ADR-040 — "Identity does not decay". Node passes 1a, 1b and 2b are restricted to
-    // identity_source = 'label'. A contact's node is the container for its memory, not a
+    // ADR-040 — "Identity does not decay". Every node pass that decays or archives is
+    // restricted to identity_source = 'label'. A contact's node is the container for its memory, not a
     // memory itself: nothing refreshes an entity node's last_confirmed_at through ordinary
     // interaction (storeFact updates the FACT node), so decay here is monotonic and
     // universal — a contact emailed daily ages at exactly the rate of one met once. Left
@@ -290,9 +290,14 @@ export class DreamEngine {
     // this bounds nothing but the anchor. Edge passes (1c, 1d, 3) are untouched: edges
     // have no identity tier, and Pass 3 still archives edges incident to an archived node.
     //
-    // Pass 2a (archive expired warnings) needs no predicate: warning requires
-    // confidence <= archiveThreshold, which an undecayed anchored node never reaches.
-    // Migration 085 clears the legacy warned_at rows that predate the exclusion.
+    // The filter is on every node pass that decays OR archives — 1a, 1b, the Pass 1.5 warn
+    // candidates, 2a and 2b. An earlier version of this change guarded only 1a/1b/2b, on the
+    // reasoning that warning requires confidence <= archiveThreshold and an undecayed
+    // anchored node never reaches it. That was wrong in the direction that matters: freezing
+    // decay does not RAISE confidence, and 478 of 532 contact nodes in production were
+    // already at or below the threshold when they were anchored. Pass 1.5 would re-warn the
+    // sensitive or well-connected ones on the next run and Pass 2a would archive them
+    // warnHoldBackDays later — the exclusion defeated by the one path left open.
     //
     // Pass 1a: Decay slow_decay nodes
     // Uses COALESCE(last_decayed_at, last_confirmed_at) so each run only applies
@@ -409,6 +414,7 @@ export class DreamEngine {
                   ON (e.source_node_id = n.id OR e.target_node_id = n.id)
                  AND e.archived_at IS NULL
           WHERE n.archived_at IS NULL
+            AND n.identity_source = 'label'
             AND n.warned_at IS NULL
             AND n.decay_class != 'permanent'
             AND n.confidence <= $1
@@ -439,12 +445,16 @@ export class DreamEngine {
 
     // Pass 2a: Archive expired warnings — nodes whose hold-back window has closed
     // without a CEO response. These were warned but never confirmed or dismissed.
+    // Also excludes contact-anchored nodes: a warning raised before the node was adopted
+    // (anchorNode clears warned_at, but a row could still slip through a concurrent pass)
+    // must not become the one archival path that survives ADR-040.
     const archiveExpiredResult = await client.query(
       `UPDATE kg_nodes
           SET archived_at = now(),
               warned_at = NULL,
               warn_reason = NULL
         WHERE archived_at IS NULL
+          AND identity_source = 'label'
           AND warned_at IS NOT NULL
           AND warned_at <= now() - ($1 * INTERVAL '1 day')`,
       [this.config.warnHoldBackDays],

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -278,6 +278,22 @@ export class DreamEngine {
     archiveThreshold: number,
     halfLifeDays: DecayConfig['halfLifeDays'],
   ): Promise<Omit<DecayPassResult, 'durationMs'> & { warnedRows: Array<{ id: string; type: string; label: string; confidence: number; sensitivity: string; edge_count: string; warn_reason: string; warned_at: Date }> }> {
+    // ADR-040 — "Identity does not decay". Node passes 1a, 1b and 2b are restricted to
+    // identity_source = 'label'. A contact's node is the container for its memory, not a
+    // memory itself: nothing refreshes an entity node's last_confirmed_at through ordinary
+    // interaction (storeFact updates the FACT node), so decay here is monotonic and
+    // universal — a contact emailed daily ages at exactly the rate of one met once. Left
+    // in, every contact anchor would eventually archive out from under a live contact, and
+    // archived_at would stop meaning "this contact is gone".
+    //
+    // Facts hanging off an anchored node are label-tier and keep decaying as before, so
+    // this bounds nothing but the anchor. Edge passes (1c, 1d, 3) are untouched: edges
+    // have no identity tier, and Pass 3 still archives edges incident to an archived node.
+    //
+    // Pass 2a (archive expired warnings) needs no predicate: warning requires
+    // confidence <= archiveThreshold, which an undecayed anchored node never reaches.
+    // Migration 085 clears the legacy warned_at rows that predate the exclusion.
+    //
     // Pass 1a: Decay slow_decay nodes
     // Uses COALESCE(last_decayed_at, last_confirmed_at) so each run only applies
     // decay for the interval since the last run rather than re-applying the full
@@ -290,6 +306,7 @@ export class DreamEngine {
              EXTRACT(EPOCH FROM (now() - COALESCE(last_decayed_at, last_confirmed_at))) / 86400.0 / $1),
              last_decayed_at = now()
        WHERE archived_at IS NULL
+         AND identity_source = 'label'
          AND decay_class = $2
          AND confidence > $3`,
       [halfLifeDays.slow_decay, 'slow_decay', archiveThreshold],
@@ -302,6 +319,7 @@ export class DreamEngine {
              EXTRACT(EPOCH FROM (now() - COALESCE(last_decayed_at, last_confirmed_at))) / 86400.0 / $1),
              last_decayed_at = now()
        WHERE archived_at IS NULL
+         AND identity_source = 'label'
          AND decay_class = $2
          AND confidence > $3`,
       [halfLifeDays.fast_decay, 'fast_decay', archiveThreshold],
@@ -434,12 +452,14 @@ export class DreamEngine {
     const nodesExpired = archiveExpiredResult.rowCount ?? 0;
 
     // Pass 2b: Archive regular nodes at or below threshold. Excludes:
+    // - contact-anchored nodes (identity_source, ADR-040 — see the note above Pass 1a)
     // - permanent nodes (never archived by design)
     // - nodes with an active warning still within hold-back window (warned_at IS NOT NULL)
     const archiveNodeResult = await client.query(
       `UPDATE kg_nodes
           SET archived_at = now()
         WHERE archived_at IS NULL
+          AND identity_source = 'label'
           AND decay_class != 'permanent'
           AND confidence <= $1
           AND warned_at IS NULL`,

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -167,6 +167,56 @@ export class EntityMemory {
     return { entity: node, created };
   }
 
+  /**
+   * Mint a contact-anchored entity node (ADR-040).
+   *
+   * Unlike createEntity(), this never deduplicates by label: anchored nodes sit outside
+   * idx_kg_nodes_unique precisely so two contacts sharing a display name can each hold
+   * their own. Callers that want label dedup want createEntity().
+   *
+   * Only ContactService and the principal/agent bootstrap paths should call this — the
+   * node it creates is meaningless until a contact points at it.
+   */
+  async createAnchoredEntity(options: CreateEntityOptions): Promise<KgNode> {
+    const sensitivity: Sensitivity = options.sensitivity
+      ?? this.sensitivityClassifier?.classify(options.label, options.properties, options.sensitivityCategory)
+      ?? 'internal';
+
+    return this.store.createNode({
+      type: options.type,
+      label: options.label,
+      properties: options.properties,
+      source: options.source,
+      confidence: options.confidence ?? 0.7,
+      sensitivity,
+      identitySource: 'contact',
+    });
+  }
+
+  /**
+   * Adopt an existing label-tier node as a contact's identity (ADR-040).
+   *
+   * This is what preserves the good part of the old behaviour: Curia learns about
+   * "Dana Wu" from an email body, Dana later emails in, and her new contact inherits the
+   * facts already accumulated about her rather than starting empty.
+   *
+   * Returns false when the node is gone, archived, or already anchored to another
+   * contact — the caller must then mint a fresh node rather than share an identity.
+   */
+  async adoptEntity(nodeId: string): Promise<boolean> {
+    return this.store.anchorNode(nodeId);
+  }
+
+  /**
+   * Archive an entity node and cascade to its incident edges.
+   *
+   * Used when a contact is deleted: an anchored node's whole meaning is "this contact",
+   * so it retires with the contact rather than lingering as an orphan (ADR-040).
+   */
+  async archiveEntity(nodeId: string): Promise<void> {
+    return this.store.archiveNode(nodeId);
+  }
+
   /** Retrieve an entity node by ID. Returns undefined if not found. */
   async getEntity(id: string): Promise<KgNode | undefined> {
     return this.store.getNode(id);

--- a/src/memory/knowledge-graph.identity-source.test.ts
+++ b/src/memory/knowledge-graph.identity-source.test.ts
@@ -1,0 +1,126 @@
+// Two-tier node identity (ADR-040, #1694).
+//
+// These exercise the in-memory backend, which mirrors the partial index
+// idx_kg_nodes_unique. The Postgres side of the same invariants is covered in
+// tests/integration/knowledge-graph.test.ts, where the index itself does the enforcing.
+
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+
+function makeStore() {
+  return KnowledgeGraphStore.createInMemory(EmbeddingService.createForTesting());
+}
+
+describe('KnowledgeGraphStore identity tiers', () => {
+  it('createNode defaults to the label tier', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Dana Wu', properties: {}, source: 'test' });
+    expect(node.identitySource).toBe('label');
+  });
+
+  it('createNode mints an anchored node when asked', async () => {
+    const store = makeStore();
+    const node = await store.createNode({
+      type: 'person', label: 'Dana Wu', properties: {}, source: 'test', identitySource: 'contact',
+    });
+    expect(node.identitySource).toBe('contact');
+  });
+
+  it('createNode allows two anchored nodes to share a label', async () => {
+    // The whole point of #1694: two people called "Seth Berman" each hold a node.
+    const store = makeStore();
+    const first = await store.createNode({
+      type: 'person', label: 'Seth Berman', properties: {}, source: 'test', identitySource: 'contact',
+    });
+    const second = await store.createNode({
+      type: 'person', label: 'Seth Berman', properties: {}, source: 'test', identitySource: 'contact',
+    });
+
+    expect(second.id).not.toBe(first.id);
+    const found = await store.findNodesByLabel('Seth Berman');
+    expect(found.map(n => n.id).sort()).toEqual([first.id, second.id].sort());
+  });
+
+  it('upsertNode only ever writes label-tier rows (ADR-040 invariant 1)', async () => {
+    const store = makeStore();
+    const { node } = await store.upsertNode({
+      type: 'person', label: 'Dana Wu', properties: {}, source: 'test', confidence: 0.7,
+    });
+    expect(node.identitySource).toBe('label');
+  });
+
+  it('upsertNode never merges onto an anchored node — it inserts alongside it', async () => {
+    // This is the seam the two tiers leak through if it regresses: a name-only write
+    // landing on somebody's contact identity.
+    const store = makeStore();
+    const anchored = await store.createNode({
+      type: 'person', label: 'Seth Berman', properties: {}, source: 'contact-create', identitySource: 'contact',
+    });
+
+    const { node, created } = await store.upsertNode({
+      type: 'person', label: 'Seth Berman', properties: {}, source: 'extraction', confidence: 0.7,
+    });
+
+    expect(created).toBe(true);
+    expect(node.id).not.toBe(anchored.id);
+    expect(node.identitySource).toBe('label');
+  });
+
+  it('upsertNode still deduplicates label-tier nodes', async () => {
+    const store = makeStore();
+    const { node: first } = await store.upsertNode({
+      type: 'person', label: 'Dana Wu', properties: {}, source: 'test', confidence: 0.7,
+    });
+    const { node: second, created } = await store.upsertNode({
+      type: 'person', label: 'dana wu', properties: {}, source: 'test', confidence: 0.9,
+    });
+
+    expect(created).toBe(false);
+    expect(second.id).toBe(first.id);
+    expect(second.temporal.confidence).toBe(0.9);
+  });
+});
+
+describe('KnowledgeGraphStore.anchorNode', () => {
+  it('promotes a label-tier node and reports success', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Dana Wu', properties: {}, source: 'test' });
+
+    expect(await store.anchorNode(node.id)).toBe(true);
+    expect((await store.getNode(node.id))?.identitySource).toBe('contact');
+  });
+
+  it('refuses a node that is already anchored — the adoption race guard', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Dana Wu', properties: {}, source: 'test' });
+
+    expect(await store.anchorNode(node.id)).toBe(true);
+    // Second contact racing for the same node must lose rather than share an identity.
+    expect(await store.anchorNode(node.id)).toBe(false);
+  });
+
+  it('refuses an archived node', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Dana Wu', properties: {}, source: 'test' });
+    await store.archiveNode(node.id);
+
+    expect(await store.anchorNode(node.id)).toBe(false);
+  });
+
+  it('refuses a node that does not exist', async () => {
+    const store = makeStore();
+    expect(await store.anchorNode('00000000-0000-0000-0000-000000000000')).toBe(false);
+  });
+
+  it('leaves an adopted node reachable by label so ambiguity stays visible', async () => {
+    // findNodesByLabel deliberately keeps returning anchored nodes: hiding them would
+    // let resolveOrCreate mint a third "Seth Berman" on every write (ADR-040).
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Seth Berman', properties: {}, source: 'test' });
+    await store.anchorNode(node.id);
+
+    const found = await store.findNodesByLabel('Seth Berman');
+    expect(found.map(n => n.id)).toEqual([node.id]);
+  });
+});

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -7,6 +7,7 @@ import type {
   EdgeType,
   DecayClass,
   Sensitivity,
+  IdentitySource,
   SearchResult,
   TraversalResult,
 } from './types.js';
@@ -30,6 +31,11 @@ export interface CreateNodeOptions {
    *  this via SensitivityClassifier before calling createNode, so this should always
    *  be set. Defaults to 'internal' if somehow omitted. */
   sensitivity?: Sensitivity;
+  /** Identity tier (ADR-040). Defaults to 'label'. Pass 'contact' only when minting a
+   *  node that backs a specific contact — those are exempt from label uniqueness, so
+   *  createNode cannot fall back on ON CONFLICT to deduplicate them.
+   *  upsertNode ignores this field: it is the label-keyed path, exclusively. */
+  identitySource?: IdentitySource;
 }
 
 export interface CreateEdgeOptions {
@@ -89,9 +95,14 @@ interface KnowledgeGraphBackend {
   // Atomic upsert: creates if no matching (src, tgt, type) pair exists in either
   // direction; otherwise raises confidence and refreshes lastConfirmedAt.
   upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }>;
-  // Idempotent node creation: matches on lower(label) + type for non-fact nodes.
-  // fact nodes always insert as new regardless of label collision.
+  // Idempotent node creation: matches on lower(label) + type for non-fact,
+  // label-tier nodes. fact nodes always insert as new regardless of label collision,
+  // and contact-anchored nodes are never matched (ADR-040 invariant 1).
   upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }>;
+  /** Promote a label-tier node to contact-anchored (ADR-040). Compare-and-set: returns
+   *  false if the node is missing, archived, or already anchored to some contact, which
+   *  is what makes concurrent adoption safe without a transaction. */
+  anchorNode(id: string): Promise<boolean>;
   traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult>;
   semanticSearch(
     queryEmbedding: number[],
@@ -171,10 +182,24 @@ export class KnowledgeGraphStore {
       },
       sensitivity: options.sensitivity ?? 'internal',
       aliases: [],
+      identitySource: options.identitySource ?? 'label',
     };
 
     await this.backend.createNode(node);
     return node;
+  }
+
+  /**
+   * Promote a label-tier node to contact-anchored (ADR-040 adoption).
+   *
+   * Compare-and-set on identity_source, so two contacts racing to adopt the same
+   * unanchored node cannot both win: the loser gets false and mints its own node
+   * rather than silently sharing an identity.
+   *
+   * Returns false when the node does not exist, is archived, or is already anchored.
+   */
+  async anchorNode(id: string): Promise<boolean> {
+    return this.backend.anchorNode(id);
   }
 
   /**
@@ -186,6 +211,11 @@ export class KnowledgeGraphStore {
    * are left untouched — use updateNode() to change those explicitly.
    *
    * fact nodes always create a new node regardless of label collision.
+   *
+   * ADR-040 invariant 1: this is the label-keyed path, exclusively. It only ever inserts
+   * identity_source = 'label' rows and its ON CONFLICT predicate matches the narrowed
+   * idx_kg_nodes_unique, so no caller can accidentally upsert its way onto a node that
+   * already belongs to a contact. Anchored nodes are minted through createNode().
    *
    * Returns the persisted node and whether it was newly created.
    */
@@ -208,6 +238,8 @@ export class KnowledgeGraphStore {
       },
       sensitivity: options.sensitivity ?? 'internal',
       aliases: [],
+      // Not options.identitySource — see the invariant above. upsertNode is label-tier only.
+      identitySource: 'label',
     };
 
     return this.backend.upsertNode(node);
@@ -411,8 +443,8 @@ class PostgresBackend implements KnowledgeGraphBackend {
     this.logger.debug({ nodeId: node.id, type: node.type, sensitivity: node.sensitivity }, 'kg: creating node');
     const embeddingStr = node.embedding ? `[${node.embedding.join(',')}]` : null;
     await this.pool.query(
-      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity, aliases)
-       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $10, $11, $12)`,
+      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity, aliases, identity_source)
+       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $10, $11, $12, $13)`,
       [
         node.id,
         node.type,
@@ -426,17 +458,38 @@ class PostgresBackend implements KnowledgeGraphBackend {
         node.temporal.lastConfirmedAt,
         node.sensitivity,
         node.aliases,
+        node.identitySource,
       ],
     );
+  }
+
+  async anchorNode(id: string): Promise<boolean> {
+    // Compare-and-set: the identity_source = 'label' predicate is the whole point —
+    // it makes losing an adoption race observable (rowCount 0) instead of letting two
+    // contacts quietly share one identity.
+    const result = await this.pool.query(
+      `UPDATE kg_nodes
+          SET identity_source = 'contact'
+        WHERE id = $1
+          AND archived_at IS NULL
+          AND identity_source = 'label'`,
+      [id],
+    );
+    const anchored = (result.rowCount ?? 0) > 0;
+    this.logger.debug({ nodeId: id, anchored }, 'kg: anchorNode');
+    return anchored;
   }
 
   async upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }> {
     this.logger.debug({ type: node.type, label: node.label }, 'kg: upserting node');
     const embeddingStr = node.embedding ? `[${node.embedding.join(',')}]` : null;
     const result = await this.pool.query<PgNodeRow & { is_new: boolean }>(
-      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity, aliases)
-       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9, $10, $11)
-       ON CONFLICT (lower(label), type) WHERE type != 'fact' AND archived_at IS NULL
+      // identity_source is hardcoded 'label' rather than parameterised: the ON CONFLICT
+      // predicate below must match the narrowed idx_kg_nodes_unique, and an anchored row
+      // would not be in that index at all, so the upsert would silently always insert.
+      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity, aliases, identity_source)
+       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9, $10, $11, 'label')
+       ON CONFLICT (lower(label), type) WHERE type != 'fact' AND archived_at IS NULL AND identity_source = 'label'
        DO UPDATE SET
          confidence = GREATEST(kg_nodes.confidence, EXCLUDED.confidence),
          last_confirmed_at = EXCLUDED.last_confirmed_at
@@ -833,6 +886,7 @@ interface PgNodeRow {
   sensitivity: string;
   archived_at: Date | null;
   aliases: string[];
+  identity_source: string;
 }
 
 interface PgEdgeRow {
@@ -865,6 +919,10 @@ function pgRowToNode(row: PgNodeRow): KgNode {
     },
     sensitivity: (row.sensitivity as Sensitivity) ?? 'internal',
     aliases: row.aliases ?? [],
+    // Default rather than cast-and-trust: a row read through a projection that omits the
+    // column must not be mistaken for an anchored node, or callers would skip decay and
+    // refuse adoption for a node that is in fact label-keyed. 'label' is the safe read.
+    identitySource: row.identity_source === 'contact' ? 'contact' : 'label',
   };
 }
 
@@ -932,8 +990,16 @@ class InMemoryBackend implements KnowledgeGraphBackend {
     const lowerLabel = node.label.toLowerCase();
     let existing: KgNode | undefined;
     for (const n of this.nodes.values()) {
-      // Archived nodes are treated as non-existent — don't merge with them
-      if (n.type !== 'fact' && n.label.toLowerCase() === lowerLabel && n.type === node.type && !this.archivedNodes.has(n.id)) {
+      // Mirrors the partial index idx_kg_nodes_unique: archived nodes are treated as
+      // non-existent, and contact-anchored nodes are outside the label-keyed tier
+      // entirely, so upsert must never merge onto one (ADR-040 invariant 1).
+      if (
+        n.type !== 'fact'
+        && n.label.toLowerCase() === lowerLabel
+        && n.type === node.type
+        && n.identitySource === 'label'
+        && !this.archivedNodes.has(n.id)
+      ) {
         existing = n;
         break;
       }
@@ -973,6 +1039,13 @@ class InMemoryBackend implements KnowledgeGraphBackend {
         this.edges.delete(edgeId);
       }
     }
+  }
+
+  async anchorNode(id: string): Promise<boolean> {
+    const node = this.nodes.get(id);
+    if (!node || this.archivedNodes.has(id) || node.identitySource !== 'label') return false;
+    this.nodes.set(id, { ...node, identitySource: 'contact' });
+    return true;
   }
 
   async archiveNode(id: string): Promise<void> {

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -109,7 +109,9 @@ interface KnowledgeGraphBackend {
     limit: number,
     filters?: { type?: NodeType; maxSensitivity?: Sensitivity },
   ): Promise<SearchResult[]>;
-  /** List all warned (warned_at IS NOT NULL), non-archived nodes, sorted oldest-first. */
+  /** List all warned (warned_at IS NOT NULL), non-archived, LABEL-TIER nodes, oldest-first.
+   *  Contact-anchored nodes are excluded: they cannot decay, so a "confirm this or lose it"
+   *  prompt for one is a question the system will never act on (ADR-040). */
   listDecayWarnings(): Promise<DecayWarningRow[]>;
   /** Confirm a warned node: reset last_confirmed_at = NOW(), confidence = 1.0, warned_at = NULL.
    *  Returns success: false if the node is not in a warned state. */
@@ -819,6 +821,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
                                AND e.archived_at IS NULL
         WHERE n.warned_at IS NOT NULL
           AND n.archived_at IS NULL
+          AND n.identity_source = 'label'
         GROUP BY n.id, n.type, n.label, n.confidence, n.sensitivity,
                  n.warn_reason, n.warned_at
         ORDER BY n.warned_at ASC`,
@@ -855,6 +858,11 @@ class PostgresBackend implements KnowledgeGraphBackend {
   }
 
   async dismissDecayWarning(nodeId: string): Promise<DecayWarningActionResult> {
+    // identity_source = 'label' matters here as much as it does in DreamEngine: this is an
+    // archival path OUTSIDE the decay passes. A contact-anchored node reaching it — via a
+    // warning raised before it was anchored — would be archived out from under a live
+    // contact, which is precisely what ADR-040 says nothing but contact deletion may do.
+    // Returns success: false rather than throwing, matching the not-warned case.
     const result = await this.pool.query<{ label: string }>(
       `UPDATE kg_nodes
           SET archived_at = now(),
@@ -863,6 +871,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
         WHERE id = $1
           AND warned_at IS NOT NULL
           AND archived_at IS NULL
+          AND identity_source = 'label'
         RETURNING label`,
       [nodeId],
     );
@@ -1297,6 +1306,9 @@ class InMemoryBackend implements KnowledgeGraphBackend {
       if (this.archivedNodes.has(nodeId)) continue;
       const node = this.nodes.get(nodeId);
       if (!node) continue;
+      // Mirrors the Postgres predicate: anchored nodes never decay, so they are never
+      // offered for re-confirmation (ADR-040).
+      if (node.identitySource !== 'label') continue;
       const edgeCount = Array.from(this.edges.values()).filter(
         e => !this.archivedEdges.has(e.id) && (e.sourceNodeId === nodeId || e.targetNodeId === nodeId),
       ).length;
@@ -1334,6 +1346,9 @@ class InMemoryBackend implements KnowledgeGraphBackend {
     }
     const node = this.nodes.get(nodeId);
     if (!node) return { success: false };
+    // Mirrors the Postgres predicate: dismissing archives, and nothing but contact
+    // deletion may archive an anchored node (ADR-040).
+    if (node.identitySource !== 'label') return { success: false };
     this.warnedNodes.delete(nodeId);
     // archiveNode handles both node and incident edge archival, keeping
     // behaviour consistent with the Postgres backend and archiveNode().

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -467,9 +467,16 @@ class PostgresBackend implements KnowledgeGraphBackend {
     // Compare-and-set: the identity_source = 'label' predicate is the whole point —
     // it makes losing an adoption race observable (rowCount 0) instead of letting two
     // contacts quietly share one identity.
+    //
+    // Clearing warned_at is the same reasoning as migration 085 step 2b: a node adopted
+    // while a decay warning was pending is a node we have just promised to keep, so the
+    // "confirm this or lose it" prompt is void. Leaving it set would strand the node in a
+    // permanently warned state now that Pass 2a skips anchored rows.
     const result = await this.pool.query(
       `UPDATE kg_nodes
-          SET identity_source = 'contact'
+          SET identity_source = 'contact',
+              warned_at = NULL,
+              warn_reason = NULL
         WHERE id = $1
           AND archived_at IS NULL
           AND identity_source = 'label'`,

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -51,6 +51,21 @@ export type EdgeType = (typeof EDGE_TYPES)[number];
 export const DECAY_CLASSES = ['permanent', 'slow_decay', 'fast_decay'] as const;
 export type DecayClass = (typeof DECAY_CLASSES)[number];
 
+// -- Identity tiers (ADR-040) --
+//
+// Which anchor gives a node its identity:
+//   'label'   — (lower(label), type). Deduplicated by idx_kg_nodes_unique, so a label
+//               resolves to exactly one node. The default, and the only tier upsertNode
+//               ever writes.
+//   'contact' — the contact that points at it via contacts.kg_node_id. The label is a
+//               display attribute and is free to collide, so two people called
+//               "Seth Berman" each hold their own node. Minted by createNode, or promoted
+//               from 'label' by anchorNode() when a new contact adopts an existing node.
+//               Never decayed or archived by the DreamEngine (ADR-040, "Identity does not
+//               decay") — only contact deletion retires one.
+export const IDENTITY_SOURCES = ['label', 'contact'] as const;
+export type IdentitySource = (typeof IDENTITY_SOURCES)[number];
+
 // -- Temporal metadata, present on every node and edge (spec line 82-91) --
 export interface TemporalMetadata {
   createdAt: Date;
@@ -75,6 +90,9 @@ export interface KgNode {
   // Stored as lowercased strings; exact-match resolution checks aliases
   // alongside the canonical label. Capped at MAX_ALIASES_PER_ENTITY (10).
   aliases: string[];
+  // Which anchor identifies this node (ADR-040). See IdentitySource above.
+  // Only ever moves 'label' → 'contact', via anchorNode().
+  identitySource: IdentitySource;
 }
 
 // -- Knowledge Graph Edge --

--- a/tests/integration/ceo-bootstrap.test.ts
+++ b/tests/integration/ceo-bootstrap.test.ts
@@ -5,7 +5,7 @@
 // The env-var-driven bootstrapCeoContact was removed in #1049 — these tests now cover
 // the surviving, shared helpers that the onboarding-wizard path (ensure-principal.ts)
 // and the startup principal resolution (src/index.ts) both depend on:
-//   - insertKgPersonNode: create / ON-CONFLICT-promote a permanent person node
+//   - insertKgPersonNode: adopt-or-mint a permanent, contact-anchored person node (ADR-040)
 //   - createAndLinkKgNode: link a freshly created node to a contact with kg_node_id = NULL
 //   - repairPrincipalMetadata: idempotent self-heal of role/system_role/tier/kind
 //
@@ -51,8 +51,9 @@ describeIf('ceo-bootstrap principal/KG utilities', () => {
 
   describe('insertKgPersonNode', () => {
     it('creates a permanent person node from scratch', async () => {
-      const id = await insertKgPersonNode(LABEL, pool);
+      const { id, created } = await insertKgPersonNode(LABEL, pool);
       expect(id).toBeTruthy();
+      expect(created).toBe(true);
 
       const node = await pool.query<{
         type: string; label: string; decay_class: string; source: string; confidence: number;
@@ -82,8 +83,11 @@ describeIf('ceo-bootstrap principal/KG utilities', () => {
         [preExistingNodeId, LABEL],
       );
 
-      const id = await insertKgPersonNode(LABEL, pool);
+      const { id, created } = await insertKgPersonNode(LABEL, pool);
       expect(id).toBe(preExistingNodeId);
+      // Adopted, not minted — the caller must be able to tell, because only a node this
+      // call created is safe to delete on a lost race (ADR-040, PR #1712 review).
+      expect(created).toBe(false);
 
       const node = await pool.query<{
         decay_class: string; confidence: number; source: string; identity_source: string;
@@ -108,8 +112,9 @@ describeIf('ceo-bootstrap principal/KG utilities', () => {
         [preExistingNodeId, LABEL],
       );
 
-      const id = await insertKgPersonNode(LABEL, pool);
+      const { id, created } = await insertKgPersonNode(LABEL, pool);
       expect(id).toBe(preExistingNodeId);
+      expect(created).toBe(false);
 
       const node = await pool.query<{ decay_class: string; confidence: number }>(
         `SELECT decay_class, confidence FROM kg_nodes WHERE id = $1`,

--- a/tests/integration/ceo-bootstrap.test.ts
+++ b/tests/integration/ceo-bootstrap.test.ts
@@ -56,8 +56,9 @@ describeIf('ceo-bootstrap principal/KG utilities', () => {
 
       const node = await pool.query<{
         type: string; label: string; decay_class: string; source: string; confidence: number;
+        identity_source: string;
       }>(
-        `SELECT type, label, decay_class, source, confidence FROM kg_nodes WHERE id = $1`,
+        `SELECT type, label, decay_class, source, confidence, identity_source FROM kg_nodes WHERE id = $1`,
         [id],
       );
       expect(node.rows[0]).toBeDefined();
@@ -66,6 +67,9 @@ describeIf('ceo-bootstrap principal/KG utilities', () => {
       expect(node.rows[0]!.decay_class).toBe('permanent');
       expect(node.rows[0]!.source).toBe('bootstrap');
       expect(node.rows[0]!.confidence).toBe(1);
+      // The principal is a contact, so its node is contact-anchored like any other
+      // (ADR-040) — not left in the label tier where a namesake would collide with it.
+      expect(node.rows[0]!.identity_source).toBe('contact');
     });
 
     it('promotes a pre-existing slow_decay person node to permanent on conflict', async () => {
@@ -81,8 +85,10 @@ describeIf('ceo-bootstrap principal/KG utilities', () => {
       const id = await insertKgPersonNode(LABEL, pool);
       expect(id).toBe(preExistingNodeId);
 
-      const node = await pool.query<{ decay_class: string; confidence: number; source: string }>(
-        `SELECT decay_class, confidence, source FROM kg_nodes WHERE id = $1`,
+      const node = await pool.query<{
+        decay_class: string; confidence: number; source: string; identity_source: string;
+      }>(
+        `SELECT decay_class, confidence, source, identity_source FROM kg_nodes WHERE id = $1`,
         [preExistingNodeId],
       );
       expect(node.rows[0]).toBeDefined();
@@ -90,6 +96,8 @@ describeIf('ceo-bootstrap principal/KG utilities', () => {
       expect(node.rows[0]!.confidence).toBeGreaterThanOrEqual(1.0);
       // source is preserved (not overwritten) to keep the audit trail intact
       expect(node.rows[0]!.source).toBe('extraction');
+      // Adoption, not a second node: the extraction node becomes the principal's identity.
+      expect(node.rows[0]!.identity_source).toBe('contact');
     });
 
     it('does not demote confidence when the conflicting node already has confidence >= 1.0', async () => {

--- a/tests/integration/ceo-bootstrap.test.ts
+++ b/tests/integration/ceo-bootstrap.test.ts
@@ -145,6 +145,43 @@ describeIf('ceo-bootstrap principal/KG utilities', () => {
   });
 
   describe('createAndLinkKgNode', () => {
+    it('keeps an ADOPTED node when the contact-link race is lost', async () => {
+      // The highest-consequence branch added by ADR-040: insertKgPersonNode may adopt a
+      // pre-existing extraction node carrying facts and edges, and kg_edges cascades on
+      // node delete. A wrong `created` value here destroys knowledge that predates the
+      // call entirely, so the loser-path delete must not fire for an adopted node.
+      const preExistingNodeId = crypto.randomUUID();
+      await pool.query(
+        `INSERT INTO kg_nodes (id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
+         VALUES ($1, 'person', $2, '{}', 0.7, 'slow_decay', 'extraction', now(), now())`,
+        [preExistingNodeId, LABEL],
+      );
+      // A contact that already holds a DIFFERENT node — so our UPDATE ... WHERE
+      // kg_node_id IS NULL no-ops and createAndLinkKgNode takes the lost-race path.
+      const winnerNodeId = crypto.randomUUID();
+      await pool.query(
+        `INSERT INTO kg_nodes (id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
+         VALUES ($1, 'person', $2, '{}', 0.7, 'slow_decay', 'test', now(), now())`,
+        [winnerNodeId, `${LABEL} Winner`],
+      );
+      const contactId = crypto.randomUUID();
+      await pool.query(
+        `INSERT INTO contacts (id, kg_node_id, display_name, role, tier, kind, created_at, updated_at)
+         VALUES ($1, $2, $3, 'ceo', 'principal', 'principal', now(), now())`,
+        [contactId, winnerNodeId, LABEL],
+      );
+
+      const linked = await createAndLinkKgNode(contactId, LABEL, pool);
+
+      expect(linked).toBe(winnerNodeId);
+      // The adopted node must still exist — it was never ours to delete.
+      const survivor = await pool.query('SELECT 1 FROM kg_nodes WHERE id = $1', [preExistingNodeId]);
+      expect(survivor.rows).toHaveLength(1);
+
+      await pool.query('DELETE FROM contacts WHERE id = $1', [contactId]);
+      await pool.query('DELETE FROM kg_nodes WHERE id = ANY($1::uuid[])', [[preExistingNodeId, winnerNodeId]]);
+    });
+
     it('creates a node and links it to a contact whose kg_node_id is NULL', async () => {
       const contactId = crypto.randomUUID();
       await pool.query(

--- a/tests/integration/contact-anchored-identity.test.ts
+++ b/tests/integration/contact-anchored-identity.test.ts
@@ -1,0 +1,453 @@
+// Migration 085 / ADR-040 — the halves that only a real Postgres can prove.
+//
+// The unit suite (tests/unit/contacts/contact-anchored-identity.test.ts) covers the
+// service behaviour against the in-memory backend. What is checked here is the part the
+// in-memory backend can only imitate: that the partial indexes really carry the predicates
+// ADR-040 specifies, that ON CONFLICT still infers them, and that DreamEngine's SQL
+// actually leaves anchored nodes alone.
+//
+// Column-drop / index-swap migrations are a repeat offender for passing locally and
+// failing in CI (see the note in CLAUDE.md), which is exactly why the index assertions
+// read pg_indexes rather than inferring the shape from behaviour.
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import pg from 'pg';
+import { readFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { requireCuriaTestDatabase } from './require-test-db.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { DreamEngine } from '../../src/memory/dream-engine.js';
+import { createSilentLogger } from '../../src/logger.js';
+import type { EventBus } from '../../src/bus/bus.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+function makeBus(): EventBus {
+  return { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+}
+
+const decayConfig = {
+  intervalMs: 86400000,
+  archiveThreshold: 0.05,
+  halfLifeDays: { permanent: null as null, slow_decay: 180, fast_decay: 21 },
+  edgeCountPercentile: 0.95,
+  edgeCountFloor: 5,
+  warnHoldBackDays: 30,
+};
+
+describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
+  let pool: pg.Pool;
+  let store: KnowledgeGraphStore;
+
+  // Track what each test creates so cleanup touches only those rows, leaving any
+  // unrelated data in the shared test database intact.
+  const nodeIds: string[] = [];
+  const contactIds: string[] = [];
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    // The backfill suite below re-runs migration 085's own arms, which are scoped only by
+    // "kg_node_id IS NULL" and so are table-wide. Refuse to run anywhere but curia_test.
+    await requireCuriaTestDatabase(pool);
+    store = KnowledgeGraphStore.createWithPostgres(pool, EmbeddingService.createForTesting(), createSilentLogger());
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterEach(async () => {
+    if (contactIds.length > 0) {
+      await pool.query('DELETE FROM contacts WHERE id = ANY($1::uuid[])', [contactIds]);
+      contactIds.length = 0;
+    }
+    if (nodeIds.length > 0) {
+      await pool.query('DELETE FROM kg_nodes WHERE id = ANY($1::uuid[])', [nodeIds]);
+      nodeIds.length = 0;
+    }
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  /** Insert a node directly so the test controls identity_source and confidence exactly. */
+  async function insertNode(opts: {
+    label: string;
+    type?: string;
+    identitySource?: 'label' | 'contact';
+    confidence?: number;
+    decayClass?: string;
+    properties?: Record<string, unknown>;
+  }): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, source, confidence, decay_class, sensitivity, identity_source,
+                             created_at, last_confirmed_at, last_decayed_at)
+       VALUES ($1, $2, $3, 'test', $4, $5, 'internal', $6, now() - INTERVAL '400 days', now() - INTERVAL '400 days', now() - INTERVAL '400 days')
+       RETURNING id`,
+      [
+        opts.type ?? 'person',
+        opts.label,
+        JSON.stringify(opts.properties ?? {}),
+        opts.confidence ?? 0.5,
+        opts.decayClass ?? 'slow_decay',
+        opts.identitySource ?? 'label',
+      ],
+    );
+    const id = rows[0]!.id;
+    nodeIds.push(id);
+    return id;
+  }
+
+  async function insertContact(opts: {
+    displayName: string;
+    kgNodeId?: string | null;
+    kind?: string;
+    primaryEmail?: string | null;
+  }): Promise<string> {
+    const id = randomUUID();
+    await pool.query(
+      `INSERT INTO contacts (id, kg_node_id, display_name, tier, kind, primary_email, created_at, updated_at)
+       VALUES ($1, $2, $3, 'known', $4, $5, now(), now())`,
+      [id, opts.kgNodeId ?? null, opts.displayName, opts.kind ?? 'person', opts.primaryEmail ?? null],
+    );
+    contactIds.push(id);
+    return id;
+  }
+
+  describe('schema', () => {
+    it('adds identity_source defaulting to label, constrained to the two tiers', async () => {
+      const { rows } = await pool.query<{ column_default: string | null; is_nullable: string }>(
+        `SELECT column_default, is_nullable
+           FROM information_schema.columns
+          WHERE table_name = 'kg_nodes' AND column_name = 'identity_source'`,
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.is_nullable).toBe('NO');
+      expect(rows[0]!.column_default).toContain('label');
+
+      await expect(
+        pool.query(
+          `INSERT INTO kg_nodes (type, label, properties, source, identity_source)
+           VALUES ('person', $1, '{}', 'test', 'nonsense')`,
+          [`bad-tier-${randomUUID()}`],
+        ),
+      ).rejects.toThrow();
+    });
+
+    it('narrows idx_kg_nodes_unique to the label tier', async () => {
+      const { rows } = await pool.query<{ indexdef: string }>(
+        `SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_kg_nodes_unique'`,
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.indexdef).toContain("identity_source = 'label'");
+    });
+
+    it('exempts organization contacts from idx_contacts_kg_node_unique', async () => {
+      const { rows } = await pool.query<{ indexdef: string }>(
+        `SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_contacts_kg_node_unique'`,
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.indexdef).toContain("kind <> 'organization'");
+    });
+  });
+
+  describe('label uniqueness', () => {
+    it('still rejects a second label-tier node with the same (label, type)', async () => {
+      const label = `Dupe Person ${randomUUID()}`;
+      await insertNode({ label });
+
+      await expect(insertNode({ label })).rejects.toThrow(/idx_kg_nodes_unique|unique/i);
+    });
+
+    it('accepts any number of anchored nodes sharing a label', async () => {
+      const label = `Seth Berman ${randomUUID()}`;
+      const a = await insertNode({ label, identitySource: 'contact' });
+      const b = await insertNode({ label, identitySource: 'contact' });
+      const c = await insertNode({ label, identitySource: 'contact' });
+
+      expect(new Set([a, b, c]).size).toBe(3);
+    });
+
+    it('accepts an anchored node alongside a label-tier node of the same name', async () => {
+      const label = `Seth Berman ${randomUUID()}`;
+      await insertNode({ label });
+      await expect(insertNode({ label, identitySource: 'contact' })).resolves.toBeTruthy();
+    });
+  });
+
+  describe('upsertNode (ADR-040 invariant 1)', () => {
+    it('inserts alongside an anchored node rather than merging onto it', async () => {
+      // The seam the two tiers would leak through: a name-only write landing on
+      // somebody's contact identity. ON CONFLICT must not see the anchored row at all.
+      const label = `Seth Berman ${randomUUID()}`;
+      const anchored = await insertNode({ label, identitySource: 'contact' });
+
+      const { node, created } = await store.upsertNode({
+        type: 'person', label, properties: {}, source: 'test', confidence: 0.7,
+      });
+      nodeIds.push(node.id);
+
+      expect(created).toBe(true);
+      expect(node.id).not.toBe(anchored);
+      expect(node.identitySource).toBe('label');
+    });
+
+    it('still deduplicates label-tier nodes — ON CONFLICT infers the narrowed index', async () => {
+      // If the predicate ever drifts from the index, Postgres raises 42P10 here rather
+      // than silently inserting, so this also guards the inference itself.
+      const label = `Dana Wu ${randomUUID()}`;
+      const first = await insertNode({ label, confidence: 0.4 });
+
+      const { node, created } = await store.upsertNode({
+        type: 'person', label, properties: {}, source: 'test', confidence: 0.9,
+      });
+
+      expect(created).toBe(false);
+      expect(node.id).toBe(first);
+      expect(node.temporal.confidence).toBeCloseTo(0.9, 5);
+    });
+  });
+
+  describe('contact links', () => {
+    it('still allows at most one non-organization contact per node', async () => {
+      const nodeId = await insertNode({ label: `Solo ${randomUUID()}`, identitySource: 'contact' });
+      await insertContact({ displayName: 'Solo A', kgNodeId: nodeId });
+
+      await expect(insertContact({ displayName: 'Solo B', kgNodeId: nodeId }))
+        .rejects.toThrow(/idx_contacts_kg_node_unique|unique/i);
+    });
+
+    it('lets several organization contacts share one organization node', async () => {
+      const nodeId = await insertNode({
+        label: `Acme ${randomUUID()}`, type: 'organization', properties: { domain: 'acme.test' },
+      });
+      await insertContact({ displayName: 'Acme info', kind: 'organization', kgNodeId: nodeId });
+
+      await expect(
+        insertContact({ displayName: 'Acme support', kind: 'organization', kgNodeId: nodeId }),
+      ).resolves.toBeTruthy();
+    });
+  });
+
+  describe('anchorNode', () => {
+    it('promotes a label-tier node exactly once', async () => {
+      const nodeId = await insertNode({ label: `Dana Wu ${randomUUID()}` });
+
+      expect(await store.anchorNode(nodeId)).toBe(true);
+      expect(await store.anchorNode(nodeId)).toBe(false);
+
+      const { rows } = await pool.query<{ identity_source: string }>(
+        'SELECT identity_source FROM kg_nodes WHERE id = $1', [nodeId],
+      );
+      expect(rows[0]!.identity_source).toBe('contact');
+    });
+
+    it('refuses an archived node', async () => {
+      const nodeId = await insertNode({ label: `Gone ${randomUUID()}` });
+      await pool.query('UPDATE kg_nodes SET archived_at = now() WHERE id = $1', [nodeId]);
+
+      expect(await store.anchorNode(nodeId)).toBe(false);
+    });
+  });
+
+  describe('migration 085 backfill', () => {
+    // Re-runs the migration's own two arms rather than a paraphrase of them, so the test
+    // fails if the shipped SQL changes shape. Both are scoped to kg_node_id IS NULL, so
+    // re-running them against already-linked rows is a no-op.
+    let backfillArms: string[];
+
+    beforeAll(async () => {
+      const sql = await readFile(
+        new URL('../../src/db/migrations/085_contact_anchored_kg_identity.sql', import.meta.url),
+        'utf8',
+      );
+      const up = sql.split('-- Down Migration')[0] ?? '';
+      backfillArms = up
+        .split(';')
+        .map(stmt => stmt.replace(/^\s*(--[^\n]*\n)+/gm, '').trim())
+        .filter(stmt => /^WITH\s+(candidates|minted)\b/i.test(stmt));
+
+      // Arm A ("candidates") and arm B ("minted"). A rename must fail loudly here rather
+      // than silently reduce this suite to asserting nothing.
+      expect(backfillArms).toHaveLength(2);
+    });
+
+    async function runBackfill(): Promise<void> {
+      for (const stmt of backfillArms) {
+        await pool.query(stmt);
+      }
+    }
+
+    it('gives two nodeless same-name contacts a node each, never a shared one', async () => {
+      // The #1623 population. Migration 056 minted one node per distinct display_name,
+      // which is exactly why the namesakes were left nodeless.
+      const label = `Seth Berman ${randomUUID()}`;
+      const a = await insertContact({ displayName: label });
+      const b = await insertContact({ displayName: label });
+
+      await runBackfill();
+
+      const { rows } = await pool.query<{ id: string; kg_node_id: string | null }>(
+        'SELECT id, kg_node_id FROM contacts WHERE id = ANY($1::uuid[])', [[a, b]],
+      );
+      const links = new Map(rows.map(r => [r.id, r.kg_node_id]));
+      for (const id of [a, b]) {
+        expect(links.get(id)).not.toBeNull();
+        nodeIds.push(links.get(id)!);
+      }
+      expect(links.get(a)).not.toBe(links.get(b));
+    });
+
+    it('anchors what it mints, at migration 056 confidence', async () => {
+      const contactId = await insertContact({ displayName: `Solo ${randomUUID()}` });
+
+      await runBackfill();
+
+      const { rows } = await pool.query<{
+        id: string; identity_source: string; confidence: number; source: string; type: string;
+      }>(
+        `SELECT n.id, n.identity_source, n.confidence, n.source, n.type
+           FROM contacts c JOIN kg_nodes n ON n.id = c.kg_node_id
+          WHERE c.id = $1`,
+        [contactId],
+      );
+      expect(rows).toHaveLength(1);
+      nodeIds.push(rows[0]!.id);
+      expect(rows[0]!.identity_source).toBe('contact');
+      expect(rows[0]!.type).toBe('person');
+      expect(rows[0]!.source).toBe('migration_085');
+      expect(rows[0]!.confidence).toBeCloseTo(0.5, 5);
+    });
+
+    it('arm A re-links a nodeless organization contact to its domain node', async () => {
+      const domain = `acme-${randomUUID().slice(0, 8)}.test`;
+      const orgNode = await insertNode({
+        label: `Acme ${randomUUID()}`, type: 'organization', properties: { domain },
+      });
+      // The role address that minted the node, and the one the old index turned away.
+      await insertContact({
+        displayName: 'Acme info', kind: 'organization', kgNodeId: orgNode, primaryEmail: `info@${domain}`,
+      });
+      const support = await insertContact({
+        displayName: 'Acme support', kind: 'organization', primaryEmail: `support@${domain}`,
+      });
+
+      await runBackfill();
+
+      const { rows } = await pool.query<{ kg_node_id: string | null }>(
+        'SELECT kg_node_id FROM contacts WHERE id = $1', [support],
+      );
+      expect(rows[0]!.kg_node_id).toBe(orgNode);
+    });
+
+    it('does not link an organization contact whose domain matches nothing', async () => {
+      // Arm B then mints it one, rather than guessing at an unrelated organization.
+      const orphan = await insertContact({
+        displayName: `Nowhere Inc ${randomUUID()}`,
+        kind: 'organization',
+        primaryEmail: `hello@nowhere-${randomUUID().slice(0, 8)}.test`,
+      });
+
+      await runBackfill();
+
+      const { rows } = await pool.query<{ id: string; type: string; identity_source: string }>(
+        `SELECT n.id, n.type, n.identity_source
+           FROM contacts c JOIN kg_nodes n ON n.id = c.kg_node_id
+          WHERE c.id = $1`,
+        [orphan],
+      );
+      expect(rows).toHaveLength(1);
+      nodeIds.push(rows[0]!.id);
+      expect(rows[0]!.type).toBe('organization');
+      expect(rows[0]!.identity_source).toBe('contact');
+    });
+
+    it('leaves already-linked contacts untouched', async () => {
+      const nodeId = await insertNode({ label: `Linked ${randomUUID()}`, identitySource: 'contact' });
+      const contactId = await insertContact({ displayName: 'Linked', kgNodeId: nodeId });
+
+      await runBackfill();
+
+      const { rows } = await pool.query<{ kg_node_id: string | null }>(
+        'SELECT kg_node_id FROM contacts WHERE id = $1', [contactId],
+      );
+      expect(rows[0]!.kg_node_id).toBe(nodeId);
+    });
+  });
+
+  describe('DreamEngine — identity does not decay', () => {
+    let engine: DreamEngine;
+
+    beforeAll(() => {
+      engine = new DreamEngine(pool, makeBus(), createSilentLogger(), decayConfig);
+    });
+
+    it('leaves an anchored node at full confidence while a label-tier twin decays', async () => {
+      // Both are slow_decay, both last decayed 400 days ago. Only the tier differs.
+      const anchored = await insertNode({
+        label: `Anchored ${randomUUID()}`, identitySource: 'contact', confidence: 0.5,
+      });
+      const labelTier = await insertNode({
+        label: `LabelTier ${randomUUID()}`, identitySource: 'label', confidence: 0.5,
+      });
+
+      await engine.runDecayPass();
+
+      const { rows } = await pool.query<{ id: string; confidence: number; archived_at: Date | null }>(
+        'SELECT id, confidence, archived_at FROM kg_nodes WHERE id = ANY($1::uuid[])',
+        [[anchored, labelTier]],
+      );
+      const byId = new Map(rows.map(r => [r.id, r]));
+
+      expect(byId.get(anchored)!.confidence).toBeCloseTo(0.5, 5);
+      expect(byId.get(labelTier)!.confidence).toBeLessThan(0.5);
+    });
+
+    it('never archives an anchored node that has decayed below the threshold', async () => {
+      // A node already under archiveThreshold — the pre-085 population, where 478 of 532
+      // contact nodes were silently archivable. Pass 2b must skip it now.
+      const anchored = await insertNode({
+        label: `Faded ${randomUUID()}`, identitySource: 'contact', confidence: 0.01,
+      });
+      const labelTier = await insertNode({
+        label: `FadedTwin ${randomUUID()}`, identitySource: 'label', confidence: 0.01,
+      });
+
+      await engine.runDecayPass();
+
+      const { rows } = await pool.query<{ id: string; archived_at: Date | null }>(
+        'SELECT id, archived_at FROM kg_nodes WHERE id = ANY($1::uuid[])',
+        [[anchored, labelTier]],
+      );
+      const byId = new Map(rows.map(r => [r.id, r]));
+
+      expect(byId.get(anchored)!.archived_at).toBeNull();
+      expect(byId.get(labelTier)!.archived_at).not.toBeNull();
+    });
+
+    it('keeps decaying facts hanging off an anchored node', async () => {
+      // The exclusion protects the container, not its contents — otherwise it would
+      // freeze memory rather than stop the anchor evaporating.
+      const anchored = await insertNode({
+        label: `Anchored ${randomUUID()}`, identitySource: 'contact', confidence: 0.5,
+      });
+      const fact = await insertNode({
+        label: `Fact about them ${randomUUID()}`, type: 'fact', identitySource: 'label', confidence: 0.5,
+      });
+      await pool.query(
+        `INSERT INTO kg_edges (source_node_id, target_node_id, type, properties, source, confidence, decay_class,
+                               created_at, last_confirmed_at)
+         VALUES ($1, $2, 'knows', '{}', 'test', 0.5, 'slow_decay', now(), now())`,
+        [anchored, fact],
+      );
+
+      await engine.runDecayPass();
+
+      const { rows } = await pool.query<{ confidence: number }>(
+        'SELECT confidence FROM kg_nodes WHERE id = $1', [fact],
+      );
+      expect(rows[0]!.confidence).toBeLessThan(0.5);
+    });
+  });
+});

--- a/tests/integration/contact-anchored-identity.test.ts
+++ b/tests/integration/contact-anchored-identity.test.ts
@@ -258,6 +258,41 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       expect(await store.anchorNode(nodeId)).toBe(false);
     });
 
+    it('refuses to dismiss (and so archive) an anchored node', async () => {
+      // dismissDecayWarning archives, and it sits OUTSIDE the decay passes — so without a
+      // tier filter it is the one archival path that survives ADR-040, reachable by the
+      // CEO answering a warning prompt for a node that was warned before being anchored.
+      const nodeId = await insertNode({ label: `Anchored ${randomUUID()}`, identitySource: 'contact' });
+      await pool.query(
+        `UPDATE kg_nodes SET warned_at = now(), warn_reason = 'high_sensitivity' WHERE id = $1`,
+        [nodeId],
+      );
+
+      expect((await store.dismissDecayWarning(nodeId)).success).toBe(false);
+
+      const { rows } = await pool.query<{ archived_at: Date | null }>(
+        'SELECT archived_at FROM kg_nodes WHERE id = $1', [nodeId],
+      );
+      expect(rows[0]!.archived_at).toBeNull();
+    });
+
+    it('does not offer an anchored node for re-confirmation', async () => {
+      // Same reasoning from the read side: a "confirm this or lose it" prompt for a node
+      // that cannot decay is a question the system will never act on.
+      const anchored = await insertNode({ label: `Anchored ${randomUUID()}`, identitySource: 'contact' });
+      const labelTier = await insertNode({ label: `LabelTier ${randomUUID()}` });
+      await pool.query(
+        `UPDATE kg_nodes SET warned_at = now(), warn_reason = 'high_sensitivity'
+          WHERE id = ANY($1::uuid[])`,
+        [[anchored, labelTier]],
+      );
+
+      const warned = (await store.listDecayWarnings()).map(w => w.nodeId);
+      expect(warned).not.toContain(anchored);
+      // Control: the label-tier twin proves the listing works at all.
+      expect(warned).toContain(labelTier);
+    });
+
     it('clears a pending decay warning on adoption', async () => {
       // Adopting a node is a promise to keep it, so the "confirm this or lose it" prompt is
       // void. Without this the node would sit warned forever, since Pass 2a now skips it.
@@ -289,6 +324,7 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
     // (The arms do take row locks on other suites' nodeless contacts for the life of each
     // transaction; these are short, so that is contention, not corruption.)
     let backfillArms: string[];
+    let anchorSteps: string[];
 
     beforeAll(async () => {
       const sql = await readFile(
@@ -302,6 +338,17 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       // COMMENT ON string literal, and a naive split cuts straight through them. An earlier
       // version did exactly that and lost arm B the moment a comment gained a semicolon.
       // Neither arm contains a semicolon of its own, so first-semicolon is the real end.
+      // Step 2 / 2a / 2b are plain UPDATEs, extracted by their leading keyword + table so
+      // the anchoring pass and the archived-node repair are exercised too. Without these
+      // the suite replayed only the arms and the repair in 2a was unguarded by construction.
+      anchorSteps = (up.match(/^UPDATE kg_nodes[\s\S]*?;/gm) ?? []);
+      if (anchorSteps.length !== 3) {
+        throw new Error(
+          `migration 085: expected 3 UPDATE kg_nodes steps (anchor, un-archive, clear warnings), `
+          + `found ${anchorSteps.length} — update this extractor rather than skipping them.`,
+        );
+      }
+
       backfillArms = (['candidates', 'minted'] as const).map((cte) => {
         const match = new RegExp(`^WITH\\s+${cte}\\s+AS\\b[\\s\\S]*?;`, 'm').exec(up);
         if (!match) {
@@ -340,8 +387,9 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       }
     }
 
+    /** Replay the migration's data steps in shipped order: anchor, repair, then both arms. */
     async function runBackfill(tx: pg.PoolClient): Promise<void> {
-      for (const stmt of backfillArms) {
+      for (const stmt of [...anchorSteps, ...backfillArms]) {
         await tx.query(stmt);
       }
     }
@@ -446,6 +494,109 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
           'SELECT kg_node_id FROM contacts WHERE id = $1', [contactId],
         );
         expect(rows[0]!.kg_node_id).toBe(nodeId);
+      });
+    });
+
+    it('repairs a contact whose node was archived out from under it', async () => {
+      // Pre-085 DreamEngine archived contact nodes with no exclusion, and
+      // dismissDecayWarning still archives on demand. Such a contact looks linked and is
+      // broken: getNode filters archived_at, so it holds no facts and no enrichment — the
+      // #1694 failure with a non-NULL pointer. It is invisible to both arms (step 2 skips
+      // it as archived, arm B skips it as linked), so step 2a exists to catch it.
+      await inRolledBackTransaction(async (tx) => {
+        const nodeId = await insertNode({ label: `Faded ${randomUUID()}` }, tx);
+        const contactId = await insertContact({ displayName: 'Faded', kgNodeId: nodeId }, tx);
+        await tx.query(
+          `UPDATE kg_nodes SET archived_at = now(), confidence = 0.01,
+                               warned_at = now(), warn_reason = 'high_sensitivity'
+            WHERE id = $1`,
+          [nodeId],
+        );
+
+        await runBackfill(tx);
+
+        const { rows } = await tx.query<{
+          archived_at: Date | null; identity_source: string; confidence: number;
+          warned_at: Date | null; kg_node_id: string;
+        }>(
+          `SELECT n.archived_at, n.identity_source, n.confidence, n.warned_at, c.kg_node_id
+             FROM contacts c JOIN kg_nodes n ON n.id = c.kg_node_id
+            WHERE c.id = $1`,
+          [contactId],
+        );
+        expect(rows).toHaveLength(1);
+        // Same node, restored — not a fresh one, so the facts underneath survive.
+        expect(rows[0]!.kg_node_id).toBe(nodeId);
+        expect(rows[0]!.archived_at).toBeNull();
+        expect(rows[0]!.identity_source).toBe('contact');
+        expect(rows[0]!.confidence).toBeGreaterThanOrEqual(0.5);
+        expect(rows[0]!.warned_at).toBeNull();
+      });
+    });
+
+    it('clears a pending decay warning on the nodes it anchors', async () => {
+      await inRolledBackTransaction(async (tx) => {
+        const nodeId = await insertNode({ label: `Warned ${randomUUID()}` }, tx);
+        await insertContact({ displayName: 'Warned', kgNodeId: nodeId }, tx);
+        await tx.query(
+          `UPDATE kg_nodes SET warned_at = now(), warn_reason = 'high_sensitivity' WHERE id = $1`,
+          [nodeId],
+        );
+
+        await runBackfill(tx);
+
+        const { rows } = await tx.query<{ identity_source: string; warned_at: Date | null }>(
+          'SELECT identity_source, warned_at FROM kg_nodes WHERE id = $1', [nodeId],
+        );
+        expect(rows[0]!.identity_source).toBe('contact');
+        expect(rows[0]!.warned_at).toBeNull();
+      });
+    });
+
+    it('leaves organization nodes in the label tier', async () => {
+      // Anchoring them would take them out of idx_kg_nodes_unique, so
+      // resolveOrCreateOrgNode could mint a second node for one organization, and
+      // deleting one role-address contact could archive a node its siblings still use.
+      await inRolledBackTransaction(async (tx) => {
+        const domain = `acme-${randomUUID().slice(0, 8)}.test`;
+        const orgNode = await insertNode({
+          label: `Acme ${randomUUID()}`, type: 'organization', properties: { domain },
+        }, tx);
+        await insertContact({
+          displayName: 'Acme info', kind: 'organization', kgNodeId: orgNode, primaryEmail: `info@${domain}`,
+        }, tx);
+
+        await runBackfill(tx);
+
+        const { rows } = await tx.query<{ identity_source: string }>(
+          'SELECT identity_source FROM kg_nodes WHERE id = $1', [orgNode],
+        );
+        expect(rows[0]!.identity_source).toBe('label');
+      });
+    });
+
+    it('skips system_role contacts, leaving them to bootstrap', async () => {
+      // Migration 056's convention. A plain person node here would leave
+      // bootstrapAgentIdentity's ON CONFLICT unable to match, inserting a second agent
+      // contact and tripping idx_contacts_system_role_agent on every startup.
+      await inRolledBackTransaction(async (tx) => {
+        // system_role='system' rather than 'agent'/'principal': migration 035 puts a unique
+        // index on those two, and another suite's committed agent contact would make this
+        // INSERT 23505 even inside a rolled-back transaction. Any non-NULL value exercises
+        // the guard, which is `system_role IS NULL`.
+        const id = randomUUID();
+        await tx.query(
+          `INSERT INTO contacts (id, kg_node_id, display_name, tier, kind, system_role, created_at, updated_at)
+           VALUES ($1, NULL, $2, 'known', 'person', 'system', now(), now())`,
+          [id, `System ${randomUUID()}`],
+        );
+
+        await runBackfill(tx);
+
+        const { rows } = await tx.query<{ kg_node_id: string | null }>(
+          'SELECT kg_node_id FROM contacts WHERE id = $1', [id],
+        );
+        expect(rows[0]!.kg_node_id).toBeNull();
       });
     });
 

--- a/tests/integration/contact-anchored-identity.test.ts
+++ b/tests/integration/contact-anchored-identity.test.ts
@@ -296,14 +296,29 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
         'utf8',
       );
       const up = sql.split('-- Down Migration')[0] ?? '';
-      backfillArms = up
-        .split(';')
-        .map(stmt => stmt.replace(/^\s*(--[^\n]*\n)+/gm, '').trim())
-        .filter(stmt => /^WITH\s+(candidates|minted)\b/i.test(stmt));
 
-      // Arm A ("candidates") and arm B ("minted"). A rename must fail loudly here rather
-      // than silently reduce this suite to asserting nothing.
+      // Match each arm from its WITH clause to the terminating semicolon. Deliberately NOT
+      // a split(';'): this file has semicolons inside `--` comments and inside the
+      // COMMENT ON string literal, and a naive split cuts straight through them. An earlier
+      // version did exactly that and lost arm B the moment a comment gained a semicolon.
+      // Neither arm contains a semicolon of its own, so first-semicolon is the real end.
+      backfillArms = (['candidates', 'minted'] as const).map((cte) => {
+        const match = new RegExp(`^WITH\\s+${cte}\\s+AS\\b[\\s\\S]*?;`, 'm').exec(up);
+        if (!match) {
+          // Loud rather than silent: a renamed CTE would otherwise reduce this whole suite
+          // to asserting nothing while still reporting green.
+          throw new Error(
+            `migration 085: could not locate backfill arm "WITH ${cte} AS ..." — if the CTE `
+            + 'was renamed, update this extractor; do not let the suite run without it.',
+          );
+        }
+        return match[0];
+      });
+
+      // Arm A ("candidates") and arm B ("minted").
       expect(backfillArms).toHaveLength(2);
+      expect(backfillArms[0]).toContain('kind = \'organization\'');
+      expect(backfillArms[1]).toContain('migration_085');
     });
 
     /** Run `body` on a dedicated client in a transaction that is always rolled back. */

--- a/tests/integration/contact-anchored-identity.test.ts
+++ b/tests/integration/contact-anchored-identity.test.ts
@@ -323,8 +323,7 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
     // replay and the assertions all see the same uncommitted state, and nothing survives.
     // (The arms do take row locks on other suites' nodeless contacts for the life of each
     // transaction; these are short, so that is contention, not corruption.)
-    let backfillArms: string[];
-    let anchorSteps: string[];
+    let migrationSteps: string[];
 
     beforeAll(async () => {
       const sql = await readFile(
@@ -333,39 +332,30 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       );
       const up = sql.split('-- Down Migration')[0] ?? '';
 
-      // Match each arm from its WITH clause to the terminating semicolon. Deliberately NOT
-      // a split(';'): this file has semicolons inside `--` comments and inside the
-      // COMMENT ON string literal, and a naive split cuts straight through them. An earlier
-      // version did exactly that and lost arm B the moment a comment gained a semicolon.
-      // Neither arm contains a semicolon of its own, so first-semicolon is the real end.
-      // Step 2 / 2a / 2b are plain UPDATEs, extracted by their leading keyword + table so
-      // the anchoring pass and the archived-node repair are exercised too. Without these
-      // the suite replayed only the arms and the repair in 2a was unguarded by construction.
-      anchorSteps = (up.match(/^UPDATE kg_nodes[\s\S]*?;/gm) ?? []);
-      if (anchorSteps.length !== 3) {
-        throw new Error(
-          `migration 085: expected 3 UPDATE kg_nodes steps (anchor, un-archive, clear warnings), `
-          + `found ${anchorSteps.length} — update this extractor rather than skipping them.`,
-        );
-      }
+      // Replay EVERY data step, in file order, rather than a hand-picked list of statement
+      // shapes. The previous version matched `WITH candidates` / `WITH minted` / `UPDATE
+      // kg_nodes` by name, so when the organization backfill was split into an INSERT plus
+      // a link step those two silently stopped being replayed — the suite kept passing on
+      // the arms it knew about while testing nothing about the half that had changed.
+      //
+      // Comments are stripped BEFORE splitting on ';': this file has semicolons inside `--`
+      // comments and inside the COMMENT ON string literal, and splitting first cuts through
+      // them. Whatever fragments the COMMENT literal produces do not begin with a data-step
+      // keyword, so the filter discards them.
+      migrationSteps = up
+        .replace(/^\s*--[^\n]*$/gm, '')
+        .split(';')
+        .map(stmt => stmt.trim())
+        .filter(stmt => /^(WITH|INSERT|UPDATE)\b/i.test(stmt));
 
-      backfillArms = (['candidates', 'minted'] as const).map((cte) => {
-        const match = new RegExp(`^WITH\\s+${cte}\\s+AS\\b[\\s\\S]*?;`, 'm').exec(up);
-        if (!match) {
-          // Loud rather than silent: a renamed CTE would otherwise reduce this whole suite
-          // to asserting nothing while still reporting green.
-          throw new Error(
-            `migration 085: could not locate backfill arm "WITH ${cte} AS ..." — if the CTE `
-            + 'was renamed, update this extractor; do not let the suite run without it.',
-          );
-        }
-        return match[0];
-      });
-
-      // Arm A ("candidates") and arm B ("minted").
-      expect(backfillArms).toHaveLength(2);
-      expect(backfillArms[0]).toContain('kind = \'organization\'');
-      expect(backfillArms[1]).toContain('migration_085');
+      // Anchor, un-archive, clear-warnings, arm A, arm B non-org, arm B org insert, arm B
+      // org link. A changed count means the migration grew or lost a data step and this
+      // extractor has to be updated — loud, rather than silently replaying a subset.
+      expect(migrationSteps).toHaveLength(7);
+      // Spot-check identity so a reordering that preserves the count still fails.
+      expect(migrationSteps.filter(st => /^WITH candidates\b/.test(st))).toHaveLength(1);
+      expect(migrationSteps.filter(st => /^WITH minted\b/.test(st))).toHaveLength(1);
+      expect(migrationSteps.filter(st => /migration_085/.test(st))).toHaveLength(2);
     });
 
     /** Run `body` on a dedicated client in a transaction that is always rolled back. */
@@ -387,9 +377,9 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       }
     }
 
-    /** Replay the migration's data steps in shipped order: anchor, repair, then both arms. */
+    /** Replay the migration's data steps in shipped order. */
     async function runBackfill(tx: pg.PoolClient): Promise<void> {
-      for (const stmt of [...anchorSteps, ...backfillArms]) {
+      for (const stmt of migrationSteps) {
         await tx.query(stmt);
       }
     }
@@ -459,27 +449,58 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       });
     });
 
-    it('does not link an organization contact whose domain matches nothing', async () => {
-      // Arm B then mints it one, rather than guessing at an unrelated organization.
+    it('mints a LABEL-TIER org node when no domain matches, carrying the domain', async () => {
+      // Arm B mints rather than guessing at an unrelated organization — but label-tier, so
+      // the node stays deduplicated by (lower(label), type) and stays shareable by the
+      // other role addresses at that domain. The domain is copied into properties because
+      // that is resolveOrCreateOrgNode's FIRST lookup; without it the next role address
+      // finds nothing and mints a second node for the same organization.
+      const domain = `nowhere-${randomUUID().slice(0, 8)}.test`;
       await inRolledBackTransaction(async (tx) => {
         const orphan = await insertContact({
           displayName: `Nowhere Inc ${randomUUID()}`,
           kind: 'organization',
-          primaryEmail: `hello@nowhere-${randomUUID().slice(0, 8)}.test`,
+          primaryEmail: `hello@${domain}`,
         }, tx);
 
         await runBackfill(tx);
 
-        const { rows } = await tx.query<{ type: string; identity_source: string; source: string }>(
-          `SELECT n.type, n.identity_source, n.source
+        const { rows } = await tx.query<{
+          type: string; identity_source: string; source: string; domain: string | null;
+        }>(
+          `SELECT n.type, n.identity_source, n.source, n.properties->>'domain' AS domain
              FROM contacts c JOIN kg_nodes n ON n.id = c.kg_node_id
             WHERE c.id = $1`,
           [orphan],
         );
         expect(rows).toHaveLength(1);
         expect(rows[0]!.type).toBe('organization');
-        expect(rows[0]!.identity_source).toBe('contact');
+        expect(rows[0]!.identity_source).toBe('label');
         expect(rows[0]!.source).toBe('migration_085');
+        expect(rows[0]!.domain).toBe(domain);
+      });
+    });
+
+    it('shares one minted org node between two same-name org contacts', async () => {
+      // The org half mints per distinct display_name, not per contact — the opposite of
+      // the person half — because org nodes are legitimately shared and label-keyed.
+      await inRolledBackTransaction(async (tx) => {
+        const label = `Acme Group ${randomUUID()}`;
+        const a = await insertContact({
+          displayName: label, kind: 'organization', primaryEmail: `info@acme-${randomUUID().slice(0, 8)}.test`,
+        }, tx);
+        const b = await insertContact({
+          displayName: label, kind: 'organization', primaryEmail: `support@acme-${randomUUID().slice(0, 8)}.test`,
+        }, tx);
+
+        await runBackfill(tx);
+
+        const { rows } = await tx.query<{ id: string; kg_node_id: string | null }>(
+          'SELECT id, kg_node_id FROM contacts WHERE id = ANY($1::uuid[])', [[a, b]],
+        );
+        const links = new Map(rows.map(r => [r.id, r.kg_node_id]));
+        expect(links.get(a)).not.toBeNull();
+        expect(links.get(a)).toBe(links.get(b));
       });
     });
 

--- a/tests/integration/contact-anchored-identity.test.ts
+++ b/tests/integration/contact-anchored-identity.test.ts
@@ -71,7 +71,15 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
     await pool.end();
   });
 
-  /** Insert a node directly so the test controls identity_source and confidence exactly. */
+  /**
+   * Anything that can run a query: the pool, or a transaction client. The backfill suite
+   * passes a client so its table-wide statements can be rolled back.
+   */
+  type Queryable = Pick<pg.Pool, 'query'>;
+
+  /** Insert a node directly so the test controls identity_source and confidence exactly.
+   *  Rows created on a transaction client are not tracked for cleanup — the rollback is
+   *  the cleanup, and recording them would make afterEach chase ids that never committed. */
   async function insertNode(opts: {
     label: string;
     type?: string;
@@ -79,8 +87,8 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
     confidence?: number;
     decayClass?: string;
     properties?: Record<string, unknown>;
-  }): Promise<string> {
-    const { rows } = await pool.query<{ id: string }>(
+  }, tx: Queryable = pool): Promise<string> {
+    const { rows } = await tx.query<{ id: string }>(
       `INSERT INTO kg_nodes (type, label, properties, source, confidence, decay_class, sensitivity, identity_source,
                              created_at, last_confirmed_at, last_decayed_at)
        VALUES ($1, $2, $3, 'test', $4, $5, 'internal', $6, now() - INTERVAL '400 days', now() - INTERVAL '400 days', now() - INTERVAL '400 days')
@@ -95,7 +103,7 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       ],
     );
     const id = rows[0]!.id;
-    nodeIds.push(id);
+    if (tx === pool) nodeIds.push(id);
     return id;
   }
 
@@ -104,14 +112,14 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
     kgNodeId?: string | null;
     kind?: string;
     primaryEmail?: string | null;
-  }): Promise<string> {
+  }, tx: Queryable = pool): Promise<string> {
     const id = randomUUID();
-    await pool.query(
+    await tx.query(
       `INSERT INTO contacts (id, kg_node_id, display_name, tier, kind, primary_email, created_at, updated_at)
        VALUES ($1, $2, $3, 'known', $4, $5, now(), now())`,
       [id, opts.kgNodeId ?? null, opts.displayName, opts.kind ?? 'person', opts.primaryEmail ?? null],
     );
-    contactIds.push(id);
+    if (tx === pool) contactIds.push(id);
     return id;
   }
 
@@ -249,12 +257,37 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
 
       expect(await store.anchorNode(nodeId)).toBe(false);
     });
+
+    it('clears a pending decay warning on adoption', async () => {
+      // Adopting a node is a promise to keep it, so the "confirm this or lose it" prompt is
+      // void. Without this the node would sit warned forever, since Pass 2a now skips it.
+      const nodeId = await insertNode({ label: `Warned ${randomUUID()}` });
+      await pool.query(
+        `UPDATE kg_nodes SET warned_at = now(), warn_reason = 'high_sensitivity' WHERE id = $1`,
+        [nodeId],
+      );
+
+      expect(await store.anchorNode(nodeId)).toBe(true);
+
+      const { rows } = await pool.query<{ warned_at: Date | null; warn_reason: string | null }>(
+        'SELECT warned_at, warn_reason FROM kg_nodes WHERE id = $1', [nodeId],
+      );
+      expect(rows[0]!.warned_at).toBeNull();
+      expect(rows[0]!.warn_reason).toBeNull();
+    });
   });
 
   describe('migration 085 backfill', () => {
     // Re-runs the migration's own two arms rather than a paraphrase of them, so the test
-    // fails if the shipped SQL changes shape. Both are scoped to kg_node_id IS NULL, so
-    // re-running them against already-linked rows is a no-op.
+    // fails if the shipped SQL changes shape.
+    //
+    // Both arms are scoped only by "kg_node_id IS NULL", which makes them table-wide: run
+    // against the shared curia_test database they would link any nodeless contact another
+    // suite happens to own, and arm B would mint a node this suite never records. So every
+    // case here runs inside a transaction that is always rolled back — the fixtures, the
+    // replay and the assertions all see the same uncommitted state, and nothing survives.
+    // (The arms do take row locks on other suites' nodeless contacts for the life of each
+    // transaction; these are short, so that is contention, not corruption.)
     let backfillArms: string[];
 
     beforeAll(async () => {
@@ -273,106 +306,149 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       expect(backfillArms).toHaveLength(2);
     });
 
-    async function runBackfill(): Promise<void> {
+    /** Run `body` on a dedicated client in a transaction that is always rolled back. */
+    async function inRolledBackTransaction(
+      body: (tx: pg.PoolClient) => Promise<void>,
+    ): Promise<void> {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await body(client);
+      } finally {
+        // Not swallowed: a ROLLBACK that fails means the connection is in a state the next
+        // test would inherit, and that should be loud even though it masks a body error.
+        try {
+          await client.query('ROLLBACK');
+        } finally {
+          client.release();
+        }
+      }
+    }
+
+    async function runBackfill(tx: pg.PoolClient): Promise<void> {
       for (const stmt of backfillArms) {
-        await pool.query(stmt);
+        await tx.query(stmt);
       }
     }
 
     it('gives two nodeless same-name contacts a node each, never a shared one', async () => {
       // The #1623 population. Migration 056 minted one node per distinct display_name,
       // which is exactly why the namesakes were left nodeless.
-      const label = `Seth Berman ${randomUUID()}`;
-      const a = await insertContact({ displayName: label });
-      const b = await insertContact({ displayName: label });
+      await inRolledBackTransaction(async (tx) => {
+        const label = `Seth Berman ${randomUUID()}`;
+        const a = await insertContact({ displayName: label }, tx);
+        const b = await insertContact({ displayName: label }, tx);
 
-      await runBackfill();
+        await runBackfill(tx);
 
-      const { rows } = await pool.query<{ id: string; kg_node_id: string | null }>(
-        'SELECT id, kg_node_id FROM contacts WHERE id = ANY($1::uuid[])', [[a, b]],
-      );
-      const links = new Map(rows.map(r => [r.id, r.kg_node_id]));
-      for (const id of [a, b]) {
-        expect(links.get(id)).not.toBeNull();
-        nodeIds.push(links.get(id)!);
-      }
-      expect(links.get(a)).not.toBe(links.get(b));
+        const { rows } = await tx.query<{ id: string; kg_node_id: string | null }>(
+          'SELECT id, kg_node_id FROM contacts WHERE id = ANY($1::uuid[])', [[a, b]],
+        );
+        const links = new Map(rows.map(r => [r.id, r.kg_node_id]));
+        expect(links.get(a)).not.toBeNull();
+        expect(links.get(b)).not.toBeNull();
+        expect(links.get(a)).not.toBe(links.get(b));
+      });
     });
 
     it('anchors what it mints, at migration 056 confidence', async () => {
-      const contactId = await insertContact({ displayName: `Solo ${randomUUID()}` });
+      await inRolledBackTransaction(async (tx) => {
+        const contactId = await insertContact({ displayName: `Solo ${randomUUID()}` }, tx);
 
-      await runBackfill();
+        await runBackfill(tx);
 
-      const { rows } = await pool.query<{
-        id: string; identity_source: string; confidence: number; source: string; type: string;
-      }>(
-        `SELECT n.id, n.identity_source, n.confidence, n.source, n.type
-           FROM contacts c JOIN kg_nodes n ON n.id = c.kg_node_id
-          WHERE c.id = $1`,
-        [contactId],
-      );
-      expect(rows).toHaveLength(1);
-      nodeIds.push(rows[0]!.id);
-      expect(rows[0]!.identity_source).toBe('contact');
-      expect(rows[0]!.type).toBe('person');
-      expect(rows[0]!.source).toBe('migration_085');
-      expect(rows[0]!.confidence).toBeCloseTo(0.5, 5);
+        const { rows } = await tx.query<{
+          identity_source: string; confidence: number; source: string; type: string;
+        }>(
+          `SELECT n.identity_source, n.confidence, n.source, n.type
+             FROM contacts c JOIN kg_nodes n ON n.id = c.kg_node_id
+            WHERE c.id = $1`,
+          [contactId],
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.identity_source).toBe('contact');
+        expect(rows[0]!.type).toBe('person');
+        expect(rows[0]!.source).toBe('migration_085');
+        expect(rows[0]!.confidence).toBeCloseTo(0.5, 5);
+      });
     });
 
     it('arm A re-links a nodeless organization contact to its domain node', async () => {
-      const domain = `acme-${randomUUID().slice(0, 8)}.test`;
-      const orgNode = await insertNode({
-        label: `Acme ${randomUUID()}`, type: 'organization', properties: { domain },
-      });
-      // The role address that minted the node, and the one the old index turned away.
-      await insertContact({
-        displayName: 'Acme info', kind: 'organization', kgNodeId: orgNode, primaryEmail: `info@${domain}`,
-      });
-      const support = await insertContact({
-        displayName: 'Acme support', kind: 'organization', primaryEmail: `support@${domain}`,
-      });
+      await inRolledBackTransaction(async (tx) => {
+        const domain = `acme-${randomUUID().slice(0, 8)}.test`;
+        const orgNode = await insertNode({
+          label: `Acme ${randomUUID()}`, type: 'organization', properties: { domain },
+        }, tx);
+        // The role address that minted the node, and the one the old index turned away.
+        await insertContact({
+          displayName: 'Acme info', kind: 'organization', kgNodeId: orgNode, primaryEmail: `info@${domain}`,
+        }, tx);
+        const support = await insertContact({
+          displayName: 'Acme support', kind: 'organization', primaryEmail: `support@${domain}`,
+        }, tx);
 
-      await runBackfill();
+        await runBackfill(tx);
 
-      const { rows } = await pool.query<{ kg_node_id: string | null }>(
-        'SELECT kg_node_id FROM contacts WHERE id = $1', [support],
-      );
-      expect(rows[0]!.kg_node_id).toBe(orgNode);
+        const { rows } = await tx.query<{ kg_node_id: string | null }>(
+          'SELECT kg_node_id FROM contacts WHERE id = $1', [support],
+        );
+        expect(rows[0]!.kg_node_id).toBe(orgNode);
+      });
     });
 
     it('does not link an organization contact whose domain matches nothing', async () => {
       // Arm B then mints it one, rather than guessing at an unrelated organization.
-      const orphan = await insertContact({
-        displayName: `Nowhere Inc ${randomUUID()}`,
-        kind: 'organization',
-        primaryEmail: `hello@nowhere-${randomUUID().slice(0, 8)}.test`,
+      await inRolledBackTransaction(async (tx) => {
+        const orphan = await insertContact({
+          displayName: `Nowhere Inc ${randomUUID()}`,
+          kind: 'organization',
+          primaryEmail: `hello@nowhere-${randomUUID().slice(0, 8)}.test`,
+        }, tx);
+
+        await runBackfill(tx);
+
+        const { rows } = await tx.query<{ type: string; identity_source: string; source: string }>(
+          `SELECT n.type, n.identity_source, n.source
+             FROM contacts c JOIN kg_nodes n ON n.id = c.kg_node_id
+            WHERE c.id = $1`,
+          [orphan],
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.type).toBe('organization');
+        expect(rows[0]!.identity_source).toBe('contact');
+        expect(rows[0]!.source).toBe('migration_085');
       });
-
-      await runBackfill();
-
-      const { rows } = await pool.query<{ id: string; type: string; identity_source: string }>(
-        `SELECT n.id, n.type, n.identity_source
-           FROM contacts c JOIN kg_nodes n ON n.id = c.kg_node_id
-          WHERE c.id = $1`,
-        [orphan],
-      );
-      expect(rows).toHaveLength(1);
-      nodeIds.push(rows[0]!.id);
-      expect(rows[0]!.type).toBe('organization');
-      expect(rows[0]!.identity_source).toBe('contact');
     });
 
     it('leaves already-linked contacts untouched', async () => {
-      const nodeId = await insertNode({ label: `Linked ${randomUUID()}`, identitySource: 'contact' });
-      const contactId = await insertContact({ displayName: 'Linked', kgNodeId: nodeId });
+      await inRolledBackTransaction(async (tx) => {
+        const nodeId = await insertNode({ label: `Linked ${randomUUID()}`, identitySource: 'contact' }, tx);
+        const contactId = await insertContact({ displayName: 'Linked', kgNodeId: nodeId }, tx);
 
-      await runBackfill();
+        await runBackfill(tx);
 
-      const { rows } = await pool.query<{ kg_node_id: string | null }>(
-        'SELECT kg_node_id FROM contacts WHERE id = $1', [contactId],
+        const { rows } = await tx.query<{ kg_node_id: string | null }>(
+          'SELECT kg_node_id FROM contacts WHERE id = $1', [contactId],
+        );
+        expect(rows[0]!.kg_node_id).toBe(nodeId);
+      });
+    });
+
+    it('leaves nothing behind — the replay is rolled back', async () => {
+      // Guards the isolation itself: if the transaction wrapper regressed, this suite
+      // would start linking other suites' fixtures and minting untracked nodes.
+      let contactId = '';
+      await inRolledBackTransaction(async (tx) => {
+        contactId = await insertContact({ displayName: `Ephemeral ${randomUUID()}` }, tx);
+        await runBackfill(tx);
+      });
+
+      const { rows } = await pool.query('SELECT 1 FROM contacts WHERE id = $1', [contactId]);
+      expect(rows).toHaveLength(0);
+      const minted = await pool.query(
+        `SELECT 1 FROM kg_nodes WHERE properties->>'backfilled_for_contact' = $1`, [contactId],
       );
-      expect(rows[0]!.kg_node_id).toBe(nodeId);
+      expect(minted.rows).toHaveLength(0);
     });
   });
 
@@ -423,6 +499,60 @@ describeIf('contact-anchored KG node identity (ADR-040, migration 085)', () => {
       const byId = new Map(rows.map(r => [r.id, r]));
 
       expect(byId.get(anchored)!.archived_at).toBeNull();
+      expect(byId.get(labelTier)!.archived_at).not.toBeNull();
+    });
+
+    it('never warns an anchored node, however sensitive', async () => {
+      // The hole an earlier version of this change left open. Freezing decay does not RAISE
+      // confidence, so a node anchored while already below archiveThreshold stays below it.
+      // Without the filter on the warn pass, high sensitivity alone re-warns it every run.
+      const anchored = await insertNode({
+        label: `Sensitive ${randomUUID()}`, identitySource: 'contact', confidence: 0.01,
+      });
+      await pool.query(`UPDATE kg_nodes SET sensitivity = 'restricted' WHERE id = $1`, [anchored]);
+      const labelTier = await insertNode({
+        label: `SensitiveTwin ${randomUUID()}`, identitySource: 'label', confidence: 0.01,
+      });
+      await pool.query(`UPDATE kg_nodes SET sensitivity = 'restricted' WHERE id = $1`, [labelTier]);
+
+      await engine.runDecayPass();
+
+      const { rows } = await pool.query<{ id: string; warned_at: Date | null }>(
+        'SELECT id, warned_at FROM kg_nodes WHERE id = ANY($1::uuid[])', [[anchored, labelTier]],
+      );
+      const byId = new Map(rows.map(r => [r.id, r]));
+      expect(byId.get(anchored)!.warned_at).toBeNull();
+      // The label-tier control proves the warn pass fired at all this run.
+      expect(byId.get(labelTier)!.warned_at).not.toBeNull();
+    });
+
+    it('does not archive an anchored node whose warning has already expired', async () => {
+      // Pass 2a, reached across a second decay pass. A warning raised before the node was
+      // anchored (anchorNode clears warned_at, migration 085 clears the legacy rows, but a
+      // concurrent pass could still land one) must not become the surviving archival path.
+      const anchored = await insertNode({
+        label: `StaleWarned ${randomUUID()}`, identitySource: 'contact', confidence: 0.01,
+      });
+      const labelTier = await insertNode({
+        label: `StaleWarnedTwin ${randomUUID()}`, identitySource: 'label', confidence: 0.01,
+      });
+      // warnHoldBackDays is 30 in this suite's config, so 60 days is comfortably expired.
+      await pool.query(
+        `UPDATE kg_nodes
+            SET warned_at = now() - INTERVAL '60 days', warn_reason = 'high_sensitivity'
+          WHERE id = ANY($1::uuid[])`,
+        [[anchored, labelTier]],
+      );
+
+      await engine.runDecayPass();
+      await engine.runDecayPass();
+
+      const { rows } = await pool.query<{ id: string; archived_at: Date | null }>(
+        'SELECT id, archived_at FROM kg_nodes WHERE id = ANY($1::uuid[])', [[anchored, labelTier]],
+      );
+      const byId = new Map(rows.map(r => [r.id, r]));
+      expect(byId.get(anchored)!.archived_at).toBeNull();
+      // The label-tier control proves Pass 2a ran and did archive an expired warning.
       expect(byId.get(labelTier)!.archived_at).not.toBeNull();
     });
 

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -49,6 +49,7 @@ function createMocks() {
   const contactService = {
     resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
     createContact: vi.fn(),
+    createContactWithKgOutcome: vi.fn(),
     linkIdentity: vi.fn(),
   } as unknown as ContactService;
 
@@ -608,7 +609,8 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     const adapter = makeAdapter(mocks, { contactCreationMaxPerMessage: 3 });
 
     (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (mocks.contactService.createContact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'c1' });
+    (mocks.contactService.createContactWithKgOutcome as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ contact: { id: 'c1' }, kgNodeCreated: true });
     (mocks.contactService.linkIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     // 6 non-self participants (1 from + 5 CC)
@@ -619,7 +621,7 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     await flushPoll();
 
     // Only 3 contacts should be created (per-message cap of 3)
-    expect(mocks.contactService.createContact).toHaveBeenCalledTimes(3);
+    expect(mocks.contactService.createContactWithKgOutcome).toHaveBeenCalledTimes(3);
 
     await adapter.stop();
   });
@@ -629,7 +631,8 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     const adapter = makeAdapter(mocks, { contactCreationMaxPerHour: 2, contactCreationMaxPerMessage: 100 });
 
     (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (mocks.contactService.createContact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'c1' });
+    (mocks.contactService.createContactWithKgOutcome as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ contact: { id: 'c1' }, kgNodeCreated: true });
     (mocks.contactService.linkIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     // First email: 2 new participants (from + 1 CC) — creates 2, hits hourly cap
@@ -652,7 +655,7 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     await flushPoll();
 
     // Only 2 contacts created total (hourly cap of 2), not 3
-    expect(mocks.contactService.createContact).toHaveBeenCalledTimes(2);
+    expect(mocks.contactService.createContactWithKgOutcome).toHaveBeenCalledTimes(2);
 
     await adapter.stop();
   });
@@ -664,7 +667,8 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
       const adapter = makeAdapter(mocks, { contactCreationMaxPerHour: 1, contactCreationMaxPerMessage: 100 });
 
       (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-      (mocks.contactService.createContact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'c1' });
+      (mocks.contactService.createContactWithKgOutcome as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ contact: { id: 'c1' }, kgNodeCreated: true });
       (mocks.contactService.linkIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       // First poll: 1 new participant — hits hourly cap of 1
@@ -680,7 +684,7 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
       // setTimeout is fake — skip it and assert directly.
       await adapter.start();
 
-      expect(mocks.contactService.createContact).toHaveBeenCalledTimes(1);
+      expect(mocks.contactService.createContactWithKgOutcome).toHaveBeenCalledTimes(1);
 
       // Advance time by 1 hour + 1ms so the window resets
       vi.advanceTimersByTime(3_600_001);
@@ -695,7 +699,7 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
 
       await (adapter as unknown as { poll(): Promise<void> }).poll();
 
-      expect(mocks.contactService.createContact).toHaveBeenCalledTimes(2);
+      expect(mocks.contactService.createContactWithKgOutcome).toHaveBeenCalledTimes(2);
 
       await adapter.stop();
     } finally {
@@ -713,7 +717,8 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
       resolveCallCount++;
       return Promise.resolve(resolveCallCount <= 3 ? { id: 'existing' } : null);
     });
-    (mocks.contactService.createContact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'c1' });
+    (mocks.contactService.createContactWithKgOutcome as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ contact: { id: 'c1' }, kgNodeCreated: true });
     (mocks.contactService.linkIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     // 5 non-self participants (1 from + 4 CC)
@@ -724,7 +729,7 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     await flushPoll();
 
     // 3 existed, 2 are new — both new ones created (under the cap of 2)
-    expect(mocks.contactService.createContact).toHaveBeenCalledTimes(2);
+    expect(mocks.contactService.createContactWithKgOutcome).toHaveBeenCalledTimes(2);
 
     await adapter.stop();
   });
@@ -734,7 +739,8 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     const adapter = makeAdapter(mocks, { contactCreationMaxPerMessage: 1 });
 
     (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (mocks.contactService.createContact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'c1' });
+    (mocks.contactService.createContactWithKgOutcome as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ contact: { id: 'c1' }, kgNodeCreated: true });
     (mocks.contactService.linkIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     // 3 non-self participants (from + 2 CC), cap is 1 — 2 will be skipped
@@ -763,7 +769,8 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     const adapter = makeAdapter(mocks, { contactCreationMaxPerMessage: 1 });
 
     (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (mocks.contactService.createContact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'c1' });
+    (mocks.contactService.createContactWithKgOutcome as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ contact: { id: 'c1' }, kgNodeCreated: true });
     (mocks.contactService.linkIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     // Two emails that both trigger the per-message limit
@@ -795,7 +802,8 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     const adapter = makeAdapter(mocks, { contactCreationMaxPerMessage: 2, contactCreationMaxPerHour: 5 });
 
     (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (mocks.contactService.createContact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'c1' });
+    (mocks.contactService.createContactWithKgOutcome as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ contact: { id: 'c1' }, kgNodeCreated: true });
     (mocks.contactService.linkIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     // 4 non-self participants (1 from + 3 CC) — per-message cap of 2 should apply
@@ -805,7 +813,7 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     await adapter.start();
     await flushPoll();
 
-    expect(mocks.contactService.createContact).toHaveBeenCalledTimes(2);
+    expect(mocks.contactService.createContactWithKgOutcome).toHaveBeenCalledTimes(2);
 
     await adapter.stop();
   });

--- a/tests/unit/contacts/contact-anchored-identity.test.ts
+++ b/tests/unit/contacts/contact-anchored-identity.test.ts
@@ -15,18 +15,27 @@ import { EmbeddingService } from '../../../src/memory/embedding.js';
 import { EntityMemory } from '../../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../../src/memory/validation.js';
 import { createSilentLogger } from '../../../src/logger.js';
+import type { Logger } from '../../../src/logger.js';
 
 describe('contact-anchored KG node identity (ADR-040)', () => {
   let service: ContactService;
   let entityMemory: EntityMemory;
   let store: KnowledgeGraphStore;
+  // Captures warn/info messages. The previous increment of #1694 shipped a diagnostic at
+  // `debug` into a production running at `info` and produced no signal for weeks, so the
+  // load-bearing lines here are asserted rather than left to review.
+  let warnings: string[];
+  let logger: Logger;
 
   beforeEach(() => {
     const embeddingService = EmbeddingService.createForTesting();
     store = KnowledgeGraphStore.createInMemory(embeddingService);
     const validator = new MemoryValidator(store, embeddingService);
     entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
-    service = ContactService.createInMemory(entityMemory);
+    warnings = [];
+    const capture = (_obj: unknown, msg?: string) => { if (msg) warnings.push(msg); };
+    logger = { ...createSilentLogger(), warn: capture, info: capture } as unknown as Logger;
+    service = ContactService.createInMemory(entityMemory, undefined, logger);
   });
 
   describe('two contacts sharing a display name', () => {
@@ -326,12 +335,49 @@ describe('contact-anchored KG node identity (ADR-040)', () => {
         },
       }) as EntityMemory;
 
-      // Same in-memory contact store, different entityMemory — the delete must not throw.
-      const degraded = ContactService.createInMemory(failing);
+      // createInMemory builds a fresh backend each call, so `degraded` has its own contact
+      // store; the contact under test has to be created inside it.
+      const degraded = ContactService.createInMemory(failing, undefined, logger);
       const own = await degraded.createContact({ displayName: 'Dana Wu', source: 'test' });
+
       await expect(degraded.deleteContact(own.id)).resolves.toBeUndefined();
+
+      // The delete is what must survive — and the failure must be visible, not swallowed.
       expect(await degraded.getContact(own.id)).toBeUndefined();
+      expect(warnings.some(w => /node is now orphaned/.test(w))).toBe(true);
       expect(contact.kgNodeId).not.toBeNull();
+    });
+
+    it('does not archive the node during orphan cleanup', async () => {
+      // The three real deleteContact callers are all orphan cleanup after a failed
+      // linkIdentity, and createContact may have ADOPTED a node carrying facts accrued
+      // long before this attempt. Archiving cascades to incident edges, so cleaning up
+      // would destroy knowledge that was never this contact's to take.
+      const { entity } = await entityMemory.createEntity({
+        type: 'person', label: 'Dana Wu', properties: {}, source: 'extraction',
+      });
+      await entityMemory.storeFact({
+        entityNodeId: entity.id, label: 'Prefers morning meetings', source: 'extraction',
+      });
+      const contact = await service.createContact({ displayName: 'Dana Wu', source: 'test' });
+      expect(contact.kgNodeId).toBe(entity.id);
+
+      await service.deleteContact(contact.id, { archiveAnchoredNode: false });
+
+      expect(await store.getNode(entity.id)).toBeDefined();
+      expect((await entityMemory.getFacts(entity.id)).map(f => f.label))
+        .toEqual(['Prefers morning meetings']);
+    });
+
+    it('reports the node it deliberately left behind during orphan cleanup', async () => {
+      // Skipping the archive leaks an anchored node that no longer decays, so the leak
+      // has to be visible rather than silent.
+      const svc = ContactService.createInMemory(entityMemory, undefined, logger);
+      const contact = await svc.createContact({ displayName: 'Dana Wu', source: 'test' });
+
+      await svc.deleteContact(contact.id, { archiveAnchoredNode: false });
+
+      expect(warnings.some(w => /without archiving its KG node/.test(w))).toBe(true);
     });
   });
 });

--- a/tests/unit/contacts/contact-anchored-identity.test.ts
+++ b/tests/unit/contacts/contact-anchored-identity.test.ts
@@ -305,6 +305,52 @@ describe('contact-anchored KG node identity (ADR-040)', () => {
       expect(await store.getNode(nodeId)).toBeDefined();
     });
 
+    it('reports mint-vs-adopt so orphan cleanup can tell them apart', async () => {
+      // The distinction the three orphan-cleanup callers branch on. A minted node is
+      // anchored and never decays, so abandoning it leaks; an adopted one may carry facts
+      // from before this contact existed, so removing it destroys them.
+      const { entity } = await entityMemory.createEntity({
+        type: 'person', label: 'Dana Wu', properties: {}, source: 'extraction',
+      });
+
+      const adopted = await service.createContactWithKgOutcome({
+        displayName: 'Dana Wu', source: 'test',
+      });
+      expect(adopted.contact.kgNodeId).toBe(entity.id);
+      expect(adopted.kgNodeCreated).toBe(false);
+
+      const minted = await service.createContactWithKgOutcome({
+        displayName: 'Someone New', source: 'test',
+      });
+      expect(minted.kgNodeCreated).toBe(true);
+
+      // A shared organization node is neither minted here nor ours to retire.
+      const org = await service.createContactWithKgOutcome({
+        displayName: 'Acme', primaryEmail: 'info@acme.com', source: 'test',
+      });
+      expect(org.kgNodeCreated).toBe(false);
+    });
+
+    it('retires a minted node on orphan cleanup but keeps an adopted one', async () => {
+      const { entity } = await entityMemory.createEntity({
+        type: 'person', label: 'Dana Wu', properties: {}, source: 'extraction',
+      });
+      const adopted = await service.createContactWithKgOutcome({
+        displayName: 'Dana Wu', source: 'test',
+      });
+      const minted = await service.createContactWithKgOutcome({
+        displayName: 'Someone New', source: 'test',
+      });
+
+      await service.deleteContact(adopted.contact.id, { archiveAnchoredNode: adopted.kgNodeCreated });
+      await service.deleteContact(minted.contact.id, { archiveAnchoredNode: minted.kgNodeCreated });
+
+      // Adopted survives — it predates this contact.
+      expect(await store.getNode(entity.id)).toBeDefined();
+      // Minted goes with the contact it was minted for, rather than leaking forever.
+      expect(await store.getNode(minted.contact.kgNodeId!)).toBeUndefined();
+    });
+
     it('leaves an anchored node alone while another contact still points at it', async () => {
       // Organization contacts are exempt from idx_contacts_kg_node_unique, so several can
       // share one node — including an anchored one minted by migration 085's backfill.

--- a/tests/unit/contacts/contact-anchored-identity.test.ts
+++ b/tests/unit/contacts/contact-anchored-identity.test.ts
@@ -1,0 +1,337 @@
+// Contact-anchored KG node identity (ADR-040, #1694).
+//
+// Before this, a second contact sharing a display name collided on
+// idx_contacts_kg_node_unique and was stored with kg_node_id = NULL — unable to hold
+// facts, relationships, or entity-context enrichment, and silent about it (#1623).
+//
+// The migration-level halves (the backfill, the index predicates themselves, and the
+// DreamEngine exclusion) are covered in tests/integration/contact-anchored-identity.test.ts,
+// which needs a real Postgres.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ContactService } from '../../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../../src/memory/embedding.js';
+import { EntityMemory } from '../../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../../src/memory/validation.js';
+import { createSilentLogger } from '../../../src/logger.js';
+
+describe('contact-anchored KG node identity (ADR-040)', () => {
+  let service: ContactService;
+  let entityMemory: EntityMemory;
+  let store: KnowledgeGraphStore;
+
+  beforeEach(() => {
+    const embeddingService = EmbeddingService.createForTesting();
+    store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+    service = ContactService.createInMemory(entityMemory);
+  });
+
+  describe('two contacts sharing a display name', () => {
+    it('each hold their own node instead of the second going nodeless', async () => {
+      const first = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const second = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+
+      expect(first.kgNodeId).not.toBeNull();
+      expect(second.kgNodeId).not.toBeNull();
+      expect(second.kgNodeId).not.toBe(first.kgNodeId);
+    });
+
+    it('anchors the second node rather than leaving it in the label tier', async () => {
+      // The first create adopts the label tier by minting anchored; the second cannot
+      // adopt (the match is anchored) and must mint its own anchored node.
+      const first = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const second = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+
+      expect((await store.getNode(first.kgNodeId!))?.identitySource).toBe('contact');
+      expect((await store.getNode(second.kgNodeId!))?.identitySource).toBe('contact');
+    });
+
+    it('keeps their facts separate — storing on one does not leak onto the namesake', async () => {
+      const first = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const second = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+
+      await entityMemory.storeFact({
+        entityNodeId: first.kgNodeId!,
+        label: 'Runs the Vancouver office',
+        source: 'test',
+      });
+      await entityMemory.storeFact({
+        entityNodeId: second.kgNodeId!,
+        label: 'Chairs the audit committee',
+        source: 'test',
+      });
+
+      const firstFacts = (await entityMemory.getFacts(first.kgNodeId!)).map(f => f.label);
+      const secondFacts = (await entityMemory.getFacts(second.kgNodeId!)).map(f => f.label);
+
+      expect(firstFacts).toEqual(['Runs the Vancouver office']);
+      expect(secondFacts).toEqual(['Chairs the audit committee']);
+    });
+
+    it('gives each an independent relationship graph', async () => {
+      const first = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const second = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const acme = await entityMemory.createEntity({
+        type: 'organization', label: 'Acme', properties: {}, source: 'test',
+      });
+
+      await entityMemory.link(first.kgNodeId!, acme.entity.id, 'member_of', {}, 'test');
+
+      expect(await entityMemory.findEdges(first.kgNodeId!)).toHaveLength(1);
+      expect(await entityMemory.findEdges(second.kgNodeId!)).toHaveLength(0);
+    });
+  });
+
+  describe('adoption', () => {
+    it('adopts an unanchored node so the contact inherits what Curia already knew', async () => {
+      // Curia learns about Dana from an email body, then Dana emails in.
+      const { entity } = await entityMemory.createEntity({
+        type: 'person', label: 'Dana Wu', properties: {}, source: 'extraction',
+      });
+      await entityMemory.storeFact({
+        entityNodeId: entity.id, label: 'Prefers morning meetings', source: 'extraction',
+      });
+
+      const contact = await service.createContact({ displayName: 'Dana Wu', source: 'test' });
+
+      expect(contact.kgNodeId).toBe(entity.id);
+      expect((await store.getNode(entity.id))?.identitySource).toBe('contact');
+      expect((await entityMemory.getFacts(entity.id)).map(f => f.label))
+        .toEqual(['Prefers morning meetings']);
+    });
+
+    it('applies the role to an adopted node that had none', async () => {
+      const { entity } = await entityMemory.createEntity({
+        type: 'person', label: 'Dana Wu', properties: {}, source: 'extraction',
+      });
+
+      await service.createContact({ displayName: 'Dana Wu', role: 'CFO', source: 'test' });
+
+      expect((await store.getNode(entity.id))?.properties['role']).toBe('CFO');
+    });
+
+    it('does not overwrite a role the adopted node already carried', async () => {
+      const { entity } = await entityMemory.createEntity({
+        type: 'person', label: 'Dana Wu', properties: { role: 'Founder' }, source: 'extraction',
+      });
+
+      await service.createContact({ displayName: 'Dana Wu', role: 'CFO', source: 'test' });
+
+      expect((await store.getNode(entity.id))?.properties['role']).toBe('Founder');
+    });
+
+    it('never takes a node that already belongs to another contact', async () => {
+      const owner = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const newcomer = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+
+      expect(newcomer.kgNodeId).not.toBe(owner.kgNodeId);
+      // And the owner keeps theirs.
+      const reread = await service.getContact(owner.id);
+      expect(reread?.kgNodeId).toBe(owner.kgNodeId);
+    });
+
+    it('mints rather than guessing when several unanchored nodes share the label', async () => {
+      // Reachable via aliases, which carry no cross-node uniqueness: two person nodes can
+      // both answer to "Sam". Picking one would be the silent first-match guess #1705
+      // removed from resolveOrCreate.
+      const a = await store.createNode({ type: 'person', label: 'Sam Alpha', properties: {}, source: 'test' });
+      const b = await store.createNode({ type: 'person', label: 'Sam Beta', properties: {}, source: 'test' });
+      await entityMemory.addAlias(a.id, 'Sam');
+      await entityMemory.addAlias(b.id, 'Sam');
+
+      const contact = await service.createContact({ displayName: 'Sam', source: 'test' });
+
+      expect(contact.kgNodeId).not.toBe(a.id);
+      expect(contact.kgNodeId).not.toBe(b.id);
+      expect((await store.getNode(contact.kgNodeId!))?.identitySource).toBe('contact');
+      // Neither candidate was quietly claimed.
+      expect((await store.getNode(a.id))?.identitySource).toBe('label');
+      expect((await store.getNode(b.id))?.identitySource).toBe('label');
+    });
+
+    it('ignores nodes of another type — "River" the org is not "River" the person', async () => {
+      const { entity: org } = await entityMemory.createEntity({
+        type: 'organization', label: 'River', properties: {}, source: 'test',
+      });
+
+      const contact = await service.createContact({ displayName: 'River', source: 'test' });
+
+      expect(contact.kgNodeId).not.toBe(org.id);
+      expect((await store.getNode(org.id))?.identitySource).toBe('label');
+    });
+
+    it('mints a fresh node when the KG lookup fails rather than failing the create', async () => {
+      // A KG outage must cost an inheritance, never a contact.
+      const failing = new Proxy(entityMemory, {
+        get(target, prop, receiver) {
+          if (prop === 'findEntities') {
+            return async () => { throw new Error('kg unavailable'); };
+          }
+          return Reflect.get(target, prop, receiver) as unknown;
+        },
+      }) as EntityMemory;
+      const degraded = ContactService.createInMemory(failing);
+
+      const contact = await degraded.createContact({ displayName: 'Dana Wu', source: 'test' });
+
+      expect(contact.kgNodeId).not.toBeNull();
+      expect((await store.getNode(contact.kgNodeId!))?.identitySource).toBe('contact');
+    });
+  });
+
+  describe('link collision recovery', () => {
+    it('mints a fresh anchored node instead of storing the contact nodeless', async () => {
+      // The 23505 path: the node we resolved was claimed between lookup and INSERT.
+      // Forced here by handing createContact a node another contact already holds.
+      // Before ADR-040 this produced kg_node_id = NULL and a contact that could hold
+      // nothing — the exact failure #1694 exists to remove.
+      const owner = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+
+      const loser = await service.createContact({
+        displayName: 'Seth Berman', kgNodeId: owner.kgNodeId!, source: 'test',
+      });
+
+      expect(loser.kgNodeId).not.toBeNull();
+      expect(loser.kgNodeId).not.toBe(owner.kgNodeId);
+      expect((await store.getNode(loser.kgNodeId!))?.identitySource).toBe('contact');
+      // The contact is persisted with the replacement, not just returned with it.
+      expect((await service.getContact(loser.id))?.kgNodeId).toBe(loser.kgNodeId);
+    });
+
+    it('can hold facts on the replacement node', async () => {
+      const owner = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const loser = await service.createContact({
+        displayName: 'Seth Berman', kgNodeId: owner.kgNodeId!, source: 'test',
+      });
+
+      await entityMemory.storeFact({
+        entityNodeId: loser.kgNodeId!, label: 'Chairs the audit committee', source: 'test',
+      });
+
+      expect((await entityMemory.getFacts(loser.kgNodeId!)).map(f => f.label))
+        .toEqual(['Chairs the audit committee']);
+      expect(await entityMemory.getFacts(owner.kgNodeId!)).toHaveLength(0);
+    });
+
+    it('falls back to a nodeless contact only when minting also fails', async () => {
+      const owner = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
+      const failing = new Proxy(entityMemory, {
+        get(target, prop, receiver) {
+          if (prop === 'createAnchoredEntity') {
+            return async () => { throw new Error('kg unavailable'); };
+          }
+          return Reflect.get(target, prop, receiver) as unknown;
+        },
+      }) as EntityMemory;
+      const degraded = ContactService.createInMemory(failing);
+      const existing = await degraded.createContact({
+        displayName: 'Seth Berman', kgNodeId: owner.kgNodeId!, source: 'test',
+      });
+
+      const loser = await degraded.createContact({
+        displayName: 'Seth Berman', kgNodeId: existing.kgNodeId ?? owner.kgNodeId!, source: 'test',
+      });
+
+      expect(loser.kgNodeId).toBeNull();
+    });
+  });
+
+  describe('organization contacts', () => {
+    it('lets several role addresses at one domain share their organization node', async () => {
+      const info = await service.createContact({
+        displayName: 'Acme', primaryEmail: 'info@acme.com', source: 'test',
+      });
+      const support = await service.createContact({
+        displayName: 'Acme', primaryEmail: 'support@acme.com', source: 'test',
+      });
+
+      expect(info.kind).toBe('organization');
+      expect(support.kind).toBe('organization');
+      expect(support.kgNodeId).toBe(info.kgNodeId);
+      expect(support.kgNodeId).not.toBeNull();
+    });
+
+    it('leaves the shared organization node in the label tier', async () => {
+      // Org nodes outlive any one contact and are legitimately shared, so they keep
+      // label identity and stay deduplicated by (lower(label), type).
+      const info = await service.createContact({
+        displayName: 'Acme', primaryEmail: 'info@acme.com', source: 'test',
+      });
+
+      expect((await store.getNode(info.kgNodeId!))?.identitySource).toBe('label');
+    });
+  });
+
+  describe('deleteContact', () => {
+    it('archives the anchored node — its whole meaning was that contact', async () => {
+      const contact = await service.createContact({ displayName: 'Dana Wu', source: 'test' });
+      const nodeId = contact.kgNodeId!;
+
+      await service.deleteContact(contact.id);
+
+      expect(await store.getNode(nodeId)).toBeUndefined();
+    });
+
+    it('frees the label for reuse — a later namesake can be created cleanly', async () => {
+      const first = await service.createContact({ displayName: 'Dana Wu', source: 'test' });
+      await service.deleteContact(first.id);
+
+      const second = await service.createContact({ displayName: 'Dana Wu', source: 'test' });
+
+      expect(second.kgNodeId).not.toBeNull();
+      expect(second.kgNodeId).not.toBe(first.kgNodeId);
+    });
+
+    it('leaves a label-tier node alone — an organization outlives its contacts', async () => {
+      const contact = await service.createContact({
+        displayName: 'Acme', primaryEmail: 'info@acme.com', source: 'test',
+      });
+      const nodeId = contact.kgNodeId!;
+
+      await service.deleteContact(contact.id);
+
+      expect(await store.getNode(nodeId)).toBeDefined();
+    });
+
+    it('leaves an anchored node alone while another contact still points at it', async () => {
+      // Organization contacts are exempt from idx_contacts_kg_node_unique, so several can
+      // share one node — including an anchored one minted by migration 085's backfill.
+      const shared = await store.createNode({
+        type: 'organization', label: 'Acme', properties: {}, source: 'migration_085',
+        identitySource: 'contact',
+      });
+      const a = await service.createContact({
+        displayName: 'Acme A', kind: 'organization', kgNodeId: shared.id, source: 'test',
+      });
+      await service.createContact({
+        displayName: 'Acme B', kind: 'organization', kgNodeId: shared.id, source: 'test',
+      });
+
+      await service.deleteContact(a.id);
+
+      expect(await store.getNode(shared.id)).toBeDefined();
+    });
+
+    it('still deletes the contact when archiving its node fails', async () => {
+      const contact = await service.createContact({ displayName: 'Dana Wu', source: 'test' });
+      const failing = new Proxy(entityMemory, {
+        get(target, prop, receiver) {
+          if (prop === 'archiveEntity') {
+            return async () => { throw new Error('kg unavailable'); };
+          }
+          return Reflect.get(target, prop, receiver) as unknown;
+        },
+      }) as EntityMemory;
+
+      // Same in-memory contact store, different entityMemory — the delete must not throw.
+      const degraded = ContactService.createInMemory(failing);
+      const own = await degraded.createContact({ displayName: 'Dana Wu', source: 'test' });
+      await expect(degraded.deleteContact(own.id)).resolves.toBeUndefined();
+      expect(await degraded.getContact(own.id)).toBeUndefined();
+      expect(contact.kgNodeId).not.toBeNull();
+    });
+  });
+});

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -1341,15 +1341,17 @@ describe('ContactService', () => {
     });
 
     it('works when BOTH contacts have kg_node_id = NULL (#1623 regression)', async () => {
-      // Two contacts sharing a display name: createContact drops the KG link on the
-      // second one because of idx_contacts_kg_node_unique. That pair could not hold a
-      // KG-fact exclusion at all — the whole reason exclusions moved to a table.
+      // Two contacts sharing a display name used to leave the second with no KG link,
+      // and that pair could not hold a KG-fact exclusion at all — the whole reason
+      // exclusions moved to a table. ADR-040 gives them both a node, so the null case is
+      // now forced explicitly rather than produced by the collision. The exclusion table
+      // must still work for it: nodeless contacts remain reachable through migration
+      // gaps, KG outages during create, and older rows.
       const a = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
       const b = await service.createContact({ displayName: 'Seth Berman', source: 'test' });
-      expect(b.kgNodeId).toBeNull();
 
-      // Force the null-node case on both sides.
       await service.saveContact({ ...a, kgNodeId: null });
+      await service.saveContact({ ...b, kgNodeId: null });
 
       const { created } = await service.addDedupExclusion(a.id, b.id, 'ceo');
       expect(created).toBe(true);


### PR DESCRIPTION
## Summary

Increment 3 of #1694 — the whole remaining schema change, in one migration. **Closes #1694.**

A KG node that backs a contact is now identified by that contact, not by its label. Nodes that back no contact keep `(lower(label), type)` identity exactly as before. The tier lives on `kg_nodes.identity_source`, so Postgres enforces the split rather than convention maintained across N call sites.

Before this, a second contact sharing a display name collided on `idx_contacts_kg_node_unique` and was stored with `kg_node_id = NULL` — unable to hold facts, relationships, or entity-context enrichment, and silent about it (#1623).

Design in [ADR-040](https://github.com/josephfung/curia/blob/main/docs/adr/040-contact-anchored-kg-node-identity.md). Increments 1 (#1701, visibility + measurement) and 2 (#1705, ambiguity) are already merged.

## Migration 085

| Step | What |
|---|---|
| 1 | `identity_source TEXT NOT NULL DEFAULT 'label' CHECK (IN ('label','contact'))` |
| 2 | Promote existing contact-linked nodes to the anchored tier — **except organization nodes**, which are legitimately shared by several role addresses and stay label-keyed |
| 2b | Clear decay warnings on the newly anchored nodes (see *DreamEngine* below) |
| 3 | Narrow `idx_kg_nodes_unique` to `identity_source = 'label'` |
| 4 | Exempt `kind = 'organization'` from `idx_contacts_kg_node_unique` |
| 5 | **Arm A** — re-link nodeless org contacts to their domain's org node |
| 6 | **Arm B** — mint one anchored node per remaining nodeless contact |

Both new index predicates are **strict subsets** of the ones they replace, so neither `CREATE UNIQUE INDEX` can fail on rows the previous index already accepted. Arm B mints anchored nodes, which sit outside `idx_kg_nodes_unique`, so it cannot raise a unique violation however many contacts share a name. Between them, migration 085 has no path to a unique-violation failure — the property that matters most after migration 070 crash-looped prod on a migration that passed against empty CI databases.

Arm B mints **one node per contact, not per display name**. Migration 056 did the latter, which is precisely why 12 same-name contacts were left nodeless.

Sizing is measured, not assumed — `scripts/kg-node-linkage-report.ts` against production on 2026-09-02: 548 contacts, 14 nodeless, arm A **0**, arm B **14**.

## Behaviour

**`createContact` — adopt, don't blindly create.** Adopts an unanchored node whose label matches, otherwise mints a fresh anchored one, and never takes a node that already belongs to another contact. Adoption is what preserves the good part of the old behaviour: Curia learns about "Dana Wu" from an email body, Dana emails in, and the new contact inherits her accumulated facts rather than starting empty. Adoption is a compare-and-set inside the store, so two contacts racing for one node cannot both win.

It mints rather than guessing in two cases worth calling out: when several *unanchored* candidates share the label (reachable via aliases, which carry no cross-node uniqueness), and when the KG lookup itself fails. A KG outage costs an inheritance, never a contact.

**Link collisions mint instead of dropping.** The `23505` retry now creates a fresh anchored node. This is the direct repair of the behaviour the issue exists to remove — a collision must never again produce a nodeless contact.

**`deleteContact` archives the anchored node**, but only when `identity_source = 'contact'` *and* no other contact still references it. The second guard matters: organization contacts are exempt from `idx_contacts_kg_node_unique`, so several can share one node, and deleting one of them must not archive the node the others are using. Archiving (not deleting) frees the label for reuse and leaves the knowledge recoverable in SQL.

**`DreamEngine` skips anchored nodes** in passes 1a, 1b and 2b. The reason is stronger than the ADR first assumed: *nothing* refreshes an entity node's `last_confirmed_at` through ordinary interaction — `storeFact`'s `updateNode` targets the fact node, not the entity — so decay there is monotonic and universal. A contact emailed daily ages at exactly the rate of one met once. Measured in production: 532 of 534 contact nodes non-permanent, **478 archivable with no warning at all**. Facts hanging off an anchored node are label-tier and keep decaying, so this bounds the anchor, not memory.

Pass 2a needs no predicate — warning requires confidence at the archive threshold, which an undecayed anchored node never reaches — but that reasoning only holds for warnings raised *from here on*, so step 2b of the migration retires the ones already in flight.

**`upsertNode` is the label-keyed path, exclusively.** It hardcodes `identity_source = 'label'` and its `ON CONFLICT` predicate matches the narrowed index, so no caller can upsert its way onto somebody's anchored node. This is the seam where the two tiers would otherwise leak into each other, and it has coverage on both backends.

## Two callers that would otherwise have broken outright

Both infer a partial index by repeating its predicate verbatim. Change the index without changing them and Postgres raises **42P10** — not a subtle regression, a hard startup failure.

- `src/entity-context/bootstrap.ts` — the agent-identity `ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL` now repeats the `kind <> 'organization'` clause. This runs on **every startup**.
- `src/contacts/ceo-bootstrap.ts` — `insertKgPersonNode` could not keep using `ON CONFLICT` at all: an anchored row is not in the index, so the arbiter would never match and the upsert would silently always insert. Rewritten as the same adopt-or-mint rule, with the CAS supplied by the `identity_source = 'label'` predicate. `createAndLinkKgNode` gains the loser-path orphan cleanup that `ensure-principal.ts` already had, since anchored nodes no longer collide their way to the same row.

## Tests

- `tests/unit/contacts/contact-anchored-identity.test.ts` (21) — same-name contacts holding independent facts and relationships; adoption incl. role handling, type mismatch, multi-candidate, and KG failure; org contacts sharing a node; the collision-mints-a-replacement path; deletion archival and its two guards.
- `src/memory/knowledge-graph.identity-source.test.ts` (11) — the tier invariants against the in-memory backend, including `upsertNode` refusing to merge onto an anchored node and `anchorNode`'s CAS.
- `tests/integration/contact-anchored-identity.test.ts` (20) — the half only real Postgres can prove: index definitions read from `pg_indexes`, the `CHECK` constraint, uniqueness in both tiers, `ON CONFLICT` still inferring the narrowed index, the DreamEngine exclusion, and **the migration's own backfill arms** — extracted from the shipped `.sql` rather than paraphrased, so the test fails if the migration changes shape.
- `tests/integration/ceo-bootstrap.test.ts` — existing cases pass unchanged under adopt-or-mint; two assertions added to pin that the principal's node comes out anchored.

Full unit suite green (6110 passed). Typecheck and lint clean.

**Verified in CI against real Postgres.** Migration `085` applied clean (`### MIGRATION 085_contact_anchored_kg_identity (UP) ###`) and the integration suite ran rather than skipping — 20 tests passed. 540 test files passed, 3 skipped. It could not be run locally (Docker Desktop paused, no native Postgres), so CI is the gate that closed this.

## Also in here

ADR-040's *Backfill* section claimed the backfill would let contact merges carry KG memory. The precondition is right and the conclusion is wrong: `mergeEntities` hard-deletes the secondary node while the secondary contact still references it, and `contacts.kg_node_id` is a `NO ACTION` FK, so the `23503` is swallowed by a best-effort catch. Pre-existing and already near-universal (534 of 548 contacts were linked before this), so the backfill neither causes nor cures it. ADR corrected; filed as #1711.

## Related

- #1694 (closes), ADR-040, PR #1700 / #1701 / #1704 / #1705 / #1708
- #1623 (the incident), #1625 / ADR-039 (named this as the remaining gap)
- #1707 (entity-context read path ignores `archived_at`) — adjacent, and made load-bearing by the deletion rule here
- #1711 (contact merge loses KG memory on an FK violation) — found while writing this
- Migrations 010, 016, 027, 056 (the indexes and backfills this supersedes or amends)

