### PR TITLE
feat(console): manage skill bundles from /tools, and surface unresolved agent pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Skill bundle registry UI** — `/tools` now enables/disables bundles and flags unresolved agent pins. (#1724)
 - **Publish-failure alert** — a failed `docker-publish` opens/updates a tracking issue, since `:edge` goes stale silently. (#1699)
 - **Contact-anchored KG identity** — same-name contacts each hold their own node, facts, and enrichment. (#1694)
 - **ADR-040 (Accepted)** — contact-anchored KG node identity; a contact's node is keyed on the contact, not its label. (#1694)

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -4,35 +4,9 @@ import { Sidebar } from '../components/Sidebar.js';
 import { Topbar, TopbarSearch } from '../components/Topbar.js';
 import { apiFetch } from '../api.js';
 import { useTheme } from '../hooks/useTheme.js';
-
-// ── Types (mirror src/registry/types.ts RegistryEntry) ──────────────────────
-type DerivedState = 'uninstalled' | 'installed' | 'enabled' | 'ghost';
-
-interface ManifestMetadata {
-  name: string;
-  description: string;
-  version: string;
-  actionRisk?: string | number;
-  sensitivity?: string;
-  capabilities?: string[];
-  role?: string;
-  modelTier?: string;
-  // PR2 (#939): vault keys a skill declares in install.requires_secrets. Cross-referenced
-  // against GET /api/vault/status to show configured/missing status and gate install/enable.
-  requiresSecrets?: string[];
-}
-
-interface RegistryEntry {
-  name: string;
-  kind: 'tool' | 'agent';
-  state: DerivedState;
-  metadata: ManifestMetadata | null;
-  manifestError?: string;
-  installedAt: string | null;
-  installedBy: string | null;
-  enabledAt: string | null;
-  enabledBy: string | null;
-}
+// Types + row-tree builder live in registry-rows.ts, shared with its unit tests
+// (mirrors src/registry/types.ts RegistryEntry).
+import { buildRows, type RegistryEntry, type DerivedState, type Row } from './registry-rows.js';
 
 // Map each DerivedState to one of the existing .status-pill modifier classes
 // (app.css) so no new CSS is needed:
@@ -455,6 +429,13 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const [entries, setEntries] = useState<RegistryEntry[]>([]);
+  const [rows, setRows] = useState<Row[]>([]);
+  // Retained on the /tools path so Task 6's drawer can warn which enabled agents
+  // pin a bundle directly, without a second round-trip to /api/registry/agents.
+  // Not read yet — this task only wires the fetch; Task 6 consumes it. The `void`
+  // keeps noUnusedLocals quiet without touching rendered markup ahead of that task.
+  const [agents, setAgents] = useState<RegistryEntry[]>([]);
+  void agents;
   const [selected, setSelected] = useState<RegistryEntry | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
@@ -469,21 +450,56 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
 
   const load = useCallback(async () => {
     try {
-      const res = await apiFetch(`/api/registry/${kindPath}`);
-      if (!res.ok) throw new Error(await errorMessage(res));
-      const data = await res.json() as Record<string, RegistryEntry[]>;
-      const list = data[kindPath] ?? [];
-      setEntries(list);
-      setLoadError(null); // clear any prior error on successful reload
-      // Keep the drawer in sync with the freshly-loaded state so action
-      // buttons reflect the true current state after a transition.
+      if (kind === 'agent') {
+        const res = await apiFetch('/api/registry/agents');
+        if (!res.ok) throw new Error(await errorMessage(res));
+        const data = await res.json() as { agents?: RegistryEntry[] };
+        const list = data.agents ?? [];
+        setEntries(list);
+        // Read here, unused on this path (only /tools's drawer needs the agent
+        // list) — set it anyway so `agents` never carries stale data from a
+        // previous /tools load.
+        setAgents(list);
+        setRows(list.map(e => ({
+          entry: e, rowKind: 'tool' as const, members: [], pinnedBy: [], unresolvedFor: [],
+        })));
+        setLoadError(null);
+        setSelected(prev => (prev ? list.find(e => e.name === prev.name) ?? null : null));
+        return;
+      }
+
+      // /tools merges three endpoints: bundles, tools, and agents (agents only so an
+      // unresolved pin can be flagged against agents that are actually enabled).
+      const [skillsRes, toolsRes, agentsRes] = await Promise.all([
+        apiFetch('/api/registry/skills'),
+        apiFetch('/api/registry/tools'),
+        apiFetch('/api/registry/agents'),
+      ]);
+      for (const res of [skillsRes, toolsRes, agentsRes]) {
+        if (!res.ok) throw new Error(await errorMessage(res));
+      }
+      const skills = (await skillsRes.json() as { skills?: RegistryEntry[] }).skills ?? [];
+      const tools = (await toolsRes.json() as { tools?: RegistryEntry[] }).tools ?? [];
+      const agentList = (await agentsRes.json() as { agents?: RegistryEntry[] }).agents ?? [];
+
+      const built = buildRows(skills, tools, agentList);
+      setRows(built);
+      // `entries` stays the flat list the search/sort/filter/pagination code already uses.
+      setEntries(built.map(r => r.entry));
+      setAgents(agentList);
+      setLoadError(null);
       setSelected(prev =>
-        prev ? list.find(e => e.name === prev.name) ?? null : null,
+        prev ? built.map(r => r.entry).find(e => e.name === prev.name) ?? null : null,
       );
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : 'Failed to load');
     }
-  }, [kindPath]);
+  }, [kind]);
+
+  // Lookup so the render can find a row (bundle members, pin state) for a paged entry.
+  // Not read yet — Task 5 wires this into the table body. Same `void` rationale as `agents`.
+  const rowByName = useMemo(() => new Map(rows.map(r => [r.entry.name, r])), [rows]);
+  void rowByName;
 
   useEffect(() => { void load(); }, [load]);
 

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -6,7 +6,7 @@ import { apiFetch } from '../api.js';
 import { useTheme } from '../hooks/useTheme.js';
 // Types + row-tree builder live in registry-rows.ts, shared with its unit tests
 // (mirrors src/registry/types.ts RegistryEntry).
-import { buildRows, collateralPins, type RegistryEntry, type DerivedState, type Row } from './registry-rows.js';
+import { buildRows, collateralPins, registryPathSegment, type RegistryEntry, type DerivedState, type Row } from './registry-rows.js';
 
 // Map each DerivedState to one of the existing .status-pill modifier classes
 // (app.css) so no new CSS is needed:
