### PR TITLE
fix(docker,ci): survive a transient registry drop, and alert when a publish fails (#1699)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,6 @@ docker/*
 !docker/postgres.Dockerfile
 !docker/postgres-init-pgaudit.sql
 !docker/postgres-verify-pgaudit.sh
+# Needed by the main Dockerfile's install steps (#1699) — without this exception
+# the COPY fails with "not found in build context" and every build breaks.
+!docker/pnpm-retry.sh

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -133,3 +133,89 @@ jobs:
           DIGEST: ${{ steps.build.outputs.digest }}
           IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+  # Turn a failed publish into an active notification (#1699).
+  #
+  # Why this is needed: when a publish fails, the mutable `edge` tag silently keeps
+  # pointing at the PREVIOUS commit. Nothing downstream notices — curia-deploy pulls
+  # `:edge` and ships older code, and its older migrations, while reporting success.
+  # The only prior signal was a red run nobody is obliged to look at before deploying.
+  # (The deploy-side half — asserting the pulled image's revision — is curia-deploy#213.)
+  #
+  # `if: failure()` deliberately excludes cancellation: `cancel-in-progress` cancels
+  # superseded builds on a rapid batch of main merges, and that is normal, not an
+  # incident. `failure()` is false for cancelled runs; `always()` or `!success()`
+  # would page on every superseded build and train everyone to ignore this.
+  notify-failure:
+    needs: build
+    if: failure() && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write     # file / comment on the tracking issue
+    steps:
+      - name: Open or update the publish-failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const label = 'publish-failure';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.sha.substring(0, 8);
+
+            const body = [
+              `**\`docker-publish\` failed on \`${context.ref}\` at \`${sha}\`.**`,
+              '',
+              `Run: ${runUrl}`,
+              '',
+              'Until a publish succeeds, `ghcr.io/josephfung/curia:edge` still points at the',
+              'previous commit. A deploy now would ship older code **and skip any migrations**',
+              'added since, while appearing to succeed. Either re-run the failed job or pin',
+              '`CURIA_IMAGE_TAG` deliberately before deploying.',
+              '',
+              'Transient npm registry drops are the known cause (#1699); re-running is usually',
+              'enough. If it recurs, the retry wrapper in `docker/pnpm-retry.sh` is not holding.',
+            ].join('\n');
+
+            // Reuse one open issue rather than filing a new one per failure — a flaky
+            // registry could otherwise produce a stream of duplicates and get muted.
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 1,
+            });
+
+            if (open.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open[0].number,
+                body,
+              });
+              core.notice(`Commented on existing publish-failure issue #${open[0].number}`);
+              return;
+            }
+
+            // The label may not exist yet on a fresh repo; create it first so the
+            // dedupe lookup above works on the next failure.
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'b60205',
+                description: 'A docker-publish run failed; :edge may be stale',
+              });
+            } catch (err) {
+              if (err.status !== 422) throw err;   // 422 = already exists, fine
+            }
+
+            const { data: created } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `docker-publish failed on main — :edge is stale at ${sha}`,
+              labels: [label, 'infra'],
+              body,
+            });
+            core.notice(`Opened publish-failure issue #${created.number}`);

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,13 @@ jobs:
   build:
     needs: guard
     runs-on: ubuntu-latest
+    # Hard wall-clock bound. The retry layers added in #1699 compose multiplicatively —
+    # pnpm's own fetch retries per request, inside up to 3 command-level attempts, across
+    # 3 install sites, on a QEMU-emulated arm64 leg. During a sustained registry outage
+    # that could otherwise grind for hours against the 6h default before failing. A normal
+    # build is ~10min (see the concurrency note above), so this is generous headroom while
+    # still failing in a bounded time instead of burning a runner all afternoon.
+    timeout-minutes: 60
     permissions:
       contents: read    # actions/checkout
       packages: write   # push + sign images in GHCR
@@ -136,19 +143,27 @@ jobs:
 
   # Turn a failed publish into an active notification (#1699).
   #
-  # Why this is needed: when a publish fails, the mutable `edge` tag silently keeps
-  # pointing at the PREVIOUS commit. Nothing downstream notices — curia-deploy pulls
-  # `:edge` and ships older code, and its older migrations, while reporting success.
-  # The only prior signal was a red run nobody is obliged to look at before deploying.
-  # (The deploy-side half — asserting the pulled image's revision — is curia-deploy#213.)
+  # Why this is needed: when a publish fails, the mutable tags it would have written
+  # silently keep pointing at whatever was published last. Nothing downstream notices —
+  # curia-deploy pulls `:edge` and ships older code, and its older migrations, while
+  # reporting success. The only prior signal was a red run nobody is obliged to look at
+  # before deploying. (The deploy-side half — asserting the pulled image's revision
+  # before restarting anything — is curia-deploy#213.)
   #
-  # `if: failure()` deliberately excludes cancellation: `cancel-in-progress` cancels
-  # superseded builds on a rapid batch of main merges, and that is normal, not an
-  # incident. `failure()` is false for cancelled runs; `always()` or `!success()`
-  # would page on every superseded build and train everyone to ignore this.
+  # Gated on `needs.build.result == 'failure'` rather than on the event name, so it
+  # fires for a failed manual republish too (the moment someone is already firefighting
+  # a stale tag) while never firing for a `guard` rejection of a malformed dispatch tag,
+  # which is a typo, not an incident.
+  #
+  # `failure()` deliberately excludes cancellation: `cancel-in-progress` cancels
+  # superseded builds on a rapid batch of main merges, and that is normal. `always()`
+  # or `!success()` would alert on every superseded build and train everyone to ignore
+  # this. Note this job sits inside the same cancellable concurrency group, so a newer
+  # push can cancel the alert itself — benign, because the newer run either succeeds
+  # (the tags are fresh, the alert was moot) or fails and raises its own.
   notify-failure:
     needs: build
-    if: failure() && github.event_name != 'workflow_dispatch'
+    if: always() && needs.build.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -162,50 +177,79 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const sha = context.sha.substring(0, 8);
 
