### PR TITLE
fix(ci): close the second docker-publish dispatch path, and the dispatches that cannot publish correctly

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,24 @@ name: docker-publish
 #                        source; without a tag, from main: same as a push to
 #                        main. A bare dispatch from any other branch publishes
 #                        nothing, by design — `edge` must only ever mean main.
+#
+# ## Re-publishing a release by hand (#1718)
+#
+# The dispatch form has two boxes, and they are two ways to say the same thing:
+#
+#   1. leave "Use workflow from" on `main` and type the tag in the `tag` input
+#   2. pick the tag itself in the "Use workflow from" dropdown, leave `tag` empty
+#
+# **Either is fine, and both do the same thing** — `resolve` below normalises
+# them to one publish target, so the tag set, the source that gets built, and
+# the stamped revision are identical. Prefer (1): the dropdown also selects
+# which *version of this workflow file* runs, so (2) re-publishes an old
+# release using that release's copy of this file, without whichever fixes have
+# landed since. That is the wrong direction on the one path where correctness
+# matters most.
+#
+# Setting both is allowed as long as they name the same tag; a mismatch is a
+# confused operator, so `resolve` fails the run rather than guessing.
 on:
   release:
     types: [published]
@@ -15,7 +33,10 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to (re)publish, e.g. v0.40.0"
+        # Optional because a bare dispatch from main is the "rebuild edge" path.
+        # If you selected the tag in the "Use workflow from" dropdown instead,
+        # leave this empty — see the note above.
+        description: "Release tag to (re)publish, e.g. v0.40.0. Leave empty to rebuild :edge from main."
         required: false
 
 # Least privilege at the workflow level; jobs opt into the scopes they need
@@ -42,8 +63,15 @@ permissions:
 # without it a manual re-publish would share main's group and be cancelled by
 # the next merge — precisely the wrong moment, since a re-publish is an
 # incident-response action.
+#
+# `github.ref_name` rather than `github.ref` so the two dispatch forms (#1718)
+# land in one group: the input gives a bare `v0.40.0`, and the ref dropdown a
+# `refs/tags/v0.40.0` that `ref_name` shortens to the same string. Otherwise two
+# runs re-publishing the same tag by different routes would race to write it.
+# This job cannot read `needs`, so the target is recomputed here; `resolve` is
+# the authority and rejects the case where these two disagree.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.tag || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: true
 
 env:
@@ -78,11 +106,34 @@ jobs:
         env:
           EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
+          LAUNCH_REF: ${{ github.ref }}
         run: |