@@ -103,9 +103,8 @@ function SecretRow({ name, configured, onSaved }: {
 
 // ── Detail drawer ────────────────────────────────────────────────────────────
 
-function RegistryDrawer({ entry, kindPath, row, agents, onClose, onChanged }: {
+function RegistryDrawer({ entry, row, agents, onClose, onChanged }: {
   entry: RegistryEntry;
-  kindPath: 'tools' | 'agents';
   // Only populated on the /tools path — used to warn before a bundle disable strips a
   // tool that some other agent pins directly (#1724).
   row?: Row;
@@ -154,7 +153,10 @@ function RegistryDrawer({ entry, kindPath, row, agents, onClose, onChanged }: {
     setErr(null);
     try {
       const res = await apiFetch(
-        `/api/registry/${kindPath}/${encodeURIComponent(entry.name)}${suffix}`,
+        // Route by the entry's own kind, not the page it's rendered on — a bundle
+        // (`kind: 'skill'`) must hit /api/registry/skills/..., even though bundle rows
+        // render on the /tools page alongside standalone tools (finding #1).
+        `/api/registry/${registryPathSegment(entry.kind)}/${encodeURIComponent(entry.name)}${suffix}`,
         { method },
       );
       if (!res.ok) throw new Error(await errorMessage(res));
@@ -164,7 +166,7 @@ function RegistryDrawer({ entry, kindPath, row, agents, onClose, onChanged }: {
     } finally {
       setBusy(false);
     }
-  }, [entry.name, kindPath, onChanged]);
+  }, [entry.name, entry.kind, onChanged]);
 
   const confirmUninstall = () => {
     if (window.confirm(`Uninstall "${entry.name}"? This removes its registry row.`)) {
@@ -179,7 +181,27 @@ function RegistryDrawer({ entry, kindPath, row, agents, onClose, onChanged }: {
   // operator with the affected agents before letting the disable through. Non-bundle rows
   // (or rows we weren't given, e.g. the /agents page) skip straight to true — nothing cascades.
   const confirmDisable = useCallback((): boolean => {
-    if (row?.rowKind !== 'bundle') return true;
+    // Key the guard on the entry's own kind, not `row?.rowKind` — `row` is only
+    // populated on the /tools page (see prop comment above), so `row?.rowKind !==
+    // 'bundle'` used to default to true (skip the warning entirely) whenever `row` was
+    // undefined. `entry.kind` is authoritative and always present (finding #3).
+    if (entry.kind !== 'skill') return true;
+
+    if (!row || row.rowKind !== 'bundle') {
+      // We know this is a bundle but don't have its member-tool row data to list what
+      // will be affected — still confirm, with a generic warning rather than silently
+      // letting the cascade through unwarned.
+      return window.confirm(
+        [
+          `Disable the "${entry.name}" bundle?`,
+          '',
+          'This also disables its member tools, but the exact list could not be determined.',
+          '',
+          'Takes effect on the next restart.',
+        ].join('\n'),
+      );
+    }
+
     const collateral = collateralPins(row, agents);
     const lines = [
       `Disable the "${entry.name}" bundle?`,
@@ -195,7 +217,7 @@ function RegistryDrawer({ entry, kindPath, row, agents, onClose, onChanged }: {
     }
     lines.push('', 'Takes effect on the next restart.');
     return window.confirm(lines.join('\n'));
-  }, [row, agents, entry.name]);
+  }, [row, agents, entry.name, entry.kind]);
 
   return (
     <aside className="drawer">
@@ -800,7 +822,6 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
                   <RegistryDrawer
                     key={selected.name}
                     entry={selected}
-                    kindPath={kindPath}
                     row={rowByName.get(selected.name)}
                     agents={agents}
                     onClose={() => setSelected(null)}

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { Topbar, TopbarSearch } from '../components/Topbar.js';
@@ -443,6 +443,16 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
   const [pageSize, setPageSize] = useState(10);
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'name', dir: 'asc' });
   const [stateFilter, setStateFilter] = useState<'all' | DerivedState>('all');
+  // Bundle rows collapse by default — a bundle with 14 members would otherwise
+  // dominate the first page.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggleExpanded = useCallback((name: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
@@ -497,9 +507,7 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
   }, [kind]);
 
   // Lookup so the render can find a row (bundle members, pin state) for a paged entry.
-  // Not read yet — Task 5 wires this into the table body. Same `void` rationale as `agents`.
   const rowByName = useMemo(() => new Map(rows.map(r => [r.entry.name, r])), [rows]);
-  void rowByName;
 
   useEffect(() => { void load(); }, [load]);
 
@@ -545,8 +553,8 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
 
   const title = kind === 'tool' ? 'Tools' : 'Agents';
   // Name, State, kind-specific columns, Version. Agents have one kind-specific
-  // column (Model tier); skills have two (Action risk, Sensitivity).
-  const colCount = kind === 'agent' ? 4 : 5;
+  // column (Model tier); tools have four (Type, Action risk, Sensitivity, Pinned by).
+  const colCount = kind === 'agent' ? 4 : 7;
 
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
@@ -613,6 +621,7 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
                               Name <span className="sort-arrow">{sortArrow('name')}</span>
                             </button>
                           </th>
+                          {kind === 'tool' && <th>Type</th>}
                           <th className="sortable" aria-sort={sort.key === 'state' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
                             <button className="sort-btn" onClick={() => toggleSort('state')}>
                               State <span className="sort-arrow">{sortArrow('state')}</span>
@@ -638,6 +647,7 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
                                   Sensitivity <span className="sort-arrow">{sortArrow('sensitivity')}</span>
                                 </button>
                               </th>
+                              <th>Pinned by</th>
                             </>
                           )}
                           <th className="sortable" aria-sort={sort.key === 'version' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
@@ -648,35 +658,98 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
                         </tr>
                       </thead>
                       <tbody>
-                        {pageRows.map(e => (
-                          <tr
-                            key={e.name}
-                            className={selected?.name === e.name ? 'active' : undefined}
-                            onClick={() => setSelected(e)}
-                            style={{ cursor: 'pointer' }}
-                          >
-                            {/* Warn icon if the manifest failed to parse */}
-                            <td>{e.name}{e.manifestError ? ' ⚠' : ''}</td>
-                            <td>
-                              <span className={`status-pill ${STATE_PILL[e.state]}`}>
-                                {/* Extra warning on ghost: manifest is gone but DB row lingers */}
-                                {e.state}{e.state === 'ghost' ? ' ⚠' : ''}
-                              </span>
-                            </td>
-                            {kind === 'agent' ? (
-                              <>
-                                <td>{e.metadata?.modelTier ?? '—'}</td>
-                              </>
-                            ) : (
-                              <>
-                                {/* actionRisk may be 0 (a valid risk score), so guard on null, not falsy. */}
-                                <td>{e.metadata?.actionRisk != null ? String(e.metadata.actionRisk) : '—'}</td>
-                                <td>{e.metadata?.sensitivity ?? '—'}</td>
-                              </>
-                            )}
-                            <td>{e.metadata?.version ?? '—'}</td>
-                          </tr>
-                        ))}
+                        {pageRows.map(e => {
+                          const row = rowByName.get(e.name);
+                          const isBundle = row?.rowKind === 'bundle';
+                          const isOpen = expanded.has(e.name);
+                          // A bundle is "broken" when it's pinned by at least one enabled
+                          // agent but the bundle itself isn't enabled — those tools are
+                          // silently missing from that agent's function list.
+                          const broken = (row?.unresolvedFor.length ?? 0) > 0;
+                          return (
+                            <Fragment key={e.name}>
+                              <tr
+                                className={selected?.name === e.name ? 'active' : undefined}
+                                onClick={() => setSelected(e)}
+                                style={{ cursor: 'pointer' }}
+                              >
+                                <td>
+                                  {isBundle && (
+                                    <button
+                                      type="button"
+                                      aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${e.name}`}
+                                      aria-expanded={isOpen}
+                                      onClick={ev => { ev.stopPropagation(); toggleExpanded(e.name); }}
+                                      style={{
+                                        background: 'none', border: 'none', cursor: 'pointer',
+                                        padding: '0 6px 0 0', color: 'inherit', font: 'inherit',
+                                      }}
+                                    >
+                                      {isOpen ? '▾' : '▸'}
+                                    </button>
+                                  )}
+                                  {/* Warn icon if the manifest failed to parse */}
+                                  {e.name}{e.manifestError ? ' ⚠' : ''}
+                                </td>
+                                {kind === 'tool' && (
+                                  <td>
+                                    <span className="status-pill">
+                                      {isBundle ? 'bundle' : 'tool'}
+                                    </span>
+                                  </td>
+                                )}
+                                <td>
+                                  <span className={`status-pill ${STATE_PILL[e.state]}`}>
+                                    {/* Extra warning on ghost: manifest is gone but DB row lingers */}
+                                    {e.state}{e.state === 'ghost' ? ' ⚠' : ''}
+                                  </span>
+                                </td>
+                                {kind === 'agent' ? (
+                                  <>
+                                    <td>{e.metadata?.modelTier ?? '—'}</td>
+                                  </>
+                                ) : (
+                                  <>
+                                    {/* actionRisk may be 0 (a valid risk score), so guard on null, not falsy. */}
+                                    <td>{e.metadata?.actionRisk != null ? String(e.metadata.actionRisk) : '—'}</td>
+                                    <td>{e.metadata?.sensitivity ?? '—'}</td>
+                                    <td>
+                                      {broken ? (
+                                        <span
+                                          className="status-pill blocked"
+                                          title={
+                                            `${row!.unresolvedFor.join(', ')} pin${row!.unresolvedFor.length === 1 ? 's' : ''} ` +
+                                            `this bundle. It is not enabled, so ${row!.members.length} ` +
+                                            `tool${row!.members.length === 1 ? '' : 's'} are missing from ` +
+                                            `${row!.unresolvedFor.length === 1 ? 'that agent' : 'those agents'}' function list.`
+                                          }
+                                        >
+                                          ⚠ {row!.unresolvedFor.join(', ')}
+                                        </span>
+                                      ) : (
+                                        row?.pinnedBy.length ? row.pinnedBy.join(', ') : '—'
+                                      )}
+                                    </td>
+                                  </>
+                                )}
+                                <td>{e.metadata?.version ?? '—'}</td>
+                              </tr>
+                              {isBundle && isOpen && row!.members.map(m => (
+                                <tr key={`${e.name}:${m.name}`} style={{ opacity: 0.75 }}>
+                                  <td style={{ paddingLeft: 28 }}>{m.name}</td>
+                                  <td />
+                                  <td>
+                                    <span className={`status-pill ${STATE_PILL[m.state]}`}>{m.state}</span>
+                                  </td>
+                                  <td colSpan={3} style={{ fontSize: 12, color: 'var(--app-fg-muted)' }}>
+                                    managed by {e.name}
+                                  </td>
+                                  <td>{m.metadata?.version ?? '—'}</td>
+                                </tr>
+                              ))}
+                            </Fragment>
+                          );
+                        })}
                         {pageRows.length === 0 && (
                           <tr>
                             <td colSpan={colCount} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -6,7 +6,7 @@ import { apiFetch } from '../api.js';
 import { useTheme } from '../hooks/useTheme.js';
 // Types + row-tree builder live in registry-rows.ts, shared with its unit tests
 // (mirrors src/registry/types.ts RegistryEntry).
-import { buildRows, collateralPins, registryPathSegment, type RegistryEntry, type DerivedState, type Row } from './registry-rows.js';
+import { buildRows, collateralPins, registryPathSegment, uninstallBlockedReason, type RegistryEntry, type DerivedState, type Row } from './registry-rows.js';
 
 // Map each DerivedState to one of the existing .status-pill modifier classes
 // (app.css) so no new CSS is needed:
@@ -168,7 +168,14 @@ function RegistryDrawer({ entry, row, agents, onClose, onChanged }: {
     }
   }, [entry.name, entry.kind, onChanged]);
 
+  // Non-null when the server would refuse this uninstall (an enabled bundle). Drives both
+  // the disabled state and the explanatory copy below the action row.
+  const uninstallBlocked = uninstallBlockedReason(entry);
+
   const confirmUninstall = () => {
+    // Belt and braces: the button is already disabled in this state, but a stray caller
+    // must not be able to fire a delete the server will reject.
+    if (uninstallBlocked !== null) return;
     if (window.confirm(`Uninstall "${entry.name}"? This removes its registry row.`)) {
       void act('DELETE', '');
     }
@@ -379,16 +386,26 @@ function RegistryDrawer({ entry, row, agents, onClose, onChanged }: {
           </button>
         )}
 
-        {/* Uninstall — available for any entry that has a registry row */}
+        {/* Uninstall — available for any entry that has a registry row. Kept visible but
+            inert for an enabled bundle: the server refuses that delete, so offering a live
+            button would invite a click that can only end in a 400. The tooltip carries the
+            reason and the remedy, which is more useful than hiding the control and leaving
+            the operator to wonder where it went. */}
         {entry.state !== 'uninstalled' && (
           <button
             type="button"
             className="btn btn-danger btn-sm"
-            disabled={busy}
+            disabled={busy || uninstallBlocked !== null}
+            title={uninstallBlocked ?? undefined}
             onClick={confirmUninstall}
           >
             Uninstall
           </button>
+        )}
+        {uninstallBlocked && (
+          <p style={{ margin: 0, fontSize: 12, color: 'var(--app-fg-muted)' }}>
+            {uninstallBlocked}
+          </p>
         )}
       </div>
     </aside>

--- a/apps/console/src/pages/RegistrySettings.tsx
+++ b/apps/console/src/pages/RegistrySettings.tsx
@@ -6,7 +6,7 @@ import { apiFetch } from '../api.js';
 import { useTheme } from '../hooks/useTheme.js';
 // Types + row-tree builder live in registry-rows.ts, shared with its unit tests
 // (mirrors src/registry/types.ts RegistryEntry).
-import { buildRows, type RegistryEntry, type DerivedState, type Row } from './registry-rows.js';
+import { buildRows, collateralPins, type RegistryEntry, type DerivedState, type Row } from './registry-rows.js';
 
 // Map each DerivedState to one of the existing .status-pill modifier classes
 // (app.css) so no new CSS is needed:
@@ -103,9 +103,13 @@ function SecretRow({ name, configured, onSaved }: {
 
 // ── Detail drawer ────────────────────────────────────────────────────────────
 
-function RegistryDrawer({ entry, kindPath, onClose, onChanged }: {
+function RegistryDrawer({ entry, kindPath, row, agents, onClose, onChanged }: {
   entry: RegistryEntry;
   kindPath: 'tools' | 'agents';
+  // Only populated on the /tools path — used to warn before a bundle disable strips a
+  // tool that some other agent pins directly (#1724).
+  row?: Row;
+  agents: RegistryEntry[];
   onClose: () => void;
   onChanged: () => void;
 }) {
@@ -167,6 +171,31 @@ function RegistryDrawer({ entry, kindPath, onClose, onChanged }: {
       void act('DELETE', '');
     }
   };
+
+  // Disabling a bundle cascades to its member tools. Some of those tools may be pinned
+  // directly by a different agent that never asked for the bundle at all — silently
+  // stripping them from that agent's function list (the real-world case: T2125-expense-tracker
+  // pins ceo-inbox-search/ceo-inbox-download-attachment, both ceo-inbox members). Warn the
+  // operator with the affected agents before letting the disable through. Non-bundle rows
+  // (or rows we weren't given, e.g. the /agents page) skip straight to true — nothing cascades.
+  const confirmDisable = useCallback((): boolean => {
+    if (row?.rowKind !== 'bundle') return true;
+    const collateral = collateralPins(row, agents);
+    const lines = [
+      `Disable the "${entry.name}" bundle?`,
+      '',
+      `This also disables ${row.members.length} member tool${row.members.length === 1 ? '' : 's'}.`,
+    ];
+    if (collateral.length > 0) {
+      lines.push(
+        '',
+        'These member tools are pinned directly by other agents, which will lose them:',
+        ...collateral.map(c => `  • ${c.tool} — ${c.agents.join(', ')}`),
+      );
+    }
+    lines.push('', 'Takes effect on the next restart.');
+    return window.confirm(lines.join('\n'));
+  }, [row, agents, entry.name]);
 
   return (
     <aside className="drawer">
@@ -322,7 +351,7 @@ function RegistryDrawer({ entry, kindPath, onClose, onChanged }: {
             type="button"
             className="btn btn-secondary btn-sm"
             disabled={busy}
-            onClick={() => void act('POST', '/disable')}
+            onClick={() => { if (confirmDisable()) void act('POST', '/disable'); }}
           >
             Disable
           </button>
@@ -430,12 +459,9 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
 
   const [entries, setEntries] = useState<RegistryEntry[]>([]);
   const [rows, setRows] = useState<Row[]>([]);
-  // Retained on the /tools path so Task 6's drawer can warn which enabled agents
-  // pin a bundle directly, without a second round-trip to /api/registry/agents.
-  // Not read yet — this task only wires the fetch; Task 6 consumes it. The `void`
-  // keeps noUnusedLocals quiet without touching rendered markup ahead of that task.
+  // Retained on the /tools path so the drawer can warn which enabled agents pin a
+  // bundle's member tools directly, without a second round-trip to /api/registry/agents.
   const [agents, setAgents] = useState<RegistryEntry[]>([]);
-  void agents;
   const [selected, setSelected] = useState<RegistryEntry | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
@@ -775,6 +801,8 @@ function RegistryPage({ kind }: { kind: 'tool' | 'agent' }) {
                     key={selected.name}
                     entry={selected}
                     kindPath={kindPath}
+                    row={rowByName.get(selected.name)}
+                    agents={agents}
                     onClose={() => setSelected(null)}
                     onChanged={() => { void load(); }}
                   />

--- a/apps/console/src/pages/registry-rows.test.ts
+++ b/apps/console/src/pages/registry-rows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildRows } from './registry-rows.js';
+import { buildRows, collateralPins } from './registry-rows.js';
 import type { RegistryEntry } from './registry-rows.js';
 
 const entry = (name: string, over: Partial<RegistryEntry> = {}): RegistryEntry => ({
@@ -68,5 +68,35 @@ describe('buildRows', () => {
     );
 
     expect(rows.map(r => r.entry.name)).toEqual(['ghost-bundle', 'orphan-tool']);
+  });
+});
+
+describe('collateralPins', () => {
+  const row = {
+    entry: bundle('ceo-inbox', ['ceo-inbox-search', 'ceo-inbox-list'], [], 'enabled'),
+    rowKind: 'bundle' as const,
+    members: [entry('ceo-inbox-search'), entry('ceo-inbox-list')],
+    pinnedBy: [],
+    unresolvedFor: [],
+  };
+
+  it('reports member tools pinned individually by other agents', () => {
+    const agents = [
+      entry('T2125-expense-tracker', {
+        kind: 'agent', state: 'enabled',
+        metadata: { name: 'T2125-expense-tracker', description: 'd', version: '1.0.0',
+          pinnedTools: ['ceo-inbox-search'] },
+      }),
+    ];
+
+    expect(collateralPins(row, agents)).toEqual([
+      { tool: 'ceo-inbox-search', agents: ['T2125-expense-tracker'] },
+    ]);
+  });
+
+  // Brief's original name implied this exercises "the bundle owner itself" too, but the
+  // assertion below only ever covers the empty-agents case — renamed to match reality.
+  it('returns nothing when no other agent pins a member', () => {
+    expect(collateralPins(row, [])).toEqual([]);
   });
 });

--- a/apps/console/src/pages/registry-rows.test.ts
+++ b/apps/console/src/pages/registry-rows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildRows, collateralPins, registryPathSegment } from './registry-rows.js';
+import { buildRows, collateralPins, registryPathSegment, uninstallBlockedReason } from './registry-rows.js';
 import type { RegistryEntry } from './registry-rows.js';
 
 const entry = (name: string, over: Partial<RegistryEntry> = {}): RegistryEntry => ({
@@ -117,5 +117,37 @@ describe('collateralPins', () => {
   // assertion below only ever covers the empty-agents case — renamed to match reality.
   it('returns nothing when no other agent pins a member', () => {
     expect(collateralPins(row, [])).toEqual([]);
+  });
+});
+
+describe('uninstallBlockedReason', () => {
+  it('blocks an enabled bundle and explains the member-tool consequence', () => {
+    const reason = uninstallBlockedReason(
+      bundle('ceo-inbox', ['ceo-inbox-list'], [], 'enabled'),
+    );
+    expect(reason).toMatch(/disable/i);
+    expect(reason).toMatch(/member tool/i);
+  });
+
+  it('allows an installed-but-not-enabled bundle', () => {
+    expect(
+      uninstallBlockedReason(bundle('ceo-inbox', ['ceo-inbox-list'], [], 'installed')),
+    ).toBeNull();
+  });
+
+  it('allows a ghost bundle — clearing the row is the only way to remove one', () => {
+    // A ghost has a registry row but no manifest, so its members are unknowable and the
+    // server permits the delete. The console must not be stricter than the server here,
+    // or the row becomes unremovable from the UI.
+    expect(
+      uninstallBlockedReason(entry('dead-bundle', { kind: 'skill', state: 'ghost' })),
+    ).toBeNull();
+  });
+
+  it('never blocks a plain tool or an agent, even when enabled', () => {
+    expect(uninstallBlockedReason(entry('bullpen', { state: 'enabled' }))).toBeNull();
+    expect(
+      uninstallBlockedReason(entry('coordinator', { kind: 'agent', state: 'enabled' })),
+    ).toBeNull();
   });
 });

--- a/apps/console/src/pages/registry-rows.test.ts
+++ b/apps/console/src/pages/registry-rows.test.ts
@@ -151,3 +151,24 @@ describe('uninstallBlockedReason', () => {
     ).toBeNull();
   });
 });
+
+describe('uninstallBlockedReason — must mirror the server, not exceed it', () => {
+  it('allows an enabled bundle whose manifest failed to parse', () => {
+    // metadata === null means the member list is unreadable. The server permits this delete
+    // precisely because there is no cascade route: disable() also rejects it, so blocking
+    // here too would leave the row with no console action at all. Note the derived state is
+    // 'enabled' (not 'ghost') — the directory IS on disk, its SKILL.md just doesn't parse —
+    // which is why keying only on state was wrong.
+    expect(
+      uninstallBlockedReason(
+        entry('broken-bundle', { kind: 'skill', state: 'enabled', metadata: null }),
+      ),
+    ).toBeNull();
+  });
+
+  it('still blocks an enabled bundle whose members are readable', () => {
+    expect(
+      uninstallBlockedReason(bundle('ceo-inbox', ['ceo-inbox-list'], [], 'enabled')),
+    ).not.toBeNull();
+  });
+});

--- a/apps/console/src/pages/registry-rows.test.ts
+++ b/apps/console/src/pages/registry-rows.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { buildRows } from './registry-rows.js';
+import type { RegistryEntry } from './registry-rows.js';
+
+const entry = (name: string, over: Partial<RegistryEntry> = {}): RegistryEntry => ({
+  name, kind: 'tool', state: 'enabled', metadata: null,
+  installedAt: null, installedBy: null, enabledAt: null, enabledBy: null, ...over,
+});
+
+const bundle = (name: string, tools: string[], pinnedBy: string[], state: RegistryEntry['state']) =>
+  entry(name, {
+    kind: 'skill', state,
+    metadata: { name, description: 'd', version: '1.0.0', tools, pinnedBy },
+  });
+
+describe('buildRows', () => {
+  it('nests member tools under their bundle and leaves standalone tools flat', () => {
+    const rows = buildRows(
+      [bundle('ceo-inbox', ['ceo-inbox-list'], [], 'enabled')],
+      [entry('ceo-inbox-list'), entry('bullpen')],
+      [],
+    );
+
+    expect(rows.map(r => r.entry.name)).toEqual(['ceo-inbox', 'bullpen']);
+    expect(rows[0]!.rowKind).toBe('bundle');
+    expect(rows[0]!.members.map(m => m.name)).toEqual(['ceo-inbox-list']);
+    expect(rows[1]!.rowKind).toBe('tool');
+    expect(rows[1]!.members).toEqual([]);
+  });
+
+  it('flags a non-enabled bundle pinned by an enabled agent', () => {
+    const rows = buildRows(
+      [bundle('ceo-inbox', ['ceo-inbox-list'], ['ceo-inbox'], 'installed')],
+      [entry('ceo-inbox-list')],
+      [entry('ceo-inbox', { kind: 'agent', state: 'enabled' })],
+    );
+
+    expect(rows[0]!.unresolvedFor).toEqual(['ceo-inbox']);
+  });
+
+  it('does not flag when the pinning agent is itself disabled', () => {
+    const rows = buildRows(
+      [bundle('learning', ['learn-x'], ['digest'], 'installed')],
+      [entry('learn-x')],
+      [entry('digest', { kind: 'agent', state: 'installed' })],
+    );
+
+    expect(rows[0]!.unresolvedFor).toEqual([]);
+  });
+
+  it('shows members for a bundle that is not installed', () => {
+    const rows = buildRows(
+      [bundle('ceo-inbox', ['ceo-inbox-list', 'ceo-inbox-read'], [], 'uninstalled')],
+      [entry('ceo-inbox-list'), entry('ceo-inbox-read')],
+      [],
+    );
+
+    expect(rows[0]!.members).toHaveLength(2);
+  });
+
+  it('keeps an orphaned member visible as a standalone row when its bundle has no manifest', () => {
+    // Ghost bundle: DB row with no manifest, so metadata (and membership) is null.
+    // The member must still appear somewhere — as a standalone row, not vanish.
+    const rows = buildRows(
+      [entry('ghost-bundle', { kind: 'skill', state: 'ghost', metadata: null })],
+      [entry('orphan-tool')],
+      [],
+    );
+
+    expect(rows.map(r => r.entry.name)).toEqual(['ghost-bundle', 'orphan-tool']);
+  });
+});

--- a/apps/console/src/pages/registry-rows.test.ts
+++ b/apps/console/src/pages/registry-rows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildRows, collateralPins } from './registry-rows.js';
+import { buildRows, collateralPins, registryPathSegment } from './registry-rows.js';
 import type { RegistryEntry } from './registry-rows.js';
 
 const entry = (name: string, over: Partial<RegistryEntry> = {}): RegistryEntry => ({
@@ -12,6 +12,25 @@ const bundle = (name: string, tools: string[], pinnedBy: string[], state: Regist
     kind: 'skill', state,
     metadata: { name, description: 'd', version: '1.0.0', tools, pinnedBy },
   });
+
+describe('registryPathSegment', () => {
+  // Regression guard for finding #1: the drawer's act() used to route on the *page's*
+  // kind (`kindPath`) instead of the entry's own kind, so a bundle row (kind: 'skill')
+  // rendered on the /tools page sent every action to /api/registry/tools/:name — which
+  // 400s because no tool manifest exists under the bundle's name. Nothing exercised the
+  // request URL before, so this pins the mapping directly.
+  it('maps a bundle (skill) entry to the skills segment', () => {
+    expect(registryPathSegment('skill')).toBe('skills');
+  });
+
+  it('maps a tool entry to the tools segment', () => {
+    expect(registryPathSegment('tool')).toBe('tools');
+  });
+
+  it('maps an agent entry to the agents segment', () => {
+    expect(registryPathSegment('agent')).toBe('agents');
+  });
+});
 
 describe('buildRows', () => {
   it('nests member tools under their bundle and leaves standalone tools flat', () => {

--- a/apps/console/src/pages/registry-rows.ts
+++ b/apps/console/src/pages/registry-rows.ts
@@ -20,6 +20,11 @@ export interface ManifestMetadata {
   tools?: string[];
   /** Agents whose pinned_skills reference this bundle — skill bundles only. */
   pinnedBy?: string[];
+  /** Raw pinned_skills for an agent — a mix of bundle names and first-class tool pins
+   *  (ADR-032). Distinct from `tools`, which means bundle membership on a skill. Used
+   *  by collateralPins to warn before a bundle disable strips a directly-pinned tool.
+   *  Agents only. */
+  pinnedTools?: string[];
 }
 
 export interface RegistryEntry {
@@ -95,4 +100,31 @@ export function buildRows(
     .map(entry => ({ entry, rowKind: 'tool', members: [], pinnedBy: [], unresolvedFor: [] }));
 
   return [...bundleRows, ...toolRows];
+}
+
+/**
+ * Member tools of `row` that some agent pins directly, by tool name.
+ *
+ * Disabling a bundle cascades to its members, which would strip those tools from an
+ * agent that never asked for the bundle at all. The operator sees this list before
+ * confirming. Only enabled agents count — a disabled agent loses nothing.
+ */
+export function collateralPins(
+  row: Row,
+  agents: RegistryEntry[],
+): Array<{ tool: string; agents: string[] }> {
+  const memberNames = new Set(row.members.map(m => m.name));
+  const byTool = new Map<string, string[]>();
+
+  for (const agent of agents) {
+    if (agent.state !== 'enabled') continue;
+    for (const pin of agent.metadata?.pinnedTools ?? []) {
+      if (!memberNames.has(pin)) continue;
+      const list = byTool.get(pin);
+      if (list) list.push(agent.name);
+      else byTool.set(pin, [agent.name]);
+    }
+  }
+
+  return [...byTool.entries()].map(([tool, names]) => ({ tool, agents: names }));
 }

--- a/apps/console/src/pages/registry-rows.ts
+++ b/apps/console/src/pages/registry-rows.ts
@@ -1,0 +1,98 @@
+// registry-rows.ts — merges the three registry endpoints into the /tools row model.
+// Extracted from RegistrySettings.tsx so the tree-building and unresolved-pin logic
+// can be unit tested without rendering the page.
+
+export type DerivedState = 'uninstalled' | 'installed' | 'enabled' | 'ghost';
+
+export interface ManifestMetadata {
+  name: string;
+  description: string;
+  version: string;
+  actionRisk?: string | number;
+  sensitivity?: string;
+  capabilities?: string[];
+  role?: string;
+  modelTier?: string;
+  // PR2 (#939): vault keys a skill declares in install.requires_secrets. Cross-referenced
+  // against GET /api/vault/status to show configured/missing status and gate install/enable.
+  requiresSecrets?: string[];
+  /** Member tool names — skill bundles only. */
+  tools?: string[];
+  /** Agents whose pinned_skills reference this bundle — skill bundles only. */
+  pinnedBy?: string[];
+}
+
+export interface RegistryEntry {
+  name: string;
+  kind: 'tool' | 'agent' | 'skill';
+  state: DerivedState;
+  metadata: ManifestMetadata | null;
+  manifestError?: string;
+  installedAt: string | null;
+  installedBy: string | null;
+  enabledAt: string | null;
+  enabledBy: string | null;
+}
+
+export type RowKind = 'bundle' | 'tool';
+
+/** One top-level row in the merged /tools view. A bundle carries its members
+ *  (rendered read-only underneath); a standalone tool carries none. */
+export interface Row {
+  entry: RegistryEntry;
+  rowKind: RowKind;
+  members: RegistryEntry[];
+  pinnedBy: string[];
+  /** Enabled agents that pin this bundle while it is not enabled. Non-empty = broken:
+   *  those agents boot with the bundle's tools missing from their function list. */
+  unresolvedFor: string[];
+}
+
+/**
+ * Build the merged row list: every bundle first (in the order returned), then any
+ * tool not claimed by a bundle.
+ *
+ * A tool is "claimed" only when a bundle's on-disk manifest lists it. A ghost bundle
+ * has no manifest, so its former members fall back to standalone rows rather than
+ * disappearing from the page entirely.
+ */
+export function buildRows(
+  skills: RegistryEntry[],
+  tools: RegistryEntry[],
+  agents: RegistryEntry[],
+): Row[] {
+  const toolByName = new Map(tools.map(t => [t.name, t]));
+  const enabledAgents = new Set(agents.filter(a => a.state === 'enabled').map(a => a.name));
+  const claimed = new Set<string>();
+
+  const bundleRows: Row[] = skills.map(entry => {
+    const memberNames = entry.metadata?.tools ?? [];
+    const members: RegistryEntry[] = [];
+    for (const name of memberNames) {
+      const tool = toolByName.get(name);
+      claimed.add(name);
+      // A member declared in the manifest but missing from tool_registry discovery is
+      // still worth showing — render it as uninstalled rather than dropping it.
+      members.push(tool ?? {
+        name, kind: 'tool', state: 'uninstalled', metadata: null,
+        installedAt: null, installedBy: null, enabledAt: null, enabledBy: null,
+      });
+    }
+    const pinnedBy = entry.metadata?.pinnedBy ?? [];
+    return {
+      entry,
+      rowKind: 'bundle',
+      members,
+      pinnedBy,
+      unresolvedFor: entry.state === 'enabled'
+        ? []
+        : pinnedBy.filter(a => enabledAgents.has(a)),
+    };
+  });
+
+  const toolRows: Row[] = tools
+    .filter(t => !claimed.has(t.name))
+    .map(entry => ({ entry, rowKind: 'tool', members: [], pinnedBy: [], unresolvedFor: [] }));
+
+  return [...bundleRows, ...toolRows];
+}

--- a/apps/console/src/pages/registry-rows.ts
+++ b/apps/console/src/pages/registry-rows.ts
@@ -85,6 +85,13 @@ export function registryPathSegment(kind: RegistryEntry['kind']): 'skills' | 'to
  */
 export function uninstallBlockedReason(entry: RegistryEntry): string | null {
   if (entry.kind !== 'skill' || entry.state !== 'enabled') return null;
+  // Mirror the server's second condition too: it only refuses when the member list is
+  // READABLE, i.e. when "disable first" is advice that actually works. A bundle whose
+  // SKILL.md fails to parse has metadata === null and derives state 'enabled' (the
+  // directory is on disk, so it is not a ghost) — and disable() rejects it for the same
+  // unreadable-member-list reason. Blocking uninstall here as well would leave that row
+  // with no console action at all, which is the dead end this guard exists to avoid.
+  if (entry.metadata?.tools == null) return null;
   return 'Disable this bundle first — uninstalling it now would leave its member tools '
     + 'enabled and callable with no bundle owning them.';
 }

--- a/apps/console/src/pages/registry-rows.ts
+++ b/apps/console/src/pages/registry-rows.ts
@@ -69,6 +69,27 @@ export function registryPathSegment(kind: RegistryEntry['kind']): 'skills' | 'to
 }
 
 /**
+ * Why uninstall is refused for this entry, or null when it is allowed.
+ *
+ * Mirrors the server guard in RegistryService.uninstall: an ENABLED bundle cannot be
+ * uninstalled, because deleting the skill_registry row leaves every member tool_registry
+ * row enabled — and runtime tool availability reads tool_registry alone, so those tools
+ * stay loaded and callable with no bundle owning them. Disable first; that cascades.
+ *
+ * Deliberately NOT stricter than the server. A bundle whose manifest is missing derives
+ * state 'ghost', not 'enabled', and the server permits that delete precisely because
+ * clearing a ghost row is the only way to remove one — blocking it here would leave the
+ * row with no console action at all. Plain tools and agents are never blocked.
+ *
+ * Returned string is shown as the button's tooltip, so it must say what to do instead.
+ */
+export function uninstallBlockedReason(entry: RegistryEntry): string | null {
+  if (entry.kind !== 'skill' || entry.state !== 'enabled') return null;
+  return 'Disable this bundle first — uninstalling it now would leave its member tools '
+    + 'enabled and callable with no bundle owning them.';
+}
+
+/**
  * Build the merged row list: every bundle first (in the order returned), then any
  * tool not claimed by a bundle.
  *

--- a/apps/console/src/pages/registry-rows.ts
+++ b/apps/console/src/pages/registry-rows.ts
@@ -54,6 +54,21 @@ export interface Row {
 }
 
 /**
+ * Map an entry's own `kind` to its URL path segment under /api/registry/.
+ *
+ * Routing must key off the entry's own kind, not the page it happens to render on — a
+ * bundle row (`kind: 'skill'`) shown on the /tools page still lives at
+ * /api/registry/skills/:name, not /api/registry/tools/:name. Getting this wrong sent
+ * every bundle enable/disable/install from the console to the tools endpoint, which
+ * 400s because no *tool* manifest exists under the bundle's name (finding #1).
+ */
+export function registryPathSegment(kind: RegistryEntry['kind']): 'skills' | 'tools' | 'agents' {
+  if (kind === 'skill') return 'skills';
+  if (kind === 'agent') return 'agents';
+  return 'tools';
+}
+
+/**
  * Build the merged row list: every bundle first (in the order returned), then any
  * tool not claimed by a bundle.
  *

--- a/docs/wip/2026-09-03-console-bundle-registry.md
+++ b/docs/wip/2026-09-03-console-bundle-registry.md
@@ -1,0 +1,1297 @@
+# Console Skill Bundle Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator enable and disable skill bundles from `/tools`, with member tools nested under their bundle, and flag any bundle that an enabled agent pins but which is not itself enabled.
+
+**Architecture:** The backend already exposes `GET /api/registry/skills` and the four state-change routes for `kind: 'skill'`. Three gaps are filled: bundle *membership* and *pin consumers* are propagated into the API payload (they are dropped today during discovery mapping); a new `BundleCascadeRepo` performs the cross-table enable/disable in one transaction; and the console merges skills + tools + agents into a single parent/child row model. HTTP routes are unchanged.
+
+**Tech Stack:** TypeScript (ESM, Node 24+), Fastify, Postgres via `pg`, React 19 + TanStack Router (console), Vitest.
+
+**Spec:** https://github.com/josephfung/curia/issues/1724 — read the issue before starting; every acceptance criterion below traces to it.
+
+## Global Constraints
+
+- ESM only — `.js` extensions on all relative imports; no `require()`.
+- No `any`. Cast through `unknown` when narrowing `Record<string, unknown>` to a typed interface.
+- Array element access (`arr[0]`, `mock.calls[0]`) is `T | undefined` under strict null checks — use `!` when the element is guaranteed, or destructure with a guard.
+- Parameterized SQL only. Table names are compile-time literals selected via a map, never runtime concatenation (`registry-repo.ts` pattern).
+- No empty `catch {}`. Every catch logs, audits, and propagates.
+- No `console.log` — pino only (backend). The console app is exempt; it has no pino.
+- Skills return `{ success: true, data }` / `{ success: false, error }` — never throw. (Not exercised here; no skill handlers change.)
+- Run `pnpm -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-bundle-registry run typecheck` before every commit touching `.ts`.
+- Commit with `-s` (DCO sign-off). No `Co-Authored-By`. No Claude/AI attribution anywhere.
+- Do **not** bump `package.json` version — that happens only at release.
+- `CHANGELOG.md` must be updated under `## [Unreleased]` before the PR; max 15 words after the em-dash.
+
+## Working directory
+
+All commands run from the worktree:
+`/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-console-bundle-registry`
+
+Use `pnpm -C <worktree>` (never `--prefix`) and `git -C <worktree>`.
+
+---
+
+### Task 1: Propagate bundle membership and pin consumers into the registry API
+
+Today `ManifestMetadata` carries only name/description/version for skills, so the API cannot say which tools a bundle contains or which agents pin it. `SkillDiscovery.metadata.tools` already holds the resolved member list — it is simply dropped in the `index.ts` mapping.
+
+**Files:**
+- Modify: `src/registry/types.ts:25-39` (add two fields to `ManifestMetadata`)
+- Modify: `src/index.ts:2354-2366` (skill discovery mapping)
+- Test: `src/registry/registry-service.test.ts`
+
+**Interfaces:**
+- Consumes: `SkillDiscovery.metadata.tools: string[]` from `src/skills/skill-types.ts:64-75`; `AgentConfig.pinned_skills?: string[]` from `src/agents/loader.ts:31`.
+- Produces: `ManifestMetadata.tools?: string[]` (bundle members, skills only) and `ManifestMetadata.pinnedBy?: string[]` (agent names pinning this bundle, skills only). Task 3 reads `tools`; Tasks 4–6 read both.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/registry/registry-service.test.ts`:
+
+```ts
+describe('RegistryService.list — skill bundle metadata', () => {
+  it('surfaces member tools and pin consumers for a bundle', async () => {
+    const skillRepo = new FakeRepo();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo,
+      [{
+        name: 'ceo-inbox',
+        metadata: {
+          name: 'ceo-inbox',
+          description: 'CEO inbox tools',
+          version: '0.1.0',
+          tools: ['ceo-inbox-list', 'ceo-inbox-read'],
+          pinnedBy: ['ceo-inbox'],
+        },
+      }],
+    );
+
+    const entries = await svc.list('skill');
+    const bundle = entries.find(e => e.name === 'ceo-inbox');
+
+    expect(bundle?.metadata?.tools).toEqual(['ceo-inbox-list', 'ceo-inbox-read']);
+    expect(bundle?.metadata?.pinnedBy).toEqual(['ceo-inbox']);
+  });
+
+  it('reports members for a bundle that is not installed', async () => {
+    // The whole point: a disabled bundle is never in SkillRegistry, so membership
+    // must come from on-disk discovery. An empty skillRepo = uninstalled.
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, new FakeRepo(),
+      [{
+        name: 'ceo-inbox',
+        metadata: {
+          name: 'ceo-inbox', description: 'd', version: '0.1.0',
+          tools: ['ceo-inbox-list'], pinnedBy: [],
+        },
+      }],
+    );
+
+    const bundle = (await svc.list('skill')).find(e => e.name === 'ceo-inbox');
+    expect(bundle?.state).toBe('uninstalled');
+    expect(bundle?.metadata?.tools).toEqual(['ceo-inbox-list']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -C <worktree> exec vitest run src/registry/registry-service.test.ts -t "skill bundle metadata"`
+Expected: FAIL — TypeScript rejects `tools` / `pinnedBy` as unknown properties on `ManifestMetadata`.
+
+- [ ] **Step 3: Add the fields to `ManifestMetadata`**
+
+In `src/registry/types.ts`, inside the `// skills` block of `ManifestMetadata`:
+
+```ts
+  /** Member tool names for a SKILL.md bundle. Sourced from on-disk discovery, NOT
+   *  SkillRegistry — a bundle that is disabled is never registered, so SkillRegistry
+   *  cannot report its members. Skills only; undefined for tools and agents. */
+  tools?: string[];
+  /** Names of agents whose `pinned_skills` reference this bundle. Static, read from
+   *  agent manifests on disk. The console cross-references each agent's own enabled
+   *  state (via /api/registry/agents) to decide which combinations are broken. */
+  pinnedBy?: string[];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm -C <worktree> exec vitest run src/registry/registry-service.test.ts -t "skill bundle metadata"`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Populate the fields at bootstrap**
+
+In `src/index.ts`, immediately before the `const registryService = new RegistryService(` call (~line 2335), build the pin index:
+
+```ts
+  // Which agents pin each skill bundle. Read from agent manifests on disk so the
+  // registry UI can flag a bundle that an agent depends on but which is not enabled —
+  // the condition that silently stripped ceo-inbox's 14 tools for a month (#1724).
+  const pinnedByBundle = new Map<string, string[]>();
+  for (const agent of agentDiscovery) {
+    for (const pin of agent.config?.pinned_skills ?? []) {
+      const list = pinnedByBundle.get(pin);
+      if (list) list.push(agent.name);
+      else pinnedByBundle.set(pin, [agent.name]);
+    }
+  }
+```
+
+Then extend the `skillBundleDiscovery.map(...)` metadata object (~line 2356) so it reads:
+
+```ts
+    skillBundleDiscovery.map(d => ({
+      name: d.name,
+      metadata: d.metadata
+        ? {
+            name: d.metadata.name,
+            description: d.metadata.description,
+            version: d.metadata.version,
+            tools: d.metadata.tools,
+            pinnedBy: pinnedByBundle.get(d.name) ?? [],
+          }
+        : null,
+      error: d.error,
+    })),
+```
+
+- [ ] **Step 6: Typecheck and run the registry suite**
+
+Run: `pnpm -C <worktree> run typecheck`
+Then: `pnpm -C <worktree> exec vitest run src/registry/`
+Expected: typecheck clean; all registry tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C <worktree> add src/registry/types.ts src/index.ts src/registry/registry-service.test.ts
+git -C <worktree> commit -s -m "feat(registry): surface bundle members and pin consumers in the API
+
+Bundle membership comes from on-disk discovery rather than SkillRegistry so a
+disabled bundle still reports its tools. Refs #1724"
+```
+
+---
+
+### Task 2: Transactional cross-table cascade repo
+
+Enabling a bundle must write `skill_registry` and every member's `tool_registry` row atomically. `RegistryRepo` is deliberately one-instance-per-table, so the cross-table write goes in its own focused module rather than distorting that contract.
+
+**Files:**
+- Create: `src/registry/bundle-cascade-repo.ts`
+- Create: `src/registry/bundle-cascade-repo.test.ts`
+- Modify: `src/registry/types.ts` (add `IBundleCascadeRepo`)
+
+**Interfaces:**
+- Consumes: `DbPool` / `DbPoolClient` from `src/db/connection.ts:9-10`; the `BEGIN`/`COMMIT`/`ROLLBACK` pattern from `src/memory/bullpen.ts:202-224`.
+- Produces:
+  ```ts
+  interface IBundleCascadeRepo {
+    enableBundle(bundle: string, tools: string[], actor: string): Promise<void>;
+    disableBundle(bundle: string, tools: string[], actor: string): Promise<void>;
+  }
+  ```
+  Task 3 injects this into `RegistryService`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/registry/bundle-cascade-repo.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { BundleCascadeRepo } from './bundle-cascade-repo.js';
+import type { DbPool } from '../db/connection.js';
+
+// Minimal fake pool: records every query text so we can assert transaction shape.
+function fakePool(failOn?: string) {
+  const queries: string[] = [];
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql.trim().split('\n')[0]!.trim());
+      if (failOn && sql.includes(failOn)) throw new Error('boom');
+      return { rows: [] };
+    }),
+    release: vi.fn(),
+  };
+  const pool = { connect: vi.fn(async () => client) } as unknown as DbPool;
+  return { pool, client, queries };
+}
+
+const logger = { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+
+describe('BundleCascadeRepo.enableBundle', () => {
+  it('writes the bundle and every member tool inside one transaction', async () => {
+    const { pool, client, queries } = fakePool();
+    const repo = new BundleCascadeRepo(pool, logger as never);
+
+    await repo.enableBundle('ceo-inbox', ['ceo-inbox-list', 'ceo-inbox-read'], 'web-app');
+
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries[queries.length - 1]).toBe('COMMIT');
+    // one skill_registry upsert + one tool_registry upsert per member
+    expect(queries.filter(q => q.includes('skill_registry'))).toHaveLength(1);
+    expect(queries.filter(q => q.includes('tool_registry'))).toHaveLength(2);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back and rethrows when a member write fails', async () => {
+    const { pool, client, queries } = fakePool('tool_registry');
+    const repo = new BundleCascadeRepo(pool, logger as never);
+
+    await expect(
+      repo.enableBundle('ceo-inbox', ['ceo-inbox-list'], 'web-app'),
+    ).rejects.toThrow('boom');
+
+    expect(queries).toContain('ROLLBACK');
+    expect(queries).not.toContain('COMMIT');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+});
+
+describe('BundleCascadeRepo.disableBundle', () => {
+  it('disables the bundle and every member tool in one transaction', async () => {
+    const { pool, queries } = fakePool();
+    const repo = new BundleCascadeRepo(pool, logger as never);
+
+    await repo.disableBundle('ceo-inbox', ['ceo-inbox-list'], 'web-app');
+
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries[queries.length - 1]).toBe('COMMIT');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -C <worktree> exec vitest run src/registry/bundle-cascade-repo.test.ts`
+Expected: FAIL — cannot resolve `./bundle-cascade-repo.js`.
+
+- [ ] **Step 3: Add the interface to `types.ts`**
+
+```ts
+/** Cross-table bundle operations. Separate from IRegistryRepo, which is deliberately
+ *  one-instance-per-table; enabling a bundle must write skill_registry and every
+ *  member's tool_registry row in a single transaction (#1724). */
+export interface IBundleCascadeRepo {
+  enableBundle(bundle: string, tools: string[], actor: string): Promise<void>;
+  disableBundle(bundle: string, tools: string[], actor: string): Promise<void>;
+}
+```
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/registry/bundle-cascade-repo.ts`:
+
+```ts
+// bundle-cascade-repo.ts — atomic enable/disable of a skill bundle together with its
+// member tools. RegistryRepo is one-instance-per-table by design; a bundle cascade
+// spans skill_registry and tool_registry, so it lives here and owns its transaction.
+//
+// A half-applied cascade is worse than the current state: it would leave a bundle
+// enabled with some members off, which is exactly the partial state the UI is meant
+// to make impossible. Hence BEGIN/COMMIT with an explicit ROLLBACK on any failure.
+
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+import type { IBundleCascadeRepo } from './types.js';
+
+// Upsert-then-enable in one statement. ON CONFLICT covers the case where the row
+// already exists (installed but disabled) — the common path for a bundle that shipped
+// disabled. Table names are compile-time literals; all values are parameterized.
+const ENABLE_SKILL = `
+  INSERT INTO skill_registry (name, enabled, installed_by, enabled_at, enabled_by)
+  VALUES ($1, true, $2, now(), $2)
+  ON CONFLICT (name) DO UPDATE
+    SET enabled = true, enabled_at = now(), enabled_by = $2`;
+
+const ENABLE_TOOL = `
+  INSERT INTO tool_registry (name, enabled, installed_by, enabled_at, enabled_by)
+  VALUES ($1, true, $2, now(), $2)
+  ON CONFLICT (name) DO UPDATE
+    SET enabled = true, enabled_at = now(), enabled_by = $2`;
+
+const DISABLE_SKILL = `
+  UPDATE skill_registry SET enabled = false, enabled_at = NULL, enabled_by = NULL
+  WHERE name = $1`;
+
+const DISABLE_TOOL = `
+  UPDATE tool_registry SET enabled = false, enabled_at = NULL, enabled_by = NULL
+  WHERE name = $1`;
+
+export class BundleCascadeRepo implements IBundleCascadeRepo {
+  constructor(private readonly pool: DbPool, private readonly logger: Logger) {}
+
+  async enableBundle(bundle: string, tools: string[], actor: string): Promise<void> {
+    await this.run('enable', bundle, tools, actor, ENABLE_SKILL, ENABLE_TOOL);
+  }
+
+  async disableBundle(bundle: string, tools: string[], actor: string): Promise<void> {
+    await this.run('disable', bundle, tools, actor, DISABLE_SKILL, DISABLE_TOOL);
+  }
+
+  private async run(
+    op: 'enable' | 'disable',
+    bundle: string,
+    tools: string[],
+    actor: string,
+    bundleSql: string,
+    toolSql: string,
+  ): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      // Disable takes only the name; enable also records the actor.
+      await client.query(bundleSql, op === 'enable' ? [bundle, actor] : [bundle]);
+      for (const tool of tools) {
+        await client.query(toolSql, op === 'enable' ? [tool, actor] : [tool]);
+      }
+      await client.query('COMMIT');
+    } catch (err) {
+      this.logger.error({ err, bundle, tools, op }, `Bundle ${op} cascade failed; rolling back`);
+      // Guard the ROLLBACK itself — if the connection dropped it may throw, and that
+      // must not mask the original error.
+      await client.query('ROLLBACK').catch((rollbackErr: unknown) => {
+        this.logger.error({ rollbackErr, bundle, op }, 'ROLLBACK failed after cascade error');
+      });
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm -C <worktree> exec vitest run src/registry/bundle-cascade-repo.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm -C <worktree> run typecheck`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C <worktree> add src/registry/bundle-cascade-repo.ts src/registry/bundle-cascade-repo.test.ts src/registry/types.ts
+git -C <worktree> commit -s -m "feat(registry): add transactional bundle cascade repo
+
+Enabling or disabling a bundle writes skill_registry and every member's
+tool_registry row in one transaction. Refs #1724"
+```
+
+---
+
+### Task 3: Cascade on `RegistryService.enable` / `disable` for `kind: 'skill'`
+
+**Files:**
+- Modify: `src/registry/registry-service.ts:22-29` (constructor), `:157-180` (enable/disable)
+- Modify: `src/index.ts` (wire `BundleCascadeRepo`)
+- Test: `src/registry/registry-service.test.ts`
+
+**Interfaces:**
+- Consumes: `IBundleCascadeRepo` (Task 2); `ManifestMetadata.tools` (Task 1).
+- Produces: `RegistryService` constructor gains an 8th parameter `cascade?: IBundleCascadeRepo`. `enable('skill', …)` / `disable('skill', …)` route through it. Signatures otherwise unchanged — routes need no edit.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/registry/registry-service.test.ts`:
+
+```ts
+class FakeCascade implements IBundleCascadeRepo {
+  enabled: Array<{ bundle: string; tools: string[] }> = [];
+  disabled: Array<{ bundle: string; tools: string[] }> = [];
+  async enableBundle(bundle: string, tools: string[]) { this.enabled.push({ bundle, tools }); }
+  async disableBundle(bundle: string, tools: string[]) { this.disabled.push({ bundle, tools }); }
+}
+
+describe('RegistryService — bundle cascade', () => {
+  const bundleDisc = [{
+    name: 'ceo-inbox',
+    metadata: {
+      name: 'ceo-inbox', description: 'd', version: '0.1.0',
+      tools: ['ceo-inbox-list', 'ceo-inbox-read'], pinnedBy: ['ceo-inbox'],
+    },
+  }];
+
+  it('enable cascades the bundle and its member tools', async () => {
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc, cascade,
+    );
+
+    await svc.enable('skill', 'ceo-inbox', 'web-app');
+
+    expect(cascade.enabled).toEqual([
+      { bundle: 'ceo-inbox', tools: ['ceo-inbox-list', 'ceo-inbox-read'] },
+    ]);
+  });
+
+  it('disable cascades the bundle and its member tools', async () => {
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc, cascade,
+    );
+
+    await svc.disable('skill', 'ceo-inbox', 'web-app');
+
+    expect(cascade.disabled).toEqual([
+      { bundle: 'ceo-inbox', tools: ['ceo-inbox-list', 'ceo-inbox-read'] },
+    ]);
+  });
+
+  it('refuses a bundle enable when no cascade repo is wired', async () => {
+    // Fail loudly rather than silently writing only skill_registry and leaving the
+    // member tools untouched — a partial enable is the bug this feature exists to stop.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc,
+    );
+
+    await expect(svc.enable('skill', 'ceo-inbox', 'web-app'))
+      .rejects.toThrow(/cascade repo not configured/i);
+  });
+
+  it('leaves tool and agent enable on the single-table path', async () => {
+    const toolRepo = new FakeRepo();
+    await toolRepo.install('bullpen', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      toolRepo, new FakeRepo(), [disc('bullpen')], [], undefined, new FakeRepo(), [], cascade,
+    );
+
+    await svc.enable('tool', 'bullpen', 'web-app');
+
+    expect(cascade.enabled).toEqual([]);
+    expect((await toolRepo.getRow('bullpen'))?.enabled).toBe(true);
+  });
+});
+```
+
+Add `IBundleCascadeRepo` to the existing type-only import at the top of the test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -C <worktree> exec vitest run src/registry/registry-service.test.ts -t "bundle cascade"`
+Expected: FAIL — constructor takes 7 parameters, not 8.
+
+- [ ] **Step 3: Implement the cascade**
+
+In `src/registry/registry-service.ts`, add to the import block:
+
+```ts
+import type {
+  IRegistryRepo, RegistryKind, RegistryEntry, Discovery, SecretsLister, IBundleCascadeRepo,
+} from './types.js';
+```
+
+Add the constructor parameter after `skillDiscovery`:
+
+```ts
+    private skillDiscovery: Discovery[] = [],
+    // Cross-table cascade for bundle enable/disable. Required for kind='skill';
+    // absent is a wiring error, not a fallback (see bundleTools()).
+    private readonly cascade?: IBundleCascadeRepo,
+```
+
+Add a private helper next to `discovery()`:
+
+```ts
+  /** Member tools of a bundle, from on-disk discovery. Empty array for a bundle whose
+   *  manifest failed to parse — cascading nothing is correct there, the bundle row
+   *  still flips and the broken manifest is already surfaced as `manifestError`. */
+  private bundleTools(name: string): string[] {
+    return this.skillDiscovery.find(d => d.name === name)?.metadata?.tools ?? [];
+  }
+
+  private requireCascade(name: string): IBundleCascadeRepo {
+    if (!this.cascade) {
+      throw new Error(
+        `RegistryService: bundle cascade repo not configured; refusing to change '${name}' ` +
+        `without cascading its member tools`,
+      );
+    }
+    return this.cascade;
+  }
+```
+
+Replace the body of `enable`:
+
+```ts
+  async enable(kind: RegistryKind, name: string, actor: string): Promise<RegistryEntry> {
+    this.assertInstallable(kind, name);
+    // Re-check at enable time too: secrets could have been deleted since install, and
+    // enable is the moment the item actually goes live on the next restart.
+    await this.assertSecretsConfigured(kind, name);
+    const row = await this.repo(kind).getRow(name);
+    if (!row) throw new RegistryGuardError(`Cannot enable '${name}': not installed. Install it first.`);
+    if (kind === 'skill') {
+      // Bundle + members in one transaction — the bundle is the unit of control (#1724).
+      await this.requireCascade(name).enableBundle(name, this.bundleTools(name), actor);
+    } else {
+      await this.repo(kind).enable(name, actor);
+    }
+    return this.entry(kind, name);
+  }
+```
+
+Replace the body of `disable`:
+
+```ts
+  async disable(kind: RegistryKind, name: string, actor: string): Promise<RegistryEntry> {
+    const row = await this.repo(kind).getRow(name);
+    if (!row) throw new RegistryGuardError(`Cannot disable '${name}': no registry row.`);
+    if (kind === 'skill') {
+      await this.requireCascade(name).disableBundle(name, this.bundleTools(name), actor);
+    } else {
+      await this.repo(kind).disable(name, actor);
+    }
+    return this.entry(kind, name);
+  }
+```
+
+Also update `installAndEnable` so the install-enable route cascades too:
+
+```ts
+  async installAndEnable(kind: RegistryKind, name: string, actor: string): Promise<RegistryEntry> {
+    this.assertInstallable(kind, name);
+    await this.assertSecretsConfigured(kind, name);
+    await this.repo(kind).install(name, actor);
+    if (kind === 'skill') {
+      await this.requireCascade(name).enableBundle(name, this.bundleTools(name), actor);
+    } else {
+      await this.repo(kind).enable(name, actor);
+    }
+    return this.entry(kind, name);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm -C <worktree> exec vitest run src/registry/`
+Expected: PASS — including the pre-existing tests, which construct the service without a cascade and only exercise tool/agent kinds.
+
+- [ ] **Step 5: Wire the real repo at bootstrap**
+
+In `src/index.ts`, add the import alongside the other registry imports:
+
+```ts
+import { BundleCascadeRepo } from './registry/bundle-cascade-repo.js';
+```
+
+Then pass it as the final `RegistryService` argument, after the `skillBundleDiscovery.map(...)` block:
+
+```ts
+    new BundleCascadeRepo(pool, logger),
+```
+
+- [ ] **Step 6: Typecheck and run the full unit suite**
+
+Run: `pnpm -C <worktree> run typecheck`
+Then: `pnpm -C <worktree> exec vitest run src/`
+Expected: typecheck clean; suite green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C <worktree> add src/registry/registry-service.ts src/registry/registry-service.test.ts src/index.ts
+git -C <worktree> commit -s -m "feat(registry): cascade bundle enable/disable to member tools
+
+Bundle becomes the unit of control; a missing cascade repo throws rather than
+writing a partial state. Refs #1724"
+```
+
+---
+
+### Task 4: Console — merged row model
+
+The console currently renders one flat `RegistryEntry[]`. It needs a tree: bundles as parents with their members nested, standalone tools flat, plus each agent's enabled state so unresolved pins can be flagged.
+
+**Files:**
+- Modify: `apps/console/src/pages/RegistrySettings.tsx:8-35` (types), `:452-490` (load)
+
+**Interfaces:**
+- Consumes: `GET /api/registry/skills`, `/tools`, `/agents` — each returns `{ [kindPath]: RegistryEntry[] }`.
+- Produces:
+  ```ts
+  type RowKind = 'bundle' | 'tool';
+  interface Row {
+    entry: RegistryEntry;
+    rowKind: RowKind;
+    members: RegistryEntry[];      // bundle only; [] for tools
+    pinnedBy: string[];            // bundle only
+    unresolvedFor: string[];       // enabled agents pinning a non-enabled bundle
+  }
+  ```
+  Tasks 5 and 6 render `Row[]`.
+
+- [ ] **Step 1: Extend the local types**
+
+In `RegistrySettings.tsx`, widen `RegistryEntry.kind` and add the two metadata fields:
+
+```ts
+interface ManifestMetadata {
+  // …existing fields unchanged…
+  /** Member tool names — skill bundles only. */
+  tools?: string[];
+  /** Agents whose pinned_skills reference this bundle — skill bundles only. */
+  pinnedBy?: string[];
+}
+
+interface RegistryEntry {
+  name: string;
+  kind: 'tool' | 'agent' | 'skill';
+  // …rest unchanged…
+}
+```
+
+Add the row model directly below `RegistryEntry`:
+
+```ts
+type RowKind = 'bundle' | 'tool';
+
+/** One top-level row in the merged /tools view. A bundle carries its members
+ *  (rendered read-only underneath); a standalone tool carries none. */
+interface Row {
+  entry: RegistryEntry;
+  rowKind: RowKind;
+  members: RegistryEntry[];
+  pinnedBy: string[];
+  /** Enabled agents that pin this bundle while it is not enabled. Non-empty = broken:
+   *  those agents boot with the bundle's tools missing from their function list. */
+  unresolvedFor: string[];
+}
+```
+
+- [ ] **Step 2: Write the failing test for the row builder**
+
+Create `apps/console/src/pages/registry-rows.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildRows } from './registry-rows.js';
+import type { RegistryEntry } from './registry-rows.js';
+
+const entry = (name: string, over: Partial<RegistryEntry> = {}): RegistryEntry => ({
+  name, kind: 'tool', state: 'enabled', metadata: null,
+  installedAt: null, installedBy: null, enabledAt: null, enabledBy: null, ...over,
+});
+
+const bundle = (name: string, tools: string[], pinnedBy: string[], state: RegistryEntry['state']) =>
+  entry(name, {
+    kind: 'skill', state,
+    metadata: { name, description: 'd', version: '1.0.0', tools, pinnedBy },
+  });
+
+describe('buildRows', () => {
+  it('nests member tools under their bundle and leaves standalone tools flat', () => {
+    const rows = buildRows(
+      [bundle('ceo-inbox', ['ceo-inbox-list'], [], 'enabled')],
+      [entry('ceo-inbox-list'), entry('bullpen')],
+      [],
+    );
+
+    expect(rows.map(r => r.entry.name)).toEqual(['ceo-inbox', 'bullpen']);
+    expect(rows[0]!.rowKind).toBe('bundle');
+    expect(rows[0]!.members.map(m => m.name)).toEqual(['ceo-inbox-list']);
+    expect(rows[1]!.rowKind).toBe('tool');
+    expect(rows[1]!.members).toEqual([]);
+  });
+
+  it('flags a non-enabled bundle pinned by an enabled agent', () => {
+    const rows = buildRows(
+      [bundle('ceo-inbox', ['ceo-inbox-list'], ['ceo-inbox'], 'installed')],
+      [entry('ceo-inbox-list')],
+      [entry('ceo-inbox', { kind: 'agent', state: 'enabled' })],
+    );
+
+    expect(rows[0]!.unresolvedFor).toEqual(['ceo-inbox']);
+  });
+
+  it('does not flag when the pinning agent is itself disabled', () => {
+    const rows = buildRows(
+      [bundle('learning', ['learn-x'], ['digest'], 'installed')],
+      [entry('learn-x')],
+      [entry('digest', { kind: 'agent', state: 'installed' })],
+    );
+
+    expect(rows[0]!.unresolvedFor).toEqual([]);
+  });
+
+  it('shows members for a bundle that is not installed', () => {
+    const rows = buildRows(
+      [bundle('ceo-inbox', ['ceo-inbox-list', 'ceo-inbox-read'], [], 'uninstalled')],
+      [entry('ceo-inbox-list'), entry('ceo-inbox-read')],
+      [],
+    );
+
+    expect(rows[0]!.members).toHaveLength(2);
+  });
+
+  it('keeps a member tool out of the flat list even when its bundle is absent from disk', () => {
+    // Ghost bundle: DB row with no manifest, so metadata (and membership) is null.
+    // The member must still appear somewhere — as a standalone row, not vanish.
+    const rows = buildRows(
+      [entry('ghost-bundle', { kind: 'skill', state: 'ghost', metadata: null })],
+      [entry('orphan-tool')],
+      [],
+    );
+
+    expect(rows.map(r => r.entry.name)).toEqual(['ghost-bundle', 'orphan-tool']);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm -C <worktree> exec vitest run apps/console/src/pages/registry-rows.test.ts`
+Expected: FAIL — cannot resolve `./registry-rows.js`.
+
+- [ ] **Step 4: Implement the row builder**
+
+Create `apps/console/src/pages/registry-rows.ts`. Move the `DerivedState`, `ManifestMetadata`, `RegistryEntry`, `RowKind` and `Row` declarations here and export them, so both the page and the test share one definition:
+
+```ts
+// registry-rows.ts — merges the three registry endpoints into the /tools row model.
+// Extracted from RegistrySettings.tsx so the tree-building and unresolved-pin logic
+// can be unit tested without rendering the page.
+
+export type DerivedState = 'uninstalled' | 'installed' | 'enabled' | 'ghost';
+
+export interface ManifestMetadata {
+  name: string;
+  description: string;
+  version: string;
+  actionRisk?: string | number;
+  sensitivity?: string;
+  capabilities?: string[];
+  role?: string;
+  modelTier?: string;
+  requiresSecrets?: string[];
+  tools?: string[];
+  pinnedBy?: string[];
+}
+
+export interface RegistryEntry {
+  name: string;
+  kind: 'tool' | 'agent' | 'skill';
+  state: DerivedState;
+  metadata: ManifestMetadata | null;
+  manifestError?: string;
+  installedAt: string | null;
+  installedBy: string | null;
+  enabledAt: string | null;
+  enabledBy: string | null;
+}
+
+export type RowKind = 'bundle' | 'tool';
+
+export interface Row {
+  entry: RegistryEntry;
+  rowKind: RowKind;
+  members: RegistryEntry[];
+  pinnedBy: string[];
+  unresolvedFor: string[];
+}
+
+/**
+ * Build the merged row list: every bundle first (in the order returned), then any
+ * tool not claimed by a bundle.
+ *
+ * A tool is "claimed" only when a bundle's on-disk manifest lists it. A ghost bundle
+ * has no manifest, so its former members fall back to standalone rows rather than
+ * disappearing from the page entirely.
+ */
+export function buildRows(
+  skills: RegistryEntry[],
+  tools: RegistryEntry[],
+  agents: RegistryEntry[],
+): Row[] {
+  const toolByName = new Map(tools.map(t => [t.name, t]));
+  const enabledAgents = new Set(agents.filter(a => a.state === 'enabled').map(a => a.name));
+  const claimed = new Set<string>();
+
+  const bundleRows: Row[] = skills.map(entry => {
+    const memberNames = entry.metadata?.tools ?? [];
+    const members: RegistryEntry[] = [];
+    for (const name of memberNames) {
+      const tool = toolByName.get(name);
+      claimed.add(name);
+      // A member declared in the manifest but missing from tool_registry discovery is
+      // still worth showing — render it as uninstalled rather than dropping it.
+      members.push(tool ?? {
+        name, kind: 'tool', state: 'uninstalled', metadata: null,
+        installedAt: null, installedBy: null, enabledAt: null, enabledBy: null,
+      });
+    }
+    const pinnedBy = entry.metadata?.pinnedBy ?? [];
+    return {
+      entry,
+      rowKind: 'bundle',
+      members,
+      pinnedBy,
+      unresolvedFor: entry.state === 'enabled'
+        ? []
+        : pinnedBy.filter(a => enabledAgents.has(a)),
+    };
+  });
+
+  const toolRows: Row[] = tools
+    .filter(t => !claimed.has(t.name))
+    .map(entry => ({ entry, rowKind: 'tool', members: [], pinnedBy: [], unresolvedFor: [] }));
+
+  return [...bundleRows, ...toolRows];
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm -C <worktree> exec vitest run apps/console/src/pages/registry-rows.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Point the page at the shared types and load all three endpoints**
+
+In `RegistrySettings.tsx`, delete the now-duplicated local type declarations and import them:
+
+```ts
+import { buildRows, type RegistryEntry, type DerivedState, type Row } from './registry-rows.js';
+```
+
+Replace the `load` callback for the tool kind so it fetches all three in parallel. Agents keep their existing single-fetch path:
+
+```ts
+  const load = useCallback(async () => {
+    try {
+      if (kind === 'agent') {
+        const res = await apiFetch('/api/registry/agents');
+        if (!res.ok) throw new Error(await errorMessage(res));
+        const data = await res.json() as { agents?: RegistryEntry[] };
+        const list = data.agents ?? [];
+        setEntries(list);
+        setRows(list.map(e => ({
+          entry: e, rowKind: 'tool' as const, members: [], pinnedBy: [], unresolvedFor: [],
+        })));
+        setLoadError(null);
+        setSelected(prev => (prev ? list.find(e => e.name === prev.name) ?? null : null));
+        return;
+      }
+
+      // /tools merges three endpoints: bundles, tools, and agents (agents only so an
+      // unresolved pin can be flagged against agents that are actually enabled).
+      const [skillsRes, toolsRes, agentsRes] = await Promise.all([
+        apiFetch('/api/registry/skills'),
+        apiFetch('/api/registry/tools'),
+        apiFetch('/api/registry/agents'),
+      ]);
+      for (const res of [skillsRes, toolsRes, agentsRes]) {
+        if (!res.ok) throw new Error(await errorMessage(res));
+      }
+      const skills = (await skillsRes.json() as { skills?: RegistryEntry[] }).skills ?? [];
+      const tools = (await toolsRes.json() as { tools?: RegistryEntry[] }).tools ?? [];
+      const agents = (await agentsRes.json() as { agents?: RegistryEntry[] }).agents ?? [];
+
+      const built = buildRows(skills, tools, agents);
+      setRows(built);
+      // `entries` stays the flat list the search/sort/filter/pagination code already uses.
+      setEntries(built.map(r => r.entry));
+      setLoadError(null);
+      setSelected(prev =>
+        prev ? built.map(r => r.entry).find(e => e.name === prev.name) ?? null : null,
+      );
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Failed to load');
+    }
+  }, [kind]);
+```
+
+Add the backing state next to `entries`:
+
+```ts
+  const [rows, setRows] = useState<Row[]>([]);
+```
+
+And a lookup so the render can find a row for a paged entry:
+
+```ts
+  const rowByName = useMemo(() => new Map(rows.map(r => [r.entry.name, r])), [rows]);
+```
+
+- [ ] **Step 7: Typecheck and commit**
+
+Run: `pnpm -C <worktree> run typecheck`
+Expected: clean.
+
+```bash
+git -C <worktree> add apps/console/src/pages/registry-rows.ts apps/console/src/pages/registry-rows.test.ts apps/console/src/pages/RegistrySettings.tsx
+git -C <worktree> commit -s -m "feat(console): merge bundles, tools and agents into one row model
+
+Extracts the tree-building and unresolved-pin logic so it is unit testable.
+Refs #1724"
+```
+
+---
+
+### Task 5: Console — render bundles, members, type pill and unresolved-pin state
+
+**Files:**
+- Modify: `apps/console/src/pages/RegistrySettings.tsx` (table header + body, ~`:596-670`)
+
+**Interfaces:**
+- Consumes: `Row` and `rowByName` from Task 4.
+- Produces: no new exports. Adds `expanded: Set<string>` local state.
+
+- [ ] **Step 1: Add expand state**
+
+```ts
+  // Bundle rows collapse by default — a bundle with 14 members would otherwise
+  // dominate the first page.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggleExpanded = useCallback((name: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      return next;
+    });
+  }, []);
+```
+
+- [ ] **Step 2: Add a Type column to the header**
+
+Insert immediately after the Name `<th>`, for the tool kind only:
+
+```tsx
+                          {kind === 'tool' && <th>Type</th>}
+```
+
+Bump the empty-state `colSpan`:
+
+```ts
+  const colCount = kind === 'agent' ? 4 : 7;
+```
+
+- [ ] **Step 3: Replace the table body rows**
+
+```tsx
+                        {pageRows.map(e => {
+                          const row = rowByName.get(e.name);
+                          const isBundle = row?.rowKind === 'bundle';
+                          const isOpen = expanded.has(e.name);
+                          const broken = (row?.unresolvedFor.length ?? 0) > 0;
+                          return (
+                            <Fragment key={e.name}>
+                              <tr
+                                className={selected?.name === e.name ? 'active' : undefined}
+                                onClick={() => setSelected(e)}
+                                style={{ cursor: 'pointer' }}
+                              >
+                                <td>
+                                  {isBundle && (
+                                    <button
+                                      type="button"
+                                      aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${e.name}`}
+                                      aria-expanded={isOpen}
+                                      onClick={ev => { ev.stopPropagation(); toggleExpanded(e.name); }}
+                                      style={{
+                                        background: 'none', border: 'none', cursor: 'pointer',
+                                        padding: '0 6px 0 0', color: 'inherit', font: 'inherit',
+                                      }}
+                                    >
+                                      {isOpen ? '▾' : '▸'}
+                                    </button>
+                                  )}
+                                  {e.name}{e.manifestError ? ' ⚠' : ''}
+                                </td>
+                                {kind === 'tool' && (
+                                  <td>
+                                    <span className="status-pill">
+                                      {isBundle ? 'bundle' : 'tool'}
+                                    </span>
+                                  </td>
+                                )}
+                                <td>
+                                  <span className={`status-pill ${STATE_PILL[e.state]}`}>
+                                    {e.state}{e.state === 'ghost' ? ' ⚠' : ''}
+                                  </span>
+                                </td>
+                                {kind === 'agent' ? (
+                                  <td>{e.metadata?.modelTier ?? '—'}</td>
+                                ) : (
+                                  <>
+                                    <td>{e.metadata?.actionRisk != null ? String(e.metadata.actionRisk) : '—'}</td>
+                                    <td>{e.metadata?.sensitivity ?? '—'}</td>
+                                    <td>
+                                      {broken ? (
+                                        <span
+                                          className="status-pill blocked"
+                                          title={
+                                            `${row!.unresolvedFor.join(', ')} pin${row!.unresolvedFor.length === 1 ? 's' : ''} ` +
+                                            `this bundle. It is not enabled, so ${row!.members.length} ` +
+                                            `tool${row!.members.length === 1 ? '' : 's'} are missing from ` +
+                                            `${row!.unresolvedFor.length === 1 ? 'that agent' : 'those agents'}' function list.`
+                                          }
+                                        >
+                                          ⚠ {row!.unresolvedFor.join(', ')}
+                                        </span>
+                                      ) : (
+                                        row?.pinnedBy.length ? row.pinnedBy.join(', ') : '—'
+                                      )}
+                                    </td>
+                                  </>
+                                )}
+                                <td>{e.metadata?.version ?? '—'}</td>
+                              </tr>
+                              {isBundle && isOpen && row!.members.map(m => (
+                                <tr key={`${e.name}:${m.name}`} style={{ opacity: 0.75 }}>
+                                  <td style={{ paddingLeft: 28 }}>{m.name}</td>
+                                  <td />
+                                  <td>
+                                    <span className={`status-pill ${STATE_PILL[m.state]}`}>{m.state}</span>
+                                  </td>
+                                  <td colSpan={3} style={{ fontSize: 12, color: 'var(--app-fg-muted)' }}>
+                                    managed by {e.name}
+                                  </td>
+                                  <td>{m.metadata?.version ?? '—'}</td>
+                                </tr>
+                              ))}
+                            </Fragment>
+                          );
+                        })}
+```
+
+Add a "Pinned by" `<th>` after Sensitivity in the tool-kind header block:
+
+```tsx
+                              <th>Pinned by</th>
+```
+
+Import `Fragment`:
+
+```ts
+import { useState, useEffect, useMemo, useCallback, Fragment } from 'react';
+```
+
+- [ ] **Step 4: Typecheck and build the console**
+
+Run: `pnpm -C <worktree> run typecheck`
+Then: `pnpm -C <worktree> --filter @curia/console run build`
+Expected: both clean. (If the console package name differs, read it from `apps/console/package.json` and use that.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C <worktree> add apps/console/src/pages/RegistrySettings.tsx
+git -C <worktree> commit -s -m "feat(console): render bundles with nested members and pin warnings
+
+Bundle rows expand to show read-only members; a bundle pinned by an enabled
+agent but not itself enabled renders as blocked. Refs #1724"
+```
+
+---
+
+### Task 6: Console — disable confirmation, and docs
+
+Disabling a bundle strips its member tools. Some of those tools are pinned individually by other agents (`T2125-expense-tracker` pins `ceo-inbox-download-attachment` and `ceo-inbox-search`), so the operator must see who is affected before confirming.
+
+**Files:**
+- Modify: `apps/console/src/pages/RegistrySettings.tsx` (`RegistryDrawer`, ~`:130-250`)
+- Modify: `CHANGELOG.md`
+- Test: `apps/console/src/pages/registry-rows.test.ts`
+
+**Interfaces:**
+- Consumes: `Row.members`, and agent entries' `metadata.pinnedBy`-equivalent (agents pin *tools* directly, so this needs a second index).
+- Produces: `collateralPins(row, agents): Array<{ tool: string; agents: string[] }>` exported from `registry-rows.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `registry-rows.test.ts`:
+
+```ts
+import { collateralPins } from './registry-rows.js';
+
+describe('collateralPins', () => {
+  const row = {
+    entry: bundle('ceo-inbox', ['ceo-inbox-search', 'ceo-inbox-list'], [], 'enabled'),
+    rowKind: 'bundle' as const,
+    members: [entry('ceo-inbox-search'), entry('ceo-inbox-list')],
+    pinnedBy: [],
+    unresolvedFor: [],
+  };
+
+  it('reports member tools pinned individually by other agents', () => {
+    const agents = [
+      entry('T2125-expense-tracker', {
+        kind: 'agent', state: 'enabled',
+        metadata: { name: 'T2125-expense-tracker', description: 'd', version: '1.0.0',
+          pinnedTools: ['ceo-inbox-search'] },
+      }),
+    ];
+
+    expect(collateralPins(row, agents)).toEqual([
+      { tool: 'ceo-inbox-search', agents: ['T2125-expense-tracker'] },
+    ]);
+  });
+
+  it('ignores the bundle owner itself and returns nothing when no one else pins a member', () => {
+    expect(collateralPins(row, [])).toEqual([]);
+  });
+});
+```
+
+Note: this reuses `entry` and `bundle` helpers already defined at the top of the file.
+
+- [ ] **Step 2: Extend the API so agents report their pinned names**
+
+`collateralPins` needs to know what each agent pins. Do **not** reuse `ManifestMetadata.tools` for this — on a skill it means "bundle members", and overloading it to mean "raw pins" on an agent makes every future reader check which kind they're holding. Add a distinct field.
+
+In `src/registry/types.ts`, in the `// agents` block of `ManifestMetadata`:
+
+```ts
+  /** Raw `pinned_skills` for an agent — a mix of bundle names and first-class tool
+   *  pins (ADR-032). Distinct from `tools`, which means bundle membership on a skill.
+   *  The console uses this to warn before a bundle disable strips a tool that some
+   *  other agent pins directly. Agents only. */
+  pinnedTools?: string[];
+```
+
+In `src/index.ts`, add it to the `agentDiscovery.map(...)` metadata object (~line 2340):
+
+```ts
+            role: d.config.role,
+            modelTier: d.config.model?.tier,
+            pinnedTools: d.config.pinned_skills ?? [],
+```
+
+Mirror the field in `apps/console/src/pages/registry-rows.ts`'s `ManifestMetadata` (add `pinnedTools?: string[];` beside `pinnedBy`).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm -C <worktree> exec vitest run apps/console/src/pages/registry-rows.test.ts -t collateralPins`
+Expected: FAIL — `collateralPins` is not exported.
+
+- [ ] **Step 4: Implement `collateralPins`**
+
+Append to `apps/console/src/pages/registry-rows.ts`:
+
+```ts
+/**
+ * Member tools of `row` that some agent pins directly, by tool name.
+ *
+ * Disabling a bundle cascades to its members, which would strip those tools from an
+ * agent that never asked for the bundle at all. The operator sees this list before
+ * confirming. Only enabled agents count — a disabled agent loses nothing.
+ */
+export function collateralPins(
+  row: Row,
+  agents: RegistryEntry[],
+): Array<{ tool: string; agents: string[] }> {
+  const memberNames = new Set(row.members.map(m => m.name));
+  const byTool = new Map<string, string[]>();
+
+  for (const agent of agents) {
+    if (agent.state !== 'enabled') continue;
+    for (const pin of agent.metadata?.pinnedTools ?? []) {
+      if (!memberNames.has(pin)) continue;
+      const list = byTool.get(pin);
+      if (list) list.push(agent.name);
+      else byTool.set(pin, [agent.name]);
+    }
+  }
+
+  return [...byTool.entries()].map(([tool, names]) => ({ tool, agents: names }));
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm -C <worktree> exec vitest run apps/console/src/pages/registry-rows.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Wire the confirmation into the drawer**
+
+`RegistryDrawer` needs the row and the agent list. Add two props (`row?: Row`, `agents: RegistryEntry[]`) and pass them from the render site. Before performing a `disable` on a bundle, gate on a confirm:
+
+```tsx
+  const confirmDisable = useCallback((): boolean => {
+    if (row?.rowKind !== 'bundle') return true;
+    const collateral = collateralPins(row, agents);
+    const lines = [
+      `Disable the "${entry.name}" bundle?`,
+      '',
+      `This also disables ${row.members.length} member tool${row.members.length === 1 ? '' : 's'}.`,
+    ];
+    if (collateral.length > 0) {
+      lines.push(
+        '',
+        'These member tools are pinned directly by other agents, which will lose them:',
+        ...collateral.map(c => `  • ${c.tool} — ${c.agents.join(', ')}`),
+      );
+    }
+    lines.push('', 'Takes effect on the next restart.');
+    return window.confirm(lines.join('\n'));
+  }, [row, agents, entry.name]);
+```
+
+Call it at the top of the disable branch of the existing action handler; return early when it yields `false`.
+
+- [ ] **Step 7: Typecheck, build, run the full suite**
+
+Run: `pnpm -C <worktree> run typecheck`
+Then: `pnpm -C <worktree> exec vitest run`
+Then: `pnpm -C <worktree> --filter @curia/console run build`
+Expected: all clean.
+
+- [ ] **Step 8: Confirm the restart notice covers bundles**
+
+The drawer already renders "Enabling or disabling takes effect on the next restart."
+(`RegistrySettings.tsx:219`). Bundles use the same drawer, so this needs verification, not
+new code: open a bundle row's drawer and confirm the notice is present. If it is gated on
+`kind`, remove the gate so it shows for bundles too.
+
+- [ ] **Step 9: Update CHANGELOG**
+
+Add under `## [Unreleased]` → `### Added`:
+
+```markdown
+- **Skill bundle registry UI** — `/tools` now enables/disables bundles and flags unresolved agent pins. (#1724)
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git -C <worktree> add apps/console/src/pages/ src/index.ts CHANGELOG.md
+git -C <worktree> commit -s -m "feat(console): confirm bundle disable when members are pinned elsewhere
+
+Warns which agents lose a directly-pinned tool before cascading a disable.
+Refs #1724"
+```
+
+---
+
+## Manual verification against prod-like state
+
+After Task 6, confirm the acceptance criteria that only show up with real data:
+
+1. Run the app locally against the dev DB (see `reference_run_curia_antfarm_locally`).
+2. With no `ceo-inbox` row in `skill_registry`, open `/tools`. Expect: a `ceo-inbox` row typed `bundle`, state `uninstalled`, and a red `⚠ ceo-inbox` in **Pinned by** whose tooltip names the 14 missing tools.
+3. Expand it. Expect 14 member rows, read-only, even though the bundle is not installed.
+4. Enable it from the drawer. Expect `skill_registry` to gain an enabled `ceo-inbox` row and all 14 `tool_registry` rows to be enabled, in one transaction.
+5. Restart. Expect no `unresolvedPins` error in the boot log for `ceo-inbox`, and `Agent tools configured` to include all 14 tools.
+6. Confirm `diagnostics` and `learning` render the same way.
+
+---
+
+## Out of scope
+
+Tracked separately, do not touch in this PR:
+
+- Pin-resolution behaviour itself (`src/skills/pin-resolution.ts`).
+- Tightening `ExecutionLayer.invoke()` so an agent cannot call a tool it was never given.
+- The `last_run_summary` feedback loop.

--- a/src/channels/http/routes/registry.ts
+++ b/src/channels/http/routes/registry.ts
@@ -136,6 +136,12 @@ export async function registryRoutes(
       await registryService.uninstall(kind, name, ACTOR);
       return reply.send({ ok: true });
     } catch (err) {
+      if (err instanceof RegistryGuardError) {
+        // Expected validation rejection (e.g. nothing to delete) — bad request, not a
+        // server failure. Mirrors the install/enable/disable action handler above.
+        request.log.info({ err, kind, name }, 'registry uninstall rejected: guard');
+        return reply.status(400).send({ error: err.message });
+      }
       request.log.error({ err, kind, name }, 'registry uninstall failed');
       return reply.status(500).send({ error: 'Uninstall failed. Check server logs.' });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,7 @@ import * as fs from 'node:fs';
 import * as yaml from 'js-yaml';
 import { RegistryRepo } from './registry/registry-repo.js';
 import { RegistryService } from './registry/registry-service.js';
+import { BundleCascadeRepo } from './registry/bundle-cascade-repo.js';
 import { reconcileRegistries, type RegistryDefaults } from './registry/reconcile.js';
 import type { Discovery, RegistryRow } from './registry/types.js';
 import { CHANNEL_CATALOG, type ChannelDescriptor } from './channels/catalog.js';
@@ -2378,6 +2379,7 @@ async function main(): Promise<void> {
         : null,
       error: d.error,
     })),
+    new BundleCascadeRepo(pool, logger),
   );
 
   // Wire skill-declared key names into McpRegistryService so uninstall

--- a/src/index.ts
+++ b/src/index.ts
@@ -2330,6 +2330,18 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Which agents pin each skill bundle. Read from agent manifests on disk so the
+  // registry UI can flag a bundle that an agent depends on but which is not enabled —
+  // the condition that silently stripped ceo-inbox's 14 tools for a month (#1724).
+  const pinnedByBundle = new Map<string, string[]>();
+  for (const agent of agentDiscovery) {
+    for (const pin of agent.config?.pinned_skills ?? []) {
+      const list = pinnedByBundle.get(pin);
+      if (list) list.push(agent.name);
+      else pinnedByBundle.set(pin, [agent.name]);
+    }
+  }
+
   // RegistryService backs the /api/registry/* routes. Seed it with the discovery
   // captured above so the UI can show uninstalled/ghost/error items, not just enabled.
   const registryService = new RegistryService(
@@ -2360,6 +2372,8 @@ async function main(): Promise<void> {
             name: d.metadata.name,
             description: d.metadata.description,
             version: d.metadata.version,
+            tools: d.metadata.tools,
+            pinnedBy: pinnedByBundle.get(d.name) ?? [],
           }
         : null,
       error: d.error,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2358,6 +2358,9 @@ async function main(): Promise<void> {
             version: d.config.version ?? '0.0.0',
             role: d.config.role,
             modelTier: d.config.model?.tier,
+            // Raw pinned_skills, unfiltered — the console cross-references this against
+            // each bundle's members to warn before a disable strips a directly-pinned tool.
+            pinnedTools: d.config.pinned_skills ?? [],
           }
         : null,
       error: d.error,

--- a/src/registry/bundle-cascade-repo.test.ts
+++ b/src/registry/bundle-cascade-repo.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BundleCascadeRepo } from './bundle-cascade-repo.js';
+import type { DbPool } from '../db/connection.js';
+
+// Minimal fake pool: records every query text so we can assert transaction shape.
+function fakePool(failOn?: string) {
+  const queries: string[] = [];
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql.trim().split('\n')[0]!.trim());
+      if (failOn && sql.includes(failOn)) throw new Error('boom');
+      return { rows: [] };
+    }),
+    release: vi.fn(),
+  };
+  const pool = { connect: vi.fn(async () => client) } as unknown as DbPool;
+  return { pool, client, queries };
+}
+
+const logger = { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+
+describe('BundleCascadeRepo.enableBundle', () => {
+  it('writes the bundle and every member tool inside one transaction', async () => {
+    const { pool, client, queries } = fakePool();
+    const repo = new BundleCascadeRepo(pool, logger as never);
+
+    await repo.enableBundle('ceo-inbox', ['ceo-inbox-list', 'ceo-inbox-read'], 'web-app');
+
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries[queries.length - 1]).toBe('COMMIT');
+    // one skill_registry upsert + one tool_registry upsert per member
+    expect(queries.filter(q => q.includes('skill_registry'))).toHaveLength(1);
+    expect(queries.filter(q => q.includes('tool_registry'))).toHaveLength(2);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back and rethrows when a member write fails', async () => {
+    const { pool, client, queries } = fakePool('tool_registry');
+    const repo = new BundleCascadeRepo(pool, logger as never);
+
+    await expect(
+      repo.enableBundle('ceo-inbox', ['ceo-inbox-list'], 'web-app'),
+    ).rejects.toThrow('boom');
+
+    expect(queries).toContain('ROLLBACK');
+    expect(queries).not.toContain('COMMIT');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+});
+
+describe('BundleCascadeRepo.disableBundle', () => {
+  it('disables the bundle and every member tool in one transaction', async () => {
+    const { pool, queries } = fakePool();
+    const repo = new BundleCascadeRepo(pool, logger as never);
+
+    await repo.disableBundle('ceo-inbox', ['ceo-inbox-list'], 'web-app');
+
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries[queries.length - 1]).toBe('COMMIT');
+  });
+});

--- a/src/registry/bundle-cascade-repo.ts
+++ b/src/registry/bundle-cascade-repo.ts
@@ -1,0 +1,76 @@
+// bundle-cascade-repo.ts — atomic enable/disable of a skill bundle together with its
+// member tools. RegistryRepo is one-instance-per-table by design; a bundle cascade
+// spans skill_registry and tool_registry, so it lives here and owns its transaction.
+//
+// A half-applied cascade is worse than the current state: it would leave a bundle
+// enabled with some members off, which is exactly the partial state the UI is meant
+// to make impossible. Hence BEGIN/COMMIT with an explicit ROLLBACK on any failure.
+
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+import type { IBundleCascadeRepo } from './types.js';
+
+// Upsert-then-enable in one statement. ON CONFLICT covers the case where the row
+// already exists (installed but disabled) — the common path for a bundle that shipped
+// disabled. Table names are compile-time literals; all values are parameterized.
+const ENABLE_SKILL = `
+  INSERT INTO skill_registry (name, enabled, installed_by, enabled_at, enabled_by)
+  VALUES ($1, true, $2, now(), $2)
+  ON CONFLICT (name) DO UPDATE
+    SET enabled = true, enabled_at = now(), enabled_by = $2`;
+
+const ENABLE_TOOL = `
+  INSERT INTO tool_registry (name, enabled, installed_by, enabled_at, enabled_by)
+  VALUES ($1, true, $2, now(), $2)
+  ON CONFLICT (name) DO UPDATE
+    SET enabled = true, enabled_at = now(), enabled_by = $2`;
+
+const DISABLE_SKILL = `
+  UPDATE skill_registry SET enabled = false, enabled_at = NULL, enabled_by = NULL
+  WHERE name = $1`;
+
+const DISABLE_TOOL = `
+  UPDATE tool_registry SET enabled = false, enabled_at = NULL, enabled_by = NULL
+  WHERE name = $1`;
+
+export class BundleCascadeRepo implements IBundleCascadeRepo {
+  constructor(private readonly pool: DbPool, private readonly logger: Logger) {}
+
+  async enableBundle(bundle: string, tools: string[], actor: string): Promise<void> {
+    await this.run('enable', bundle, tools, actor, ENABLE_SKILL, ENABLE_TOOL);
+  }
+
+  async disableBundle(bundle: string, tools: string[], actor: string): Promise<void> {
+    await this.run('disable', bundle, tools, actor, DISABLE_SKILL, DISABLE_TOOL);
+  }
+
+  private async run(
+    op: 'enable' | 'disable',
+    bundle: string,
+    tools: string[],
+    actor: string,
+    bundleSql: string,
+    toolSql: string,
+  ): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      // Disable takes only the name; enable also records the actor.
+      await client.query(bundleSql, op === 'enable' ? [bundle, actor] : [bundle]);
+      for (const tool of tools) {
+        await client.query(toolSql, op === 'enable' ? [tool, actor] : [tool]);
+      }
+      await client.query('COMMIT');
+    } catch (err) {
+      this.logger.error({ err, bundle, tools, op }, `Bundle ${op} cascade failed; rolling back`);
+      // Guard the ROLLBACK itself — if the connection dropped it may throw, and that
+      // must not mask the original error.
+      await client.query('ROLLBACK').catch((rollbackErr: unknown) => {
+        this.logger.error({ rollbackErr, bundle, op }, 'ROLLBACK failed after cascade error');
+      });
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/registry/bundle-cascade-repo.ts
+++ b/src/registry/bundle-cascade-repo.ts
@@ -53,6 +53,10 @@ export class BundleCascadeRepo implements IBundleCascadeRepo {
     toolSql: string,
   ): Promise<void> {
     const client = await this.pool.connect();
+    // Set only if ROLLBACK itself throws — passed to client.release() below so the pool
+    // destroys the connection instead of recycling one still stuck mid-transaction
+    // (node-postgres convention: release(err) signals "don't reuse this client").
+    let releaseErr: Error | undefined;
     try {
       await client.query('BEGIN');
       // Disable takes only the name; enable also records the actor.
@@ -67,10 +71,11 @@ export class BundleCascadeRepo implements IBundleCascadeRepo {
       // must not mask the original error.
       await client.query('ROLLBACK').catch((rollbackErr: unknown) => {
         this.logger.error({ rollbackErr, bundle, op }, 'ROLLBACK failed after cascade error');
+        releaseErr = rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr));
       });
       throw err;
     } finally {
-      client.release();
+      client.release(releaseErr);
     }
   }
 }

--- a/src/registry/reconcile.test.ts
+++ b/src/registry/reconcile.test.ts
@@ -25,7 +25,7 @@ class FakeRepo implements IRegistryRepo {
     const r = this.rows.get(name)!; const n = { ...r, enabled: false, enabledAt: null, enabledBy: null, updatedAt: 't1' };
     this.rows.set(name, n); return n;
   }
-  async uninstall(name: string) { this.rows.delete(name); }
+  async uninstall(name: string) { return this.rows.delete(name); }
 }
 
 const logger = createLogger('silent');

--- a/src/registry/reconcile.test.ts
+++ b/src/registry/reconcile.test.ts
@@ -26,6 +26,14 @@ class FakeRepo implements IRegistryRepo {
     this.rows.set(name, n); return n;
   }
   async uninstall(name: string) { return this.rows.delete(name); }
+  /** Names passed to the conditional delete — lets tests assert which path was taken. */
+  conditionalDeletes: string[] = [];
+  async uninstallIfDisabled(name: string) {
+    this.conditionalDeletes.push(name);
+    const row = this.rows.get(name);
+    if (!row || row.enabled) return false;
+    return this.rows.delete(name);
+  }
 }
 
 const logger = createLogger('silent');

--- a/src/registry/registry-repo.ts
+++ b/src/registry/registry-repo.ts
@@ -47,6 +47,7 @@ const SQL: Record<RegistryTable, {
   enable: string;
   disable: string;
   uninstall: string;
+  uninstallIfDisabled: string;
 }> = {
   tool_registry: {
     list: `SELECT ${COLS} FROM tool_registry`,
@@ -68,6 +69,7 @@ const SQL: Record<RegistryTable, {
               WHERE name = $1
               RETURNING ${COLS}`,
     uninstall: `DELETE FROM tool_registry WHERE name = $1`,
+    uninstallIfDisabled: `DELETE FROM tool_registry WHERE name = $1 AND enabled = false`,
   },
   agent_registry: {
     list: `SELECT ${COLS} FROM agent_registry`,
@@ -89,6 +91,7 @@ const SQL: Record<RegistryTable, {
               WHERE name = $1
               RETURNING ${COLS}`,
     uninstall: `DELETE FROM agent_registry WHERE name = $1`,
+    uninstallIfDisabled: `DELETE FROM agent_registry WHERE name = $1 AND enabled = false`,
   },
   skill_registry: {
     list: `SELECT ${COLS} FROM skill_registry`,
@@ -112,6 +115,7 @@ const SQL: Record<RegistryTable, {
               WHERE name = $1
               RETURNING ${COLS}`,
     uninstall: `DELETE FROM skill_registry WHERE name = $1`,
+    uninstallIfDisabled: `DELETE FROM skill_registry WHERE name = $1 AND enabled = false`,
   },
 };
 
@@ -168,6 +172,13 @@ export class RegistryRepo implements IRegistryRepo {
     const { rows } = await this.pool.query<DbRegistryRow>(this.sql.disable, [name]);
     if (!rows[0]) throw new Error(`disable: no registry row for '${name}'`);
     return mapRow(rows[0]);
+  }
+
+  /** Delete only while still disabled — the predicate lives in the statement so the
+   *  "refuse to uninstall an enabled bundle" guard cannot be raced by a concurrent enable. */
+  async uninstallIfDisabled(name: string): Promise<boolean> {
+    const result = await this.pool.query(this.sql.uninstallIfDisabled, [name]);
+    return (result.rowCount ?? 0) > 0;
   }
 
   async uninstall(name: string): Promise<boolean> {

--- a/src/registry/registry-repo.ts
+++ b/src/registry/registry-repo.ts
@@ -170,7 +170,10 @@ export class RegistryRepo implements IRegistryRepo {
     return mapRow(rows[0]);
   }
 
-  async uninstall(name: string): Promise<void> {
-    await this.pool.query(this.sql.uninstall, [name]);
+  async uninstall(name: string): Promise<boolean> {
+    const result = await this.pool.query(this.sql.uninstall, [name]);
+    // rowCount is null for statement types that don't report it (never DELETE in
+    // practice, but pg's types allow it) — treat that as "nothing confirmed deleted".
+    return (result.rowCount ?? 0) > 0;
   }
 }

--- a/src/registry/registry-service.test.ts
+++ b/src/registry/registry-service.test.ts
@@ -322,4 +322,48 @@ describe('RegistryService — bundle cascade', () => {
     expect(cascade.enabled).toEqual([]);
     expect((await toolRepo.getRow('bullpen'))?.enabled).toBe(true);
   });
+
+  it('installAndEnable cascades the bundle and its member tools', async () => {
+    // Starts from an empty skillRepo so this genuinely installs then enables —
+    // this is the /api/registry/skills/:name/install-enable route an operator
+    // actually uses to enrol a bundle for the first time (#1724).
+    const skillRepo = new FakeRepo();
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc, cascade,
+    );
+
+    await svc.installAndEnable('skill', 'ceo-inbox', 'web-app');
+
+    expect(cascade.enabled).toEqual([
+      { bundle: 'ceo-inbox', tools: ['ceo-inbox-list', 'ceo-inbox-read'] },
+    ]);
+    const row = await skillRepo.getRow('ceo-inbox');
+    expect(row).not.toBeNull();
+    expect(row?.installedBy).toBe('web-app');
+  });
+
+  it('refuses installAndEnable on a bundle when no cascade repo is wired', async () => {
+    const skillRepo = new FakeRepo();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc,
+    );
+
+    await expect(svc.installAndEnable('skill', 'ceo-inbox', 'web-app'))
+      .rejects.toThrow(/cascade repo not configured/i);
+  });
+
+  it('refuses a bundle disable when no cascade repo is wired', async () => {
+    // Symmetry with the enable-side guard: cheap to assert, and its absence is what
+    // would let a future refactor silently reintroduce the single-table fallback on
+    // disable while enable stays guarded.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc,
+    );
+
+    await expect(svc.disable('skill', 'ceo-inbox', 'web-app'))
+      .rejects.toThrow(/cascade repo not configured/i);
+  });
 });

--- a/src/registry/registry-service.test.ts
+++ b/src/registry/registry-service.test.ts
@@ -43,6 +43,14 @@ class FakeRepo implements IRegistryRepo {
     this.rows.set(name, next); return next;
   }
   async uninstall(name: string) { return this.rows.delete(name); }
+  /** Names passed to the conditional delete — lets tests assert which path was taken. */
+  conditionalDeletes: string[] = [];
+  async uninstallIfDisabled(name: string) {
+    this.conditionalDeletes.push(name);
+    const row = this.rows.get(name);
+    if (!row || row.enabled) return false;
+    return this.rows.delete(name);
+  }
 }
 
 const disc = (name: string, extra: Partial<Discovery> = {}): Discovery => ({
@@ -520,5 +528,73 @@ describe('RegistryService — bundle cascade', () => {
 
     await expect(svc.disable('skill', 'ceo-inbox', 'web-app'))
       .rejects.toThrow(/cascade repo not configured/i);
+  });
+});
+
+describe('RegistryService.uninstall — enabled check and delete are atomic', () => {
+  const readableDisc = [{
+    name: 'ceo-inbox',
+    metadata: {
+      name: 'ceo-inbox', description: 'd', version: '0.1.0',
+      tools: ['ceo-inbox-list'], pinnedBy: [],
+    },
+  }];
+
+  it('uses the conditional delete for a bundle whose members are readable', async () => {
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, readableDisc,
+      new FakeCascade(),
+    );
+
+    await svc.uninstall('skill', 'ceo-inbox', 'web-app');
+
+    expect(skillRepo.conditionalDeletes).toEqual(['ceo-inbox']);
+    expect(await skillRepo.getRow('ceo-inbox')).toBeNull();
+  });
+
+  it('rejects when the row is enabled by a concurrent caller between check and delete', async () => {
+    // The race the conditional delete closes: the guard used to read `enabled`, then DELETE
+    // unconditionally, so an enable committing in between would have its bundle row deleted
+    // while its member tools stayed enabled — orphaning exactly what this guard protects.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    await skillRepo.enable('ceo-inbox', 'other-actor'); // the concurrent enable
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, readableDisc,
+      new FakeCascade(),
+    );
+
+    await expect(svc.uninstall('skill', 'ceo-inbox', 'web-app'))
+      .rejects.toThrow(/while it is enabled/i);
+    // The row must survive a refused uninstall.
+    expect(await skillRepo.getRow('ceo-inbox')).not.toBeNull();
+  });
+
+  it('still reports the no-row case distinctly', async () => {
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, new FakeRepo(), readableDisc,
+      new FakeCascade(),
+    );
+    await expect(svc.uninstall('skill', 'ceo-inbox', 'web-app'))
+      .rejects.toThrow(/no registry row exists/i);
+  });
+
+  it('uses the unconditional delete when the member list is unreadable', async () => {
+    // Broken manifest: discovery entry present, metadata null. No cascade route exists, so
+    // the delete must still go through or the row becomes unremovable.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('broken', 'test');
+    await skillRepo.enable('broken', 'test');
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo,
+      [{ name: 'broken', metadata: null, error: 'bad yaml' }], new FakeCascade(),
+    );
+
+    await svc.uninstall('skill', 'broken', 'web-app');
+
+    expect(skillRepo.conditionalDeletes).toEqual([]);
+    expect(await skillRepo.getRow('broken')).toBeNull();
   });
 });

--- a/src/registry/registry-service.test.ts
+++ b/src/registry/registry-service.test.ts
@@ -42,7 +42,7 @@ class FakeRepo implements IRegistryRepo {
     const next = { ...row, enabled: false, enabledAt: null, enabledBy: null, updatedAt: 't1' };
     this.rows.set(name, next); return next;
   }
-  async uninstall(name: string) { this.rows.delete(name); }
+  async uninstall(name: string) { return this.rows.delete(name); }
 }
 
 const disc = (name: string, extra: Partial<Discovery> = {}): Discovery => ({
@@ -127,6 +127,16 @@ describe('RegistryService lifecycle guards', () => {
     await skillRepo.install('gone', 'web-app');
     await svc.uninstall('tool', 'gone', 'web-app');
     expect(await skillRepo.getRow('gone')).toBeNull();
+  });
+
+  it('uninstall rejects when there is no registry row to delete', async () => {
+    // Finding #2: the routing bug (finding #1) sent bundle deletes to the tools table,
+    // which matched zero rows — and the old signature had no way to notice. A delete
+    // that removes nothing must fail loudly, naming the item, so the console never
+    // reports success while the item is still there.
+    svc.setDiscovery('tool', [disc('never-installed')]);
+    await expect(svc.uninstall('tool', 'never-installed', 'web-app'))
+      .rejects.toThrow(/never-installed/);
   });
 });
 
@@ -323,11 +333,23 @@ describe('RegistryService — bundle cascade', () => {
     expect((await toolRepo.getRow('bullpen'))?.enabled).toBe(true);
   });
 
-  it('installAndEnable cascades the bundle and its member tools', async () => {
+  it('installAndEnable cascades the bundle and its member tools without a separate install() call', async () => {
     // Starts from an empty skillRepo so this genuinely installs then enables —
     // this is the /api/registry/skills/:name/install-enable route an operator
     // actually uses to enrol a bundle for the first time (#1724).
+    //
+    // Finding #4: a separate repo.install() before the cascade would commit outside
+    // the cascade's own transaction — if enableBundle() then failed, the bundle would
+    // be left installed with zero member tools touched. Spy on skillRepo.install to
+    // prove that never happens: the bundle must reach "enabled" through the cascade's
+    // upsert alone.
     const skillRepo = new FakeRepo();
+    let installCalls = 0;
+    const originalInstall = skillRepo.install.bind(skillRepo);
+    skillRepo.install = async (name: string, actor: string) => {
+      installCalls++;
+      return originalInstall(name, actor);
+    };
     const cascade = new FakeCascade();
     const svc = new RegistryService(
       new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc, cascade,
@@ -338,9 +360,7 @@ describe('RegistryService — bundle cascade', () => {
     expect(cascade.enabled).toEqual([
       { bundle: 'ceo-inbox', tools: ['ceo-inbox-list', 'ceo-inbox-read'] },
     ]);
-    const row = await skillRepo.getRow('ceo-inbox');
-    expect(row).not.toBeNull();
-    expect(row?.installedBy).toBe('web-app');
+    expect(installCalls).toBe(0);
   });
 
   it('refuses installAndEnable on a bundle when no cascade repo is wired', async () => {

--- a/src/registry/registry-service.test.ts
+++ b/src/registry/registry-service.test.ts
@@ -373,6 +373,141 @@ describe('RegistryService — bundle cascade', () => {
       .rejects.toThrow(/cascade repo not configured/i);
   });
 
+  // ── Finding #1: the secrets gate must cover the bundle path ────────────────
+  //
+  // A bundle enable writes its members' tool_registry rows through the cascade — the same
+  // rows that make a tool live — so it has to clear the same vault check the member tools
+  // enforce individually. Before the fix, assertSecretsConfigured returned early for
+  // kind='skill' and enabling the bundle was a way around the per-tool gate entirely.
+
+  it('rejects a bundle enable when a member tool needs an unconfigured secret', async () => {
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('web', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(),
+      [discWithSecrets('web-search', ['tavily_api_key'])], // member tool declares the secret
+      [], new FakeSecrets([]),                             // vault has nothing
+      skillRepo,
+      [disc('web', { metadata: { name: 'web', description: 'd', version: '0.1.0', tools: ['web-search'] } })],
+      cascade,
+    );
+
+    await expect(svc.enable('skill', 'web', 'web-app'))
+      .rejects.toThrow(/tavily_api_key/);
+    // The operator needs to know which member is asking, not just which key is missing.
+    await expect(svc.enable('skill', 'web', 'web-app'))
+      .rejects.toThrow(/web-search/);
+    // And nothing was written — the gate runs before the cascade.
+    expect(cascade.enabled).toEqual([]);
+  });
+
+  it('allows a bundle enable once the member tool secret is configured', async () => {
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('web', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(),
+      [discWithSecrets('web-search', ['tavily_api_key'])],
+      [], new FakeSecrets(['tavily_api_key']),             // vault now has the key
+      skillRepo,
+      [disc('web', { metadata: { name: 'web', description: 'd', version: '0.1.0', tools: ['web-search'] } })],
+      cascade,
+    );
+
+    const entry = await svc.enable('skill', 'web', 'web-app');
+
+    // FakeCascade records rather than writing rows, so the derived state still reflects the
+    // untouched fake repo row — what matters here is that the gate let the cascade run.
+    expect(entry.name).toBe('web');
+    expect(cascade.enabled).toEqual([{ bundle: 'web', tools: ['web-search'] }]);
+  });
+
+  // ── Finding #2: disable must refuse when the member list is unreadable ─────
+
+  it('refuses to disable a bundle whose manifest failed to parse, without cascading', async () => {
+    // Cascading `[]` here would flip only skill_registry; the member tool_registry rows
+    // would stay enabled and — since runtime gating reads tool_registry alone — the tools
+    // would stay live while the console reported success.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    await skillRepo.enable('ceo-inbox', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo,
+      [{ name: 'ceo-inbox', metadata: null, error: 'bad yaml' }],
+      cascade,
+    );
+
+    await expect(svc.disable('skill', 'ceo-inbox', 'web-app'))
+      .rejects.toThrow(/member tool list cannot be read/i);
+    expect(cascade.disabled).toEqual([]);
+  });
+
+  it('disables a bundle whose manifest legitimately lists no tools, cascading an empty list', async () => {
+    // The counterpart to the test above: a manifest that parsed and lists zero members is
+    // not a failure — cascading nothing is correct, and the bundle row must still flip.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('empty-bundle', 'test');
+    await skillRepo.enable('empty-bundle', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo,
+      [{ name: 'empty-bundle', metadata: { name: 'empty-bundle', description: 'd', version: '0.1.0', tools: [] } }],
+      cascade,
+    );
+
+    const entry = await svc.disable('skill', 'empty-bundle', 'web-app');
+
+    // The call succeeds and cascades an explicitly empty member list (FakeCascade records
+    // rather than writing, so the derived state still comes from the untouched fake row).
+    expect(entry.name).toBe('empty-bundle');
+    expect(cascade.disabled).toEqual([{ bundle: 'empty-bundle', tools: [] }]);
+  });
+
+  // ── Finding #3: uninstall must not strand an enabled bundle's members ──────
+
+  it('refuses to uninstall an enabled bundle and points at disable first', async () => {
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    await skillRepo.enable('ceo-inbox', 'test');
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc, new FakeCascade(),
+    );
+
+    await expect(svc.uninstall('skill', 'ceo-inbox', 'web-app'))
+      .rejects.toThrow(/disable the bundle first/i);
+    // The row is untouched, so the operator can still take the cascading route.
+    expect((await skillRepo.getRow('ceo-inbox'))?.enabled).toBe(true);
+  });
+
+  it('uninstalls a bundle that is installed but not enabled', async () => {
+    // Nothing live to strand: its member tool rows were never enabled by the cascade.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc, new FakeCascade(),
+    );
+
+    await svc.uninstall('skill', 'ceo-inbox', 'web-app');
+
+    expect(await skillRepo.getRow('ceo-inbox')).toBeNull();
+  });
+
+  it('still clears a ghost bundle row (no discovery entry)', async () => {
+    // Deleting the row is the ONLY way to remove a ghost — the console offers no other
+    // action for one — so the finding #3 guard must not swallow this case.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('gone-bundle', 'test');
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, [], new FakeCascade(),
+    );
+
+    await svc.uninstall('skill', 'gone-bundle', 'web-app');
+
+    expect(await skillRepo.getRow('gone-bundle')).toBeNull();
+  });
+
   it('refuses a bundle disable when no cascade repo is wired', async () => {
     // Symmetry with the enable-side guard: cheap to assert, and its absence is what
     // would let a future refactor silently reintroduce the single-table fallback on

--- a/src/registry/registry-service.test.ts
+++ b/src/registry/registry-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { RegistryService } from './registry-service.js';
-import type { IRegistryRepo, RegistryRow, Discovery, SecretsLister } from './types.js';
+import type { IRegistryRepo, RegistryRow, Discovery, SecretsLister, IBundleCascadeRepo } from './types.js';
 
 // In-memory fake vault — returns whatever key names it was seeded with.
 class FakeSecrets implements SecretsLister {
@@ -247,5 +247,79 @@ describe('RegistryService.list — skill bundle metadata', () => {
     const bundle = (await svc.list('skill')).find(e => e.name === 'ceo-inbox');
     expect(bundle?.state).toBe('uninstalled');
     expect(bundle?.metadata?.tools).toEqual(['ceo-inbox-list']);
+  });
+});
+
+class FakeCascade implements IBundleCascadeRepo {
+  enabled: Array<{ bundle: string; tools: string[] }> = [];
+  disabled: Array<{ bundle: string; tools: string[] }> = [];
+  async enableBundle(bundle: string, tools: string[]) { this.enabled.push({ bundle, tools }); }
+  async disableBundle(bundle: string, tools: string[]) { this.disabled.push({ bundle, tools }); }
+}
+
+describe('RegistryService — bundle cascade', () => {
+  const bundleDisc = [{
+    name: 'ceo-inbox',
+    metadata: {
+      name: 'ceo-inbox', description: 'd', version: '0.1.0',
+      tools: ['ceo-inbox-list', 'ceo-inbox-read'], pinnedBy: ['ceo-inbox'],
+    },
+  }];
+
+  it('enable cascades the bundle and its member tools', async () => {
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc, cascade,
+    );
+
+    await svc.enable('skill', 'ceo-inbox', 'web-app');
+
+    expect(cascade.enabled).toEqual([
+      { bundle: 'ceo-inbox', tools: ['ceo-inbox-list', 'ceo-inbox-read'] },
+    ]);
+  });
+
+  it('disable cascades the bundle and its member tools', async () => {
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc, cascade,
+    );
+
+    await svc.disable('skill', 'ceo-inbox', 'web-app');
+
+    expect(cascade.disabled).toEqual([
+      { bundle: 'ceo-inbox', tools: ['ceo-inbox-list', 'ceo-inbox-read'] },
+    ]);
+  });
+
+  it('refuses a bundle enable when no cascade repo is wired', async () => {
+    // Fail loudly rather than silently writing only skill_registry and leaving the
+    // member tools untouched — a partial enable is the bug this feature exists to stop.
+    const skillRepo = new FakeRepo();
+    await skillRepo.install('ceo-inbox', 'test');
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo, bundleDisc,
+    );
+
+    await expect(svc.enable('skill', 'ceo-inbox', 'web-app'))
+      .rejects.toThrow(/cascade repo not configured/i);
+  });
+
+  it('leaves tool and agent enable on the single-table path', async () => {
+    const toolRepo = new FakeRepo();
+    await toolRepo.install('bullpen', 'test');
+    const cascade = new FakeCascade();
+    const svc = new RegistryService(
+      toolRepo, new FakeRepo(), [disc('bullpen')], [], undefined, new FakeRepo(), [], cascade,
+    );
+
+    await svc.enable('tool', 'bullpen', 'web-app');
+
+    expect(cascade.enabled).toEqual([]);
+    expect((await toolRepo.getRow('bullpen'))?.enabled).toBe(true);
   });
 });

--- a/src/registry/registry-service.test.ts
+++ b/src/registry/registry-service.test.ts
@@ -205,3 +205,47 @@ describe('RegistryService secrets gate', () => {
       .rejects.toThrow(/vault is unavailable/);
   });
 });
+
+describe('RegistryService.list — skill bundle metadata', () => {
+  it('surfaces member tools and pin consumers for a bundle', async () => {
+    const skillRepo = new FakeRepo();
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, skillRepo,
+      [{
+        name: 'ceo-inbox',
+        metadata: {
+          name: 'ceo-inbox',
+          description: 'CEO inbox tools',
+          version: '0.1.0',
+          tools: ['ceo-inbox-list', 'ceo-inbox-read'],
+          pinnedBy: ['ceo-inbox'],
+        },
+      }],
+    );
+
+    const entries = await svc.list('skill');
+    const bundle = entries.find(e => e.name === 'ceo-inbox');
+
+    expect(bundle?.metadata?.tools).toEqual(['ceo-inbox-list', 'ceo-inbox-read']);
+    expect(bundle?.metadata?.pinnedBy).toEqual(['ceo-inbox']);
+  });
+
+  it('reports members for a bundle that is not installed', async () => {
+    // The whole point: a disabled bundle is never in SkillRegistry, so membership
+    // must come from on-disk discovery. An empty skillRepo = uninstalled.
+    const svc = new RegistryService(
+      new FakeRepo(), new FakeRepo(), [], [], undefined, new FakeRepo(),
+      [{
+        name: 'ceo-inbox',
+        metadata: {
+          name: 'ceo-inbox', description: 'd', version: '0.1.0',
+          tools: ['ceo-inbox-list'], pinnedBy: [],
+        },
+      }],
+    );
+
+    const bundle = (await svc.list('skill')).find(e => e.name === 'ceo-inbox');
+    expect(bundle?.state).toBe('uninstalled');
+    expect(bundle?.metadata?.tools).toEqual(['ceo-inbox-list']);
+  });
+});

--- a/src/registry/registry-service.ts
+++ b/src/registry/registry-service.ts
@@ -193,10 +193,16 @@ export class RegistryService {
   async installAndEnable(kind: RegistryKind, name: string, actor: string): Promise<RegistryEntry> {
     this.assertInstallable(kind, name);
     await this.assertSecretsConfigured(kind, name);
-    await this.repo(kind).install(name, actor);
     if (kind === 'skill') {
+      // No separate install() here: ENABLE_SKILL (bundle-cascade-repo.ts) is already an
+      // upsert (`INSERT ... ON CONFLICT DO UPDATE`), so the cascade alone installs-and-
+      // enables the bundle + its member tools in one transaction. Pre-installing via
+      // repo(kind).install() would commit outside that transaction — if the cascade then
+      // failed, the bundle would be left installed with zero member tools touched, the
+      // exact partial state this feature exists to prevent (finding #4).
       await this.requireCascade(name).enableBundle(name, this.bundleTools(name), actor);
     } else {
+      await this.repo(kind).install(name, actor);
       await this.repo(kind).enable(name, actor);
     }
     return this.entry(kind, name);
@@ -213,8 +219,14 @@ export class RegistryService {
     return this.entry(kind, name);
   }
 
-  /** Uninstall is allowed even for ghosts — it's the only way to clear a ghost row. */
+  /** Uninstall is allowed even for ghosts — it's the only way to clear a ghost row.
+   *  Rejects when nothing was actually deleted: a DELETE that matches zero rows (e.g.
+   *  the bundle-routing bug that sent `DELETE /skills/ceo-inbox` to the tools table)
+   *  must not report success while leaving the item in place (finding #2). */
   async uninstall(kind: RegistryKind, name: string, _actor: string): Promise<void> {
-    await this.repo(kind).uninstall(name);
+    const deleted = await this.repo(kind).uninstall(name);
+    if (!deleted) {
+      throw new RegistryGuardError(`Cannot uninstall ${kind} '${name}': no registry row exists.`);
+    }
   }
 }

--- a/src/registry/registry-service.ts
+++ b/src/registry/registry-service.ts
@@ -53,11 +53,39 @@ export class RegistryService {
     return this.skillDiscovery;
   }
 
-  /** Member tools of a bundle, from on-disk discovery. Empty array for a bundle whose
-   *  manifest failed to parse — cascading nothing is correct there, the bundle row
-   *  still flips and the broken manifest is already surfaced as `manifestError`. */
-  private bundleTools(name: string): string[] {
-    return this.skillDiscovery.find(d => d.name === name)?.metadata?.tools ?? [];
+  /** Member tools of a bundle, from on-disk discovery.
+   *
+   *  Returns `null` when the member list CANNOT be determined — no discovery entry at all
+   *  (a ghost bundle) or `metadata === null` because the manifest failed to parse. That is
+   *  emphatically NOT the same as a manifest that parsed and legitimately lists no tools,
+   *  which returns `[]`.
+   *
+   *  The distinction is load-bearing (finding #2). A tool's runtime availability is gated
+   *  ONLY by `tool_registry.enabled` — src/index.ts builds the enabled-tool set purely from
+   *  `tool_registry` with no join to `skill_registry`, and tools are loaded before
+   *  SkillRegistry is even populated. So cascading `[]` because we could not read the member
+   *  list would flip only the `skill_registry` row while every member tool_registry row
+   *  stayed enabled: the tools remain live and callable, and the operator is told the
+   *  disable succeeded. Callers must therefore treat `null` as "refuse", never as "nothing
+   *  to do". */
+  private bundleTools(name: string): string[] | null {
+    const disc = this.skillDiscovery.find(d => d.name === name);
+    if (!disc || disc.metadata === null) return null;
+    return disc.metadata.tools ?? [];
+  }
+
+  /** bundleTools() for callers that have already passed assertInstallable — which
+   *  guarantees a discovery entry with parsed metadata, hence a determinable member list.
+   *  The throw is a defensive invariant check, not an expected operator-facing rejection. */
+  private requireBundleTools(name: string): string[] {
+    const tools = this.bundleTools(name);
+    if (tools === null) {
+      throw new RegistryGuardError(
+        `Cannot determine the member tools of bundle '${name}': its manifest is missing or ` +
+        `failed to parse. Repair the manifest before enabling the bundle.`,
+      );
+    }
+    return tools;
   }
 
   private requireCascade(name: string): IBundleCascadeRepo {
@@ -145,9 +173,18 @@ export class RegistryService {
    *  install.requires_secrets that aren't all present in the vault. Items with no declared
    *  secrets are unaffected. A declared-but-unverifiable secret (no lister wired) fails
    *  closed — we never let something requiring secrets go live without confirming them.
-   *  Bundle skills do not declare requires_secrets (member tools do). */
+   *
+   *  A bundle skill declares no requires_secrets of its own — its member tools do — so the
+   *  bundle path delegates to assertBundleSecretsConfigured, which gates on the union of the
+   *  members' declarations. Returning early for kind='skill' (as this used to) let an
+   *  operator bypass the gate entirely: enabling `web-search` directly was refused when its
+   *  key was absent, but enabling the `web` bundle wrote the same tool_registry row through
+   *  the cascade and the tool went live at the next restart with no credential (finding #1). */
   private async assertSecretsConfigured(kind: RegistryKind, name: string): Promise<void> {
-    if (kind === 'skill') return; // secrets gate is per-tool
+    if (kind === 'skill') {
+      await this.assertBundleSecretsConfigured(name);
+      return;
+    }
     const disc = this.discovery(kind).find(d => d.name === name);
     const required = disc?.metadata?.requiresSecrets ?? [];
     if (required.length === 0) return;
@@ -163,6 +200,60 @@ export class RegistryService {
       throw new RegistryGuardError(
         `Cannot install '${name}': required secret(s) not configured in the vault: ${missing.join(', ')}. ` +
         `Configure them before installing.`,
+      );
+    }
+  }
+
+  /** Bundle arm of the secrets gate (finding #1). Enabling a bundle writes its member
+   *  tool_registry rows through the cascade — the very rows that make a tool live — so the
+   *  bundle must clear the same vault check the member tools would have enforced had they
+   *  been enabled one at a time.
+   *
+   *  We track WHICH member declared each key, not just the key set, because an operator
+   *  staring at "bundle web needs tavily_api_key" has to know it is `web-search` asking, so
+   *  they can decide whether to supply the credential or drop the member.
+   *
+   *  A member with no discovery entry (or an unparsable manifest) contributes nothing here:
+   *  its own per-tool gate still runs whenever it is enabled directly, and a tool whose
+   *  manifest cannot be read never loads at runtime anyway, so it cannot go live without a
+   *  credential. Failing closed on such members would instead block bundles whose members
+   *  simply are not in the tool discovery set (e.g. under test or partial discovery). */
+  private async assertBundleSecretsConfigured(bundle: string): Promise<void> {
+    // Same member list the cascade will write, so the gate can never cover a different set
+    // of tools than the operation itself touches.
+    const members = this.requireBundleTools(bundle);
+
+    // secret key → member tools that declare it (deduped by construction).
+    const requiredBy = new Map<string, string[]>();
+    for (const member of members) {
+      const memberDisc = this.toolDiscovery.find(d => d.name === member);
+      for (const secret of memberDisc?.metadata?.requiresSecrets ?? []) {
+        const declarers = requiredBy.get(secret) ?? [];
+        declarers.push(member);
+        requiredBy.set(secret, declarers);
+      }
+    }
+    if (requiredBy.size === 0) return;
+
+    const required = [...requiredBy.keys()];
+    // Renders "key (required by tool-a, tool-b)" so the message names the credential AND
+    // the member that needs it.
+    const describe = (keys: string[]): string =>
+      keys.map(k => `${k} (required by ${requiredBy.get(k)!.join(', ')})`).join('; ');
+
+    if (!this.secrets) {
+      // Fail closed, exactly as the per-tool path does: unverifiable is not the same as fine.
+      throw new RegistryGuardError(
+        `Cannot enable bundle '${bundle}': its member tools require secrets ` +
+        `(${describe(required)}) but the secrets vault is unavailable.`,
+      );
+    }
+    const configured = new Set(await this.secrets.list());
+    const missing = required.filter(s => !configured.has(s));
+    if (missing.length > 0) {
+      throw new RegistryGuardError(
+        `Cannot enable bundle '${bundle}': required secret(s) not configured in the vault: ` +
+        `${describe(missing)}. Configure them before enabling the bundle.`,
       );
     }
   }
@@ -183,7 +274,9 @@ export class RegistryService {
     if (!row) throw new RegistryGuardError(`Cannot enable '${name}': not installed. Install it first.`);
     if (kind === 'skill') {
       // Bundle + members in one transaction — the bundle is the unit of control (#1724).
-      await this.requireCascade(name).enableBundle(name, this.bundleTools(name), actor);
+      // requireBundleTools (not bundleTools) because assertInstallable above has already
+      // proven the manifest parsed, so the member list must be determinable here.
+      await this.requireCascade(name).enableBundle(name, this.requireBundleTools(name), actor);
     } else {
       await this.repo(kind).enable(name, actor);
     }
@@ -200,7 +293,7 @@ export class RegistryService {
       // repo(kind).install() would commit outside that transaction — if the cascade then
       // failed, the bundle would be left installed with zero member tools touched, the
       // exact partial state this feature exists to prevent (finding #4).
-      await this.requireCascade(name).enableBundle(name, this.bundleTools(name), actor);
+      await this.requireCascade(name).enableBundle(name, this.requireBundleTools(name), actor);
     } else {
       await this.repo(kind).install(name, actor);
       await this.repo(kind).enable(name, actor);
@@ -212,7 +305,29 @@ export class RegistryService {
     const row = await this.repo(kind).getRow(name);
     if (!row) throw new RegistryGuardError(`Cannot disable '${name}': no registry row.`);
     if (kind === 'skill') {
-      await this.requireCascade(name).disableBundle(name, this.bundleTools(name), actor);
+      // Deliberately NOT assertInstallable: disabling a bundle whose manifest is merely
+      // broken is a legitimate thing to want to do — it is often exactly why the operator
+      // is here. What we must refuse is a disable whose cascade would be INCOMPLETE.
+      //
+      // bundleTools() returns null when the member list cannot be read (ghost bundle, or a
+      // manifest that failed to parse). Cascading `[]` there would flip only the
+      // skill_registry row while every member tool_registry row stayed enabled — and since
+      // runtime availability is gated on tool_registry alone, those tools would stay live
+      // and callable while the console reported success. Re-enabling is blocked by
+      // assertInstallable, so there would be no bundle-level route back to a consistent
+      // state either. Fail loudly and tell the operator the two ways out (finding #2).
+      const tools = this.bundleTools(name);
+      if (tools === null) {
+        throw new RegistryGuardError(
+          `Cannot disable bundle '${name}': its member tool list cannot be read (no manifest ` +
+          `on disk, or the manifest failed to parse), so the cascade would leave its member ` +
+          `tools enabled and still callable. Disable the member tools individually, or repair ` +
+          `the bundle's manifest and try again.`,
+        );
+      }
+      // A manifest that parsed and lists zero tools reaches here with `[]` — cascading
+      // nothing is correct in that case, and the bundle row still flips.
+      await this.requireCascade(name).disableBundle(name, tools, actor);
     } else {
       await this.repo(kind).disable(name, actor);
     }
@@ -220,10 +335,40 @@ export class RegistryService {
   }
 
   /** Uninstall is allowed even for ghosts — it's the only way to clear a ghost row.
-   *  Rejects when nothing was actually deleted: a DELETE that matches zero rows (e.g.
+   *  Rejects an ENABLED bundle whose members are known (finding #3 — see inline), and
+   *  rejects when nothing was actually deleted: a DELETE that matches zero rows (e.g.
    *  the bundle-routing bug that sent `DELETE /skills/ceo-inbox` to the tools table)
    *  must not report success while leaving the item in place (finding #2). */
   async uninstall(kind: RegistryKind, name: string, _actor: string): Promise<void> {
+    if (kind === 'skill') {
+      // Finding #3: uninstall deletes the skill_registry row only — it never routes through
+      // the cascade. Uninstalling an ENABLED bundle therefore removed the row that owns the
+      // members while leaving every member tool_registry row enabled = true; after a restart
+      // those tools still load (runtime gating reads tool_registry alone) and stay callable
+      // by any agent, with no bundle owning them. The console offers Uninstall in the
+      // 'enabled' state, so this is one misclick away.
+      //
+      // Refuse, and point at disable — which DOES cascade — as the way to get there. We do
+      // not silently disable-then-uninstall on the operator's behalf: an unrequested cascade
+      // that strips 14 tools is not something to do implicitly.
+      const row = await this.repo(kind).getRow(name);
+      // The refusal is scoped to bundles whose member list is readable — i.e. exactly the
+      // bundles for which "disable first" is a route that actually works. A ghost (no
+      // manifest on disk) or a bundle with an unparsable manifest has no cascade route at
+      // all: disable() rejects it for the same reason, and the console derives 'ghost' state
+      // so it never even offers Disable. Blocking uninstall there too would leave the row
+      // with no console action whatsoever, and clearing a ghost row is the only way to
+      // remove one. So those fall through and the row delete proceeds.
+      if (row?.enabled && this.bundleTools(name) !== null) {
+        throw new RegistryGuardError(
+          `Cannot uninstall bundle '${name}' while it is enabled: its member tools would stay ` +
+          `enabled and callable with no bundle owning them. Disable the bundle first (that ` +
+          `cascades to its member tools), then uninstall it.`,
+        );
+      }
+      // An 'installed' (not enabled) bundle falls through too: it has no live members to
+      // strand, so deleting its row is safe.
+    }
     const deleted = await this.repo(kind).uninstall(name);
     if (!deleted) {
       throw new RegistryGuardError(`Cannot uninstall ${kind} '${name}': no registry row exists.`);

--- a/src/registry/registry-service.ts
+++ b/src/registry/registry-service.ts
@@ -7,7 +7,7 @@
 // Kinds: tool (atom), skill (bundle), agent.
 
 import type {
-  IRegistryRepo, RegistryKind, RegistryEntry, Discovery, SecretsLister,
+  IRegistryRepo, RegistryKind, RegistryEntry, Discovery, SecretsLister, IBundleCascadeRepo,
 } from './types.js';
 import { RegistryGuardError } from './types.js';
 
@@ -27,6 +27,9 @@ export class RegistryService {
     private readonly secrets?: SecretsLister,
     private readonly skillRepo?: IRegistryRepo,
     private skillDiscovery: Discovery[] = [],
+    // Cross-table cascade for bundle enable/disable. Required for kind='skill';
+    // absent is a wiring error, not a fallback (see bundleTools()).
+    private readonly cascade?: IBundleCascadeRepo,
   ) {}
 
   setDiscovery(kind: RegistryKind, discovery: Discovery[]): void {
@@ -48,6 +51,23 @@ export class RegistryService {
     if (kind === 'tool') return this.toolDiscovery;
     if (kind === 'agent') return this.agentDiscovery;
     return this.skillDiscovery;
+  }
+
+  /** Member tools of a bundle, from on-disk discovery. Empty array for a bundle whose
+   *  manifest failed to parse — cascading nothing is correct there, the bundle row
+   *  still flips and the broken manifest is already surfaced as `manifestError`. */
+  private bundleTools(name: string): string[] {
+    return this.skillDiscovery.find(d => d.name === name)?.metadata?.tools ?? [];
+  }
+
+  private requireCascade(name: string): IBundleCascadeRepo {
+    if (!this.cascade) {
+      throw new Error(
+        `RegistryService: bundle cascade repo not configured; refusing to change '${name}' ` +
+        `without cascading its member tools`,
+      );
+    }
+    return this.cascade;
   }
 
   /** Every known item (on disk and/or in DB) with its derived state. */
@@ -161,7 +181,12 @@ export class RegistryService {
     await this.assertSecretsConfigured(kind, name);
     const row = await this.repo(kind).getRow(name);
     if (!row) throw new RegistryGuardError(`Cannot enable '${name}': not installed. Install it first.`);
-    await this.repo(kind).enable(name, actor);
+    if (kind === 'skill') {
+      // Bundle + members in one transaction — the bundle is the unit of control (#1724).
+      await this.requireCascade(name).enableBundle(name, this.bundleTools(name), actor);
+    } else {
+      await this.repo(kind).enable(name, actor);
+    }
     return this.entry(kind, name);
   }
 
@@ -169,14 +194,22 @@ export class RegistryService {
     this.assertInstallable(kind, name);
     await this.assertSecretsConfigured(kind, name);
     await this.repo(kind).install(name, actor);
-    await this.repo(kind).enable(name, actor);
+    if (kind === 'skill') {
+      await this.requireCascade(name).enableBundle(name, this.bundleTools(name), actor);
+    } else {
+      await this.repo(kind).enable(name, actor);
+    }
     return this.entry(kind, name);
   }
 
   async disable(kind: RegistryKind, name: string, actor: string): Promise<RegistryEntry> {
     const row = await this.repo(kind).getRow(name);
     if (!row) throw new RegistryGuardError(`Cannot disable '${name}': no registry row.`);
-    await this.repo(kind).disable(name, actor);
+    if (kind === 'skill') {
+      await this.requireCascade(name).disableBundle(name, this.bundleTools(name), actor);
+    } else {
+      await this.repo(kind).disable(name, actor);
+    }
     return this.entry(kind, name);
   }
 

--- a/src/registry/registry-service.ts
+++ b/src/registry/registry-service.ts
@@ -351,23 +351,35 @@ export class RegistryService {
       // Refuse, and point at disable — which DOES cascade — as the way to get there. We do
       // not silently disable-then-uninstall on the operator's behalf: an unrequested cascade
       // that strips 14 tools is not something to do implicitly.
-      const row = await this.repo(kind).getRow(name);
       // The refusal is scoped to bundles whose member list is readable — i.e. exactly the
       // bundles for which "disable first" is a route that actually works. A ghost (no
       // manifest on disk) or a bundle with an unparsable manifest has no cascade route at
-      // all: disable() rejects it for the same reason, and the console derives 'ghost' state
-      // so it never even offers Disable. Blocking uninstall there too would leave the row
-      // with no console action whatsoever, and clearing a ghost row is the only way to
-      // remove one. So those fall through and the row delete proceeds.
-      if (row?.enabled && this.bundleTools(name) !== null) {
-        throw new RegistryGuardError(
-          `Cannot uninstall bundle '${name}' while it is enabled: its member tools would stay ` +
-          `enabled and callable with no bundle owning them. Disable the bundle first (that ` +
-          `cascades to its member tools), then uninstall it.`,
-        );
+      // all: disable() rejects those for the same unreadable-member-list reason, so blocking
+      // uninstall too would leave the row with no route out at all, and clearing a ghost row
+      // is the only way to remove one. Those fall through to the unconditional delete below.
+      if (this.bundleTools(name) !== null) {
+        // Conditional delete rather than read-then-delete: checking `enabled` and then
+        // DELETEing in two statements leaves a window in which a concurrent enable commits
+        // its bundle+member cascade, after which the DELETE strips the owning bundle row and
+        // strands its members enabled — the exact orphaning this guard exists to prevent.
+        // The predicate rides in the statement, so the check and the delete are atomic.
+        const deleted = await this.repo(kind).uninstallIfDisabled(name);
+        if (deleted) return;
+
+        // Nothing deleted: either no row, or it is enabled. Re-read only to pick the right
+        // message — this read carries no correctness weight, the delete already did that.
+        const row = await this.repo(kind).getRow(name);
+        if (row?.enabled) {
+          throw new RegistryGuardError(
+            `Cannot uninstall bundle '${name}' while it is enabled: its member tools would stay ` +
+            `enabled and callable with no bundle owning them. Disable the bundle first (that ` +
+            `cascades to its member tools), then uninstall it.`,
+          );
+        }
+        throw new RegistryGuardError(`Cannot uninstall ${kind} '${name}': no registry row exists.`);
       }
-      // An 'installed' (not enabled) bundle falls through too: it has no live members to
-      // strand, so deleting its row is safe.
+      // An 'installed' (not enabled) bundle needs no special handling: it has no live members
+      // to strand, and the conditional delete above already covers it.
     }
     const deleted = await this.repo(kind).uninstall(name);
     if (!deleted) {

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -103,8 +103,11 @@ export interface IRegistryRepo {
   enable(name: string, actor: string): Promise<RegistryRow>;
   /** Set enabled=false (+ clear enabled_at/by). Throws if no row exists. */
   disable(name: string, actor: string): Promise<RegistryRow>;
-  /** Delete the row. No error if absent. */
-  uninstall(name: string): Promise<void>;
+  /** Delete the row. No error if absent — the caller (RegistryService.uninstall)
+   *  decides whether a no-op delete is a guard rejection. Returns whether a row was
+   *  actually deleted so a route/UI action can't report success after deleting
+   *  nothing (finding #2). */
+  uninstall(name: string): Promise<boolean>;
 }
 
 /** Cross-table bundle operations. Separate from IRegistryRepo, which is deliberately

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -108,6 +108,14 @@ export interface IRegistryRepo {
    *  actually deleted so a route/UI action can't report success after deleting
    *  nothing (finding #2). */
   uninstall(name: string): Promise<boolean>;
+  /** Delete the row only while it is still disabled, in a single statement. Returns false
+   *  when nothing was deleted — either no row exists, or it is enabled.
+   *
+   *  Exists so RegistryService.uninstall's "refuse while enabled" guard cannot be raced: a
+   *  read-then-delete leaves a window in which a concurrent enable commits its bundle+member
+   *  cascade, after which the DELETE would strip the owning bundle row and strand its member
+   *  tools enabled. The predicate moves that check into the same statement as the delete. */
+  uninstallIfDisabled(name: string): Promise<boolean>;
 }
 
 /** Cross-table bundle operations. Separate from IRegistryRepo, which is deliberately

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -101,3 +101,11 @@ export interface IRegistryRepo {
   /** Delete the row. No error if absent. */
   uninstall(name: string): Promise<void>;
 }
+
+/** Cross-table bundle operations. Separate from IRegistryRepo, which is deliberately
+ *  one-instance-per-table; enabling a bundle must write skill_registry and every
+ *  member's tool_registry row in a single transaction (#1724). */
+export interface IBundleCascadeRepo {
+  enableBundle(bundle: string, tools: string[], actor: string): Promise<void>;
+  disableBundle(bundle: string, tools: string[], actor: string): Promise<void>;
+}

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -44,6 +44,11 @@ export interface ManifestMetadata {
   // agents
   role?: string;
   modelTier?: string;
+  /** Raw `pinned_skills` for an agent — a mix of bundle names and first-class tool
+   *  pins (ADR-032). Distinct from `tools`, which means bundle membership on a skill.
+   *  The console uses this to warn before a bundle disable strips a tool that some
+   *  other agent pins directly. Agents only. */
+  pinnedTools?: string[];
 }
 
 /** One on-disk item found during discovery. `metadata` is null when the manifest

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -33,6 +33,14 @@ export interface ManifestMetadata {
   /** Vault keys the skill's install block declares it needs (install.requires_secrets).
    *  Surfaced to the registry UI and consulted by the install/enable secrets gate. */
   requiresSecrets?: string[];
+  /** Member tool names for a SKILL.md bundle. Sourced from on-disk discovery, NOT
+   *  SkillRegistry — a bundle that is disabled is never registered, so SkillRegistry
+   *  cannot report its members. Skills only; undefined for tools and agents. */
+  tools?: string[];
+  /** Names of agents whose `pinned_skills` reference this bundle. Static, read from
+   *  agent manifests on disk. The console cross-references each agent's own enabled
+   *  state (via /api/registry/agents) to decide which combinations are broken. */
+  pinnedBy?: string[];
   // agents
   role?: string;
   modelTier?: string;


### PR DESCRIPTION
## Summary

Makes skill **bundles** manageable from the web console's `/tools` page. Closes #1724.

Bundles were invisible and unmanageable in the UI: `/tools` reads `tool_registry` only, so a bundle that ships disabled could not be seen, let alone enabled. That gap is why `ceo-inbox` silently ran for a month with all 14 of its tools missing from its function list — the console showed every one of those tools as `enabled`, because they were, in the table it reads.

Most of the backend already existed (`RegistryKind` includes `'skill'`, `skill_registry` CRUD, and all five `/api/registry/skills/*` routes). The gaps filled here are bundle *membership* and *pin consumers* reaching the API, a transactional cross-table cascade, and the console itself.

## What changed

**Backend**
- `ManifestMetadata` gains `tools` (bundle members, skills) and `pinnedBy` (agents pinning the bundle), populated at bootstrap. Membership is read from **on-disk discovery, not `SkillRegistry`** — a disabled bundle is never registered there, so it would report nothing for exactly the bundles this feature exists to surface.
- New `BundleCascadeRepo`: enable/disable writes `skill_registry` and every member's `tool_registry` row in one transaction, with a guarded rollback that passes the error to `client.release()` so a poisoned connection is destroyed rather than recycled.
- `RegistryService.enable` / `disable` / `installAndEnable` route `kind: 'skill'` through the cascade, and **throw** if no cascade repo is wired rather than silently writing only the bundle row.

**Console**
- `/tools` merges skills, tools and agents into one row model. Bundles render as expandable parents with read-only nested members; standalone tools stay flat.
- A "Pinned by" column, and a blocked state on any bundle that an **enabled** agent pins while the bundle itself is not enabled — the exact condition that went unnoticed for a month.
- Disabling a bundle confirms first, naming any member tool another agent pins directly and which agents lose it (real case: `T2125-expense-tracker` pins `ceo-inbox-download-attachment` and `ceo-inbox-search`).

## Defects found and fixed during review

Review caught four issues that would have shipped, all of the same silent-failure class this PR exists to eliminate:

- **Bundle actions were routed by page kind, not entry kind** — every bundle enable/disable POSTed to `/api/registry/tools/<name>` and 400'd, and uninstall silently reported success after deleting zero rows. The headline capability was non-functional and `BundleCascadeRepo` was dead code. Fixed, with `registryPathSegment()` extracted and unit tested so it cannot recur.
- **Bundle enable bypassed the per-tool secrets gate.** `assertSecretsConfigured` returned early for skills while the cascade wrote member rows via raw SQL, so enabling the `web` bundle would have put `web-search` live with no API key. Now gates on the union of member secrets, naming which tool needs which key.
- **Disabling a bundle with a broken manifest cascaded nothing, silently.** `bundleTools()` returned `[]`, flipping only the bundle row while members stayed live — and re-enable was then blocked, leaving no route back. Now distinguishes "manifest parsed, legitimately zero tools" from "member list cannot be determined" and refuses loudly on the latter.
- **Uninstalling an enabled bundle stranded its members.** Runtime tool availability is gated by `tool_registry.enabled` alone (`src/index.ts:1132`, `src/skills/loader.ts:188-200`), with no join to `skill_registry` — so the 14 orphaned tools stayed loaded and callable with no bundle owning them. Now refused server-side, and the console disables the button with the reason and the remedy.

## Known limitations

- Uninstalling a **ghost** bundle (registry row, no manifest) still leaves member rows enabled. Unavoidable — the member list is unreadable — and deliberately permitted, since clearing a ghost row is the only way to remove one. Those tools remain individually visible and manageable in `/tools`.
- Member tools whose own manifest is unparsable are invisible to the bundle secrets gate. Safe today because such tools never load.
- Bundle uninstall does not cascade; disable-then-uninstall is the supported path and is now enforced.

## Testing

- Full suite: **6259 passed, 0 failed**, 388 skipped.
- Root and `@curia/console` typechecks clean; console builds.
- New unit coverage: cascade enable/disable, cascade rollback, the no-cascade-wired guard on all three mutating methods, unresolved-pin detection, membership resolution for a **disabled** bundle, the endpoint path mapping, the bundle secrets gate, the broken-manifest disable guard, and the uninstall guards.

> **Note on the root typecheck script.** `pnpm run typecheck` does **not** cover `apps/console` — it reported clean while two real errors existed. Console work here used `pnpm --filter @curia/console run typecheck`. Worth closing separately; it is a standing blind spot, not something this PR introduces.

## Verification still to do

Against a live DB, before merge: confirm `ceo-inbox` renders flagged as an unresolved pin, expands to 14 members while uninstalled, and that enabling it writes the `skill_registry` row plus all 14 `tool_registry` rows — after which the boot log should emit no `unresolvedPins` error and `Agent tools configured` should include all 14 tools. `diagnostics` and `learning` are in the same un-enrolled state and should behave identically.