+            // Say what actually happened rather than hardcoding "main" / ":edge".
+            // This workflow also runs on `release: published`, where main is not
+            // involved and it is the semver + `latest` tags that are missing.
+            const isRelease = context.eventName === 'release';
+            const what = isRelease
+              ? `release \`${context.ref.replace('refs/tags/', '')}\``
+              : `\`${context.ref}\` at \`${sha}\``;
+            const staleTags = isRelease
+              ? 'the release\'s semver and `latest` tags may not have been published'
+              : '`:edge` may still point at the previously published commit';
+
             const body = [
-              `**\`docker-publish\` failed on \`${context.ref}\` at \`${sha}\`.**`,
+              `**\`docker-publish\` failed for ${what}.**`,
               '',
               `Run: ${runUrl}`,
               '',
-              'Until a publish succeeds, `ghcr.io/josephfung/curia:edge` still points at the',
-              'previous commit. A deploy now would ship older code **and skip any migrations**',
-              'added since, while appearing to succeed. Either re-run the failed job or pin',
-              '`CURIA_IMAGE_TAG` deliberately before deploying.',
+              `Until a publish succeeds, ${staleTags}. If so, a deploy would ship older code`,
+              '**and skip any migrations** added since, while appearing to succeed.',
               '',
-              'Transient npm registry drops are the known cause (#1699); re-running is usually',
-              'enough. If it recurs, the retry wrapper in `docker/pnpm-retry.sh` is not holding.',
+              '**Check the run before acting** — this job cannot tell which part failed:',
+              '- the matrix builds `curia` and `curia-postgres` independently (`fail-fast: false`),',
+              '  so one image may have published fine while the other did not;',
+              '- signing runs *after* the push, so a cosign failure means the image was',
+              '  actually published and is current — only its signature is missing.',
+              '',
+              '_Possible causes, not a diagnosis:_ a transient registry or Debian-mirror drop is',
+              'the known flake (#1699) and a re-run clears it. But if the logs show every retry',
+              'failing the same way, it is not transient — read the underlying error (an outdated',
+              'lockfile is the usual culprit) instead of re-running.',
             ].join('\n');
 
             // Reuse one open issue rather than filing a new one per failure — a flaky
             // registry could otherwise produce a stream of duplicates and get muted.
-            const { data: open } = await github.rest.issues.listForRepo({
+            // Bounded to recent activity so a long-abandoned thread does not become a
+            // permanent black hole that silently swallows every future alert.
+            const REUSE_WINDOW_DAYS = 7;
+            const { data: candidates } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: label,
-              per_page: 1,
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 20,
             });
 
-            if (open.length > 0) {
+            // listForRepo returns pull requests too; a labelled PR would otherwise
+            // swallow every alert as a comment on a merged PR thread.
+            const cutoff = Date.now() - REUSE_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+            const existing = candidates.find(
+              (i) => !i.pull_request && new Date(i.updated_at).getTime() >= cutoff,
+            );
+
+            if (existing) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: open[0].number,
+                issue_number: existing.number,
                 body,
               });
-              core.notice(`Commented on existing publish-failure issue #${open[0].number}`);
+              core.notice(`Commented on existing publish-failure issue #${existing.number}`);
               return;
             }
 
