### PR TITLE
fix(contacts): fold secondary KG memory after contact-merge commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Contact merge** — secondary KG memory folds into the survivor after the contact delete. (#1711)
 - **`entity-context` assembler** — archived nodes, facts, and edges no longer assemble. (#1707)
 - **`entity-context` cache** — an archived node is re-checked before a TTL hit is served. (#1707)
 - **`DreamEngine`** — flushes entity-context cache after a decay pass archives. (#1707)

--- a/docs/adr/040-contact-anchored-kg-node-identity.md
+++ b/docs/adr/040-contact-anchored-kg-node-identity.md
@@ -230,12 +230,13 @@ contacts might be one person. That is the dedup sweep's job.
 
 An earlier draft of this ADR claimed the backfill also makes contact merges carry KG memory,
 because `mergeContacts` only calls `mergeEntities` when *both* sides have a node. The
-precondition is right and the conclusion is wrong. `mergeEntities` hard-`DELETE`s the
-secondary node while the secondary contact still points at it, and `contacts.kg_node_id`
-is a `NO ACTION` foreign key, so the delete raises `23503` and the merge is swallowed as
-"KG node merge failed (non-fatal)". This is pre-existing and already near-universal —
-534 of 548 contacts were linked before `085` — so the backfill neither causes it nor cures
-it. Tracked separately in #1711; until that lands, a contact merge still loses KG memory.
+precondition is right and the conclusion was wrong: `mergeEntities` hard-`DELETE`s the
+secondary node, and `contacts.kg_node_id` is a `NO ACTION` foreign key, so calling it
+*before* the contact-merge transaction raised `23503` and the failure was swallowed as
+"KG node merge failed (non-fatal)". That was pre-existing and already near-universal —
+534 of 548 contacts were linked before `085` — so the backfill neither caused it nor
+cured it. #1711 moved `mergeEntities` to after the secondary contact row is gone, so a
+merge of two linked contacts now folds facts, aliases and edges into the survivor.
 
 ### Rejected alternatives
 

--- a/docs/specs/09-contacts-and-identity.md
+++ b/docs/specs/09-contacts-and-identity.md
@@ -574,7 +574,7 @@ Contact CRUD operations are exposed as skills, invoked by the Coordinator during
 | `contact.lookup` | Look up a contact by name, role, or channel identifier |
 | `contact.list` | List contacts filtered by role, `tier`, or `kind`, with limit/offset. Default view excludes `automated` and `agent` contacts. Filtering is DB-level for performance. |
 | `contact.set-tier` | Set a contact's `tier` directly ("treat Dana as trusted"); principal-auth guarded, rejects `tier='principal'`. |
-| `contact.merge` | Merge two contacts into one (consolidates channel identities, overrides, and KG memory) |
+| `contact.merge` | Merge two contacts into one (channel identities and overrides always; KG memory fold is best-effort — on failure the merge stays committed and the secondary node is archived) |
 
 All contact mutations are audit-logged. The Coordinator confirms changes with the CEO before writing:
 

--- a/docs/specs/09-contacts-and-identity.md
+++ b/docs/specs/09-contacts-and-identity.md
@@ -574,7 +574,7 @@ Contact CRUD operations are exposed as skills, invoked by the Coordinator during
 | `contact.lookup` | Look up a contact by name, role, or channel identifier |
 | `contact.list` | List contacts filtered by role, `tier`, or `kind`, with limit/offset. Default view excludes `automated` and `agent` contacts. Filtering is DB-level for performance. |
 | `contact.set-tier` | Set a contact's `tier` directly ("treat Dana as trusted"); principal-auth guarded, rejects `tier='principal'`. |
-| `contact.merge` | Merge two contacts into one (consolidates channel identities and overrides) |
+| `contact.merge` | Merge two contacts into one (consolidates channel identities, overrides, and KG memory) |
 
 All contact mutations are audit-logged. The Coordinator confirms changes with the CEO before writing:
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1585,7 +1585,9 @@ export class ContactService {
    * - tier: blocked-on-either-side wins (most restrictive); otherwise the higher TIER_RANK
    * - channel identities: union (duplicates discarded)
    * - auth overrides: union (primary wins on same-permission conflict)
-   * - KG nodes: merged via entityMemory.mergeEntities() (Phase 1: scalar + facts)
+   * - KG nodes: merged via entityMemory.mergeEntities() after the secondary
+   *   contact row is deleted, so the node delete is not blocked by the
+   *   contacts.kg_node_id foreign key (#1711)
    *
    * @param dryRun - if true, return proposal without writing (default: false)
    */
@@ -1647,35 +1649,20 @@ export class ContactService {
       this.logger?.warn({ err, primaryId, secondaryId }, 'contacts: dedup exclusion check failed before merge (non-fatal)');
     }
 
-    // Merge KG nodes (best-effort — failure does not abort the contact merge).
-    //
-    // This currently fails on essentially every merge: mergeEntities ends by hard-deleting
-    // the secondary node while the secondary contact still references it, and
-    // contacts.kg_node_id is a NO ACTION foreign key, so Postgres raises 23503 (#1711).
-    // Track the outcome — since ADR-040 the secondary's node is anchored, and an anchored
-    // node excluded from every decay and archival pass would otherwise survive forever with
-    // no contact pointing at it. Two same-label person nodes make resolveOrCreate return
-    // 'ambiguous', so extract-facts would then drop every fact about that name: merging two
-    // contacts to consolidate their memory would stop memory being written about them.
-    let kgMerged = false;
-    if (primary.kgNodeId && secondary.kgNodeId && this.entityMemory) {
-      try {
-        await this.entityMemory.mergeEntities(primary.kgNodeId, secondary.kgNodeId);
-        kgMerged = true;
-      } catch (err) {
-        this.logger?.warn({ err, primaryId, secondaryId, primaryKgNodeId: primary.kgNodeId, secondaryKgNodeId: secondary.kgNodeId }, 'KG node merge failed (non-fatal)');
-      }
-    }
-
     // The whole write sequence runs on one client inside one transaction (#1695).
     // Before that it was five independent pool queries, so a failure part-way could
     // leave the secondary alive with its identities, auth overrides and CEO dedup
     // rulings already re-pointed onto the survivor — the next sweep would then see the
     // secondary again with none of its "not the same person" rulings attached.
     //
-    // Deliberately outside the transaction: the KG mergeEntities call above (a different
-    // store, documented as best-effort) and the notifications below, which must describe
-    // committed state only.
+    // Deliberately outside the transaction: KG mergeEntities (a different store,
+    // documented as best-effort) and the notifications below, which must describe
+    // committed state only. mergeEntities runs AFTER this commit — it ends by
+    // hard-deleting the secondary node, and contacts.kg_node_id is a NO ACTION
+    // foreign key, so the delete raises 23503 while the secondary contact still
+    // points at that node (#1711). Waiting until the contact row is gone unblocks
+    // the node delete, and a rolled-back contact merge cannot have already
+    // collapsed the two KG nodes.
     let exclusions: ReattachExclusionsResult;
     try {
       exclusions = await this.backend.withTransaction(async (client) => {
@@ -1709,13 +1696,33 @@ export class ContactService {
     } catch (err) {
       // One transaction, so the failure rolled the whole sequence back: both contacts,
       // their identities, auth overrides and exclusion rows are exactly as they were and
-      // the merge can simply be retried. The KG node merge above is the one thing not
-      // covered — it may already have collapsed the two nodes.
+      // the merge can simply be retried. KG nodes are untouched — mergeEntities runs
+      // only after this commit (#1711).
       this.logger?.error(
         { err, primaryId, secondaryId },
-        'Contact merge rolled back — no contact rows changed; a KG node merge may already have been applied (#1695)',
+        'Contact merge rolled back — no contact rows changed; KG nodes were not touched (#1695)',
       );
       throw err;
+    }
+
+    // Merge KG nodes (best-effort — failure does not abort the already-committed
+    // contact merge). Track the outcome: since ADR-040 the secondary's node is
+    // anchored, and an anchored node excluded from every decay and archival pass
+    // would otherwise survive forever with no contact pointing at it. Two
+    // same-label person nodes make resolveOrCreate return 'ambiguous', so
+    // extract-facts would then drop every fact about that name.
+    //
+    // Node ids were captured on the Contact objects loaded before the
+    // transaction; the secondary contact row is now gone, so the FK no longer
+    // blocks deleteNode (#1711).
+    let kgMerged = false;
+    if (primary.kgNodeId && secondary.kgNodeId && this.entityMemory) {
+      try {
+        await this.entityMemory.mergeEntities(primary.kgNodeId, secondary.kgNodeId);
+        kgMerged = true;
+      } catch (err) {
+        this.logger?.warn({ err, primaryId, secondaryId, primaryKgNodeId: primary.kgNodeId, secondaryKgNodeId: secondary.kgNodeId }, 'KG node merge failed (non-fatal)');
+      }
     }
 
     // The secondary contact row is now gone. If the KG merge did not fold its node into the
@@ -1862,8 +1869,8 @@ export class ContactService {
    * `scripts/kg-node-linkage-report.ts` for the query that finds them.
    *
    * mergeContacts deletes the secondary through the backend directly and handles its own
-   * node disposal — see the note there. (It cannot rely on `mergeEntities` having folded
-   * the node into the survivor's: that call currently fails on a foreign key, #1711.)
+   * node disposal — mergeEntities after the contact row is gone, then archiveAnchoredNode
+   * if that fold fails (#1711).
    */
   async deleteContact(
     id: string,

--- a/tests/integration/contact-merge-kg.test.ts
+++ b/tests/integration/contact-merge-kg.test.ts
@@ -1,0 +1,217 @@
+// Integration test — ContactService.mergeContacts folds KG memory (#1711).
+//
+// mergeEntities hard-deletes the secondary node. contacts.kg_node_id is a NO ACTION
+// foreign key, so that delete used to raise 23503 while the secondary contact still
+// pointed at the node. The failure was swallowed as "KG node merge failed (non-fatal)",
+// and the secondary's facts, aliases and edges never reached the survivor.
+//
+// In-memory tests cannot catch this: they have no FK. This suite uses real Postgres.
+//
+// Every fixture row is created by this suite and deleted by id in afterEach.
+// Skips gracefully when DATABASE_URL is not set.
+
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest';
+import pg from 'pg';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { createSilentLogger } from '../../src/logger.js';
+import type { Logger } from '../../src/logger.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+function mockLogger(): Logger & { warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> } {
+  const warn = vi.fn();
+  const error = vi.fn();
+  const logger = {
+    info: vi.fn(),
+    warn,
+    error,
+    debug: vi.fn(),
+    child() { return this; },
+  };
+  return logger as unknown as Logger & { warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+}
+
+describeIf('mergeContacts KG memory (#1711)', () => {
+  let pool: pg.Pool;
+  let entityMemory: EntityMemory;
+
+  const createdContactIds: string[] = [];
+  const createdKgNodeIds: string[] = [];
+
+  function trackContact(id: string, kgNodeId?: string | null): void {
+    createdContactIds.push(id);
+    if (kgNodeId) createdKgNodeIds.push(kgNodeId);
+  }
+
+  function trackNode(id: string | null | undefined): void {
+    if (id) createdKgNodeIds.push(id);
+  }
+
+  async function makeNodelessContact(displayName: string): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO contacts (display_name, kg_node_id) VALUES ($1, NULL) RETURNING id`,
+      [displayName],
+    );
+    const id = rows[0]!.id;
+    createdContactIds.push(id);
+    return id;
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const logger = createSilentLogger();
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+    await pool.query('SELECT 1 FROM contacts LIMIT 0');
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterEach(async () => {
+    if (createdContactIds.length > 0) {
+      await pool.query(`DELETE FROM contacts WHERE id = ANY($1::uuid[])`, [createdContactIds]);
+      createdContactIds.length = 0;
+    }
+    if (createdKgNodeIds.length > 0) {
+      await pool.query(
+        `DELETE FROM kg_edges WHERE source_node_id = ANY($1::uuid[]) OR target_node_id = ANY($1::uuid[])`,
+        [createdKgNodeIds],
+      );
+      await pool.query(`DELETE FROM kg_nodes WHERE id = ANY($1::uuid[])`, [createdKgNodeIds]);
+      createdKgNodeIds.length = 0;
+    }
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('folds the secondary\'s facts, aliases and edges into the survivor when both have a node', async () => {
+    const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const logger = mockLogger();
+    const contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
+
+    const primary = await contactService.createContact({
+      displayName: `KG Merge Primary ${runId}`,
+      source: 'ceo_stated',
+      tier: 'known',
+    });
+    trackContact(primary.id, primary.kgNodeId);
+    const secondary = await contactService.createContact({
+      displayName: `KG Merge Secondary ${runId}`,
+      source: 'email_participant',
+      tier: 'unknown',
+    });
+    trackContact(secondary.id, secondary.kgNodeId);
+
+    expect(primary.kgNodeId).toBeTruthy();
+    expect(secondary.kgNodeId).toBeTruthy();
+    expect(primary.kgNodeId).not.toBe(secondary.kgNodeId);
+
+    await entityMemory.storeFact({
+      entityNodeId: primary.kgNodeId!,
+      label: `Prefers morning meetings ${runId}`,
+      source: 'itest-1711',
+    });
+    await entityMemory.storeFact({
+      entityNodeId: secondary.kgNodeId!,
+      label: `Allergic to shellfish ${runId}`,
+      source: 'itest-1711',
+    });
+    for (const fact of await entityMemory.getFacts(primary.kgNodeId!)) trackNode(fact.id);
+    for (const fact of await entityMemory.getFacts(secondary.kgNodeId!)) trackNode(fact.id);
+
+    await entityMemory.addAlias(secondary.kgNodeId!, `j. merge ${runId}`);
+
+    const { entity: org } = await entityMemory.createEntity({
+      type: 'organization',
+      label: `KG Merge Org ${runId}`,
+      properties: {},
+      source: 'itest-1711',
+    });
+    trackNode(org.id);
+    await entityMemory.upsertEdge(secondary.kgNodeId!, org.id, 'member_of', {}, 'itest-1711', 0.8);
+
+    await contactService.mergeContacts(primary.id, secondary.id, false);
+
+    expect(logger.warn.mock.calls.some(([, msg]) => String(msg).includes('KG node merge failed'))).toBe(false);
+
+    expect(await contactService.getContact(secondary.id)).toBeUndefined();
+    const survivor = await contactService.getContact(primary.id);
+    expect(survivor?.kgNodeId).toBe(primary.kgNodeId);
+
+    const survivorNode = await entityMemory.getEntity(primary.kgNodeId!);
+    expect(survivorNode).toBeDefined();
+    expect(survivorNode!.aliases).toContain(`j. merge ${runId}`);
+
+    const factLabels = (await entityMemory.getFacts(primary.kgNodeId!)).map(f => f.label);
+    expect(factLabels).toContain(`Prefers morning meetings ${runId}`);
+    expect(factLabels).toContain(`Allergic to shellfish ${runId}`);
+    for (const fact of await entityMemory.getFacts(primary.kgNodeId!)) trackNode(fact.id);
+
+    const edges = await entityMemory.findEdges(primary.kgNodeId!);
+    expect(edges.some(e => e.node.id === org.id && e.edge.type === 'member_of')).toBe(true);
+
+    expect(await entityMemory.getEntity(secondary.kgNodeId!)).toBeUndefined();
+  });
+
+  it('merges successfully when only the primary has a KG node', async () => {
+    const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const contactService = ContactService.createWithPostgres(pool, entityMemory, createSilentLogger());
+
+    const primary = await contactService.createContact({
+      displayName: `KG One-Side Primary ${runId}`,
+      source: 'ceo_stated',
+    });
+    trackContact(primary.id, primary.kgNodeId);
+    expect(primary.kgNodeId).toBeTruthy();
+
+    const secondaryId = await makeNodelessContact(`KG One-Side Secondary ${runId}`);
+
+    await contactService.mergeContacts(primary.id, secondaryId, false);
+
+    expect(await contactService.getContact(secondaryId)).toBeUndefined();
+    expect((await contactService.getContact(primary.id))?.kgNodeId).toBe(primary.kgNodeId);
+    expect(await entityMemory.getEntity(primary.kgNodeId!)).toBeDefined();
+  });
+
+  it('merges successfully when only the secondary has a KG node', async () => {
+    const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const contactService = ContactService.createWithPostgres(pool, entityMemory, createSilentLogger());
+
+    const primaryId = await makeNodelessContact(`KG Secondary-Only Primary ${runId}`);
+    const secondary = await contactService.createContact({
+      displayName: `KG Secondary-Only Secondary ${runId}`,
+      source: 'email_participant',
+    });
+    trackContact(secondary.id, secondary.kgNodeId);
+    expect(secondary.kgNodeId).toBeTruthy();
+
+    await contactService.mergeContacts(primaryId, secondary.id, false);
+
+    expect(await contactService.getContact(secondary.id)).toBeUndefined();
+    // No fold is possible without a survivor node; the secondary's anchored node is archived.
+    expect(await entityMemory.getEntity(secondary.kgNodeId!)).toBeUndefined();
+  });
+
+  it('merges successfully when neither contact has a KG node', async () => {
+    const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const contactService = ContactService.createWithPostgres(pool, entityMemory, createSilentLogger());
+
+    const primaryId = await makeNodelessContact(`KG Neither Primary ${runId}`);
+    const secondaryId = await makeNodelessContact(`KG Neither Secondary ${runId}`);
+
+    await contactService.mergeContacts(primaryId, secondaryId, false);
+
+    expect(await contactService.getContact(secondaryId)).toBeUndefined();
+    expect(await contactService.getContact(primaryId)).toBeDefined();
+  });
+});

--- a/tests/integration/contact-merge-kg.test.ts
+++ b/tests/integration/contact-merge-kg.test.ts
@@ -19,6 +19,7 @@ import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../src/memory/validation.js';
 import { createSilentLogger } from '../../src/logger.js';
 import type { Logger } from '../../src/logger.js';
+import { requireCuriaTestDatabase } from './require-test-db.js';
 
 const { Pool } = pg;
 
@@ -41,6 +42,10 @@ function mockLogger(): Logger & { warn: ReturnType<typeof vi.fn>; error: ReturnT
 describeIf('mergeContacts KG memory (#1711)', () => {
   let pool: pg.Pool;
   let entityMemory: EntityMemory;
+  // Set true only after requireCuriaTestDatabase confirms we're on curia_test. vitest still
+  // fires afterEach/afterAll after a FAILED beforeAll, so without this flag a guard abort
+  // against a mispointed DATABASE_URL would still run the teardown DELETEs.
+  let onTestDb = false;
 
   const createdContactIds: string[] = [];
   const createdKgNodeIds: string[] = [];
@@ -66,6 +71,8 @@ describeIf('mergeContacts KG memory (#1711)', () => {
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
+    await requireCuriaTestDatabase(pool);
+    onTestDb = true;
     const logger = createSilentLogger();
     const embeddingService = EmbeddingService.createForTesting();
     const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
@@ -76,6 +83,7 @@ describeIf('mergeContacts KG memory (#1711)', () => {
   });
 
   afterEach(async () => {
+    if (!onTestDb) return;
     if (createdContactIds.length > 0) {
       await pool.query(`DELETE FROM contacts WHERE id = ANY($1::uuid[])`, [createdContactIds]);
       createdContactIds.length = 0;
@@ -91,7 +99,7 @@ describeIf('mergeContacts KG memory (#1711)', () => {
   });
 
   afterAll(async () => {
-    await pool.end();
+    await pool?.end();
   });
 
   it('folds the secondary\'s facts, aliases and edges into the survivor when both have a node', async () => {

--- a/tests/integration/contact-merge-transaction.test.ts
+++ b/tests/integration/contact-merge-transaction.test.ts
@@ -13,9 +13,13 @@
 // Every fixture row is created by this suite and deleted by id in afterEach.
 // Skips gracefully when DATABASE_URL is not set.
 
-import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import pg from 'pg';
 import { ContactService } from '../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
 import { createSilentLogger } from '../../src/logger.js';
 import { requireCuriaTestDatabase } from './require-test-db.js';
 
@@ -29,8 +33,11 @@ const FAIL_TRIGGER = 'itest_1695_block_secondary_delete';
 describeIf('mergeContacts transactionality (#1695)', () => {
   let pool: pg.Pool;
   let contactService: ContactService;
+  let contactServiceWithKg: ContactService;
+  let entityMemory: EntityMemory;
 
   const createdContactIds: string[] = [];
+  const createdKgNodeIds: string[] = [];
 
   /** Insert a contact directly: kg_node_id stays NULL so no KG merge is attempted. */
   async function makeContact(displayName: string): Promise<string> {
@@ -127,9 +134,16 @@ describeIf('mergeContacts transactionality (#1695)', () => {
     // never point at a real database even though every row it writes is its own.
     await requireCuriaTestDatabase(pool);
 
-    // No EntityMemory: the fixtures have kg_node_id = NULL, so mergeContacts skips the
-    // KG merge entirely and the suite needs no embedding credentials.
+    // No EntityMemory on the original service: the fixtures have kg_node_id = NULL, so
+    // mergeContacts skips the KG merge entirely and those tests need no embeddings.
     contactService = ContactService.createWithPostgres(pool, undefined, createSilentLogger());
+
+    const logger = createSilentLogger();
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+    contactServiceWithKg = ContactService.createWithPostgres(pool, entityMemory, logger);
 
     // Fails fast when migration 084 has not been applied.
     await pool.query('SELECT 1 FROM contact_dedup_exclusions LIMIT 0');
@@ -141,6 +155,14 @@ describeIf('mergeContacts transactionality (#1695)', () => {
     if (createdContactIds.length > 0) {
       await pool.query(`DELETE FROM contacts WHERE id = ANY($1::uuid[])`, [createdContactIds]);
       createdContactIds.length = 0;
+    }
+    if (createdKgNodeIds.length > 0) {
+      await pool.query(
+        `DELETE FROM kg_edges WHERE source_node_id = ANY($1::uuid[]) OR target_node_id = ANY($1::uuid[])`,
+        [createdKgNodeIds],
+      );
+      await pool.query(`DELETE FROM kg_nodes WHERE id = ANY($1::uuid[])`, [createdKgNodeIds]);
+      createdKgNodeIds.length = 0;
     }
   });
 
@@ -186,6 +208,55 @@ describeIf('mergeContacts transactionality (#1695)', () => {
       a: secondary < other ? secondary : other,
       b: secondary < other ? other : secondary,
     });
+  });
+
+  it('leaves both KG nodes untouched when the contact-merge transaction rolls back (#1711)', async () => {
+    const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const error = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error,
+      debug: vi.fn(),
+      child: vi.fn().mockReturnThis(),
+    } as never;
+    const loggedService = ContactService.createWithPostgres(pool, entityMemory, logger);
+
+    const primary = await contactServiceWithKg.createContact({
+      displayName: `Tx KG Primary ${runId}`,
+      source: 'itest-1711',
+    });
+    const secondary = await contactServiceWithKg.createContact({
+      displayName: `Tx KG Secondary ${runId}`,
+      source: 'itest-1711',
+    });
+    createdContactIds.push(primary.id, secondary.id);
+    expect(primary.kgNodeId).toBeTruthy();
+    expect(secondary.kgNodeId).toBeTruthy();
+    createdKgNodeIds.push(primary.kgNodeId!, secondary.kgNodeId!);
+
+    await entityMemory.storeFact({
+      entityNodeId: secondary.kgNodeId!,
+      label: `Secondary-only fact ${runId}`,
+      source: 'itest-1711',
+    });
+    const secondaryFactsBefore = await entityMemory.getFacts(secondary.kgNodeId!);
+    expect(secondaryFactsBefore).toHaveLength(1);
+    createdKgNodeIds.push(secondaryFactsBefore[0]!.id);
+
+    await blockDeleteOf(secondary.id);
+
+    await expect(loggedService.mergeContacts(primary.id, secondary.id, false))
+      .rejects.toThrow(/forced merge failure/);
+
+    expect(error.mock.calls.some(([, msg]) => String(msg).includes('may already have been applied'))).toBe(false);
+    expect(error.mock.calls.some(([, msg]) => String(msg).includes('KG nodes were not touched'))).toBe(true);
+
+    expect(await entityMemory.getEntity(primary.kgNodeId!)).toBeDefined();
+    expect(await entityMemory.getEntity(secondary.kgNodeId!)).toBeDefined();
+    const secondaryFactsAfter = (await entityMemory.getFacts(secondary.kgNodeId!)).map(f => f.label);
+    expect(secondaryFactsAfter).toEqual([`Secondary-only fact ${runId}`]);
+    expect(await entityMemory.getFacts(primary.kgNodeId!)).toHaveLength(0);
   });
 
   it('commits the same sequence when nothing fails', async () => {

--- a/tests/integration/dedup-contacts-merge.test.ts
+++ b/tests/integration/dedup-contacts-merge.test.ts
@@ -36,6 +36,7 @@ const createdKgNodeIds: string[] = [];
 describeIf('dedup-contacts merge integration', () => {
   let pool: pg.Pool;
   let contactService: ContactService;
+  let entityMemory: EntityMemory;
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
@@ -48,7 +49,7 @@ describeIf('dedup-contacts merge integration', () => {
     const embeddingService = EmbeddingService.createForTesting();
     const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
     const validator = new MemoryValidator(kgStore, embeddingService);
-    const entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
 
     const auditLogger = new AuditLogger(pool, logger);
     // Wire EventBus with the write-ahead audit hook — identical to the CLI entry point.
@@ -165,6 +166,12 @@ describeIf('dedup-contacts merge integration', () => {
       const secondaryBefore = await contactService.getContact(secondary.id);
       expect(primaryBefore).toBeDefined();
       expect(secondaryBefore).toBeDefined();
+      // Both sides hold a node — the path #1711 covers. The assertions after merge
+      // check the survivor kept its node and the secondary's node is gone, not just
+      // contact-level outcomes.
+      expect(primaryBefore!.kgNodeId).toBeTruthy();
+      expect(secondaryBefore!.kgNodeId).toBeTruthy();
+      expect(primaryBefore!.kgNodeId).not.toBe(secondaryBefore!.kgNodeId);
 
       // --- 3. Run the REAL merge path used by the script ---
       //
@@ -226,6 +233,12 @@ describeIf('dedup-contacts merge integration', () => {
       // Confirm the payload carries both contact IDs (no deep JSON parse needed — text search is fine)
       expect(auditRow!.payload).toContain(primary.id);
       expect(auditRow!.payload).toContain(secondary.id);
+
+      // --- 7. Assert: secondary KG node is gone; survivor still holds its node (#1711) ---
+      const survivor = await contactService.getContact(primary.id);
+      expect(survivor?.kgNodeId).toBe(primaryBefore!.kgNodeId);
+      expect(await entityMemory.getEntity(primaryBefore!.kgNodeId!)).toBeDefined();
+      expect(await entityMemory.getEntity(secondaryBefore!.kgNodeId!)).toBeUndefined();
     },
   );
 });

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -1614,17 +1614,27 @@ describe('ContactService', () => {
       expect(primary.kgNodeId).toBeTruthy();
       expect(secondary.kgNodeId).toBeTruthy();
 
+      // invocationCallOrder on withTransaction records entry, not commit. An
+      // implementation that called mergeEntities inside the callback would still
+      // pass that check. Record an explicit post-callback marker so this test
+      // fails unless mergeEntities runs after withTransaction has returned.
+      const order: string[] = [];
       const backend = backendOf(service);
-      const withTransaction = vi.spyOn(backend, 'withTransaction');
-      const mergeEntities = vi.spyOn(entityMemory, 'mergeEntities');
+      const originalWithTransaction = backend.withTransaction.bind(backend);
+      vi.spyOn(backend, 'withTransaction').mockImplementation(async (fn) => {
+        const result = await originalWithTransaction(fn);
+        order.push('committed');
+        return result;
+      });
+      const originalMerge = entityMemory.mergeEntities.bind(entityMemory);
+      vi.spyOn(entityMemory, 'mergeEntities').mockImplementation(async (primaryId, secondaryId) => {
+        order.push('mergeEntities');
+        return originalMerge(primaryId, secondaryId);
+      });
 
       await service.mergeContacts(primary.id, secondary.id, false);
 
-      expect(withTransaction).toHaveBeenCalledTimes(1);
-      expect(mergeEntities).toHaveBeenCalledTimes(1);
-      expect(mergeEntities).toHaveBeenCalledWith(primary.kgNodeId, secondary.kgNodeId);
-      expect(mergeEntities.mock.invocationCallOrder[0]!)
-        .toBeGreaterThan(withTransaction.mock.invocationCallOrder[0]!);
+      expect(order).toEqual(['committed', 'mergeEntities']);
     });
 
     it('does not merge KG nodes when the contact-merge transaction rolls back (#1711)', async () => {

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -999,6 +999,44 @@ describe('ContactService', () => {
       expect(proposal.goldenRecord.notes).toContain('Primary note');
       expect(proposal.goldenRecord.notes).toContain('Secondary note');
     });
+
+    it('does not call mergeEntities when only the primary has a KG node', async () => {
+      const primary = await service.createContact({ displayName: 'Has Node', source: 'test' });
+      const secondary = await service.createContact({ displayName: 'No Node', source: 'test' });
+      await service.saveContact({ ...secondary, kgNodeId: null });
+      const mergeEntities = vi.spyOn(entityMemory, 'mergeEntities');
+
+      await service.mergeContacts(primary.id, secondary.id, false);
+
+      expect(mergeEntities).not.toHaveBeenCalled();
+      expect(await service.getContact(secondary.id)).toBeUndefined();
+      expect((await service.getContact(primary.id))?.kgNodeId).toBe(primary.kgNodeId);
+    });
+
+    it('does not call mergeEntities when only the secondary has a KG node', async () => {
+      const primary = await service.createContact({ displayName: 'No Node', source: 'test' });
+      const secondary = await service.createContact({ displayName: 'Has Node', source: 'test' });
+      await service.saveContact({ ...primary, kgNodeId: null });
+      const mergeEntities = vi.spyOn(entityMemory, 'mergeEntities');
+
+      await service.mergeContacts(primary.id, secondary.id, false);
+
+      expect(mergeEntities).not.toHaveBeenCalled();
+      expect(await service.getContact(secondary.id)).toBeUndefined();
+    });
+
+    it('does not call mergeEntities when neither contact has a KG node', async () => {
+      const primary = await service.createContact({ displayName: 'No Node A', source: 'test' });
+      const secondary = await service.createContact({ displayName: 'No Node B', source: 'test' });
+      await service.saveContact({ ...primary, kgNodeId: null });
+      await service.saveContact({ ...secondary, kgNodeId: null });
+      const mergeEntities = vi.spyOn(entityMemory, 'mergeEntities');
+
+      await service.mergeContacts(primary.id, secondary.id, false);
+
+      expect(mergeEntities).not.toHaveBeenCalled();
+      expect(await service.getContact(secondary.id)).toBeUndefined();
+    });
   });
   describe('dedup hook (onDuplicateDetected)', () => {
     it('calls onDuplicateDetected when a certain duplicate is created', async () => {
@@ -1568,6 +1606,47 @@ describe('ContactService', () => {
 
       // The sequence aborts at the failing write — the delete never runs.
       expect(deleteContact).not.toHaveBeenCalled();
+    });
+
+    it('folds KG nodes only after the contact-merge transaction commits (#1711)', async () => {
+      const primary = await service.createContact({ displayName: 'Kg Tx Primary', source: 'test' });
+      const secondary = await service.createContact({ displayName: 'Kg Tx Secondary', source: 'test' });
+      expect(primary.kgNodeId).toBeTruthy();
+      expect(secondary.kgNodeId).toBeTruthy();
+
+      const backend = backendOf(service);
+      const withTransaction = vi.spyOn(backend, 'withTransaction');
+      const mergeEntities = vi.spyOn(entityMemory, 'mergeEntities');
+
+      await service.mergeContacts(primary.id, secondary.id, false);
+
+      expect(withTransaction).toHaveBeenCalledTimes(1);
+      expect(mergeEntities).toHaveBeenCalledTimes(1);
+      expect(mergeEntities).toHaveBeenCalledWith(primary.kgNodeId, secondary.kgNodeId);
+      expect(mergeEntities.mock.invocationCallOrder[0]!)
+        .toBeGreaterThan(withTransaction.mock.invocationCallOrder[0]!);
+    });
+
+    it('does not merge KG nodes when the contact-merge transaction rolls back (#1711)', async () => {
+      const error = vi.fn();
+      const svc = ContactService.createInMemory(
+        entityMemory,
+        undefined,
+        { info: vi.fn(), warn: vi.fn(), error, debug: vi.fn() } as never,
+      );
+      const primary = await svc.createContact({ displayName: 'Kg Rollback Primary', source: 'test' });
+      const secondary = await svc.createContact({ displayName: 'Kg Rollback Secondary', source: 'test' });
+
+      const mergeEntities = vi.spyOn(entityMemory, 'mergeEntities');
+      vi.spyOn(backendOf(svc), 'deleteContact')
+        .mockRejectedValue(new Error('forced delete failure'));
+
+      await expect(svc.mergeContacts(primary.id, secondary.id, false))
+        .rejects.toThrow('forced delete failure');
+
+      expect(mergeEntities).not.toHaveBeenCalled();
+      expect(error.mock.calls.some(([, msg]) => String(msg).includes('may already have been applied'))).toBe(false);
+      expect(error.mock.calls.some(([, msg]) => String(msg).includes('KG nodes were not touched'))).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Contact merge was silently dropping the secondary contact's knowledge-graph memory whenever both sides had a node — the common case in production (~97% of contacts).

`mergeContacts` called `entityMemory.mergeEntities` **before** the transaction that deletes the secondary contact. `mergeEntities` ends with a hard `DELETE` of that node, and `contacts.kg_node_id` is a `NO ACTION` foreign key, so Postgres raised `23503`. The call was wrapped in a best-effort `try/catch`, so the only signal was `KG node merge failed (non-fatal)`. Facts, aliases, and edges never folded into the survivor.

This moves `mergeEntities` to **after** the contact-merge transaction commits, keeping the node ids in locals. Once the secondary contact row is gone, the FK no longer blocks the node delete. A rolled-back contact merge can no longer have already collapsed the two KG nodes.

Closes #1711

## Changes

- Run `mergeEntities` after the contact-merge transaction commits, not before
- On rollback, log that KG nodes were not touched (no "may already have been applied")
- Integration coverage for both-have-nodes (facts, aliases, edges), one-side, neither-side, and rollback
- Unit tests for call order, rollback not merging KG, and nodeless sides
- ADR-040 backfill note updated now that #1711 has landed

## Related Issues

Closes #1711

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes
- [x] CI passes