+          # The third way a tag can arrive: an operator who used the "Use
+          # workflow from" dropdown instead of the `tag` input (see the note at
+          # the top of this file). That makes `github.ref` a tag ref rather than
+          # a branch — the one case where it *does* name the build target.
+          REF_TAG=""
+          case "$LAUNCH_REF" in
+            refs/tags/*) REF_TAG="${LAUNCH_REF#refs/tags/}" ;;
+          esac
+
+          # Filling in both boxes is fine when they agree, and is how a careful
+          # operator double-checks themselves. Disagreeing means one of the two
+          # is not what they think it is, and the consequences diverge — the
+          # input decides what gets built and tagged, the dropdown decides which
+          # version of this workflow runs. Refuse rather than silently honouring
+          # one of them.
+          if [ -n "$INPUT_TAG" ] && [ -n "$REF_TAG" ] && [ "$INPUT_TAG" != "$REF_TAG" ]; then
+            echo "::error::Dispatched with tag input '${INPUT_TAG}' from ref '${LAUNCH_REF}'. Pick one: type the tag and launch from main, or select the tag in the ref dropdown and leave the input empty."
+            exit 1
+          fi
+
           # A dispatch input wins; on a release event it is empty and the
-          # release's own tag is used. On a push — or a bare dispatch — both are
-          # empty, which is the signal for an `edge` build.
+          # release's own tag is used; failing both, a tag ref in the launch ref
+          # is the ref-dropdown form. On a push — or a bare dispatch from a
+          # branch — all three are empty, the signal for an `edge` build.
           TAG="${INPUT_TAG:-$EVENT_TAG}"
+          TAG="${TAG:-$REF_TAG}"
           # Strict SemVer 2.0.0 with a mandatory `v`, and no `+build` metadata
           # (a `+` is not a legal Docker tag character anyway). Being loose here
           # is not a harmless typo check: `metadata-action` silently *skips* a
@@ -95,7 +146,17 @@ jobs:
               || { echo "Invalid tag format: refusing to build"; exit 1; }
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Publish target: ${TAG:-main (edge)}"
+          # Surfaced as a notice so the resolved target shows on the run summary
+          # page, not only inside the step log. This is an incident-response
+          # button: "which thing did I just publish?" should be answerable at a
+          # glance. Report the launch ref verbatim for an edge build rather than
+          # asserting "main" — a bare dispatch from a feature branch lands here
+          # too, and publishes nothing.
+          if [ -n "$TAG" ]; then
+            echo "::notice::Publish target: release ${TAG}, rebuilt from its own source."
+          else
+            echo "::notice::Publish target: ${LAUNCH_REF} (:edge — published only if that ref is main)."
+          fi
 
   build:
     needs: resolve

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,10 +3,12 @@ name: docker-publish
 # Build, push, sign, and SBOM-attest the Curia app + Postgres images to GHCR.
 # - release published -> semver + latest (app), pg16 + latest (postgres)
 # - push to main      -> edge (both), for dogfood / curia-deploy pulls
-# - manual dispatch   -> with a tag: that tag's semver only, rebuilt from its
-#                        source; without a tag, from main: same as a push to
-#                        main. A bare dispatch from any other branch publishes
-#                        nothing, by design — `edge` must only ever mean main.
+# - manual dispatch   -> with a tag (named either way, see below): that tag's
+#                        semver only, rebuilt from its source; without a tag,
+#                        from main: same as a push to main. A dispatch that
+#                        would publish nothing, or that names a tag from an
+#                        unrelated branch, is refused rather than run —
+#                        `edge` must only ever mean main.
 #
 # ## Re-publishing a release by hand (#1718)
 #
@@ -64,14 +66,24 @@ permissions:
 # the next merge — precisely the wrong moment, since a re-publish is an
 # incident-response action.
 #
-# `github.ref_name` rather than `github.ref` so the two dispatch forms (#1718)
-# land in one group: the input gives a bare `v0.40.0`, and the ref dropdown a
-# `refs/tags/v0.40.0` that `ref_name` shortens to the same string. Otherwise two
-# runs re-publishing the same tag by different routes would race to write it.
-# This job cannot read `needs`, so the target is recomputed here; `resolve` is
-# the authority and rejects the case where these two disagree.
+# A release gets its own namespace, because cancellation here is not symmetric
+# (#1718). A release publishes `latest` / `pg16`; a re-publish of the same tag
+# deliberately does not. Without the prefix those two share a group — the ref
+# dropdown makes `github.ref` the tag ref, exactly what a release event carries
+# — so re-publishing vX.Y.Z while its release build is still running would
+# cancel the release and leave the floating pointers on the previous version.
+# Nothing would report it either: `notify-failure` excludes cancellation. Only
+# a run that publishes a superset may cancel one that publishes a subset, and
+# the release event is the only superset there is.
+#
+# The two dispatch forms of the same tag do NOT share a group (one keys on
+# `v0.40.0`, the other on `refs/tags/v0.40.0`). That is deliberate: normalising
+# them with `github.ref_name` would flatten the branch, tag and input
+# namespaces into one string space, letting a `tag: main` typo cancel an
+# in-flight `edge` build. Two identical re-publishes racing is the cheaper
+# problem, and GHCR resolves it last-write-wins with the same content.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.tag || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'release' && 'release-' || '' }}${{ inputs.tag || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -117,14 +129,20 @@ jobs:
             refs/tags/*) REF_TAG="${LAUNCH_REF#refs/tags/}" ;;
           esac
 
-          # Filling in both boxes is fine when they agree, and is how a careful
-          # operator double-checks themselves. Disagreeing means one of the two
-          # is not what they think it is, and the consequences diverge — the
-          # input decides what gets built and tagged, the dropdown decides which
-          # version of this workflow runs. Refuse rather than silently honouring
-          # one of them.
-          if [ -n "$INPUT_TAG" ] && [ -n "$REF_TAG" ] && [ "$INPUT_TAG" != "$REF_TAG" ]; then
-            echo "::error::Dispatched with tag input '${INPUT_TAG}' from ref '${LAUNCH_REF}'. Pick one: type the tag and launch from main, or select the tag in the ref dropdown and leave the input empty."
+          # The `tag` input says *what to build*; the launch ref also decides
+          # *which copy of this workflow runs*. So a tag re-publish is only
+          # well-formed from `main` (the reviewed definition) or from that same
+          # tag (the ref-dropdown form). Anything else is one of:
+          #
+          #   - the two boxes naming different tags — ambiguous, and honouring
+          #     either one silently is a guess about which the operator meant;
+          #   - a tag re-publish launched from a feature branch, which would
+          #     publish a real release image using unreviewed YAML. The branch
+          #     most likely to be selected here is one editing this very file.
+          #
+          # Neither is a thing to guess at while firefighting a stale tag.
+          if [ -n "$INPUT_TAG" ] && [ "$LAUNCH_REF" != "refs/heads/main" ] && [ "$REF_TAG" != "$INPUT_TAG" ]; then
+            echo "::error::Tag input '${INPUT_TAG}' was dispatched from '${LAUNCH_REF}'. Re-publish a tag from main (leaving the ref dropdown alone), or select that same tag in the dropdown and leave the input empty."
             exit 1
           fi
 
@@ -134,6 +152,25 @@ jobs:
           # branch — all three are empty, the signal for an `edge` build.
           TAG="${INPUT_TAG:-$EVENT_TAG}"
           TAG="${TAG:-$REF_TAG}"
+
+          # No tag and not on main: there is nothing this run could publish.
+          # `edge` may only ever mean main, and no release was named. `push` is
+          # restricted to `branches: [main]`, so only a bare dispatch off main
+          # reaches here.
+          #
+          # This used to be a green run: both matrix legs derived an empty tag
+          # list and skipped with a notice buried in the job log. But a publish
+          # workflow that publishes nothing, reports success, and leaves every
+          # tag pointing where it was is the #1715 / #1718 failure mode itself —
+          # the operator's mental model is "I re-published", and nothing on the
+          # summary contradicts them. Fail here instead, before the build burns
+          # a ten-minute multi-arch runner. (`notify-failure` stays quiet: it
+          # gates on `build` *failing*, and a resolve rejection leaves `build`
+          # skipped. An operator mis-click is not an incident.)
+          if [ -z "$TAG" ] && [ "$LAUNCH_REF" != "refs/heads/main" ]; then
+            echo "::error::Nothing to publish: dispatched from '${LAUNCH_REF}' with no tag. ':edge' may only ever mean main, so launch from main to rebuild it, or name a release tag to re-publish."
+            exit 1
+          fi
           # Strict SemVer 2.0.0 with a mandatory `v`, and no `+build` metadata
           # (a `+` is not a legal Docker tag character anyway). Being loose here
           # is not a harmless typo check: `metadata-action` silently *skips* a
@@ -142,20 +179,39 @@ jobs:
           # `v1.2.3.4` or `v1.2.3-rc..1` would therefore move `latest` onto a
           # build with no version tag beside it. Reject it before the build.
           if [ -n "$TAG" ]; then
+            # `grep` is line-oriented: it answers "does any line match", so a
+            # multi-line value would pass on the strength of its first line and
+            # carry the rest through unvalidated. `tag=$TAG` is then written to
+            # GITHUB_OUTPUT as several lines, and the runner reads the last one
+            # — an arbitrary unvalidated string — as the output. Reject anything
+            # that is not a single line before asking grep about its shape.
+            if [ "$(printf '%s' "$TAG" | wc -l)" -ne 0 ]; then
+              echo "::error::Refusing to build: the publish target spans multiple lines."
+              exit 1
+            fi
             printf '%s' "$TAG" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$' \
-              || { echo "Invalid tag format: refusing to build"; exit 1; }
+              || {
+                # `::error::` rather than a plain echo, and name the value and
+                # where it came from. This is reachable from the ref dropdown
+                # now, where the operator typed nothing at all — "Invalid tag
+                # format" with no offending value would leave them guessing.
+                if [ -n "$INPUT_TAG" ]; then SOURCE="the tag input"; else SOURCE="the launch ref ${LAUNCH_REF}"; fi
+                echo "::error::Refusing to build: '${TAG}' (from ${SOURCE}) is not a strict SemVer release tag of the form vMAJOR.MINOR.PATCH[-prerelease]."
+                exit 1
+              }
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           # Surfaced as a notice so the resolved target shows on the run summary
           # page, not only inside the step log. This is an incident-response
           # button: "which thing did I just publish?" should be answerable at a
-          # glance. Report the launch ref verbatim for an edge build rather than
-          # asserting "main" — a bare dispatch from a feature branch lands here
-          # too, and publishes nothing.
+          # glance.
           if [ -n "$TAG" ]; then
             echo "::notice::Publish target: release ${TAG}, rebuilt from its own source."
           else
-            echo "::notice::Publish target: ${LAUNCH_REF} (:edge — published only if that ref is main)."
+            # No hedge here: an empty target that reached this line is main, by
+            # the guard above. A step that reports "published only if…" and then
+            # exits 0 is the ambiguity this issue is about.
+            echo "::notice::Publish target: main (:edge on both images)."
           fi
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`docker-publish` re-publish** — the ref-dropdown form now resolves and validates its tag like the input form. (#1718)
-- **`docker-publish` dispatch** — a tag input disagreeing with the launch ref fails instead of silently picking one. (#1718)
+- **`docker-publish` dispatch** — a dispatch that would publish nothing, or name a tag from an unrelated branch, is refused. (#1718)
+- **`docker-publish` concurrency** — a re-publish can no longer cancel the release build of the same tag. (#1718)
+- **`docker-publish` tag guard** — a multi-line tag input no longer passes on the strength of its first line. (#1718)
 - **`resolveOrCreate` / `addAlias` / `memory-store`** — error logs keep the class name, not the message. (#1713)
 - **`resolveOrCreate` / `addAlias`** — logs use node id instead of the raw label or alias. (#1713)
 - **`memory-store`** — fact-loop logs use node id instead of the raw entity name. (#1713)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`docker-publish` re-publish** — the ref-dropdown form now resolves and validates its tag like the input form. (#1718)
+- **`docker-publish` dispatch** — a tag input disagreeing with the launch ref fails instead of silently picking one. (#1718)
 - **`resolveOrCreate` / `addAlias` / `memory-store`** — error logs keep the class name, not the message. (#1713)
 - **`resolveOrCreate` / `addAlias`** — logs use node id instead of the raw label or alias. (#1713)
 - **`memory-store`** — fact-loop logs use node id instead of the raw entity name. (#1713)

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -131,6 +131,18 @@ Both images are built for `linux/amd64` + `linux/arm64` and signed with **cosign
   than off `github.ref`, which on a dispatch names the launch branch and not the built
   source (mirrors `release.yml`).
 
+**Re-publishing a release by hand.** There are two ways to name the tag, and they are
+equivalent — `resolve` normalises both to one publish target (#1718):
+
+1. Leave "Use workflow from" on `main` and type the tag into the `tag` input.
+2. Select the tag itself in the "Use workflow from" dropdown and leave `tag` empty.
+
+**Prefer (1).** The dropdown also chooses which *version of the workflow file* runs, so
+(2) re-publishes an old release using that release's copy of `docker-publish.yml`,
+missing every fix landed since — the wrong direction on an incident-response path. Both
+boxes may be filled if they name the same tag; a mismatch fails the run rather than
+guessing which one the operator meant.
+
 **`install.sh` — the supported self-host path** (`install.sh`, download-then-run; it uses
 interactive `read` prompts, so `curl … | bash` does not work). The script:
 

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -139,9 +139,28 @@ equivalent — `resolve` normalises both to one publish target (#1718):
 
 **Prefer (1).** The dropdown also chooses which *version of the workflow file* runs, so
 (2) re-publishes an old release using that release's copy of `docker-publish.yml`,
-missing every fix landed since — the wrong direction on an incident-response path. Both
-boxes may be filled if they name the same tag; a mismatch fails the run rather than
-guessing which one the operator meant.
+missing every fix landed since — the wrong direction on an incident-response path.
+
+`resolve` refuses anything outside those two shapes, rather than publishing on a guess:
+
+- both boxes filled with **different** tags — ambiguous;
+- a `tag` input dispatched from a **branch other than `main`** — it would publish a real
+  release image while running that branch's unreviewed copy of the workflow, and the
+  branch most likely to be selected is one editing that very file;
+- a **bare dispatch from a branch other than `main`** — `edge` may only ever mean main and
+  no tag was named, so the run has nothing it could publish. This was previously a green
+  run that skipped both images with a notice, which is a publish workflow reporting
+  success having published nothing (#1718).
+
+A rejection fails `resolve` and leaves `build` *skipped*, so no publish-failure issue is
+filed — an operator mis-click is a typo, not an incident.
+
+Concurrency groups keep a release in its own namespace. A release publishes `latest` and
+`pg16`; a re-publish of that same tag deliberately does not. With `cancel-in-progress`,
+sharing a group would let an impatient re-publish cancel the release build still in
+flight and strand the floating pointers on the previous version, with no alert —
+`notify-failure` excludes cancellation. Only a run publishing a superset may cancel one
+publishing a subset.
 
 **`install.sh` — the supported self-host path** (`install.sh`, download-then-run; it uses
 interactive `read` prompts, so `curl … | bash` does not work). The script:

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -125,7 +125,9 @@ Both images are built for `linux/amd64` + `linux/arm64` and signed with **cosign
   under its semver tags **only**. `edge`, `latest`, and `pg16` are floating "newest"
   pointers, and a re-publish names an arbitrary older tag, so a dispatch never moves
   them — doing so shipped old code past migrations that had already run (#1715). A
-  dispatch with **no** `tag` behaves exactly like a push to `main`.
+  dispatch with **no** `tag`, launched from `main`, behaves exactly like a push to
+  `main`; from any other branch it is refused (see *Re-publishing a release by hand*
+  below).
 - The tag being built is resolved once (in the `resolve` job) and validated against
   strict semver before checkout, and every downstream tag decision keys off that rather
   than off `github.ref`, which on a dispatch names the launch branch and not the built

--- a/tests/unit/ci/docker-publish-tags.test.ts
+++ b/tests/unit/ci/docker-publish-tags.test.ts
@@ -22,7 +22,7 @@
  * stay green while the workflow did something entirely different.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -136,9 +136,22 @@ function evalBoolean(expr: string, ctx: Context): boolean {
     });
 }
 
-/** Substitute `${{ path }}` / `${{ a || b }}` spans inside a string value. */
+/**
+ * GitHub's ternary idiom: `<condition> && '<then>' || '<else>'`. Both branches
+ * must be string literals — modelling an arbitrary expression there would mean
+ * a general evaluator, and this file's whole premise is that it refuses what it
+ * does not understand.
+ */
+const TERNARY = /^(.+?)\s*&&\s*'([^']*)'\s*\|\|\s*'([^']*)'$/;
+
+/** Substitute `${{ path }}` / `${{ a || b }}` / ternary spans in a string value. */
 function interpolate(raw: string, ctx: Context): string {
   return raw.replace(/\$\{\{([^}]*)\}\}/g, (_full, inner: string) => {
+    const ternary = TERNARY.exec(inner.trim());
+    if (ternary) {
+      const [, condition, whenTrue, whenFalse] = ternary;
+      return evalBoolean(condition!, ctx) ? whenTrue! : whenFalse!;
+    }
     // `a || b` is GitHub's coalesce: first non-falsy operand wins.
     for (const operand of inner.split('||').map((s) => s.trim())) {
       if (!/^[A-Za-z_][A-Za-z0-9_.]*$/.test(operand)) {
@@ -343,37 +356,60 @@ function checkoutRef(): string {
  *
  * `bash -e` matches the default shell GitHub Actions runs a `run:` block under.
  */
-function runResolve(ctx: Context): { status: number; tag: string; stderr: string } {
-  const step = workflow.jobs.resolve.steps.find((s) => typeof s.run === 'string');
-  if (!step) throw new Error('no `run` step in jobs.resolve.steps');
+function runResolve(ctx: Context): { status: number; wrote: boolean; tag: string; output: string } {
+  // By id, not by position — the same principle `checkoutRef` states above. A
+  // setup step with its own `run:` inserted ahead of this one would otherwise
+  // silently redirect the whole suite onto the wrong script, with the wrong
+  // `env:` block interpolated alongside it.
+  const step = workflow.jobs.resolve.steps.find((s) => s.id === 'resolve' && typeof s.run === 'string');
+  if (!step) throw new Error("no `run` step with id 'resolve' in jobs.resolve.steps");
 
   const dir = mkdtempSync(join(tmpdir(), 'docker-publish-resolve-'));
-  const scriptPath = join(dir, 'resolve.sh');
-  const outputPath = join(dir, 'github_output');
-  writeFileSync(scriptPath, step.run!);
-  writeFileSync(outputPath, '');
-
-  // Only the variables the step declares, plus GITHUB_OUTPUT. Inheriting the
-  // ambient environment would let a stray INPUT_TAG on a developer's machine
-  // change the result.
-  const env: Record<string, string> = { PATH: process.env.PATH ?? '', GITHUB_OUTPUT: outputPath };
-  for (const [name, expr] of Object.entries(step.env ?? {})) {
-    env[name] = interpolate(String(expr), ctx);
-  }
-
-  let status = 0;
-  let stderr = '';
   try {
-    execFileSync('bash', ['-e', scriptPath], { env, encoding: 'utf8', stdio: 'pipe' });
-  } catch (err) {
-    const failure = err as { status?: number; stdout?: string; stderr?: string };
-    status = failure.status ?? 1;
-    // The workflow reports failures with `::error::` on stdout, not stderr.
-    stderr = `${failure.stdout ?? ''}${failure.stderr ?? ''}`;
-  }
+    const scriptPath = join(dir, 'resolve.sh');
+    const outputPath = join(dir, 'github_output');
+    writeFileSync(scriptPath, step.run!);
+    writeFileSync(outputPath, '');
 
-  const match = /^tag=(.*)$/m.exec(readFileSync(outputPath, 'utf8'));
-  return { status, tag: match?.[1] ?? '', stderr };
+    // Only the variables the step declares, plus GITHUB_OUTPUT. Inheriting the
+    // ambient environment would let a stray INPUT_TAG on a developer's machine
+    // change the result.
+    //
+    // Note this models `step.env` only — a future edit reading a workflow- or
+    // job-level `env` var would be exercised here as unset while the real
+    // runner has it set. Extend this if the resolve script ever needs one.
+    const env: Record<string, string> = { PATH: process.env.PATH ?? '', GITHUB_OUTPUT: outputPath };
+    for (const [name, expr] of Object.entries(step.env ?? {})) {
+      env[name] = interpolate(String(expr), ctx);
+    }
+
+    let status = 0;
+    let output = '';
+    try {
+      // The workflow writes both `::error::` and `::notice::` to stdout, so
+      // capture it on the success path too — those annotations are the run
+      // summary's only account of what got published, and are asserted below.
+      output = execFileSync('bash', ['-e', scriptPath], { env, encoding: 'utf8', stdio: 'pipe' });
+    } catch (err) {
+      const failure = err as { status?: number; stdout?: string; stderr?: string };
+      // `execFileSync` also throws when bash cannot be spawned, on maxBuffer
+      // overflow, and on death by signal — in all of which `status` is absent.
+      // Coercing those to 1 would let a broken harness masquerade as the script
+      // correctly refusing, quietly passing every negative test below.
+      if (typeof failure.status !== 'number') throw err;
+      status = failure.status;
+      output = `${failure.stdout ?? ''}${failure.stderr ?? ''}`;
+    }
+
+    // Last write wins, matching the runner's GITHUB_OUTPUT semantics — a script
+    // that wrote a default and then overrode it would otherwise be read here as
+    // the opposite of what really runs. `wrote` keeps "never written" separate
+    // from "written empty", which an `?? ''` fallback would collapse.
+    const written = [...readFileSync(outputPath, 'utf8').matchAll(/^tag=(.*)$/gm)];
+    return { status, wrote: written.length > 0, tag: written.at(-1)?.[1] ?? '', output };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 function tagsFor(imageName: string, ctx: Context): string[] {
@@ -441,11 +477,13 @@ describe('docker-publish.yml tag derivation', () => {
   });
 
   describe('bare workflow_dispatch from a branch other than main', () => {
-    // Not an oversight: `edge` means "the newest main", so a dispatch launched
-    // from a feature branch must publish nothing rather than mint an `edge`
-    // that points at unmerged code. The run is green with a skip notice per
-    // image; before #1715 it failed red inside buildx instead.
-    it('publishes nothing at all', () => {
+    // `edge` means "the newest main", so this must never mint one from unmerged
+    // code — and it does not. But there is also nothing else it could publish,
+    // so as of #1718 `resolve` refuses the run outright (asserted below in
+    // "the resolve job, executed"). It used to be green with a skip notice per
+    // image, which is a publish workflow reporting success having published
+    // nothing: the #1715 failure mode wearing a different hat.
+    it('would publish nothing, on both images', () => {
       expect(tagsFor('curia', DISPATCH_BARE_OFF_MAIN)).toEqual([]);
       expect(tagsFor('curia-postgres', DISPATCH_BARE_OFF_MAIN)).toEqual([]);
     });
@@ -477,13 +515,45 @@ describe('docker-publish.yml tag derivation', () => {
       expect(tagsFor('curia-postgres', DISPATCH_FROM_TAG_REF)).toEqual([]);
     });
 
-    it('checks out the tag, and shares the input form concurrency group', () => {
+    it('checks out the tag', () => {
       expect(interpolate(checkoutRef(), DISPATCH_FROM_TAG_REF)).toBe('v0.40.0');
-      // Both routes re-publish the same tag, so they must not run concurrently
-      // and race to write it. `github.ref_name` is what makes them agree.
-      expect(interpolate(workflow.concurrency.group, DISPATCH_FROM_TAG_REF)).toBe(
-        interpolate(workflow.concurrency.group, DISPATCH_WITH_TAG),
-      );
+    });
+  });
+
+  describe('concurrency grouping', () => {
+    const groupFor = (ctx: Context) => interpolate(workflow.concurrency.group, ctx);
+
+    it('isolates a release from a re-publish of the very same tag', () => {
+      // The asymmetry that makes this matter: a release publishes semver +
+      // `latest` + `pg16`; a re-publish of that tag publishes semver only. With
+      // `cancel-in-progress`, sharing a group means an impatient re-publish
+      // ("is the release build stuck?") cancels the release and strands
+      // `latest` and `pg16` on the previous version. Nothing would report it:
+      // `notify-failure` gates on failure and excludes cancellation.
+      const releaseOfSameTag = contextFor({
+        eventName: 'release',
+        ref: 'refs/tags/v0.40.0',
+        releaseTag: 'v0.40.0',
+      });
+      expect(groupFor(releaseOfSameTag)).not.toBe(groupFor(DISPATCH_WITH_TAG));
+      expect(groupFor(releaseOfSameTag)).not.toBe(groupFor(DISPATCH_FROM_TAG_REF));
+    });
+
+    it('collapses a push to main with a bare dispatch from main', () => {
+      // Both write exactly `:edge`, so the newer one superseding the older is
+      // the intended behaviour rather than a lost publish.
+      expect(groupFor(DISPATCH_BARE)).toBe(groupFor(PUSH_MAIN));
+    });
+
+    it('keeps a tag-shaped input away from the branch it names', () => {
+      // Groups are evaluated at queue time, before `resolve` can reject
+      // anything. So `tag: main` — a plausible misreading of the input box —
+      // must not land in main's group and cancel an in-flight `edge` build on
+      // its way to being refused. This is why the group is not normalised with
+      // `github.ref_name`, which would flatten branches, tags and inputs into
+      // one string space.
+      const typo = contextFor({ eventName: 'workflow_dispatch', ref: 'refs/heads/main', inputTag: 'main' });
+      expect(groupFor(typo)).not.toBe(groupFor(PUSH_MAIN));
     });
   });
 
@@ -495,14 +565,24 @@ describe('docker-publish.yml tag derivation', () => {
       ['a dispatch with a tag input', DISPATCH_WITH_TAG, 'v0.40.0'],
       ['a dispatch from a tag ref', DISPATCH_FROM_TAG_REF, 'v0.40.0'],
       ['a bare dispatch from main', DISPATCH_BARE, ''],
-      ['a bare dispatch off main', DISPATCH_BARE_OFF_MAIN, ''],
     ])('resolves %s to %o', (_name, ctx, expected) => {
       const result = runResolve(ctx as Context);
       expect(result.status).toBe(0);
+      expect(result.wrote).toBe(true);
       expect(result.tag).toBe(expected);
       // The fixtures feed the tag assertions above; if the real script and the
       // fixture disagree, every other test in this file is measuring fiction.
       expect(result.tag).toBe(lookup('needs.resolve.outputs.tag', ctx as Context));
+    });
+
+    it.each([
+      ['a tag build', DISPATCH_WITH_TAG, '::notice::Publish target: release v0.40.0'],
+      ['an edge build', PUSH_MAIN, '::notice::Publish target: main'],
+    ])('announces %s on the run summary', (_name, ctx, expected) => {
+      // The notices are the run summary's only account of what was published.
+      // Without this they could be deleted, or inverted to report a tag build
+      // as an edge build, with every other test still green.
+      expect(runResolve(ctx as Context).output).toContain(expected);
     });
 
     it('accepts both boxes filled when they name the same tag', () => {
@@ -511,7 +591,7 @@ describe('docker-publish.yml tag derivation', () => {
         ref: 'refs/tags/v0.40.0',
         inputTag: 'v0.40.0',
       });
-      expect(runResolve(agreeing)).toMatchObject({ status: 0, tag: 'v0.40.0' });
+      expect(runResolve(agreeing)).toMatchObject({ status: 0, wrote: true, tag: 'v0.40.0' });
     });
 
     it('refuses a dispatch whose tag input and launch ref disagree', () => {
@@ -524,8 +604,33 @@ describe('docker-publish.yml tag derivation', () => {
       });
       const result = runResolve(conflicting);
       expect(result.status).not.toBe(0);
-      expect(result.tag).toBe('');
-      expect(result.stderr).toContain('::error::');
+      expect(result.wrote).toBe(false);
+      expect(result.output).toContain("::error::Tag input 'v0.40.0' was dispatched from 'refs/tags/v0.41.0'");
+    });
+
+    it('refuses a tag re-publish launched from an unrelated branch', () => {
+      // Resolves to the right *target*, but would run that branch's copy of the
+      // workflow — and the branch most likely to be selected here is one
+      // editing this very file. A real release image built from unreviewed YAML.
+      const offMain = contextFor({
+        eventName: 'workflow_dispatch',
+        ref: 'refs/heads/some-feature',
+        inputTag: 'v0.40.0',
+      });
+      const result = runResolve(offMain);
+      expect(result.status).not.toBe(0);
+      expect(result.wrote).toBe(false);
+      expect(result.output).toContain('::error::');
+    });
+
+    it('refuses a bare dispatch that could publish nothing', () => {
+      // There is no tag and `edge` may only ever mean main, so this run has
+      // nothing it could write. It used to be green with a skip notice per
+      // image — a publish workflow reporting success having published nothing.
+      const result = runResolve(DISPATCH_BARE_OFF_MAIN);
+      expect(result.status).not.toBe(0);
+      expect(result.wrote).toBe(false);
+      expect(result.output).toContain('::error::Nothing to publish');
     });
 
     it('refuses a malformed tag before anything is built', () => {
@@ -536,7 +641,25 @@ describe('docker-publish.yml tag derivation', () => {
       });
       const result = runResolve(bad);
       expect(result.status).not.toBe(0);
-      expect(result.tag).toBe('');
+      expect(result.wrote).toBe(false);
+      // Naming the offending value and where it came from is the point: this is
+      // reachable from the ref dropdown, where the operator typed nothing.
+      expect(result.output).toContain("::error::Refusing to build: 'v1.2.3.4' (from the tag input)");
+    });
+
+    it('refuses a multi-line tag rather than validating only its first line', () => {
+      // `grep` asks "does any line match", so `v1.2.3\nfoo` passed the SemVer
+      // guard on its first line and wrote two lines into GITHUB_OUTPUT — where
+      // the runner reads the *last* one as the output, unvalidated.
+      const sneaky = contextFor({
+        eventName: 'workflow_dispatch',
+        ref: 'refs/heads/main',
+        inputTag: 'v1.2.3\nnot-a-version',
+      });
+      const result = runResolve(sneaky);
+      expect(result.status).not.toBe(0);
+      expect(result.wrote).toBe(false);
+      expect(result.output).toContain('::error::Refusing to build: the publish target spans multiple lines.');
     });
 
     it('refuses a malformed tag arriving via the ref dropdown', () => {
@@ -545,6 +668,8 @@ describe('docker-publish.yml tag derivation', () => {
       // leaving a green run that published nothing.
       const bad = contextFor({ eventName: 'workflow_dispatch', ref: 'refs/tags/nightly-2026-09-02' });
       const result = runResolve(bad);
+      expect(result.wrote).toBe(false);
+      expect(result.output).toContain('(from the launch ref refs/tags/nightly-2026-09-02)');
       expect(result.status).not.toBe(0);
       expect(result.tag).toBe('');
     });

--- a/tests/unit/ci/docker-publish-tags.test.ts
+++ b/tests/unit/ci/docker-publish-tags.test.ts
@@ -22,7 +22,9 @@
  * stay green while the workflow did something entirely different.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as yaml from 'js-yaml';
 
@@ -35,9 +37,18 @@ interface MatrixEntry {
   tags: string;
 }
 
+interface Step {
+  id?: string;
+  uses?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, unknown>;
+}
+
 interface Workflow {
   concurrency: { group: string };
   jobs: {
+    resolve: { steps: Step[] };
     build: {
       strategy: { matrix: { include: MatrixEntry[] } };
       steps: Array<Record<string, unknown>>;
@@ -60,6 +71,10 @@ function assertWorkflowShape(doc: unknown): asserts doc is Workflow {
   const build = root.jobs?.build;
   if (!build) problems.push('jobs.build');
   if (!Array.isArray(build?.steps) || build.steps.length === 0) problems.push('jobs.build.steps');
+  const resolveSteps = root.jobs?.resolve?.steps;
+  if (!Array.isArray(resolveSteps) || !resolveSteps.some((s) => typeof s?.run === 'string')) {
+    problems.push('jobs.resolve.steps (needs a step with a `run` block)');
+  }
   const include = build?.strategy?.matrix?.include;
   if (!Array.isArray(include) || include.length === 0) {
     problems.push('jobs.build.strategy.matrix.include');
@@ -243,13 +258,23 @@ function renderTags(tagsBlock: string, ctx: Context): string[] {
  * `needs.resolve.outputs.tag` is the workflow's own answer to "what release is
  * being built?" — computed by the `resolve` job from either trigger. Mirrored
  * here so the fixture stays a single source of truth per scenario.
+ *
+ * The precedence must match the shell in `resolve`: dispatch input, then the
+ * release event's tag, then a `refs/tags/*` launch ref. That last one is the
+ * ref-dropdown dispatch form (#1718), and it is the only case where
+ * `github.ref` legitimately names the build target rather than the launch site.
  */
 function contextFor(opts: { eventName: string; ref: string; inputTag?: string; releaseTag?: string }): Context {
-  const resolvedTag = opts.inputTag || opts.releaseTag || '';
+  const refTag = opts.ref.startsWith('refs/tags/') ? opts.ref.slice('refs/tags/'.length) : '';
+  const resolvedTag = opts.inputTag || opts.releaseTag || refTag;
   return {
     github: {
       event_name: opts.eventName,
       ref: opts.ref,
+      // `ref_name` is `ref` with its `refs/heads/` or `refs/tags/` prefix
+      // stripped; the concurrency group reads it. Derived rather than passed in
+      // so a fixture can never state a ref and a ref_name that disagree.
+      ref_name: opts.ref.replace(/^refs\/(heads|tags)\//, ''),
       event: { release: { tag_name: opts.releaseTag ?? '' } },
     },
     inputs: { tag: opts.inputTag ?? '' },
@@ -268,6 +293,11 @@ const DISPATCH_BARE = contextFor({ eventName: 'workflow_dispatch', ref: 'refs/he
 const DISPATCH_BARE_OFF_MAIN = contextFor({
   eventName: 'workflow_dispatch',
   ref: 'refs/heads/some-feature',
+});
+/** The other dispatch form: the tag picked in "Use workflow from", input empty. */
+const DISPATCH_FROM_TAG_REF = contextFor({
+  eventName: 'workflow_dispatch',
+  ref: 'refs/tags/v0.40.0',
 });
 
 /**
@@ -295,6 +325,55 @@ function checkoutRef(): string {
     throw new Error('no actions/checkout step with a `ref` in jobs.build.steps');
   }
   return checkout.with.ref;
+}
+
+// --- running the real `resolve` script ---------------------------------------
+
+/**
+ * The rest of this file *models* the workflow. That model now has a second
+ * source of truth to stay in sync with — `contextFor` mirrors the precedence
+ * rules inside the `resolve` job's shell — and a mirror that drifts is worse
+ * than no test, because it stays green while describing a workflow that no
+ * longer exists.
+ *
+ * So run the actual script. Its `env:` block is interpolated against the same
+ * simulated context the tag assertions use, giving one end-to-end path:
+ * trigger context -> env vars -> the real shell -> the resolved target. Anyone
+ * editing the precedence in the YAML and not here gets a red test.
+ *
+ * `bash -e` matches the default shell GitHub Actions runs a `run:` block under.
+ */
+function runResolve(ctx: Context): { status: number; tag: string; stderr: string } {
+  const step = workflow.jobs.resolve.steps.find((s) => typeof s.run === 'string');
+  if (!step) throw new Error('no `run` step in jobs.resolve.steps');
+
+  const dir = mkdtempSync(join(tmpdir(), 'docker-publish-resolve-'));
+  const scriptPath = join(dir, 'resolve.sh');
+  const outputPath = join(dir, 'github_output');
+  writeFileSync(scriptPath, step.run!);
+  writeFileSync(outputPath, '');
+
+  // Only the variables the step declares, plus GITHUB_OUTPUT. Inheriting the
+  // ambient environment would let a stray INPUT_TAG on a developer's machine
+  // change the result.
+  const env: Record<string, string> = { PATH: process.env.PATH ?? '', GITHUB_OUTPUT: outputPath };
+  for (const [name, expr] of Object.entries(step.env ?? {})) {
+    env[name] = interpolate(String(expr), ctx);
+  }
+
+  let status = 0;
+  let stderr = '';
+  try {
+    execFileSync('bash', ['-e', scriptPath], { env, encoding: 'utf8', stdio: 'pipe' });
+  } catch (err) {
+    const failure = err as { status?: number; stdout?: string; stderr?: string };
+    status = failure.status ?? 1;
+    // The workflow reports failures with `::error::` on stdout, not stderr.
+    stderr = `${failure.stdout ?? ''}${failure.stderr ?? ''}`;
+  }
+
+  const match = /^tag=(.*)$/m.exec(readFileSync(outputPath, 'utf8'));
+  return { status, tag: match?.[1] ?? '', stderr };
 }
 
 function tagsFor(imageName: string, ctx: Context): string[] {
@@ -374,6 +453,100 @@ describe('docker-publish.yml tag derivation', () => {
     it('never mints an edge tag from a non-main branch', () => {
       expect(tagsFor('curia', DISPATCH_BARE_OFF_MAIN)).not.toContain('edge');
       expect(tagsFor('curia-postgres', DISPATCH_BARE_OFF_MAIN)).not.toContain('edge');
+    });
+  });
+
+  describe('workflow_dispatch from the ref dropdown (#1718)', () => {
+    // The second way to re-publish: pick the tag in "Use workflow from" and
+    // leave the `tag` input empty. It has to reach the same place as the input
+    // form, or the workflow has two behaviours and its documentation can only
+    // describe one of them.
+    it('publishes the same tags as the input form', () => {
+      expect(tagsFor('curia', DISPATCH_FROM_TAG_REF).sort()).toEqual(
+        tagsFor('curia', DISPATCH_WITH_TAG).sort(),
+      );
+      expect(tagsFor('curia-postgres', DISPATCH_FROM_TAG_REF)).toEqual(
+        tagsFor('curia-postgres', DISPATCH_WITH_TAG),
+      );
+    });
+
+    it('publishes that release semver and nothing floating', () => {
+      expect(tagsFor('curia', DISPATCH_FROM_TAG_REF).sort()).toEqual(['v0.40', 'v0.40.0']);
+      expect(tagsFor('curia', DISPATCH_FROM_TAG_REF)).not.toContain('edge');
+      expect(tagsFor('curia', DISPATCH_FROM_TAG_REF)).not.toContain('latest');
+      expect(tagsFor('curia-postgres', DISPATCH_FROM_TAG_REF)).toEqual([]);
+    });
+
+    it('checks out the tag, and shares the input form concurrency group', () => {
+      expect(interpolate(checkoutRef(), DISPATCH_FROM_TAG_REF)).toBe('v0.40.0');
+      // Both routes re-publish the same tag, so they must not run concurrently
+      // and race to write it. `github.ref_name` is what makes them agree.
+      expect(interpolate(workflow.concurrency.group, DISPATCH_FROM_TAG_REF)).toBe(
+        interpolate(workflow.concurrency.group, DISPATCH_WITH_TAG),
+      );
+    });
+  });
+
+  describe('the resolve job, executed', () => {
+    // These run the workflow's own shell rather than the model of it above.
+    it.each([
+      ['push to main', PUSH_MAIN, ''],
+      ['a release', RELEASE, 'v0.42.0'],
+      ['a dispatch with a tag input', DISPATCH_WITH_TAG, 'v0.40.0'],
+      ['a dispatch from a tag ref', DISPATCH_FROM_TAG_REF, 'v0.40.0'],
+      ['a bare dispatch from main', DISPATCH_BARE, ''],
+      ['a bare dispatch off main', DISPATCH_BARE_OFF_MAIN, ''],
+    ])('resolves %s to %o', (_name, ctx, expected) => {
+      const result = runResolve(ctx as Context);
+      expect(result.status).toBe(0);
+      expect(result.tag).toBe(expected);
+      // The fixtures feed the tag assertions above; if the real script and the
+      // fixture disagree, every other test in this file is measuring fiction.
+      expect(result.tag).toBe(lookup('needs.resolve.outputs.tag', ctx as Context));
+    });
+
+    it('accepts both boxes filled when they name the same tag', () => {
+      const agreeing = contextFor({
+        eventName: 'workflow_dispatch',
+        ref: 'refs/tags/v0.40.0',
+        inputTag: 'v0.40.0',
+      });
+      expect(runResolve(agreeing)).toMatchObject({ status: 0, tag: 'v0.40.0' });
+    });
+
+    it('refuses a dispatch whose tag input and launch ref disagree', () => {
+      // Ambiguous, and the two boxes have different consequences: the input
+      // decides what is built, the dropdown decides which workflow file runs.
+      const conflicting = contextFor({
+        eventName: 'workflow_dispatch',
+        ref: 'refs/tags/v0.41.0',
+        inputTag: 'v0.40.0',
+      });
+      const result = runResolve(conflicting);
+      expect(result.status).not.toBe(0);
+      expect(result.tag).toBe('');
+      expect(result.stderr).toContain('::error::');
+    });
+
+    it('refuses a malformed tag before anything is built', () => {
+      const bad = contextFor({
+        eventName: 'workflow_dispatch',
+        ref: 'refs/heads/main',
+        inputTag: 'v1.2.3.4',
+      });
+      const result = runResolve(bad);
+      expect(result.status).not.toBe(0);
+      expect(result.tag).toBe('');
+    });
+
+    it('refuses a malformed tag arriving via the ref dropdown', () => {
+      // Before #1718 this path bypassed the guard entirely: `resolve` saw no
+      // tag, and metadata-action silently dropped the unparseable semver entry,
+      // leaving a green run that published nothing.
+      const bad = contextFor({ eventName: 'workflow_dispatch', ref: 'refs/tags/nightly-2026-09-02' });
+      const result = runResolve(bad);
+      expect(result.status).not.toBe(0);
+      expect(result.tag).toBe('');
     });
   });
 

--- a/tests/unit/ci/docker-publish-tags.test.ts
+++ b/tests/unit/ci/docker-publish-tags.test.ts
@@ -285,8 +285,14 @@ function contextFor(opts: { eventName: string; ref: string; inputTag?: string; r
       event_name: opts.eventName,
       ref: opts.ref,
       // `ref_name` is `ref` with its `refs/heads/` or `refs/tags/` prefix
-      // stripped; the concurrency group reads it. Derived rather than passed in
-      // so a fixture can never state a ref and a ref_name that disagree.
+      // stripped. Deliberately unread today — the concurrency group keys on
+      // `github.ref`, because `ref_name` would flatten branches, tags and
+      // inputs into one string space (see "keeps a tag-shaped input away from
+      // the branch it names"). It stays in the fixture because `lookup` fails
+      // soft: an expression that started reading `github.ref_name` would
+      // otherwise render as `''` here and quietly assert nonsense. Derived
+      // rather than passed in so a fixture cannot state a ref and a ref_name
+      // that disagree.
       ref_name: opts.ref.replace(/^refs\/(heads|tags)\//, ''),
       event: { release: { tag_name: opts.releaseTag ?? '' } },
     },


### PR DESCRIPTION
## Summary

Closes #1718.

#1718 is largely a duplicate of #1715, fixed by PR #1717 / #1721. Four of its six acceptance criteria were already met on `main`. This PR covers the residual gap — and one real bug the merged fix missed.

**The ref-dropdown dispatch form bypassed `resolve` entirely.** A re-publish can name its tag two ways: type it into the `tag` input, or select the tag in "Use workflow from". #1715 fixed the first. The second left the resolved target empty, so only `metadata-action`'s implicit ref fallback produced any tags at all. That meant the strict-SemVer guard never ran, and the "produced its version tags" assert never ran either — it is gated on a non-empty target. A non-SemVer tag selected there gave a **green run publishing nothing**: the same silent-wrong-publish class #1715 was about, reached through the other door.

`resolve` now takes a `refs/tags/*` launch ref as a third tag source, after the input and the release event. Both forms normalise to one target and validate, assert, check out and tag identically.

## Refusals added

`resolve` now fails rather than publishing on a guess. Each of these was previously a green run:

| dispatch | was | now |
|---|---|---|
| both boxes, **different** tags | silently honoured the input | refused — ambiguous |
| `tag` input from a branch other than `main` | published a real release image using **that branch's copy of this workflow** | refused |
| bare dispatch from a branch other than `main` | both legs skipped with a notice buried in the job log; run green | refused — nothing it could publish |
| multi-line `tag` input | `grep` is line-oriented, so `v1.2.3\nfoo` passed on its first line and wrote two lines to `GITHUB_OUTPUT`, where the runner reads the **last** — unvalidated — as the output | refused |

A rejection leaves `build` *skipped*, not failed, so `notify-failure` stays quiet. An operator mis-click is a typo, not an incident.

The SemVer rejection is an `::error::` annotation now, naming the offending value and which box it came from — the ref dropdown reaches it with the operator having typed nothing at all. And the resolved target is announced as a `::notice::`, so "which thing did I just publish?" is answerable from the run summary rather than the step log.

## Concurrency

The first commit keyed the group on `github.ref_name` to collapse the two dispatch forms. **That was wrong, and review caught it.** A release carries no `tag` input, so it fell through to the bare tag name and merged into the dispatch group. With `cancel-in-progress`, re-publishing `vX.Y.Z` while its release build was still running would cancel the release — and since `latest`/`pg16` are gated on `event_name == 'release'`, the surviving run strands them on the previous version. `notify-failure` excludes cancellation, so nothing reports it.

Reverted, and the release is namespaced instead:

```yaml
group: ${{ github.workflow }}-${{ github.event_name == 'release' && 'release-' || '' }}${{ inputs.tag || github.ref }}
```

Only a run publishing a superset may cancel one publishing a subset, and the release event is the only superset. **This also closes a hazard that predates this branch:** a ref-dropdown dispatch already shared `refs/tags/vX.Y.Z` with the release event on `main` today.

The two dispatch forms now sit in separate groups. That is the cheaper problem — identical builds of the same source, resolved by GHCR last-write-wins. In exchange, a `tag: main` typo can no longer land in main's group and cancel an in-flight `edge` build on its way to being refused; groups are evaluated at queue time, before `resolve` runs.

## Resulting behaviour

| trigger | launch ref | `tag` | outcome |
|---|---|---|---|
| push | `main` | — | `edge` on both images |
| release | the tag | — | `vX.Y.Z`, `vX.Y`, `latest` / `pg16`, `latest` |
| dispatch | `main` | `vX.Y.Z` | `vX.Y.Z`, `vX.Y` (DB leg skipped) |
| dispatch | the tag | empty | identical to the row above |
| dispatch | the tag | same tag | identical to the row above |
| dispatch | `main` | empty | `edge` on both images |
| dispatch | a branch | anything | **refused** |
| dispatch | tag A | tag B | **refused** |
| any | — | malformed | **refused** |

Rows 1, 2, 3 and 6 are unchanged. Row 4 previously published nothing for a non-SemVer tag and skipped its version assert.

## Verification

`tests/unit/ci/docker-publish-tags.test.ts` now **executes the real `resolve` shell** rather than only modelling it. The existing fixtures mirror its precedence rules, and a mirror that drifts is worse than no test — it stays green while describing a workflow that no longer exists. Running the script closes that loop: fixture and shell are asserted to agree on every scenario.

**All nine new or strengthened assertions fail against the previous workflow**, verified by stashing the YAML and re-running.

Review also hardened the harness itself: locate the resolve step by `id` rather than by being the first with a `run` block; rethrow when `execFileSync` throws without a numeric status, so a spawn failure cannot masquerade as the script correctly refusing; read the **last** `tag=` from `GITHUB_OUTPUT` as the runner does, and track whether it was written at all rather than collapsing that into `''`; capture stdout on the success path and assert the notices, which had no coverage and could have been inverted.

Local: `tsc --noEmit -p tsconfig.tests.json` clean, `eslint` clean, `vitest run tests/unit` 2801 passed.

**AC #5 still needs you.** Verifying by an actual dispatch publishes real images to GHCR, so I have not run it. Runbook in a comment on #1718 — a throwaway `v0.0.1` on v0.41.0's commit, so it also proves `org.opencontainers.image.revision` names the built commit rather than main's HEAD.

## One AC deliberately not met

**AC #1 asks a dispatch re-publish to publish `latest`. It does not, and I did not change that.** PR #1721 argued `latest` is a floating "newest" pointer like `edge`, so re-publishing an arbitrary older tag must not advance it. I agree, and the concurrency finding above is downstream of exactly that asymmetry. Flagging it because the AC as written is unmet — say if you want it the other way.

## Spotted nearby, not touched

`release.yml`'s `resolve` has no `refs/tags/*` fallback either, so the ref-dropdown form fails there with `Invalid or missing release tag: ''`. It **fails closed** — the regex rejects the empty tag before checkout, so nothing wrong is published — but the error is confusing for an operator who did name a tag, just in the other box.