-            // The label may not exist yet on a fresh repo; create it first so the
-            // dedupe lookup above works on the next failure.
+            // The label may not exist yet; create it first so the dedupe lookup above
+            // works on the next failure.
             try {
               await github.rest.issues.createLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name: label,
                 color: 'b60205',
-                description: 'A docker-publish run failed; :edge may be stale',
+                description: 'A docker-publish run failed; published tags may be stale',
               });
             } catch (err) {
               if (err.status !== 422) throw err;   // 422 = already exists, fine
@@ -214,7 +258,7 @@ jobs:
             const { data: created } = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `docker-publish failed on main — :edge is stale at ${sha}`,
+              title: `docker-publish failed for ${isRelease ? context.ref.replace('refs/tags/', '') : 'main'} (${sha})`,
               labels: [label, 'infra'],
               body,
             });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Contact merge** — secondary KG memory folds into the survivor after the contact delete. (#1711)
 - **`docker-publish`** — a transient registry drop mid-`pnpm install` retries instead of failing the publish. (#1699)
+- **`docker-publish`** — `apt` fetches retry too; the `curia-postgres` leg has no other network step. (#1699)
 - **`entity-context` assembler** — archived nodes, facts, and edges no longer assemble. (#1707)
 - **`entity-context` cache** — an archived node is re-checked before a TTL hit is served. (#1707)
 - **`DreamEngine`** — flushes entity-context cache after a decay pass archives. (#1707)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Publish-failure alert** — a failed `docker-publish` opens/updates a tracking issue, since `:edge` goes stale silently. (#1699)
 - **Contact-anchored KG identity** — same-name contacts each hold their own node, facts, and enrichment. (#1694)
 - **ADR-040 (Accepted)** — contact-anchored KG node identity; a contact's node is keyed on the contact, not its label. (#1694)
 - **ADR-040 measured population** — migration `085` sizing recorded from production: 14 nodeless contacts, arm A empty. (#1694)
@@ -67,6 +68,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Contact merge** — secondary KG memory folds into the survivor after the contact delete. (#1711)
+- **`docker-publish`** — a transient registry drop mid-`pnpm install` retries instead of failing the publish. (#1699)
 - **`entity-context` assembler** — archived nodes, facts, and edges no longer assemble. (#1707)
 - **`entity-context` cache** — an archived node is re-checked before a TTL hit is served. (#1707)
 - **`DreamEngine`** — flushes entity-context cache after a decay pass archives. (#1707)

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,13 @@ COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
 # pulseaudio-utils provides parec/pacat, which SignalAudioTransport spawns to
 # move call PCM through the Pulse socket shared from the signal-cli container
 # (#1672). Client tools only — no PulseAudio daemon runs in this image.
-RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get install -y --no-install-recommends curl pulseaudio-utils \
+# Acquire::Retries covers a transient Debian mirror hiccup, the apt-side equivalent of
+# the npm registry drop that motivated #1699. Without it a single failed fetch fails the
+# whole publish — and for the curia-postgres image this apt call is the ONLY network step,
+# so it gets no benefit from the pnpm retry wrapper.
+RUN apt-get -o Acquire::Retries=3 update \
+ && apt-get -o Acquire::Retries=3 upgrade -y \
+ && apt-get -o Acquire::Retries=3 install -y --no-install-recommends curl pulseaudio-utils \
  && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root system user/group for the runtime process.
@@ -158,7 +162,10 @@ RUN pnpm-retry pnpm add -w --save-prod --prod tsx
 # /root/.cache/node/corepack (confirmed by the Trivy alert path); the alternate
 # layout /root/.cache/corepack (used by older corepack versions) is removed too
 # so this stays correct across future base-image bumps.
-RUN rm -rf /root/.cache/node/corepack /root/.cache/corepack
+# pnpm-retry is build-only tooling; the last runtime-stage use is the `pnpm add` above.
+# Drop it here so it doesn't ship in the published image, consistent with this stage
+# already stripping unused npm/npx and the corepack cache (#1699).
+RUN rm -rf /root/.cache/node/corepack /root/.cache/corepack /usr/local/bin/pnpm-retry
 
 # Copy compiled output from build stage
 COPY --from=build /app/dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/console/package.json ./apps/console/
 COPY apps/antfarm/package.json ./apps/antfarm/
 COPY packages/shared-types/package.json ./packages/shared-types/
-RUN pnpm install --frozen-lockfile
+# Retry wrapper: a dropped registry connection can abort the Node process outright
+# (unhandled stream error), which pnpm's own fetchRetries cannot catch. See
+# docker/pnpm-retry.sh for the incident and why both layers are needed (#1699).
+COPY docker/pnpm-retry.sh /usr/local/bin/pnpm-retry
+RUN pnpm-retry pnpm install --frozen-lockfile
 
 # Build backend
 COPY src/ ./src/
@@ -119,7 +123,9 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 # does a strict re-resolution.) shared-types is imported type-only (erased at build), so
 # it isn't required at runtime, but shipping the member keeps the manifest honest.
 COPY --from=build /app/packages/shared-types ./packages/shared-types
-RUN pnpm install --frozen-lockfile --prod
+# Same transient-network guard as the build stage (#1699).
+COPY docker/pnpm-retry.sh /usr/local/bin/pnpm-retry
+RUN pnpm-retry pnpm install --frozen-lockfile --prod
 
 # tsx is needed at runtime: skill handlers are .ts files loaded via dynamic
 # import(), and they use ESM .js extension mapping (e.g., import from './foo.js'
@@ -139,7 +145,7 @@ RUN pnpm install --frozen-lockfile --prod
 #   --save-prod: tsx is declared as a *devDependency* in package.json, so --prod alone
 #     would leave it there and never install it — no ./node_modules/.bin/tsx, which the
 #     CMD below invokes. --save-prod promotes tsx into `dependencies` so it installs.
-RUN pnpm add -w --save-prod --prod tsx
+RUN pnpm-retry pnpm add -w --save-prod --prod tsx
 
 # Remove corepack's cached pnpm tarballs. Node 24's bundled corepack pre-caches
 # pnpm@11.0.8 (the version shipped with Node 24) during `corepack enable`, even

--- a/docker/pnpm-retry.sh
+++ b/docker/pnpm-retry.sh
@@ -22,14 +22,31 @@
 #   - pnpm-workspace.yaml fetch* settings  -> retry individual requests pnpm catches
 #   - this wrapper                         -> retry the whole command when it dies
 #
-# Retrying a pnpm install is safe: the store is content-addressable and installs are
+# Retrying `pnpm install` is safe: the store is content-addressable and installs are
 # idempotent, so a partially-completed attempt is resumed rather than corrupted.
+#
+# `pnpm add` is NOT idempotent in the same way — it mutates package.json and the
+# lockfile. An attempt aborted mid-mutation (exactly the incident shape: the process
+# dies, so no cleanup runs) can leave a half-written tree, and the retry may then fail
+# with a *derived* error such as ERR_PNPM_INCLUDED_DEPS_CONFLICT rather than the
+# original network fault. Retrying is still better than failing outright, but that is
+# why the give-up message below reports the FIRST attempt's exit code as well as the
+# last: when they differ, the retry itself changed the failure mode and the first one
+# is the real cause.
+#
+# This wrapper does NOT classify failures — every non-zero exit is retried, including
+# deterministic ones like ERR_PNPM_OUTDATED_LOCKFILE. Distinguishing them reliably
+# would mean parsing pnpm's output, which is its own fragility. Instead the messages
+# stay honest about what is and is not known: nothing here claims a failure was
+# transient. If every attempt fails identically, it almost certainly was not.
 #
 # POSIX sh (not bash): this runs in `node:24-slim` Docker layers via /bin/sh.
 #
 # Usage:  docker/pnpm-retry.sh pnpm install --frozen-lockfile
 # Env:    PNPM_RETRY_ATTEMPTS (default 3)   total attempts, not extra retries
 #         PNPM_RETRY_DELAY    (default 10)  base seconds; backs off linearly
+# Both are overridable mainly so the tests can run fast and deterministically; Docker
+# RUN layers inherit no host environment, so image builds always use the defaults.
 set -eu
 
 attempts="${PNPM_RETRY_ATTEMPTS:-3}"
@@ -40,7 +57,19 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
+# Validate the knobs up front. Without this a non-numeric value makes the `-ge`
+# comparison below fail under `set -e`, so the script exits 2 and the wrapped
+# command's real exit code is silently replaced.
+case "$attempts" in
+  ''|*[!0-9]*) echo "pnpm-retry: PNPM_RETRY_ATTEMPTS must be a positive integer (got '$attempts')" >&2; exit 2 ;;
+esac
+[ "$attempts" -ge 1 ] || { echo "pnpm-retry: PNPM_RETRY_ATTEMPTS must be >= 1 (got '$attempts')" >&2; exit 2; }
+case "$base_delay" in
+  ''|*[!0-9]*) echo "pnpm-retry: PNPM_RETRY_DELAY must be a non-negative integer (got '$base_delay')" >&2; exit 2 ;;
+esac
+
 attempt=1
+first_status=""
 while :; do
   # `set -e` must not abort on a failed attempt — that is the case being handled,
   # so `|| status=$?` both suppresses the abort and captures the real exit code.
@@ -56,10 +85,20 @@ while :; do
     exit 0
   fi
 
+  [ -n "$first_status" ] || first_status="$status"
+
   if [ "$attempt" -ge "$attempts" ]; then
     # Give up loudly and preserve the wrapped command's exit status, so a genuine
     # (non-transient) failure still fails the build rather than being masked.
     echo "pnpm-retry: '$*' failed after ${attempts} attempt(s); giving up (exit ${status})" >&2
+    if [ "$first_status" = "$status" ]; then
+      # Same failure every time — a registry blip does not reproduce this reliably.
+      # Say so, so nobody burns time looking for a network fault that isn't there.
+      echo "pnpm-retry: every attempt failed identically (exit ${status}); this is very likely a real, deterministic failure (e.g. an outdated lockfile), NOT a transient network fault — read the pnpm error above rather than re-running." >&2
+    else
+      # The retry changed the failure mode: attempt 1 is the cause, the rest are derived.
+      echo "pnpm-retry: first attempt exited ${first_status} but the last exited ${status} — the retry changed the failure mode, so the FIRST error above is the real cause." >&2
+    fi
     exit "$status"
   fi
 

--- a/docker/pnpm-retry.sh
+++ b/docker/pnpm-retry.sh
@@ -38,7 +38,14 @@
 # deterministic ones like ERR_PNPM_OUTDATED_LOCKFILE. Distinguishing them reliably
 # would mean parsing pnpm's output, which is its own fragility. Instead the messages
 # stay honest about what is and is not known: nothing here claims a failure was
-# transient. If every attempt fails identically, it almost certainly was not.
+# transient, and nothing here claims one was not.
+#
+# In particular, do NOT read meaning into repeated *equal* exit statuses. pnpm exits 1
+# for very nearly everything, and so does Node on an uncaught exception — the incident
+# above (unhandled 'error' on a Readable) and an outdated lockfile both exit 1. A
+# sustained registry outage therefore produces three identical exit 1s, which is the
+# flagship case for retrying, not evidence against it. Equal statuses carry no signal;
+# only *differing* ones do, and only in the narrow sense noted above.
 #
 # POSIX sh (not bash): this runs in `node:24-slim` Docker layers via /bin/sh.
 #
@@ -67,6 +74,19 @@ esac
 case "$base_delay" in
   ''|*[!0-9]*) echo "pnpm-retry: PNPM_RETRY_DELAY must be a non-negative integer (got '$base_delay')" >&2; exit 2 ;;
 esac
+# Strip leading zeros before the value ever reaches `$(( ))`. POSIX arithmetic follows
+# C integer-constant rules, so a leading zero means OCTAL: `010` would silently become 8,
+# and `08` is not a valid octal constant at all — it aborts the shell under `set -e`,
+# replacing the wrapped command's exit code with the shell's. That is the same
+# silent-substitution hazard the validation above exists to prevent, so normalize rather
+# than reject: a leading zero is a sloppy spelling of a decimal, not a request for octal.
+# `test -ge` (used for $attempts) parses decimal and needs no such treatment.
+while :; do
+  case "$base_delay" in
+    0[0-9]*) base_delay="${base_delay#0}" ;;
+    *) break ;;
+  esac
+done
 
 attempt=1
 first_status=""
@@ -92,9 +112,10 @@ while :; do
     # (non-transient) failure still fails the build rather than being masked.
     echo "pnpm-retry: '$*' failed after ${attempts} attempt(s); giving up (exit ${status})" >&2
     if [ "$first_status" = "$status" ]; then
-      # Same failure every time — a registry blip does not reproduce this reliably.
-      # Say so, so nobody burns time looking for a network fault that isn't there.
-      echo "pnpm-retry: every attempt failed identically (exit ${status}); this is very likely a real, deterministic failure (e.g. an outdated lockfile), NOT a transient network fault — read the pnpm error above rather than re-running." >&2
+      # Equal statuses are NOT evidence of a deterministic failure: pnpm and Node both
+      # exit 1 for nearly everything, so a sustained outage looks exactly like a bad
+      # lockfile here. Report the observation and refuse to guess at the cause.
+      echo "pnpm-retry: every attempt exited ${status}; the wrapper cannot tell transient from deterministic (pnpm exits 1 for nearly everything) — read the pnpm error above." >&2
     else
       # The retry changed the failure mode: attempt 1 is the cause, the rest are derived.
       echo "pnpm-retry: first attempt exited ${first_status} but the last exited ${status} — the retry changed the failure mode, so the FIRST error above is the real cause." >&2

--- a/docker/pnpm-retry.sh
+++ b/docker/pnpm-retry.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+# Retry a pnpm command that failed for transient network reasons (curia#1699).
+#
+# Why this exists, and why pnpm's own fetchRetries is not sufficient on its own:
+#
+# The docker-publish build died mid-`pnpm install` on the emulated linux/arm64 leg
+# (run 33556099876) when the npm registry dropped a TLS connection:
+#
+#   TypeError: terminated
+#     at Fetch.onAborted (node:internal/deps/undici/undici:13842:53)
+#     [cause]: SocketError: other side closed   code: 'UND_ERR_SOCKET'
+#   Emitted 'error' event on Readable instance at:
+#   node:events:505   throw er; // Unhandled 'error' event
+#
+# That is an UNHANDLED stream error, not a request pnpm classified as retryable.
+# pnpm retries what it catches (e.g. ERR_SOCKET_TIMEOUT, which it logs as
+# "Will retry in 10 seconds"), but here Node aborted the process before pnpm could
+# act. Raising fetchRetries would not have saved this build. The only thing that
+# survives a hard process abort is re-running the command, which is what this does.
+#
+# The two layers are complementary, not redundant:
+#   - pnpm-workspace.yaml fetch* settings  -> retry individual requests pnpm catches
+#   - this wrapper                         -> retry the whole command when it dies
+#
+# Retrying a pnpm install is safe: the store is content-addressable and installs are
+# idempotent, so a partially-completed attempt is resumed rather than corrupted.
+#
+# POSIX sh (not bash): this runs in `node:24-slim` Docker layers via /bin/sh.
+#
+# Usage:  docker/pnpm-retry.sh pnpm install --frozen-lockfile
+# Env:    PNPM_RETRY_ATTEMPTS (default 3)   total attempts, not extra retries
+#         PNPM_RETRY_DELAY    (default 10)  base seconds; backs off linearly
+set -eu
+
+attempts="${PNPM_RETRY_ATTEMPTS:-3}"
+base_delay="${PNPM_RETRY_DELAY:-10}"
+
+if [ "$#" -eq 0 ]; then
+  echo "pnpm-retry: no command given" >&2
+  exit 2
+fi
+
+attempt=1
+while :; do
+  # `set -e` must not abort on a failed attempt — that is the case being handled,
+  # so `|| status=$?` both suppresses the abort and captures the real exit code.
+  #
+  # Do NOT restructure this as `if "$@"; then exit 0; fi` followed by `status=$?`:
+  # POSIX says an `if` with no branch taken returns 0, so the status read after `fi`
+  # is the *if statement's* 0, not the command's failure. That silently turns a
+  # persistent failure into a successful build. Covered by test 3 in
+  # tests/docker/test-pnpm-retry.sh.
+  status=0
+  "$@" || status=$?
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+
+  if [ "$attempt" -ge "$attempts" ]; then
+    # Give up loudly and preserve the wrapped command's exit status, so a genuine
+    # (non-transient) failure still fails the build rather than being masked.
+    echo "pnpm-retry: '$*' failed after ${attempts} attempt(s); giving up (exit ${status})" >&2
+    exit "$status"
+  fi
+
+  delay=$((base_delay * attempt))
+  echo "pnpm-retry: '$*' failed (attempt ${attempt}/${attempts}, exit ${status}); retrying in ${delay}s" >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -9,8 +9,12 @@
 # the digest within the major. Re-resolve the digest when intentionally moving pg majors.
 FROM pgvector/pgvector:pg16@sha256:ccc6e83d6e35e931dc7c5def2022729d5a6c370318d099181995567ff1fb4d6b
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-16-pgaudit \
+# Acquire::Retries covers a transient Debian mirror hiccup, the apt-side equivalent of
+# the npm registry drop that motivated #1699. Without it a single failed fetch fails the
+# whole publish — and for the curia-postgres image this apt call is the ONLY network step,
+# so it gets no benefit from the pnpm retry wrapper.
+RUN apt-get -o Acquire::Retries=3 update \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends postgresql-16-pgaudit \
     && rm -rf /var/lib/apt/lists/*
 
 # Startup verification script ensures pgAudit is correctly set up on every boot,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "tsup src/index.ts --format esm --dts",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "test:shell": "bash tests/setup/test-setup-functions.sh",
+    "test:shell": "bash tests/setup/test-setup-functions.sh && bash tests/docker/test-pnpm-retry.sh",
     "test:postgres-image": "bash tests/docker/test-postgres-init.sh",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json && tsc --noEmit -p tsconfig.tests.json && pnpm --filter @curia/antfarm run typecheck",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,11 +69,17 @@ minimumReleaseAge: 1440
 # install, so they apply inside the image build, not just on a developer machine.
 # Purely transport-level: no interaction with minimumReleaseAge or the Dependabot
 # cooldown, which govern WHICH versions may be selected, not how they are fetched.
-fetchRetries: 5
+# Kept deliberately modest. These compose MULTIPLICATIVELY with the command-level
+# retry: worst case is (fetchRetries + 1) requests x fetchTimeout, inside up to
+# PNPM_RETRY_ATTEMPTS runs, at each of the three install sites. Chasing a bigger budget
+# buys little against a sustained outage and mostly delays an honest failure, so the
+# `build` job also carries a timeout-minutes bound. Note the two knobs read differently:
+# fetchRetries counts RETRIES (so 3 = 4 tries), PNPM_RETRY_ATTEMPTS counts TOTAL attempts.
+fetchRetries: 3
 fetchRetryFactor: 2
 fetchRetryMintimeout: 10000
-fetchRetryMaxtimeout: 90000
-fetchTimeout: 120000
+fetchRetryMaxtimeout: 60000
+fetchTimeout: 90000
 
 # Dependency version overrides. pnpm v10+ reads `overrides` ONLY from this file —
 # a `pnpm.overrides` block in package.json is silently ignored. These pins force

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,6 +49,32 @@ trustPolicyIgnoreAfter: 10080
 # nosemgrep: package_managers.pnpm.pnpm-missing-minimum-release-age.pnpm-minimum-release-age
 minimumReleaseAge: 1440
 
+# -- Registry request resilience (#1699) --
+#
+# These raise pnpm's own retry budget for request failures it CATCHES and classifies
+# as retryable (e.g. ERR_SOCKET_TIMEOUT, which it logs as "Will retry in Ns").
+# Defaults are fetchRetries: 2 with a 10s floor, which is thin for the emulated
+# linux/arm64 leg of docker-publish: it installs ~1000 packages under QEMU, so it
+# stays connected to the registry far longer than a native build and sees more of
+# any registry wobble.
+#
+# These settings alone are NOT the whole fix. The failure in run 33556099876 was an
+# UNHANDLED undici stream error (UND_ERR_SOCKET) that aborted the Node process before
+# pnpm could retry anything — no value here would have prevented it. The command-level
+# retry in docker/pnpm-retry.sh covers that case; these cover the softer ones, so a
+# hard process abort stays rare rather than routine.
+#
+# pnpm v10+ reads these from this file (camelCase), not .npmrc — the same reason
+# `overrides` lives here. The Dockerfile COPYs pnpm-workspace.yaml before every
+# install, so they apply inside the image build, not just on a developer machine.
+# Purely transport-level: no interaction with minimumReleaseAge or the Dependabot
+# cooldown, which govern WHICH versions may be selected, not how they are fetched.
+fetchRetries: 5
+fetchRetryFactor: 2
+fetchRetryMintimeout: 10000
+fetchRetryMaxtimeout: 90000
+fetchTimeout: 120000
+
 # Dependency version overrides. pnpm v10+ reads `overrides` ONLY from this file —
 # a `pnpm.overrides` block in package.json is silently ignored. These pins force
 # transitive deps onto patched versions to clear known CVEs.

--- a/tests/docker/test-pnpm-retry.sh
+++ b/tests/docker/test-pnpm-retry.sh
@@ -68,10 +68,20 @@ check_eq "  ...after exactly 3 attempts" "3" "$(cat "$d/count")"
 
 # 3. A persistently failing command eventually gives up and fails the build.
 #    A retry wrapper that masked a real failure would be worse than none.
-d="$tmpdir/t3"; mkdir -p "$d"; make_stub "$d/cmd" 99
+#    The stub exits 78 so this also pins the documented promise to "preserve the
+#    wrapped command's exit status" — a regression to a hardcoded `exit 1` would
+#    still be non-zero and would slip past a bare `-ne 0` assertion.
+d="$tmpdir/t3"; mkdir -p "$d"
+cat > "$d/cmd" <<'STUB'
+#!/usr/bin/env bash
+count_file="$(dirname "$0")/count"
+n=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
+echo "$n" > "$count_file"
+exit 78
+STUB
+chmod +x "$d/cmd"; rm -f "$d/count"
 PNPM_RETRY_DELAY=0 PNPM_RETRY_ATTEMPTS=3 "$WRAPPER" "$d/cmd" >/dev/null 2>&1
-rc=$?
-if [ "$rc" -ne 0 ]; then ok "gives up after the attempt limit (non-zero exit)"; else bad "masked a persistent failure"; fi
+check_eq "gives up and preserves the wrapped exit code" "78" "$?"
 check_eq "  ...having tried exactly the limit" "3" "$(cat "$d/count")"
 
 # 4. Attempt count is configurable, so the Dockerfile can tune it per stage.
@@ -79,16 +89,68 @@ d="$tmpdir/t4"; mkdir -p "$d"; make_stub "$d/cmd" 99
 PNPM_RETRY_DELAY=0 PNPM_RETRY_ATTEMPTS=2 "$WRAPPER" "$d/cmd" >/dev/null 2>&1
 check_eq "honours PNPM_RETRY_ATTEMPTS" "2" "$(cat "$d/count")"
 
-# 5. Arguments reach the wrapped command intact — the real call sites pass
-#    flags like --frozen-lockfile --prod that must not be swallowed.
+# 5. Arguments reach the wrapped command as SEPARATE words, preserving any that
+#    contain spaces. Recording "$@" one-per-line (not "$*") is what makes this able
+#    to fail: a wrapper that collapsed argv via `sh -c "$*"` would join everything
+#    into one word and split "a b" into two, and a "$*" comparison could not tell.
 d="$tmpdir/t5"; mkdir -p "$d"
 cat > "$d/cmd" <<'STUB'
 #!/usr/bin/env bash
-printf '%s\n' "$*" > "$(dirname "$0")/args"
+printf '%s\n' "$@" > "$(dirname "$0")/args"
 STUB
 chmod +x "$d/cmd"
-PNPM_RETRY_DELAY=0 "$WRAPPER" "$d/cmd" install --frozen-lockfile --prod >/dev/null 2>&1
-check_eq "passes arguments through unchanged" "install --frozen-lockfile --prod" "$(cat "$d/args")"
+PNPM_RETRY_DELAY=0 "$WRAPPER" "$d/cmd" install --frozen-lockfile "spaced arg" >/dev/null 2>&1
+expected=$(printf 'install\n--frozen-lockfile\nspaced arg')
+check_eq "passes arguments through as distinct words" "$expected" "$(cat "$d/args")"
+
+# 6. Misuse is rejected rather than silently treated as success.
+PNPM_RETRY_DELAY=0 "$WRAPPER" >/dev/null 2>&1
+check_eq "no command given exits 2" "2" "$?"
+
+# 7. A non-numeric knob is rejected up front. Without the guard, the `-ge` comparison
+#    fails under `set -e` and replaces the wrapped command's real exit code with 2.
+d="$tmpdir/t7"; mkdir -p "$d"; make_stub "$d/cmd" 0
+PNPM_RETRY_DELAY=0 PNPM_RETRY_ATTEMPTS=abc "$WRAPPER" "$d/cmd" >/dev/null 2>&1
+check_eq "rejects a non-numeric PNPM_RETRY_ATTEMPTS" "2" "$?"
+if [ ! -f "$d/count" ]; then ok "  ...before running the command at all"; else bad "  ...ran the command anyway"; fi
+
+# 8. When every attempt fails the same way, the operator is told it is NOT transient.
+#    The whole risk of a retry wrapper is that it makes deterministic breakage (a stale
+#    lockfile is the common one) read as flakiness.
+d="$tmpdir/t8"; mkdir -p "$d"; make_stub "$d/cmd" 99
+out=$(PNPM_RETRY_DELAY=0 PNPM_RETRY_ATTEMPTS=2 "$WRAPPER" "$d/cmd" 2>&1 || true)
+case "$out" in
+  *"failed identically"*) ok "warns that an identical repeat failure is not transient" ;;
+  *) bad "no not-transient warning on identical repeat failures" ;;
+esac
+
+# 9. Re-run the load-bearing cases under the shells the Dockerfile ACTUALLY uses.
+#    The wrapper's shebang is `#!/usr/bin/env sh`, and in node:24-slim /bin/sh is dash,
+#    not bash. Testing only under bash hid a real bug: `[ 1 -ge abc ]` returns 2 in dash,
+#    which an `if` reads as false, so a non-numeric attempts value looped forever instead
+#    of giving up — an unbounded hang burning the CI job limit. These cases pin the
+#    guard under each available shell rather than trusting bash to be representative.
+for shell in sh dash bash; do
+  command -v "$shell" >/dev/null 2>&1 || continue
+
+  d="$tmpdir/shell-$shell"; mkdir -p "$d"
+  printf '#!/bin/sh\nexit 42\n' > "$d/fail"; chmod +x "$d/fail"
+
+  # Non-numeric attempts must exit 2 promptly, never spin.
+  PNPM_RETRY_ATTEMPTS=abc PNPM_RETRY_DELAY=0 "$shell" "$WRAPPER" "$d/fail" >/dev/null 2>&1
+  check_eq "[$shell] non-numeric attempts exits 2 (does not hang)" "2" "$?"
+
+  # Zero/negative attempts would also skip the give-up branch.
+  PNPM_RETRY_ATTEMPTS=0 PNPM_RETRY_DELAY=0 "$shell" "$WRAPPER" "$d/fail" >/dev/null 2>&1
+  check_eq "[$shell] zero attempts exits 2" "2" "$?"
+
+  # Exit-status preservation is the anti-masking property; verify per shell.
+  PNPM_RETRY_ATTEMPTS=2 PNPM_RETRY_DELAY=0 "$shell" "$WRAPPER" "$d/fail" >/dev/null 2>&1
+  check_eq "[$shell] preserves wrapped exit code on give-up" "42" "$?"
+
+  PNPM_RETRY_DELAY=0 "$shell" "$WRAPPER" true >/dev/null 2>&1
+  check_eq "[$shell] success exits 0" "0" "$?"
+done
 
 echo
 echo "pnpm-retry: $pass passed, $fail failed"

--- a/tests/docker/test-pnpm-retry.sh
+++ b/tests/docker/test-pnpm-retry.sh
@@ -114,17 +114,65 @@ PNPM_RETRY_DELAY=0 PNPM_RETRY_ATTEMPTS=abc "$WRAPPER" "$d/cmd" >/dev/null 2>&1
 check_eq "rejects a non-numeric PNPM_RETRY_ATTEMPTS" "2" "$?"
 if [ ! -f "$d/count" ]; then ok "  ...before running the command at all"; else bad "  ...ran the command anyway"; fi
 
-# 8. When every attempt fails the same way, the operator is told it is NOT transient.
-#    The whole risk of a retry wrapper is that it makes deterministic breakage (a stale
-#    lockfile is the common one) read as flakiness.
+# 8. When every attempt fails the same way, the operator gets the observation and NO
+#    verdict. An earlier version called an identical repeat failure "very likely
+#    deterministic, NOT a transient network fault" — which is backwards for the exact
+#    incident this wrapper exists for: pnpm and Node both exit 1 for nearly everything,
+#    so a sustained registry outage produces three identical exit 1s and would have been
+#    reported as a lockfile problem. Equal statuses carry no signal; don't pretend.
 d="$tmpdir/t8"; mkdir -p "$d"; make_stub "$d/cmd" 99
 out=$(PNPM_RETRY_DELAY=0 PNPM_RETRY_ATTEMPTS=2 "$WRAPPER" "$d/cmd" 2>&1 || true)
 case "$out" in
-  *"failed identically"*) ok "warns that an identical repeat failure is not transient" ;;
-  *) bad "no not-transient warning on identical repeat failures" ;;
+  *"every attempt exited 1"*) ok "reports an identical repeat failure without a verdict" ;;
+  *) bad "no report of identical repeat failures" ;;
+esac
+case "$out" in
+  *"cannot tell transient from deterministic"*) ok "  ...and says the cause is unknown" ;;
+  *) bad "  ...but does not admit the cause is unknown" ;;
+esac
+# Guard the regression directly: never claim a repeated failure is non-transient.
+case "$out" in
+  *"NOT a transient"*|*"failed identically"*) bad "  ...but still asserts a deterministic cause" ;;
+  *) ok "  ...and never asserts the failure was non-transient" ;;
 esac
 
-# 9. Re-run the load-bearing cases under the shells the Dockerfile ACTUALLY uses.
+# 9. A zero-prefixed PNPM_RETRY_DELAY is a decimal, not an octal constant.
+#    `$(( ))` follows C rules, so an unnormalized `010` silently means 8, and `08` is not
+#    a valid octal constant at all: the shell aborts under `set -e` and the wrapped
+#    command's exit code is replaced by the shell's. Both slip past the digits-only
+#    validator, so the normalization is the only thing standing between them and a
+#    build whose reported failure is not the failure that happened.
+#
+#    `sleep` is shadowed on PATH so these run instantly AND so the delay the wrapper
+#    actually computed is observable rather than merely inferred from timing.
+d="$tmpdir/t9"; mkdir -p "$d/bin"
+printf '#!/bin/sh\nexit 42\n' > "$d/cmd"; chmod +x "$d/cmd"
+printf '#!/bin/sh\necho "SLEPT:$1" >&2\n' > "$d/bin/sleep"; chmod +x "$d/bin/sleep"
+
+out=$(PATH="$d/bin:$PATH" PNPM_RETRY_DELAY=010 PNPM_RETRY_ATTEMPTS=2 "$WRAPPER" "$d/cmd" 2>&1)
+check_eq "zero-prefixed delay 010 preserves the wrapped exit code" "42" "$?"
+case "$out" in
+  *"SLEPT:10"*) ok "  ...and waits 10s (decimal), not 8s (octal)" ;;
+  *) bad "  ...but waited the octal value ($(printf '%s' "$out" | tr '\n' ' '))" ;;
+esac
+
+# `08` is the sharper case: invalid octal, so it kills the shell mid-retry.
+out=$(PATH="$d/bin:$PATH" PNPM_RETRY_DELAY=08 PNPM_RETRY_ATTEMPTS=2 "$WRAPPER" "$d/cmd" 2>&1)
+check_eq "invalid-octal delay 08 preserves the wrapped exit code" "42" "$?"
+case "$out" in
+  *"SLEPT:8"*) ok "  ...and still retries rather than aborting the shell" ;;
+  *) bad "  ...but did not retry ($(printf '%s' "$out" | tr '\n' ' '))" ;;
+esac
+
+# A delay of all zeros must normalize to 0, not to the empty string.
+out=$(PATH="$d/bin:$PATH" PNPM_RETRY_DELAY=000 PNPM_RETRY_ATTEMPTS=2 "$WRAPPER" "$d/cmd" 2>&1)
+check_eq "all-zero delay 000 preserves the wrapped exit code" "42" "$?"
+case "$out" in
+  *"SLEPT:0"*) ok "  ...and normalizes to 0" ;;
+  *) bad "  ...but did not normalize to 0 ($(printf '%s' "$out" | tr '\n' ' '))" ;;
+esac
+
+# 10. Re-run the load-bearing cases under the shells the Dockerfile ACTUALLY uses.
 #    The wrapper's shebang is `#!/usr/bin/env sh`, and in node:24-slim /bin/sh is dash,
 #    not bash. Testing only under bash hid a real bug: `[ 1 -ge abc ]` returns 2 in dash,
 #    which an `if` reads as false, so a non-numeric attempts value looped forever instead
@@ -150,6 +198,13 @@ for shell in sh dash bash; do
 
   PNPM_RETRY_DELAY=0 "$shell" "$WRAPPER" true >/dev/null 2>&1
   check_eq "[$shell] success exits 0" "0" "$?"
+
+  # Octal is an arithmetic-evaluation behaviour, so it belongs in the per-shell sweep:
+  # `08` aborts sh, dash, and bash alike, each with its own status, and any of them
+  # would overwrite the wrapped command's 42.
+  mkdir -p "$d/bin"; printf '#!/bin/sh\necho "SLEPT:$1" >&2\n' > "$d/bin/sleep"; chmod +x "$d/bin/sleep"
+  PATH="$d/bin:$PATH" PNPM_RETRY_ATTEMPTS=2 PNPM_RETRY_DELAY=08 "$shell" "$WRAPPER" "$d/fail" >/dev/null 2>&1
+  check_eq "[$shell] invalid-octal delay does not replace the exit code" "42" "$?"
 done
 
 echo

--- a/tests/docker/test-pnpm-retry.sh
+++ b/tests/docker/test-pnpm-retry.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tests for docker/pnpm-retry.sh (curia#1699).
+#
+# Why this wrapper exists: the docker-publish build died on a transient npm
+# registry socket drop during the emulated arm64 `pnpm install` (run 33556099876).
+# The failure shape matters — it was NOT a timeout that pnpm caught and retried:
+#
+#   TypeError: terminated
+#     [cause]: SocketError: other side closed   UND_ERR_SOCKET
+#   Emitted 'error' event on Readable instance
+#   node:events:505  throw er; // Unhandled 'error' event
+#
+# Node aborted the process. pnpm's own fetchRetries never engaged, because the
+# stream error was unhandled rather than surfaced as a retryable request failure.
+# So config alone cannot fix it; the command has to be retried from outside.
+#
+# These tests use a stub command rather than a real pnpm so they are fast, offline,
+# and deterministic. Run: bash tests/docker/test-pnpm-retry.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$REPO_ROOT/docker/pnpm-retry.sh"
+
+pass=0
+fail=0
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+ok()   { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '  FAIL %s\n' "$1"; fail=$((fail + 1)); }
+
+check_eq() { # label expected actual
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+
+# A stub that fails the first N invocations then succeeds, counting attempts in a file.
+make_stub() { # path fail_times
+  cat > "$1" <<STUB
+#!/usr/bin/env bash
+count_file="\$(dirname "\$0")/count"
+n=\$(( \$(cat "\$count_file" 2>/dev/null || echo 0) + 1 ))
+echo "\$n" > "\$count_file"
+if [ "\$n" -le $2 ]; then echo "stub: simulated failure \$n" >&2; exit 1; fi
+echo "stub: success on attempt \$n"
+exit 0
+STUB
+  chmod +x "$1"
+  rm -f "$(dirname "$1")/count"
+}
+
+echo "docker/pnpm-retry.sh"
+
+[ -f "$WRAPPER" ] || { echo "  FAIL wrapper not found at $WRAPPER"; exit 1; }
+[ -x "$WRAPPER" ] || bad "wrapper is not executable"
+
+# 1. A command that succeeds first time runs exactly once (no wasted retries).
+d="$tmpdir/t1"; mkdir -p "$d"; make_stub "$d/cmd" 0
+PNPM_RETRY_DELAY=0 "$WRAPPER" "$d/cmd" >/dev/null 2>&1
+check_eq "succeeds first try, runs once" "1" "$(cat "$d/count")"
+
+# 2. A command that fails twice then succeeds is retried and ultimately succeeds.
+#    This is the exact incident shape: transient failure, then a clean run.
+d="$tmpdir/t2"; mkdir -p "$d"; make_stub "$d/cmd" 2
+PNPM_RETRY_DELAY=0 "$WRAPPER" "$d/cmd" >/dev/null 2>&1
+rc=$?
+check_eq "retries a transient failure, then succeeds" "0" "$rc"
+check_eq "  ...after exactly 3 attempts" "3" "$(cat "$d/count")"
+
+# 3. A persistently failing command eventually gives up and fails the build.
+#    A retry wrapper that masked a real failure would be worse than none.
+d="$tmpdir/t3"; mkdir -p "$d"; make_stub "$d/cmd" 99
+PNPM_RETRY_DELAY=0 PNPM_RETRY_ATTEMPTS=3 "$WRAPPER" "$d/cmd" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then ok "gives up after the attempt limit (non-zero exit)"; else bad "masked a persistent failure"; fi
+check_eq "  ...having tried exactly the limit" "3" "$(cat "$d/count")"
+
+# 4. Attempt count is configurable, so the Dockerfile can tune it per stage.
+d="$tmpdir/t4"; mkdir -p "$d"; make_stub "$d/cmd" 99
+PNPM_RETRY_DELAY=0 PNPM_RETRY_ATTEMPTS=2 "$WRAPPER" "$d/cmd" >/dev/null 2>&1
+check_eq "honours PNPM_RETRY_ATTEMPTS" "2" "$(cat "$d/count")"
+
+# 5. Arguments reach the wrapped command intact — the real call sites pass
+#    flags like --frozen-lockfile --prod that must not be swallowed.
+d="$tmpdir/t5"; mkdir -p "$d"
+cat > "$d/cmd" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$(dirname "$0")/args"
+STUB
+chmod +x "$d/cmd"
+PNPM_RETRY_DELAY=0 "$WRAPPER" "$d/cmd" install --frozen-lockfile --prod >/dev/null 2>&1
+check_eq "passes arguments through unchanged" "install --frozen-lockfile --prod" "$(cat "$d/args")"
+
+echo
+echo "pnpm-retry: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Makes `docker-publish` survive a transient registry drop, and makes a failed publish impossible to miss.

Closes #1699.

## The premise in the issue was wrong, and it changed the fix

#1699 (which I wrote) proposed pnpm `fetch-retry` settings. Investigating showed **that alone would not have prevented the failure.**

pnpm does retry what it catches — it logs `ERR_SOCKET_TIMEOUT ... Will retry in 10 seconds`. But run 33556099876 failed differently:

```
TypeError: terminated
  [cause]: SocketError: other side closed   UND_ERR_SOCKET
Emitted 'error' event on Readable instance
node:events:505   throw er; // Unhandled 'error' event
```

That is an **unhandled** stream error. Node aborted the process before pnpm could retry anything. No `fetchRetries` value would have saved that build. Shipping config-only would have closed the issue while leaving the bug live.

So the fix is two complementary layers:

| Layer | Catches |
|---|---|
| `pnpm-workspace.yaml` `fetch*` settings | request failures pnpm classifies as retryable |
| `docker/pnpm-retry.sh` | the whole command dying, which is the only thing that survives a process abort |

## Changes

**Retry wrapper** (`docker/pnpm-retry.sh`, POSIX sh) applied to all **three** network-fetching pnpm invocations — the build install, the prod install, and `pnpm add tsx`, which had the same exposure.

**`apt` retries** (`Acquire::Retries=3`) in both Dockerfiles. This matters more than it looks: `apt` is the `curia-postgres` leg's *only* network step, so that image got zero benefit from the pnpm work while a failure alert would have blamed npm.

**`.dockerignore`** needed `!docker/pnpm-retry.sh` — `docker/*` is excluded with an allowlist, so without it the `COPY` fails and **every** build breaks.

**Failure alert** (`notify-failure` job) opens or comments a labelled tracking issue. `GITHUB_TOKEN` is this repo's only secret, so a GitHub issue is the one dependency-free channel available.

**Job timeout** (`timeout-minutes: 60`) bounds the retry layers, which compose multiplicatively.

## Three bugs caught before CI

**The wrapper silently green-lit persistent failures.** My first version read `status=$?` *after* `if cmd; then … fi`. POSIX returns 0 when no branch is taken, so a real failure exited **0**. A retry wrapper that masks failures is worse than none. Test 3 caught it; the fix carries a comment explaining why it must not be restructured back.

**A non-numeric `PNPM_RETRY_ATTEMPTS` looped forever.** Under dash, `[ 1 -ge abc ]` exits 2, which `if` reads as false — so the give-up branch never ran. An unbounded hang burning the CI job limit. Found only because a reviewer ran it under dash; my tests were bash-only, and the wrapper runs under dash in `node:24-slim`. The tests now re-run the load-bearing cases under **sh, dash, and bash**.

**`.dockerignore` would have broken every build**, as above.

## The alert stopped asserting things that are often false

The first version hardcoded `failed on main — :edge is stale`. That is wrong in three real cases:

- **release trigger** — `:edge` is not applied at all; the missing tags are semver and `latest`
- **one matrix leg** — `fail-fast: false`, so the other image may have published fine
- **cosign failure** — signing runs *after* the push, so the image is current and only its signature is missing

It now derives wording from the event and tells the reader to check which part failed. It also no longer asserts a transient registry drop as the cause: an identical repeat failure is deterministic (a stale lockfile is the usual culprit), and both the wrapper and the issue now say so instead of sending the operator to debug the retry.

Dedupe hardened: `listForRepo` also returns pull requests, so a labelled PR could have swallowed every future alert onto a merged thread; and reuse is bounded to 7 days so an abandoned issue cannot become a permanent black hole — the same "nobody looks at it" failure one layer up.

## Verification

- **23 wrapper tests**, wired into `test:shell` → CI. Cover: runs once on success, retries transients, gives up preserving the wrapped exit code, rejects bad knobs before running anything, warns when a repeat failure is not transient, and passes argv through as distinct words.
- The argv test previously **could not fail** — a `"$*"` comparison cannot detect argv collapsing. It now uses `"$@"` with a space-containing argument; I confirmed a deliberately-collapsing wrapper fails it.
- **10 mocked assertions** on the notification logic (create/reuse/PR-skip/stale-thread/release-wording/hedging), run against a stubbed Octokit.
- Embedded github-script syntax-checked with `node --check` as github-script wraps it, since that code otherwise only executes when a publish fails.
- Action SHA resolved and verified against the real repo (`v9.0.0` → `3a2844b7`), not invented.
- pnpm reads the settings back (`pnpm config get fetchRetries` → `3`); no config warnings; lockfile untouched.
- Full suite 6144 passed; typecheck and lint clean.

**Not verified locally:** Docker is paused on my machine, so I have **not built the image**. The `COPY`, PATH, and executable-bit behaviour is evidence-backed (git records `100755`; `.dockerignore` exception matches the existing working pattern) but proven only in CI.

## Follow-up spotted, not fixed here

A `workflow_dispatch` from the `main` ref with a `tag` input checks out that tag but computes tags from `github.ref`, so `type=semver` yields nothing while `edge` evaluates true — a green run that publishes an **old release as `:edge`** and no release tags. Pre-existing and out of scope; filed as **#1718**.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] CHANGELOG updated
- [ ] CI passes
