### PR TITLE
fix(ci): key docker-publish tags off the build target, not the launch ref

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,8 @@ name: docker-publish
 # Build, push, sign, and SBOM-attest the Curia app + Postgres images to GHCR.
 # - release published -> semver + latest (app), pg16 + latest (postgres)
 # - push to main      -> edge (both), for dogfood / curia-deploy pulls
+# - manual dispatch   -> with a tag: that tag's semver only, rebuilt from its
+#                        source; without a tag: same as a push to main.
 on:
   release:
     types: [published]
@@ -17,49 +19,77 @@ on:
 # Least privilege at the workflow level; jobs opt into the scopes they need
 # (mirrors release.yml). Only the `build` job touches GHCR / OIDC, so the
 # `packages: write` + `id-token: write` scopes live there, not here — the
-# `guard` job (which only validates a tag string) never receives them.
+# `resolve` job (which only validates a tag string) never receives them.
 permissions:
   contents: read
 
-# Only the newest run per ref needs to publish. A rapid batch of main merges
-# (e.g. several back-to-back dependency bumps) each retag `edge`, so keeping
-# every superseded ~10min build running is pure waste — cancel the in-flight
-# one when a newer commit for the same ref arrives.
+# Only the newest run per publish target needs to publish. A rapid batch of main
+# merges (e.g. several back-to-back dependency bumps) each retag `edge`, so
+# keeping every superseded ~10min build running is pure waste — cancel the
+# in-flight one when a newer commit for the same target arrives.
 #
-# Keying on `github.ref` (not just the workflow name) keeps the trigger types
+# Keying on the target (not just the workflow name) keeps the trigger types
 # independent: `push` to main collapses into one group (refs/heads/main) so
 # older edge builds get cancelled, while each `release` sits in its own
 # per-tag group (refs/tags/vX.Y.Z) and is never cancelled by another release
 # or by a main push. `edge` is a mutable last-write-wins tag, so cancelling a
 # partial push just leaves the previous `edge` in place until the winner lands.
+#
+# `inputs.tag` has to come first: on a workflow_dispatch, `github.ref` is the
+# branch the run was launched from rather than the tag being built (#1715), so
+# without it a manual re-publish would share main's group and be cancelled by
+# the next merge — precisely the wrong moment, since a re-publish is an
+# incident-response action.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.tag || github.ref }}
   cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
-  # Validate a workflow_dispatch tag input against strict semver to avoid
-  # injection (mirrors release.yml). No-op on release/push triggers.
-  guard:
+  # Resolve what is being *built*, before anything else keys off it.
+  #
+  # `github.ref` and `github.event_name` describe where a run was launched from,
+  # not what gets checked out: a workflow_dispatch carrying `tag: v0.40.0` still
+  # reports `refs/heads/main`. Keying the image tags off those meant a manual
+  # re-publish built the old release's source and pushed it as `:edge` — moving
+  # the pointer production consumes by default *backwards*, onto code whose
+  # migrations had already run against the live database — while publishing no
+  # semver tag at all (#1715).
+  #
+  # So the target is resolved once, here, and everything downstream reads
+  # `needs.resolve.outputs.tag`. Mirrors the `resolve` job in release.yml.
+  resolve:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      # The release tag being published or re-published; empty for an edge build.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
-      - name: Validate dispatch tag
-        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
-        # Pass the input through an env var so the shell never sees raw
-        # expression output — prevents injection if the value contains
-        # shell metacharacters (mirrors the pattern in release.yml).
+      - name: Resolve and validate the publish target
+        id: resolve
+        # Pass the event/input values through env vars so the shell never sees
+        # raw expression output — prevents injection if a value contains shell
+        # metacharacters (mirrors the pattern in release.yml).
         env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          printf '%s' "$INPUT_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
-            || { echo "Invalid tag format"; exit 1; }
+          # A dispatch input wins; on a release event it is empty and the
+          # release's own tag is used. On a push — or a bare dispatch — both are
+          # empty, which is the signal for an `edge` build.
+          TAG="${INPUT_TAG:-$EVENT_TAG}"
+          if [ -n "$TAG" ]; then
+            printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
+              || { echo "Invalid tag format: refusing to build"; exit 1; }
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Publish target: ${TAG:-main (edge)}"
 
   build:
-    needs: guard
+    needs: resolve
     runs-on: ubuntu-latest
     # Hard wall-clock bound. The retry layers added in #1699 compose multiplicatively —
     # pnpm's own fetch retries per request, inside up to 3 command-level attempts, across
@@ -79,28 +109,53 @@ jobs:
           - name: curia
             image: curia
             dockerfile: Dockerfile
-            # App tags: semver+latest on release, edge on main.
+            # App tags: semver on any release build (published or re-published),
+            # `latest` only on a real release, `edge` only on a main build.
+            #
+            # `value=` pins the semver source to the resolved target. Without it
+            # metadata-action falls back to its default `context: workflow` and
+            # derives the version from `github.ref`, which on a dispatch is a
+            # branch and yields no semver tag at all.
+            #
+            # `latest` deliberately stays keyed to the event rather than to the
+            # target: like `edge` it is a floating "newest" pointer, and a
+            # re-publish names an arbitrary older tag, so only an actual release
+            # may advance it.
             tags: |
