### PR TITLE
fix(ci): stop metadata-action putting :latest on a dispatched re-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -303,6 +303,25 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: ${{ matrix.tags }}
+          # `latest` comes from the `type=raw` line in `matrix.tags` and NOWHERE
+          # else. metadata-action's default is `latest=auto`, under which
+          # `procSemver` sets latest for *any non-prerelease semver it resolves*
+          # — it does not care that our raw entry said `enable=false`, and it
+          # does not require a tag ref.
+          #
+          # That default was harmless until #1715 gave the semver entries an
+          # explicit `value=`. Before that, a dispatch resolved no version at
+          # all (branch ref, no value), so auto-latest had nothing to attach to.
+          # Afterwards a re-publish of v0.41.0 resolved a version, auto-latest
+          # fired, and `latest` moved **backwards** onto the old release —
+          # the exact failure #1715 and #1718 were about, reintroduced through
+          # an input neither of them touched. Caught by the live dispatch in
+          # #1718's AC #5; expression-level tests could not see it, because the
+          # tags block they model was correct and the default is not in it.
+          #
+          # Keep this pinned off, so `latest` is only ever written by a rule
+          # visible in this file.
+          flavor: latest=false
           # Overrides metadata-action's `github.sha` default — see the step above.
           labels: |
             org.opencontainers.image.revision=${{ steps.src.outputs.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`docker-publish` `:latest`** — pinned `flavor: latest=false`; a dispatched re-publish no longer moves `latest` backwards. (#1718)
 - **`docker-publish` re-publish** — the ref-dropdown form now resolves and validates its tag like the input form. (#1718)
 - **`docker-publish` dispatch** — a dispatch that would publish nothing, or name a tag from an unrelated branch, is refused. (#1718)
 - **`docker-publish` concurrency** — a re-publish can no longer cancel the release build of the same tag. (#1718)

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -132,6 +132,13 @@ Both images are built for `linux/amd64` + `linux/arm64` and signed with **cosign
   strict semver before checkout, and every downstream tag decision keys off that rather
   than off `github.ref`, which on a dispatch names the launch branch and not the built
   source (mirrors `release.yml`).
+- `metadata-action` runs with **`flavor: latest=false`**, so `latest` is only ever
+  written by the `type=raw` rule above. Its default is `latest=auto`, under which any
+  non-prerelease semver it resolves adds `latest` regardless of that rule's `enable=`.
+  Combined with the explicit `value=` added in #1715, that silently moved `latest` onto
+  a dispatched re-publish of an old release — found by an actual dispatch, since every
+  expression in the workflow was correct and the offending default was not in the file
+  at all (#1718).
 
 **Re-publishing a release by hand.** There are two ways to name the tag, and they are
 equivalent — `resolve` normalises both to one publish target (#1718):

--- a/tests/unit/ci/docker-publish-tags.test.ts
+++ b/tests/unit/ci/docker-publish-tags.test.ts
@@ -235,8 +235,32 @@ function applyPattern(pattern: string, rawVersion: string): string {
 }
 
 /** Render a matrix entry's `tags` block into the tag names it would publish. */
+/**
+ * Whether metadata-action's implicit auto-`latest` is disabled in the workflow.
+ *
+ * This models an input the workflow can *omit*, which is why it exists. The
+ * `tags:` block is not the only source of `latest`: metadata-action defaults to
+ * `flavor: latest=auto`, and under `auto` its `procSemver` sets latest for any
+ * non-prerelease semver it resolves — regardless of what the `type=raw` latest
+ * entry's `enable=` said, and regardless of whether the ref is a tag.
+ *
+ * That default published `latest` from a dispatched re-publish of an old
+ * release, moving it backwards, while every expression in the file evaluated
+ * correctly. A model that reads only what is written cannot catch a default
+ * that isn't — so read the flavor and model the default when it is absent.
+ */
+function autoLatestDisabled(): boolean {
+  const meta = workflow.jobs.build.steps.find((s) => (s as Step).id === 'meta') as Step | undefined;
+  if (!meta) throw new Error("no step with id 'meta' in jobs.build.steps");
+  return /(^|\s)latest=false(\s|$)/.test(String(meta.with?.flavor ?? ''));
+}
+
 function renderTags(tagsBlock: string, ctx: Context): string[] {
   const published: string[] = [];
+  // Set when a semver entry resolves a non-prerelease version, mirroring
+  // `procSemver`. Only consulted if the workflow has not pinned latest off.
+  let autoLatest = false;
+
   for (const rawLine of tagsBlock.split('\n')) {
     const line = rawLine.trim();
     if (line === '' || line.startsWith('#')) continue;
@@ -257,10 +281,16 @@ function renderTags(tagsBlock: string, ctx: Context): string[] {
       const ref = lookup('github.ref', ctx);
       const version = explicit || (ref.startsWith('refs/tags/') ? ref.slice('refs/tags/'.length) : '');
       if (version === '') continue;
+      // `procSemver` skips auto-latest for a prerelease, and only for that.
+      if (!/-/.test(version)) autoLatest = true;
       published.push(applyPattern(attrs.get('pattern') ?? '', version));
       continue;
     }
     throw new Error(`renderTags: unsupported tag type '${type}' — extend the evaluator`);
+  }
+
+  if (autoLatest && !autoLatestDisabled() && !published.includes('latest')) {
+    published.push('latest');
   }
   return published;
 }
@@ -709,6 +739,37 @@ describe('docker-publish.yml tag derivation', () => {
     it('matches what the app image will actually publish for an accepted tag', () => {
       expect(tagGuardPattern().test('v0.40.0')).toBe(true);
       expect(tagsFor('curia', DISPATCH_WITH_TAG).sort()).toEqual(['v0.40', 'v0.40.0']);
+    });
+  });
+
+  describe('implicit auto-latest (the #1718 AC-5 finding)', () => {
+    // Found by an actual dispatch, not by this file: a re-publish of v0.41.0
+    // published `latest` alongside its semver tags, moving the pointer
+    // backwards onto old code. Every expression in the workflow was correct.
+    // The extra tag came from metadata-action's default `flavor: latest=auto`,
+    // an input the workflow did not set — so there was nothing here to model.
+    it('is pinned off in the workflow', () => {
+      const meta = workflow.jobs.build.steps.find((s) => (s as Step).id === 'meta') as Step;
+      expect(String(meta.with?.flavor ?? '')).toMatch(/(^|\s)latest=false(\s|$)/);
+    });
+
+    it('would otherwise put :latest on a dispatched re-publish', () => {
+      // Guards the guard: if `latest=false` is dropped, this proves the model
+      // notices, so the assertions below are not passing for a stale reason.
+      expect(renderTags('type=semver,pattern=v{{version}},value=v0.40.0', DISPATCH_WITH_TAG)).toEqual([
+        'v0.40.0',
+      ]);
+      expect(autoLatestDisabled()).toBe(true);
+    });
+
+    it('leaves :latest on a re-publish coming only from the release rule', () => {
+      // The behavioural assertion. `latest` must appear for a release and for
+      // nothing else — including the two dispatch forms, both of which resolve
+      // a real non-prerelease semver and would trip auto-latest.
+      expect(tagsFor('curia', RELEASE)).toContain('latest');
+      expect(tagsFor('curia', DISPATCH_WITH_TAG)).not.toContain('latest');
+      expect(tagsFor('curia', DISPATCH_FROM_TAG_REF)).not.toContain('latest');
+      expect(tagsFor('curia', PUSH_MAIN)).not.toContain('latest');
     });
   });
 


### PR DESCRIPTION
## Summary

Re-opens and fixes the last part of #1718.

The live dispatch that #1718 required as its final acceptance criterion **found a real bug**. Re-publishing `v0.41.0` published `ghcr.io/josephfung/curia:latest` alongside its semver tags — moving the pointer self-hosters pull by default **backwards** onto old code. That is precisely the failure #1715 and #1718 exist to prevent, arriving through an input neither of them touched.

`curia:latest` went from `c80668e3…` (v0.42.0) to `8e2665f1…` (the image built from v0.41.0's source). It is **still wrong in GHCR** — see *Not fixed by this PR* below.

## Root cause

`latest` has two sources, not one.

The visible one is `type=raw,value=latest,enable=${{ github.event_name == 'release' }}`. It evaluated `false` correctly and was never the problem.

The other is `metadata-action`'s default **`flavor: latest=auto`**. In v6.2.0, `procSemver` sets latest for *any* non-prerelease semver it resolves:

```ts
if (semver.prerelease(vraw)) { /* … latest stays false */ }
else { /* … */ latest = true; }
return Meta.setVersion(version, vraw, this.flavor.latest == 'auto' ? latest : this.flavor.latest == 'true');
```

It does not consult the raw entry's `enable=`, and it does not require the ref to be a tag. (The README's "requires a git tag reference" describes only the ref-derived path, not an explicit `value=`.)

**This was armed by #1715's own fix.** Before it, a dispatch resolved no version at all — branch ref, no `value=` — so auto-latest had nothing to attach to. Adding `value=${{ needs.resolve.outputs.tag }}` made the semver entry resolve on a dispatch for the first time, and auto-latest came along with it. The run log shows three tags where the expressions predict two:

```
ghcr.io/josephfung/curia:v0.0.1
ghcr.io/josephfung/curia:v0.0
ghcr.io/josephfung/curia:latest   ← from flavor, not from enable=
```

## The fix

```yaml
flavor: latest=false
```

`latest` now comes only from a rule visible in this file. No behaviour change on a release — the raw entry still writes it there. The postgres image was never affected: it declares no semver entries, so `procSemver` never runs for it, which matches the observation that all three of its tags were untouched by the dispatch.

## Why the tests missed it, and what changed

The test file models the `tags:` block faithfully, and every expression in that block was **correct**. The offending default was not in the file at all — so there was nothing to model. A model built from what is written cannot see a default that isn't.

So `renderTags` now reads the step's `flavor` and applies auto-latest when it is not pinned off, mirroring `procSemver`'s prerelease rule. **Removing `flavor: latest=false` now fails 7 tests** — and four of them are *pre-existing* assertions that `latest` does not move on a re-publish. Those passed for weeks while the real workflow moved it. That gap is the finding here, as much as the bug is.

There is also a direct assertion that the workflow sets the flavor, plus a guards-the-guard test so the behavioural assertions can't pass for a stale reason.

## Verification

Local: `tsc --noEmit -p tsconfig.tests.json` clean, `eslint` clean, `vitest run tests/unit` **2804 passed**.

Live evidence is in the #1718 thread: run [33756309735](https://github.com/josephfung/curia/actions/runs/33756309735), plus the before/after digests for all five floating tags. `edge` and all three postgres tags were correctly untouched; only `latest` moved.

## Not fixed by this PR

**Merging this does not repair the already-published tag.** `ghcr.io/josephfung/curia:latest` still points at the v0.41.0-source image and will keep doing so until it is re-pointed or the next release overwrites it:

```bash
docker buildx imagetools create --tag ghcr.io/josephfung/curia:latest \
  ghcr.io/josephfung/curia@sha256:c80668e3c0fa171e892eb9d453c4d91f6466cb3924f68d86b3d3e71179a1130c
```

(`c80668e3…` is v0.42.0's digest, confirmed identical to what `v0.42` points at.)

Also still outstanding from #1718's AC #5: the throwaway `v0.0.1` tag and its `v0.0.1` / `v0.0` GHCR versions need deleting, and the three dispatch-guard checks were not run — they need refs cut from current `main`, because dispatching from an old tag runs *that tag's* copy of the workflow.