### PR TITLE
fix(memory): keep raw entity names out of resolveOrCreate, addAlias, and memory-store logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`resolveOrCreate` / `addAlias` / `memory-store`** — error logs keep the class name, not the message. (#1713)
 - **`resolveOrCreate` / `addAlias`** — logs use node id instead of the raw label or alias. (#1713)
 - **`memory-store`** — fact-loop logs use node id instead of the raw entity name. (#1713)
 - **Contact merge** — secondary KG memory folds into the survivor after the contact delete. (#1711)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`resolveOrCreate` / `addAlias`** — logs use node id instead of the raw label or alias. (#1713)
+- **`memory-store`** — fact-loop logs use node id instead of the raw entity name. (#1713)
 - **Contact merge** — secondary KG memory folds into the survivor after the contact delete. (#1711)
 - **`docker-publish`** — a transient registry drop mid-`pnpm install` retries instead of failing the publish. (#1699)
 - **`docker-publish`** — `apt` fetches retry too; the `curia-postgres` leg has no other network step. (#1699)

--- a/skills/memory/tools/memory-store/handler.test.ts
+++ b/skills/memory/tools/memory-store/handler.test.ts
@@ -663,4 +663,376 @@ describe('MemoryStoreHandler', () => {
       expect((result as { success: false; error: string }).error).toContain('DB connection lost');
     });
   });
+
+  // -- PII guard: fact-loop logs (#1713) --
+  //
+  // `entity` is a caller-supplied name (usually a person's name) and the pino
+  // redact list does not cover it. Substitute entityNodeId where a node is
+  // resolved; otherwise log type/presence flags. UUID paths log the UUID as
+  // entityNodeId (it is already a node id, not a name).
+  describe('fact-loop logs never carry the raw entity name (PII guard)', () => {
+    const PII_ENTITY = 'Priya Ramanathan';
+    const NODE_ID = 'entity-1';
+    const UNNORMALIZABLE_PHONE = '020 7946 0958';
+    const UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+    function spyLog() {
+      const log = {
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      };
+      log.child.mockReturnValue(log);
+      return log;
+    }
+
+    function findCall(fn: ReturnType<typeof vi.fn>, messageRe: RegExp) {
+      return fn.mock.calls.find(c => messageRe.test(String(c[c.length - 1])));
+    }
+
+    function serializeLogPayload(payload: unknown): string {
+      const obj = payload as Record<string, unknown> | null;
+      const err = obj?.err;
+      const errText = err instanceof Error
+        ? `${err.name} ${err.message} ${err.stack ?? ''}`
+        : '';
+      return `${JSON.stringify(payload)}\n${errText}`;
+    }
+
+    function expectNoPii(call: unknown[] | undefined, extraForbidden: string[] = []) {
+      expect(call).toBeDefined();
+      const serialized = serializeLogPayload(call![0]);
+      expect(serialized).not.toContain(PII_ENTITY);
+      for (const s of extraForbidden) {
+        expect(serialized).not.toContain(s);
+      }
+      expect(call![0]).not.toHaveProperty('entity');
+    }
+
+    function piiInput(overrides: Record<string, unknown> = {}) {
+      return {
+        entity: PII_ENTITY,
+        field: 'preferred_airline',
+        value: 'Air Canada',
+        source: 'test',
+        ...overrides,
+      };
+    }
+
+    function mockMem(storeFactResult: Record<string, unknown>, node: { id: string; label: string; type: string } = {
+      id: NODE_ID,
+      label: PII_ENTITY,
+      type: 'person',
+    }) {
+      return {
+        resolveOrCreate: vi.fn().mockResolvedValue({ kind: 'found', node }),
+        storeFact: vi.fn().mockResolvedValue(storeFactResult),
+        getEntity: vi.fn().mockResolvedValue(node),
+        addAlias: vi.fn().mockResolvedValue(undefined),
+      };
+    }
+
+    function ctxFor(
+      entityMemory: ReturnType<typeof mockMem> | EntityMemory,
+      input: Record<string, unknown>,
+      extras: Record<string, unknown> = {},
+    ) {
+      const log = spyLog();
+      const ctx = {
+        input,
+        secret: () => 'test-key',
+        log,
+        entityMemory,
+        ...extras,
+      } as unknown as ToolContext;
+      return { ctx, log };
+    }
+
+    it('UUID entity_type-ignored warn', async () => {
+      const entityMemory = mockMem({ stored: true, action: 'created', nodeId: 'fact-1' }, {
+        id: UUID, label: PII_ENTITY, type: 'person',
+      });
+      const { ctx, log } = ctxFor(entityMemory, piiInput({ entity: UUID, entity_type: 'person' }));
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /entity_type hint is ignored/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', UUID);
+      expect(call![0]).toHaveProperty('entity_type', 'person');
+    });
+
+    it('UUID-not-found warn', async () => {
+      const entityMemory = {
+        ...mockMem({}),
+        getEntity: vi.fn().mockResolvedValue(undefined),
+      };
+      const { ctx, log } = ctxFor(entityMemory, piiInput({ entity: UUID }));
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /entity UUID not found/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', UUID);
+    });
+
+    it('ambiguous-entity debug', async () => {
+      const { mem, store } = makeEntityMemory();
+      await store.createNode({ type: 'person', label: PII_ENTITY, properties: {}, source: 'test' });
+      await store.createNode({ type: 'organization', label: PII_ENTITY, properties: {}, source: 'test' });
+      const { ctx, log } = ctxFor(mem, piiInput());
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.debug, /ambiguous entity label/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('candidateCount', 2);
+      expect(call![0]).toHaveProperty('expectedType', 'concept');
+      expect(call![0]).not.toHaveProperty('entityNodeId');
+    });
+
+    it('canonical-normalization-failed warn', async () => {
+      const entityMemory = mockMem({ stored: true, action: 'created', nodeId: 'fact-1' });
+      const { ctx, log } = ctxFor(
+        entityMemory,
+        piiInput({ field: 'phone', value: UNNORMALIZABLE_PHONE }),
+        {
+          contactService: {
+            findContactByKgNodeId: vi.fn().mockResolvedValue({ id: 'contact-1' }),
+            updateContactFields: vi.fn(),
+          },
+        },
+      );
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /canonical attribute normalization failed/);
+      expectNoPii(call, [UNNORMALIZABLE_PHONE, '7946 0958']);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('field', 'phone');
+      expect(call![0]).toHaveProperty('reason', 'phone_normalization_failed');
+    });
+
+    it('findContactByKgNodeId-failed warn', async () => {
+      const entityMemory = mockMem({ stored: true, action: 'created', nodeId: 'fact-1' });
+      const { ctx, log } = ctxFor(
+        entityMemory,
+        piiInput({ field: 'timezone', value: 'America/Toronto' }),
+        {
+          contactService: {
+            findContactByKgNodeId: vi.fn().mockRejectedValue(new Error('connection timeout')),
+            updateContactFields: vi.fn(),
+          },
+        },
+      );
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /findContactByKgNodeId failed/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('field', 'timezone');
+    });
+
+    it('canonical-redirected info', async () => {
+      const entityMemory = mockMem({});
+      const { ctx, log } = ctxFor(
+        entityMemory,
+        piiInput({ field: 'timezone', value: 'America/Toronto' }),
+        {
+          contactService: {
+            findContactByKgNodeId: vi.fn().mockResolvedValue({ id: 'contact-1' }),
+            updateContactFields: vi.fn().mockResolvedValue({ id: 'contact-1' }),
+          },
+        },
+      );
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.info, /canonical attribute redirected/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('contactId', 'contact-1');
+    });
+
+    it('canonical-redirect-failed warn', async () => {
+      const entityMemory = mockMem({});
+      const { ctx, log } = ctxFor(
+        entityMemory,
+        piiInput({ field: 'primary_email', value: 'priya@example.com' }),
+        {
+          contactService: {
+            findContactByKgNodeId: vi.fn().mockResolvedValue({ id: 'contact-1' }),
+            updateContactFields: vi.fn().mockRejectedValue(
+              new Error('primaryEmail not found in contact_channel_identities'),
+            ),
+          },
+        },
+      );
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /canonical attribute redirect to ContactService failed/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('contactId', 'contact-1');
+    });
+
+    it('memoryWriteSource-fallback debug', async () => {
+      const entityMemory = mockMem({ stored: true, action: 'created', nodeId: 'fact-1' });
+      const { ctx, log } = ctxFor(entityMemory, piiInput());
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.debug, /memoryWriteSource not set/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('field', 'preferred_airline');
+    });
+
+    it('sensitivity-fallback warn', async () => {
+      const entityMemory = mockMem({
+        stored: true,
+        action: 'updated',
+        nodeId: 'fact-1',
+        sensitivity: 'internal',
+        sensitivityFallback: true,
+      });
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /sensitivity in result may be inaccurate/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('nodeId', 'fact-1');
+    });
+
+    it('fact-stored info', async () => {
+      const entityMemory = mockMem({ stored: true, action: 'created', nodeId: 'fact-1', sensitivity: 'internal' });
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.info, /memory-store: fact stored/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('action', 'created');
+      expect(call![0]).toHaveProperty('nodeId', 'fact-1');
+    });
+
+    it('fact-conflict warn', async () => {
+      const entityMemory = mockMem({
+        stored: false,
+        action: 'conflict',
+        conflict: 'contradicts existing value',
+        existingNodeId: 'fact-old',
+      });
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /fact conflicts with existing KG data/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('existingNodeId', 'fact-old');
+    });
+
+    it('entity-gone-at-write-time warn', async () => {
+      const entityMemory = mockMem({
+        stored: false,
+        action: 'entity_not_found',
+        conflict: 'Entity node not found: entity-1',
+      });
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /entity node gone at write time/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+    });
+
+    it('rate-limited warn', async () => {
+      const entityMemory = mockMem({
+        stored: false,
+        action: 'rate_limited',
+        conflict: 'Memory write rate limit exceeded (50 per agent per task)',
+      });
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.warn, /write rate limit reached/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+    });
+
+    it('auto-rejected info', async () => {
+      const entityMemory = mockMem({
+        stored: false,
+        action: 'auto_rejected',
+        conflict: 'existing has higher confidence',
+        existingNodeId: 'fact-old',
+      });
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.info, /fact auto-rejected/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('existingNodeId', 'fact-old');
+    });
+
+    it('impossible storeFact state error', async () => {
+      const entityMemory = mockMem({ stored: false, action: 'created' });
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.error, /impossible storeFact state/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).toHaveProperty('action', 'created');
+    });
+
+    it('unhandled storeFact action error', async () => {
+      const entityMemory = mockMem({ stored: false, action: 'not_a_real_action' });
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.error, /unhandled storeFact action/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+    });
+
+    it('unexpected-error after resolution', async () => {
+      const entityMemory = mockMem({});
+      entityMemory.storeFact.mockRejectedValue(new Error('DB connection lost'));
+      const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.error, /memory-store: unexpected error/);
+      expectNoPii(call);
+      expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
+      expect(call![0]).not.toHaveProperty('entity');
+    });
+
+    it('unexpected-error before resolution', async () => {
+      const entityMemory = mockMem({});
+      entityMemory.resolveOrCreate.mockRejectedValue(new Error('DB connection lost'));
+      const { ctx, log } = ctxFor(entityMemory, piiInput());
+
+      await handler.execute(ctx);
+
+      const call = findCall(log.error, /memory-store: unexpected error/);
+      expectNoPii(call);
+      expect((call![0] as Record<string, unknown>).entityNodeId).toBeUndefined();
+    });
+  });
 });

--- a/skills/memory/tools/memory-store/handler.test.ts
+++ b/skills/memory/tools/memory-store/handler.test.ts
@@ -1012,7 +1012,7 @@ describe('MemoryStoreHandler', () => {
 
     it('unexpected-error after resolution', async () => {
       const entityMemory = mockMem({});
-      entityMemory.storeFact.mockRejectedValue(new Error('DB connection lost'));
+      entityMemory.storeFact.mockRejectedValue(new Error(`DB connection lost for ${PII_ENTITY}`));
       const { ctx, log } = ctxFor(entityMemory, piiInput(), { memoryWriteSource: 'agent:test/task:1' });
 
       await handler.execute(ctx);
@@ -1021,11 +1021,14 @@ describe('MemoryStoreHandler', () => {
       expectNoPii(call);
       expect(call![0]).toHaveProperty('entityNodeId', NODE_ID);
       expect(call![0]).not.toHaveProperty('entity');
+      expect(call![0]).not.toHaveProperty('err');
+      expect(call![0]).not.toHaveProperty('error');
+      expect(call![0]).toHaveProperty('errorName', 'Error');
     });
 
     it('unexpected-error before resolution', async () => {
       const entityMemory = mockMem({});
-      entityMemory.resolveOrCreate.mockRejectedValue(new Error('DB connection lost'));
+      entityMemory.resolveOrCreate.mockRejectedValue(new Error(`DB connection lost for ${PII_ENTITY}`));
       const { ctx, log } = ctxFor(entityMemory, piiInput());
 
       await handler.execute(ctx);
@@ -1033,6 +1036,9 @@ describe('MemoryStoreHandler', () => {
       const call = findCall(log.error, /memory-store: unexpected error/);
       expectNoPii(call);
       expect((call![0] as Record<string, unknown>).entityNodeId).toBeUndefined();
+      expect(call![0]).not.toHaveProperty('err');
+      expect(call![0]).not.toHaveProperty('error');
+      expect(call![0]).toHaveProperty('errorName', 'Error');
     });
   });
 });

--- a/skills/memory/tools/memory-store/handler.ts
+++ b/skills/memory/tools/memory-store/handler.ts
@@ -102,6 +102,10 @@ export class MemoryStoreHandler implements ToolHandler {
       return { success: false, error: 'Entity memory not available — database not configured' };
     }
 
+    // Hoisted so catch can log entityNodeId when resolution completed.
+    // Never log the raw `entity` name — it is PII and the pino redact list does not cover it.
+    let entityNode: KgNode | undefined;
+
     try {
       // --- Entity resolution ---
       //
@@ -113,20 +117,19 @@ export class MemoryStoreHandler implements ToolHandler {
       // if not found); UUIDs return entity_not_found if the node was deleted.
 
       const resolvedEntityType = (entity_type as NodeType | undefined) ?? 'concept';
-      let entityNode: KgNode;
 
       if (UUID_PATTERN.test(entity)) {
         // entity_type has no effect when a UUID is supplied — the node type is already
         // determined by the existing KG node. Log a warning so LLM callers notice the mismatch.
         if (entity_type !== undefined) {
           ctx.log.warn(
-            { entity, entity_type },
+            { entityNodeId: entity, entity_type },
             'memory-store: entity_type hint is ignored when entity is a UUID — type is fixed by the existing KG node',
           );
         }
         const byId = await ctx.entityMemory.getEntity(entity);
         if (!byId) {
-          ctx.log.warn({ entity }, 'memory-store: entity UUID not found in KG — entity may have been deleted');
+          ctx.log.warn({ entityNodeId: entity }, 'memory-store: entity UUID not found in KG — entity may have been deleted');
           return {
             success: true,
             data: {
@@ -151,7 +154,10 @@ export class MemoryStoreHandler implements ToolHandler {
         });
 
         if (resolved.kind === 'ambiguous') {
-          ctx.log.debug({ entity, count: resolved.candidates.length }, 'memory-store: ambiguous entity label');
+          ctx.log.debug(
+            { candidateCount: resolved.candidates.length, expectedType: resolvedEntityType },
+            'memory-store: ambiguous entity label',
+          );
           return {
             success: true,
             data: {
@@ -185,7 +191,7 @@ export class MemoryStoreHandler implements ToolHandler {
           if (patch.fallbackToKg) {
             // Normalization failed (e.g. unparseable phone number) — let the KG write through.
             ctx.log.warn(
-              { entity, field, reason: patch.reason },
+              { entityNodeId: entityNode.id, field, reason: patch.reason },
               'memory-store: canonical attribute normalization failed — falling back to KG write',
             );
           } else {
@@ -197,7 +203,7 @@ export class MemoryStoreHandler implements ToolHandler {
               contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
             } catch (lookupErr) {
               ctx.log.warn(
-                { entity, field, entityNodeId: entityNode.id, err: lookupErr },
+                { entityNodeId: entityNode.id, field, err: lookupErr },
                 'memory-store: findContactByKgNodeId failed — falling back to KG write',
               );
             }
@@ -206,7 +212,7 @@ export class MemoryStoreHandler implements ToolHandler {
               try {
                 await ctx.contactService.updateContactFields(contact.id, patch.fields);
                 ctx.log.info(
-                  { entity, field, contactId: contact.id },
+                  { entityNodeId: entityNode.id, field, contactId: contact.id },
                   'memory-store: canonical attribute redirected to ContactService',
                 );
                 return {
@@ -222,7 +228,7 @@ export class MemoryStoreHandler implements ToolHandler {
                 // are surfaced as a skill error — the agent can retry or adjust.
                 const msg = err instanceof Error ? err.message : String(err);
                 ctx.log.warn(
-                  { entity, field, contactId: contact.id, err },
+                  { entityNodeId: entityNode.id, field, contactId: contact.id, err },
                   'memory-store: canonical attribute redirect to ContactService failed',
                 );
                 return { success: false, error: `Could not update contact field "${field}": ${msg}` };
@@ -251,7 +257,7 @@ export class MemoryStoreHandler implements ToolHandler {
         // taskEventId is available. If this fires in production, it means channelId
         // or agentId wasn't threaded through InvokeOptions — check the caller.
         ctx.log.debug(
-          { entity, field, fallbackSource: source },
+          { entityNodeId: entityNode.id, field, fallbackSource: source },
           'memory-store: memoryWriteSource not set — using LLM-provided source fallback',
         );
       }
@@ -269,12 +275,12 @@ export class MemoryStoreHandler implements ToolHandler {
       if (result.stored) {
         if (result.sensitivityFallback) {
           ctx.log.warn(
-            { entity, field, nodeId: result.nodeId, sensitivity: result.sensitivity },
+            { entityNodeId: entityNode.id, field, nodeId: result.nodeId, sensitivity: result.sensitivity },
             'memory-store: sensitivity in result may be inaccurate — stored node was unreadable after update (race/transient DB error)',
           );
         }
         ctx.log.info(
-          { entity, field, action: result.action, nodeId: result.nodeId },
+          { entityNodeId: entityNode.id, field, action: result.action, nodeId: result.nodeId },
           'memory-store: fact stored',
         );
         return {
@@ -290,7 +296,7 @@ export class MemoryStoreHandler implements ToolHandler {
 
       if (result.action === 'conflict') {
         ctx.log.warn(
-          { entity, field, existingNodeId: result.existingNodeId },
+          { entityNodeId: entityNode.id, field, existingNodeId: result.existingNodeId },
           'memory-store: fact conflicts with existing KG data — surfacing to agent',
         );
         return {
@@ -307,13 +313,13 @@ export class MemoryStoreHandler implements ToolHandler {
       switch (result.action) {
         case 'entity_not_found':
           // Validator race guard — entity existed at resolution time but was deleted before write.
-          ctx.log.warn({ entity, field }, 'memory-store: entity node gone at write time — validator race');
+          ctx.log.warn({ entityNodeId: entityNode.id, field }, 'memory-store: entity node gone at write time — validator race');
           return {
             success: true,
             data: { stored: false, action: 'entity_not_found', reason: result.conflict },
           };
         case 'rate_limited':
-          ctx.log.warn({ entity, field, reason: result.conflict }, 'memory-store: write rate limit reached');
+          ctx.log.warn({ entityNodeId: entityNode.id, field, reason: result.conflict }, 'memory-store: write rate limit reached');
           return {
             success: true,
             data: { stored: false, action: 'rate_limited', reason: result.conflict },
@@ -322,7 +328,7 @@ export class MemoryStoreHandler implements ToolHandler {
           // Auto-rejected: existing fact had higher confidence — write was dropped.
           // Surface to the agent so it knows the write was skipped and why.
           ctx.log.info(
-            { entity, field, existingNodeId: result.existingNodeId },
+            { entityNodeId: entityNode.id, field, existingNodeId: result.existingNodeId },
             'memory-store: fact auto-rejected — existing has higher confidence',
           );
           return {
@@ -345,7 +351,7 @@ export class MemoryStoreHandler implements ToolHandler {
           // resolve to a ToolResult, never throw), surface the impossible state as a
           // logged failure rather than a thrown Error.
           ctx.log.error(
-            { entity, field, action: result.action },
+            { entityNodeId: entityNode.id, field, action: result.action },
             'memory-store: impossible storeFact state (stored-only action reached the stored=false branch)',
           );
           return {
@@ -358,7 +364,7 @@ export class MemoryStoreHandler implements ToolHandler {
           // return a logged failure rather than throw, per the skill contract.
           const _exhaustive: never = result.action;
           ctx.log.error(
-            { entity, field, action: String(_exhaustive) },
+            { entityNodeId: entityNode.id, field, action: String(_exhaustive) },
             'memory-store: unhandled storeFact action',
           );
           return {
@@ -368,7 +374,16 @@ export class MemoryStoreHandler implements ToolHandler {
         }
       }
     } catch (err) {
-      ctx.log.error({ err, entity, field }, 'memory-store: unexpected error');
+      ctx.log.error(
+        {
+          err,
+          // Never the raw entity name. entityNodeId is set after resolution
+          // succeeds; undefined here is the pre-resolve signal.
+          entityNodeId: entityNode?.id,
+          field,
+        },
+        'memory-store: unexpected error',
+      );
       return { success: false, error: err instanceof Error ? err.message : String(err) };
     }
   }

--- a/skills/memory/tools/memory-store/handler.ts
+++ b/skills/memory/tools/memory-store/handler.ts
@@ -376,7 +376,10 @@ export class MemoryStoreHandler implements ToolHandler {
     } catch (err) {
       ctx.log.error(
         {
-          err,
+          // errorName, not the raw Error: pino serializes err.message, which can
+          // echo the caller-supplied entity name. The skill result still returns
+          // the message to the agent.
+          errorName: err instanceof Error ? err.name : typeof err,
           // Never the raw entity name. entityNodeId is set after resolution
           // succeeds; undefined here is the pre-resolve signal.
           entityNodeId: entityNode?.id,

--- a/skills/memory/tools/memory-store/tool.json
+++ b/skills/memory/tools/memory-store/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "memory-store",
   "description": "Write a named fact about a known entity to the knowledge graph. Resolves the entity by name (finding or auto-creating the KG node) or by node ID. Returns one of several outcomes: created (new fact node, stored), updated (near-duplicate merged, stored), auto_resolved (contradiction auto-resolved in favor of the incoming fact because the existing one had lower confidence, stored), auto_rejected (incoming fact discarded because an existing contradicting fact had higher confidence, not stored), conflict (contradicts an existing attribute fact of comparable confidence — surface to CEO before proceeding, not stored), entity_not_found (UUID entity gone — retry with name, not stored), rate_limited (write limit reached for this task, not stored), or redirected_to_contact (a canonical contact attribute was written to the contact record instead of the KG, not stored). When multiple entities share the same name and none matches the expected type, returns an ambiguous response with candidates for disambiguation — that response omits both action and stored.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -3,12 +3,13 @@
 //
 // Uses the in-memory KG backend — no Postgres required.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { KnowledgeGraphStore } from './knowledge-graph.js';
 import { EmbeddingService } from './embedding.js';
 import { EntityMemory, FUZZY_RESOLVE_THRESHOLD, FUZZY_AMBIGUITY_FLOOR, MAX_ALIASES_PER_ENTITY } from './entity-memory.js';
 import { MemoryValidator, MAX_WRITES_PER_AGENT_TASK } from './validation.js';
 import { createSilentLogger } from '../logger.js';
+import type { Logger } from '../logger.js';
 
 function makeEntityMemory() {
   const embeddingService = EmbeddingService.createForTesting();
@@ -803,5 +804,187 @@ describe('EntityMemory.search — alias exact-match path', () => {
     expect(results[0]!.score).toBe(1.0);
     // Verify the secondary node (non-alias-matched) also appears via vector search
     expect(results.some(r => r.node.label === 'searchterm adjacent')).toBe(true);
+  });
+});
+
+// -- PII guard: resolveOrCreate / addAlias logs (#1713) --
+//
+// extract-facts (and memory-store) pass the caller-supplied entity name as
+// `label` / `alias`. Those strings are usually a person's name, and the pino
+// redact list does not cover `label` or `alias`. Substitute nodeId where a
+// node is resolved; otherwise log type/presence flags only.
+describe('resolveOrCreate / addAlias logs never carry the raw label or alias (PII guard)', () => {
+  const PII_LABEL = 'Priya Ramanathan';
+
+  function spyLog() {
+    const log = {
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    };
+    log.child.mockReturnValue(log);
+    return log;
+  }
+
+  function makeMem(log: ReturnType<typeof spyLog>) {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    return {
+      mem: new EntityMemory(store, validator, embeddingService, log as unknown as Logger),
+      store,
+      embeddingService,
+    };
+  }
+
+  function findCall(fn: ReturnType<typeof vi.fn>, messageRe: RegExp) {
+    return fn.mock.calls.find(c => messageRe.test(String(c[c.length - 1])));
+  }
+
+  function serializeLogPayload(payload: unknown): string {
+    const obj = payload as Record<string, unknown> | null;
+    const err = obj?.err;
+    const errText = err instanceof Error
+      ? `${err.name} ${err.message} ${err.stack ?? ''}`
+      : '';
+    const errorField = obj?.error;
+    const errorText = typeof errorField === 'string' ? errorField : '';
+    return `${JSON.stringify(payload)}\n${errText}\n${errorText}`;
+  }
+
+  function expectNoPii(call: unknown[] | undefined) {
+    expect(call).toBeDefined();
+    const serialized = serializeLogPayload(call![0]);
+    expect(serialized).not.toContain(PII_LABEL);
+    expect(serialized.toLowerCase()).not.toContain(PII_LABEL.toLowerCase());
+    expect(call![0]).not.toHaveProperty('label');
+    expect(call![0]).not.toHaveProperty('alias');
+  }
+
+  it('single-match type-differs warn', async () => {
+    const log = spyLog();
+    const { mem } = makeMem(log);
+    const { entity } = await mem.createEntity({
+      type: 'person', label: PII_LABEL, properties: {}, source: 'test',
+    });
+
+    await mem.resolveOrCreate({
+      label: PII_LABEL,
+      type: 'organization',
+      source: 'test',
+    });
+
+    const call = findCall(log.warn, /single match type differs from caller hint/);
+    expectNoPii(call);
+    expect(call![0]).toHaveProperty('nodeId', entity.id);
+    expect(call![0]).toHaveProperty('expectedType', 'organization');
+    expect(call![0]).toHaveProperty('actualType', 'person');
+  });
+
+  it('fuzzy auto-resolve type-differs warn', async () => {
+    const log = spyLog();
+    const { mem, store, embeddingService } = makeMem(log);
+    const queryEmbedding = await embeddingService.embed(PII_LABEL);
+    const node = await store.createNode({
+      type: 'person',
+      label: 'Completely Unrelated Org Label',
+      properties: {},
+      source: 'test',
+      embedding: queryEmbedding,
+    });
+
+    await mem.resolveOrCreate({
+      label: PII_LABEL,
+      type: 'organization',
+      source: 'test',
+    });
+
+    const call = findCall(log.warn, /fuzzy auto-resolve type differs from caller hint/);
+    expectNoPii(call);
+    expect(call![0]).toHaveProperty('nodeId', node.id);
+    expect(call![0]).toHaveProperty('expectedType', 'organization');
+    expect(call![0]).toHaveProperty('actualType', 'person');
+  });
+
+  it('fuzzy semantic-search-failed warn', async () => {
+    const log = spyLog();
+    const { mem, store } = makeMem(log);
+    vi.spyOn(store, 'semanticSearch').mockRejectedValueOnce(new Error('embedding timeout'));
+
+    await mem.resolveOrCreate({
+      label: PII_LABEL,
+      type: 'person',
+      source: 'test',
+    });
+
+    const call = findCall(log.warn, /fuzzy semantic search failed/);
+    expectNoPii(call);
+    expect(call![0]).toHaveProperty('expectedType', 'person');
+    expect(call![0]).not.toHaveProperty('nodeId');
+    expect(call![0]).toHaveProperty('error', 'embedding timeout');
+  });
+
+  it('addAlias entity-node-not-found warn', async () => {
+    const log = spyLog();
+    const { mem } = makeMem(log);
+    const missingId = '00000000-0000-0000-0000-000000000000';
+
+    await mem.addAlias(missingId, PII_LABEL);
+
+    const call = findCall(log.warn, /addAlias: entity node not found/);
+    expectNoPii(call);
+    expect(call![0]).toHaveProperty('nodeId', missingId);
+  });
+
+  it('addAlias alias-cap-reached warn', async () => {
+    const log = spyLog();
+    const { mem } = makeMem(log);
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+    for (let i = 0; i < MAX_ALIASES_PER_ENTITY; i++) {
+      await mem.addAlias(entity.id, `alias-${i}`);
+    }
+
+    await mem.addAlias(entity.id, PII_LABEL);
+
+    const call = findCall(log.warn, /addAlias: alias cap reached/);
+    expectNoPii(call);
+    expect(call![0]).toHaveProperty('nodeId', entity.id);
+    expect(call![0]).toHaveProperty('count', MAX_ALIASES_PER_ENTITY);
+    expect(call![0]).toHaveProperty('max', MAX_ALIASES_PER_ENTITY);
+  });
+
+  it('addAlias backend-rejected debug', async () => {
+    const log = spyLog();
+    const { mem } = makeMem(log);
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    await mem.addAlias(entity.id, PII_LABEL);
+    await mem.addAlias(entity.id, PII_LABEL);
+
+    const call = findCall(log.debug, /addAlias: backend rejected/);
+    expectNoPii(call);
+    expect(call![0]).toHaveProperty('nodeId', entity.id);
+  });
+
+  it('addAlias unexpected-error warn', async () => {
+    const log = spyLog();
+    const { mem, store } = makeMem(log);
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+    vi.spyOn(store, 'getNode').mockRejectedValueOnce(new Error('connection timeout'));
+
+    await mem.addAlias(entity.id, PII_LABEL);
+
+    const call = findCall(log.warn, /addAlias: unexpected error/);
+    expectNoPii(call);
+    expect(call![0]).toHaveProperty('nodeId', entity.id);
+    expect(call![0]).toHaveProperty('error', 'connection timeout');
   });
 });

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -911,7 +911,9 @@ describe('resolveOrCreate / addAlias logs never carry the raw label or alias (PI
   it('fuzzy semantic-search-failed warn', async () => {
     const log = spyLog();
     const { mem, store } = makeMem(log);
-    vi.spyOn(store, 'semanticSearch').mockRejectedValueOnce(new Error('embedding timeout'));
+    vi.spyOn(store, 'semanticSearch').mockRejectedValueOnce(
+      new Error(`embedding timeout for ${PII_LABEL}`),
+    );
 
     await mem.resolveOrCreate({
       label: PII_LABEL,
@@ -923,7 +925,9 @@ describe('resolveOrCreate / addAlias logs never carry the raw label or alias (PI
     expectNoPii(call);
     expect(call![0]).toHaveProperty('expectedType', 'person');
     expect(call![0]).not.toHaveProperty('nodeId');
-    expect(call![0]).toHaveProperty('error', 'embedding timeout');
+    expect(call![0]).not.toHaveProperty('error');
+    expect(call![0]).not.toHaveProperty('err');
+    expect(call![0]).toHaveProperty('errorName', 'Error');
   });
 
   it('addAlias entity-node-not-found warn', async () => {
@@ -978,13 +982,17 @@ describe('resolveOrCreate / addAlias logs never carry the raw label or alias (PI
     const { entity } = await mem.createEntity({
       type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
     });
-    vi.spyOn(store, 'getNode').mockRejectedValueOnce(new Error('connection timeout'));
+    vi.spyOn(store, 'getNode').mockRejectedValueOnce(
+      new Error(`connection timeout for ${PII_LABEL}`),
+    );
 
     await mem.addAlias(entity.id, PII_LABEL);
 
     const call = findCall(log.warn, /addAlias: unexpected error/);
     expectNoPii(call);
     expect(call![0]).toHaveProperty('nodeId', entity.id);
-    expect(call![0]).toHaveProperty('error', 'connection timeout');
+    expect(call![0]).not.toHaveProperty('error');
+    expect(call![0]).not.toHaveProperty('err');
+    expect(call![0]).toHaveProperty('errorName', 'Error');
   });
 });

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -361,7 +361,9 @@ export class EntityMemory {
       // See: https://github.com/josephfung/curia/issues/474
       if (node.type !== options.type) {
         this.logger.warn(
-          { label: options.label, expectedType: options.type, actualType: node.type, nodeId: node.id },
+          // nodeId, not label: the caller-supplied name is PII and the
+          // pino redact list does not cover it.
+          { expectedType: options.type, actualType: node.type, nodeId: node.id },
           'resolveOrCreate: single match type differs from caller hint',
         );
       }
@@ -428,7 +430,7 @@ export class EntityMemory {
 
         if (best.node.type !== options.type) {
           this.logger.warn(
-            { label: options.label, expectedType: options.type, actualType: best.node.type, nodeId: best.node.id },
+            { expectedType: options.type, actualType: best.node.type, nodeId: best.node.id },
             'resolveOrCreate: fuzzy auto-resolve type differs from caller hint',
           );
         }
@@ -456,7 +458,8 @@ export class EntityMemory {
       }
     } catch (err) {
       this.logger.warn(
-        { label: options.label, error: err instanceof Error ? err.message : String(err) },
+        // No node id yet — log the type hint, not the raw label.
+        { expectedType: options.type, error: err instanceof Error ? err.message : String(err) },
         'resolveOrCreate: fuzzy semantic search failed — falling back to entity creation',
       );
       // Fall through to Phase 3 intentionally: fact storage must not block on
@@ -498,7 +501,8 @@ export class EntityMemory {
       // the backend, so this read is for logging only — not for correctness.
       const node = await this.store.getNode(nodeId);
       if (!node) {
-        this.logger.warn({ nodeId, alias }, 'addAlias: entity node not found');
+        // nodeId, not alias: the variant is PII and the pino redact list does not cover it.
+        this.logger.warn({ nodeId }, 'addAlias: entity node not found');
         return;
       }
 
@@ -510,7 +514,7 @@ export class EntityMemory {
       // Log before delegating so the warning appears even if the backend silently rejects.
       if (node.aliases.length >= MAX_ALIASES_PER_ENTITY) {
         this.logger.warn(
-          { nodeId, alias, count: node.aliases.length, max: MAX_ALIASES_PER_ENTITY },
+          { nodeId, count: node.aliases.length, max: MAX_ALIASES_PER_ENTITY },
           'addAlias: alias cap reached — skipping',
         );
         return;
@@ -521,13 +525,13 @@ export class EntityMemory {
         // Backend rejected — likely a dedup or cap race between our pre-flight read and this write.
         // The backend's atomic predicate handled it correctly; this is just for observability.
         this.logger.debug(
-          { nodeId, alias: lowerAlias },
+          { nodeId },
           'addAlias: backend rejected (dedup or cap race)',
         );
       }
     } catch (err) {
       this.logger.warn(
-        { nodeId, alias, error: err instanceof Error ? err.message : String(err) },
+        { nodeId, error: err instanceof Error ? err.message : String(err) },
         'addAlias: unexpected error — skipping',
       );
       // Best-effort: do not rethrow

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -459,7 +459,9 @@ export class EntityMemory {
     } catch (err) {
       this.logger.warn(
         // No node id yet — log the type hint, not the raw label.
-        { expectedType: options.type, error: err instanceof Error ? err.message : String(err) },
+        // errorName, not err.message: embedding/DB errors can echo the query
+        // (the caller-supplied name) and pino does not redact it.
+        { expectedType: options.type, errorName: err instanceof Error ? err.name : typeof err },
         'resolveOrCreate: fuzzy semantic search failed — falling back to entity creation',
       );
       // Fall through to Phase 3 intentionally: fact storage must not block on
@@ -531,7 +533,7 @@ export class EntityMemory {
       }
     } catch (err) {
       this.logger.warn(
-        { nodeId, error: err instanceof Error ? err.message : String(err) },
+        { nodeId, errorName: err instanceof Error ? err.name : typeof err },
         'addAlias: unexpected error — skipping',
       );
       // Best-effort: do not rethrow


### PR DESCRIPTION
## Summary

Follow-up to #1706 / PR #1709. That PR stopped `extract-facts` fact-loop logs from emitting the raw `subject` name. The name still reached logs through callees (`resolveOrCreate`, `addAlias`) and the sibling `memory-store` write path.

This applies the same substitution: log the resolved node id where one exists; otherwise log type/presence flags. Does not add `subject` / `entity` / `alias` / `label` to the pino redact list.

## Changes

- `resolveOrCreate` type-mismatch and fuzzy-search-failed warns log `nodeId` / `expectedType`, not `label`
- `addAlias` log sites drop the raw `alias` (node id + counts remain)
- `memory-store` fact-loop logs use `entityNodeId` instead of the caller-supplied `entity` name; catch logs the id only after resolution
- PII-guard tests per affected path, matching the `extract-facts` guards
- Patch-bump `memory-store` to 1.1.1

## Related Issues

Closes #1713

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` (use pino)
- [x] Spec docs updated if behavior changes — N/A (log hygiene only)
- [x] CI passes