-              type=semver,pattern=v{{version}}
-              type=semver,pattern=v{{major}}.{{minor}}
+              type=semver,pattern=v{{version}},value=${{ needs.resolve.outputs.tag }}
+              type=semver,pattern=v{{major}}.{{minor}},value=${{ needs.resolve.outputs.tag }}
               type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-              type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+              type=raw,value=edge,enable=${{ needs.resolve.outputs.tag == '' && github.ref == 'refs/heads/main' }}
           - name: curia-postgres
             image: curia-postgres
             dockerfile: docker/postgres.Dockerfile
-            # DB is versioned by pg major, not app semver.
+            # DB is versioned by pg major, not app semver — so every tag it has
+            # is a floating pointer, and none of them may be moved by a
+            # re-publish of an old app release. That leaves a dispatched
+            # re-publish with nothing to write for this image; the steps below
+            # skip the leg rather than failing on an empty tag list.
             tags: |
               type=raw,value=pg16,enable=${{ github.event_name == 'release' }}
               type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-              type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+              type=raw,value=edge,enable=${{ needs.resolve.outputs.tag == '' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # On a manual workflow_dispatch re-publish, check out the requested
-          # tag so the built image matches inputs.tag (validated in the guard
-          # job). For release/push triggers inputs.tag is empty, so fall back to
-          # the event ref (the release tag or the pushed branch).
-          ref: ${{ inputs.tag || github.ref }}
+          # On a manual re-publish, check out the requested tag so the built
+          # image really is that release's source. For release/push triggers the
+          # resolved tag is the release tag or empty, so this falls back to the
+          # event ref (the release tag or the pushed branch).
+          ref: ${{ needs.resolve.outputs.tag || github.ref }}
+
+      # metadata-action stamps `org.opencontainers.image.revision` from
+      # `github.sha`, which on a dispatch is the launch branch's HEAD — not the
+      # tag just checked out. A re-published v0.40.0 image would therefore claim
+      # main's revision, and curia-deploy's deploy-time revision assert
+      # (curia-deploy#213 / #215) would wave that old image straight through.
+      # Read the commit that was actually checked out instead.
+      - name: Resolve the built commit
+        id: src
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -118,9 +173,23 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: ${{ matrix.tags }}
+          # Overrides metadata-action's `github.sha` default — see the step above.
+          labels: |
+            org.opencontainers.image.revision=${{ steps.src.outputs.sha }}
+
+      # With no tags, `push: true` fails buildx outright ("tag is needed when
+      # pushing to registry"), which would turn a correct no-op into a red run
+      # and file a spurious publish-failure issue. Skip instead — but say so in
+      # the run log, so a skipped image is never mistaken for a published one.
+      - name: Report an image with nothing to publish
+        if: steps.meta.outputs.tags == ''
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: echo "::notice::No tags apply to ${IMAGE} on this trigger; skipping its build and push."
 
       - name: Build and push
         id: build
+        if: steps.meta.outputs.tags != ''
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -133,9 +202,11 @@ jobs:
           sbom: true
 
       - name: Install cosign
+        if: steps.meta.outputs.tags != ''
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the pushed image by digest
+        if: steps.meta.outputs.tags != ''
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
           IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
@@ -152,8 +223,11 @@ jobs:
   #
   # Gated on `needs.build.result == 'failure'` rather than on the event name, so it
   # fires for a failed manual republish too (the moment someone is already firefighting
-  # a stale tag) while never firing for a `guard` rejection of a malformed dispatch tag,
-  # which is a typo, not an incident.
+  # a stale tag) while never firing for a `resolve` rejection of a malformed tag, which
+  # is a typo, not an incident — `build` is then `skipped`, not `failure`. That covers a
+  # malformed *release* tag as well, which `resolve` now rejects: it stops the publish
+  # dead instead of pushing `latest` with no semver tag beside it, and you are standing
+  # at the release you just cut when it happens.
   #
   # `failure()` deliberately excludes cancellation: `cancel-in-progress` cancels
   # superseded builds on a rapid batch of main merges, and that is normal. `always()`
@@ -162,7 +236,7 @@ jobs:
   # push can cancel the alert itself — benign, because the newer run either succeeds
   # (the tags are fresh, the alert was moot) or fails and raises its own.
   notify-failure:
-    needs: build
+    needs: [resolve, build]
     if: always() && needs.build.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
@@ -171,6 +245,9 @@ jobs:
     steps:
       - name: Open or update the publish-failure issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # The publish *target*, which on a dispatch is not `context.ref` (#1715).
+          RESOLVED_TAG: ${{ needs.resolve.outputs.tag }}
         with:
           script: |
             const label = 'publish-failure';
@@ -178,14 +255,20 @@ jobs:
             const sha = context.sha.substring(0, 8);
 
             // Say what actually happened rather than hardcoding "main" / ":edge".
-            // This workflow also runs on `release: published`, where main is not
-            // involved and it is the semver + `latest` tags that are missing.
+            // This workflow also runs on `release: published` (where main is not
+            // involved and it is the semver + `latest` tags that are missing) and
+            // on a manual re-publish of an existing tag. Key off the resolved
+            // target, not `context.ref` — on a dispatch the latter is the branch
+            // the run was launched from, not the tag being built (#1715).
+            const targetTag = process.env.RESOLVED_TAG || '';
             const isRelease = context.eventName === 'release';
-            const what = isRelease
-              ? `release \`${context.ref.replace('refs/tags/', '')}\``
+            const what = targetTag
+              ? `${isRelease ? 'release' : 're-publish of'} \`${targetTag}\``
               : `\`${context.ref}\` at \`${sha}\``;
-            const staleTags = isRelease
-              ? 'the release\'s semver and `latest` tags may not have been published'
+            const staleTags = targetTag
+              ? (isRelease
+                  ? 'the release\'s semver and `latest` tags may not have been published'
+                  : `the semver tags for \`${targetTag}\` may not have been re-published`)
               : '`:edge` may still point at the previously published commit';
 
             const body = [
@@ -258,7 +341,7 @@ jobs:
             const { data: created } = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `docker-publish failed for ${isRelease ? context.ref.replace('refs/tags/', '') : 'main'} (${sha})`,
+              title: `docker-publish failed for ${targetTag || `main (${sha})`}`,
               labels: [label, 'infra'],
               body,
             });

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,9 @@ name: docker-publish
 # - release published -> semver + latest (app), pg16 + latest (postgres)
 # - push to main      -> edge (both), for dogfood / curia-deploy pulls
 # - manual dispatch   -> with a tag: that tag's semver only, rebuilt from its
-#                        source; without a tag: same as a push to main.
+#                        source; without a tag, from main: same as a push to
+#                        main. A bare dispatch from any other branch publishes
+#                        nothing, by design — `edge` must only ever mean main.
 on:
   release:
     types: [published]
@@ -81,8 +83,15 @@ jobs:
           # release's own tag is used. On a push — or a bare dispatch — both are
           # empty, which is the signal for an `edge` build.
           TAG="${INPUT_TAG:-$EVENT_TAG}"
+          # Strict SemVer 2.0.0 with a mandatory `v`, and no `+build` metadata
+          # (a `+` is not a legal Docker tag character anyway). Being loose here
+          # is not a harmless typo check: `metadata-action` silently *skips* a
+          # `type=semver` entry it cannot parse, while `latest` — keyed to the
+          # event, not to the version — publishes regardless. A tag like
+          # `v1.2.3.4` or `v1.2.3-rc..1` would therefore move `latest` onto a
+          # build with no version tag beside it. Reject it before the build.
           if [ -n "$TAG" ]; then
-            printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
+            printf '%s' "$TAG" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$' \
               || { echo "Invalid tag format: refusing to build"; exit 1; }
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -109,6 +118,9 @@ jobs:
           - name: curia
             image: curia
             dockerfile: Dockerfile
+            # This is the only image carrying app semver, so it is the only one
+            # a tag build must produce a version for (asserted after `meta`).
+            expects_semver: true
             # App tags: semver on any release build (published or re-published),
             # `latest` only on a real release, `edge` only on a main build.
             #
@@ -129,6 +141,7 @@ jobs:
           - name: curia-postgres
             image: curia-postgres
             dockerfile: docker/postgres.Dockerfile
+            expects_semver: false
             # DB is versioned by pg major, not app semver — so every tag it has
             # is a floating pointer, and none of them may be moved by a
             # re-publish of an old app release. That leaves a dispatched
@@ -176,6 +189,22 @@ jobs:
           # Overrides metadata-action's `github.sha` default — see the step above.
           labels: |
             org.opencontainers.image.revision=${{ steps.src.outputs.sha }}
+
+      # The regex in `resolve` predicts what metadata-action will accept; this
+      # checks what it actually did. Belt and braces on purpose — the failure it
+      # guards against is silent and production-facing (`latest` advancing onto a
+      # build with no version tag), and a prediction can be wrong in a way a
+      # direct check cannot.
+      - name: Assert a tag build produced its version tags
+        if: needs.resolve.outputs.tag != '' && matrix.expects_semver
+        env:
+          META_VERSION: ${{ steps.meta.outputs.version }}
+          TARGET: ${{ needs.resolve.outputs.tag }}
+        run: |
+          if [ -z "$META_VERSION" ]; then
+            echo "::error::Building ${TARGET} produced no version tag. Refusing to publish, since \`latest\` would move onto a build with no semver tag beside it."
+            exit 1
+          fi
 
       # With no tags, `push: true` fails buildx outright ("tag is needed when
       # pushing to registry"), which would turn a correct no-op into a red run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`resolveOrCreate` / `addAlias` / `memory-store`** — error logs keep the class name, not the message. (#1713)
 - **`resolveOrCreate` / `addAlias`** — logs use node id instead of the raw label or alias. (#1713)
 - **`memory-store`** — fact-loop logs use node id instead of the raw entity name. (#1713)
+- **`docker-publish`** — a dispatched re-publish no longer retags `:edge` backwards; it publishes semver. (#1715)
+- **`docker-publish`** — the image revision label now records the commit built, not the launch ref. (#1715)
 - **Contact merge** — secondary KG memory folds into the survivor after the contact delete. (#1711)
 - **`docker-publish`** — a transient registry drop mid-`pnpm install` retries instead of failing the publish. (#1699)
 - **`docker-publish`** — `apt` fetches retry too; the `curia-postgres` leg has no other network step. (#1699)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`memory-store`** — fact-loop logs use node id instead of the raw entity name. (#1713)
 - **`docker-publish`** — a dispatched re-publish no longer retags `:edge` backwards; it publishes semver. (#1715)
 - **`docker-publish`** — the image revision label now records the commit built, not the launch ref. (#1715)
+- **`docker-publish`** — strict SemVer tag guard; a malformed tag no longer moves `latest` alone. (#1715)
 - **Contact merge** — secondary KG memory folds into the survivor after the contact delete. (#1711)
 - **`docker-publish`** — a transient registry drop mid-`pnpm install` retries instead of failing the publish. (#1699)
 - **`docker-publish`** — `apt` fetches retry too; the `curia-postgres` leg has no other network step. (#1699)

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -121,8 +121,15 @@ Both images are built for `linux/amd64` + `linux/arm64` and signed with **cosign
 - **Push to `main`** → `:edge` on both images (for dogfood use).
 - **Release published** → app gets `vX.Y.Z`, `vX.Y`, and `latest`; the DB image gets
   `pg16` and `latest` (versioned by Postgres major, not app semver).
-- A `workflow_dispatch` input re-publishes a given tag; the dispatched tag is validated
-  against strict semver before build (mirrors `release.yml`).
+- **Manual dispatch** with a `tag` input → that release's source is rebuilt and pushed
+  under its semver tags **only**. `edge`, `latest`, and `pg16` are floating "newest"
+  pointers, and a re-publish names an arbitrary older tag, so a dispatch never moves
+  them — doing so shipped old code past migrations that had already run (#1715). A
+  dispatch with **no** `tag` behaves exactly like a push to `main`.
+- The tag being built is resolved once (in the `resolve` job) and validated against
+  strict semver before checkout, and every downstream tag decision keys off that rather
+  than off `github.ref`, which on a dispatch names the launch branch and not the built
+  source (mirrors `release.yml`).
 
 **`install.sh` — the supported self-host path** (`install.sh`, download-then-run; it uses
 interactive `read` prompts, so `curl … | bash` does not work). The script:

--- a/tests/unit/ci/docker-publish-tags.test.ts
+++ b/tests/unit/ci/docker-publish-tags.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Which image tags `docker-publish.yml` writes, per trigger (curia#1715).
+ *
+ * Why a test for a YAML file: the tags this workflow publishes are decided by
+ * GitHub expressions that only evaluate inside a real run, and `:edge` is what
+ * production consumes by default. #1715 sat latent for months precisely because
+ * nothing exercised the `workflow_dispatch` path — a dispatch carrying
+ * `tag: v0.40.0` built the old release's source and published it as `:edge`,
+ * moving the "newest main" pointer *backwards* onto code whose migrations had
+ * already run against prod, while publishing no semver tag at all.
+ *
+ * The root cause is that `github.ref` / `github.event_name` describe where a run
+ * was *launched from*, not what got checked out. So these tests render the tag
+ * expressions against a simulated context for each trigger and assert the
+ * resulting tag set. Verifying by dispatching the real workflow costs a ~10min
+ * multi-arch build and a throwaway tag; this costs milliseconds and runs on
+ * every PR.
+ *
+ * The mini expression evaluator below covers only the constructs this workflow
+ * actually uses, and throws on anything else. That is deliberate: an evaluator
+ * that silently ignored a construct it did not understand would let this test
+ * stay green while the workflow did something entirely different.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as yaml from 'js-yaml';
+
+const WORKFLOW_PATH = join(import.meta.dirname, '../../../.github/workflows/docker-publish.yml');
+
+interface MatrixEntry {
+  name: string;
+  image: string;
+  dockerfile: string;
+  tags: string;
+}
+
+interface Workflow {
+  concurrency: { group: string };
+  jobs: {
+    build: {
+      strategy: { matrix: { include: MatrixEntry[] } };
+      steps: Array<Record<string, unknown>>;
+    };
+  };
+}
+
+// The workflow is plain YAML; the `${{ … }}` expressions load as ordinary strings.
+const workflow = yaml.load(readFileSync(WORKFLOW_PATH, 'utf8')) as unknown as Workflow;
+
+// --- a deliberately narrow GitHub Actions expression evaluator ---------------
+
+type Context = Record<string, unknown>;
+
+/**
+ * Resolve a dotted context path. GitHub returns the empty string for a path
+ * that does not resolve (e.g. `inputs.tag` on a `push` event), rather than
+ * failing the expression — so this mirrors that, not a throw.
+ */
+function lookup(path: string, ctx: Context): string {
+  let cur: unknown = ctx;
+  for (const part of path.split('.')) {
+    if (typeof cur !== 'object' || cur === null || !(part in (cur as object))) return '';
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return cur === undefined || cur === null ? '' : String(cur);
+}
+
+const OPERAND = /^([A-Za-z_][A-Za-z0-9_.]*)\s*(==|!=)\s*'([^']*)'$/;
+
+/** Evaluate an `&&`-joined chain of string comparisons. Throws on anything else. */
+function evalBoolean(expr: string, ctx: Context): boolean {
+  const trimmed = expr.trim();
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (trimmed.includes('||')) {
+    throw new Error(`evalBoolean: unsupported '||' in ${trimmed} — extend the evaluator`);
+  }
+  return trimmed
+    .split('&&')
+    .map((operand) => operand.trim())
+    .every((operand) => {
+      const match = OPERAND.exec(operand);
+      if (!match) throw new Error(`evalBoolean: unparseable operand '${operand}'`);
+      const [, path, op, literal] = match;
+      const actual = lookup(path!, ctx);
+      return op === '==' ? actual === literal : actual !== literal;
+    });
+}
+
+/** Substitute `${{ path }}` / `${{ a || b }}` spans inside a string value. */
+function interpolate(raw: string, ctx: Context): string {
+  return raw.replace(/\$\{\{([^}]*)\}\}/g, (_full, inner: string) => {
+    // `a || b` is GitHub's coalesce: first non-falsy operand wins.
+    for (const operand of inner.split('||').map((s) => s.trim())) {
+      if (!/^[A-Za-z_][A-Za-z0-9_.]*$/.test(operand)) {
+        throw new Error(`interpolate: unsupported expression '${operand}'`);
+      }
+      const value = lookup(operand, ctx);
+      if (value !== '') return value;
+    }
+    return '';
+  });
+}
+
+/** Split `type=raw,value=x,enable=${{ a && b }}` on commas outside `${{ … }}`. */
+function splitAttrs(line: string): string[] {
+  const parts: string[] = [];
+  let buf = '';
+  let depth = 0;
+  for (let i = 0; i < line.length; i++) {
+    if (line.startsWith('${{', i)) {
+      depth++;
+      buf += '${{';
+      i += 2;
+      continue;
+    }
+    if (depth > 0 && line.startsWith('}}', i)) {
+      depth--;
+      buf += '}}';
+      i += 1;
+      continue;
+    }
+    const ch = line[i]!;
+    if (ch === ',' && depth === 0) {
+      parts.push(buf);
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  parts.push(buf);
+  return parts;
+}
+
+function parseAttrs(line: string): Map<string, string> {
+  const attrs = new Map<string, string>();
+  for (const part of splitAttrs(line)) {
+    const eq = part.indexOf('=');
+    if (eq === -1) throw new Error(`parseAttrs: malformed attribute '${part}' in '${line}'`);
+    attrs.set(part.slice(0, eq).trim(), part.slice(eq + 1));
+  }
+  return attrs;
+}
+
+const SEMVER = /^v?(\d+)\.(\d+)\.(\d+)(?:[-.]([0-9A-Za-z.]+))?$/;
+
+/** Expand metadata-action's `{{version}}` / `{{major}}` / `{{minor}}` placeholders. */
+function applyPattern(pattern: string, rawVersion: string): string {
+  const match = SEMVER.exec(rawVersion);
+  if (!match) throw new Error(`applyPattern: '${rawVersion}' is not semver`);
+  const [, major, minor, patch, prerelease] = match;
+  const version = prerelease ? `${major}.${minor}.${patch}-${prerelease}` : `${major}.${minor}.${patch}`;
+  if (prerelease && pattern !== 'v{{version}}') {
+    // metadata-action does not let a prerelease claim a stable `{{major}}.{{minor}}`
+    // tag. Rather than model that rule, refuse — so adding a prerelease scenario
+    // here fails loudly instead of asserting a tag the real action never writes.
+    throw new Error(`applyPattern: prerelease '${rawVersion}' with pattern '${pattern}' is not modelled`);
+  }
+  return pattern.replace(/\{\{(\w+)\}\}/g, (_full, name: string) => {
+    switch (name) {
+      case 'version':
+        return version;
+      case 'major':
+        return major!;
+      case 'minor':
+        return minor!;
+      case 'patch':
+        return patch!;
+      default:
+        throw new Error(`applyPattern: unsupported placeholder '{{${name}}}'`);
+    }
+  });
+}
+
+/** Render a matrix entry's `tags` block into the tag names it would publish. */
+function renderTags(tagsBlock: string, ctx: Context): string[] {
+  const published: string[] = [];
+  for (const rawLine of tagsBlock.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+
+    const attrs = parseAttrs(line);
+    const type = attrs.get('type');
+    const enable = attrs.get('enable');
+    if (enable !== undefined && !evalBoolean(enable.replace(/^\$\{\{|\}\}$/g, ''), ctx)) continue;
+
+    if (type === 'raw') {
+      published.push(interpolate(attrs.get('value') ?? '', ctx));
+      continue;
+    }
+    if (type === 'semver') {
+      // metadata-action falls back to the git ref when `value` is empty, and
+      // only a `refs/tags/*` ref yields a version — a branch ref yields nothing.
+      const explicit = interpolate(attrs.get('value') ?? '', ctx);
+      const ref = lookup('github.ref', ctx);
+      const version = explicit || (ref.startsWith('refs/tags/') ? ref.slice('refs/tags/'.length) : '');
+      if (version === '') continue;
+      published.push(applyPattern(attrs.get('pattern') ?? '', version));
+      continue;
+    }
+    throw new Error(`renderTags: unsupported tag type '${type}' — extend the evaluator`);
+  }
+  return published;
+}
+
+// --- simulated trigger contexts ---------------------------------------------
+
+/**
+ * `needs.resolve.outputs.tag` is the workflow's own answer to "what release is
+ * being built?" — computed by the `resolve` job from either trigger. Mirrored
+ * here so the fixture stays a single source of truth per scenario.
+ */
+function contextFor(opts: { eventName: string; ref: string; inputTag?: string; releaseTag?: string }): Context {
+  const resolvedTag = opts.inputTag || opts.releaseTag || '';
+  return {
+    github: {
+      event_name: opts.eventName,
+      ref: opts.ref,
+      event: { release: { tag_name: opts.releaseTag ?? '' } },
+    },
+    inputs: { tag: opts.inputTag ?? '' },
+    needs: { resolve: { outputs: { tag: resolvedTag } } },
+  };
+}
+
+const PUSH_MAIN = contextFor({ eventName: 'push', ref: 'refs/heads/main' });
+const RELEASE = contextFor({ eventName: 'release', ref: 'refs/tags/v0.42.0', releaseTag: 'v0.42.0' });
+const DISPATCH_WITH_TAG = contextFor({
+  eventName: 'workflow_dispatch',
+  ref: 'refs/heads/main',
+  inputTag: 'v0.40.0',
+});
+const DISPATCH_BARE = contextFor({ eventName: 'workflow_dispatch', ref: 'refs/heads/main' });
+
+function tagsFor(imageName: string, ctx: Context): string[] {
+  const entry = workflow.jobs.build.strategy.matrix.include.find((e) => e.name === imageName);
+  if (!entry) throw new Error(`no matrix entry named '${imageName}'`);
+  return renderTags(entry.tags, ctx);
+}
+
+describe('docker-publish.yml tag derivation', () => {
+  describe('push to main (unchanged behaviour)', () => {
+    it('publishes only :edge on both images', () => {
+      expect(tagsFor('curia', PUSH_MAIN)).toEqual(['edge']);
+      expect(tagsFor('curia-postgres', PUSH_MAIN)).toEqual(['edge']);
+    });
+  });
+
+  describe('release published (unchanged behaviour)', () => {
+    it('publishes semver + latest on the app image', () => {
+      expect(tagsFor('curia', RELEASE).sort()).toEqual(['latest', 'v0.42', 'v0.42.0']);
+    });
+
+    it('publishes pg16 + latest on the DB image', () => {
+      expect(tagsFor('curia-postgres', RELEASE).sort()).toEqual(['latest', 'pg16']);
+    });
+
+    it('never moves :edge', () => {
+      expect(tagsFor('curia', RELEASE)).not.toContain('edge');
+      expect(tagsFor('curia-postgres', RELEASE)).not.toContain('edge');
+    });
+  });
+
+  describe('workflow_dispatch with a tag (the #1715 bug)', () => {
+    it('does not touch :edge on either image', () => {
+      expect(tagsFor('curia', DISPATCH_WITH_TAG)).not.toContain('edge');
+      expect(tagsFor('curia-postgres', DISPATCH_WITH_TAG)).not.toContain('edge');
+    });
+
+    it('publishes the requested version as semver tags', () => {
+      expect(tagsFor('curia', DISPATCH_WITH_TAG).sort()).toEqual(['v0.40', 'v0.40.0']);
+    });
+
+    it('does not move :latest or :pg16 backwards onto the re-published release', () => {
+      // These are floating "newest" pointers like :edge. A re-publish is an
+      // arbitrary older tag, so only a real `release` event may advance them.
+      expect(tagsFor('curia', DISPATCH_WITH_TAG)).not.toContain('latest');
+      expect(tagsFor('curia-postgres', DISPATCH_WITH_TAG)).toEqual([]);
+    });
+
+    it('checks out the requested tag, and the concurrency group follows it', () => {
+      const checkout = workflow.jobs.build.steps[0] as { with: { ref: string } };
+      expect(interpolate(checkout.with.ref, DISPATCH_WITH_TAG)).toBe('v0.40.0');
+      // Not `refs/heads/main`, or a routine main merge would cancel a rollback.
+      expect(interpolate(workflow.concurrency.group, DISPATCH_WITH_TAG)).not.toContain('refs/heads/main');
+    });
+  });
+
+  describe('workflow_dispatch with no tag (unchanged behaviour)', () => {
+    it('still publishes :edge from main', () => {
+      expect(tagsFor('curia', DISPATCH_BARE)).toEqual(['edge']);
+      expect(tagsFor('curia-postgres', DISPATCH_BARE)).toEqual(['edge']);
+    });
+
+    it('checks out the launch ref', () => {
+      const checkout = workflow.jobs.build.steps[0] as { with: { ref: string } };
+      expect(interpolate(checkout.with.ref, DISPATCH_BARE)).toBe('refs/heads/main');
+    });
+  });
+
+  describe('provenance', () => {
+    it('stamps the revision of the commit actually built, not the launch ref', () => {
+      // metadata-action defaults `org.opencontainers.image.revision` to
+      // `github.sha`, which on a dispatch is the launch branch's HEAD rather
+      // than the checked-out tag. curia-deploy's deploy-time revision assert
+      // trusts this label, so a wrong value makes that check fail *open*.
+      const steps = workflow.jobs.build.steps;
+      const resolvesSha = steps.some((step) => /git rev-parse HEAD/.test(String(step.run ?? '')));
+      expect(resolvesSha).toBe(true);
+
+      const meta = steps.find((step) => step.id === 'meta') as { with: { labels?: string } };
+      expect(meta.with.labels ?? '').toContain('org.opencontainers.image.revision=');
+    });
+  });
+});

--- a/tests/unit/ci/docker-publish-tags.test.ts
+++ b/tests/unit/ci/docker-publish-tags.test.ts
@@ -45,8 +45,41 @@ interface Workflow {
   };
 }
 
+const WORKFLOW_SOURCE = readFileSync(WORKFLOW_PATH, 'utf8');
+
+/**
+ * Check the shape we depend on before asserting the type, so a restructured
+ * workflow fails here with a sentence about what is missing rather than ten
+ * lines down on `Cannot read properties of undefined`.
+ */
+function assertWorkflowShape(doc: unknown): asserts doc is Workflow {
+  const problems: string[] = [];
+  const root = doc as Partial<Workflow> | null;
+  if (typeof root !== 'object' || root === null) throw new Error('workflow did not parse to an object');
+  if (typeof root.concurrency?.group !== 'string') problems.push('concurrency.group');
+  const build = root.jobs?.build;
+  if (!build) problems.push('jobs.build');
+  if (!Array.isArray(build?.steps) || build.steps.length === 0) problems.push('jobs.build.steps');
+  const include = build?.strategy?.matrix?.include;
+  if (!Array.isArray(include) || include.length === 0) {
+    problems.push('jobs.build.strategy.matrix.include');
+  } else {
+    for (const entry of include) {
+      if (typeof entry?.name !== 'string' || typeof entry?.tags !== 'string') {
+        problems.push(`matrix entry ${JSON.stringify(entry?.name)} (needs name + tags)`);
+      }
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(`docker-publish.yml is missing or has restructured: ${problems.join(', ')}`);
+  }
+}
+
 // The workflow is plain YAML; the `${{ … }}` expressions load as ordinary strings.
-const workflow = yaml.load(readFileSync(WORKFLOW_PATH, 'utf8')) as unknown as Workflow;
+const parsed: unknown = yaml.load(WORKFLOW_SOURCE);
+// Cast only after the runtime check above.
+assertWorkflowShape(parsed);
+const workflow: Workflow = parsed;
 
 // --- a deliberately narrow GitHub Actions expression evaluator ---------------
 
@@ -232,6 +265,37 @@ const DISPATCH_WITH_TAG = contextFor({
   inputTag: 'v0.40.0',
 });
 const DISPATCH_BARE = contextFor({ eventName: 'workflow_dispatch', ref: 'refs/heads/main' });
+const DISPATCH_BARE_OFF_MAIN = contextFor({
+  eventName: 'workflow_dispatch',
+  ref: 'refs/heads/some-feature',
+});
+
+/**
+ * The `resolve` job's tag guard, lifted from the workflow itself rather than
+ * copied — a test that restates the pattern would pass against its own copy
+ * while the real one drifted. The grammar uses only constructs that mean the
+ * same thing in POSIX ERE and JS (no lookaround, no `\d`, trailing `-` inside
+ * the bracket expressions), so `grep -E` and `RegExp` agree.
+ */
+function tagGuardPattern(): RegExp {
+  const match = /grep -Eq '(\^v[^']*)'/.exec(WORKFLOW_SOURCE);
+  if (!match) throw new Error('could not find the tag-validation grep in the resolve job');
+  return new RegExp(match[1]!);
+}
+
+/**
+ * Locate the checkout step by what it *is*, not where it sits — a new setup
+ * step inserted above it should not fail these tests for ordering.
+ */
+function checkoutRef(): string {
+  const checkout = workflow.jobs.build.steps.find((step) =>
+    String(step.uses ?? '').startsWith('actions/checkout@'),
+  ) as { with?: { ref?: string } } | undefined;
+  if (typeof checkout?.with?.ref !== 'string') {
+    throw new Error('no actions/checkout step with a `ref` in jobs.build.steps');
+  }
+  return checkout.with.ref;
+}
 
 function tagsFor(imageName: string, ctx: Context): string[] {
   const entry = workflow.jobs.build.strategy.matrix.include.find((e) => e.name === imageName);
@@ -280,8 +344,7 @@ describe('docker-publish.yml tag derivation', () => {
     });
 
     it('checks out the requested tag, and the concurrency group follows it', () => {
-      const checkout = workflow.jobs.build.steps[0] as { with: { ref: string } };
-      expect(interpolate(checkout.with.ref, DISPATCH_WITH_TAG)).toBe('v0.40.0');
+      expect(interpolate(checkoutRef(), DISPATCH_WITH_TAG)).toBe('v0.40.0');
       // Not `refs/heads/main`, or a routine main merge would cancel a rollback.
       expect(interpolate(workflow.concurrency.group, DISPATCH_WITH_TAG)).not.toContain('refs/heads/main');
     });
@@ -294,8 +357,54 @@ describe('docker-publish.yml tag derivation', () => {
     });
 
     it('checks out the launch ref', () => {
-      const checkout = workflow.jobs.build.steps[0] as { with: { ref: string } };
-      expect(interpolate(checkout.with.ref, DISPATCH_BARE)).toBe('refs/heads/main');
+      expect(interpolate(checkoutRef(), DISPATCH_BARE)).toBe('refs/heads/main');
+    });
+  });
+
+  describe('bare workflow_dispatch from a branch other than main', () => {
+    // Not an oversight: `edge` means "the newest main", so a dispatch launched
+    // from a feature branch must publish nothing rather than mint an `edge`
+    // that points at unmerged code. The run is green with a skip notice per
+    // image; before #1715 it failed red inside buildx instead.
+    it('publishes nothing at all', () => {
+      expect(tagsFor('curia', DISPATCH_BARE_OFF_MAIN)).toEqual([]);
+      expect(tagsFor('curia-postgres', DISPATCH_BARE_OFF_MAIN)).toEqual([]);
+    });
+
+    it('never mints an edge tag from a non-main branch', () => {
+      expect(tagsFor('curia', DISPATCH_BARE_OFF_MAIN)).not.toContain('edge');
+      expect(tagsFor('curia-postgres', DISPATCH_BARE_OFF_MAIN)).not.toContain('edge');
+    });
+  });
+
+  describe('the resolve job tag guard', () => {
+    // A loose guard is not a harmless typo check. metadata-action silently skips
+    // a `type=semver` entry it cannot parse, while `latest` is keyed to the
+    // event rather than to the version — so a tag that looks version-ish but is
+    // not SemVer would advance `latest` onto a build with no version tag.
+    it.each(['v1.2.3', 'v0.43.0', 'v1.0.0', 'v1.2.3-rc.1', 'v1.2.3-beta', 'v10.20.30'])(
+      'accepts %s',
+      (tag) => {
+        expect(tagGuardPattern().test(tag)).toBe(true);
+      },
+    );
+
+    it.each([
+      'v1.2.3.4', // four components — not SemVer
+      'v1.2.3-rc..1', // empty prerelease identifier
+      'v01.2.3', // leading zero
+      'v1.2.3+build.1', // build metadata; `+` is not a legal Docker tag character
+      'v1.2', // missing patch
+      '1.2.3', // missing the `v`
+      'v1.2.3-', // empty prerelease
+      'v1.2.3 ; rm -rf /', // shell metacharacters
+    ])('rejects %s', (tag) => {
+      expect(tagGuardPattern().test(tag)).toBe(false);
+    });
+
+    it('matches what the app image will actually publish for an accepted tag', () => {
+      expect(tagGuardPattern().test('v0.40.0')).toBe(true);
+      expect(tagsFor('curia', DISPATCH_WITH_TAG).sort()).toEqual(['v0.40', 'v0.40.0']);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #1715.

A `workflow_dispatch` carrying `tag: v0.40.0` checked out that tag's source and then published it as **`:edge`** — moving the pointer production consumes by default *backwards*, onto code whose migrations had already run against the live database — while publishing no semver tag at all. Never fired in anger, but the button is an incident-response one, so it would have landed mid-rollback.

Root cause: `github.ref` and `github.event_name` describe **where a run was launched from**, not what got checked out. On a dispatch they still report `refs/heads/main`, so the `edge` enable was true, `latest` was false, and `metadata-action` (default `context: workflow`) derived no version from a branch ref.

## Approach

Resolve the publish target **once**, in a `resolve` job mirroring the one already in `release.yml`, and key every downstream decision off `needs.resolve.outputs.tag`:

- semver types take an explicit `value=`, so a dispatch actually publishes `vX.Y.Z` / `vX.Y`
- `edge` requires an empty target, so a dispatch with a tag cannot touch it
- `latest` and `pg16` stay keyed to the `release` event — they are floating "newest" pointers too, and a re-publish names an arbitrary older tag, so the same backwards-move applies to them
- the concurrency group follows the target, so a routine main merge no longer cancels an in-flight re-publish
- the DB image has nothing to publish on a re-publish, so its matrix leg is skipped with a run-log notice rather than failing buildx on an empty tag list

**Also fixed:** `org.opencontainers.image.revision` now comes from `git rev-parse HEAD` instead of `github.sha`. On a dispatch the default is the *launch branch's* HEAD, so a re-published old image would claim `main`'s revision — meaning curia-deploy's deploy-time revision assert (curia-deploy#213 / #215) would wave it straight through, failing open on the exact case it exists for.

## Resulting behaviour

| trigger | `curia` | `curia-postgres` |
|---|---|---|
| push to `main` | `edge` | `edge` |
| release published | `vX.Y.Z`, `vX.Y`, `latest` | `pg16`, `latest` |
| dispatch **with** `tag` | `vX.Y.Z`, `vX.Y` | *(nothing — leg skipped)* |
| dispatch **without** `tag` | `edge` | `edge` |

Rows 1, 2 and 4 are unchanged from today. Row 3 previously produced exactly one tag: `edge`.

## Verification

`tests/unit/ci/docker-publish-tags.test.ts` renders the workflow's tag expressions against a simulated context per trigger and asserts the resulting tag set. It reproduced the bug before the fix (dispatch yielded exactly `['edge']`) and now passes; the push/release cases lock in the unchanged behaviour. Its mini expression evaluator deliberately **throws** on any construct it does not model, so it cannot stay green while the workflow quietly does something else.

Also verified against primary sources rather than assumed:

- GitHub's context-availability table — `needs` is available in `jobs.<job_id>.strategy` and `inputs` in workflow-level `concurrency`, so all the new expressions are legal.
- `metadata-action` v6.2.0 source — `procSemver` returns early when `value=` is empty and the ref is a branch (so push-to-main is untouched), and `getLabels()` folds custom labels through a `Map` (so the revision override replaces rather than duplicates).

Local: `typecheck` clean, `lint` 0 errors, `vitest run tests/unit` 2764 passed, `test:shell` 34 passed.

**Still outstanding — AC #5 needs a human.** Verifying by an actual dispatch against a throwaway tag, then `docker buildx imagetools inspect ghcr.io/josephfung/curia:edge`, publishes real images to GHCR, so I have not done it. The test is a model of the workflow, not the workflow itself.

## Two calls that go slightly beyond the issue text

Both are easy to drop if you disagree:

1. **The concurrency group** now keys on `inputs.tag || github.ref`. It is a third expression with the same launch-site-vs-build-target bug, and the block's own comment already claimed the behaviour it did not have — a main merge could cancel an in-flight rollback re-publish.
2. **`resolve` now validates release tags too**, not just dispatch inputs. A malformed release tag stops the publish instead of pushing `latest` with no semver tag beside it. This is a behaviour change on the release path, though only for a tag the documented release process would never produce. When it happens `build` is `skipped`, not `failure`, so no publish-failure issue is filed — you are standing at the release you just cut, so that seemed right, but say if you would rather it alerted.